### PR TITLE
Set YieldNest technical risk to low

### DIFF
--- a/eth_defi/vault/risk.py
+++ b/eth_defi/vault/risk.py
@@ -114,7 +114,7 @@ VAULT_PROTOCOL_RISK_MATRIX = {
     "Singularity Finance": None,
     "Brink": None,
     "Accountable": VaultTechnicalRisk.severe,
-    "YieldNest": None,
+    "YieldNest": VaultTechnicalRisk.low,
     "Dolomite": None,
     "HypurrFi": None,
     "Fluid": VaultTechnicalRisk.low,


### PR DESCRIPTION
## Summary
- Update the vault protocol risk matrix to classify YieldNest as low technical risk instead of unclassified (None)

🤖 Generated with [Claude Code](https://claude.com/claude-code)