### PR TITLE
feat: Add Mainstreet Finance vault protocol support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Current
 
+- Add: New protocol: Mainstreet Finance - synthetic USD stablecoin ecosystem on Sonic (2026-01-05)
 - Add: New protocol: Gearbox - composable leverage protocol lending pools (2026-01-05)
 - Add: New vault type: Maple Finance AQRU Pool - Real-World Receivables vault (2026-01-05)
 - Add: New protocol: Spectra USDN Wrapper - ERC4626 wrapper for WUSDN (SmarDex) (2026-01-05)

--- a/docs/protocol-research/mainstreet-finance-0xc7990369da608c2f4903715e3bd22f2970536c29.md
+++ b/docs/protocol-research/mainstreet-finance-0xc7990369da608c2f4903715e3bd22f2970536c29.md
@@ -1,0 +1,104 @@
+# Mainstreet Finance - smsUSD (Staked msUSD)
+
+## Basic information
+
+- **Chain**: Sonic
+- **Address**: `0xc7990369DA608C2F4903715E3bD22f2970536C29`
+- **Contract name**: smsUSD Token (StakedmsUSD)
+- **Contract type**: ERC-4626 vault (upgradeable proxy - ERC-1967)
+- **Explorer link**: https://sonicscan.org/address/0xc7990369DA608C2F4903715E3bD22f2970536C29
+- **Protocol name**: Mainstreet Finance (Main Street)
+- **Deployer**: `0xe0f9d2797082797bb7361c6e26b42d68c9da5c56` (Mainstreet: Deployer)
+
+## Protocol links
+
+- **Website**: https://mainstreet.finance/
+- **Documentation**: https://mainstreet-finance.gitbook.io/mainstreet.finance
+- **Twitter/X**: https://x.com/Main_St_Finance
+- **GitHub repository**: https://github.com/Mainstreet-Labs/mainstreet-core
+- **DefiLlama**: https://defillama.com/stablecoin/main-street-usd
+
+## Contract addresses (Sonic - Legacy)
+
+| Contract | Address |
+|----------|---------|
+| msUSDV2 Token | `0xE5Fb2Ed6832deF99ddE57C0b9d9A56537C89121D` |
+| smsUSD Token | `0xc7990369DA608C2F4903715E3bD22f2970536C29` |
+| msUSDSilo | `0xecC73952d38E98D37Cb0151615dFDB73af65FF6c` |
+| Mint/Redeem | `0xb1E423c251E989bd4e49228eF55AC4747D63F54D` |
+
+## Contract addresses (Sonic - Current)
+
+| Contract | Address |
+|----------|---------|
+| msUSDV2 | `0x4ba01f22827018b4772CD326C7627FB4956A7C00` |
+| Minter | `0x70C0c12fBb3acFFf8E48aBf027436971cF2Ade14` |
+| msY | `0x890A5122Aa1dA30fEC4286DE7904Ff808F0bd74A` |
+| msYBridger | `0x22eB4e61FE4D4e31113979e8b1F4377D46bc98F2` |
+| msUSDSilo | `0x6f188821283923953121f35d74E69a5e73EA6871` |
+| FeeSilo | `0x6665efDe9f1916a9e16f7f955375ecD392b98B81` |
+| CustodianManager | `0x4cC94169605069DDf82C815493Cf6048f1935D0A` |
+| USDC Oracle | `0x098e47096856eb292D8B2D379b74E987E23CD2Af` |
+
+## Protocol overview
+
+Main Street Finance is a synthetic USD stablecoin ecosystem built on multi-asset collateralisation. The protocol delivers institutional-grade delta-neutral yield strategies through a dual-token system:
+
+- **msUSD**: The base synthetic stablecoin (non-yield-bearing), always redeemable 1:1 for USDC
+- **smsUSD**: The staked version of msUSD that earns yield from protocol trading strategies
+
+### How it works
+
+1. Users deposit USDC to mint msUSD
+2. msUSD can be staked into smsUSD (an ERC-4626 vault) to earn yield
+3. The underlying USDC is deployed into options arbitrage strategies (CME index box spreads)
+4. Yields are distributed to smsUSD holders through automatic exchange rate appreciation
+
+### Key features
+
+- **Cross-chain**: Built on LayerZero's OFT standard for omnichain functionality
+- **Cooldown system**: Configurable withdrawal delay (currently 7 days default, max 90 days)
+- **KYC required**: Users must be whitelisted to mint msUSD
+
+## Fee information
+
+### Protocol fees (deducted from gross yields)
+
+| Fee | Percentage |
+|-----|------------|
+| Insurance fund | 10% |
+| Treasury | 10% |
+| User distribution | 80% |
+
+### Smart contract fees
+
+- **taxRate**: Configurable percentage (out of 1000) sent to feeSilo upon reward distribution
+- **Mint tax**: Configurable fee applied during msUSD minting
+- **coverageRatio**: Default 1e18 (100%), can be reduced in undercollateralised scenarios
+
+## Audit reports
+
+### WatchPug Security Audit 1 (July 2025)
+- **Scope**: Mainstreet v2 smart contract system
+- **Findings**: 11 total (1 medium, 4 low, 6 informational)
+- **Status**: 4 fixed, 7 acknowledged
+- **PDF**: [Mainstreet_v2_Audit_Report_by_WatchPug.pdf](https://2732132553-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FvwA4hjA4e9xA076Qn9YB%2Fuploads%2FAj3iL1Prv4DjvzSyYQc0%2FMainstreet_v2_Audit_Report_by_WatchPug.pdf)
+- **Audited commit**: https://github.com/Mainstreet-Labs/mainstreet-core/commit/65af88a4bca55696cf5cb052363c5f91b9a6b0a5
+
+### WatchPug Security Audit 2 (December 2025)
+- **Scope**: StakedmsUSD and msYBridger
+- **PDF**: [Mainstreet_StakedmsUSD_&_msYBridger_Audit_Report_by_WatchPug_rev2.pdf](https://2732132553-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FvwA4hjA4e9xA076Qn9YB%2Fuploads%2FAJagbBCXLwuilwiGIzx6%2FMainstreet_StakedmsUSD_%26_msYBridger_Audit_Report_by_WatchPug_rev%202.pdf)
+
+## Technical notes
+
+- The smsUSD contract (StakedmsUSD) is an ERC-4626 liquid staking vault
+- Uses UUPS upgradeable proxy pattern (OpenZeppelin ERC-1967)
+- Minimum shares requirement (MIN_SHARES = 1 ether) for donation attack protection
+- Compiled with Solidity v0.8.20, 200 optimisation runs, Shanghai EVM
+
+## Notes
+
+- Smart contracts are developed by Mainstreet Labs (https://github.com/Mainstreet-Labs)
+- The smsUSD token at `0xc7990369DA608C2F4903715E3bD22f2970536C29` is listed as a "Legacy" contract in the documentation; current contracts may use different addresses
+- Protocol is similar to Ethena but uses options arbitrage instead of basis trading for yield generation
+- Active integrations with Pendle, Beets V3, and other Sonic DeFi protocols

--- a/docs/source/vaults/index.rst
+++ b/docs/source/vaults/index.rst
@@ -52,6 +52,7 @@ Supported protocols
    lagoon/index
    liquidity_royalty/index
    llamma/index
+   mainstreet/index
    maple/index
    nashpoint/index
    plutus/index

--- a/docs/source/vaults/mainstreet/index.rst
+++ b/docs/source/vaults/mainstreet/index.rst
@@ -1,0 +1,34 @@
+Mainstreet Finance API
+----------------------
+
+`Mainstreet Finance <https://mainstreet.finance/>`__ integration.
+
+Mainstreet Finance is a synthetic USD stablecoin ecosystem built on multi-asset
+collateralisation on the Sonic blockchain. The protocol delivers institutional-grade
+delta-neutral yield strategies through a dual-token system - msUSD (the synthetic
+stablecoin) and smsUSD (the staked version that earns yield from options arbitrage
+strategies).
+
+Users deposit USDC to mint msUSD, which can then be staked into smsUSD to earn
+yield. The underlying collateral is deployed into CME index box spreads and options
+arbitrage strategies, with profits distributed to smsUSD holders.
+
+Key features:
+
+- 20% protocol fee on yields (10% to insurance fund, 10% to treasury)
+- 80% of yields distributed to smsUSD holders
+- Governance-configurable cooldown period for withdrawals (up to 90 days, default 7 days)
+- Cross-chain functionality via LayerZero OFT standard
+
+- `Homepage <https://mainstreet.finance/>`__
+- `Documentation <https://mainstreet-finance.gitbook.io/mainstreet.finance>`__
+- `GitHub <https://github.com/Mainstreet-Labs/mainstreet-core>`__
+- `Twitter <https://x.com/Main_St_Finance>`__
+- `smsUSD vault contract on Sonicscan <https://sonicscan.org/address/0xc7990369DA608C2F4903715E3bD22f2970536C29>`__ (the only ERC-4626 vault; msY token is a LayerZero satellite, not a vault)
+
+
+.. autosummary::
+   :toctree: _autosummary_mainstreet
+   :recursive:
+
+   eth_defi.erc_4626.vault_protocol.mainstreet.vault

--- a/eth_defi/abi/mainstreet/StakedmsUSD.json
+++ b/eth_defi/abi/mainstreet/StakedmsUSD.json
@@ -1,0 +1,318 @@
+[
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{"internalType": "string", "name": "", "type": "string"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{"internalType": "string", "name": "", "type": "string"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{"internalType": "uint8", "name": "", "type": "uint8"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "address", "name": "account", "type": "address"}],
+    "name": "balanceOf",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "asset",
+    "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalAssets",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "uint256", "name": "shares", "type": "uint256"}],
+    "name": "convertToAssets",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "uint256", "name": "assets", "type": "uint256"}],
+    "name": "convertToShares",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "address", "name": "", "type": "address"}],
+    "name": "maxDeposit",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "address", "name": "", "type": "address"}],
+    "name": "maxMint",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "address", "name": "owner", "type": "address"}],
+    "name": "maxRedeem",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "address", "name": "owner", "type": "address"}],
+    "name": "maxWithdraw",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "uint256", "name": "assets", "type": "uint256"}],
+    "name": "previewDeposit",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "uint256", "name": "shares", "type": "uint256"}],
+    "name": "previewMint",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "uint256", "name": "shares", "type": "uint256"}],
+    "name": "previewRedeem",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "uint256", "name": "assets", "type": "uint256"}],
+    "name": "previewWithdraw",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {"internalType": "uint256", "name": "assets", "type": "uint256"},
+      {"internalType": "address", "name": "receiver", "type": "address"}
+    ],
+    "name": "deposit",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {"internalType": "uint256", "name": "shares", "type": "uint256"},
+      {"internalType": "address", "name": "receiver", "type": "address"}
+    ],
+    "name": "mint",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {"internalType": "uint256", "name": "assets", "type": "uint256"},
+      {"internalType": "address", "name": "receiver", "type": "address"},
+      {"internalType": "address", "name": "owner", "type": "address"}
+    ],
+    "name": "withdraw",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {"internalType": "uint256", "name": "shares", "type": "uint256"},
+      {"internalType": "address", "name": "receiver", "type": "address"},
+      {"internalType": "address", "name": "owner", "type": "address"}
+    ],
+    "name": "redeem",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "cooldownDuration",
+    "outputs": [{"internalType": "uint24", "name": "", "type": "uint24"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "taxRate",
+    "outputs": [{"internalType": "uint16", "name": "", "type": "uint16"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "coverageRatio",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "depositsEnabled",
+    "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "silo",
+    "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewarder",
+    "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "feeSilo",
+    "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastDistributionTimestamp",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "address", "name": "", "type": "address"}],
+    "name": "cooldowns",
+    "outputs": [
+      {"internalType": "uint104", "name": "cooldownEnd", "type": "uint104"},
+      {"internalType": "uint152", "name": "underlyingAmount", "type": "uint152"}
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MIN_SHARES",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_COOLDOWN_DURATION",
+    "outputs": [{"internalType": "uint24", "name": "", "type": "uint24"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {"internalType": "uint256", "name": "assets", "type": "uint256"},
+      {"internalType": "address", "name": "owner", "type": "address"}
+    ],
+    "name": "cooldownAssets",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {"internalType": "uint256", "name": "shares", "type": "uint256"},
+      {"internalType": "address", "name": "owner", "type": "address"}
+    ],
+    "name": "cooldownShares",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "address", "name": "receiver", "type": "address"}],
+    "name": "unstake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {"internalType": "address", "name": "owner", "type": "address"},
+      {"internalType": "address", "name": "spender", "type": "address"}
+    ],
+    "name": "allowance",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {"internalType": "address", "name": "spender", "type": "address"},
+      {"internalType": "uint256", "name": "amount", "type": "uint256"}
+    ],
+    "name": "approve",
+    "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {"internalType": "address", "name": "to", "type": "address"},
+      {"internalType": "uint256", "name": "amount", "type": "uint256"}
+    ],
+    "name": "transfer",
+    "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {"internalType": "address", "name": "from", "type": "address"},
+      {"internalType": "address", "name": "to", "type": "address"},
+      {"internalType": "uint256", "name": "amount", "type": "uint256"}
+    ],
+    "name": "transferFrom",
+    "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/eth_defi/data/vaults/mainstreet-finance.yaml
+++ b/eth_defi/data/vaults/mainstreet-finance.yaml
@@ -1,0 +1,42 @@
+name: Mainstreet Finance
+slug: mainstreet-finance
+short_description: |
+  Synthetic USD stablecoin ecosystem with options arbitrage yield strategies.
+long_description: |
+  Mainstreet Finance is a synthetic USD stablecoin ecosystem built on multi-asset
+  collateralisation on the Sonic blockchain. The protocol delivers institutional-grade
+  delta-neutral yield strategies through a dual-token system - msUSD (the synthetic
+  stablecoin) and smsUSD (the staked version that earns yield from options arbitrage
+  strategies).
+
+  Users deposit USDC to mint msUSD, which can then be staked into smsUSD to earn
+  yield. The underlying collateral is deployed into CME index box spreads and options
+  arbitrage strategies, with profits distributed to smsUSD holders.
+
+  Key features:
+
+  - Dual-token system: msUSD (non-yield-bearing) and smsUSD (yield-bearing)
+  - Yield from institutional-grade options arbitrage strategies
+  - Cross-chain functionality via LayerZero OFT standard
+  - Governance-configurable cooldown period for withdrawals (up to 90 days, default 7 days)
+fee_description: |
+  20% protocol fee on gross yields:
+  - 10% to insurance fund
+  - 10% to treasury
+  - 80% distributed to smsUSD holders
+
+  No management fees, deposit fees, or withdrawal fees at the smart contract level.
+links:
+  homepage: https://mainstreet.finance/
+  app: https://mainstreet.finance/
+  twitter: https://x.com/Main_St_Finance
+  github: https://github.com/Mainstreet-Labs/mainstreet-core
+  documentation: https://mainstreet-finance.gitbook.io/mainstreet.finance
+  defillama: https://defillama.com/stablecoin/main-street-usd
+  audits: https://mainstreet-finance.gitbook.io/mainstreet.finance/audits/watchpug-security-audit-1
+  fees: https://mainstreet-finance.gitbook.io/mainstreet.finance/returns-calculation-and-distribution
+  trading_strategy:
+  integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/mainstreet/index.html
+example_smart_contracts:
+  # smsUSD is the only ERC-4626 vault; msY (0x890A5122Aa1dA30fEC4286DE7904Ff808F0bd74A) is a LayerZero satellite token, not a vault
+  - https://sonicscan.org/address/0xc7990369DA608C2F4903715E3bD22f2970536C29

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -16,7 +16,9 @@ from web3.types import BlockIdentifier
 
 from eth_defi.abi import ZERO_ADDRESS_BYTES, ZERO_ADDRESS_STR
 from eth_defi.erc_4626.core import ERC4626Feature
-from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult, read_multicall_chunked
+from eth_defi.event_reader.multicall_batcher import (EncodedCall,
+                                                     EncodedCallResult,
+                                                     read_multicall_chunked)
 from eth_defi.event_reader.web3factory import Web3Factory
 from eth_defi.vault.base import VaultBase, VaultSpec
 from eth_defi.vault.risk import BROKEN_VAULT_CONTRACTS
@@ -978,7 +980,8 @@ def create_vault_instance(
 
         return D2Vault(web3, spec, token_cache=token_cache, features=features)
     elif ERC4626Feature.untangled_like in features:
-        from eth_defi.erc_4626.vault_protocol.untangle.vault import UntangleVault
+        from eth_defi.erc_4626.vault_protocol.untangle.vault import \
+            UntangleVault
 
         return UntangleVault(web3, spec, token_cache=token_cache, features=features)
     elif ERC4626Feature.cap_like in features:
@@ -991,7 +994,8 @@ def create_vault_instance(
 
         return FoxifyVault(web3, spec, token_cache=token_cache, features=features)
     elif ERC4626Feature.liquidity_royalty_like in features:
-        from eth_defi.erc_4626.vault_protocol.liquidity_royalty.vault import LiquidityRoyalyJuniorVault
+        from eth_defi.erc_4626.vault_protocol.liquidity_royalty.vault import \
+            LiquidityRoyalyJuniorVault
 
         return LiquidityRoyalyJuniorVault(web3, spec, token_cache=token_cache, features=features)
     elif ERC4626Feature.csigma_like in features:
@@ -1004,7 +1008,8 @@ def create_vault_instance(
         return SparkVault(web3, spec, token_cache=token_cache, features=features)
     elif ERC4626Feature.yearn_morpho_compounder_like in features:
         # Yearn V3 vault with Morpho Compounder strategy
-        from eth_defi.erc_4626.vault_protocol.yearn.morpho_compounder import YearnMorphoCompounderStrategy
+        from eth_defi.erc_4626.vault_protocol.yearn.morpho_compounder import \
+            YearnMorphoCompounderStrategy
 
         return YearnMorphoCompounderStrategy(web3, spec, token_cache=token_cache, features=features)
     elif ERC4626Feature.yearn_v3_like in features or ERC4626Feature.yearn_tokenised_strategy in features:
@@ -1019,17 +1024,20 @@ def create_vault_instance(
         return GoatVault(web3, spec, token_cache=token_cache, features=features)
     elif ERC4626Feature.usdai_like in features:
         # Both of these have fees internatilised
-        from eth_defi.erc_4626.vault_protocol.usdai.vault import StakedUSDaiVault
+        from eth_defi.erc_4626.vault_protocol.usdai.vault import \
+            StakedUSDaiVault
 
         return StakedUSDaiVault(web3, spec, token_cache=token_cache, features=features)
     elif ERC4626Feature.autopool_like in features:
         # Both of these have fees internatilised
-        from eth_defi.erc_4626.vault_protocol.autopool.vault import AutoPoolVault
+        from eth_defi.erc_4626.vault_protocol.autopool.vault import \
+            AutoPoolVault
 
         return AutoPoolVault(web3, spec, token_cache=token_cache, features=features)
     elif ERC4626Feature.nashpoint_like in features:
         # Both of these have fees internatilised
-        from eth_defi.erc_4626.vault_protocol.nashpoint.vault import NashpointNodeVault
+        from eth_defi.erc_4626.vault_protocol.nashpoint.vault import \
+            NashpointNodeVault
 
         return NashpointNodeVault(web3, spec, token_cache=token_cache, features=features)
 
@@ -1059,7 +1067,8 @@ def create_vault_instance(
 
     elif ERC4626Feature.superform_like in features:
         # Both of these have fees internatilised
-        from eth_defi.erc_4626.vault_protocol.superform.vault import SuperformVault
+        from eth_defi.erc_4626.vault_protocol.superform.vault import \
+            SuperformVault
 
         return SuperformVault(web3, spec, token_cache=token_cache, features=features)
 
@@ -1088,12 +1097,14 @@ def create_vault_instance(
         return SyrupVault(web3, spec, token_cache=token_cache, features=features)
 
     elif ERC4626Feature.maple_aqru_like in features:
-        from eth_defi.erc_4626.vault_protocol.maple.aqru_vault import AQRUPoolVault
+        from eth_defi.erc_4626.vault_protocol.maple.aqru_vault import \
+            AQRUPoolVault
 
         return AQRUPoolVault(web3, spec, token_cache=token_cache, features=features)
 
     elif ERC4626Feature.centrifuge_like in features:
-        from eth_defi.erc_4626.vault_protocol.centrifuge.vault import CentrifugeVault
+        from eth_defi.erc_4626.vault_protocol.centrifuge.vault import \
+            CentrifugeVault
 
         return CentrifugeVault(web3, spec, token_cache=token_cache, features=features)
 
@@ -1108,12 +1119,14 @@ def create_vault_instance(
         return USSDVault(web3, spec, token_cache=token_cache, features=features)
 
     elif ERC4626Feature.term_finance_like in features:
-        from eth_defi.erc_4626.vault_protocol.term_finance.vault import TermFinanceVault
+        from eth_defi.erc_4626.vault_protocol.term_finance.vault import \
+            TermFinanceVault
 
         return TermFinanceVault(web3, spec, token_cache=token_cache, features=features)
 
     elif ERC4626Feature.zerolend_like in features:
-        from eth_defi.erc_4626.vault_protocol.zerolend.vault import ZeroLendVault
+        from eth_defi.erc_4626.vault_protocol.zerolend.vault import \
+            ZeroLendVault
 
         return ZeroLendVault(web3, spec, token_cache=token_cache, features=features)
 
@@ -1123,12 +1136,14 @@ def create_vault_instance(
         return RoycoVault(web3, spec, token_cache=token_cache, features=features)
 
     elif ERC4626Feature.eth_strategy_like in features:
-        from eth_defi.erc_4626.vault_protocol.eth_strategy.vault import EthStrategyVault
+        from eth_defi.erc_4626.vault_protocol.eth_strategy.vault import \
+            EthStrategyVault
 
         return EthStrategyVault(web3, spec, token_cache=token_cache, features=features)
 
     elif ERC4626Feature.yuzu_money_like in features:
-        from eth_defi.erc_4626.vault_protocol.yuzu_money.vault import YuzuMoneyVault
+        from eth_defi.erc_4626.vault_protocol.yuzu_money.vault import \
+            YuzuMoneyVault
 
         return YuzuMoneyVault(web3, spec, token_cache=token_cache, features=features)
 
@@ -1138,7 +1153,8 @@ def create_vault_instance(
         return AlturaVault(web3, spec, token_cache=token_cache, features=features)
 
     elif ERC4626Feature.spectra_usdn_wrapper_like in features:
-        from eth_defi.erc_4626.vault_protocol.spectra.wusdn_vault import SpectraUSDNWrapperVault
+        from eth_defi.erc_4626.vault_protocol.spectra.wusdn_vault import \
+            SpectraUSDNWrapperVault
 
         return SpectraUSDNWrapperVault(web3, spec, token_cache=token_cache, features=features)
 
@@ -1146,6 +1162,12 @@ def create_vault_instance(
         from eth_defi.erc_4626.vault_protocol.gearbox.vault import GearboxVault
 
         return GearboxVault(web3, spec, token_cache=token_cache, features=features)
+
+    elif ERC4626Feature.mainstreet_like in features:
+        from eth_defi.erc_4626.vault_protocol.mainstreet.vault import \
+            MainstreetVault
+
+        return MainstreetVault(web3, spec, token_cache=token_cache, features=features)
 
     else:
         # Generic ERC-4626 without fee data
@@ -1238,6 +1260,9 @@ HARDCODED_PROTOCOLS = {
     # Spectra Finance - ERC4626 wrapper for WUSDN (SmarDex delta-neutral synthetic dollar)
     # https://etherscan.io/address/0x06a491e3efee37eb191d0434f54be6e42509f9d3
     "0x06a491e3efee37eb191d0434f54be6e42509f9d3": {ERC4626Feature.spectra_usdn_wrapper_like},
+    # Mainstreet Finance - smsUSD (legacy) vault on Sonic
+    # https://sonicscan.org/address/0xc7990369DA608C2F4903715E3bD22f2970536C29
+    "0xc7990369da608c2f4903715e3bd22f2970536c29": {ERC4626Feature.mainstreet_like},
 }
 
 for a in HARDCODED_PROTOCOLS.keys():

--- a/eth_defi/erc_4626/core.py
+++ b/eth_defi/erc_4626/core.py
@@ -383,6 +383,12 @@ class ERC4626Feature(enum.Enum):
     #: https://gearbox.finance/
     gearbox_like = "gearbox_like"
 
+    #: Mainstreet Finance
+    #:
+    #: Synthetic USD stablecoin ecosystem with smsUSD staking vault on Sonic.
+    #: https://mainstreet.finance/
+    mainstreet_like = "mainstreet_like"
+
 
 def get_vault_protocol_name(features: set[ERC4626Feature]) -> str:
     """Deduct vault protocol name based on Vault smart contract features.
@@ -551,6 +557,9 @@ def get_vault_protocol_name(features: set[ERC4626Feature]) -> str:
 
     elif ERC4626Feature.gearbox_like in features:
         return "Gearbox"
+
+    elif ERC4626Feature.mainstreet_like in features:
+        return "Mainstreet Finance"
 
     # No idea
     if ERC4626Feature.erc_7540_like in features:

--- a/eth_defi/erc_4626/vault_protocol/mainstreet/__init__.py
+++ b/eth_defi/erc_4626/vault_protocol/mainstreet/__init__.py
@@ -1,0 +1,1 @@
+"""Mainstreet Finance protocol integration."""

--- a/eth_defi/erc_4626/vault_protocol/mainstreet/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/mainstreet/vault.py
@@ -1,0 +1,100 @@
+"""Mainstreet Finance protocol vault support.
+
+Mainstreet Finance is a synthetic USD stablecoin ecosystem built on multi-asset
+collateralisation. The protocol delivers institutional-grade delta-neutral yield
+strategies through a dual-token system - msUSD (the synthetic stablecoin) and
+smsUSD (the staked version that earns yield from options arbitrage strategies).
+
+Key features:
+
+- 20% protocol fee on yields (10% to insurance fund, 10% to treasury)
+- 80% of yields distributed to smsUSD holders
+- Cooldown period of up to 90 days for withdrawals (configurable by governance)
+- Yield comes from CME index box spreads and options arbitrage strategies
+
+- Homepage: https://mainstreet.finance/
+- Documentation: https://mainstreet-finance.gitbook.io/mainstreet.finance
+- GitHub: https://github.com/Mainstreet-Labs/mainstreet-core
+- Twitter: https://x.com/Main_St_Finance
+- Legacy smsUSD contract: https://sonicscan.org/address/0xc7990369DA608C2F4903715E3bD22f2970536C29
+"""
+
+import datetime
+import logging
+
+from eth_typing import BlockIdentifier
+
+from eth_defi.erc_4626.vault import ERC4626Vault
+
+logger = logging.getLogger(__name__)
+
+
+class MainstreetVault(ERC4626Vault):
+    """Mainstreet Finance protocol vault support.
+
+    Mainstreet smsUSD vault allows users to stake msUSD and earn yield from
+    protocol options arbitrage strategies (CME index box spreads). The vault
+    implements a flexible cooldown mechanism controlled by governance.
+
+    - Homepage: https://mainstreet.finance/
+    - Documentation: https://mainstreet-finance.gitbook.io/mainstreet.finance
+    - GitHub: https://github.com/Mainstreet-Labs/mainstreet-core
+    - Twitter: https://x.com/Main_St_Finance
+    - Legacy smsUSD contract: https://sonicscan.org/address/0xc7990369DA608C2F4903715E3bD22f2970536C29
+    """
+
+    def has_custom_fees(self) -> bool:
+        """Whether this vault has deposit/withdrawal fees.
+
+        Mainstreet smsUSD vault does not charge deposit/withdrawal fees at the
+        smart contract level.
+        """
+        return False
+
+    def get_management_fee(self, block_identifier: BlockIdentifier) -> float | None:
+        """Get the current management fee as a percent.
+
+        Mainstreet does not charge management fees. However, the protocol takes
+        20% of yields (10% insurance fund + 10% treasury).
+
+        :return:
+            0.1 = 10%
+        """
+        return 0.0
+
+    def get_performance_fee(self, block_identifier: BlockIdentifier) -> float | None:
+        """Get the current performance fee as a percent.
+
+        Mainstreet takes 20% of gross yields:
+        - 10% to insurance fund
+        - 10% to treasury
+
+        :return:
+            0.1 = 10%
+        """
+        return 0.20
+
+    def get_estimated_lock_up(self) -> datetime.timedelta | None:
+        """Get estimated lock-up period if any.
+
+        Mainstreet smsUSD vault has a governance-configurable cooldown period
+        of up to 90 days (MAX_COOLDOWN_DURATION). Default is 7 days.
+        When cooldown is enabled, users must initiate cooldownAssets/cooldownShares
+        and wait before claiming via unstake(). When cooldown is disabled
+        (duration = 0), withdrawals are instant.
+
+        This returns the default cooldown for conservative estimation.
+        The actual cooldown duration can be read from the contract.
+        """
+        return datetime.timedelta(days=7)
+
+    def get_link(self, referral: str | None = None) -> str:
+        """Get the vault's web UI link.
+
+        :param referral:
+            Optional referral code (not used currently).
+
+        :return:
+            Link to the Mainstreet Finance app.
+        """
+        return "https://mainstreet.finance/"

--- a/eth_defi/vault/fee.py
+++ b/eth_defi/vault/fee.py
@@ -84,6 +84,7 @@ VAULT_PROTOCOL_FEE_MATRIX = {
     "Altura": VaultFeeMode.feeless,
     # Gearbox has fees internalised in share price via APY spread between borrower and lender rates
     "Gearbox": VaultFeeMode.internalised_skimming,
+    "Mainstreet Finance": None,
 }
 
 

--- a/eth_defi/vault/risk.py
+++ b/eth_defi/vault/risk.py
@@ -107,6 +107,7 @@ VAULT_PROTOCOL_RISK_MATRIX = {
     "Altura": VaultTechnicalRisk.severe,
     "Spectra": VaultTechnicalRisk.low,
     "Gearbox": VaultTechnicalRisk.low,
+    "Mainstreet Finance": None,
 }
 
 #: Particular vaults that are broken, misleading or otherwise problematic.

--- a/tests/erc_4626/vault_protocol/test_mainstreet.py
+++ b/tests/erc_4626/vault_protocol/test_mainstreet.py
@@ -1,0 +1,59 @@
+"""Test Mainstreet Finance vault metadata."""
+
+import os
+from pathlib import Path
+
+import flaky
+import pytest
+from web3 import Web3
+
+from eth_defi.erc_4626.classification import create_vault_instance_autodetect
+from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.erc_4626.vault_protocol.mainstreet.vault import MainstreetVault
+
+JSON_RPC_SONIC = os.environ.get("JSON_RPC_SONIC")
+
+pytestmark = pytest.mark.skipif(JSON_RPC_SONIC is None, reason="JSON_RPC_SONIC needed to run these tests")
+
+
+@pytest.fixture(scope="module")
+def anvil_sonic_fork(request) -> AnvilLaunch:
+    """Fork at a specific block for reproducibility."""
+    launch = fork_network_anvil(JSON_RPC_SONIC, fork_block_number=59_684_622)
+    try:
+        yield launch
+    finally:
+        launch.close()
+
+
+@pytest.fixture(scope="module")
+def web3(anvil_sonic_fork):
+    web3 = create_multi_provider_web3(anvil_sonic_fork.json_rpc_url)
+    return web3
+
+
+@flaky.flaky
+def test_mainstreet_legacy_smsUSD(
+    web3: Web3,
+    tmp_path: Path,
+):
+    """Read Mainstreet Finance legacy smsUSD vault metadata."""
+
+    vault = create_vault_instance_autodetect(
+        web3,
+        vault_address="0xc7990369DA608C2F4903715E3bD22f2970536C29",
+    )
+
+    assert isinstance(vault, MainstreetVault)
+    assert vault.get_protocol_name() == "Mainstreet Finance"
+    assert vault.features == {ERC4626Feature.mainstreet_like}
+
+    # Mainstreet has 20% performance fee (10% insurance + 10% treasury)
+    assert vault.get_management_fee("latest") == 0.0
+    assert vault.get_performance_fee("latest") == 0.20
+    assert vault.has_custom_fees() is False
+
+    # Check vault link
+    assert vault.get_link() == "https://mainstreet.finance/"


### PR DESCRIPTION
## Summary

- Add support for Mainstreet Finance, a synthetic USD stablecoin ecosystem on Sonic blockchain
- Mainstreet Finance uses a dual-token system: msUSD (non-yield-bearing) and smsUSD (yield-bearing ERC-4626 vault)
- The smsUSD vault earns yield from options arbitrage strategies with 20% performance fee and 7-day default cooldown

## Changes

- Add `MainstreetVault` class with protocol-specific fee and cooldown handling
- Add `mainstreet_like` feature flag to `ERC4626Feature` enum
- Add to `HARDCODED_PROTOCOLS` (single vault protocol with only one ERC-4626 contract)
- Add ABI, tests, documentation, and metadata YAML

## Links

- Homepage: https://mainstreet.finance/
- Documentation: https://mainstreet-finance.gitbook.io/mainstreet.finance
- GitHub: https://github.com/Mainstreet-Labs/mainstreet-core
- smsUSD vault: https://sonicscan.org/address/0xc7990369DA608C2F4903715E3bD22f2970536C29

🤖 Generated with [Claude Code](https://claude.com/claude-code)