### PR TITLE
fix: Add broken Berachain Gains vault address to BROKEN_VAULT_CONTRACTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.39
 
+- Fix: Add broken Gains vault address on Berachain to `BROKEN_VAULT_CONTRACTS` so price scanner skips it (2026-02-02)
 - Fix: Broken vault contracts filtering in `scan_historical_prices_to_parquet` now properly applies to all subsequent code instead of being silently ignored (2026-02-02)
 - Add: Gains vault historical scan test covering the full stateful multicall pipeline (2026-02-02)
 - Add: Vault state fields (`max_deposit`, `max_redeem`, `deposits_open`, `redemption_open`, `trading`) to historical vault reads with protocol-specific readers for Gains/Ostium, D2 Finance, and Plutus (2026-01-31)

--- a/eth_defi/vault/risk.py
+++ b/eth_defi/vault/risk.py
@@ -239,7 +239,8 @@ _BROKEN_VAULT_CONTRACTS = {
     "0xc5a9938F265690e3c904fC37c27d1B6D0Aab8612",  # Age old mainnet contract
     "0x8763e4686ba2fdCd0b71CeE0411100585C875278",  # Age old mainnet contract
     "0xF1d402fCbEb2d0C8946F13196D72dB7258B0B296",
-    "0x5705554BAa86Da01fF4A82d29a1598c5B3A8B476",  # Gains-like on Berachain: AssertionError: total_supply call missing for <GainsVault: VaultSpec(chain_id=80094, vault_address='0x6a6e4ad4a5ca14b940cd6949b1a90f947ae21c19')>, we got [('nextEpochValuesRequestCount', <Call EncodedCall(func_name='nextEpochValuesRequestCount', address='0x5705554BAa86Da01fF4A82d29a1598c5B3A8B476', data=HexBytes('0xb8feee64'), extra_data={'function': 'nextEpochValuesRequestCount', 'vault': '0x6a6E4ad4a5ca14B940Cd6949b1A90f947AE21c19'}, first_block_number=812267, call_id=202, _hash=3894220416) at block 16487097, success True, result: 0000000000000000000000000000000000000000000000000000000000000000, result len 32>)]
+    "0x6a6E4ad4a5ca14B940Cd6949b1A90f947AE21c19",  # Broken Gains vault on Berachain - its open PnL feed contract (0x5705554B) causes multicall failures
+    "0x5705554BAa86Da01fF4A82d29a1598c5B3A8B476",  # Open PnL feed helper contract for broken Gains vault on Berachain
 }
 
 #: Cause excessive gas fees, RPC havoc.


### PR DESCRIPTION
## Summary

- The Gains vault on Berachain (`0x6a6E...21c19`) was not being filtered by the price scanner because only its helper open PnL feed contract (`0x5705554B`) was listed in `BROKEN_VAULT_CONTRACTS`
- The scan filters on `vault_address`, so the actual vault address must also be present to skip it
- Added the vault address to `_BROKEN_VAULT_CONTRACTS` and cleaned up the comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)