### PR TITLE
fix: reserve bridge fee margin for HyperCore → HyperEVM spot withdrawals

### DIFF
--- a/eth_defi/hyperliquid/constants.py
+++ b/eth_defi/hyperliquid/constants.py
@@ -6,6 +6,7 @@ Shared constants used across the Hyperliquid modules
 """
 
 import datetime
+from decimal import Decimal
 from pathlib import Path
 
 from eth_typing import HexAddress
@@ -56,6 +57,36 @@ HYPERLIQUID_USER_VAULT_LOCKUP: datetime.timedelta = datetime.timedelta(days=1)
 #:
 #: Source: https://hyperliquid.gitbook.io/hyperliquid-docs/hypercore/vaults/for-vault-depositors
 HYPERLIQUID_PROTOCOL_VAULT_LOCKUP: datetime.timedelta = datetime.timedelta(days=4)
+
+
+# ──────────────────────────────────────────────
+# HyperCore <> HyperEVM bridge fees
+# ──────────────────────────────────────────────
+
+#: Fee margin reserved when bridging the full HyperCore spot balance
+#: back to HyperEVM via ``sendAsset`` (CoreWriter action ID 13).
+#:
+#: Hyperliquid charges a bridge fee on HyperCore spot **before** the
+#: linked token settles on HyperEVM.  The fee equals 200k gas at the
+#: base gas price of the next HyperEVM block.  HYPE is consumed first
+#: if available; otherwise the fee is taken in USDC.
+#:
+#: Source: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/hypercore-less-than-greater-than-hyperevm-transfers
+#:
+#: In manual mainnet verification (2026-03-23), bridging 9 USDC in tx
+#: `0x82c7ca18fed4952dfdfdffb4e7565cc768c2ab14fe7533bb42a0734cfdf36b16
+#: <https://hyperevmscan.io/tx/0x82c7ca18fed4952dfdfdffb4e7565cc768c2ab14fe7533bb42a0734cfdf36b16>`__
+#: returned 9 USDC to HyperEVM while reducing spot by ~9.000783 USDC
+#: (fee ~0.000783 USDC at 0.1 Gwei base gas price).
+#:
+#: When withdrawing the **entire** spot balance, this margin must be
+#: subtracted from the withdrawal amount so enough USDC remains on spot
+#: to cover the fee.  Without it the withdrawal silently fails (no error,
+#: no event — USDC stays in spot).  The value (0.01 USDC) provides ~12×
+#: headroom over the observed fee.
+#:
+#: See :py:func:`~eth_defi.hyperliquid.core_writer.compute_spot_to_evm_withdrawal_amount`.
+HYPERCORE_BRIDGE_FEE_MARGIN: Decimal = Decimal("0.01")
 
 
 # ──────────────────────────────────────────────

--- a/eth_defi/hyperliquid/core_writer.py
+++ b/eth_defi/hyperliquid/core_writer.py
@@ -46,6 +46,7 @@ Example::
 
 from __future__ import annotations
 
+from decimal import Decimal
 from typing import TYPE_CHECKING
 
 from eth_abi import encode
@@ -55,6 +56,7 @@ from web3.contract import Contract
 from web3.contract.contract import ContractFunction
 
 from eth_defi.abi import encode_function_call, get_contract, get_deployed_contract
+from eth_defi.hyperliquid.constants import HYPERCORE_BRIDGE_FEE_MARGIN
 
 if TYPE_CHECKING:
     from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
@@ -507,11 +509,55 @@ def build_hypercore_send_asset_to_evm_call(
         <https://hyperevmscan.io/tx/0x82c7ca18fed4952dfdfdffb4e7565cc768c2ab14fe7533bb42a0734cfdf36b16>`__
         returned 9 USDC to HyperEVM and consumed about 0.000783 USDC in spot
         bridge fees.
+
+    .. warning::
+
+        When bridging the **entire** spot balance, the caller must reduce
+        ``evm_usdc_amount`` to leave room for the bridge fee.  Use
+        :py:func:`compute_spot_to_evm_withdrawal_amount` to compute the
+        adjusted amount.  Without this the withdrawal silently fails (no
+        error, no event — USDC stays in spot).
     """
     return _build_hypercore_send_raw_action_call(
         lagoon_vault,
         encode_send_asset_to_evm(USDC_TOKEN_INDEX, evm_usdc_amount),
     )
+
+
+def compute_spot_to_evm_withdrawal_amount(
+    spot_balance: Decimal,
+    desired_amount: Decimal,
+) -> Decimal:
+    """Compute the actual ``sendAsset`` amount after reserving bridge fee margin.
+
+    HyperCore charges a bridge fee on spot **before** the linked token
+    settles on HyperEVM.  When the caller intends to bridge the **entire**
+    spot balance, the requested amount must be reduced by
+    :py:data:`~eth_defi.hyperliquid.constants.HYPERCORE_BRIDGE_FEE_MARGIN`
+    so that enough USDC remains on spot to cover the fee.
+
+    If the desired amount already leaves sufficient margin
+    (``spot_balance - desired_amount >= HYPERCORE_BRIDGE_FEE_MARGIN``),
+    it is returned unchanged.
+
+    If the spot balance is too small (at or below the fee margin),
+    returns ``Decimal(0)`` — callers must check for this and skip the
+    withdrawal or raise an operator error.
+
+    :param spot_balance:
+        Current HyperCore spot free USDC balance (human-readable).
+    :param desired_amount:
+        Amount the caller wants to bridge to HyperEVM (human-readable).
+    :return:
+        Adjusted withdrawal amount (human-readable).  May be zero if
+        the spot balance cannot cover the fee margin.
+    """
+    headroom = spot_balance - desired_amount
+    if headroom >= HYPERCORE_BRIDGE_FEE_MARGIN:
+        return desired_amount
+    if spot_balance > HYPERCORE_BRIDGE_FEE_MARGIN:
+        return spot_balance - HYPERCORE_BRIDGE_FEE_MARGIN
+    return Decimal(0)
 
 
 def build_hypercore_deposit_multicall(
@@ -868,13 +914,13 @@ def build_hypercore_withdraw_multicall(
     3. ``CoreWriter.sendRawAction(sendAsset)`` — bridge USDC back to HyperEVM
 
     The final bridge leg is subject to Hyperliquid Core -> HyperEVM bridge
-    fees paid from spot. A successful withdrawal can therefore leave a small
-    residual reduction on HyperCore spot in addition to the requested EVM
-    transfer amount. In manual mainnet verification, transaction
-    `0x82c7ca18fed4952dfdfdffb4e7565cc768c2ab14fe7533bb42a0734cfdf36b16
-    <https://hyperevmscan.io/tx/0x82c7ca18fed4952dfdfdffb4e7565cc768c2ab14fe7533bb42a0734cfdf36b16>`__
-    consumed about 0.000783 USDC in bridge fees on spot while returning
-    9 USDC to HyperEVM.
+    fees paid from spot (see
+    :py:data:`~eth_defi.hyperliquid.constants.HYPERCORE_BRIDGE_FEE_MARGIN`).
+    The fee is an extra deduction from spot — the EVM side receives exactly
+    the requested amount — so the fee is absorbed by any pre-existing spot
+    surplus.  If the Safe has **no** pre-existing spot balance, the caller
+    should use :py:func:`compute_spot_to_evm_withdrawal_amount` to reduce
+    the amount before building the multicall.
 
     When the EVM block finishes execution, all queued CoreWriter actions
     are processed sequentially on HyperCore (~47k gas per action).

--- a/tests/hyperliquid/test_core_writer_fee_margin.py
+++ b/tests/hyperliquid/test_core_writer_fee_margin.py
@@ -1,0 +1,87 @@
+"""Test HyperCore → HyperEVM bridge fee margin helper.
+
+Verifies that :py:func:`compute_spot_to_evm_withdrawal_amount` correctly
+adjusts the withdrawal amount to leave enough USDC on HyperCore spot to
+cover the bridge fee.
+
+1. When spot balance has surplus beyond the desired amount, return the
+   desired amount unchanged.
+2. When withdrawing the full spot balance, reduce by the fee margin.
+3. When spot balance is dust (at or below fee margin), return zero.
+"""
+
+from decimal import Decimal
+
+from eth_defi.hyperliquid.constants import HYPERCORE_BRIDGE_FEE_MARGIN
+from eth_defi.hyperliquid.core_writer import compute_spot_to_evm_withdrawal_amount
+
+
+def test_spot_to_evm_withdrawal_with_surplus():
+    """When spot balance exceeds desired + margin, return desired amount unchanged.
+
+    1. Set spot balance to 10 USDC and desired amount to 7 USDC.
+    2. Call compute_spot_to_evm_withdrawal_amount.
+    3. Assert result equals 7 USDC (headroom of 3 USDC > margin).
+    """
+    result = compute_spot_to_evm_withdrawal_amount(
+        spot_balance=Decimal("10"),
+        desired_amount=Decimal("7"),
+    )
+    assert result == Decimal("7")
+
+
+def test_spot_to_evm_withdrawal_full_balance():
+    """When withdrawing full spot balance, reduce by fee margin.
+
+    1. Set spot balance and desired amount both to 7.787157 USDC (the
+       crash scenario from production).
+    2. Call compute_spot_to_evm_withdrawal_amount.
+    3. Assert result equals 7.787157 - 0.01 = 7.777157 USDC.
+    """
+    result = compute_spot_to_evm_withdrawal_amount(
+        spot_balance=Decimal("7.787157"),
+        desired_amount=Decimal("7.787157"),
+    )
+    assert result == Decimal("7.787157") - HYPERCORE_BRIDGE_FEE_MARGIN
+
+
+def test_spot_to_evm_withdrawal_nearly_full():
+    """When desired amount leaves less than fee margin, clamp to spot - margin.
+
+    1. Set spot balance to 10 USDC and desired amount to 9.995 USDC.
+    2. Headroom is 0.005 which is less than HYPERCORE_BRIDGE_FEE_MARGIN.
+    3. Assert result equals 10 - 0.01 = 9.99 USDC.
+    """
+    result = compute_spot_to_evm_withdrawal_amount(
+        spot_balance=Decimal("10"),
+        desired_amount=Decimal("9.995"),
+    )
+    assert result == Decimal("10") - HYPERCORE_BRIDGE_FEE_MARGIN
+
+
+def test_spot_to_evm_withdrawal_dust_balance():
+    """When spot balance is at or below fee margin, return zero.
+
+    1. Set spot balance to 0.005 USDC (below the 0.01 margin).
+    2. Call compute_spot_to_evm_withdrawal_amount.
+    3. Assert result is zero — caller must skip the withdrawal.
+    """
+    result = compute_spot_to_evm_withdrawal_amount(
+        spot_balance=Decimal("0.005"),
+        desired_amount=Decimal("0.005"),
+    )
+    assert result == Decimal(0)
+
+
+def test_spot_to_evm_withdrawal_exact_margin():
+    """When spot balance equals exactly the fee margin, return zero.
+
+    1. Set spot balance to exactly HYPERCORE_BRIDGE_FEE_MARGIN.
+    2. Call compute_spot_to_evm_withdrawal_amount.
+    3. Assert result is zero — there is nothing left after the fee.
+    """
+    result = compute_spot_to_evm_withdrawal_amount(
+        spot_balance=HYPERCORE_BRIDGE_FEE_MARGIN,
+        desired_amount=HYPERCORE_BRIDGE_FEE_MARGIN,
+    )
+    assert result == Decimal(0)


### PR DESCRIPTION
## Why

HyperCore charges a bridge fee (200k gas at base gas price) from HyperCore
spot **before** the linked token settles on HyperEVM.  When withdrawing the
entire spot balance via `sendAsset`, the withdrawal silently fails because
there is nothing left to cover the fee.

This was discovered when the `run_hyperliquid_cleanup` script crashed trying
to recover stranded USDC from a closed Hypercore vault position — the
spot→EVM leg timed out because the USDC never arrived on HyperEVM.

Source: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/hypercore-less-than-greater-than-hyperevm-transfers

Empirical data: tx `0x82c7ca18...` — 9 USDC bridged, ~0.000783 USDC fee
deducted from spot at 0.1 Gwei base gas price.

## Lessons learnt

- HyperCore→HyperEVM bridge fee is variable (200k gas × base gas price),
  paid in HYPE first then USDC fallback
- Withdrawals that try to bridge the exact spot balance fail **silently**
  (no error, no event — USDC stays in spot)
- The EVM side receives exactly the requested amount; the fee is an extra
  deduction from spot

## Summary

- Add `HYPERCORE_BRIDGE_FEE_MARGIN` constant (`0.01` USDC, ~12× observed
  fee) to `eth_defi.hyperliquid.constants` with full documentation
- Add `compute_spot_to_evm_withdrawal_amount()` helper to `core_writer.py`
  that adjusts the withdrawal amount to leave room for the fee
- Update docstrings on `build_hypercore_send_asset_to_evm_call` and
  `build_hypercore_withdraw_multicall` to reference the new helper
- Add 5 unit tests covering surplus, full-balance, nearly-full, dust, and
  exact-margin scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)