### PR TITLE
fix: enable Hypercore guard setup in anyAsset mode

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/lagoon/deployment.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/deployment.py
@@ -70,6 +70,24 @@ CONTRACTS_ROOT = Path(os.path.dirname(__file__)) / ".." / ".." / ".." / ".." / "
 
 DEFAULT_LAGOON_VAULT_ABI = "v0.5.0/Vault.sol"
 
+
+def should_enable_hypercore_guard(
+    *,
+    chain_id: int,
+    any_asset: bool,
+    hypercore_vaults: list[HexAddress | str] | None,
+) -> bool:
+    """Should Hypercore guard support be enabled for this deployment.
+
+    ``any_asset=True`` intentionally bypasses per-vault Hypercore address
+    checks, but Hypercore deposits and withdrawals still require CoreWriter
+    actions and CoreDepositWallet approval/target validation to be whitelisted.
+    """
+    from eth_defi.hyperliquid.core_writer import CORE_DEPOSIT_WALLET
+
+    return bool(hypercore_vaults) or (any_asset and chain_id in CORE_DEPOSIT_WALLET)
+
+
 # struct InitStruct {
 #     IERC20 underlying;
 #     string name;
@@ -1409,9 +1427,13 @@ def setup_guard(
     else:
         logger.info("Not whitelisted: CCTP")
 
-    # Whitelist Hypercore native vaults (HyperEVM only)
+    # Whitelist Hypercore native vault support (HyperEVM only).
     # Batch CoreWriter + all vault whitelisting into a single multicall transaction.
-    if hypercore_vaults:
+    if should_enable_hypercore_guard(
+        chain_id=web3.eth.chain_id,
+        any_asset=any_asset,
+        hypercore_vaults=hypercore_vaults,
+    ):
         from eth_defi.hyperliquid.core_writer import CORE_WRITER_ADDRESS
         from eth_defi.hyperliquid.guard_whitelist import get_core_deposit_wallet
 
@@ -1423,45 +1445,57 @@ def setup_guard(
             cdw_address,
         )
 
-        # The deposit multicall calls approve(USDC) as its first step,
-        # so the underlying token must be whitelisted for transfer/approve.
-        if vault is not None:
-            underlying_address = Web3.to_checksum_address(vault.functions.asset().call())
-        elif underlying_token_address is not None:
-            underlying_address = Web3.to_checksum_address(underlying_token_address)
-        else:
-            raise ValueError("hypercore_vaults requires either vault or underlying_token_address")
+        multicalls = []
 
-        multicalls = [
-            module.functions.whitelistToken(
-                underlying_address,
-                "Underlying token for Hypercore deposit approve",
-            ),
+        # The bridge flow starts with approve(USDC, CoreDepositWallet).
+        # In explicit-asset mode we must whitelist the underlying token.
+        # In anyAsset mode token-level call site checks are intentionally bypassed,
+        # so only CoreDepositWallet/CoreWriter permissions need to be installed.
+        if not any_asset:
+            if vault is not None:
+                underlying_address = Web3.to_checksum_address(vault.functions.asset().call())
+            elif underlying_token_address is not None:
+                underlying_address = Web3.to_checksum_address(underlying_token_address)
+            else:
+                raise ValueError("Hypercore guard setup without any_asset requires either vault or underlying_token_address")
+
+            multicalls.append(
+                module.functions.whitelistToken(
+                    underlying_address,
+                    "Underlying token for Hypercore deposit approve",
+                )
+            )
+
+        multicalls.append(
             module.functions.whitelistCoreWriter(
                 Web3.to_checksum_address(CORE_WRITER_ADDRESS),
                 Web3.to_checksum_address(cdw_address),
                 "Hypercore vault trading",
-            ),
-        ]
-
-        for idx, hv_address in enumerate(hypercore_vaults, start=1):
-            logger.info("Whitelisting Hypercore vault #%d: %s", idx, hv_address)
-            multicalls.append(
-                module.functions.whitelistHypercoreVault(
-                    Web3.to_checksum_address(hv_address),
-                    f"Hypercore vault: {hv_address}",
-                )
             )
+        )
+
+        if hypercore_vaults:
+            for idx, hv_address in enumerate(hypercore_vaults, start=1):
+                logger.info("Whitelisting Hypercore vault #%d: %s", idx, hv_address)
+                multicalls.append(
+                    module.functions.whitelistHypercoreVault(
+                        Web3.to_checksum_address(hv_address),
+                        f"Hypercore vault: {hv_address}",
+                    )
+                )
+        else:
+            logger.info("No explicit Hypercore vault list supplied; any_asset mode will allow any Hypercore vault address")
 
         call = module.functions.multicall(encode_multicalls(multicalls))
         tx_hash = _broadcast(call)
         assert_transaction_success_with_explanation(web3, tx_hash)
 
         entries.append(WhitelistEntry("Hypercore", "CoreWriter", CORE_WRITER_ADDRESS))
-        for hv_address in hypercore_vaults:
+        entries.append(WhitelistEntry("Hypercore", "CoreDepositWallet", cdw_address))
+        for hv_address in hypercore_vaults or []:
             entries.append(WhitelistEntry("Hypercore vault", str(hv_address), hv_address))
 
-        logger.info("Hypercore whitelisting complete: %d vault(s)", len(hypercore_vaults))
+        logger.info("Hypercore whitelisting complete: %d vault(s)", len(hypercore_vaults or []))
     else:
         logger.info("Not whitelisted: Hypercore")
 

--- a/eth_defi/hyperliquid/evm_escrow.py
+++ b/eth_defi/hyperliquid/evm_escrow.py
@@ -186,6 +186,22 @@ def is_account_activated(
     return exists
 
 
+def _assert_activation_guard_config(
+    lagoon_vault: "LagoonVault",
+    core_deposit_wallet_address: HexAddress | str,
+) -> None:
+    """Preflight-check Lagoon guard permissions required for Hypercore activation."""
+    module = lagoon_vault.trading_strategy_module
+    safe_address = Web3.to_checksum_address(lagoon_vault.safe_address)
+    core_deposit_wallet_address = Web3.to_checksum_address(core_deposit_wallet_address)
+
+    if not module.functions.isAllowedApprovalDestination(core_deposit_wallet_address).call():
+        raise RuntimeError(f"TradingStrategyModuleV0 {module.address} does not allow approving CoreDepositWallet {core_deposit_wallet_address}. Hypercore activation requires whitelistCoreWriter() to be configured on the guard. On HyperEVM deployments this should be enabled whenever Hypercore trading is intended, including anyAsset mode.")
+
+    if not module.functions.isAllowedReceiver(safe_address).call():
+        raise RuntimeError(f"TradingStrategyModuleV0 {module.address} does not allow Safe {safe_address} as a receiver. Hypercore activation via depositFor() requires the Safe to be whitelisted as an allowed receiver.")
+
+
 def activate_account(
     web3: Web3,
     lagoon_vault: LagoonVault,
@@ -217,8 +233,8 @@ def activate_account(
     .. warning::
 
         The Safe must hold sufficient EVM USDC for the activation amount.
-        The guard must have ``depositFor`` whitelisted via
-        ``whitelistCoreWriter()`` (included since guard v0.x).
+        The guard must whitelist the CoreDepositWallet approval destination
+        and ``depositFor`` target via ``whitelistCoreWriter()``.
 
     Example::
 
@@ -288,6 +304,7 @@ def activate_account(
     usdc_contract = get_deployed_contract(web3, "centre/ERC20.json", asset_address)
     cdw_address = CORE_DEPOSIT_WALLET[chain_id]
     core_deposit_wallet = get_core_deposit_wallet_contract(web3, cdw_address)
+    _assert_activation_guard_config(lagoon_vault, cdw_address)
 
     # Step 1: Approve USDC to CoreDepositWallet via trading strategy module
     approve_fn = lagoon_vault.transact_via_trading_strategy_module(

--- a/tests/hyperliquid/test_evm_escrow.py
+++ b/tests/hyperliquid/test_evm_escrow.py
@@ -1,0 +1,75 @@
+from types import SimpleNamespace
+
+import pytest
+
+from eth_defi.erc_4626.vault_protocol.lagoon.deployment import should_enable_hypercore_guard
+from eth_defi.hyperliquid.evm_escrow import _assert_activation_guard_config
+
+
+class _FakeCall:
+    def __init__(self, value: bool):
+        self.value = value
+
+    def call(self) -> bool:
+        return self.value
+
+
+class _FakeFunctions:
+    def __init__(self, *, approval_allowed: bool, receiver_allowed: bool):
+        self.approval_allowed = approval_allowed
+        self.receiver_allowed = receiver_allowed
+
+    def isAllowedApprovalDestination(self, _address):
+        return _FakeCall(self.approval_allowed)
+
+    def isAllowedReceiver(self, _address):
+        return _FakeCall(self.receiver_allowed)
+
+
+def _make_vault(*, approval_allowed: bool, receiver_allowed: bool):
+    module = SimpleNamespace(
+        address="0xdA1262A20Ed853Fa3BbA16e079Bbe2d1e0728d2f",
+        functions=_FakeFunctions(
+            approval_allowed=approval_allowed,
+            receiver_allowed=receiver_allowed,
+        ),
+    )
+    return SimpleNamespace(
+        safe_address="0x49Be988d2090aa221586e9A51cacBA3D3A1eA087",
+        trading_strategy_module=module,
+    )
+
+
+def test_should_enable_hypercore_guard_for_any_asset_on_hyperevm():
+    assert should_enable_hypercore_guard(
+        chain_id=999,
+        any_asset=True,
+        hypercore_vaults=None,
+    )
+
+
+def test_should_not_enable_hypercore_guard_off_hyperevm_without_vaults():
+    assert not should_enable_hypercore_guard(
+        chain_id=1,
+        any_asset=True,
+        hypercore_vaults=None,
+    )
+
+
+def test_activation_guard_check_rejects_missing_core_deposit_wallet_approval():
+    vault = _make_vault(approval_allowed=False, receiver_allowed=True)
+
+    with pytest.raises(RuntimeError, match="does not allow approving CoreDepositWallet"):
+        _assert_activation_guard_config(
+            vault,
+            "0x6B9E773128f453f5c2C60935Ee2DE2CBc5390A24",
+        )
+
+
+def test_activation_guard_check_accepts_whitelisted_hypercore_setup():
+    vault = _make_vault(approval_allowed=True, receiver_allowed=True)
+
+    _assert_activation_guard_config(
+        vault,
+        "0x6B9E773128f453f5c2C60935Ee2DE2CBc5390A24",
+    )


### PR DESCRIPTION
## Summary
- enable Hypercore guard plumbing on HyperEVM when `anyAsset=true`, even without an explicit Hypercore vault list
- keep explicit underlying token whitelisting only for non-`anyAsset` mode
- add a guard preflight for Hypercore activation so misconfigured deployments fail with a direct error

## Testing
- `.venv/bin/pytest -q deps/web3-ethereum-defi/tests/hyperliquid/test_evm_escrow.py`