### PR TITLE
feat: skip unchanged static R2 uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Current
 
+- feat: Skip unchanged static R2 uploads with `head_object()` checksum checks for protocol, stablecoin, curator, and exported data files; deterministic gzip payloads now avoid redundant metadata and logo uploads on repeat runs (2026-04-11)
 - fix: Hyperliquid vault metrics DuckDB thread race — every method reachable from `joblib.Parallel(backend="threading")` workers now uses `self.con.cursor()` so concurrent `execute().fetchone()` calls no longer clobber each other's result sets; the HF scan was crashing with `Invalid Input Error: No open result set` on startup, and the same latent race existed in the daily scanner (2026-04-10)
 - fix: Cache ERC-4626 vault share/asset token addresses to disk and remove `vault-scanner-looped` log flood — new `eth_defi.erc_4626.vault_token` module persists immutable per-vault address lookups via `TokenDiskCache`, eliminating redundant `share()`/`asset()` eth_calls on every scan iteration, with cache-poisoning protection for transient RPC failures and a historical-reader safety guard (2026-04-10)
 - feat: Upgrade vault scanner and vault analysis Docker images to Python 3.14.4 — hypersync-temp 0.10.0 now ships cp314 linux wheels, removing the blocker that kept these containers on 3.12 (2026-04-10)

--- a/eth_defi/cloudflare_r2.py
+++ b/eth_defi/cloudflare_r2.py
@@ -1,0 +1,407 @@
+"""Cloudflare R2 upload helpers.
+
+These helpers add cheap ``head_object()``-based change detection for
+uploads. By storing source checksums in S3 object metadata, callers can
+skip unchanged uploads without downloading the remote object body.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+#: Custom S3 metadata key for the source payload SHA-256 digest.
+R2_SOURCE_SHA256_METADATA_KEY = "source_sha256"
+
+#: Custom S3 metadata key for the source payload byte length.
+R2_SOURCE_SIZE_METADATA_KEY = "source_size"
+
+
+@dataclass(slots=True)
+class R2SourceDigest:
+    """Checksum metadata for a source payload.
+
+    The digest always describes the original source payload before any
+    transport encoding such as gzip is applied. This makes checksum
+    comparisons stable even if the upload body is encoded differently.
+
+    :param sha256:
+        Hex-encoded SHA-256 digest of the source payload.
+
+    :param size:
+        Source payload length in bytes.
+    """
+
+    #: Hex-encoded SHA-256 digest of the source payload.
+    sha256: str
+
+    #: Source payload length in bytes.
+    size: int
+
+    def as_metadata(self) -> dict[str, str]:
+        """Convert the digest to S3 metadata fields.
+
+        The return value is suitable for ``put_object()`` or
+        ``upload_fileobj()`` ``Metadata`` arguments.
+
+        :return:
+            Custom S3 metadata mapping.
+        """
+        return {
+            R2_SOURCE_SHA256_METADATA_KEY: self.sha256,
+            R2_SOURCE_SIZE_METADATA_KEY: str(self.size),
+        }
+
+
+def create_r2_client(
+    endpoint_url: str,
+    access_key_id: str,
+    secret_access_key: str,
+    max_pool_connections: int | None = None,
+) -> Any:
+    """Create an authenticated Cloudflare R2 S3 client.
+
+    ``boto3`` is imported lazily because the Cloudflare R2 dependency is
+    optional for this library.
+
+    :param endpoint_url:
+        R2 S3-compatible API endpoint URL.
+
+    :param access_key_id:
+        R2 access key ID.
+
+    :param secret_access_key:
+        R2 secret access key.
+
+    :param max_pool_connections:
+        Optional connection pool size override for concurrent uploads.
+
+    :return:
+        Configured boto3 S3 client.
+    """
+    import boto3  # noqa: PLC0415
+    from botocore.config import Config  # noqa: PLC0415
+
+    client_kwargs: dict[str, Any] = {
+        "endpoint_url": endpoint_url,
+        "aws_access_key_id": access_key_id,
+        "aws_secret_access_key": secret_access_key,
+        "region_name": "auto",
+    }
+    if max_pool_connections is not None:
+        client_kwargs["config"] = Config(max_pool_connections=max_pool_connections)
+
+    return boto3.client("s3", **client_kwargs)
+
+
+def calculate_bytes_digest(payload: bytes) -> R2SourceDigest:
+    """Calculate checksum metadata for an in-memory payload.
+
+    :param payload:
+        Raw source payload bytes.
+
+    :return:
+        SHA-256 digest and source size.
+    """
+    return R2SourceDigest(
+        sha256=hashlib.sha256(payload).hexdigest(),
+        size=len(payload),
+    )
+
+
+def calculate_file_digest(file_path: Path) -> R2SourceDigest:
+    """Calculate checksum metadata for a file on disk.
+
+    The file is streamed in chunks so large parquet and pickle files do
+    not need to be loaded into memory in one go.
+
+    :param file_path:
+        Path to the source file.
+
+    :return:
+        SHA-256 digest and source size.
+    """
+    sha256 = hashlib.sha256()
+
+    with file_path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            sha256.update(chunk)
+
+    return R2SourceDigest(
+        sha256=sha256.hexdigest(),
+        size=file_path.stat().st_size,
+    )
+
+
+def fetch_r2_object_head(
+    s3_client: Any,
+    bucket_name: str,
+    object_name: str,
+) -> dict[str, Any] | None:
+    """Fetch object metadata using ``head_object()``.
+
+    Missing objects return ``None``. Any other S3 error is raised to the
+    caller unchanged so upload scripts fail loudly instead of silently
+    skipping work.
+
+    :param s3_client:
+        Authenticated boto3 S3 client.
+
+    :param bucket_name:
+        Target R2 bucket name.
+
+    :param object_name:
+        Object key inside the bucket.
+
+    :return:
+        ``head_object()`` response, or ``None`` if the object does not
+        exist.
+    """
+    from botocore.exceptions import ClientError  # noqa: PLC0415
+
+    try:
+        return s3_client.head_object(Bucket=bucket_name, Key=object_name)
+    except ClientError as exc:
+        error_code = str(exc.response.get("Error", {}).get("Code", ""))
+        if error_code in {"404", "NoSuchKey", "NotFound"}:
+            return None
+        raise
+
+
+def _calculate_md5_hex(payload: bytes) -> str:
+    """Calculate MD5 for S3 ETag comparisons.
+
+    Some Python environments expose the ``usedforsecurity`` argument and
+    some do not. This helper keeps the call portable.
+
+    :param payload:
+        Bytes to hash.
+
+    :return:
+        Hex-encoded MD5 digest.
+    """
+    try:
+        return hashlib.md5(payload, usedforsecurity=False).hexdigest()
+    except TypeError:
+        return hashlib.md5(payload).hexdigest()  # noqa: S324
+
+
+def _is_remote_object_current(  # noqa: PLR0917
+    remote_head: dict[str, Any],
+    source_digest: R2SourceDigest,
+    expected_length: int,
+    content_type: str | None = None,
+    content_encoding: str | None = None,
+    payload_md5: str | None = None,
+) -> bool:
+    """Check whether a remote object already matches a local source.
+
+    First we compare the checksum metadata written by this helper. For
+    older uploads without checksum metadata, we fall back to an ETag
+    comparison for single-part uploads when an MD5 digest is available.
+
+    :param remote_head:
+        ``head_object()`` response for the remote object.
+
+    :param source_digest:
+        Digest of the original source payload.
+
+    :param expected_length:
+        Expected remote object length in bytes.
+
+    :param content_type:
+        Expected MIME type, if relevant for this upload.
+
+    :param content_encoding:
+        Expected content encoding, if relevant for this upload.
+
+    :param payload_md5:
+        Optional MD5 digest of the exact uploaded body for ETag fallback.
+
+    :return:
+        ``True`` if the remote object already matches the local source.
+    """
+    if remote_head.get("ContentLength") != expected_length:
+        return False
+
+    if content_type is not None and remote_head.get("ContentType") != content_type:
+        return False
+
+    if content_encoding is not None and remote_head.get("ContentEncoding") != content_encoding:
+        return False
+
+    metadata = {key.lower(): value for key, value in (remote_head.get("Metadata") or {}).items()}
+
+    if metadata.get(R2_SOURCE_SHA256_METADATA_KEY) == source_digest.sha256 and metadata.get(R2_SOURCE_SIZE_METADATA_KEY) == str(source_digest.size):
+        return True
+
+    etag = str(remote_head.get("ETag", "")).strip('"')
+    if payload_md5 and etag and "-" not in etag and etag == payload_md5:
+        return True
+
+    return False
+
+
+def upload_bytes_to_r2(
+    s3_client: Any,
+    payload: bytes,
+    bucket_name: str,
+    object_name: str,
+    *,
+    content_type: str | None = None,
+    content_encoding: str | None = None,
+    skip_if_current: bool = False,
+    source_digest: R2SourceDigest | None = None,
+) -> bool:
+    """Upload an in-memory payload to R2.
+
+    When ``skip_if_current`` is enabled, the helper performs a cheap
+    ``head_object()`` request and compares remote metadata against the
+    local checksum before uploading.
+
+    :param s3_client:
+        Authenticated boto3 S3 client.
+
+    :param payload:
+        Exact bytes that will be sent to R2.
+
+    :param bucket_name:
+        Target R2 bucket name.
+
+    :param object_name:
+        Destination object key.
+
+    :param content_type:
+        Optional MIME type for the upload.
+
+    :param content_encoding:
+        Optional content encoding for the upload.
+
+    :param skip_if_current:
+        Skip the upload if the existing object already matches the local
+        source payload.
+
+    :param source_digest:
+        Optional digest of the original source payload. If omitted, the
+        upload body itself is used as the source payload.
+
+    :return:
+        ``True`` if the object was uploaded, ``False`` if it was skipped
+        as unchanged.
+    """
+    from botocore.exceptions import ClientError  # noqa: PLC0415
+
+    source_digest = source_digest or calculate_bytes_digest(payload)
+
+    if skip_if_current:
+        remote_head = fetch_r2_object_head(s3_client, bucket_name, object_name)
+        if remote_head and _is_remote_object_current(
+            remote_head=remote_head,
+            source_digest=source_digest,
+            expected_length=len(payload),
+            content_type=content_type,
+            content_encoding=content_encoding,
+            payload_md5=_calculate_md5_hex(payload),
+        ):
+            return False
+
+    put_kwargs: dict[str, Any] = {
+        "Bucket": bucket_name,
+        "Key": object_name,
+        "Body": payload,
+        "Metadata": source_digest.as_metadata(),
+    }
+    if content_type is not None:
+        put_kwargs["ContentType"] = content_type
+    if content_encoding is not None:
+        put_kwargs["ContentEncoding"] = content_encoding
+
+    try:
+        s3_client.put_object(**put_kwargs)
+    except ClientError as exc:
+        raise RuntimeError(f"Failed to upload {object_name} to bucket {bucket_name}: {exc}") from exc
+
+    return True
+
+
+def upload_file_to_r2(
+    s3_client: Any,
+    file_path: Path,
+    bucket_name: str,
+    object_name: str,
+    *,
+    skip_if_current: bool = False,
+    content_type: str | None = None,
+    callback: Callable[[int], None] | None = None,
+) -> bool:
+    """Upload a file from disk to R2.
+
+    The helper stores checksum metadata for the source file so later runs
+    can skip unchanged uploads using a ``head_object()`` request alone.
+
+    :param s3_client:
+        Authenticated boto3 S3 client.
+
+    :param file_path:
+        Source file path on disk.
+
+    :param bucket_name:
+        Target R2 bucket name.
+
+    :param object_name:
+        Destination object key.
+
+    :param skip_if_current:
+        Skip the upload if the remote object already matches the local
+        file checksum.
+
+    :param content_type:
+        Optional MIME type for the upload.
+
+    :param callback:
+        Optional boto3 progress callback.
+
+    :return:
+        ``True`` if the file was uploaded, ``False`` if it was skipped as
+        unchanged.
+    """
+    from botocore.exceptions import ClientError  # noqa: PLC0415
+
+    source_digest = calculate_file_digest(file_path)
+
+    if skip_if_current:
+        remote_head = fetch_r2_object_head(s3_client, bucket_name, object_name)
+        if remote_head and _is_remote_object_current(
+            remote_head=remote_head,
+            source_digest=source_digest,
+            expected_length=source_digest.size,
+            content_type=content_type,
+        ):
+            return False
+
+    extra_args: dict[str, Any] = {
+        "Metadata": source_digest.as_metadata(),
+    }
+    if content_type is not None:
+        extra_args["ContentType"] = content_type
+
+    with file_path.open("rb") as handle:
+        try:
+            s3_client.upload_fileobj(
+                handle,
+                bucket_name,
+                object_name,
+                ExtraArgs=extra_args,
+                Callback=callback,
+            )
+        except ClientError as exc:
+            raise RuntimeError(f"Failed to upload {object_name} to bucket {bucket_name}: {exc}") from exc
+
+    return True

--- a/eth_defi/research/sparkline.py
+++ b/eth_defi/research/sparkline.py
@@ -8,14 +8,15 @@ import gzip
 import warnings
 from io import BytesIO
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 
 import matplotlib
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
+from eth_defi.cloudflare_r2 import calculate_bytes_digest, create_r2_client, upload_bytes_to_r2
 from eth_defi.research.wrangle_vault_prices import forward_fill_vault
 from eth_defi.vault.base import VaultSpec
 
@@ -215,7 +216,7 @@ def export_sparkline_as_svg(
     return svg_bytes
 
 
-def upload_to_r2_compressed(
+def upload_to_r2_compressed(  # noqa: PLR0917, FBT001, FBT002
     payload: bytes,
     bucket_name: str,
     object_name: str,
@@ -223,6 +224,7 @@ def upload_to_r2_compressed(
     access_key_id: str,
     secret_access_key: str,
     content_type: str,
+    skip_if_current: bool = False,
 ):
     """Uploads a the vault sparklines payload to a Cloudflare R2 bucket.
 
@@ -236,26 +238,22 @@ def upload_to_r2_compressed(
     :param access_key_id: Your R2 access key ID.
     :param secret_access_key: Your R2 secret access key.
     :param content_type: The MIME type of the file.
+    :param skip_if_current: Skip upload if the remote object already matches the local source payload.
+    :return: ``True`` if uploaded, ``False`` if skipped as unchanged.
     """
-
-    import boto3
-    from botocore.exceptions import ClientError
-
-    s3_client = boto3.client(
-        "s3",
+    s3_client = create_r2_client(
         endpoint_url=endpoint_url,
-        aws_access_key_id=access_key_id,
-        aws_secret_access_key=secret_access_key,
-        region_name="auto",  # Must be "auto"
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
     )
 
-    try:
-        s3_client.put_object(
-            Bucket=bucket_name,
-            Key=object_name,
-            Body=gzip.compress(payload),
-            ContentType=content_type,
-            ContentEncoding="gzip",
-        )
-    except ClientError as e:
-        raise RuntimeError(f"Failed to upload {object_name} to bucket {bucket_name} (endpoint: {endpoint_url}, access_key_id: {access_key_id}): {e}") from e
+    return upload_bytes_to_r2(
+        s3_client=s3_client,
+        payload=gzip.compress(payload, mtime=0),
+        bucket_name=bucket_name,
+        object_name=object_name,
+        content_type=content_type,
+        content_encoding="gzip",
+        skip_if_current=skip_if_current,
+        source_digest=calculate_bytes_digest(payload),
+    )

--- a/eth_defi/stablecoin_metadata.py
+++ b/eth_defi/stablecoin_metadata.py
@@ -809,11 +809,9 @@ def process_and_upload_stablecoin_metadata(
     metadata = build_stablecoin_metadata_json(yaml_path, public_url=public_url)
     slug = yaml_path.stem
 
-    logger.info("Uploading stablecoin metadata for: %s", slug)
-
     # Upload metadata JSON
     json_bytes = json.dumps(metadata, indent=2).encode()
-    upload_to_r2_compressed(
+    metadata_uploaded = upload_to_r2_compressed(
         payload=json_bytes,
         bucket_name=bucket_name,
         object_name=f"stablecoin-metadata/{key_prefix}{slug}/metadata.json",
@@ -821,13 +819,14 @@ def process_and_upload_stablecoin_metadata(
         access_key_id=access_key_id,
         secret_access_key=secret_access_key,
         content_type="application/json",
+        skip_if_current=True,
     )
+    logger.info("%s stablecoin metadata for: %s", "Uploaded" if metadata_uploaded else "Skipped unchanged", slug)
 
     # Upload logo if available
     logo_path = STABLECOIN_FORMATTED_LOGOS_DIR / slug / "light.png"
     if logo_path.exists():
-        logger.info("Uploading light logo for stablecoin: %s", slug)
-        upload_to_r2_compressed(
+        logo_uploaded = upload_to_r2_compressed(
             payload=logo_path.read_bytes(),
             bucket_name=bucket_name,
             object_name=f"stablecoin-metadata/{key_prefix}{slug}/light.png",
@@ -835,7 +834,9 @@ def process_and_upload_stablecoin_metadata(
             access_key_id=access_key_id,
             secret_access_key=secret_access_key,
             content_type="image/png",
+            skip_if_current=True,
         )
+        logger.info("%s light logo for stablecoin: %s", "Uploaded" if logo_uploaded else "Skipped unchanged", slug)
 
     return metadata
 
@@ -878,10 +879,8 @@ def upload_stablecoin_index(
 
     index = build_stablecoin_index(public_url=public_url)
 
-    logger.info("Uploading stablecoin index with %d entries", len(index))
-
     json_bytes = json.dumps(index, indent=2).encode()
-    upload_to_r2_compressed(
+    index_uploaded = upload_to_r2_compressed(
         payload=json_bytes,
         bucket_name=bucket_name,
         object_name=f"stablecoin-metadata/{key_prefix}index.json",
@@ -889,6 +888,12 @@ def upload_stablecoin_index(
         access_key_id=access_key_id,
         secret_access_key=secret_access_key,
         content_type="application/json",
+        skip_if_current=True,
+    )
+    logger.info(
+        "%s stablecoin index with %d entries",
+        "Uploaded" if index_uploaded else "Skipped unchanged",
+        len(index),
     )
 
     return index

--- a/eth_defi/vault/curator.py
+++ b/eth_defi/vault/curator.py
@@ -622,10 +622,8 @@ def process_and_upload_curator_metadata(
     metadata = build_curator_metadata_json(yaml_path)
     slug = metadata["slug"]
 
-    logger.info("Uploading curator metadata for: %s", slug)
-
     json_bytes = json.dumps(metadata, indent=2).encode()
-    upload_to_r2_compressed(
+    metadata_uploaded = upload_to_r2_compressed(
         payload=json_bytes,
         bucket_name=bucket_name,
         object_name=f"curator-metadata/{key_prefix}{slug}/metadata.json",
@@ -633,7 +631,9 @@ def process_and_upload_curator_metadata(
         access_key_id=access_key_id,
         secret_access_key=secret_access_key,
         content_type="application/json",
+        skip_if_current=True,
     )
+    logger.info("%s curator metadata for: %s", "Uploaded" if metadata_uploaded else "Skipped unchanged", slug)
 
     return metadata
 
@@ -675,10 +675,9 @@ def upload_protocol_curator_metadata(
 
     for metadata in entries:
         slug = metadata["slug"]
-        logger.info("Uploading protocol-curator metadata for: %s", slug)
 
         json_bytes = json.dumps(metadata, indent=2).encode()
-        upload_to_r2_compressed(
+        metadata_uploaded = upload_to_r2_compressed(
             payload=json_bytes,
             bucket_name=bucket_name,
             object_name=f"curator-metadata/{key_prefix}{slug}/metadata.json",
@@ -686,6 +685,12 @@ def upload_protocol_curator_metadata(
             access_key_id=access_key_id,
             secret_access_key=secret_access_key,
             content_type="application/json",
+            skip_if_current=True,
+        )
+        logger.info(
+            "%s protocol-curator metadata for: %s",
+            "Uploaded" if metadata_uploaded else "Skipped unchanged",
+            slug,
         )
 
     return entries
@@ -744,10 +749,8 @@ def upload_curator_index(
 
     index = build_curator_index()
 
-    logger.info("Uploading curator index with %d entries", len(index))
-
     json_bytes = json.dumps(index, indent=2).encode()
-    upload_to_r2_compressed(
+    index_uploaded = upload_to_r2_compressed(
         payload=json_bytes,
         bucket_name=bucket_name,
         object_name=f"curator-metadata/{key_prefix}index.json",
@@ -755,6 +758,12 @@ def upload_curator_index(
         access_key_id=access_key_id,
         secret_access_key=secret_access_key,
         content_type="application/json",
+        skip_if_current=True,
+    )
+    logger.info(
+        "%s curator index with %d entries",
+        "Uploaded" if index_uploaded else "Skipped unchanged",
+        len(index),
     )
 
     return index

--- a/eth_defi/vault/protocol_metadata.py
+++ b/eth_defi/vault/protocol_metadata.py
@@ -254,12 +254,10 @@ def process_and_upload_protocol_metadata(
     # Build metadata with logo URLs
     metadata = build_metadata_json(yaml_path, public_url)
 
-    logger.info("Uploading metadata for protocol: %s", slug)
-
     # Upload metadata JSON
     # Object name format: vault-protocol-metadata/{key_prefix}{slug}/metadata.json
     json_bytes = json.dumps(metadata, indent=2).encode()
-    upload_to_r2_compressed(
+    metadata_uploaded = upload_to_r2_compressed(
         payload=json_bytes,
         bucket_name=bucket_name,
         object_name=f"vault-protocol-metadata/{key_prefix}{slug}/metadata.json",
@@ -267,15 +265,16 @@ def process_and_upload_protocol_metadata(
         access_key_id=access_key_id,
         secret_access_key=secret_access_key,
         content_type="application/json",
+        skip_if_current=True,
     )
+    logger.info("%s metadata for protocol: %s", "Uploaded" if metadata_uploaded else "Skipped unchanged", slug)
 
     # Upload available logos
     logo_dir = FORMATTED_LOGOS_DIR / slug
     for variant in ["dark", "light"]:
         logo_path = logo_dir / f"{variant}.png"
         if logo_path.exists():
-            logger.info("Uploading %s logo for protocol: %s", variant, slug)
-            upload_to_r2_compressed(
+            logo_uploaded = upload_to_r2_compressed(
                 payload=logo_path.read_bytes(),
                 bucket_name=bucket_name,
                 object_name=f"vault-protocol-metadata/{key_prefix}{slug}/{variant}.png",
@@ -283,6 +282,13 @@ def process_and_upload_protocol_metadata(
                 access_key_id=access_key_id,
                 secret_access_key=secret_access_key,
                 content_type="image/png",
+                skip_if_current=True,
+            )
+            logger.info(
+                "%s %s logo for protocol: %s",
+                "Uploaded" if logo_uploaded else "Skipped unchanged",
+                variant,
+                slug,
             )
 
     return metadata

--- a/scripts/erc-4626/export-data-files.py
+++ b/scripts/erc-4626/export-data-files.py
@@ -24,17 +24,16 @@ import logging
 import os
 from pathlib import Path
 
-import boto3
-from botocore.exceptions import ClientError
 from tqdm_loggable.auto import tqdm
 
+from eth_defi.cloudflare_r2 import create_r2_client, upload_file_to_r2
 from eth_defi.utils import setup_console_logging
 from eth_defi.vault.vaultdb import get_pipeline_data_dir
 
 logger = logging.getLogger(__name__)
 
 
-def upload_files_to_r2(
+def upload_files_to_r2(  # noqa: PLR0917
     file_paths: list[Path],
     bucket_name: str,
     endpoint_url: str,
@@ -68,42 +67,54 @@ def upload_files_to_r2(
         logger.info("No files to upload after filtering")
         return 0
 
-    logger.info("Uploading %d files to R2 bucket %s (excluded %d files)", len(files_to_upload), bucket_name, len(file_paths) - len(files_to_upload))
+    logger.info("Checking %d files for R2 upload to bucket %s (excluded %d files)", len(files_to_upload), bucket_name, len(file_paths) - len(files_to_upload))
 
-    s3_client = boto3.client(
-        "s3",
+    s3_client = create_r2_client(
         endpoint_url=endpoint_url,
-        aws_access_key_id=access_key_id,
-        aws_secret_access_key=secret_access_key,
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
     )
+
+    uploaded_count = 0
+    skipped_count = 0
 
     for file_path in files_to_upload:
         s3_key = f"{key_prefix}{file_path.name}"
         file_size = file_path.stat().st_size
 
-        logger.info("Uploading %s to s3://%s/%s", file_path, bucket_name, s3_key)
+        with tqdm(total=file_size, unit="B", unit_scale=True, desc=f"Uploading {s3_key}") as pbar:
 
-        with open(file_path, "rb") as f:
-            with tqdm(total=file_size, unit="B", unit_scale=True, desc=f"Uploading {s3_key}") as pbar:
+            def upload_callback(bytes_amount):
+                pbar.update(bytes_amount)
 
-                def upload_callback(bytes_amount):
-                    pbar.update(bytes_amount)
+            uploaded = upload_file_to_r2(
+                s3_client=s3_client,
+                file_path=file_path,
+                bucket_name=bucket_name,
+                object_name=s3_key,
+                skip_if_current=True,
+                callback=upload_callback,
+            )
 
-                try:
-                    s3_client.upload_fileobj(
-                        f,
-                        bucket_name,
-                        s3_key,
-                        Callback=upload_callback,
-                    )
-                except ClientError as e:
-                    raise RuntimeError(f"Failed to upload {s3_key} to bucket {bucket_name} (endpoint: {endpoint_url}, access_key_id: {access_key_id}): {e}") from e
+        if uploaded:
+            uploaded_count += 1
+            logger.info("Uploaded %s to s3://%s/%s", file_path, bucket_name, s3_key)
+        else:
+            skipped_count += 1
+            logger.info("Skipped unchanged file %s for s3://%s/%s", file_path, bucket_name, s3_key)
 
-        if public_url:
+        if public_url and uploaded:
             final_url = f"{public_url.rstrip('/')}/{s3_key}"
             print(f"  -> {final_url}")
 
-    return len(files_to_upload)
+    logger.info(
+        "Data file upload summary for bucket %s: %d uploaded, %d skipped unchanged",
+        bucket_name,
+        uploaded_count,
+        skipped_count,
+    )
+
+    return uploaded_count
 
 
 def main():
@@ -141,7 +152,7 @@ def main():
         base_path / "vault-reader-state-1h.pickle",
     ]
 
-    print(f"\nExporting data files to R2")
+    print("\nExporting data files to R2")
     print(f"  Bucket: {bucket_name}")
     if alt_bucket_name:
         print(f"  Alternative bucket: {alt_bucket_name}")

--- a/tests/test_cloudflare_r2.py
+++ b/tests/test_cloudflare_r2.py
@@ -1,0 +1,192 @@
+"""Unit tests for Cloudflare R2 upload helpers."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+from pathlib import Path
+
+from botocore.exceptions import ClientError
+
+from eth_defi.cloudflare_r2 import calculate_bytes_digest, calculate_file_digest, upload_bytes_to_r2, upload_file_to_r2
+
+
+class FakeS3Client:
+    """Small in-memory S3 client stub for upload helper tests."""
+
+    def __init__(self) -> None:
+        self.head_responses: dict[tuple[str, str], dict] = {}
+        self.put_calls: list[dict] = []
+        self.upload_calls: list[dict] = []
+
+    def head_object(self, **kwargs) -> dict:
+        """Return a stored head response or raise a not-found error."""
+        bucket = kwargs["Bucket"]
+        key = kwargs["Key"]
+        try:
+            return self.head_responses[bucket, key]
+        except KeyError as exc:
+            raise ClientError({"Error": {"Code": "404", "Message": "Not found"}}, "HeadObject") from exc
+
+    def put_object(self, **kwargs) -> None:
+        """Record a put-object call and update the stored head state."""
+        self.put_calls.append(kwargs)
+        self.head_responses[kwargs["Bucket"], kwargs["Key"]] = {
+            "ContentLength": len(kwargs["Body"]),
+            "ContentType": kwargs.get("ContentType"),
+            "ContentEncoding": kwargs.get("ContentEncoding"),
+            "Metadata": kwargs.get("Metadata", {}),
+            "ETag": f'"{_md5_hex(kwargs["Body"])}"',
+        }
+
+    def upload_fileobj(self, fileobj, bucket_name: str, object_name: str, **kwargs) -> None:
+        """Record an upload-fileobj call and update the stored head state."""
+        payload = fileobj.read()
+        callback = kwargs.get("Callback")
+        if callback is not None:
+            callback(len(payload))
+
+        extra_args = kwargs.get("ExtraArgs") or {}
+        self.upload_calls.append(
+            {
+                "Bucket": bucket_name,
+                "Key": object_name,
+                "Body": payload,
+                "ExtraArgs": extra_args,
+            }
+        )
+        self.head_responses[bucket_name, object_name] = {
+            "ContentLength": len(payload),
+            "ContentType": extra_args.get("ContentType"),
+            "Metadata": extra_args.get("Metadata", {}),
+        }
+
+
+def _md5_hex(payload: bytes) -> str:
+    """Calculate an MD5 digest for legacy ETag test fixtures."""
+    return hashlib.md5(payload, usedforsecurity=False).hexdigest()
+
+
+def test_upload_bytes_to_r2_skips_when_remote_checksum_matches() -> None:
+    """Checksum metadata should skip unchanged compressed payload uploads."""
+    s3_client = FakeS3Client()
+    payload = b'{"slug":"lagoon-finance"}'
+    compressed_payload = gzip.compress(payload, mtime=0)
+    source_digest = calculate_bytes_digest(payload)
+
+    s3_client.head_responses["bucket", "metadata.json"] = {
+        "ContentLength": len(compressed_payload),
+        "ContentType": "application/json",
+        "ContentEncoding": "gzip",
+        "Metadata": source_digest.as_metadata(),
+    }
+
+    uploaded = upload_bytes_to_r2(
+        s3_client=s3_client,
+        payload=compressed_payload,
+        bucket_name="bucket",
+        object_name="metadata.json",
+        content_type="application/json",
+        content_encoding="gzip",
+        skip_if_current=True,
+        source_digest=source_digest,
+    )
+
+    assert uploaded is False
+    assert s3_client.put_calls == []
+
+
+def test_upload_bytes_to_r2_skips_with_matching_legacy_etag() -> None:
+    """Legacy single-part uploads should still skip via matching ETag."""
+    s3_client = FakeS3Client()
+    payload = b'{"slug":"untangle-finance"}'
+    compressed_payload = gzip.compress(payload, mtime=0)
+
+    s3_client.head_responses["bucket", "metadata.json"] = {
+        "ContentLength": len(compressed_payload),
+        "ContentType": "application/json",
+        "ContentEncoding": "gzip",
+        "Metadata": {},
+        "ETag": f'"{_md5_hex(compressed_payload)}"',
+    }
+
+    uploaded = upload_bytes_to_r2(
+        s3_client=s3_client,
+        payload=compressed_payload,
+        bucket_name="bucket",
+        object_name="metadata.json",
+        content_type="application/json",
+        content_encoding="gzip",
+        skip_if_current=True,
+        source_digest=calculate_bytes_digest(payload),
+    )
+
+    assert uploaded is False
+    assert s3_client.put_calls == []
+
+
+def test_upload_bytes_to_r2_uploads_and_sets_checksum_metadata() -> None:
+    """Fresh uploads should persist checksum metadata for later HEAD checks."""
+    s3_client = FakeS3Client()
+    payload = b"vault metadata"
+
+    uploaded = upload_bytes_to_r2(
+        s3_client=s3_client,
+        payload=payload,
+        bucket_name="bucket",
+        object_name="metadata.json",
+        content_type="application/json",
+        skip_if_current=True,
+    )
+
+    assert uploaded is True
+    assert len(s3_client.put_calls) == 1
+    assert s3_client.put_calls[0]["Metadata"] == calculate_bytes_digest(payload).as_metadata()
+
+
+def test_upload_file_to_r2_skips_when_remote_checksum_matches(tmp_path: Path) -> None:
+    """File uploads should skip when stored checksum metadata matches."""
+    s3_client = FakeS3Client()
+    file_path = tmp_path / "vault-prices-1h.parquet"
+    file_path.write_bytes(b"parquet-data")
+    source_digest = calculate_file_digest(file_path)
+
+    s3_client.head_responses["bucket", file_path.name] = {
+        "ContentLength": file_path.stat().st_size,
+        "Metadata": source_digest.as_metadata(),
+    }
+
+    uploaded = upload_file_to_r2(
+        s3_client=s3_client,
+        file_path=file_path,
+        bucket_name="bucket",
+        object_name=file_path.name,
+        skip_if_current=True,
+    )
+
+    assert uploaded is False
+    assert s3_client.upload_calls == []
+
+
+def test_upload_file_to_r2_uploads_when_remote_checksum_differs(tmp_path: Path) -> None:
+    """File uploads should refresh objects with missing or stale checksums."""
+    s3_client = FakeS3Client()
+    file_path = tmp_path / "vault-reader-state-1h.pickle"
+    file_path.write_bytes(b"reader-state")
+
+    s3_client.head_responses["bucket", file_path.name] = {
+        "ContentLength": file_path.stat().st_size,
+        "Metadata": {},
+    }
+
+    uploaded = upload_file_to_r2(
+        s3_client=s3_client,
+        file_path=file_path,
+        bucket_name="bucket",
+        object_name=file_path.name,
+        skip_if_current=True,
+    )
+
+    assert uploaded is True
+    assert len(s3_client.upload_calls) == 1
+    assert s3_client.upload_calls[0]["ExtraArgs"]["Metadata"] == calculate_file_digest(file_path).as_metadata()

--- a/tests/test_cloudflare_r2.py
+++ b/tests/test_cloudflare_r2.py
@@ -6,9 +6,17 @@ import gzip
 import hashlib
 from pathlib import Path
 
-from botocore.exceptions import ClientError
+import pytest
 
 from eth_defi.cloudflare_r2 import calculate_bytes_digest, calculate_file_digest, upload_bytes_to_r2, upload_file_to_r2
+
+try:
+    from botocore.exceptions import ClientError
+except ModuleNotFoundError:  # pragma: no cover - exercised in CI dependency matrix
+    pytestmark = pytest.mark.skip(reason="Cloudflare R2 tests require optional boto3/botocore dependency")
+
+    class ClientError(Exception):
+        """Fallback exception for optional botocore-free environments."""
 
 
 class FakeS3Client:


### PR DESCRIPTION
## Why

The vault post-processing pipeline was re-uploading the same static protocol metadata, logos, curator metadata, and exported data files on every run. This adds noise to the logs and wastes R2 operations even when nothing has changed.

## Lessons learnt

Using the authenticated S3-compatible `head_object()` path is more reliable than a public HTTP `HEAD` for this workflow, because we can compare object metadata without downloading the payload. Making gzip output deterministic also matters, otherwise unchanged compressed uploads still look different between runs.

## Summary

- add shared Cloudflare R2 helpers to compare remote object metadata and skip unchanged uploads
- store source checksum metadata on uploaded objects, with ETag fallback for older small objects
- apply the skip logic to protocol, stablecoin, and curator metadata uploads plus exported parquet and pickle files
- update logging to distinguish uploaded objects from unchanged objects that were skipped
- add focused unit tests covering checksum-match and legacy-ETag skip behaviour
