### PR TITLE
Set HypurrFi technical risk to severe

### DIFF
--- a/eth_defi/vault/risk.py
+++ b/eth_defi/vault/risk.py
@@ -116,7 +116,8 @@ VAULT_PROTOCOL_RISK_MATRIX = {
     "Accountable": VaultTechnicalRisk.severe,
     "YieldNest": VaultTechnicalRisk.low,
     "Dolomite": None,
-    "HypurrFi": None,
+    # No public GitHub repository for the contract development
+    "HypurrFi": VaultTechnicalRisk.severe,
     "Fluid": VaultTechnicalRisk.low,
     "ZeroLend": VaultTechnicalRisk.dangerous,
     "USDX Money": None,


### PR DESCRIPTION
## Summary
- Set HypurrFi vault protocol technical risk to severe due to no public GitHub repository for contract development

🤖 Generated with [Claude Code](https://claude.com/claude-code)