### PR TITLE
notes: Mark Peapods Interest Bearing USDC - 22 as illiquid

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -121,6 +121,8 @@ MISSING_IN_PROTOCOL_FRONTEND = "This vault is missing in the protocol's primary 
 
 SUBVAULT = "This vault is likely not intended to be directly exposed to the end users. It may be used by other vaults as a part of the strategy mix and has erratic TVL."
 
+PEAPODS_ILLIQUID = "Peapods vault is illiquid"
+
 YIELDNEST_YNRWAX = """ynRWAx: Tokenized Australian residential real estate credit earning 11% APY, allocated to mortgage-backed loans on verified house-and-land developments. Made safe in collaboration with a fully licensed and insured fund manager, [Kimber Capital](https://kimbercapital.au/) (AFS Licence No. 425278).
 
 Fees: 0%.
@@ -315,6 +317,8 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0x74847d0d124ce5c89ca8f4e7547aecd09e86b2e0": (VaultFlag.unofficial, MISSING_IN_PROTOCOL_FRONTEND),
     # Borrowable USDC Deposit, SiloId: 125 on Avalanche
     "0xe0345f66318f482acccd67244a921c7fdc410957": (VaultFlag.illiquid, XUSD_MESSAGE),
+    # Peapods Interest Bearing USDC - 22 (Arbitrum)
+    "0x0319c82013cf676661f7bde576c6731869a93fc0": (VaultFlag.illiquid, PEAPODS_ILLIQUID),
 }
 
 for addr in VAULT_FLAGS_AND_NOTES.keys():


### PR DESCRIPTION
## Summary
- Mark Peapods Interest Bearing USDC - 22 (Arbitrum, `0x0319c82013cf676661f7bde576c6731869a93fc0`) as illiquid

🤖 Generated with [Claude Code](https://claude.com/claude-code)