### PR TITLE
fix: Remove .html suffix from Sphinx generated sitemap URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Current
+
+- Fix: Remove `.html` suffix from Sphinx generated sitemap URLs for Cloudflare Pages compatibility (2026-02-05)
+
 # 0.40
 
 - Update: Relax NumPy version constraint from `<2` to `<3` to allow NumPy 2.x (2026-02-05)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -156,3 +156,29 @@ highlight_language = "none"
 pygments_style = None
 
 from eth_defi.docs import monkeypatch
+
+
+def strip_html_from_sitemap(app, exception):
+    """Remove .html suffix from generated sitemap URLs.
+
+    Runs as a ``build-finished`` event handler after sphinx-sitemap
+    has written the sitemap file.  Cloudflare Pages serves pages
+    without the ``.html`` extension, so the sitemap should match.
+    """
+    if exception:
+        return
+
+    from pathlib import Path
+    import re
+
+    filename = Path(app.outdir) / app.config.sitemap_filename
+    if not filename.exists():
+        return
+
+    content = filename.read_text(encoding="utf-8")
+    content = re.sub(r"\.html</loc>", "</loc>", content)
+    filename.write_text(content, encoding="utf-8")
+
+
+def setup(app):
+    app.connect("build-finished", strip_html_from_sitemap)


### PR DESCRIPTION
## Summary

- Strip `.html` suffix from all URLs in the Sphinx-generated sitemap (`sitemap-generated.xml`) so they match the canonical URLs served by Cloudflare Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)