### PR TITLE
feat: Fix timeout tuple crash in web3 session cache eviction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Current
 
+- Fix threading.Timer crash when HTTP timeout tuple leaks into web3 session cache eviction under high concurrency (2026-02-12)
 - Fix Euler vault description crash when vault is not in Euler's GitHub labels metadata (2026-02-12)
 - Lagoon vaults now return offchain description as notes when no manual notes are set (2026-02-12)
 - Lagoon vault lockup estimation now uses average settlement time from offchain metadata (2026-02-12)


### PR DESCRIPTION
## Summary
- Fix `TypeError: '>' not supported between instances of 'tuple' and 'int'` crash in `threading.Timer` during high-concurrency vault scanning
- The `requests` library timeout tuple `(connect_timeout, read_timeout)` leaked through the monkey-patched `_make_request` into web3's `HTTPSessionManager`, which passed it to `threading.Timer()` on session cache eviction
- Flatten the tuple to the read timeout float before passing to the global session manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)