### PR TITLE
feat: Add YieldFi yUSD vault on Ethereum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.39
 
+- Add: [YieldFi](https://tradingstrategy.ai/trading-view/vaults/protocols/yieldfi) yUSD vault on Ethereum (2026-01-28)
 - Add: [Gearbox](https://tradingstrategy.ai/trading-view/vaults/protocols/gearbox) PoolV3 GHO vault on Ethereum mainnet with `poolQuotaKeeper()` detection for older deployments (2026-01-27)
 - Add: `extract-test-set.py` script to extract raw price data and generate pytest test modules for individual vaults (2026-01-27)
 - Add: `remove_inactive_lead_time()` function to remove initial inactive period from vault price history where total supply hasn't changed (2026-01-26)

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -1706,6 +1706,9 @@ HARDCODED_PROTOCOLS = {
     # YieldFi - yUSD vault on Ethereum
     # https://etherscan.io/address/0x1ce7d9942ff78c328a4181b9f3826fee6d845a97
     "0x1ce7d9942ff78c328a4181b9f3826fee6d845a97": {ERC4626Feature.yieldfi_like},
+    # YieldFi - yUSD vault on Ethereum
+    # https://etherscan.io/address/0x19ebd191f7a24ece672ba13a302212b5ef7f35cb
+    "0x19ebd191f7a24ece672ba13a302212b5ef7f35cb": {ERC4626Feature.yieldfi_like},
     # Resolv - wstUSR (Wrapped stUSR) vault on Ethereum
     # ERC-4626 wrapper around rebasing staked USR token
     # https://etherscan.io/address/0x1202f5c7b4b9e47a1a484e8b270be34dbbc75055

--- a/tests/erc_4626/vault_protocol/test_yieldfi.py
+++ b/tests/erc_4626/vault_protocol/test_yieldfi.py
@@ -83,6 +83,29 @@ def test_yieldfi_yusd_ethereum(
     assert vault.get_link() == "https://yield.fi/"
 
 
+@flaky.flaky
+def test_yieldfi_yusd_ethereum_2(
+    web3: Web3,
+):
+    """Read YieldFi yUSD vault metadata on Ethereum (0x19ebd191)"""
+
+    vault = create_vault_instance_autodetect(
+        web3,
+        vault_address="0x19ebd191f7a24ece672ba13a302212b5ef7f35cb",
+    )
+
+    assert isinstance(vault, YieldFiVault)
+    assert vault.get_protocol_name() == "YieldFi"
+    assert ERC4626Feature.yieldfi_like in vault.features
+
+    # Fee data - YieldFi has configurable fees but currently set to 0
+    assert vault.get_management_fee("latest") == 0.0
+    assert vault.has_custom_fees() is False
+
+    # Check link
+    assert vault.get_link() == "https://yield.fi/"
+
+
 @pytest.fixture(scope="module")
 def anvil_arbitrum_fork(request) -> AnvilLaunch:
     """Fork Arbitrum at a specific block for reproducibility"""


### PR DESCRIPTION
## Summary
- Add hardcoded YieldFi yUSD vault `0x19ebd191f7a24ece672ba13a302212b5ef7f35cb` on Ethereum mainnet
- Add test for the new vault
- Update changelog

Protocol: YieldFi
Homepage: https://yield.fi/
Example contract: https://etherscan.io/address/0x19ebd191f7a24ece672ba13a302212b5ef7f35cb

🤖 Generated with [Claude Code](https://claude.com/claude-code)