### PR TITLE
feat: Add deterministic cross-chain Safe deployment using CREATE2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Current
 
 - **Add: Circle CCTP V2 cross-chain USDC transfer support with guard whitelisting and Lagoon vault integration (2026-02-15)**
+- Add: Deterministic cross-chain Safe deployment using CREATE2 via canonical SafeProxyFactory (2026-02-16)
 
 # 1.0.2
 

--- a/eth_defi/safe/deployment.py
+++ b/eth_defi/safe/deployment.py
@@ -12,7 +12,12 @@ import time
 
 from eth_account.signers.local import LocalAccount
 from eth_typing import HexAddress
+from hexbytes import HexBytes
+from safe_eth.eth.constants import NULL_ADDRESS
+from safe_eth.eth.contracts import get_safe_contract
+from safe_eth.eth.utils import get_empty_tx_params
 from safe_eth.safe import Safe
+from safe_eth.safe.proxy_factory import ProxyFactory
 from safe_eth.safe.safe import SafeV141
 from web3 import Web3
 from web3.contract.contract import ContractFunction
@@ -94,6 +99,195 @@ def deploy_safe(
     assert retrieved_owners == owners
 
     logger.info("Safe deployed at %s", safe.address)
+    return safe
+
+
+#: Safe v1.4.1 ProxyFactory — deployed at the same address on all EVM chains.
+#: See https://docs.safe.global/advanced/smart-account-supported-networks/v1.4.1
+SAFE_PROXY_FACTORY_ADDRESS = "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67"
+
+#: Safe v1.4.1 L2 singleton (master copy) — deployed at the same address on all EVM chains.
+SAFE_L2_MASTER_COPY_ADDRESS = "0x29fcB43b46531BcA003ddC8FCB67FFE91900C762"
+
+
+def _build_safe_initializer(
+    web3: Web3,
+    owners: list[str],
+    threshold: int,
+) -> bytes:
+    """Build the Safe ``setup()`` initializer calldata.
+
+    :param owners:
+        Checksummed owner addresses.
+
+    :param threshold:
+        Number of required confirmations.
+
+    :return:
+        ABI-encoded initializer bytes for Safe proxy deployment.
+    """
+    safe_contract = get_safe_contract(web3, NULL_ADDRESS)
+    initializer = safe_contract.functions.setup(
+        owners,
+        threshold,
+        NULL_ADDRESS,  # Contract address for optional delegate call
+        b"",  # Data payload for optional delegate call
+        NULL_ADDRESS,  # Handler for fallback calls to this contract
+        NULL_ADDRESS,  # Payment token
+        0,  # Payment
+        NULL_ADDRESS,  # Payment receiver
+    ).build_transaction(get_empty_tx_params())["data"]
+    return HexBytes(initializer)
+
+
+def calculate_deterministic_safe_address(
+    web3: Web3,
+    owners: list[HexAddress | str],
+    threshold: int,
+    salt_nonce: int,
+    master_copy_address: HexAddress | str = SAFE_L2_MASTER_COPY_ADDRESS,
+    proxy_factory_address: HexAddress | str = SAFE_PROXY_FACTORY_ADDRESS,
+) -> HexAddress:
+    """Pre-compute the deterministic Safe address without deploying.
+
+    Uses the same CREATE2 formula as :func:`deploy_safe_with_deterministic_address`
+    to predict the Safe proxy address before deployment. The address depends only on
+    the owner list, threshold, salt nonce, master copy, and proxy factory — all of which
+    are the same on every EVM chain, enabling cross-chain address prediction.
+
+    :param owners:
+        List of owner addresses. Must be in the same order across chains.
+
+    :param threshold:
+        Number of required confirmations.
+
+    :param salt_nonce:
+        Uint256 salt for CREATE2. Use the same value across chains for the same address.
+
+    :param master_copy_address:
+        Safe singleton address. Default is Safe v1.4.1 L2.
+
+    :param proxy_factory_address:
+        Safe ProxyFactory address. Default is the canonical v1.4.1 factory.
+
+    :return:
+        The predicted Safe proxy address.
+    """
+    assert len(owners) >= 1, "Safe must have at least one owner"
+    assert 1 <= threshold <= len(owners), f"Threshold={threshold} must be >= 1 and <= {len(owners)}"
+
+    owners = [Web3.to_checksum_address(a) for a in owners]
+    master_copy_address = Web3.to_checksum_address(master_copy_address)
+    proxy_factory_address = Web3.to_checksum_address(proxy_factory_address)
+
+    ethereum_client = create_safe_ethereum_client(web3)
+    proxy_factory = ProxyFactory(proxy_factory_address, ethereum_client, version="1.4.1")
+
+    initializer = _build_safe_initializer(web3, owners, threshold)
+
+    return proxy_factory.calculate_proxy_address(
+        master_copy=master_copy_address,
+        initializer=initializer,
+        salt_nonce=salt_nonce,
+    )
+
+
+def deploy_safe_with_deterministic_address(
+    web3: Web3,
+    deployer: LocalAccount,
+    owners: list[HexAddress | str],
+    threshold: int,
+    salt_nonce: int,
+    master_copy_address: HexAddress | str = SAFE_L2_MASTER_COPY_ADDRESS,
+    proxy_factory_address: HexAddress | str = SAFE_PROXY_FACTORY_ADDRESS,
+    post_deploy_delay_seconds: float = 10.0,
+) -> Safe:
+    """Deploy a new Safe wallet at a deterministic address using CREATE2.
+
+    Uses the canonical Safe v1.4.1 ProxyFactory (deployed at the same address on
+    all EVM chains) with ``createProxyWithNonce()`` to produce the same Safe address
+    across multiple chains, given identical parameters.
+
+    For cross-chain deterministic deployment, ensure:
+
+    - Same ``owners`` list (same order)
+    - Same ``threshold``
+    - Same ``salt_nonce``
+    - Same ``master_copy_address`` and ``proxy_factory_address`` (defaults are fine)
+
+    :param deployer:
+        Must be LocalAccount due to Safe library limitations.
+
+    :param owners:
+        List of owner addresses. Must be in the same order across chains.
+
+    :param threshold:
+        Number of required confirmations.
+
+    :param salt_nonce:
+        Uint256 salt for CREATE2. Use the same value across chains for the same address.
+
+    :param master_copy_address:
+        Safe singleton address. Default is Safe v1.4.1 L2.
+
+    :param proxy_factory_address:
+        Safe ProxyFactory address. Default is the canonical v1.4.1 factory.
+
+    :param post_deploy_delay_seconds:
+        Sleep after deployment on non-Anvil networks to let state propagate.
+    """
+    assert len(owners) >= 1, "Safe must have at least one owner"
+    assert isinstance(deployer, LocalAccount), "Safe can be only deployed using LocalAccount"
+    for a in owners:
+        assert type(a) == str and a.startswith("0x"), f"owners must be hex addresses, got {type(a)}"
+
+    owners = [Web3.to_checksum_address(a) for a in owners]
+    master_copy_address = Web3.to_checksum_address(master_copy_address)
+    proxy_factory_address = Web3.to_checksum_address(proxy_factory_address)
+
+    logger.info(
+        "Deploying Safe with deterministic address (CREATE2).\nInitial cosigner list: %s\nInitial threshold: %s\nSalt nonce: %s",
+        owners,
+        threshold,
+        salt_nonce,
+    )
+
+    ethereum_client = create_safe_ethereum_client(web3)
+    proxy_factory = ProxyFactory(proxy_factory_address, ethereum_client, version="1.4.1")
+
+    initializer = _build_safe_initializer(web3, owners, threshold)
+
+    # Pre-compute the expected address
+    expected_address = proxy_factory.calculate_proxy_address(
+        master_copy=master_copy_address,
+        initializer=initializer,
+        salt_nonce=salt_nonce,
+    )
+    logger.info("Expected deterministic Safe address: %s", expected_address)
+
+    # Deploy via ProxyFactory.createProxyWithNonce (CREATE2)
+    tx_sent = proxy_factory.deploy_proxy_contract_with_nonce(
+        deployer_account=deployer,
+        master_copy=master_copy_address,
+        initializer=initializer,
+        salt_nonce=salt_nonce,
+    )
+
+    assert_transaction_success_with_explanation(web3, tx_sent.tx_hash)
+
+    contract_address = tx_sent.contract_address
+    assert contract_address == expected_address, f"Deployed address {contract_address} does not match expected {expected_address}"
+
+    safe = SafeV141(contract_address, ethereum_client)
+
+    if not is_anvil(web3):
+        logger.info("Sleeping for %d seconds for Safe deployment state to propagate", post_deploy_delay_seconds)
+        time.sleep(post_deploy_delay_seconds)
+
+    retrieved_owners = safe.retrieve_owners()
+    assert retrieved_owners == owners, f"Owner mismatch: expected {owners}, got {retrieved_owners}"
+
+    logger.info("Safe deployed at deterministic address %s", safe.address)
     return safe
 
 

--- a/tests/safe/test_safe_deterministic_deploy.py
+++ b/tests/safe/test_safe_deterministic_deploy.py
@@ -1,0 +1,242 @@
+"""Test deterministic Safe deployment across multiple chains.
+
+Verifies that:
+1. The raw helper produces the same Safe address on Base and Arbitrum forks
+2. The Lagoon automated deployment produces the same Safe address when given a salt nonce
+"""
+
+import logging
+import os
+
+import pytest
+from eth_account import Account
+from eth_account.signers.local import LocalAccount
+from eth_typing import HexAddress
+from web3 import Web3
+
+from eth_defi.hotwallet import HotWallet
+from eth_defi.erc_4626.vault_protocol.lagoon.deployment import (
+    LagoonDeploymentParameters,
+    deploy_automated_lagoon_vault,
+)
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.safe.deployment import (
+    calculate_deterministic_safe_address,
+    deploy_safe_with_deterministic_address,
+)
+from eth_defi.token import USDC_NATIVE_TOKEN
+
+logger = logging.getLogger(__name__)
+
+JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
+JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
+
+pytestmark = pytest.mark.skipif(
+    not JSON_RPC_BASE or not JSON_RPC_ARBITRUM,
+    reason="JSON_RPC_BASE and JSON_RPC_ARBITRUM environment variables required",
+)
+
+#: Fixed private key so the deployer address is the same on both chains.
+DEPLOYER_PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+#: Fixed owner addresses (Anvil default accounts).
+OWNER_1 = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
+OWNER_2 = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
+
+
+@pytest.fixture()
+def deployer() -> LocalAccount:
+    return Account.from_key(DEPLOYER_PRIVATE_KEY)
+
+
+@pytest.fixture()
+def owners() -> list[HexAddress]:
+    return [OWNER_1, OWNER_2]
+
+
+@pytest.fixture()
+def anvil_base(request) -> AnvilLaunch:
+    """Base mainnet fork."""
+    launch = fork_network_anvil(JSON_RPC_BASE)
+    try:
+        yield launch
+    finally:
+        launch.close(log_level=logging.ERROR)
+
+
+@pytest.fixture()
+def anvil_arbitrum(request) -> AnvilLaunch:
+    """Arbitrum mainnet fork."""
+    launch = fork_network_anvil(JSON_RPC_ARBITRUM)
+    try:
+        yield launch
+    finally:
+        launch.close(log_level=logging.ERROR)
+
+
+@pytest.fixture()
+def web3_base(anvil_base) -> Web3:
+    web3 = create_multi_provider_web3(
+        anvil_base.json_rpc_url,
+        default_http_timeout=(3, 250.0),
+    )
+    assert web3.eth.chain_id == 8453
+    return web3
+
+
+@pytest.fixture()
+def web3_arbitrum(anvil_arbitrum) -> Web3:
+    web3 = create_multi_provider_web3(
+        anvil_arbitrum.json_rpc_url,
+        default_http_timeout=(3, 250.0),
+    )
+    assert web3.eth.chain_id == 42161
+    return web3
+
+
+def test_deterministic_safe_same_address_base_and_arbitrum(
+    web3_base: Web3,
+    web3_arbitrum: Web3,
+    deployer: LocalAccount,
+    owners: list[HexAddress],
+):
+    """Deploy a deterministic Safe on both Base and Arbitrum forks and verify same address.
+
+    - Pre-compute the address on both chains, verify they match
+    - Deploy on both chains, verify deployed addresses match
+    - Verify owners are correctly set on both chains
+    """
+    salt_nonce = 12345
+    threshold = 2
+
+    # Fund deployer on both chains
+    web3_base.provider.make_request("anvil_setBalance", [deployer.address, hex(10 * 10**18)])
+    web3_arbitrum.provider.make_request("anvil_setBalance", [deployer.address, hex(10 * 10**18)])
+
+    # Pre-compute addresses — should be identical
+    predicted_base = calculate_deterministic_safe_address(
+        web3_base,
+        owners,
+        threshold,
+        salt_nonce,
+    )
+    predicted_arbitrum = calculate_deterministic_safe_address(
+        web3_arbitrum,
+        owners,
+        threshold,
+        salt_nonce,
+    )
+    assert predicted_base == predicted_arbitrum, f"Predicted addresses differ: Base={predicted_base}, Arbitrum={predicted_arbitrum}"
+    logger.info("Predicted Safe address (both chains): %s", predicted_base)
+
+    # Deploy on Base
+    safe_base = deploy_safe_with_deterministic_address(
+        web3_base,
+        deployer,
+        owners,
+        threshold,
+        salt_nonce,
+    )
+    logger.info("Base Safe deployed at: %s", safe_base.address)
+
+    # Deploy on Arbitrum
+    safe_arbitrum = deploy_safe_with_deterministic_address(
+        web3_arbitrum,
+        deployer,
+        owners,
+        threshold,
+        salt_nonce,
+    )
+    logger.info("Arbitrum Safe deployed at: %s", safe_arbitrum.address)
+
+    # Verify addresses match
+    assert safe_base.address == safe_arbitrum.address, f"Deployed addresses differ: Base={safe_base.address}, Arbitrum={safe_arbitrum.address}"
+    assert safe_base.address == predicted_base, f"Deployed address does not match prediction: {safe_base.address} != {predicted_base}"
+
+    # Verify owners on both chains
+    assert safe_base.retrieve_owners() == [Web3.to_checksum_address(a) for a in owners]
+    assert safe_arbitrum.retrieve_owners() == [Web3.to_checksum_address(a) for a in owners]
+
+
+def test_lagoon_deterministic_safe_base_and_arbitrum(
+    web3_base: Web3,
+    web3_arbitrum: Web3,
+    deployer: LocalAccount,
+):
+    """Deploy Lagoon automated vaults on Base and Arbitrum with deterministic Safe.
+
+    - Both deployments use the same salt nonce
+    - Verify the Safe addresses from deploy_automated_lagoon_vault() are identical across chains
+    - Verify the vault addresses are (expectedly) different
+
+    .. note::
+
+        This test deploys full Lagoon setups which include many transactions
+        (vault, module, guard whitelisting, ownership). If the underlying RPC
+        is slow, individual transactions may time out. The core deterministic Safe
+        behaviour is verified by the simpler test above.
+    """
+    salt_nonce = 42
+
+    deployer_wallet_base = HotWallet(deployer)
+    deployer_wallet_arb = HotWallet(deployer)
+
+    # Fund deployer on both chains
+    web3_base.provider.make_request("anvil_setBalance", [deployer.address, hex(100 * 10**18)])
+    web3_arbitrum.provider.make_request("anvil_setBalance", [deployer.address, hex(100 * 10**18)])
+
+    asset_manager = deployer.address
+    safe_owners = [OWNER_1, OWNER_2]
+
+    # Deploy on Base
+    deployer_wallet_base.sync_nonce(web3_base)
+    base_params = LagoonDeploymentParameters(
+        underlying=USDC_NATIVE_TOKEN[8453],
+        name="Test Vault",
+        symbol="TV",
+    )
+    base_deploy = deploy_automated_lagoon_vault(
+        web3=web3_base,
+        deployer=deployer_wallet_base,
+        asset_manager=asset_manager,
+        parameters=base_params,
+        safe_owners=safe_owners,
+        safe_threshold=2,
+        uniswap_v2=None,
+        uniswap_v3=None,
+        any_asset=True,
+        safe_salt_nonce=salt_nonce,
+    )
+    base_safe_address = base_deploy.vault.safe_address
+    base_vault_address = base_deploy.vault.address
+    logger.info("Base: Safe=%s, Vault=%s", base_safe_address, base_vault_address)
+
+    # Deploy on Arbitrum
+    deployer_wallet_arb.sync_nonce(web3_arbitrum)
+    arb_params = LagoonDeploymentParameters(
+        underlying=USDC_NATIVE_TOKEN[42161],
+        name="Test Vault",
+        symbol="TV",
+    )
+    arb_deploy = deploy_automated_lagoon_vault(
+        web3=web3_arbitrum,
+        deployer=deployer_wallet_arb,
+        asset_manager=asset_manager,
+        parameters=arb_params,
+        safe_owners=safe_owners,
+        safe_threshold=2,
+        uniswap_v2=None,
+        uniswap_v3=None,
+        any_asset=True,
+        safe_salt_nonce=salt_nonce,
+    )
+    arb_safe_address = arb_deploy.vault.safe_address
+    arb_vault_address = arb_deploy.vault.address
+    logger.info("Arbitrum: Safe=%s, Vault=%s", arb_safe_address, arb_vault_address)
+
+    # Safe addresses must be the same
+    assert base_safe_address == arb_safe_address, f"Safe addresses differ: Base={base_safe_address}, Arbitrum={arb_safe_address}"
+
+    # Vault addresses should be different (different chain, different init code)
+    assert base_vault_address != arb_vault_address, "Vault addresses unexpectedly identical across chains"


### PR DESCRIPTION
## Summary

- Add `deploy_safe_with_deterministic_address()` and `calculate_deterministic_safe_address()` helpers that use the canonical Safe v1.4.1 ProxyFactory (`0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67`) with `createProxyWithNonce()` (CREATE2) to deploy Safe multisig wallets at the same address across multiple EVM chains
- Add `safe_salt_nonce` parameter to `deploy_automated_lagoon_vault()` so Lagoon deployments can opt into deterministic Safe addresses
- Add integration tests verifying identical Safe addresses on Base and Arbitrum Anvil forks

🤖 Generated with [Claude Code](https://claude.com/claude-code)