### PR TITLE
fix: document HyperEVM testnet activation failure and add configurable activation params

### DIFF
--- a/eth_defi/hyperliquid/core_writer.py
+++ b/eth_defi/hyperliquid/core_writer.py
@@ -372,6 +372,74 @@ def build_hypercore_deposit_multicall(
     return module.functions.multicall(calls)
 
 
+def build_activate_account_multicall(
+    lagoon_vault: LagoonVault,
+    activation_amount: int | None = None,
+) -> ContractFunction:
+    """Build a multicall to activate a Safe's HyperCore account.
+
+    Smart contracts (like Safe multisigs) must be activated on HyperCore
+    before ``CoreDepositWallet.deposit()`` bridge actions will clear the
+    EVM escrow.  This multicall performs the activation in a single
+    transaction via the Safe's trading strategy module:
+
+    1. ``approve(CoreDepositWallet, activation_amount)``
+    2. ``CoreDepositWallet.depositFor(safe, activation_amount, SPOT_DEX)``
+
+    .. note::
+
+        New HyperCore accounts incur a **1 USDC account creation fee**.
+        The default ``activation_amount`` of 2 USDC exceeds the fee.
+
+    :param lagoon_vault:
+        Lagoon vault instance with ``trading_strategy_module_address`` configured.
+
+    :param activation_amount:
+        USDC amount in raw units (6 decimals) for activation.
+        Defaults to :py:data:`~eth_defi.hyperliquid.evm_escrow.DEFAULT_ACTIVATION_AMOUNT` (2 USDC).
+
+    :return:
+        Bound ``module.functions.multicall(data)`` ready to ``.transact()``.
+    """
+    from eth_defi.hyperliquid.evm_escrow import DEFAULT_ACTIVATION_AMOUNT
+
+    if activation_amount is None:
+        activation_amount = DEFAULT_ACTIVATION_AMOUNT
+
+    web3 = lagoon_vault.web3
+    module = lagoon_vault.trading_strategy_module
+    chain_id = lagoon_vault.spec.chain_id
+    safe_address = lagoon_vault.safe_address
+
+    asset_address = lagoon_vault.vault_contract.functions.asset().call()
+    usdc_contract = get_deployed_contract(web3, "centre/ERC20.json", asset_address)
+    cdw_address = CORE_DEPOSIT_WALLET[chain_id]
+    core_deposit_wallet = get_core_deposit_wallet_contract(web3, cdw_address)
+
+    calls = [
+        # 1. Approve USDC to CoreDepositWallet
+        _encode_perform_call(
+            module,
+            usdc_contract.address,
+            usdc_contract.functions.approve(
+                Web3.to_checksum_address(core_deposit_wallet.address),
+                activation_amount,
+            ),
+        ),
+        # 2. CoreDepositWallet.depositFor(safe, amount, SPOT_DEX)
+        _encode_perform_call(
+            module,
+            core_deposit_wallet.address,
+            core_deposit_wallet.functions.depositFor(
+                Web3.to_checksum_address(safe_address),
+                activation_amount,
+                SPOT_DEX,
+            ),
+        ),
+    ]
+    return module.functions.multicall(calls)
+
+
 def build_hypercore_deposit_phase1(
     lagoon_vault: LagoonVault,
     evm_usdc_amount: int,

--- a/eth_defi/hyperliquid/evm_escrow.py
+++ b/eth_defi/hyperliquid/evm_escrow.py
@@ -90,6 +90,14 @@ Expected latencies
 
 The :py:func:`wait_for_evm_escrow_clear` helper uses conservative defaults
 (60 s timeout, 2 s poll interval) to handle worst-case scenarios.
+
+Known issues
+------------
+
+- ``depositFor`` on HyperEVM **testnet** does not create HyperCore accounts
+  for contract addresses (e.g. Safe multisigs). The EVM transaction succeeds
+  but the account is never created and USDC is lost.
+  See `hyperliquid-dex/node#138 <https://github.com/hyperliquid-dex/node/issues/138>`_.
 """
 
 from __future__ import annotations

--- a/scripts/hyperliquid/README-hyperliquid-vaults.md
+++ b/scripts/hyperliquid/README-hyperliquid-vaults.md
@@ -213,11 +213,13 @@ SCAN_HYPERCORE=true LOG_LEVEL=info \
 
 ### Docker: scan only Hypercore
 
+Start `./vault-shell.sh` and then
+
 ```shell
 SCAN_HYPERCORE=true \
   DISABLE_CHAINS=Ethereum,Arbitrum,Base,Polygon,Avalanche,Optimism,Binance,Sonic,Berachain,Unichain,Mantle,Mode,Abstract,Celo,Soneium,zkSync,Gnosis,Blast,Zora,Ink,Hemi,Linea,TAC,Plasma,Katana,Monad,HyperEVM \
   LOG_LEVEL=info \
-  docker compose run vault-scanner
+  python scripts/erc-4626/scan-vaults-all-chains.py
 ```
 
 ## Manual testing commands

--- a/scripts/hyperliquid/deploy-lagoon-hyperliquid-vault.py
+++ b/scripts/hyperliquid/deploy-lagoon-hyperliquid-vault.py
@@ -58,8 +58,12 @@ Environment variables
   (testnet: ``0xa15099a30bbf2e68942d6f4c43d70d04faeab0a0``,
   mainnet: ``0xdfc24b077bc1425ad1dea75bcb6f8158e10df303``).
 - ``USDC_AMOUNT``: USDC amount in human units for the vault deposit (default: ``2``).
-  On live networks, an additional 2 USDC is automatically added for
-  HyperCore account activation (1 USDC creation fee + 1 USDC reaches spot).
+  On live networks, an additional activation USDC is automatically added for
+  HyperCore account activation (1 USDC creation fee + remainder reaches spot).
+- ``ACTIVATION_AMOUNT``: USDC amount in human units for HyperCore account
+  activation (default: ``2``). Increase to 5 if activation fails on testnet.
+- ``ACTIVATION_TIMEOUT``: Seconds to wait for activation verification
+  (default: ``60``). Increase to 180 on testnet.
 - ``DEPOSIT_MODE``: ``two_phase`` (default) or ``batched``.
   ``two_phase`` splits bridge and vault deposit with an escrow wait;
   ``batched`` uses a single multicall but can silently fail under load.
@@ -81,7 +85,7 @@ Usage::
     SIMULATE=true NETWORK=testnet python scripts/hyperliquid/deploy-lagoon-hyperliquid-vault.py
 
     # Testnet deposit only (deploy + deposit, wait 1 day before withdrawal)
-    NETWORK=testnet ACTION=deposit USDC_AMOUNT=1 python scripts/hyperliquid/deploy-lagoon-hyperliquid-vault.py
+    NETWORK=testnet USDC_AMOUNT=1 python scripts/hyperliquid/deploy-lagoon-hyperliquid-vault.py
 
     # Mainnet deposit only
     NETWORK=mainnet ACTION=deposit USDC_AMOUNT=1 python scripts/hyperliquid/deploy-lagoon-hyperliquid-vault.py
@@ -104,6 +108,10 @@ If deposit lands on EVM but the vault position is missing, use
 
 Common issues:
 
+- **Account activation fails on testnet**: ``depositFor`` to contract
+  addresses (Safe multisigs) does not create HyperCore accounts on testnet.
+  The EVM transaction succeeds but USDC is lost. Use mainnet instead.
+  See https://github.com/hyperliquid-dex/node/issues/138
 - **USDC stuck in EVM escrow**: the bridge step succeeded but HyperCore
   has not yet processed the deposit. Wait and re-check.
 - **USDC in spot but no vault position**: ``transferUsdClass`` or
@@ -196,6 +204,8 @@ def _do_deposit(
     network: str,
     simulate: bool,
     deposit_mode: str = "batched",
+    activation_amount: int = DEFAULT_ACTIVATION_AMOUNT,
+    activation_timeout: float = 60.0,
 ):
     """Execute deposit into a Hypercore vault via Lagoon.
 
@@ -223,6 +233,8 @@ def _do_deposit(
                 lagoon_vault=lagoon_vault,
                 deployer=deployer,
                 session=session,
+                activation_amount=activation_amount,
+                timeout=activation_timeout,
             )
             deployer.sync_nonce(web3)
 
@@ -435,6 +447,10 @@ def main():
     deposit_mode = os.environ.get("DEPOSIT_MODE", "two_phase").lower()
     assert deposit_mode in ("batched", "two_phase"), f"DEPOSIT_MODE must be 'batched' or 'two_phase', got '{deposit_mode}'"
 
+    # Activation parameters (configurable for testnet troubleshooting)
+    activation_human = int(os.environ.get("ACTIVATION_AMOUNT", "2"))
+    activation_timeout = float(os.environ.get("ACTIVATION_TIMEOUT", "60"))
+
     # Existing deployment addresses (skip deploy + whitelist when set)
     existing_lagoon_vault = os.environ.get("LAGOON_VAULT")
     existing_module = os.environ.get("TRADING_STRATEGY_MODULE")
@@ -469,12 +485,11 @@ def main():
     hypercore_amount = usdc_amount  # Hypercore uses same decimals as EVM USDC
 
     # On live networks doing deposits, the Safe needs extra USDC for
-    # HyperCore account activation (2 USDC: 1 USDC fee + 1 USDC reaches spot).
+    # HyperCore account activation (1 USDC fee + remainder reaches spot).
     # In simulate mode, activation is skipped (no real HyperCore state).
-    activation_raw = DEFAULT_ACTIVATION_AMOUNT if (not simulate and action in ("deposit", "both")) else 0
-    activation_human = activation_raw / 10**6
+    activation_raw = int(activation_human * 10**6) if (not simulate and action in ("deposit", "both")) else 0
     total_safe_funding_raw = usdc_amount + activation_raw
-    total_safe_funding_human = usdc_human + activation_human
+    total_safe_funding_human = usdc_human + (activation_raw / 10**6)
 
     # Check deployer has enough HYPE (gas) and USDC before doing anything expensive
     if not simulate:
@@ -574,7 +589,7 @@ def main():
                     transfer_amount,
                     safe_address,
                     usdc_human,
-                    int(activation_human),
+                    activation_raw // 10**6,
                 )
                 tx_hash = deployer.transact_and_broadcast_with_contract(
                     usdc.transfer(safe_address, transfer_amount),
@@ -604,6 +619,8 @@ def main():
             network=network,
             simulate=bool(simulate),
             deposit_mode=deposit_mode,
+            activation_amount=activation_raw,
+            activation_timeout=activation_timeout,
         )
 
     if action in ("withdraw", "both"):


### PR DESCRIPTION
## Summary

- Document the HyperEVM testnet `depositFor` activation failure in code and link to upstream issue
- Add configurable `ACTIVATION_AMOUNT` and `ACTIVATION_TIMEOUT` environment variables to the deploy script
- Add `build_activate_account_multicall()` helper to `core_writer.py`

Related issues:
- Upstream: https://github.com/hyperliquid-dex/node/issues/138
- Tracking: https://github.com/tradingstrategy-ai/web3-ethereum-defi/issues/813
- Tutorial: https://web3-ethereum-defi.tradingstrategy.ai/tutorials/lagoon-hyperliquid.html


🤖 Generated with [Claude Code](https://claude.com/claude-code)