### PR TITLE
refactor: Use PeriodMetrics for legacy lifetime/3M/1M fields

### DIFF
--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -87,11 +87,11 @@ def test_calculate_lifetime_metrics(
     assert sample_row["cagr"] == pytest.approx(0.02483940718068034)
     assert sample_row["cagr_net"] == pytest.approx(0.02483940718068034)
 
-    # The prices file does not have enough data for three moths
-    assert sample_row["three_months_cagr"] == pytest.approx(0)
-    assert sample_row["three_months_cagr_net"] == pytest.approx(0)
-    assert sample_row["three_months_sharpe"] == pytest.approx(0)
-    assert sample_row["three_months_sharpe_net"] == pytest.approx(0)
+    # Three months metrics - the test data spans ~41 days, which fits within 3M tolerance
+    assert sample_row["three_months_cagr"] == pytest.approx(0.02483940718068034)
+    assert sample_row["three_months_cagr_net"] == pytest.approx(0.02483940718068034)
+    assert sample_row["three_months_sharpe"] == pytest.approx(5.280916994701033)
+    assert sample_row["three_months_sharpe_net"] == pytest.approx(5.280916994701033)
 
     assert sample_row["one_month_returns"] == pytest.approx(0.0018523254977500514)
     assert sample_row["one_month_returns_net"] == pytest.approx(0.0018523254977500514)


### PR DESCRIPTION
## Summary

- Refactored `calculate_vault_record()` to use values from `calculate_period_metrics()` instead of duplicating the calculation logic
- Legacy fields (`lifetime_*`, `three_months_*`, `one_month_*`) are now extracted from `PeriodMetrics` objects for backward compatibility
- Updated 3M period tolerance from 120 days to 135 days (as defined in `LOOKBACK_AND_TOLERANCES`), allowing more sparse data to produce valid 3M metrics
- Updated test values to reflect the new behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)