### PR TITLE
feat: Add Trading Strategy links to all vault protocol documentation

### DIFF
--- a/docs/source/vaults/aarna/index.rst
+++ b/docs/source/vaults/aarna/index.rst
@@ -16,6 +16,7 @@ and execute allocation strategies. Vaults are compliant with ERC-4626 standards 
 Links
 ~~~~~
 
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/aarna>`__
 - `Homepage <https://www.aarna.ai/>`__
 - `Documentation <https://docs.aarna.ai/>`__
 - `App <https://engine.aarna.ai/>`__

--- a/docs/source/vaults/accountable/index.rst
+++ b/docs/source/vaults/accountable/index.rst
@@ -16,6 +16,7 @@ on Monad blockchain.
 Links
 ~~~~~
 
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/accountable>`__
 - `Homepage <https://www.accountable.capital/>`__
 - `Twitter <https://x.com/AccountableData>`__
 - `LinkedIn <https://www.linkedin.com/company/accountablecapital/>`__

--- a/docs/source/vaults/altura/index.rst
+++ b/docs/source/vaults/altura/index.rst
@@ -30,6 +30,10 @@ Altura charges a minimal exit fee on instant withdrawals only:
 - **Epoch withdrawal fee**: 0% for queued withdrawals
 - **Management/Performance fees**: None (yield accrues via Price-Per-Share mechanism)
 
+Links
+~~~~~
+
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/altura>`__
 - `Homepage <https://altura.trade/>`__
 - `App <https://app.altura.trade/>`__
 - `Documentation <https://docs.altura.trade/>`__

--- a/docs/source/vaults/avant/index.rst
+++ b/docs/source/vaults/avant/index.rst
@@ -18,6 +18,7 @@ options through senior and junior tranches.
 Links
 ~~~~~
 
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/avant>`__
 - `Homepage <https://www.avantprotocol.com/>`__
 - `Documentation <https://docs.avantprotocol.com/>`__
 - `Twitter <https://x.com/avantprotocol>`__

--- a/docs/source/vaults/brink/index.rst
+++ b/docs/source/vaults/brink/index.rst
@@ -14,6 +14,7 @@ Fees are internalised in the share price with no explicit fee getter functions e
 Links
 ~~~~~
 
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/brink>`__
 - `Homepage <https://brink.money/>`__
 - `App <https://brink.money/app>`__
 - `Documentation <https://doc.brink.money/>`__

--- a/docs/source/vaults/csigma/index.rst
+++ b/docs/source/vaults/csigma/index.rst
@@ -16,6 +16,10 @@ As of Q1 2025, cSigma Finance has tokenised over $80 million in business loans f
 mid-market companies across the United States, European Union, and Asia. The tokenised
 loans are accessible on 11 major blockchain networks, including Ethereum, Arbitrum, and BNB.
 
+Links
+~~~~~
+
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/csigma-finance>`__
 - `Homepage <https://csigma.finance/>`__
 - `csUSD vault <https://www.csigma.finance/csusd>`__
 - `Medium <https://csigma.medium.com/>`__

--- a/docs/source/vaults/curvance/index.rst
+++ b/docs/source/vaults/curvance/index.rst
@@ -15,6 +15,7 @@ deployed on Monad, Ethereum, Arbitrum, Base, and other chains.
 Links
 ~~~~~
 
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/curvance>`__
 - `Homepage <https://www.curvance.com/>`__
 - `Documentation <https://docs.curvance.com/>`__
 - `GitHub <https://github.com/curvance/curvance-contracts>`__

--- a/docs/source/vaults/deltr/index.rst
+++ b/docs/source/vaults/deltr/index.rst
@@ -5,6 +5,11 @@ Deltr API
 
 - Unknown protocol
 
+Links
+~~~~~
+
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/deltr>`__
+
 .. autosummary::
    :toctree: _autosummary_deltr
    :recursive:

--- a/docs/source/vaults/dolomite/index.rst
+++ b/docs/source/vaults/dolomite/index.rst
@@ -21,6 +21,10 @@ Key features:
 - Instant deposits and withdrawals (subject to market liquidity)
 - Chainlink Automation secures price updates for vault assets
 
+Links
+~~~~~
+
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/dolomite>`__
 - `Homepage <https://dolomite.io/>`__
 - `Application <https://app.dolomite.io/>`__
 - `Documentation <https://docs.dolomite.io/>`__

--- a/docs/source/vaults/eth_strategy/index.rst
+++ b/docs/source/vaults/eth_strategy/index.rst
@@ -11,6 +11,10 @@ The ESPN (ETH Strategy Perpetual Note) vault is an ERC-4626 compliant vault that
 to deposit USDS stablecoins. The protocol takes no fees on deposits or redemptions and is
 DAO-governed with rage quit functionality.
 
+Links
+~~~~~
+
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/eth-strategy>`__
 - `Website <https://www.ethstrat.xyz/>`__
 - `Documentation <https://docs.ethstrat.xyz/>`__
 - `GitHub <https://github.com/dangerousfood/ethstrategy>`__

--- a/docs/source/vaults/ethena/index.rst
+++ b/docs/source/vaults/ethena/index.rst
@@ -22,6 +22,10 @@ Key features:
 - Governance-configurable cooldown period for withdrawals (up to 90 days)
 - Fully backed by USDe
 
+Links
+~~~~~
+
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/ethena>`__
 - `Homepage <https://ethena.fi/>`__
 - `Documentation <https://docs.ethena.fi/>`__
 - `GitHub <https://github.com/ethena-labs>`__

--- a/docs/source/vaults/fluid/index.rst
+++ b/docs/source/vaults/fluid/index.rst
@@ -19,6 +19,7 @@ and Smart debt features.
 Links
 ~~~~~
 
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/fluid>`__
 - `Homepage <https://fluid.io/>`__
 - `Documentation <https://docs.fluid.instadapp.io/>`__
 - `GitHub <https://github.com/Instadapp/fluid-contracts-public>`__

--- a/docs/source/vaults/foxify/index.rst
+++ b/docs/source/vaults/foxify/index.rst
@@ -10,6 +10,10 @@ Users can deposit USDC into vaults to earn yield from trading fees.
 FUNDED by FOXIFY is a Web3 prop trading layer, providing perpetuals traders instant access to additional capital to boost their income from trading.
 Traders can access up to $10,000, either by completing one of two FUNDED challenge journeys (Entry/Pro) or through FLASH FUNDING.
 
+Links
+~~~~~
+
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/foxify>`__
 - `Website <https://www.foxify.trade/>`__
 - `Documentation <https://docs.foxify.trade/>`__
 - `Twitter <https://x.com/foxifytrade>`__

--- a/docs/source/vaults/hyperlend/index.rst
+++ b/docs/source/vaults/hyperlend/index.rst
@@ -21,6 +21,10 @@ Key features:
 - Vault shares can be used as collateral for borrowing in Isolated Pools
 - Managed by Paxos Labs
 
+Links
+~~~~~
+
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/hyperlend>`__
 - `Homepage <https://hyperlend.finance/>`__
 - `Documentation <https://docs.hyperlend.finance/>`__
 - `wHLP documentation <https://docs.loopingcollective.org/products/wrapped-hlp>`__

--- a/docs/source/vaults/hypurrfi/index.rst
+++ b/docs/source/vaults/hypurrfi/index.rst
@@ -12,6 +12,7 @@ to borrowers seeking leveraged exposure to Hyperliquid-native assets.
 Links
 ~~~~~
 
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/hypurrfi>`__
 - `Homepage <https://www.hypurr.fi/>`__
 - `App <https://app.hypurr.fi/>`__
 - `Documentation <https://docs.hypurr.fi/>`__

--- a/docs/source/vaults/infinifi/index.rst
+++ b/docs/source/vaults/infinifi/index.rst
@@ -18,6 +18,7 @@ holders absorb losses first, then siUSD stakers, and finally plain iUSD holders.
 Links
 ~~~~~
 
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/infinifi>`__
 - `Homepage <https://infinifi.xyz/>`__
 - `App <https://app.infinifi.xyz/deposit>`__
 - `Twitter <https://x.com/infinifi_>`__

--- a/docs/source/vaults/liquidity_royalty/index.rst
+++ b/docs/source/vaults/liquidity_royalty/index.rst
@@ -17,6 +17,10 @@ Key features:
 - 7-day cooldown period for penalty-free withdrawals
 - 20% penalty for early withdrawals without cooldown, plus 1% base withdrawal fee
 
+Links
+~~~~~
+
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/liquidity-royalty-tranching>`__
 - `Homepage <https://github.com/stratosphere-network/LiquidRoyaltyContracts>`__
 - `Documentation <https://github.com/stratosphere-network/LiquidRoyaltyContracts/tree/master/docs>`__
 - `Github <https://github.com/stratosphere-network/LiquidRoyaltyContracts>`__

--- a/docs/source/vaults/mainstreet/index.rst
+++ b/docs/source/vaults/mainstreet/index.rst
@@ -20,6 +20,10 @@ Key features:
 - Governance-configurable cooldown period for withdrawals (up to 90 days, default 7 days)
 - Cross-chain functionality via LayerZero OFT standard
 
+Links
+~~~~~
+
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/mainstreet-finance>`__
 - `Homepage <https://mainstreet.finance/>`__
 - `Documentation <https://mainstreet-finance.gitbook.io/mainstreet.finance>`__
 - `GitHub <https://github.com/Mainstreet-Labs/mainstreet-core>`__

--- a/docs/source/vaults/renalta/index.rst
+++ b/docs/source/vaults/renalta/index.rst
@@ -13,6 +13,7 @@ Renalta is a yield protocol deployed on Base.
 Links
 ~~~~~
 
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/renalta>`__
 - `Homepage <https://renalta.com/>`__
 
 .. autosummary::

--- a/docs/source/vaults/resolv/index.rst
+++ b/docs/source/vaults/resolv/index.rst
@@ -20,6 +20,10 @@ Key features:
 - Yield accrues through the underlying stUSR rebasing mechanism
 - Instant deposits and withdrawals
 
+Links
+~~~~~
+
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/resolv>`__
 - `Homepage <https://resolv.xyz/>`__
 - `Documentation <https://docs.resolv.xyz/>`__
 - `Twitter <https://x.com/ResolvLabs>`__

--- a/docs/source/vaults/royco/index.rst
+++ b/docs/source/vaults/royco/index.rst
@@ -12,6 +12,10 @@ Royco allows protocols to deploy incentive campaigns for their vaults, enabling 
 to earn rewards in the form of ERC-20 tokens or points programmes alongside the underlying
 vault yield.
 
+Links
+~~~~~
+
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/royco>`__
 - `Homepage <https://royco.org/>`__
 - `Documentation <https://docs.royco.org/>`__
 - `Github <https://github.com/roycoprotocol/royco>`__

--- a/docs/source/vaults/sentiment/index.rst
+++ b/docs/source/vaults/sentiment/index.rst
@@ -14,6 +14,7 @@ allocation strategies. Fees are taken from interest earned and new shares are mi
 Links
 ~~~~~
 
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/sentiment>`__
 - `Homepage <https://www.sentiment.xyz/>`__
 - `Documentation <https://docs.sentiment.xyz/>`__
 - `GitHub <https://github.com/sentimentxyz/protocol-v2>`__

--- a/docs/source/vaults/singularity/index.rst
+++ b/docs/source/vaults/singularity/index.rst
@@ -21,6 +21,7 @@ Key features:
 Links
 ~~~~~
 
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/singularity-finance>`__
 - `Homepage <https://singularityfinance.ai/>`__
 - `Documentation <https://docs.singularityfinance.ai/>`__
 - `Twitter <https://x.com/singularity_fi>`__

--- a/docs/source/vaults/sky/index.rst
+++ b/docs/source/vaults/sky/index.rst
@@ -17,6 +17,10 @@ Key features:
 - Instant deposits and withdrawals
 - Fully decentralised and battle-tested infrastructure
 
+Links
+~~~~~
+
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/sky>`__
 - `Homepage <https://sky.money/>`__
 - `Documentation <https://developers.sky.money/>`__
 - `GitHub <https://github.com/sky-ecosystem/stusds>`__

--- a/docs/source/vaults/spark/index.rst
+++ b/docs/source/vaults/spark/index.rst
@@ -18,6 +18,10 @@ Key features:
 - Instant deposits and withdrawals (subject to PSM liquidity)
 - Fully backed by sUSDS (savings USDS)
 
+Links
+~~~~~
+
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/spark>`__
 - `Homepage <https://spark.fi/>`__
 - `Savings page <https://app.spark.fi/savings/mainnet/spusdc>`__
 - `Documentation <https://docs.spark.fi/>`__

--- a/docs/source/vaults/spectra/index.rst
+++ b/docs/source/vaults/spectra/index.rst
@@ -7,8 +7,10 @@ Spectra is an open-source interest rate derivatives protocol that enables yield 
 The protocol splits ERC-4626 compliant interest-bearing tokens into Principal Tokens (PT) and
 Yield Tokens (YT), allowing users to fix rates, trade yield, and earn on liquidity positions.
 
-Spectra Finance:
+Links
+~~~~~
 
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/spectra>`__
 - `Homepage <https://www.spectra.finance/>`__
 - `App <https://app.spectra.finance>`__
 - `Documentation <https://docs.spectra.finance/>`__

--- a/docs/source/vaults/teller/index.rst
+++ b/docs/source/vaults/teller/index.rst
@@ -30,6 +30,10 @@ The protocol is built on TellerV2 which handles the core lending mechanics,
 with `LenderCommitmentGroup_Pool_V2` contract providing the ERC-4626 vault interface
 for pool-style lending.
 
+Links
+~~~~~
+
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/teller>`__
 - `Homepage <https://www.teller.org/>`__
 - `Documentation <https://docs.teller.org/teller-v2>`__
 - `GitHub <https://github.com/teller-protocol/teller-protocol-v2>`__

--- a/docs/source/vaults/term_finance/index.rst
+++ b/docs/source/vaults/term_finance/index.rst
@@ -19,6 +19,10 @@ Key features:
 - Collateral sits in isolated noncustodial smart contracts (repoLocker)
 - No rehypothecation - collateral cannot be lent to other borrowers
 
+Links
+~~~~~
+
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/term-finance>`__
 - `Homepage <https://www.term.finance/>`__
 - `App <https://app.term.finance/>`__
 - `Documentation <https://developers.term.finance>`__

--- a/docs/source/vaults/usdd/index.rst
+++ b/docs/source/vaults/usdd/index.rst
@@ -16,6 +16,10 @@ Key features:
 - Instant deposits and withdrawals
 - Cross-chain deployment on Ethereum and BNB Chain
 
+Links
+~~~~~
+
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/decentralized-usd>`__
 - `Homepage <https://usdd.io/>`__
 - `Documentation <https://docs.usdd.io/>`__
 - `Twitter <https://x.com/usaborning>`__

--- a/docs/source/vaults/usdx_money/index.rst
+++ b/docs/source/vaults/usdx_money/index.rst
@@ -22,6 +22,10 @@ Key features:
 - 8-hour vesting period for reward distributions
 - Configurable cooldown mechanism for unstaking (up to 90 days)
 
+Links
+~~~~~
+
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/usdx-money>`__
 - `Homepage <https://usdx.money/>`__
 - `Documentation <https://docs.usdx.money/>`__
 - `GitHub <https://github.com/X-Financial-Technologies/usdx>`__

--- a/docs/source/vaults/yieldfi/index.rst
+++ b/docs/source/vaults/yieldfi/index.rst
@@ -14,6 +14,7 @@ mechanisms for risk management.
 Links
 ~~~~~
 
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/yieldfi>`__
 - `Homepage <https://yield.fi/>`__
 - `Documentation <https://docs.yield.fi/>`__
 - `Twitter <https://x.com/getyieldfi>`__

--- a/docs/source/vaults/yo/index.rst
+++ b/docs/source/vaults/yo/index.rst
@@ -20,6 +20,10 @@ Key features:
 - Configurable deposit and withdrawal fees
 - Asynchronous redemption for cross-chain operations
 
+Links
+~~~~~
+
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/yo>`__
 - `Homepage <https://www.yo.xyz/>`__
 - `Documentation <https://docs.yo.xyz/>`__
 - `GitHub <https://github.com/yoprotocol/core>`__

--- a/docs/source/vaults/yuzu_money/index.rst
+++ b/docs/source/vaults/yuzu_money/index.rst
@@ -29,6 +29,10 @@ where a consistent weekly yield target is distributed to users, backed by a Rese
 that acts as a buffer. This approach provides more predictable returns without explicit
 management or performance fees.
 
+Links
+~~~~~
+
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/yuzu-money>`__
 - `Homepage <https://yuzu.money/>`__
 - `App <https://app.yuzu.money/>`__
 - `Documentation <https://yuzu-money.gitbook.io/yuzu-money/>`__

--- a/docs/source/vaults/zerolend/index.rst
+++ b/docs/source/vaults/zerolend/index.rst
@@ -11,6 +11,10 @@ ZeroLend uses `Royco Protocol's <https://royco.org/>`__ WrappedVault infrastruct
 incentivised ERC-4626 vault wrappers with integrated rewards systems. This allows ZeroLend
 vaults to offer additional reward programmes alongside the underlying vault yield.
 
+Links
+~~~~~
+
+- `Listing <https://tradingstrategy.ai/trading-view/vaults/protocols/zerolend>`__
 - `Homepage <https://zerolend.xyz/>`__
 - `Application <https://app.zerolend.xyz/>`__
 - `Documentation <https://docs.zerolend.xyz/>`__

--- a/eth_defi/data/vaults/metadata/aarna.yaml
+++ b/eth_defi/data/vaults/metadata/aarna.yaml
@@ -30,7 +30,7 @@ links:
   defillama:
   audits: https://skynet.certik.com/projects/aarna-protocol
   fees:
-  trading_strategy:
+  trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/aarna
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/aarna/index.html
 example_smart_contracts:
   - https://etherscan.io/address/0xb9c1344105faa4681bc7ffd68c5c526da61f2ae8

--- a/eth_defi/data/vaults/metadata/accountable.yaml
+++ b/eth_defi/data/vaults/metadata/accountable.yaml
@@ -23,7 +23,7 @@ links:
   defillama: https://defillama.com/protocol/accountable
   audits: https://docs.accountable.capital/accountable-documentation/readme/audits
   fees:
-  trading_strategy:
+  trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/accountable
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/accountable/index.html
   linkedin: https://www.linkedin.com/company/accountablecapital/
 example_smart_contracts:

--- a/eth_defi/data/vaults/metadata/avant.yaml
+++ b/eth_defi/data/vaults/metadata/avant.yaml
@@ -21,7 +21,7 @@ links:
   defillama: https://defillama.com/protocol/avant-protocol
   audits: https://docs.avantprotocol.com/overview/audit-and-security
   fees:
-  trading_strategy:
+  trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/avant
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/avant/index.html
 example_smart_contracts:
   - https://snowtrace.io/address/0x06d47f3fb376649c3a9dafe069b3d6e35572219e

--- a/eth_defi/data/vaults/metadata/brink.yaml
+++ b/eth_defi/data/vaults/metadata/brink.yaml
@@ -21,7 +21,7 @@ links:
   defillama:
   audits: https://www.halborn.com/audits/lendle/brink-a73cf0
   fees:
-  trading_strategy:
+  trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/brink
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/brink/index.html
 example_smart_contracts:
   - https://mantlescan.xyz/address/0xE12EED61E7cC36E4CF3304B8220b433f1fD6e254

--- a/eth_defi/data/vaults/metadata/curvance.yaml
+++ b/eth_defi/data/vaults/metadata/curvance.yaml
@@ -29,7 +29,7 @@ links:
   defillama: https://defillama.com/protocol/curvance
   audits: https://docs.curvance.com/cve/security/security-and-audits
   fees:
-  trading_strategy:
+  trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/curvance
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/curvance/index.html
 example_smart_contracts:
   - https://monadscan.com/address/0xad4aa2a713fb86fbb6b60de2af9e32a11db6abf2

--- a/eth_defi/data/vaults/metadata/deltr.yaml
+++ b/eth_defi/data/vaults/metadata/deltr.yaml
@@ -14,7 +14,7 @@ links:
   defillama:
   audits:
   fees:
-  trading_strategy:
+  trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/deltr
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/deltr/index.html
 example_smart_contracts:
   - https://etherscan.io/address/0xa7a31e6a81300120b7c4488ec3126bc1ad11f320

--- a/eth_defi/data/vaults/metadata/fluid.yaml
+++ b/eth_defi/data/vaults/metadata/fluid.yaml
@@ -36,7 +36,7 @@ links:
   defillama: https://defillama.com/protocol/fluid
   audits: https://docs.fluid.instadapp.io/security/audits
   fees:
-  trading_strategy:
+  trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/fluid
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/fluid/index.html
 example_smart_contracts:
   - https://plasmascan.to/address/0x1DD4b13fcAE900C60a350589BE8052959D2Ed27B

--- a/eth_defi/data/vaults/metadata/hyperlend.yaml
+++ b/eth_defi/data/vaults/metadata/hyperlend.yaml
@@ -31,7 +31,7 @@ links:
   defillama: https://defillama.com/protocol/hyperlend
   audits:
   fees: https://docs.loopingcollective.org/products/wrapped-hlp
-  trading_strategy:
+  trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/hyperlend
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/hyperlend/index.html
 example_smart_contracts:
   - https://hyperevmscan.io/address/0x06fd9d03b3d0f18e4919919b72d30c582f0a97e5

--- a/eth_defi/data/vaults/metadata/hypurrfi.yaml
+++ b/eth_defi/data/vaults/metadata/hypurrfi.yaml
@@ -27,7 +27,7 @@ links:
   defillama:
   audits: https://docs.hypurr.fi/introduction/security
   fees:
-  trading_strategy:
+  trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/hypurrfi
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/hypurrfi/index.html
 example_smart_contracts:
   - https://hyperevmscan.io/address/0x8001e1e7b05990d22dd8cdb9737f9fe6589827ce

--- a/eth_defi/data/vaults/metadata/infinifi.yaml
+++ b/eth_defi/data/vaults/metadata/infinifi.yaml
@@ -30,7 +30,7 @@ links:
   defillama: https://defillama.com/protocol/infinifi
   audits: https://cantina.xyz/competitions/2ac7f906-1661-47eb-bfd6-519f5db0d36b
   fees:
-  trading_strategy:
+  trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/infinifi
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/infinifi/index.html
 example_smart_contracts:
   - https://etherscan.io/address/0xdbdc1ef57537e34680b898e1febd3d68c7389bcb

--- a/eth_defi/data/vaults/metadata/mainstreet-finance.yaml
+++ b/eth_defi/data/vaults/metadata/mainstreet-finance.yaml
@@ -38,7 +38,7 @@ links:
   defillama: https://defillama.com/stablecoin/main-street-usd
   audits: https://mainstreet-finance.gitbook.io/mainstreet.finance/audits/watchpug-security-audit-1
   fees: https://mainstreet-finance.gitbook.io/mainstreet.finance/returns-calculation-and-distribution
-  trading_strategy:
+  trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/mainstreet-finance
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/mainstreet/index.html
 example_smart_contracts:
   # smsUSD is the only ERC-4626 vault; msY (0x890A5122Aa1dA30fEC4286DE7904Ff808F0bd74A) is a LayerZero satellite token, not a vault

--- a/eth_defi/data/vaults/metadata/ostium.yaml
+++ b/eth_defi/data/vaults/metadata/ostium.yaml
@@ -29,7 +29,7 @@ links:
   defillama: https://defillama.com/protocol/ostium
   audits: https://ostium-labs.gitbook.io/ostium-docs/security/smart-contract-audits
   fees: https://ostium-labs.gitbook.io/ostium-docs/fee-breakdown
-  trading_strategy:
+  trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/ostium
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/gains/index.html
 example_smart_contracts:
   - https://arbiscan.io/address/0x20d419a8e12c45f88fda7c5760bb6923cee27f98

--- a/eth_defi/data/vaults/metadata/renalta.yaml
+++ b/eth_defi/data/vaults/metadata/renalta.yaml
@@ -18,7 +18,7 @@ links:
   defillama:
   audits:
   fees:
-  trading_strategy:
+  trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/renalta
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/renalta/index.html
 example_smart_contracts:
   - https://basescan.org/address/0x0ff79b6d6c0fb5faf54bd26db5ce97062a105f81

--- a/eth_defi/data/vaults/metadata/sentiment.yaml
+++ b/eth_defi/data/vaults/metadata/sentiment.yaml
@@ -30,7 +30,7 @@ links:
   defillama: https://defillama.com/protocol/sentiment
   audits: https://github.com/sentimentxyz/protocol-v2/tree/master/audits
   fees:
-  trading_strategy:
+  trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/sentiment
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/sentiment/index.html
 example_smart_contracts:
   - https://hyperevmscan.io/address/0xe45e7272da7208c7a137505dfb9491e330bf1a4e

--- a/eth_defi/data/vaults/metadata/singularity-finance.yaml
+++ b/eth_defi/data/vaults/metadata/singularity-finance.yaml
@@ -20,7 +20,7 @@ links:
   defillama: https://defillama.com/protocol/singularity-finance
   audits: https://paladinsec.co/projects/singularitydao/
   fees:
-  trading_strategy:
+  trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/singularity-finance
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/singularity/index.html
 example_smart_contracts:
   - https://basescan.org/address/0xdf71487381Ab5bD5a6B17eAa61FE2E6045A0e805

--- a/eth_defi/data/vaults/metadata/yieldfi.yaml
+++ b/eth_defi/data/vaults/metadata/yieldfi.yaml
@@ -25,7 +25,7 @@ links:
   defillama: https://defillama.com/protocol/yieldfi
   audits: https://docs.yield.fi/resources/audits
   fees:
-  trading_strategy:
+  trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/yieldfi
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/yieldfi/index.html
 example_smart_contracts:
   - https://etherscan.io/address/0x2e3c5e514eef46727de1fe44618027a9b70d92fc

--- a/eth_defi/data/vaults/metadata/yo.yaml
+++ b/eth_defi/data/vaults/metadata/yo.yaml
@@ -25,7 +25,7 @@ links:
   defillama: https://defillama.com/protocol/yo
   audits:
   fees:
-  trading_strategy:
+  trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/yo
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/yo/index.html
 example_smart_contracts:
   - https://etherscan.io/address/0x0000000f2eb9f69274678c76222b35eec7588a65


### PR DESCRIPTION
## Summary

- Add Trading Strategy listing links to 34 vault protocol RST documentation pages that were missing them
- Add Trading Strategy URLs to 17 vault protocol metadata YAML files that had empty `trading_strategy:` fields
- All vault protocol documentation pages now include a properly formatted Links section with Trading Strategy listing as the first link

Links follow the pattern: `https://tradingstrategy.ai/trading-view/vaults/protocols/{protocol-slug}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)