### PR TITLE
feat: Add Derive (Lyra L2) chain support

### DIFF
--- a/eth_defi/chain.py
+++ b/eth_defi/chain.py
@@ -66,6 +66,7 @@ CHAIN_NAMES = {
     59144: "Linea",
     747474: "Katana",
     143: "Monad",
+    957: "Derive",
 }
 
 #: For linking on reports
@@ -98,6 +99,7 @@ CHAIN_HOMEPAGES = {
     59144: {"name": "Linea", "homepage": "https://linea.build/"},
     747474: {"name": "Katana", "homepage": "https://katana.network/"},
     143: {"name": "Monad", "homepage": "https://monad.xyz"},
+    957: {"name": "Derive", "homepage": "https://derive.xyz"},
 }
 
 #: Chain avg block times.
@@ -135,6 +137,7 @@ EVM_BLOCK_TIMES = {
     59144: 2,  # Block Time: Approximately 2 seconds soft finality
     747474: 1,  # Katana, ~1s block time avg
     143: 0.4,  # Monad, target ~1s block times on mainnet
+    957: 2,  # Derive (Lyra L2), ~2s block time
 }
 
 

--- a/eth_defi/erc_4626/vault_protocol/lagoon/deployment.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/deployment.py
@@ -1272,4 +1272,10 @@ LAGOON_BEACON_PROXY_FACTORIES = {
         "abi": "lagoon/OptinProxyFactory.json",
         "address": "0xb1ee4f77a1691696a737ab9852e389cf4cb1f1f5",
     },
+    # Derive
+    # https://explorer.derive.xyz/address/0x4058140097F313886536bd64a7C1D25FF7356931
+    957: {
+        "abi": "lagoon/BeaconProxyFactory.json",
+        "address": "0x4058140097F313886536bd64a7C1D25FF7356931",
+    },
 }

--- a/eth_defi/token.py
+++ b/eth_defi/token.py
@@ -78,6 +78,8 @@ WRAPPED_NATIVE_TOKEN: dict[int, HexAddress | str] = {
     43114: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
     # WETH: Arbitrum Sepolia
     421614: "0x7b79995e5f793A07Bc00c21412e50Ecae098E7f9",
+    # WETH: Derive (OP Stack, same as Base/Optimism)
+    957: "0x4200000000000000000000000000000000000006",
 }
 
 #: Addresses of USDC of different chains
@@ -95,6 +97,8 @@ USDC_NATIVE_TOKEN: dict[int, HexAddress | str] = {
     56: "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d",
     # Arbitrum Sepolia
     421614: "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
+    # Derive (Lyra L2)
+    957: "0x6879287835A86F50f784313dBEd5E5cCC5bb8481",
 }
 
 #: Bridged USDC of different chains


### PR DESCRIPTION
## Summary

- Add Derive chain (ID 957) to `CHAIN_NAMES`, `CHAIN_HOMEPAGES`, and `EVM_BLOCK_TIMES`
- Add USDC and WETH addresses for Derive to `USDC_NATIVE_TOKEN` and `WRAPPED_NATIVE_TOKEN`
- Add deployed BeaconProxyFactory address to `LAGOON_BEACON_PROXY_FACTORIES`

Towards tradingstrategy-ai/trade-executor#1264

🤖 Generated with [Claude Code](https://claude.ai/code)