### PR TITLE
feat: Add cSigma cSuperior Quality Private Credit vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Current
 
+- Add: cSigma Finance cSuperior Quality Private Credit vault (2026-01-05)
 - Add: New protocol: ETH Strategy - DeFi treasury protocol with ESPN vault (2026-01-05)
 - Add: New protocol: ZeroLend - multi-chain DeFi lending with Royco integration (2026-01-05)
 - Add: Claude Code skill for identifying vault protocols (2026-01-05)

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -1135,6 +1135,9 @@ HARDCODED_PROTOCOLS = {
     # cSigma Finance - CsigmaV2Pool on Ethereum
     # https://etherscan.io/address/0x438982ea288763370946625fd76c2508ee1fb229
     "0x438982ea288763370946625fd76c2508ee1fb229": {ERC4626Feature.csigma_like},
+    # cSigma Finance - cSuperior Quality Private Credit vault on Ethereum
+    # https://etherscan.io/address/0x50d59b785df23728d9948804f8ca3543237a1495
+    "0x50d59b785df23728d9948804f8ca3543237a1495": {ERC4626Feature.csigma_like},
     # Spark - sUSDC vault on Ethereum
     # https://etherscan.io/address/0xbc65ad17c5c0a2a4d159fa5a503f4992c7b545fe
     "0xbc65ad17c5c0a2a4d159fa5a503f4992c7b545fe": {ERC4626Feature.spark_like},

--- a/tests/erc_4626/vault_protocol/test_csigma.py
+++ b/tests/erc_4626/vault_protocol/test_csigma.py
@@ -82,3 +82,28 @@ def test_csigma_v2_pool(
 
     # Check vault link
     assert vault.get_link() == "https://edge.csigma.finance/"
+
+
+@flaky.flaky
+def test_csigma_supqpv(
+    web3: Web3,
+    tmp_path: Path,
+):
+    """Read cSigma Finance cSuperior Quality Private Credit vault metadata."""
+
+    vault = create_vault_instance_autodetect(
+        web3,
+        vault_address="0x50d59b785df23728d9948804f8ca3543237a1495",
+    )
+
+    assert isinstance(vault, CsigmaVault)
+    assert vault.get_protocol_name() == "cSigma Finance"
+    assert vault.features == {ERC4626Feature.csigma_like}
+
+    # Fees are not yet known for cSigma
+    assert vault.get_management_fee("latest") is 0
+    assert vault.get_performance_fee("latest") is 0
+    assert vault.has_custom_fees() is False
+
+    # Check vault link
+    assert vault.get_link() == "https://edge.csigma.finance/"


### PR DESCRIPTION
## Summary

- Add support for cSigma Finance's cSuperior Quality Private Credit (cSUPQPV) vault on Ethereum

## Details

- **Vault address**: 0x50d59b785df23728d9948804f8ca3543237a1495
- **Chain**: Ethereum
- **Token**: cSUPQPV (cSuperior Quality Private Credit)
- **Underlying asset**: USDT

🤖 Generated with [Claude Code](https://claude.com/claude-code)