### PR TITLE
fix: remove trailing slash from Morpho app vault links

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v1.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v1.py
@@ -192,7 +192,7 @@ class MorphoV1Vault(ERC4626Vault):
 
     def get_link(self, referral: str | None = None) -> str:
         chain_name = get_chain_name(self.chain_id).lower()
-        return f"https://app.morpho.org/{chain_name}/vault/{self.vault_address}/"
+        return f"https://app.morpho.org/{chain_name}/vault/{self.vault_address}"
 
     def fetch_available_liquidity(self, block_identifier: BlockIdentifier = "latest") -> Decimal | None:
         """Get the amount of denomination token available for immediate withdrawal.

--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
@@ -277,7 +277,7 @@ class MorphoV2Vault(ERC4626Vault):
             URL to the vault page on app.morpho.org
         """
         chain_name = get_chain_name(self.chain_id).lower()
-        return f"https://app.morpho.org/{chain_name}/vault/{self.vault_address}/"
+        return f"https://app.morpho.org/{chain_name}/vault/{self.vault_address}"
 
     def get_adapters_count(self, block_identifier: BlockIdentifier = "latest") -> int | None:
         """Get the number of adapters configured for this vault.


### PR DESCRIPTION
## Why

Every Morpho vault link emitted by the vault metadata system lands in an infinite 301 redirect loop on `app.morpho.org`. The link shown on e.g. https://tradingstrategy.ai/trading-view/vaults/hackarrot-usdc-prime never resolves for end users.

The root cause is a trailing slash in the URL template:

```
https://app.morpho.org/ethereum/vault/0xb5a4...afc061/   → 301 loop (curl hits max 20 redirects)
https://app.morpho.org/ethereum/vault/0xb5a4...afc061    → HTTP 200
```

Morpho's Next.js router 301s the slash off, then something in their routing re-appends it, producing the loop. Confirmed against multiple vaults (`hackarrot-usdc-prime`, `steakhouse-usdt`).

## Lessons learnt

- When generating deep links into third-party dapps, always curl the produced URL end-to-end at least once — a single character (`/`) is enough to break every link the codebase emits, and simple unit tests that use `"morpho.org" in link` will happily pass through a dead URL.
- Morpho's canonical vault URL is slug-less (`/vault/{checksum_address}`), not `/vault/{address}/`. If we ever want to be extra safe we could emit `Web3.to_checksum_address(...)` directly to avoid the single normalising redirect, but that is not required to fix the loop.

## Summary

- Drop the trailing `/` in `MorphoV1Vault.get_link()` ([vault_v1.py:195](eth_defi/erc_4626/vault_protocol/morpho/vault_v1.py#L195)).
- Drop the trailing `/` in `MorphoV2Vault.get_link()` ([vault_v2.py:280](eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py#L280)).
- No test updates needed — the existing `test_morpho_v2.py` assertion only checks substring membership and still passes.