### PR TITLE
Fix BPS and percent confusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Current
+
+- Fix: `swap_with_slippage_protection()` interpreted `max_slippage` as percent,
+  even though the doc string says BPS
+- API change: `swap_with_slippage_protection(max_slippage=15)` - change the default Uniswap v3
+  trade slippage tolerance from (unrealistic) 0.1 BPS to 15 BPS.
+
 # 0.22.30
 
 - API change: Handle `wait_and_broadcast_multiple_nodes()` so that it will attempt 

--- a/eth_defi/uniswap_v3/swap.py
+++ b/eth_defi/uniswap_v3/swap.py
@@ -22,7 +22,7 @@ def swap_with_slippage_protection(
     quote_token: Contract,
     pool_fees: list[int],
     intermediate_token: Contract | None = None,
-    max_slippage: float = 0.1,
+    max_slippage: float = 15,
     amount_in: int | None = None,
     amount_out: int | None = None,
     deadline: int = FOREVER_DEADLINE,
@@ -72,7 +72,10 @@ def swap_with_slippage_protection(
     :param pool_fees: List of all pools' trading fees in the path as raw_fee
     :param amount_in: How much of the quote token we want to pay, this has to be `None` if `amount_out` is specified
     :param amount_out: How much of the base token we want to receive, this has to be `None` if `amount_in` is specified
-    :param max_slippage: Max slippage express in bps, default = 0.1 bps (0.001%)
+
+    :param max_slippage:
+        Max slippage express in bps, default = 5 bps (0.05%)
+
     :param deadline: Time limit of the swap transaction, by default = forever (no deadline)
     :return: Prepared swap function which can be used directly to build transaction
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "web3-ethereum-defi"
-version = "0.22.29"
+version = "0.22.30"
 description = "Python library for Uniswap, Aave, ChainLink, Enzyme and other protocols on BNB Chain, Polygon, Ethereum and other blockchains"
 authors = ["Mikko Ohtamaa <mikko@tradingstrategy.ai>"]
 license = "MIT"


### PR DESCRIPTION
- Fix: `swap_with_slippage_protection()` clarify `max_slippage` is BPS
- API change: `swap_with_slippage_protection(max_slippage=15)` - change the default Uniswap v3
  trade slippage tolerance from (unrealistic) 0.1 BPS to 15 BPS.