### PR TITLE
fix: Accountable vault native links

### DIFF
--- a/scripts/erc-4626/update-vault-links.py
+++ b/scripts/erc-4626/update-vault-links.py
@@ -1,0 +1,289 @@
+"""Refresh native vault links for one protocol in the vault metadata pickle.
+
+This helper rewrites ``VaultRow["Link"]`` values using each protocol-specific
+vault Python class as the source of truth. It is intended for fixing persisted
+metadata rows after a ``get_link()`` implementation has changed without doing a
+full chain rescan.
+
+Usage:
+
+.. code-block:: shell
+
+    source .local-test.env && PROTOCOL_ID=accountable poetry run python scripts/erc-4626/update-vault-links.py
+
+Optional environment variables:
+
+- ``VAULT_DB``: metadata pickle path, defaults to ``~/.tradingstrategy/vaults/vault-metadata-db.pickle``
+- ``DRY_RUN``: set to ``true`` to report changes without writing
+- ``LOG_LEVEL``: console log level, defaults to ``info``
+
+The script reads chain RPC URLs from ``JSON_RPC_{CHAIN}`` environment variables,
+for example ``JSON_RPC_MONAD`` for Accountable vaults on Monad.
+"""
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from web3 import Web3
+
+from eth_defi.erc_4626.classification import create_vault_instance
+from eth_defi.erc_4626.core import ERC4262VaultDetection
+from eth_defi.provider.env import get_json_rpc_env, read_json_rpc_url
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.research.vault_metrics import slugify_protocol
+from eth_defi.token import TokenDiskCache
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.base import VaultBase, VaultSpec
+from eth_defi.vault.vaultdb import DEFAULT_VAULT_DATABASE, VaultDatabase, VaultRow
+
+logger = logging.getLogger(__name__)
+
+
+VaultFactory = Callable[[Web3, ERC4262VaultDetection, TokenDiskCache], VaultBase | None]
+
+
+@dataclass(slots=True)
+class VaultLinkUpdate:
+    """Describe a single vault link refresh.
+
+    :param spec:
+        Vault chain/address key in the metadata database.
+
+    :param protocol_id:
+        Normalised protocol id matched from the vault row.
+
+    :param vault_class:
+        Python vault class used to regenerate the link.
+
+    :param old_link:
+        Link value currently stored in the pickle.
+
+    :param new_link:
+        Link returned by the vault class.
+    """
+
+    spec: VaultSpec
+    protocol_id: str
+    vault_class: str
+    old_link: str | None
+    new_link: str
+
+    @property
+    def changed(self) -> bool:
+        """Whether this refresh changes the stored link value.
+
+        :return:
+            ``True`` when ``old_link`` and ``new_link`` differ.
+        """
+        return self.old_link != self.new_link
+
+
+def _get_row_protocol_id(row: VaultRow) -> str:
+    """Resolve a protocol id from a vault metadata row.
+
+    Older pickles may not have ``protocol_slug`` stored, so this falls back to
+    slugifying the human-readable ``Protocol`` field.
+
+    :param row:
+        Vault metadata row.
+
+    :return:
+        Normalised protocol id.
+    """
+    existing_slug = row.get("protocol_slug")
+    if existing_slug:
+        return existing_slug
+
+    protocol_name = row.get("Protocol")
+    if not protocol_name:
+        raise ValueError(f"Vault row is missing Protocol field: {row}")
+
+    return slugify_protocol(protocol_name)
+
+
+def _create_vault_from_detection(
+    web3: Web3,
+    detection: ERC4262VaultDetection,
+    token_cache: TokenDiskCache,
+) -> VaultBase | None:
+    """Create a vault instance for a detection row.
+
+    :param web3:
+        Web3 connection for the detection chain.
+
+    :param detection:
+        Persisted vault detection metadata.
+
+    :param token_cache:
+        Token metadata cache shared across refreshes.
+
+    :return:
+        Protocol-specific vault instance, or ``None`` if the detection is not supported.
+    """
+    return create_vault_instance(
+        web3,
+        detection.address,
+        detection.features,
+        token_cache=token_cache,
+    )
+
+
+def refresh_vault_links_for_protocol(
+    vault_db: VaultDatabase,
+    protocol_id: str,
+    web3_by_chain: dict[int, Web3],
+    token_cache: TokenDiskCache,
+    vault_factory: VaultFactory = _create_vault_from_detection,
+) -> list[VaultLinkUpdate]:
+    """Refresh native app links for all vault rows matching a protocol.
+
+    The function first reconstructs every matching vault instance and computes
+    every new link. Only after all rows have succeeded are the rows mutated. This
+    keeps the caller from writing a partially refreshed pickle if one vault
+    fails.
+
+    :param vault_db:
+        Vault metadata database loaded from pickle.
+
+    :param protocol_id:
+        Protocol id to refresh, e.g. ``"accountable"``.
+
+    :param web3_by_chain:
+        Web3 connections keyed by chain id. Must contain every chain used by
+        matching rows.
+
+    :param token_cache:
+        Token metadata cache passed to reconstructed vault instances.
+
+    :param vault_factory:
+        Factory for constructing vault instances. Defaults to
+        :py:func:`eth_defi.erc_4626.classification.create_vault_instance` via
+        ``_create_vault_from_detection``.
+
+    :return:
+        List of applied updates.
+    """
+    protocol_id = slugify_protocol(protocol_id)
+    pending_updates: list[tuple[VaultRow, VaultLinkUpdate]] = []
+
+    for spec, row in vault_db.rows.items():
+        row_protocol_id = _get_row_protocol_id(row)
+        if row_protocol_id != protocol_id:
+            continue
+
+        detection = row.get("_detection_data")
+        if not isinstance(detection, ERC4262VaultDetection):
+            raise ValueError(f"Vault row {spec} is missing ERC4262VaultDetection: {detection}")
+
+        web3 = web3_by_chain.get(spec.chain_id)
+        if web3 is None:
+            env_var = get_json_rpc_env(spec.chain_id)
+            raise ValueError(f"Missing Web3 connection for chain {spec.chain_id}. Set {env_var} and retry.")
+
+        vault = vault_factory(web3, detection, token_cache)
+        if vault is None:
+            raise ValueError(f"Could not resolve vault class for {spec}, features: {detection.features}")
+
+        new_link = vault.get_link()
+        if not new_link:
+            raise ValueError(f"Vault class {vault.__class__.__name__} returned an empty link for {spec}")
+
+        pending_updates.append(
+            (
+                row,
+                VaultLinkUpdate(
+                    spec=spec,
+                    protocol_id=row_protocol_id,
+                    vault_class=vault.__class__.__name__,
+                    old_link=row.get("Link"),
+                    new_link=new_link,
+                ),
+            )
+        )
+
+    if not pending_updates:
+        raise ValueError(f"No vault rows found for protocol id {protocol_id}")
+
+    for row, update in pending_updates:
+        row["Link"] = update.new_link
+
+    return [update for _, update in pending_updates]
+
+
+def _create_web3_connections_for_protocol(vault_db: VaultDatabase, protocol_id: str) -> dict[int, Web3]:
+    """Create Web3 connections for all chains used by a protocol.
+
+    :param vault_db:
+        Vault metadata database loaded from pickle.
+
+    :param protocol_id:
+        Protocol id to refresh, e.g. ``"accountable"``.
+
+    :return:
+        Web3 connections keyed by chain id.
+    """
+    protocol_id = slugify_protocol(protocol_id)
+    chain_ids = sorted({spec.chain_id for spec, row in vault_db.rows.items() if _get_row_protocol_id(row) == protocol_id})
+    if not chain_ids:
+        raise ValueError(f"No vault rows found for protocol id {protocol_id}")
+
+    web3_by_chain: dict[int, Web3] = {}
+    for chain_id in chain_ids:
+        rpc_url = read_json_rpc_url(chain_id)
+        web3 = create_multi_provider_web3(rpc_url)
+        connected_chain_id = web3.eth.chain_id
+        if connected_chain_id != chain_id:
+            env_var = get_json_rpc_env(chain_id)
+            raise ValueError(f"{env_var} points to chain {connected_chain_id}, expected {chain_id}")
+        web3_by_chain[chain_id] = web3
+
+    return web3_by_chain
+
+
+def main() -> None:
+    """Run the vault link refresh from environment variables.
+
+    Reads ``PROTOCOL_ID`` and optional ``VAULT_DB`` / ``DRY_RUN`` environment
+    variables, refreshes matching rows, and writes the pickle atomically using
+    :py:meth:`eth_defi.vault.vaultdb.VaultDatabase.write`.
+    """
+    setup_console_logging(default_log_level=os.environ.get("LOG_LEVEL", "info"))
+
+    protocol_id = os.environ.get("PROTOCOL_ID")
+    if not protocol_id:
+        msg = "Set PROTOCOL_ID environment variable, e.g. PROTOCOL_ID=accountable"
+        raise RuntimeError(msg)
+
+    vault_db_path = Path(os.environ.get("VAULT_DB", str(DEFAULT_VAULT_DATABASE))).expanduser()
+    dry_run = os.environ.get("DRY_RUN", "false").lower() in {"1", "true", "yes"}
+
+    logger.info("Reading vault metadata from %s", vault_db_path)
+    vault_db = VaultDatabase.read(vault_db_path)
+    web3_by_chain = _create_web3_connections_for_protocol(vault_db, protocol_id)
+    token_cache = TokenDiskCache()
+
+    updates = refresh_vault_links_for_protocol(
+        vault_db=vault_db,
+        protocol_id=protocol_id,
+        web3_by_chain=web3_by_chain,
+        token_cache=token_cache,
+    )
+
+    changed = [update for update in updates if update.changed]
+    logger.info("Refreshed %d %s vault links, %d changed", len(updates), slugify_protocol(protocol_id), len(changed))
+    for update in changed:
+        logger.info("%s %s: %s -> %s", update.vault_class, update.spec.as_string_id(), update.old_link, update.new_link)
+
+    if dry_run:
+        logger.info("DRY_RUN=true, not writing %s", vault_db_path)
+        return
+
+    vault_db.write(vault_db_path)
+    logger.info("Wrote refreshed vault metadata to %s", vault_db_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/erc_4626/test_update_vault_links.py
+++ b/tests/erc_4626/test_update_vault_links.py
@@ -1,0 +1,130 @@
+"""Test vault metadata link refresh helper script."""
+
+import datetime
+import importlib.util
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
+from eth_defi.token import TokenDiskCache
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.vaultdb import VaultDatabase
+
+
+def _load_update_vault_links_module():
+    """Load the helper script as a Python module for unit testing."""
+    repo_root = Path(__file__).parents[2]
+    script_path = repo_root / "scripts" / "erc-4626" / "update-vault-links.py"
+    spec = importlib.util.spec_from_file_location("update_vault_links", script_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _create_detection(chain_id: int, address: str) -> ERC4262VaultDetection:
+    """Create a minimal persisted vault detection for link refresh tests."""
+    timestamp = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC).replace(tzinfo=None)
+    return ERC4262VaultDetection(
+        chain=chain_id,
+        address=address,
+        first_seen_at_block=1,
+        first_seen_at=timestamp,
+        features={ERC4626Feature.accountable_like},
+        updated_at=timestamp,
+        deposit_count=1,
+        redeem_count=1,
+    )
+
+
+class FakeVault:
+    """Minimal vault class with native link generation."""
+
+    def __init__(self, link: str):
+        self.link = link
+
+    def get_link(self) -> str:
+        """Return a deterministic native vault link."""
+        return self.link
+
+
+def test_refresh_vault_links_for_protocol_updates_matching_rows():
+    """Refresh links for matching protocol rows using the resolved vault class."""
+    module = _load_update_vault_links_module()
+    spec = VaultSpec(chain_id=143, vault_address="0x58ba69b289de313e66a13b7d1f822fc98b970554")
+    other_spec = VaultSpec(chain_id=1, vault_address="0x0000000000000000000000000000000000000001")
+    vault_db = VaultDatabase(
+        rows={
+            spec: {
+                "Protocol": "Accountable",
+                "Address": spec.vault_address,
+                "Link": "https://yield.accountable.capital/vaults",
+                "_detection_data": _create_detection(spec.chain_id, spec.vault_address),
+            },
+            other_spec: {
+                "Protocol": "Morpho",
+                "Address": other_spec.vault_address,
+                "Link": "https://example.com/unchanged",
+                "_detection_data": _create_detection(other_spec.chain_id, other_spec.vault_address),
+            },
+        }
+    )
+
+    def vault_factory(_web3, detection, _token_cache):
+        return FakeVault(f"https://yield.accountable.capital/vaults/{detection.address}")
+
+    updates = module.refresh_vault_links_for_protocol(
+        vault_db=vault_db,
+        protocol_id="accountable",
+        web3_by_chain={143: object()},
+        token_cache=cast(TokenDiskCache, object()),
+        vault_factory=vault_factory,
+    )
+
+    assert len(updates) == 1
+    assert updates[0].vault_class == "FakeVault"
+    assert vault_db.rows[spec]["Link"] == "https://yield.accountable.capital/vaults/0x58ba69b289de313e66a13b7d1f822fc98b970554"
+    assert vault_db.rows[other_spec]["Link"] == "https://example.com/unchanged"
+
+
+def test_refresh_vault_links_for_protocol_does_not_partially_update_on_error():
+    """Do not mutate any rows if one matching vault cannot be refreshed."""
+    module = _load_update_vault_links_module()
+    first_spec = VaultSpec(chain_id=143, vault_address="0x58ba69b289de313e66a13b7d1f822fc98b970554")
+    second_spec = VaultSpec(chain_id=143, vault_address="0x3a2c4aaae6776dc1c31316de559598f2f952e2cb")
+    vault_db = VaultDatabase(
+        rows={
+            first_spec: {
+                "Protocol": "Accountable",
+                "Address": first_spec.vault_address,
+                "Link": "https://yield.accountable.capital/vaults",
+                "_detection_data": _create_detection(first_spec.chain_id, first_spec.vault_address),
+            },
+            second_spec: {
+                "Protocol": "Accountable",
+                "Address": second_spec.vault_address,
+                "Link": "https://yield.accountable.capital/vaults",
+                "_detection_data": _create_detection(second_spec.chain_id, second_spec.vault_address),
+            },
+        }
+    )
+
+    def vault_factory(_web3, detection, _token_cache):
+        if detection.address == second_spec.vault_address:
+            msg = "Cannot resolve vault"
+            raise ValueError(msg)
+        return FakeVault(f"https://yield.accountable.capital/vaults/{detection.address}")
+
+    with pytest.raises(ValueError, match="Cannot resolve vault"):
+        module.refresh_vault_links_for_protocol(
+            vault_db=vault_db,
+            protocol_id="accountable",
+            web3_by_chain={143: object()},
+            token_cache=cast(TokenDiskCache, object()),
+            vault_factory=vault_factory,
+        )
+
+    assert vault_db.rows[first_spec]["Link"] == "https://yield.accountable.capital/vaults"
+    assert vault_db.rows[second_spec]["Link"] == "https://yield.accountable.capital/vaults"


### PR DESCRIPTION
## Why

Accountable vault rows in the persisted metadata database can contain the legacy generic app URL even though the current vault implementation builds per-vault links. Because vault discovery is incremental, existing rows are not rewritten just because a protocol-specific link implementation changes.

## Lessons learnt

The vault Python class should remain the source of truth for native vault links. For stale persisted metadata, a small explicit refresh script is cleaner than duplicating protocol link generation in the JSON export path.

## Summary

- Add `scripts/erc-4626/update-vault-links.py` to refresh `VaultRow["Link"]` for all rows of a given `PROTOCOL_ID`.
- Reconstruct vault instances from persisted detection data and call each vault class `get_link()`.
- Write the metadata pickle atomically using `VaultDatabase.write()` after all matching rows refresh successfully.
- Add unit tests for successful protocol link refresh and fail-closed behaviour.