### PR TITLE
feat: Add Term Finance vault protocol support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add: New protocol: Centrifuge - RWA tokenisation and financing with ERC-7540 liquidity pools
 - Add: New protocol: Ethena - sUSDe synthetic dollar staking vault
 - Add: New protocol: Decentralized USD (USDD) - sUSDD savings vaults on Ethereum and BNB Chain
+- Add: New protocol: Term Finance - fixed-rate DeFi lending via auction-based matching
 - Fix: Various RPC error code workarounds (Monad, Arbitrum, Hyperliquid)
 
 # 0.37

--- a/docs/source/vaults/index.rst
+++ b/docs/source/vaults/index.rst
@@ -57,6 +57,7 @@ Supported protocols
    summer/index
    superform/index
    teller/index
+   term_finance/index
    truefi/index
    umami/index
    untangle/index

--- a/docs/source/vaults/term_finance/index.rst
+++ b/docs/source/vaults/term_finance/index.rst
@@ -1,0 +1,34 @@
+Term Finance API
+----------------
+
+`Term Finance <https://www.term.finance/>`__ integration.
+
+Term Finance is a noncustodial fixed-rate liquidity protocol modelled on tri-party
+repo arrangements common in traditional finance (TradFi). Liquidity suppliers and
+takers are matched through a unique weekly auction process where liquidity takers
+submit bids and suppliers submit offers to the protocol.
+
+The protocol determines a "market clearing rate" that matches supply and demand.
+Bidders who bid more than the clearing rate receive loans and lenders asking less
+than the clearing rate supply liquidity.
+
+Key features:
+
+- Fixed-rate DeFi lending and borrowing via auctions
+- Scalable transactions with no spread, no slippage, and low fees
+- Collateral sits in isolated noncustodial smart contracts (repoLocker)
+- No rehypothecation - collateral cannot be lent to other borrowers
+
+- `Homepage <https://www.term.finance/>`__
+- `App <https://app.term.finance/>`__
+- `Documentation <https://developers.term.finance>`__
+- `GitHub <https://github.com/term-finance/term-finance-contracts>`__
+- `Twitter <https://x.com/term_labs>`__
+- `Example vault on Etherscan <https://etherscan.io/address/0xa10c40f9e318b0ed67ecc3499d702d8db9437228>`__
+
+
+.. autosummary::
+   :toctree: _autosummary_term_finance
+   :recursive:
+
+   eth_defi.erc_4626.vault_protocol.term_finance.vault

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -1034,6 +1034,11 @@ def create_vault_instance(
 
         return USSDVault(web3, spec, token_cache=token_cache, features=features)
 
+    elif ERC4626Feature.term_finance_like in features:
+        from eth_defi.erc_4626.vault_protocol.term_finance.vault import TermFinanceVault
+
+        return TermFinanceVault(web3, spec, token_cache=token_cache, features=features)
+
     else:
         # Generic ERC-4626 without fee data
         from eth_defi.erc_4626.vault import ERC4626Vault

--- a/eth_defi/erc_4626/vault_protocol/term_finance/__init__.py
+++ b/eth_defi/erc_4626/vault_protocol/term_finance/__init__.py
@@ -1,0 +1,1 @@
+"""Term Finance protocol integration."""

--- a/eth_defi/erc_4626/vault_protocol/term_finance/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/term_finance/vault.py
@@ -1,0 +1,85 @@
+"""Term Finance vault support.
+
+Term Finance is a noncustodial fixed-rate liquidity protocol modelled on tri-party
+repo arrangements common in traditional finance (TradFi). Liquidity suppliers and
+takers are matched through a unique weekly auction process where liquidity takers
+submit bids and suppliers submit offers to the protocol.
+
+The protocol determines a "market clearing rate" that matches supply and demand.
+Bidders who bid more than the clearing rate receive loans and lenders asking less
+than the clearing rate supply liquidity.
+
+Key features:
+
+- Fixed-rate DeFi lending and borrowing via auctions
+- Scalable transactions with no spread, no slippage, and low fees
+- Collateral sits in isolated noncustodial smart contracts (repoLocker)
+- No rehypothecation - collateral cannot be lent to other borrowers
+- Audited by Sigma Prime with DeFi Safety score of 93%
+
+Term Finance vaults use the Yearn V3 tokenised strategy pattern as a base,
+with fees internalised in the share price via the "discount rate markup".
+
+- Homepage: https://www.term.finance/
+- App: https://app.term.finance/
+- Documentation: https://developers.term.finance
+- GitHub: https://github.com/term-finance/term-finance-contracts
+- Twitter: https://x.com/term_labs
+
+Example vault contracts:
+
+- Ethereum: https://etherscan.io/address/0xa10c40f9e318b0ed67ecc3499d702d8db9437228
+"""
+
+import datetime
+import logging
+
+from eth_typing import BlockIdentifier
+
+from eth_defi.erc_4626.vault import ERC4626Vault
+
+logger = logging.getLogger(__name__)
+
+
+class TermFinanceVault(ERC4626Vault):
+    """Term Finance vault.
+
+    Term Finance provides fixed-rate DeFi lending via auction-based matching
+    of liquidity suppliers and takers. Vaults use the Yearn V3 tokenised
+    strategy pattern with fees internalised in the share price.
+
+    - Homepage: https://www.term.finance/
+    - App: https://app.term.finance/
+    - Documentation: https://developers.term.finance
+    - GitHub: https://github.com/term-finance/term-finance-contracts
+    - Twitter: https://x.com/term_labs
+    """
+
+    def has_custom_fees(self) -> bool:
+        """Term Finance vaults use internalised fee structure."""
+        return False
+
+    def get_management_fee(self, block_identifier: BlockIdentifier) -> float | None:
+        """Fees are internalised in the share price."""
+        return None
+
+    def get_performance_fee(self, block_identifier: BlockIdentifier) -> float | None:
+        """Fees are internalised in the share price."""
+        return None
+
+    def get_estimated_lock_up(self) -> datetime.timedelta | None:
+        """Term Finance vaults have no lock-up period."""
+        return None
+
+    def get_link(self, referral: str | None = None) -> str:
+        """Get link to the Term Finance vault page.
+
+        :param referral:
+            Optional referral code (not used currently).
+
+        :return:
+            Link to the vault on Term Finance app.
+        """
+        chain_id = self.spec.chain_id
+        address = self.vault_address.lower()
+        return f"https://app.term.finance/vaults/{address}/{chain_id}"

--- a/eth_defi/vault/fee.py
+++ b/eth_defi/vault/fee.py
@@ -74,6 +74,7 @@ VAULT_PROTOCOL_FEE_MATRIX = {
     "Sky": VaultFeeMode.feeless,
     "cSigma Finance": VaultFeeMode.feeless,
     "Ethena": VaultFeeMode.feeless,
+    "Term Finance": VaultFeeMode.internalised_skimming,
 }
 
 

--- a/eth_defi/vault/risk.py
+++ b/eth_defi/vault/risk.py
@@ -97,6 +97,7 @@ VAULT_PROTOCOL_RISK_MATRIX = {
     "Ethena": VaultTechnicalRisk.negligible,
     "Decentralized USD": VaultTechnicalRisk.severe,
     "Liquidity Royalty Tranching": VaultTechnicalRisk.severe,
+    "Term Finance": None,
 }
 
 #: Particular vaults that are broken, misleading or otherwise problematic.

--- a/tests/erc_4626/vault_protocol/test_term_finance.py
+++ b/tests/erc_4626/vault_protocol/test_term_finance.py
@@ -1,0 +1,62 @@
+"""Test Term Finance vault metadata."""
+
+import os
+from pathlib import Path
+
+import flaky
+import pytest
+from web3 import Web3
+
+from eth_defi.erc_4626.classification import create_vault_instance_autodetect
+from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.erc_4626.vault_protocol.term_finance.vault import TermFinanceVault
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+
+JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
+
+pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests")
+
+
+@pytest.fixture(scope="module")
+def anvil_ethereum_fork(request) -> AnvilLaunch:
+    """Fork at a specific block for reproducibility."""
+    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=24_141_000)
+    try:
+        yield launch
+    finally:
+        launch.close()
+
+
+@pytest.fixture(scope="module")
+def web3(anvil_ethereum_fork):
+    web3 = create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url)
+    return web3
+
+
+@flaky.flaky
+def test_term_finance_vault(
+    web3: Web3,
+    tmp_path: Path,
+):
+    """Read Term Finance vault metadata."""
+
+    vault = create_vault_instance_autodetect(
+        web3,
+        vault_address="0xa10c40f9e318b0ed67ecc3499d702d8db9437228",
+    )
+
+    assert isinstance(vault, TermFinanceVault)
+    assert vault.get_protocol_name() == "Term Finance"
+    assert ERC4626Feature.term_finance_like in vault.features
+
+    # Term Finance has internalised fees
+    assert vault.get_management_fee("latest") is None
+    assert vault.get_performance_fee("latest") is None
+    assert vault.has_custom_fees() is False
+
+    # Check vault link
+    assert vault.get_link() == "https://app.term.finance/vaults/0xa10c40f9e318b0ed67ecc3499d702d8db9437228/1"
+
+    # Risk level is None (to be assessed later)
+    assert vault.get_risk() is None


### PR DESCRIPTION
## Summary

- Add support for Term Finance, a noncustodial fixed-rate liquidity protocol
- Term Finance matches liquidity suppliers and takers through weekly auctions
- Uses Yearn V3 tokenised strategy pattern with internalised fees

## Changes

- Add `TermFinanceVault` class with internalised fee structure
- Add vault instantiation case in `create_vault_instance()`
- Add to risk matrix (None - to be assessed later)
- Add to fee matrix (`internalised_skimming`)
- Add documentation and tests

## Protocol links

- Homepage: https://www.term.finance/
- App: https://app.term.finance/
- Documentation: https://developers.term.finance
- GitHub: https://github.com/term-finance/term-finance-contracts
- Twitter: https://x.com/term_labs
- Example vault: https://etherscan.io/address/0xa10c40f9e318b0ed67ecc3499d702d8db9437228

🤖 Generated with [Claude Code](https://claude.com/claude-code)