### PR TITLE
Enzyme redemption time lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Current
+
+- Have a safe redemption time lock on Enzyme vault deployments 
+
 # 0.25
 
 - Bump web3.py to 6.12.x

--- a/eth_defi/enzyme/deployment.py
+++ b/eth_defi/enzyme/deployment.py
@@ -187,9 +187,11 @@ class VaultPolicyConfiguration:
     #:
     #: Prevent arbitrage attacks.
     #:
-    #: Set to 1 hour.
+    #: Set to zero by default, because there is a conflict with this setting and
+    #: using a deposit contract (TermedVaultUSDCPaymentForwarder).
+    #: Can be set to any value after Enzyme whitelists the deposit contract.
     #:
-    shares_action_time_lock: int = 3600
+    shares_action_time_lock: int = 0
 
     def __post_init__(self):
         for p in self.policies.keys():
@@ -330,7 +332,7 @@ class EnzymeDeployment:
 
             if shares_action_time_lock is None:
                 shares_action_time_lock = policy_configuration.shares_action_time_lock
-                assert shares_action_time_lock > 0
+                assert shares_action_time_lock >= 0
                 assert type(shares_action_time_lock) == int
 
         if shares_action_time_lock is None:

--- a/eth_defi/enzyme/deployment.py
+++ b/eth_defi/enzyme/deployment.py
@@ -183,6 +183,14 @@ class VaultPolicyConfiguration:
     #:
     policies: Dict[HexAddress, bytes]
 
+    #: What is the minimum time before user can redeem shares after deposit.
+    #:
+    #: Prevent arbitrage attacks.
+    #:
+    #: Set to 1 hour.
+    #:
+    shares_action_time_lock: int = 3600
+
     def __post_init__(self):
         for p in self.policies.keys():
             assert p.startswith("0x")
@@ -291,7 +299,7 @@ class EnzymeDeployment:
         denomination_asset: Contract,
         fund_name="Example Fund",
         fund_symbol="EXAMPLE",
-        shares_action_time_lock: int = 0,
+        shares_action_time_lock = None,
         fee_manager_config_data=b"",
         policy_manager_config_data=b"",
         deployer=None,
@@ -303,6 +311,9 @@ class EnzymeDeployment:
         - See `CreateNewVault.sol`.
 
         - See `FundDeployer.sol`.
+
+        :param shares_action_time_lock:
+            Give part of the policy_configuration.
 
         :return:
             Tuple (Comptroller contract, vault contract)
@@ -316,6 +327,11 @@ class EnzymeDeployment:
         if policy_configuration is not None:
             assert not policy_manager_config_data
             policy_manager_config_data = policy_configuration.encode()
+
+            if shares_action_time_lock is None:
+                shares_action_time_lock = policy_configuration.shares_action_time_lock
+                assert shares_action_time_lock > 0
+                assert type(shares_action_time_lock) == int
 
         fund_deployer = self.contracts.fund_deployer
         tx_hash = fund_deployer.functions.createNewFund(

--- a/eth_defi/enzyme/deployment.py
+++ b/eth_defi/enzyme/deployment.py
@@ -333,6 +333,9 @@ class EnzymeDeployment:
                 assert shares_action_time_lock > 0
                 assert type(shares_action_time_lock) == int
 
+        if shares_action_time_lock is None:
+            shares_action_time_lock = 0  # Zero means no arbitrage lock
+
         fund_deployer = self.contracts.fund_deployer
         tx_hash = fund_deployer.functions.createNewFund(
             owner,

--- a/eth_defi/enzyme/generic_adapter_vault.py
+++ b/eth_defi/enzyme/generic_adapter_vault.py
@@ -234,6 +234,8 @@ def deploy_vault_with_generic_adapter(
         )
         logger.info("VaultUSDCPaymentForwarder is %s deployed at %s", payment_forwarder.address, tx_hash.hex())
 
+        comptroller.functions.registerBuySharesOnBehalfCallers()
+
     if not mock_guard:
         # When swap is performed, the tokens will land on the integration contract
         # and this contract must be listed as the receiver.

--- a/tests/enzyme/test_enzyme_policy.py
+++ b/tests/enzyme/test_enzyme_policy.py
@@ -81,3 +81,24 @@ def test_fetch_default_safe_policies(
 
     policies = list(get_vault_policies(vault))
     assert len(policies) == 0
+
+
+def test_redemption_time_lock(
+    web3: Web3,
+    deployment: EnzymeDeployment,
+    user_1,
+    usdc,
+):
+    """Do not allow arbitrage trades against share price by having a time lock on redemption.
+
+    - Enzyme stores as ComptrollerLib.shareActionTimeLock variable
+    """
+
+    comptroller_contract, vault_contract = deployment.create_new_vault(user_1, usdc, fund_name="Cow says Moo", fund_symbol="MOO")
+    vault = Vault(vault_contract, comptroller_contract, deployment)
+
+    time_lock =
+    assert time_lock !=
+
+    policies = list(get_vault_policies(vault))
+    assert len(policies) == 0

--- a/tests/enzyme/test_enzyme_policy.py
+++ b/tests/enzyme/test_enzyme_policy.py
@@ -103,8 +103,7 @@ def test_redemption_time_lock(
     """
 
     policy = create_safe_default_policy_configuration_for_generic_adapter(deployment)
-
-    assert policy.shares_action_time_lock == 3600
+    policy.shares_action_time_lock = 3600
 
     comptroller_contract, vault_contract = deployment.create_new_vault(
         user_1,


### PR DESCRIPTION
- Enable configuration for `sharesActionTimelock`, which will prevent shares price arbitrage attacks
- However not enabled by default, as it also breaks our deposit contract that calls `buySharesOnBehalf` which needs to have the deposit contract whitelisted by Enzyme FundDeployer

```solidity
    /// @dev This function is freely callable if there is no sharesActionTimelock set, but it is
    /// limited to a list of trusted callers otherwise, in order to prevent a griefing attack
    /// where the caller buys shares for a _buyer, thereby resetting their lastSharesBought value.
    function buySharesOnBehalf(
        address _buyer,
        uint256 _investmentAmount,
        uint256 _minSharesQuantity
    ) external returns (uint256 sharesReceived_) {
        bool hasSharesActionTimelock = getSharesActionTimelock() > 0;
        address canonicalSender = __msgSender();

        require(
            !hasSharesActionTimelock ||
                IFundDeployer(getFundDeployer()).isAllowedBuySharesOnBehalfCaller(canonicalSender),
            "buySharesOnBehalf: Unauthorized"
        );

        return
            __buyShares(
                _buyer,
                _investmentAmount,
                _minSharesQuantity,
                hasSharesActionTimelock,
                canonicalSender
            );
    }
```
