### PR TITLE
Allow `pool_fee` to be input as single `int` for Uniswap V3

### DIFF
--- a/eth_defi/uniswap_v3/swap.py
+++ b/eth_defi/uniswap_v3/swap.py
@@ -61,7 +61,8 @@ def swap_with_slippage_protection(
     :param base_token: Base token of the trading pair
     :param quote_token: Quote token of the trading pair
     :param intermediate_token: Intermediate token which the swap can go through
-    :param pool_fees: List of all pools' trading fees in the path
+    :param pool_fees: List of all pools' trading fees in the path. Each fee is \
+        specified as BPS * 10_000 
     :param amount_in: How much of the quote token we want to pay, this has to be `None` if `amount_out` is specified
     :param amount_out: How much of the base token we want to receive, this has to be `None` if `amount_in` is specified
     :param max_slippage: Max slippage express in bps, default = 0.1 bps (0.001%)
@@ -77,10 +78,11 @@ def swap_with_slippage_protection(
     if max_slippage == 0:
         warnings.warn("max_slippage is set to 0, this can potentially lead to reverted transaction. It's recommended to set use default max_slippage instead (0.1 bps) to ensure successful transaction")
     
-    assert (pool_fees > 1 and type(pool_fees) == int), "pool_fees must be passed as int. BPS x 10,000"
-      
     if type(pool_fees) == int:
         pool_fees = [pool_fees]
+    
+    for fee in pool_fees:
+        assert (fee > 1), "pool_fees must be passed as int. BPS x 10_000"
 
     router = uniswap_v3_deployment.swap_router
     price_helper = UniswapV3PriceHelper(uniswap_v3_deployment)

--- a/eth_defi/uniswap_v3/swap.py
+++ b/eth_defi/uniswap_v3/swap.py
@@ -16,7 +16,7 @@ def swap_with_slippage_protection(
     recipient_address: HexAddress,
     base_token: Contract,
     quote_token: Contract,
-    pool_fees: list[float] | float,
+    pool_fees: list[int] | int,
     intermediate_token: Contract | None = None,
     max_slippage: float = 0.1,
     amount_in: int | None = None,
@@ -76,8 +76,10 @@ def swap_with_slippage_protection(
 
     if max_slippage == 0:
         warnings.warn("max_slippage is set to 0, this can potentially lead to reverted transaction. It's recommended to set use default max_slippage instead (0.1 bps) to ensure successful transaction")
-        
-    if type(pool_fees) == float:
+    
+    assert (pool_fees > 1 and type(pool_fees) == int), "pool_fees must be passed as int. BPS x 10,000"
+      
+    if type(pool_fees) == int:
         pool_fees = [pool_fees]
 
     router = uniswap_v3_deployment.swap_router

--- a/eth_defi/uniswap_v3/swap.py
+++ b/eth_defi/uniswap_v3/swap.py
@@ -16,7 +16,7 @@ def swap_with_slippage_protection(
     recipient_address: HexAddress,
     base_token: Contract,
     quote_token: Contract,
-    pool_fees: list[float],
+    pool_fees: list[float] | float,
     intermediate_token: Contract | None = None,
     max_slippage: float = 0.1,
     amount_in: int | None = None,
@@ -76,6 +76,9 @@ def swap_with_slippage_protection(
 
     if max_slippage == 0:
         warnings.warn("max_slippage is set to 0, this can potentially lead to reverted transaction. It's recommended to set use default max_slippage instead (0.1 bps) to ensure successful transaction")
+        
+    if type(pool_fees) == float:
+        pool_fees = [pool_fees]
 
     router = uniswap_v3_deployment.swap_router
     price_helper = UniswapV3PriceHelper(uniswap_v3_deployment)

--- a/eth_defi/uniswap_v3/swap.py
+++ b/eth_defi/uniswap_v3/swap.py
@@ -80,9 +80,11 @@ def swap_with_slippage_protection(
     
     if type(pool_fees) == int:
         pool_fees = [pool_fees]
+    elif type(pool_fees) != list:
+        raise ValueError("pool_fees must be passed as an int or int list. Each fee is BPS x 100")
     
     for fee in pool_fees:
-        assert (fee > 1), "pool_fees must be passed as int. BPS x 10_000"
+        assert (fee > 1 and type(fee) == int), "pool_fees must be passed as an int or int list. Each fee is BPS x 100"
 
     router = uniswap_v3_deployment.swap_router
     price_helper = UniswapV3PriceHelper(uniswap_v3_deployment)

--- a/tests/uniswap_v3/test_uniswap_v3_swap.py
+++ b/tests/uniswap_v3/test_uniswap_v3_swap.py
@@ -233,6 +233,57 @@ def test_buy_with_slippage_when_you_know_quote_amount(
     assert tx_receipt.status == 1
 
 
+def test_buy_with_slippage_fee_as_int(
+    web3: Web3,
+    deployer: str,
+    uniswap_v3: UniswapV3Deployment,
+    weth: Contract,
+    usdc: Contract,
+    weth_usdc_pool: Contract,
+    hot_wallet: LocalAccount,
+    pool_trading_fee: int,
+):
+    """Use local hot wallet to buy as much as possible WETH on Uniswap v3 using
+    define amout of mock USDC.
+    """
+
+    router = uniswap_v3.swap_router
+    hw_address = hot_wallet.address
+
+    # Give hot wallet some USDC to buy ETH (also some ETH as well to send tx)
+    web3.eth.send_transaction({"from": deployer, "to": hw_address, "value": 1 * 10**18})
+    usdc_amount_to_pay = 500 * 10**18
+    usdc.functions.transfer(hw_address, usdc_amount_to_pay).transact({"from": deployer})
+    usdc.functions.approve(router.address, usdc_amount_to_pay).transact({"from": hw_address})
+
+    # build transaction
+    swap_func = swap_with_slippage_protection(
+        uniswap_v3_deployment=uniswap_v3,
+        recipient_address=hw_address,
+        base_token=weth,
+        quote_token=usdc,
+        pool_fees=pool_trading_fee,
+        amount_in=usdc_amount_to_pay,
+        max_slippage=50,  # 50 bps = 0.5%
+    )
+    tx = swap_func.build_transaction(
+        {
+            "from": hw_address,
+            "chainId": web3.eth.chain_id,
+            "gas": 350_000,  # estimate max 350k gas per swap
+        }
+    )
+    tx = fill_nonce(web3, tx)
+    gas_fees = estimate_gas_fees(web3)
+    apply_gas(tx, gas_fees)
+
+    # sign and broadcast
+    signed_tx = hot_wallet.sign_transaction(tx)
+    tx_hash = web3.eth.send_raw_transaction(signed_tx.rawTransaction)
+    tx_receipt = web3.eth.get_transaction_receipt(tx_hash)
+    assert tx_receipt.status == 1
+
+
 def test_sell_three_way_with_slippage_when_you_know_base_amount(
     web3: Web3,
     deployer: str,


### PR DESCRIPTION
- Allows `pool_fees` argument to be specified as a single `int`, instead of array. E.g. user can input `3000` instead of `[3000]`
- This makes the api for two way trades between Uniswap V2 and V3 identical, and slightly simplifies development efforts for Tradeexecutor module 
- Fix `pool_fees` typing bug (previously specified as float, supposed to be int)
- Add assertions for `pool_fees` type
- Adds 3 more tests for swapping on Uniswap V3.
     - One were the fee is provided as int
     - One were the fee is provided as float. Test is expected to raise ValueError
     - One were the fee is provided as a float list. Test is expected to raise AssertionError.