### PR TITLE
fix: Lagoon risk level

### DIFF
--- a/eth_defi/vault/risk.py
+++ b/eth_defi/vault/risk.py
@@ -61,7 +61,7 @@ VAULT_PROTOCOL_RISK_MATRIX = {
     "Euler": VaultTechnicalRisk.negligible,
     "Morpho": VaultTechnicalRisk.negligible,
     "Enzyme": VaultTechnicalRisk.negligible,
-    "Lagoon": VaultTechnicalRisk.minimal,
+    "Lagoon Finance": VaultTechnicalRisk.minimal,
     "IPOR": VaultTechnicalRisk.minimal,
     "Velvet Capital": VaultTechnicalRisk.high,
     "Umami": VaultTechnicalRisk.severe,


### PR DESCRIPTION
## Summary

- Fixed Lagoon protocol name in risk matrix from `"Lagoon"` to `"Lagoon Finance"` to match the value returned by `get_vault_protocol_name()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)