### PR TITLE
Split deploy guard

### DIFF
--- a/contracts/in-house/src/GuardedGenericAdapter.sol
+++ b/contracts/in-house/src/GuardedGenericAdapter.sol
@@ -29,7 +29,7 @@ interface IGuard {
  * - Adapter is associated with a specific vault
  *
  */
-contract   is AdapterBase {
+contract GuardedGenericAdapter is AdapterBase {
 
     // The vault this adapter is associated with.
     //

--- a/contracts/in-house/src/GuardedGenericAdapter.sol
+++ b/contracts/in-house/src/GuardedGenericAdapter.sol
@@ -29,7 +29,7 @@ interface IGuard {
  * - Adapter is associated with a specific vault
  *
  */
-contract GuardedGenericAdapter is AdapterBase {
+contract   is AdapterBase {
 
     // The vault this adapter is associated with.
     //

--- a/eth_defi/enzyme/generic_adapter_vault.py
+++ b/eth_defi/enzyme/generic_adapter_vault.py
@@ -175,9 +175,9 @@ def deploy_vault_with_generic_adapter(
         deployed_at_block,
     )
 
-    generic_adapter, tx_hash = deploy_contract_with_forge(
-        web3,
-        CONTRACTS_ROOT / "in-house",
+
+    generic_adapter = deploy_generic_adapter_with_guard(
+        deployment,
         "GuardedGenericAdapter.sol",
         "GuardedGenericAdapter",
         deployer,
@@ -484,3 +484,30 @@ def deploy_guard(
             assert_transaction_success_with_explanation(web3, tx_hash)
 
     return guard
+
+
+
+def deploy_generic_adapter_with_guard(
+    deployment: EnzymeDeployment,
+    deployer: HotWallet,
+    guard: Contract,
+    etherscan_api_key: str | None = None,
+) -> Contract:
+    """Deploy a new generic adapter for a vault."""
+    assert isinstance(guard, Contract)
+
+    web3 = deployment.web3
+
+    assert CONTRACTS_ROOT.exists(), f"Cannot find contracts folder {CONTRACTS_ROOT.resolve()} - are you running from git checkout?"
+
+    generic_adapter, tx_hash = deploy_contract_with_forge(
+        web3,
+        CONTRACTS_ROOT / "in-house",
+        "GuardedGenericAdapter.sol",
+        "GuardedGenericAdapter",
+        deployer,
+        [deployment.contracts.integration_manager.address, guard.address],
+        etherscan_api_key=etherscan_api_key,
+    )
+    logger.info("GuardedGenericAdapter is %s deployed at %s", generic_adapter.address, tx_hash.hex())
+    return generic_adapter

--- a/eth_defi/enzyme/generic_adapter_vault.py
+++ b/eth_defi/enzyme/generic_adapter_vault.py
@@ -266,8 +266,8 @@ def deploy_vault_with_generic_adapter(
     whitelist_sender_receiver(
         guard,
         deployer,
-        allow_sender=generic_adapter.address,
-        allow_receiver=vault.address,
+        allow_sender=vault.address,
+        allow_receiver=generic_adapter.address,
     )
 
     assert generic_adapter.functions.getIntegrationManager().call() == deployment.contracts.integration_manager.address
@@ -546,6 +546,7 @@ def bind_vault(
     meta: str,
     deployer: HotWallet,
 ):
+    """Make GenericAdapter to work with a single vault only."""
     assert isinstance(vault, Contract), f"Got {vault}"
     web3 = vault.w3
     tx_hash = generic_adapter.functions.bindVault(

--- a/eth_defi/enzyme/generic_adapter_vault.py
+++ b/eth_defi/enzyme/generic_adapter_vault.py
@@ -380,22 +380,25 @@ def deploy_guard(
         # When swap is performed, the tokens will land on the integration contract
         # and this contract must be listed as the receiver.
         # Enzyme will then internally move tokens to its vault from here.
-        tx_hash = guard.functions.allowReceiver(allow_receiver, "").transact({"from": deployer.address})
-        assert_transaction_success_with_explanation(web3, tx_hash)
+        if allow_receiver:
+            tx_hash = guard.functions.allowReceiver(allow_receiver, "").transact({"from": deployer.address})
+            assert_transaction_success_with_explanation(web3, tx_hash)
 
         # Because Enzyme does not pass the asset manager address to through integration manager,
         # we set the vault address itself as asset manager for the guard
-        tx_hash = guard.functions.allowSender(allow_sender, "").transact({"from": deployer.address})
-        assert_transaction_success_with_explanation(web3, tx_hash)
+        if allow_sender:
+            tx_hash = guard.functions.allowSender(allow_sender, "").transact({"from": deployer.address})
+            assert_transaction_success_with_explanation(web3, tx_hash)
 
-        logger.info("GenericAdapter %s whitelisted as receiver, vault as sender", allow_receiver, allow_sender)
+        logger.info("GenericAdapter %s whitelisted as receiver, %s as sender", allow_receiver, allow_sender)
     else:
         # Production deployment foobar - add this warning message for now until figuring
         # out why allowReceiver() failed
         logger.warning("No receiver whitelisted")
 
     if not mock_guard:
-        assert guard.functions.isAllowedSender(allow_sender).call()  # vault = asset manager for the guard
+        if allow_sender:
+            assert guard.functions.isAllowedSender(allow_sender).call()  # vault = asset manager for the guard
 
         usdc_token = fetch_erc20_details(web3, denomination_asset.address)
         all_assets = [usdc_token] + whitelisted_assets

--- a/eth_defi/enzyme/generic_adapter_vault.py
+++ b/eth_defi/enzyme/generic_adapter_vault.py
@@ -323,6 +323,8 @@ def deploy_guard(
 
     - Can be deployment standalone and the vault upgraded to use a newer version of the guard
 
+    See :py:func:`deploy_vault_with_generic_adapter` for more details.
+
     :param mock_guard:
         Set to true to disable actual deployment.
 

--- a/eth_defi/enzyme/policy.py
+++ b/eth_defi/enzyme/policy.py
@@ -198,7 +198,7 @@ def update_adapter_policy(
 
     assert vault.get_owner() == deployer.address, "update_adapter_policy(): You can perform this transaction only as a vault owner"
 
-    tx_hash = policy_manager.functions.enablePolicyForFund(
+    tx_hash = policy_manager.functions.updatePolicySettingsForFund(
         vault.comptroller.address,
         contracts.allowed_adapters_policy.address,
         encode_single_address_list_policy_args(generic_adapter.address),

--- a/eth_defi/enzyme/policy.py
+++ b/eth_defi/enzyme/policy.py
@@ -18,6 +18,8 @@ from web3.contract import Contract
 from eth_defi.abi import get_deployed_contract
 from eth_defi.enzyme.deployment import EnzymeDeployment, VaultPolicyConfiguration
 from eth_defi.enzyme.vault import Vault
+from eth_defi.hotwallet import HotWallet
+from eth_defi.trace import assert_transaction_success_with_explanation
 
 
 class AddressListUpdateType(enum.Enum):
@@ -43,10 +45,8 @@ def get_vault_policies(vault: Vault) -> Iterable[Contract]:
     """
 
     web3 = vault.web3
-
     policy_manager_address = vault.comptroller.functions.getPolicyManager().call()
     policy_manager = get_deployed_contract(web3, "enzyme/PolicyManager.json", policy_manager_address)
-
     policies = policy_manager.functions.getEnabledPoliciesForFund(vault.comptroller.address).call()
     for policy_address in policies:
         policy = get_deployed_contract(web3, "enzyme/IPolicy.json", policy_address)
@@ -115,7 +115,7 @@ def create_safe_default_policy_configuration_for_generic_adapter(
         contracts.allowed_external_position_types_policy.address: b"",
     }
 
-    # Lock policy
+    # Lock adapter policy to use only our adapter
     if generic_adapter is not None:
         policies.update({
             contracts.allowed_adapters_policy.address: encode_single_address_list_policy_args(generic_adapter.address),
@@ -162,3 +162,24 @@ def encode_single_address_list_policy_args(
     initial_items = [address]
     new_list_args = [encode(["uint256", "address[]"], [update_type.value, initial_items])]
     return encode(["uint256[]", "bytes[]"], [existing_list_ids, new_list_args])
+
+
+def update_adapter_policy(
+    vault: Vault,
+    generic_adapter: Contract,
+    deployer: HotWallet,
+):
+    """Set vault to use a new generic adapter."""
+    assert isinstance(generic_adapter, Contract)
+
+    web3 = vault.web3
+    policy_manager_address = vault.comptroller.functions.getPolicyManager().call()
+    contracts = vault.deployment.contracts
+    policy_manager = get_deployed_contract(web3, "enzyme/PolicyManager.json", policy_manager_address)
+
+    policy_manager.functions.enablePolicyForFund(
+        contracts.allowed_adapters_policy.address,
+        encode_single_address_list_policy_args(generic_adapter.address),
+    ).transact({"from": deployer.address})
+
+    assert_transaction_success_with_explanation(web3, tx_hash)

--- a/eth_defi/enzyme/policy.py
+++ b/eth_defi/enzyme/policy.py
@@ -176,6 +176,11 @@ def update_adapter_policy(
     """Set vault to use a new generic adapter.
 
     - Overwrite the existing AllowedAdapterPolicy configuration
+
+    .. warning::
+
+        Existing adapter policy cannot be changed. Only new set.
+
     """
     assert isinstance(generic_adapter, Contract)
 
@@ -198,10 +203,15 @@ def update_adapter_policy(
 
     assert vault.get_owner() == deployer.address, "update_adapter_policy(): You can perform this transaction only as a vault owner"
 
-    tx_hash = policy_manager.functions.updatePolicySettingsForFund(
+    # tx_hash = policy_manager.functions.disablePolicyForFund(
+    #     vault.comptroller.address,
+    #     contracts.allowed_adapters_policy.address,
+    # ).transact({"from": deployer.address})
+    # assert_transaction_success_with_explanation(web3, tx_hash)
+
+    tx_hash = policy_manager.functions.enablePolicyForFund(
         vault.comptroller.address,
         contracts.allowed_adapters_policy.address,
         encode_single_address_list_policy_args(generic_adapter.address),
     ).transact({"from": deployer.address})
-
     assert_transaction_success_with_explanation(web3, tx_hash)

--- a/eth_defi/trace.py
+++ b/eth_defi/trace.py
@@ -311,7 +311,7 @@ def assert_transaction_success_with_explanation(
             trace_data = trace_evm_transaction(web3, tx_hash, TraceMethod.parity)
             trace_output = print_symbolic_trace(get_or_create_contract_registry(web3), trace_data)
             raise RaisedException(
-                f"Transaction failed: {tx_details}\n" f"Revert reason: {revert_reason}\n" f"Solidity stack trace:\n" f"{trace_output}\n",
+                f"Revert reason: {revert_reason}\nSolidity stack trace:\n{trace_output}\nTransaction details:\n{tx_details}",
                 revert_reason=revert_reason,
                 solidity_stack_trace=trace_output,
             )

--- a/tests/enzyme/test_guard_enzyme_uniswap_v2.py
+++ b/tests/enzyme/test_guard_enzyme_uniswap_v2.py
@@ -9,12 +9,14 @@ import random
 
 from web3.middleware import construct_sign_and_send_raw_middleware
 
-from eth_defi.enzyme.generic_adapter_vault import deploy_vault_with_generic_adapter
+from eth_defi.enzyme.generic_adapter_vault import deploy_vault_with_generic_adapter, deploy_guard, whitelist_sender_receiver, bind_vault, deploy_generic_adapter_with_guard
 
 import pytest
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
 from eth_typing import HexAddress
+
+from eth_defi.enzyme.policy import update_adapter_policy
 from eth_defi.terms_of_service.acceptance_message import (
     generate_acceptance_message,
     get_signing_hash,
@@ -147,6 +149,20 @@ def enzyme(
 
     return deployment
 
+@pytest.fixture()
+def hot_wallet(web3):
+
+    _deployer = web3.eth.accounts[0]
+    account: LocalAccount = Account.create()
+    stash = web3.eth.get_balance(_deployer)
+    tx_hash = web3.eth.send_transaction({"from": _deployer, "to": account.address, "value": stash // 2})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+
+    hot_wallet = HotWallet(account)
+    hot_wallet.sync_nonce(web3)
+    web3.middleware_onion.add(construct_sign_and_send_raw_middleware(account))
+    return hot_wallet
+
 
 @pytest.fixture()
 def vault(
@@ -158,6 +174,7 @@ def vault(
     mln: Contract,
     usdc: Contract,
     terms_of_service: Contract,
+    hot_wallet: HotWallet,
 ) -> Vault:
     """Deploy an Enzyme vault.
 
@@ -168,16 +185,6 @@ def vault(
     - TermsOfService
     - TermedVaultUSDCPaymentForwarder
     """
-
-    _deployer = web3.eth.accounts[0]
-    account: LocalAccount = Account.create()
-    stash = web3.eth.get_balance(_deployer)
-    tx_hash = web3.eth.send_transaction({"from": _deployer, "to": account.address, "value": stash // 2})
-    assert_transaction_success_with_explanation(web3, tx_hash)
-
-    hot_wallet = HotWallet(account)
-    hot_wallet.sync_nonce(web3)
-    web3.middleware_onion.add(construct_sign_and_send_raw_middleware(account))
 
     return deploy_vault_with_generic_adapter(enzyme, hot_wallet, asset_manager, deployer, usdc, terms_of_service)
 
@@ -529,3 +536,135 @@ def test_enzyme_enable_transfer(
 
     revert_reason = exc_info.value.revert_reason
     assert "Approve address does not match" in revert_reason
+
+
+def test_enzyme_guarded_trade_singlehop_uniswap_v2_guard_redeploy(
+    web3: Web3,
+    deployer: HexAddress,
+    asset_manager: HexAddress,
+    enzyme: EnzymeDeployment,
+    vault: Vault,
+    vault_investor: LocalAccount,
+    weth_token: TokenDetails,
+    mln: Contract,
+    usdc_token: TokenDetails,
+    usdc_usd_mock_chainlink_aggregator: Contract,
+    payment_forwarder: Contract,
+    acceptance_message: str,
+    terms_of_service: Contract,
+    uniswap_v2_whitelisted: UniswapV2Deployment,
+    weth_usdc_pair: Contract,
+    hot_wallet,
+    vault_owner: Account,
+):
+    """Make a single-hop swap that goes through the call guard."""
+
+    assert vault.is_supported_asset(usdc_token.address)
+    assert vault.is_supported_asset(weth_token.address)
+
+    # Sign terms of service
+    acceptance_hash, signature = sign_terms_of_service(vault_investor, acceptance_message)
+
+    # The transfer will expire in one hour
+    # in the test EVM timeline
+    block = web3.eth.get_block("latest")
+    valid_before = block["timestamp"] + 3600
+
+    # Construct bounded ContractFunction instance
+    # that will transact with MockEIP3009Receiver.deposit()
+    # smart contract function.
+    bound_func = make_eip_3009_transfer(
+        token=usdc_token,
+        from_=vault_investor,
+        to=payment_forwarder.address,
+        func=payment_forwarder.functions.buySharesOnBehalfUsingTransferWithAuthorizationAndTermsOfService,
+        value=500 * 10**6,  # 500 USD,
+        valid_before=valid_before,
+        extra_args=(1, acceptance_hash, signature),
+        authorization_type=EIP3009AuthorizationType.TransferWithAuthorization,
+    )
+
+    # Sign and broadcast the tx
+    tx_hash = bound_func.transact(
+        {
+            "from": vault_investor.address,
+        }
+    )
+
+    # Print out Solidity stack trace if this fails
+    assert_transaction_success_with_explanation(web3, tx_hash)
+
+    assert payment_forwarder.functions.amountProxied().call() == 500 * 10**6  # Got shares
+
+    assert vault.get_gross_asset_value() == 500 * 10**6  # Vault has been funded
+
+    hot_wallet.sync_nonce(web3)
+
+    # Adds a new guard to the vault
+    guard = deploy_guard(
+        web3=web3,
+        deployer=hot_wallet,
+        asset_manager=asset_manager,
+        owner=hot_wallet.address,
+        denomination_asset=usdc_token.contract,
+        whitelisted_assets=[weth_token, usdc_token],
+        etherscan_api_key=None,
+        uniswap_v2=True,
+    )
+
+    generic_adapter = deploy_generic_adapter_with_guard(
+        enzyme,
+        hot_wallet,
+        guard,
+        etherscan_api_key=None,
+    )
+
+    # TODO: Fix this so we do not need to fetch Vault twice
+    vault = Vault.fetch(
+        web3,
+        vault.address,
+        extra_addresses={
+            "comptroller_lib": enzyme.contracts.comptroller_lib.address,
+            "allowed_adapters_policy": enzyme.contracts.allowed_adapters_policy.address,
+            "generic_adapter": generic_adapter.address,
+        }
+    )
+
+    bind_vault(
+        generic_adapter,
+        vault.vault,
+        False,
+        "",
+        hot_wallet,
+    )
+
+    update_adapter_policy(
+        vault,
+        generic_adapter,
+        hot_wallet
+    )
+
+    whitelist_sender_receiver(
+        guard,
+        hot_wallet,
+        allow_receiver=generic_adapter.address,
+        allow_sender=vault.address,
+    )
+
+    # Vault swaps USDC->ETH for both users
+    # Buy ETH worth of 200 USD
+    prepared_tx = prepare_swap(
+        enzyme,
+        vault,
+        uniswap_v2_whitelisted,
+        vault.generic_adapter,
+        usdc_token.contract,
+        weth_token.contract,
+        200 * 10**6,  # 200 USD
+    )
+
+    tx_hash = prepared_tx.transact({"from": asset_manager, "gas": 1_000_000})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+
+    # Bought ETH landed in the vault
+    assert weth_token.contract.functions.balanceOf(vault.address).call() == pytest.approx(0.12450087262998791 * 10**18)

--- a/tests/enzyme/test_guard_enzyme_uniswap_v2.py
+++ b/tests/enzyme/test_guard_enzyme_uniswap_v2.py
@@ -16,7 +16,7 @@ from eth_account import Account
 from eth_account.signers.local import LocalAccount
 from eth_typing import HexAddress
 
-from eth_defi.enzyme.policy import update_adapter_policy
+from eth_defi.enzyme.policy import update_adapter_policy, create_safe_default_policy_configuration_for_generic_adapter
 from eth_defi.terms_of_service.acceptance_message import (
     generate_acceptance_message,
     get_signing_hash,
@@ -538,6 +538,7 @@ def test_enzyme_enable_transfer(
     assert "Approve address does not match" in revert_reason
 
 
+@pytest.mark.skip(reason="Currently Enzyme does not way to update AdapterPolicy. Instead, the whole vault needs to be reconfigured with 7 days delay.")
 def test_enzyme_guarded_trade_singlehop_uniswap_v2_guard_redeploy(
     web3: Web3,
     deployer: HexAddress,
@@ -638,11 +639,16 @@ def test_enzyme_guarded_trade_singlehop_uniswap_v2_guard_redeploy(
         hot_wallet,
     )
 
-    update_adapter_policy(
-        vault,
+    policy_configuration = create_safe_default_policy_configuration_for_generic_adapter(
+        enzyme,
         generic_adapter,
-        hot_wallet
     )
+
+    # update_adapter_policy(
+    #    vault,
+    #    generic_adapter,
+    #    hot_wallet
+    #)
 
     whitelist_sender_receiver(
         guard,


### PR DESCRIPTION
- Move `deploy_guard()` to its own function and refactor Enzyme vault deployment to more manageable