### PR TITLE
feat: Add Mainstreet Finance Staked msUSD vault on Ethereum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Current
 
+- Add: New vault type: [Mainstreet Finance](https://tradingstrategy.ai/trading-view/vaults/protocols/mainstreet-finance) Staked msUSD vault on Ethereum (2026-01-12)
 - Add: New protocol: [Singularity Finance](https://singularityfinance.ai/) - AI-powered DeFi yield vaults on Base (2026-01-12)
 - Add: Ostium protocol logo assets (2026-01-08)
 - Add: Blacklist Superform vault 0x942bed98560e9b2aa0d4ec76bbda7a7e55f6b2d6 (2026-01-08)

--- a/docs/source/vaults/mainstreet/index.rst
+++ b/docs/source/vaults/mainstreet/index.rst
@@ -3,11 +3,11 @@ Mainstreet Finance API
 
 `Mainstreet Finance <https://mainstreet.finance/>`__ integration.
 
-Mainstreet Finance is a synthetic USD stablecoin ecosystem built on multi-asset
-collateralisation on the Sonic blockchain. The protocol delivers institutional-grade
-delta-neutral yield strategies through a dual-token system - msUSD (the synthetic
-stablecoin) and smsUSD (the staked version that earns yield from options arbitrage
-strategies).
+Mainstreet Finance (developed by Mainstreet Labs) is a synthetic USD stablecoin
+ecosystem built on multi-asset collateralisation. The protocol delivers
+institutional-grade delta-neutral yield strategies through a dual-token system -
+msUSD (the synthetic stablecoin) and smsUSD/Staked msUSD (the staked version that
+earns yield from options arbitrage strategies).
 
 Users deposit USDC to mint msUSD, which can then be staked into smsUSD to earn
 yield. The underlying collateral is deployed into CME index box spreads and options
@@ -24,7 +24,11 @@ Key features:
 - `Documentation <https://mainstreet-finance.gitbook.io/mainstreet.finance>`__
 - `GitHub <https://github.com/Mainstreet-Labs/mainstreet-core>`__
 - `Twitter <https://x.com/Main_St_Finance>`__
-- `smsUSD vault contract on Sonicscan <https://sonicscan.org/address/0xc7990369DA608C2F4903715E3bD22f2970536C29>`__ (the only ERC-4626 vault; msY token is a LayerZero satellite, not a vault)
+
+Vaults:
+
+- `Staked msUSD on Ethereum <https://etherscan.io/address/0x890a5122aa1da30fec4286de7904ff808f0bd74a>`__
+- `smsUSD (legacy) on Sonic <https://sonicscan.org/address/0xc7990369DA608C2F4903715E3bD22f2970536C29>`__ (msY token is a LayerZero satellite, not a vault)
 
 
 .. autosummary::

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -1309,6 +1309,9 @@ HARDCODED_PROTOCOLS = {
     # Mainstreet Finance - smsUSD (legacy) vault on Sonic
     # https://sonicscan.org/address/0xc7990369DA608C2F4903715E3bD22f2970536C29
     "0xc7990369da608c2f4903715e3bd22f2970536c29": {ERC4626Feature.mainstreet_like},
+    # Mainstreet Finance - Staked msUSD vault on Ethereum
+    # https://etherscan.io/address/0x890a5122aa1da30fec4286de7904ff808f0bd74a
+    "0x890a5122aa1da30fec4286de7904ff808f0bd74a": {ERC4626Feature.mainstreet_like},
     # YieldFi - vyUSD vault on Ethereum
     # https://etherscan.io/address/0x2e3c5e514eef46727de1fe44618027a9b70d92fc
     "0x2e3c5e514eef46727de1fe44618027a9b70d92fc": {ERC4626Feature.yieldfi_like},

--- a/eth_defi/erc_4626/vault_protocol/mainstreet/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/mainstreet/vault.py
@@ -1,9 +1,10 @@
 """Mainstreet Finance protocol vault support.
 
-Mainstreet Finance is a synthetic USD stablecoin ecosystem built on multi-asset
-collateralisation. The protocol delivers institutional-grade delta-neutral yield
-strategies through a dual-token system - msUSD (the synthetic stablecoin) and
-smsUSD (the staked version that earns yield from options arbitrage strategies).
+Mainstreet Finance (developed by Mainstreet Labs) is a synthetic USD stablecoin
+ecosystem built on multi-asset collateralisation. The protocol delivers
+institutional-grade delta-neutral yield strategies through a dual-token system -
+msUSD (the synthetic stablecoin) and smsUSD/Staked msUSD (the staked version
+that earns yield from options arbitrage strategies).
 
 Key features:
 
@@ -12,11 +13,14 @@ Key features:
 - Cooldown period of up to 90 days for withdrawals (configurable by governance)
 - Yield comes from CME index box spreads and options arbitrage strategies
 
+The smart contracts are developed by Mainstreet Labs.
+
 - Homepage: https://mainstreet.finance/
 - Documentation: https://mainstreet-finance.gitbook.io/mainstreet.finance
 - GitHub: https://github.com/Mainstreet-Labs/mainstreet-core
 - Twitter: https://x.com/Main_St_Finance
-- Legacy smsUSD contract: https://sonicscan.org/address/0xc7990369DA608C2F4903715E3bD22f2970536C29
+- Legacy smsUSD contract (Sonic): https://sonicscan.org/address/0xc7990369DA608C2F4903715E3bD22f2970536C29
+- Staked msUSD contract (Ethereum): https://etherscan.io/address/0x890a5122aa1da30fec4286de7904ff808f0bd74a
 """
 
 import datetime
@@ -29,6 +33,15 @@ from eth_defi.erc_4626.vault import ERC4626Vault
 logger = logging.getLogger(__name__)
 
 
+#: Custom vault names for Mainstreet vaults by address (lowercased)
+#:
+#: Some vaults have generic on-chain names that we override for clarity.
+MAINSTREET_VAULT_NAMES: dict[str, str] = {
+    # Ethereum Staked msUSD vault
+    "0x890a5122aa1da30fec4286de7904ff808f0bd74a": "Staked msUSD",
+}
+
+
 class MainstreetVault(ERC4626Vault):
     """Mainstreet Finance protocol vault support.
 
@@ -36,12 +49,26 @@ class MainstreetVault(ERC4626Vault):
     protocol options arbitrage strategies (CME index box spreads). The vault
     implements a flexible cooldown mechanism controlled by governance.
 
+    The smart contracts are developed by Mainstreet Labs.
+
     - Homepage: https://mainstreet.finance/
     - Documentation: https://mainstreet-finance.gitbook.io/mainstreet.finance
     - GitHub: https://github.com/Mainstreet-Labs/mainstreet-core
     - Twitter: https://x.com/Main_St_Finance
-    - Legacy smsUSD contract: https://sonicscan.org/address/0xc7990369DA608C2F4903715E3bD22f2970536C29
+    - Legacy smsUSD contract (Sonic): https://sonicscan.org/address/0xc7990369DA608C2F4903715E3bD22f2970536C29
+    - Staked msUSD contract (Ethereum): https://etherscan.io/address/0x890a5122aa1da30fec4286de7904ff808f0bd74a
     """
+
+    @property
+    def name(self) -> str:
+        """Return a human-readable name for this vault.
+
+        Uses custom names for known vaults, falls back to on-chain token name.
+        """
+        custom_name = MAINSTREET_VAULT_NAMES.get(self.vault_address.lower())
+        if custom_name:
+            return custom_name
+        return super().name
 
     def has_custom_fees(self) -> bool:
         """Whether this vault has deposit/withdrawal fees.


### PR DESCRIPTION
## Summary

- Add support for the Mainstreet Finance Staked msUSD vault on Ethereum mainnet
- Vault address: `0x890a5122aa1da30fec4286de7904ff808f0bd74a`
- Override vault name to "Staked msUSD" for clarity
- Document relationship between Mainstreet Finance and Mainstreet Labs (smart contract author)

## Changes

- Add vault to `HARDCODED_PROTOCOLS` in classification.py
- Add `MAINSTREET_VAULT_NAMES` dictionary and `name` property override in MainstreetVault
- Update documentation to list both Sonic and Ethereum vaults
- Add test `test_mainstreet_staked_msusd_ethereum`
- Update CHANGELOG

🤖 Generated with [Claude Code](https://claude.ai/code)