### PR TITLE
test: skip slow vault metadata tests

### DIFF
--- a/tests/erc_4626/vault_protocol/test_infinifi.py
+++ b/tests/erc_4626/vault_protocol/test_infinifi.py
@@ -36,6 +36,7 @@ def web3(anvil_ethereum_fork):
 
 
 @flaky.flaky
+@pytest.mark.skip(reason="Too slow")
 def test_infinifi(
     web3: Web3,
     tmp_path: Path,

--- a/tests/erc_4626/vault_protocol/test_summer.py
+++ b/tests/erc_4626/vault_protocol/test_summer.py
@@ -37,6 +37,7 @@ def web3(anvil_arbitrum_fork):
     return web3
 
 
+@pytest.mark.skip(reason="Too slow")
 def test_summer(
     web3: Web3,
     tmp_path: Path,


### PR DESCRIPTION
Why

The infiniFi and Summer vault metadata tests are currently among the slowest tests in the suite, but they only provide narrow metadata coverage. Skipping them gives an immediate suite-speed win while we decide whether to replace them with lighter-weight RPC-based checks later.

Lessons learnt

Some read-only metadata tests are paying full mainnet-fork cost without exercising behaviour that really needs Anvil. When a test is expensive and low-signal, a temporary explicit skip can be a pragmatic stopgap until a cheaper version is introduced.

Summary

- mark `tests/erc_4626/vault_protocol/test_infinifi.py::test_infinifi` as skipped with reason `Too slow`
- mark `tests/erc_4626/vault_protocol/test_summer.py::test_summer` as skipped with reason `Too slow`