### PR TITLE
feat: Hyperliquid market-data Info API primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Current
 
+- feat: Hyperliquid market-data Info API primitives — `fetch_candle_snapshot`, `fetch_funding_history`, `fetch_perp_meta` in `eth_defi.hyperliquid.api` with typed `HyperliquidCandle` / `HyperliquidFundingRate` dataclasses, routed through `HyperliquidSession.post_info()` for automatic Webshare proxy rotation on rate-limit failures; `post_info()` now distinguishes rate-limit responses (429/5xx rotate without marking proxy dead) from connection errors (rotate and record as dead for the 14-day grace period), preserving the Webshare proxy pool across throttled runs (2026-04-10)
 - feat: IPOR Fusion fee mode classification — added `IPOR Fusion` to `VAULT_PROTOCOL_FEE_MATRIX` as `internalised_minting`, documented the share-minting mechanism (FeeManager / FeeAccount / PlasmaVault) with source-code line references in the `IPORVault` class docstring and `ipor-fusion.yaml` metadata (2026-04-10)
 - feat: Atomic parquet and pickle writes for vault price pipeline — prevents data corruption from interruptions using `atomicwrites` library with fsync + directory sync (2026-04-09)
 - feat: Incremental cycle state persistence — scan progress saved after each chain so interrupted scans skip completed items on restart, `FORCE_RESCAN` env var for one-off full rescans (2026-04-09)

--- a/eth_defi/hyperliquid/api.py
+++ b/eth_defi/hyperliquid/api.py
@@ -652,9 +652,7 @@ def wait_for_vault_deposit_confirmation(
 
         remaining = deadline - time.time()
         if remaining <= 0:
-            raise HypercoreDepositVerificationError(
-                f"Vault deposit for {user} in vault {vault_address} could not be verified within {timeout}s. Expected deposit: {expected_deposit} USDC, existing equity: {existing_equity}, last queried equity: {last_eq.equity if last_eq else None}. The deposit may have been silently rejected by HyperCore. Check HyperCore spot/perp for stranded USDC."
-            )
+            raise HypercoreDepositVerificationError(f"Vault deposit for {user} in vault {vault_address} could not be verified within {timeout}s. Expected deposit: {expected_deposit} USDC, existing equity: {existing_equity}, last queried equity: {last_eq.equity if last_eq else None}. The deposit may have been silently rejected by HyperCore. Check HyperCore spot/perp for stranded USDC.")
 
         time.sleep(min(poll_interval, remaining))
 

--- a/eth_defi/hyperliquid/api.py
+++ b/eth_defi/hyperliquid/api.py
@@ -652,7 +652,9 @@ def wait_for_vault_deposit_confirmation(
 
         remaining = deadline - time.time()
         if remaining <= 0:
-            raise HypercoreDepositVerificationError(f"Vault deposit for {user} in vault {vault_address} could not be verified within {timeout}s. Expected deposit: {expected_deposit} USDC, existing equity: {existing_equity}, last queried equity: {last_eq.equity if last_eq else None}. The deposit may have been silently rejected by HyperCore. Check HyperCore spot/perp for stranded USDC.")
+            raise HypercoreDepositVerificationError(
+                f"Vault deposit for {user} in vault {vault_address} could not be verified within {timeout}s. Expected deposit: {expected_deposit} USDC, existing equity: {existing_equity}, last queried equity: {last_eq.equity if last_eq else None}. The deposit may have been silently rejected by HyperCore. Check HyperCore spot/perp for stranded USDC."
+            )
 
         time.sleep(min(poll_interval, remaining))
 
@@ -989,3 +991,282 @@ def fetch_leaderboard(
             all_time_volume=Decimal(str(all_time.get("vlm", 0))),
         )
     return index
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Market-data primitives: candleSnapshot, fundingHistory, meta
+#
+# These wrap the perpetual market-data Info endpoints for bulk historical
+# downloads. Unlike the account-query helpers above (which call
+# ``session.post()`` directly), they route through
+# :py:meth:`HyperliquidSession.post_info` so they automatically benefit
+# from proxy rotation on rate-limit and connectivity failures. This matches
+# the architectural rule enforced by the
+# ``test_post_info_proxy_fix`` test in
+# ``tests/hyperliquid/test_high_freq_metrics.py``.
+#
+# Prices, volume and funding rates are stored as :class:`float` for
+# direct pandas/numpy compatibility in backtesting notebooks. Callers
+# needing arbitrage-level precision should consume the raw API response.
+#
+# Funding cadence: Hyperliquid pays funding **every hour** at 1/8 of
+# the computed 8-hour rate. Authoritative reference:
+# https://hyperliquid.gitbook.io/hyperliquid-docs/trading/funding
+# (This differs from Binance/Bybit/OKX which pay every 8 hours on the
+# clock — see ``HyperliquidFundingRate`` below.)
+# ─────────────────────────────────────────────────────────────────────
+
+#: Hard cap on candles returned by a single ``candleSnapshot`` request.
+#:
+#: The Hyperliquid Info API silently truncates responses to this many
+#: candles regardless of the requested window. Callers needing longer
+#: histories must paginate by advancing ``startTime`` past the last
+#: returned candle.
+HYPERLIQUID_CANDLE_SNAPSHOT_LIMIT: int = 5000
+
+#: Hard cap on records returned by a single ``fundingHistory`` request.
+#:
+#: Hyperliquid pays funding **every hour** (at 1/8 of the computed 8-hour
+#: rate), so 500 records ≈ 20 days per call. A 3-year pull per symbol
+#: needs ~55 paginated requests. Authoritative reference for the cadence:
+#: https://hyperliquid.gitbook.io/hyperliquid-docs/trading/funding
+HYPERLIQUID_FUNDING_HISTORY_LIMIT: int = 500
+
+
+@dataclass(slots=True)
+class HyperliquidCandle:
+    """A single OHLCV candle from the ``candleSnapshot`` Info endpoint.
+
+    Prices and volume are stored as :class:`float` for direct
+    pandas/numpy compatibility in backtesting notebooks. Callers
+    needing arbitrage-level precision should consume the raw API
+    response instead.
+    """
+
+    #: Open time, naive UTC datetime.
+    open_time: datetime.datetime
+    #: Close time, naive UTC datetime.
+    close_time: datetime.datetime
+    #: Base symbol, e.g. ``"BTC"``.
+    coin: str
+    #: Candle interval, one of ``"1m"``, ``"5m"``, ``"15m"``, ``"1h"``, ``"4h"``, ``"1d"`` …
+    interval: str
+    open: float
+    high: float
+    low: float
+    close: float
+    #: Base-asset volume. Zero for pre-launch (backfilled) candles.
+    volume: float
+    #: Number of trades that formed this candle.
+    trades: int
+
+
+@dataclass(slots=True)
+class HyperliquidFundingRate:
+    """A single funding-rate observation from the ``fundingHistory`` endpoint.
+
+    Hyperliquid pays funding **every hour** at 1/8 of the computed
+    8-hour funding rate, so one of these dataclasses represents the
+    funding charge/payment for a single 1-hour window. Authoritative
+    reference for the cadence and formula:
+    https://hyperliquid.gitbook.io/hyperliquid-docs/trading/funding
+
+    Funding rate and premium are stored as :class:`float` for direct
+    pandas/numpy compatibility.
+    """
+
+    #: Start of the 1-hour funding window, naive UTC datetime.
+    timestamp: datetime.datetime
+    #: Base symbol, e.g. ``"BTC"``.
+    coin: str
+    #: Per-hour funding rate as a fraction (= 1/8 of the 8-hour-window
+    #: rate).  For example, ``0.0000125`` = 1.25 bps charged over the
+    #: hour starting at :attr:`timestamp`.
+    funding_rate: float
+    #: Premium (index vs mark divergence) at the start of the interval.
+    premium: float
+
+
+def fetch_candle_snapshot(
+    session: HyperliquidSession,
+    *,
+    coin: str,
+    interval: str,
+    start_time: datetime.datetime,
+    end_time: datetime.datetime,
+    timeout: float = 30.0,
+) -> list[HyperliquidCandle]:
+    """Fetch up to 5,000 OHLCV candles for a single coin.
+
+    Calls the ``candleSnapshot`` Info endpoint. The response is capped at
+    :data:`HYPERLIQUID_CANDLE_SNAPSHOT_LIMIT` candles regardless of window
+    width, so callers needing longer histories must paginate.
+
+    Pre-launch candles (before ~April 2023) are returned but have zero
+    volume — these are backfilled price data, not authentic Hyperliquid
+    trades. Filter by ``volume > 0`` for real bars only.
+
+    Uses :py:meth:`HyperliquidSession.post_info` for automatic proxy
+    rotation on rate-limit or connectivity failures.
+
+    - `Info endpoint docs <https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint#candle-snapshot>`__.
+
+    Example::
+
+        from datetime import datetime
+        from eth_defi.hyperliquid.api import fetch_candle_snapshot
+        from eth_defi.hyperliquid.session import create_hyperliquid_session
+
+        session = create_hyperliquid_session()
+        candles = fetch_candle_snapshot(
+            session,
+            coin="BTC",
+            interval="4h",
+            start_time=datetime(2023, 5, 1),
+            end_time=datetime(2023, 6, 1),
+        )
+        print(f"{len(candles)} candles, first close={candles[0].close}")
+
+    :param session:
+        Session from :py:func:`~eth_defi.hyperliquid.session.create_hyperliquid_session`.
+    :param coin:
+        Base symbol only (e.g. ``"BTC"``), **not** a CCXT-style pair.
+    :param interval:
+        One of ``"1m"``, ``"3m"``, ``"5m"``, ``"15m"``, ``"30m"``,
+        ``"1h"``, ``"2h"``, ``"4h"``, ``"8h"``, ``"12h"``, ``"1d"``,
+        ``"3d"``, ``"1w"``, ``"1M"``.
+    :param start_time:
+        Earliest candle, naive UTC datetime.
+    :param end_time:
+        Latest candle, naive UTC datetime.
+    :param timeout:
+        HTTP request timeout in seconds.
+    :return:
+        Candles in ascending time order. Empty list if no data.
+    """
+    payload = {
+        "type": "candleSnapshot",
+        "req": {
+            "coin": coin,
+            "interval": interval,
+            "startTime": int(start_time.timestamp() * 1000),
+            "endTime": int(end_time.timestamp() * 1000),
+        },
+    }
+
+    logger.debug("Fetching candleSnapshot coin=%s interval=%s", coin, interval)
+
+    response = session.post_info(payload, timeout=timeout)
+    response.raise_for_status()
+    data = response.json() or []
+
+    results: list[HyperliquidCandle] = []
+    for entry in data:
+        results.append(
+            HyperliquidCandle(
+                open_time=from_unix_timestamp(int(entry["t"]) / 1000),
+                close_time=from_unix_timestamp(int(entry["T"]) / 1000),
+                coin=entry.get("s", coin),
+                interval=entry.get("i", interval),
+                open=float(entry["o"]),
+                high=float(entry["h"]),
+                low=float(entry["l"]),
+                close=float(entry["c"]),
+                volume=float(entry["v"]),
+                trades=int(entry.get("n", 0)),
+            )
+        )
+
+    logger.debug("coin=%s returned %d candles", coin, len(results))
+    return results
+
+
+def fetch_funding_history(
+    session: HyperliquidSession,
+    *,
+    coin: str,
+    start_time: datetime.datetime,
+    end_time: datetime.datetime | None = None,
+    timeout: float = 30.0,
+) -> list[HyperliquidFundingRate]:
+    """Fetch up to 500 funding-rate observations for a single coin.
+
+    Calls the ``fundingHistory`` Info endpoint. Hyperliquid pays funding
+    **every hour** at 1/8 of the computed 8-hour rate, so
+    :data:`HYPERLIQUID_FUNDING_HISTORY_LIMIT` records ≈ 20 days per
+    call. A 3-year history per symbol needs roughly 55 paginated
+    requests. Callers needing long histories should use the higher-level
+    :py:func:`strategycore.hyperliquid.fetch_funding_rate_history`
+    wrapper, which handles pagination and parquet caching.
+
+    Uses :py:meth:`HyperliquidSession.post_info` for automatic proxy
+    rotation on rate-limit or connectivity failures.
+
+    - Funding cadence and formula: `Hyperliquid Docs › Trading › Funding
+      <https://hyperliquid.gitbook.io/hyperliquid-docs/trading/funding>`__.
+    - API endpoint: `Info endpoint › fundingHistory
+      <https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint/perpetuals#retrieve-historical-funding-rates>`__.
+
+    :param session:
+        Session from :py:func:`create_hyperliquid_session`.
+    :param coin:
+        Base symbol only, e.g. ``"BTC"``.
+    :param start_time:
+        Earliest funding observation, naive UTC datetime.
+    :param end_time:
+        Optional latest observation, naive UTC datetime. If ``None``,
+        the API returns up to 500 records starting at ``start_time``.
+    :param timeout:
+        HTTP request timeout in seconds.
+    :return:
+        Funding-rate observations in ascending time order.
+    """
+    payload: dict = {
+        "type": "fundingHistory",
+        "coin": coin,
+        "startTime": int(start_time.timestamp() * 1000),
+    }
+    if end_time is not None:
+        payload["endTime"] = int(end_time.timestamp() * 1000)
+
+    logger.debug("Fetching fundingHistory coin=%s", coin)
+
+    response = session.post_info(payload, timeout=timeout)
+    response.raise_for_status()
+    data = response.json() or []
+
+    results: list[HyperliquidFundingRate] = []
+    for entry in data:
+        results.append(
+            HyperliquidFundingRate(
+                timestamp=from_unix_timestamp(int(entry["time"]) / 1000),
+                coin=entry.get("coin", coin),
+                funding_rate=float(entry["fundingRate"]),
+                premium=float(entry.get("premium", "0")),
+            )
+        )
+    return results
+
+
+def fetch_perp_meta(
+    session: HyperliquidSession,
+    timeout: float = 10.0,
+) -> dict:
+    """Fetch the perpetual universe metadata (``{"type": "meta"}``).
+
+    Used primarily for symbol discovery. Returns the raw dict with
+    keys such as ``universe`` (list of per-coin metadata entries).
+
+    Uses :py:meth:`HyperliquidSession.post_info` for automatic proxy
+    rotation on rate-limit or connectivity failures.
+
+    :param session:
+        Session from :py:func:`create_hyperliquid_session`.
+    :param timeout:
+        HTTP request timeout in seconds.
+    :return:
+        Raw metadata dict.
+    """
+    response = session.post_info({"type": "meta"}, timeout=timeout)
+    response.raise_for_status()
+    return response.json() or {}

--- a/eth_defi/hyperliquid/session.py
+++ b/eth_defi/hyperliquid/session.py
@@ -250,17 +250,25 @@ class HyperliquidSession(Session):
     # ──────────────────────────────────────────────
 
     def post_info(self, payload: dict, timeout: float = 30.0) -> requests_lib.Response:
-        """POST to the Hyperliquid ``/info`` endpoint with proxy rotation.
+        """POST to the Hyperliquid ``/info`` endpoint with graceful proxy rotation.
 
-        Uses the session's configured proxy (if any). On connection errors
-        or HTTP 429/5xx responses, rotates to the next proxy and retries.
-        After :data:`MAX_PROXY_ROTATIONS` consecutive failures in a single
-        call, falls back to a direct (no-proxy) connection for the
-        remainder of this request.
+        Uses the session's configured proxy (if any). Rotation policy:
 
-        Failures are recorded via the rotator's
-        :py:class:`~eth_defi.event_reader.webshare.ProxyStateManager` so
-        that persistently bad proxies are skipped in future runs.
+        - **Rate-limit / backend overload responses** (HTTP 429, 500,
+          502, 503, 504): rotate to the next proxy but do NOT record
+          the current proxy as dead — it is only throttled, and will
+          recover within minutes. This avoids shrinking the working
+          pool across runs via the
+          :py:class:`~eth_defi.event_reader.webshare.ProxyStateManager`
+          14-day grace period.
+        - **Connection errors** (``requests.ConnectionError``,
+          ``requests.Timeout``, ``OSError``): rotate AND record the
+          current proxy as dead via the state manager, because the
+          proxy itself is unreachable.
+
+        After :data:`MAX_PROXY_ROTATIONS` consecutive rotations in a
+        single call, returns whatever response comes back (or re-raises
+        the last exception) rather than continuing to rotate.
 
         :param payload:
             JSON request body for the ``/info`` endpoint.
@@ -273,6 +281,10 @@ class HyperliquidSession(Session):
         :raises requests.Timeout:
             If the request times out and no proxy rotation is available.
         """
+        # HTTP statuses that signal "slow down / upstream is overloaded",
+        # but the proxy itself is fine. Rotate without marking dead.
+        throttle_statuses = {429, 500, 502, 503, 504}
+
         rotations = 0
         while True:
             req_proxies = self._build_proxy_dict()
@@ -285,16 +297,26 @@ class HyperliquidSession(Session):
                     timeout=timeout,
                     proxies=req_proxies,
                 )
-                if response.status_code in {429, 502, 503} and self.proxy_enabled and rotations < self.max_proxy_rotations:
+                if response.status_code in throttle_statuses and self.proxy_enabled and rotations < self.max_proxy_rotations:
                     rotations += 1
                     self._rotation_count += 1
-                    self._rotate_proxy(reason=f"HTTP {response.status_code}")
+                    # Rotate without failure_reason — the ProxyStateManager
+                    # must NOT mark this proxy as dead. It is only throttled
+                    # and will recover within minutes.
+                    self._rotator.rotate(failure_reason=None)
+                    logger.log(
+                        self._rotator.log_level,
+                        "Rotated on HTTP %d (throttled, proxy not marked dead)",
+                        response.status_code,
+                    )
                     continue
                 return response
             except (requests_lib.ConnectionError, requests_lib.Timeout, OSError) as exc:
                 if self.proxy_enabled and rotations < self.max_proxy_rotations:
                     rotations += 1
                     self._rotation_count += 1
+                    # Genuine connection failure — record via state manager
+                    # so the proxy is blocked for the grace period.
                     self._rotate_proxy(reason=str(exc)[:80])
                     continue
                 raise

--- a/tests/hyperliquid/test_session.py
+++ b/tests/hyperliquid/test_session.py
@@ -1,0 +1,162 @@
+"""Unit tests for HyperliquidSession.post_info rotation behaviour.
+
+Covers the 429-vs-connection-error distinction added for market-data
+bulk downloads: throttled responses must rotate without marking the
+proxy as dead; connection errors still mark it dead.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from eth_defi.event_reader.webshare import ProxyRotator, WebshareProxy
+from eth_defi.hyperliquid.session import create_hyperliquid_session
+
+
+def _make_proxy(idx: int) -> WebshareProxy:
+    return WebshareProxy(
+        proxy_address=f"10.0.0.{idx}",
+        port=8080 + idx,
+        username="u",
+        password="p",
+        country_code="US",
+        city_name="NYC",
+    )
+
+
+def _fake_rotator(n_proxies: int = 3) -> ProxyRotator:
+    """Build a :class:`ProxyRotator` with a mocked state manager.
+
+    The state manager is a :class:`~unittest.mock.MagicMock` so tests can
+    assert whether ``record_failure`` was called without touching the
+    on-disk grace-period store.
+    """
+    state_mgr = MagicMock()
+    state_mgr.is_blocked.return_value = False
+    state_mgr.record_failure = MagicMock()
+    return ProxyRotator(
+        proxies=[_make_proxy(i) for i in range(n_proxies)],
+        state_manager=state_mgr,
+    )
+
+
+@pytest.fixture
+def session_with_proxies():
+    rotator = _fake_rotator()
+    return create_hyperliquid_session(rotator=rotator)
+
+
+def test_429_rotates_without_recording_failure(session_with_proxies):
+    """A 429 response must rotate the proxy but NOT mark it dead."""
+    rotator = session_with_proxies._rotator
+    state_mgr = rotator.state_manager
+    initial_proxy = rotator.current()
+
+    # First call returns 429, second returns 200
+    responses = [
+        MagicMock(status_code=429),
+        MagicMock(status_code=200),
+    ]
+    with patch.object(session_with_proxies, "post", side_effect=responses) as m:
+        resp = session_with_proxies.post_info({"type": "meta"})
+
+    assert resp.status_code == 200
+    assert m.call_count == 2
+    # Rotator advanced to the next proxy
+    assert rotator.current() != initial_proxy
+    # But state manager was NOT told to record a failure
+    state_mgr.record_failure.assert_not_called()
+
+
+def test_503_rotates_without_recording_failure(session_with_proxies):
+    """503 (upstream overload) behaves the same as 429."""
+    rotator = session_with_proxies._rotator
+    state_mgr = rotator.state_manager
+    responses = [MagicMock(status_code=503), MagicMock(status_code=200)]
+    with patch.object(session_with_proxies, "post", side_effect=responses):
+        session_with_proxies.post_info({"type": "meta"})
+    state_mgr.record_failure.assert_not_called()
+
+
+def test_504_rotates_without_recording_failure(session_with_proxies):
+    """504 gateway timeout is treated as throttle, not a dead proxy."""
+    rotator = session_with_proxies._rotator
+    state_mgr = rotator.state_manager
+    responses = [MagicMock(status_code=504), MagicMock(status_code=200)]
+    with patch.object(session_with_proxies, "post", side_effect=responses):
+        session_with_proxies.post_info({"type": "meta"})
+    state_mgr.record_failure.assert_not_called()
+
+
+def test_connection_error_rotates_and_records_failure(session_with_proxies):
+    """A real connection error must mark the proxy dead via ProxyStateManager."""
+    rotator = session_with_proxies._rotator
+    state_mgr = rotator.state_manager
+    initial_proxy = rotator.current()
+
+    side_effects = [
+        requests.ConnectionError("boom"),
+        MagicMock(status_code=200),
+    ]
+    with patch.object(session_with_proxies, "post", side_effect=side_effects):
+        session_with_proxies.post_info({"type": "meta"})
+
+    # Rotator advanced
+    assert rotator.current() != initial_proxy
+    # State manager WAS told to record a failure
+    assert state_mgr.record_failure.called
+    recorded = state_mgr.record_failure.call_args
+    # First arg is the failed proxy, second is the reason string
+    assert recorded.args[0].proxy_address == initial_proxy.proxy_address
+
+
+def test_timeout_rotates_and_records_failure(session_with_proxies):
+    """A requests.Timeout is a genuine connectivity signal — mark dead."""
+    rotator = session_with_proxies._rotator
+    state_mgr = rotator.state_manager
+    side_effects = [
+        requests.Timeout("slow"),
+        MagicMock(status_code=200),
+    ]
+    with patch.object(session_with_proxies, "post", side_effect=side_effects):
+        session_with_proxies.post_info({"type": "meta"})
+    assert state_mgr.record_failure.called
+
+
+def test_rotation_budget_respected(session_with_proxies):
+    """After max_proxy_rotations, stop rotating and return the last response."""
+    session_with_proxies.max_proxy_rotations = 2
+    # Every request returns 429 — rotate twice then give up
+    responses = [MagicMock(status_code=429)] * 5
+    with patch.object(session_with_proxies, "post", side_effect=responses) as m:
+        resp = session_with_proxies.post_info({"type": "meta"})
+    assert resp.status_code == 429
+    # 1 initial + 2 rotations = 3 calls
+    assert m.call_count == 3
+
+
+def test_no_rotation_when_proxies_disabled():
+    """Without a rotator, 429 just returns to the caller without rotation."""
+    session = create_hyperliquid_session()  # no rotator
+    responses = [MagicMock(status_code=429)]
+    with patch.object(session, "post", side_effect=responses) as m:
+        resp = session.post_info({"type": "meta"})
+    assert resp.status_code == 429
+    assert m.call_count == 1
+
+
+def test_successful_200_short_circuits(session_with_proxies):
+    """A 200 response returns immediately without rotation."""
+    rotator = session_with_proxies._rotator
+    state_mgr = rotator.state_manager
+    initial_proxy = rotator.current()
+
+    responses = [MagicMock(status_code=200)]
+    with patch.object(session_with_proxies, "post", side_effect=responses) as m:
+        resp = session_with_proxies.post_info({"type": "meta"})
+
+    assert resp.status_code == 200
+    assert m.call_count == 1
+    assert rotator.current() == initial_proxy
+    state_mgr.record_failure.assert_not_called()


### PR DESCRIPTION
## Why

Downstream research projects (e.g. contrarian funding-rate backtesting in `freqtrade-strategies`) need bulk historical OHLCV candles and funding-rate history from Hyperliquid. The existing `eth_defi.hyperliquid.api` module has excellent wrappers for account-level data (vault equities, clearinghouse state, portfolios, leaderboards), but nothing for the `candleSnapshot` and `fundingHistory` Info endpoints. Downstream callers were left with three bad options: write ad-hoc HTTP themselves and lose the SQLite rate limiting + Webshare proxy rotation baked into `HyperliquidSession`, use `ccxt.hyperliquid` and lose the same features, or inline the logic into every consumer.

A second, subtler issue: `HyperliquidSession.post_info()` was marking proxies as dead on any HTTP 429/502/503 response, which shrinks the Webshare pool across runs even though a 429 is just a per-IP throttle that resolves within minutes. For a 150-symbol × 3-year download of hourly funding rates (~8,250 requests), we hit the per-IP rate limit routinely and end up blocking perfectly healthy proxies for the 14-day `ProxyStateManager` grace period.

## Summary

### New market-data primitives in `eth_defi.hyperliquid.api`

- `HyperliquidCandle` dataclass — typed OHLCV candle with naive-UTC timestamps; `float` fields for direct pandas/numpy compatibility
- `HyperliquidFundingRate` dataclass — typed funding observation (`timestamp`, `coin`, `funding_rate`, `premium`) with explicit documentation that Hyperliquid pays hourly at 1/8 of the 8-hour-window rate
- `HYPERLIQUID_CANDLE_SNAPSHOT_LIMIT = 5000`
- `HYPERLIQUID_FUNDING_HISTORY_LIMIT = 500`
- `fetch_candle_snapshot(session, *, coin, interval, start_time, end_time, timeout)` — single paginated-page OHLCV fetcher
- `fetch_funding_history(session, *, coin, start_time, end_time, timeout)` — single paginated-page funding fetcher
- `fetch_perp_meta(session, timeout)` — universe metadata for symbol discovery

All three route through `HyperliquidSession.post_info()` (not raw `session.post()`), matching the architectural rule enforced by `test_post_info_proxy_fix` in `tests/hyperliquid/test_high_freq_metrics.py`. Every fetcher now automatically benefits from Webshare proxy rotation without the caller having to know anything about it.

Each docstring carries a link to the authoritative Hyperliquid funding cadence page ([hyperliquid.gitbook.io › Trading › Funding](https://hyperliquid.gitbook.io/hyperliquid-docs/trading/funding)) so future maintainers can verify the 1-hour cadence claim themselves.

### Graceful 429 failover in `HyperliquidSession.post_info()`

Rotation policy is now split:

- **Rate-limit / backend overload responses** (HTTP 429, 500, 502, 503, 504): rotate to the next proxy via `self._rotator.rotate(failure_reason=None)` — this advances the index but does NOT call `ProxyStateManager.record_failure()`. The proxy is only throttled and will recover in minutes; marking it dead for 14 days needlessly shrinks the working pool.
- **Connection errors** (`requests.ConnectionError`, `requests.Timeout`, `OSError`): unchanged — rotate AND record the proxy as dead via the state manager, because the proxy itself is unreachable.

504 Gateway Timeout is also included in the throttle-statuses set. If the upstream is overloaded, the proxy is still fine.

### Tests: `tests/hyperliquid/test_session.py`

Eight deterministic unit tests using a mocked transport (no network, no real proxies):

- `test_429_rotates_without_recording_failure`
- `test_503_rotates_without_recording_failure`
- `test_504_rotates_without_recording_failure`
- `test_connection_error_rotates_and_records_failure`
- `test_timeout_rotates_and_records_failure`
- `test_rotation_budget_respected`
- `test_no_rotation_when_proxies_disabled`
- `test_successful_200_short_circuits`

All 8 pass in <100 ms. The pre-existing `test_post_info_proxy_fix` architectural test still passes — this change does not regress any existing behaviour, it only adds the mark-dead-vs-throttle distinction.

## Lessons learnt

- **Throttling and proxy death are different failures.** The previous blanket `record_failure()` call on any 4xx/5xx response was a subtle but corrosive bug for high-volume bulk downloads — every run reduced the usable proxy pool by however many 429s were hit, and the damage persisted for 14 days via the state manager. The fix is small but important: pass `failure_reason=None` for throttle responses and only record real connection failures.
- **Market-data functions must route through `post_info()`.** The existing `test_post_info_proxy_fix` test enforces this rule for vault and high-frequency metrics code; the same rule applies to any new fetcher that will be called thousands of times during a backtest download. Routing through the raw `session.post()` loses all the rate-limiting and proxy-rotation work baked into `HyperliquidSession`.
- **Mocked transport beats live tests for rotation logic.** Simulating 429/503/504 responses with `unittest.mock.patch.object(session, "post")` is much more reliable than trying to trigger real rate limits in an integration test. All eight new tests run in <100 ms and exercise exactly the branches we care about.