### PR TITLE
update hyperliquid readme

### DIFF
--- a/scripts/hyperliquid/README-hyperliquid-backfill.md
+++ b/scripts/hyperliquid/README-hyperliquid-backfill.md
@@ -187,6 +187,51 @@ export AWS_SECRET_ACCESS_KEY=...
 
 Add these to your `.local-test.env` or shell profile for persistence.
 
+### 4a. If MFA is enabled on your account
+
+Some AWS accounts enforce MFA authentication via an identity-based policy (e.g.
+`Manage_credentials_and_MFA_settings`). In this case, long-term access keys alone
+are not sufficient — all S3 requests return `AccessDenied` even with valid credentials
+and `--request-payer requester`.
+
+**Signs that MFA is required:**
+
+- `aws s3 ls s3://hyperliquid-archive/...` returns `AccessDenied`
+- `aws iam list-attached-user-policies` returns an error mentioning
+  `explicit deny in an identity-based policy`
+
+You must obtain **temporary session credentials** via `sts:GetSessionToken` before
+accessing the bucket. Use the helper script:
+
+```shell
+# Update ~/.aws/credentials for a named profile (recommended)
+scripts/hyperliquid/refresh-mfa-session.sh --otp 123456 --profile YOUR_PROFILE
+
+# Environment variable mode — injects credentials into the current shell
+eval $(scripts/hyperliquid/refresh-mfa-session.sh --otp 123456 --profile YOUR_PROFILE --export)
+```
+
+The script auto-detects your MFA device ARN. You can also provide it explicitly:
+
+```shell
+scripts/hyperliquid/refresh-mfa-session.sh \
+  --otp 123456 \
+  --profile YOUR_PROFILE \
+  --serial arn:aws:iam::123456789012:mfa/my-device \
+  --duration 43200
+```
+
+When using environment variables, add `AWS_SESSION_TOKEN` alongside the other two:
+
+```shell
+export AWS_ACCESS_KEY_ID=ASIA...    # Note: starts with ASIA, not AKIA
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_SESSION_TOKEN=...
+```
+
+Session tokens expire after 12 hours by default (`--duration 43200`). Re-run the
+script with a fresh OTP code to renew.
+
 ### 5. Verify access (optional)
 
 If you also have the AWS CLI installed, you can verify:
@@ -195,7 +240,12 @@ If you also have the AWS CLI installed, you can verify:
 # macOS: brew install awscli
 # Linux: pip install awscli
 
+# Without MFA (long-term credentials via environment variables)
 aws s3 ls s3://hyperliquid-archive/account_values/ --request-payer requester | head -5
+
+# With MFA (session credentials via named profile)
+aws s3 ls s3://hyperliquid-archive/account_values/ --request-payer requester \
+    --profile YOUR_PROFILE | head -5
 ```
 
 ### 6. Install Python dependencies
@@ -208,10 +258,27 @@ poetry install -E hyperliquid_backfill
 
 ### Step 1: Extract vault data (download + extract)
 
-The extract script downloads files from S3 and extracts vault data in one step:
+The extract script downloads files from S3 and extracts vault data in one step.
+
+**Without MFA** (long-term credentials):
 
 ```shell
 AWS_ACCESS_KEY_ID=AKIA... AWS_SECRET_ACCESS_KEY=... LOG_LEVEL=info \
+    poetry run python scripts/hyperliquid/extract-s3-vault-data.py
+```
+
+**With MFA** (session credentials — see [section 4a](#4a-if-mfa-is-enabled-on-your-account)):
+
+```shell
+# First, refresh session token (required once per 12 hours)
+scripts/hyperliquid/refresh-mfa-session.sh --otp 123456 --profile YOUR_PROFILE
+
+# Option A: profile mode (credentials file updated by refresh-mfa-session.sh)
+AWS_PROFILE=YOUR_PROFILE LOG_LEVEL=info \
+    poetry run python scripts/hyperliquid/extract-s3-vault-data.py
+
+# Option B: environment variable mode
+AWS_ACCESS_KEY_ID=ASIA... AWS_SECRET_ACCESS_KEY=... AWS_SESSION_TOKEN=... LOG_LEVEL=info \
     poetry run python scripts/hyperliquid/extract-s3-vault-data.py
 ```
 
@@ -221,14 +288,22 @@ new files are downloaded and already-extracted dates are skipped.
 To extract a specific date range:
 
 ```shell
+# Without MFA
 AWS_ACCESS_KEY_ID=AKIA... AWS_SECRET_ACCESS_KEY=... \
+START_DATE=2025-11-01 END_DATE=2026-01-31 DELETE_LZ4=false LOG_LEVEL=info \
+    poetry run python scripts/hyperliquid/extract-s3-vault-data.py
+
+# With MFA (profile mode)
+AWS_PROFILE=YOUR_PROFILE \
 START_DATE=2025-11-01 END_DATE=2026-01-31 DELETE_LZ4=false LOG_LEVEL=info \
     poetry run python scripts/hyperliquid/extract-s3-vault-data.py
 ```
 
 Environment variables:
-- `AWS_ACCESS_KEY_ID` — AWS access key ID for S3 download
+- `AWS_ACCESS_KEY_ID` — AWS access key ID for S3 download (long-term: starts `AKIA`, session: starts `ASIA`)
 - `AWS_SECRET_ACCESS_KEY` — AWS secret access key for S3 download
+- `AWS_SESSION_TOKEN` — temporary session token (required when MFA is enforced on the account)
+- `AWS_PROFILE` — named profile from `~/.aws/credentials` (alternative to the three variables above)
 - `S3_DATA_DIR` — directory with pre-downloaded `.csv.lz4` files (skips S3 download if set)
 - `S3_DOWNLOAD_DIR` — where to cache downloaded files (default: `~/hl-archive/account_values/`)
 - `STAGING_DB_PATH` — staging DB path (default: `~/.tradingstrategy/hyperliquid/s3-vault-backfill.duckdb`)
@@ -300,7 +375,16 @@ Tests use synthetic LZ4 files and verify:
 
 ```shell
 # Stage 1: Download + extract a single day into test staging DB
+
+# Without MFA
 AWS_ACCESS_KEY_ID=AKIA... AWS_SECRET_ACCESS_KEY=... \
+START_DATE=2026-03-01 END_DATE=2026-03-01 \
+STAGING_DB_PATH=/tmp/staging.duckdb DELETE_LZ4=false \
+    poetry run python scripts/hyperliquid/extract-s3-vault-data.py
+
+# With MFA — refresh session first, then use profile or env vars
+scripts/hyperliquid/refresh-mfa-session.sh --otp 123456 --profile YOUR_PROFILE
+AWS_PROFILE=YOUR_PROFILE \
 START_DATE=2026-03-01 END_DATE=2026-03-01 \
 STAGING_DB_PATH=/tmp/staging.duckdb DELETE_LZ4=false \
     poetry run python scripts/hyperliquid/extract-s3-vault-data.py
@@ -327,7 +411,14 @@ db.close()
 ```shell
 # 1. Download + extract full S3 archive (~8-15 GB compressed, ~10-25 min download)
 # Resumable — safe to interrupt and restart. Only downloads new files on re-run.
+
+# Without MFA
 AWS_ACCESS_KEY_ID=AKIA... AWS_SECRET_ACCESS_KEY=... LOG_LEVEL=info \
+    poetry run python scripts/hyperliquid/extract-s3-vault-data.py
+
+# With MFA — refresh session first (tokens last 12 hours), then run
+scripts/hyperliquid/refresh-mfa-session.sh --otp 123456 --profile YOUR_PROFILE
+AWS_PROFILE=YOUR_PROFILE LOG_LEVEL=info \
     poetry run python scripts/hyperliquid/extract-s3-vault-data.py
 
 # 2. Back up production database

--- a/scripts/hyperliquid/refresh-mfa-session.sh
+++ b/scripts/hyperliquid/refresh-mfa-session.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+#
+# Refresh AWS MFA session credentials for Hyperliquid S3 archive access
+#
+# Some AWS accounts enforce MFA authentication, which means long-term access keys
+# alone are not sufficient to access requester-pays S3 buckets. This script
+# obtains temporary session credentials via sts:GetSessionToken and either
+# updates ~/.aws/credentials or prints export commands for your shell.
+#
+# Requirements:
+#   - aws CLI installed and configured
+#   - python3 installed (for credentials file update)
+#   - MFA device registered on your IAM user
+#
+# Usage:
+#   ./refresh-mfa-session.sh [options]
+#
+# Options:
+#   -o, --otp CODE           6-digit OTP code from your MFA device (required)
+#   -p, --profile NAME       AWS profile to update in ~/.aws/credentials (default: default)
+#   -s, --serial ARN         MFA device serial number ARN. Auto-detected if not provided.
+#   -d, --duration SECONDS   Session duration in seconds (default: 43200 = 12 hours)
+#   -e, --export             Print export commands instead of updating credentials file
+#   -h, --help               Show this help message
+#
+# Examples:
+#   # Update credentials file for a named profile
+#   ./refresh-mfa-session.sh --otp 123456 --profile tradingstrategy
+#
+#   # Auto-detect MFA device, use default profile
+#   ./refresh-mfa-session.sh --otp 123456
+#
+#   # Print export commands for use in current shell (environment variable mode)
+#   eval $(./refresh-mfa-session.sh --otp 123456 --export)
+#
+#   # Use a specific MFA device ARN and 8-hour session
+#   ./refresh-mfa-session.sh --otp 123456 \
+#     --serial arn:aws:iam::123456789012:mfa/my-device \
+#     --duration 28800
+#
+
+set -euo pipefail
+
+# Default values
+OTP=""
+PROFILE="default"
+SERIAL=""
+DURATION=43200
+EXPORT_MODE=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -o|--otp)
+            OTP="$2"
+            shift 2
+            ;;
+        -p|--profile)
+            PROFILE="$2"
+            shift 2
+            ;;
+        -s|--serial)
+            SERIAL="$2"
+            shift 2
+            ;;
+        -d|--duration)
+            DURATION="$2"
+            shift 2
+            ;;
+        -e|--export)
+            EXPORT_MODE=true
+            shift
+            ;;
+        -h|--help)
+            sed -n '3,45p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            echo "Run with --help for usage." >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Validate required arguments
+if [[ -z "$OTP" ]]; then
+    echo "Error: --otp is required." >&2
+    echo "Run with --help for usage." >&2
+    exit 1
+fi
+
+if [[ ! "$OTP" =~ ^[0-9]{6}$ ]]; then
+    echo "Error: OTP must be exactly 6 digits, got: $OTP" >&2
+    exit 1
+fi
+
+# Check for required tools
+for cmd in aws python3; do
+    if ! command -v "$cmd" &> /dev/null; then
+        echo "Error: $cmd is required but not installed." >&2
+        exit 1
+    fi
+done
+
+# Auto-detect MFA serial number if not provided
+if [[ -z "$SERIAL" ]]; then
+    echo "Auto-detecting MFA device for profile '$PROFILE'..." >&2
+    SERIAL=$(aws iam list-mfa-devices \
+        --profile "$PROFILE" \
+        --query 'MFADevices[0].SerialNumber' \
+        --output text 2>/dev/null || true)
+
+    if [[ -z "$SERIAL" || "$SERIAL" == "None" ]]; then
+        echo "Error: Could not auto-detect MFA device serial number." >&2
+        echo "Provide it explicitly with --serial arn:aws:iam::ACCOUNT:mfa/DEVICE" >&2
+        exit 1
+    fi
+    echo "Found MFA device: $SERIAL" >&2
+fi
+
+# Obtain temporary session credentials
+echo "Requesting session token (duration: ${DURATION}s = $(( DURATION / 3600 ))h)..." >&2
+
+RESULT=$(aws sts get-session-token \
+    --profile "$PROFILE" \
+    --serial-number "$SERIAL" \
+    --token-code "$OTP" \
+    --duration-seconds "$DURATION" \
+    --output json 2>&1)
+
+if ! echo "$RESULT" | python3 -c "import sys, json; json.load(sys.stdin)" &> /dev/null; then
+    echo "Error: Failed to obtain session token:" >&2
+    echo "$RESULT" >&2
+    exit 1
+fi
+
+# Parse credentials from JSON response
+ACCESS_KEY=$(echo "$RESULT" | python3 -c "import sys, json; print(json.load(sys.stdin)['Credentials']['AccessKeyId'])")
+SECRET_KEY=$(echo "$RESULT" | python3 -c "import sys, json; print(json.load(sys.stdin)['Credentials']['SecretAccessKey'])")
+SESSION_TOKEN=$(echo "$RESULT" | python3 -c "import sys, json; print(json.load(sys.stdin)['Credentials']['SessionToken'])")
+EXPIRY=$(echo "$RESULT" | python3 -c "import sys, json; print(json.load(sys.stdin)['Credentials']['Expiration'])")
+
+if [[ "$EXPORT_MODE" == true ]]; then
+    # Print export commands for eval in current shell
+    echo "export AWS_ACCESS_KEY_ID=$ACCESS_KEY"
+    echo "export AWS_SECRET_ACCESS_KEY=$SECRET_KEY"
+    echo "export AWS_SESSION_TOKEN=$SESSION_TOKEN"
+    echo "# Session expires: $EXPIRY" >&2
+else
+    # Update ~/.aws/credentials using Python for reliable INI parsing
+    python3 - <<PYEOF
+import configparser
+import os
+
+creds_path = os.path.expanduser("~/.aws/credentials")
+creds = configparser.ConfigParser()
+creds.read(creds_path)
+
+profile = "$PROFILE"
+if profile not in creds:
+    creds[profile] = {}
+
+creds[profile]["aws_access_key_id"] = "$ACCESS_KEY"
+creds[profile]["aws_secret_access_key"] = "$SECRET_KEY"
+creds[profile]["aws_session_token"] = "$SESSION_TOKEN"
+
+with open(creds_path, "w") as f:
+    creds.write(f)
+
+print(f"Updated profile '{profile}' in {creds_path}")
+print(f"Session expires: $EXPIRY")
+PYEOF
+
+    # Verify the new credentials work
+    echo "" >&2
+    echo "Verifying credentials..." >&2
+    IDENTITY=$(aws sts get-caller-identity --profile "$PROFILE" --output json 2>&1)
+    if echo "$IDENTITY" | python3 -c "import sys, json; d=json.load(sys.stdin); print(f\"Authenticated as: {d['Arn']}\")" 2>/dev/null; then
+        echo "Session credentials are valid." >&2
+    else
+        echo "Warning: Could not verify credentials — check output above." >&2
+    fi
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/hyperliquid/refresh-mfa-session.sh` — helper script to obtain AWS STS session credentials for accounts with MFA enforcement, auto-detects MFA device ARN and updates `~/.aws/credentials` automatically
- Update `README-hyperliquid-backfill.md` with MFA authentication section (section 4a) and expand all credential commands to show both without-MFA and with-MFA variants