### PR TITLE
feat: add Hyperliquid vault daily deposit/withdrawal netflow metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Current
 
+- Add: Hyperliquid vault daily deposit/withdrawal netflow metrics with configurable backfill, exported as NetflowMetrics with 1d/7d/30d periods in JSON (2026-03-10)
 - **Add: LI.FI cross-chain gas feeding module for keeping hot wallets funded across EVM chains, with native token and USDC source support (2026-03-10)**
 - Add: `activate_account_sponsored()` for deployer-EOA-funded HyperCore account activation, bypassing Safe routing (2026-03-09)
 - Add: Track Hyperliquid vault `leader_fraction` and `leader_commission` in daily metrics pipeline (2026-03-09)

--- a/eth_defi/hyperliquid/daily_metrics.py
+++ b/eth_defi/hyperliquid/daily_metrics.py
@@ -40,6 +40,7 @@ from tqdm_loggable.auto import tqdm
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.hyperliquid.combined_analysis import _calculate_share_price
 from eth_defi.hyperliquid.constants import HYPERCORE_CHAIN_ID, HYPERLIQUID_DAILY_METRICS_DATABASE
+from eth_defi.hyperliquid.deposit import aggregate_daily_flows, fetch_vault_deposits
 from eth_defi.hyperliquid.session import HyperliquidSession
 from eth_defi.hyperliquid.vault import (
     HyperliquidVault,
@@ -263,6 +264,24 @@ class HyperliquidDailyMetricsDatabase:
         except duckdb.CatalogException:
             pass
 
+        # Migration for existing databases: add daily deposit/withdrawal flow columns
+        for col, col_type in [
+            ("daily_deposit_count", "INTEGER"),
+            ("daily_withdrawal_count", "INTEGER"),
+            ("daily_deposit_usd", "DOUBLE"),
+            ("daily_withdrawal_usd", "DOUBLE"),
+        ]:
+            try:
+                self.con.execute(f"ALTER TABLE vault_daily_prices ADD COLUMN {col} {col_type}")
+            except duckdb.CatalogException:
+                pass
+
+        # Migration for existing databases: track how far back flow data has been backfilled
+        try:
+            self.con.execute("ALTER TABLE vault_metadata ADD COLUMN flow_data_earliest_date DATE")
+        except duckdb.CatalogException:
+            pass
+
     def upsert_vault_metadata(
         self,
         vault_address: HexAddress,
@@ -277,19 +296,23 @@ class HyperliquidDailyMetricsDatabase:
         tvl: float | None,
         apr: float | None,
         allow_deposits: bool = True,
+        flow_data_earliest_date: datetime.date | None = None,
     ):
         """Insert or update a vault's metadata.
 
         :param vault_address:
             Vault address (will be lowercased).
+        :param flow_data_earliest_date:
+            Earliest date for which daily deposit/withdrawal flow data
+            has been backfilled. ``None`` means no flow data yet.
         """
         self.con.execute(
             """
             INSERT INTO vault_metadata (
                 vault_address, name, leader, description, is_closed,
                 allow_deposits, relationship_type, create_time, commission_rate,
-                follower_count, tvl, apr, last_updated
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                follower_count, tvl, apr, last_updated, flow_data_earliest_date
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT (vault_address)
             DO UPDATE SET
                 name = EXCLUDED.name,
@@ -303,7 +326,8 @@ class HyperliquidDailyMetricsDatabase:
                 follower_count = EXCLUDED.follower_count,
                 tvl = EXCLUDED.tvl,
                 apr = EXCLUDED.apr,
-                last_updated = EXCLUDED.last_updated
+                last_updated = EXCLUDED.last_updated,
+                flow_data_earliest_date = COALESCE(EXCLUDED.flow_data_earliest_date, vault_metadata.flow_data_earliest_date)
             """,
             [
                 vault_address.lower(),
@@ -319,6 +343,7 @@ class HyperliquidDailyMetricsDatabase:
                 tvl,
                 apr,
                 native_datetime_utc_now(),
+                flow_data_earliest_date,
             ],
         )
 
@@ -330,13 +355,21 @@ class HyperliquidDailyMetricsDatabase:
         """Bulk upsert daily price rows for a vault.
 
         :param rows:
-            List of tuples: (vault_address, date, share_price, tvl,
+            List of tuples: ``(vault_address, date, share_price, tvl,
             cumulative_pnl, daily_pnl, daily_return, follower_count, apr,
-            is_closed, allow_deposits, leader_fraction, leader_commission).
+            is_closed, allow_deposits, leader_fraction, leader_commission,
+            daily_deposit_count, daily_withdrawal_count,
+            daily_deposit_usd, daily_withdrawal_usd)``.
+
             The ``is_closed``, ``allow_deposits``, ``leader_fraction``, and
             ``leader_commission`` fields should be ``None`` for historical rows
             and only set for the latest (today's) row, so that we track how
             these values evolve over time.
+
+            The flow columns (``daily_deposit_count`` etc.) should be ``None``
+            for dates outside the backfill window and ``0`` for dates with
+            no activity within the backfill window. ``COALESCE`` preserves
+            existing values when ``None`` is passed.
         :param cutoff_date:
             If provided, only store rows up to this date (inclusive).
             Used for incremental scanning / testing.
@@ -352,8 +385,10 @@ class HyperliquidDailyMetricsDatabase:
             INSERT INTO vault_daily_prices (
                 vault_address, date, share_price, tvl, cumulative_pnl,
                 daily_pnl, daily_return, follower_count, apr,
-                is_closed, allow_deposits, leader_fraction, leader_commission
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                is_closed, allow_deposits, leader_fraction, leader_commission,
+                daily_deposit_count, daily_withdrawal_count,
+                daily_deposit_usd, daily_withdrawal_usd
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT (vault_address, date)
             DO UPDATE SET
                 share_price = EXCLUDED.share_price,
@@ -366,7 +401,11 @@ class HyperliquidDailyMetricsDatabase:
                 is_closed = COALESCE(EXCLUDED.is_closed, vault_daily_prices.is_closed),
                 allow_deposits = COALESCE(EXCLUDED.allow_deposits, vault_daily_prices.allow_deposits),
                 leader_fraction = COALESCE(EXCLUDED.leader_fraction, vault_daily_prices.leader_fraction),
-                leader_commission = COALESCE(EXCLUDED.leader_commission, vault_daily_prices.leader_commission)
+                leader_commission = COALESCE(EXCLUDED.leader_commission, vault_daily_prices.leader_commission),
+                daily_deposit_count = COALESCE(EXCLUDED.daily_deposit_count, vault_daily_prices.daily_deposit_count),
+                daily_withdrawal_count = COALESCE(EXCLUDED.daily_withdrawal_count, vault_daily_prices.daily_withdrawal_count),
+                daily_deposit_usd = COALESCE(EXCLUDED.daily_deposit_usd, vault_daily_prices.daily_deposit_usd),
+                daily_withdrawal_usd = COALESCE(EXCLUDED.daily_withdrawal_usd, vault_daily_prices.daily_withdrawal_usd)
             """,
             rows,
         )
@@ -496,6 +535,7 @@ def fetch_and_store_vault(
     summary: VaultSummary,
     cutoff_date: datetime.date | None = None,
     timeout: float = 30.0,
+    flow_backfill_days: int = 7,
 ) -> bool:
     """Fetch a single vault's details and store metrics in the database.
 
@@ -509,6 +549,10 @@ def fetch_and_store_vault(
         If provided, only store price data up to this date.
     :param timeout:
         HTTP request timeout.
+    :param flow_backfill_days:
+        Number of complete days to backfill deposit/withdrawal flow data.
+        Only complete days are fetched (up to yesterday). Set to ``0``
+        to disable flow fetching.
     :return:
         True if the vault was successfully processed.
     """
@@ -537,12 +581,50 @@ def fetch_and_store_vault(
         logger.debug("Skipping vault %s (%s): empty combined DataFrame", summary.name, vault_address)
         return False
 
+    # Fetch deposit/withdrawal events for flow metrics.
+    # Only fetch complete days (up to yesterday 23:59:59 UTC).
+    daily_flows: dict[datetime.date, tuple[int, int, float, float]] = {}
+    flow_start_date: datetime.date | None = None
+
+    if flow_backfill_days > 0:
+        today = datetime.date.today()
+        yesterday = today - datetime.timedelta(days=1)
+        flow_start_date = today - datetime.timedelta(days=flow_backfill_days)
+        flow_start_dt = datetime.datetime(flow_start_date.year, flow_start_date.month, flow_start_date.day)
+        flow_end_dt = datetime.datetime(yesterday.year, yesterday.month, yesterday.day, 23, 59, 59)
+
+        try:
+            events = list(
+                fetch_vault_deposits(
+                    session,
+                    vault_address,
+                    start_time=flow_start_dt,
+                    end_time=flow_end_dt,
+                    timeout=timeout,
+                )
+            )
+            daily_flows = aggregate_daily_flows(events)
+            logger.debug(
+                "Fetched %d deposit events for %s (%s), %d days with activity",
+                len(events),
+                summary.name,
+                vault_address,
+                len(daily_flows),
+            )
+        except Exception as e:
+            logger.warning("Failed to fetch deposit events for %s (%s): %s", summary.name, vault_address, e)
+
     # Store metadata
     follower_count = len(info.followers)
     commission_rate = float(info.commission_rate) if info.commission_rate is not None else None
     leader_fraction = float(info.leader_fraction) if info.leader_fraction is not None else None
     leader_commission = float(info.leader_commission) if info.leader_commission is not None else None
     apr_val = float(summary.apr) if summary.apr is not None else None
+
+    # Determine earliest flow data date for this vault.
+    # Use the backfill start date, or if we already have earlier data,
+    # keep the existing earliest date (handled by COALESCE in upsert).
+    flow_data_earliest_date = flow_start_date
 
     db.upsert_vault_metadata(
         vault_address=vault_address,
@@ -557,11 +639,17 @@ def fetch_and_store_vault(
         tvl=float(summary.tvl),
         apr=apr_val,
         allow_deposits=info.allow_deposits,
+        flow_data_earliest_date=flow_data_earliest_date,
     )
 
     # Build daily price rows.
     # Only the latest row gets the current deposit status from the API;
     # historical rows get None so we track how status evolves over time.
+    #
+    # Flow columns: for dates within the backfill window, store 0 for
+    # days with no events (confirmed zero activity). For dates outside
+    # the backfill window, store None (preserves existing values via
+    # COALESCE in upsert).
     last_idx = len(combined_df) - 1
     rows = []
     prev_share_price = None
@@ -591,6 +679,16 @@ def fetch_and_store_vault(
             row_leader_fraction = None
             row_leader_commission = None
 
+        # Flow data: only populate for dates within the backfill window
+        if flow_start_date is not None and flow_start_date <= date_val <= (datetime.date.today() - datetime.timedelta(days=1)):
+            flow = daily_flows.get(date_val, (0, 0, 0.0, 0.0))
+            dep_count, wd_count, dep_usd, wd_usd = flow
+        else:
+            dep_count = None
+            wd_count = None
+            dep_usd = None
+            wd_usd = None
+
         rows.append(
             (
                 vault_address,
@@ -606,6 +704,10 @@ def fetch_and_store_vault(
                 row_allow_deposits,
                 row_leader_fraction,
                 row_leader_commission,
+                dep_count,
+                wd_count,
+                dep_usd,
+                wd_usd,
             )
         )
 
@@ -621,9 +723,17 @@ def _process_vault_worker(
     summary: VaultSummary,
     cutoff_date: datetime.date | None,
     timeout: float,
+    flow_backfill_days: int,
 ) -> bool:
     """Worker function for parallel vault processing."""
-    return fetch_and_store_vault(session, db, summary, cutoff_date=cutoff_date, timeout=timeout)
+    return fetch_and_store_vault(
+        session,
+        db,
+        summary,
+        cutoff_date=cutoff_date,
+        timeout=timeout,
+        flow_backfill_days=flow_backfill_days,
+    )
 
 
 def run_daily_scan(
@@ -635,13 +745,15 @@ def run_daily_scan(
     cutoff_date: datetime.date | None = None,
     timeout: float = 30.0,
     vault_addresses: list[str] | None = None,
+    flow_backfill_days: int = 7,
 ) -> HyperliquidDailyMetricsDatabase:
     """Run the daily Hyperliquid vault metrics scan.
 
     1. Bulk-fetches all vaults from stats-data API
     2. Filters by TVL and vault limit (or by explicit address list)
     3. Fetches per-vault details and computes share prices
-    4. Stores everything in DuckDB
+    4. Fetches deposit/withdrawal events for flow metrics
+    5. Stores everything in DuckDB
 
     :param session:
         HTTP session with rate limiting.
@@ -664,10 +776,15 @@ def run_daily_scan(
     :param vault_addresses:
         If provided, only scan these specific vault addresses.
         Overrides ``min_tvl`` and ``max_vaults`` filters.
+    :param flow_backfill_days:
+        Number of complete days to backfill deposit/withdrawal flow data.
+        Only complete days are fetched (up to yesterday). Set to ``0``
+        to disable flow fetching. Use a large value (e.g. ``365``) for
+        initial deep backfill.
     :return:
         The metrics database instance.
     """
-    logger.info("Starting daily Hyperliquid vault scan")
+    logger.info("Starting daily Hyperliquid vault scan (flow_backfill_days=%d)", flow_backfill_days)
 
     db = HyperliquidDailyMetricsDatabase(db_path)
 
@@ -708,7 +825,7 @@ def run_daily_scan(
 
     # Fetch details and compute prices in parallel
     desc = "Fetching Hyperliquid vault details"
-    results = Parallel(n_jobs=max_workers, backend="threading")(delayed(_process_vault_worker)(session, db, summary, cutoff_date, timeout) for summary in tqdm(filtered, desc=desc))
+    results = Parallel(n_jobs=max_workers, backend="threading")(delayed(_process_vault_worker)(session, db, summary, cutoff_date, timeout, flow_backfill_days) for summary in tqdm(filtered, desc=desc))
 
     success_count = sum(1 for r in results if r)
     fail_count = sum(1 for r in results if not r)

--- a/eth_defi/hyperliquid/deposit.py
+++ b/eth_defi/hyperliquid/deposit.py
@@ -398,6 +398,44 @@ def create_deposit_dataframe(events: list[VaultDepositEvent]) -> pd.DataFrame:
     return df
 
 
+def aggregate_daily_flows(
+    events: list[VaultDepositEvent],
+) -> dict[datetime.date, tuple[int, int, float, float]]:
+    """Aggregate vault events into daily deposit/withdrawal flow metrics.
+
+    Groups events by calendar date and computes:
+
+    - Number of deposit events
+    - Number of withdrawal events
+    - Total USD deposited (positive)
+    - Total USD withdrawn (positive, absolute value)
+
+    Only ``vault_deposit`` and ``vault_withdraw`` events are counted.
+    Other event types (``vault_create``, ``vault_distribution``,
+    ``vault_leader_commission``) are excluded.
+
+    :param events:
+        List of vault events from :py:func:`fetch_vault_deposits`.
+    :return:
+        Dict mapping date to ``(deposit_count, withdrawal_count, deposit_usd, withdrawal_usd)``.
+    """
+    daily: dict[datetime.date, list] = {}
+
+    for event in events:
+        date_key = event.timestamp.date()
+        if date_key not in daily:
+            daily[date_key] = [0, 0, 0.0, 0.0]
+
+        if event.event_type == VaultEventType.vault_deposit:
+            daily[date_key][0] += 1
+            daily[date_key][2] += float(event.usdc)
+        elif event.event_type == VaultEventType.vault_withdraw:
+            daily[date_key][1] += 1
+            daily[date_key][3] += float(abs(event.usdc))
+
+    return {k: (v[0], v[1], v[2], v[3]) for k, v in daily.items()}
+
+
 def get_deposit_summary(events: list[VaultDepositEvent]) -> dict:
     """Generate a summary of vault deposit/withdrawal activity.
 

--- a/eth_defi/hyperliquid/vault_data_export.py
+++ b/eth_defi/hyperliquid/vault_data_export.py
@@ -249,6 +249,10 @@ def build_raw_prices_dataframe(db: HyperliquidDailyMetricsDatabase) -> pd.DataFr
             "errors": "",
             "leader_fraction": prices_df["leader_fraction"].values if "leader_fraction" in prices_df.columns else float("nan"),
             "leader_commission": prices_df["leader_commission"].values if "leader_commission" in prices_df.columns else float("nan"),
+            "daily_deposit_count": prices_df["daily_deposit_count"].values if "daily_deposit_count" in prices_df.columns else float("nan"),
+            "daily_withdrawal_count": prices_df["daily_withdrawal_count"].values if "daily_withdrawal_count" in prices_df.columns else float("nan"),
+            "daily_deposit_usd": prices_df["daily_deposit_usd"].values if "daily_deposit_usd" in prices_df.columns else float("nan"),
+            "daily_withdrawal_usd": prices_df["daily_withdrawal_usd"].values if "daily_withdrawal_usd" in prices_df.columns else float("nan"),
         },
     )
 

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -131,6 +131,37 @@ class PeriodMetrics:
     ranking_protocol: int | None = None
 
 
+@dataclass(slots=True)
+class NetflowMetrics:
+    """Deposit and withdrawal flow metrics for a time period.
+
+    Aggregates daily deposit/withdrawal event counts and USD values
+    over a given period (e.g. ``"1d"``, ``"7d"``, ``"30d"``).
+
+    Only available for chains that support vault flow tracking
+    (currently Hyperliquid). For other chains this will be ``None``
+    in the vault record.
+    """
+
+    #: Period label (e.g. ``"1d"``, ``"7d"``, ``"30d"``)
+    period: str
+
+    #: Number of deposit events in the period
+    deposit_count: int = 0
+
+    #: Number of withdrawal events in the period
+    withdrawal_count: int = 0
+
+    #: Total USD deposited in the period
+    deposit_usd: float = 0.0
+
+    #: Total USD withdrawn in the period (positive value)
+    withdrawal_usd: float = 0.0
+
+    #: Net flow (deposit_usd - withdrawal_usd)
+    net_flow_usd: float = 0.0
+
+
 #: Period -> Perioud duration, max sparse sample mismatch
 LOOKBACK_AND_TOLERANCES: dict[Period, tuple[pd.DateOffset, pd.Timedelta]] = {
     "1W": (pd.DateOffset(days=7), pd.Timedelta(days=7 + 5)),
@@ -676,6 +707,68 @@ def _unnullify(x: str | None, default: str = "<unknown>") -> str:
     return x
 
 
+def _calculate_netflow_metrics(
+    prices_df: pd.DataFrame,
+    now_: pd.Timestamp | None = None,
+) -> list[NetflowMetrics] | None:
+    """Aggregate daily deposit/withdrawal flow data into period summaries.
+
+    Computes :py:class:`NetflowMetrics` for 1d, 7d, and 30d periods by
+    summing the daily flow columns in ``prices_df``.
+
+    Only complete days are considered. If the required flow columns are
+    missing or contain no non-null data, returns ``None``.
+
+    :param prices_df:
+        Cleaned price DataFrame with a DatetimeIndex and optional columns
+        ``daily_deposit_count``, ``daily_withdrawal_count``,
+        ``daily_deposit_usd``, ``daily_withdrawal_usd``.
+    :param now_:
+        Reference timestamp for period lookback. Defaults to the last
+        timestamp in the DataFrame.
+    :return:
+        List of :py:class:`NetflowMetrics` for periods 1d, 7d, 30d,
+        or ``None`` if flow data is unavailable.
+    """
+    flow_cols = ["daily_deposit_count", "daily_withdrawal_count", "daily_deposit_usd", "daily_withdrawal_usd"]
+
+    if not all(col in prices_df.columns for col in flow_cols):
+        return None
+
+    # Check if there is any non-null flow data at all
+    has_data = any(prices_df[col].notna().any() for col in flow_cols)
+    if not has_data:
+        return None
+
+    if now_ is None:
+        now_ = prices_df.index.max()
+
+    results = []
+    for period_label, days in [("1d", 1), ("7d", 7), ("30d", 30)]:
+        cutoff = now_ - pd.Timedelta(days=days)
+        mask = prices_df.index > cutoff
+
+        subset = prices_df.loc[mask, flow_cols].dropna(how="all")
+
+        dep_count = int(subset["daily_deposit_count"].sum()) if not subset.empty else 0
+        wd_count = int(subset["daily_withdrawal_count"].sum()) if not subset.empty else 0
+        dep_usd = float(subset["daily_deposit_usd"].sum()) if not subset.empty else 0.0
+        wd_usd = float(subset["daily_withdrawal_usd"].sum()) if not subset.empty else 0.0
+
+        results.append(
+            NetflowMetrics(
+                period=period_label,
+                deposit_count=dep_count,
+                withdrawal_count=wd_count,
+                deposit_usd=dep_usd,
+                withdrawal_usd=wd_usd,
+                net_flow_usd=dep_usd - wd_usd,
+            )
+        )
+
+    return results
+
+
 def calculate_period_metrics(
     period: Period,
     gross_fee_data: FeeData,
@@ -1130,6 +1223,14 @@ def calculate_vault_record(
         if pd.notna(last_val):
             leader_commission = float(last_val)
 
+    # Reference timestamp for period lookback — used by both netflow and
+    # period metric calculations below.
+    now_ = prices_df.index.max()
+
+    # Deposit/withdrawal flow metrics aggregated over 1d, 7d, 30d periods.
+    # Only available for chains with daily flow data (currently Hyperliquid).
+    netflow = _calculate_netflow_metrics(prices_df, now_=now_)
+
     # Vault descriptions from offchain metadata (Euler, Lagoon, etc.)
     description = vault_metadata.get("_description")
     short_description = vault_metadata.get("_short_description")
@@ -1162,7 +1263,6 @@ def calculate_vault_record(
     share_price_hourly = prices_df["share_price"]
     share_price_daily = share_price_hourly.resample("D").last()
     tvl_series = prices_df["total_assets"]
-    now_ = prices_df.index.max()
 
     period_results = []
     for period in LOOKBACK_AND_TOLERANCES.keys():
@@ -1341,6 +1441,8 @@ def calculate_vault_record(
             # Hypercore leader metrics
             "leader_fraction": leader_fraction,
             "leader_commission": leader_commission,
+            # Deposit/withdrawal flow metrics (1d, 7d, 30d)
+            "netflow": netflow,
             # Offchain vault descriptions (Euler, Lagoon, etc.)
             "description": description,
             "short_description": short_description,
@@ -1892,6 +1994,7 @@ def format_lifetime_table(
             "utilisation": "Utilisation",
             "leader_fraction": "Leader fraction",
             "leader_commission": "Leader commission",
+            "netflow": "Netflow",
         }
     )
 

--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -55,6 +55,10 @@ VAULT_STATE_COLUMNS = {
     "utilisation": float("nan"),
     "leader_fraction": float("nan"),
     "leader_commission": float("nan"),
+    "daily_deposit_count": float("nan"),
+    "daily_withdrawal_count": float("nan"),
+    "daily_deposit_usd": float("nan"),
+    "daily_withdrawal_usd": float("nan"),
 }
 
 

--- a/scripts/hyperliquid/README-hyperliquid-vaults.md
+++ b/scripts/hyperliquid/README-hyperliquid-vaults.md
@@ -76,21 +76,25 @@ in the Hyperliquid docs.
 See `constants.py` for storage.
 
 ```
-vault_metadata                     vault_daily_prices
-==============                     ==================
-vault_address    VARCHAR PK        vault_address      VARCHAR  \
-name             VARCHAR           date               DATE      > composite PK
-leader           VARCHAR           share_price        DOUBLE
-description      VARCHAR           tvl                DOUBLE
-is_closed        BOOLEAN           cumulative_pnl     DOUBLE
-allow_deposits   BOOLEAN           daily_pnl          DOUBLE
-commission_rate  DOUBLE            daily_return       DOUBLE
-follower_count   INTEGER           follower_count     INTEGER
-tvl              DOUBLE            apr                DOUBLE
-apr              DOUBLE            is_closed          BOOLEAN
-create_time      TIMESTAMP         allow_deposits     BOOLEAN
-last_updated     TIMESTAMP         leader_fraction    DOUBLE
-                                   leader_commission  DOUBLE
+vault_metadata                        vault_daily_prices
+==============                        ==================
+vault_address           VARCHAR PK    vault_address            VARCHAR  \
+name                    VARCHAR       date                     DATE      > composite PK
+leader                  VARCHAR       share_price              DOUBLE
+description             VARCHAR       tvl                      DOUBLE
+is_closed               BOOLEAN       cumulative_pnl           DOUBLE
+allow_deposits          BOOLEAN       daily_pnl                DOUBLE
+commission_rate         DOUBLE        daily_return             DOUBLE
+follower_count          INTEGER       follower_count           INTEGER
+tvl                     DOUBLE        apr                      DOUBLE
+apr                     DOUBLE        is_closed                BOOLEAN
+create_time             TIMESTAMP     allow_deposits           BOOLEAN
+last_updated            TIMESTAMP     leader_fraction          DOUBLE
+flow_data_earliest_date DATE          leader_commission        DOUBLE
+                                      daily_deposit_count      INTEGER
+                                      daily_withdrawal_count   INTEGER
+                                      daily_deposit_usd        DOUBLE
+                                      daily_withdrawal_usd     DOUBLE
 ```
 
 ### Fees
@@ -171,6 +175,55 @@ The cleaned Parquet gains these extra columns. For EVM vaults they are `NA`:
 - `daily_pnl` -- daily PnL in USD
 - `leader_fraction` -- leader's capital share of the vault (e.g. 0.10 = 10%), latest row only
 - `leader_commission` -- leader commission value from the API (semantics unclear), latest row only
+- `daily_deposit_count` -- number of deposit events on that day
+- `daily_withdrawal_count` -- number of withdrawal events on that day
+- `daily_deposit_usd` -- total USD deposited on that day
+- `daily_withdrawal_usd` -- total USD withdrawn on that day (positive value)
+
+### Deposit/withdrawal netflow metrics
+
+The pipeline tracks daily deposit and withdrawal flows per vault using the
+Hyperliquid `userNonFundingLedgerUpdates` API. These are aggregated into
+`NetflowMetrics` dataclasses with 1d, 7d, and 30d periods in the JSON output.
+
+Flow data is only fetched for **complete days** (up to yesterday 23:59:59 UTC)
+to avoid partial-day artefacts. The backfill window is controlled by the
+`FLOW_BACKFILL_DAYS` environment variable (default 7). Each scan fills the
+most recent N complete days and uses `COALESCE` upserts so older data is never
+overwritten with NULL.
+
+The `flow_data_earliest_date` column in `vault_metadata` tracks how far back
+flow data has been backfilled per vault.
+
+Chains that do not support netflow (all EVM chains) will have `null` for the
+`netflow` field in the JSON output.
+
+## Backfilling netflow data for existing vaults
+
+If you have an existing DuckDB database and want to backfill deposit/withdrawal
+flow data further back than the default 7 days, use `FLOW_BACKFILL_DAYS`:
+
+```shell
+# Backfill 90 days of deposit/withdrawal flow data
+LOG_LEVEL=info FLOW_BACKFILL_DAYS=90 \
+  poetry run python scripts/hyperliquid/daily-vault-metrics.py
+```
+
+For a specific set of vaults:
+
+```shell
+LOG_LEVEL=info FLOW_BACKFILL_DAYS=90 \
+  VAULT_ADDRESSES=0xdfc24b077bc1425ad1dea75bcb6f8158e10df303,0x1e37a337ed460039d1b15bd3bc489de789768d5e \
+  poetry run python scripts/hyperliquid/daily-vault-metrics.py
+```
+
+The backfill is idempotent — running it multiple times will not produce
+duplicates, and existing flow data is preserved via `COALESCE` upserts.
+There is no known API retention limit for `userNonFundingLedgerUpdates`,
+so you can backfill as far as the vault has existed.
+
+After a one-time backfill, set `FLOW_BACKFILL_DAYS` back to 7 (or omit it)
+for regular daily runs to avoid unnecessary API calls.
 
 ## Quick start example
 
@@ -327,6 +380,7 @@ for v in data['vaults'][:5]:
 | `MIN_TVL` | `5000` | Minimum TVL in USD to include a vault |
 | `MAX_VAULTS` | `500` | Maximum number of vaults to process |
 | `MAX_WORKERS` | `16` | Parallel worker threads for API calls |
+| `FLOW_BACKFILL_DAYS` | `7` | Number of complete days to backfill deposit/withdrawal flow data |
 | `VAULT_DB_PATH` | `~/.tradingstrategy/vaults/vault-metadata-db.pickle` | ERC-4626 VaultDatabase pickle to merge into |
 | `PARQUET_PATH` | `~/.tradingstrategy/vaults/cleaned-vault-prices-1h.parquet` | Cleaned Parquet to merge into |
 
@@ -335,6 +389,7 @@ for v in data['vaults'][:5]:
 | Module | Role |
 |--------|------|
 | `eth_defi/hyperliquid/daily_metrics.py` | DuckDB storage, share price computation, parallel scanning |
+| `eth_defi/hyperliquid/deposit.py` | Deposit/withdrawal event fetching and daily flow aggregation |
 | `eth_defi/hyperliquid/vault_data_export.py` | Bridge to ERC-4626 pipeline (VaultRow builder, Parquet/pickle merge) |
 | `eth_defi/hyperliquid/combined_analysis.py` | `_calculate_share_price()` -- time-weighted return logic |
 | `eth_defi/hyperliquid/vault.py` | API client (`fetch_all_vaults`, `HyperliquidVault`, `VaultInfo`) |

--- a/scripts/hyperliquid/daily-vault-metrics.py
+++ b/scripts/hyperliquid/daily-vault-metrics.py
@@ -79,6 +79,8 @@ def main():
     max_vaults = int(os.environ.get("MAX_VAULTS", "20000"))
     max_workers = int(os.environ.get("MAX_WORKERS", "16"))
 
+    flow_backfill_days = int(os.environ.get("FLOW_BACKFILL_DAYS", "7"))
+
     vault_db_path_str = os.environ.get("VAULT_DB_PATH")
     vault_db_path = Path(vault_db_path_str).expanduser() if vault_db_path_str else DEFAULT_VAULT_DATABASE
 
@@ -93,6 +95,7 @@ def main():
         print(f"Min TVL: ${min_tvl:,.0f}")
         print(f"Max vaults: {max_vaults}")
     print(f"Max workers: {max_workers}")
+    print(f"Flow backfill days: {flow_backfill_days}")
     print(f"VaultDB path: {vault_db_path}")
     print(f"Uncleaned parquet path: {uncleaned_path}")
 
@@ -108,6 +111,7 @@ def main():
         max_vaults=max_vaults,
         max_workers=max_workers,
         vault_addresses=vault_addresses,
+        flow_backfill_days=flow_backfill_days,
     )
 
     try:

--- a/tests/hyperliquid/test_daily_metrics_integration.py
+++ b/tests/hyperliquid/test_daily_metrics_integration.py
@@ -248,6 +248,28 @@ def test_unified_vault_metrics_json(tmp_path):
         lifetime = [p for p in periods if p["period"] == "lifetime"]
         assert len(lifetime) == 1, f"Missing lifetime period for vault {vault.get('name')}"
 
+    # Hyperliquid vault should have netflow metrics with 1d, 7d, 30d periods
+    assert "netflow" in hl_vault, f"Missing netflow field for Hyperliquid vault"
+    hl_netflow = hl_vault["netflow"]
+    assert hl_netflow is not None, "Hyperliquid vault should have netflow data"
+    assert isinstance(hl_netflow, list), f"Expected netflow to be a list, got {type(hl_netflow)}"
+    assert len(hl_netflow) == 3, f"Expected 3 netflow periods (1d, 7d, 30d), got {len(hl_netflow)}"
+
+    netflow_periods = {nf["period"] for nf in hl_netflow}
+    assert netflow_periods == {"1d", "7d", "30d"}, f"Unexpected netflow periods: {netflow_periods}"
+
+    for nf in hl_netflow:
+        assert "deposit_count" in nf
+        assert "withdrawal_count" in nf
+        assert "deposit_usd" in nf
+        assert "withdrawal_usd" in nf
+        assert "net_flow_usd" in nf
+        assert nf["deposit_count"] >= 0
+        assert nf["withdrawal_count"] >= 0
+
+    # Arbitrum vault has no flow data — netflow should be null
+    assert arb_vault.get("netflow") is None, f"Arbitrum vault should have null netflow, got: {arb_vault.get('netflow')}"
+
 
 @pytest.mark.timeout(120)
 def test_deposit_closed_vault_pipeline(tmp_path):
@@ -313,6 +335,18 @@ def test_deposit_closed_vault_pipeline(tmp_path):
 
         assert latest_row["leader_commission"] is not None, "Latest row should have leader_commission"
         assert historical_rows["leader_commission"].isna().all(), "Historical rows should have leader_commission=NULL"
+
+        # Verify flow columns are present in DuckDB after scan
+        assert "daily_deposit_count" in prices_df_raw.columns, "daily_deposit_count column missing"
+        assert "daily_withdrawal_count" in prices_df_raw.columns, "daily_withdrawal_count column missing"
+        assert "daily_deposit_usd" in prices_df_raw.columns, "daily_deposit_usd column missing"
+        assert "daily_withdrawal_usd" in prices_df_raw.columns, "daily_withdrawal_usd column missing"
+
+        # Verify flow_data_earliest_date is tracked in metadata
+        metadata_df = db.get_all_vault_metadata()
+        vault_meta = metadata_df[metadata_df["vault_address"] == vault_address.lower()]
+        flow_earliest = vault_meta.iloc[0].get("flow_data_earliest_date")
+        assert flow_earliest is not None, "flow_data_earliest_date should be set after scan"
 
         # Step 3: Merge into VaultDatabase and verify _deposit_closed_reason
         merge_into_vault_database(db, vault_db_path)

--- a/tests/hyperliquid/test_daily_metrics_resume.py
+++ b/tests/hyperliquid/test_daily_metrics_resume.py
@@ -99,5 +99,16 @@ def test_daily_metrics_resume(tmp_path):
         assert "leader_fraction" in second_run_df.columns, "leader_fraction column missing from daily prices"
         assert "leader_commission" in second_run_df.columns, "leader_commission column missing from daily prices"
 
+        # Verify flow columns are present after both runs
+        for col in ["daily_deposit_count", "daily_withdrawal_count", "daily_deposit_usd", "daily_withdrawal_usd"]:
+            assert col in second_run_df.columns, f"{col} column missing from daily prices after resume"
+
+        # Verify that flow data from first run is preserved after resume (COALESCE behaviour).
+        # The backfill window for both runs covers the same dates, so values should
+        # be consistent — not overwritten with NULL.
+        first_run_flow = first_run_df[first_run_df["daily_deposit_count"].notna()]
+        second_run_flow = second_run_df[second_run_df["daily_deposit_count"].notna()]
+        assert len(second_run_flow) >= len(first_run_flow), "Resume should not lose flow data rows"
+
     finally:
         db.close()

--- a/tests/hyperliquid/test_deposit.py
+++ b/tests/hyperliquid/test_deposit.py
@@ -11,7 +11,7 @@ from datetime import datetime
 import pandas as pd
 import pytest
 
-from eth_defi.hyperliquid.deposit import VaultDepositEvent, create_deposit_dataframe, fetch_vault_deposits, get_deposit_summary
+from eth_defi.hyperliquid.deposit import VaultDepositEvent, VaultEventType, aggregate_daily_flows, create_deposit_dataframe, fetch_vault_deposits, get_deposit_summary
 
 
 @pytest.fixture(scope="module")
@@ -102,3 +102,83 @@ def test_summary_values(vault_events: list[VaultDepositEvent]):
     assert summary["deposits"] == 8, f"Expected 8 deposits, got {summary['deposits']}"
     assert summary["total_deposited"] == pytest.approx(3650.0), f"Expected 3650 USDC deposited"
     assert summary["net_flow"] == pytest.approx(3650.0), "Net flow should equal total deposited when no withdrawals"
+
+
+def test_aggregate_daily_flows(vault_events: list[VaultDepositEvent]):
+    """Test daily flow aggregation from vault events."""
+    flows = aggregate_daily_flows(vault_events)
+
+    assert isinstance(flows, dict)
+
+    # The test vault has 8 deposits in the 2025-12-01 to 2025-12-28 period
+    total_dep_count = sum(f[0] for f in flows.values())
+    total_wd_count = sum(f[1] for f in flows.values())
+    total_dep_usd = sum(f[2] for f in flows.values())
+    total_wd_usd = sum(f[3] for f in flows.values())
+
+    assert total_dep_count == 8
+    assert total_wd_count == 0
+    assert total_dep_usd == pytest.approx(3650.0)
+    assert total_wd_usd == pytest.approx(0.0)
+
+    # Each date key should be a datetime.date
+    for date_key in flows.keys():
+        assert hasattr(date_key, "year")
+
+    # Each value is a 4-tuple: (dep_count, wd_count, dep_usd, wd_usd)
+    for val in flows.values():
+        assert len(val) == 4
+        assert val[0] >= 0  # deposit count
+        assert val[1] >= 0  # withdrawal count
+        assert val[2] >= 0.0  # deposit usd
+        assert val[3] >= 0.0  # withdrawal usd
+
+
+def test_aggregate_daily_flows_synthetic():
+    """Test daily flow aggregation with synthetic events including withdrawals."""
+    from decimal import Decimal
+
+    events = [
+        VaultDepositEvent(
+            event_type=VaultEventType.vault_deposit,
+            vault_address="0xabc",
+            user_address="0x123",
+            usdc=Decimal("1000"),
+            timestamp=datetime(2025, 12, 15, 10, 0, 0),
+        ),
+        VaultDepositEvent(
+            event_type=VaultEventType.vault_deposit,
+            vault_address="0xabc",
+            user_address="0x456",
+            usdc=Decimal("500"),
+            timestamp=datetime(2025, 12, 15, 14, 0, 0),
+        ),
+        VaultDepositEvent(
+            event_type=VaultEventType.vault_withdraw,
+            vault_address="0xabc",
+            user_address="0x789",
+            usdc=Decimal("-200"),
+            timestamp=datetime(2025, 12, 16, 9, 0, 0),
+        ),
+        # Distribution event — should be ignored by aggregate_daily_flows
+        VaultDepositEvent(
+            event_type=VaultEventType.vault_distribution,
+            vault_address="0xabc",
+            user_address=None,
+            usdc=Decimal("50"),
+            timestamp=datetime(2025, 12, 16, 12, 0, 0),
+        ),
+    ]
+
+    flows = aggregate_daily_flows(events)
+
+    from datetime import date
+
+    assert date(2025, 12, 15) in flows
+    assert flows[date(2025, 12, 15)] == (2, 0, 1500.0, 0.0)
+
+    assert date(2025, 12, 16) in flows
+    assert flows[date(2025, 12, 16)] == (0, 1, 0.0, 200.0)
+
+    # Distribution event should not create an entry on its own
+    assert len(flows) == 2


### PR DESCRIPTION
## Summary

- Track daily deposit/withdrawal flows for Hyperliquid vaults using `userNonFundingLedgerUpdates` API with separate counts and USD values
- Export as `NetflowMetrics` dataclass with 1d, 7d, 30d period aggregations in JSON output (chains without flow support produce `null`)
- Configurable backfill window (`FLOW_BACKFILL_DAYS`, default 7) with COALESCE upserts for crash resilience and `flow_data_earliest_date` tracking per vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)