### PR TITLE
Logical TokenDetails equality comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Current
+
+- Fix: Token equality: `TokenDetails` does a logical comparison with chain id and address,
+  instaed of object comparison. This makes TokenDetails good for ifs and hash maps. This
+  adds `TokenDetails.__eq__` and `TokenDetails.__hash__`.
+
 # 0.20
 
 - Add USDC (Centre FiatToken)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   instaed of object comparison. This makes TokenDetails good for ifs and hash maps. This
   adds `TokenDetails.__eq__` and `TokenDetails.__hash__`.
 - Fix `TradeSuccess.price` is in Python `Decimal`
+- Add: `TradeSucces.get_human_price(reverse_token_order: bool)`
 
 # 0.20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix: Token equality: `TokenDetails` does a logical comparison with chain id and address,
   instaed of object comparison. This makes TokenDetails good for ifs and hash maps. This
   adds `TokenDetails.__eq__` and `TokenDetails.__hash__`.
+- Fix `TradeSuccess.price` is in Python `Decimal`
 
 # 0.20
 

--- a/eth_defi/token.py
+++ b/eth_defi/token.py
@@ -46,6 +46,18 @@ class TokenDetails:
     #: Number of decimals
     decimals: Optional[int] = None
 
+    def __eq__(self, other):
+        """Token is the same if it's on the same chain and has the same contract address.
+
+        .. note ::
+
+            May cause RPC call, because `chain_id` is an RPC call.
+            This should be cached if the cache middleware is installed.
+
+        """
+        assert isinstance(other, TokenDetails)
+        return (self.contract.address == other.contract.address) and (self.contract.w3.eth.chain_id == other.contract.w3.eth.chain_id)
+
     def __repr__(self):
         return f"<{self.name} ({self.symbol}) at {self.contract.address}, {self.decimals} decimals>"
 

--- a/eth_defi/token.py
+++ b/eth_defi/token.py
@@ -6,6 +6,7 @@ Deploy ERC-20 tokens to be used within your test suite.
 """
 from dataclasses import dataclass
 from decimal import Decimal
+from functools import cached_property
 from typing import Optional, Union
 
 from eth_tester.exceptions import TransactionFailed
@@ -47,19 +48,21 @@ class TokenDetails:
     decimals: Optional[int] = None
 
     def __eq__(self, other):
-        """Token is the same if it's on the same chain and has the same contract address.
-
-        .. note ::
-
-            May cause RPC call, because `chain_id` is an RPC call.
-            This should be cached if the cache middleware is installed.
-
-        """
+        """Token is the same if it's on the same chain and has the same contract address."""
         assert isinstance(other, TokenDetails)
-        return (self.contract.address == other.contract.address) and (self.contract.w3.eth.chain_id == other.contract.w3.eth.chain_id)
+        return (self.contract.address == other.contract.address) and (self.chain_id == other.chain_id)
+
+    def __hash__(self):
+        """Token hash."""
+        return hash((self.chain_id, self.contract.address))
 
     def __repr__(self):
-        return f"<{self.name} ({self.symbol}) at {self.contract.address}, {self.decimals} decimals>"
+        return f"<{self.name} ({self.symbol}) at {self.contract.address}, {self.decimals} decimals, on chain {self.chain_id}>"
+
+    @cached_property
+    def chain_id(self) -> int:
+        """The EVM chain id where this token lives."""
+        return self.contract.w3.eth.chain_id
 
     @property
     def address(self) -> HexAddress:

--- a/eth_defi/trade.py
+++ b/eth_defi/trade.py
@@ -40,7 +40,7 @@ class TradeSuccess(TradeResult):
     #:
     #: Note that you get inverse price, if you route ETH-USD or USD-ETH e.g. are you doing buy or sell.
     #:
-    #: See also :py:meth:`get_human_price)`
+    #: See also :py:meth:`get_human_price`
     price: Decimal
 
     #: Token information book keeping
@@ -50,7 +50,19 @@ class TradeSuccess(TradeResult):
     amount_out_decimals: int
 
     def get_human_price(self, reverse_token_order=False) -> Decimal:
-        """Get the executed price of this trade.
+        """Get the executed price of this trade in a human-readable form.
+
+        This depends on:
+
+        - If we do buy or sell
+
+        - If quote token is token0 or token1 in Uniswap v3 pool
+
+        Example:
+
+        .. code-block:: python
+
+            pass
 
         :param reverse_token_order:
             Base and quote token order.
@@ -60,7 +72,7 @@ class TradeSuccess(TradeResult):
             otherwise `token1`.
         """
         if reverse_token_order:
-            return self.price / Decimal(1)
+            return Decimal(1) / self.price
         else:
             return self.price
 

--- a/eth_defi/trade.py
+++ b/eth_defi/trade.py
@@ -39,11 +39,30 @@ class TradeSuccess(TradeResult):
     #: Price includes any fees paid during the order routing path.
     #:
     #: Note that you get inverse price, if you route ETH-USD or USD-ETH e.g. are you doing buy or sell.
+    #:
+    #: See also :py:meth:`get_human_price)`
     price: Decimal
 
-    # Token information book keeping
+    #: Token information book keeping
     amount_in_decimals: int
+
+    #: Token information book keeping
     amount_out_decimals: int
+
+    def get_human_price(self, reverse_token_order=False) -> Decimal:
+        """Get the executed price of this trade.
+
+        :param reverse_token_order:
+            Base and quote token order.
+
+            Quote token should be natural quote token  like USD or ETH based token of the trade.
+            If `reverse_token_order` is set quote token is `token0` of the pool,
+            otherwise `token1`.
+        """
+        if reverse_token_order:
+            return self.price / Decimal(1)
+        else:
+            return self.price
 
 
 @dataclass

--- a/eth_defi/trade.py
+++ b/eth_defi/trade.py
@@ -49,6 +49,10 @@ class TradeSuccess(TradeResult):
     #: Token information book keeping
     amount_out_decimals: int
 
+    def __post_init__(self):
+        if self.price is not None:
+            assert isinstance(self.price, Decimal)
+
     def get_human_price(self, reverse_token_order=False) -> Decimal:
         """Get the executed price of this trade in a human-readable form.
 

--- a/eth_defi/trade.py
+++ b/eth_defi/trade.py
@@ -74,6 +74,8 @@ class TradeSuccess(TradeResult):
 
         This depends on:
 
+        - If we are on Uniswap v2 or v3
+
         - If we do buy or sell
 
         - If quote token is token0 or token1 in Uniswap v3 pool
@@ -82,6 +84,7 @@ class TradeSuccess(TradeResult):
 
         .. code-block:: python
 
+            # TODO
             pass
 
         :param reverse_token_order:

--- a/eth_defi/trade.py
+++ b/eth_defi/trade.py
@@ -4,6 +4,8 @@ from typing import List, Optional
 
 from eth_typing import HexAddress
 
+from eth_defi.token import TokenDetails
+
 
 @dataclass
 class TradeResult:
@@ -28,13 +30,17 @@ class TradeSuccess(TradeResult):
     """
 
     #: Routing path that was used for this trade
-    path: Optional[List[HexAddress]]
+    path: List[HexAddress] | None
 
     amount_in: int
-    amount_out_min: Optional[int]
+    amount_out_min: int | None
     amount_out: int
 
-    #: Overall price paid as in token (first in the path) to out token (last in the path).
+    #: The price of the trade in some order.
+    #:
+    #: - Uniswap v2: Overall price paid as in token (first in the path) to out token (last in the path).
+    #:
+    #: - Uniswap v3: depends on ticks and order of token0 and token1 in the underlying pool smart contract
     #:
     #: Price includes any fees paid during the order routing path.
     #:
@@ -43,11 +49,21 @@ class TradeSuccess(TradeResult):
     #: See also :py:meth:`get_human_price`
     price: Decimal
 
-    #: Token information book keeping
+    #: Token information bookkeeping
     amount_in_decimals: int
 
-    #: Token information book keeping
+    #: Token information bookkeeping
     amount_out_decimals: int
+
+    #: Uniswap v3 pool token 0
+    #:
+    #: Needed to calculate reverse token order.
+    token0: TokenDetails | None
+
+    #: Uniswap v3 pool token 1
+    #:
+    #: Needed to calculate reverse token order.
+    token1: TokenDetails | None
 
     def __post_init__(self):
         if self.price is not None:

--- a/eth_defi/uniswap_v2/analysis.py
+++ b/eth_defi/uniswap_v2/analysis.py
@@ -198,6 +198,8 @@ def analyse_trade_by_receipt(web3: Web3, uniswap: UniswapV2Deployment, tx: dict,
         price=price,
         amount_in_decimals=in_token_details.decimals,
         amount_out_decimals=out_token_details.decimals,
+        token0=None,
+        token1=None,
     )
 
 

--- a/eth_defi/uniswap_v3/analysis.py
+++ b/eth_defi/uniswap_v3/analysis.py
@@ -65,7 +65,7 @@ def analyse_trade_by_receipt(
     .. warning::
 
         Do not use `TradeSuccess.price` directly, as this price depends on in which order token0 and token1
-        are in the pool smart contract. Use `TradeSucces.get_human_price()` instead.
+        are in the pool smart contract. Use `TradeSuccess.get_human_price()` instead.
 
 
     :param tx_receipt:

--- a/eth_defi/uniswap_v3/analysis.py
+++ b/eth_defi/uniswap_v3/analysis.py
@@ -141,4 +141,6 @@ def analyse_trade_by_receipt(
         price,
         in_token_details.decimals,
         out_token_details.decimals,
+        token0=pool.token0,
+        token1=pool.token1,
     )

--- a/eth_defi/uniswap_v3/analysis.py
+++ b/eth_defi/uniswap_v3/analysis.py
@@ -129,7 +129,7 @@ def analyse_trade_by_receipt(
 
     in_token_details = fetch_erc20_details(web3, path[0])
     out_token_details = fetch_erc20_details(web3, path[-1])
-    price = pool.convert_price_to_human(tick, in_token_details == pool.token1)
+    price = pool.convert_price_to_human(tick)  # Return price of token0/token1
 
     return TradeSuccess(
         gas_used,

--- a/eth_defi/uniswap_v3/analysis.py
+++ b/eth_defi/uniswap_v3/analysis.py
@@ -62,6 +62,11 @@ def analyse_trade_by_receipt(
 
     - Slippage, etc.
 
+    .. warning::
+
+        Do not use `TradeSuccess.price` directly, as this price depends on in which order token0 and token1
+        are in the pool smart contract. Use `TradeSucces.get_human_price()` instead.
+
 
     :param tx_receipt:
         Transaction receipt

--- a/eth_defi/uniswap_v3/pool.py
+++ b/eth_defi/uniswap_v3/pool.py
@@ -1,4 +1,5 @@
 """Uniswap v3 pool data."""
+from decimal import Decimal
 from dataclasses import dataclass
 from typing import Union
 
@@ -35,7 +36,7 @@ class PoolDetails:
     def __repr__(self):
         return f"Pool {self.address} is {self.token0.symbol}-{self.token1.symbol}, with the fee {self.fee * 100:.04f}%"
 
-    def convert_price_to_human(self, tick: int, reverse_token_order=False):
+    def convert_price_to_human(self, tick: int, reverse_token_order=False) -> Decimal:
         """Convert the price obtained through
 
         :param tick:
@@ -45,12 +46,12 @@ class PoolDetails:
             For natural base - quote token order. If set,
             assume quote token is token0.
         """
-        raw_price = 1.0001**tick
+        raw_price = Decimal("1.0001") ** tick
 
         if reverse_token_order:
-            return (1 / raw_price) / 10 ** (self.token0.decimals - self.token1.decimals)
+            return (Decimal(1) / raw_price) / Decimal(10 ** (self.token0.decimals - self.token1.decimals))
         else:
-            return raw_price / 10 ** (self.token1.decimals - self.token0.decimals)
+            return raw_price / Decimal(10 ** (self.token1.decimals - self.token0.decimals))
 
 
 def fetch_pool_details(web3, pool_contact_address: Union[str, HexAddress]) -> PoolDetails:

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -118,3 +118,14 @@ def test_fetch_token_details_broken_load(web3: Web3, deployer: str):
     malformed_token = deploy_contract(web3, "MalformedERC20.json", deployer)
     with pytest.raises(TokenDetailError):
         fetch_erc20_details(web3, malformed_token.address)
+
+
+def test_compare_token(web3: Web3, deployer: str):
+    """token __eq__ works by chain id and address"""
+    token_1_contract = create_token(web3, deployer, "Hentai books token", "HENTAI", 100_000 * 10**18, 6)
+    token_2_contract = create_token(web3, deployer, "Animu token", "ANIMU", 100_000 * 10 ** 18, 6)
+    token_1 = fetch_erc20_details(web3, token_1_contract.address)
+    token_2 = fetch_erc20_details(web3, token_2_contract.address)
+    token_1_again = fetch_erc20_details(web3, token_1.address)
+    assert token_1 == token_1_again
+    assert token_2 != token_1

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -129,3 +129,4 @@ def test_compare_token(web3: Web3, deployer: str):
     token_1_again = fetch_erc20_details(web3, token_1.address)
     assert token_1 == token_1_again
     assert token_2 != token_1
+    assert hash(token_1) == hash(token_1_again)

--- a/tests/uniswap_v3/test_uniswap_v3_analysis.py
+++ b/tests/uniswap_v3/test_uniswap_v3_analysis.py
@@ -1,4 +1,4 @@
-from decimal import Decimal
+"""Uniswap v3 slippage and trade success tests."""
 
 import pytest
 from eth_tester import EthereumTester

--- a/tests/uniswap_v3/test_uniswap_v3_analysis.py
+++ b/tests/uniswap_v3/test_uniswap_v3_analysis.py
@@ -1,4 +1,5 @@
 """Uniswap v3 slippage and trade success tests."""
+from decimal import Decimal
 
 import pytest
 from eth_tester import EthereumTester
@@ -160,7 +161,7 @@ def test_analyse_by_receipt(
     # user_1 has less than 500 USDC left to loses in the LP fees
     analysis = analyse_trade_by_receipt(web3, uniswap_v3, tx, tx_hash, receipt)
     assert isinstance(analysis, TradeSuccess)
-    assert analysis.price == pytest.approx(1699.9102484539058)
+    assert analysis.price == pytest.approx(Decimal(1699.9102484539058))
     assert analysis.get_effective_gas_price_gwei() == 1
     assert analysis.amount_out_decimals == 18
     assert analysis.amount_in_decimals == 6
@@ -187,7 +188,9 @@ def test_analyse_by_receipt(
     analysis = analyse_trade_by_receipt(web3, uniswap_v3, tx, tx_hash, receipt)
 
     assert isinstance(analysis, TradeSuccess)
-    assert analysis.price == pytest.approx(1699.9102484539058)
+    assert analysis.price == pytest.approx(Decimal(1699.9102484539058))
+    assert analysis.get_human_price(reverse_token_order=False) == pytest.approx(Decimal(1699.9102484539058))
+    assert analysis.get_human_price(reverse_token_order=True) == pytest.approx(Decimal(1 / 1699.9102484539058))
     assert analysis.get_effective_gas_price_gwei() == 1
     assert analysis.amount_out_decimals == 6
     assert analysis.amount_in_decimals == 18


### PR DESCRIPTION
- Compare tokens by chain_id and address
- Make TokenDetails hashable
- Fix Uniswap v3 `analyse_by_receipt()` giving inverse price 