### PR TITLE
fix: Correct Brink vault event signatures for HyperSync discovery

### DIFF
--- a/eth_defi/abi/brink/IBrinkVault.json
+++ b/eth_defi/abi/brink/IBrinkVault.json
@@ -5,12 +5,30 @@
       "inputs": [
         {
           "indexed": false,
+          "internalType": "address",
+          "name": "caller",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "recipient",
+          "type": "address"
+        },
+        {
+          "indexed": false,
           "internalType": "uint256",
-          "name": "assetBalance",
+          "name": "assets",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "shares",
           "type": "uint256"
         }
       ],
-      "name": "DepositFunds",
+      "name": "Deposited",
       "type": "event"
     },
     {
@@ -18,12 +36,30 @@
       "inputs": [
         {
           "indexed": false,
+          "internalType": "address",
+          "name": "caller",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "recipient",
+          "type": "address"
+        },
+        {
+          "indexed": false,
           "internalType": "uint256",
-          "name": "assetBalance",
+          "name": "received",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "shares",
           "type": "uint256"
         }
       ],
-      "name": "WithdrawFunds",
+      "name": "Withdrawal",
       "type": "event"
     }
   ]

--- a/eth_defi/erc_4626/discovery_base.py
+++ b/eth_defi/erc_4626/discovery_base.py
@@ -95,15 +95,15 @@ def get_standard_erc_4626_vault_discovery_events(web3) -> list[Type[ContractEven
 def get_brink_vault_discovery_events(web3) -> list[Type[ContractEvent]]:
     """Get list of BrinkVault events we use in vault discovery.
 
-    BrinkVault uses modified events instead of standard ERC-4626 Deposit/Withdraw:
+    BrinkVault uses custom events instead of standard ERC-4626 Deposit/Withdraw:
 
-    - DepositFunds(uint256 assetBalance)
-    - WithdrawFunds(uint256 assetBalance)
+    - Deposited(address caller, address recipient, uint256 assets, uint256 shares)
+    - Withdrawal(address caller, address recipient, uint256 received, uint256 shares)
     """
     IBrinkVault = get_brink_vault_contract(web3)
     return [
-        IBrinkVault.events.DepositFunds,
-        IBrinkVault.events.WithdrawFunds,
+        IBrinkVault.events.Deposited,
+        IBrinkVault.events.Withdrawal,
     ]
 
 

--- a/tests/erc_4626/test_scan_brink_mantle.py
+++ b/tests/erc_4626/test_scan_brink_mantle.py
@@ -1,0 +1,82 @@
+"""Test Brink vault scanning on Mantle using HyperSync.
+
+Brink is a DeFi protocol providing yield-bearing vaults on Mantle and other chains.
+This test verifies that Brink's specialised Deposited/Withdrawal events
+are correctly picked up by the HyperSync vault scanner.
+
+- Homepage: https://brink.money/
+- App: https://brink.money/app
+- Documentation: https://doc.brink.money/
+"""
+
+import os
+
+import flaky
+import hypersync
+import pytest
+
+from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.erc_4626.hypersync_discovery import HypersyncVaultDiscover
+from eth_defi.hypersync.server import get_hypersync_server
+from eth_defi.provider.multi_provider import create_multi_provider_web3, MultiProviderWeb3Factory
+
+JSON_RPC_MANTLE = os.environ.get("JSON_RPC_MANTLE")
+HYPERSYNC_API_KEY = os.environ.get("HYPERSYNC_API_KEY")
+
+pytestmark = pytest.mark.skipif(
+    JSON_RPC_MANTLE is None or HYPERSYNC_API_KEY is None,
+    reason="JSON_RPC_MANTLE and HYPERSYNC_API_KEY needed to run these tests"
+)
+
+BRINK_VAULT_ADDRESS = "0xE12EED61E7cC36E4CF3304B8220b433f1fD6e254"
+DEPOSIT_BLOCK = 89361462  # Block with known Deposited event
+
+
+@flaky.flaky
+def test_4626_scan_brink_mantle():
+    """Test that Brink Deposited events are picked up on Mantle.
+
+    Uses HyperSync to scan for vault events and verifies:
+    - Brink vault is detected via its Deposited event
+    - Vault is correctly classified as brink_like
+    - Deposit count includes the known deposit
+
+    Reference transaction:
+    https://mantlescan.xyz/tx/0x24f657a17f3039d41141a4aa4cef01110112696fc1f88db56a3a113596482a48
+
+    Note: Scanner requires both deposit and withdrawal events to fully classify
+    a vault. Use a wider block range to capture both event types.
+    """
+    web3 = create_multi_provider_web3(JSON_RPC_MANTLE)
+    web3factory = MultiProviderWeb3Factory(JSON_RPC_MANTLE)
+
+    hypersync_url = get_hypersync_server(web3)
+    client = hypersync.HypersyncClient(
+        hypersync.ClientConfig(url=hypersync_url, bearer_token=HYPERSYNC_API_KEY)
+    )
+
+    # Use wider block range to ensure we capture both deposit and withdrawal events
+    # (scanner requires both to classify a vault as candidate)
+    start_block = DEPOSIT_BLOCK - 100_000
+    end_block = DEPOSIT_BLOCK + 100_000
+
+    vault_discover = HypersyncVaultDiscover(
+        web3,
+        web3factory,
+        client,
+    )
+
+    report = vault_discover.scan_vaults(start_block, end_block, display_progress=False)
+
+    # Verify the Brink vault was detected
+    brink_detection = report.detections.get(BRINK_VAULT_ADDRESS.lower())
+    assert brink_detection is not None, f"Brink vault {BRINK_VAULT_ADDRESS} not found in detections"
+
+    # Verify it has brink_like feature (meaning it was classified as Brink protocol)
+    assert ERC4626Feature.brink_like in brink_detection.features
+
+    # Verify deposit was counted (from Deposited event)
+    assert brink_detection.deposit_count >= 1
+
+    # Verify withdrawal was counted (from Withdrawal event)
+    assert brink_detection.redeem_count >= 1


### PR DESCRIPTION
## Summary

- Fixed incorrect Brink vault event signatures in the ABI
- The actual events emitted by Brink vaults are `Deposited(address,address,uint256,uint256)` and `Withdrawal(address,address,uint256,uint256)`, not `DepositFunds(uint256)` and `WithdrawFunds(uint256)`
- Added test to verify Brink deposit events are picked up using HyperSync on Mantle


🤖 Generated with [Claude Code](https://claude.com/claude-code)