### PR TITLE
feat: classify IPOR Fusion fee mode as internalised_minting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Current
 
+- feat: IPOR Fusion fee mode classification — added `IPOR Fusion` to `VAULT_PROTOCOL_FEE_MATRIX` as `internalised_minting`, documented the share-minting mechanism (FeeManager / FeeAccount / PlasmaVault) with source-code line references in the `IPORVault` class docstring and `ipor-fusion.yaml` metadata (2026-04-10)
 - feat: Atomic parquet and pickle writes for vault price pipeline — prevents data corruption from interruptions using `atomicwrites` library with fsync + directory sync (2026-04-09)
 - feat: Incremental cycle state persistence — scan progress saved after each chain so interrupted scans skip completed items on restart, `FORCE_RESCAN` env var for one-off full rescans (2026-04-09)
 - feat: Scan dashboard shows cycle interval and hours remaining for not-due chains (2026-04-09)

--- a/eth_defi/data/vaults/metadata/ipor-fusion.yaml
+++ b/eth_defi/data/vaults/metadata/ipor-fusion.yaml
@@ -20,6 +20,88 @@ long_description: |
   - Siloed risk exposure between Fusion vaults (losses not socialised)
   - Built with battle-tested smart contracts and audited by top-tier firms
 fee_description: |
+  IPOR Fusion uses the **internalised minting** fee mode. Both the management
+  fee and the performance fee are realised by minting new vault shares to
+  dedicated technical holding accounts, so fees are paid by existing share
+  holders through dilution. Investors do not pay any explicit fee at deposit
+  or redemption, and the share price reported by the vault is already
+  fees-net.
+
+  Fee caps (from ``PlasmaVaultLib.sol``):
+
+  - **Management fee**: up to 5% per year on assets under management
+    (``MANAGEMENT_MAX_FEE_IN_PERCENTAGE = 500``, 2-decimal precision).
+  - **Performance fee**: up to 50% on gains above a high-water mark
+    (``PERFORMANCE_MAX_FEE_IN_PERCENTAGE = 5000``).
+
+  Share-minting mechanism (``contracts/vaults/PlasmaVault.sol``):
+
+  - Every vault operation (deposit, mint, withdraw, redeem, execute,
+    updateMarketsBalances) runs through fee hooks that call
+    ``_realizeManagementFee()`` and ``_addPerformanceFee()``.
+  - ``_realizeManagementFee()`` (line 1413) — NatSpec: *"Realizes management
+    fees by minting shares to fee recipient"*. Time-based accrual on
+    ``grossTotalAssets`` is converted to shares via ``convertToShares()``
+    and those shares are minted directly to ``MANAGEMENT_FEE_ACCOUNT``
+    (``_mint(recipient, unrealizedFeeInShares)`` at line 1437). The
+    management-fee timestamp is only updated after a successful mint
+    (IL-6959 fix) to prevent fee suppression by many small transactions.
+  - ``_addPerformanceFee()`` (line 1381) — uses a high-water mark model. If
+    ``totalAssetsAfter >= totalAssetsBefore``, the gain above the HWM is
+    multiplied by the performance-fee rate, converted to shares by
+    ``PlasmaVaultFeesLib.prepareForAddPerformanceFee()`` and minted
+    (``_mint(recipient, feeShares)`` at line 1402). The HWM is stored in
+    ``HighWaterMarkPerformanceFeeStorage`` and can be auto-lowered on a
+    configurable update interval.
+  - Both mint paths temporarily disable ``totalSupplyCap`` validation so
+    the fee mint cannot be blocked by the cap.
+
+  Downstream distribution (``contracts/managers/fee/FeeManager.sol``):
+
+  - ``harvestManagementFee()`` (line 194) and ``harvestPerformanceFee()``
+    (line 247) read the already-minted share balances via
+    ``IERC4626(PLASMA_VAULT).balanceOf(MANAGEMENT_FEE_ACCOUNT)`` and
+    ``balanceOf(PERFORMANCE_FEE_ACCOUNT)``.
+  - ``_transferDaoFee()`` (line 636) moves the IPOR DAO portion via
+    ``PLASMA_VAULT.transferFrom(feeAccount, daoRecipient, amount)``
+    (line 650). ``_transferRecipientFee()`` (line 682) distributes the
+    remainder to atomist-defined recipients using the same ``transferFrom``
+    pattern (line 705).
+  - ``FeeAccount`` (``contracts/managers/fee/FeeAccount.sol``) is a tiny
+    holding contract that only exposes ``approveMaxForFeeManager()`` so the
+    ``FeeManager`` can pull the pre-minted shares — it never mints or burns
+    anything itself.
+
+  Why this is internalised minting and not skimming or externalised:
+
+  - Skimming would transfer underlying assets out of the vault at the
+    moment of profit. IPOR never moves assets for fees — it mints shares.
+  - Externalised fees (e.g. Lagoon) would deduct from the investor at
+    redemption, so the vault share price is fees-gross. IPOR share price
+    is fees-net: the dilution has already happened on-chain by the time
+    ``totalAssets()`` / ``convertToAssets()`` are read.
+  - The ``FeeManager`` is a distribution layer on top of already-minted
+    fee shares, not a separate fee-collection mechanism.
+
+  Optional deposit fee (per-vault add-on, usually 0):
+
+  - ``FeeManager.setDepositFee()`` (line 508) allows an atomist to
+    configure an explicit deposit fee with 18-decimal precision. NatSpec
+    says the fee is *"deducted from the user's deposit amount before
+    minting shares"*, making it an externalised fee at deposit time. This
+    is orthogonal to the management/performance fee mode and most Plasma
+    Vaults leave it at 0.
+
+  Individual Plasma Vaults configure their own management and performance
+  percentages within the caps above.
+
+  References:
+
+  - `IPOR Fusion fee distribution (deepwiki) <https://deepwiki.com/IPOR-Labs/ipor-fusion/6.2-fee-distribution>`_
+  - `PlasmaVault.sol <https://github.com/IPOR-Labs/ipor-fusion/blob/main/contracts/vaults/PlasmaVault.sol>`_
+  - `PlasmaVaultLib.sol <https://github.com/IPOR-Labs/ipor-fusion/blob/main/contracts/libraries/PlasmaVaultLib.sol>`_
+  - `FeeManager.sol <https://github.com/IPOR-Labs/ipor-fusion/blob/main/contracts/managers/fee/FeeManager.sol>`_
+  - `FeeAccount.sol <https://github.com/IPOR-Labs/ipor-fusion/blob/main/contracts/managers/fee/FeeAccount.sol>`_
 links:
   homepage: https://www.ipor.io/
   app: https://app.ipor.io/

--- a/eth_defi/erc_4626/vault_protocol/ipor/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/ipor/vault.py
@@ -201,6 +201,100 @@ class IPORVault(ERC4626Vault):
       and ` Example vault <https://app.ipor.io/fusion/base/0x45aa96f0b3188d47a1dafdbefce1db6b37f58216>`__
 
     - `IPOR custom error codes <https://www.codeslaw.app/contracts/ethereum/0x1f8397de7c32cc7f042477326892953ca102ded0?tab=abi>`__ like `0x1425ea42` ABI-decoded
+
+    Fee mode
+    ~~~~~~~~
+
+    IPOR Fusion uses :py:attr:`~eth_defi.vault.fee.VaultFeeMode.internalised_minting`.
+    Both the management fee and the performance fee are realised by **minting
+    new vault shares** to dedicated technical holding accounts. Fees are therefore
+    paid by existing share holders through **dilution** — the share price itself
+    is never rewritten, and investors do not pay any explicit fee at deposit or
+    redemption.
+
+    Fee caps (from ``PlasmaVaultLib.sol``):
+
+    - Management fee: up to **5% per year** on assets under management
+      (``MANAGEMENT_MAX_FEE_IN_PERCENTAGE = 500``, 2-decimal precision).
+    - Performance fee: up to **50%** on gains above a high-water mark
+      (``PERFORMANCE_MAX_FEE_IN_PERCENTAGE = 5000``).
+
+    Share-minting mechanism (``contracts/vaults/PlasmaVault.sol``):
+
+    - Every vault operation (deposit, mint, withdraw, redeem, execute,
+      updateMarketsBalances) runs through fee hooks that call
+      ``_realizeManagementFee()`` and ``_addPerformanceFee()``
+      (see call sites at lines 417, 451, 677, 738, 758, 1258, 1275, 1364).
+
+    - ``_realizeManagementFee()`` at line 1413 — NatSpec: *"Realizes management
+      fees by minting shares to fee recipient"*. Time-based accrual on
+      ``grossTotalAssets`` is converted to shares via ``convertToShares()``
+      and those shares are minted directly to ``MANAGEMENT_FEE_ACCOUNT``::
+
+          _mint(recipient, unrealizedFeeInShares);  // line 1437
+
+      The management-fee timestamp is only updated after a successful mint
+      (IL-6959 fix) to prevent fee suppression by many small transactions.
+
+    - ``_addPerformanceFee()`` at line 1381 — uses a high-water mark (HWM)
+      model. If ``totalAssetsAfter >= totalAssetsBefore``, the gain above the
+      HWM is multiplied by the performance-fee rate, converted to shares by
+      ``PlasmaVaultFeesLib.prepareForAddPerformanceFee()`` and minted::
+
+          _mint(recipient, feeShares);  // line 1402
+
+      Both mint paths temporarily disable ``totalSupplyCap`` validation so the
+      fee mint cannot be blocked by the cap. The HWM is stored in
+      ``HighWaterMarkPerformanceFeeStorage`` and can be auto-lowered on a
+      configurable update interval (``updateIntervalHighWaterMarkPerformanceFee``).
+
+    Downstream distribution (``contracts/managers/fee/FeeManager.sol``):
+
+    - ``harvestManagementFee()`` (line 194) and ``harvestPerformanceFee()``
+      (line 247) read the already-minted share balances via::
+
+          IERC4626(PLASMA_VAULT).balanceOf(MANAGEMENT_FEE_ACCOUNT);
+          IERC4626(PLASMA_VAULT).balanceOf(PERFORMANCE_FEE_ACCOUNT);
+
+    - ``_transferDaoFee()`` (line 636) moves the IPOR DAO share via
+      ``PLASMA_VAULT.transferFrom(feeAccount, daoRecipient, amount)``
+      (line 650), and ``_transferRecipientFee()`` (line 682) distributes the
+      remainder to atomist-defined recipients using the same ``transferFrom``
+      pattern (line 705).
+
+    - ``FeeAccount`` (``contracts/managers/fee/FeeAccount.sol``) is a tiny
+      holding contract that only exposes ``approveMaxForFeeManager()`` so the
+      ``FeeManager`` can pull the pre-minted shares — it never mints or burns
+      anything itself.
+
+    Summary of why this is ``internalised_minting`` and **not** skimming or
+    externalised:
+
+    - Skimming would transfer underlying assets out of the vault at the moment
+      of profit. IPOR never moves assets for fees — it mints shares.
+    - Externalised fees (e.g. Lagoon) would deduct from the investor at
+      redemption, so the vault share price is fees-gross. IPOR share price is
+      fees-net: the dilution has already happened on-chain by the time
+      ``totalAssets()`` / ``convertToAssets()`` are read.
+    - The ``FeeManager`` is a distribution layer on top of already-minted
+      fee shares, not a separate fee-collection mechanism.
+
+    Optional deposit fee (not modelled by :class:`eth_defi.vault.fee.FeeData`):
+
+    - ``FeeManager.setDepositFee()`` (line 508) allows an atomist to configure
+      an explicit deposit fee with 18-decimal precision. NatSpec says the fee
+      is *"deducted from the user's deposit amount before minting shares"*,
+      making it an externalised fee at deposit time. This is a per-vault
+      optional add-on and is orthogonal to the management/performance fee
+      mode; most Plasma Vaults leave it at 0.
+
+    References:
+
+    - `IPOR Fusion fee distribution (deepwiki) <https://deepwiki.com/IPOR-Labs/ipor-fusion/6.2-fee-distribution>`__
+    - `PlasmaVault.sol <https://github.com/IPOR-Labs/ipor-fusion/blob/main/contracts/vaults/PlasmaVault.sol>`__
+    - `PlasmaVaultLib.sol <https://github.com/IPOR-Labs/ipor-fusion/blob/main/contracts/libraries/PlasmaVaultLib.sol>`__
+    - `FeeManager.sol <https://github.com/IPOR-Labs/ipor-fusion/blob/main/contracts/managers/fee/FeeManager.sol>`__
+    - `FeeAccount.sol <https://github.com/IPOR-Labs/ipor-fusion/blob/main/contracts/managers/fee/FeeAccount.sol>`__
     """
 
     @cached_property

--- a/eth_defi/vault/fee.py
+++ b/eth_defi/vault/fee.py
@@ -150,6 +150,12 @@ VAULT_PROTOCOL_FEE_MATRIX = {
     "Liquid Royalty": VaultFeeMode.feeless,
     # Inverse Finance sDOLA - no explicit fees, yield via DBR auction mechanism
     "Inverse Finance": VaultFeeMode.feeless,
+    # IPOR Fusion - management fees (up to 5%/yr on AUM) and performance fees (up to 50%, high-water mark)
+    # are both collected by minting new vault shares to FeeAccount contracts, which the FeeManager then
+    # distributes between IPOR DAO and atomist-defined recipients. From an investor's perspective fees
+    # are internalised in the share price through dilution — there is no fee charged at redemption.
+    # https://deepwiki.com/IPOR-Labs/ipor-fusion/6.2-fee-distribution
+    "IPOR Fusion": VaultFeeMode.internalised_minting,
 }
 
 

--- a/tests/ipor/test_ipor_info.py
+++ b/tests/ipor/test_ipor_info.py
@@ -18,6 +18,7 @@ from eth_defi.vault.base import (
     DEPOSIT_CLOSED_UTILISATION,
     VaultSpec,
 )
+from eth_defi.vault.fee import VaultFeeMode
 
 JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
 
@@ -41,7 +42,9 @@ def test_block_number() -> int:
 def vault(web3) -> IPORVault:
     """TODO: Optimise test speed - fetch vault data only once per this module"""
     spec = VaultSpec(8545, "0x45aa96f0b3188d47a1dafdbefce1db6b37f58216")
-    return IPORVault(web3, spec)
+    # Pass features so get_protocol_name() / get_fee_mode() resolve to "IPOR Fusion"
+    # without running detect_vault_features() in every test.
+    return IPORVault(web3, spec, features={ERC4626Feature.ipor_like})
 
 
 def test_ipor_fee(
@@ -49,10 +52,27 @@ def test_ipor_fee(
     vault: IPORVault,
     test_block_number,
 ):
-    """Read IPOR vault fees."""
+    """Read IPOR vault fees and verify fee mode classification.
+
+    IPOR Fusion realises both management and performance fees by minting new
+    shares to dedicated FeeAccount holding contracts, so the fee mode must be
+    :py:attr:`~eth_defi.vault.fee.VaultFeeMode.internalised_minting`.
+
+    1. Read management fee for the fixed fork block
+    2. Read performance fee for the fixed fork block
+    3. Assert the protocol-level fee mode is ``internalised_minting``
+    """
     block_number = test_block_number
+
+    # 1. Management fee at fork block
     assert vault.get_management_fee(block_number) == 0.01
+
+    # 2. Performance fee at fork block
     assert vault.get_performance_fee(block_number) == 0.10
+
+    # 3. IPOR Fusion collects both fees via share minting (dilution),
+    # which maps to internalised_minting in VAULT_PROTOCOL_FEE_MATRIX
+    assert vault.get_fee_mode() == VaultFeeMode.internalised_minting
 
 
 # 500 Server Error: Internal Server Error for url:


### PR DESCRIPTION
## Why

IPOR Fusion was missing from `VAULT_PROTOCOL_FEE_MATRIX` in [eth_defi/vault/fee.py](eth_defi/vault/fee.py), so `vault.get_fee_mode()` returned `None` for all Plasma Vaults. This blocks downstream fee-aware logic — net-fee accounting, share-price classification, curator analytics — from treating IPOR correctly. The mode had to be grounded in the actual on-chain mechanism, not inferred from third-party docs.

## Lessons learnt

- **Deepwiki was misleading.** The 6.2 fee-distribution page says fees are *"externalized at distribution"* — but that refers to the `FeeManager` distribution layer living in a separate contract, **not** to investor-facing fees. The real mechanism is **share minting** / dilution.

- **Verified against the actual IPOR source** (`main` branch of `IPOR-Labs/ipor-fusion`):

  - [`contracts/vaults/PlasmaVault.sol`](https://github.com/IPOR-Labs/ipor-fusion/blob/main/contracts/vaults/PlasmaVault.sol)
    - `_realizeManagementFee()` at line 1413 — NatSpec: *"Realizes management fees by minting shares to fee recipient"*. Calls `_mint(recipient, unrealizedFeeInShares)` at line 1437 directly into `MANAGEMENT_FEE_ACCOUNT`.
    - `_addPerformanceFee()` at line 1381 — uses a high-water mark, computes `feeShares` via `PlasmaVaultFeesLib.prepareForAddPerformanceFee()` and calls `_mint(recipient, feeShares)` at line 1402 into `PERFORMANCE_FEE_ACCOUNT`.
    - Fee hooks are wired into deposit / mint / withdraw / redeem / execute / updateMarketsBalances call sites (lines 417, 451, 677, 738, 758, 1258, 1275, 1364).
  - [`contracts/managers/fee/FeeManager.sol`](https://github.com/IPOR-Labs/ipor-fusion/blob/main/contracts/managers/fee/FeeManager.sol)
    - `harvestManagementFee()` / `harvestPerformanceFee()` (lines 194, 247) only read `balanceOf(feeAccount)` and move **pre-minted** shares via `transferFrom` at lines 650 / 705. The manager never mints.
  - [`contracts/managers/fee/FeeAccount.sol`](https://github.com/IPOR-Labs/ipor-fusion/blob/main/contracts/managers/fee/FeeAccount.sol) is a tiny holding contract that only exposes `approveMaxForFeeManager()`.

  Conclusion: investors pay nothing at deposit or redemption; the share price is already fees-net by the time `totalAssets()` / `convertToAssets()` are read. This is exactly `VaultFeeMode.internalised_minting` (same bucket as Morpho V2 / AUTO Finance), **not** skimming (no underlying asset movement) and **not** externalised (no redemption-time deduction).

- **Test fixture gotcha:** `IPORVault(web3, spec)` constructed directly without `features=` makes `get_protocol_name()` fall back to `<not ERC-4626>`, so `get_fee_mode()` returned `None` in the new assertion. Fixed by passing `features={ERC4626Feature.ipor_like}` in the test fixture.

## Summary

- **[eth_defi/vault/fee.py](eth_defi/vault/fee.py)** — added `"IPOR Fusion": VaultFeeMode.internalised_minting` to `VAULT_PROTOCOL_FEE_MATRIX` with a comment summarising the share-minting mechanism and a link to the deepwiki fee-distribution page.

- **[eth_defi/erc_4626/vault_protocol/ipor/vault.py](eth_defi/erc_4626/vault_protocol/ipor/vault.py)** — expanded the `IPORVault` class docstring with a detailed "Fee mode" section covering:
  - Fee caps from `PlasmaVaultLib.sol` (5% management / 50% performance).
  - `_realizeManagementFee()` and `_addPerformanceFee()` mechanics with exact `_mint()` line numbers.
  - HWM storage in `HighWaterMarkPerformanceFeeStorage` with auto-lower update interval.
  - `FeeManager.harvestManagementFee()` / `harvestPerformanceFee()` downstream distribution via `transferFrom`.
  - Role of `FeeAccount` as a passive holding contract.
  - Explicit justification for `internalised_minting` vs skimming vs externalised.
  - Optional `setDepositFee()` add-on (externalised at deposit, usually 0).
  - Links to all four IPOR source files + deepwiki reference.

- **[eth_defi/data/vaults/metadata/ipor-fusion.yaml](eth_defi/data/vaults/metadata/ipor-fusion.yaml)** — mirrored the same detailed fee explanation in `fee_description`, including source line-number references and reStructuredText links.

- **[tests/ipor/test_ipor_info.py](tests/ipor/test_ipor_info.py)** — extended `test_ipor_fee` with a docstring (numbered steps), added an assertion that `vault.get_fee_mode() == VaultFeeMode.internalised_minting`, and updated the `vault` fixture to pass `features={ERC4626Feature.ipor_like}` so `get_protocol_name()` resolves without running full detection.

- **[CHANGELOG.md](CHANGELOG.md)** — added a feature entry dated 2026-04-10.

All 8 IPOR mainnet-fork tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)