### PR TITLE
Make vault historical reading resumeable

### DIFF
--- a/eth_defi/event_reader/multicall_batcher.py
+++ b/eth_defi/event_reader/multicall_batcher.py
@@ -1275,10 +1275,10 @@ def read_multicall_historical_stateful(
         # Drop vaults that have peaked/dysfunctional
         accepted_calls = [c for c, state in calls.items() if state.should_invoke(c, block_number, timestamp)]
 
-        logger.info(f"Compiling calls for {block_number:,}, {timestamp}, total calls {len(all_calls):,}, accepted calls {len(accepted_calls):,}")
+        logger.debug(f"Compiling calls for {block_number:,}, {timestamp}, total calls {len(all_calls):,}, accepted calls {len(accepted_calls):,}")
 
         if len(accepted_calls) == 0:
-            logger.info("Block %d has no calls to perform, skipping", block_number)
+            logger.debug("Block %d has no calls to perform, skipping", block_number)
             continue
 
         task = MulticallHistoricalTask(

--- a/scripts/erc-4626/scan-prices.py
+++ b/scripts/erc-4626/scan-prices.py
@@ -38,7 +38,7 @@ from eth_defi.erc_4626.core import ERC4262VaultDetection
 from eth_defi.provider.multi_provider import create_multi_provider_web3, MultiProviderWeb3Factory
 from eth_defi.token import TokenDiskCache
 from eth_defi.utils import setup_console_logging
-from eth_defi.vault.historical import scan_historical_prices_to_parquet
+from eth_defi.vault.historical import scan_historical_prices_to_parquet, pformat_scan_result
 
 logger = logging.getLogger(__name__)
 
@@ -134,7 +134,7 @@ def main():
         web3=web3,
         web3factory=web3factory,
         vaults=vaults,
-        start_block=start,
+        start_block=None,
         end_block=end_block,
         max_workers=max_workers,
         chunk_size=32,
@@ -147,12 +147,16 @@ def main():
     states = scan_result["reader_states"]
     if states:
         print(f"Saving {len(states)} reader states to {reader_state_db}")
+        example_state = next(iter(states.values()))
+        print("Example state:\n", pformat(example_state))
         pickle.dump(states, reader_state_db.open("wb"))
+    else:
+        print("No states to save")
 
     token_cache.commit()
     print(f"Token cache size is {token_cache.get_file_size():,} bytes, {len(token_cache):,} tokens")
     print("Scan complete")
-    print(pformat(scan_result))
+    print(pformat_scan_result(scan_result))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- When starting historical vault price scan, start from the last read block for the chain