### PR TITLE
feat: Add remove_inactive_lead_time() for vault price cleaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.39
 
+- Add: `remove_inactive_lead_time()` function to remove initial inactive period from vault price history where total supply hasn't changed (2026-01-26)
 - Add: Reader state display to `check-vault-metadata.py` script for debugging vault scanner state (2026-01-26)
 - Add: New protocol: [Yo](https://www.yo.xyz/) - decentralised yield optimisation platform with multi-chain asset allocation on Ethereum (2026-01-24)
 - Add: New protocol: [aarnâ](https://www.aarna.ai/) - Agentic Onchain Treasury (AOT) protocol using AI agents for DeFi management on Ethereum (2026-01-23)


### PR DESCRIPTION
## Summary

- Add `remove_inactive_lead_time()` function to remove initial inactive period from vault price history
- At the beginning of a vault's lifecycle, total supply may remain constant while the vault is inactive (e.g., 1, 1000)
- When the vault activates, the share price may jump, causing abnormal returns numbers
- This cleaning step runs before `fix_outlier_share_prices()` to ensure clean data for downstream processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)