### PR TITLE
fix: forward-fill Hyperliquid HF metadata in export

### DIFF
--- a/eth_defi/hyperliquid/vault_data_export.py
+++ b/eth_defi/hyperliquid/vault_data_export.py
@@ -270,8 +270,8 @@ def _prepare_hypercore_export(
 ) -> pd.DataFrame:
     """Shared helper for building Hypercore export DataFrames.
 
-    Handles forward-filling state columns, computing deposit status,
-    and constructing the EVM-compatible output schema.
+    Handles forward-filling sparse snapshot columns, computing deposit
+    status, and constructing the EVM-compatible output schema.
 
     :param prices_df:
         Raw price data from DuckDB (daily or HF).
@@ -287,12 +287,25 @@ def _prepare_hypercore_export(
     :return:
         DataFrame matching the uncleaned Parquet schema.
     """
-    # Forward-fill sparse state columns within each vault
-    state_cols = ["is_closed", "allow_deposits", "leader_fraction"]
-    existing_state_cols = [c for c in state_cols if c in prices_df.columns]
-    if existing_state_cols:
+    # Forward-fill sparse snapshot columns within each vault.
+    #
+    # The HF scanner intentionally records metadata snapshots only on the
+    # latest row of each fetch. Export forwards these values within the
+    # observed history so raw and cleaned consumers do not need to
+    # reimplement "last non-null per vault" logic. Rows before the first
+    # observed snapshot remain NULL.
+    snapshot_cols = [
+        "is_closed",
+        "allow_deposits",
+        "leader_fraction",
+        "leader_commission",
+        "follower_count",
+        "cumulative_volume",
+    ]
+    existing_snapshot_cols = [c for c in snapshot_cols if c in prices_df.columns]
+    if existing_snapshot_cols:
         prices_df = prices_df.sort_values(sort_columns)
-        prices_df[existing_state_cols] = prices_df.groupby("vault_address")[existing_state_cols].ffill()
+        prices_df[existing_snapshot_cols] = prices_df.groupby("vault_address")[existing_snapshot_cols].ffill()
 
     # Compute deposit_closed_reason per row from forward-filled state.
     deposit_reasons = _compute_deposit_closed_reason_column(prices_df)

--- a/scripts/hyperliquid/README-hyperliquid-vaults-high-frequency.md
+++ b/scripts/hyperliquid/README-hyperliquid-vaults-high-frequency.md
@@ -170,7 +170,7 @@ accepts both `daily_db` and `hf_db` as optional parameters.
 
 Both export functions (`build_raw_prices_dataframe` and
 `build_raw_prices_dataframe_hf`) delegate to the shared
-`_prepare_hypercore_export()` helper for forward-filling state columns,
+`_prepare_hypercore_export()` helper for forward-filling sparse metadata snapshots,
 computing deposit status, and building the EVM-compatible DataFrame.
 
 This means:
@@ -205,13 +205,39 @@ but the downstream Parquet/cleaning pipeline expects `daily_deposit_count`,
 `daily_withdrawal_count`, etc. The `_prepare_hypercore_export()` helper handles
 this mapping via the `flow_col_map` parameter.
 
+### Metadata snapshot handling
+
+The HF DuckDB keeps metadata snapshots sparse by design. Each fetch writes
+`apr`, `follower_count`, `is_closed`, `allow_deposits`, `leader_fraction`,
+`leader_commission`, and `cumulative_volume` only on the latest row observed
+for that vault during that fetch. Historical rows stay `NULL` unless a later
+overlap re-upsert touches the exact same timestamp.
+
+The downstream export path then forward-fills the non-critical snapshot fields
+within the observed history of each vault:
+
+- `is_closed`
+- `allow_deposits`
+- `leader_fraction`
+- `leader_commission`
+- `follower_count`
+- `cumulative_volume`
+
+Rows before the first observed snapshot still remain `NULL` — export does not
+invent earlier metadata. `apr` stays metadata-only in this version and is not
+exported to the parquet / cleaned datasets.
+
+Because the fix lives in export, existing HF DuckDB history does not need a
+schema or data migration. To heal existing downstream datasets, re-run the
+Hypercore parquet merge and the cleaning pipeline.
+
 ### COALESCE upsert semantics
 
 Both the daily and HF pipelines use `ON CONFLICT DO UPDATE SET` with `COALESCE`
 for sparse columns. This means:
 
 - `share_price`, `tvl`, `cumulative_pnl`: always overwrite (most recent wins)
-- `is_closed`, `allow_deposits`, `leader_fraction`, flow fields: `COALESCE(new, existing)` —
+- `is_closed`, `allow_deposits`, `leader_fraction`, `leader_commission`, `follower_count`, `cumulative_volume`, flow fields: `COALESCE(new, existing)` —
   a `None` new value preserves the existing value, so tombstone rows and
   overlap re-upserts do not wipe state
 

--- a/tests/hyperliquid/test_high_freq_export.py
+++ b/tests/hyperliquid/test_high_freq_export.py
@@ -19,7 +19,9 @@ from eth_defi.hyperliquid.high_freq_metrics import (
     HyperliquidHighFreqMetricsDatabase,
     HyperliquidHighFreqPriceRow,
 )
-from eth_defi.hyperliquid.vault_data_export import build_raw_prices_dataframe_hf
+from eth_defi.hyperliquid.vault_data_export import build_raw_prices_dataframe_hf, create_hyperliquid_vault_row
+from eth_defi.research.vault_metrics import calculate_hourly_returns_for_all_vaults, calculate_lifetime_metrics, export_lifetime_row
+from eth_defi.research.wrangle_vault_prices import process_raw_vault_scan_data
 from eth_defi.compat import native_datetime_utc_now
 
 
@@ -144,6 +146,172 @@ def test_hf_export_raw_timestamps(tmp_path):
         assert returns.iloc[1] == pytest.approx(0.01, rel=1e-5)
         # Row 2 return: (1.020 - 1.010) / 1.010
         assert returns.iloc[2] == pytest.approx(0.0099, rel=1e-2)
+
+    finally:
+        db.close()
+
+
+@pytest.mark.timeout(30)
+def test_hf_export_forward_fills_sparse_metadata_snapshots(tmp_path):
+    """HF export should forward-fill sparse metadata snapshots within observed history."""
+    duckdb_path = tmp_path / "hf-export-forward-fill.duckdb"
+    db = HyperliquidHighFreqMetricsDatabase(duckdb_path)
+
+    try:
+        vault_addr = "0xbbbb0000000000000000000000000000bbbbbbbb"
+        base_ts = datetime.datetime(2025, 6, 1, 0, 0, 0)
+        now = native_datetime_utc_now()
+
+        rows = [
+            HyperliquidHighFreqPriceRow(
+                vault_address=vault_addr,
+                timestamp=base_ts,
+                share_price=1.000,
+                tvl=100000.0,
+                cumulative_pnl=0.0,
+                written_at=now,
+            ),
+            HyperliquidHighFreqPriceRow(
+                vault_address=vault_addr,
+                timestamp=base_ts + datetime.timedelta(hours=4),
+                share_price=1.010,
+                tvl=101000.0,
+                cumulative_pnl=1000.0,
+                follower_count=7,
+                is_closed=False,
+                allow_deposits=True,
+                leader_fraction=0.12,
+                leader_commission=3.0,
+                cumulative_volume=1000.0,
+                written_at=now,
+            ),
+            HyperliquidHighFreqPriceRow(
+                vault_address=vault_addr,
+                timestamp=base_ts + datetime.timedelta(hours=8),
+                share_price=1.020,
+                tvl=102000.0,
+                cumulative_pnl=2000.0,
+                written_at=now,
+            ),
+            HyperliquidHighFreqPriceRow(
+                vault_address=vault_addr,
+                timestamp=base_ts + datetime.timedelta(hours=12),
+                share_price=1.030,
+                tvl=103000.0,
+                cumulative_pnl=3000.0,
+                written_at=now,
+            ),
+        ]
+        db.upsert_high_freq_prices(rows)
+        db.save()
+
+        result_df = build_raw_prices_dataframe_hf(db).sort_values("timestamp").reset_index(drop=True)
+
+        assert "apr" not in result_df.columns
+
+        first_row = result_df.iloc[0]
+        assert pd.isna(first_row["follower_count"])
+        assert pd.isna(first_row["cumulative_volume"])
+        assert pd.isna(first_row["leader_commission"])
+        assert pd.isna(first_row["leader_fraction"])
+        assert pd.isna(first_row["deposits_open"])
+
+        for idx in range(1, 4):
+            row = result_df.iloc[idx]
+            assert row["follower_count"] == 7
+            assert row["cumulative_volume"] == pytest.approx(1000.0)
+            assert row["leader_commission"] == pytest.approx(3.0)
+            assert row["leader_fraction"] == pytest.approx(0.12)
+            assert row["deposits_open"] == "true"
+            assert row["deposit_closed_reason"] is None
+
+    finally:
+        db.close()
+
+
+@pytest.mark.timeout(30)
+def test_hf_forward_filled_metadata_reaches_cleaned_and_lifetime_outputs(tmp_path):
+    """HF metadata forward-fill should reach cleaned data and lifetime exports."""
+    duckdb_path = tmp_path / "hf-cleaned-forward-fill.duckdb"
+    db = HyperliquidHighFreqMetricsDatabase(duckdb_path)
+
+    try:
+        vault_addr = "0xcccc0000000000000000000000000000cccccccc"
+        base_ts = datetime.datetime(2025, 6, 1, 0, 0, 0)
+        now = native_datetime_utc_now()
+
+        rows = [
+            HyperliquidHighFreqPriceRow(
+                vault_address=vault_addr,
+                timestamp=base_ts,
+                share_price=1.000,
+                tvl=100000.0,
+                cumulative_pnl=0.0,
+                written_at=now,
+            ),
+            HyperliquidHighFreqPriceRow(
+                vault_address=vault_addr,
+                timestamp=base_ts + datetime.timedelta(hours=4),
+                share_price=1.010,
+                tvl=101000.0,
+                cumulative_pnl=1000.0,
+                follower_count=9,
+                is_closed=False,
+                allow_deposits=True,
+                leader_fraction=0.15,
+                leader_commission=5.0,
+                cumulative_volume=1500.0,
+                written_at=now,
+            ),
+            HyperliquidHighFreqPriceRow(
+                vault_address=vault_addr,
+                timestamp=base_ts + datetime.timedelta(hours=8),
+                share_price=1.020,
+                tvl=102000.0,
+                cumulative_pnl=2000.0,
+                written_at=now,
+            ),
+        ]
+        db.upsert_high_freq_prices(rows)
+        db.save()
+
+        raw_df = build_raw_prices_dataframe_hf(db)
+        spec, vault_row = create_hyperliquid_vault_row(
+            vault_address=vault_addr,
+            name="HF Forward Fill",
+            description=None,
+            tvl=102000.0,
+            create_time=base_ts,
+        )
+        cleaned_df = process_raw_vault_scan_data(
+            {spec: vault_row},
+            raw_df,
+            logger=lambda msg: None,
+            display=lambda _: None,
+        )
+        vault_df = cleaned_df[cleaned_df["id"] == spec.as_string_id()].sort_index()
+        latest_cleaned_row = vault_df.iloc[-1]
+
+        assert latest_cleaned_row["follower_count"] == 9
+        assert latest_cleaned_row["cumulative_volume"] == pytest.approx(1500.0)
+        assert latest_cleaned_row["leader_commission"] == pytest.approx(5.0)
+        assert latest_cleaned_row["leader_fraction"] == pytest.approx(0.15)
+
+        returns_df = calculate_hourly_returns_for_all_vaults(cleaned_df)
+        lifetime_df = calculate_lifetime_metrics(returns_df, {spec: vault_row})
+
+        assert len(lifetime_df) == 1
+        lifetime_row = lifetime_df.iloc[0]
+        assert lifetime_row["follower_count"] == 9
+        assert lifetime_row["cumulative_volume"] == pytest.approx(1500.0)
+        assert lifetime_row["leader_commission"] == pytest.approx(5.0)
+        assert lifetime_row["leader_fraction"] == pytest.approx(0.15)
+
+        exported = export_lifetime_row(lifetime_row)
+        assert exported["follower_count"] == 9
+        assert exported["cumulative_volume"] == pytest.approx(1500.0)
+        assert exported["leader_commission"] == pytest.approx(5.0)
+        assert exported["leader_fraction"] == pytest.approx(0.15)
 
     finally:
         db.close()


### PR DESCRIPTION
## Why

The high-frequency Hyperliquid reader already fetches the relevant metadata snapshots, but downstream consumers only saw a subset of those values because the export path forward-filled deposit-state fields only. This left `leader_commission`, `follower_count`, and `cumulative_volume` sparse in raw and cleaned datasets even though forward fill is acceptable for these non-critical metadata fields.

## Lessons learnt

- The HF DuckDB intentionally stores metadata snapshots sparsely on the latest row of each fetch; the gap was in export semantics, not in the fetcher.
- Repairing the downstream view is enough here because existing HF history can be healed by re-running the Hypercore merge and cleaning pipeline.
- `apr` should stay metadata-only for now so we do not widen the parquet contract unnecessarily.

## Summary

- Forward-fill sparse Hypercore snapshot columns in the shared export helper for `leader_commission`, `follower_count`, and `cumulative_volume` alongside the existing deposit-state fields.
- Add focused HF regression tests for raw export forward fill and for cleaned/lifetime output propagation.
- Document the sparse-DuckDB versus forward-filled-export behaviour in the HF Hyperliquid README.
