### PR TITLE
fix: flag abnormal vault listings

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -159,7 +159,13 @@ HLT_IRREGULAR_SHARE_PRICE = "This vault has experienced irregular share price re
 
 LOW_TVL_ABNORMAL_PRICE = "Low-TVL vault with abnormal price behaviour"
 
+ILLIQUID_ABNORMAL_SHARE_PRICE = "Vault likely illiquid. Share price chart has abnormal high returns while deposits are still enabled."
+
 MISSING_IN_PROTOCOL_FRONTEND = "This vault is missing in the protocol's primary website and cannot be verified."
+
+TEST_VAULT = "This appears to be a test vault and should not be shown to end users."
+
+UNKNOWN_ABNORMAL_SHARE_PRICE = "Share price chart has abnormal high returns and the vault protocol is not yet identified."
 
 SUBVAULT = "This vault is likely not intended to be directly exposed to the end users. It may be used by other vaults as a part of the strategy mix and has erratic TVL."
 
@@ -263,6 +269,15 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0x196f3c7443e940911ee2bb88e019fd71400349d9": (VaultFlag.illiquid, XUSD_MESSAGE),
     # Borrowable USDC Deposit, SiloId: 170
     "0x7786dba2a1f7a4b0b7abf0962c449154c4f2b8ac": (VaultFlag.illiquid, XUSD_MESSAGE),
+    # Borrowable USDC Deposit, SiloId: 105
+    "0x4f55e28d36b30a638c3aa1d5cbf9c4ccb3831506": (VaultFlag.illiquid, ILLIQUID_ABNORMAL_SHARE_PRICE),
+    # 40avax-USDC-VAULT on Avalanche
+    "0xbed7c02887efd6b5eb9a547ac1a4d5e582791647": (VaultFlag.abnormal_share_price, UNKNOWN_ABNORMAL_SHARE_PRICE),
+    # XAU Aplha Vault on Arbitrum
+    "0x5424293637cc59ad7580ad1cac46e28d4801a587": (VaultFlag.abnormal_share_price, UNKNOWN_ABNORMAL_SHARE_PRICE),
+    # HaUSDC Share - Test on Hyperliquid
+    "0x7db7bcd6746f4dcfa2fdcdd80c1c313cc371f166": (VaultFlag.unofficial, TEST_VAULT),
+    "0x25b4dc5f96312c7083a58d80d8ecad6ecddbbdfb": (VaultFlag.unofficial, TEST_VAULT),
     # Valamor aUSDC/USDC/USDT etc.
     # https://x.com/VarlamoreCap/status/1986290754688541003
     "0x3d7b0c3997e48fa3fc96cd057d1fb4e5f891835b": (VaultFlag.illiquid, XUSD_MESSAGE),

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -1,0 +1,33 @@
+"""Test vault manual flags."""
+
+import pytest
+
+from eth_defi.vault.flag import BAD_FLAGS, VaultFlag, get_notes, get_vault_special_flags, is_flagged_vault
+from eth_defi.vault.risk import VaultTechnicalRisk, get_vault_risk
+
+
+@pytest.mark.parametrize(
+    ("address", "protocol", "expected_flag", "expected_note"),
+    [
+        ("0x4f55e28d36b30a638c3aa1d5cbf9c4ccb3831506", "Silo Finance", VaultFlag.illiquid, "likely illiquid"),
+        ("0xbed7c02887efd6b5eb9a547ac1a4d5e582791647", "<protocol not yet identified>", VaultFlag.abnormal_share_price, "abnormal high returns"),
+        ("0x5424293637cc59ad7580ad1cac46e28d4801a587", "<protocol not yet identified>", VaultFlag.abnormal_share_price, "abnormal high returns"),
+        ("0x7db7bcd6746f4dcfa2fdcdd80c1c313cc371f166", "<unknown ERC-7540>", VaultFlag.unofficial, "test vault"),
+        ("0x25b4dc5f96312c7083a58d80d8ecad6ecddbbdfb", "<unknown ERC-7540>", VaultFlag.unofficial, "test vault"),
+    ],
+)
+def test_abnormal_main_listing_vaults_are_hidden(
+    address: str,
+    protocol: str,
+    expected_flag: VaultFlag,
+    expected_note: str,
+):
+    """Abnormal main listing vaults are marked with bad manual flags."""
+
+    flags = get_vault_special_flags(address)
+
+    assert flags == {expected_flag}
+    assert expected_flag in BAD_FLAGS
+    assert is_flagged_vault(address)
+    assert expected_note in get_notes(address)
+    assert get_vault_risk(protocol, address) == VaultTechnicalRisk.blacklisted


### PR DESCRIPTION
## Why

The public top vault listing contains depositable vaults whose share-price histories produce implausible returns, but these vaults are not yet marked with bad flags. This lets likely illiquid, test, or broken listings appear in rankings.

## Lessons learnt

The main listing feed is a useful sanity check for unflagged depositable vaults with capped annualised returns. SiloId 105 is the supported-protocol example; the other matches are unknown or explicit test vaults and should be hidden more conservatively.

## Summary

- Added manual bad flags and notes for five abnormal main listing vaults.
- Added a regression test that verifies these flags blacklist the affected vaults.
