### PR TITLE
Swap fee assertion

### DIFF
--- a/eth_defi/uniswap_v2/swap.py
+++ b/eth_defi/uniswap_v2/swap.py
@@ -116,7 +116,7 @@ def swap_with_slippage_protection(
         Prepared swap function which can be used directly to build transaction
     """
     
-    assert fee, "fee must be non-zero"
+    assert fee > 0, "fee must be non-zero"
 
     if amount_in:
         assert type(amount_in) == int

--- a/eth_defi/uniswap_v2/swap.py
+++ b/eth_defi/uniswap_v2/swap.py
@@ -115,6 +115,8 @@ def swap_with_slippage_protection(
     :return:
         Prepared swap function which can be used directly to build transaction
     """
+    
+    assert fee, "fee must be non-zero"
 
     if amount_in:
         assert type(amount_in) == int

--- a/eth_defi/uniswap_v3/swap.py
+++ b/eth_defi/uniswap_v3/swap.py
@@ -68,6 +68,9 @@ def swap_with_slippage_protection(
     :param deadline: Time limit of the swap transaction, by default = forever (no deadline)
     :return: Prepared swap function which can be used directly to build transaction
     """
+    for fee in pool_fees:
+        assert fee, "fee must be non-zero"
+    
     if not amount_in and not amount_out:
         raise ValueError("amount_in is specified, amount_out has to be None")
 

--- a/eth_defi/uniswap_v3/swap.py
+++ b/eth_defi/uniswap_v3/swap.py
@@ -69,7 +69,7 @@ def swap_with_slippage_protection(
     :return: Prepared swap function which can be used directly to build transaction
     """
     for fee in pool_fees:
-        assert fee, "fee must be non-zero"
+        assert fee > 0, "fee must be non-zero"
     
     if not amount_in and not amount_out:
         raise ValueError("amount_in is specified, amount_out has to be None")


### PR DESCRIPTION
Using a fee of 0 in some tests in tradeexecutor package resulted in a confusing web3 error that was seemingly unrelated difficult to debug `(ValidationError: No valid "from" key was provided in the transaction which is required for transaction signing)`. This adds an assertion to prevent this from happening in the future.