### PR TITLE
feat: Derive funding rate full history fetch with inception detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Current
 
+- Add: Derive funding rate full history fetch — fix API parameter names (`start_timestamp`/`end_timestamp`), auto-detect instrument inception dates, 28-day chunked fetch with progress bar (2026-03-18)
 - Add: Derive funding rate history — public API wrapper, DuckDB storage with resumable sync, scan script for all perpetual instruments (2026-03-17, [#867](https://github.com/tradingstrategy-ai/web3-ethereum-defi/pull/867))
 - Fix: Harmonise stablecoin names — remove brackets, use issuer-first format for consistent frontend display (2026-03-17)
 - Add: Split stablecoin YAML `description` into `short_description` and `long_description` fields with markdown support; JSON export includes both plus backwards-compatible `description` key (2026-03-16)

--- a/eth_defi/derive/README-derive.md
+++ b/eth_defi/derive/README-derive.md
@@ -8,9 +8,17 @@
 
 ## Funding rate history
 
-The `scan-funding-rates.py` script fetches hourly funding rate snapshots for Derive perpetual instruments and stores them in a local DuckDB database. The scan is resumeable — running it again fetches only new data since the last sync.
+The `scan-funding-rates.py` script fetches hourly funding rate snapshots for Derive perpetual instruments and stores them in a local DuckDB database. On first run it auto-detects each instrument's inception date and fetches the full available history. Subsequent runs resume from the last stored timestamp.
 
-The Derive API limits history to 30 days per request, so run the script at least once every 30 days to avoid gaps.
+### API quirks (discovered 2026-03-18)
+
+The Derive `get_funding_rate_history` endpoint has several undocumented behaviours:
+
+- **Parameter names**: The API requires `start_timestamp` / `end_timestamp` (not `start_time` / `end_time` as the docs suggest). Using the wrong names silently falls back to the most recent 30 days.
+- **Maximum window**: The API returns empty results for windows >= 30 days. The maximum usable window is **28 days** (29 days also works but 28 is a safe round number).
+- **Pagination ignored**: `page` and `page_size` parameters are accepted but have no effect — the API always returns all entries in the requested time window.
+- **Full history available**: Despite the docs claiming a 30-day limit, the correct parameter names allow querying data back to instrument inception (ETH-PERP since 2024-01-05, ~800+ days).
+- **Hourly resolution**: Data is returned at 1-hour intervals. A 28-day chunk returns ~672 entries.
 
 ### Quick snapshot (1 day, single instrument)
 
@@ -18,11 +26,13 @@ The Derive API limits history to 30 days per request, so run the script at least
 LIMIT_DAYS=1 INSTRUMENTS=ETH-PERP poetry run python scripts/derive/scan-funding-rates.py
 ```
 
-### Full sync (all instruments, 30 days)
+### Full sync (all instruments, full history)
 
 ```shell
 poetry run python scripts/derive/scan-funding-rates.py
 ```
+
+On first run, the script probes each instrument's inception date via binary search (~10 API calls per instrument), then fetches the full history in 28-day chunks. For 12 instruments with ~800 days of history each, the initial sync takes roughly 2–3 minutes at 2 requests/second.
 
 ### With verbose logging
 
@@ -41,26 +51,9 @@ DB_PATH=/tmp/derive-funding.duckdb poetry run python scripts/derive/scan-funding
 | Variable | Description | Default |
 |---|---|---|
 | `INSTRUMENTS` | Comma-separated instrument names | All active perps (auto-discovered) |
-| `LIMIT_DAYS` | Limit history to N days | 30 |
+| `LIMIT_DAYS` | Limit history to N days | Not set (full history / resume) |
 | `DB_PATH` | DuckDB file path | `~/.tradingstrategy/derive/funding-rates.duckdb` |
 | `LOG_LEVEL` | Logging level (debug, info, warning, error) | warning |
-
-### Example output
-
-```
-Database: /Users/you/.tradingstrategy/derive/funding-rates.duckdb
-Instruments: 42
-Limit: 30 days (from 2026-02-15 20:00 UTC)
-
-Instrument      New rows    Total rows  Oldest            Newest
-------------  ----------  ------------  ----------------  ----------------
-BTC-PERP             720           720  2026-02-15 20:00  2026-03-17 19:00
-ETH-PERP             720           720  2026-02-15 20:00  2026-03-17 19:00
-SOL-PERP             720           720  2026-02-15 20:00  2026-03-17 19:00
-...
-
-Total: 30240 new rows, 30240 total rows across 42 instruments
-```
 
 ### Running tests
 
@@ -68,4 +61,23 @@ Total: 30240 new rows, 30240 total rows across 42 instruments
 source .local-test.env && poetry run pytest tests/derive/test_funding_rate_history.py -v --timeout=180
 ```
 
-Tests use the public API (no credentials needed) and fetch a small window of data.
+Tests use the public API (no credentials needed). The `test_fetch_early_history` test verifies that data from 6 months ago is accessible.
+
+## Samples
+
+```
+Instrument      New rows    Total rows  Oldest            Newest
+------------  ----------  ------------  ----------------  ----------------
+AAVE-PERP          11200         11200  2024-11-02 16:00  2026-03-17 22:00
+BNB-PERP            4014          4014  2025-08-12 14:00  2026-03-18 04:00
+BTC-PERP           19782         19782  2023-12-14 19:00  2026-03-18 12:00
+DOGE-PERP          11358         11358  2024-10-16 22:00  2026-03-17 16:00
+ENA-PERP           10482         10482  2024-12-01 11:00  2026-03-16 10:00
+ETH-PERP           19260         19260  2024-01-05 15:00  2026-03-18 12:00
+HYPE-PERP           3193          3193  2025-11-05 12:00  2026-03-18 12:00
+LINK-PERP          10316         10316  2024-12-02 18:00  2026-03-16 10:00
+OP-PERP            11139         11139  2024-11-02 18:00  2026-03-16 10:00
+SOL-PERP           14433         14433  2024-07-21 22:00  2026-03-18 12:00
+SUI-PERP           11377         11377  2024-11-03 01:00  2026-03-16 10:00
+XRP-PERP            2714          2714  2025-11-03 10:00  2026-03-18 03:00
+```

--- a/eth_defi/derive/api.py
+++ b/eth_defi/derive/api.py
@@ -167,13 +167,20 @@ def fetch_funding_rate_history(
     Calls the public ``get_funding_rate_history`` endpoint.
     No authentication required.
 
-    The API restricts ``start_time`` to at most 30 days in the past.
-    For accumulating historical data beyond 30 days, see
-    :py:class:`~eth_defi.derive.historical.DeriveFundingRateDatabase`
-    which handles resumable syncs.
-
     Data is returned at hourly resolution — the native funding rate
-    interval on Derive.
+    interval on Derive.  The full history is available back to
+    instrument inception (ETH-PERP since 2024-01-05).
+
+    For best results, keep the query window to one day at a time
+    and use :py:class:`~eth_defi.derive.historical.DeriveFundingRateDatabase`
+    for bulk historical fetches.
+
+    .. note::
+
+       The Derive API requires the parameter names ``start_timestamp``
+       and ``end_timestamp`` (not ``start_time`` / ``end_time``).
+       Using the wrong names silently falls back to the most recent
+       30 days.
 
     Example::
 
@@ -191,7 +198,6 @@ def fetch_funding_rate_history(
         Perpetual instrument name (e.g. ``"ETH-PERP"``).
     :param start_time:
         Start of the query window (naive UTC). Defaults to 30 days ago.
-        API rejects values older than 30 days from now.
     :param end_time:
         End of the query window (naive UTC). Defaults to now.
     :param base_url:
@@ -208,10 +214,10 @@ def fetch_funding_rate_history(
     params: dict = {"instrument_name": instrument_name}
 
     if start_time is not None:
-        params["start_time"] = int(start_time.replace(tzinfo=datetime.timezone.utc).timestamp() * 1000)
+        params["start_timestamp"] = int(start_time.replace(tzinfo=datetime.timezone.utc).timestamp() * 1000)
 
     if end_time is not None:
-        params["end_time"] = int(end_time.replace(tzinfo=datetime.timezone.utc).timestamp() * 1000)
+        params["end_timestamp"] = int(end_time.replace(tzinfo=datetime.timezone.utc).timestamp() * 1000)
 
     response = session.post(
         url,
@@ -238,5 +244,5 @@ def fetch_funding_rate_history(
         )
 
     entries.sort(key=lambda e: e.timestamp_ms)
-    logger.info("Fetched %d funding rate entries for %s", len(entries), instrument_name)
+    logger.debug("Fetched %d funding rate entries for %s", len(entries), instrument_name)
     return entries

--- a/eth_defi/derive/historical.py
+++ b/eth_defi/derive/historical.py
@@ -1,8 +1,8 @@
 """DuckDB persistence for Derive funding rate history.
 
 Stores hourly funding rate snapshots for perpetual instruments.
-Incremental sync accumulates data beyond the 30-day API window
-by fetching successive chunks and storing them in DuckDB.
+Incremental sync fetches the full available history (back to
+instrument inception) by walking the time range in 1-day chunks.
 
 The sync is crash-resumeable: partial batches are safely re-inserted
 on restart via ``INSERT OR IGNORE`` on natural primary keys.
@@ -55,11 +55,30 @@ from eth_defi.derive.constants import DERIVE_MAINNET_API_URL
 
 logger = logging.getLogger(__name__)
 
+
+def _format_count(n: int) -> str:
+    """Format a count with k/M suffixes for compact display."""
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}k"
+    return str(n)
+
+
 #: Default DuckDB path for Derive funding rate history
 DEFAULT_FUNDING_RATE_DB_PATH = Path("~/.tradingstrategy/derive/funding-rates.duckdb").expanduser()
 
-#: Maximum API window in days (API constraint)
-MAX_API_WINDOW_DAYS = 30
+#: Size of each API fetch chunk in days.
+#:
+#: The Derive API returns empty results for windows >= 30 days,
+#: so we use 28-day chunks as the maximum safe window.
+CHUNK_DAYS = 28
+
+#: Maximum lookback for inception-date binary search (days).
+#:
+#: We probe up to this many days into the past to find the
+#: first day an instrument had funding rate data.
+MAX_INCEPTION_PROBE_DAYS = 1100
 
 #: Data type name for sync state tracking
 DATA_TYPE_FUNDING_RATES = "funding_rates"
@@ -71,8 +90,9 @@ class DeriveFundingRateDatabase:
     Stores hourly funding rate snapshots for perpetual instruments
     at the native resolution provided by Derive (one entry per hour).
 
-    Supports incremental sync that accumulates data beyond the
-    30-day API window limit by running regularly.
+    On first sync, fetches the full available history back to
+    ``DEFAULT_LOOKBACK_DAYS`` using 1-day API chunks.  On subsequent
+    syncs, fetches only new data since the last stored timestamp.
 
     The database is crash-resumeable: interrupted syncs can be safely
     re-run without data loss or duplicates.
@@ -136,6 +156,96 @@ class DeriveFundingRateDatabase:
                 )
             """)
 
+    def find_inception_date(
+        self,
+        session: Session,
+        instrument_name: str,
+        base_url: str = DERIVE_MAINNET_API_URL,
+        timeout: float = 30.0,
+    ) -> datetime.datetime | None:
+        """Find the earliest available funding rate data for an instrument.
+
+        Uses binary search over day-sized probes to locate the first
+        day with data.  Typically requires ~10 API calls.
+
+        :param session:
+            HTTP session.
+        :param instrument_name:
+            Perpetual instrument name.
+        :param base_url:
+            Derive API base URL.
+        :param timeout:
+            HTTP request timeout.
+        :return:
+            Start of the earliest day with data (naive UTC),
+            or ``None`` if no data exists at all.
+        """
+        now = native_datetime_utc_now()
+        one_day = datetime.timedelta(days=1)
+
+        # Quick check: does any recent data exist?
+        recent = fetch_funding_rate_history(
+            session,
+            instrument_name,
+            start_time=now - datetime.timedelta(days=7),
+            end_time=now,
+            base_url=base_url,
+            timeout=timeout,
+        )
+        if not recent:
+            return None
+
+        # lo = days ago where data EXISTS (closer to now)
+        # hi = days ago where data does NOT exist (further back)
+        lo = 7
+        hi = MAX_INCEPTION_PROBE_DAYS
+
+        # Check if data exists at the maximum lookback
+        probe_start = now - datetime.timedelta(days=hi)
+        probe = fetch_funding_rate_history(
+            session,
+            instrument_name,
+            start_time=probe_start,
+            end_time=probe_start + one_day,
+            base_url=base_url,
+            timeout=timeout,
+        )
+        if probe:
+            # Data goes back further than our max probe window
+            logger.info(
+                "Instrument %s has data at %d days ago, using that as inception",
+                instrument_name,
+                hi,
+            )
+            return probe_start
+
+        # Binary search for the boundary
+        while hi - lo > 1:
+            mid = (lo + hi) // 2
+            probe_start = now - datetime.timedelta(days=mid)
+            probe = fetch_funding_rate_history(
+                session,
+                instrument_name,
+                start_time=probe_start,
+                end_time=probe_start + one_day,
+                base_url=base_url,
+                timeout=timeout,
+            )
+            if probe:
+                lo = mid
+            else:
+                hi = mid
+
+        inception = now - datetime.timedelta(days=lo)
+        inception = inception.replace(hour=0, minute=0, second=0, microsecond=0)
+        logger.info(
+            "Found inception date for %s: %s (%d days ago)",
+            instrument_name,
+            inception.strftime("%Y-%m-%d"),
+            lo,
+        )
+        return inception
+
     def sync_instrument(
         self,
         session: Session,
@@ -144,17 +254,18 @@ class DeriveFundingRateDatabase:
         end_time: datetime.datetime | None = None,
         base_url: str = DERIVE_MAINNET_API_URL,
         timeout: float = 30.0,
+        progress: tqdm | None = None,
     ) -> int:
-        """Fetch new funding rate data and store it.
+        """Fetch funding rate data and store it.
 
-        On the first run, fetches the maximum available history
-        (30 days). On subsequent runs, resumes from the last
-        stored timestamp.
+        Walks the time range in :py:data:`CHUNK_DAYS`-sized windows
+        (1 day by default) to fetch the full available history from
+        the Derive API.
 
-        The API limits ``start_time`` to at most 30 days ago.
-        If the last sync is older than 30 days, data in the gap
-        between the last sync and 30 days ago is lost — run this
-        at least once every 30 days to avoid gaps.
+        On the first run, uses :py:meth:`find_inception_date` to
+        discover how far back data is available, then fetches from
+        inception to now.  On subsequent runs, resumes forward from
+        the last stored timestamp.
 
         :param session:
             HTTP session from :py:func:`~eth_defi.derive.session.create_derive_session`.
@@ -162,66 +273,80 @@ class DeriveFundingRateDatabase:
             Perpetual instrument name (e.g. ``"ETH-PERP"``).
         :param start_time:
             Override start time (naive UTC). Defaults to resume point
-            or 30 days ago.
+            or instrument inception date.
         :param end_time:
             Override end time (naive UTC). Defaults to now.
         :param base_url:
             Derive API base URL.
         :param timeout:
             HTTP request timeout.
+        :param progress:
+            Optional external :py:class:`tqdm` progress bar to update
+            per chunk.  When ``None``, no progress bar is shown (use
+            :py:meth:`sync_instruments` for progress tracking).
         :return:
             Number of new funding rate entries inserted.
         """
         now = native_datetime_utc_now()
-        max_lookback = now - datetime.timedelta(days=MAX_API_WINDOW_DAYS)
 
         # Determine effective start time
         if start_time is None:
             state = self._get_sync_state_row(instrument_name)
             if state is not None and state["newest_ts"] is not None:
                 # Resume from last known timestamp
-                resume_ts = datetime.datetime.fromtimestamp(state["newest_ts"] / 1000, tz=datetime.timezone.utc).replace(tzinfo=None)
-                start_time = max(resume_ts, max_lookback)
+                start_time = datetime.datetime.fromtimestamp(
+                    state["newest_ts"] / 1000,
+                    tz=datetime.timezone.utc,
+                ).replace(tzinfo=None)
             else:
-                start_time = max_lookback
+                # First run: discover inception date
+                inception = self.find_inception_date(
+                    session,
+                    instrument_name,
+                    base_url=base_url,
+                    timeout=timeout,
+                )
+                if inception is None:
+                    logger.info("No funding rate data available for %s", instrument_name)
+                    return 0
+                start_time = inception
 
         if end_time is None:
             end_time = now
 
-        # Clamp start_time to API limit
-        if start_time < max_lookback:
-            logger.warning(
-                "Clamping start_time from %s to %s (API 30-day limit)",
-                start_time,
-                max_lookback,
+        # Walk the window in day-sized chunks
+        total_inserted = 0
+        chunk_delta = datetime.timedelta(days=CHUNK_DAYS)
+        chunk_start = start_time
+
+        while chunk_start < end_time:
+            chunk_end = min(chunk_start + chunk_delta, end_time)
+
+            entries = fetch_funding_rate_history(
+                session,
+                instrument_name,
+                start_time=chunk_start,
+                end_time=chunk_end,
+                base_url=base_url,
+                timeout=timeout,
             )
-            start_time = max_lookback
 
-        # Fetch from API
-        entries = fetch_funding_rate_history(
-            session,
-            instrument_name,
-            start_time=start_time,
-            end_time=end_time,
-            base_url=base_url,
-            timeout=timeout,
-        )
+            if entries:
+                total_inserted += self._insert_batch(entries)
 
-        if not entries:
-            logger.info("No new funding rate data for %s", instrument_name)
-            return 0
+            chunk_start = chunk_end
+            if progress is not None:
+                progress.update(1)
 
-        # Insert into DuckDB
-        inserted = self._insert_batch(entries)
-        self._update_sync_state(instrument_name)
+        if total_inserted > 0:
+            self._update_sync_state(instrument_name)
 
         logger.info(
-            "Inserted %d new funding rate entries for %s (total fetched: %d)",
-            inserted,
+            "Inserted %d new funding rate entries for %s",
+            total_inserted,
             instrument_name,
-            len(entries),
         )
-        return inserted
+        return total_inserted
 
     def sync_instruments(
         self,
@@ -234,7 +359,12 @@ class DeriveFundingRateDatabase:
     ) -> dict[str, int]:
         """Sync funding rate history for multiple instruments.
 
-        Iterates over instruments with a progress bar.
+        Two-phase process:
+
+        1. **Probe** — determine the effective time range for each
+           instrument (inception date or resume point).
+        2. **Fetch** — walk all instruments day-by-day with a single
+           progress bar showing total days remaining.
 
         :param session:
             HTTP session.
@@ -251,20 +381,70 @@ class DeriveFundingRateDatabase:
         :return:
             Dict mapping instrument name to number of new entries inserted.
         """
+        now = native_datetime_utc_now()
+        if end_time is None:
+            end_time = now
+
+        tqdm_logging.set_level(logging.INFO)
+
+        # Phase 1: determine effective start for each instrument
+        ranges: dict[str, datetime.datetime] = {}
+        probe_bar = tqdm(instrument_names, desc="Probing inception dates", unit="instrument")
+        for name in probe_bar:
+            probe_bar.set_postfix(instrument=name)
+
+            if start_time is not None:
+                ranges[name] = start_time
+                continue
+
+            state = self._get_sync_state_row(name)
+            if state is not None and state["newest_ts"] is not None:
+                ranges[name] = datetime.datetime.fromtimestamp(
+                    state["newest_ts"] / 1000,
+                    tz=datetime.timezone.utc,
+                ).replace(tzinfo=None)
+            else:
+                inception = self.find_inception_date(
+                    session,
+                    name,
+                    base_url=base_url,
+                    timeout=timeout,
+                )
+                if inception is not None:
+                    ranges[name] = inception
+                else:
+                    logger.warning("No data available for %s, skipping", name)
+        probe_bar.close()
+
+        if not ranges:
+            return {}
+
+        # Phase 2: fetch with a chunk-level progress bar
+        total_chunks = sum(max((end_time - inst_start).days // CHUNK_DAYS + 1, 1) for inst_start in ranges.values())
+
         results = {}
-        tqdm_logging.set_level(logging.DEBUG)
-        progress = tqdm(instrument_names, desc="Syncing funding rates", unit="instrument")
-        for name in progress:
-            progress.set_postfix(instrument=name)
+        total_new = 0
+        fetch_bar = tqdm(total=total_chunks, desc="Fetching funding rates", unit="chunk")
+        for name, inst_start in ranges.items():
+            fetch_bar.set_postfix(
+                instrument=name,
+                range=f"{inst_start.strftime('%Y-%m-%d')}..{end_time.strftime('%Y-%m-%d')}",
+                rows=_format_count(total_new),
+            )
             inserted = self.sync_instrument(
                 session,
                 name,
-                start_time=start_time,
+                start_time=inst_start,
                 end_time=end_time,
                 base_url=base_url,
                 timeout=timeout,
+                progress=fetch_bar,
             )
             results[name] = inserted
+            total_new += inserted
+        fetch_bar.set_postfix(rows=_format_count(total_new))
+        fetch_bar.close()
+
         return results
 
     def get_funding_rates(

--- a/scripts/derive/scan-funding-rates.py
+++ b/scripts/derive/scan-funding-rates.py
@@ -4,14 +4,15 @@ Fetches hourly funding rate snapshots for all (or selected) Derive
 perpetual instruments and stores them in a local DuckDB database.
 
 The scan is resumeable — running it again fetches only new data
-since the last sync.
+since the last sync.  On first run it fetches the full available
+history (up to ~2 years back).
 
 Usage::
 
+    # Full sync (all available history, resumable)
     poetry run python scripts/derive/scan-funding-rates.py
 
-Quick test run (1 day, single instrument)::
-
+    # Quick test run (1 day, single instrument)
     LIMIT_DAYS=1 INSTRUMENTS=ETH-PERP poetry run python scripts/derive/scan-funding-rates.py
 
 Environment variables:
@@ -19,7 +20,7 @@ Environment variables:
 - ``LOG_LEVEL``: Logging level (debug, info, warning, error). Default: warning
 - ``DB_PATH``: DuckDB path. Default: ~/.tradingstrategy/derive/funding-rates.duckdb
 - ``INSTRUMENTS``: Comma-separated instrument names. Default: all active perps (auto-discovered)
-- ``LIMIT_DAYS``: Limit history to N days (for quick test runs). Default: 30
+- ``LIMIT_DAYS``: Limit history to N days (for quick test runs). Default: not set (full history / resume)
 """
 
 import datetime
@@ -42,7 +43,7 @@ def main():
     default_log_level = os.environ.get("LOG_LEVEL", "warning")
     db_path_str = os.environ.get("DB_PATH")
     instruments_str = os.environ.get("INSTRUMENTS", "").strip()
-    limit_days = int(os.environ.get("LIMIT_DAYS", "30"))
+    limit_days_str = os.environ.get("LIMIT_DAYS", "").strip()
 
     # Setup logging
     setup_console_logging(
@@ -65,13 +66,21 @@ def main():
         instruments = fetch_perpetual_instruments(session)
         logger.info("Discovered %d active perpetual instruments", len(instruments))
 
-    # Compute start time from LIMIT_DAYS
-    now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
-    start_time = now - datetime.timedelta(days=limit_days)
+    # When LIMIT_DAYS is set, use it as the start time.
+    # When not set, start_time=None lets sync_instrument auto-discover
+    # the inception date and fetch the full history.
+    if limit_days_str:
+        limit_days = int(limit_days_str)
+        now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        start_time = now - datetime.timedelta(days=limit_days)
+        mode_label = f"Window: {limit_days} days (from {start_time.strftime('%Y-%m-%d %H:%M')} UTC)"
+    else:
+        start_time = None
+        mode_label = "Window: full history (auto-detect inception, resumable)"
 
     print(f"Database: {db_path}")
     print(f"Instruments: {len(instruments)}")
-    print(f"Limit: {limit_days} days (from {start_time.strftime('%Y-%m-%d %H:%M')} UTC)")
+    print(mode_label)
     print()
 
     # Sync

--- a/tests/derive/test_funding_rate_history.py
+++ b/tests/derive/test_funding_rate_history.py
@@ -110,3 +110,34 @@ def test_funding_rate_db_dataframe(session, tmp_path):
         assert "instrument" in df.columns
     finally:
         db.close()
+
+
+@pytest.mark.timeout(60)
+def test_fetch_early_history(session):
+    """Verify that the API returns funding rates from well before the 30-day window.
+
+    The Derive API uses ``start_timestamp`` / ``end_timestamp`` params
+    (not ``start_time`` / ``end_time``) to query arbitrary historical
+    windows.  This test fetches one month of data from ~6 months ago
+    to confirm we can reach beyond the default 30-day window.
+
+    1. Pick a 30-day window starting 6 months ago (clean day boundaries).
+    2. Fetch funding rate history for ETH-PERP in that window.
+    3. Assert we get hourly data and timestamps fall within the window.
+    """
+    now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+
+    # 1. Pick a window 6 months ago, truncated to day boundaries
+    start = (now - datetime.timedelta(days=180 + 30)).replace(hour=0, minute=0, second=0, microsecond=0)
+    end = (now - datetime.timedelta(days=180)).replace(hour=0, minute=0, second=0, microsecond=0)
+
+    # 2. Fetch
+    rates = fetch_funding_rate_history(session, "ETH-PERP", start_time=start, end_time=end)
+
+    # 3. Assert we got data and it falls within the window
+    assert len(rates) >= 24 * 28, f"Expected at least 28 days of hourly data, got {len(rates)} entries"
+
+    for r in rates:
+        assert r.timestamp >= start, f"Entry {r.timestamp} is before start {start}"
+        assert r.timestamp <= end, f"Entry {r.timestamp} is after end {end}"
+        assert isinstance(r.funding_rate, Decimal)


### PR DESCRIPTION
## Summary

- **Fix API parameter names**: The Derive API uses `start_timestamp`/`end_timestamp` (not `start_time`/`end_time` as their docs suggest). Using the wrong names silently falls back to the last 30 days. With the correct names, full history back to instrument inception is available (ETH-PERP since 2024-01-05).
- **Auto-detect inception dates**: Binary search (~10 API calls per instrument) finds the earliest available data point. Skipped on subsequent runs when sync state already exists.
- **28-day chunked fetch**: The API returns empty results for windows >= 30 days. Uses 28-day chunks as the maximum safe window, reducing API calls ~28x compared to daily chunks.
- **Two-phase progress bar**: Phase 1 probes inception dates, phase 2 fetches data with a chunk-level progress bar showing instrument name, date range, and row count.
- **Full history in ~2–3 minutes**: Initial sync for all 12 instruments (~800 days each) completes in roughly 2–3 minutes at 2 req/sec. Subsequent runs only fetch new data (seconds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)