### PR TITLE
feat: Add Gearbox vault protocol support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- Add: New protocol: Gearbox - composable leverage protocol lending pools (2026-01-05)
+- Add: New vault type: Maple Finance AQRU Pool - Real-World Receivables vault (2026-01-05)
 - Add: New protocol: Spectra USDN Wrapper - ERC4626 wrapper for WUSDN (SmarDex) (2026-01-05)
 - Add: New protocol: Altura - multi-strategy yield protocol on HyperEVM (2026-01-05)
 - Add: New protocol: Yuzu Money - overcollateralised stablecoin protocol on Plasma chain (2026-01-05)

--- a/docs/source/vaults/gearbox/index.rst
+++ b/docs/source/vaults/gearbox/index.rst
@@ -1,0 +1,49 @@
+Gearbox API
+-----------
+
+`Gearbox Protocol <https://gearbox.finance/>`__ integration.
+
+Gearbox Protocol is a composable leverage protocol that allows users to take
+leverage in one place and use it across various DeFi protocols. The protocol
+has two sides: passive liquidity providers who earn yield by depositing assets,
+and active traders/farmers who can borrow assets for leveraged positions.
+
+The PoolV3 contracts are ERC-4626 compatible lending pools that manage liquidity
+from passive lenders. When users deposit stablecoins or other assets, they receive
+pool shares (dTokens) representing their deposit. The underlying deposits are
+lent to credit accounts that pay interest on borrowed funds.
+
+Key features:
+
+- Composable leverage: Use borrowed funds across integrated DeFi protocols
+- Passive yield: Earn interest from leveraged borrowers
+- ERC-4626 compatible: Standard vault interface for easy integration
+- Multiple audits: ChainSecurity audits for V3 core contracts
+
+Fee structure:
+
+- Withdrawal fee: 0% for passive lenders
+- APY spread: ~50% between borrower rate and lender rate goes to protocol
+- For passive lenders, fees are internalised in the share price
+
+Example vault contracts:
+
+- `Hyperithm USDT0 Pool on Plasma <https://plasmascan.to/address/0xb74760fd26400030620027dd29d19d74d514700e>`__
+
+Links
+~~~~~
+
+- `Homepage <https://gearbox.finance/>`__
+- `App <https://app.gearbox.fi/>`__
+- `Documentation <https://docs.gearbox.finance/>`__
+- `Protocol fees <https://docs.gearbox.finance/overview/protocol-fees>`__
+- `GitHub <https://github.com/Gearbox-protocol/core-v3>`__
+- `Twitter <https://x.com/GearboxProtocol>`__
+- `Audits <https://docs.gearbox.finance/risk-and-security/audits-bug-bounty>`__
+
+
+.. autosummary::
+   :toctree: _autosummary_gearbox
+   :recursive:
+
+   eth_defi.erc_4626.vault_protocol.gearbox.vault

--- a/docs/source/vaults/index.rst
+++ b/docs/source/vaults/index.rst
@@ -45,6 +45,7 @@ Supported protocols
    eth_strategy/index
    foxify/index
    gains/index
+   gearbox/index
    goat/index
    harvest/index
    ipor/index

--- a/eth_defi/erc_4626/core.py
+++ b/eth_defi/erc_4626/core.py
@@ -304,11 +304,18 @@ class ERC4626Feature(enum.Enum):
     #: https://etherscan.io/address/0x99cd4ec3f88a45940936f469e4bb72a2a701eeb9
     sky_like = "sky_like"
 
-    #: Maple Finance
+    #: Maple Finance Syrup
     #:
     #: Institutional-grade DeFi lending protocol with Syrup yield products.
     #: https://maple.finance/
     maple_like = "maple_like"
+
+    #: Maple Finance AQRU Pool
+    #:
+    #: AQRU Receivables Pool for IRS tax credit receivables on Maple Finance.
+    #: Real-world receivables pool bridging DeFi with traditional assets.
+    #: https://aqru.io/real-world-receivables/
+    maple_aqru_like = "maple_aqru_like"
 
     #: Centrifuge
     #:
@@ -369,6 +376,12 @@ class ERC4626Feature(enum.Enum):
     #: https://www.spectra.finance/
     #: https://smardex.io/usdn
     spectra_usdn_wrapper_like = "spectra_usdn_wrapper_like"
+
+    #: Gearbox Protocol
+    #:
+    #: Composable leverage protocol with ERC-4626 compatible lending pools (PoolV3).
+    #: https://gearbox.finance/
+    gearbox_like = "gearbox_like"
 
 
 def get_vault_protocol_name(features: set[ERC4626Feature]) -> str:
@@ -506,6 +519,9 @@ def get_vault_protocol_name(features: set[ERC4626Feature]) -> str:
     elif ERC4626Feature.maple_like in features:
         return "Maple"
 
+    elif ERC4626Feature.maple_aqru_like in features:
+        return "Maple"
+
     elif ERC4626Feature.centrifuge_like in features:
         return "Centrifuge"
 
@@ -532,6 +548,9 @@ def get_vault_protocol_name(features: set[ERC4626Feature]) -> str:
 
     elif ERC4626Feature.spectra_usdn_wrapper_like in features:
         return "Spectra"
+
+    elif ERC4626Feature.gearbox_like in features:
+        return "Gearbox"
 
     # No idea
     if ERC4626Feature.erc_7540_like in features:

--- a/eth_defi/erc_4626/vault_protocol/gearbox/__init__.py
+++ b/eth_defi/erc_4626/vault_protocol/gearbox/__init__.py
@@ -1,0 +1,1 @@
+"""Gearbox Protocol integration."""

--- a/eth_defi/erc_4626/vault_protocol/gearbox/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/gearbox/vault.py
@@ -1,0 +1,73 @@
+"""Gearbox Protocol vault support.
+
+Gearbox Protocol is a composable leverage protocol that provides lending pools
+compatible with ERC-4626. The PoolV3 contract manages liquidity deposits from
+passive lenders and borrowing by credit accounts.
+
+- Homepage: https://gearbox.finance/
+- App: https://app.gearbox.fi/
+- Documentation: https://docs.gearbox.finance/
+- GitHub: https://github.com/Gearbox-protocol/core-v3
+- Twitter: https://x.com/GearboxProtocol
+- Audits: https://docs.gearbox.finance/risk-and-security/audits-bug-bounty
+
+Fee structure:
+
+- Withdrawal fee: 0% for passive lenders
+- APY spread: ~50% between borrower rate and lender rate goes to DAO
+- For passive lenders, fees are internalised in the share price
+
+Example vault contracts:
+
+- Hyperithm USDT0 Pool on Plasma: https://plasmascan.to/address/0xb74760fd26400030620027dd29d19d74d514700e
+"""
+
+import datetime
+import logging
+
+from eth_typing import BlockIdentifier
+
+from eth_defi.erc_4626.vault import ERC4626Vault
+
+logger = logging.getLogger(__name__)
+
+
+class GearboxVault(ERC4626Vault):
+    """Gearbox Protocol PoolV3 vault.
+
+    Gearbox pools allow passive liquidity providers to deposit assets and earn
+    yield from borrowers (credit accounts) who pay interest on borrowed funds.
+
+    Key features:
+
+    - ERC-4626 compatible lending pool
+    - Yield from institutional-grade leveraged positions
+    - Zero withdrawal fees for passive lenders
+    - Credit manager integration for leveraged borrowing
+
+    - Homepage: https://gearbox.finance/
+    - App: https://app.gearbox.fi/
+    - Documentation: https://docs.gearbox.finance/
+    - GitHub: https://github.com/Gearbox-protocol/core-v3
+    - Twitter: https://x.com/GearboxProtocol
+    """
+
+    def has_custom_fees(self) -> bool:
+        """Gearbox pools have no custom deposit/withdrawal fees for passive lenders."""
+        return False
+
+    def get_management_fee(self, block_identifier: BlockIdentifier) -> float | None:
+        """No management fee for passive lenders."""
+        return 0.0
+
+    def get_performance_fee(self, block_identifier: BlockIdentifier) -> float | None:
+        """No performance fee for passive lenders (fees internalised in share price)."""
+        return 0.0
+
+    def get_estimated_lock_up(self) -> datetime.timedelta | None:
+        """Gearbox pools have no lock-up for passive lenders."""
+        return None
+
+    def get_link(self, referral: str | None = None) -> str:
+        """Get link to the Gearbox app."""
+        return "https://app.gearbox.fi/"

--- a/eth_defi/vault/fee.py
+++ b/eth_defi/vault/fee.py
@@ -82,6 +82,8 @@ VAULT_PROTOCOL_FEE_MATRIX = {
     "Yuzu Money": VaultFeeMode.feeless,
     # Altura has minimal exit fees (0.01%) on instant withdrawals only, no management/performance fees
     "Altura": VaultFeeMode.feeless,
+    # Gearbox has fees internalised in share price via APY spread between borrower and lender rates
+    "Gearbox": VaultFeeMode.internalised_skimming,
 }
 
 

--- a/eth_defi/vault/risk.py
+++ b/eth_defi/vault/risk.py
@@ -106,6 +106,7 @@ VAULT_PROTOCOL_RISK_MATRIX = {
     "Yuzu Money": VaultTechnicalRisk.low,
     "Altura": VaultTechnicalRisk.severe,
     "Spectra": VaultTechnicalRisk.low,
+    "Gearbox": VaultTechnicalRisk.low,
 }
 
 #: Particular vaults that are broken, misleading or otherwise problematic.

--- a/tests/erc_4626/vault_protocol/test_gearbox.py
+++ b/tests/erc_4626/vault_protocol/test_gearbox.py
@@ -1,0 +1,63 @@
+"""Test Gearbox Protocol vault metadata."""
+
+import os
+from pathlib import Path
+
+import flaky
+import pytest
+from web3 import Web3
+
+from eth_defi.erc_4626.classification import create_vault_instance_autodetect
+from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.erc_4626.vault_protocol.gearbox.vault import GearboxVault
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.vault.base import VaultTechnicalRisk
+
+JSON_RPC_PLASMA = os.environ.get("JSON_RPC_PLASMA")
+
+pytestmark = pytest.mark.skipif(JSON_RPC_PLASMA is None, reason="JSON_RPC_PLASMA needed to run these tests")
+
+
+@pytest.fixture(scope="module")
+def anvil_plasma_fork(request) -> AnvilLaunch:
+    """Fork at a specific block for reproducibility."""
+    launch = fork_network_anvil(JSON_RPC_PLASMA, fork_block_number=10_696_914)
+    try:
+        yield launch
+    finally:
+        launch.close()
+
+
+@pytest.fixture(scope="module")
+def web3(anvil_plasma_fork):
+    web3 = create_multi_provider_web3(anvil_plasma_fork.json_rpc_url)
+    return web3
+
+
+@flaky.flaky
+def test_gearbox_hyperithm_usdt0(
+    web3: Web3,
+    tmp_path: Path,
+):
+    """Read Gearbox Hyperithm USDT0 vault metadata on Plasma."""
+
+    vault = create_vault_instance_autodetect(
+        web3,
+        vault_address="0xb74760fd26400030620027dd29d19d74d514700e",
+    )
+
+    assert isinstance(vault, GearboxVault)
+    assert vault.get_protocol_name() == "Gearbox"
+    assert vault.features == {ERC4626Feature.gearbox_like}
+
+    # Gearbox has zero fees for passive lenders (internalised in share price)
+    assert vault.get_management_fee("latest") == 0.0
+    assert vault.get_performance_fee("latest") == 0.0
+    assert vault.has_custom_fees() is False
+
+    # Check vault link
+    assert vault.get_link() == "https://app.gearbox.fi/"
+
+    # Check risk level
+    assert vault.get_risk() == VaultTechnicalRisk.low


### PR DESCRIPTION
## Summary

- Add support for Gearbox Protocol ERC-4626 vaults (PoolV3 contracts)
- Auto-detection via `contractType()` returning "POOL" as bytes32
- Risk level: low (multiple ChainSecurity audits, active bug bounty)
- Fee mode: internalised_skimming (fees baked into share price via borrower/lender spread)

Protocol: Gearbox
Homepage: https://gearbox.finance/
GitHub: https://github.com/Gearbox-protocol/core-v3
Docs: https://docs.gearbox.finance/
Example contract: https://plasmascan.to/address/0xb74760fd26400030620027dd29d19d74d514700e

🤖 Generated with [Claude Code](https://claude.com/claude-code)