### PR TITLE
feat: JSON-RPC failover proxy for multi-provider Anvil forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,10 +123,10 @@ jobs:
           echo ""
           echo "=== Installed Packages (Web3-related) ==="
           poetry run python -c "
-          import pkg_resources
-          web3_packages = [pkg for pkg in pkg_resources.working_set if 'web3' in pkg.project_name.lower() or 'eth' in pkg.project_name.lower()]
-          for pkg in sorted(web3_packages, key=lambda x: x.project_name):
-              print(f'{pkg.project_name}: {pkg.version}')
+          from importlib.metadata import distributions
+          web3_packages = [d for d in distributions() if 'web3' in d.metadata['Name'].lower() or 'eth' in d.metadata['Name'].lower()]
+          for d in sorted(web3_packages, key=lambda x: x.metadata['Name']):
+              print(f'{d.metadata[\"Name\"]}: {d.metadata[\"Version\"]}')
           "
 
       # Setup Debug Session before tests - Enable this when you need to debug test issues

--- a/eth_defi/provider/rpc_proxy.py
+++ b/eth_defi/provider/rpc_proxy.py
@@ -47,6 +47,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from requests.exceptions import ConnectionError, Timeout
 
+from eth_defi.compat import native_datetime_utc_now
 from eth_defi.middleware import (
     DEFAULT_RETRYABLE_HTTP_STATUS_CODES,
     DEFAULT_RETRYABLE_RPC_ERROR_CODES,
@@ -325,7 +326,7 @@ class UpstreamRPCProviderStatistics:
 
     def record_failure(self, method: str, error_summary: str, http_status: int | None = None, max_error_replies: int = 100) -> None:
         """Record a failed request to this provider."""
-        now = datetime.datetime.utcnow()
+        now = native_datetime_utc_now()
         with self._lock:
             self.failure_count += 1
             self.last_failure = now

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,11 @@ asyncio_mode = "auto"
 filterwarnings = [
   "ignore::DeprecationWarning:pkg_resources.*:",
   "ignore::DeprecationWarning:eth_tester.*:",
+  # asyncio.iscoroutinefunction deprecated in Python 3.14, fixed in pytest-asyncio >=0.25
+  # but that requires pytest >=8.2 (we are on pytest 7.x)
+  "ignore:'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning:pytest_asyncio.*:",
+  "ignore:'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning:eth_retry.*:",
+  "ignore:'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning:cached_property.*:",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Why

Anvil accepts only a single `--fork-url` and has no internal retry or failover logic. When the upstream RPC is slow or rate-limited, Anvil hangs indefinitely. We need a lightweight proxy that sits between Anvil and multiple upstream RPCs, providing automatic failover, retry, and per-provider statistics.

## Lessons learnt

- `datetime.datetime.utcnow()` is deprecated in Python 3.14 — use `native_datetime_utc_now()` from `eth_defi.compat`
- pytest-asyncio >=0.25 fixes the `asyncio.iscoroutinefunction` deprecation but requires pytest >=8.2 — suppress warnings until the pytest major version bump is feasible
- `pkg_resources` is deprecated — use `importlib.metadata.distributions()` instead
- Token cache in EthereumTester-based tests can get poisoned by deterministic addresses across tests — pass `token_cache=None` to disable caching

## Summary

- Add `eth_defi.provider.rpc_proxy` module — a threaded HTTP proxy presenting a single JSON-RPC endpoint backed by multiple upstream providers with automatic failover, retry, configurable failure detection, and per-provider statistics
- Add `AnvilLaunch` integration: `fork_network_anvil()` now accepts `fork_url` as a space-separated list of RPC URLs and automatically starts the proxy
- Fix CI deprecation warnings: replace `datetime.utcnow()` with `native_datetime_utc_now()`, replace `pkg_resources` with `importlib.metadata` in CI workflow
- Suppress ~3.2M `asyncio.iscoroutinefunction` deprecation warnings from third-party packages (pytest-asyncio, eth-retry, cached-property)
- Fix token cache poisoning in Uniswap v2 analysis tests
- Mark flaky tests on Python 3.14

🤖 Generated with [Claude Code](https://claude.com/claude-code)