### PR TITLE
fix: broken assertion in decode_path and in-place list mutation in encode_path

### DIFF
--- a/eth_defi/one_delta/utils.py
+++ b/eth_defi/one_delta/utils.py
@@ -36,8 +36,8 @@ def encode_path(
         assert fee in DEFAULT_FEES
 
     if trade_type == TradeType.EXACT_OUTPUT:
-        path.reverse()
-        fees.reverse()
+        path = path[::-1]
+        fees = fees[::-1]
 
     match operation:
         case TradeOperation.OPEN:

--- a/eth_defi/uniswap_v3/utils.py
+++ b/eth_defi/uniswap_v3/utils.py
@@ -47,8 +47,8 @@ def encode_path(
     assert len(fees) == len(path) - 1
 
     if exact_output:
-        path.reverse()
-        fees.reverse()
+        path = path[::-1]
+        fees = fees[::-1]
 
     encoded = b""
     for index, token in enumerate(path):
@@ -69,7 +69,7 @@ def decode_path(full_path_encoded: bytes) -> list:
         Fully decoded path array including addresses and fees
     """
 
-    assert type(full_path_encoded == bytes), "encoded path must be provided as bytes"
+    assert isinstance(full_path_encoded, bytes), "encoded path must be provided as bytes"
 
     path_pos = 0
     full_path_decoded = []


### PR DESCRIPTION
## Why

Two bugs in Uniswap v3 / 1delta path encoding utilities:

1. **`decode_path()` assertion never validates input type** — `type(full_path_encoded == bytes)` evaluates `==` first (always `False`), then `type(False)` is `<class 'bool'>` which is truthy. The assertion passes for any input type.

2. **`encode_path()` mutates caller's lists** — `list.reverse()` modifies in-place. If the caller reuses `path` or `fees` after calling `encode_path(..., exact_output=True)`, they silently contain reversed data.

## Lessons learnt

- `assert type(x == SomeType)` is a common Python gotcha — always use `isinstance()`
- Prefer slice copies (`[::-1]`) over in-place `reverse()` when the caller may reuse the list

## Summary

- Fix `decode_path()` to use `isinstance(full_path_encoded, bytes)`
- Fix `encode_path()` in both `uniswap_v3/utils.py` and `one_delta/utils.py` to use `[::-1]` instead of `.reverse()`

Original PR #880 by @sueun-dev, rebased onto master.