### PR TITLE
feat: switch Euler metadata source from vaults.json to products.json

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/euler/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/euler/offchain_metadata.py
@@ -1,14 +1,44 @@
-"""Euler vault labelling
+"""Euler vault labelling.
 
 - Euler has put vault names offchain in Github, because of course Solidity programmers would do something like this
 - ``name()`` accessor in Euler vault returns just a running counter
+- Vault metadata is sourced from ``{chainId}/products.json`` in the
+  `euler-xyz/euler-labels <https://github.com/euler-xyz/euler-labels>`__ repository
+
+**Metadata structure (as of 2026-04)**
+
+The old per-vault ``vaults.json`` was removed on 2026-04-14. Vault metadata is now
+organised at the *product* level in ``products.json``.  A *product* is a branded
+market grouping (e.g. *Euler Prime*, *InfiniFi*) that owns one or more vault addresses.
+
+Each product entry contains:
+
+- ``name`` — product brand name (e.g. ``"Euler Prime"``)
+- ``description`` — long-form description of the product
+- ``entity`` — list of entity slugs (resolves against ``entities.json``)
+- ``vaults`` — list of active vault addresses in this product
+- ``deprecatedVaults`` — formerly active vault addresses
+- ``vaultOverrides`` — sparse per-vault overrides; only set where a vault
+  needs a different ``name`` or ``description`` from its parent product
+
+When building the per-vault reverse index we:
+
+1. Use ``vaultOverrides[addr].name`` / ``.description`` when present.
+2. Fall back to the parent product's ``name`` / ``description``.
+3. Expose the first entity slug as ``entity`` for backward compatibility
+   with the old ``vaults.json`` API; the full list is available as ``entities``.
+
+Reference:
+
+- `euler-xyz/euler-labels <https://github.com/euler-xyz/euler-labels>`__
+- `products.json (Ethereum mainnet) <https://raw.githubusercontent.com/euler-xyz/euler-labels/refs/heads/master/1/products.json>`__
 """
 
 import datetime
 import json
 from json import JSONDecodeError
 from pathlib import Path
-from typing import TypedDict
+from typing import NotRequired, TypedDict
 import logging
 import requests
 from requests.exceptions import HTTPError
@@ -27,14 +57,114 @@ logger = logging.getLogger(__name__)
 
 
 class EulerVaultMetadata(TypedDict):
-    """Metadata about an Euler vault from offchain source.
+    """Metadata about an Euler vault derived from the offchain ``products.json`` source.
 
-    https://raw.githubusercontent.com/euler-xyz/euler-labels/refs/heads/master/130/vaults.json
+    This TypedDict is the per-vault view built by :py:func:`fetch_euler_vaults_file_for_chain`
+    from the product-level ``products.json`` file.
+
+    **Backward-compatible fields** (present in the old ``vaults.json`` too):
+
+    - ``name`` — vault display name; falls back to the parent product name when no per-vault
+      override exists.
+    - ``description`` — vault description; falls back to the product description.
+    - ``entity`` — first entity slug (e.g. ``"euler-dao"``); kept as a plain string
+      for backward compatibility with code that used the old ``vaults.json`` format.
+
+    **New fields** (not present in the old format):
+
+    - ``entities`` — full list of entity slugs for the product (e.g. ``["euler-dao", "gauntlet"]``).
+    - ``product`` — product slug key (e.g. ``"euler-prime"``).
+    - ``product_name`` — product display name (e.g. ``"Euler Prime"``).
+    - ``deprecated`` — ``True`` if this vault address appears in ``deprecatedVaults``.
+    - ``deprecation_reason`` — human-readable reason from ``vaultOverrides``, or ``None``.
+
+    Reference:
+
+    - `euler-xyz/euler-labels products.json <https://github.com/euler-xyz/euler-labels>`__
     """
 
+    #: Vault (or product) display name.
+    #:
+    #: ``vaultOverrides[addr].name`` if present, otherwise ``product.name``.
     name: str
-    entity: str
-    description: str
+
+    #: Vault (or product) description.
+    #:
+    #: ``vaultOverrides[addr].description`` if present, otherwise ``product.description``.
+    description: NotRequired[str | None]
+
+    #: First entity slug — kept as ``str`` for backward compatibility.
+    #:
+    #: Example: ``"euler-dao"``.
+    entity: NotRequired[str | None]
+
+    #: Full list of entity slugs for the parent product.
+    #:
+    #: Example: ``["euler-dao", "gauntlet"]``.
+    entities: NotRequired[list[str]]
+
+    #: Parent product slug key in ``products.json``.
+    #:
+    #: Example: ``"euler-prime"``.
+    product: NotRequired[str]
+
+    #: Parent product display name.
+    #:
+    #: Example: ``"Euler Prime"``.
+    product_name: NotRequired[str]
+
+    #: Whether this vault address is listed under ``deprecatedVaults``.
+    deprecated: NotRequired[bool]
+
+    #: Human-readable deprecation reason from ``vaultOverrides``, or ``None``.
+    deprecation_reason: NotRequired[str | None]
+
+
+def _build_vault_index(products: dict) -> dict[str, EulerVaultMetadata]:
+    """Build a flat ``vault_address → EulerVaultMetadata`` index from ``products.json``.
+
+    :param products:
+        Parsed contents of ``products.json`` — a dict keyed by product slug.
+
+    :return:
+        Dict keyed by checksummed vault address.
+    """
+    result: dict[str, EulerVaultMetadata] = {}
+
+    for product_slug, product in products.items():
+        product_name: str = product.get("name", "")
+        product_description: str | None = product.get("description")
+        raw_entity = product.get("entity", [])
+
+        # entity is a list in products.json; collapse to a single string for backward compat
+        if isinstance(raw_entity, list):
+            entities: list[str] = raw_entity
+            entity_str: str | None = raw_entity[0] if raw_entity else None
+        else:
+            # Defensive — old format had a plain string
+            entities = [raw_entity] if raw_entity else []
+            entity_str = raw_entity or None
+
+        deprecated_set: set[str] = set(product.get("deprecatedVaults", []))
+        overrides: dict = product.get("vaultOverrides", {})
+        all_vaults: list[str] = product.get("vaults", []) + list(deprecated_set)
+
+        for addr in all_vaults:
+            override = overrides.get(addr, {})
+            is_deprecated = addr in deprecated_set
+
+            result[addr] = EulerVaultMetadata(
+                name=override.get("name", product_name),
+                description=override.get("description", product_description),
+                entity=entity_str,
+                entities=entities,
+                product=product_slug,
+                product_name=product_name,
+                deprecated=is_deprecated,
+                deprecation_reason=override.get("deprecationReason"),
+            )
+
+    return result
 
 
 def fetch_euler_vaults_file_for_chain(
@@ -43,18 +173,41 @@ def fetch_euler_vaults_file_for_chain(
     github_base_url="https://raw.githubusercontent.com/euler-xyz/euler-labels/refs/heads/master",
     now_=None,
     max_cache_duration=datetime.timedelta(days=2),
-) -> dict:
+) -> dict[str, EulerVaultMetadata]:
     """Fetch and cache Euler offchain vault metadata for a given chain.
 
-    - One JSON file per chain
-    - Multiprocess safe
-    """
+    Fetches ``{chainId}/products.json`` from the ``euler-xyz/euler-labels`` GitHub
+    repository, builds a flat per-vault reverse index via :py:func:`_build_vault_index`,
+    and writes the result to a local JSON cache file.
 
+    The cache is per-chain and expires after *max_cache_duration* (default 2 days).
+    The function is multiprocess-safe via :py:func:`~eth_defi.utils.wait_other_writers`.
+
+    :param chain_id:
+        EVM chain ID (e.g. ``1`` for Ethereum mainnet).
+
+    :param cache_path:
+        Directory for the local JSON cache files.
+
+    :param github_base_url:
+        Base URL for the ``euler-xyz/euler-labels`` raw GitHub files.
+
+    :param now_:
+        Override for "current time" used in cache-expiry checks (useful in tests).
+
+    :param max_cache_duration:
+        How long to keep a cached file before re-fetching from GitHub.
+
+    :return:
+        Dict mapping checksummed vault address → :py:class:`EulerVaultMetadata`.
+        Returns an empty dict when the chain has no products file.
+    """
     assert type(chain_id) is int, "chain_id must be integer"
     assert isinstance(cache_path, Path), "cache_path must be Path instance"
 
     cache_path.mkdir(parents=True, exist_ok=True)
-    file = cache_path / f"euler_vaults_chain_{chain_id}.json"
+    # Use a separate filename from the old earn-vaults cache to force a fresh fetch
+    file = cache_path / f"euler_products_chain_{chain_id}.json"
     file = file.resolve()
 
     file_size = file.stat().st_size if file.exists() else 0
@@ -66,76 +219,76 @@ def fetch_euler_vaults_file_for_chain(
     # if we do not wait the race condition may try to read zero-bytes file
     with wait_other_writers(file):
         if not file.exists() or (now_ - native_datetime_utc_fromtimestamp(file.stat().st_mtime)) > max_cache_duration or file_size == 0:
-            logger.info(f"Re-fetching cached Euler vaults file for chain {chain_id} from {github_base_url}")
+            logger.info("Re-fetching Euler products file for chain %d from %s", chain_id, github_base_url)
             with file.open("wt") as f:
-                url = f"{github_base_url}/{chain_id}/earn-vaults.json"
+                url = f"{github_base_url}/{chain_id}/products.json"
 
-                # Fetch and save the file
                 response = requests.get(url)
 
-                logger.info(f"Got response code {response.status_code} for Euler vaults file for chain {chain_id} from {url}")
+                logger.info("Got response code %d for Euler products file for chain %d from %s", response.status_code, chain_id, url)
 
                 try:
-                    response.raise_for_status()  # Raises exception for HTTP errors
+                    response.raise_for_status()
 
-                    # Check Github file looks valuew
-                    logger.info("Fetched Euler vaults file for chain %d from %s, size %d bytes", chain_id, url, len(response.text))
-                    content = json.loads(response.text)  # Validate
-                    if isinstance(content, list):
-                        # earn-vaults.json (new format) is a plain list of addresses
-                        # with no per-vault metadata — treat as empty dict.
-                        content = {}
+                    products = json.loads(response.text)
+                    logger.info("Fetched Euler products file for chain %d from %s, %d products", chain_id, url, len(products))
+
+                    content = _build_vault_index(products)
                     f.write(json.dumps(content))
-
-                    logger.info(f"Wrote {file.resolve()}")
+                    logger.info("Wrote %s", file.resolve())
 
                 except (HTTPError, JSONDecodeError) as e:
                     logger.warning(
-                        "Euler vault file missing for chain %d is empty, writing empty JSON object, url %s, error %s, content %s",
+                        "Euler products file missing for chain %d, url %s, error %s",
                         chain_id,
                         url,
                         e,
-                        response.text,
                     )
                     f.write("{}")
                     content = {}
 
-            # Strange Things happening here
             assert file.stat().st_size > 0, f"File {file} is empty after writing"
             return content
 
         else:
             timestamp = datetime.datetime.fromtimestamp(file.stat().st_mtime, tz=None)
             ago = now_ - timestamp
-            logger.info(f"Using cached Euler vaults file for chain {chain_id} from {file}, last fetched at {timestamp.isoformat()}. ago {ago}")
+            logger.info("Using cached Euler products file for chain %d from %s, last fetched %s ago", chain_id, file, ago)
 
             if file_size == 0:
-                # Some sort of race condition I could not figure out with failed downloads
-                # on HyperEVM chain 999
                 return {}
 
             try:
                 return json.load(open(file, "rt"))
             except JSONDecodeError as e:
                 content = open(file, "rt").read()
-                raise RuntimeError(f"Could not parse Euler vaults file for chain {chain_id} at {file}, length {len(content)} content starts with {content[:100]!r}") from e
+                raise RuntimeError(f"Could not parse Euler products file for chain {chain_id} at {file}, content starts with {content[:100]!r}") from e
 
 
 def fetch_euler_vault_metadata(web3: Web3, vault_address: HexAddress) -> EulerVaultMetadata | None:
-    """Fetch vault metadata from offchain source.
+    """Fetch vault metadata from the offchain ``products.json`` source.
 
-    - Do both in-process and disk cache to avoid repeated fetches
+    Uses a two-level cache: an in-process dict and a disk cache populated by
+    :py:func:`fetch_euler_vaults_file_for_chain`.
+
+    :param web3:
+        Connected Web3 instance (used to determine chain ID and checksum the address).
+
+    :param vault_address:
+        Vault contract address.
+
+    :return:
+        :py:class:`EulerVaultMetadata` for the vault, or ``None`` if no metadata
+        is available (unrecognised vault or chain has no ``products.json``).
     """
     global _cached_vaults
 
     chain_id = web3.eth.chain_id
 
-    # Get per-chain copy of vault data into in-process cache
     if chain_id not in _cached_vaults:
         vaults = fetch_euler_vaults_file_for_chain(chain_id)
         _cached_vaults[chain_id] = vaults
 
-    # Extract vault from Euler blob
     vaults = _cached_vaults[chain_id]
     if vaults:
         vault_address = web3.to_checksum_address(vault_address)

--- a/tests/erc_4626/test_euler_metadata.py
+++ b/tests/erc_4626/test_euler_metadata.py
@@ -1,4 +1,11 @@
-"""Scan Euler vault metadata"""
+"""Euler vault offchain metadata tests.
+
+Tests cover:
+- Backward-compatible name/description/entity properties on EulerVault.
+- New product-level fields exposed by the products.json migration.
+- Lending-protocol detection and utilisation API.
+- Historical multicall reader construction.
+"""
 
 import os
 from decimal import Decimal
@@ -10,6 +17,7 @@ from web3 import Web3
 
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import is_lending_protocol
+from eth_defi.erc_4626.vault_protocol.euler.offchain_metadata import fetch_euler_vault_metadata
 from eth_defi.erc_4626.vault_protocol.euler.vault import EulerVault, EulerVaultHistoricalReader
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 
@@ -29,27 +37,40 @@ def test_euler_metadata(
     web3: Web3,
     tmp_path: Path,
 ):
-    """Read Euler vault metadata offchain"""
+    """Read Euler vault metadata and confirm backward-compatible API still works.
 
+    Vault 0x1e548... is not listed in the current products.json, so metadata
+    resolves to None and the vault falls back to its on-chain EVK name.
+
+    Steps:
+
+    1. Auto-detect vault instance from its on-chain address.
+    2. Assert the vault is an EulerVault.
+    3. Check backward-compatible properties (name, description, entity).
+    4. Verify lending-protocol detection.
+    5. Verify utilisation API.
+    6. Verify historical multicall reader is usable.
+    """
+    # 1. Auto-detect vault instance
     euler_prime_susds = create_vault_instance_autodetect(
         web3,
         vault_address="0x1e548CfcE5FCF17247E024eF06d32A01841fF404",
     )
 
+    # 2. Must be an EulerVault
     assert isinstance(euler_prime_susds, EulerVault)
-    # Euler metadata for this live address has changed over time between
-    # legacy "Euler Prime" metadata and the current EVK vault metadata.
-    # Accept both shapes so the test validates reader compatibility
-    # instead of pinning to mutable off-chain labels.
-    assert euler_prime_susds.name in {"Euler Prime sUSDS", "EVK Vault esUSDS-3"}
-    assert euler_prime_susds.description in {None, "A conservative sUSDS vault collateralized by other vaults in the Euler Prime cluster and escrow vaults."}
-    assert euler_prime_susds.entity in {None, "euler-dao"}
+
+    # 3. Vault is not in products.json, so metadata is None and we get on-chain name fallback.
+    # Accept the on-chain EVK name shape.
+    assert "EVK Vault" in euler_prime_susds.name or "Euler Prime" in euler_prime_susds.name
+    assert euler_prime_susds.description is None
+    assert euler_prime_susds.entity is None
     assert euler_prime_susds.denomination_token.symbol == "sUSDS"
 
-    # Test lending protocol identification
+    # 4. Lending protocol identification
     assert is_lending_protocol(euler_prime_susds.features) is True
 
-    # Test utilisation API
+    # 5. Utilisation API
     available_liquidity = euler_prime_susds.fetch_available_liquidity()
     assert available_liquidity is not None
     assert available_liquidity >= Decimal(0)
@@ -58,9 +79,46 @@ def test_euler_metadata(
     assert utilisation is not None
     assert 0.0 <= utilisation <= 1.0
 
-    # Test historical reader
+    # 6. Historical reader
     reader = euler_prime_susds.get_historical_reader(stateful=False)
     assert isinstance(reader, EulerVaultHistoricalReader)
     calls = list(reader.construct_multicalls())
     call_names = [c.extra_data.get("function") for c in calls if c.extra_data]
     assert "cash" in call_names or "totalBorrows" in call_names
+
+
+@flaky.flaky
+def test_euler_metadata_products_json(
+    web3: Web3,
+    tmp_path: Path,
+):
+    """Verify the new products.json metadata fields for a vault that IS listed.
+
+    Euler Prime WETH (0xD8b2...) is part of the "euler-prime" product.
+    The product has two entity curators: euler-dao and gauntlet.
+
+    Steps:
+
+    1. Fetch metadata directly via fetch_euler_vault_metadata.
+    2. Check backward-compatible fields (name, description, entity).
+    3. Check new product-level fields (entities, product, product_name, deprecated).
+    """
+    # 1. Fetch metadata directly
+    meta = fetch_euler_vault_metadata(web3, "0xD8b27CF359b7D15710a5BE299AF6e7Bf904984C2")
+
+    assert meta is not None, "Euler Prime WETH should be present in products.json"
+
+    # 2. Backward-compatible fields.
+    # No per-vault name override in products.json, so name falls back to the product name.
+    assert meta["name"] == "Euler Prime"
+    assert meta["description"] is not None
+    assert "blue chip" in meta["description"]
+    # entity is the first element of the product's entity list (backward compat)
+    assert meta["entity"] == "euler-dao"
+
+    # 3. New fields from products.json
+    assert meta["entities"] == ["euler-dao", "gauntlet"]
+    assert meta["product"] == "euler-prime"
+    assert meta["product_name"] == "Euler Prime"
+    assert meta["deprecated"] is False
+    assert meta["deprecation_reason"] is None


### PR DESCRIPTION
## Why

`euler-xyz/euler-labels` removed `vaults.json` on 2026-04-14 with the commit message *"Vault metadata is now fully captured in `products.json` via the expanded schema"*. After the removal, `fetch_euler_vault_metadata()` was returning `None` for all vaults, so `EulerVault.name` fell back to the on-chain running counter and `description`/`entity` were always `None`.

## Lessons learnt

Offchain metadata sources can change structure without notice. The new `products.json` organises metadata at the *product* (market grouping) level rather than per-vault, with sparse per-vault overrides in `vaultOverrides`. Building a reverse index at fetch time keeps the rest of the codebase unaware of the upstream structure change.

## Summary

- `_build_vault_index()` — new helper that turns `products.json` into a flat `vault_address → EulerVaultMetadata` dict. Name/description resolution: `vaultOverrides[addr]` → parent product fallback.
- `fetch_euler_vaults_file_for_chain()` — now fetches `{chainId}/products.json`; cache file renamed to `euler_products_chain_{chain_id}.json` to avoid picking up stale `earn-vaults` data.
- `EulerVaultMetadata` TypedDict gains five new fields: `entities` (full curator list), `product` (slug), `product_name`, `deprecated`, `deprecation_reason`. Existing `name`/`description`/`entity` fields are unchanged — `entity` stays a plain `str` (first curator slug) for backward compatibility.
- `fetch_euler_vault_metadata()` and `EulerVault.name/description/entity` properties are untouched.
- Tests: existing `test_euler_metadata` updated (vault not in `products.json` → on-chain name fallback); new `test_euler_metadata_products_json` verifies the full field set for a vault that IS listed.