### PR TITLE
feat: Add Google Analytics tracking to documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.39
 
+- Add: Google Analytics tracking to Sphinx documentation (2026-02-04)
 - Add: `CHAIN_ORDER` environment variable for `scan-vaults-all-chains.py` to control chain scan order (2026-02-04)
 - Add: Cloudflare Pages documentation hosting with custom domain `web3-ethereum-defi.tradingstrategy.ai` (2026-02-03)
 - Add: [Derive.xyz](https://www.derive.xyz/) perpetuals and options DEX integration with session key authentication and account balance reading (2026-02-03)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,6 +62,14 @@ if os.environ.get("READTHEDOCS"):
 #
 html_theme = "furo"
 
+# Furo theme options
+# https://pradyunsg.me/furo/customisation/
+html_theme_options = {
+    "analytics": {
+        "google": "G-5JZ8F9H4WH",
+    },
+}
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".


### PR DESCRIPTION
## Summary
- Add Google Analytics 4 tracking to Sphinx documentation using Furo theme's built-in analytics support
- Measurement ID: G-5JZ8F9H4WH

🤖 Generated with [Claude Code](https://claude.com/claude-code)