### PR TITLE
feat: add top traders by trade count script with ASXN Hyperscreener integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Current
 
+- Add: Top traders by trade count script with ASXN Hyperscreener integration, portfolio/leaderboard API functions in `eth_defi.hyperliquid.api` (2026-03-13)
 - Add: Hyperliquid copy trading platforms and HFT account identification research documentation (2026-03-13)
 - Add: Configurable `proxy_failure_log_level` on `create_hyperliquid_session()` to suppress noisy proxy rotation/failure warnings in scan mode (2026-03-13)
 - **Add: Hyperliquid trade history reconstruction with round-trip trade grouping, funding payment tracking, DuckDB persistence for whitelisted accounts, and event-accurate share price computation (2026-03-12)**

--- a/eth_defi/hyperliquid/api.py
+++ b/eth_defi/hyperliquid/api.py
@@ -23,12 +23,16 @@ import time
 from dataclasses import dataclass
 from decimal import Decimal
 
+import requests
 from eth_typing import HexAddress
 
 from eth_defi.hyperliquid.session import HyperliquidSession
 from eth_defi.utils import from_unix_timestamp
 
 logger = logging.getLogger(__name__)
+
+#: Hyperliquid stats-data leaderboard endpoint (public GET, no auth, 32K+ entries)
+LEADERBOARD_URL = "https://stats-data.hyperliquid.xyz/Mainnet/leaderboard"
 
 #: Default cache timeout for :py:func:`fetch_user_vault_equity` in seconds (15 minutes).
 DEFAULT_VAULT_EQUITY_CACHE_TIMEOUT = 15 * 60
@@ -175,6 +179,50 @@ class PerpClearinghouseState:
 
     #: Active perpetual positions
     asset_positions: list[AssetPosition]
+
+
+@dataclass(slots=True)
+class PortfolioAllTimeData:
+    """All-time PnL and trading volume for a Hyperliquid address.
+
+    Fetched from the ``portfolio`` info endpoint, which works for **any**
+    address — not just leaderboard participants.
+
+    Returned by :py:func:`fetch_portfolio`.
+    """
+
+    #: Latest cumulative PnL in USD (from the last entry in ``pnlHistory``)
+    all_time_pnl: Decimal | None
+
+    #: All-time trading volume in USD
+    all_time_volume: Decimal | None
+
+
+@dataclass(slots=True)
+class LeaderboardEntry:
+    """A single trader from the Hyperliquid public leaderboard.
+
+    The leaderboard contains 32K+ traders who have opted in.
+    Fetched in bulk by :py:func:`fetch_leaderboard`.
+    """
+
+    #: Ethereum address (lowercased)
+    address: HexAddress
+
+    #: Display name chosen by the trader (``None`` if not set)
+    display_name: str | None
+
+    #: Account value in USD at time of leaderboard snapshot
+    account_value: Decimal
+
+    #: All-time PnL in USD
+    all_time_pnl: Decimal
+
+    #: All-time ROI as a ratio (e.g. ``0.25`` = 25%)
+    all_time_roi: Decimal
+
+    #: All-time trading volume in USD
+    all_time_volume: Decimal
 
 
 def fetch_user_vault_equities(
@@ -461,3 +509,134 @@ def fetch_perp_clearinghouse_state(
         withdrawable=Decimal(data.get("withdrawable", "0")),
         asset_positions=positions,
     )
+
+
+def fetch_portfolio(
+    session: HyperliquidSession,
+    address: HexAddress | str,
+    timeout: float = 15.0,
+) -> PortfolioAllTimeData | None:
+    """Fetch all-time PnL and volume for any Hyperliquid address.
+
+    Calls the ``portfolio`` info endpoint which returns account value history,
+    PnL history, and volume across multiple time windows (day, week, month, allTime).
+
+    Unlike the leaderboard, this works for **any** address — including those
+    that have not opted in to the public leaderboard.
+
+    Example::
+
+        from eth_defi.hyperliquid.api import fetch_portfolio
+        from eth_defi.hyperliquid.session import create_hyperliquid_session
+
+        session = create_hyperliquid_session()
+        portfolio = fetch_portfolio(session, "0x1234...")
+        if portfolio is not None:
+            print(f"All-time PnL: {portfolio.all_time_pnl}")
+            print(f"All-time volume: {portfolio.all_time_volume}")
+            # Example output:
+            # All-time PnL: -58459.412942
+            # All-time volume: 1893425014.9738
+
+    The raw API response is an array of ``[period, data]`` pairs::
+
+        [["day", {"accountValueHistory": [...], "pnlHistory": [...], "vlm": "..."}], ["allTime", {"accountValueHistory": [...], "pnlHistory": [[ts, pnl], ...], "vlm": "1893425014.9738"}]]
+
+    :param session:
+        Session from :py:func:`~eth_defi.hyperliquid.session.create_hyperliquid_session`.
+
+    :param address:
+        Hyperliquid user address.
+
+    :param timeout:
+        HTTP request timeout in seconds.
+
+    :return:
+        All-time PnL and volume, or ``None`` on network/API error.
+    """
+    try:
+        url = f"{session.api_url}/info"
+        resp = session.post(
+            url,
+            json={"type": "portfolio", "user": address},
+            headers={"Content-Type": "application/json"},
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        # Response is array of [period, {accountValueHistory, pnlHistory, vlm}]
+        periods = dict(data)
+        all_time = periods.get("allTime", {})
+        pnl_history = all_time.get("pnlHistory", [])
+        latest_pnl = Decimal(str(pnl_history[-1][1])) if pnl_history else None
+        vlm = all_time.get("vlm")
+        volume = Decimal(str(vlm)) if vlm else None
+
+        logger.info("Portfolio for %s: pnl=%s, volume=%s", address, latest_pnl, volume)
+
+        return PortfolioAllTimeData(
+            all_time_pnl=latest_pnl,
+            all_time_volume=volume,
+        )
+    except Exception:
+        logger.warning("Failed to fetch portfolio for %s", address, exc_info=True)
+        return None
+
+
+def fetch_leaderboard(
+    timeout: float = 60.0,
+) -> dict[str, LeaderboardEntry]:
+    """Fetch the full Hyperliquid trader leaderboard.
+
+    Calls the public ``stats-data.hyperliquid.xyz/Mainnet/leaderboard``
+    endpoint which returns 32K+ traders who have opted in, indexed by
+    lowercased address for easy lookup.
+
+    Does **not** require a :py:class:`HyperliquidSession` — this is a
+    plain GET to a stats endpoint with no rate limiting.
+
+    Example::
+
+        from eth_defi.hyperliquid.api import fetch_leaderboard
+
+        leaderboard = fetch_leaderboard()
+        print(f"Leaderboard has {len(leaderboard)} traders")
+
+        # Look up a specific address
+        entry = leaderboard.get("0x1234abcd...")
+        if entry:
+            print(f"{entry.display_name}: PnL={entry.all_time_pnl}, ROI={entry.all_time_roi}")
+            # Example output:
+            # HyperTrader42: PnL=1234567.89, ROI=0.4523
+
+    The raw API response::
+
+        {"leaderboardRows": [{"ethAddress": "0x...", "accountValue": "123456.78", "displayName": "HyperTrader42", "windowPerformances": [["allTime", {"pnl": "1234567.89", "roi": "0.4523", "vlm": "98765432.10"}], ...]}, ...]}
+
+    :param timeout:
+        HTTP request timeout in seconds.
+
+    :return:
+        Dict mapping lowercased address to :py:class:`LeaderboardEntry`.
+    """
+    logger.info("Fetching leaderboard from %s", LEADERBOARD_URL)
+    resp = requests.get(LEADERBOARD_URL, timeout=timeout)
+    resp.raise_for_status()
+    data = resp.json()
+    rows = data["leaderboardRows"]
+    logger.info("Got %d leaderboard entries", len(rows))
+
+    index: dict[str, LeaderboardEntry] = {}
+    for row in rows:
+        addr = row["ethAddress"].lower()
+        windows = dict(row.get("windowPerformances", []))
+        all_time = windows.get("allTime", {})
+        index[addr] = LeaderboardEntry(
+            address=addr,
+            display_name=row.get("displayName") or None,
+            account_value=Decimal(str(row.get("accountValue", 0))),
+            all_time_pnl=Decimal(str(all_time.get("pnl", 0))),
+            all_time_roi=Decimal(str(all_time.get("roi", 0))),
+            all_time_volume=Decimal(str(all_time.get("vlm", 0))),
+        )
+    return index

--- a/scripts/hyperliquid/README-hyperliquid-copy-trading.md
+++ b/scripts/hyperliquid/README-hyperliquid-copy-trading.md
@@ -156,6 +156,44 @@ The repository already has substantial Hyperliquid infrastructure that can be re
 | `scripts/hyperliquid/sync-trade-history.py` | Incremental trade history sync for whitelisted accounts |
 | `scripts/hyperliquid/vault-trade-history.py` | Display trade history + share prices for a single account |
 
+## Scripts
+
+### Top traders by trade count
+
+`scripts/hyperliquid/top-traders-by-trade-count.py` fetches the top traders by trade count
+from the ASXN Hyperscreener (reverse-engineered CloudFront endpoint), enriches with PnL/volume
+from the Hyperliquid leaderboard, and fetches live margin data via `clearinghouseState`.
+
+Outputs a JSON file and prints two summary tables: top by trade count and top by PnL.
+
+```shell
+# Default: top 100 traders, output to top-traders-by-trade-count.json
+poetry run python scripts/hyperliquid/top-traders-by-trade-count.py
+
+# Quick test: top 10 only
+TOP_N=10 poetry run python scripts/hyperliquid/top-traders-by-trade-count.py
+
+# Filter by minimum trade count (e.g. 100M+)
+MIN_TRADES=100000000 TOP_N=20 poetry run python scripts/hyperliquid/top-traders-by-trade-count.py
+
+# Custom output path and parallel workers
+OUTPUT=/tmp/traders.json MAX_WORKERS=8 poetry run python scripts/hyperliquid/top-traders-by-trade-count.py
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TOP_N` | `100` | Number of top traders to output |
+| `MIN_TRADES` | `0` | Minimum trade count filter |
+| `OUTPUT` | `~/.tradingstrategy/hyperliquid/top-traders-by-trade-count.json` | Output JSON path |
+| `MAX_WORKERS` | `4` | Parallel threads for `clearinghouseState` calls |
+| `LOG_LEVEL` | `warning` | Logging level |
+
+Data sources (all public, no auth required):
+
+- `d2v1fiwobg9w6.cloudfront.net/largest_user_trade_count` — top 1000 by trade count
+- `stats-data.hyperliquid.xyz/Mainnet/leaderboard` — 32K+ traders with PnL/ROI/volume
+- `api.hyperliquid.xyz/info` clearinghouseState — live margin per address
+
 ## Key SDKs
 
 - **Python**: [hyperliquid-python-sdk](https://github.com/hyperliquid-dex/hyperliquid-python-sdk) (1,459 stars) — `Info` class with `user_state()`, fill history, etc.

--- a/scripts/hyperliquid/top-traders-by-trade-count.py
+++ b/scripts/hyperliquid/top-traders-by-trade-count.py
@@ -1,0 +1,291 @@
+"""Fetch top Hyperliquid traders by trade count from ASXN Hyperscreener.
+
+Reverse-engineered from ``hyperscreener.asxn.xyz/traders/overview``.
+Fetches the top 1000 traders by trade count from a public CloudFront
+endpoint, enriches with PnL/volume from the Hyperliquid leaderboard,
+and fetches live margin data via ``clearinghouseState``.
+
+Outputs a JSON file and prints two summary tables:
+1. Top traders by trade count
+2. Top traders by all-time PnL
+
+Data sources (all public, no auth):
+
+- ``d2v1fiwobg9w6.cloudfront.net/largest_user_trade_count`` — top 1000 by trade count
+- ``stats-data.hyperliquid.xyz/Mainnet/leaderboard`` — 32K+ traders with PnL/volume
+- ``api.hyperliquid.xyz/info`` clearinghouseState — live margin per address
+- ``api.hyperliquid.xyz/info`` portfolio — all-time PnL/volume for any address (fallback for non-leaderboard)
+
+Usage:
+
+.. code-block:: shell
+
+    # Default: top 100
+    poetry run python scripts/hyperliquid/top-traders-by-trade-count.py
+
+    # Quick test: top 10
+    TOP_N=10 poetry run python scripts/hyperliquid/top-traders-by-trade-count.py
+
+    # High trade count filter
+    MIN_TRADES=100000000 TOP_N=20 poetry run python scripts/hyperliquid/top-traders-by-trade-count.py
+
+Environment variables:
+
+- ``TOP_N``: Number of top traders to output. Default: 100
+- ``MIN_TRADES``: Minimum trade count filter. Default: 0
+- ``OUTPUT``: Output JSON path. Default: ~/.tradingstrategy/hyperliquid/top-traders-by-trade-count.json
+- ``MAX_WORKERS``: Parallel threads for clearinghouseState. Default: 4
+- ``LOG_LEVEL``: Logging level. Default: warning
+"""
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import TypedDict
+
+import requests
+from joblib import Parallel, delayed
+from tabulate import tabulate
+from tqdm_loggable.auto import tqdm
+
+from eth_defi.hyperliquid.api import (
+    PerpClearinghouseState,
+    PortfolioAllTimeData,
+    fetch_leaderboard,
+    fetch_perp_clearinghouse_state,
+    fetch_portfolio,
+)
+from eth_defi.hyperliquid.session import create_hyperliquid_session
+from eth_defi.utils import setup_console_logging
+
+logger = logging.getLogger(__name__)
+
+#: ASXN Hyperscreener CloudFront endpoint for top traders by trade count
+TRADE_COUNT_URL = "https://d2v1fiwobg9w6.cloudfront.net/largest_user_trade_count"
+
+#: Default output path for top traders JSON
+DEFAULT_OUTPUT_PATH = Path("~/.tradingstrategy/hyperliquid/top-traders-by-trade-count.json").expanduser()
+
+
+class TraderRecord(TypedDict):
+    """Schema for a single trader record in the output JSON."""
+
+    rank: int
+    address: str
+    display_name: str | None
+    trade_count: int
+    # From leaderboard (allTime window)
+    all_time_pnl: float | None
+    all_time_roi: float | None
+    all_time_volume: float | None
+    leaderboard_account_value: float | None
+    # From clearinghouseState (live)
+    live_account_value: float | None
+    total_notional_position: float | None
+    total_margin_used: float | None
+    open_position_count: int | None
+
+
+def _human(n: float | None) -> str:
+    """Format a number with M/k suffixes for display."""
+    if n is None:
+        return "-"
+    if abs(n) >= 1_000_000:
+        return f"${n / 1_000_000:.1f}M"
+    if abs(n) >= 1_000:
+        return f"${n / 1_000:.0f}k"
+    return f"${n:,.0f}"
+
+
+def _pct(n: float | None) -> str:
+    """Format a ratio as percentage."""
+    if n is None:
+        return "-"
+    return f"{n * 100:.1f}%"
+
+
+def _trade_count_human(n: int) -> str:
+    """Format trade count with M/k suffixes."""
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.0f}k"
+    return str(n)
+
+
+class TradeCountEntry(TypedDict):
+    """A single entry from the CloudFront trade count endpoint."""
+
+    name: str
+    value: float
+
+
+def fetch_trade_counts() -> list[TradeCountEntry]:
+    """Fetch top 1000 traders by trade count from ASXN CloudFront.
+
+    :return:
+        List of ``{"name": "0x...", "value": 701547800}`` sorted descending.
+    """
+    logger.info("Fetching trade counts from %s", TRADE_COUNT_URL)
+    resp = requests.get(TRADE_COUNT_URL, timeout=30)
+    resp.raise_for_status()
+    data = resp.json()
+    items: list[TradeCountEntry] = data["table_data"]
+    logger.info("Got %d traders from trade count endpoint", len(items))
+    return items
+
+
+def main():
+    default_log_level = os.environ.get("LOG_LEVEL", "warning")
+    setup_console_logging(default_log_level=default_log_level)
+
+    top_n = int(os.environ.get("TOP_N", "100"))
+    min_trades = int(os.environ.get("MIN_TRADES", "0"))
+    output_path_str = os.environ.get("OUTPUT")
+    output_path = Path(output_path_str).expanduser() if output_path_str else DEFAULT_OUTPUT_PATH
+    max_workers = int(os.environ.get("MAX_WORKERS", "4"))
+
+    print("Hyperliquid top traders by trade count")  # noqa: T201
+    print(f"  Source: ASXN Hyperscreener (CloudFront) + Hyperliquid leaderboard + clearinghouseState")  # noqa: T201
+    print(f"  TOP_N={top_n}, MIN_TRADES={min_trades}, MAX_WORKERS={max_workers}")  # noqa: T201
+
+    # Step 1: Fetch bulk data
+    trade_counts = fetch_trade_counts()
+    leaderboard = fetch_leaderboard()
+
+    # Step 2: Filter by min trades
+    if min_trades > 0:
+        trade_counts = [t for t in trade_counts if t["value"] >= min_trades]
+        print(f"  After MIN_TRADES filter: {len(trade_counts)} traders")  # noqa: T201
+
+    # Step 3: Take top N
+    top_traders = trade_counts[:top_n]
+
+    # Find addresses not on the leaderboard — need portfolio API for PnL
+    missing_from_leaderboard = {t["name"] for t in top_traders if t["name"].lower() not in leaderboard}
+    print(f"\n  Enriching {len(top_traders)} traders ({len(missing_from_leaderboard)} not on leaderboard)...")  # noqa: T201
+
+    # Step 4: Fetch live margin + portfolio data in parallel
+    session = create_hyperliquid_session(requests_per_second=2.75)
+
+    def _fetch_one(address: str, needs_portfolio: bool) -> tuple[str, PerpClearinghouseState | None, PortfolioAllTimeData | None]:
+        try:
+            ch = fetch_perp_clearinghouse_state(session, address)
+        except Exception:
+            logger.warning("Failed to fetch clearinghouseState for %s", address, exc_info=True)
+            ch = None
+        pf = fetch_portfolio(session, address) if needs_portfolio else None
+        return address, ch, pf
+
+    live_data: dict[str, PerpClearinghouseState] = {}
+    portfolio_data: dict[str, PortfolioAllTimeData] = {}
+    results = Parallel(n_jobs=max_workers, backend="threading")(delayed(_fetch_one)(t["name"], t["name"] in missing_from_leaderboard) for t in tqdm(top_traders, desc="Fetching live data"))
+    for addr, ch, pf in results:
+        if ch:
+            live_data[addr] = ch
+        if pf:
+            portfolio_data[addr] = pf
+
+    print(f"  Got clearinghouseState for {len(live_data)}/{len(top_traders)}, portfolio for {len(portfolio_data)}/{len(missing_from_leaderboard)}")  # noqa: T201
+
+    # Step 5: Build records
+    records: list[TraderRecord] = []
+    for i, t in enumerate(top_traders):
+        addr = t["name"].lower()
+        lb = leaderboard.get(addr)
+        live = live_data.get(t["name"])
+        pf = portfolio_data.get(t["name"])
+
+        # Use leaderboard data if available, otherwise fall back to portfolio API
+        if lb:
+            all_time_pnl = float(lb.all_time_pnl)
+            all_time_volume = float(lb.all_time_volume)
+            all_time_roi = float(lb.all_time_roi)
+            display_name = lb.display_name
+            leaderboard_account_value = float(lb.account_value)
+        else:
+            all_time_pnl = float(pf.all_time_pnl) if pf and pf.all_time_pnl is not None else None
+            all_time_volume = float(pf.all_time_volume) if pf and pf.all_time_volume is not None else None
+            all_time_roi = None
+            display_name = None
+            leaderboard_account_value = None
+
+        record: TraderRecord = {
+            "rank": i + 1,
+            "address": t["name"],
+            "display_name": display_name,
+            "trade_count": int(t["value"]),
+            "all_time_pnl": all_time_pnl,
+            "all_time_roi": all_time_roi,
+            "all_time_volume": all_time_volume,
+            "leaderboard_account_value": leaderboard_account_value,
+            "live_account_value": float(live.margin_summary.account_value) if live else None,
+            "total_notional_position": float(live.margin_summary.total_ntl_pos) if live else None,
+            "total_margin_used": float(live.margin_summary.total_margin_used) if live else None,
+            "open_position_count": len(live.asset_positions) if live else None,
+        }
+        records.append(record)
+
+    # Step 6: Write JSON
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        json.dump(records, f, indent=2)
+    print(f"\n  Wrote {len(records)} records to {output_path}")  # noqa: T201
+
+    # Step 7: Print summary tables
+
+    # Table 1: Top traders by trade count
+    print("\n\n=== Top traders by trade count ===\n")  # noqa: T201
+    rows_by_count = []
+    for r in records:
+        rows_by_count.append(
+            [
+                r["rank"],
+                r["display_name"] or r["address"][:16] + "...",
+                _trade_count_human(r["trade_count"]),
+                _human(r["all_time_pnl"]),
+                _pct(r["all_time_roi"]),
+                _human(r["all_time_volume"]),
+                _human(r["live_account_value"]),
+                _human(r["total_margin_used"]),
+                r["open_position_count"] if r["open_position_count"] is not None else "-",
+            ]
+        )
+    print(
+        tabulate(  # noqa: T201
+            rows_by_count,
+            headers=["#", "Name", "Trades", "PnL", "ROI", "Volume", "Acct Value", "Margin Used", "Positions"],
+            tablefmt="simple",
+        )
+    )
+
+    # Table 2: Top traders by PnL (re-sort)
+    print("\n\n=== Top traders by all-time PnL ===\n")  # noqa: T201
+    by_pnl = sorted(records, key=lambda r: r["all_time_pnl"] or 0, reverse=True)
+    rows_by_pnl = []
+    for i, r in enumerate(by_pnl):
+        rows_by_pnl.append(
+            [
+                i + 1,
+                r["display_name"] or r["address"][:16] + "...",
+                _trade_count_human(r["trade_count"]),
+                _human(r["all_time_pnl"]),
+                _pct(r["all_time_roi"]),
+                _human(r["all_time_volume"]),
+                _human(r["live_account_value"]),
+                _human(r["total_margin_used"]),
+                r["open_position_count"] if r["open_position_count"] is not None else "-",
+            ]
+        )
+    print(
+        tabulate(  # noqa: T201
+            rows_by_pnl,
+            headers=["#", "Name", "Trades", "PnL", "ROI", "Volume", "Acct Value", "Margin Used", "Positions"],
+            tablefmt="simple",
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `fetch_portfolio()` and `fetch_leaderboard()` to `eth_defi.hyperliquid.api` with typed `PortfolioAllTimeData` and `LeaderboardEntry` dataclasses (Decimal fields, rich docstrings with examples)
- Create `scripts/hyperliquid/top-traders-by-trade-count.py` — fetches top 1000 traders from reverse-engineered ASXN Hyperscreener CloudFront endpoint, enriches with PnL/volume from leaderboard + portfolio API, and live margin via `clearinghouseState`
- Default output path: `~/.tradingstrategy/hyperliquid/top-traders-by-trade-count.json`
- Reuses existing `fetch_perp_clearinghouse_state()` from `api.py` instead of duplicating

🤖 Generated with [Claude Code](https://claude.com/claude-code)