### PR TITLE
notes: Flag LTether USDT and LUSD vaults as broken

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -241,6 +241,10 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0x942bed98560e9b2aa0d4ec76bbda7a7e55f6b2d6": (None, ZEROLEND_SUPERFORM_WITHDRAW_ONLY),
     # Euler MEV Capital USDC
     "0xa446938b0204aa4055cdfed68ddf0e0d1bab3e9e": (VaultFlag.unofficial, MISSING_IN_PROTOCOL_FRONTEND),
+    # LTether USDT
+    "0x4c8e1656e042a206eef7e8fcff99bac667e4623e": (VaultFlag.broken, BROKEN_VAULT),
+    # LUSD
+    "0x0ddb1ea478f8ef0e22c7706d2903a41e94b1299b": (VaultFlag.broken, BROKEN_VAULT),
 }
 
 for addr in VAULT_FLAGS_AND_NOTES.keys():


### PR DESCRIPTION
## Summary

- Flag vault `0x4c8e1656E042A206EEf7e8fcff99BaC667E4623e` (LTether USDT) as broken with `VaultFlag.broken`
- Flag vault `0x0ddb1ea478f8ef0e22c7706d2903a41e94b1299b` (LUSD) as broken with `VaultFlag.broken`

🤖 Generated with [Claude Code](https://claude.com/claude-code)