### PR TITLE
feat: Add Sky sDAI (Savings DAI) vault support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.39
 
+- Add: [Sky](https://tradingstrategy.ai/trading-view/vaults/protocols/sky) sDAI (Savings DAI) vault on Ethereum (2026-01-18)
 - Fix: YieldNest protocol detection now uses hardcoded address for ynRWAx vault on Ethereum, with fixed maturity date (15 Oct 2026) and vault-specific notes (2026-01-18)
 - Add: New protocol: [Sentiment](https://www.sentiment.xyz/) - decentralised leverage lending protocol with SuperPool vault aggregators on HyperEVM (2026-01-18)
 - Add: New protocol: [Hyperlend](https://hyperlend.finance/) - Wrapped HLP vault on HyperEVM for tokenised HyperLiquidity Provider (2026-01-18)

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -1628,6 +1628,9 @@ HARDCODED_PROTOCOLS = {
     # Sky (formerly MakerDAO) - sUSDS vault on Ethereum
     # https://etherscan.io/address/0xa3931d71877c0e7a3148cb7eb4463524fec27fbd
     "0xa3931d71877c0e7a3148cb7eb4463524fec27fbd": {ERC4626Feature.sky_like},
+    # Sky (formerly MakerDAO) - sDAI (Savings DAI) vault on Ethereum
+    # https://etherscan.io/address/0x83f20f44975d03b1b09e64809b757c47f942beea
+    "0x83f20f44975d03b1b09e64809b757c47f942beea": {ERC4626Feature.sky_like},
     # Maple Finance - syrupUSDC vault on Ethereum
     # https://etherscan.io/address/0x80ac24aa929eaf5013f6436cda2a7ba190f5cc0b
     "0x80ac24aa929eaf5013f6436cda2a7ba190f5cc0b": {ERC4626Feature.maple_like},

--- a/eth_defi/erc_4626/vault_protocol/sky/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/sky/vault.py
@@ -4,19 +4,23 @@ Sky (formerly MakerDAO) is one of the oldest and most established DeFi protocols
 The protocol provides the USDS stablecoin and allows users to earn yield through
 staking USDS in Sky savings vaults.
 
-Sky offers two ERC-4626 compliant tokenised vaults:
+Sky offers ERC-4626 compliant tokenised vaults:
 
-- **stUSDS** (Staked USDS): The original Sky savings vault
+- **stUSDS** (Staked USDS): The original Sky savings vault for USDS
 - **sUSDS** (Savings USDS): An additional savings vault with the same mechanics
+- **sDAI** (Savings DAI): The original MakerDAO DAI Savings Rate vault
 
-Both vaults allow users to stake USDS and earn the Sky Savings Rate (SSR). The
+The USDS vaults allow users to stake USDS and earn the Sky Savings Rate (SSR). The
 vaults accumulate yield through the ``drip()`` mechanism which accrues interest
 based on the ``chi`` rate accumulator.
+
+The sDAI vault allows users to deposit DAI and earn the DAI Savings Rate (DSR)
+through MakerDAO's Pot contract.
 
 Key features:
 
 - No deposit/withdrawal fees at the smart contract level
-- Yield accrues through the Sky Savings Rate (SSR)
+- Yield accrues through the Sky Savings Rate (SSR) or DAI Savings Rate (DSR)
 - Instant deposits and withdrawals
 - Fully decentralised and battle-tested infrastructure
 
@@ -26,6 +30,7 @@ Key features:
 - Twitter: https://x.com/SkyEcosystem
 - stUSDS Contract: https://etherscan.io/address/0x99cd4ec3f88a45940936f469e4bb72a2a701eeb9
 - sUSDS Contract: https://etherscan.io/address/0xa3931d71877c0e7a3148cb7eb4463524fec27fbd
+- sDAI Contract: https://etherscan.io/address/0x83f20f44975d03b1b09e64809b757c47f942beea
 """
 
 import datetime
@@ -41,9 +46,10 @@ logger = logging.getLogger(__name__)
 class SkyVault(ERC4626Vault):
     """Sky protocol vault support.
 
-    Sky savings vaults (stUSDS and sUSDS) allow users to stake USDS and earn the
-    Sky Savings Rate. The vaults accumulate yield through the ``chi`` rate
-    accumulator which is updated via the ``drip()`` function.
+    Sky savings vaults (stUSDS, sUSDS, and sDAI) allow users to stake stablecoins
+    and earn yield. The USDS vaults earn the Sky Savings Rate while sDAI earns the
+    DAI Savings Rate. The vaults accumulate yield through rate accumulators which
+    are updated via the ``drip()`` function.
 
     - Homepage: https://sky.money/
     - Documentation: https://developers.sky.money/
@@ -51,6 +57,7 @@ class SkyVault(ERC4626Vault):
     - Twitter: https://x.com/SkyEcosystem
     - stUSDS Contract: https://etherscan.io/address/0x99cd4ec3f88a45940936f469e4bb72a2a701eeb9
     - sUSDS Contract: https://etherscan.io/address/0xa3931d71877c0e7a3148cb7eb4463524fec27fbd
+    - sDAI Contract: https://etherscan.io/address/0x83f20f44975d03b1b09e64809b757c47f942beea
     """
 
     def has_custom_fees(self) -> bool:

--- a/tests/erc_4626/vault_protocol/test_sky.py
+++ b/tests/erc_4626/vault_protocol/test_sky.py
@@ -89,3 +89,31 @@ def test_sky_susds(
 
     # Check risk level
     assert vault.get_risk() == VaultTechnicalRisk.negligible
+
+
+@flaky.flaky
+def test_sky_sdai(
+    web3: Web3,
+    tmp_path: Path,
+):
+    """Read Sky sDAI (Savings DAI) vault metadata."""
+
+    vault = create_vault_instance_autodetect(
+        web3,
+        vault_address="0x83f20f44975d03b1b09e64809b757c47f942beea",
+    )
+
+    assert isinstance(vault, SkyVault)
+    assert vault.get_protocol_name() == "Sky"
+    assert vault.features == {ERC4626Feature.sky_like}
+
+    # Sky does not charge fees
+    assert vault.get_management_fee("latest") == 0.0
+    assert vault.get_performance_fee("latest") == 0.0
+    assert vault.has_custom_fees() is False
+
+    # Check vault link
+    assert vault.get_link() == "https://sky.money/"
+
+    # Check risk level
+    assert vault.get_risk() == VaultTechnicalRisk.negligible


### PR DESCRIPTION
## Summary
- Add sDAI vault (Savings DAI) to Sky protocol support
- sDAI is the original MakerDAO DAI Savings Rate vault on Ethereum
- Vault address: 0x83f20f44975d03b1b09e64809b757c47f942beea

🤖 Generated with [Claude Code](https://claude.com/claude-code)