### PR TITLE
chore: remove external multicall package dependency

### DIFF
--- a/eth_defi/vault/valuation.py
+++ b/eth_defi/vault/valuation.py
@@ -19,12 +19,11 @@ from typing import Iterable, Any, TypeAlias, Hashable
 import pandas as pd
 from eth_typing import HexAddress, BlockIdentifier
 from matplotlib._api import classproperty
-from multicall import Call, Multicall
 from web3 import Web3
 from web3.contract import Contract
 
 from eth_defi.abi import decode_function_output
-from eth_defi.event_reader.multicall_batcher import get_multicall_contract, call_multicall_batched_single_thread, MulticallWrapper, call_multicall_debug_single_thread
+from eth_defi.event_reader.multicall_batcher import get_multicall_contract, call_multicall_batched_single_thread, MulticallWrapper
 from eth_defi.provider.anvil import is_mainnet_fork
 from eth_defi.provider.broken_provider import get_almost_latest_block_number
 from eth_defi.token import TokenDetails, fetch_erc20_details, TokenAddress
@@ -141,10 +140,6 @@ class Route:
         return None
 
     @property
-    def function_signature_string(self) -> str:
-        return self.signature[0]
-
-    @property
     def token(self) -> TokenDetails:
         return self.source_token
 
@@ -163,12 +158,7 @@ class Route:
 
 @dataclass(slots=True, frozen=True)
 class ValuationMulticallWrapper(MulticallWrapper):
-    """Wrap the undertlying Multicall with diagnostics data.
-
-    - Because the underlying Multicall lib is not powerful enough.
-
-    - And we do not have time to fix it
-    """
+    """Wrap a valuation quoter call with diagnostics data for multicall batching."""
 
     quoter: "ValuationQuoter"
     route: Route
@@ -182,11 +172,6 @@ class ValuationMulticallWrapper(MulticallWrapper):
 
     def get_human_id(self) -> str:
         return str(self.get_key())
-
-    def create_multicall(self) -> Call:
-        """Create underlying call about."""
-        call = Call(self.contract_address, self.signature, [(self.route, self)])
-        return call
 
     def handle(self, success, raw_return_value: bytes) -> TokenAmount | None:
         if not success:
@@ -589,7 +574,6 @@ class NetAssetValueCalculator:
         multicall_gas_limit=10_000_000,
         debug=False,
         batch_size=15,
-        legacy_multicall=False,
     ):
         """Create a new NAV calculator.
 
@@ -639,7 +623,6 @@ class NetAssetValueCalculator:
         self.multicall_gas_limit = multicall_gas_limit
         self.debug = debug
         self.batch_size = batch_size
-        self.legacy_multicall = legacy_multicall
 
         if block_identifier is None:
             block_identifier = get_almost_latest_block_number(web3)
@@ -775,37 +758,17 @@ class NetAssetValueCalculator:
         self,
         calls: list[MulticallWrapper],
     ):
-        """Multicall mess untangling."""
-        if self.legacy_multicall:
-            # Old bantg path.
-            # Do not use.
-            # Only headche.
-            multicall = Multicall(
-                calls=[c.create_multicall() for c in calls],
-                block_id=self.block_identifier,
-                _w3=self.web3,
-                require_success=False,
-                gas_limit=self.multicall_gas_limit,
-            )
-            batched_result = multicall()
-            return batched_result
-        else:
-            multicall_contract = get_multicall_contract(
-                self.web3,
-                block_identifier=self.block_identifier,
-            )
-            # return call_multicall_debug_single_thread(
-            #     multicall_contract,
-            #     calls=calls,
-            #     block_identifier=self.block_identifier,
-            # )
-
-            return call_multicall_batched_single_thread(
-                multicall_contract,
-                calls=calls,
-                block_identifier=self.block_identifier,
-                batch_size=self.batch_size,
-            )
+        """Execute batched multicall using internal Multicall3 contract wrapper."""
+        multicall_contract = get_multicall_contract(
+            self.web3,
+            block_identifier=self.block_identifier,
+        )
+        return call_multicall_batched_single_thread(
+            multicall_contract,
+            calls=calls,
+            block_identifier=self.block_identifier,
+            batch_size=self.batch_size,
+        )
 
     def fetch_onchain_valuations(
         self,

--- a/poetry.lock
+++ b/poetry.lock
@@ -2148,21 +2148,6 @@ pydantic = ">=2.5.2,<3"
 typing_extensions = ">=4.8.0,<5"
 
 [[package]]
-name = "eth-retry"
-version = "0.3.7"
-description = "Provides a decorator that automatically catches known transient exceptions that are common in the Ethereum/EVM ecosystem and reattempts to evaluate your decorated function"
-optional = false
-python-versions = "<4,>=3.10"
-groups = ["main"]
-files = [
-    {file = "eth_retry-0.3.7-py3-none-any.whl", hash = "sha256:3155584bf6a178b95aa959d344dd077851295ceecba263b97a733cc9c1b1629c"},
-    {file = "eth_retry-0.3.7.tar.gz", hash = "sha256:0a0d7efbdd2f986e965e5bc8f6698d4efc001387b74d509b16216fc165d5aa5f"},
-]
-
-[package.dependencies]
-typing_extensions = ">=4.0.1"
-
-[[package]]
 name = "eth-rlp"
 version = "2.2.0"
 description = "eth-rlp: RLP definitions for common Ethereum objects in Python"
@@ -4938,23 +4923,6 @@ files = [
 [package.extras]
 toml = ["tomli ; python_version < \"3.11\"", "tomli_w"]
 yaml = ["pyyaml"]
-
-[[package]]
-name = "multicall"
-version = "0.12.3"
-description = "aggregate results from multiple ethereum contract calls"
-optional = false
-python-versions = "<4,>=3.8"
-groups = ["main"]
-files = [
-    {file = "multicall-0.12.3-py3-none-any.whl", hash = "sha256:573fa5411ca1c3ae618ec1150d840c30e622be60c36a34bad4ef49ce6d8dc29b"},
-    {file = "multicall-0.12.3.tar.gz", hash = "sha256:9bd0229639e39dbb29fc6e7ee4e1af30a5b3bb390110a3584cdd99a8f77d8385"},
-]
-
-[package.dependencies]
-cchecksum = ">=0.0.3,<1"
-eth_retry = ">=0.1.8"
-web3 = ">=5.27,<5.29.dev0 || >5.31.0,<5.31.1 || >5.31.1,<5.31.2 || >5.31.2"
 
 [[package]]
 name = "multidict"
@@ -9954,4 +9922,4 @@ test = ["pytest-xdist"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "087d25198c7ffd775d3bea9b669cb22ee588caeaed12b5d2ccaa353aeca9b562"
+content-hash = "c05ee2bdfde7cf971ae82634eea329be2b7635d224561e86fb48d6daa39a496c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ zope-dottedname = {version = "^6.0", optional = true}
 # Removed
 # Only soft dependency in tests, but RTD complains
 # terms-of-service = {path = "contracts/terms-of-service", develop = true}
-#multicall = "^0.12.3"
+# multicall removed - replaced by internal eth_defi.event_reader.multicall_batcher
 #safe-eth-py = "^7.5.1"
 base58 = "^2.1.1"
 joblib = "^1.4.2"
@@ -121,7 +121,6 @@ evm-trace = "^0.2.6"
 filelock = "^3.20.0"
 # Hyperliquid L1 action signing (phantom agent protocol) in eth_defi.hyperliquid.block
 msgpack = "^1.0"
-multicall = "^0.12.3"
 safe-eth-py = "^7.8.0"
 web3 = "^7.12.0"
 zstandard = "^0.25.0"


### PR DESCRIPTION
## Why

The external `multicall` package (bantg's library) was only used in one file (`eth_defi/vault/valuation.py`) in a legacy code path that defaulted to disabled and was marked "Old bantg path. Do not use. Only headche." The codebase already has a fully functional internal replacement in `eth_defi.event_reader.multicall_batcher` used everywhere else.

## Lessons learnt

- The internal `multicall_batcher.py` with `call_multicall_batched_single_thread` is the standard approach for all multicall operations
- Dead code paths with external dependencies should be cleaned up promptly

## Summary

- Removed `from multicall import Call, Multicall` import
- Removed `ValuationMulticallWrapper.create_multicall()` method (only used by legacy path)
- Removed dead `Route.function_signature_string` property
- Removed `legacy_multicall` parameter from `NetAssetValueCalculator.__init__`
- Removed legacy bantg multicall branch from `do_multicall()`
- Removed `multicall = "^0.12.3"` from `pyproject.toml`
- Updated `poetry.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)