### PR TITLE
fix: Speed up sparkline export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Current
 
+- Fix sparkline export hanging on vault filtering and parallelise rendering with multiprocessing (2026-02-18)
 - Fix block timestamp scan range clipping to prevent querying blocks beyond HyperSync database range (2026-02-18)
 - Switch from ujson to orjson for faster JSON-RPC response decoding (2026-02-18)
 - Add Accountable Capital offchain metadata for vault descriptions, company info, and performance fees (2026-02-18)

--- a/eth_defi/research/sparkline.py
+++ b/eth_defi/research/sparkline.py
@@ -11,6 +11,9 @@ from io import BytesIO
 import pandas as pd
 import numpy as np
 
+import matplotlib
+
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
 from eth_defi.research.wrangle_vault_prices import forward_fill_vault


### PR DESCRIPTION
## Summary

- **Fix vault filtering hang**: Replace per-vault `get_group()` calls with a single `groupby().max()` aggregation. The original code called `get_group()` for every vault row, triggering expensive pyarrow `ChunkedArray.take()` operations that caused the script to appear hung.
- **Parallelise rendering**: Force matplotlib Agg backend (no macOS NSWindow issue), then use `joblib.Parallel(prefer="processes")` for rendering instead of a sequential loop.
- **Eliminate duplicate work**: Combine SVG + PNG renders into a single function that shares data extraction, resampling, and forward-fill per vault.
- **Reuse boto3 client**: Create one S3 client for all uploads instead of one per file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)