### PR TITLE
feat: Add reader state display to check-vault-metadata script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.39
 
+- Add: Reader state display to `check-vault-metadata.py` script for debugging vault scanner state (2026-01-26)
 - Add: New protocol: [Yo](https://www.yo.xyz/) - decentralised yield optimisation platform with multi-chain asset allocation on Ethereum (2026-01-24)
 - Add: New protocol: [aarnâ](https://www.aarna.ai/) - Agentic Onchain Treasury (AOT) protocol using AI agents for DeFi management on Ethereum (2026-01-23)
 - Add: [YieldFi](https://tradingstrategy.ai/trading-view/vaults/protocols/yieldfi) vyUSD vault on Base and yUSD vault on Ethereum (2026-01-23)

--- a/scripts/erc-4626/check-vault-metadata.py
+++ b/scripts/erc-4626/check-vault-metadata.py
@@ -3,13 +3,35 @@
 - See our internal scanner database has correctly identifier a vault, its features and flags
 """
 
+import pickle
+import sys
+from pathlib import Path
 from pprint import pprint
 
 from eth_defi.vault.base import VaultSpec
-from eth_defi.vault.vaultdb import VaultDatabase
+from eth_defi.vault.vaultdb import DEFAULT_READER_STATE_DATABASE, VaultDatabase
 
-# Foxify LP token on Sonic
-vault_id = VaultSpec.parse_string("143-0x0a4AfB907672279926c73Dc1F77151931c2A55cC")
+# Harvest
+# https://tradingstrategy.ai/trading-view/vaults/harvest-usdc-vault-0x0f6d
+vault_id = VaultSpec.parse_string("8453-0x0f6d1d626fd6284c6c1c1345f30996b89b879689")
 vault_db = VaultDatabase.read()
 vault_record = vault_db.get(vault_id)
+print("Stored metadata:")
 pprint(vault_record)
+
+# Check reader status
+reader_state_db = Path(DEFAULT_READER_STATE_DATABASE)
+if not reader_state_db.exists():
+    print("No reader state database found, skipping reader state check")
+    sys.exit(1)
+
+reader_states = pickle.load(reader_state_db.open("rb"))
+unique_chains = set(spec.chain_id for spec in reader_states.keys())
+print(f"Loaded {len(reader_states)} reader states from {reader_state_db}, contains {len(unique_chains)} chains")
+
+# Display reader state for the selected vault
+if vault_id in reader_states:
+    print(f"\nReader state for {vault_id}:")
+    pprint(reader_states[vault_id])
+else:
+    print(f"\nNo reader state found for {vault_id}")


### PR DESCRIPTION
## Summary
- Add reader state display to `check-vault-metadata.py` script for debugging vault scanner state
- Loads vault reader state from the scanner pickle database and displays it alongside vault metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)