### PR TITLE
fix: broken assertion in decode_path and in-place list mutation in encode_path

### DIFF
--- a/eth_defi/one_delta/utils.py
+++ b/eth_defi/one_delta/utils.py
@@ -36,8 +36,8 @@ def encode_path(
         assert fee in DEFAULT_FEES
 
     if trade_type == TradeType.EXACT_OUTPUT:
-        path.reverse()
-        fees.reverse()
+        path = path[::-1]
+        fees = fees[::-1]
 
     match operation:
         case TradeOperation.OPEN:

--- a/eth_defi/uniswap_v3/utils.py
+++ b/eth_defi/uniswap_v3/utils.py
@@ -47,8 +47,8 @@ def encode_path(
     assert len(fees) == len(path) - 1
 
     if exact_output:
-        path.reverse()
-        fees.reverse()
+        path = path[::-1]
+        fees = fees[::-1]
 
     encoded = b""
     for index, token in enumerate(path):
@@ -69,7 +69,7 @@ def decode_path(full_path_encoded: bytes) -> list:
         Fully decoded path array including addresses and fees
     """
 
-    assert type(full_path_encoded == bytes), "encoded path must be provided as bytes"
+    assert isinstance(full_path_encoded, bytes), "encoded path must be provided as bytes"
 
     path_pos = 0
     full_path_decoded = []


### PR DESCRIPTION
## Summary

Found two bugs while reading through the Uniswap v3 and 1delta path encoding utilities:

### 1. `decode_path()` - assertion never validates input type

**File:** `eth_defi/uniswap_v3/utils.py`, line 72

```python
# Before (broken)
assert type(full_path_encoded == bytes), "encoded path must be provided as bytes"

# After (fixed)
assert isinstance(full_path_encoded, bytes), "encoded path must be provided as bytes"
```

`full_path_encoded == bytes` evaluates the `==` operator first, which compares the value against the `bytes` type object and returns `False`. Then `type(False)` returns `<class 'bool'>`, which is always truthy. So this assertion passes for any input type (str, int, None, etc.) and never catches invalid arguments.

### 2. `encode_path()` - in-place `list.reverse()` mutates caller's data

**Files:** `eth_defi/uniswap_v3/utils.py` lines 50-51, `eth_defi/one_delta/utils.py` lines 39-40

```python
# Before (mutates caller's lists)
path.reverse()
fees.reverse()

# After (creates reversed copies)
path = path[::-1]
fees = fees[::-1]
```

`list.reverse()` modifies the list in-place. If the caller reuses `path` or `fees` after calling `encode_path(..., exact_output=True)`, they silently contain reversed data, which can lead to incorrect swap routing through wrong pools/tokens.

## Test plan

- [x] Verify `decode_path` now correctly rejects non-bytes input
- [x] Verify `encode_path` no longer modifies caller's lists
- [ ] Existing test suite should pass with no changes