### PR TITLE
Retry nonce too low errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.22.12
+
+- Retry [nonce too low errors](https://github.com/tradingstrategy-ai/web3-ethereum-defi/pull/153),
+  (related to LLamaNodes). 
+
 # 0.22.11
 
 - Add `eth_defi.provider.llamanodes` and work around issues with LlamaNodes.com

--- a/eth_defi/middleware.py
+++ b/eth_defi/middleware.py
@@ -79,7 +79,6 @@ DEFAULT_RETRYABLE_HTTP_STATUS_CODES = (
 DEFAULT_RETRYABLE_RPC_ERROR_CODES = (
     # ValueError: {'message': 'Internal JSON-RPC error.', 'code': -32603}
     -32603,
-
     # ValueError: {'code': -32000, 'message': 'nonce too low'}.
     # Might happen when we are broadcasting multiple transactions through multiple RPC providers
     # using eth_sendRawTransaction

--- a/eth_defi/middleware.py
+++ b/eth_defi/middleware.py
@@ -76,7 +76,16 @@ DEFAULT_RETRYABLE_HTTP_STATUS_CODES = (
 #:
 #: See GoEthereum error codes https://github.com/ethereum/go-ethereum/blob/master/rpc/errors.go
 #:
-DEFAULT_RETRYABLE_RPC_ERROR_CODES = (-32603,)
+DEFAULT_RETRYABLE_RPC_ERROR_CODES = (
+    # ValueError: {'message': 'Internal JSON-RPC error.', 'code': -32603}
+    -32603,
+
+    # ValueError: {'code': -32000, 'message': 'nonce too low'}.
+    # Might happen when we are broadcasting multiple transactions through multiple RPC providers
+    # using eth_sendRawTransaction
+    # One provide has not yet seeing a transaction broadcast through the other provider.
+    -32000,
+)
 
 
 def is_retryable_http_exception(


### PR DESCRIPTION
The nonce too low error is:

```
ValueError: {'code': -32000, 'message': 'nonce too low'}.
```

This might happen when we are broadcasting multiple transactions through multiple RPC providers using `eth_sendRawTransaction`. One provide is not yet seeing a transaction broadcast through the other provider.