### PR TITLE
Work around BadFunctionCallOutput:  Insufficient bytes error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.22.16
+
+- Work around BadFunctionCallOutput: Insufficient bytes error: A special case of eth_call returning an empty result.
+  This happens if you call a smart contract for a block number
+  for which the node does not yet have data or is still processing data.
+  This happens often on low-quality RPC providers (Ankr)
+  that route your call between different nodes between subsequent calls, and those nodes
+  see a different state of EVM.
+  Down the line, not in the middleware stack, this would lead to `BadFunctionCallOutput` output. We work around this by detecting this condition in the middleware stack and triggering the middleware fall-over node switch if the condition is detected.
+
 # 0.22.15
 
 - Fix [FallbackProvider](https://web3-ethereum-defi.readthedocs.io/api/provider/_autosummary_provider/eth_defi.provider.fallback.html) to work with [certain problematic error codes](https://twitter.com/moo9000/status/1707672647264346205)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,17 @@
 # 0.22.16
 
-- Work around BadFunctionCallOutput: Insufficient bytes error: A special case of eth_call returning an empty result.
+- Work around ``BadFunctionCallOutput``: Insufficient bytes exception: A special case of eth_call returning an empty result.
   This happens if you call a smart contract for a block number
   for which the node does not yet have data or is still processing data.
   This happens often on low-quality RPC providers (Ankr)
   that route your call between different nodes between subsequent calls, and those nodes
   see a different state of EVM.
   Down the line, not in the middleware stack, this would lead to `BadFunctionCallOutput` output. We work around this by detecting this condition in the middleware stack and triggering the middleware fall-over node switch if the condition is detected.
+- Set `FallbackProvider` to have the default `4` blocks latency for all `latest` calls,
+  in `get_default_block_tip_latency()` so that fail over switches are more robust.
 
 # 0.22.15
-
+    
 - Fix [FallbackProvider](https://web3-ethereum-defi.readthedocs.io/api/provider/_autosummary_provider/eth_defi.provider.fallback.html) to work with [certain problematic error codes](https://twitter.com/moo9000/status/1707672647264346205)
 - Log non-retryable exceptions in fallback middleware, so 
   there is better diagnostics why fallback fails

--- a/eth_defi/middleware.py
+++ b/eth_defi/middleware.py
@@ -95,6 +95,13 @@ DEFAULT_RETRYABLE_RPC_ERROR_CODES = (
 )
 
 
+class ProbablyNodeHasNoBlock(Exception):
+    """A special exception raised when we suspect JSON-RPC node does not yet have data for a block we asked.
+
+    See :py:mod:`eth_defi.provider.fallback` for details.
+    """
+
+
 def is_retryable_http_exception(
     exc: Exception,
     retryable_exceptions: Tuple[BaseException] = DEFAULT_RETRYABLE_EXCEPTIONS,
@@ -130,6 +137,9 @@ def is_retryable_http_exception(
                 if code is None or type(code) != int:
                     raise RuntimeError(f"Bad ValueError: {arg} - {exc}")
                 return code in retryable_rpc_error_codes
+
+    if isinstance(exc, ProbablyNodeHasNoBlock):
+        return True
 
     if isinstance(exc, HTTPError):
         return exc.response.status_code in retryable_status_codes

--- a/eth_defi/middleware.py
+++ b/eth_defi/middleware.py
@@ -98,6 +98,10 @@ DEFAULT_RETRYABLE_RPC_ERROR_CODES = (
 class ProbablyNodeHasNoBlock(Exception):
     """A special exception raised when we suspect JSON-RPC node does not yet have data for a block we asked.
 
+    - Calling a contract on a block before contract was deployed
+
+    - Calling a contract on a block where the node does not have the block data yet
+
     See :py:mod:`eth_defi.provider.fallback` for details.
     """
 

--- a/eth_defi/provider/ankr.py
+++ b/eth_defi/provider/ankr.py
@@ -4,8 +4,8 @@
 
 .. warning ::
 
-    We do not recommend using Ankr as it randomly returns empty responses to eth_call RPC method
-    and this is not fixable at the client side.
+    Ankr has different EVM state between calls and is very hard to work with.
+    See :py:class:`eth_defi.provider.fallback.FallbackProvider` for workarounds.
 
 See also :py:mod:`eth_defi.provider.broken_provider`.
 """

--- a/eth_defi/provider/broken_provider.py
+++ b/eth_defi/provider/broken_provider.py
@@ -8,6 +8,9 @@
 from eth_defi.provider.ankr import is_ankr
 from web3 import Web3
 
+from eth_defi.provider.fallback import FallbackProvider
+from eth_defi.provider.mev_blocker import MEVBlockerProvider
+
 
 def get_default_block_tip_latency(web3: Web3) -> int:
     """Workaround for Ankr and other node providers that do not handle the chain tip properly.
@@ -21,6 +24,12 @@ def get_default_block_tip_latency(web3: Web3) -> int:
     :return:
         Number of blocks we need to subtract from the latest block
     """
+
+    if isinstance(web3.provider, (FallbackProvider, MEVBlockerProvider)):
+        # With fallback provider, assume 4 blocks delay,
+        # so that if there is a fail over switch,
+        # the next provider is likely to hae the block immediately
+        return 4
 
     if is_ankr(web3):
         # Assume Ankr can safely deal with chain tip minus two blocks.

--- a/eth_defi/provider/fallback.py
+++ b/eth_defi/provider/fallback.py
@@ -29,12 +29,16 @@ class FallbackProvider(BaseNamedProvider):
 
     Fall back to the next provider on the list if a JSON-RPC request fails.
     Contains build-in retry logic in round-robin manner.
+    We will also recover from situations when we suspect the node does not
+    have the block data we are asking yet (but should have shorty).
 
     See also
 
     - :py:func:`eth_defi.middlware.exception_retry_middleware`
 
-    .. warning::
+    - :py:func:`eth_defi.middlware.ProbablyNodeHasNoBlock`
+
+    .. note::
 
         :py:class:`FallbackProvider` does not call any middlewares installed on the providers themselves.
     """

--- a/eth_defi/provider/fallback.py
+++ b/eth_defi/provider/fallback.py
@@ -202,19 +202,7 @@ class FallbackProvider(BaseNamedProvider):
                     new_provider_name = get_provider_name(self.get_active_provider())
 
                     if i < self.retries:
-                        logger.log(self.switchover_noisiness,
-                                   "Encountered JSON-RPC retryable error %s when calling method:\n"
-                                   "%s(%s)\n" 
-                                   "Switching providers %s -> %s\n" 
-                                   "Retrying in %f seconds, retry #%d / %d",
-                                   e,
-                                   method,
-                                   params,
-                                   old_provider_name,
-                                   new_provider_name,
-                                   current_sleep,
-                                   i,
-                                   self.retries)
+                        logger.log(self.switchover_noisiness, "Encountered JSON-RPC retryable error %s when calling method:\n" "%s(%s)\n" "Switching providers %s -> %s\n" "Retrying in %f seconds, retry #%d / %d", e, method, params, old_provider_name, new_provider_name, current_sleep, i, self.retries)
                         time.sleep(current_sleep)
                         current_sleep *= self.backoff
                         self.retry_count += 1

--- a/eth_defi/provider/fallback.py
+++ b/eth_defi/provider/fallback.py
@@ -202,7 +202,11 @@ class FallbackProvider(BaseNamedProvider):
                     new_provider_name = get_provider_name(self.get_active_provider())
 
                     if i < self.retries:
-                        logger.log(self.switchover_noisiness, "Encountered JSON-RPC retryable error %s when calling method %s(%s)\n" "Switching providers %s -> %s\n" "Retrying in %f seconds, retry #%d / %d",
+                        logger.log(self.switchover_noisiness,
+                                   "Encountered JSON-RPC retryable error %s when calling method:\n"
+                                   "%s(%s)\n" 
+                                   "Switching providers %s -> %s\n" 
+                                   "Retrying in %f seconds, retry #%d / %d",
                                    e,
                                    method,
                                    params,

--- a/eth_defi/provider/fallback.py
+++ b/eth_defi/provider/fallback.py
@@ -177,7 +177,15 @@ class FallbackProvider(BaseNamedProvider):
                     new_provider_name = get_provider_name(self.get_active_provider())
 
                     if i < self.retries:
-                        logger.log(self.switchover_noisiness, "Encountered JSON-RPC retryable error %s when calling method %s.\n" "Switching providers %s -> %s\n" "Retrying in %f seconds, retry #%d / %d", e, method, old_provider_name, new_provider_name, current_sleep, i, self.retries)
+                        logger.log(self.switchover_noisiness, "Encountered JSON-RPC retryable error %s when calling method %s(%s)\n" "Switching providers %s -> %s\n" "Retrying in %f seconds, retry #%d / %d",
+                                   e,
+                                   method,
+                                   params,
+                                   old_provider_name,
+                                   new_provider_name,
+                                   current_sleep,
+                                   i,
+                                   self.retries)
                         time.sleep(current_sleep)
                         current_sleep *= self.backoff
                         self.retry_count += 1

--- a/eth_defi/token.py
+++ b/eth_defi/token.py
@@ -27,22 +27,30 @@ _call_missing_exceptions = (TransactionFailed, BadFunctionCallOutput, ValueError
 
 @dataclass
 class TokenDetails:
-    """ERC-20 Python presentation.
+    """ERC-20 token Python presentation.
 
     - A helper class to work with ERC-20 tokens.
 
     - Read on-chain data, deal with token value decimal conversions.
 
     - Any field can be ``None`` for non-well-formed tokens.
+
+    Example how to get USDC details on Polygon:
+
+    .. code-block:: python
+
+        usdc = fetch_erc20_details(web3, "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174")  # USDC on Polygon
+        formatted = f"Token {usdc.name} ({usdc.symbol}) at {usdc.address} on chain {usdc.chain_id}"
+        assert formatted == "Token USD Coin (PoS) (USDC) at 0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174 on chain 137"
     """
 
     #: The underlying ERC-20 contract proxy class instance
     contract: Contract
 
-    #: Token name e.g. `USD Circle`
+    #: Token name e.g. ``USD Circle``
     name: Optional[str] = None
 
-    #: Token symbol e.g. `USDC`
+    #: Token symbol e.g. ``USDC``
     symbol: Optional[str] = None
 
     #: Token supply as raw units

--- a/eth_defi/token.py
+++ b/eth_defi/token.py
@@ -27,9 +27,13 @@ _call_missing_exceptions = (TransactionFailed, BadFunctionCallOutput, ValueError
 
 @dataclass
 class TokenDetails:
-    """A helper class to detail with token instructions.
+    """ERC-20 Python presentation.
 
-    Any field can be None for non-wellformed tokens.
+    - A helper class to work with ERC-20 tokens.
+
+    - Read on-chain data, deal with token value decimal conversions.
+
+    - Any field can be ``None`` for non-well-formed tokens.
     """
 
     #: The underlying ERC-20 contract proxy class instance

--- a/tests/rpc/test_fallback_provider.py
+++ b/tests/rpc/test_fallback_provider.py
@@ -185,7 +185,12 @@ def test_eth_call_not_having_block(fallback_provider: FallbackProvider, provider
     json_rpc_url = os.environ["JSON_RPC_POLYGON"]
     provider = HTTPProvider(json_rpc_url)
     # We don't do real fallbacks, but test the internal
-    fallback_provider = FallbackProvider([provider, provider], sleep=0.1, backoff=1)  # Low thresholds for unit test
+    fallback_provider = FallbackProvider(
+        [provider, provider],
+        sleep=0.1,  # Low thresholds for unit test
+        backoff=1,
+        state_missing_switch_over_delay=0.1,
+    )
 
     web3 = Web3(fallback_provider)
 

--- a/tests/rpc/test_fallback_provider.py
+++ b/tests/rpc/test_fallback_provider.py
@@ -183,8 +183,8 @@ def test_eth_call_not_having_block(fallback_provider: FallbackProvider, provider
     json_rpc_url = os.environ["JSON_RPC_POLYGON"]
     provider = HTTPProvider(json_rpc_url)
     # We don't do real fallbacks, but test the internal
-    FallbackProvider([provider, provider], sleep=0.1, backoff=1)  # Low thresholds for unit test
-    web3 = Web3(provider)
+    fallback_provider = FallbackProvider([provider, provider], sleep=0.1, backoff=1)  # Low thresholds for unit test
+    web3 = Web3(fallback_provider)
     usdc = fetch_erc20_details(web3, "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174")  # USDC on Polygon
 
     bad_block = 1  # We get empty response if the contract has not been deployed yet

--- a/tests/rpc/test_fallback_provider.py
+++ b/tests/rpc/test_fallback_provider.py
@@ -5,6 +5,7 @@ from unittest.mock import patch, DEFAULT
 import pytest
 import requests
 from eth_account import Account
+from eth_defi.provider.broken_provider import get_default_block_tip_latency
 from web3 import HTTPProvider, Web3
 
 from eth_defi.anvil import launch_anvil, AnvilLaunch
@@ -185,7 +186,12 @@ def test_eth_call_not_having_block(fallback_provider: FallbackProvider, provider
     provider = HTTPProvider(json_rpc_url)
     # We don't do real fallbacks, but test the internal
     fallback_provider = FallbackProvider([provider, provider], sleep=0.1, backoff=1)  # Low thresholds for unit test
+
     web3 = Web3(fallback_provider)
+
+    # See that we have fallback provider latency configured
+    assert get_default_block_tip_latency(web3) == 4
+
     usdc = fetch_erc20_details(web3, "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174")  # USDC on Polygon
 
     bad_block = 1  # We get empty response if the contract has not been deployed yet

--- a/tests/rpc/test_fallback_provider.py
+++ b/tests/rpc/test_fallback_provider.py
@@ -13,6 +13,7 @@ from eth_defi.hotwallet import HotWallet
 from eth_defi.provider.fallback import FallbackProvider
 from eth_defi.token import fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
+from eth_defi.uniswap_v2.utils import ZERO_ADDRESS
 
 
 @pytest.fixture(scope="module")
@@ -172,18 +173,19 @@ def test_fallback_nonce_too_low(web3, deployer: str):
     assert fallback_provider.api_retry_counts[0]["eth_sendRawTransaction"] == 3  # 5 attempts, 3 retries, the last retry does not count
 
 
-
 @pytest.mark.skipif(
     os.environ.get("JSON_RPC_POLYGON") is None,
     reason="Set JSON_RPC_POLYGON environment variable to a privately configured Polygon node",
 )
 def test_eth_call_not_having_block(fallback_provider: FallbackProvider, provider_1):
-    """What happens if you ask data from non-existing block"""
+    """What happens if you ask data from non-existing block."""
 
     json_rpc_url = os.environ["JSON_RPC_POLYGON"]
     provider = HTTPProvider(json_rpc_url)
     # We don't do real fallbacks, but test the internal
-    FallbackProvider([provider, provider], sleep=0.1, backoff=1)
-    web3 = Web3(fallback_provider)
-    usdc = fetch_erc20_details("0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174") # USDC on Polygon
+    FallbackProvider([provider, provider], sleep=0.1, backoff=1)  # Low thresholds for unit test
+    web3 = Web3(provider)
+    usdc = fetch_erc20_details(web3, "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174")  # USDC on Polygon
 
+    bad_block = 1  # We get empty response if the contract has not been deployed yet
+    usdc.contract.functions.balanceOf(ZERO_ADDRESS).call(block_identifier=bad_block)

--- a/tests/test_lazy_timestamp_reader.py
+++ b/tests/test_lazy_timestamp_reader.py
@@ -2,7 +2,7 @@
 
 """
 import pytest
-from eth_defi.anvil import launch_anvil, AnvilLaunch, mine
+from eth_defi.provider.anvil import launch_anvil, AnvilLaunch, mine
 from eth_defi.chain import install_chain_middleware
 from web3 import HTTPProvider, Web3
 

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1,16 +1,11 @@
 """Solidity linking tests."""
 import pytest
-from _pytest.fixtures import FixtureRequest
-from eth.constants import ZERO_ADDRESS
 
-from web3 import Web3, EthereumTesterProvider, HTTPProvider
+from web3 import Web3, EthereumTesterProvider
 
 from eth_defi.aave_v3.deployer import get_aave_hardhard_export
 from eth_defi.abi import get_contract, get_linked_contract
-from eth_defi.anvil import AnvilLaunch, launch_anvil
 from eth_defi.chain import install_chain_middleware
-from eth_defi.trace import assert_transaction_success_with_explanation
-from eth_defi.utils import ZERO_ADDRESS_STR
 
 #
 # @pytest.fixture()

--- a/tests/test_revert_reason.py
+++ b/tests/test_revert_reason.py
@@ -22,7 +22,7 @@ from web3.middleware import construct_sign_and_send_raw_middleware
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
 
-from eth_defi.anvil import fork_network_anvil
+from eth_defi.provider.anvil import fork_network_anvil
 from eth_defi.chain import install_chain_middleware
 from eth_defi.gas import node_default_gas_price_strategy
 from eth_defi.revert_reason import fetch_transaction_revert_reason


### PR DESCRIPTION
A special case of eth_call returning an empty result.

This happens if you call a smart contract for a block number
for which the node does not yet have data or is still processing data.
This happens often on low-quality RPC providers (Ankr)
that route your call between different nodes between subsequent calls, and those nodes
see a different state of EVM.
Down the line, not in the middleware stack, this would lead to `BadFunctionCallOutput` output. We work around this by detecting this condition in the middleware stack and triggering the middleware fall-over node switch if the condition is detected.


