### PR TITLE
feat: Expose Ember vault description as vault notes

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/ember/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/ember/vault.py
@@ -126,5 +126,16 @@ class EmberVault(ERC4626Vault):
                 return datetime.timedelta(days=days)
         return datetime.timedelta(days=4)
 
+    def get_notes(self) -> str | None:
+        """Get notes for this vault.
+
+        - Returns manual notes from the vault flags if set
+        - Otherwise falls back to the full description from Ember's offchain metadata
+        """
+        manual_notes = super().get_notes()
+        if manual_notes:
+            return manual_notes
+        return self.description
+
     def get_link(self, referral: str | None = None) -> str:
         return "https://ember.so/earn"


### PR DESCRIPTION
## Why

Ember vault descriptions from the Bluefin offchain API were captured in the metadata database but not exposed through `get_notes()`, so they didn't appear in vault reports.

## Lessons learnt

- Ember offchain metadata flows through `EmberVaultMetadata` → `EmberVault.description` → scan record `_description`
- The `get_notes()` method is a separate path used by the metrics pipeline — needs explicit override per protocol (as Lagoon already does)

## Summary

- Added `get_notes()` override to `EmberVault`, following the same pattern as `LagoonVault`
- Returns manual notes from vault flags if set, otherwise falls back to the description from Ember's Bluefin API

🤖 Generated with [Claude Code](https://claude.com/claude-code)