### PR TITLE
notes: Mark Borrowable USDC Deposit SiloId 27 as illiquid

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -174,6 +174,8 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0x2f5dc399b1e31f9808d1ef1256917abd2447c74f": (VaultFlag.illiquid, XUSD_MESSAGE),
     # Borrowable USDC Deposit, SiloId: 55, Sonic
     "0x4935fadb17df859667cc4f7bfe6a8cb24f86f8d0": (VaultFlag.illiquid, XUSD_MESSAGE),
+    # Borrowable USDC Deposit, SiloId: 27, Sonic
+    "0x7e88ae5e50474a48dea4c42a634aa7485e7caa62": (VaultFlag.illiquid, XUSD_MESSAGE),
     # EVK Vault eUSDC-1, Sonic
     "0x9ccf74e64922d8a48b87aa4200b7c27b2b1d860a": (VaultFlag.illiquid, XUSD_MESSAGE),
     # Frontier Yala USDC


### PR DESCRIPTION
## Summary
- Mark Borrowable USDC Deposit, SiloId: 27 vault (0x7e88ae5e50474a48dea4c42a634aa7485e7caa62) on Sonic as illiquid due to xUSD exposure

🤖 Generated with [Claude Code](https://claude.com/claude-code)