### PR TITLE
fix: default vault-scanner-looped stdout to WARNING, fix log file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -180,7 +180,7 @@ services:
       SCAN_GRVT: ${SCAN_GRVT:-true}
       SCAN_LIGHTER: ${SCAN_LIGHTER:-true}
 
-      LOG_LEVEL: ${LOG_LEVEL:-info}
+      LOG_LEVEL: ${LOG_LEVEL:-warning}
       MAX_WORKERS: ${MAX_WORKERS:-50}
       WEBSHARE_API_KEY: ${WEBSHARE_API_KEY:-}
 

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -1402,6 +1402,8 @@ def main():
       checking per-item cycle intervals to decide what is due.
     """
     # Setup logging with daily log rotation
+    # - stdout: defaults to WARNING to keep container logs clean
+    # - log file: always INFO for full diagnostics
     log_dir = Path("logs")
     log_dir.mkdir(parents=True, exist_ok=True)
     setup_console_logging(
@@ -1417,7 +1419,12 @@ def main():
     )
     rotating_handler.setLevel(logging.INFO)
     rotating_handler.setFormatter(logging.Formatter("%(asctime)s %(name)-44s [%(threadName)s] %(message)s", "%Y-%m-%d %H:%M:%S"))
-    logging.getLogger().addHandler(rotating_handler)
+
+    root = logging.getLogger()
+    root.addHandler(rotating_handler)
+    # Root logger level must be low enough for INFO messages to reach
+    # the file handler; console handler level gates stdout independently.
+    root.setLevel(min(root.level, logging.INFO))
 
     # Read configuration from environment
     retry_count = int(os.environ.get("RETRY_COUNT", "1"))


### PR DESCRIPTION
## Why

The vault-scanner-looped container was flooding stdout with INFO-level messages, making it hard to spot real issues. Additionally, the log file (`logs/scan-all-chains.log`) was silently dropping INFO messages due to a root logger level mismatch.

## Lessons learnt

When adding a file handler after `setup_console_logging()`, the root logger level must be lowered to accommodate the file handler's level — otherwise the root logger filters messages before they reach any handler.

## Summary

- Changed docker-compose default `LOG_LEVEL` for vault-scanner-looped from `info` to `warning`
- Fixed root logger level in `scan_all_chains.main()` so the `TimedRotatingFileHandler` at INFO actually receives INFO messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)