### PR TITLE
feat: Add CAP AaveV3Lender USDC vault on Ethereum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Current
 
 - Add: New protocol: [YieldFi](https://yield.fi/) - Web3 asset management platform with vyToken vaults (2026-01-07)
+- Add: New vault type: [CAP](https://tradingstrategy.ai/trading-view/vaults/protocols/cap) AaveV3Lender USDC vault on Ethereum (2026-01-07)
 
 # 0.38
 

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -1187,6 +1187,9 @@ def create_vault_instance_autodetect(
 HARDCODED_PROTOCOLS = {
     # CAP - Covered Agent Protocol
     "0x3ed6aa32c930253fc990de58ff882b9186cd0072": {ERC4626Feature.cap_like},
+    # CAP - Covered Agent Protocol - AaveV3Lender USDC vault on Ethereum
+    # https://etherscan.io/address/0x7d7f72d393f242da6e22d3b970491c06742984ff
+    "0x7d7f72d393f242da6e22d3b970491c06742984ff": {ERC4626Feature.cap_like},
     # Foxify - Sonic chain
     "0x3ccff8c929b497c1ff96592b8ff592b45963e732": {ERC4626Feature.foxify_like},
     # Liquidity Royalty Tranching - Junior Vault on Berachain

--- a/tests/erc_4626/vault_protocol/test_cap.py
+++ b/tests/erc_4626/vault_protocol/test_cap.py
@@ -53,3 +53,24 @@ def test_cap_vault(
     assert vault.get_management_fee("latest") == 0.0
     assert vault.get_performance_fee("latest") == 0.0
     assert vault.has_custom_fees() is False
+
+
+@flaky.flaky
+def test_cap_aave_v3_lender_vault(
+    web3: Web3,
+    tmp_path: Path,
+):
+    """Read CAP AaveV3Lender USDC vault metadata."""
+
+    vault = create_vault_instance_autodetect(
+        web3,
+        vault_address="0x7d7f72d393f242da6e22d3b970491c06742984ff",
+    )
+    assert vault.features == {ERC4626Feature.cap_like}
+    assert isinstance(vault, CAPVault)
+    assert vault.get_protocol_name() == "CAP"
+
+    # CAP vaults have fees internalised
+    assert vault.get_management_fee("latest") == 0.0
+    assert vault.get_performance_fee("latest") == 0.0
+    assert vault.has_custom_fees() is False


### PR DESCRIPTION
## Summary

- Add CAP AaveV3Lender USDC vault (`0x7d7f72d393f242da6e22d3b970491c06742984ff`) to hardcoded protocols
- Add test case for the new vault
- Update CHANGELOG

Example contract: https://etherscan.io/address/0x7d7f72d393f242da6e22d3b970491c06742984ff

🤖 Generated with [Claude Code](https://claude.com/claude-code)