### PR TITLE
fix: register custom pairlist plugins in Freqtrade schema

### DIFF
--- a/eth_defi/gmx/freqtrade/patched_entrypoint.py
+++ b/eth_defi/gmx/freqtrade/patched_entrypoint.py
@@ -73,6 +73,13 @@ def apply_patch():
     patch_logging()  # Add sensitive data filtering to all log handlers
     _patch_status_table_profit_format()  # Show profit with 3 decimal places instead of 5 sig figs
 
+    # Register custom pairlist plugins so schema validation accepts them.
+    # Must happen before freqtrade.config_schema is imported.
+    from freqtrade.constants import AVAILABLE_PAIRLISTS
+    for name in ("HistoricalVolumePairList", "GMXLiquidityFilter"):
+        if name not in AVAILABLE_PAIRLISTS:
+            AVAILABLE_PAIRLISTS.append(name)
+
     # Verify the patch worked correctly
     print("Verifying GMX monkeypatch...", flush=True)
     import ccxt.async_support


### PR DESCRIPTION
## Summary

- Extends `AVAILABLE_PAIRLISTS` in `patched_entrypoint.py` to include `HistoricalVolumePairList` and `GMXLiquidityFilter`
- Freqtrade's config schema validator rejects unknown pairlist methods — this patch registers them before the schema is built
- Follows the same pattern as `_patch_status_table_profit_format()` — a runtime patch in `apply_patch()`

## Test plan

- [x] Verified in container: `AVAILABLE_PAIRLISTS` includes both custom names after patch
- [x] Verified schema enum accepts `HistoricalVolumePairList`
- [x] Vault bot starts and runs trading cycles with `HistoricalVolumePairList` in pairlist chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)