### PR TITLE
Set YieldNest management and performance fees to zero

### DIFF
--- a/eth_defi/data/vaults/metadata/yieldnest.yaml
+++ b/eth_defi/data/vaults/metadata/yieldnest.yaml
@@ -8,7 +8,7 @@ long_description: |
   The platform's core mission centres on democratising DeFi access through secure, innovative products. YieldNest enables users to gain diversified exposure across multiple protocols and chains simultaneously through non-custodial solutions with robust security measures.
 
 fee_description: |
-  YieldNest implements dynamic withdrawal fees that vary based on buffer availability. The baseWithdrawalFee() function returns the current fee in basis points. Management and performance fees are not explicitly documented in the smart contracts.
+  YieldNest implements dynamic withdrawal fees that vary based on buffer availability. The baseWithdrawalFee() function returns the current fee in basis points. YieldNest does not charge management or performance fees.
 links:
   homepage: https://www.yieldnest.finance
   twitter: https://twitter.com/YieldNestFi

--- a/eth_defi/erc_4626/vault_protocol/yieldnest/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/yieldnest/vault.py
@@ -65,22 +65,22 @@ class YieldNestVault(ERC4626Vault):
     def get_management_fee(self, block_identifier: BlockIdentifier) -> float:
         """Get the current management fee as a percent.
 
-        YieldNest does not appear to have explicit management fees documented.
+        YieldNest does not charge management fees.
 
         :return:
-            None if not available
+            0.0
         """
-        return None
+        return 0.0
 
-    def get_performance_fee(self, block_identifier: BlockIdentifier) -> float | None:
+    def get_performance_fee(self, block_identifier: BlockIdentifier) -> float:
         """Get the current performance fee as a percent.
 
-        YieldNest does not appear to have explicit performance fees documented.
+        YieldNest does not charge performance fees.
 
         :return:
-            None if not available
+            0.0
         """
-        return None
+        return 0.0
 
     def get_estimated_lock_up(self) -> datetime.timedelta | None:
         """YieldNest vaults support instant withdrawals from buffer or queue-based withdrawals.

--- a/tests/erc_4626/vault_protocol/test_yieldnest.py
+++ b/tests/erc_4626/vault_protocol/test_yieldnest.py
@@ -59,9 +59,9 @@ def test_yieldnest_ynrwax(
     assert vault.get_protocol_name() == "YieldNest"
     assert vault.features == {ERC4626Feature.yieldnest_like}
 
-    # Check that management and performance fees return None (not documented)
-    assert vault.get_management_fee("latest") is None
-    assert vault.get_performance_fee("latest") is None
+    # Check that management and performance fees are zero
+    assert vault.get_management_fee("latest") == 0.0
+    assert vault.get_performance_fee("latest") == 0.0
 
     # Check risk level
     assert vault.get_risk() is None


### PR DESCRIPTION
## Summary
- Update YieldNest vault to return `0.0` instead of `None` for management and performance fees
- YieldNest does not charge management or performance fees
- Update metadata and tests to reflect this

🤖 Generated with [Claude Code](https://claude.com/claude-code)