### PR TITLE
Add SavingsUsdd vault to Decentralized USD protocol

### DIFF
--- a/eth_defi/data/vaults/metadata/decentralized-usd.yaml
+++ b/eth_defi/data/vaults/metadata/decentralized-usd.yaml
@@ -35,4 +35,5 @@ links:
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/usdd/index.html
 example_smart_contracts:
   - https://etherscan.io/address/0xC5d6A7B61d18AfA11435a889557b068BB9f29930
+  - https://etherscan.io/address/0xf94f97677914d298844ec8fa590fab09ccc324d0
   - https://bscscan.com/address/0x8bA9dA757d1D66c58b1ae7e2ED6c04087348A82d

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -1639,6 +1639,9 @@ HARDCODED_PROTOCOLS = {
     # Decentralized USD (USDD) - sUSDD vault on BNB Chain
     # https://bscscan.com/address/0x8bA9dA757d1D66c58b1ae7e2ED6c04087348A82d
     "0x8ba9da757d1d66c58b1ae7e2ed6c04087348a82d": {ERC4626Feature.usdd_like},
+    # Decentralized USD (USDD) - SavingsUsdd vault on Ethereum
+    # https://etherscan.io/address/0xf94f97677914d298844ec8fa590fab09ccc324d0
+    "0xf94f97677914d298844ec8fa590fab09ccc324d0": {ERC4626Feature.usdd_like},
     # Yearn SparkCompounder - ysUSDS vault on Ethereum
     # https://etherscan.io/address/0xc9f01b5c6048b064e6d925d1c2d7206d4feef8a3
     "0xc9f01b5c6048b064e6d925d1c2d7206d4feef8a3": {ERC4626Feature.yearn_tokenised_strategy},

--- a/tests/erc_4626/vault_protocol/test_usdd.py
+++ b/tests/erc_4626/vault_protocol/test_usdd.py
@@ -61,3 +61,31 @@ def test_usdd_susdd_ethereum(
 
     # Check risk level
     assert vault.get_risk() == VaultTechnicalRisk.severe
+
+
+@flaky.flaky
+def test_usdd_savings_usdd_ethereum(
+    web3: Web3,
+    tmp_path: Path,
+):
+    """Read USDD SavingsUsdd vault metadata on Ethereum."""
+
+    vault = create_vault_instance_autodetect(
+        web3,
+        vault_address="0xf94f97677914d298844ec8fa590fab09ccc324d0",
+    )
+
+    assert isinstance(vault, USSDVault)
+    assert vault.get_protocol_name() == "Decentralized USD"
+    assert vault.features == {ERC4626Feature.usdd_like}
+
+    # USDD does not charge fees
+    assert vault.get_management_fee("latest") == 0.0
+    assert vault.get_performance_fee("latest") == 0.0
+    assert vault.has_custom_fees() is False
+
+    # Check vault link
+    assert vault.get_link() == "https://usdd.io/"
+
+    # Check risk level
+    assert vault.get_risk() == VaultTechnicalRisk.severe


### PR DESCRIPTION
## Summary
- Added SavingsUsdd vault (0xf94f97677914d298844ec8fa590fab09ccc324d0) on Ethereum to the Decentralized USD protocol hardcoded protocols list

Example contract: https://etherscan.io/address/0xf94f97677914d298844ec8fa590fab09ccc324d0

🤖 Generated with [Claude Code](https://claude.com/claude-code)