### PR TITLE
feat: Add Yuzu Money vault protocol support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Current
 
+- Add: New protocol: Yuzu Money - overcollateralised stablecoin protocol on Plasma chain (2026-01-05)
 - Add: cSigma Finance cSuperior Quality Private Credit vault (2026-01-05)
 - Add: New protocol: ETH Strategy - DeFi treasury protocol with ESPN vault (2026-01-05)
 - Add: New protocol: ZeroLend - multi-chain DeFi lending with Royco integration (2026-01-05)

--- a/docs/protocol-research/yuzu-money.md
+++ b/docs/protocol-research/yuzu-money.md
@@ -1,0 +1,77 @@
+# Yuzu Money
+
+Yuzu Money is a DeFi protocol that packages high-yield strategies into an overcollateralised stablecoin (yzUSD).
+
+## Summary
+
+- **Chain**: Plasma (chain ID: 9745)
+- **Address**: `0xebfc8c2fe73c431ef2a371aea9132110aab50dca` (yzPP - Yuzu Protection Pool)
+- **Explorer link**: https://plasmascan.to/address/0xebfc8c2fe73c431ef2a371aea9132110aab50dca
+- **Protocol name**: Yuzu Money
+- **Web page**: https://yuzu.money/
+- **App**: https://app.yuzu.money/
+- **Github repository**: https://github.com/Telos-Consilium/ouroboros-contracts (private, referenced in audit)
+- **Documentation link**: https://yuzu-money.gitbook.io/yuzu-money/
+- **DefiLlama link**: https://defillama.com/protocol/yuzu-money
+- **DefiLlama adapter**: https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/yuzu-money/index.js
+- **TVL**: ~$40M (as of January 2026)
+
+## Token structure
+
+| Token | Symbol | Description | Type |
+|-------|--------|-------------|------|
+| Yuzu Stablecoin | yzUSD | Overcollateralised stablecoin targeting $1 USD, backed 1:1 by USDC | ERC-20 |
+| Staked Yuzu USD | syzUSD | Yield-bearing token received when staking yzUSD | ERC-4626 vault |
+| Yuzu Protection Pool | yzPP | Junior tranche / insurance liquidity pool token | ERC-20 (first-loss) |
+| YUZU | YUZU | Governance and utility token | ERC-20 |
+
+### Key addresses on Plasma
+
+- **yzUSD**: `0x6695c0f8706c5ace3bdf8995073179cca47926dc`
+- **yzPP**: `0xebfc8c2fe73c431ef2a371aea9132110aab50dca`
+
+## Audit reports
+
+1. **Pashov Audit Group** - YuzuUSD Security Review (2025-08-28)
+   - PDF: https://github.com/pashov/audits/blob/master/team/pdf/YuzuUSD-security-review_2025-08-28.pdf
+   - Markdown: https://github.com/pashov/audits/blob/master/team/md/YuzuUSD-security-review_2025-08-28.md
+   - Auditors: unforgiven, merlinboii, IvanFitro, ni8mare
+   - Scope: YuzuUSD.sol, YuzuILP.sol, StakedYuzuUSD.sol, YuzuIssuer.sol, YuzuOrderBook.sol, YuzuProto.sol
+   - Total issues found: 18 (3 High, 2 Medium, 13 Low)
+   - All High and Medium issues marked as resolved
+
+## Fee information
+
+- Redemption fees apply when redeeming yzUSD and syzUSD
+- Fee can be positive (fee) or negative (incentive) depending on protocol parameters
+- Specific fee percentages are configurable by protocol admin via `setRedeemOrderFee()` and `setRedeemFeePpm()`
+- Performance fees mentioned in documentation but specific percentages not publicly disclosed
+- From audit: fee calculation uses parts-per-million (PPM) with 1e6 = 100%
+
+## Security infrastructure
+
+- **Hypernative/Sentinel**: Real-time threat detection and monitoring
+- **Nexus Mutual**: Smart contract insurance coverage
+- **Fordefi MPC**: Multi-party computation for wallet infrastructure
+- **Multisig**: 3/5 multisig with 48-hour timelock for admin actions
+- **Proof of Reserves**: https://yuzu.accountable.capital/
+
+## Smart contract developer
+
+Smart contracts are developed in the private repository `Telos-Consilium/ouroboros-contracts`, as referenced in the Pashov Audit Group security review. The protocol is incubated by Ouroboros Capital.
+
+## Notes
+
+- yzUSD minting/redemption is restricted to qualified/accredited investors only (KYC/KYB required)
+- Secondary market trading of yzUSD is permissionless on DEXs
+- syzUSD is the yield-bearing wrapper and is ERC-4626 compliant
+- yzPP (Protection Pool) acts as first-loss capital / junior tranche for the protocol
+- Protocol uses transparent proxy pattern (ERC-1967) for upgradeability
+- Deployed October 2025, relatively new protocol
+- Integrations: Euler Finance lending markets, Pendle Finance liquidity provision
+
+## Social links
+
+- **Twitter/X**: https://x.com/YuzuMoneyX
+- **Discord**: https://discord.gg/yuzumoney
+- **Medium**: https://yuzumoney.medium.com/

--- a/docs/source/vaults/index.rst
+++ b/docs/source/vaults/index.rst
@@ -68,4 +68,5 @@ Supported protocols
    usdai/index
    usdd/index
    yearn/index
+   yuzu_money/index
    zerolend/index

--- a/docs/source/vaults/yuzu_money/index.rst
+++ b/docs/source/vaults/yuzu_money/index.rst
@@ -1,0 +1,45 @@
+Yuzu Money API
+--------------
+
+`Yuzu Money <https://yuzu.money/>`__ integration.
+
+Yuzu Money is a DeFi protocol that packages high-yield strategies into an overcollateralised
+stablecoin (yzUSD). The protocol is deployed on the Plasma chain and offers multiple products
+for users seeking yield on their stablecoin holdings.
+
+The protocol features a multi-token architecture:
+
+- **yzUSD**: Overcollateralised stablecoin targeting $1 USD, backed 1:1 by USDC
+- **syzUSD**: Yield-bearing token received when staking yzUSD (ERC-4626 vault)
+- **yzPP**: Junior tranche / insurance liquidity pool providing first-loss capital
+
+Key features:
+
+- Institutional-grade risk mitigation with risk tranching
+- Nexus Mutual smart contract insurance coverage
+- Hypernative threat monitoring
+- Real-time Proof of Reserves dashboard
+- Audited by Pashov Audit Group
+
+Fee structure:
+
+Yuzu Money does not charge traditional performance fees. Instead, the protocol employs a
+`yield-smoothing mechanism <https://yuzu-money.gitbook.io/yuzu-money/faq-1/performance-fee>`__
+where a consistent weekly yield target is distributed to users, backed by a Reserve Fund
+that acts as a buffer. This approach provides more predictable returns without explicit
+management or performance fees.
+
+- `Homepage <https://yuzu.money/>`__
+- `App <https://app.yuzu.money/>`__
+- `Documentation <https://yuzu-money.gitbook.io/yuzu-money/>`__
+- `Twitter <https://x.com/YuzuMoneyX>`__
+- `Audit report <https://github.com/pashov/audits/blob/master/team/pdf/YuzuUSD-security-review_2025-08-28.pdf>`__
+- `DefiLlama <https://defillama.com/protocol/yuzu-money>`__
+- `Contract on Plasmascan <https://plasmascan.to/address/0xebfc8c2fe73c431ef2a371aea9132110aab50dca>`__
+
+
+.. autosummary::
+   :toctree: _autosummary_yuzu_money
+   :recursive:
+
+   eth_defi.erc_4626.vault_protocol.yuzu_money.vault

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -1095,6 +1095,11 @@ def create_vault_instance(
 
         return EthStrategyVault(web3, spec, token_cache=token_cache, features=features)
 
+    elif ERC4626Feature.yuzu_money_like in features:
+        from eth_defi.erc_4626.vault_protocol.yuzu_money.vault import YuzuMoneyVault
+
+        return YuzuMoneyVault(web3, spec, token_cache=token_cache, features=features)
+
     else:
         # Generic ERC-4626 without fee data
         from eth_defi.erc_4626.vault import ERC4626Vault
@@ -1174,6 +1179,9 @@ HARDCODED_PROTOCOLS = {
     # ETH Strategy - ESPN (EthStrategyPerpetualNote) vault on Ethereum
     # https://etherscan.io/address/0xb250c9e0f7be4cff13f94374c993ac445a1385fe
     "0xb250c9e0f7be4cff13f94374c993ac445a1385fe": {ERC4626Feature.eth_strategy_like},
+    # Yuzu Money - yzPP (Yuzu Protection Pool) vault on Plasma
+    # https://plasmascan.to/address/0xebfc8c2fe73c431ef2a371aea9132110aab50dca
+    "0xebfc8c2fe73c431ef2a371aea9132110aab50dca": {ERC4626Feature.yuzu_money_like},
 }
 
 for a in HARDCODED_PROTOCOLS.keys():

--- a/eth_defi/erc_4626/core.py
+++ b/eth_defi/erc_4626/core.py
@@ -349,6 +349,13 @@ class ERC4626Feature(enum.Enum):
     #: https://www.ethstrat.xyz/
     eth_strategy_like = "eth_strategy_like"
 
+    #: Yuzu Money
+    #:
+    #: DeFi protocol packaging high-yield strategies into an overcollateralised stablecoin.
+    #: Deployed on Plasma chain with yzUSD, syzUSD, and yzPP products.
+    #: https://yuzu.money/
+    yuzu_money_like = "yuzu_money_like"
+
 
 def get_vault_protocol_name(features: set[ERC4626Feature]) -> str:
     """Deduct vault protocol name based on Vault smart contract features.
@@ -502,6 +509,9 @@ def get_vault_protocol_name(features: set[ERC4626Feature]) -> str:
 
     elif ERC4626Feature.eth_strategy_like in features:
         return "ETH Strategy"
+
+    elif ERC4626Feature.yuzu_money_like in features:
+        return "Yuzu Money"
 
     # No idea
     if ERC4626Feature.erc_7540_like in features:

--- a/eth_defi/erc_4626/vault_protocol/yuzu_money/__init__.py
+++ b/eth_defi/erc_4626/vault_protocol/yuzu_money/__init__.py
@@ -1,0 +1,1 @@
+"""Yuzu Money protocol integration."""

--- a/eth_defi/erc_4626/vault_protocol/yuzu_money/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/yuzu_money/vault.py
@@ -1,0 +1,134 @@
+"""Yuzu Money protocol vault support.
+
+Yuzu Money is a DeFi protocol that packages high-yield strategies into an
+overcollateralised stablecoin (yzUSD). The protocol is deployed on the Plasma
+chain and offers multiple products including yzUSD, syzUSD (staked yzUSD),
+and yzPP (Yuzu Protection Pool).
+
+Key features:
+
+- yzUSD: Overcollateralised stablecoin targeting $1 USD, backed 1:1 by USDC
+- syzUSD: Yield-bearing token received when staking yzUSD (ERC-4626 vault)
+- yzPP: Junior tranche / insurance liquidity pool providing first-loss capital
+- No performance fees - uses yield-smoothing mechanism instead
+- Two-step redemption process with delay period
+
+The yzPP vault (Yuzu Protection Pool) is the insurance liquidity pool that:
+
+- Accrues yield from protocol strategies
+- Bears first-loss risk on underlying strategies
+- Uses time-delayed redemptions for risk management
+
+Fee structure:
+
+Yuzu Money does not charge traditional performance fees. Instead, they employ
+a yield-smoothing mechanism where a consistent weekly yield target is distributed,
+backed by a Reserve Fund that acts as a buffer. See:
+https://yuzu-money.gitbook.io/yuzu-money/faq-1/performance-fee
+
+Security:
+
+- Audited by Pashov Audit Group (August 2025)
+- Hypernative threat monitoring
+- Nexus Mutual smart contract insurance
+- 3/5 multisig with 48-hour timelock
+
+- Homepage: https://yuzu.money/
+- App: https://app.yuzu.money/
+- Documentation: https://yuzu-money.gitbook.io/yuzu-money/
+- Fee documentation: https://yuzu-money.gitbook.io/yuzu-money/faq-1/performance-fee
+- Audit report: https://github.com/pashov/audits/blob/master/team/pdf/YuzuUSD-security-review_2025-08-28.pdf
+- DefiLlama: https://defillama.com/protocol/yuzu-money
+- Twitter: https://x.com/YuzuMoneyX
+- Contract (yzPP): https://plasmascan.to/address/0xebfc8c2fe73c431ef2a371aea9132110aab50dca
+"""
+
+import datetime
+import logging
+
+from eth_typing import BlockIdentifier
+
+from eth_defi.erc_4626.vault import ERC4626Vault
+
+logger = logging.getLogger(__name__)
+
+
+class YuzuMoneyVault(ERC4626Vault):
+    """Yuzu Money protocol vault support.
+
+    Yuzu Money yzPP (Protection Pool) vault is the junior tranche of the protocol
+    that provides first-loss capital and earns higher yields in return.
+
+    Key characteristics:
+
+    - ERC-4626 compliant vault
+    - Time-delayed redemptions (not instant)
+    - No performance fees (yield-smoothing mechanism)
+    - Bears first-loss risk for protocol strategies
+
+    Fee structure:
+
+    Yuzu Money does not charge traditional performance fees. Instead, they employ
+    a yield-smoothing mechanism. See:
+    https://yuzu-money.gitbook.io/yuzu-money/faq-1/performance-fee
+
+    - Homepage: https://yuzu.money/
+    - App: https://app.yuzu.money/
+    - Documentation: https://yuzu-money.gitbook.io/yuzu-money/
+    - Contract (yzPP): https://plasmascan.to/address/0xebfc8c2fe73c431ef2a371aea9132110aab50dca
+    """
+
+    def has_custom_fees(self) -> bool:
+        """Whether this vault has deposit/withdrawal fees.
+
+        Yuzu Money does not charge performance fees. They use a yield-smoothing
+        mechanism instead. See:
+        https://yuzu-money.gitbook.io/yuzu-money/faq-1/performance-fee
+        """
+        return False
+
+    def get_management_fee(self, block_identifier: BlockIdentifier) -> float | None:
+        """Get the current management fee as a percent.
+
+        Yuzu Money does not charge management fees.
+
+        :return:
+            0.0 - no management fee
+        """
+        return 0.0
+
+    def get_performance_fee(self, block_identifier: BlockIdentifier) -> float | None:
+        """Get the current performance fee as a percent.
+
+        Yuzu Money does not charge traditional performance fees. Instead, they
+        employ a yield-smoothing mechanism where a consistent weekly yield target
+        is distributed, backed by a Reserve Fund.
+
+        See: https://yuzu-money.gitbook.io/yuzu-money/faq-1/performance-fee
+
+        :return:
+            0.0 - no performance fee
+        """
+        return 0.0
+
+    def get_estimated_lock_up(self) -> datetime.timedelta | None:
+        """Get estimated lock-up period if any.
+
+        Yuzu Money yzPP vault uses time-delayed redemptions.
+        Users must initiate a redeem order and wait for the delay period
+        before finalising the redemption.
+
+        The exact delay period is configurable by the protocol admin.
+        """
+        return None
+
+    def get_link(self, referral: str | None = None) -> str:
+        """Get the vault's web UI link.
+
+        :param referral:
+            Optional referral code (not used currently).
+
+        :return:
+            Link to the Yuzu Money app.
+        """
+        return "https://app.yuzu.money/"

--- a/eth_defi/vault/fee.py
+++ b/eth_defi/vault/fee.py
@@ -77,6 +77,9 @@ VAULT_PROTOCOL_FEE_MATRIX = {
     "Term Finance": VaultFeeMode.internalised_skimming,
     "Royco": None,
     "ETH Strategy": VaultFeeMode.feeless,
+    # Yuzu Money has no performance fee, uses yield-smoothing mechanism instead
+    # https://yuzu-money.gitbook.io/yuzu-money/faq-1/performance-fee
+    "Yuzu Money": VaultFeeMode.feeless,
 }
 
 

--- a/eth_defi/vault/risk.py
+++ b/eth_defi/vault/risk.py
@@ -103,6 +103,7 @@ VAULT_PROTOCOL_RISK_MATRIX = {
     "Superform": VaultTechnicalRisk.severe,
     "Royco": None,
     "ETH Strategy": VaultTechnicalRisk.low,
+    "Yuzu Money": VaultTechnicalRisk.low,
 }
 
 #: Particular vaults that are broken, misleading or otherwise problematic.

--- a/tests/erc_4626/vault_protocol/test_yuzu_money.py
+++ b/tests/erc_4626/vault_protocol/test_yuzu_money.py
@@ -1,0 +1,57 @@
+"""Test Yuzu Money vault metadata."""
+
+import os
+
+import pytest
+from web3 import Web3
+
+from eth_defi.erc_4626.classification import create_vault_instance_autodetect
+from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.erc_4626.vault_protocol.yuzu_money.vault import YuzuMoneyVault
+from eth_defi.provider.anvil import fork_network_anvil, AnvilLaunch
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+
+JSON_RPC_PLASMA = os.environ.get("JSON_RPC_PLASMA")
+
+pytestmark = pytest.mark.skipif(
+    JSON_RPC_PLASMA is None,
+    reason="JSON_RPC_PLASMA needed to run these tests",
+)
+
+
+@pytest.fixture(scope="module")
+def anvil_plasma_fork(request) -> AnvilLaunch:
+    """Fork at a specific block for reproducibility."""
+    launch = fork_network_anvil(JSON_RPC_PLASMA, fork_block_number=10687319)
+    try:
+        yield launch
+    finally:
+        launch.close()
+
+
+@pytest.fixture(scope="module")
+def web3(anvil_plasma_fork):
+    web3 = create_multi_provider_web3(anvil_plasma_fork.json_rpc_url)
+    return web3
+
+
+def test_yuzu_money(web3: Web3):
+    """Read Yuzu Money vault metadata."""
+
+    # yzPP (Yuzu Protection Pool) vault on Plasma
+    vault = create_vault_instance_autodetect(
+        web3,
+        vault_address="0xebfc8c2fe73c431ef2a371aea9132110aab50dca",
+    )
+
+    assert isinstance(vault, YuzuMoneyVault)
+    assert vault.get_protocol_name() == "Yuzu Money"
+    assert vault.features == {ERC4626Feature.yuzu_money_like}
+
+    # Yuzu Money has no fees (uses yield-smoothing mechanism)
+    # https://yuzu-money.gitbook.io/yuzu-money/faq-1/performance-fee
+    assert vault.get_management_fee("latest") == 0.0
+    assert vault.get_performance_fee("latest") == 0.0
+
+    # Check the vault link
+    assert vault.get_link() == "https://app.yuzu.money/"


### PR DESCRIPTION
## Summary

- Add support for Yuzu Money protocol on Plasma chain (yzPP vault)
- Yuzu Money is a DeFi protocol that packages high-yield strategies into an overcollateralised stablecoin (yzUSD)
- Uses hardcoded address detection for this single-vault protocol
- Feeless structure (uses yield-smoothing mechanism instead of traditional performance fees)

## Links

- Homepage: https://yuzu.money/
- App: https://app.yuzu.money/
- Documentation: https://yuzu-money.gitbook.io/yuzu-money/
- Fee documentation: https://yuzu-money.gitbook.io/yuzu-money/faq-1/performance-fee
- Audit: https://github.com/pashov/audits/blob/master/team/pdf/YuzuUSD-security-review_2025-08-28.pdf
- DefiLlama: https://defillama.com/protocol/yuzu-money
- Contract: https://plasmascan.to/address/0xebfc8c2fe73c431ef2a371aea9132110aab50dca

🤖 Generated with [Claude Code](https://claude.com/claude-code)