### PR TITLE
fix: Replace deprecated datetime functions with Python 3.12+ compatible alternatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Current
 
+- Fix: Replace deprecated `datetime.utcnow()` and `pd.Timestamp.utcfromtimestamp()` with Python 3.12+ compatible alternatives (2026-02-08)
 - Add: New protocol: [sBOLD](https://tradingstrategy.ai/trading-view/vaults/protocols/sbold) - yield-bearing tokenised representation of deposits into Liquity V2 Stability Pools by K3 Capital (2026-02-08)
 - Fix: Multi-chain vault scanner now captures and displays exceptions per chain instead of crashing, with full tracebacks printed before the final dashboard (2026-02-05)
 - Fix: Remove `.html` suffix from Sphinx generated sitemap URLs for Cloudflare Pages compatibility (2026-02-05)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,14 @@
 - Say things like `visualise` instead of `visualize`
 - For headings, only capitalise the first letter of heading, do not use title case
 
+## Installing dependencies
+
+Use Poetry version `<2.3` as newer versions may have compatibility issues. Install dependencies with all required extras:
+
+```shell
+poetry install -E web3v6 -E data -E test -E docs -E hypersync -E ccxt -E cloudflare_r2 -E duckdb
+```
+
 ## Running Python scripts
 
 When running a Python script use `poetry run python` command instead of plain `python` command, so that the virtual environment is activated.
@@ -23,7 +31,7 @@ To run tests you need to use the installed Poetry environment, with given enviro
 To run tests use the `pytest` wrapper command:
 
 ```shell
-source .local-test.env && poetry pytest run {test case name or pattern here}
+source .local-test.env && poetry run pytest {test case name or pattern here}
 ```
 
 Always prefix pytest command with relevant source command,
@@ -45,26 +53,6 @@ In the environment file, the RPC URLs are provided in the project-specific space
 - If there is a space in RPC URL given by a environment variable like `JSON_RPC_ETHEREUM`, it can be only used with Python call `create_multi_provider_web3()`
 - If you are going to use this RPC URL with other commands, like `curl`, you need to parse the RPC environment variable by spltting it by spaces and taking the first entry
 - All environment variables point to EVM archive nodes
-
-## Running tests
-
-If we have not run tests before make sure the user has created a gitignored file `.local-test.env` in the repository root. This will use `source` shell command to include the actual test secrets which lie outside the repository structure. Note: this file does not contain actual environment variables, just a `source` command to get them from elsewhere. **Never edit this file** and always ask the user to prepare the file for Claude Code.
-
-To run tests you need to use the installed Poetry environment, with given environment secrets file.
-
-To run tests use the `pytest` wrapper command:
-
-```shell
-source .local-test.env && poetry pytest run {test case name or pattern here}
-```
-
-Always prefix pytest command with relevant source command,
-otherwise the test cannot find environment variables.
-
-Avoid running the whole test suite as it takes several minutes. Only run specific test cases.
-
-When running pytest or any test commands, always use an extended timeout
-by specifying `timeout: 180000` (3 minutes) in the bash tool parameters.
 
 ## Formatting code
 

--- a/eth_defi/event_reader/reorganisation_monitor.py
+++ b/eth_defi/event_reader/reorganisation_monitor.py
@@ -413,7 +413,7 @@ class ReorganisationMonitor(ABC):
         """Return UNIX UTC timestamp of a block."""
 
         ts = self.get_block_timestamp(block_number)
-        return pd.Timestamp.utcfromtimestamp(ts).tz_localize(None)
+        return pd.Timestamp.fromtimestamp(ts, tz="UTC").tz_localize(None)
 
     def update_chain(self) -> ChainReorganisationResolution:
         """Update the internal memory buffer of block headers from the blockchain node.

--- a/eth_defi/token_analysis/tokenrisk.py
+++ b/eth_defi/token_analysis/tokenrisk.py
@@ -22,6 +22,7 @@ from eth_typing import HexAddress
 from requests import Session
 from requests.sessions import HTTPAdapter
 
+from eth_defi.compat import native_datetime_utc_now
 from eth_defi.sqlite_cache import PersistentKeyValueStore
 from eth_defi.velvet.logging_retry import LoggingRetry
 
@@ -258,7 +259,7 @@ class TokenRisk:
 
         # Add timestamp when this was recorded,
         # so cache can have this also as a content value
-        data["data_fetched_at"] = datetime.datetime.utcnow().isoformat()
+        data["data_fetched_at"] = native_datetime_utc_now().isoformat()
 
         return data
 
@@ -353,7 +354,7 @@ class CachedTokenRisk(TokenRisk):
         cached = self.cache.get(cache_key)
         if not cached:
             decoded = super().fetch_token_info(chain_id, address)
-            decoded["cached_at"] = datetime.datetime.utcnow().isoformat()
+            decoded["cached_at"] = native_datetime_utc_now().isoformat()
             self.cache[cache_key] = json.dumps(decoded)
             decoded["cached"] = False
         else:


### PR DESCRIPTION
## Summary

- Replace `datetime.utcnow()` with `native_datetime_utc_now()` in `tokenrisk.py`
- Replace `pd.Timestamp.utcfromtimestamp()` with `pd.Timestamp.fromtimestamp(ts, tz="UTC")` in `reorganisation_monitor.py`
- Update `CLAUDE.md` with Poetry installation instructions and fix pytest command syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)