### PR TITLE
Preserve Lagoon helper token cache

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/lagoon/testing.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/testing.py
@@ -13,6 +13,7 @@ from eth_defi.event_reader.conversion import convert_uint256_string_to_int, conv
 from eth_defi.event_reader.multicall_batcher import EncodedCall
 from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
 from eth_defi.hotwallet import HotWallet
+from eth_defi.token import TokenDiskCache
 from eth_defi.trace import assert_transaction_success_with_explanation
 
 logger = logging.getLogger(__name__)
@@ -27,6 +28,7 @@ def fund_lagoon_vault(
     amount=Decimal(500),
     nav=Decimal(0),
     hot_wallet: HotWallet | None = None,
+    token_cache: TokenDiskCache | None = None,
 ):
     """Deposit tokens into a Lagoon vault so the Safe holds funds.
 
@@ -102,6 +104,7 @@ def fund_lagoon_vault(
         features={ERC4626Feature.lagoon_like},
         default_block_identifier="latest",
         require_denomination_token=True,
+        token_cache=token_cache,
     )
     assert isinstance(vault, LagoonVault), f"Vault is not a Lagoon vault: {vault}"
 
@@ -159,6 +162,7 @@ def redeem_vault_shares(
     vault_address: HexAddress,
     redeemer: HexAddress,
     hot_wallet: HotWallet | None = None,
+    token_cache: TokenDiskCache | None = None,
 ) -> LagoonVault:
     """Request a full redemption of vault shares for a given depositor.
 
@@ -220,6 +224,7 @@ def redeem_vault_shares(
         features={ERC4626Feature.lagoon_like},
         default_block_identifier="latest",
         require_denomination_token=True,
+        token_cache=token_cache,
     )
     assert isinstance(vault, LagoonVault), f"Vault is not a Lagoon vault: {vault}"
 


### PR DESCRIPTION
## Why

Lagoon helper flows that recreate a vault instance inside `fund_lagoon_vault()` and `redeem_vault_shares()` were dropping the caller-provided token cache. This caused share-token metadata lookups to fall back to the default in-memory cache even when the CLI had already initialised a disk-backed token cache.

## Lessons learnt

Preparing a token cache at the command boundary is not enough if helper functions reconstruct cached objects internally. Any helper that creates a fresh vault instance needs an explicit `token_cache` parameter so downstream token lookups remain on the same cache object.

## Summary

- Added `token_cache` parameters to Lagoon testing helpers that recreate vault instances.
- Passed the cache through to `create_vault_instance()` in those helpers.
- Preserved the existing helper behaviour while keeping token metadata lookups on the caller's disk-backed cache.
