### PR TITLE
fix: vault-scanner-looped starts scanning immediately on startup

### DIFF
--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -1425,13 +1425,23 @@ def main():
             with wait_other_writers(pipeline_lock_path, timeout=60):
                 if looped_mode:
                     state = load_cycle_state(cycle_state_path)
-                    due_chains, due_protocols = get_due_items(
-                        chains,
-                        all_protocols,
-                        cycle_overrides,
-                        default_cycle,
-                        state,
-                    )
+                    if cycle == 1:
+                        # On the first tick after startup always scan everything,
+                        # regardless of cycle state. Without this the container
+                        # would sleep a full LOOP_INTERVAL_SECONDS before doing any
+                        # work whenever the on-disc cycle state has fresh timestamps
+                        # (e.g. from a prior run or the single-run vault-scanner).
+                        logger.info("Cycle %d: first tick after startup, scanning all items", cycle)
+                        due_chains = list(chains)
+                        due_protocols = list(all_protocols)
+                    else:
+                        due_chains, due_protocols = get_due_items(
+                            chains,
+                            all_protocols,
+                            cycle_overrides,
+                            default_cycle,
+                            state,
+                        )
 
                     if due_chains or due_protocols:
                         # Compute items not due in this cycle with hours remaining


### PR DESCRIPTION
## Why

When the `vault-scanner-looped` container restarted it would log `Cycle 1: nothing due, sleeping` and then wait a full `LOOP_INTERVAL_SECONDS` (typically 1h) before doing any work. This happened because the persisted `scan-cycle-state.json` is shared with the single-run `vault-scanner` container, so on restart the state usually already had fresh timestamps for every chain and protocol and `get_due_items()` returned empty.

## Lessons learnt

Persistent cycle state that is shared across multiple containers needs special handling on startup — you cannot assume an empty state file. A looped service should always do useful work on its first tick after startup, otherwise operators have no feedback that the container is healthy and restarts become invisible no-ops for up to a full loop interval.

## Summary

- On the first tick after startup, treat all chains and native protocols as due regardless of the on-disc cycle state.
- Subsequent cycles keep using the normal per-item cycle logic via `get_due_items()`.
- New log line on startup: `Cycle 1: first tick after startup, scanning all items`.