### PR TITLE
fix: Guard against divide-by-zero in share price calculation

### DIFF
--- a/eth_defi/hyperliquid/combined_analysis.py
+++ b/eth_defi/hyperliquid/combined_analysis.py
@@ -276,8 +276,9 @@ def _calculate_share_price(
                 # Calculate shares to mint/burn at current share price
                 # For deposits: shares_minted = deposit_amount / share_price
                 # For withdrawals: shares_burned = withdrawal_amount / share_price
-                shares_change = netflow / current_share_price
-                current_total_supply += shares_change
+                if current_share_price > 0:
+                    shares_change = netflow / current_share_price
+                    current_total_supply += shares_change
 
         # Ensure total_supply doesn't go negative
         current_total_supply = max(0.0, current_total_supply)


### PR DESCRIPTION
## Summary
- Fixed RuntimeWarning for divide-by-zero in `_calculate_share_price()` when processing closed/fully-withdrawn Hyperliquid vaults
- Closed vaults can have `total_assets=0`, which sets share price to 0, causing the next netflow division to blow up

🤖 Generated with [Claude Code](https://claude.com/claude-code)