### PR TITLE
feat: Auto-blacklist HyperCore subvaults and abnormal share price vaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Current
 
+- Auto-blacklist HyperCore HLP child sub-vaults and vaults with abnormal share price > $1M (2026-02-21)
 - **Add: GRVT (Gravity Markets) native vault metrics pipeline with dynamic vault discovery via public endpoints, DuckDB storage, and unified ERC-4626 pipeline export (2026-02-20)**
 - **Fix: Route Hypercore vaults through the standard ERC-4626 cleaning pipeline to fix abnormal profit metrics (2026-02-20)**
 - **Add: Ember protocol vault integration with custom VaultDeposit/RequestRedeemed event support, offchain metadata, and disk cache consolidation (2026-02-20, [#755](https://github.com/tradingstrategy-ai/web3-ethereum-defi/pull/755))**

--- a/eth_defi/hyperliquid/vault_data_export.py
+++ b/eth_defi/hyperliquid/vault_data_export.py
@@ -45,6 +45,7 @@ from eth_defi.hyperliquid.daily_metrics import HyperliquidDailyMetricsDatabase
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.fee import FeeData
 from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.risk import VaultTechnicalRisk
 from eth_defi.vault.vaultdb import VaultDatabase, VaultRow
 
 logger = logging.getLogger(__name__)
@@ -107,8 +108,10 @@ def create_hyperliquid_vault_row(
     flags = {VaultFlag.perp_dex_trading_vault}
 
     # HLP child sub-vaults are internal system vaults not directly investable by users
+    risk = None
     if relationship_type == "child":
         flags.add(VaultFlag.subvault)
+        risk = VaultTechnicalRisk.blacklisted
 
     detection = ERC4262VaultDetection(
         chain=chain_id,
@@ -159,6 +162,7 @@ def create_hyperliquid_vault_row(
         "_deposit_next_open": None,
         "_redemption_closed_reason": None,
         "_redemption_next_open": None,
+        "_risk": risk,
     }
 
     spec = VaultSpec(chain_id=chain_id, vault_address=address)

--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -56,6 +56,9 @@ class VaultFlag(str, enum.Enum):
     #: This vault is a subvault used by other vaults
     subvault = "subvault"
 
+    #: Share price is unrealistically high (> $1M), likely a broken contract
+    abnormal_share_price = "abnormal_share_price"
+
     #: Tnis vault is a perp dex trading vault on Hyperliquid, Orderly, Lighter, etc.
     perp_dex_trading_vault = "perp_dex_trading_vault"
 
@@ -68,6 +71,7 @@ BAD_FLAGS = {
     VaultFlag.abnormal_tvl,
     VaultFlag.unofficial,
     VaultFlag.abnormal_price_on_low_tvl,
+    VaultFlag.abnormal_share_price,
     VaultFlag.subvault,
 }
 
@@ -123,6 +127,8 @@ MALICIOUS_VAULT = "This vault is reported as malicious, and may have some sort o
 MAINST_VAULT = "Main Street Market related products were wiped out in Oct 10th event https://x.com/Main_St_Finance/status/1976972055951147194"
 
 ABNORMAL_TVL = "The TVL on this vault is abnormal"
+
+ABNORMAL_SHARE_PRICE = "Share price is unrealistically high, likely a broken smart contract"
 
 
 HYPERCORE_VAULT_NOTE = "Profit calculations are cleaned from deposit/redeem net flow and differ from the account Profit and Loss (PnL) on Hyperliquid website"

--- a/eth_defi/vault/vaultdb.py
+++ b/eth_defi/vault/vaultdb.py
@@ -17,6 +17,7 @@ from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature, get_va
 from eth_defi.erc_4626.discovery_base import PotentialVaultMatch
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.risk import VaultTechnicalRisk
 
 #: Where we store the vault metadata database by default
 DEFAULT_VAULT_DATABASE = Path.home() / ".tradingstrategy" / "vaults" / "vault-metadata-db.pickle"
@@ -69,6 +70,11 @@ class VaultRow(TypedDict):
     features: set[ERC4626Feature]
 
     _flags: set[VaultFlag]
+
+    #: Override the risk level for this vault.
+    #:
+    #: If set, takes priority over :py:func:`~eth_defi.vault.risk.get_vault_risk`.
+    _risk: VaultTechnicalRisk | None
 
     __annotations__ = {
         "First seen at": datetime.datetime,


### PR DESCRIPTION
## Summary

- Auto-blacklist HyperCore HLP child sub-vaults by setting `_risk=blacklisted` on the `VaultRow` at creation time, so they no longer appear on reports
- Add `_risk` field to `VaultRow` TypedDict for per-vault risk overrides, checked before `get_vault_risk()` in `calculate_vault_record()`
- Add `VaultFlag.abnormal_share_price` to blacklist vaults with share price > $1M (broken contracts)
- Extract `MAX_VALID_NAV` and `MAX_VALID_SHARE_PRICE` constants

🤖 Generated with [Claude Code](https://claude.com/claude-code)