### PR TITLE
feat: Fix Euler description crash, add Lagoon notes fallback and lockup estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Current
 
+- Fix Euler vault description crash when vault is not in Euler's GitHub labels metadata (2026-02-12)
+- Lagoon vaults now return offchain description as notes when no manual notes are set (2026-02-12)
+- Lagoon vault lockup estimation now uses average settlement time from offchain metadata (2026-02-12)
 - Rename IPOR protocol to "IPOR Fusion" with slug `ipor-fusion` to match official branding (2026-02-11)
 - Remove unreliable maxRedeem lock-up check from IPOR Fusion vaults (2026-02-11)
 

--- a/eth_defi/erc_4626/vault_protocol/euler/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/euler/vault.py
@@ -191,11 +191,15 @@ class EulerVault(ERC4626Vault):
 
     @property
     def description(self) -> str | None:
-        return self.euler_metadata.get("description")
+        if self.euler_metadata:
+            return self.euler_metadata.get("description")
+        return None
 
     @property
     def entity(self) -> str | None:
-        return self.euler_metadata.get("entity")
+        if self.euler_metadata:
+            return self.euler_metadata.get("entity")
+        return None
 
     def get_management_fee(self, block_identifier: BlockIdentifier) -> float:
         """Euler vault kit vaults never have management fee"""


### PR DESCRIPTION
## Summary

- Fix production `AttributeError: 'NoneType' object has no attribute 'get'` crash in `EulerVault.description` when vault is not in Euler's GitHub labels metadata
- Lagoon vaults now return their offchain long description in the `notes` field when no manual notes are set via vault flags
- Lagoon vault lockup estimation now uses `average_settlement` from Lagoon's web app API metadata instead of a hardcoded 3-day default; returns `None` when metadata is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)