### PR TITLE
feat: Parallel CCTP bridging, Iris V2 monitor, per-chain multichain config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- **Add: Parallel CCTP bridging with Iris V2 transfer monitoring module and phased burn/attest/receive flow (2026-02-23)**
+- **Add: Per-chain LagoonConfig for multichain deployment, CCTP bridge helper, Monad/HyperEVM CCTP support, and tutorial script (2026-02-23)**
 - **Add: Hypercore native vault guard support with CoreWriter whitelisting, Forge library linking, and chain-conditional deployment for HyperEVM Safe multisig deposits (2026-02-22)**
 - Update GRVT vault protocol logo to high-quality brand icon (2026-02-23)
 - Add comma-separated VAULT_ID support to scan-prices.py with vault-aware parquet deletion and START_BLOCK env var (2026-02-22)

--- a/eth_defi/cctp/bridge.py
+++ b/eth_defi/cctp/bridge.py
@@ -1,0 +1,596 @@
+"""CCTP V2 bridge helpers for Lagoon vaults.
+
+High-level functions to bridge USDC from a Lagoon vault's Safe on one chain
+to Safe addresses on other chains via Circle's Cross-Chain Transfer Protocol V2.
+
+Provides both sequential (single-destination) and parallel (multi-destination)
+bridging. The parallel flow is structured in three phases:
+
+1. **Burn phase** — approve + ``depositForBurn()`` for each destination (sequential
+   on the source chain for nonce ordering)
+2. **Attestation phase** — poll Circle's Iris API or forge attestations
+   (parallel across destinations)
+3. **Receive phase** — ``receiveMessage()`` on each destination chain
+   (parallel across chains)
+
+Supports both simulation (Anvil fork with forged attestations) and
+production (polling Circle's Iris attestation API) modes.
+
+Example (single bridge, simulation)::
+
+    from eth_defi.cctp.bridge import bridge_usdc_cctp
+    from eth_defi.cctp.testing import replace_attester_on_fork
+
+    test_attester = replace_attester_on_fork(web3_destination)
+    result = bridge_usdc_cctp(
+        source_web3=web3_arbitrum,
+        dest_web3=web3_base,
+        source_vault=arb_vault,
+        dest_safe_address=base_safe_address,
+        amount=1_000_000,  # 1 USDC
+        sender=deployer.address,
+        simulate=True,
+        test_attester=test_attester,
+    )
+
+Example (parallel bridges to 4 chains)::
+
+    from eth_defi.cctp.bridge import CCTPBridgeDestination, bridge_usdc_cctp_parallel
+    from eth_defi.cctp.testing import replace_attester_on_fork
+
+    # Prepare test attesters on each destination fork
+    test_attesters = {
+        web3_eth.eth.chain_id: replace_attester_on_fork(web3_eth),
+        web3_base.eth.chain_id: replace_attester_on_fork(web3_base),
+        web3_hyper.eth.chain_id: replace_attester_on_fork(web3_hyper),
+        web3_monad.eth.chain_id: replace_attester_on_fork(web3_monad),
+    }
+
+    destinations = [
+        CCTPBridgeDestination(dest_web3=web3_eth, dest_safe_address=eth_safe, amount=1_000_000),
+        CCTPBridgeDestination(dest_web3=web3_base, dest_safe_address=base_safe, amount=1_000_000),
+        CCTPBridgeDestination(dest_web3=web3_hyper, dest_safe_address=hyper_safe, amount=1_000_000),
+        CCTPBridgeDestination(dest_web3=web3_monad, dest_safe_address=monad_safe, amount=1_000_000),
+    ]
+
+    results = bridge_usdc_cctp_parallel(
+        source_web3=web3_arbitrum,
+        source_vault=arb_vault,
+        destinations=destinations,
+        sender=deployer.address,
+        simulate=True,
+        test_attesters=test_attesters,
+    )
+"""
+
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+
+from eth_account.signers.local import LocalAccount
+from eth_typing import HexAddress
+from web3 import Web3
+
+from eth_defi.cctp.constants import CHAIN_ID_TO_CCTP_DOMAIN
+from eth_defi.cctp.receive import prepare_receive_message
+from eth_defi.cctp.transfer import prepare_approve_for_burn, prepare_deposit_for_burn
+from eth_defi.token import USDC_NATIVE_TOKEN
+from eth_defi.trace import assert_transaction_success_with_explanation
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class CCTPBridgeResult:
+    """Result of a CCTP bridge operation."""
+
+    #: Transaction hash of the burn on the source chain
+    burn_tx_hash: str
+
+    #: Transaction hash of the receive on the destination chain
+    receive_tx_hash: str
+
+    #: Amount bridged in raw USDC units (6 decimals)
+    amount: int
+
+    #: Source chain ID
+    source_chain_id: int
+
+    #: Destination chain ID
+    dest_chain_id: int
+
+
+@dataclass(slots=True)
+class CCTPBurnResult:
+    """Result of the burn phase of a CCTP bridge.
+
+    Returned by :func:`burn_usdc_cctp`. Contains everything needed
+    to proceed with attestation and receive phases.
+    """
+
+    #: Transaction hash of the burn on the source chain
+    burn_tx_hash: str
+
+    #: Amount burned in raw USDC units (6 decimals)
+    amount: int
+
+    #: Source EVM chain ID
+    source_chain_id: int
+
+    #: Destination EVM chain ID
+    dest_chain_id: int
+
+    #: Safe address on the destination chain where USDC will be minted
+    dest_safe_address: str
+
+
+@dataclass(slots=True)
+class CCTPBridgeDestination:
+    """Destination configuration for parallel CCTP bridges.
+
+    Used with :func:`bridge_usdc_cctp_parallel` to specify
+    where USDC should be bridged to.
+    """
+
+    #: Web3 connected to the destination chain
+    dest_web3: Web3
+
+    #: Safe address on the destination chain
+    dest_safe_address: HexAddress
+
+    #: Amount in raw USDC units (6 decimals)
+    amount: int
+
+
+def burn_usdc_cctp(
+    *,
+    source_web3: Web3,
+    source_vault,
+    dest_chain_id: int,
+    dest_safe_address: HexAddress,
+    amount: int,
+    sender: HexAddress,
+    gas: int = 1_000_000,
+) -> CCTPBurnResult:
+    """Execute the approve + burn phase of a CCTP bridge.
+
+    Approves USDC to TokenMessengerV2 and calls ``depositForBurn()``
+    through the vault's TradingStrategyModuleV0 guard.
+
+    This is the source-chain portion of a CCTP bridge. After burning,
+    proceed with attestation (simulation or Iris API) and then
+    :func:`receive_usdc_cctp` on the destination chain.
+
+    :param source_web3:
+        Web3 connected to the source chain.
+
+    :param source_vault:
+        Lagoon vault on the source chain.
+
+    :param dest_chain_id:
+        EVM chain ID of the destination chain.
+
+    :param dest_safe_address:
+        Safe address on the destination chain.
+
+    :param amount:
+        Amount in raw USDC units (6 decimals).
+
+    :param sender:
+        Address of the asset manager.
+
+    :param gas:
+        Gas limit for transactions.
+
+    :return:
+        :class:`CCTPBurnResult` with burn transaction hash and metadata.
+    """
+    source_chain_id = source_web3.eth.chain_id
+
+    assert source_chain_id in CHAIN_ID_TO_CCTP_DOMAIN, f"Source chain {source_chain_id} is not CCTP-enabled"
+    assert dest_chain_id in CHAIN_ID_TO_CCTP_DOMAIN, f"Destination chain {dest_chain_id} is not CCTP-enabled"
+
+    logger.info(
+        "Burning %d raw USDC on chain %d for chain %d (safe %s)",
+        amount,
+        source_chain_id,
+        dest_chain_id,
+        dest_safe_address,
+    )
+
+    # Step 1: Approve USDC to TokenMessengerV2
+    approve_fn = prepare_approve_for_burn(source_web3, amount)
+    moduled_tx = source_vault.transact_via_trading_strategy_module(approve_fn)
+    tx_hash = moduled_tx.transact({"from": sender, "gas": gas})
+    assert_transaction_success_with_explanation(source_web3, tx_hash)
+    logger.info("USDC approval for CCTP burn confirmed: %s", tx_hash.hex())
+
+    # Step 2: Burn USDC via depositForBurn
+    burn_fn = prepare_deposit_for_burn(
+        source_web3,
+        amount=amount,
+        destination_chain_id=dest_chain_id,
+        mint_recipient=dest_safe_address,
+    )
+    moduled_tx = source_vault.transact_via_trading_strategy_module(burn_fn)
+    burn_tx_hash = moduled_tx.transact({"from": sender, "gas": gas})
+    assert_transaction_success_with_explanation(source_web3, burn_tx_hash)
+    logger.info("CCTP burn confirmed: %s", burn_tx_hash.hex())
+
+    return CCTPBurnResult(
+        burn_tx_hash=burn_tx_hash.hex(),
+        amount=amount,
+        source_chain_id=source_chain_id,
+        dest_chain_id=dest_chain_id,
+        dest_safe_address=dest_safe_address,
+    )
+
+
+def receive_usdc_cctp(
+    *,
+    dest_web3: Web3,
+    message: bytes,
+    attestation: bytes,
+    sender: HexAddress,
+    gas: int = 1_000_000,
+) -> str:
+    """Execute the receive phase of a CCTP bridge on the destination chain.
+
+    Calls ``receiveMessage()`` on the destination chain's
+    MessageTransmitterV2. Anyone can relay — no special permissions required.
+
+    :param dest_web3:
+        Web3 connected to the destination chain.
+
+    :param message:
+        CCTP message bytes (from attestation or :func:`~eth_defi.cctp.testing.craft_cctp_message`).
+
+    :param attestation:
+        Signed attestation bytes.
+
+    :param sender:
+        Relayer address (can be any funded account).
+
+    :param gas:
+        Gas limit for the receive transaction.
+
+    :return:
+        Transaction hash of the receive as hex string.
+    """
+    dest_chain_id = dest_web3.eth.chain_id
+
+    receive_fn = prepare_receive_message(dest_web3, message, attestation)
+    relayer = dest_web3.eth.accounts[0] if dest_web3.eth.accounts else sender
+    receive_tx_hash = receive_fn.transact({"from": relayer, "gas": gas})
+    assert_transaction_success_with_explanation(dest_web3, receive_tx_hash)
+    logger.info("CCTP receive confirmed on chain %d: %s", dest_chain_id, receive_tx_hash.hex())
+
+    return receive_tx_hash.hex()
+
+
+def bridge_usdc_cctp(
+    *,
+    source_web3: Web3,
+    dest_web3: Web3,
+    source_vault,
+    dest_safe_address: HexAddress,
+    amount: int,
+    sender: HexAddress,
+    simulate: bool = False,
+    test_attester: LocalAccount | None = None,
+    attestation_timeout: float = 300.0,
+    gas: int = 1_000_000,
+) -> CCTPBridgeResult:
+    """Bridge USDC from a Lagoon vault Safe to a destination Safe via CCTP.
+
+    Performs the full approve -> burn -> attest -> receive flow sequentially
+    for a single destination. For bridging to multiple destinations, use
+    :func:`bridge_usdc_cctp_parallel` instead.
+
+    :param source_web3:
+        Web3 connected to the source chain.
+
+    :param dest_web3:
+        Web3 connected to the destination chain.
+
+    :param source_vault:
+        :class:`LagoonVault` on the source chain. USDC is burned from its Safe
+        via ``transact_via_trading_strategy_module()``.
+
+    :param dest_safe_address:
+        Safe address on the destination chain where USDC will be minted.
+
+    :param amount:
+        Amount in raw USDC units (6 decimals). E.g. ``1_000_000`` for 1 USDC.
+
+    :param sender:
+        Address of the asset manager that executes trades via the module.
+
+    :param simulate:
+        If True, use forged attestations on Anvil forks instead of
+        polling Circle's Iris API. Requires ``test_attester``.
+
+    :param test_attester:
+        Test attester account from :func:`~eth_defi.cctp.testing.replace_attester_on_fork`.
+        Required when ``simulate=True``.
+
+    :param attestation_timeout:
+        Maximum seconds to wait for Iris API attestation (production mode only).
+
+    :param gas:
+        Gas limit for transactions.
+
+    :return:
+        :class:`CCTPBridgeResult` with transaction hashes and amount.
+    """
+    dest_chain_id = dest_web3.eth.chain_id
+
+    if simulate:
+        assert test_attester is not None, "test_attester is required in simulate mode"
+
+    # Phase 1: Burn
+    burn_result = burn_usdc_cctp(
+        source_web3=source_web3,
+        source_vault=source_vault,
+        dest_chain_id=dest_chain_id,
+        dest_safe_address=dest_safe_address,
+        amount=amount,
+        sender=sender,
+        gas=gas,
+    )
+
+    # Phase 2: Attestation
+    message, attestation = _get_attestation(
+        burn_result=burn_result,
+        simulate=simulate,
+        test_attester=test_attester,
+        attestation_timeout=attestation_timeout,
+    )
+
+    # Phase 3: Receive
+    receive_tx_hash = receive_usdc_cctp(
+        dest_web3=dest_web3,
+        message=message,
+        attestation=attestation,
+        sender=sender,
+        gas=gas,
+    )
+
+    return CCTPBridgeResult(
+        burn_tx_hash=burn_result.burn_tx_hash,
+        receive_tx_hash=receive_tx_hash,
+        amount=amount,
+        source_chain_id=burn_result.source_chain_id,
+        dest_chain_id=dest_chain_id,
+    )
+
+
+def bridge_usdc_cctp_parallel(
+    *,
+    source_web3: Web3,
+    source_vault,
+    destinations: list[CCTPBridgeDestination],
+    sender: HexAddress,
+    simulate: bool = False,
+    test_attesters: dict[int, LocalAccount] | None = None,
+    attestation_timeout: float = 1200.0,
+    gas: int = 1_000_000,
+    max_workers: int | None = None,
+) -> list[CCTPBridgeResult]:
+    """Bridge USDC from a Lagoon vault to multiple destination chains in parallel.
+
+    Executes the CCTP bridge flow in three phases to minimise wall-clock time:
+
+    1. **Burns** (sequential) — approve + ``depositForBurn()`` for each destination.
+       Sequential because all burns happen on the same source chain and need
+       ordered nonce management.
+
+    2. **Attestations** (parallel) — poll Iris API or forge attestations for
+       all burns simultaneously. In production mode this is the bottleneck
+       (~15-19 minutes per transfer); parallelism reduces total wait from
+       ``N * 15min`` to ``~15min``.
+
+    3. **Receives** (parallel) — ``receiveMessage()`` on each destination chain
+       simultaneously. Each chain is independent.
+
+    :param source_web3:
+        Web3 connected to the source chain (e.g. Arbitrum).
+
+    :param source_vault:
+        Lagoon vault on the source chain.
+
+    :param destinations:
+        List of :class:`CCTPBridgeDestination` for each target chain.
+
+    :param sender:
+        Address of the asset manager.
+
+    :param simulate:
+        If True, use forged attestations. Requires ``test_attesters``.
+
+    :param test_attesters:
+        Mapping of destination chain ID to test attester account.
+        Required when ``simulate=True``. Create via
+        :func:`~eth_defi.cctp.testing.replace_attester_on_fork`.
+
+    :param attestation_timeout:
+        Maximum seconds to wait for Iris API attestations. Default 20 minutes.
+
+    :param gas:
+        Gas limit for transactions.
+
+    :param max_workers:
+        Maximum parallel threads for attestation polling and receives.
+        Defaults to number of destinations.
+
+    :return:
+        List of :class:`CCTPBridgeResult` in the same order as ``destinations``.
+    """
+    if not destinations:
+        return []
+
+    if simulate:
+        assert test_attesters is not None, "test_attesters is required in simulate mode"
+
+    if max_workers is None:
+        max_workers = len(destinations)
+
+    n_dest = len(destinations)
+    total_amount = sum(d.amount for d in destinations)
+    logger.info(
+        "Parallel CCTP bridge: %d destinations, %d total raw USDC",
+        n_dest,
+        total_amount,
+    )
+
+    # --- Phase 1: Burns (sequential on source chain) ---
+    logger.info("Phase 1: Burning USDC for %d destinations...", n_dest)
+    burn_results: list[CCTPBurnResult] = []
+    for dest in destinations:
+        dest_chain_id = dest.dest_web3.eth.chain_id
+        burn_result = burn_usdc_cctp(
+            source_web3=source_web3,
+            source_vault=source_vault,
+            dest_chain_id=dest_chain_id,
+            dest_safe_address=dest.dest_safe_address,
+            amount=dest.amount,
+            sender=sender,
+            gas=gas,
+        )
+        burn_results.append(burn_result)
+
+    logger.info("Phase 1 complete: %d burns confirmed", len(burn_results))
+
+    # --- Phase 2: Attestations (parallel) ---
+    logger.info("Phase 2: Obtaining attestations for %d burns...", n_dest)
+    attestation_data: list[tuple[bytes, bytes]] = []
+
+    if simulate:
+        # Simulation mode: forge attestations in parallel (instant)
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {}
+            for idx, burn_result in enumerate(burn_results):
+                dest_chain_id = burn_result.dest_chain_id
+                attester = test_attesters[dest_chain_id]
+                future = executor.submit(
+                    _get_attestation,
+                    burn_result=burn_result,
+                    simulate=True,
+                    test_attester=attester,
+                    attestation_timeout=attestation_timeout,
+                )
+                futures[future] = idx
+
+            indexed_results: dict[int, tuple[bytes, bytes]] = {}
+            for future in as_completed(futures):
+                idx = futures[future]
+                indexed_results[idx] = future.result()
+
+            attestation_data = [indexed_results[i] for i in range(n_dest)]
+    else:
+        # Production mode: poll Iris API in parallel
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {}
+            for idx, burn_result in enumerate(burn_results):
+                future = executor.submit(
+                    _get_attestation,
+                    burn_result=burn_result,
+                    simulate=False,
+                    test_attester=None,
+                    attestation_timeout=attestation_timeout,
+                )
+                futures[future] = idx
+
+            indexed_results: dict[int, tuple[bytes, bytes]] = {}
+            for future in as_completed(futures):
+                idx = futures[future]
+                indexed_results[idx] = future.result()
+
+            attestation_data = [indexed_results[i] for i in range(n_dest)]
+
+    logger.info("Phase 2 complete: %d attestations obtained", len(attestation_data))
+
+    # --- Phase 3: Receives (parallel across destination chains) ---
+    logger.info("Phase 3: Receiving on %d destination chains...", n_dest)
+    receive_tx_hashes: list[str] = [""] * n_dest
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {}
+        for idx, (dest, (message, attestation)) in enumerate(zip(destinations, attestation_data)):
+            future = executor.submit(
+                receive_usdc_cctp,
+                dest_web3=dest.dest_web3,
+                message=message,
+                attestation=attestation,
+                sender=sender,
+                gas=gas,
+            )
+            futures[future] = idx
+
+        for future in as_completed(futures):
+            idx = futures[future]
+            receive_tx_hashes[idx] = future.result()
+
+    logger.info("Phase 3 complete: %d receives confirmed", n_dest)
+
+    # Build results in input order
+    results = []
+    for idx, (burn_result, dest) in enumerate(zip(burn_results, destinations)):
+        results.append(
+            CCTPBridgeResult(
+                burn_tx_hash=burn_result.burn_tx_hash,
+                receive_tx_hash=receive_tx_hashes[idx],
+                amount=burn_result.amount,
+                source_chain_id=burn_result.source_chain_id,
+                dest_chain_id=burn_result.dest_chain_id,
+            )
+        )
+
+    return results
+
+
+def _get_attestation(
+    *,
+    burn_result: CCTPBurnResult,
+    simulate: bool,
+    test_attester: LocalAccount | None,
+    attestation_timeout: float,
+    nonce_base: int = 999_999_000,
+) -> tuple[bytes, bytes]:
+    """Obtain attestation for a burn, either forged or from Iris API.
+
+    :return:
+        Tuple of (message_bytes, attestation_bytes).
+    """
+    source_chain_id = burn_result.source_chain_id
+    dest_chain_id = burn_result.dest_chain_id
+    source_domain = CHAIN_ID_TO_CCTP_DOMAIN[source_chain_id]
+    dest_domain = CHAIN_ID_TO_CCTP_DOMAIN[dest_chain_id]
+
+    if simulate:
+        from eth_defi.cctp.testing import craft_cctp_message, forge_attestation
+
+        # Use dest_domain as nonce offset to avoid collisions across destinations
+        nonce = nonce_base + dest_domain
+
+        message = craft_cctp_message(
+            source_domain=source_domain,
+            destination_domain=dest_domain,
+            nonce=nonce,
+            mint_recipient=burn_result.dest_safe_address,
+            amount=burn_result.amount,
+            burn_token=USDC_NATIVE_TOKEN[source_chain_id],
+        )
+        attestation = forge_attestation(message, test_attester)
+        logger.info("Forged attestation for chain %d (nonce=%d)", dest_chain_id, nonce)
+        return message, attestation
+    else:
+        from eth_defi.cctp.attestation import fetch_attestation
+
+        cctp_attestation = fetch_attestation(
+            source_domain=source_domain,
+            transaction_hash=burn_result.burn_tx_hash,
+            timeout=attestation_timeout,
+        )
+        logger.info("Attestation received from Iris API for chain %d", dest_chain_id)
+        return cctp_attestation.message, cctp_attestation.attestation

--- a/eth_defi/cctp/constants.py
+++ b/eth_defi/cctp/constants.py
@@ -16,6 +16,7 @@ to mint. The caller does not need to specify the destination USDC address.
 All CCTP V2 contracts share the same address across all EVM chains (deployed via CREATE2).
 
 - `CCTP V2 documentation <https://developers.circle.com/cctp>`_
+- `Supported chains and domains <https://developers.circle.com/cctp/concepts/supported-chains-and-domains>`_
 - `EVM contract addresses <https://developers.circle.com/cctp/evm-smart-contracts>`_
 - `Circle CCTP GitHub <https://github.com/circlefin/evm-cctp-contracts>`_
 """
@@ -46,14 +47,28 @@ CCTP_DOMAIN_BASE = 6
 #: CCTP domain ID for Polygon PoS
 CCTP_DOMAIN_POLYGON = 7
 
+#: CCTP domain ID for Monad
+#:
+#: For the full list of supported chains and domains, see:
+#: https://developers.circle.com/cctp/concepts/supported-chains-and-domains
+CCTP_DOMAIN_MONAD = 15
+
+#: CCTP domain ID for HyperEVM (Hyperliquid)
+CCTP_DOMAIN_HYPEREVM = 19
+
 #: Mapping from EVM chain ID to CCTP domain ID.
 #:
 #: CCTP uses its own domain identifiers, not EVM chain IDs.
+#:
+#: For the full list of supported chains and domains, see:
+#: https://developers.circle.com/cctp/concepts/supported-chains-and-domains
 CHAIN_ID_TO_CCTP_DOMAIN: dict[int, int] = {
     1: CCTP_DOMAIN_ETHEREUM,
     42161: CCTP_DOMAIN_ARBITRUM,
     8453: CCTP_DOMAIN_BASE,
     137: CCTP_DOMAIN_POLYGON,
+    143: CCTP_DOMAIN_MONAD,
+    999: CCTP_DOMAIN_HYPEREVM,
 }
 
 #: Reverse mapping from CCTP domain to EVM chain ID.
@@ -65,6 +80,8 @@ CCTP_DOMAIN_NAMES: dict[int, str] = {
     CCTP_DOMAIN_ARBITRUM: "Arbitrum",
     CCTP_DOMAIN_BASE: "Base",
     CCTP_DOMAIN_POLYGON: "Polygon",
+    CCTP_DOMAIN_MONAD: "Monad",
+    CCTP_DOMAIN_HYPEREVM: "HyperEVM",
 }
 
 #: Circle Iris attestation API base URL (mainnet).

--- a/eth_defi/cctp/monitor.py
+++ b/eth_defi/cctp/monitor.py
@@ -1,0 +1,379 @@
+"""CCTP V2 transfer status monitoring via Circle's Iris API.
+
+Programmatically inspect the status of cross-chain USDC transfers
+using the ``/v2/messages`` endpoint. Supports both one-shot status
+checks and blocking/parallel polling for multiple transfers.
+
+The Iris API tracks transfers from ``depositForBurn()`` through to
+attestation readiness. Status progresses as:
+
+1. **404 Not Found** — burn transaction not yet indexed by Iris
+2. **pending_confirmations** — burn detected, awaiting block finality
+3. **complete** — attestation signed, ready for ``receiveMessage()``
+
+Additionally, the ``delay_reason`` field explains holds on transfers:
+
+- ``insufficient_fee`` — Fast Transfer fee too low
+- ``amount_above_max`` — exceeds single-transfer cap
+- ``insufficient_allowance_available`` — Fast Transfer allowance exhausted
+
+Example (one-shot status check)::
+
+    from eth_defi.cctp.monitor import fetch_transfer_status
+
+    status = fetch_transfer_status(
+        source_domain=3,  # Arbitrum
+        transaction_hash="0xabc...",
+    )
+    if status and status.is_complete:
+        print("Transfer ready for receive!")
+
+Example (parallel polling for multiple transfers)::
+
+    from eth_defi.cctp.monitor import CCTPTransferQuery, poll_transfers_parallel
+
+    queries = [
+        CCTPTransferQuery(source_domain=3, transaction_hash="0xabc..."),
+        CCTPTransferQuery(source_domain=3, transaction_hash="0xdef..."),
+    ]
+    statuses = poll_transfers_parallel(queries, timeout=1200.0)
+    for s in statuses:
+        print(f"Domain {s.source_domain} -> {s.dest_domain}: {s.status}")
+
+Rate limits
+-----------
+
+The Iris API allows 35 requests/second. Exceeding this triggers a
+5-minute block (HTTP 429). When polling multiple transfers, the
+default 10-second interval keeps well within limits.
+
+For the full API reference, see:
+`Circle CCTP V2 messages endpoint <https://developers.circle.com/api-reference/cctp/all/get-messages-v-2>`_
+"""
+
+import logging
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+
+import requests
+
+from eth_defi.cctp.constants import IRIS_API_BASE_URL
+
+logger = logging.getLogger(__name__)
+
+#: HTTP 404 status code indicating resource not found
+HTTP_NOT_FOUND = 404
+
+#: HTTP 429 status code indicating rate limit exceeded
+HTTP_TOO_MANY_REQUESTS = 429
+
+
+@dataclass(slots=True)
+class CCTPTransferStatus:
+    """Status of a CCTP transfer from Circle's Iris V2 API.
+
+    Represents the full state of a single cross-chain USDC transfer
+    as reported by the ``/v2/messages/{sourceDomainId}`` endpoint.
+    """
+
+    #: Transfer status: ``"complete"`` or ``"pending_confirmations"``
+    status: str
+
+    #: CCTP source domain ID
+    source_domain: int
+
+    #: CCTP destination domain ID (from decoded message, 0 if unavailable)
+    dest_domain: int
+
+    #: Signed attestation bytes, or ``None`` if not yet available
+    attestation: bytes | None
+
+    #: Raw CCTP message bytes, or ``None`` if not yet available
+    message: bytes | None
+
+    #: Event nonce as string, or ``None`` if unavailable
+    nonce: str | None
+
+    #: Reason for delay, or ``None`` if no delay.
+    #: Values: ``"insufficient_fee"``, ``"amount_above_max"``,
+    #: ``"insufficient_allowance_available"``
+    delay_reason: str | None
+
+    #: Transaction hash of the burn on the source chain
+    transaction_hash: str
+
+    #: CCTP protocol version (1 or 2)
+    cctp_version: int | None = None
+
+    @property
+    def is_complete(self) -> bool:
+        """Whether the attestation is signed and ready for ``receiveMessage()``."""
+        return self.status == "complete" and self.attestation is not None
+
+    @property
+    def is_pending(self) -> bool:
+        """Whether the transfer is still awaiting block finality."""
+        return self.status == "pending_confirmations"
+
+    @property
+    def is_delayed(self) -> bool:
+        """Whether the transfer has a delay reason set."""
+        return self.delay_reason is not None
+
+
+@dataclass(slots=True)
+class CCTPTransferQuery:
+    """Query parameters for looking up a CCTP transfer.
+
+    Pass to :func:`poll_transfers_parallel` to poll multiple
+    transfers concurrently.
+    """
+
+    #: CCTP domain ID of the source chain
+    source_domain: int
+
+    #: Transaction hash of the ``depositForBurn()`` call
+    transaction_hash: str
+
+
+def fetch_transfer_status(
+    source_domain: int,
+    transaction_hash: str,
+    api_base_url: str = IRIS_API_BASE_URL,
+) -> CCTPTransferStatus | None:
+    """One-shot check of a CCTP transfer's status.
+
+    Returns ``None`` if the transaction is not yet indexed by Iris (HTTP 404).
+    Does not block or retry.
+
+    :param source_domain:
+        CCTP domain ID of the source chain (e.g. 3 for Arbitrum).
+
+    :param transaction_hash:
+        Transaction hash of the ``depositForBurn()`` call.
+
+    :param api_base_url:
+        Iris API base URL. Defaults to mainnet.
+
+    :return:
+        :class:`CCTPTransferStatus` or ``None`` if not yet indexed.
+
+    :raises requests.HTTPError:
+        If the API returns a non-retryable error (not 404).
+    """
+    if not transaction_hash.startswith("0x"):
+        transaction_hash = f"0x{transaction_hash}"
+
+    url = f"{api_base_url}/v2/messages/{source_domain}?transactionHash={transaction_hash}"
+
+    response = requests.get(url, timeout=30)
+
+    if response.status_code == HTTP_NOT_FOUND:
+        return None
+
+    response.raise_for_status()
+
+    data = response.json()
+    messages = data.get("messages", [])
+
+    if not messages:
+        return None
+
+    msg = messages[0]
+    return _parse_transfer_status(msg, source_domain, transaction_hash)
+
+
+def poll_transfer_status(
+    source_domain: int,
+    transaction_hash: str,
+    timeout: float = 300.0,
+    poll_interval: float = 10.0,
+    api_base_url: str = IRIS_API_BASE_URL,
+) -> CCTPTransferStatus:
+    """Block until a CCTP transfer reaches ``complete`` status.
+
+    Polls the Iris V2 API at regular intervals. Handles 404 (not yet indexed)
+    and ``pending_confirmations`` by retrying.
+
+    :param source_domain:
+        CCTP domain ID of the source chain.
+
+    :param transaction_hash:
+        Transaction hash of the ``depositForBurn()`` call.
+
+    :param timeout:
+        Maximum seconds to wait. Default 5 minutes.
+
+    :param poll_interval:
+        Seconds between polling attempts. Default 10 seconds.
+
+    :param api_base_url:
+        Iris API base URL.
+
+    :return:
+        :class:`CCTPTransferStatus` with ``is_complete == True``.
+
+    :raises TimeoutError:
+        If the transfer does not reach ``complete`` within the timeout.
+    """
+    if not transaction_hash.startswith("0x"):
+        transaction_hash = f"0x{transaction_hash}"
+
+    start_time = time.time()
+    attempt = 0
+
+    while True:
+        elapsed = time.time() - start_time
+        if elapsed >= timeout:
+            raise TimeoutError(f"CCTP transfer not complete after {timeout}s for tx {transaction_hash} on domain {source_domain}")
+
+        attempt += 1
+        logger.info(
+            "Polling CCTP transfer status: domain=%s, tx=%s, attempt=%d, elapsed=%.1fs",
+            source_domain,
+            transaction_hash,
+            attempt,
+            elapsed,
+        )
+
+        status = fetch_transfer_status(source_domain, transaction_hash, api_base_url)
+
+        if status is None:
+            logger.info("Transfer not yet indexed (404), retrying in %.1fs...", poll_interval)
+        elif status.is_complete:
+            logger.info("Transfer complete: domain=%s, tx=%s", source_domain, transaction_hash)
+            return status
+        else:
+            logger.info(
+                "Transfer status: %s, delay_reason: %s, retrying in %.1fs...",
+                status.status,
+                status.delay_reason,
+                poll_interval,
+            )
+
+        time.sleep(poll_interval)
+
+
+def poll_transfers_parallel(
+    transfers: list[CCTPTransferQuery],
+    timeout: float = 300.0,
+    poll_interval: float = 10.0,
+    api_base_url: str = IRIS_API_BASE_URL,
+    max_workers: int | None = None,
+) -> list[CCTPTransferStatus]:
+    """Poll multiple CCTP transfers in parallel until all complete.
+
+    Uses threads to poll the Iris API concurrently. Each transfer
+    is polled independently; all must reach ``complete`` within
+    the timeout or a :class:`TimeoutError` is raised.
+
+    Results are returned in the same order as the input ``transfers`` list.
+
+    :param transfers:
+        List of transfer queries to monitor.
+
+    :param timeout:
+        Maximum seconds to wait for all transfers. Default 5 minutes.
+
+    :param poll_interval:
+        Seconds between polling attempts per transfer. Default 10 seconds.
+
+    :param api_base_url:
+        Iris API base URL.
+
+    :param max_workers:
+        Maximum number of polling threads. Defaults to number of transfers.
+
+    :return:
+        List of completed :class:`CCTPTransferStatus` in input order.
+
+    :raises TimeoutError:
+        If any transfer does not complete within the timeout.
+    """
+    if not transfers:
+        return []
+
+    if max_workers is None:
+        max_workers = len(transfers)
+
+    logger.info("Polling %d CCTP transfers in parallel (timeout=%.0fs)", len(transfers), timeout)
+
+    # Map future → index for ordered results
+    results: dict[int, CCTPTransferStatus] = {}
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {}
+        for idx, query in enumerate(transfers):
+            future = executor.submit(
+                poll_transfer_status,
+                source_domain=query.source_domain,
+                transaction_hash=query.transaction_hash,
+                timeout=timeout,
+                poll_interval=poll_interval,
+                api_base_url=api_base_url,
+            )
+            futures[future] = idx
+
+        for future in as_completed(futures):
+            idx = futures[future]
+            # Let exceptions propagate (TimeoutError, HTTPError, etc.)
+            results[idx] = future.result()
+
+    # Return in input order
+    return [results[i] for i in range(len(transfers))]
+
+
+def _parse_transfer_status(
+    msg: dict,
+    source_domain: int,
+    transaction_hash: str,
+) -> CCTPTransferStatus:
+    """Parse a single message object from the Iris V2 API response.
+
+    :param msg:
+        Message dict from the ``messages`` array in the API response.
+
+    :param source_domain:
+        Source domain for context.
+
+    :param transaction_hash:
+        Transaction hash for context.
+
+    :return:
+        Parsed :class:`CCTPTransferStatus`.
+    """
+    status = msg.get("status", "")
+    attestation_hex = msg.get("attestation")
+    message_hex = msg.get("message", "")
+
+    # Parse attestation bytes (None if pending)
+    attestation_bytes = None
+    if attestation_hex and attestation_hex != "PENDING":
+        attestation_bytes = bytes.fromhex(attestation_hex.replace("0x", ""))
+
+    # Parse message bytes (None if empty)
+    message_bytes = None
+    if message_hex and message_hex != "0x":
+        message_bytes = bytes.fromhex(message_hex.replace("0x", ""))
+
+    # Extract destination domain from decoded message if available
+    dest_domain = 0
+    decoded = msg.get("decodedMessage", {})
+    if decoded:
+        try:
+            dest_domain = int(decoded.get("destinationDomain", 0))
+        except (ValueError, TypeError):
+            pass
+
+    return CCTPTransferStatus(
+        status=status,
+        source_domain=source_domain,
+        dest_domain=dest_domain,
+        attestation=attestation_bytes,
+        message=message_bytes,
+        nonce=msg.get("eventNonce"),
+        delay_reason=msg.get("delayReason"),
+        transaction_hash=transaction_hash,
+        cctp_version=msg.get("cctpVersion"),
+    )

--- a/eth_defi/erc_4626/vault_protocol/lagoon/deployment.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/deployment.py
@@ -33,14 +33,12 @@ from web3.contract import Contract
 from web3.contract.contract import ContractFunction
 
 from eth_defi.aave_v3.deployment import AaveV3Deployment
-from eth_defi.abi import (ZERO_ADDRESS, ZERO_ADDRESS_STR, encode_multicalls,
-                          get_deployed_contract)
+from eth_defi.abi import ZERO_ADDRESS, ZERO_ADDRESS_STR, encode_multicalls, get_deployed_contract
 from eth_defi.cctp.whitelist import CCTPDeployment
 from eth_defi.cow.constants import COWSWAP_SETTLEMENT, COWSWAP_VAULT_RELAYER
 from eth_defi.deploy import build_guard_forge_libraries, deploy_contract
 from eth_defi.erc_4626.vault import ERC4626Vault
-from eth_defi.erc_4626.vault_protocol.lagoon.beacon_proxy import \
-    deploy_beacon_proxy
+from eth_defi.erc_4626.vault_protocol.lagoon.beacon_proxy import deploy_beacon_proxy
 from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
 from eth_defi.foundry.forge import deploy_contract_with_forge
 from eth_defi.gas import apply_gas, estimate_gas_price
@@ -48,12 +46,9 @@ from eth_defi.gmx.whitelist import GMXDeployment
 from eth_defi.hotwallet import HotWallet
 from eth_defi.orderly.vault import OrderlyVault
 from eth_defi.provider.anvil import is_anvil
-from eth_defi.safe.deployment import (add_new_safe_owners, deploy_safe,
-                                      deploy_safe_with_deterministic_address,
-                                      fetch_safe_deployment)
+from eth_defi.safe.deployment import add_new_safe_owners, deploy_safe, deploy_safe_with_deterministic_address, fetch_safe_deployment
 from eth_defi.safe.execute import execute_safe_tx
-from eth_defi.token import (WRAPPED_NATIVE_TOKEN, fetch_erc20_details,
-                            get_wrapped_native_token_address)
+from eth_defi.token import WRAPPED_NATIVE_TOKEN, fetch_erc20_details, get_wrapped_native_token_address
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.tx import get_tx_broadcast_data
 from eth_defi.uniswap_v2.deployment import UniswapV2Deployment
@@ -838,8 +833,7 @@ def deploy_safe_trading_strategy_module(
         # even when the deployer has big blocks enabled, so we use the known big
         # block gas limit constant instead.
         # https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/dual-block-architecture
-        from eth_defi.hyperliquid.block import (HYPEREVM_BIG_BLOCK_GAS_LIMIT,
-                                                is_hyperevm)
+        from eth_defi.hyperliquid.block import HYPEREVM_BIG_BLOCK_GAS_LIMIT, is_hyperevm
 
         if is_hyperevm(chain_id):
             block_gas_limit = HYPEREVM_BIG_BLOCK_GAS_LIMIT
@@ -887,6 +881,7 @@ def deploy_safe_trading_strategy_module(
             logger.info("Deploying HypercoreVaultLib for HyperEVM chain %d", chain_id)
             if "HypercoreVaultLib" not in library_addresses:
                 from eth_defi.hyperliquid.block import big_blocks_for_deployment as _big_blocks
+
                 with _big_blocks(web3, deployer.key.hex()):
                     hypercore_lib = deploy_contract(
                         web3,
@@ -903,6 +898,7 @@ def deploy_safe_trading_strategy_module(
         # TradingStrategyModuleV0 needs ~5.4M gas — exceeds small block limit on HyperEVM.
         # Enable big blocks only for this deployment; libraries above fit in small blocks.
         from eth_defi.hyperliquid.block import big_blocks_for_deployment
+
         with big_blocks_for_deployment(web3, deployer.key.hex()):
             logger.info("Deploying TradingStrategyModuleV0 with libraries %s and gas %d", library_addresses, guard_gas)
             module = deploy_contract(
@@ -1197,8 +1193,7 @@ def setup_guard(
     # Batch CoreWriter + all vault whitelisting into a single multicall transaction.
     if hypercore_vaults:
         from eth_defi.hyperliquid.core_writer import CORE_WRITER_ADDRESS
-        from eth_defi.hyperliquid.guard_whitelist import \
-            get_core_deposit_wallet
+        from eth_defi.hyperliquid.guard_whitelist import get_core_deposit_wallet
 
         chain_id = web3.eth.chain_id
         cdw_address = get_core_deposit_wallet(chain_id)
@@ -1729,6 +1724,12 @@ LAGOON_BEACON_PROXY_FACTORIES = {
         "abi": "lagoon/OptinProxyFactory.json",
         "address": "0x90beB507A1BA7D64633540cbce615B574224CD84",
     },
+    # Monad
+    # https://docs.lagoon.finance/resources/networks-and-addresses
+    143: {
+        "abi": "lagoon/OptinProxyFactory.json",
+        "address": "0xcCdC4d06cA12A29C47D5d105fED59a6D07E9cf70",
+    },
 }
 
 
@@ -1736,8 +1737,7 @@ def deploy_multichain_lagoon_vault(
     *,
     chain_web3: dict[str, Web3],
     deployer: LocalAccount,
-    config: LagoonConfig,
-    cctp_enabled: bool = False,
+    chain_configs: dict[str, LagoonConfig],
     max_workers: int | None = None,
 ) -> LagoonMultichainDeployment:
     """Deploy Lagoon vaults across multiple chains with a shared deterministic Safe.
@@ -1748,8 +1748,10 @@ def deploy_multichain_lagoon_vault(
 
     Deploys all chains in parallel using threads to minimise wall-clock time.
 
-    If ``cctp_enabled`` is True, CCTP whitelisting is automatically configured
-    per chain. Chains without CCTP support (e.g. HyperEVM) are silently skipped.
+    Each chain receives its own :class:`LagoonConfig` with chain-specific
+    whitelisting (ERC-4626 vaults, Hypercore vaults, CCTP, CowSwap, etc.).
+    All configs must share the same ``safe_salt_nonce`` to ensure deterministic
+    Safe addresses.
 
     :param chain_web3:
         Mapping of chain names (lowercase, matching :data:`eth_defi.chain.CHAIN_NAMES`)
@@ -1759,15 +1761,11 @@ def deploy_multichain_lagoon_vault(
         The deployer account. A separate :class:`HotWallet` is created per chain
         for nonce management.
 
-    :param config:
-        Shared :class:`LagoonConfig`. Must have ``safe_salt_nonce`` set.
+    :param chain_configs:
+        Per-chain :class:`LagoonConfig` instances. Keys must match ``chain_web3`` keys.
+        All configs must have the same ``safe_salt_nonce`` set.
         The ``parameters.underlying`` field is auto-resolved per chain from
         :data:`eth_defi.token.USDC_NATIVE_TOKEN` if set to a zero/empty address.
-
-    :param cctp_enabled:
-        If True, auto-create :class:`CCTPDeployment` per chain using
-        :func:`CCTPDeployment.create_for_chain`. Chains not in
-        :data:`CHAIN_ID_TO_CCTP_DOMAIN` are silently skipped.
 
     :param max_workers:
         Maximum number of parallel deployment threads.
@@ -1779,17 +1777,20 @@ def deploy_multichain_lagoon_vault(
     from concurrent.futures import ThreadPoolExecutor, as_completed
     from copy import deepcopy
 
-    from eth_defi.cctp.constants import CHAIN_ID_TO_CCTP_DOMAIN
     from eth_defi.token import USDC_NATIVE_TOKEN
 
-    assert config.safe_salt_nonce is not None, "safe_salt_nonce must be set for multichain deployment"
     assert len(chain_web3) >= 1, "Must deploy to at least one chain"
+    assert set(chain_configs.keys()) == set(chain_web3.keys()), f"chain_configs and chain_web3 must have the same keys: configs={set(chain_configs.keys())}, web3={set(chain_web3.keys())}"
+
+    # Validate all configs share the same safe_salt_nonce
+    salt_nonces = {name: c.safe_salt_nonce for name, c in chain_configs.items()}
+    unique_nonces = set(salt_nonces.values())
+    assert len(unique_nonces) == 1, f"All configs must share the same safe_salt_nonce: {salt_nonces}"
+    safe_salt_nonce = next(iter(unique_nonces))
+    assert safe_salt_nonce is not None, "safe_salt_nonce must be set for multichain deployment"
 
     if max_workers is None:
         max_workers = len(chain_web3)
-
-    # Pre-compute CCTP-capable chain IDs for destination resolution
-    cctp_chain_ids = {name: w3.eth.chain_id for name, w3 in chain_web3.items() if w3.eth.chain_id in CHAIN_ID_TO_CCTP_DOMAIN} if cctp_enabled else {}
 
     def _deploy_single_chain(chain_name: str, web3: Web3) -> tuple[str, LagoonAutomatedDeployment]:
         chain_id = web3.eth.chain_id
@@ -1799,30 +1800,14 @@ def deploy_multichain_lagoon_vault(
         wallet = HotWallet(deployer)
         wallet.sync_nonce(web3)
 
-        # Deep-copy config so per-chain overrides don't leak
-        per_chain_config = deepcopy(config)
+        # Deep-copy config so thread-local mutations don't leak
+        per_chain_config = deepcopy(chain_configs[chain_name])
 
         # Auto-resolve underlying token (USDC) per chain if not already set
         if per_chain_config.parameters.underlying is None or per_chain_config.parameters.underlying == "":
             usdc = USDC_NATIVE_TOKEN.get(chain_id)
             assert usdc is not None, f"No USDC address known for chain {chain_id}. Set parameters.underlying manually."
             per_chain_config.parameters.underlying = usdc
-
-        # Auto-configure CCTP per chain
-        if cctp_enabled:
-            if chain_id in CHAIN_ID_TO_CCTP_DOMAIN:
-                other_chain_ids = [cid for name, cid in cctp_chain_ids.items() if name != chain_name]
-                if other_chain_ids:
-                    per_chain_config.cctp_deployment = CCTPDeployment.create_for_chain(
-                        chain_id=chain_id,
-                        allowed_destinations=other_chain_ids,
-                    )
-                    logger.info("CCTP enabled on %s with destinations: %s", chain_name, other_chain_ids)
-                else:
-                    logger.info("CCTP enabled on %s but no other CCTP-capable chains in deployment", chain_name)
-            else:
-                logger.info("CCTP not available on %s (chain %d), skipping", chain_name, chain_id)
-                per_chain_config.cctp_deployment = None
 
         deployment = deploy_automated_lagoon_vault(
             web3=web3,
@@ -1850,5 +1835,5 @@ def deploy_multichain_lagoon_vault(
     return LagoonMultichainDeployment(
         safe_address=next(iter(unique_safe_addresses)),
         deployments=deployments,
-        safe_salt_nonce=config.safe_salt_nonce,
+        safe_salt_nonce=safe_salt_nonce,
     )

--- a/eth_defi/token.py
+++ b/eth_defi/token.py
@@ -21,11 +21,8 @@ import cachetools
 from web3.contract.contract import ContractFunction, ContractFunctions
 
 from eth_defi.compat import native_datetime_utc_now
-from eth_defi.event_reader.conversion import (convert_int256_bytes_to_int,
-                                              convert_solidity_bytes_to_string)
-from eth_defi.event_reader.multicall_batcher import (EncodedCall,
-                                                     EncodedCallResult,
-                                                     read_multicall_chunked)
+from eth_defi.event_reader.conversion import convert_int256_bytes_to_int, convert_solidity_bytes_to_string
+from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult, read_multicall_chunked
 from eth_defi.event_reader.web3factory import Web3Factory
 from eth_defi.provider.named import get_provider_name
 from eth_defi.sqlite_cache import PersistentKeyValueStore
@@ -87,6 +84,9 @@ WRAPPED_NATIVE_TOKEN: dict[int, HexAddress | str] = {
     999: "0x5555555555555555555555555555555555555555",
     # WHYPE: HyperEVM testnet (same address as mainnet)
     998: "0x5555555555555555555555555555555555555555",
+    # WMON: Monad
+    # https://docs.monad.xyz/developer-essentials/network-information
+    143: "0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A",
 }
 
 #: Addresses of USDC of different chains
@@ -114,6 +114,9 @@ USDC_NATIVE_TOKEN: dict[int, HexAddress | str] = {
     999: "0xb88339CB7199b77E23DB6E890353E22632Ba630f",
     # HyperEVM testnet (6 decimals, actual testnet USDC)
     998: "0x2B3370eE501B4a559b57D449569354196457D8Ab",
+    # Monad
+    # https://developers.circle.com/stablecoins/usdc-contract-addresses
+    143: "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
 }
 
 #: Bridged USDC of different chains
@@ -136,6 +139,9 @@ USDC_WHALE: dict[int, HexAddress | str] = {
     # https://arbiscan.io/token/0xaf88d065e77c8cc2239327c5edb3a432268e5831#balances
     42161: "0x3DD1D15b3c78d6aCFD75a254e857Cbe5b9fF0aF2",
     # To find large holder accounts, use polygonscan <https://polygonscan.com/token/0x2791bca1f2de4661ed88a30c99a7a9449aa84174#balances>
+    # Monad
+    # RWA Backed Lending by Valos vault — large USDC holder
+    143: "0x8d3f9f9eb2f5e8b48efbb4074440d1e2a34bc365",
 }
 
 # Bridged USDC.e

--- a/scripts/lagoon/deploy-lagoon-multichain.py
+++ b/scripts/lagoon/deploy-lagoon-multichain.py
@@ -1,0 +1,524 @@
+"""Tutorial: Deploying Lagoon vaults across 5 chains with CCTP bridging.
+
+Deploys a multichain Lagoon vault setup where all chains share the same
+deterministic Safe address via CREATE2:
+
+- **Arbitrum**: Lagoon vault (deposit/redeem entry point) + Safe
+- **Ethereum**: Safe + TradingStrategyModuleV0 + CowSwap
+- **Base**: Safe + TradingStrategyModuleV0
+- **HyperEVM**: Safe + TradingStrategyModuleV0 + Hypercore vaults
+- **Monad**: Safe + TradingStrategyModuleV0
+
+After deployment, bridges 1 USDC from the Arbitrum vault to each other
+chain via Circle's CCTP V2 protocol to verify cross-chain connectivity.
+
+Simulation mode
+---------------
+
+Set ``SIMULATE=true`` to run using Anvil mainnet forks of all 5 chains.
+CCTP bridging uses forged attestations in simulation mode.
+
+.. code-block:: shell
+
+    SIMULATE=true \\
+    JSON_RPC_ETHEREUM="https://..." \\
+    JSON_RPC_ARBITRUM="https://..." \\
+    JSON_RPC_BASE="https://..." \\
+    JSON_RPC_HYPERLIQUID="https://..." \\
+    JSON_RPC_MONAD="https://..." \\
+    poetry run python scripts/lagoon/deploy-lagoon-multichain.py
+
+Architecture overview
+---------------------
+
+::
+
+    Arbitrum (Lagoon vault — deposit/redeem entry)
+        │
+        ├── CCTP V2 ────► Ethereum Safe (CowSwap + ERC-4626 vaults)
+        ├── CCTP V2 ────► Base Safe (ERC-4626 vaults)
+        ├── CCTP V2 ────► HyperEVM Safe (Hypercore + ERC-4626 vaults)
+        └── CCTP V2 ────► Monad Safe (ERC-4626 vaults)
+
+All Safes share the same deterministic address across all chains.
+Each chain has its own TradingStrategyModuleV0 guard with
+chain-specific whitelisting rules.
+"""
+
+import logging
+import os
+import random
+from copy import deepcopy
+from decimal import Decimal
+from typing import cast
+
+from eth_account import Account
+from eth_account.signers.local import LocalAccount
+from eth_typing import HexAddress, HexStr
+from web3 import Web3
+
+from eth_defi.cctp.bridge import CCTPBridgeDestination, CCTPBridgeResult, bridge_usdc_cctp_parallel
+from eth_defi.cctp.constants import CHAIN_ID_TO_CCTP_DOMAIN
+from eth_defi.cctp.testing import replace_attester_on_fork
+from eth_defi.cctp.whitelist import CCTPDeployment
+from eth_defi.erc_4626.classification import create_vault_instance, detect_vault_features
+from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.erc_4626.vault_protocol.lagoon.deployment import (
+    LagoonConfig,
+    LagoonDeploymentParameters,
+    LagoonMultichainDeployment,
+    deploy_multichain_lagoon_vault,
+)
+from eth_defi.hotwallet import HotWallet
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.token import USDC_NATIVE_TOKEN, USDC_WHALE, fetch_erc20_details
+from eth_defi.trace import assert_transaction_success_with_explanation
+from eth_defi.utils import setup_console_logging
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Per-chain ERC-4626 vault addresses to whitelist (top vaults by TVL)
+#
+# Data source: https://top-defi-vaults.tradingstrategy.ai/top_vaults_by_chain.json
+# ---------------------------------------------------------------------------
+
+#: Arbitrum ERC-4626 vaults
+ARBITRUM_VAULTS: list[str] = [
+    "0xacb7432a4bb15402ce2afe0a7c9d5b738604f6f9",  # Silo Finance: Borrowable USDC (SiloId 146)
+    "0x2ba39e5388ac6c702cb29aea78d52aa66832f1ee",  # Euler: Varlamore USDC Growth
+    "0x0b2b2b2076d95dda7817e785989fe353fe955ef9",  # USDai: Staked USDai
+    "0x2433d6ac11193b4695d9ca73530de93c538ad18a",  # Silo Finance: Borrowable USDC (SiloId 127)
+]
+
+#: Ethereum ERC-4626 vaults
+ETHEREUM_VAULTS: list[str] = [
+    "0x4880799ee5200fc58da299e965df644fbf46780b",  # Centrifuge: Anemoy AAA CLO Fund
+    "0xe9d1f733f406d4bbbdfac6d4cfcd2e13a6ee1d01",  # Centrifuge: Anemoy AAA CLO Fund
+    "0xfe7c47895edb12a990b311df33b90cfea1d44c24",  # Euler: bUSD0 Zero Rate Vault
+    "0xc5d6a7b61d18afa11435a889557b068bb9f29930",  # Decentralized USD: Savings Usdd
+]
+
+#: Base ERC-4626 vaults
+BASE_VAULTS: list[str] = [
+    "0xee8f4ec5672f09119b96ab6fb59c27e1b7e44b61",  # Morpho: Gauntlet USDC Prime
+    "0xbeefe94c8ad530842bfe7d8b397938ffc1cb83b2",  # Morpho: Steakhouse Prime USDC
+    "0xbeef010f9cb27031ad51e3333f9af9c6b1228183",  # Morpho: Steakhouse USDC
+    "0x944766f715b51967e56afde5f0aa76ceacc9e7f9",  # Avantis USDC Vault
+]
+
+#: HyperEVM ERC-4626 vaults (chain 999)
+HYPEREVM_VAULTS: list[str] = [
+    "0x8a862fd6c12f9ad34c9c2ff45ab2b6712e8cea27",  # Morpho: Felix USDC
+    "0x808f72b6ff632fba005c88b49c2a76ab01cab545",  # Morpho: Felix USDC (Frontier)
+    "0x274f854b2042db1aa4d6c6e45af73588bed4fc9d",  # Morpho: Felix USDH (Frontier)
+    "0xfc5126377f0efc0041c0969ef9ba903ce67d151e",  # Morpho: Felix USDT0
+]
+
+#: Hypercore native vaults (chain 9999 in data source, whitelisted on HyperEVM via CoreWriter)
+HYPERCORE_VAULT_ADDRESSES: list[str] = [
+    "0xdfc24b077bc1425ad1dea75bcb6f8158e10df303",  # Hyperliquidity Provider (HLP)
+    "0x31ca8395cf837de08b24da3f660e77761dfb974b",  # HLP Strategy B
+    "0x010461c14e146ac35fe42271bdc1134ee31c703a",  # HLP Strategy A
+    "0xb0a55f13d22f66e6d495ac98113841b2326e9540",  # HLP Liquidator 2
+]
+
+#: Monad ERC-4626 vaults
+MONAD_VAULTS: list[str] = [
+    "0x8d3f9f9eb2f5e8b48efbb4074440d1e2a34bc365",  # Accountable: RWA Backed Lending by Valos
+    "0x7cd231120a60f500887444a9baf5e1bd753a5e59",  # Accountable: Hyperithm Delta Neutral
+    "0x6b343f7b797f1488aa48c49d540690f2b2c89751",  # Gearbox: EDGE UltraYield USDC
+    "0xad4aa2a713fb86fbb6b60de2af9e32a11db6abf2",  # Curvance: Curvance AUSD
+]
+
+#: Chain names mapping to environment variable names for RPC URLs
+CHAIN_RPC_ENV_VARS: dict[str, str] = {
+    "arbitrum": "JSON_RPC_ARBITRUM",
+    "ethereum": "JSON_RPC_ETHEREUM",
+    "base": "JSON_RPC_BASE",
+    "hyperliquid": "JSON_RPC_HYPERLIQUID",
+    "monad": "JSON_RPC_MONAD",
+}
+
+
+def resolve_vaults(web3: Web3, vault_addresses: list[str]) -> list[ERC4626Vault]:
+    """Resolve ERC-4626 vault addresses into vault instances.
+
+    Detects vault features and creates proper vault instances
+    for whitelisting during deployment.
+
+    :param web3:
+        Web3 connection to the chain.
+
+    :param vault_addresses:
+        List of ERC-4626 vault smart contract addresses.
+
+    :return:
+        List of resolved vault instances.
+    """
+    vaults = []
+    for addr in vault_addresses:
+        addr = Web3.to_checksum_address(addr)
+        try:
+            features = detect_vault_features(web3, addr)
+            vault = cast(ERC4626Vault, create_vault_instance(web3, addr, features=features))
+            if vault.is_valid():
+                logger.info("Resolved vault %s: %s", addr, vault.name)
+                vaults.append(vault)
+            else:
+                logger.warning("Skipping invalid vault at %s", addr)
+        except Exception as e:
+            logger.warning("Could not resolve vault at %s: %s", addr, e)
+    return vaults
+
+
+def create_multichain_whitelisting_configuration(
+    chain_web3: dict[str, Web3],
+    asset_manager: HexAddress,
+    safe_owners: list[HexAddress],
+    safe_threshold: int,
+    safe_salt_nonce: int,
+) -> dict[str, LagoonConfig]:
+    """Build per-chain LagoonConfig dicts for multichain deployment.
+
+    Shared across all chains:
+
+    - USDC as underlying (auto-resolved per chain)
+    - CCTP whitelisting (configured for all CCTP-capable chains)
+    - Safe owners, threshold, salt nonce
+    - Asset manager
+
+    Chain-specific:
+
+    - Arbitrum: Lagoon vault entry point + ERC-4626 vaults
+    - Ethereum: ERC-4626 vaults + CowSwap
+    - Base: ERC-4626 vaults
+    - HyperEVM: Hypercore vaults + ERC-4626 vaults
+    - Monad: ERC-4626 vaults
+
+    :param chain_web3:
+        Mapping of chain names to Web3 instances.
+
+    :param asset_manager:
+        Address that manages vault assets and executes trades.
+
+    :param safe_owners:
+        Addresses of Safe multisig owners.
+
+    :param safe_threshold:
+        Number of owner signatures required.
+
+    :param safe_salt_nonce:
+        CREATE2 salt for deterministic Safe address.
+
+    :return:
+        Per-chain LagoonConfig dict ready for ``deploy_multichain_lagoon_vault()``.
+    """
+    configs: dict[str, LagoonConfig] = {}
+
+    # Shared base parameters
+    base_params = LagoonDeploymentParameters(
+        underlying=None,  # auto-resolved per chain from USDC_NATIVE_TOKEN
+        name="Multichain Strategy Vault",
+        symbol="MSV",
+    )
+
+    def make_base_config(**kwargs) -> LagoonConfig:
+        """Create a LagoonConfig with shared settings."""
+        return LagoonConfig(
+            parameters=deepcopy(base_params),
+            asset_manager=asset_manager,
+            safe_owners=list(safe_owners),
+            safe_threshold=safe_threshold,
+            safe_salt_nonce=safe_salt_nonce,
+            any_asset=True,
+            **kwargs,
+        )
+
+    # --- Arbitrum: vault entry point ---
+    configs["arbitrum"] = make_base_config(
+        erc_4626_vaults=resolve_vaults(chain_web3["arbitrum"], ARBITRUM_VAULTS),
+    )
+
+    # --- Ethereum: CowSwap + vaults ---
+    configs["ethereum"] = make_base_config(
+        cowswap=True,
+        erc_4626_vaults=resolve_vaults(chain_web3["ethereum"], ETHEREUM_VAULTS),
+    )
+
+    # --- Base: vaults ---
+    configs["base"] = make_base_config(
+        erc_4626_vaults=resolve_vaults(chain_web3["base"], BASE_VAULTS),
+    )
+
+    # --- HyperEVM: Hypercore + ERC-4626 vaults ---
+    configs["hyperliquid"] = make_base_config(
+        hypercore_vaults=HYPERCORE_VAULT_ADDRESSES,
+        erc_4626_vaults=resolve_vaults(chain_web3["hyperliquid"], HYPEREVM_VAULTS),
+    )
+
+    # --- Monad: vaults ---
+    configs["monad"] = make_base_config(
+        erc_4626_vaults=resolve_vaults(chain_web3["monad"], MONAD_VAULTS),
+    )
+
+    # --- Configure CCTP for all CCTP-capable chains ---
+    cctp_chain_ids = []
+    for chain_name, web3 in chain_web3.items():
+        chain_id = web3.eth.chain_id
+        if chain_id in CHAIN_ID_TO_CCTP_DOMAIN:
+            cctp_chain_ids.append((chain_name, chain_id))
+
+    for chain_name, chain_id in cctp_chain_ids:
+        other_ids = [cid for name, cid in cctp_chain_ids if name != chain_name]
+        if other_ids:
+            configs[chain_name].cctp_deployment = CCTPDeployment.create_for_chain(
+                chain_id=chain_id,
+                allowed_destinations=other_ids,
+            )
+            logger.info("CCTP configured on %s with destinations: %s", chain_name, other_ids)
+
+    return configs
+
+
+def setup_simulate_chains() -> tuple[dict[str, Web3], list[AnvilLaunch]]:
+    """Create Anvil forks for all 5 chains.
+
+    :return:
+        Tuple of (chain_name→Web3 dict, list of AnvilLaunch handles for cleanup).
+    """
+    anvil_launches = []
+    chain_web3 = {}
+
+    for chain_name, env_var in CHAIN_RPC_ENV_VARS.items():
+        rpc_url = os.environ.get(env_var)
+        assert rpc_url, f"{env_var} environment variable is required"
+        rpc_url = rpc_url.split()[0]  # Take first URL if space-separated fallback format
+
+        # HyperEVM needs higher gas limit for TradingStrategyModuleV0 deployment
+        # due to dual-block architecture (small blocks ~2-3M gas, large blocks ~30M)
+        extra_args = {}
+        if chain_name == "hyperliquid":
+            extra_args["gas_limit"] = 30_000_000
+
+        # Unlock USDC whales for funding
+        chain_id_map = {
+            "arbitrum": 42161,
+            "ethereum": 1,
+            "base": 8453,
+            "hyperliquid": 999,
+            "monad": 143,
+        }
+        chain_id = chain_id_map[chain_name]
+        unlocked = []
+        if chain_id in USDC_WHALE:
+            unlocked.append(USDC_WHALE[chain_id])
+
+        launch = fork_network_anvil(rpc_url, unlocked_addresses=unlocked, **extra_args)
+        anvil_launches.append(launch)
+
+        web3 = create_multi_provider_web3(
+            launch.json_rpc_url,
+            default_http_timeout=(3, 250.0),
+        )
+        assert web3.eth.chain_id == chain_id, f"Expected chain {chain_id} for {chain_name}, got {web3.eth.chain_id}"
+        chain_web3[chain_name] = web3
+        logger.info("Anvil fork for %s (chain %d) started at %s", chain_name, chain_id, launch.json_rpc_url)
+
+    return chain_web3, anvil_launches
+
+
+def setup_real_chains() -> dict[str, Web3]:
+    """Create Web3 connections for real networks.
+
+    :return:
+        chain_name→Web3 dict.
+    """
+    chain_web3 = {}
+    for chain_name, env_var in CHAIN_RPC_ENV_VARS.items():
+        rpc_url = os.environ.get(env_var)
+        assert rpc_url, f"{env_var} environment variable is required"
+        web3 = create_multi_provider_web3(rpc_url)
+        chain_web3[chain_name] = web3
+        logger.info("Connected to %s (chain %d)", chain_name, web3.eth.chain_id)
+    return chain_web3
+
+
+def fund_vault(web3: Web3, vault, usdc_details, depositor: str, asset_manager: str, amount_usdc: int = 200):
+    """Deposit USDC into the vault and settle so the Safe holds funds."""
+    raw_amount = usdc_details.convert_to_raw(amount_usdc)
+
+    tx_hash = vault.post_new_valuation(Decimal(0)).transact({"from": asset_manager})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+
+    tx_hash = usdc_details.contract.functions.approve(
+        vault.address,
+        raw_amount,
+    ).transact({"from": depositor})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+
+    tx_hash = vault.request_deposit(depositor, raw_amount).transact({"from": depositor})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+
+    tx_hash = vault.post_new_valuation(Decimal(0)).transact({"from": asset_manager})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+
+    tx_hash = vault.settle_via_trading_strategy_module(Decimal(0)).transact(
+        {"from": asset_manager, "gas": 1_000_000},
+    )
+    assert_transaction_success_with_explanation(web3, tx_hash)
+
+    balance = vault.underlying_token.fetch_balance_of(vault.safe_address)
+    logger.info("Vault funded with %d USDC (Safe balance: %s)", amount_usdc, balance)
+
+
+def main():
+    setup_console_logging(logging.INFO)
+
+    simulate = os.environ.get("SIMULATE", "").lower() in ("true", "1", "yes")
+    salt_nonce = int(os.environ.get("SALT_NONCE", str(random.randint(1, 2**32))))
+
+    print("=" * 70)
+    print("Lagoon multichain deployment tutorial")
+    print("=" * 70)
+    print(f"  Mode: {'SIMULATE (Anvil forks)' if simulate else 'REAL (live networks)'}")
+    print(f"  Salt nonce: {salt_nonce}")
+    print(f"  Chains: Arbitrum, Ethereum, Base, HyperEVM, Monad")
+    print()
+
+    anvil_launches: list[AnvilLaunch] = []
+
+    try:
+        # --- Step 1: Set up chain connections ---
+        if simulate:
+            chain_web3, anvil_launches = setup_simulate_chains()
+        else:
+            chain_web3 = setup_real_chains()
+
+        # --- Step 2: Set up deployer wallet ---
+        if simulate:
+            deployer = Account.create()
+            # Fund deployer with ETH/native on all chains
+            for chain_name, web3 in chain_web3.items():
+                web3.provider.make_request("anvil_setBalance", [deployer.address, hex(100 * 10**18)])
+            print(f"  Deployer: {deployer.address} (simulated, funded with 100 ETH)")
+        else:
+            private_key = os.environ.get("PRIVATE_KEY")
+            assert private_key, "PRIVATE_KEY environment variable is required in real mode"
+            deployer = Account.from_key(private_key)
+            print(f"  Deployer: {deployer.address}")
+
+        # Use deployer as both asset manager and single Safe owner for tutorial
+        asset_manager = deployer.address
+        safe_owners = [deployer.address]
+        safe_threshold = 1
+
+        # --- Step 3: Build per-chain configurations ---
+        print("\nBuilding per-chain whitelisting configurations...")
+        chain_configs = create_multichain_whitelisting_configuration(
+            chain_web3=chain_web3,
+            asset_manager=asset_manager,
+            safe_owners=safe_owners,
+            safe_threshold=safe_threshold,
+            safe_salt_nonce=salt_nonce,
+        )
+
+        for chain_name, config in chain_configs.items():
+            n_vaults = len(config.erc_4626_vaults) if config.erc_4626_vaults else 0
+            n_hypercore = len(config.hypercore_vaults) if config.hypercore_vaults else 0
+            cctp = "yes" if config.cctp_deployment else "no"
+            print(f"  {chain_name}: {n_vaults} ERC-4626 vaults, {n_hypercore} Hypercore vaults, CCTP: {cctp}")
+
+        # --- Step 4: Deploy across all chains ---
+        print("\nDeploying Lagoon vaults across all chains (parallel)...")
+        result = deploy_multichain_lagoon_vault(
+            chain_web3=chain_web3,
+            deployer=deployer,
+            chain_configs=chain_configs,
+        )
+
+        # --- Step 5: Print deployment summary ---
+        print("\n" + "=" * 70)
+        print("Deployment summary")
+        print("=" * 70)
+        print(f"  Deterministic Safe address: {result.safe_address}")
+        print(f"  Salt nonce: {result.safe_salt_nonce}")
+        print()
+        for chain_name, deployment in sorted(result.deployments.items()):
+            print(f"  {chain_name}:")
+            print(f"    Vault:  {deployment.vault.address}")
+            print(f"    Safe:   {deployment.vault.safe_address}")
+            print(f"    Module: {deployment.trading_strategy_module.address if deployment.trading_strategy_module else 'N/A'}")
+
+        # --- Step 6: Fund Arbitrum vault for bridging ---
+        if simulate:
+            print("\nFunding Arbitrum vault with 10 USDC for bridge testing...")
+            arb_web3 = chain_web3["arbitrum"]
+            arb_vault = result.deployments["arbitrum"].vault
+            arb_usdc = fetch_erc20_details(arb_web3, USDC_NATIVE_TOKEN[42161])
+            depositor = USDC_WHALE[42161]
+            fund_vault(arb_web3, arb_vault, arb_usdc, depositor, asset_manager, amount_usdc=10)
+        else:
+            print("\nSkipping vault funding in real mode (vault must be pre-funded).")
+
+        # --- Step 7: Bridge 1 USDC from Arbitrum to each CCTP-enabled chain (parallel) ---
+        print("\nBridging 1 USDC from Arbitrum to each destination chain (parallel)...")
+        arb_vault = result.deployments["arbitrum"].vault
+        arb_usdc = fetch_erc20_details(chain_web3["arbitrum"], USDC_NATIVE_TOKEN[42161])
+        bridge_amount = arb_usdc.convert_to_raw(1)  # 1 USDC
+
+        # Prepare test attesters on destination forks (simulate mode only)
+        # Keyed by chain ID for bridge_usdc_cctp_parallel()
+        test_attesters: dict[int, LocalAccount] | None = None
+        if simulate:
+            test_attesters = {}
+            for chain_name in ["ethereum", "base", "hyperliquid", "monad"]:
+                dest_chain_id = chain_web3[chain_name].eth.chain_id
+                test_attesters[dest_chain_id] = replace_attester_on_fork(chain_web3[chain_name])
+
+        # Build destination list for parallel bridging
+        dest_chain_names = ["ethereum", "base", "hyperliquid", "monad"]
+        destinations = []
+        for dest_chain_name in dest_chain_names:
+            dest_safe = result.deployments[dest_chain_name].vault.safe_address
+            destinations.append(
+                CCTPBridgeDestination(
+                    dest_web3=chain_web3[dest_chain_name],
+                    dest_safe_address=dest_safe,
+                    amount=bridge_amount,
+                )
+            )
+            print(f"  Destination: {dest_chain_name} (Safe: {dest_safe})")
+
+        # Execute parallel bridge: burns sequentially, attestations + receives in parallel
+        bridge_results = bridge_usdc_cctp_parallel(
+            source_web3=chain_web3["arbitrum"],
+            source_vault=arb_vault,
+            destinations=destinations,
+            sender=asset_manager,
+            simulate=simulate,
+            test_attesters=test_attesters,
+        )
+
+        for dest_name, br in zip(dest_chain_names, bridge_results):
+            print(f"\n  {dest_name}:")
+            print(f"    Burn TX:    {br.burn_tx_hash}")
+            print(f"    Receive TX: {br.receive_tx_hash}")
+
+        # --- Step 8: Print final summary ---
+        print("\n" + "=" * 70)
+        print("Bridge summary")
+        print("=" * 70)
+        for br in bridge_results:
+            print(f"  Chain {br.source_chain_id} -> {br.dest_chain_id}: {arb_usdc.convert_to_decimals(br.amount):.2f} USDC")
+
+        print("\nDone!")
+
+    finally:
+        for launch in anvil_launches:
+            launch.close(log_level=logging.ERROR)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/lagoon/test_lagoon_multichain_deploy.py
+++ b/tests/lagoon/test_lagoon_multichain_deploy.py
@@ -1,8 +1,9 @@
-"""Test multichain Lagoon vault deployment with deterministic Safe and CCTP bridging.
+"""Test multichain Lagoon vault deployment with deterministic Safe and parallel CCTP bridging.
 
 - Deploys Lagoon vaults across Ethereum, Arbitrum, Base, and HyperEVM forks
 - Verifies the same deterministic Safe address across all chains
-- Tests CCTP bridging: Arbitrum → Base (burn on Arbitrum, receive on Base)
+- Tests parallel CCTP bridging: Arbitrum -> Ethereum, Base, HyperEVM simultaneously
+- Uses per-chain LagoonConfig with explicit CCTP configuration
 """
 
 import logging
@@ -14,16 +15,20 @@ from eth_account import Account
 from eth_account.signers.local import LocalAccount
 from eth_typing import HexAddress
 
-from eth_defi.cctp.constants import CCTP_DOMAIN_ARBITRUM, CCTP_DOMAIN_BASE
-from eth_defi.cctp.receive import prepare_receive_message
-from eth_defi.cctp.testing import (craft_cctp_message, forge_attestation,
-                                   replace_attester_on_fork)
-from eth_defi.cctp.transfer import (prepare_approve_for_burn,
-                                    prepare_deposit_for_burn)
+from eth_defi.cctp.bridge import (
+    CCTPBridgeDestination,
+    CCTPBridgeResult,
+    bridge_usdc_cctp_parallel,
+)
+from eth_defi.cctp.constants import CHAIN_ID_TO_CCTP_DOMAIN
+from eth_defi.cctp.testing import replace_attester_on_fork
+from eth_defi.cctp.whitelist import CCTPDeployment
 from eth_defi.erc_4626.vault_protocol.lagoon.deployment import (
-    LagoonConfig, LagoonDeploymentParameters, LagoonMultichainDeployment,
-    deploy_multichain_lagoon_vault)
-from eth_defi.hotwallet import HotWallet
+    LagoonConfig,
+    LagoonDeploymentParameters,
+    LagoonMultichainDeployment,
+    deploy_multichain_lagoon_vault,
+)
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.token import USDC_NATIVE_TOKEN, USDC_WHALE, fetch_erc20_details
@@ -48,6 +53,9 @@ DEPLOYER_PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d
 #: Anvil default accounts #1 and #2. Used as Safe owners.
 OWNER_1 = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8"
 OWNER_2 = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"
+
+#: All chain IDs in the test (Ethereum, Arbitrum, Base, HyperEVM)
+TEST_CHAIN_IDS = [1, 42161, 8453, 999]
 
 
 @pytest.fixture()
@@ -95,7 +103,7 @@ def anvil_base(request) -> AnvilLaunch:
 def anvil_hyperliquid(request) -> AnvilLaunch:
     launch = fork_network_anvil(
         JSON_RPC_HYPERLIQUID,
-        gas_limit=30_000_000,  # HyperEVM small blocks have 2–3M gas limit; override to large block limit (30M) for TradingStrategyModuleV0 (~5.4M gas). See https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/dual-block-architecture
+        gas_limit=30_000_000,  # HyperEVM small blocks have 2-3M gas limit; override to large block limit (30M) for TradingStrategyModuleV0 (~5.4M gas). See https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/dual-block-architecture
     )
     try:
         yield launch
@@ -151,9 +159,56 @@ def web3_hyperliquid(anvil_hyperliquid) -> "Web3":
     return web3
 
 
+def _make_chain_configs(
+    deployer_address: HexAddress,
+    salt_nonce: int,
+) -> dict[str, LagoonConfig]:
+    """Build per-chain LagoonConfig dicts with explicit CCTP configuration.
+
+    Each chain gets its own config with CCTP whitelisting to all other
+    CCTP-capable chains in the test set.
+    """
+    chain_names = ["ethereum", "arbitrum", "base", "hyperliquid"]
+    chain_id_map = {
+        "ethereum": 1,
+        "arbitrum": 42161,
+        "base": 8453,
+        "hyperliquid": 999,
+    }
+
+    configs = {}
+    for chain_name in chain_names:
+        chain_id = chain_id_map[chain_name]
+
+        # Configure CCTP with all other chains as allowed destinations
+        cctp = None
+        if chain_id in CHAIN_ID_TO_CCTP_DOMAIN:
+            other_chain_ids = [cid for cid in TEST_CHAIN_IDS if cid != chain_id and cid in CHAIN_ID_TO_CCTP_DOMAIN]
+            cctp = CCTPDeployment.create_for_chain(
+                chain_id=chain_id,
+                allowed_destinations=other_chain_ids,
+            )
+
+        configs[chain_name] = LagoonConfig(
+            parameters=LagoonDeploymentParameters(
+                underlying=None,
+                name="Multichain Test Vault",
+                symbol="MTV",
+            ),
+            asset_manager=deployer_address,
+            safe_owners=[OWNER_1, OWNER_2],
+            safe_threshold=2,
+            any_asset=True,
+            safe_salt_nonce=salt_nonce,
+            cctp_deployment=cctp,
+        )
+
+    return configs
+
+
 def _fund_vault(web3, vault, usdc_details, depositor, asset_manager, amount_usdc=100):
     """Deposit USDC into the vault and settle so the Safe holds funds."""
-    raw_amount = amount_usdc * 10**6
+    raw_amount = usdc_details.convert_to_raw(amount_usdc)
 
     tx_hash = vault.post_new_valuation(Decimal(0)).transact({"from": asset_manager})
     assert_transaction_success_with_explanation(web3, tx_hash)
@@ -176,20 +231,21 @@ def _fund_vault(web3, vault, usdc_details, depositor, asset_manager, amount_usdc
     assert vault.underlying_token.fetch_balance_of(vault.safe_address) == amount_usdc
 
 
-
 @pytest.mark.timeout(900)
 @pytest.mark.skipif(CI, reason="This is a long-running test that deploys multiple vaults and performs cross-chain bridging. Run locally for testing.")
-def test_multichain_lagoon_deploy_and_cctp_bridge(
+def test_multichain_lagoon_deploy_and_parallel_cctp_bridge(
     web3_ethereum,
     web3_arbitrum,
     web3_base,
     web3_hyperliquid,
     deployer,
 ):
-    """Deploy Lagoon vaults on 4 chains with deterministic Safe, then bridge USDC via CCTP.
+    """Deploy Lagoon vaults on 4 chains with deterministic Safe, then bridge USDC via parallel CCTP.
 
-    Part 1: Multichain deployment — verify same Safe address on all 4 chains.
-    Part 2: CCTP bridging — Arbitrum → Base burn and forged attestation receive.
+    Part 1: Multichain deployment - verify same Safe address on all 4 chains,
+    including HyperEVM CCTP whitelisting.
+    Part 2: Parallel CCTP bridging - Arbitrum -> Ethereum, Base, HyperEVM simultaneously.
+    Burns are sequential (same source chain), attestations and receives are parallel.
     """
 
     salt_nonce = 42
@@ -198,20 +254,9 @@ def test_multichain_lagoon_deploy_and_cctp_bridge(
     for web3 in [web3_ethereum, web3_arbitrum, web3_base, web3_hyperliquid]:
         web3.provider.make_request("anvil_setBalance", [deployer.address, hex(100 * 10**18)])
 
-    # --- Part 1: Multichain deployment ---
+    # --- Part 1: Multichain deployment with per-chain configs ---
 
-    config = LagoonConfig(
-        parameters=LagoonDeploymentParameters(
-            underlying=None,  # auto-resolved per chain from USDC_NATIVE_TOKEN
-            name="Multichain Test Vault",
-            symbol="MTV",
-        ),
-        asset_manager=deployer.address,
-        safe_owners=[OWNER_1, OWNER_2],
-        safe_threshold=2,
-        any_asset=True,
-        safe_salt_nonce=salt_nonce,
-    )
+    chain_configs = _make_chain_configs(deployer.address, salt_nonce)
 
     chain_web3 = {
         "ethereum": web3_ethereum,
@@ -223,8 +268,7 @@ def test_multichain_lagoon_deploy_and_cctp_bridge(
     result = deploy_multichain_lagoon_vault(
         chain_web3=chain_web3,
         deployer=deployer,
-        config=config,
-        cctp_enabled=True,
+        chain_configs=chain_configs,
     )
 
     # Verify all Safe addresses are the same
@@ -237,74 +281,95 @@ def test_multichain_lagoon_deploy_and_cctp_bridge(
     vault_addresses = {name: d.vault.address for name, d in result.deployments.items()}
     assert len(set(vault_addresses.values())) == 4, f"Vault addresses should differ: {vault_addresses}"
 
-    # Verify CCTP was configured on Ethereum, Arbitrum, Base but NOT on HyperEVM
-    for chain_name in ["ethereum", "arbitrum", "base"]:
+    # Verify CCTP was configured on all 4 chains (including HyperEVM with domain 19)
+    for chain_name in ["ethereum", "arbitrum", "base", "hyperliquid"]:
         guard = result.deployments[chain_name].trading_strategy_module
-        # CCTP whitelisting should have been applied — check the guard has the CCTP TokenMessenger whitelisted
         assert guard is not None
 
-    # --- Part 2: CCTP bridging Arbitrum → Base ---
+    # --- Part 2: Parallel CCTP bridging Arbitrum -> Ethereum, Base, HyperEVM ---
 
-    arb_deployment = result.deployments["arbitrum"]
-    base_deployment = result.deployments["base"]
-    arb_vault = arb_deployment.vault
-    base_vault = base_deployment.vault
-
+    arb_vault = result.deployments["arbitrum"].vault
     arb_usdc = fetch_erc20_details(web3_arbitrum, USDC_NATIVE_TOKEN[42161])
 
-    # Fund the Arbitrum vault with USDC so we can burn
+    # Fund the Arbitrum vault with USDC so we can burn to 3 destinations
     arb_depositor = USDC_WHALE[42161]
-    _fund_vault(web3_arbitrum, arb_vault, arb_usdc, arb_depositor, deployer.address, amount_usdc=200)
+    _fund_vault(web3_arbitrum, arb_vault, arb_usdc, arb_depositor, deployer.address, amount_usdc=400)
 
-    bridge_amount = 100 * 10**6  # 100 USDC
+    bridge_amount = arb_usdc.convert_to_raw(100)  # 100 USDC per destination
 
     safe_balance_before = arb_usdc.contract.functions.balanceOf(arb_vault.safe_address).call()
-    assert safe_balance_before >= bridge_amount
+    assert safe_balance_before >= bridge_amount * 3
 
-    # Step 1: Approve USDC to TokenMessengerV2 through the Arbitrum vault
-    approve_fn = prepare_approve_for_burn(web3_arbitrum, bridge_amount)
-    moduled_tx = arb_vault.transact_via_trading_strategy_module(approve_fn)
-    tx_hash = moduled_tx.transact({"from": deployer.address, "gas": 1_000_000})
-    assert_transaction_success_with_explanation(web3_arbitrum, tx_hash)
+    # Replace attesters on all 3 destination forks
+    test_attesters = {
+        1: replace_attester_on_fork(web3_ethereum),
+        8453: replace_attester_on_fork(web3_base),
+        999: replace_attester_on_fork(web3_hyperliquid),
+    }
 
-    # Step 2: Burn USDC cross-chain to Base vault Safe
-    burn_fn = prepare_deposit_for_burn(
-        web3_arbitrum,
-        amount=bridge_amount,
-        destination_chain_id=8453,
-        mint_recipient=base_vault.safe_address,
+    # Record destination balances before bridging
+    dest_chains = {
+        "ethereum": (web3_ethereum, 1),
+        "base": (web3_base, 8453),
+        "hyperliquid": (web3_hyperliquid, 999),
+    }
+    dest_balances_before = {}
+    for chain_name, (web3, chain_id) in dest_chains.items():
+        usdc = fetch_erc20_details(web3, USDC_NATIVE_TOKEN[chain_id])
+        dest_safe = result.deployments[chain_name].vault.safe_address
+        dest_balances_before[chain_name] = usdc.contract.functions.balanceOf(dest_safe).call()
+
+    # Build parallel bridge destinations
+    destinations = [
+        CCTPBridgeDestination(
+            dest_web3=web3_ethereum,
+            dest_safe_address=result.deployments["ethereum"].vault.safe_address,
+            amount=bridge_amount,
+        ),
+        CCTPBridgeDestination(
+            dest_web3=web3_base,
+            dest_safe_address=result.deployments["base"].vault.safe_address,
+            amount=bridge_amount,
+        ),
+        CCTPBridgeDestination(
+            dest_web3=web3_hyperliquid,
+            dest_safe_address=result.deployments["hyperliquid"].vault.safe_address,
+            amount=bridge_amount,
+        ),
+    ]
+
+    # Execute parallel bridge: burns sequential, attestations + receives parallel
+    bridge_results = bridge_usdc_cctp_parallel(
+        source_web3=web3_arbitrum,
+        source_vault=arb_vault,
+        destinations=destinations,
+        sender=deployer.address,
+        simulate=True,
+        test_attesters=test_attesters,
     )
-    moduled_tx = arb_vault.transact_via_trading_strategy_module(burn_fn)
-    tx_hash = moduled_tx.transact({"from": deployer.address, "gas": 1_000_000})
-    assert_transaction_success_with_explanation(web3_arbitrum, tx_hash)
 
-    # Step 3: Verify USDC was burned on Arbitrum
+    # Verify results
+    assert len(bridge_results) == 3
+    for br in bridge_results:
+        assert isinstance(br, CCTPBridgeResult)
+        assert br.source_chain_id == 42161
+        assert br.amount == bridge_amount
+        assert br.burn_tx_hash
+        assert br.receive_tx_hash
+
+    # Verify destination chain IDs match
+    assert bridge_results[0].dest_chain_id == 1  # Ethereum
+    assert bridge_results[1].dest_chain_id == 8453  # Base
+    assert bridge_results[2].dest_chain_id == 999  # HyperEVM
+
+    # Verify USDC was burned on Arbitrum (3 * 100 USDC)
     safe_balance_after = arb_usdc.contract.functions.balanceOf(arb_vault.safe_address).call()
-    assert safe_balance_after == safe_balance_before - bridge_amount
+    assert safe_balance_after == safe_balance_before - (bridge_amount * 3)
 
-    # Step 4: Receive on Base fork — replace attester and forge attestation
-    test_attester = replace_attester_on_fork(web3_base)
-
-    nonce = 999_999_999
-    message = craft_cctp_message(
-        source_domain=CCTP_DOMAIN_ARBITRUM,
-        destination_domain=CCTP_DOMAIN_BASE,
-        nonce=nonce,
-        mint_recipient=base_vault.safe_address,
-        amount=bridge_amount,
-        burn_token=USDC_NATIVE_TOKEN[42161],
-    )
-    attestation = forge_attestation(message, test_attester)
-
-    base_usdc = fetch_erc20_details(web3_base, USDC_NATIVE_TOKEN[8453])
-    base_safe_balance_before = base_usdc.contract.functions.balanceOf(base_vault.safe_address).call()
-
-    # Step 5: Call receiveMessage() on Base — anyone can relay
-    receive_fn = prepare_receive_message(web3_base, message, attestation)
-    relayer = web3_base.eth.accounts[9]
-    tx_hash = receive_fn.transact({"from": relayer, "gas": 1_000_000})
-    assert_transaction_success_with_explanation(web3_base, tx_hash)
-
-    # Step 6: Verify USDC was minted to the Base vault Safe
-    base_safe_balance_after = base_usdc.contract.functions.balanceOf(base_vault.safe_address).call()
-    assert base_safe_balance_after == base_safe_balance_before + bridge_amount
+    # Verify USDC was minted on each destination chain
+    dest_chain_names = ["ethereum", "base", "hyperliquid"]
+    for chain_name, (web3, chain_id) in dest_chains.items():
+        usdc = fetch_erc20_details(web3, USDC_NATIVE_TOKEN[chain_id])
+        dest_safe = result.deployments[chain_name].vault.safe_address
+        balance_after = usdc.contract.functions.balanceOf(dest_safe).call()
+        assert balance_after == dest_balances_before[chain_name] + bridge_amount, f"USDC not minted on {chain_name}: before={dest_balances_before[chain_name]}, after={balance_after}"


### PR DESCRIPTION
## Summary

- **New `eth_defi/cctp/monitor.py`**: CCTP transfer status monitoring via Circle's Iris V2 API (`/v2/messages`) with `fetch_transfer_status()` (one-shot), `poll_transfer_status()` (blocking), and `poll_transfers_parallel()` (threaded concurrent polling)
- **Refactored `eth_defi/cctp/bridge.py`**: Split monolithic bridge into composable `burn_usdc_cctp()` / `receive_usdc_cctp()` phases, plus `bridge_usdc_cctp_parallel()` that burns sequentially then polls attestations and receives in parallel — reduces N-chain bridging from `N × 15min` to `~15min`
- **Refactored `deploy_multichain_lagoon_vault()`**: Now accepts `chain_configs: dict[str, LagoonConfig]` instead of single `config` + `cctp_enabled` flag, giving callers full control over per-chain whitelisting
- **Added Monad (143) and HyperEVM (999) CCTP support**: Domain IDs 15 and 19, Lagoon factory, token constants
- **New tutorial script** `scripts/lagoon/deploy-lagoon-multichain.py` deploying across 5 chains with parallel CCTP bridging

🤖 Generated with [Claude Code](https://claude.com/claude-code)