### PR TITLE
fix: Use different TVL thresholds for vault rankings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Current
 
+- Fix: Use different TVL thresholds for vault rankings - $50k for overall, $10k for chain/protocol rankings (2026-01-13)
 - Add: New protocol: [Brink](https://brink.money/) - yield-bearing vaults on Mantle with modified ERC-4626 events (2026-01-12)
 - Add: [Morpho Vault V2](https://tradingstrategy.ai/trading-view/vaults/protocols/morpho) adapter-based architecture support (2026-01-12)
 - Fix: GMX CCXT limit order tests and price sanity test flakiness - added `get_mock_oracle_price()` helper for fork tests, fixed ticker cache mutation, and updated examples to use mock oracle prices (2026-01-13)


### PR DESCRIPTION
## Summary

- Overall rankings now require minimum TVL of $50,000
- Chain and protocol rankings use minimum TVL of $10,000
- Match frontend a bit more closely

🤖 Generated with [Claude Code](https://claude.com/claude-code)