### PR TITLE
feat: Add Blockscout verifier support for Forge contract deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ logs/
 
 # Local test env symlink
 .local-test.env
+
+# Claude Code local settings
+.claude/settings.local.json

--- a/scripts/forge/test-blockscout-verification.py
+++ b/scripts/forge/test-blockscout-verification.py
@@ -1,0 +1,84 @@
+"""Manual test script for Blockscout contract verification.
+
+Tests deploying and verifying a contract on Base mainnet using Blockscout.
+
+Usage:
+
+.. code-block:: shell
+
+    source .local-test.env && poetry run python scripts/forge/test-blockscout-verification.py
+
+Environment variables:
+
+- ``JSON_RPC_BASE``: Base mainnet RPC URL
+- ``DEPLOYER_PRIVATE_KEY``: Private key for the deployer account (must have ETH on Base)
+"""
+
+import logging
+import os
+from pathlib import Path
+
+from eth_account import Account
+from web3 import HTTPProvider, Web3
+
+from eth_defi.chain import install_chain_middleware
+from eth_defi.foundry.forge import deploy_contract_with_forge
+from eth_defi.hotwallet import HotWallet
+from eth_defi.utils import setup_console_logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def main():
+    setup_console_logging(default_log_level="info")
+
+    json_rpc_url = os.environ.get("JSON_RPC_BASE")
+    assert json_rpc_url, "JSON_RPC_BASE environment variable required"
+
+    # Handle multi-provider URL format by taking the first URL
+    if " " in json_rpc_url:
+        json_rpc_url = json_rpc_url.split()[0]
+
+    private_key = os.environ.get("DEPLOYER_PRIVATE_KEY")
+    assert private_key, "DEPLOYER_PRIVATE_KEY environment variable required"
+
+    web3 = Web3(HTTPProvider(json_rpc_url))
+    install_chain_middleware(web3)
+
+    deployer_account = Account.from_key(private_key)
+    deployer = HotWallet(deployer_account)
+    deployer.sync_nonce(web3)
+
+    balance = web3.eth.get_balance(deployer.address)
+    logger.info("Deployer: %s, balance: %s ETH", deployer.address, balance / 10**18)
+
+    if balance < 0.00001 * 10**18:
+        raise ValueError(f"Deployer account {deployer.address} has insufficient balance on Base mainnet")
+
+    # Deploy a simple contract using Blockscout verification
+    project_folder = Path(__file__).parent.parent.parent / "contracts" / "guard"
+    assert project_folder.exists(), f"Project folder not found: {project_folder}"
+
+    logger.info("Deploying GuardV0 with Blockscout verification on Base mainnet...")
+
+    contract, tx_hash = deploy_contract_with_forge(
+        web3,
+        project_folder,
+        Path("GuardV0.sol"),
+        "GuardV0",
+        deployer,
+        constructor_args=[],
+        verifier="blockscout",
+        verifier_url="https://base.blockscout.com/api/",
+        verify_retries=5,
+        verbose=True,
+    )
+
+    logger.info("Contract deployed at: %s", contract.address)
+    logger.info("Transaction hash: %s", tx_hash.hex())
+    logger.info("Check verification at: https://base.blockscout.com/address/%s", contract.address)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `verifier` and `verifier_url` parameters to `deploy_contract_with_forge()` to support Blockscout and other verification providers (sourcify, oklink) in addition to Etherscan
- Update Lagoon deployment functions to pass through the new parameters
- Add manual test script for Base mainnet with Blockscout verification

This enables Lagoon vault deployment on chains like Derive Chain (957) that use Blockscout instead of Etherscan.

Closes #678

## Usage

**Blockscout (Derive Chain):**
```python
contract, tx_hash = deploy_contract_with_forge(
    web3, project_folder, "Contract.sol", "Contract", deployer,
    verifier="blockscout",
    verifier_url="https://explorer.derive.xyz/api/",
)
```

**Etherscan (unchanged):**
```python
contract, tx_hash = deploy_contract_with_forge(
    web3, project_folder, "Contract.sol", "Contract", deployer,
    etherscan_api_key="YOUR_KEY",
)
```

## Verification

Tested successfully on Base mainnet - contract deployed and verified on Blockscout:
https://base.blockscout.com/address/0xA3d724e816921F148d686fd1F802734EEC29Fa5c

🤖 Generated with [Claude Code](https://claude.com/claude-code)