### PR TITLE
fix: use explicit spot baseline for hypercore escrow verification

### DIFF
--- a/eth_defi/hyperliquid/core_writer.py
+++ b/eth_defi/hyperliquid/core_writer.py
@@ -800,6 +800,10 @@ def build_hypercore_deposit_phase1(
         fn1 = build_hypercore_deposit_phase1(lagoon_vault, evm_usdc_amount=1_000_000)
         tx_hash = fn1.transact({"from": asset_manager})
 
+        # WARNING: Escrow clearance alone can be a misleading success signal
+        # for fast-settling deposits. If the caller needs to prove that a
+        # specific USDC amount reached HyperCore spot, pass expected_usdc and,
+        # when available, a true pre-phase baseline to wait_for_evm_escrow_clear().
         # Wait for escrow to clear
         wait_for_evm_escrow_clear(session, user=safe_address)
 

--- a/eth_defi/hyperliquid/evm_escrow.py
+++ b/eth_defi/hyperliquid/evm_escrow.py
@@ -554,6 +554,7 @@ def wait_for_evm_escrow_clear(
     timeout: float = 60.0,
     poll_interval: float = 2.0,
     expected_usdc: Decimal | None = None,
+    baseline_usdc: Decimal | None = None,
 ) -> None:
     """Wait until the user's EVM escrow is empty (all bridged funds have cleared).
 
@@ -598,6 +599,13 @@ def wait_for_evm_escrow_clear(
         captures the pre-existing USDC spot balance and verifies that the
         balance increased by at least this amount after escrows clear.
 
+    :param baseline_usdc:
+        Optional explicit pre-phase baseline for the user's HyperCore spot
+        USDC balance. Use this when the caller already captured the spot
+        balance before the EVM deposit transaction was broadcast. This avoids
+        a late-snapshot race where capturing the baseline after phase 1 has
+        already settled would make the observed increase look like zero.
+
     :raises TimeoutError:
         If the escrow does not clear within the timeout period.
     """
@@ -606,9 +614,19 @@ def wait_for_evm_escrow_clear(
     deadline = time.time() + timeout
     attempt = 0
 
-    # P15: Capture baseline spot USDC balance before waiting.
-    baseline_usdc: Decimal | None = None
-    if expected_usdc is not None:
+    # WARNING: The caller may already know the correct pre-phase-1 spot
+    # baseline. Prefer that explicit baseline over a fresh read here.
+    # Capturing the baseline after the phase 1 tx has already landed can
+    # produce a false zero-delta reading when the deposit settled faster
+    # than the receipt/verification pipeline.
+    if expected_usdc is not None and baseline_usdc is not None:
+        logger.info(
+            "P15: Using caller-provided baseline USDC spot balance for %s: %s (expecting +%s)",
+            user,
+            baseline_usdc,
+            expected_usdc,
+        )
+    elif expected_usdc is not None:
         try:
             baseline_state = fetch_spot_clearinghouse_state(session, user=user)
             baseline_usdc = _get_usdc_spot_balance(baseline_state)

--- a/tests/hyperliquid/test_evm_escrow.py
+++ b/tests/hyperliquid/test_evm_escrow.py
@@ -163,6 +163,41 @@ def test_wait_for_evm_escrow_clear_waits_for_spot_balance_after_escrow_clears():
     # 3. Verify the helper keeps polling until the spot balance actually reaches the expected level.
 
 
+def test_wait_for_evm_escrow_clear_uses_explicit_pre_phase_baseline():
+    """Use the caller-provided pre-phase baseline when the first poll is already post-deposit.
+
+    1. Mock the first observed HyperCore state as already escrow-cleared and already post-deposit.
+    2. Run ``wait_for_evm_escrow_clear()`` with both ``expected_usdc`` and an explicit ``baseline_usdc``.
+    3. Verify the helper succeeds from the explicit baseline without trying to re-snapshot a later one.
+    """
+    from eth_defi.hyperliquid.evm_escrow import wait_for_evm_escrow_clear
+
+    post_deposit_state = SimpleNamespace(
+        evm_escrows=[],
+        balances=[SimpleNamespace(coin="USDC", total=Decimal("150"), hold=Decimal("0"))],
+    )
+
+    # 1. Mock the first observed HyperCore state as already escrow-cleared and already post-deposit.
+    with patch(
+        "eth_defi.hyperliquid.evm_escrow.fetch_spot_clearinghouse_state",
+        return_value=post_deposit_state,
+    ) as mock_fetch:
+        with patch("eth_defi.hyperliquid.evm_escrow.time.sleep"):
+            with patch("eth_defi.hyperliquid.evm_escrow.time.time", side_effect=_monotonic_time()):
+                # 2. Run wait_for_evm_escrow_clear() with both expected_usdc and an explicit baseline_usdc.
+                wait_for_evm_escrow_clear(
+                    session=object(),
+                    user="0x0000000000000000000000000000000000000001",
+                    expected_usdc=Decimal("50"),
+                    baseline_usdc=Decimal("100"),
+                    timeout=10.0,
+                    poll_interval=1.0,
+                )
+
+    # 3. Verify the helper succeeds from the explicit baseline without trying to re-snapshot a later one.
+    assert mock_fetch.call_count == 1
+
+
 def test_wait_for_evm_escrow_clear_times_out_if_spot_balance_never_arrives():
     """Raise TimeoutError if escrow clears but the expected spot USDC never appears.
 


### PR DESCRIPTION
## Why

HyperCore deposit phase 1 can settle quickly enough that by the time the caller starts waiting for escrow clearance, the spot balance snapshot is already post-deposit. In that case the helper can observe a zero increase and falsely time out even though the USDC already arrived in spot.

## Lessons learnt

Late balance snapshots are unsafe in asynchronous HyperCore settlement flows. When the caller already knows a true pre-phase baseline, the helper should use that explicit value instead of re-snapshotting after the EVM tx has landed.

## Summary

- add an optional `baseline_usdc` parameter to `wait_for_evm_escrow_clear()`
- prefer the caller-provided pre-phase baseline over a fresh late snapshot
- add a regression test for the already-post-deposit first-poll race
