### PR TITLE
Add YieldFi vaults on Base and Ethereum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.39
 
+- Add: [YieldFi](https://tradingstrategy.ai/trading-view/vaults/protocols/yieldfi) vyUSD vault on Base and yUSD vault on Ethereum (2026-01-23)
 - Add: New protocol: [Avant](https://www.avantprotocol.com/) - decentralised stablecoin protocol on Avalanche with savUSD staking vault (2026-01-19)
 - Add: New protocol: [Renalta](https://renalta.com/) - yield protocol on Base blockchain with unverified smart contract source code (2026-01-19)
 - Add: New protocol: [infiniFi](https://infinifi.xyz/) - on-chain fractional reserve banking protocol with siUSD liquid staking vault on Ethereum (2026-01-18)

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -1675,6 +1675,12 @@ HARDCODED_PROTOCOLS = {
     # YieldFi - yUSD vault on Arbitrum
     # https://arbiscan.io/address/0x4772d2e014f9fc3a820c444e3313968e9a5c8121
     "0x4772d2e014f9fc3a820c444e3313968e9a5c8121": {ERC4626Feature.yieldfi_like},
+    # YieldFi - vyUSD vault on Base
+    # https://basescan.org/address/0xf4f447e6afa04c9d11ef0e2fc0d7f19c24ee55de
+    "0xf4f447e6afa04c9d11ef0e2fc0d7f19c24ee55de": {ERC4626Feature.yieldfi_like},
+    # YieldFi - yUSD vault on Ethereum
+    # https://etherscan.io/address/0x1ce7d9942ff78c328a4181b9f3826fee6d845a97
+    "0x1ce7d9942ff78c328a4181b9f3826fee6d845a97": {ERC4626Feature.yieldfi_like},
     # Resolv - wstUSR (Wrapped stUSR) vault on Ethereum
     # ERC-4626 wrapper around rebasing staked USR token
     # https://etherscan.io/address/0x1202f5c7b4b9e47a1a484e8b270be34dbbc75055

--- a/tests/erc_4626/vault_protocol/test_yieldfi.py
+++ b/tests/erc_4626/vault_protocol/test_yieldfi.py
@@ -15,6 +15,7 @@ from eth_defi.provider.multi_provider import create_multi_provider_web3
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
+JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
 
 pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests")
 
@@ -59,6 +60,29 @@ def test_yieldfi(
     assert vault.get_link() == "https://yield.fi/"
 
 
+@flaky.flaky
+def test_yieldfi_yusd_ethereum(
+    web3: Web3,
+):
+    """Read YieldFi yUSD vault metadata on Ethereum"""
+
+    vault = create_vault_instance_autodetect(
+        web3,
+        vault_address="0x1ce7d9942ff78c328a4181b9f3826fee6d845a97",
+    )
+
+    assert isinstance(vault, YieldFiVault)
+    assert vault.get_protocol_name() == "YieldFi"
+    assert ERC4626Feature.yieldfi_like in vault.features
+
+    # Fee data - YieldFi has configurable fees but currently set to 0
+    assert vault.get_management_fee("latest") == 0.0
+    assert vault.has_custom_fees() is False
+
+    # Check link
+    assert vault.get_link() == "https://yield.fi/"
+
+
 @pytest.fixture(scope="module")
 def anvil_arbitrum_fork(request) -> AnvilLaunch:
     """Fork Arbitrum at a specific block for reproducibility"""
@@ -86,6 +110,47 @@ def test_yieldfi_arbitrum(
     vault = create_vault_instance_autodetect(
         web3_arbitrum,
         vault_address="0x4772d2e014f9fc3a820c444e3313968e9a5c8121",
+    )
+
+    assert isinstance(vault, YieldFiVault)
+    assert vault.get_protocol_name() == "YieldFi"
+    assert ERC4626Feature.yieldfi_like in vault.features
+
+    # Fee data - YieldFi has configurable fees but currently set to 0
+    assert vault.get_management_fee("latest") == 0.0
+    assert vault.has_custom_fees() is False
+
+    # Check link
+    assert vault.get_link() == "https://yield.fi/"
+
+
+@pytest.fixture(scope="module")
+def anvil_base_fork(request) -> AnvilLaunch:
+    """Fork Base at a specific block for reproducibility"""
+    if JSON_RPC_BASE is None:
+        pytest.skip("JSON_RPC_BASE needed to run this test")
+    launch = fork_network_anvil(JSON_RPC_BASE, fork_block_number=41186545)
+    try:
+        yield launch
+    finally:
+        launch.close()
+
+
+@pytest.fixture(scope="module")
+def web3_base(anvil_base_fork):
+    web3 = create_multi_provider_web3(anvil_base_fork.json_rpc_url)
+    return web3
+
+
+@flaky.flaky
+def test_yieldfi_base(
+    web3_base: Web3,
+):
+    """Read YieldFi vyUSD vault metadata on Base"""
+
+    vault = create_vault_instance_autodetect(
+        web3_base,
+        vault_address="0xf4f447e6afa04c9d11ef0e2fc0d7f19c24ee55de",
     )
 
     assert isinstance(vault, YieldFiVault)


### PR DESCRIPTION
## Summary
- Add vyUSD vault on Base (0xf4f447e6afa04c9d11ef0e2fc0d7f19c24ee55de)
- Add yUSD vault on Ethereum (0x1ce7d9942ff78c328a4181b9f3826fee6d845a97)
- Add tests for both new vaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)