### PR TITLE
feat: Add backwards-compatible wrappers for eth_defi.ipor

### DIFF
--- a/eth_defi/ipor/__init__.py
+++ b/eth_defi/ipor/__init__.py
@@ -1,0 +1,15 @@
+"""Backwards-compatible import shim for eth_defi.ipor.
+
+This module has been moved to eth_defi.erc_4626.vault_protocol.ipor.
+This shim provides backwards compatibility for existing code.
+"""
+
+import warnings
+
+warnings.warn(
+    "eth_defi.ipor is deprecated, use eth_defi.erc_4626.vault_protocol.ipor instead",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+from eth_defi.erc_4626.vault_protocol.ipor import *  # noqa: F401, F403

--- a/eth_defi/ipor/vault.py
+++ b/eth_defi/ipor/vault.py
@@ -1,0 +1,15 @@
+"""Backwards-compatible import shim for eth_defi.ipor.vault.
+
+This module has been moved to eth_defi.erc_4626.vault_protocol.ipor.vault.
+This shim provides backwards compatibility for existing code.
+"""
+
+import warnings
+
+warnings.warn(
+    "eth_defi.ipor.vault is deprecated, use eth_defi.erc_4626.vault_protocol.ipor.vault instead",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+from eth_defi.erc_4626.vault_protocol.ipor.vault import *  # noqa: F401, F403


### PR DESCRIPTION
## Summary

- Add deprecation shims for `eth_defi.ipor` module that redirect imports to the new location at `eth_defi.erc_4626.vault_protocol.ipor`
- Follow the same pattern as the existing `eth_defi.lagoon` backwards-compatible wrappers
- Include wrapper for both package-level imports and the `vault` submodule

🤖 Generated with [Claude Code](https://claude.com/claude-code)