### PR TITLE
fix: Add get_link() method for Untangle Finance vault

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/untangle/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/untangle/vault.py
@@ -60,3 +60,14 @@ class UntangleVault(ERC7540Vault):
 
     def get_performance_fee(self, block_identifier: BlockIdentifier) -> float | None:
         return 0.0
+
+    def get_link(self, referral: str | None = None) -> str:
+        """Get the vault's web UI link.
+
+        :param referral:
+            Optional referral code (not used currently).
+
+        :return:
+            Link to the Untangle Finance app.
+        """
+        return "https://app.untangled.finance/"


### PR DESCRIPTION
## Summary
- Add `get_link()` method to `UntangleVault` class that returns `https://app.untangled.finance/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)