### PR TITLE
Add another retryable error message

### DIFF
--- a/eth_defi/middleware.py
+++ b/eth_defi/middleware.py
@@ -129,14 +129,15 @@ DEFAULT_RETRYABLE_RPC_ERROR_CODES = (
 #: See :py:data:`DEFAULT_RETRYABLE_RPC_ERROR_CODES`.
 #:
 DEFAULT_RETRYABLE_RPC_ERROR_MESSAGES = {
-
     # When broadcasting batch transactions, the RPC provider
     # has a load balancer that is not internally coherent
     "nonce too low",
-
     # Some random load balancer error?
     # https://github.com/MetaMask/metamask-extension/issues/7234
-    "header not found"
+    "header not found",
+    # Error from Alchemy
+    # ValueError: {'code': -32000, 'message': 'execution aborted (timeout = 5s)'}
+    "execution aborted (timeout = 5s)",
 }
 
 #: Ethereum JSON-RPC calls where the value never changes


### PR DESCRIPTION
Add `ValueError: {'code': -32000, 'message': 'execution aborted (timeout = 5s)'}` to be retryable in multiprovider