### PR TITLE
fix: clamp period_start_at to vault inception for young vaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Current
 
-- Add: Derive funding rate full history fetch — fix API parameter names (`start_timestamp`/`end_timestamp`), auto-detect instrument inception dates, 28-day chunked fetch with progress bar (2026-03-18)
+- Fix: Clamp `period_start_at` to vault inception when vault is younger than the requested period, preventing period start dates from appearing before the vault existed (2026-03-18)
+- Add: Derive funding rate full history fetch — fix API parameter names (`start_timestamp`/`end_timestamp`), auto-detect instrument inception dates, 28-day chunked fetch with progress bar (2026-03-18, [#868](https://github.com/tradingstrategy-ai/web3-ethereum-defi/pull/868))
 - Add: Derive funding rate history — public API wrapper, DuckDB storage with resumable sync, scan script for all perpetual instruments (2026-03-17, [#867](https://github.com/tradingstrategy-ai/web3-ethereum-defi/pull/867))
 - Fix: Harmonise stablecoin names — remove brackets, use issuer-first format for consistent frontend display (2026-03-17)
 - Add: Split stablecoin YAML `description` into `short_description` and `long_description` fields with markdown support; JSON export includes both plus backwards-compatible `description` key (2026-03-16)

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -817,9 +817,12 @@ def calculate_period_metrics(
     samples_start_at = share_price_hourly.index.asof(period_start_at)
 
     # Handle case where no sample exists at or before period_start_at
+    # (i.e. vault is younger than the requested period)
     if pd.isna(samples_start_at):
-        # Fall back to the first available sample
+        # Fall back to the first available sample and clamp period_start_at
+        # so it does not appear to precede the vault's actual inception
         samples_start_at = share_price_hourly.index[0]
+        period_start_at = samples_start_at
 
     period_samples_hourly = share_price_hourly.loc[samples_start_at:]
 


### PR DESCRIPTION
## Why

When a vault is younger than a requested lookback period (e.g. 3M, 6M, 1Y), `calculate_period_metrics()` fell back to the vault's first data point for `samples_start_at` but left `period_start_at` as `now - period_duration` — a date that predates the vault's existence. The website was displaying this stale `period_start_at`, showing period start dates before the vault was ever created.

Observed on the ember-polymarket vault (`0x0b9342c15143e8f54a83f887c280a922f4c48771`).

## What changed

In `eth_defi/research/vault_metrics.py`, when no share price sample exists at or before `period_start_at` (vault is younger than the requested period), `period_start_at` is now clamped to `samples_start_at` so the displayed period start never precedes the vault's actual inception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)