### PR TITLE
fix: handle Lagoon vault false positives in vault scanner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Current
 
+- Fix: Lagoon vault false positive in vault scanner crashing Base chain scan when a non-Lagoon contract matches MAX_MANAGEMENT_RATE() selector (2026-03-11)
 - Fix: Hyperliquid vault share price epoch resets now chain-linked (carry forward last price instead of resetting to 1.0), with offline recomputation from stored DuckDB data, multi-period merge for higher resolution, and spike smoother bypass for Hypercore vaults (2026-03-11)
 - Add: Hyperliquid vault daily deposit/withdrawal netflow metrics with configurable backfill, exported as NetflowMetrics with 1d/7d/30d periods in JSON (2026-03-10, [#818](https://github.com/tradingstrategy-ai/web3-ethereum-defi/pull/818))
 - **Add: LI.FI cross-chain gas feeding module for keeping hot wallets funded across EVM chains, with native token and USDC source support (2026-03-10)**

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -809,9 +809,13 @@ def identify_vault_features(
         features.add(ERC4626Feature.kiln_metavault_like)
 
     if calls["MAX_MANAGEMENT_RATE"].success:
-        features.add(ERC4626Feature.lagoon_like)
-        # All Lagoon should be ERC-7575
-        assert ERC4626Feature.erc_7540_like in features, f"Lagoon vault did not pass ERC-7540 check: {debug_text}"
+        if ERC4626Feature.erc_7540_like in features:
+            features.add(ERC4626Feature.lagoon_like)
+        else:
+            # False positive: contract has MAX_MANAGEMENT_RATE() but lacks ERC-7540 isOperator(),
+            # so it is not a real Lagoon vault.
+            # E.g. 0x7be599a641c6b99a5d7c8beb062fc3915ff9dd4f on Base.
+            logger.warning("Vault has MAX_MANAGEMENT_RATE but lacks ERC-7540 isOperator, skipping Lagoon classification: %s", debug_text)
 
     if calls["GOV"].success:
         features.add(ERC4626Feature.yearn_compounder_like)


### PR DESCRIPTION
## Summary

- Convert hard `assert` to soft check in vault classification when a contract responds to `MAX_MANAGEMENT_RATE()` but lacks ERC-7540 `isOperator()`, preventing the entire chain scan from crashing on false positive matches (e.g. `0x7be599a641c6b99a5d7c8beb062fc3915ff9dd4f` on Base)


🤖 Generated with [Claude Code](https://claude.com/claude-code)