### PR TITLE
Add Hyperliquid open-state snapshots to trade history sync

### DIFF
--- a/eth_defi/hyperliquid/api.py
+++ b/eth_defi/hyperliquid/api.py
@@ -22,6 +22,7 @@ import logging
 import time
 from dataclasses import dataclass
 from decimal import Decimal
+from typing import Any
 
 import requests
 from eth_typing import HexAddress
@@ -210,6 +211,30 @@ class AssetPosition:
     #: Liquidation price (``None`` if no position)
     liquidation_price: Decimal | None
 
+    #: Position mode (e.g. ``"oneWay"``)
+    position_type: str | None = None
+
+    #: Leverage mode (e.g. ``"cross"``)
+    leverage_type: str | None = None
+
+    #: Configured leverage value
+    leverage_value: int | None = None
+
+    #: Maximum allowed leverage
+    max_leverage: int | None = None
+
+    #: Return on equity ratio
+    return_on_equity: Decimal | None = None
+
+    #: Cumulative funding across the full lifetime
+    cumulative_funding_all_time: Decimal | None = None
+
+    #: Cumulative funding since the position was opened
+    cumulative_funding_since_open: Decimal | None = None
+
+    #: Cumulative funding since the last position size change
+    cumulative_funding_since_change: Decimal | None = None
+
 
 @dataclass(slots=True)
 class PerpClearinghouseState:
@@ -280,6 +305,90 @@ class LeaderboardEntry:
 
     #: All-time trading volume in USD
     all_time_volume: Decimal
+
+
+def _post_info_json(
+    session: HyperliquidSession,
+    payload: dict[str, Any],
+    timeout: float,
+) -> Any:
+    """POST to the Hyperliquid ``/info`` endpoint and decode JSON."""
+    response = session.post_info(payload, timeout=timeout)
+    response.raise_for_status()
+    return response.json()
+
+
+def fetch_open_orders_raw(
+    session: HyperliquidSession,
+    user: HexAddress | str,
+    timeout: float = 10.0,
+) -> list[dict]:
+    """Fetch raw ``openOrders`` payload for a user."""
+    payload = {"type": "openOrders", "user": user}
+    data = _post_info_json(session, payload, timeout=timeout)
+    assert isinstance(data, list), f"Expected list response, got {type(data)}"
+    return data
+
+
+def fetch_frontend_open_orders_raw(
+    session: HyperliquidSession,
+    user: HexAddress | str,
+    timeout: float = 10.0,
+) -> list[dict]:
+    """Fetch raw ``frontendOpenOrders`` payload for a user."""
+    payload = {"type": "frontendOpenOrders", "user": user}
+    data = _post_info_json(session, payload, timeout=timeout)
+    assert isinstance(data, list), f"Expected list response, got {type(data)}"
+    return data
+
+
+def fetch_historical_orders_raw(
+    session: HyperliquidSession,
+    user: HexAddress | str,
+    timeout: float = 10.0,
+) -> list[dict]:
+    """Fetch raw ``historicalOrders`` payload for a user."""
+    payload = {"type": "historicalOrders", "user": user}
+    data = _post_info_json(session, payload, timeout=timeout)
+    assert isinstance(data, list), f"Expected list response, got {type(data)}"
+    return data
+
+
+def fetch_user_twap_slice_fills_raw(
+    session: HyperliquidSession,
+    user: HexAddress | str,
+    timeout: float = 10.0,
+) -> list[dict]:
+    """Fetch raw ``userTwapSliceFills`` payload for a user."""
+    payload = {"type": "userTwapSliceFills", "user": user}
+    data = _post_info_json(session, payload, timeout=timeout)
+    assert isinstance(data, list), f"Expected list response, got {type(data)}"
+    return data
+
+
+def fetch_active_asset_data_raw(
+    session: HyperliquidSession,
+    user: HexAddress | str,
+    coin: str,
+    timeout: float = 10.0,
+) -> dict:
+    """Fetch raw ``activeAssetData`` payload for a user and coin."""
+    payload = {"type": "activeAssetData", "user": user, "coin": coin}
+    data = _post_info_json(session, payload, timeout=timeout)
+    assert isinstance(data, dict), f"Expected dict response, got {type(data)}"
+    return data
+
+
+def fetch_perp_clearinghouse_state_raw(
+    session: HyperliquidSession,
+    user: HexAddress | str,
+    timeout: float = 10.0,
+) -> dict:
+    """Fetch raw ``clearinghouseState`` payload for a user."""
+    payload = {"type": "clearinghouseState", "user": user}
+    data = _post_info_json(session, payload, timeout=timeout)
+    assert isinstance(data, dict), f"Expected dict response, got {type(data)}"
+    return data
 
 
 def fetch_user_vault_equities(
@@ -703,19 +812,8 @@ def fetch_perp_clearinghouse_state(
     :return:
         Perpetual clearinghouse state with margin info and positions.
     """
-    url = f"{session.api_url}/info"
-    payload = {"type": "clearinghouseState", "user": user}
-
-    logger.debug("Fetching clearinghouseState for %s from %s", user, url)
-
-    response = session.post(
-        url,
-        json=payload,
-        headers={"Content-Type": "application/json"},
-        timeout=timeout,
-    )
-    response.raise_for_status()
-    data = response.json()
+    logger.debug("Fetching clearinghouseState for %s", user)
+    data = fetch_perp_clearinghouse_state_raw(session, user, timeout=timeout)
 
     ms = data["crossMarginSummary"]
     margin_summary = MarginSummary(
@@ -730,6 +828,10 @@ def fetch_perp_clearinghouse_state(
         pos = ap.get("position", ap)
         liq_px = pos.get("liquidationPx")
         entry_px = pos.get("entryPx")
+        leverage = pos.get("leverage", {})
+        cumulative_funding = pos.get("cumFunding", {})
+        max_leverage = pos.get("maxLeverage")
+        return_on_equity = pos.get("returnOnEquity")
         positions.append(
             AssetPosition(
                 coin=pos["coin"],
@@ -739,6 +841,14 @@ def fetch_perp_clearinghouse_state(
                 margin_used=Decimal(pos.get("marginUsed", "0")),
                 position_value=Decimal(pos.get("positionValue", "0")),
                 liquidation_price=Decimal(liq_px) if liq_px else None,
+                position_type=ap.get("type"),
+                leverage_type=leverage.get("type"),
+                leverage_value=int(leverage["value"]) if leverage.get("value") is not None else None,
+                max_leverage=int(max_leverage) if max_leverage is not None else None,
+                return_on_equity=Decimal(return_on_equity) if return_on_equity is not None else None,
+                cumulative_funding_all_time=Decimal(cumulative_funding["allTime"]) if cumulative_funding.get("allTime") is not None else None,
+                cumulative_funding_since_open=Decimal(cumulative_funding["sinceOpen"]) if cumulative_funding.get("sinceOpen") is not None else None,
+                cumulative_funding_since_change=Decimal(cumulative_funding["sinceChange"]) if cumulative_funding.get("sinceChange") is not None else None,
             )
         )
 

--- a/eth_defi/hyperliquid/trade_history_db.py
+++ b/eth_defi/hyperliquid/trade_history_db.py
@@ -42,6 +42,7 @@ Example::
 """
 
 import datetime
+import json
 import logging
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -55,9 +56,22 @@ from tqdm import tqdm as tqdm_std
 from tqdm_loggable.auto import tqdm
 
 from eth_defi.compat import native_datetime_utc_now
+from eth_defi.hyperliquid.api import (
+    fetch_active_asset_data_raw,
+    fetch_frontend_open_orders_raw,
+    fetch_historical_orders_raw,
+    fetch_open_orders_raw,
+    fetch_perp_clearinghouse_state_raw,
+    fetch_user_twap_slice_fills_raw,
+)
 from eth_defi.hyperliquid.position import Fill
 from eth_defi.hyperliquid.session import HyperliquidSession
-from eth_defi.hyperliquid.trade_history import FundingPayment
+from eth_defi.hyperliquid.trade_history import (
+    FundingPayment,
+    attach_funding_to_trades,
+    group_fills_into_trades,
+)
+from eth_defi.hyperliquid.position import reconstruct_position_history
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +105,50 @@ MAX_PER_REQUEST = 2000
 
 #: Maximum records per API request for funding
 MAX_FUNDING_PER_REQUEST = 500
+
+#: Snapshot run schema version
+SNAPSHOT_VERSION = 1
+
+#: Account-level raw snapshot sources
+SNAPSHOT_SOURCE_NAMES: tuple[str, ...] = (
+    "clearinghouseState",
+    "openOrders",
+    "frontendOpenOrders",
+    "historicalOrders",
+    "userTwapSliceFills",
+)
+
+
+def _json_dumps(data: object) -> str:
+    """Serialise raw payload data to compact JSON text."""
+    return json.dumps(data, separators=(",", ":"), ensure_ascii=True)
+
+
+def _decimal_or_none(value: object) -> Decimal | None:
+    """Convert a raw payload value to :py:class:`Decimal` when present."""
+    if value is None:
+        return None
+    return Decimal(str(value))
+
+
+def _float_or_none(value: object) -> float | None:
+    """Convert a raw payload value to float when present."""
+    if value is None:
+        return None
+    return float(value)
+
+
+def _int_or_none(value: object) -> int | None:
+    """Convert a raw payload value to int when present."""
+    if value is None:
+        return None
+    return int(value)
+
+
+def _normalise_order_entry(entry: dict) -> tuple[dict, str | None, int | None]:
+    """Extract an order payload plus optional status metadata."""
+    order = entry.get("order", entry)
+    return order, entry.get("status"), _int_or_none(entry.get("statusTimestamp"))
 
 
 def _format_count(n: int) -> str:
@@ -247,6 +305,120 @@ class HyperliquidTradeHistoryDatabase:
                 row_count INTEGER,
                 last_synced BIGINT NOT NULL,
                 PRIMARY KEY (address, data_type)
+            )
+        """)
+
+        self.con.execute("""
+            CREATE TABLE IF NOT EXISTS account_snapshot_runs (
+                address VARCHAR NOT NULL,
+                ts BIGINT NOT NULL,
+                label VARCHAR,
+                is_vault BOOLEAN NOT NULL,
+                dex VARCHAR NOT NULL DEFAULT '',
+                fills_row_count INTEGER NOT NULL,
+                funding_row_count INTEGER NOT NULL,
+                ledger_row_count INTEGER NOT NULL,
+                open_position_count INTEGER NOT NULL DEFAULT 0,
+                open_trade_count INTEGER NOT NULL DEFAULT 0,
+                open_order_count INTEGER NOT NULL DEFAULT 0,
+                historical_order_count INTEGER,
+                twap_slice_fill_count INTEGER,
+                snapshot_version INTEGER NOT NULL DEFAULT 1,
+                PRIMARY KEY (address, ts)
+            )
+        """)
+
+        self.con.execute("""
+            CREATE TABLE IF NOT EXISTS account_snapshot_sources (
+                address VARCHAR NOT NULL,
+                ts BIGINT NOT NULL,
+                source VARCHAR NOT NULL,
+                status VARCHAR NOT NULL,
+                item_count INTEGER,
+                payload_json VARCHAR,
+                error_message VARCHAR,
+                PRIMARY KEY (address, ts, source)
+            )
+        """)
+
+        self.con.execute("""
+            CREATE TABLE IF NOT EXISTS open_position_snapshots (
+                address VARCHAR NOT NULL,
+                ts BIGINT NOT NULL,
+                coin VARCHAR NOT NULL,
+                position_type VARCHAR,
+                size FLOAT NOT NULL,
+                entry_px FLOAT,
+                unrealised_pnl FLOAT NOT NULL,
+                margin_used FLOAT NOT NULL,
+                position_value FLOAT NOT NULL,
+                liquidation_px FLOAT,
+                leverage_type VARCHAR,
+                leverage_value INTEGER,
+                max_leverage INTEGER,
+                return_on_equity FLOAT,
+                cumulative_funding_all_time FLOAT,
+                cumulative_funding_since_open FLOAT,
+                cumulative_funding_since_change FLOAT,
+                mark_px FLOAT,
+                available_to_trade_long FLOAT,
+                available_to_trade_short FLOAT,
+                max_trade_sz_long FLOAT,
+                max_trade_sz_short FLOAT,
+                position_json VARCHAR NOT NULL,
+                active_asset_data_json VARCHAR,
+                PRIMARY KEY (address, ts, coin)
+            )
+        """)
+
+        self.con.execute("""
+            CREATE TABLE IF NOT EXISTS open_trade_snapshots (
+                address VARCHAR NOT NULL,
+                ts BIGINT NOT NULL,
+                trade_index INTEGER NOT NULL,
+                coin VARCHAR NOT NULL,
+                direction VARCHAR NOT NULL,
+                is_complete BOOLEAN NOT NULL,
+                opened_at BIGINT NOT NULL,
+                entry_price FLOAT,
+                current_size FLOAT NOT NULL,
+                max_size FLOAT NOT NULL,
+                realised_pnl FLOAT NOT NULL,
+                funding_pnl FLOAT NOT NULL,
+                total_fees FLOAT NOT NULL,
+                net_pnl FLOAT NOT NULL,
+                unrealised_pnl FLOAT,
+                fill_count INTEGER NOT NULL,
+                trade_json VARCHAR NOT NULL,
+                PRIMARY KEY (address, ts, trade_index)
+            )
+        """)
+
+        self.con.execute("""
+            CREATE TABLE IF NOT EXISTS open_order_snapshots (
+                address VARCHAR NOT NULL,
+                ts BIGINT NOT NULL,
+                order_index INTEGER NOT NULL,
+                source VARCHAR NOT NULL,
+                coin VARCHAR NOT NULL,
+                side VARCHAR,
+                limit_px FLOAT,
+                sz FLOAT,
+                orig_sz FLOAT,
+                oid BIGINT,
+                cloid VARCHAR,
+                order_ts BIGINT,
+                status VARCHAR,
+                status_timestamp BIGINT,
+                trigger_condition VARCHAR,
+                is_trigger BOOLEAN,
+                trigger_px FLOAT,
+                is_position_tpsl BOOLEAN,
+                reduce_only BOOLEAN,
+                order_type VARCHAR,
+                tif VARCHAR,
+                order_json VARCHAR NOT NULL,
+                PRIMARY KEY (address, ts, order_index)
             )
         """)
 
@@ -846,6 +1018,380 @@ class HyperliquidTradeHistoryDatabase:
         return after - before
 
     # ──────────────────────────────────────────────
+    # Snapshots
+    # ──────────────────────────────────────────────
+
+    def _delete_snapshot_rows(self, address: str, timestamp_ms: int) -> None:
+        """Delete any existing snapshot rows for one account + timestamp."""
+        with self._db_lock:
+            for table in (
+                "account_snapshot_runs",
+                "account_snapshot_sources",
+                "open_position_snapshots",
+                "open_trade_snapshots",
+                "open_order_snapshots",
+            ):
+                self.con.execute(
+                    f"DELETE FROM {table} WHERE address = ? AND ts = ?",
+                    [address, timestamp_ms],
+                )
+
+    def _insert_snapshot_run(self, row: tuple) -> None:
+        """Insert one snapshot run row."""
+        with self._db_lock:
+            self.con.execute(
+                """
+                INSERT INTO account_snapshot_runs (
+                    address, ts, label, is_vault, dex,
+                    fills_row_count, funding_row_count, ledger_row_count,
+                    open_position_count, open_trade_count, open_order_count,
+                    historical_order_count, twap_slice_fill_count, snapshot_version
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                row,
+            )
+
+    def _insert_snapshot_source(
+        self,
+        address: str,
+        timestamp_ms: int,
+        source: str,
+        *,
+        status: str,
+        item_count: int | None,
+        payload: object | None,
+        error_message: str | None = None,
+    ) -> None:
+        """Insert one raw source payload or source error."""
+        payload_json = _json_dumps(payload) if payload is not None else None
+        with self._db_lock:
+            self.con.execute(
+                """
+                INSERT INTO account_snapshot_sources (
+                    address, ts, source, status, item_count, payload_json, error_message
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                [address, timestamp_ms, source, status, item_count, payload_json, error_message],
+            )
+
+    def _insert_open_positions_batch(self, rows: list[tuple]) -> None:
+        """Insert materialised open position rows for a snapshot."""
+        if not rows:
+            return
+        with self._db_lock:
+            self.con.executemany(
+                """
+                INSERT INTO open_position_snapshots (
+                    address, ts, coin, position_type, size, entry_px,
+                    unrealised_pnl, margin_used, position_value, liquidation_px,
+                    leverage_type, leverage_value, max_leverage, return_on_equity,
+                    cumulative_funding_all_time, cumulative_funding_since_open,
+                    cumulative_funding_since_change, mark_px,
+                    available_to_trade_long, available_to_trade_short,
+                    max_trade_sz_long, max_trade_sz_short, position_json,
+                    active_asset_data_json
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                rows,
+            )
+
+    def _insert_open_orders_batch(self, rows: list[tuple]) -> None:
+        """Insert materialised open order rows for a snapshot."""
+        if not rows:
+            return
+        with self._db_lock:
+            self.con.executemany(
+                """
+                INSERT INTO open_order_snapshots (
+                    address, ts, order_index, source, coin, side, limit_px,
+                    sz, orig_sz, oid, cloid, order_ts, status,
+                    status_timestamp, trigger_condition, is_trigger, trigger_px,
+                    is_position_tpsl, reduce_only, order_type, tif, order_json
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                rows,
+            )
+
+    def _insert_open_trades_batch(self, rows: list[tuple]) -> None:
+        """Insert materialised derived open trade rows for a snapshot."""
+        if not rows:
+            return
+        with self._db_lock:
+            self.con.executemany(
+                """
+                INSERT INTO open_trade_snapshots (
+                    address, ts, trade_index, coin, direction, is_complete,
+                    opened_at, entry_price, current_size, max_size,
+                    realised_pnl, funding_pnl, total_fees, net_pnl,
+                    unrealised_pnl, fill_count, trade_json
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                rows,
+            )
+
+    def capture_account_snapshots(
+        self,
+        session: HyperliquidSession,
+        address: HexAddress,
+        *,
+        is_vault: bool,
+        label: str | None = None,
+        timeout: float = 30.0,
+        snapshot_time: datetime.datetime | None = None,
+    ) -> dict[str, int]:
+        """Capture open-state snapshots for a single account.
+
+        Stores raw payloads for each source and materialises row-level
+        open positions, open orders, and derived open trades.
+        """
+        addr = address.lower()
+        snapshot_time = snapshot_time or native_datetime_utc_now()
+        timestamp_ms = int(snapshot_time.timestamp() * 1000)
+
+        self._delete_snapshot_rows(addr, timestamp_ms)
+
+        fills = self.get_fills(addr)
+        funding = self.get_funding(addr)
+        ledger_count = self.get_ledger_count(addr)
+
+        clearinghouse_positions: dict[str, object] = {}
+        open_orders_payload: list[dict] | None = None
+        frontend_open_orders_payload: list[dict] | None = None
+        historical_orders_payload: list[dict] | None = None
+        twap_slice_fills_payload: list[dict] | None = None
+        open_positions_rows: list[tuple] = []
+        open_order_rows: list[tuple] = []
+
+        try:
+            raw_clearinghouse = fetch_perp_clearinghouse_state_raw(session, addr, timeout=timeout)
+            for asset_position in raw_clearinghouse.get("assetPositions", []):
+                pos = asset_position.get("position", asset_position)
+                leverage = pos.get("leverage", {})
+                cumulative_funding = pos.get("cumFunding", {})
+                coin = pos["coin"]
+                clearinghouse_positions[coin] = _decimal_or_none(pos.get("unrealizedPnl"))
+
+                active_asset_data = None
+                source_name = f"activeAssetData:{coin}"
+                try:
+                    active_asset_data = fetch_active_asset_data_raw(session, addr, coin, timeout=timeout)
+                    self._insert_snapshot_source(
+                        addr,
+                        timestamp_ms,
+                        source_name,
+                        status="ok",
+                        item_count=1,
+                        payload=active_asset_data,
+                    )
+                except Exception as exc:
+                    logger.warning("Failed to fetch %s for %s", source_name, addr, exc_info=True)
+                    self._insert_snapshot_source(
+                        addr,
+                        timestamp_ms,
+                        source_name,
+                        status="error",
+                        item_count=None,
+                        payload=None,
+                        error_message=str(exc),
+                    )
+
+                available_to_trade = active_asset_data.get("availableToTrade", []) if active_asset_data else []
+                max_trade_szs = active_asset_data.get("maxTradeSzs", []) if active_asset_data else []
+                open_positions_rows.append(
+                    (
+                        addr,
+                        timestamp_ms,
+                        coin,
+                        asset_position.get("type"),
+                        float(pos.get("szi", 0)),
+                        _float_or_none(pos.get("entryPx")),
+                        float(pos.get("unrealizedPnl", 0)),
+                        float(pos.get("marginUsed", 0)),
+                        float(pos.get("positionValue", 0)),
+                        _float_or_none(pos.get("liquidationPx")),
+                        leverage.get("type"),
+                        _int_or_none(leverage.get("value")),
+                        _int_or_none(pos.get("maxLeverage")),
+                        _float_or_none(pos.get("returnOnEquity")),
+                        _float_or_none(cumulative_funding.get("allTime")),
+                        _float_or_none(cumulative_funding.get("sinceOpen")),
+                        _float_or_none(cumulative_funding.get("sinceChange")),
+                        _float_or_none(active_asset_data.get("markPx")) if active_asset_data else None,
+                        _float_or_none(available_to_trade[0]) if len(available_to_trade) > 0 else None,
+                        _float_or_none(available_to_trade[1]) if len(available_to_trade) > 1 else None,
+                        _float_or_none(max_trade_szs[0]) if len(max_trade_szs) > 0 else None,
+                        _float_or_none(max_trade_szs[1]) if len(max_trade_szs) > 1 else None,
+                        _json_dumps(asset_position),
+                        _json_dumps(active_asset_data) if active_asset_data is not None else None,
+                    )
+                )
+
+            self._insert_snapshot_source(
+                addr,
+                timestamp_ms,
+                "clearinghouseState",
+                status="ok",
+                item_count=len(raw_clearinghouse["assetPositions"]),
+                payload=raw_clearinghouse,
+            )
+        except Exception as exc:
+            logger.warning("Failed to fetch clearinghouseState for %s", addr, exc_info=True)
+            self._insert_snapshot_source(
+                addr,
+                timestamp_ms,
+                "clearinghouseState",
+                status="error",
+                item_count=None,
+                payload=None,
+                error_message=str(exc),
+            )
+
+        for source_name, fetcher in (
+            ("openOrders", fetch_open_orders_raw),
+            ("frontendOpenOrders", fetch_frontend_open_orders_raw),
+            ("historicalOrders", fetch_historical_orders_raw),
+            ("userTwapSliceFills", fetch_user_twap_slice_fills_raw),
+        ):
+            try:
+                payload = fetcher(session, addr, timeout=timeout)
+                self._insert_snapshot_source(
+                    addr,
+                    timestamp_ms,
+                    source_name,
+                    status="ok",
+                    item_count=len(payload),
+                    payload=payload,
+                )
+                if source_name == "openOrders":
+                    open_orders_payload = payload
+                elif source_name == "frontendOpenOrders":
+                    frontend_open_orders_payload = payload
+                elif source_name == "historicalOrders":
+                    historical_orders_payload = payload
+                else:
+                    twap_slice_fills_payload = payload
+            except Exception as exc:
+                logger.warning("Failed to fetch %s for %s", source_name, addr, exc_info=True)
+                self._insert_snapshot_source(
+                    addr,
+                    timestamp_ms,
+                    source_name,
+                    status="error",
+                    item_count=None,
+                    payload=None,
+                    error_message=str(exc),
+                )
+
+        chosen_order_source = "frontendOpenOrders" if frontend_open_orders_payload is not None else "openOrders"
+        chosen_orders = frontend_open_orders_payload if frontend_open_orders_payload is not None else (open_orders_payload or [])
+        for index, entry in enumerate(chosen_orders):
+            order, status, status_timestamp = _normalise_order_entry(entry)
+            open_order_rows.append(
+                (
+                    addr,
+                    timestamp_ms,
+                    index,
+                    chosen_order_source,
+                    order["coin"],
+                    order.get("side"),
+                    _float_or_none(order.get("limitPx")),
+                    _float_or_none(order.get("sz")),
+                    _float_or_none(order.get("origSz")),
+                    _int_or_none(order.get("oid")),
+                    order.get("cloid"),
+                    _int_or_none(order.get("timestamp")),
+                    status,
+                    status_timestamp,
+                    order.get("triggerCondition"),
+                    order.get("isTrigger"),
+                    _float_or_none(order.get("triggerPx")),
+                    order.get("isPositionTpsl"),
+                    order.get("reduceOnly"),
+                    order.get("orderType"),
+                    order.get("tif"),
+                    _json_dumps(entry),
+                )
+            )
+
+        events = list(reconstruct_position_history(iter(fills))) if fills else []
+        closed_trades, open_trades = group_fills_into_trades(iter(events), fills=fills)
+        attach_funding_to_trades(closed_trades, open_trades, funding)
+
+        open_trade_rows = []
+        for index, trade in enumerate(open_trades):
+            live_position = clearinghouse_positions.get(trade.coin)
+            trade.unrealised_pnl = live_position
+            trade_payload = {
+                "coin": trade.coin,
+                "direction": trade.direction.value,
+                "is_complete": trade.is_complete,
+                "opened_at": int(trade.opened_at.timestamp() * 1000),
+                "entry_price": float(trade.entry_price),
+                "current_size": float(trade.current_size),
+                "max_size": float(trade.max_size),
+                "realised_pnl": float(trade.realised_pnl),
+                "funding_pnl": float(trade.funding_pnl),
+                "total_fees": float(trade.total_fees),
+                "net_pnl": float(trade.net_pnl),
+                "unrealised_pnl": _float_or_none(trade.unrealised_pnl),
+                "fill_count": trade.fill_count,
+            }
+            open_trade_rows.append(
+                (
+                    addr,
+                    timestamp_ms,
+                    index,
+                    trade.coin,
+                    trade.direction.value,
+                    trade.is_complete,
+                    int(trade.opened_at.timestamp() * 1000),
+                    float(trade.entry_price),
+                    float(trade.current_size),
+                    float(trade.max_size),
+                    float(trade.realised_pnl),
+                    float(trade.funding_pnl),
+                    float(trade.total_fees),
+                    float(trade.net_pnl),
+                    _float_or_none(trade.unrealised_pnl),
+                    trade.fill_count,
+                    _json_dumps(trade_payload),
+                )
+            )
+
+        self._insert_snapshot_run(
+            (
+                addr,
+                timestamp_ms,
+                label,
+                is_vault,
+                "",
+                len(fills),
+                len(funding),
+                ledger_count,
+                len(open_positions_rows),
+                len(open_trade_rows),
+                len(open_order_rows),
+                len(historical_orders_payload) if historical_orders_payload is not None else None,
+                len(twap_slice_fills_payload) if twap_slice_fills_payload is not None else None,
+                SNAPSHOT_VERSION,
+            )
+        )
+        self._insert_open_positions_batch(open_positions_rows)
+        self._insert_open_orders_batch(open_order_rows)
+        self._insert_open_trades_batch(open_trade_rows)
+
+        return {
+            "open_positions": len(open_positions_rows),
+            "open_trades": len(open_trade_rows),
+            "open_orders": len(open_order_rows),
+        }
+
+    # ──────────────────────────────────────────────
     # Sync: orchestrator
     # ──────────────────────────────────────────────
 
@@ -858,6 +1404,7 @@ class HyperliquidTradeHistoryDatabase:
         timeout: float = 30.0,
         progress: tqdm | None = None,
         label: str | None = None,
+        capture_snapshots: bool = True,
     ) -> dict[str, int]:
         """Sync all data types for a single account.
 
@@ -887,8 +1434,10 @@ class HyperliquidTradeHistoryDatabase:
             External tqdm bar to reuse across data types (None for auto).
         :param label:
             Short display name for progress bars (falls back to address prefix).
+        :param capture_snapshots:
+            Capture live open-state snapshots after syncing event history.
         :return:
-            Dict with counts: ``{"fills": N, "funding": N, "ledger": N}``.
+            Dict with counts for synced event history and snapshots.
         """
         addr = address.lower()
         short = label or addr[:10]
@@ -900,7 +1449,7 @@ class HyperliquidTradeHistoryDatabase:
         if progress is not None:
             progress.n = 0
             progress.last_print_n = 0
-            progress.total = 3
+            progress.total = 4 if capture_snapshots else 3
             progress.unit = "step"
             progress.set_postfix_str("")
             progress.set_description_str(_colour_desc("Fills", short))
@@ -931,7 +1480,32 @@ class HyperliquidTradeHistoryDatabase:
             progress.update(1)
             progress.set_postfix_str(_colour_postfix(fills=_format_count(fills_count), funding=_format_count(funding_count), ledger=_format_count(ledger_count)))
 
-        result = {"fills": fills_count, "funding": funding_count, "ledger": ledger_count}
+        snapshot_counts = {"open_positions": 0, "open_trades": 0, "open_orders": 0}
+        if capture_snapshots:
+            if progress is not None:
+                progress.set_description_str(_colour_desc("Snapshots", short))
+            snapshot_counts = self.capture_account_snapshots(
+                session,
+                addr,
+                is_vault=self.is_vault_address(addr),
+                label=label,
+                timeout=timeout,
+            )
+            self.save()
+            if progress is not None:
+                progress.update(1)
+                progress.set_postfix_str(
+                    _colour_postfix(
+                        fills=_format_count(fills_count),
+                        funding=_format_count(funding_count),
+                        ledger=_format_count(ledger_count),
+                        open_positions=_format_count(snapshot_counts["open_positions"]),
+                        open_trades=_format_count(snapshot_counts["open_trades"]),
+                        open_orders=_format_count(snapshot_counts["open_orders"]),
+                    )
+                )
+
+        result = {"fills": fills_count, "funding": funding_count, "ledger": ledger_count, **snapshot_counts}
         logger.info("Sync complete for %s: %s", addr, result)
         return result
 
@@ -941,6 +1515,7 @@ class HyperliquidTradeHistoryDatabase:
         max_workers: int = 1,
         timeout: float = 30.0,
         is_vault: bool | None = None,
+        capture_snapshots: bool = True,
     ) -> dict[str, dict[str, int]]:
         """Sync whitelisted accounts, optionally filtered by vault status.
 
@@ -979,15 +1554,26 @@ class HyperliquidTradeHistoryDatabase:
             return {}
 
         # Print existing database entry counts before syncing
-        existing = self.con.execute("SELECT (SELECT COUNT(*) FROM fills), (SELECT COUNT(*) FROM funding), (SELECT COUNT(*) FROM ledger)").fetchone()
+        existing = self.con.execute(
+            """
+            SELECT
+                (SELECT COUNT(*) FROM fills),
+                (SELECT COUNT(*) FROM funding),
+                (SELECT COUNT(*) FROM ledger),
+                (SELECT COUNT(*) FROM account_snapshot_runs)
+            """
+        ).fetchone()
         print(  # noqa: T201
-            f"Database: {_format_count(existing[0])} fills, {_format_count(existing[1])} funding, {_format_count(existing[2])} ledger entries for {len(accounts)} accounts"
+            f"Database: {_format_count(existing[0])} fills, {_format_count(existing[1])} funding, {_format_count(existing[2])} ledger entries, {_format_count(existing[3])} snapshot runs for {len(accounts)} accounts"
         )
 
         results = {}
         total_fills = 0
         total_funding = 0
         total_ledger = 0
+        total_open_positions = 0
+        total_open_trades = 0
+        total_open_orders = 0
 
         def _proxy_postfix(sessions: list[HyperliquidSession], **kwargs) -> str:
             """Build postfix string including proxy rotation stats if proxies are used."""
@@ -1002,6 +1588,9 @@ class HyperliquidTradeHistoryDatabase:
                 fills=_format_count(total_fills),
                 funding=_format_count(total_funding),
                 ledger=_format_count(total_ledger),
+                open_positions=_format_count(total_open_positions),
+                open_trades=_format_count(total_open_trades),
+                open_orders=_format_count(total_open_orders),
                 **extra,
             )
 
@@ -1019,15 +1608,18 @@ class HyperliquidTradeHistoryDatabase:
                 label = account.get("label", addr[:10])
                 overall.set_postfix_str(_totals_postfix(all_sessions, account=label))
                 try:
-                    result = self.sync_account(session, addr, timeout=timeout)
+                    result = self.sync_account(session, addr, timeout=timeout, capture_snapshots=capture_snapshots)
                     results[addr] = result
                     total_fills += result.get("fills", 0)
                     total_funding += result.get("funding", 0)
                     total_ledger += result.get("ledger", 0)
+                    total_open_positions += result.get("open_positions", 0)
+                    total_open_trades += result.get("open_trades", 0)
+                    total_open_orders += result.get("open_orders", 0)
                     overall.set_postfix_str(_totals_postfix(all_sessions, account=label))
                 except Exception:
                     logger.exception("Failed to sync account %s", addr)
-                    results[addr] = {"fills": 0, "funding": 0, "ledger": 0, "error": True}
+                    results[addr] = {"fills": 0, "funding": 0, "ledger": 0, "open_positions": 0, "open_trades": 0, "open_orders": 0, "error": True}
             return results
 
         # Threaded path with nested progress bars.
@@ -1074,11 +1666,11 @@ class HyperliquidTradeHistoryDatabase:
             with session_lock:
                 worker_session = session_pool.pop()
             try:
-                result = self.sync_account(worker_session, addr, timeout=timeout, progress=bar, label=short_label)
+                result = self.sync_account(worker_session, addr, timeout=timeout, progress=bar, label=short_label, capture_snapshots=capture_snapshots)
                 return addr, result
             except Exception:
                 logger.exception("Failed to sync account %s", addr)
-                return addr, {"fills": 0, "funding": 0, "ledger": 0, "error": True}
+                return addr, {"fills": 0, "funding": 0, "ledger": 0, "open_positions": 0, "open_trades": 0, "open_orders": 0, "error": True}
             finally:
                 bar.set_description_str(f"{_DIM}Worker idle{_RESET}")
                 bar.set_postfix_str("")
@@ -1098,6 +1690,9 @@ class HyperliquidTradeHistoryDatabase:
                         total_fills += result.get("fills", 0)
                         total_funding += result.get("funding", 0)
                         total_ledger += result.get("ledger", 0)
+                        total_open_positions += result.get("open_positions", 0)
+                        total_open_trades += result.get("open_trades", 0)
+                        total_open_orders += result.get("open_orders", 0)
                         overall.update(1)
                         overall.set_postfix_str(_totals_postfix(all_sessions, workers=str(n_bars)))
                 except KeyboardInterrupt:
@@ -1297,13 +1892,252 @@ class HyperliquidTradeHistoryDatabase:
         """Get total row counts across all accounts for each table.
 
         :return:
-            Dict with keys ``fills``, ``funding``, ``ledger`` and integer counts.
+            Dict with row counts for core event and snapshot tables.
         """
         with self._db_lock:
             fills = self.con.execute("SELECT COUNT(*) FROM fills").fetchone()[0]
             funding = self.con.execute("SELECT COUNT(*) FROM funding").fetchone()[0]
             ledger = self.con.execute("SELECT COUNT(*) FROM ledger").fetchone()[0]
-        return {"fills": fills, "funding": funding, "ledger": ledger}
+            snapshot_runs = self.con.execute("SELECT COUNT(*) FROM account_snapshot_runs").fetchone()[0]
+            snapshot_sources = self.con.execute("SELECT COUNT(*) FROM account_snapshot_sources").fetchone()[0]
+            open_positions = self.con.execute("SELECT COUNT(*) FROM open_position_snapshots").fetchone()[0]
+            open_trades = self.con.execute("SELECT COUNT(*) FROM open_trade_snapshots").fetchone()[0]
+            open_orders = self.con.execute("SELECT COUNT(*) FROM open_order_snapshots").fetchone()[0]
+        return {
+            "fills": fills,
+            "funding": funding,
+            "ledger": ledger,
+            "snapshot_runs": snapshot_runs,
+            "snapshot_sources": snapshot_sources,
+            "open_positions": open_positions,
+            "open_trades": open_trades,
+            "open_orders": open_orders,
+        }
+
+    def _get_latest_snapshot_timestamp(self, address: HexAddress) -> int | None:
+        """Get the latest snapshot timestamp for an account."""
+        with self._db_lock:
+            row = self.con.execute(
+                "SELECT MAX(ts) FROM account_snapshot_runs WHERE address = ?",
+                [address.lower()],
+            ).fetchone()
+        return row[0] if row and row[0] is not None else None
+
+    def get_snapshot_runs(self, address: HexAddress) -> list[dict]:
+        """Get all snapshot runs for an account."""
+        with self._db_lock:
+            rows = self.con.execute(
+                """
+                SELECT ts, label, is_vault, dex, fills_row_count, funding_row_count,
+                       ledger_row_count, open_position_count, open_trade_count,
+                       open_order_count, historical_order_count,
+                       twap_slice_fill_count, snapshot_version
+                FROM account_snapshot_runs
+                WHERE address = ?
+                ORDER BY ts ASC
+                """,
+                [address.lower()],
+            ).fetchall()
+        return [
+            {
+                "ts": r[0],
+                "label": r[1],
+                "is_vault": r[2],
+                "dex": r[3],
+                "fills_row_count": r[4],
+                "funding_row_count": r[5],
+                "ledger_row_count": r[6],
+                "open_position_count": r[7],
+                "open_trade_count": r[8],
+                "open_order_count": r[9],
+                "historical_order_count": r[10],
+                "twap_slice_fill_count": r[11],
+                "snapshot_version": r[12],
+            }
+            for r in rows
+        ]
+
+    def get_snapshot_source(
+        self,
+        address: HexAddress,
+        source: str,
+        timestamp_ms: int | None = None,
+    ) -> dict | None:
+        """Get one raw snapshot source payload."""
+        addr = address.lower()
+        timestamp_ms = timestamp_ms if timestamp_ms is not None else self._get_latest_snapshot_timestamp(addr)
+        if timestamp_ms is None:
+            return None
+
+        with self._db_lock:
+            row = self.con.execute(
+                """
+                SELECT status, item_count, payload_json, error_message
+                FROM account_snapshot_sources
+                WHERE address = ? AND ts = ? AND source = ?
+                """,
+                [addr, timestamp_ms, source],
+            ).fetchone()
+
+        if row is None:
+            return None
+        return {
+            "status": row[0],
+            "item_count": row[1],
+            "payload_json": row[2],
+            "error_message": row[3],
+        }
+
+    def get_open_position_snapshots(
+        self,
+        address: HexAddress,
+        timestamp_ms: int | None = None,
+    ) -> list[dict]:
+        """Get materialised open positions for a snapshot."""
+        addr = address.lower()
+        timestamp_ms = timestamp_ms if timestamp_ms is not None else self._get_latest_snapshot_timestamp(addr)
+        if timestamp_ms is None:
+            return []
+
+        with self._db_lock:
+            rows = self.con.execute(
+                """
+                SELECT coin, position_type, size, entry_px, unrealised_pnl,
+                       margin_used, position_value, liquidation_px, leverage_type,
+                       leverage_value, max_leverage, return_on_equity,
+                       cumulative_funding_all_time, cumulative_funding_since_open,
+                       cumulative_funding_since_change, mark_px,
+                       available_to_trade_long, available_to_trade_short,
+                       max_trade_sz_long, max_trade_sz_short,
+                       position_json, active_asset_data_json
+                FROM open_position_snapshots
+                WHERE address = ? AND ts = ?
+                ORDER BY coin ASC
+                """,
+                [addr, timestamp_ms],
+            ).fetchall()
+        return [
+            {
+                "coin": r[0],
+                "position_type": r[1],
+                "size": r[2],
+                "entry_px": r[3],
+                "unrealised_pnl": r[4],
+                "margin_used": r[5],
+                "position_value": r[6],
+                "liquidation_px": r[7],
+                "leverage_type": r[8],
+                "leverage_value": r[9],
+                "max_leverage": r[10],
+                "return_on_equity": r[11],
+                "cumulative_funding_all_time": r[12],
+                "cumulative_funding_since_open": r[13],
+                "cumulative_funding_since_change": r[14],
+                "mark_px": r[15],
+                "available_to_trade_long": r[16],
+                "available_to_trade_short": r[17],
+                "max_trade_sz_long": r[18],
+                "max_trade_sz_short": r[19],
+                "position_json": r[20],
+                "active_asset_data_json": r[21],
+            }
+            for r in rows
+        ]
+
+    def get_open_order_snapshots(
+        self,
+        address: HexAddress,
+        timestamp_ms: int | None = None,
+    ) -> list[dict]:
+        """Get materialised open orders for a snapshot."""
+        addr = address.lower()
+        timestamp_ms = timestamp_ms if timestamp_ms is not None else self._get_latest_snapshot_timestamp(addr)
+        if timestamp_ms is None:
+            return []
+
+        with self._db_lock:
+            rows = self.con.execute(
+                """
+                SELECT order_index, source, coin, side, limit_px, sz, orig_sz,
+                       oid, cloid, order_ts, status, status_timestamp,
+                       trigger_condition, is_trigger, trigger_px,
+                       is_position_tpsl, reduce_only, order_type, tif, order_json
+                FROM open_order_snapshots
+                WHERE address = ? AND ts = ?
+                ORDER BY order_index ASC
+                """,
+                [addr, timestamp_ms],
+            ).fetchall()
+        return [
+            {
+                "order_index": r[0],
+                "source": r[1],
+                "coin": r[2],
+                "side": r[3],
+                "limit_px": r[4],
+                "sz": r[5],
+                "orig_sz": r[6],
+                "oid": r[7],
+                "cloid": r[8],
+                "order_ts": r[9],
+                "status": r[10],
+                "status_timestamp": r[11],
+                "trigger_condition": r[12],
+                "is_trigger": r[13],
+                "trigger_px": r[14],
+                "is_position_tpsl": r[15],
+                "reduce_only": r[16],
+                "order_type": r[17],
+                "tif": r[18],
+                "order_json": r[19],
+            }
+            for r in rows
+        ]
+
+    def get_open_trade_snapshots(
+        self,
+        address: HexAddress,
+        timestamp_ms: int | None = None,
+    ) -> list[dict]:
+        """Get materialised derived open trades for a snapshot."""
+        addr = address.lower()
+        timestamp_ms = timestamp_ms if timestamp_ms is not None else self._get_latest_snapshot_timestamp(addr)
+        if timestamp_ms is None:
+            return []
+
+        with self._db_lock:
+            rows = self.con.execute(
+                """
+                SELECT trade_index, coin, direction, is_complete, opened_at,
+                       entry_price, current_size, max_size, realised_pnl,
+                       funding_pnl, total_fees, net_pnl, unrealised_pnl,
+                       fill_count, trade_json
+                FROM open_trade_snapshots
+                WHERE address = ? AND ts = ?
+                ORDER BY trade_index ASC
+                """,
+                [addr, timestamp_ms],
+            ).fetchall()
+        return [
+            {
+                "trade_index": r[0],
+                "coin": r[1],
+                "direction": r[2],
+                "is_complete": r[3],
+                "opened_at": r[4],
+                "entry_price": r[5],
+                "current_size": r[6],
+                "max_size": r[7],
+                "realised_pnl": r[8],
+                "funding_pnl": r[9],
+                "total_fees": r[10],
+                "net_pnl": r[11],
+                "unrealised_pnl": r[12],
+                "fill_count": r[13],
+                "trade_json": r[14],
+            }
+            for r in rows
+        ]
 
     # ──────────────────────────────────────────────
     # Sync state

--- a/scripts/hyperliquid/sync-trade-history.py
+++ b/scripts/hyperliquid/sync-trade-history.py
@@ -40,6 +40,7 @@ Environment variables:
 - ``PARQUET_PATH``: Path to cleaned vault prices Parquet (for MIN_VAULT_PEAK_TVL).
 - ``INTERACTIVE``: Set to ``false`` to skip confirmation prompts (for CI/cron). Default: true.
 - ``MAX_WORKERS``: Parallel threads (default: 1, DuckDB single-writer).
+- ``CAPTURE_SNAPSHOTS``: Capture open-state snapshots after each account sync. Default: true.
 - ``WEBSHARE_API_KEY``: Webshare proxy API token. When set, each worker gets
   its own proxy for API requests, with automatic rotation on failure.
 - ``SCAN``: Address source mode. Currently supports ``top_traders`` which uses
@@ -325,12 +326,14 @@ def main():
     min_peak_tvl_str = os.environ.get("MIN_VAULT_PEAK_TVL", "").strip()
     scan_mode = os.environ.get("SCAN", "").strip().lower()
     interactive = os.environ.get("INTERACTIVE", "true").strip().lower() != "false"
+    capture_snapshots = os.environ.get("CAPTURE_SNAPSHOTS", "true").strip().lower() != "false"
 
     max_workers = int(os.environ.get("MAX_WORKERS", "1"))
 
     print("Hyperliquid trade history sync")  # noqa: T201
     print(f"DuckDB path: {db_path}")  # noqa: T201
     print(f"Max workers: {max_workers}")  # noqa: T201
+    print(f"Capture snapshots: {capture_snapshots}")  # noqa: T201
 
     # Scan mode: use curated top traders set
     if scan_mode == "top_traders" and not addresses:
@@ -431,7 +434,7 @@ def main():
         interrupted = False
         results = {}
         try:
-            results = db.sync_all(session, max_workers=max_workers, is_vault=sync_vault_filter)
+            results = db.sync_all(session, max_workers=max_workers, is_vault=sync_vault_filter, capture_snapshots=capture_snapshots)
             db.save()
         except KeyboardInterrupt:
             interrupted = True
@@ -459,6 +462,9 @@ def main():
                         r.get("fills", 0),
                         r.get("funding", 0),
                         r.get("ledger", 0),
+                        r.get("open_positions", 0),
+                        r.get("open_trades", 0),
+                        r.get("open_orders", 0),
                         _human(state.get("fills", {}).get("row_count", 0)),
                         _human(state.get("funding", {}).get("row_count", 0)),
                         _human(state.get("ledger", {}).get("row_count", 0)),
@@ -470,14 +476,14 @@ def main():
                 "\n"
                 + tabulate(
                     rows,
-                    headers=["Label", "Address", "New fills", "New funding", "New ledger", "Total fills", "Total funding", "Total ledger", "Status"],
+                    headers=["Label", "Address", "New fills", "New funding", "New ledger", "Open positions", "Open trades", "Open orders", "Total fills", "Total funding", "Total ledger", "Status"],
                     tablefmt="simple",
                 )
             )
 
         # Always print grand totals (even on Ctrl+C)
         totals = db.get_total_row_counts()
-        print(f"\nDatabase totals: {_human(totals['fills'])} fills, {_human(totals['funding'])} funding, {_human(totals['ledger'])} ledger")
+        print(f"\nDatabase totals: {_human(totals['fills'])} fills, {_human(totals['funding'])} funding, {_human(totals['ledger'])} ledger, {_human(totals['snapshot_runs'])} snapshot runs, {_human(totals['open_positions'])} open positions, {_human(totals['open_trades'])} open trades, {_human(totals['open_orders'])} open orders")
         print(f"Database path: {db_path}")
 
         if interrupted:

--- a/tests/hyperliquid/test_snapshot_api.py
+++ b/tests/hyperliquid/test_snapshot_api.py
@@ -1,0 +1,154 @@
+"""Offline unit tests for Hyperliquid snapshot API readers."""
+
+from decimal import Decimal
+
+from eth_defi.hyperliquid.api import (
+    fetch_active_asset_data_raw,
+    fetch_frontend_open_orders_raw,
+    fetch_historical_orders_raw,
+    fetch_open_orders_raw,
+    fetch_perp_clearinghouse_state,
+    fetch_user_twap_slice_fills_raw,
+)
+
+
+class DummyResponse:
+    """Minimal response stub for API reader tests."""
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self) -> None:
+        """Pretend the response succeeded."""
+
+    def json(self):
+        """Return the mocked JSON payload."""
+        return self.payload
+
+
+class DummySession:
+    """Minimal session stub that records requests."""
+
+    def __init__(self, payload):
+        self.payload = payload
+        self.calls: list[tuple[dict, float]] = []
+
+    def post_info(self, payload: dict, timeout: float = 30.0) -> DummyResponse:
+        """Record the request and return the configured payload."""
+        self.calls.append((payload, timeout))
+        return DummyResponse(self.payload)
+
+
+def test_fetch_open_orders_raw_returns_payload_unchanged():
+    """openOrders raw reader passes through the JSON response unchanged."""
+    payload = [{"coin": "BTC", "side": "B"}]
+    session = DummySession(payload)
+
+    result = fetch_open_orders_raw(session, "0xabc", timeout=12.5)
+
+    assert result == payload
+    assert session.calls == [({"type": "openOrders", "user": "0xabc"}, 12.5)]
+
+
+def test_fetch_frontend_open_orders_raw_returns_payload_unchanged():
+    """frontendOpenOrders raw reader passes through the JSON response unchanged."""
+    payload = [{"order": {"coin": "ETH", "side": "A"}, "status": "open"}]
+    session = DummySession(payload)
+
+    result = fetch_frontend_open_orders_raw(session, "0xabc")
+
+    assert result == payload
+    assert session.calls == [({"type": "frontendOpenOrders", "user": "0xabc"}, 10.0)]
+
+
+def test_fetch_historical_orders_raw_returns_payload_unchanged():
+    """historicalOrders raw reader passes through the JSON response unchanged."""
+    payload = [{"order": {"coin": "SOL"}, "status": "filled"}]
+    session = DummySession(payload)
+
+    result = fetch_historical_orders_raw(session, "0xabc")
+
+    assert result == payload
+    assert session.calls == [({"type": "historicalOrders", "user": "0xabc"}, 10.0)]
+
+
+def test_fetch_user_twap_slice_fills_raw_returns_payload_unchanged():
+    """userTwapSliceFills raw reader passes through the JSON response unchanged."""
+    payload = [{"coin": "BTC", "px": "50000", "sz": "1"}]
+    session = DummySession(payload)
+
+    result = fetch_user_twap_slice_fills_raw(session, "0xabc")
+
+    assert result == payload
+    assert session.calls == [({"type": "userTwapSliceFills", "user": "0xabc"}, 10.0)]
+
+
+def test_fetch_active_asset_data_raw_returns_payload_unchanged():
+    """activeAssetData raw reader passes through the JSON response unchanged."""
+    payload = {
+        "user": "0xabc",
+        "coin": "BTC",
+        "leverage": {"type": "cross", "value": 20},
+        "maxTradeSzs": ["10", "20"],
+        "availableToTrade": ["1000", "2000"],
+        "markPx": "50000",
+    }
+    session = DummySession(payload)
+
+    result = fetch_active_asset_data_raw(session, "0xabc", "BTC", timeout=5.0)
+
+    assert result == payload
+    assert session.calls == [({"type": "activeAssetData", "user": "0xabc", "coin": "BTC"}, 5.0)]
+
+
+def test_fetch_perp_clearinghouse_state_parses_snapshot_fields():
+    """clearinghouseState parser keeps the richer position fields we rely on."""
+    payload = {
+        "crossMarginSummary": {
+            "accountValue": "1000",
+            "totalNtlPos": "250",
+            "totalRawUsd": "980",
+            "totalMarginUsed": "50",
+        },
+        "withdrawable": "950",
+        "assetPositions": [
+            {
+                "type": "oneWay",
+                "position": {
+                    "coin": "BTC",
+                    "szi": "1.25",
+                    "entryPx": "50000",
+                    "unrealizedPnl": "25",
+                    "marginUsed": "50",
+                    "positionValue": "62500",
+                    "liquidationPx": "42000",
+                    "returnOnEquity": "0.5",
+                    "maxLeverage": 40,
+                    "leverage": {"type": "cross", "value": 20},
+                    "cumFunding": {
+                        "allTime": "10.5",
+                        "sinceOpen": "3.25",
+                        "sinceChange": "-0.75",
+                    },
+                },
+            }
+        ],
+    }
+    session = DummySession(payload)
+
+    state = fetch_perp_clearinghouse_state(session, "0xabc")
+
+    assert state.margin_summary.account_value == Decimal("1000")
+    assert state.withdrawable == Decimal("950")
+    assert len(state.asset_positions) == 1
+
+    position = state.asset_positions[0]
+    assert position.coin == "BTC"
+    assert position.position_type == "oneWay"
+    assert position.leverage_type == "cross"
+    assert position.leverage_value == 20
+    assert position.max_leverage == 40
+    assert position.return_on_equity == Decimal("0.5")
+    assert position.cumulative_funding_all_time == Decimal("10.5")
+    assert position.cumulative_funding_since_open == Decimal("3.25")
+    assert position.cumulative_funding_since_change == Decimal("-0.75")

--- a/tests/hyperliquid/test_trade_history_integration.py
+++ b/tests/hyperliquid/test_trade_history_integration.py
@@ -237,6 +237,97 @@ def test_fetch_portfolio_first_activity(session):
     assert portfolio.first_activity_at is not None, "Expected first_activity_at from pnlHistory"
     assert portfolio.all_time_pnl is not None
     assert portfolio.all_time_volume is not None
-
     # HLP has been active since late 2023
     assert portfolio.first_activity_at < datetime.datetime(2024, 1, 1), f"HLP first activity {portfolio.first_activity_at} should be before 2024-01-01"
+
+
+@pytest.mark.timeout(120)
+def test_sync_account_writes_snapshot_rows(session, tmp_path):
+    """sync_account stores snapshot runs and raw source payloads."""
+    db = HyperliquidTradeHistoryDatabase(tmp_path / "trade-history.duckdb")
+    try:
+        db.add_account(VAULT_ADDRESS, label="Growi HF", is_vault=True)
+
+        result = db.sync_account(
+            session,
+            VAULT_ADDRESS,
+            start_time=TEST_START,
+            end_time=TEST_END,
+        )
+        db.save()
+
+        runs = db.get_snapshot_runs(VAULT_ADDRESS)
+        assert len(runs) == 1
+        run = runs[0]
+
+        assert run["open_position_count"] == result["open_positions"]
+        assert run["open_trade_count"] == result["open_trades"]
+        assert run["open_order_count"] == result["open_orders"]
+
+        for source_name in (
+            "clearinghouseState",
+            "openOrders",
+            "frontendOpenOrders",
+            "historicalOrders",
+            "userTwapSliceFills",
+        ):
+            source = db.get_snapshot_source(VAULT_ADDRESS, source_name)
+            assert source is not None, f"Missing snapshot source {source_name}"
+            assert source["status"] in {"ok", "error"}
+
+        if run["open_position_count"] > 0:
+            positions = db.get_open_position_snapshots(VAULT_ADDRESS)
+            assert len(positions) == run["open_position_count"]
+
+        if run["open_order_count"] > 0:
+            orders = db.get_open_order_snapshots(VAULT_ADDRESS)
+            assert len(orders) == run["open_order_count"]
+
+        if run["open_trade_count"] > 0:
+            trades = db.get_open_trade_snapshots(VAULT_ADDRESS)
+            assert len(trades) == run["open_trade_count"]
+    finally:
+        db.close()
+
+
+@pytest.mark.timeout(180)
+def test_sync_account_adds_second_snapshot_run_without_duplicating_event_rows(session, tmp_path):
+    """A second sync writes a new snapshot run while event-row counts stay stable."""
+    db = HyperliquidTradeHistoryDatabase(tmp_path / "trade-history.duckdb")
+    try:
+        db.add_account(VAULT_ADDRESS, label="Growi HF", is_vault=True)
+
+        first_result = db.sync_account(
+            session,
+            VAULT_ADDRESS,
+            start_time=TEST_START,
+            end_time=TEST_END,
+        )
+        db.save()
+        first_state = db.get_sync_state(VAULT_ADDRESS)
+        first_runs = db.get_snapshot_runs(VAULT_ADDRESS)
+
+        second_result = db.sync_account(
+            session,
+            VAULT_ADDRESS,
+            start_time=TEST_START,
+            end_time=TEST_END,
+        )
+        db.save()
+        second_state = db.get_sync_state(VAULT_ADDRESS)
+        second_runs = db.get_snapshot_runs(VAULT_ADDRESS)
+
+        assert first_result["fills"] > 0
+        assert second_result["fills"] == 0
+        assert second_result["funding"] == 0
+        assert second_result["ledger"] == 0
+
+        assert second_state["fills"]["row_count"] == first_state["fills"]["row_count"]
+        assert second_state["funding"]["row_count"] == first_state["funding"]["row_count"]
+        assert second_state["ledger"]["row_count"] == first_state["ledger"]["row_count"]
+
+        assert len(first_runs) == 1
+        assert len(second_runs) == 2
+        assert second_runs[-1]["ts"] >= first_runs[-1]["ts"]
+    finally:
+        db.close()

--- a/tests/hyperliquid/test_trade_history_integration.py
+++ b/tests/hyperliquid/test_trade_history_integration.py
@@ -7,10 +7,18 @@ Requires network access to the Hyperliquid API.
 """
 
 import datetime
+import json
 
 import pytest
+import requests
 
-from eth_defi.hyperliquid.api import fetch_portfolio
+from eth_defi.hyperliquid.api import (
+    LEADERBOARD_URL,
+    fetch_frontend_open_orders_raw,
+    fetch_open_orders_raw,
+    fetch_perp_clearinghouse_state_raw,
+    fetch_portfolio,
+)
 from eth_defi.hyperliquid.session import create_hyperliquid_session
 from eth_defi.hyperliquid.trade_history import (
     fetch_account_funding,
@@ -26,11 +34,55 @@ VAULT_ADDRESS = "0x1e37a337ed460039d1b15bd3bc489de789768d5e"
 TEST_START = datetime.datetime(2025, 12, 7)
 TEST_END = datetime.datetime(2025, 12, 14)
 
+#: Public top traders that currently have substantial live open state.
+#:
+#: These are used as preferred live candidates before falling back to
+#: the current public leaderboard rows.
+LIVE_OPEN_STATE_CANDIDATES = (
+    ("ABC", "0x162cc7c861ebd0c06b3d72319201150482518185"),
+    ("Leaderboard rank 8", "0xecb63caa47c7c4e77f60f1ce858cf28dc2b82b00"),
+    ("Leaderboard rank 5", "0xc926ddba8b7617dbc65712f20cf8e1b58b8598d3"),
+)
+
 
 @pytest.fixture(scope="module")
 def session():
     """Create a shared HTTP session for all tests in this module."""
     return create_hyperliquid_session()
+
+
+def _iter_live_snapshot_candidates() -> list[tuple[str | None, str]]:
+    """Return public trader addresses ordered by likelihood of live open state."""
+    candidates: list[tuple[str | None, str]] = list(LIVE_OPEN_STATE_CANDIDATES)
+    seen_addresses = {address.lower() for _, address in candidates}
+
+    response = requests.get(LEADERBOARD_URL, timeout=30)
+    response.raise_for_status()
+    leaderboard_rows = response.json()["leaderboardRows"]
+
+    for row in leaderboard_rows[:20]:
+        address = row["ethAddress"].lower()
+        if address in seen_addresses:
+            continue
+        candidates.append((row.get("displayName") or None, address))
+        seen_addresses.add(address)
+
+    return candidates
+
+
+def _select_live_snapshot_account(session) -> tuple[str | None, str, dict, list[dict], list[dict]]:
+    """Pick a public leaderboard trader with live positions or live orders."""
+    for display_name, address in _iter_live_snapshot_candidates():
+        clearinghouse_state = fetch_perp_clearinghouse_state_raw(session, address)
+        open_orders = fetch_open_orders_raw(session, address)
+        frontend_open_orders = fetch_frontend_open_orders_raw(session, address)
+
+        position_count = len(clearinghouse_state.get("assetPositions", []))
+        materialised_order_count = len(frontend_open_orders)
+        if position_count > 0 or materialised_order_count > 0:
+            return display_name, address, clearinghouse_state, open_orders, frontend_open_orders
+
+    pytest.skip("Could not find a public Hyperliquid leaderboard trader with live open state")
 
 
 @pytest.mark.timeout(60)
@@ -329,5 +381,68 @@ def test_sync_account_adds_second_snapshot_run_without_duplicating_event_rows(se
         assert len(first_runs) == 1
         assert len(second_runs) == 2
         assert second_runs[-1]["ts"] >= first_runs[-1]["ts"]
+    finally:
+        db.close()
+
+
+@pytest.mark.timeout(180)
+def test_capture_account_snapshots_materialises_live_open_state_for_public_trader(session, tmp_path):
+    """capture_account_snapshots stores live open positions and orders for a public trader."""
+    display_name, address, _, _, _ = _select_live_snapshot_account(session)
+
+    db = HyperliquidTradeHistoryDatabase(tmp_path / "live-open-state.duckdb")
+    try:
+        db.add_account(address, label=display_name or "Live trader", is_vault=False)
+
+        result = db.capture_account_snapshots(
+            session,
+            address,
+            is_vault=False,
+            label=display_name,
+        )
+        db.save()
+
+        runs = db.get_snapshot_runs(address)
+        assert len(runs) == 1
+
+        run = runs[0]
+        assert run["open_position_count"] > 0 or run["open_order_count"] > 0
+
+        clearinghouse_source = db.get_snapshot_source(address, "clearinghouseState")
+        assert clearinghouse_source is not None
+        assert clearinghouse_source["status"] == "ok"
+        stored_clearinghouse_state = json.loads(clearinghouse_source["payload_json"])
+        expected_position_count = len(stored_clearinghouse_state["assetPositions"])
+        assert clearinghouse_source["item_count"] == expected_position_count
+        assert run["open_position_count"] == expected_position_count
+        assert result["open_positions"] == expected_position_count
+
+        open_orders_source = db.get_snapshot_source(address, "openOrders")
+        assert open_orders_source is not None
+        assert open_orders_source["status"] == "ok"
+        stored_open_orders = json.loads(open_orders_source["payload_json"])
+        assert open_orders_source["item_count"] == len(stored_open_orders)
+
+        frontend_orders_source = db.get_snapshot_source(address, "frontendOpenOrders")
+        assert frontend_orders_source is not None
+        assert frontend_orders_source["status"] == "ok"
+        stored_frontend_open_orders = json.loads(frontend_orders_source["payload_json"])
+        expected_order_count = len(stored_frontend_open_orders)
+        assert frontend_orders_source["item_count"] == expected_order_count
+        assert run["open_order_count"] == expected_order_count
+        assert result["open_orders"] == expected_order_count
+
+        positions = db.get_open_position_snapshots(address)
+        assert len(positions) == expected_position_count
+        if positions:
+            expected_coins = {item.get("position", item)["coin"] for item in stored_clearinghouse_state["assetPositions"]}
+            stored_coins = {position["coin"] for position in positions}
+            assert stored_coins == expected_coins
+            assert all(position["active_asset_data_json"] is not None for position in positions)
+
+        orders = db.get_open_order_snapshots(address)
+        assert len(orders) == expected_order_count
+        if orders:
+            assert all(order["source"] == "frontendOpenOrders" for order in orders)
     finally:
         db.close()

--- a/tests/hyperliquid/test_trade_history_snapshots.py
+++ b/tests/hyperliquid/test_trade_history_snapshots.py
@@ -1,0 +1,307 @@
+"""Synthetic tests for Hyperliquid snapshot persistence."""
+
+import datetime
+import shutil
+from pathlib import Path
+
+from eth_defi.hyperliquid.trade_history_db import HyperliquidTradeHistoryDatabase
+
+
+FIXTURE_DB = Path(__file__).parent / "fixtures" / "trade-history-sample.duckdb"
+ADDRESS = "0x1e37a337ed460039d1b15bd3bc489de789768d5e"
+SNAPSHOT_TIME = datetime.datetime(2026, 3, 22, 12, 0, 0)
+
+
+class DummyResponse:
+    """Minimal response stub for snapshot tests."""
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self) -> None:
+        """Pretend the response succeeded."""
+
+    def json(self):
+        """Return the mocked JSON payload."""
+        return self.payload
+
+
+class DummySession:
+    """Session stub keyed by Hyperliquid ``type`` payloads."""
+
+    def __init__(self, payloads: dict[str, object], failures: dict[str, Exception] | None = None):
+        self.payloads = payloads
+        self.failures = failures or {}
+        self.calls: list[dict] = []
+
+    def post_info(self, payload: dict, timeout: float = 30.0) -> DummyResponse:
+        """Return the configured payload for the requested type."""
+        self.calls.append(payload)
+        request_type = payload["type"]
+        if request_type == "activeAssetData":
+            request_type = f"activeAssetData:{payload['coin']}"
+
+        failure = self.failures.get(request_type)
+        if failure is not None:
+            raise failure
+
+        return DummyResponse(self.payloads[request_type])
+
+
+def _seed_open_btc_trade(db: HyperliquidTradeHistoryDatabase, address: str) -> None:
+    """Insert minimal local trade history for one open BTC trade."""
+    db._insert_fills_batch(  # noqa: SLF001
+        address,
+        [
+            (
+                address,
+                1,
+                int(datetime.datetime(2026, 3, 20, 10, 0, 0).timestamp() * 1000),
+                "BTC",
+                0,
+                1.0,
+                50000.0,
+                0.0,
+                0.0,
+                1.5,
+                111,
+            )
+        ],
+    )
+    db._insert_funding_batch(  # noqa: SLF001
+        address,
+        [
+            (
+                address,
+                int(datetime.datetime(2026, 3, 21, 10, 0, 0).timestamp() * 1000),
+                "BTC",
+                -2.0,
+                1.0,
+                0.0001,
+            )
+        ],
+    )
+
+
+def _make_payloads() -> dict[str, object]:
+    """Build deterministic snapshot payloads for tests."""
+    return {
+        "clearinghouseState": {
+            "crossMarginSummary": {
+                "accountValue": "1000",
+                "totalNtlPos": "100",
+                "totalRawUsd": "990",
+                "totalMarginUsed": "50",
+            },
+            "withdrawable": "940",
+            "assetPositions": [
+                {
+                    "type": "oneWay",
+                    "position": {
+                        "coin": "BTC",
+                        "szi": "1",
+                        "entryPx": "50000",
+                        "unrealizedPnl": "25",
+                        "marginUsed": "50",
+                        "positionValue": "50025",
+                        "liquidationPx": "42000",
+                        "returnOnEquity": "0.5",
+                        "maxLeverage": 20,
+                        "leverage": {"type": "cross", "value": 10},
+                        "cumFunding": {
+                            "allTime": "12",
+                            "sinceOpen": "5",
+                            "sinceChange": "-1",
+                        },
+                    },
+                }
+            ],
+        },
+        "activeAssetData:BTC": {
+            "user": ADDRESS,
+            "coin": "BTC",
+            "leverage": {"type": "cross", "value": 10},
+            "maxTradeSzs": ["10", "20"],
+            "availableToTrade": ["1000", "900"],
+            "markPx": "50025",
+        },
+        "openOrders": [
+            {
+                "coin": "BTC",
+                "side": "B",
+                "limitPx": "50010",
+                "sz": "1",
+                "origSz": "1",
+                "oid": 99,
+                "timestamp": 1770000000000,
+                "triggerCondition": "N/A",
+                "isTrigger": False,
+                "triggerPx": "0",
+                "children": [],
+                "isPositionTpsl": False,
+                "reduceOnly": False,
+                "orderType": "Limit",
+                "tif": "Gtc",
+                "cloid": None,
+            }
+        ],
+        "frontendOpenOrders": [
+            {
+                "order": {
+                    "coin": "BTC",
+                    "side": "A",
+                    "limitPx": "50020",
+                    "sz": "2",
+                    "origSz": "2",
+                    "oid": 100,
+                    "timestamp": 1770000000100,
+                    "triggerCondition": "N/A",
+                    "isTrigger": False,
+                    "triggerPx": "0",
+                    "children": [],
+                    "isPositionTpsl": False,
+                    "reduceOnly": True,
+                    "orderType": "Limit",
+                    "tif": "Gtc",
+                    "cloid": "abc-123",
+                },
+                "status": "open",
+                "statusTimestamp": 1770000000200,
+            }
+        ],
+        "historicalOrders": [
+            {
+                "order": {
+                    "coin": "BTC",
+                    "side": "B",
+                    "limitPx": "49990",
+                    "sz": "0",
+                    "origSz": "1",
+                    "oid": 77,
+                    "timestamp": 1769990000000,
+                    "triggerCondition": "N/A",
+                    "isTrigger": False,
+                    "triggerPx": "0",
+                    "children": [],
+                    "isPositionTpsl": False,
+                    "reduceOnly": False,
+                    "orderType": "Limit",
+                    "tif": "Ioc",
+                    "cloid": None,
+                },
+                "status": "filled",
+                "statusTimestamp": 1769990000000,
+            }
+        ],
+        "userTwapSliceFills": [{"coin": "BTC", "px": "50000", "sz": "0.5"}],
+    }
+
+
+def test_capture_account_snapshots_persists_raw_and_materialised_rows(tmp_path):
+    """Snapshot capture stores raw payloads and materialised position/order/trade rows."""
+    db = HyperliquidTradeHistoryDatabase(tmp_path / "trade-history.duckdb")
+    try:
+        db.add_account(ADDRESS, label="Growi HF", is_vault=True)
+        _seed_open_btc_trade(db, ADDRESS)
+        session = DummySession(_make_payloads())
+
+        result = db.capture_account_snapshots(
+            session,
+            ADDRESS,
+            is_vault=True,
+            label="Growi HF",
+            snapshot_time=SNAPSHOT_TIME,
+        )
+
+        assert result == {"open_positions": 1, "open_trades": 1, "open_orders": 1}
+
+        runs = db.get_snapshot_runs(ADDRESS)
+        assert len(runs) == 1
+        assert runs[0]["open_position_count"] == 1
+        assert runs[0]["open_trade_count"] == 1
+        assert runs[0]["open_order_count"] == 1
+        assert runs[0]["historical_order_count"] == 1
+        assert runs[0]["twap_slice_fill_count"] == 1
+
+        source = db.get_snapshot_source(ADDRESS, "clearinghouseState")
+        assert source is not None
+        assert source["status"] == "ok"
+        assert source["item_count"] == 1
+        assert '"coin":"BTC"' in source["payload_json"]
+
+        active_asset_source = db.get_snapshot_source(ADDRESS, "activeAssetData:BTC")
+        assert active_asset_source is not None
+        assert active_asset_source["status"] == "ok"
+
+        positions = db.get_open_position_snapshots(ADDRESS)
+        assert len(positions) == 1
+        assert positions[0]["coin"] == "BTC"
+        assert positions[0]["mark_px"] == 50025.0
+
+        orders = db.get_open_order_snapshots(ADDRESS)
+        assert len(orders) == 1
+        assert orders[0]["source"] == "frontendOpenOrders"
+        assert orders[0]["oid"] == 100
+        assert orders[0]["reduce_only"] is True
+
+        trades = db.get_open_trade_snapshots(ADDRESS)
+        assert len(trades) == 1
+        assert trades[0]["coin"] == "BTC"
+        assert trades[0]["unrealised_pnl"] == 25.0
+        assert trades[0]["funding_pnl"] == -2.0
+    finally:
+        db.close()
+
+
+def test_capture_account_snapshots_falls_back_to_open_orders_and_records_errors(tmp_path):
+    """Snapshot capture uses openOrders when frontendOpenOrders fails."""
+    db = HyperliquidTradeHistoryDatabase(tmp_path / "trade-history.duckdb")
+    try:
+        db.add_account(ADDRESS, label="Growi HF", is_vault=True)
+        _seed_open_btc_trade(db, ADDRESS)
+        session = DummySession(
+            _make_payloads(),
+            failures={"frontendOpenOrders": RuntimeError("frontend unavailable")},
+        )
+
+        result = db.capture_account_snapshots(
+            session,
+            ADDRESS,
+            is_vault=True,
+            label="Growi HF",
+            snapshot_time=SNAPSHOT_TIME,
+        )
+
+        assert result["open_orders"] == 1
+
+        source = db.get_snapshot_source(ADDRESS, "frontendOpenOrders")
+        assert source is not None
+        assert source["status"] == "error"
+        assert "frontend unavailable" in source["error_message"]
+
+        orders = db.get_open_order_snapshots(ADDRESS)
+        assert len(orders) == 1
+        assert orders[0]["source"] == "openOrders"
+        assert orders[0]["oid"] == 99
+    finally:
+        db.close()
+
+
+def test_snapshot_schema_migration_preserves_existing_trade_history(tmp_path):
+    """Opening an existing DB fixture adds snapshot tables without changing old counts."""
+    test_db = tmp_path / "trade-history-sample.duckdb"
+    shutil.copy2(FIXTURE_DB, test_db)
+
+    db = HyperliquidTradeHistoryDatabase(test_db)
+    try:
+        totals = db.get_total_row_counts()
+        assert totals["fills"] == 400
+        assert totals["funding"] == 156
+        assert totals["ledger"] == 526
+        assert totals["snapshot_runs"] == 0
+        assert totals["snapshot_sources"] == 0
+        assert totals["open_positions"] == 0
+        assert totals["open_trades"] == 0
+        assert totals["open_orders"] == 0
+    finally:
+        db.close()


### PR DESCRIPTION
## Why

We need to retain Hyperliquid open-state data alongside the historical event pipeline so each scanner run captures the current account state, not only fills, funding, and ledger entries.

This adds raw snapshot storage for the Hyperliquid account endpoints we use, plus normalised tables for open positions, open orders, and derived open trades.

## Lessons learnt

The `clearinghouseState` payload already exposes leverage, return on equity, and cumulative funding fields that are worth parsing and persisting instead of treating the response as a minimal position snapshot.

When running tests from a git worktree in this repository, `PYTHONPATH=$PWD` was needed so `poetry run` exercised the modified checkout instead of the parent editable install.

## Summary

Added raw Hyperliquid snapshot API helpers and expanded `clearinghouseState` parsing for the extra position fields we now persist.

Added additive DuckDB schema and snapshot collection logic for account runs, raw source payloads, open positions, open orders, and derived open trades.

Added offline API unit tests plus snapshot persistence and integration coverage, and ran a local HLP-only collection cycle to confirm the end-to-end snapshot pipeline writes data.
