### PR TITLE
feat: Add CHAIN_ORDER env var to control chain scan order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.39
 
+- Add: `CHAIN_ORDER` environment variable for `scan-vaults-all-chains.py` to control chain scan order (2026-02-04)
 - Add: Cloudflare Pages documentation hosting with custom domain `web3-ethereum-defi.tradingstrategy.ai` (2026-02-03)
 - Add: [Derive.xyz](https://www.derive.xyz/) perpetuals and options DEX integration with session key authentication and account balance reading (2026-02-03)
 - Fix: ERC-4626 core result processing gracefully handles missing `total_supply` and `total_assets` calls instead of crashing with asserts (2026-02-02)


### PR DESCRIPTION
## Summary

- Add `CHAIN_ORDER` environment variable to `scan-vaults-all-chains.py` that controls which chains are scanned and in what order
- Chains not listed in `CHAIN_ORDER` are marked as "skipped" in the dashboard
- Add final dashboard output at the end of the scan

Example usage:
```bash
CHAIN_ORDER="Ethereum, Base, Arbitrum" poetry run python scripts/erc-4626/scan-vaults-all-chains.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)