### PR TITLE
Enable session passing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,7 @@ jobs:
           BNB_CHAIN_JSON_RPC: ${{ secrets.BNB_CHAIN_JSON_RPC }}
           JSON_RPC_POLYGON_ARCHIVE: ${{ secrets.JSON_RPC_POLYGON_ARCHIVE }}
           JSON_RPC_POLYGON: ${{ secrets.JSON_RPC_POLYGON }}
+          JSON_RPC_ETHEREUM: ${{ secrets.JSON_RPC_ETHEREUM }}
       # Disabled for now
       # https://github.com/reviewdog/action-flake8/issues/40
       # - name: Run flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Current
 
 - Allow passing `request_kwargs` to [create_multi_provider_web3](https://web3-ethereum-defi.readthedocs.io/api/provider/_autosummary_provider/eth_defi.provider.multi_provider.create_multi_provider_web3.html#eth_defi.provider.multi_provider.create_multi_provider_web3)
+- When setting up [TunedWeb3Factory](https://web3-ethereum-defi.readthedocs.io/api/event_reader/_autosummary_enzyne/eth_defi.event_reader.web3factory.TunedWeb3Factory.html?highlight=tunedweb3factory) use `create_multi_provider_web3` to set up the connections
+  instead pooled threads and processed
 
 # 0.22.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Allow passing `request_kwargs` to [create_multi_provider_web3](https://web3-ethereum-defi.readthedocs.io/api/provider/_autosummary_provider/eth_defi.provider.multi_provider.create_multi_provider_web3.html#eth_defi.provider.multi_provider.create_multi_provider_web3)
 - When setting up [TunedWeb3Factory](https://web3-ethereum-defi.readthedocs.io/api/event_reader/_autosummary_enzyne/eth_defi.event_reader.web3factory.TunedWeb3Factory.html?highlight=tunedweb3factory) use `create_multi_provider_web3` to set up the connections
   instead pooled threads and processed
+- Switch to ujson for JSON-RPC decoding by default with `create_multi_provider_web3`
+- Fix `test_block_reader` tests
 
 # 0.22.12
 

--- a/eth_defi/event_reader/web3factory.py
+++ b/eth_defi/event_reader/web3factory.py
@@ -55,15 +55,17 @@ class TunedWeb3Factory(Web3Factory):
 
     def __init__(
         self,
-        json_rpc_url: str,
+        rpc_config_line: str,
         http_adapter: Optional[HTTPAdapter] = None,
         thread_local_cache=False,
         api_counter=False,
     ):
         """Set up a factory.
 
-        :param json_rpc_url:
-            Node JSON-RPC server URL.
+        :param rpc_config_line:
+            JSON-RPC config line.
+
+            See :py:mod:`eth_defi.provider.multi_provider`.
 
         :param http_adapter:
             Connection pooling for HTTPS.
@@ -81,7 +83,7 @@ class TunedWeb3Factory(Web3Factory):
             Enable API counters
 
         """
-        self.json_rpc_url = json_rpc_url
+        self.rpc_config_line = rpc_config_line
 
         if not http_adapter:
             http_adapter = HTTPAdapter(pool_connections=10, pool_maxsize=10)
@@ -112,7 +114,7 @@ class TunedWeb3Factory(Web3Factory):
         session = requests.Session()
         session.mount("https://", self.http_adapter)
 
-        web3 = create_multi_provider_web3(self.json_rpc_url, session=session)
+        web3 = create_multi_provider_web3(self.rpc_config_line, session=session)
 
         if self.thread_local_cache:
             _web3_thread_local_cache.web3 = web3

--- a/eth_defi/event_reader/web3factory.py
+++ b/eth_defi/event_reader/web3factory.py
@@ -12,7 +12,7 @@ from web3 import HTTPProvider, Web3
 
 from eth_defi.chain import install_chain_middleware, install_retry_middleware, install_api_call_counter_middleware
 from eth_defi.event_reader.fast_json_rpc import patch_web3
-
+from eth_defi.provider.multi_provider import create_multi_provider_web3
 
 _web3_thread_local_cache = local()
 
@@ -112,14 +112,7 @@ class TunedWeb3Factory(Web3Factory):
         session = requests.Session()
         session.mount("https://", self.http_adapter)
 
-        web3 = Web3(HTTPProvider(self.json_rpc_url, session=session))
-
-        # Enable faster ujson reads
-        patch_web3(web3)
-
-        web3.middleware_onion.clear()
-        install_chain_middleware(web3)
-        install_retry_middleware(web3)
+        web3 = create_multi_provider_web3(self.json_rpc_url, session=session)
 
         if self.thread_local_cache:
             _web3_thread_local_cache.web3 = web3

--- a/eth_defi/provider/multi_provider.py
+++ b/eth_defi/provider/multi_provider.py
@@ -10,7 +10,7 @@ from urllib3.util import parse_url, Url
 from web3 import Web3, HTTPProvider
 
 from eth_defi.chain import install_chain_middleware
-from eth_defi.event_reader.fast_json_rpc import patch_provider
+from eth_defi.event_reader.fast_json_rpc import patch_provider, patch_web3
 from eth_defi.provider.fallback import FallbackProvider
 from eth_defi.provider.mev_blocker import MEVBlockerProvider
 from eth_defi.provider.named import NamedProvider, get_provider_name
@@ -213,6 +213,8 @@ def create_multi_provider_web3(
     )
 
     web3 = MultiProviderWeb3(provider)
+
+    patch_web3(web3)
 
     web3.middleware_onion.clear()
 

--- a/eth_defi/provider/multi_provider.py
+++ b/eth_defi/provider/multi_provider.py
@@ -91,6 +91,7 @@ def create_multi_provider_web3(
     fallback_sleep=0.1,
     fallback_backoff=1.1,
     request_kwargs: Optional[Any] = None,
+    session: Optional[Any] = None,
 ) -> MultiProviderWeb3:
     """Create a Web3 instance with multi-provider support.
 
@@ -135,12 +136,18 @@ def create_multi_provider_web3(
         Sleep increase multiplier.
 
     :param request_kwargs:
-        Passed to HTTPProvider, arguments for ``request`` library when doing HTTP requests.
+        Passed to HTTPProvider, arguments for :py:mod:`requests` library when doing HTTP requests.
 
         See :py:class:`web3.HTTPProvider` for details.
 
         Example: ``request_kwargs={"timeout": 10.0}``
 
+    :param session:
+        Use specific HTTP 1.1 session with :py:mod:`requests`.
+
+        See :py:class:`web3.HTTPProvider` for details.
+
+        Example: ``request_kwargs={"timeout": 10.0}``
     :return:
         Configured Web3 instance with multiple providers
     """
@@ -178,7 +185,7 @@ def create_multi_provider_web3(
     if len(call_endpoints) < 0:
         raise MultiProviderConfigurationError(f"At least one call endpoint must be specified, configuration was {configuration_line}")
 
-    call_providers = [HTTPProvider(url, request_kwargs=request_kwargs) for url in call_endpoints]
+    call_providers = [HTTPProvider(url, request_kwargs=request_kwargs, session=session) for url in call_endpoints]
 
     # Do uJSON patching
     for p in call_providers:
@@ -188,7 +195,7 @@ def create_multi_provider_web3(
     transact_provider = None
     if len(transact_endpoints) > 0:
         transact_endpoint = transact_endpoints[0]
-        transact_provider = HTTPProvider(transact_endpoint, request_kwargs=request_kwargs)
+        transact_provider = HTTPProvider(transact_endpoint, request_kwargs=request_kwargs, session=session)
 
         _fix_provider(transact_provider)
 

--- a/tests/test_block_reader.py
+++ b/tests/test_block_reader.py
@@ -21,7 +21,8 @@ from eth_defi.abi import get_contract
 from eth_defi.event_reader.conversion import (
     convert_uint256_bytes_to_address,
     convert_uint256_string_to_address,
-    decode_data, convert_jsonrpc_value_to_int,
+    decode_data,
+    convert_jsonrpc_value_to_int,
 )
 from eth_defi.event_reader.fast_json_rpc import patch_web3
 from eth_defi.event_reader.logresult import LogContext, LogResult

--- a/tests/test_block_reader.py
+++ b/tests/test_block_reader.py
@@ -21,7 +21,7 @@ from eth_defi.abi import get_contract
 from eth_defi.event_reader.conversion import (
     convert_uint256_bytes_to_address,
     convert_uint256_string_to_address,
-    decode_data,
+    decode_data, convert_jsonrpc_value_to_int,
 )
 from eth_defi.event_reader.fast_json_rpc import patch_web3
 from eth_defi.event_reader.logresult import LogContext, LogResult
@@ -30,9 +30,11 @@ from eth_defi.event_reader.web3factory import TunedWeb3Factory
 from eth_defi.event_reader.web3worker import create_thread_pool_executor
 from eth_defi.token import TokenDetails, fetch_erc20_details
 
+JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_URL") or os.environ.get("JSON_RPC_ETHEREUM")
+
 pytestmark = pytest.mark.skipif(
-    os.environ.get("JSON_RPC_URL") is None,
-    reason="Set JSON_RPC_URL environment variable to Ethereum mainnet node to run this test",
+    JSON_RPC_ETHEREUM is None,
+    reason="Set JSON_RPC_ETHEREUM environment variable to Ethereum mainnet node to run this test",
 )
 
 
@@ -51,7 +53,7 @@ class TokenCache(LogContext):
         return self.cache[address]
 
 
-def decode_pair_created(log: LogResult) -> dict:
+def decode_pair_created(web3: Web3, log: LogResult) -> dict:
     """Process a pair created event.
 
     This function does manually optimised high speed decoding of the event.
@@ -67,7 +69,6 @@ def decode_pair_created(log: LogResult) -> dict:
     # {'address': '0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f', 'blockHash': '0x359d1dc4f14f9a07cba3ae8416958978ce98f78ad7b8d505925dad9722081f04', 'blockNumber': '0x98b723', 'data': '0x000000000000000000000000b4e16d0168e52d35cacd2c6185b44281ec28c9dc0000000000000000000000000000000000000000000000000000000000000001', 'logIndex': '0x22', 'removed': False, 'topics': ['0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9', '0x000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', '0x000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'], 'transactionHash': '0xd07cbde817318492092cc7a27b3064a69bd893c01cb593d6029683ffd290ab3a', 'transactionIndex': '0x26', 'event': <class 'web3._utils.datatypes.PairCreated'>, 'timestamp': 1588710145}
 
     # Do additional lookup for the token data
-    web3 = log["event"].web3
     token_cache: TokenCache = log["context"]
 
     # Any indexed Solidity event parameter will be in topics data.
@@ -89,9 +90,9 @@ def decode_pair_created(log: LogResult) -> dict:
     token1 = token_cache.get_token_info(web3, token1_address)
 
     data = {
-        "block_number": int(log["blockNumber"], 16),
+        "block_number": convert_jsonrpc_value_to_int(log["blockNumber"]),
         "tx_hash": log["transactionHash"],
-        "log_index": int(log["logIndex"], 16),
+        "log_index": convert_jsonrpc_value_to_int(log["logIndex"]),
         "factory_contract_address": factory_address,
         "pair_contract_address": pair_contract_address,
         "pair_count_index": pair_count,
@@ -109,7 +110,7 @@ def test_read_events():
     # HTTP 1.1 keep-alive
     session = requests.Session()
 
-    json_rpc_url = os.environ["JSON_RPC_URL"]
+    json_rpc_url = JSON_RPC_ETHEREUM
     web3 = Web3(HTTPProvider(json_rpc_url, session=session))
 
     # Enable faster ujson reads
@@ -118,7 +119,7 @@ def test_read_events():
     web3.middleware_onion.clear()
 
     # Get contracts
-    Factory = get_contract(web3, "UniswapV2Factory.json")
+    Factory = get_contract(web3, "sushi/UniswapV2Factory.json")
 
     events = [
         Factory.events.PairCreated,  # https://etherscan.io/txs?ea=0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f&topic0=0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9
@@ -141,7 +142,7 @@ def test_read_events():
         context=token_cache,
         extract_timestamps=None,
     ):
-        out.append(decode_pair_created(log_result))
+        out.append(decode_pair_created(web3, log_result))
 
     assert len(out) == 2
 
@@ -162,7 +163,7 @@ def test_read_events():
 def test_read_events_concurrent():
     """Read events quickly over JSON-RPC API using a thread pool."""
 
-    json_rpc_url = os.environ["JSON_RPC_URL"]
+    json_rpc_url = JSON_RPC_ETHEREUM
     token_cache = TokenCache()
     threads = 16
     http_adapter = HTTPAdapter(pool_connections=threads, pool_maxsize=threads)
@@ -171,7 +172,7 @@ def test_read_events_concurrent():
     executor = create_thread_pool_executor(web3_factory, token_cache, max_workers=threads)
 
     # Get contracts
-    Factory = get_contract(web3, "UniswapV2Factory.json")
+    Factory = get_contract(web3, "sushi/UniswapV2Factory.json")
 
     events = [
         Factory.events.PairCreated,  # https://etherscan.io/txs?ea=0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f&topic0=0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9
@@ -192,7 +193,7 @@ def test_read_events_concurrent():
         context=token_cache,
         extract_timestamps=None,
     ):
-        out.append(decode_pair_created(log_result))
+        out.append(decode_pair_created(web3, log_result))
 
     assert len(out) == 2
 
@@ -208,3 +209,42 @@ def test_read_events_concurrent():
     assert e["token1_symbol"] == "USDC"
     assert e["token0_symbol"] == "USDP"
     assert e["tx_hash"] == "0xb0621ca74cee9f540dda6d575f6a7b876133b42684c1259aaeb59c831410ccb2"
+
+
+def test_read_events_concurrent_two_nodes():
+    """TunedWeb3Factory accepts fallover nodes as config."""
+
+    json_rpc_url = JSON_RPC_ETHEREUM
+    token_cache = TokenCache()
+    threads = 16
+    http_adapter = HTTPAdapter(pool_connections=threads, pool_maxsize=threads)
+    config_line = json_rpc_url + " " + json_rpc_url + "?foo=bar"  # Fake
+    web3_factory = TunedWeb3Factory(config_line, http_adapter)
+    web3 = web3_factory(token_cache)
+    executor = create_thread_pool_executor(web3_factory, token_cache, max_workers=threads)
+
+    # Get contracts
+    Factory = get_contract(web3, "sushi/UniswapV2Factory.json")
+
+    events = [
+        Factory.events.PairCreated,  # https://etherscan.io/txs?ea=0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f&topic0=0x0d3648bd0f6ba80134a33ba9275ac585d9d315f0ad8355cddefde31afa28d0e9
+    ]
+
+    start_block = 10_000_835  # Uni deployed
+    end_block = 10_009_000  # The first pair created before this block
+
+    # Read through the blog ran
+    out = []
+    for log_result in read_events_concurrent(
+        executor,
+        start_block,
+        end_block,
+        events,
+        None,
+        chunk_size=100,
+        context=token_cache,
+        extract_timestamps=None,
+    ):
+        out.append(decode_pair_created(web3, log_result))
+
+    assert len(out) == 2


### PR DESCRIPTION
- Allow the user to pass a custom `requests.Session` used with thread pooling by `TunedWeb3Factory`
- Switch to `ujson` for JSON-RPC decoding by default
- Fix `test_block_reader` and run it on Github CI