### PR TITLE
use `raw_price` instead of `price`

### DIFF
--- a/eth_defi/uniswap_v3/analysis.py
+++ b/eth_defi/uniswap_v3/analysis.py
@@ -92,7 +92,6 @@ def analyse_trade_by_receipt(web3: Web3, uniswap: UniswapV3Deployment, tx: dict,
 
     # see https://stackoverflow.com/a/74619134
     raw_price = tick_to_price(tick)
-    price = raw_price / 10 ** (out_token_details.decimals - in_token_details.decimals)
 
     return TradeSuccess(
         gas_used,
@@ -101,7 +100,7 @@ def analyse_trade_by_receipt(web3: Web3, uniswap: UniswapV3Deployment, tx: dict,
         amount_in,
         amount_out_min,
         abs(amount_out),
-        price,
+        raw_price,
         in_token_details.decimals,
         out_token_details.decimals,
     )


### PR DESCRIPTION
Small change

- In `eth_defi.uniswap_v3.analysis`, `raw_price` is returned  in `TradeSuccess` instance instead of price
- This is because calculating price would require an additional parameter whether to reverse order. Decided not to do this.