### PR TITLE
Handle Pokt Network internal server errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- Attempt to overcome `ValueError: {'message': 'Internal JSON-RPC error.', 'code': -32603}` if served by a Pokt relat
+
 # 0.13.5
 
 - `has_graphql_support` made more robust

--- a/eth_defi/middleware.py
+++ b/eth_defi/middleware.py
@@ -46,11 +46,32 @@ DEFAULT_RETRYABLE_HTTP_STATUS_CODES = (
     504,
 )
 
+#: List of ValueError status codes we know we might want to retry after a timeout
+#:
+#: This is a self-managed list curated by pain.
+#:
+#: JSON-RPC error might be mapped to :py:class:`ValueError`
+#: if nothing else is available.
+#:
+#: Example from Pokt Network:
+#:
+#: `ValueError: {'message': 'Internal JSON-RPC error.', 'code': -32603}`
+#:
+#: We assume this is a broken RPC node and Pokt will reroute the
+#: the next retried request to some other node.
+#:
+#: See GoEthereum error codes https://github.com/ethereum/go-ethereum/blob/master/rpc/errors.go
+#:
+DEFAULT_RETRYABLE_RPC_ERROR_CODES = (
+    -32603,
+)
+
 
 def is_retryable_http_exception(
     exc: Exception,
     retryable_exceptions: Tuple[BaseException] = DEFAULT_RETRYABLE_EXCEPTIONS,
     retryable_status_codes: Collection[int] = DEFAULT_RETRYABLE_HTTP_STATUS_CODES,
+    retryable_rpc_error_codes: Collection[int] = DEFAULT_RETRYABLE_RPC_ERROR_CODES,
 ):
     """Helper to check retryable errors from JSON-RPC calls.
 
@@ -71,6 +92,17 @@ def is_retryable_http_exception(
         HTTP status codes we can retry. E.g. 429 Too Many requests.
     """
 
+    if isinstance(exc, ValueError):
+        # raise ValueError(response["error"])
+        # ValueError: {'message': 'Internal JSON-RPC error.', 'code': -32603}
+        if len(exc.args) > 0:
+            arg = exc.args[0]
+            if type(arg) == dict:
+                code = arg.get("code")
+                if code is None or type(code) != int:
+                    raise RuntimeError(f"Bad ValueError: {arg} - {exc}")
+                return code in retryable_rpc_error_codes
+
     if isinstance(exc, HTTPError):
         return exc.response.status_code in retryable_status_codes
 
@@ -85,6 +117,7 @@ def exception_retry_middleware(
     web3: "Web3",
     retryable_exceptions: Collection[Type[BaseException]],
     retryable_status_codes: Collection[int],
+    retryable_rpc_error_codes: Collection[int],
     retries: int = 10,
     sleep: int = 5,
     backoff: float = 1.6,
@@ -158,4 +191,5 @@ def http_retry_request_with_sleep_middleware(
         web3,
         DEFAULT_RETRYABLE_EXCEPTIONS,
         DEFAULT_RETRYABLE_HTTP_STATUS_CODES,
+        DEFAULT_RETRYABLE_RPC_ERROR_CODES,
     )

--- a/eth_defi/middleware.py
+++ b/eth_defi/middleware.py
@@ -62,9 +62,7 @@ DEFAULT_RETRYABLE_HTTP_STATUS_CODES = (
 #:
 #: See GoEthereum error codes https://github.com/ethereum/go-ethereum/blob/master/rpc/errors.go
 #:
-DEFAULT_RETRYABLE_RPC_ERROR_CODES = (
-    -32603,
-)
+DEFAULT_RETRYABLE_RPC_ERROR_CODES = (-32603,)
 
 
 def is_retryable_http_exception(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "web3-ethereum-defi"
-version = "0.13.4"
+version = "0.13.5"
 description = "DeFi integration library for smart contracts, DeFi trading (Uniswap, PancakeSwap), Ethereum JSON-RPC, EVM transactions and automated test suites."
 authors = ["Mikko Ohtamaa <mikko@tradingstrategy.ai>"]
 license = "MIT"

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -49,3 +49,10 @@ def test_connection_error_is_retryable():
 def test_with_retry(web3):
     """Normal API request with retry middleware."""
     assert web3.eth.block_number > 0
+
+
+def test_pokt_network_broken():
+    """Test for Internal server error from Pokt relay."""
+    exc = ValueError({'message': 'Internal JSON-RPC error.', 'code': -32603})
+    assert is_retryable_http_exception(exc)
+

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -53,6 +53,5 @@ def test_with_retry(web3):
 
 def test_pokt_network_broken():
     """Test for Internal server error from Pokt relay."""
-    exc = ValueError({'message': 'Internal JSON-RPC error.', 'code': -32603})
+    exc = ValueError({"message": "Internal JSON-RPC error.", "code": -32603})
     assert is_retryable_http_exception(exc)
-


### PR DESCRIPTION
Try to deal with

```
{'message': 'Internal JSON-RPC error.', 'code': -32603}
```

When served by a Pokt Relay.