### PR TITLE
feat: upgrade vault scanner containers to Python 3.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Current
 
+- feat: Upgrade vault scanner and vault analysis Docker images to Python 3.14.4 — hypersync-temp 0.10.0 now ships cp314 linux wheels, removing the blocker that kept these containers on 3.12 (2026-04-10)
 - feat: Hyperliquid market-data Info API primitives — `fetch_candle_snapshot`, `fetch_funding_history`, `fetch_perp_meta` in `eth_defi.hyperliquid.api` with typed `HyperliquidCandle` / `HyperliquidFundingRate` dataclasses, routed through `HyperliquidSession.post_info()` for automatic Webshare proxy rotation on rate-limit failures; `post_info()` now distinguishes rate-limit responses (429/5xx rotate without marking proxy dead) from connection errors (rotate and record as dead for the 14-day grace period), preserving the Webshare proxy pool across throttled runs (2026-04-10)
 - feat: IPOR Fusion fee mode classification — added `IPOR Fusion` to `VAULT_PROTOCOL_FEE_MATRIX` as `internalised_minting`, documented the share-minting mechanism (FeeManager / FeeAccount / PlasmaVault) with source-code line references in the `IPORVault` class docstring and `ipor-fusion.yaml` metadata (2026-04-10)
 - feat: Atomic parquet and pickle writes for vault price pipeline — prevents data corruption from interruptions using `atomicwrites` library with fsync + directory sync (2026-04-09)

--- a/Dockerfile.analysis-vault
+++ b/Dockerfile.analysis-vault
@@ -1,7 +1,5 @@
 # Base image
-# Note: hypersync does not publish wheels for Python 3.14 yet,
-# so Docker images stay on 3.12 until upstream adds support
-FROM python:3.12
+FROM python:3.14.4
 
 # Build args
 ARG GIT_VERSION_TAG=unspecified
@@ -45,7 +43,7 @@ RUN .venv/bin/pip install gspread gspread-dataframe google-auth google-auth-oaut
 RUN poetry cache clear pypi --all --no-interaction
 
 # Speed up Python
-RUN python -m compileall -q /usr/local/lib/python3.12
+RUN python -m compileall -q /usr/local/lib/python3.14
 RUN python -m compileall -q eth_defi
 
 # Entrypoint

--- a/Dockerfile.vault-scanner
+++ b/Dockerfile.vault-scanner
@@ -22,9 +22,7 @@
 #
 #
 
-# Note: hypersync does not publish wheels for Python 3.14 yet,
-# so Docker images stay on 3.12 until upstream adds support
-FROM python:3.12
+FROM python:3.14.4
 
 # Passed from Github Actions
 ARG GIT_VERSION_TAG=unspecifiedls
@@ -64,7 +62,7 @@ RUN poetry install -E data -E hypersync -E cloudflare_r2 -E duckdb -E posts --no
 RUN poetry cache clear pypi --all --no-interaction
 
 # Speed up Python process startup
-RUN python -m compileall -q /usr/local/lib/python3.12
+RUN python -m compileall -q /usr/local/lib/python3.14
 RUN python -m compileall -q eth_defi
 
 ENV SCAN_PRICES=true


### PR DESCRIPTION
## Why

`hypersync-temp` 0.10.0 now publishes `cp314` linux wheels (aarch64, i686, x86_64), removing the blocker noted in the old comments that kept `Dockerfile.vault-scanner` and `Dockerfile.analysis-vault` on Python 3.12. Bringing these containers forward puts them on the latest bugfix release (3.14.4) in line with the rest of the project.

## Lessons learnt

- Pin to a full `X.Y.Z` tag (`python:3.14.4`) instead of `python:3.14` so image rebuilds are reproducible and can be tied to a known CPython bugfix.
- Whenever a "blocked on upstream wheels" comment is carried in a Dockerfile, it is worth re-checking PyPI periodically — `hypersync-temp` shipped cp314 wheels between 0.10.0 builds without a version bump.

## Summary

- `Dockerfile.vault-scanner`: base image `python:3.12` → `python:3.14.4`, `compileall` path updated to `python3.14`, stale hypersync 3.14 blocker comment removed.
- `Dockerfile.analysis-vault`: same changes as above.
- `CHANGELOG.md`: entry added under **Current**.