### PR TITLE
Add Maple Finance vault protocol support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,9 @@
 - Add: New vault type: Yearn Morpho Compounder strategy
 - Add: New protocol: Teller (Base)
 - Add: New protocol: Deltr (Ethereum)
-<<<<<<< HEAD
 - Add: New protocol: Upshift (Ethereum)
-=======
 - Add: New protocol: Sky (Ethereum) - formerly MakerDAO, stUSDS vault
->>>>>>> 45f1282a (Sky temp commit)
+- Add: New protocol: Maple Finance: - syrupUSDC and syrupUSDT vaults
 - Fix: Various RPC error code workarounds (Monad, Arbitrum, Hyperliquid)
 
 # 0.37

--- a/docs/source/vaults/index.rst
+++ b/docs/source/vaults/index.rst
@@ -46,6 +46,7 @@ Supported protocols
    lagoon/index
    liquidity_royalty/index
    llamma/index
+   maple/index
    nashpoint/index
    plutus/index
    silo/index

--- a/docs/source/vaults/maple/index.rst
+++ b/docs/source/vaults/maple/index.rst
@@ -1,0 +1,40 @@
+Maple API
+---------
+
+`Maple Finance <https://maple.finance/>`__ integration.
+
+Maple Finance is an institutional-grade DeFi lending protocol that connects
+capital providers with vetted institutional borrowers. The Syrup protocol
+provides permissionless access to yield-bearing tokens (syrupUSDC, syrupUSDT)
+that represent deposits in Maple's institutional lending pools.
+
+When users deposit USDC or USDT into Syrup, they receive syrup tokens in return.
+These tokens are yield-bearing LP tokens, similar to Aave's aUSDC or Compound's cUSDC.
+The underlying deposits are lent to vetted institutional borrowers like market makers
+and trading firms, with loans secured by overcollateralised digital asset collateral.
+
+Key features:
+
+- Institutional yield: Access to real-world lending rates typically higher than
+  standard DeFi lending (10-15% APY)
+- Overcollateralised: Loans are secured by digital asset collateral (BTC, ETH)
+  at ratios significantly above 100%
+- Permissionless: Unlike Maple's core institutional pools, Syrup is accessible
+  to anyone with a DeFi wallet
+- Composability: syrup tokens are standard ERC-20 tokens that can be used in
+  other DeFi applications
+
+- `Homepage <https://maple.finance/>`__
+- `App <https://app.maple.finance/earn>`__
+- `Documentation <https://docs.maple.finance/>`__
+- `GitHub <https://github.com/maple-labs/maple-core-v2>`__
+- `Twitter <https://x.com/maplefinance>`__
+- `syrupUSDC on Etherscan <https://etherscan.io/address/0x80ac24aa929eaf5013f6436cda2a7ba190f5cc0b>`__
+- `syrupUSDT on Etherscan <https://etherscan.io/address/0x356b8d89c1e1239cbbb9de4815c39a1474d5ba7d>`__
+
+
+.. autosummary::
+   :toctree: _autosummary_maple
+   :recursive:
+
+   eth_defi.erc_4626.vault_protocol.maple.vault

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -977,6 +977,11 @@ def create_vault_instance(
 
         return SkyVault(web3, spec, token_cache=token_cache, features=features)
 
+    elif ERC4626Feature.maple_like in features:
+        from eth_defi.erc_4626.vault_protocol.maple.vault import SyrupVault
+
+        return SyrupVault(web3, spec, token_cache=token_cache, features=features)
+
     else:
         # Generic ERC-4626 without fee data
         from eth_defi.erc_4626.vault import ERC4626Vault
@@ -1023,4 +1028,10 @@ HARDCODED_PROTOCOLS = {
     # Sky (formerly MakerDAO) - stUSDS vault on Ethereum
     # https://etherscan.io/address/0x99cd4ec3f88a45940936f469e4bb72a2a701eeb9
     "0x99cd4ec3f88a45940936f469e4bb72a2a701eeb9": {ERC4626Feature.sky_like},
+    # Maple Finance - syrupUSDC vault on Ethereum
+    # https://etherscan.io/address/0x80ac24aa929eaf5013f6436cda2a7ba190f5cc0b
+    "0x80ac24aa929eaf5013f6436cda2a7ba190f5cc0b": {ERC4626Feature.maple_like},
+    # Maple Finance - syrupUSDT vault on Ethereum
+    # https://etherscan.io/address/0x356b8d89c1e1239cbbb9de4815c39a1474d5ba7d
+    "0x356b8d89c1e1239cbbb9de4815c39a1474d5ba7d": {ERC4626Feature.maple_like},
 }

--- a/eth_defi/erc_4626/core.py
+++ b/eth_defi/erc_4626/core.py
@@ -294,6 +294,12 @@ class ERC4626Feature(enum.Enum):
     #: https://etherscan.io/address/0x99cd4ec3f88a45940936f469e4bb72a2a701eeb9
     sky_like = "sky_like"
 
+    #: Maple Finance
+    #:
+    #: Institutional-grade DeFi lending protocol with Syrup yield products.
+    #: https://maple.finance/
+    maple_like = "maple_like"
+
 
 def get_vault_protocol_name(features: set[ERC4626Feature]) -> str:
     """Deduct vault protocol name based on Vault smart contract features.
@@ -426,6 +432,9 @@ def get_vault_protocol_name(features: set[ERC4626Feature]) -> str:
         return "Upshift"
     elif ERC4626Feature.sky_like in features:
         return "Sky"
+
+    elif ERC4626Feature.maple_like in features:
+        return "Maple"
 
     # No idea
     if ERC4626Feature.erc_7540_like in features:

--- a/eth_defi/erc_4626/vault_protocol/maple/__init__.py
+++ b/eth_defi/erc_4626/vault_protocol/maple/__init__.py
@@ -1,0 +1,1 @@
+"""Maple Finance protocol integration."""

--- a/eth_defi/erc_4626/vault_protocol/maple/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/maple/vault.py
@@ -1,0 +1,80 @@
+"""Maple Finance Syrup vault support.
+
+Maple Finance is an institutional-grade DeFi lending protocol. The Syrup protocol
+provides permissionless access to yield-bearing tokens (syrupUSDC, syrupUSDT) that
+represent deposits in Maple's institutional lending pools.
+
+When users deposit USDC or USDT into Syrup, they receive syrup tokens in return.
+These tokens are yield-bearing LP tokens, similar to Aave's aUSDC or Compound's cUSDC.
+The underlying deposits are lent to vetted, institutional borrowers like market makers
+and trading firms, with loans secured by overcollateralised digital asset collateral.
+
+- Homepage: https://maple.finance/
+- App: https://app.maple.finance/earn
+- Documentation: https://docs.maple.finance/
+- GitHub: https://github.com/maple-labs/maple-core-v2
+- Twitter: https://x.com/maplefinance
+
+Example vault contracts:
+
+- syrupUSDC: https://etherscan.io/address/0x80ac24aa929eaf5013f6436cda2a7ba190f5cc0b
+- syrupUSDT: https://etherscan.io/address/0x356b8d89c1e1239cbbb9de4815c39a1474d5ba7d
+"""
+
+import datetime
+import logging
+
+from eth_typing import BlockIdentifier
+
+from eth_defi.erc_4626.vault import ERC4626Vault
+
+logger = logging.getLogger(__name__)
+
+
+class SyrupVault(ERC4626Vault):
+    """Maple Finance Syrup vault.
+
+    Syrup is a permissionless yield product by Maple Finance that provides access
+    to institutional-grade lending yields. Users deposit stablecoins (USDC, USDT)
+    and receive yield-bearing syrup tokens in return.
+
+    Key features:
+
+    - Institutional yield: Access to real-world lending rates typically higher than
+      standard DeFi lending (10-15% APY)
+    - Overcollateralised: Loans are secured by digital asset collateral (BTC, ETH)
+      at ratios significantly above 100%
+    - Permissionless: Unlike Maple's core institutional pools, Syrup is accessible
+      to anyone with a DeFi wallet
+
+    - Homepage: https://maple.finance/
+    - App: https://app.maple.finance/earn
+    - Documentation: https://docs.maple.finance/
+    - GitHub: https://github.com/maple-labs/maple-core-v2
+    - Twitter: https://x.com/maplefinance
+    """
+
+    def has_custom_fees(self) -> bool:
+        """Maple Syrup vaults use internalised fee structure."""
+        return False
+
+    def get_management_fee(self, block_identifier: BlockIdentifier) -> float | None:
+        """Fees are internalised in the share price."""
+        return None
+
+    def get_performance_fee(self, block_identifier: BlockIdentifier) -> float | None:
+        """Fees are internalised in the share price."""
+        return None
+
+    def get_estimated_lock_up(self) -> datetime.timedelta | None:
+        """Syrup has withdrawal request mechanism.
+
+        While deposits can be made instantly, withdrawals may require going through
+        a withdrawal queue depending on pool liquidity. The withdrawal window is
+        typically cyclical.
+        """
+        return None
+
+    def get_link(self, referral: str | None = None) -> str:
+        """Get link to the Maple Syrup earn page."""
+        return "https://app.maple.finance/earn"

--- a/eth_defi/vault/risk.py
+++ b/eth_defi/vault/risk.py
@@ -92,6 +92,7 @@ VAULT_PROTOCOL_RISK_MATRIX = {
     "Deltr": VaultTechnicalRisk.dangerous,
     "Upshift": VaultTechnicalRisk.severe,
     "Sky": VaultTechnicalRisk.negligible,
+    "Maple": VaultTechnicalRisk.negligible,
 }
 
 #: Particular vaults that are broken, misleading or otherwise problematic.

--- a/tests/erc_4626/vault_protocol/test_maple.py
+++ b/tests/erc_4626/vault_protocol/test_maple.py
@@ -1,0 +1,83 @@
+"""Test Maple Finance Syrup vault metadata."""
+
+import os
+from pathlib import Path
+
+import flaky
+import pytest
+from web3 import Web3
+
+from eth_defi.erc_4626.classification import create_vault_instance_autodetect
+from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.erc_4626.vault_protocol.maple.vault import SyrupVault
+from eth_defi.vault.base import VaultTechnicalRisk
+
+JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
+
+pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests")
+
+
+@pytest.fixture(scope="module")
+def anvil_ethereum_fork(request) -> AnvilLaunch:
+    """Fork at a specific block for reproducibility."""
+    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=24_141_000)
+    try:
+        yield launch
+    finally:
+        launch.close()
+
+
+@pytest.fixture(scope="module")
+def web3(anvil_ethereum_fork):
+    web3 = create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url)
+    return web3
+
+
+@flaky.flaky
+def test_maple_syrup_usdc(
+    web3: Web3,
+    tmp_path: Path,
+):
+    """Read Maple syrupUSDC vault metadata."""
+
+    vault = create_vault_instance_autodetect(
+        web3,
+        vault_address="0x80ac24aa929eaf5013f6436cda2a7ba190f5cc0b",
+    )
+
+    assert isinstance(vault, SyrupVault)
+    assert vault.get_protocol_name() == "Maple"
+    assert vault.features == {ERC4626Feature.maple_like}
+
+    # Maple has internalised fees
+    assert vault.get_management_fee("latest") is None
+    assert vault.get_performance_fee("latest") is None
+    assert vault.has_custom_fees() is False
+
+    # Check vault link
+    assert vault.get_link() == "https://app.maple.finance/earn"
+
+    # Check risk level
+    assert vault.get_risk() == VaultTechnicalRisk.negligible
+
+
+@flaky.flaky
+def test_maple_syrup_usdt(
+    web3: Web3,
+    tmp_path: Path,
+):
+    """Read Maple syrupUSDT vault metadata."""
+
+    vault = create_vault_instance_autodetect(
+        web3,
+        vault_address="0x356b8d89c1e1239cbbb9de4815c39a1474d5ba7d",
+    )
+
+    assert isinstance(vault, SyrupVault)
+    assert vault.get_protocol_name() == "Maple"
+    assert vault.features == {ERC4626Feature.maple_like}
+
+    # Check risk level
+    assert vault.get_risk() == VaultTechnicalRisk.negligible


### PR DESCRIPTION
## Summary

- Add support for Maple Finance Syrup vaults on Ethereum mainnet
- Implements `SyrupVault` class for syrupUSDC and syrupUSDT vaults
- Uses `HARDCODED_PROTOCOLS` approach since there are only two vault instances

## Vault addresses

- **syrupUSDC**: `0x80ac24aa929eaf5013f6436cda2a7ba190f5cc0b`
- **syrupUSDT**: `0x356b8d89c1e1239cbbb9de4815c39a1474d5ba7d`

## Links

- Protocol: https://maple.finance/
- App: https://app.maple.finance/earn
- Docs: https://docs.maple.finance/
- GitHub: https://github.com/maple-labs/maple-core-v2

## Test plan

- [x] Run `pytest tests/erc_4626/vault_protocol/test_maple.py` - both tests pass
- [x] Run `pytest -k vault_protocol` - all 26 vault protocol tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)