### PR TITLE
fix: skip UniswapLib deployment when Uniswap is disabled

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/lagoon/deployment.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/deployment.py
@@ -992,6 +992,8 @@ def deploy_safe_trading_strategy_module(
     verifier: Literal["etherscan", "blockscout", "sourcify", "oklink"] | None = None,
     verifier_url: str | None = None,
     enable_on_safe=True,
+    uniswap_v2: UniswapV2Deployment | None = None,
+    uniswap_v3: UniswapV3Deployment | None = None,
     cowswap: bool = False,
     velora: bool = False,
     gmx_deployment: GMXDeployment | None = None,
@@ -1058,7 +1060,7 @@ def deploy_safe_trading_strategy_module(
         module_gas = min(10_000_000, big_block_gas_limit - 100_000)
 
         # TradingStrategyModuleV0 uses external Forge libraries via DELEGATECALL:
-        # - UniswapLib: Uniswap V2/V3 swap validation (always deployed)
+        # - UniswapLib: Uniswap V2/V3 swap validation
         # - CowSwapLib: CowSwap order creation/signing
         # - GmxLib: GMX perpetuals validation
         # - HypercoreVaultLib: Hypercore vault validation (HyperEVM only)
@@ -1067,15 +1069,18 @@ def deploy_safe_trading_strategy_module(
 
         library_addresses = {}
 
-        # UniswapLib is always needed — it validates all Uniswap V2/V3 swaps
-        uniswap_lib = deploy_contract(
-            web3,
-            "guard/UniswapLib.json",
-            deployer,
-            gas=guard_gas,
-        )
-        library_addresses["UniswapLib"] = uniswap_lib.address
-        logger.info("Deployed UniswapLib at %s", uniswap_lib.address)
+        if uniswap_v2 or uniswap_v3:
+            uniswap_lib = deploy_contract(
+                web3,
+                "guard/UniswapLib.json",
+                deployer,
+                gas=guard_gas,
+            )
+            library_addresses["UniswapLib"] = uniswap_lib.address
+            logger.info("Deployed UniswapLib at %s", uniswap_lib.address)
+        else:
+            library_addresses["UniswapLib"] = ZERO_ADDRESS
+            logger.info("UniswapLib not needed, linking with zero address")
 
         if cowswap:
             cowswap_lib = deploy_contract(
@@ -1917,6 +1922,8 @@ def deploy_automated_lagoon_vault(
         verifier_url=verifier_url,
         use_forge=False,
         enable_on_safe=not guard_only,
+        uniswap_v2=uniswap_v2,
+        uniswap_v3=uniswap_v3,
         cowswap=cowswap,
         velora=velora,
         gmx_deployment=gmx_deployment,

--- a/tests/lagoon/test_lagoon_module_library_deploy.py
+++ b/tests/lagoon/test_lagoon_module_library_deploy.py
@@ -1,0 +1,136 @@
+"""Tests for Lagoon module library deployment selection."""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+from _pytest.monkeypatch import MonkeyPatch
+from eth_account import Account
+from eth_account.signers.local import LocalAccount
+
+from eth_defi.abi import ZERO_ADDRESS
+from eth_defi.erc_4626.vault_protocol.lagoon.deployment import (
+    deploy_safe_trading_strategy_module,
+)
+
+
+def _make_fake_web3() -> SimpleNamespace:
+    """Create a tiny Web3 stub for module deployment tests."""
+    return SimpleNamespace(
+        eth=SimpleNamespace(
+            chain_id=1,
+            get_block=lambda _block_id: {"gasLimit": 30_000_000},
+        )
+    )
+
+
+def _make_fake_safe() -> SimpleNamespace:
+    """Create a tiny Safe stub for module deployment tests."""
+    return SimpleNamespace(address="0x1000000000000000000000000000000000000001")
+
+
+@contextmanager
+def _no_op_big_blocks(_web3, _private_key_hex: str):
+    """Replace HyperEVM big block toggling in unit tests."""
+    yield
+
+
+def test_deploy_safe_trading_strategy_module_skips_uniswap_library_when_disabled(
+    monkeypatch: MonkeyPatch,
+):
+    """Test UniswapLib deployment is skipped when no Uniswap routes are configured and why.
+
+    1. Build a fake deployment environment with no Uniswap configuration.
+    2. Patch contract deployment helpers to capture linked library addresses.
+    3. Deploy the module and verify UniswapLib is linked to the zero address.
+    """
+
+    # 1. Build a fake deployment environment with no Uniswap configuration.
+    web3 = _make_fake_web3()
+    safe = _make_fake_safe()
+    deployer: LocalAccount = Account.create()
+    deploy_calls: list[dict] = []
+
+    # 2. Patch contract deployment helpers to capture linked library addresses.
+    def fake_deploy_contract(_web3, contract_name: str, _deployer, *constructor_args, **kwargs):
+        deploy_calls.append(
+            {
+                "contract_name": contract_name,
+                "constructor_args": constructor_args,
+                "kwargs": kwargs,
+            }
+        )
+        return SimpleNamespace(address=f"0x{len(deploy_calls):040x}")
+
+    monkeypatch.setattr(
+        "eth_defi.erc_4626.vault_protocol.lagoon.deployment.deploy_contract",
+        fake_deploy_contract,
+    )
+    monkeypatch.setattr(
+        "eth_defi.hyperliquid.block.big_blocks_for_deployment",
+        _no_op_big_blocks,
+    )
+
+    # 3. Deploy the module and verify UniswapLib is linked to the zero address.
+    deploy_safe_trading_strategy_module(
+        web3=web3,
+        deployer=deployer,
+        safe=safe,
+        enable_on_safe=False,
+    )
+
+    assert [call["contract_name"] for call in deploy_calls] == [
+        "safe-integration/TradingStrategyModuleV0.json",
+    ]
+    assert deploy_calls[0]["kwargs"]["libraries"]["UniswapLib"] == ZERO_ADDRESS
+
+
+def test_deploy_safe_trading_strategy_module_deploys_uniswap_library_when_enabled(
+    monkeypatch: MonkeyPatch,
+):
+    """Test UniswapLib deployment still happens when Uniswap routing is configured and why.
+
+    1. Build a fake deployment environment with Uniswap v3 configured.
+    2. Patch contract deployment helpers to capture the deployment sequence.
+    3. Deploy the module and verify UniswapLib is deployed and linked.
+    """
+
+    # 1. Build a fake deployment environment with Uniswap v3 configured.
+    web3 = _make_fake_web3()
+    safe = _make_fake_safe()
+    deployer: LocalAccount = Account.create()
+    deploy_calls: list[dict] = []
+
+    # 2. Patch contract deployment helpers to capture the deployment sequence.
+    def fake_deploy_contract(_web3, contract_name: str, _deployer, *constructor_args, **kwargs):
+        deploy_calls.append(
+            {
+                "contract_name": contract_name,
+                "constructor_args": constructor_args,
+                "kwargs": kwargs,
+            }
+        )
+        return SimpleNamespace(address=f"0x{len(deploy_calls):040x}")
+
+    monkeypatch.setattr(
+        "eth_defi.erc_4626.vault_protocol.lagoon.deployment.deploy_contract",
+        fake_deploy_contract,
+    )
+    monkeypatch.setattr(
+        "eth_defi.hyperliquid.block.big_blocks_for_deployment",
+        _no_op_big_blocks,
+    )
+
+    # 3. Deploy the module and verify UniswapLib is deployed and linked.
+    deploy_safe_trading_strategy_module(
+        web3=web3,
+        deployer=deployer,
+        safe=safe,
+        enable_on_safe=False,
+        uniswap_v3=SimpleNamespace(swap_router=SimpleNamespace(address="0x3000000000000000000000000000000000000003")),
+    )
+
+    assert [call["contract_name"] for call in deploy_calls] == [
+        "guard/UniswapLib.json",
+        "safe-integration/TradingStrategyModuleV0.json",
+    ]
+    assert deploy_calls[1]["kwargs"]["libraries"]["UniswapLib"] == "0x0000000000000000000000000000000000000001"


### PR DESCRIPTION
## Why

Lagoon module deployment was always deploying and linking `UniswapLib`, even when both `uniswap_v2` and `uniswap_v3` were disabled.

That made Hypercore-only and other non-Uniswap deployments pay for an unnecessary library deployment and produced confusing deploy logs that suggested Uniswap support was active when it was not.

## Lessons learnt

The Lagoon deploy flow treats library linking and protocol whitelisting as separate steps.

Because of that split, `UniswapLib` had become unconditional in the module deployer even though the later guard setup correctly skipped Uniswap router whitelisting.

## Summary

Pass the resolved `uniswap_v2` and `uniswap_v3` deployments into `deploy_safe_trading_strategy_module()`.

Only deploy and link `UniswapLib` when at least one Uniswap deployment is configured; otherwise link the zero address.

Add a focused pytest file covering both the disabled and enabled Uniswap library-selection paths.