### PR TITLE
Nonce reuse checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.22.26
+
+- Add `eth_defi.confirmation.check_nonce_mismatch` to verify our signed transactions
+  have good nonces based on on-chain data
+- Add `wait_and_broadcast_multiple_nodes(check_nonce_validity)` and by default 
+  try to figure nonce issues before attemping to broadcast transactions
+
 # 0.22.25
 
 - Internal change: Increased logging for transaction broadcast issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.22.25
+
+- Internal change: Increased logging for transaction broadcast issues
+- Internal change: more aggressive change reading nodes in multi-node tx broadcast
+
 # 0.22.24
 
 - Internal change: more verbose logging for `wait_and_broadcast_multiple_nodes`

--- a/eth_defi/confirmation.py
+++ b/eth_defi/confirmation.py
@@ -543,10 +543,4 @@ def check_nonce_mismatch(web3: Web3, txs: Collection[SignedTxType]):
         on_chain_nonce = web3.eth.get_transaction_count(address)
 
         if on_chain_nonce != nonce:
-            raise NonceMismatch(
-                f"Nonce mismatch for broadcasted transactions.\n" +
-                f"Address {address}, we have signed with nonce {nonce}, but on-chain is {on_chain_nonce}.\n" +
-                f"Potential reasons include incorrectly shared hot wallet or badly synced hot wallet nonce."
-            )
-
-
+            raise NonceMismatch(f"Nonce mismatch for broadcasted transactions.\n" + f"Address {address}, we have signed with nonce {nonce}, but on-chain is {on_chain_nonce}.\n" + f"Potential reasons include incorrectly shared hot wallet or badly synced hot wallet nonce.")

--- a/eth_defi/confirmation.py
+++ b/eth_defi/confirmation.py
@@ -526,6 +526,11 @@ def check_for_min_nonces(web3: Web3, txs: Collection[SignedTxType]):
         If your transaction broadcast is going to fail because nonce too low.
     """
 
+    #
+    # We can broadcast for multiple addresses, each address can contain multipe txs
+    # Check the lowest on-chain nonce for each address
+    #
+
     #: address, starting nonce mappings
     min_nonces = {}
     for tx in txs:

--- a/eth_defi/confirmation.py
+++ b/eth_defi/confirmation.py
@@ -34,6 +34,10 @@ class ConfirmationTimedOut(Exception):
     """We exceeded the transaction confirmation timeout."""
 
 
+class NonceMismatch(Exception):
+    """Chain has a different nonce than we expect."""
+
+
 def wait_transactions_to_complete(
     web3: Web3,
     txs: List[Union[HexBytes, str]],
@@ -349,6 +353,7 @@ def wait_and_broadcast_multiple_nodes(
     max_timeout=datetime.timedelta(minutes=5),
     poll_delay=datetime.timedelta(seconds=1),
     node_switch_timeout=datetime.timedelta(minutes=3),
+    check_nonce_validity=True,
 ) -> Dict[HexBytes, dict]:
     """Try to broadcast transactions through multiple nodes.
 
@@ -363,6 +368,8 @@ def wait_and_broadcast_multiple_nodes(
     :param txs:
         List of transaction to broadcast.
 
+        Most be pre-ordered by ``(address, nonce)``.
+
     :param confirmation_block_count:
         How many blocks wait for the transaction receipt to settle.
         Set to zero to return as soon as we see the first transaction receipt.
@@ -376,12 +383,19 @@ def wait_and_broadcast_multiple_nodes(
 
         See :py:class:`eth_defi.provider.fallback.FallbackProvider` for details.
 
+    :param check_nonce_validity:
+        Check if signed nonces match on-chain data before attempting to broadcat.
+
     :return:
         Map of transaction hashes -> receipt
 
     :raise ConfirmationTimedOut:
         If we cannot get transactions out
 
+    :raise NonceMismatch:
+        Starting nonce does not match what we see on chain.
+
+        When ``check_nonce_validity`` is set.
     """
 
     assert isinstance(poll_delay, datetime.timedelta)
@@ -393,6 +407,9 @@ def wait_and_broadcast_multiple_nodes(
 
     for tx in txs:
         assert getattr(tx, "hash", None), f"Does not look like compatible TxType: {tx.__class__}: {tx}"
+
+    if check_nonce_validity:
+        check_for_min_nonces(web3, txs)
 
     provider = get_fallback_provider(web3)
     providers = provider.providers
@@ -500,3 +517,25 @@ def wait_and_broadcast_multiple_nodes(
                 _broadcast_multiple_nodes(providers, tx)
 
     return receipts_received
+
+
+def check_for_min_nonces(web3: Web3, txs: Collection[SignedTxType]):
+    """Check for nonce re-use issues.
+
+    :raise NonceMismatch:
+        If your transaction broadcast is going to fail because nonce too low.
+    """
+
+    #: address, starting nonce mappings
+    min_nonces = {}
+    for tx in txs:
+        address = tx.address
+        min_nonces[address] = min(tx.nonce, min_nonces.get(address, 9_999_999))
+
+    for address, nonce in min_nonces.items():
+        on_chain_nonce = web3.eth.get_transaction_count(address)
+
+        if on_chain_nonce != nonce:
+            raise NonceMismatch(f"Nonce mismatch for broadcasted transactions. Address {address}, we have signed {nonce}, but on-chain is {on_chain_nonce}")
+
+

--- a/eth_defi/hotwallet.py
+++ b/eth_defi/hotwallet.py
@@ -161,7 +161,10 @@ class HotWallet:
         assert "nonce" not in tx
         tx["nonce"] = self.allocate_nonce()
         _signed = self.account.sign_transaction(tx)
+
+        # Check that we can decode
         decode_signed_transaction(_signed.rawTransaction)
+
         signed = SignedTransactionWithNonce(
             rawTransaction=_signed.rawTransaction,
             hash=_signed.hash,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "web3-ethereum-defi"
-version = "0.22.24"
+version = "0.22.25"
 description = "Python library for Uniswap, Aave, ChainLink, Enzyme and other protocols on BNB Chain, Polygon, Ethereum and other blockchains"
 authors = ["Mikko Ohtamaa <mikko@tradingstrategy.ai>"]
 license = "MIT"

--- a/tests/provider/README.md
+++ b/tests/provider/README.md
@@ -1,0 +1,1 @@
+Certain service provider integration specific tests.

--- a/tests/rpc/README.md
+++ b/tests/rpc/README.md
@@ -1,0 +1,1 @@
+Tests covering different JSON-RPC scenarios.

--- a/tests/rpc/test_fallback_provider.py
+++ b/tests/rpc/test_fallback_provider.py
@@ -7,7 +7,7 @@ import pytest
 import requests
 from eth_account import Account
 
-from eth_defi.confirmation import wait_and_broadcast_multiple_nodes
+from eth_defi.confirmation import wait_and_broadcast_multiple_nodes, NonceMismatch
 from eth_defi.provider.broken_provider import get_default_block_tip_latency
 from web3 import HTTPProvider, Web3
 
@@ -246,3 +246,83 @@ def test_broadcast_and_wait_multiple(web3: Web3, deployer: str):
 
     assert signed_tx2.hash in receipt_map
     assert signed_tx3.hash in receipt_map
+
+
+def test_broadcast_and_wait_multiple_nonce_reuse(web3: Web3, deployer: str):
+    """Detect nonce mismatch conditions.
+
+    - Nonce reuse
+    """
+
+    web3.eth.set_gas_price_strategy(node_default_gas_price_strategy)
+
+    user = Account.create()
+    hot_wallet = HotWallet(user)
+
+    # Fill in user wallet
+    tx1_hash = web3.eth.send_transaction({"from": deployer, "to": user.address, "value": 5 * 10**18})
+    assert_transaction_success_with_explanation(web3, tx1_hash)
+
+    hot_wallet.sync_nonce(web3)
+
+    # First send a transaction with a correct nonce
+    tx2 = {"chainId": web3.eth.chain_id, "from": user.address, "to": deployer, "value": 1 * 10**18, "gas": 30_000}
+    HotWallet.fill_in_gas_price(web3, tx2)
+    signed_tx2 = hot_wallet.sign_transaction_with_new_nonce(tx2)
+
+    # Use low timeouts so this should stress out the logic
+    wait_and_broadcast_multiple_nodes(
+        web3,
+        [signed_tx2],
+        max_timeout=datetime.timedelta(seconds=10),
+        node_switch_timeout=datetime.timedelta(seconds=1),
+        check_nonce_validity=True,
+    )
+
+    tx3 = {"chainId": web3.eth.chain_id, "from": user.address, "to": deployer, "value": 1 * 10**18, "gas": 30_000}
+    HotWallet.fill_in_gas_price(web3, tx3)
+    hot_wallet.current_nonce = 0  # Set to reused nonce
+    signed_tx3 = hot_wallet.sign_transaction_with_new_nonce(tx3)
+
+    with pytest.raises(NonceMismatch):
+        wait_and_broadcast_multiple_nodes(
+            web3,
+            [signed_tx3],
+            max_timeout=datetime.timedelta(seconds=10),
+            node_switch_timeout=datetime.timedelta(seconds=1),
+            check_nonce_validity=True,
+        )
+
+
+def test_broadcast_and_wait_multiple_nonce_too_high(web3: Web3, deployer: str):
+    """Detect nonce mismatch conditions.
+
+    - Nonce too high
+    """
+
+    web3.eth.set_gas_price_strategy(node_default_gas_price_strategy)
+
+    user = Account.create()
+    hot_wallet = HotWallet(user)
+
+    # Fill in user wallet
+    tx1_hash = web3.eth.send_transaction({"from": deployer, "to": user.address, "value": 5 * 10**18})
+    assert_transaction_success_with_explanation(web3, tx1_hash)
+
+    hot_wallet.sync_nonce(web3)
+    hot_wallet.current_nonce = 999
+
+    # First send a transaction with a correct nonce
+    tx2 = {"chainId": web3.eth.chain_id, "from": user.address, "to": deployer, "value": 1 * 10**18, "gas": 30_000}
+    HotWallet.fill_in_gas_price(web3, tx2)
+    signed_tx2 = hot_wallet.sign_transaction_with_new_nonce(tx2)
+
+    with pytest.raises(NonceMismatch):
+        wait_and_broadcast_multiple_nodes(
+            web3,
+            [signed_tx2],
+            max_timeout=datetime.timedelta(seconds=10),
+            node_switch_timeout=datetime.timedelta(seconds=1),
+            check_nonce_validity=True,
+        )
+

--- a/tests/rpc/test_fallback_provider.py
+++ b/tests/rpc/test_fallback_provider.py
@@ -325,4 +325,3 @@ def test_broadcast_and_wait_multiple_nonce_too_high(web3: Web3, deployer: str):
             node_switch_timeout=datetime.timedelta(seconds=1),
             check_nonce_validity=True,
         )
-


### PR DESCRIPTION
- Try to abort `wait_and_broadcast_multiple_nodes`  early if we see nonce issues in the signed transactions
- Update dependencies to the latest versions