### PR TITLE
fix: Apply BROKEN_VAULT_CONTRACTS filtering to all scan_prices logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.39
 
+- Fix: Broken vault contracts filtering in `scan_historical_prices_to_parquet` now properly applies to all subsequent code instead of being silently ignored (2026-02-02)
 - Add: Gains vault historical scan test covering the full stateful multicall pipeline (2026-02-02)
 - Add: Vault state fields (`max_deposit`, `max_redeem`, `deposits_open`, `redemption_open`, `trading`) to historical vault reads with protocol-specific readers for Gains/Ostium, D2 Finance, and Plutus (2026-01-31)
 - Add: `redemption-status.py` script to display Lagoon vault deposit and redemption status (2026-01-29)

--- a/eth_defi/vault/historical.py
+++ b/eth_defi/vault/historical.py
@@ -577,6 +577,8 @@ def scan_historical_prices_to_parquet(
             continue
         cleaned_vaults.append(v)
 
+    vaults = cleaned_vaults
+
     assert all(v.first_seen_at_block for v in vaults), f"You need to set vault.first_seen_at_block hint in order to run this reader"
     assert all(v.chain_id == chain_id for v in vaults), f"All vaults must be on the same chain"
 


### PR DESCRIPTION
## Summary

- `scan_historical_prices_to_parquet` filtered broken vault contracts into a `cleaned_vaults` list but never reassigned it back to `vaults`, so asserts, block range calculations, and logging still operated on the unfiltered list
- Added `vaults = cleaned_vaults` after the filtering loop so all subsequent code properly excludes broken contracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)