### PR TITLE
fix: remove scripts bind-mount from Docker containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,12 +119,11 @@ services:
     # OOM kill disable (use with caution)
     oom_kill_disable: ${OOM_KILL_DISABLE:-false}
 
+    # To run ad-hoc scripts inside the container use ./vault-shell.sh
+    # which spawns a bash shell with the same environment.
     volumes:
       # Writing vault data files here
       - ${HOME}/.tradingstrategy:/root/.tradingstrategy:rw
-      # Expose hosts scan-all-chains.sh script to container,
-      # as we need to live-edit it for problematic RPCs all the time
-      - ./scripts:/usr/src/web3-ethereum-defi/scripts:ro
       # Expose log file output to host
       - ./logs:/usr/src/web3-ethereum-defi/logs:rw
       # Expose token cache files and other cache files reused by the vault scanner
@@ -229,9 +228,10 @@ services:
     memswap_limit: ${MEMSWAP_LIMIT:-64g}
     shm_size: ${SHM_SIZE:-2g}
     oom_kill_disable: ${OOM_KILL_DISABLE:-false}
+    # To run ad-hoc scripts inside the container use ./vault-shell.sh
+    # which spawns a bash shell with the same environment.
     volumes:
       - ${HOME}/.tradingstrategy:/root/.tradingstrategy:rw
-      - ./scripts:/usr/src/web3-ethereum-defi/scripts:ro
       - ./logs:/usr/src/web3-ethereum-defi/logs:rw
       - ${HOME}/.cache:/root/.cache:rw
 
@@ -257,7 +257,6 @@ services:
     mem_reservation: 512m
     volumes:
       - ${HOME}/.tradingstrategy:/root/.tradingstrategy:rw
-      - ./scripts:/usr/src/web3-ethereum-defi/scripts:ro
       # The scanner will update YAML files with failed RSS feeds and Twitter accounts,
       # then we manually push them to github now and then
       - ./eth_defi/data/feeds:/usr/src/web3-ethereum-defi/eth_defi/data/feeds:rw

--- a/vault-shell.sh
+++ b/vault-shell.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Spawn a bash shell inside the vault-scanner-looped container.
+#
+# Use this to run ad-hoc scripts or debug inside the running container
+# instead of bind-mounting ./scripts from the host, which can cause
+# import mismatches between host scripts and the baked-in eth_defi package.
+#
+# Usage:
+#   ./vault-shell.sh
+#
+# Then inside the container you can run e.g.:
+#   python scripts/erc-4626/export-data-files.py
+#
+set -euo pipefail
+
+CONTAINER="${1:-vault-scanner-looped}"
+
+exec docker compose exec "$CONTAINER" /bin/bash


### PR DESCRIPTION
## Why

The `./scripts` volume mount in docker-compose.yml overrode the baked-in scripts directory with host versions. When host scripts were updated to import `eth_defi.cloudflare_r2` (added in `98953a22`) but the Docker image hadn't been rebuilt, the container hit `ModuleNotFoundError` because the baked-in `eth_defi` package didn't include the new module.

Bind-mounting scripts creates a coupling where the host repo and the Docker image must always be in sync — defeating the purpose of a self-contained image.

## Lessons learnt

- Bind-mounting source code into containers breaks the isolation guarantee of Docker images. Host-side code can reference modules that don't exist in the image's installed packages.
- The error presented as a missing module but the root cause was a version mismatch between mounted scripts and the baked-in package.

## Summary

- Removed `./scripts:/usr/src/web3-ethereum-defi/scripts:ro` bind-mount from all three services (`vault-scanner`, `vault-scanner-looped`, `post-scanner`)
- Added `vault-shell.sh` helper script to spawn a bash shell inside the running container for ad-hoc script execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)