### PR TITLE
fix: improve Cloudflare R2 access diagnostics

### DIFF
--- a/eth_defi/cloudflare_r2.py
+++ b/eth_defi/cloudflare_r2.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +59,112 @@ class R2SourceDigest:
             R2_SOURCE_SHA256_METADATA_KEY: self.sha256,
             R2_SOURCE_SIZE_METADATA_KEY: str(self.size),
         }
+
+
+class R2OperationError(RuntimeError):
+    """Raised when an R2 operation fails with enriched diagnostics."""
+
+
+class R2AccessDeniedError(R2OperationError):
+    """Raised when R2 rejects an operation because access is denied."""
+
+
+def _mask_access_key_id(access_key_id: str | None) -> str:
+    """Mask an access key ID for safe logging.
+
+    :param access_key_id:
+        Raw access key ID from the boto3 client credentials.
+
+    :return:
+        Masked access key ID safe to emit in logs.
+    """
+    if not access_key_id:
+        return "<unknown>"
+    if len(access_key_id) <= 8:
+        return access_key_id
+    return f"{access_key_id[:4]}...{access_key_id[-4:]}"
+
+
+def _extract_r2_client_context(s3_client: Any) -> tuple[str | None, str | None, str | None]:
+    """Extract endpoint, access key and account ID from an R2 client.
+
+    :param s3_client:
+        boto3-compatible S3 client.
+
+    :return:
+        Tuple of endpoint URL, access key ID and parsed account ID.
+    """
+    endpoint_url = getattr(getattr(s3_client, "meta", None), "endpoint_url", None)
+    credentials = getattr(getattr(s3_client, "_request_signer", None), "_credentials", None)
+    access_key_id = getattr(credentials, "access_key", None)
+
+    account_id = None
+    if endpoint_url:
+        hostname = urlparse(endpoint_url).hostname or ""
+        if hostname.endswith(".r2.cloudflarestorage.com"):
+            account_id = hostname.removesuffix(".r2.cloudflarestorage.com")
+
+    return endpoint_url, access_key_id, account_id
+
+
+def _create_r2_operation_error(
+    exc: Exception,
+    s3_client: Any,
+    bucket_name: str,
+    object_name: str,
+) -> R2OperationError:
+    """Create an enriched exception for an R2 client failure.
+
+    The returned exception is intended to be raised ``from`` the
+    original botocore error so the full traceback remains available.
+
+    :param exc:
+        Original botocore client error.
+
+    :param s3_client:
+        boto3-compatible S3 client.
+
+    :param bucket_name:
+        Target bucket name.
+
+    :param object_name:
+        Target object key.
+
+    :return:
+        Enriched exception instance.
+    """
+    operation_name = getattr(exc, "operation_name", "<unknown>")
+    response = getattr(exc, "response", {}) or {}
+    error = response.get("Error", {}) or {}
+    error_code = str(error.get("Code", "")) or "<unknown>"
+    error_message = str(error.get("Message", "")) or "<no message>"
+    http_status = response.get("ResponseMetadata", {}).get("HTTPStatusCode", "<unknown>")
+    endpoint_url, access_key_id, account_id = _extract_r2_client_context(s3_client)
+    masked_access_key_id = _mask_access_key_id(access_key_id)
+
+    detail_lines = [
+        f"R2 {operation_name} failed for bucket={bucket_name!r}, key={object_name!r}, error_code={error_code!r}, http_status={http_status!r}.",
+        f"Endpoint URL: {endpoint_url or '<unknown>'}",
+        f"Access key ID: {masked_access_key_id}",
+    ]
+    if account_id:
+        detail_lines.append(f"Cloudflare account ID from endpoint: {account_id}")
+
+    if error_code == "InvalidAccessKeyId":
+        detail_lines.append("Likely cause: the R2 access key ID is wrong, revoked, or belongs to a different Cloudflare account.")
+        return R2AccessDeniedError(" ".join(detail_lines))
+
+    if error_code == "SignatureDoesNotMatch":
+        detail_lines.append("Likely cause: the R2 secret access key does not match the access key ID, or the endpoint account ID is wrong.")
+        return R2AccessDeniedError(" ".join(detail_lines))
+
+    if error_code in {"403", "AccessDenied", "Forbidden"} or http_status == 403:
+        detail_lines.append("Likely causes: wrong R2 access key ID; wrong R2 secret access key; wrong Cloudflare account ID in the endpoint URL; wrong bucket name; or missing read/write permission for this bucket.")
+        detail_lines.append(f"Original R2 error message: {error_message}")
+        return R2AccessDeniedError(" ".join(detail_lines))
+
+    detail_lines.append(f"Original R2 error message: {error_message}")
+    return R2OperationError(" ".join(detail_lines))
 
 
 def create_r2_client(
@@ -147,9 +254,10 @@ def fetch_r2_object_head(
 ) -> dict[str, Any] | None:
     """Fetch object metadata using ``head_object()``.
 
-    Missing objects return ``None``. Any other S3 error is raised to the
-    caller unchanged so upload scripts fail loudly instead of silently
-    skipping work.
+    Missing objects return ``None``. Any other R2 error is re-raised as
+    an enriched runtime exception with Cloudflare-specific diagnostics,
+    while preserving the original botocore exception as the nested
+    cause.
 
     :param s3_client:
         Authenticated boto3 S3 client.
@@ -172,12 +280,7 @@ def fetch_r2_object_head(
         error_code = str(exc.response.get("Error", {}).get("Code", ""))
         if error_code in {"404", "NoSuchKey", "NotFound"}:
             return None
-        if error_code == "403":
-            raise ClientError(
-                exc.response,
-                exc.operation_name,
-            ) from RuntimeError(f"R2 returned 403 Forbidden for HeadObject on bucket={bucket_name!r}, key={object_name!r}. Check that the R2 API token has read/write access to this bucket and that the bucket name is correct.")
-        raise
+        raise _create_r2_operation_error(exc, s3_client, bucket_name, object_name) from exc
 
 
 def _calculate_md5_hex(payload: bytes) -> str:
@@ -306,16 +409,25 @@ def upload_bytes_to_r2(
     source_digest = source_digest or calculate_bytes_digest(payload)
 
     if skip_if_current:
-        remote_head = fetch_r2_object_head(s3_client, bucket_name, object_name)
-        if remote_head and _is_remote_object_current(
-            remote_head=remote_head,
-            source_digest=source_digest,
-            expected_length=len(payload),
-            content_type=content_type,
-            content_encoding=content_encoding,
-            payload_md5=_calculate_md5_hex(payload),
-        ):
-            return False
+        try:
+            remote_head = fetch_r2_object_head(s3_client, bucket_name, object_name)
+        except R2AccessDeniedError as exc:
+            logger.warning(
+                "R2 HeadObject pre-flight failed for s3://%s/%s while checking whether upload can be skipped. Proceeding with upload attempt anyway. %s",
+                bucket_name,
+                object_name,
+                exc,
+            )
+        else:
+            if remote_head and _is_remote_object_current(
+                remote_head=remote_head,
+                source_digest=source_digest,
+                expected_length=len(payload),
+                content_type=content_type,
+                content_encoding=content_encoding,
+                payload_md5=_calculate_md5_hex(payload),
+            ):
+                return False
 
     put_kwargs: dict[str, Any] = {
         "Bucket": bucket_name,
@@ -331,7 +443,7 @@ def upload_bytes_to_r2(
     try:
         s3_client.put_object(**put_kwargs)
     except ClientError as exc:
-        raise RuntimeError(f"Failed to upload {object_name} to bucket {bucket_name}: {exc}") from exc
+        raise _create_r2_operation_error(exc, s3_client, bucket_name, object_name) from exc
 
     return True
 
@@ -382,14 +494,23 @@ def upload_file_to_r2(
     source_digest = calculate_file_digest(file_path)
 
     if skip_if_current:
-        remote_head = fetch_r2_object_head(s3_client, bucket_name, object_name)
-        if remote_head and _is_remote_object_current(
-            remote_head=remote_head,
-            source_digest=source_digest,
-            expected_length=source_digest.size,
-            content_type=content_type,
-        ):
-            return False
+        try:
+            remote_head = fetch_r2_object_head(s3_client, bucket_name, object_name)
+        except R2AccessDeniedError as exc:
+            logger.warning(
+                "R2 HeadObject pre-flight failed for s3://%s/%s while checking whether upload can be skipped. Proceeding with upload attempt anyway. %s",
+                bucket_name,
+                object_name,
+                exc,
+            )
+        else:
+            if remote_head and _is_remote_object_current(
+                remote_head=remote_head,
+                source_digest=source_digest,
+                expected_length=source_digest.size,
+                content_type=content_type,
+            ):
+                return False
 
     extra_args: dict[str, Any] = {
         "Metadata": source_digest.as_metadata(),
@@ -407,6 +528,6 @@ def upload_file_to_r2(
                 Callback=callback,
             )
         except ClientError as exc:
-            raise RuntimeError(f"Failed to upload {object_name} to bucket {bucket_name}: {exc}") from exc
+            raise _create_r2_operation_error(exc, s3_client, bucket_name, object_name) from exc
 
     return True

--- a/eth_defi/hyperliquid/core_writer.py
+++ b/eth_defi/hyperliquid/core_writer.py
@@ -800,6 +800,10 @@ def build_hypercore_deposit_phase1(
         fn1 = build_hypercore_deposit_phase1(lagoon_vault, evm_usdc_amount=1_000_000)
         tx_hash = fn1.transact({"from": asset_manager})
 
+        # WARNING: Escrow clearance alone can be a misleading success signal
+        # for fast-settling deposits. If the caller needs to prove that a
+        # specific USDC amount reached HyperCore spot, pass expected_usdc and,
+        # when available, a true pre-phase baseline to wait_for_evm_escrow_clear().
         # Wait for escrow to clear
         wait_for_evm_escrow_clear(session, user=safe_address)
 

--- a/eth_defi/hyperliquid/evm_escrow.py
+++ b/eth_defi/hyperliquid/evm_escrow.py
@@ -554,6 +554,7 @@ def wait_for_evm_escrow_clear(
     timeout: float = 60.0,
     poll_interval: float = 2.0,
     expected_usdc: Decimal | None = None,
+    baseline_usdc: Decimal | None = None,
 ) -> None:
     """Wait until the user's EVM escrow is empty (all bridged funds have cleared).
 
@@ -598,6 +599,13 @@ def wait_for_evm_escrow_clear(
         captures the pre-existing USDC spot balance and verifies that the
         balance increased by at least this amount after escrows clear.
 
+    :param baseline_usdc:
+        Optional explicit pre-phase baseline for the user's HyperCore spot
+        USDC balance. Use this when the caller already captured the spot
+        balance before the EVM deposit transaction was broadcast. This avoids
+        a late-snapshot race where capturing the baseline after phase 1 has
+        already settled would make the observed increase look like zero.
+
     :raises TimeoutError:
         If the escrow does not clear within the timeout period.
     """
@@ -606,9 +614,19 @@ def wait_for_evm_escrow_clear(
     deadline = time.time() + timeout
     attempt = 0
 
-    # P15: Capture baseline spot USDC balance before waiting.
-    baseline_usdc: Decimal | None = None
-    if expected_usdc is not None:
+    # WARNING: The caller may already know the correct pre-phase-1 spot
+    # baseline. Prefer that explicit baseline over a fresh read here.
+    # Capturing the baseline after the phase 1 tx has already landed can
+    # produce a false zero-delta reading when the deposit settled faster
+    # than the receipt/verification pipeline.
+    if expected_usdc is not None and baseline_usdc is not None:
+        logger.info(
+            "P15: Using caller-provided baseline USDC spot balance for %s: %s (expecting +%s)",
+            user,
+            baseline_usdc,
+            expected_usdc,
+        )
+    elif expected_usdc is not None:
         try:
             baseline_state = fetch_spot_clearinghouse_state(session, user=user)
             baseline_usdc = _get_usdc_spot_balance(baseline_state)

--- a/eth_defi/vault/post_processing.py
+++ b/eth_defi/vault/post_processing.py
@@ -12,6 +12,7 @@ import importlib.util
 import logging
 import os
 from pathlib import Path
+from typing import Any
 
 from eth_defi.cloudflare_r2 import create_r2_client, upload_file_to_r2
 from eth_defi.grvt.constants import GRVT_CHAIN_ID, GRVT_DAILY_METRICS_DATABASE
@@ -36,6 +37,164 @@ _R2_TOP_VAULTS_REQUIRED_ENV_VARS = (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _mask_access_key_id(access_key_id: str | None) -> str:
+    """Mask an R2 access key ID for safe logging.
+
+    :param access_key_id:
+        Raw access key ID.
+
+    :return:
+        Masked access key ID.
+    """
+    if not access_key_id:
+        return "<unknown>"
+    if len(access_key_id) <= 8:
+        return access_key_id
+    return f"{access_key_id[:4]}...{access_key_id[-4:]}"
+
+
+def _upload_top_vaults_json_to_bucket(
+    s3_client: Any,
+    output_path: Path,
+    bucket_name: str,
+    endpoint_url: str,
+    object_key: str,
+    access_key_id: str,
+    *,
+    public_url: str = "",
+    bucket_label: str,
+) -> bool:
+    """Upload the generated top-vaults JSON to one configured bucket.
+
+    Each bucket is handled independently so that one misconfigured R2
+    target does not stop follow-up uploads to other buckets.
+
+    :param s3_client:
+        Authenticated boto3 S3 client.
+
+    :param output_path:
+        Generated JSON file path.
+
+    :param bucket_name:
+        Target bucket name.
+
+    :param endpoint_url:
+        R2 endpoint URL for logging.
+
+    :param object_key:
+        Destination object key.
+
+    :param access_key_id:
+        R2 access key ID for masked logging.
+
+    :param public_url:
+        Optional public URL to log for the primary bucket.
+
+    :param bucket_label:
+        Human-readable label such as ``primary`` or ``alternative``.
+
+    :return:
+        ``True`` if the bucket upload succeeded or was skipped as
+        unchanged, ``False`` on failure.
+    """
+    try:
+        uploaded = upload_file_to_r2(
+            s3_client=s3_client,
+            file_path=output_path,
+            bucket_name=bucket_name,
+            object_name=object_key,
+            skip_if_current=True,
+        )
+        if uploaded:
+            logger.info("Uploaded %s to %s s3://%s/%s", output_path, bucket_label, bucket_name, object_key)
+            if public_url:
+                logger.info("  -> %s/%s", public_url.rstrip("/"), object_key)
+        else:
+            logger.info("Skipped unchanged %s for %s s3://%s/%s", output_path, bucket_label, bucket_name, object_key)
+        return True
+    except Exception:
+        logger.exception(
+            "Top vaults JSON %s bucket upload failed — bucket=%s, endpoint=%s, object_key=%s, access_key_id=%s",
+            bucket_label,
+            bucket_name,
+            endpoint_url,
+            object_key,
+            _mask_access_key_id(access_key_id),
+        )
+        return False
+
+
+def _upload_top_vaults_json_to_configured_buckets(
+    s3_client: Any,
+    output_path: Path,
+    bucket_name: str,
+    endpoint_url: str,
+    object_key: str,
+    access_key_id: str,
+    *,
+    public_url: str = "",
+    alt_bucket_name: str | None = None,
+) -> bool:
+    """Upload the generated top-vaults JSON to all configured buckets.
+
+    The primary and alternative buckets are attempted independently.
+    This means a permission issue on one bucket does not stop the other
+    upload attempt or later post-processing steps.
+
+    :param s3_client:
+        Authenticated boto3 S3 client.
+
+    :param output_path:
+        Generated JSON file path.
+
+    :param bucket_name:
+        Primary bucket name.
+
+    :param endpoint_url:
+        R2 endpoint URL for logging.
+
+    :param object_key:
+        Destination object key.
+
+    :param access_key_id:
+        R2 access key ID for masked logging.
+
+    :param public_url:
+        Optional public URL for the primary bucket.
+
+    :param alt_bucket_name:
+        Optional alternative bucket name.
+
+    :return:
+        ``True`` if all configured uploads succeeded or were skipped as
+        unchanged, otherwise ``False``.
+    """
+    primary_success = _upload_top_vaults_json_to_bucket(
+        s3_client=s3_client,
+        output_path=output_path,
+        bucket_name=bucket_name,
+        endpoint_url=endpoint_url,
+        object_key=object_key,
+        access_key_id=access_key_id,
+        public_url=public_url,
+        bucket_label="primary",
+    )
+
+    alternative_success = True
+    if alt_bucket_name:
+        alternative_success = _upload_top_vaults_json_to_bucket(
+            s3_client=s3_client,
+            output_path=output_path,
+            bucket_name=alt_bucket_name,
+            endpoint_url=endpoint_url,
+            object_key=object_key,
+            access_key_id=access_key_id,
+            bucket_label="alternative",
+        )
+
+    return primary_success and alternative_success
 
 
 def merge_native_protocols(
@@ -279,6 +438,12 @@ def export_top_vaults_json(
         any failure. Matches the behaviour of the other ``export_*``
         helpers so the caller can log and continue.
     """
+    bucket_name = "<unset>"
+    endpoint_url = "<unset>"
+    object_key = "<unset>"
+    access_key_id = ""
+    public_url = ""
+
     try:
         validate_top_vaults_config(skip_top_vaults=False)
 
@@ -317,41 +482,25 @@ def export_top_vaults_json(
             secret_access_key=secret_access_key,
         )
 
-        # Primary upload — the public bucket that serves
-        # https://top-defi-vaults.tradingstrategy.ai/top_vaults_by_chain.json
-        uploaded = upload_file_to_r2(
-            s3_client=s3_client,
-            file_path=output_path,
-            bucket_name=bucket_name,
-            object_name=object_key,
-            skip_if_current=True,
-        )
-        if uploaded:
-            logger.info("Uploaded %s to s3://%s/%s", output_path, bucket_name, object_key)
-            if public_url:
-                logger.info("  -> %s/%s", public_url.rstrip("/"), object_key)
-        else:
-            logger.info("Skipped unchanged %s for s3://%s/%s", output_path, bucket_name, object_key)
-
         # TODO: phase out public R2_TOP_VAULTS_BUCKET_NAME later once
         # downstream consumers (classification.py, add-vault-note skill,
         # deploy-lagoon-multichain.py) migrate to the private bucket.
         alt_bucket_name = os.environ.get("R2_TOP_VAULTS_ALTERNATIVE_BUCKET_NAME")
-        if alt_bucket_name:
-            alt_uploaded = upload_file_to_r2(
-                s3_client=s3_client,
-                file_path=output_path,
-                bucket_name=alt_bucket_name,
-                object_name=object_key,
-                skip_if_current=True,
-            )
-            if alt_uploaded:
-                logger.info("Uploaded %s to alternative s3://%s/%s", output_path, alt_bucket_name, object_key)
-            else:
-                logger.info("Skipped unchanged %s for alternative s3://%s/%s", output_path, alt_bucket_name, object_key)
-
-        logger.info("Top vaults JSON export complete")
-        return True
+        uploads_ok = _upload_top_vaults_json_to_configured_buckets(
+            s3_client=s3_client,
+            output_path=output_path,
+            bucket_name=bucket_name,
+            endpoint_url=endpoint_url,
+            object_key=object_key,
+            access_key_id=access_key_id,
+            public_url=public_url,
+            alt_bucket_name=alt_bucket_name,
+        )
+        if uploads_ok:
+            logger.info("Top vaults JSON export complete")
+        else:
+            logger.warning("Top vaults JSON export completed with one or more upload failures")
+        return uploads_ok
     except Exception:
         logger.exception(
             "Export top vaults JSON failed — bucket=%s, endpoint=%s, object_key=%s, access_key_id=%s...%s",

--- a/tests/erc_4626/test_post_processing.py
+++ b/tests/erc_4626/test_post_processing.py
@@ -1,0 +1,40 @@
+"""Tests for vault post-processing error handling."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from eth_defi.vault import post_processing
+
+
+def test_upload_top_vaults_json_to_configured_buckets_continues_after_primary_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Alternative bucket upload should still run after a primary failure."""
+    output_path = tmp_path / "top_vaults_by_chain.json"
+    output_path.write_text("{}", encoding="utf-8")
+    upload_attempts: list[str] = []
+
+    def fake_upload_file_to_r2(*, bucket_name: str, **_: object) -> bool:
+        upload_attempts.append(bucket_name)
+        if bucket_name == "public-bucket":
+            raise RuntimeError("403 Forbidden")
+        return True
+
+    monkeypatch.setattr(post_processing, "upload_file_to_r2", fake_upload_file_to_r2)
+
+    success = post_processing._upload_top_vaults_json_to_configured_buckets(
+        s3_client=object(),
+        output_path=output_path,
+        bucket_name="public-bucket",
+        endpoint_url="https://db6295230fa08e641c3ce159dcda30a8.r2.cloudflarestorage.com",
+        object_key="top_vaults_by_chain.json",
+        access_key_id="e24301234567dac",
+        alt_bucket_name="private-bucket",
+    )
+
+    assert success is False
+    assert upload_attempts == ["public-bucket", "private-bucket"]

--- a/tests/hyperliquid/test_evm_escrow.py
+++ b/tests/hyperliquid/test_evm_escrow.py
@@ -163,6 +163,41 @@ def test_wait_for_evm_escrow_clear_waits_for_spot_balance_after_escrow_clears():
     # 3. Verify the helper keeps polling until the spot balance actually reaches the expected level.
 
 
+def test_wait_for_evm_escrow_clear_uses_explicit_pre_phase_baseline():
+    """Use the caller-provided pre-phase baseline when the first poll is already post-deposit.
+
+    1. Mock the first observed HyperCore state as already escrow-cleared and already post-deposit.
+    2. Run ``wait_for_evm_escrow_clear()`` with both ``expected_usdc`` and an explicit ``baseline_usdc``.
+    3. Verify the helper succeeds from the explicit baseline without trying to re-snapshot a later one.
+    """
+    from eth_defi.hyperliquid.evm_escrow import wait_for_evm_escrow_clear
+
+    post_deposit_state = SimpleNamespace(
+        evm_escrows=[],
+        balances=[SimpleNamespace(coin="USDC", total=Decimal("150"), hold=Decimal("0"))],
+    )
+
+    # 1. Mock the first observed HyperCore state as already escrow-cleared and already post-deposit.
+    with patch(
+        "eth_defi.hyperliquid.evm_escrow.fetch_spot_clearinghouse_state",
+        return_value=post_deposit_state,
+    ) as mock_fetch:
+        with patch("eth_defi.hyperliquid.evm_escrow.time.sleep"):
+            with patch("eth_defi.hyperliquid.evm_escrow.time.time", side_effect=_monotonic_time()):
+                # 2. Run wait_for_evm_escrow_clear() with both expected_usdc and an explicit baseline_usdc.
+                wait_for_evm_escrow_clear(
+                    session=object(),
+                    user="0x0000000000000000000000000000000000000001",
+                    expected_usdc=Decimal("50"),
+                    baseline_usdc=Decimal("100"),
+                    timeout=10.0,
+                    poll_interval=1.0,
+                )
+
+    # 3. Verify the helper succeeds from the explicit baseline without trying to re-snapshot a later one.
+    assert mock_fetch.call_count == 1
+
+
 def test_wait_for_evm_escrow_clear_times_out_if_spot_balance_never_arrives():
     """Raise TimeoutError if escrow clears but the expected spot USDC never appears.
 

--- a/tests/test_cloudflare_r2.py
+++ b/tests/test_cloudflare_r2.py
@@ -4,11 +4,20 @@ from __future__ import annotations
 
 import gzip
 import hashlib
+import logging
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-from eth_defi.cloudflare_r2 import calculate_bytes_digest, calculate_file_digest, upload_bytes_to_r2, upload_file_to_r2
+from eth_defi.cloudflare_r2 import (
+    R2AccessDeniedError,
+    calculate_bytes_digest,
+    calculate_file_digest,
+    fetch_r2_object_head,
+    upload_bytes_to_r2,
+    upload_file_to_r2,
+)
 
 try:
     from botocore.exceptions import ClientError
@@ -22,15 +31,25 @@ except ModuleNotFoundError:  # pragma: no cover - exercised in CI dependency mat
 class FakeS3Client:
     """Small in-memory S3 client stub for upload helper tests."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        endpoint_url: str = "https://db6295230fa08e641c3ce159dcda30a8.r2.cloudflarestorage.com",
+        access_key_id: str = "e24301234567dac",
+    ) -> None:
         self.head_responses: dict[tuple[str, str], dict] = {}
+        self.head_exceptions: dict[tuple[str, str], Exception] = {}
         self.put_calls: list[dict] = []
         self.upload_calls: list[dict] = []
+        self.meta = SimpleNamespace(endpoint_url=endpoint_url)
+        self._request_signer = SimpleNamespace(_credentials=SimpleNamespace(access_key=access_key_id))
 
     def head_object(self, **kwargs) -> dict:
         """Return a stored head response or raise a not-found error."""
         bucket = kwargs["Bucket"]
         key = kwargs["Key"]
+        forced_exception = self.head_exceptions.get((bucket, key))
+        if forced_exception is not None:
+            raise forced_exception
         try:
             return self.head_responses[bucket, key]
         except KeyError as exc:
@@ -198,3 +217,53 @@ def test_upload_file_to_r2_uploads_when_remote_checksum_differs(tmp_path: Path) 
     assert uploaded is True
     assert len(s3_client.upload_calls) == 1
     assert s3_client.upload_calls[0]["ExtraArgs"]["Metadata"] == calculate_file_digest(file_path).as_metadata()
+
+
+def test_fetch_r2_object_head_raises_enriched_access_denied_error() -> None:
+    """403 responses should include Cloudflare-specific credential hints."""
+    s3_client = FakeS3Client()
+    s3_client.head_exceptions["bucket", "metadata.json"] = ClientError(
+        {
+            "Error": {"Code": "403", "Message": "Forbidden"},
+            "ResponseMetadata": {"HTTPStatusCode": 403},
+        },
+        "HeadObject",
+    )
+
+    with pytest.raises(R2AccessDeniedError) as exc_info:
+        fetch_r2_object_head(s3_client, "bucket", "metadata.json")
+
+    message = str(exc_info.value)
+    assert "HeadObject" in message
+    assert "wrong R2 access key ID" in message
+    assert "wrong R2 secret access key" in message
+    assert "Cloudflare account ID from endpoint" in message
+    assert "e243...7dac" in message
+    assert isinstance(exc_info.value.__cause__, ClientError)
+
+
+def test_upload_file_to_r2_continues_after_head_access_denied(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Upload should continue when the skip-if-current HEAD check is forbidden."""
+    s3_client = FakeS3Client()
+    file_path = tmp_path / "top_vaults_by_chain.json"
+    file_path.write_bytes(b'{"vaults":[]}')
+    s3_client.head_exceptions["bucket", file_path.name] = ClientError(
+        {
+            "Error": {"Code": "403", "Message": "Forbidden"},
+            "ResponseMetadata": {"HTTPStatusCode": 403},
+        },
+        "HeadObject",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        uploaded = upload_file_to_r2(
+            s3_client=s3_client,
+            file_path=file_path,
+            bucket_name="bucket",
+            object_name=file_path.name,
+            skip_if_current=True,
+        )
+
+    assert uploaded is True
+    assert len(s3_client.upload_calls) == 1
+    assert "Proceeding with upload attempt anyway" in caplog.text


### PR DESCRIPTION
## Why

Cloudflare R2 access failures during top-vault export did not explain clearly whether the problem was the access key ID, secret key, account endpoint, bucket name or bucket permissions. The `skip_if_current` pre-flight `HeadObject` check could also stop useful follow-up work even when a direct upload might still succeed.

## Lessons learnt

- R2 403 responses need Cloudflare-specific context, not only the raw botocore error.
- A failed `HeadObject` optimisation should not block a direct upload attempt or follow-up bucket uploads.
- Per-bucket isolation in post-processing keeps the scanner useful even when one R2 target is misconfigured.

## Summary

- add enriched `R2AccessDeniedError` and `R2OperationError` diagnostics with masked key IDs, endpoint account IDs and likely root-cause hints while preserving the original nested traceback
- fall back from forbidden `HeadObject` checks to a real upload attempt so `skip_if_current` does not stop progress unnecessarily
- upload top-vault JSON to primary and alternative buckets independently so one failing bucket does not block the other or later post-processing work
- add targeted pytest coverage for enriched R2 errors, `HeadObject` fallback behaviour and per-bucket top-vault upload isolation
