### PR TITLE
fix: query actual GMX market count from DataStore instead of hardcoded limit

### DIFF
--- a/eth_defi/gmx/core/markets.py
+++ b/eth_defi/gmx/core/markets.py
@@ -12,7 +12,8 @@ from eth_typing import HexAddress
 from eth_utils import to_checksum_address
 
 from eth_defi.gmx.config import GMXConfig
-from eth_defi.gmx.contracts import get_contract_addresses, get_reader_contract, get_tokens_metadata_dict
+from eth_defi.gmx.contracts import get_contract_addresses, get_datastore_contract, get_reader_contract, get_tokens_metadata_dict
+from eth_defi.gmx.keys import MARKET_LIST
 from eth_defi.gmx.core.oracle import OraclePrices
 from eth_defi.gmx.types import MarketData, MarketSymbol
 
@@ -218,10 +219,15 @@ class Markets:
         contract_addresses = get_contract_addresses(self.config.chain)
         data_store_contract_address = contract_addresses.datastore
 
+        # Query the actual market count from the DataStore rather than
+        # using a hardcoded limit that silently breaks when GMX adds markets.
+        datastore_contract = get_datastore_contract(self.config.web3, self.config.chain)
+        market_count = datastore_contract.functions.getAddressCount(MARKET_LIST).call()
+
         return reader_contract.functions.getMarkets(
             data_store_contract_address,
             0,
-            115,
+            market_count,
         ).call()
 
     def _process_markets(self) -> dict:


### PR DESCRIPTION
## Summary

- The on-chain `getMarkets()` call used a hardcoded limit of `115`, but the GMX DataStore now contains ~130+ entries (including swap-only, synthetic, and deprecated markets). Newer markets (e.g. SKY) were silently excluded, causing `ValueError` crashes when `OrderArgumentParser` tried to resolve them.
- Now queries `DataStore.getAddressCount(MARKET_LIST)` first (one lightweight storage slot read), then fetches exactly that many markets — no more magic numbers to bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)