### PR TITLE
feat: Update Singularity Finance vault metadata and add fee reading

### DIFF
--- a/eth_defi/data/vaults/metadata/singularity-finance.yaml
+++ b/eth_defi/data/vaults/metadata/singularity-finance.yaml
@@ -18,7 +18,7 @@ links:
   github:
   documentation: https://docs.singularityfinance.ai/
   defillama: https://defillama.com/protocol/singularity-finance
-  audits:
+  audits: https://paladinsec.co/projects/singularitydao/
   fees:
   trading_strategy:
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/singularity/index.html

--- a/eth_defi/vault/fee.py
+++ b/eth_defi/vault/fee.py
@@ -90,8 +90,8 @@ VAULT_PROTOCOL_FEE_MATRIX = {
     # Curvance uses interest-based fees (up to 60% of borrower interest) which are internalised
     # Depositors don't pay explicit fees - the protocol earns from borrower interest spread
     "Curvance": VaultFeeMode.internalised_skimming,
-    # Singularity Finance fees are internalised in the share price
-    "Singularity Finance": None,
+    # Singularity Finance fees are internalised in the share price via minting shares
+    "Singularity Finance": VaultFeeMode.internalised_minting,
 }
 
 


### PR DESCRIPTION
## Summary
- Add audit link to Paladin Security (https://paladinsec.co/projects/singularitydao/)
- Set fee mode to `internalised_minting` (fees taken via minting shares to vault owner)
- Add `SingularityManager.json` ABI for manager contract
- Add `manager_contract` property to access fee configuration
- Implement `get_management_fee()` and `get_performance_fee()` methods
- Fees are read via `vault.manager().getFees()` returning basis points

🤖 Generated with [Claude Code](https://claude.com/claude-code)
