### PR TITLE
feat: Morpho Blue flag analytics submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- feat: Morpho Blue flag analytics submodule — extract warning analytics from inline code into `eth_defi/erc_4626/vault_protocol/morpho/flag_analytics.py` with `MorphoFlagAnalytics` dataclass, `analyze_morpho_flags()` entry point, and `print_morpho_flag_analytics()` CLI printer; `get_notes()` on `MorphoV1Vault` and `MorphoV2Vault` now returns the dynamically generated Morpho issue note (2026-04-28)
+
 - feat: Morpho Blue offchain warnings — fetch vault and market-level RED/YELLOW warnings from the Morpho Blue GraphQL API, cache them 24 h on disk, expose via `get_morpho_vault_flags()` / `get_morpho_market_flags()` on `MorphoV1Vault` and `MorphoV2Vault`, set `VaultFlag.morpho_issues` when any RED warning is present, and surface `morpho_vault_flags` / `morpho_market_flags` in `calculate_vault_record()` `other_data` (2026-04-25)
 
 - feat: Add avg_utilisation per period to PeriodMetrics — lending vaults now expose average utilisation for each lookback window (1W, 1M, 3M, 6M, 1Y, lifetime) via PeriodMetrics.avg_utilisation; utilisation (latest) was already present as a top-level column (2026-04-21)

--- a/eth_defi/erc_4626/vault_protocol/morpho/flag_analytics.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/flag_analytics.py
@@ -14,6 +14,7 @@ serialises to a human-readable string via ``str()``.
 """
 
 from dataclasses import dataclass
+from typing import Any
 
 from eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata import MorphoVaultData
 
@@ -151,13 +152,16 @@ def generate_morpho_issue_note(data: MorphoVaultData) -> str | None:
     return analyze_morpho_flags(data).note
 
 
-def print_morpho_flag_analytics(vault) -> None:
-    """Print a formatted Morpho Blue warning summary for a vault to stdout.
+def format_morpho_flag_analytics(vault: Any) -> str:
+    """Return a formatted Morpho Blue warning summary for a vault as a string.
 
-    Intended for CLI diagnostic scripts (e.g. ``check-vault-onchain.py``).
-    Prints a message when the vault has no Morpho offchain data.
+    Builds a multi-line human-readable block suitable for CLI diagnostic scripts
+    (e.g. ``check-vault-onchain.py``). The caller decides how to output it — typically
+    via ``print(format_morpho_flag_analytics(vault))``.
 
-    Displays:
+    Returns a single-line message when the vault has no Morpho offchain data.
+
+    Includes:
 
     - Vault-level and market-level warning type sets
     - Per-warning detail lines (severity level, type, market ID, bad-debt USD / share)
@@ -167,19 +171,22 @@ def print_morpho_flag_analytics(vault) -> None:
         A :py:class:`~eth_defi.erc_4626.vault_protocol.morpho.vault_v1.MorphoV1Vault`
         or :py:class:`~eth_defi.erc_4626.vault_protocol.morpho.vault_v2.MorphoV2Vault`
         instance.
+
+    :return:
+        Formatted multi-line string with the warning summary.
     """
     data = vault.morpho_offchain_data
     if data is None:
-        print("  No data (vault not indexed by Morpho Blue API)")  # noqa: T201
-        return
+        return "  No data (vault not indexed by Morpho Blue API)"
 
     analytics = analyze_morpho_flags(data)
+    lines: list[str] = []
 
-    print(f"  Vault-level warning types:  {analytics.vault_flag_types or 'none'}")  # noqa: T201
-    print(f"  Market-level warning types: {analytics.market_flag_types or 'none'}")  # noqa: T201
+    lines.append(f"  Vault-level warning types:  {analytics.vault_flag_types or 'none'}")
+    lines.append(f"  Market-level warning types: {analytics.market_flag_types or 'none'}")
 
     for w in data.get("vault_warnings", []):
-        print(f"    vault  [{w.get('level', '?'):6s}] {w.get('type', '?')}")  # noqa: T201
+        lines.append(f"    vault  [{w.get('level', '?'):6s}] {w.get('type', '?')}")
 
     for w in data.get("market_warnings", []):
         extra = ""
@@ -187,7 +194,9 @@ def print_morpho_flag_analytics(vault) -> None:
             extra = f"  bad_debt_usd={w['bad_debt_usd']:.2f}  bad_debt_share={w.get('bad_debt_share', 0):.4f}"
         market_id = w.get("market_id", "?")
         short_id = market_id[:_MARKET_ID_PREFIX_LEN] + "..." if len(market_id) > _MARKET_ID_PREFIX_LEN else market_id
-        print(f"    market [{w.get('level', '?'):6s}] {w.get('type', '?')}  market_id={short_id}{extra}")  # noqa: T201
+        lines.append(f"    market [{w.get('level', '?'):6s}] {w.get('type', '?')}  market_id={short_id}{extra}")
 
     if analytics.note:
-        print(f"\n  Note: {analytics.note}")  # noqa: T201
+        lines.append(f"\n  Note: {analytics.note}")
+
+    return "\n".join(lines)

--- a/eth_defi/erc_4626/vault_protocol/morpho/flag_analytics.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/flag_analytics.py
@@ -1,0 +1,193 @@
+"""Morpho Blue warning analytics helpers.
+
+Provides pure-data helpers and a structured result type that operate on
+:py:class:`MorphoVaultData` dicts returned by
+:py:func:`~eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata.fetch_morpho_vault_data`,
+plus a diagnostic printer for CLI scripts.
+
+All list fields use sorted output so JSON / Series exports are deterministic
+regardless of the order the API returns warnings.
+
+Main entry point: :py:func:`analyze_morpho_flags` returns a
+:py:class:`MorphoFlagAnalytics` dataclass that bundles all derived fields and
+serialises to a human-readable string via ``str()``.
+"""
+
+from dataclasses import dataclass
+
+from eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata import MorphoVaultData
+
+#: Number of hex characters to display from a Morpho market ID before truncating
+_MARKET_ID_PREFIX_LEN = 10
+
+
+@dataclass(slots=True)
+class MorphoFlagAnalytics:
+    """Structured analytics derived from Morpho Blue API warning data.
+
+    All list fields are sorted for deterministic JSON output.
+
+    Typical usage::
+
+        data = vault.morpho_offchain_data
+        if data is not None:
+            analytics = analyze_morpho_flags(data)
+            print(analytics)  # human-readable summary
+            print(analytics.note)  # pipeline note text or None
+    """
+
+    #: Sorted vault-level warning type strings (any severity).
+    #: Example: ``["not_whitelisted", "short_timelock"]``
+    vault_flag_types: list[str]
+
+    #: Sorted market-level warning type strings (any severity).
+    #: Example: ``["bad_debt_unrealized", "not_whitelisted"]``
+    market_flag_types: list[str]
+
+    #: Sorted RED-level warning type strings across vault and market warnings.
+    #: Non-empty when :py:attr:`~eth_defi.vault.flag.VaultFlag.morpho_issues` must be set.
+    #: Example: ``["bad_debt_unrealized", "short_timelock"]``
+    red_flags: list[str]
+
+    #: Human-readable note for the pipeline / ``get_notes()`` output.
+    #: ``None`` when there are no RED warnings.
+    note: str | None
+
+    def __str__(self) -> str:
+        """Return a compact one-line summary for logging and diagnostics."""
+        parts = []
+        if self.vault_flag_types:
+            parts.append(f"vault=[{', '.join(self.vault_flag_types)}]")
+        if self.market_flag_types:
+            parts.append(f"market=[{', '.join(self.market_flag_types)}]")
+        if self.red_flags:
+            parts.append(f"RED=[{', '.join(self.red_flags)}]")
+        return " ".join(parts) if parts else "no warnings"
+
+
+def analyze_morpho_flags(data: MorphoVaultData) -> MorphoFlagAnalytics:
+    """Build a :py:class:`MorphoFlagAnalytics` summary from raw Morpho API data.
+
+    Single entry point that computes all derived warning fields in one pass.
+    Prefer this over calling the individual helper functions separately.
+
+    :param data:
+        Morpho vault data from the GraphQL API.
+
+    :return:
+        Fully populated :py:class:`MorphoFlagAnalytics` instance.
+    """
+    vault_flag_types = sorted({w["type"] for w in data.get("vault_warnings", [])})
+    market_flag_types = sorted({w["type"] for w in data.get("market_warnings", [])})
+
+    red_vault = {w["type"] for w in data.get("vault_warnings", []) if w.get("level") == "RED"}
+    red_market = {w["type"] for w in data.get("market_warnings", []) if w.get("level") == "RED"}
+    red_flags = sorted(red_vault | red_market)
+
+    note = f"Morpho has flagged this vault with the following issues: {', '.join(red_flags)}" if red_flags else None
+
+    return MorphoFlagAnalytics(
+        vault_flag_types=vault_flag_types,
+        market_flag_types=market_flag_types,
+        red_flags=red_flags,
+        note=note,
+    )
+
+
+def get_morpho_red_flags(data: MorphoVaultData) -> list[str]:
+    """Return all RED-level warning type strings across vault and market warnings.
+
+    :param data:
+        Morpho vault data from the GraphQL API.
+
+    :return:
+        Sorted list of RED warning type strings, e.g.
+        ``["bad_debt_unrealized", "short_timelock"]``.
+        Empty list when there are no RED warnings.
+    """
+    return analyze_morpho_flags(data).red_flags
+
+
+def get_morpho_vault_flag_types(data: MorphoVaultData) -> list[str]:
+    """Return all vault-level warning type strings (any severity).
+
+    :param data:
+        Morpho vault data from the GraphQL API.
+
+    :return:
+        Sorted list of vault-warning type strings,
+        e.g. ``["not_whitelisted", "short_timelock"]``.
+    """
+    return analyze_morpho_flags(data).vault_flag_types
+
+
+def get_morpho_market_flag_types(data: MorphoVaultData) -> list[str]:
+    """Return all market-level warning type strings (any severity).
+
+    :param data:
+        Morpho vault data from the GraphQL API.
+
+    :return:
+        Sorted list of market-warning type strings,
+        e.g. ``["bad_debt_unrealized", "not_whitelisted"]``.
+    """
+    return analyze_morpho_flags(data).market_flag_types
+
+
+def generate_morpho_issue_note(data: MorphoVaultData) -> str | None:
+    """Generate a human-readable note for RED-level Morpho warnings.
+
+    Returns ``None`` when there are no RED warnings so callers can use a
+    simple ``notes = notes or generate_morpho_issue_note(data)`` pattern.
+
+    :param data:
+        Morpho vault data from the GraphQL API.
+
+    :return:
+        Note string such as
+        ``"Morpho has flagged this vault with the following issues: bad_debt_unrealized, short_timelock"``,
+        or ``None`` if there are no RED warnings.
+    """
+    return analyze_morpho_flags(data).note
+
+
+def print_morpho_flag_analytics(vault) -> None:
+    """Print a formatted Morpho Blue warning summary for a vault to stdout.
+
+    Intended for CLI diagnostic scripts (e.g. ``check-vault-onchain.py``).
+    Prints a message when the vault has no Morpho offchain data.
+
+    Displays:
+
+    - Vault-level and market-level warning type sets
+    - Per-warning detail lines (severity level, type, market ID, bad-debt USD / share)
+    - The pipeline note text from :py:attr:`MorphoFlagAnalytics.note`
+
+    :param vault:
+        A :py:class:`~eth_defi.erc_4626.vault_protocol.morpho.vault_v1.MorphoV1Vault`
+        or :py:class:`~eth_defi.erc_4626.vault_protocol.morpho.vault_v2.MorphoV2Vault`
+        instance.
+    """
+    data = vault.morpho_offchain_data
+    if data is None:
+        print("  No data (vault not indexed by Morpho Blue API)")  # noqa: T201
+        return
+
+    analytics = analyze_morpho_flags(data)
+
+    print(f"  Vault-level warning types:  {analytics.vault_flag_types or 'none'}")  # noqa: T201
+    print(f"  Market-level warning types: {analytics.market_flag_types or 'none'}")  # noqa: T201
+
+    for w in data.get("vault_warnings", []):
+        print(f"    vault  [{w.get('level', '?'):6s}] {w.get('type', '?')}")  # noqa: T201
+
+    for w in data.get("market_warnings", []):
+        extra = ""
+        if w.get("bad_debt_usd") is not None:
+            extra = f"  bad_debt_usd={w['bad_debt_usd']:.2f}  bad_debt_share={w.get('bad_debt_share', 0):.4f}"
+        market_id = w.get("market_id", "?")
+        short_id = market_id[:_MARKET_ID_PREFIX_LEN] + "..." if len(market_id) > _MARKET_ID_PREFIX_LEN else market_id
+        print(f"    market [{w.get('level', '?'):6s}] {w.get('type', '?')}  market_id={short_id}{extra}")  # noqa: T201
+
+    if analytics.note:
+        print(f"\n  Note: {analytics.note}")  # noqa: T201

--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v1.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v1.py
@@ -19,11 +19,11 @@ from web3 import Web3
 
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
-from eth_defi.erc_4626.vault_protocol.morpho.flag_analytics import generate_morpho_issue_note
+from eth_defi.erc_4626.vault_protocol.morpho.flag_analytics import analyze_morpho_flags
 from eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata import MorphoVaultData, fetch_morpho_vault_data
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.types import Percent
-from eth_defi.vault.base import VaultHistoricalReader, VaultHistoricalRead
+from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
 from eth_defi.vault.flag import VaultFlag
 
 logger = logging.getLogger(__name__)
@@ -225,7 +225,7 @@ class MorphoV1Vault(ERC4626Vault):
             return note
         data = self.morpho_offchain_data
         if data is not None:
-            return generate_morpho_issue_note(data)
+            return analyze_morpho_flags(data).note
         return None
 
     def get_flags(self) -> set[VaultFlag]:

--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v1.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v1.py
@@ -19,6 +19,7 @@ from web3 import Web3
 
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
+from eth_defi.erc_4626.vault_protocol.morpho.flag_analytics import generate_morpho_issue_note
 from eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata import MorphoVaultData, fetch_morpho_vault_data
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.types import Percent
@@ -204,6 +205,28 @@ class MorphoV1Vault(ERC4626Vault):
         if not data:
             return set()
         return {w["type"] for w in data.get("market_warnings", [])}
+
+    def get_notes(self) -> str | None:
+        """Return a human-readable note about RED-level Morpho warnings, if any.
+
+        Checks the hardcoded flag table first (via the base class), then falls back
+        to a dynamically generated note from the Morpho Blue GraphQL API when RED
+        warnings are present.
+
+        The generated text follows the form::
+
+            "Morpho has flagged this vault with the following issues: bad_debt_unrealized, short_timelock"
+
+        :return:
+            Note string, or ``None`` if no hardcoded note and no RED warnings.
+        """
+        note = super().get_notes()
+        if note:
+            return note
+        data = self.morpho_offchain_data
+        if data is not None:
+            return generate_morpho_issue_note(data)
+        return None
 
     def get_flags(self) -> set[VaultFlag]:
         """Get vault flags, adding ``morpho_issues`` when RED warnings are detected.

--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
@@ -28,7 +28,7 @@ from web3 import Web3
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
-from eth_defi.erc_4626.vault_protocol.morpho.flag_analytics import generate_morpho_issue_note
+from eth_defi.erc_4626.vault_protocol.morpho.flag_analytics import analyze_morpho_flags
 from eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata import MorphoVaultData, fetch_morpho_vault_data
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.types import Percent
@@ -266,7 +266,7 @@ class MorphoV2Vault(ERC4626Vault):
             return note
         data = self.morpho_offchain_data
         if data is not None:
-            return generate_morpho_issue_note(data)
+            return analyze_morpho_flags(data).note
         return None
 
     def get_flags(self) -> set[VaultFlag]:

--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
@@ -28,6 +28,7 @@ from web3 import Web3
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
+from eth_defi.erc_4626.vault_protocol.morpho.flag_analytics import generate_morpho_issue_note
 from eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata import MorphoVaultData, fetch_morpho_vault_data
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.types import Percent
@@ -246,6 +247,27 @@ class MorphoV2Vault(ERC4626Vault):
         if not data:
             return set()
         return {w["type"] for w in data.get("market_warnings", [])}
+
+    def get_notes(self) -> str | None:
+        """Return a human-readable note about RED-level Morpho warnings, if any.
+
+        Checks the hardcoded flag table first (via the base class), then falls back
+        to a dynamically generated note from the Morpho Blue GraphQL API when RED
+        warnings are present.
+
+        For current V2 vaults the Morpho Blue API returns ``NOT_FOUND``, so this
+        will typically return ``None`` unless a hardcoded note exists.
+
+        :return:
+            Note string, or ``None`` if no hardcoded note and no RED warnings.
+        """
+        note = super().get_notes()
+        if note:
+            return note
+        data = self.morpho_offchain_data
+        if data is not None:
+            return generate_morpho_issue_note(data)
+        return None
 
     def get_flags(self) -> set[VaultFlag]:
         """Get vault flags, adding ``morpho_issues`` when RED warnings are detected.

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -26,6 +26,7 @@ from tqdm.auto import tqdm
 from eth_defi.chain import get_chain_name
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.erc_4626.core import ERC4262VaultDetection
+from eth_defi.erc_4626.vault_protocol.morpho.flag_analytics import MorphoFlagAnalytics, analyze_morpho_flags
 from eth_defi.research.value_table import format_grouped_series_as_multi_column_grid, format_series_as_multi_column_grid
 from eth_defi.research.wrangle_vault_prices import forward_fill_vault
 from eth_defi.token import is_stablecoin_like, normalise_token_symbol
@@ -1320,20 +1321,19 @@ def calculate_vault_record(
     morpho_vault_flags: list[str] = []
     morpho_market_flags: list[str] = []
 
+    morpho_analytics: MorphoFlagAnalytics | None = None
     if morpho_offchain_data is not None:
-        # Use sorted lists for stable JSON output (sets have non-deterministic ordering)
-        morpho_vault_flags = sorted({w["type"] for w in morpho_offchain_data.get("vault_warnings", [])})
-        morpho_market_flags = sorted({w["type"] for w in morpho_offchain_data.get("market_warnings", [])})
+        morpho_analytics = analyze_morpho_flags(morpho_offchain_data)
+        morpho_vault_flags = morpho_analytics.vault_flag_types
+        morpho_market_flags = morpho_analytics.market_flag_types
 
-        all_red_flags = sorted({w["type"] for w in morpho_offchain_data.get("vault_warnings", []) if w.get("level") == "RED"} | {w["type"] for w in morpho_offchain_data.get("market_warnings", []) if w.get("level") == "RED"})
-        if all_red_flags:
+        if morpho_analytics.red_flags:
             # Add the flag unconditionally — any RED warning warrants the flag
             flags = set(flags)
             flags.add(VaultFlag.morpho_issues)
             # Only generate the note text when no existing manual or abnormal-metric note is set
             if not notes:
-                morpho_flags_str = ", ".join(all_red_flags)
-                notes = f"Morpho reports the vault is facing the following issues: {morpho_flags_str}"
+                notes = morpho_analytics.note
 
     # ``other_data`` is a protocol-specific extension dict included in the metrics Series.
     # Currently populated for Morpho vaults; all other protocols return empty lists.

--- a/scripts/erc-4626/check-vault-onchain.py
+++ b/scripts/erc-4626/check-vault-onchain.py
@@ -17,6 +17,9 @@ Example output::
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.classification import create_vault_instance, detect_vault_features
+from eth_defi.erc_4626.vault_protocol.morpho.flag_analytics import print_morpho_flag_analytics
+from eth_defi.erc_4626.vault_protocol.morpho.vault_v1 import MorphoV1Vault
+from eth_defi.erc_4626.vault_protocol.morpho.vault_v2 import MorphoV2Vault
 from eth_defi.provider.env import read_json_rpc_url
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.utils import setup_console_logging
@@ -24,8 +27,8 @@ from eth_defi.vault.base import VaultSpec
 
 setup_console_logging(default_log_level="INFO")
 
-# Ostium LP on Arbitrum
-spec = VaultSpec.parse_string("42161-0x20d419a8e12c45f88fda7c5760bb6923cee27f98")
+# frobUSDC on Arbitrum — has short_timelock (RED) vault warning + bad_debt_unrealized (RED) market warning
+spec = VaultSpec.parse_string("42161-0xC3415c9231Dad88F8146107372143f6dAE042967")
 
 json_rpc_url = read_json_rpc_url(spec.chain_id)
 web3 = create_multi_provider_web3(json_rpc_url)
@@ -65,6 +68,12 @@ print("\nFlags and notes:")
 print(f"  Flags: {flags or 'None'}")
 print(f"  Notes: {notes or 'None'}")
 print("-" * 80)
+
+# Morpho-specific offchain warnings from Morpho Blue GraphQL API
+if isinstance(vault, (MorphoV1Vault, MorphoV2Vault)):
+    print("\nMorpho offchain warnings:")
+    print_morpho_flag_analytics(vault)
+    print("-" * 80)
 
 # Check deposit/redemption status
 print("\nDeposit/Redemption status:")

--- a/scripts/erc-4626/check-vault-onchain.py
+++ b/scripts/erc-4626/check-vault-onchain.py
@@ -17,7 +17,7 @@ Example output::
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.classification import create_vault_instance, detect_vault_features
-from eth_defi.erc_4626.vault_protocol.morpho.flag_analytics import print_morpho_flag_analytics
+from eth_defi.erc_4626.vault_protocol.morpho.flag_analytics import format_morpho_flag_analytics
 from eth_defi.erc_4626.vault_protocol.morpho.vault_v1 import MorphoV1Vault
 from eth_defi.erc_4626.vault_protocol.morpho.vault_v2 import MorphoV2Vault
 from eth_defi.provider.env import read_json_rpc_url
@@ -72,7 +72,7 @@ print("-" * 80)
 # Morpho-specific offchain warnings from Morpho Blue GraphQL API
 if isinstance(vault, (MorphoV1Vault, MorphoV2Vault)):
     print("\nMorpho offchain warnings:")
-    print_morpho_flag_analytics(vault)
+    print(format_morpho_flag_analytics(vault))
     print("-" * 80)
 
 # Check deposit/redemption status


### PR DESCRIPTION
## Why

The Morpho warning analytics logic was duplicated across `vault_metrics.py` (inline computation) and `check-vault-onchain.py` (inline display). Extracting it into a dedicated submodule makes it reusable, testable, and gives the vault classes proper `get_notes()` support so diagnostic scripts see the generated note without going through the pipeline.

## Summary

**New `eth_defi/erc_4626/vault_protocol/morpho/flag_analytics.py`:**
- `MorphoFlagAnalytics` dataclass — bundles `vault_flag_types`, `market_flag_types`, `red_flags`, `note` with a `__str__()` one-liner for logging
- `analyze_morpho_flags(data)` — single entry point that computes all derived fields in one pass; individual helpers (`get_morpho_red_flags`, `get_morpho_vault_flag_types`, `get_morpho_market_flag_types`, `generate_morpho_issue_note`) delegate to it
- `print_morpho_flag_analytics(vault)` — CLI printer for diagnostic scripts

**`MorphoV1Vault` and `MorphoV2Vault`** — added `get_notes()` override: checks hardcoded flag.py table first, then falls back to `generate_morpho_issue_note()` from the Morpho Blue API. `check-vault-onchain.py` now shows the note in the `Flags and notes` section automatically.

**`vault_metrics.py`** — replaced the inline analytics block with `analyze_morpho_flags()` and reads fields from the returned dataclass.

**`check-vault-onchain.py`** — now calls `print_morpho_flag_analytics(vault)` and relies on `vault.get_notes()` for the note text.

## Lessons learnt

- Putting `get_notes()` on the vault class (rather than only in the pipeline) means CLI scripts and any future consumers get the note for free without knowing about `flag_analytics` internals.
- `analyze_morpho_flags()` as a single entry point avoids redundant iteration over the warnings lists — all four derived fields are computed in one traversal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)