### PR TITLE
feat: Add Hibachi native vault DuckDB reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- feat: Hibachi native vault DuckDB reader — full metrics pipeline for Hibachi vaults (API fetch → DuckDB → VaultDatabase pickle → uncleaned Parquet → cleaning), with `HibachiSession`, production scanner wiring (`SCAN_HIBACHI`), and post-processing integration (2026-04-30)
+
 - feat: Add 40acres vault protocol — cashflow lending for veNFT collateral with ERC-4626 USDC supply vaults on Avalanche, Base, and Optimism (2026-04-30)
 
 - feat: Hibachi vault API — reverse-engineered `data-api.hibachi.xyz` REST endpoints for vault metadata and performance; documented in `eth_defi/hibachi/README.md` (2026-04-30)

--- a/docs/source/api/hibachi/index.rst
+++ b/docs/source/api/hibachi/index.rst
@@ -1,0 +1,28 @@
+Hibachi API
+-----------
+
+`Hibachi <https://hibachi.xyz/>`__ stablecoin-native FX / crypto perpetuals exchange integration.
+
+This module provides tools for extracting Hibachi vault data
+via public endpoints, mirroring the :doc:`GRVT integration <../grvt/index>`:
+
+- Vault metadata via the public `data API <https://data-api.hibachi.xyz/vault/info>`__
+- Daily share price and TVL history via the `performance endpoint <https://data-api.hibachi.xyz/vault/performance>`__
+- DuckDB storage for daily metrics and point-in-time snapshots
+- Bridge into the ERC-4626 pipeline (VaultDatabase pickle + uncleaned Parquet)
+
+No authentication is required -- all data comes from public endpoints.
+
+For architecture details, API endpoint reference, and DuckDB schema, see
+`README-hibachi-vaults.md <https://github.com/tradingstrategy-ai/web3-ethereum-defi/blob/master/scripts/hibachi/README-hibachi-vaults.md>`__
+and `eth_defi/hibachi/README.md <https://github.com/tradingstrategy-ai/web3-ethereum-defi/blob/master/eth_defi/hibachi/README.md>`__.
+
+.. autosummary::
+   :toctree: _autosummary_hibachi
+   :recursive:
+
+   eth_defi.hibachi.vault
+   eth_defi.hibachi.daily_metrics
+   eth_defi.hibachi.vault_data_export
+   eth_defi.hibachi.session
+   eth_defi.hibachi.constants

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -28,6 +28,7 @@ See :ref:`tutorials <tutorials>` for guides and examples on how to use the libra
    hyperliquid/index
    grvt/index
    lighter/index
+   hibachi/index
    cctp/index
    orderly/index
    one_delta/index

--- a/eth_defi/chain.py
+++ b/eth_defi/chain.py
@@ -112,6 +112,7 @@ SEQUENCERS: dict[int, dict[str, str]] = {
 #: Manually maintained shorthand names for different EVM chains
 CHAIN_NAMES = {
     325: "Grvt",  # GRVT (Gravity Markets) decentralised perp DEX
+    9997: "Hibachi",  # Synthetic in-house ID for Hibachi native vaults (non-EVM, not an EVM JSON-RPC chain ID)
     9998: "Lighter",  # Synthetic in-house ID for Lighter DEX pools (ZK-rollup)
     9999: "Hypercore",  # Synthetic in-house ID for native Hyperliquid vaults (non-EVM)
     1: "Ethereum",
@@ -168,6 +169,7 @@ CHAIN_HOMEPAGES = {
     5000: {"name": "Mantle", "homepage": "https://www.mantle.xyz"},
     999: {"name": "Hyperliquid", "homepage": "https://hyperliquid.xyz"},  # HyperEVM, see https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm
     998: {"name": "Hyperliquid Testnet", "homepage": "https://hyperliquid.xyz"},  # HyperEVM testnet
+    9997: {"name": "Hibachi", "homepage": "https://hibachi.xyz"},  # Synthetic in-house ID, not EVM RPC
     9998: {"name": "Lighter", "homepage": "https://lighter.xyz"},  # See eth_defi.lighter.constants.LIGHTER_CHAIN_ID for synthetic chain ID for Lighter pools (ZK-rollup)
     9999: {"name": "Hyperliquid", "homepage": "https://hyperliquid.xyz"},  # See eth_defi.hyperliquid.constants.HYPERCORE_CHAIN_ID for synthetic chain ID for Hyperliquid native vaults (non-EVM)
     42161: {"name": "Arbitrum", "homepage": "https://arbitrum.io"},

--- a/eth_defi/data/vaults/metadata/hibachi.yaml
+++ b/eth_defi/data/vaults/metadata/hibachi.yaml
@@ -1,0 +1,37 @@
+name: Hibachi
+slug: hibachi
+short_description: |
+  Native perpetual trading vaults on the Hibachi stablecoin FX exchange.
+long_description: |
+  Hibachi is a stablecoin-native FX and crypto perpetuals exchange
+  built on a custom L2. Investment vaults allow strategy operators
+  to trade perpetual futures using pooled funds from depositors,
+  with automated execution and disciplined leverage management.
+
+  All vaults are denominated in USDT. There is currently no lockup
+  period (minUnlockHours = 0 for all vaults).
+
+  Key features:
+
+  - Strategy operators deploy perpetual trading strategies on Hibachi
+  - All vault-level fees are zero (no management, performance, deposit, or withdrawal fees)
+  - Platform charges trading taker fees (0.045%) and deposit/withdrawal fees separately
+  - Zero maker fees for trading
+  - All vaults denominated in USDT
+fee_description: |
+  All vault-level fees are zero — no management, performance, deposit, or
+  withdrawal fees at the vault level. The platform charges trading taker
+  fees (0.045%) and deposit/withdrawal fees (approx 0.68% deposit, 1.81%
+  withdrawal) separately at the exchange level. These platform fees are
+  not vault-specific and do not affect the share price.
+links:
+  homepage: https://hibachi.xyz
+  app: https://hibachi.xyz/vaults
+  twitter:
+  github:
+  documentation:
+  defillama:
+  audits:
+  fees:
+  trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/hibachi
+  integration_documentation: https://web3-ethereum-defi.readthedocs.io/api/hibachi/index.html

--- a/eth_defi/erc_4626/core.py
+++ b/eth_defi/erc_4626/core.py
@@ -566,6 +566,13 @@ class ERC4626Feature(enum.Enum):
     #: https://lighter.xyz
     lighter_native = "lighter_native"
 
+    #: Hibachi native vault
+    #:
+    #: Native Hibachi perpetuals trading vault (non-EVM, custom L2).
+    #: Not an ERC-4626 vault but shares the same metrics interface.
+    #: https://hibachi.xyz/vaults
+    hibachi_native = "hibachi_native"
+
     #: Ember Protocol
     #:
     #: Investment platform for launching and distributing onchain financial products.
@@ -869,6 +876,9 @@ def get_vault_protocol_name(features: set[ERC4626Feature]) -> str:
 
     elif ERC4626Feature.lighter_native in features:
         return "Lighter"
+
+    elif ERC4626Feature.hibachi_native in features:
+        return "Hibachi"
 
     elif ERC4626Feature.ember_like in features:
         return "Ember"

--- a/eth_defi/hibachi/README.md
+++ b/eth_defi/hibachi/README.md
@@ -132,6 +132,12 @@ GET https://data-api.hibachi.xyz/vault/performance?vaultId=3&timeRange=All
 | `perSharePrice` | str decimal | Share price in USDT at this snapshot |
 | `totalValueLocked` | str decimal | TVL in USDT at this snapshot |
 
+**Granularity note:** Daily is the only available granularity. The API
+accepts extra query parameters like `interval`, `granularity`, and
+`resolution` without error, but silently ignores them — the response
+always contains the same daily data points with exactly 86 400-second
+(24 h) gaps. The `interval` field in every entry is hardcoded to `"1d"`.
+
 ---
 
 ### `GET /market/inventory`

--- a/eth_defi/hibachi/__init__.py
+++ b/eth_defi/hibachi/__init__.py
@@ -1,0 +1,1 @@
+"""Hibachi exchange native vault integration."""

--- a/eth_defi/hibachi/constants.py
+++ b/eth_defi/hibachi/constants.py
@@ -1,0 +1,43 @@
+"""Constants for the Hibachi integration.
+
+Shared constants used across the Hibachi modules
+(:py:mod:`~eth_defi.hibachi.daily_metrics`,
+:py:mod:`~eth_defi.hibachi.vault_data_export`, etc.).
+"""
+
+import datetime
+from pathlib import Path
+
+from eth_defi.vault.fee import VaultFeeMode
+
+#: Hibachi synthetic chain ID.
+#:
+#: In-house synthetic ID — NOT an EVM JSON-RPC chain ID.
+#: 9997 collides with AltLayer Testnet on chainid.network,
+#: consistent with how 9998 (Lighter) and 9999 (Hypercore) collide too.
+#:
+#: Added to :py:data:`eth_defi.chain.CHAIN_NAMES` as ``9997: "Hibachi"``.
+HIBACHI_CHAIN_ID: int = 9997
+
+#: Default path for Hibachi daily metrics DuckDB database.
+HIBACHI_DAILY_METRICS_DATABASE = Path.home() / ".tradingstrategy" / "vaults" / "hibachi-vaults.duckdb"
+
+#: Hibachi public data API base URL.
+#:
+#: Used for all vault and market data endpoints.
+#: No authentication required.
+HIBACHI_DATA_API_URL: str = "https://data-api.hibachi.xyz"
+
+#: Fee mode for Hibachi native vaults.
+#:
+#: All vault-level fees are zero (management, performance, deposit,
+#: withdrawal are all ``"0.00000000"`` in the API response).
+#: The platform charges trading taker fees (0.045%) and
+#: deposit/withdrawal fees separately at the exchange level,
+#: but these are not vault-specific.
+HIBACHI_VAULT_FEE_MODE: VaultFeeMode = VaultFeeMode.feeless
+
+#: Lockup period for Hibachi vaults.
+#:
+#: Both vaults report ``minUnlockHours: 0`` — no lockup.
+HIBACHI_VAULT_LOCKUP: datetime.timedelta = datetime.timedelta(hours=0)

--- a/eth_defi/hibachi/daily_metrics.py
+++ b/eth_defi/hibachi/daily_metrics.py
@@ -1,0 +1,390 @@
+"""Hibachi daily vault metrics with DuckDB storage.
+
+This module provides a daily pipeline for scanning Hibachi vault
+metrics and storing them in a DuckDB database. It derives daily share
+prices from the public ``/vault/performance`` endpoint on the
+Hibachi data API.
+
+The pipeline:
+
+1. Fetches vault metadata via ``/vault/info``
+2. Fetches per-vault share price history via ``/vault/performance``
+3. Stores daily prices and metadata in DuckDB
+
+Example::
+
+    from eth_defi.hibachi.daily_metrics import run_daily_scan, HibachiDailyMetricsDatabase
+
+    db = run_daily_scan()
+    print(f"Stored metrics for {db.get_vault_count()} vaults")
+    db.close()
+
+"""
+
+import logging
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+from tqdm_loggable.auto import tqdm
+
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.hibachi.constants import HIBACHI_DAILY_METRICS_DATABASE
+from eth_defi.hibachi.session import HibachiSession
+from eth_defi.hibachi.vault import (
+    HibachiVaultInfo,
+    fetch_vault_info,
+    fetch_vault_performance,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class HibachiDailyMetricsDatabase:
+    """DuckDB database for storing Hibachi vault daily metrics.
+
+    Stores daily share price time series and vault metadata.
+    The share prices come from the Hibachi data API's
+    ``/vault/performance`` endpoint.
+
+    Example::
+
+        from pathlib import Path
+        from eth_defi.hibachi.daily_metrics import HibachiDailyMetricsDatabase
+
+        db = HibachiDailyMetricsDatabase(Path("/tmp/metrics.duckdb"))
+        df = db.get_all_daily_prices()
+        print(df)
+        db.close()
+
+    """
+
+    def __init__(self, path: Path):
+        """Initialise the database connection.
+
+        :param path:
+            Path to the DuckDB file. Parent directories will be created if needed.
+        """
+        assert isinstance(path, Path), f"Expected Path for path, got {type(path)}"
+        assert not path.is_dir(), f"Expected file path, got directory: {path}"
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        self.path = path
+        self.con = duckdb.connect(str(path))
+        self._init_schema()
+
+    def __del__(self):
+        if hasattr(self, "con") and self.con is not None:
+            self.con.close()
+            self.con = None
+
+    def _init_schema(self):
+        """Create tables if they don't exist."""
+        self.con.execute("""
+            CREATE TABLE IF NOT EXISTS vault_metadata (
+                vault_id INTEGER PRIMARY KEY,
+                symbol VARCHAR NOT NULL,
+                short_description VARCHAR,
+                description VARCHAR,
+                per_share_price DOUBLE,
+                outstanding_shares DOUBLE,
+                tvl DOUBLE,
+                min_unlock_hours INTEGER,
+                vault_pub_key VARCHAR,
+                vault_asset_id INTEGER,
+                last_updated TIMESTAMP NOT NULL
+            )
+        """)
+
+        self.con.execute("""
+            CREATE TABLE IF NOT EXISTS vault_daily_prices (
+                vault_id INTEGER NOT NULL,
+                date DATE NOT NULL,
+                per_share_price DOUBLE NOT NULL,
+                tvl DOUBLE,
+                daily_return DOUBLE,
+                written_at TIMESTAMP,
+                PRIMARY KEY (vault_id, date)
+            )
+        """)
+
+    def upsert_vault_metadata(
+        self,
+        vault_id: int,
+        symbol: str,
+        short_description: str | None,
+        description: str | None,
+        per_share_price: float | None,
+        outstanding_shares: float | None,
+        tvl: float | None,
+        min_unlock_hours: int | None,
+        vault_pub_key: str | None = None,
+        vault_asset_id: int | None = None,
+    ):
+        """Insert or update a vault's metadata.
+
+        :param vault_id:
+            Unique vault ID on the Hibachi platform.
+        :param symbol:
+            Short ticker symbol (e.g. ``GAV``).
+        :param short_description:
+            Display name.
+        :param description:
+            Long description of the vault strategy.
+        :param per_share_price:
+            Current share price in USDT.
+        :param outstanding_shares:
+            Total shares issued.
+        :param tvl:
+            Current TVL in USDT.
+        :param min_unlock_hours:
+            Minimum lockup period in hours.
+        :param vault_pub_key:
+            Vault's on-exchange public key.
+        :param vault_asset_id:
+            Native asset ID of the vault share token.
+        """
+        self.con.execute(
+            """
+            INSERT INTO vault_metadata (
+                vault_id, symbol, short_description, description,
+                per_share_price, outstanding_shares, tvl,
+                min_unlock_hours, vault_pub_key, vault_asset_id, last_updated
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (vault_id)
+            DO UPDATE SET
+                symbol = EXCLUDED.symbol,
+                short_description = EXCLUDED.short_description,
+                description = EXCLUDED.description,
+                per_share_price = EXCLUDED.per_share_price,
+                outstanding_shares = EXCLUDED.outstanding_shares,
+                tvl = EXCLUDED.tvl,
+                min_unlock_hours = EXCLUDED.min_unlock_hours,
+                vault_pub_key = EXCLUDED.vault_pub_key,
+                vault_asset_id = EXCLUDED.vault_asset_id,
+                last_updated = EXCLUDED.last_updated
+            """,
+            [
+                vault_id,
+                symbol,
+                short_description,
+                description,
+                per_share_price,
+                outstanding_shares,
+                tvl,
+                min_unlock_hours,
+                vault_pub_key,
+                vault_asset_id,
+                native_datetime_utc_now(),
+            ],
+        )
+
+    def upsert_daily_prices(self, rows: list[tuple]):
+        """Bulk upsert daily price rows for a vault.
+
+        :param rows:
+            List of tuples: ``(vault_id, date, per_share_price, tvl, daily_return, written_at)``.
+        """
+        if not rows:
+            return
+
+        self.con.executemany(
+            """
+            INSERT INTO vault_daily_prices (
+                vault_id, date, per_share_price, tvl, daily_return, written_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT (vault_id, date)
+            DO UPDATE SET
+                per_share_price = EXCLUDED.per_share_price,
+                tvl = EXCLUDED.tvl,
+                daily_return = EXCLUDED.daily_return,
+                written_at = EXCLUDED.written_at
+            """,
+            rows,
+        )
+
+    def get_all_daily_prices(self) -> pd.DataFrame:
+        """Get all daily price data across all vaults.
+
+        :return:
+            DataFrame with all daily price records, ordered by vault then date.
+        """
+        return self.con.execute("""
+            SELECT * FROM vault_daily_prices
+            ORDER BY vault_id, date
+        """).df()
+
+    def get_vault_daily_prices(self, vault_id: int) -> pd.DataFrame:
+        """Get daily price data for a specific vault.
+
+        :param vault_id:
+            Vault ID to query.
+        :return:
+            DataFrame with price records for this vault, ordered by date.
+        """
+        return self.con.execute(
+            """
+            SELECT * FROM vault_daily_prices
+            WHERE vault_id = ?
+            ORDER BY date
+            """,
+            [vault_id],
+        ).df()
+
+    def get_all_vault_metadata(self) -> pd.DataFrame:
+        """Get metadata for all vaults.
+
+        :return:
+            DataFrame with one row per vault.
+        """
+        return self.con.execute("SELECT * FROM vault_metadata ORDER BY tvl DESC NULLS LAST").df()
+
+    def get_vault_count(self) -> int:
+        """Get the number of unique vaults with price data."""
+        return self.con.execute("SELECT COUNT(DISTINCT vault_id) FROM vault_daily_prices").fetchone()[0]
+
+    def save(self):
+        """Force a checkpoint to ensure data is written to disk."""
+        self.con.commit()
+
+    def close(self):
+        """Close the database connection."""
+        logger.info("Closing Hibachi daily metrics database at %s", self.path)
+        if self.con is not None:
+            self.con.close()
+            self.con = None
+
+
+def fetch_and_store_vault(
+    session: HibachiSession,
+    db: HibachiDailyMetricsDatabase,
+    vault_info: HibachiVaultInfo,
+    timeout: float = 30.0,
+) -> bool:
+    """Fetch a single vault's share price history and store in the database.
+
+    :param session:
+        HTTP session.
+    :param db:
+        The metrics database to write into.
+    :param vault_info:
+        Vault metadata from the listing.
+    :param timeout:
+        HTTP request timeout.
+    :return:
+        True if the vault was successfully processed.
+    """
+    try:
+        daily_prices = fetch_vault_performance(
+            session,
+            vault_id=vault_info.vault_id,
+            timeout=timeout,
+        )
+    except Exception as e:
+        logger.warning("Failed to fetch share price history for %s (vault %d): %s", vault_info.symbol, vault_info.vault_id, e)
+        return False
+
+    if not daily_prices:
+        logger.debug("Skipping vault %s (vault %d): empty share price history", vault_info.symbol, vault_info.vault_id)
+        return False
+
+    # Store metadata
+    db.upsert_vault_metadata(
+        vault_id=vault_info.vault_id,
+        symbol=vault_info.symbol,
+        short_description=vault_info.short_description,
+        description=vault_info.description,
+        per_share_price=vault_info.per_share_price,
+        outstanding_shares=vault_info.outstanding_shares,
+        tvl=vault_info.tvl,
+        min_unlock_hours=vault_info.min_unlock_hours,
+        vault_pub_key=vault_info.vault_pub_key,
+        vault_asset_id=vault_info.vault_asset_id,
+    )
+
+    # Build daily price rows
+    written_at = native_datetime_utc_now()
+    rows = []
+    for dp in daily_prices:
+        rows.append(
+            (
+                dp.vault_id,
+                dp.date,
+                dp.per_share_price,
+                dp.tvl,
+                dp.daily_return,
+                written_at,
+            )
+        )
+
+    db.upsert_daily_prices(rows)
+
+    logger.debug("Stored %d daily prices for vault %s (vault %d)", len(rows), vault_info.symbol, vault_info.vault_id)
+    return True
+
+
+def run_daily_scan(
+    session: HibachiSession | None = None,
+    db_path: Path = HIBACHI_DAILY_METRICS_DATABASE,
+    timeout: float = 30.0,
+    vault_ids: list[int] | None = None,
+) -> HibachiDailyMetricsDatabase:
+    """Run the daily Hibachi vault metrics scan.
+
+    1. Fetches vault metadata via ``/vault/info``
+    2. Fetches per-vault share price history via ``/vault/performance``
+    3. Stores everything in DuckDB
+
+    No authentication is required — all data comes from public endpoints.
+
+    :param session:
+        HTTP session. If None, a plain ``requests.Session()`` is created.
+    :param db_path:
+        Path to the DuckDB database file.
+    :param timeout:
+        HTTP request timeout.
+    :param vault_ids:
+        If provided, only scan these specific vault IDs (integers).
+        Overrides the default vault listing.
+    :return:
+        The metrics database instance.
+    """
+    if session is None:
+        from eth_defi.hibachi.session import create_hibachi_session
+
+        session = create_hibachi_session()
+
+    logger.info("Starting daily Hibachi vault scan")
+
+    db = HibachiDailyMetricsDatabase(db_path)
+
+    # Step 1: Discover vaults
+    vault_summaries = fetch_vault_info(session, timeout=timeout)
+
+    if vault_ids is not None:
+        vault_id_set = set(vault_ids)
+        vault_summaries = [s for s in vault_summaries if s.vault_id in vault_id_set]
+
+    logger.info("Processing %d Hibachi vaults", len(vault_summaries))
+
+    # Step 2: Fetch and store share price history per vault
+    success_count = 0
+    fail_count = 0
+    for vault_info in tqdm(vault_summaries, desc="Fetching Hibachi vault details"):
+        if fetch_and_store_vault(session, db, vault_info, timeout):
+            success_count += 1
+        else:
+            fail_count += 1
+
+    db.save()
+
+    logger.info(
+        "Daily scan complete. Processed %d vaults (%d successful, %d failed) into %s",
+        len(vault_summaries),
+        success_count,
+        fail_count,
+        db_path,
+    )
+
+    return db

--- a/eth_defi/hibachi/session.py
+++ b/eth_defi/hibachi/session.py
@@ -1,0 +1,94 @@
+"""HTTP session management for Hibachi API.
+
+This module provides session creation with retry logic for
+Hibachi API requests.
+
+The :py:class:`HibachiSession` carries the API URL so that downstream
+functions do not need a separate ``api_url`` argument.
+
+No rate limiting is applied — the ``data-api.hibachi.xyz`` endpoint
+has not shown any rate limiting behaviour.
+"""
+
+import logging
+
+from requests import Session
+
+from eth_defi.hibachi.constants import HIBACHI_DATA_API_URL
+from eth_defi.velvet.logging_retry import LoggingRetry
+
+logger = logging.getLogger(__name__)
+
+#: Default number of retries for API requests
+DEFAULT_RETRIES: int = 5
+
+#: Default backoff factor for retries (seconds)
+DEFAULT_BACKOFF_FACTOR: float = 0.5
+
+
+class HibachiSession(Session):
+    """A :py:class:`requests.Session` subclass that carries the Hibachi API URL.
+
+    All Hibachi API functions accept a ``HibachiSession`` and read
+    :py:attr:`api_url` from it, removing the need for a separate
+    ``api_url`` argument on every call.
+
+    Use :py:func:`create_hibachi_session` to create instances.
+    """
+
+    #: Hibachi data API base URL (e.g. ``https://data-api.hibachi.xyz``).
+    api_url: str
+
+    def __init__(self, api_url: str = HIBACHI_DATA_API_URL):
+        super().__init__()
+        self.api_url = api_url
+
+    def __repr__(self) -> str:
+        return f"<HibachiSession api_url={self.api_url!r}>"
+
+
+def create_hibachi_session(
+    api_url: str = HIBACHI_DATA_API_URL,
+    retries: int = DEFAULT_RETRIES,
+    backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
+) -> HibachiSession:
+    """Create a :py:class:`HibachiSession` configured for Hibachi API.
+
+    The session is configured with retry logic for handling transient
+    errors using exponential backoff. No rate limiting is applied —
+    the Hibachi data API has not shown rate limiting behaviour.
+
+    Example::
+
+        from eth_defi.hibachi.session import create_hibachi_session
+
+        session = create_hibachi_session()
+
+    :param api_url:
+        Hibachi data API base URL. Defaults to
+        :py:data:`~eth_defi.hibachi.constants.HIBACHI_DATA_API_URL`.
+    :param retries:
+        Maximum number of retry attempts for failed requests.
+    :param backoff_factor:
+        Backoff factor for exponential retry delays.
+    :return:
+        Configured :py:class:`HibachiSession` with retry logic.
+    """
+    session = HibachiSession(api_url=api_url)
+
+    retry_policy = LoggingRetry(
+        total=retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=[429, 500, 502, 503, 504],
+        respect_retry_after_header=True,
+        logger=logger,
+    )
+
+    from requests.adapters import HTTPAdapter
+
+    adapter = HTTPAdapter(
+        max_retries=retry_policy,
+    )
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session

--- a/eth_defi/hibachi/vault.py
+++ b/eth_defi/hibachi/vault.py
@@ -1,0 +1,214 @@
+"""Hibachi vault data extraction.
+
+This module fetches Hibachi vault metadata and daily share price
+history from the public data API at ``https://data-api.hibachi.xyz``.
+
+No authentication is required — all data comes from public endpoints.
+
+Endpoints used:
+
+- ``GET /vault/info`` — vault metadata (all vaults or filtered by ``vaultId``)
+- ``GET /vault/performance?vaultId={id}&timeRange=All`` — daily share price history
+
+For full API documentation see ``eth_defi/hibachi/README.md``.
+"""
+
+import datetime
+import logging
+from dataclasses import dataclass
+
+from eth_defi.compat import native_datetime_utc_fromtimestamp
+from eth_defi.hibachi.session import HibachiSession
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class HibachiVaultInfo:
+    """Metadata for a Hibachi vault.
+
+    Parsed from the ``/vault/info`` endpoint response.
+
+    - `Hibachi vaults page <https://hibachi.xyz/vaults>`__
+    """
+
+    #: Unique vault ID on the Hibachi platform (e.g. 2, 3)
+    vault_id: int
+
+    #: Short ticker symbol (e.g. ``GAV``, ``FLP``)
+    symbol: str
+
+    #: Display name (e.g. ``"Growi Alpha Vault"``)
+    short_description: str
+
+    #: Long description of the vault strategy
+    description: str | None
+
+    #: Current share price in USDT
+    per_share_price: float
+
+    #: Total shares issued
+    outstanding_shares: float
+
+    #: Minimum lockup period in hours (0 = no lockup)
+    min_unlock_hours: int
+
+    #: Vault's on-exchange public key, for traceability
+    vault_pub_key: str
+
+    #: Native asset ID of the vault share token
+    vault_asset_id: int
+
+    @property
+    def tvl(self) -> float:
+        """Current TVL in USDT (``perSharePrice × outstandingShares``)."""
+        return self.per_share_price * self.outstanding_shares
+
+    @property
+    def address(self) -> str:
+        """Synthetic pipeline address (``hibachi-vault-{vault_id}``)."""
+        return f"hibachi-vault-{self.vault_id}"
+
+
+@dataclass(slots=True)
+class HibachiVaultDailyPrice:
+    """One daily price snapshot for a Hibachi vault.
+
+    Parsed from the ``/vault/performance`` endpoint response.
+    """
+
+    #: Vault ID
+    vault_id: int
+
+    #: Date of the snapshot (UTC)
+    date: datetime.date
+
+    #: Share price in USDT at this snapshot
+    per_share_price: float
+
+    #: TVL in USDT at this snapshot
+    tvl: float
+
+    #: Daily return as a decimal fraction, or ``None`` for the first data point
+    daily_return: float | None
+
+
+def _parse_vault_info(raw: list[dict]) -> list[HibachiVaultInfo]:
+    """Parse raw JSON from ``/vault/info`` into dataclass instances.
+
+    :param raw:
+        JSON array from the API response.
+    :return:
+        List of parsed vault info objects.
+    """
+    results = []
+    for entry in raw:
+        results.append(
+            HibachiVaultInfo(
+                vault_id=entry["vaultId"],
+                symbol=entry["symbol"],
+                short_description=entry["shortDescription"],
+                description=entry.get("description"),
+                per_share_price=float(entry["perSharePrice"]),
+                outstanding_shares=float(entry["outstandingShares"]),
+                min_unlock_hours=entry.get("minUnlockHours", 0),
+                vault_pub_key=entry.get("vaultPubKey", ""),
+                vault_asset_id=entry.get("vaultAssetId", 0),
+            )
+        )
+    return results
+
+
+def _parse_vault_performance(raw: dict, vault_id: int) -> list[HibachiVaultDailyPrice]:
+    """Parse raw JSON from ``/vault/performance`` into daily price snapshots.
+
+    Timestamps are converted to UTC dates. Rows are sorted ascending
+    by timestamp, and daily returns are computed from consecutive
+    share prices.
+
+    :param raw:
+        JSON object from the API response.
+    :param vault_id:
+        Vault ID to tag each row with.
+    :return:
+        List of daily price snapshots, sorted by date ascending.
+    """
+    intervals = raw.get("vaultPerformanceIntervals", [])
+
+    # Sort by timestamp ascending
+    intervals = sorted(intervals, key=lambda x: x["timestamp"])
+
+    results = []
+    prev_price = None
+    for entry in intervals:
+        ts = entry["timestamp"]
+        price = float(entry["perSharePrice"])
+        tvl = float(entry["totalValueLocked"])
+        date = native_datetime_utc_fromtimestamp(ts).date()
+
+        if prev_price is not None and prev_price != 0:
+            daily_return = (price - prev_price) / prev_price
+        else:
+            daily_return = None
+
+        results.append(
+            HibachiVaultDailyPrice(
+                vault_id=vault_id,
+                date=date,
+                per_share_price=price,
+                tvl=tvl,
+                daily_return=daily_return,
+            )
+        )
+        prev_price = price
+
+    return results
+
+
+def fetch_vault_info(
+    session: HibachiSession,
+    timeout: float = 30.0,
+) -> list[HibachiVaultInfo]:
+    """Fetch metadata for all Hibachi vaults.
+
+    Calls ``GET /vault/info`` on the public data API.
+
+    :param session:
+        HTTP session.
+    :param timeout:
+        HTTP request timeout in seconds.
+    :return:
+        List of vault info objects.
+    """
+    url = f"{session.api_url}/vault/info"
+    resp = session.get(url, timeout=timeout)
+    resp.raise_for_status()
+    return _parse_vault_info(resp.json())
+
+
+def fetch_vault_performance(
+    session: HibachiSession,
+    vault_id: int,
+    timeout: float = 30.0,
+) -> list[HibachiVaultDailyPrice]:
+    """Fetch daily share price history for a single Hibachi vault.
+
+    Calls ``GET /vault/performance?vaultId={vault_id}&timeRange=All``
+    on the public data API.
+
+    Only ``timeRange=All`` is supported; other values return HTTP 400.
+
+    :param session:
+        HTTP session.
+    :param vault_id:
+        Vault ID to query (e.g. 2 or 3).
+    :param timeout:
+        HTTP request timeout in seconds.
+    :return:
+        List of daily price snapshots, sorted by date ascending.
+    """
+    url = f"{session.api_url}/vault/performance"
+    params = {"vaultId": vault_id, "timeRange": "All"}
+    resp = session.get(url, params=params, timeout=timeout)
+    resp.raise_for_status()
+    return _parse_vault_performance(resp.json(), vault_id)

--- a/eth_defi/hibachi/vault_data_export.py
+++ b/eth_defi/hibachi/vault_data_export.py
@@ -1,0 +1,302 @@
+"""Export Hibachi vault data into the ERC-4626 pipeline format.
+
+This module bridges the Hibachi-specific DuckDB data into the formats
+consumed by the existing ERC-4626 vault metrics pipeline:
+
+- Synthetic :py:class:`~eth_defi.vault.vaultdb.VaultRow` entries for the
+  :py:class:`~eth_defi.vault.vaultdb.VaultDatabase` pickle
+- Raw price DataFrames matching the uncleaned Parquet schema, so that
+  Hibachi data goes through the same cleaning pipeline as EVM vaults
+- Merge functions to append Hibachi data into existing files
+
+Example::
+
+    from pathlib import Path
+    from eth_defi.hibachi.daily_metrics import HibachiDailyMetricsDatabase
+    from eth_defi.hibachi.vault_data_export import merge_into_vault_database, merge_into_uncleaned_parquet
+
+    db = HibachiDailyMetricsDatabase(Path("daily-metrics.duckdb"))
+
+    merge_into_vault_database(db, vault_db_path)
+    merge_into_uncleaned_parquet(db, uncleaned_parquet_path)
+
+    db.close()
+
+"""
+
+import datetime
+import logging
+from decimal import Decimal
+from pathlib import Path
+
+import pandas as pd
+
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
+from eth_defi.hibachi.constants import HIBACHI_CHAIN_ID, HIBACHI_VAULT_FEE_MODE, HIBACHI_VAULT_LOCKUP
+from eth_defi.hibachi.daily_metrics import HibachiDailyMetricsDatabase
+from eth_defi.vault.base import VaultHistoricalRead, VaultSpec
+from eth_defi.vault.fee import FeeData
+from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.vaultdb import VaultDatabase, VaultRow
+
+logger = logging.getLogger(__name__)
+
+
+def create_hibachi_vault_row(
+    vault_id: int,
+    symbol: str,
+    name: str,
+    description: str | None,
+    tvl: float,
+) -> tuple[VaultSpec, VaultRow]:
+    """Create a synthetic VaultRow for a Hibachi native vault.
+
+    Builds a :py:class:`~eth_defi.vault.vaultdb.VaultRow` that matches what
+    :py:func:`~eth_defi.research.vault_metrics.calculate_vault_record` expects,
+    using the Hibachi synthetic chain ID.
+
+    All Hibachi vault-level fees are zero.
+    ``vault_pub_key`` and ``vault_asset_id`` are stored only in the DuckDB
+    metadata table for traceability; they are not surfaced in ``VaultRow``.
+
+    :param vault_id:
+        Vault ID on the Hibachi platform (e.g. 2, 3).
+    :param symbol:
+        Short ticker symbol (e.g. ``GAV``).
+    :param name:
+        Vault display name.
+    :param description:
+        Vault description text.
+    :param tvl:
+        Current TVL in USDT.
+    :return:
+        Tuple of (VaultSpec, VaultRow).
+    """
+    address = f"hibachi-vault-{vault_id}"
+    chain_id = HIBACHI_CHAIN_ID
+
+    flags = {VaultFlag.perp_dex_trading_vault}
+
+    detection = ERC4262VaultDetection(
+        chain=chain_id,
+        address=address,
+        first_seen_at_block=0,
+        first_seen_at=datetime.datetime(2025, 1, 1),
+        features={ERC4626Feature.hibachi_native},
+        updated_at=native_datetime_utc_now(),
+        deposit_count=1,
+        redeem_count=0,
+    )
+
+    fee_data = FeeData(
+        fee_mode=HIBACHI_VAULT_FEE_MODE,
+        management=0.0,
+        performance=0.0,
+        deposit=0.0,
+        withdraw=0.0,
+    )
+
+    row: VaultRow = {
+        "Symbol": symbol[:10] if symbol else "",
+        "Name": name or "",
+        "Address": address,
+        "Denomination": "USDT",
+        "Share token": symbol[:10] if symbol else "",
+        "NAV": Decimal(str(tvl)),
+        "Shares": Decimal("0"),
+        "Protocol": "Hibachi",
+        "Link": "https://hibachi.xyz/vaults",
+        "First seen": datetime.datetime(2025, 1, 1),
+        "Mgmt fee": 0.0,
+        "Perf fee": 0.0,
+        "Deposit fee": 0.0,
+        "Withdraw fee": 0.0,
+        "Features": "",
+        "_detection_data": detection,
+        "_denomination_token": {"address": "0x0000000000000000000000000000000000000000", "symbol": "USDT", "decimals": 6},
+        "_share_token": None,
+        "_fees": fee_data,
+        "_flags": flags,
+        "_lockup": HIBACHI_VAULT_LOCKUP,
+        "_description": description,
+        "_short_description": name,
+        "_available_liquidity": None,
+        "_utilisation": None,
+        "_deposit_closed_reason": None,
+        "_deposit_next_open": None,
+        "_redemption_closed_reason": None,
+        "_redemption_next_open": None,
+    }
+
+    spec = VaultSpec(chain_id=chain_id, vault_address=address)
+    return spec, row
+
+
+def build_raw_prices_dataframe(db: HibachiDailyMetricsDatabase) -> pd.DataFrame:
+    """Build a raw prices DataFrame from the Hibachi DuckDB.
+
+    Produces rows matching the schema of the EVM vault scanner
+    (:py:meth:`~eth_defi.vault.base.VaultHistoricalRead.export`),
+    so Hibachi data can go through the same cleaning pipeline
+    (:py:func:`~eth_defi.research.wrangle_vault_prices.process_raw_vault_scan_data`)
+    as ERC-4626 vaults.
+
+    The output has ``timestamp`` as a column (not index), matching
+    the raw uncleaned Parquet format.
+
+    :param db:
+        The Hibachi daily metrics database.
+    :return:
+        DataFrame with columns matching the uncleaned Parquet schema.
+    """
+    prices_df = db.get_all_daily_prices()
+
+    if prices_df.empty:
+        return pd.DataFrame()
+
+    chain_id = HIBACHI_CHAIN_ID
+
+    # Build synthetic addresses from vault IDs
+    addresses = prices_df["vault_id"].apply(lambda vid: f"hibachi-vault-{vid}")
+
+    result = pd.DataFrame(
+        {
+            "chain": chain_id,
+            "address": addresses.values,
+            "block_number": 0,
+            "timestamp": pd.to_datetime(prices_df["date"]).values,
+            "share_price": prices_df["per_share_price"].values,
+            "total_assets": prices_df["tvl"].values if "tvl" in prices_df.columns else 0.0,
+            "total_supply": 0.0,
+            "performance_fee": 0.0,
+            "management_fee": 0.0,
+            "errors": "",
+            "written_at": prices_df["written_at"].values if "written_at" in prices_df.columns else pd.NaT,
+        },
+    )
+
+    # Ensure correct dtypes
+    result["chain"] = result["chain"].astype("int32")
+    result["block_number"] = result["block_number"].astype("int64")
+
+    return result
+
+
+def merge_into_vault_database(
+    db: HibachiDailyMetricsDatabase,
+    vault_db_path: Path,
+) -> VaultDatabase:
+    """Merge Hibachi vault metadata into an existing VaultDatabase pickle.
+
+    Reads the existing pickle, upserts Hibachi VaultRow entries
+    (keyed by VaultSpec), and writes back. Idempotent: running twice
+    produces the same result.
+
+    If the pickle file does not exist, creates a new VaultDatabase.
+
+    :param db:
+        The Hibachi daily metrics database.
+    :param vault_db_path:
+        Path to the VaultDatabase pickle file.
+    :return:
+        The updated VaultDatabase.
+    """
+    if vault_db_path.exists():
+        vault_db = VaultDatabase.read(vault_db_path)
+    else:
+        vault_db_path.parent.mkdir(parents=True, exist_ok=True)
+        vault_db = VaultDatabase()
+
+    metadata_df = db.get_all_vault_metadata()
+
+    added = 0
+    updated = 0
+    for _, row in metadata_df.iterrows():
+        spec, vault_row = create_hibachi_vault_row(
+            vault_id=int(row["vault_id"]),
+            symbol=row["symbol"],
+            name=row.get("short_description") or row["symbol"],
+            description=row.get("description"),
+            tvl=row.get("tvl", 0.0) or 0.0,
+        )
+
+        if spec in vault_db.rows:
+            updated += 1
+        else:
+            added += 1
+
+        vault_db.rows[spec] = vault_row
+
+    vault_db.write(vault_db_path)
+
+    logger.info(
+        "Merged %d Hibachi vaults into %s (%d new, %d updated)",
+        added + updated,
+        vault_db_path,
+        added,
+        updated,
+    )
+
+    return vault_db
+
+
+def merge_into_uncleaned_parquet(
+    db: HibachiDailyMetricsDatabase,
+    parquet_path: Path,
+) -> pd.DataFrame:
+    """Merge Hibachi daily prices into the uncleaned Parquet file.
+
+    Writes Hibachi raw data in the same format as the EVM vault scanner,
+    so the standard cleaning pipeline
+    (:py:func:`~eth_defi.research.wrangle_vault_prices.process_raw_vault_scan_data`)
+    can process all vaults together.
+
+    Reads the existing Parquet, removes any prior Hibachi rows
+    (chain == 9997), appends fresh Hibachi daily price rows,
+    and writes back. Idempotent: running twice produces the same result.
+
+    If the Parquet file does not exist, creates a new one.
+
+    :param db:
+        The Hibachi daily metrics database.
+    :param parquet_path:
+        Path to the uncleaned Parquet file
+        (typically ``vault-prices-1h.parquet``).
+    :return:
+        The combined DataFrame.
+    """
+    hibachi_df = build_raw_prices_dataframe(db)
+
+    if hibachi_df.empty:
+        logger.warning("No Hibachi data to merge")
+        if parquet_path.exists():
+            return pd.read_parquet(parquet_path)
+        return pd.DataFrame()
+
+    if parquet_path.exists():
+        existing_df = pd.read_parquet(parquet_path)
+
+        # Remove any existing Hibachi rows
+        existing_df = existing_df[existing_df["chain"] != HIBACHI_CHAIN_ID]
+
+        combined = pd.concat([existing_df, hibachi_df], ignore_index=True)
+    else:
+        parquet_path.parent.mkdir(parents=True, exist_ok=True)
+        combined = hibachi_df
+
+    # Sort for compression efficiency
+    combined = combined.sort_values(["chain", "address", "timestamp"])
+
+    # Use PyArrow writer to preserve canonical schema types.
+    VaultHistoricalRead.write_uncleaned_parquet(combined, parquet_path)
+
+    hibachi_vault_count = hibachi_df["address"].nunique()
+    logger.info(
+        "Merged %d Hibachi vaults (%d rows) into uncleaned %s",
+        hibachi_vault_count,
+        len(hibachi_df),
+        parquet_path,
+    )
+
+    return combined

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -1762,7 +1762,7 @@ def calculate_vault_rankings(
 #:
 #: These vaults get their data from off-chain APIs (e.g. GRVT, Hyperliquid, Lighter)
 #: or are hardcoded protocol entries that may lack standard ERC-4626 events.
-SPECIAL_VAULT_PROTOCOL_SLUGS = {"grvt", "hyperliquid", "lighter"}
+SPECIAL_VAULT_PROTOCOL_SLUGS = {"grvt", "hyperliquid", "lighter", "hibachi"}
 
 
 def is_special_vault(

--- a/eth_defi/utils.py
+++ b/eth_defi/utils.py
@@ -26,6 +26,7 @@ def is_good_multichain_address(address: str) -> bool:
     - EVM vaults use ``0x``-prefixed hex addresses
     - Non-EVM protocols like GRVT use platform-specific IDs (e.g. ``VLT:xxx``)
     - Lighter pools use synthetic IDs (e.g. ``lighter-pool-281474976710654``)
+    - Hibachi vaults use synthetic IDs (e.g. ``hibachi-vault-2``)
 
     :param address:
         The vault address string to validate.
@@ -33,7 +34,7 @@ def is_good_multichain_address(address: str) -> bool:
         ``True`` if the address starts with a known prefix.
     """
     addr_lower = address.lower()
-    return addr_lower.startswith("0x") or addr_lower.startswith("vlt:") or addr_lower.startswith("lighter-pool-")
+    return addr_lower.startswith("0x") or addr_lower.startswith("vlt:") or addr_lower.startswith("lighter-pool-") or addr_lower.startswith("hibachi-vault-")
 
 
 def sanitise_string(s: str, max_length: int | None = None) -> str:

--- a/eth_defi/vault/base.py
+++ b/eth_defi/vault/base.py
@@ -71,7 +71,7 @@ class VaultSpec:
     def __post_init__(self):
         assert isinstance(self.chain_id, int)
         assert isinstance(self.vault_address, str), f"Expected str, got {self.vault_address}"
-        assert is_good_multichain_address(self.vault_address), f"Vault address must start with 0x or VLT: prefix, got: {self.vault_address}"
+        assert is_good_multichain_address(self.vault_address), f"Vault address must start with 0x, VLT:, lighter-pool-, or hibachi-vault- prefix, got: {self.vault_address}"
         # TODO: Get rid of old codepaths so we can make this dataclass frozen
         self.vault_address = self.vault_address.lower()
 

--- a/eth_defi/vault/fee.py
+++ b/eth_defi/vault/fee.py
@@ -146,6 +146,9 @@ VAULT_PROTOCOL_FEE_MATRIX = {
     # already reflected in share prices (internalised skimming).
     # Per-pool operator fees range from 0% (LLP) to variable amounts for user pools.
     "Lighter": VaultFeeMode.internalised_skimming,
+    # Hibachi - all vault-level fees are zero (management, performance, deposit, withdrawal)
+    # Platform charges trading taker fees and deposit/withdrawal fees at exchange level
+    "Hibachi": VaultFeeMode.feeless,
     # Liquid Royalty has no management/performance fees, but 20% early withdrawal penalty within 7-day cooldown
     "Liquid Royalty": VaultFeeMode.feeless,
     # Inverse Finance sDOLA - no explicit fees, yield via DBR auction mechanism

--- a/eth_defi/vault/post_processing.py
+++ b/eth_defi/vault/post_processing.py
@@ -23,6 +23,9 @@ from eth_defi.hyperliquid.vault_data_export import open_and_merge_hypercore_pric
 from eth_defi.lighter.constants import LIGHTER_CHAIN_ID, LIGHTER_DAILY_METRICS_DATABASE
 from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase
 from eth_defi.lighter.vault_data_export import merge_into_uncleaned_parquet as lighter_merge_parquet
+from eth_defi.hibachi.constants import HIBACHI_CHAIN_ID, HIBACHI_DAILY_METRICS_DATABASE
+from eth_defi.hibachi.daily_metrics import HibachiDailyMetricsDatabase
+from eth_defi.hibachi.vault_data_export import merge_into_uncleaned_parquet as hibachi_merge_parquet
 from eth_defi.research.wrangle_vault_prices import generate_cleaned_vault_datasets
 from eth_defi.vault.vaultdb import DEFAULT_UNCLEANED_PRICE_DATABASE, get_pipeline_data_dir
 
@@ -201,11 +204,13 @@ def merge_native_protocols(
     merge_hypercore: bool = False,
     merge_grvt: bool = False,
     merge_lighter: bool = False,
+    merge_hibachi: bool = False,
     uncleaned_parquet_path: Path | None = None,
     hyperliquid_db_path: Path | None = None,
     hyperliquid_hf_db_path: Path | None = None,
     grvt_db_path: Path | None = None,
     lighter_db_path: Path | None = None,
+    hibachi_db_path: Path | None = None,
 ) -> dict[str, bool]:
     """Merge native protocol price data into the uncleaned parquet.
 
@@ -219,11 +224,13 @@ def merge_native_protocols(
     :param merge_hypercore: Merge Hyperliquid native (Hypercore) vault data
     :param merge_grvt: Merge GRVT native vault data
     :param merge_lighter: Merge Lighter native pool data
+    :param merge_hibachi: Merge Hibachi native vault data
     :param uncleaned_parquet_path: Override for the uncleaned parquet path
     :param hyperliquid_db_path: Override for the daily Hyperliquid DuckDB path
     :param hyperliquid_hf_db_path: Override for the HF Hyperliquid DuckDB path
     :param grvt_db_path: Override for the GRVT DuckDB path
     :param lighter_db_path: Override for the Lighter DuckDB path
+    :param hibachi_db_path: Override for the Hibachi DuckDB path
     :return: Dictionary mapping step name to success boolean
     """
     parquet_path = uncleaned_parquet_path or DEFAULT_UNCLEANED_PRICE_DATABASE
@@ -275,6 +282,22 @@ def merge_native_protocols(
         except Exception:
             logger.exception("Lighter price merge failed")
             steps["lighter-price-merge"] = False
+
+    if merge_hibachi:
+        try:
+            logger.info("Merging Hibachi prices into uncleaned parquet")
+            h_db_path = hibachi_db_path or HIBACHI_DAILY_METRICS_DATABASE
+            db = HibachiDailyMetricsDatabase(h_db_path)
+            try:
+                combined_df = hibachi_merge_parquet(db, parquet_path)
+                hibachi_rows = len(combined_df[combined_df["chain"] == HIBACHI_CHAIN_ID]) if len(combined_df) > 0 else 0
+                logger.info("Hibachi price merge: %d Hibachi price entries in uncleaned parquet", hibachi_rows)
+            finally:
+                db.close()
+            steps["hibachi-price-merge"] = True
+        except Exception:
+            logger.exception("Hibachi price merge failed")
+            steps["hibachi-price-merge"] = False
 
     return steps
 
@@ -517,6 +540,7 @@ def run_post_processing(
     scan_hypercore: bool = False,
     scan_grvt: bool = False,
     scan_lighter: bool = False,
+    scan_hibachi: bool = False,
     skip_cleaning: bool = False,
     skip_top_vaults: bool = False,
     skip_sparklines: bool = False,
@@ -527,6 +551,7 @@ def run_post_processing(
     hyperliquid_hf_db_path: Path | None = None,
     grvt_db_path: Path | None = None,
     lighter_db_path: Path | None = None,
+    hibachi_db_path: Path | None = None,
     vault_db_path: Path | None = None,
     cleaned_path: Path | None = None,
 ) -> dict[str, bool]:
@@ -543,6 +568,7 @@ def run_post_processing(
     :param scan_hypercore: Whether to merge Hypercore data
     :param scan_grvt: Whether to merge GRVT data
     :param scan_lighter: Whether to merge Lighter data
+    :param scan_hibachi: Whether to merge Hibachi data
     :param skip_cleaning: Skip price cleaning step
     :param skip_top_vaults: Skip top-vaults JSON generation and R2 upload
     :param skip_sparklines: Skip sparkline image export to R2
@@ -553,6 +579,7 @@ def run_post_processing(
     :param hyperliquid_hf_db_path: Override for the HF Hyperliquid DuckDB path
     :param grvt_db_path: Override for the GRVT DuckDB path
     :param lighter_db_path: Override for the Lighter DuckDB path
+    :param hibachi_db_path: Override for the Hibachi DuckDB path
     :param vault_db_path: Override for the vault database pickle path
     :param cleaned_path: Override for the cleaned parquet output path
     :return: Dictionary mapping step name to success boolean
@@ -564,11 +591,13 @@ def run_post_processing(
         merge_hypercore=scan_hypercore,
         merge_grvt=scan_grvt,
         merge_lighter=scan_lighter,
+        merge_hibachi=scan_hibachi,
         uncleaned_parquet_path=uncleaned_parquet_path,
         hyperliquid_db_path=hyperliquid_db_path,
         hyperliquid_hf_db_path=hyperliquid_hf_db_path,
         grvt_db_path=grvt_db_path,
         lighter_db_path=lighter_db_path,
+        hibachi_db_path=hibachi_db_path,
     )
     steps.update(merge_results)
 

--- a/eth_defi/vault/risk.py
+++ b/eth_defi/vault/risk.py
@@ -148,6 +148,8 @@ VAULT_PROTOCOL_RISK_MATRIX = {
     "Ember": VaultTechnicalRisk.low,
     # Lighter - centralised perp DEX on ZK-rollup, closed-source
     "Lighter": VaultTechnicalRisk.severe,
+    # Hibachi - closed-source native perp venue
+    "Hibachi": VaultTechnicalRisk.severe,
     # Inverse Finance - sDOLA savings vault, open source but limited audits
     "Inverse Finance": VaultTechnicalRisk.severe,
     # 40acres - 4 independent audits by Sherlock, active bug bounty, open source contracts

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -41,6 +41,9 @@ from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase
 from eth_defi.lighter.daily_metrics import run_daily_scan as lighter_run_daily_scan
 from eth_defi.lighter.session import create_lighter_session
 from eth_defi.lighter.vault_data_export import merge_into_vault_database as lighter_merge_vault_db
+from eth_defi.hibachi.constants import HIBACHI_DAILY_METRICS_DATABASE
+from eth_defi.hibachi.daily_metrics import run_daily_scan as hibachi_run_daily_scan
+from eth_defi.hibachi.vault_data_export import merge_into_vault_database as hibachi_merge_vault_db
 from eth_defi.provider.broken_provider import verify_archive_node
 from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
 from eth_defi.token import TokenDiskCache
@@ -943,6 +946,60 @@ def scan_lighter_fn(
     return result
 
 
+def scan_hibachi_fn(
+    db_path: Path | None = None,
+    vault_db_path: Path = DEFAULT_VAULT_DATABASE,
+) -> ChainResult:
+    """Scan Hibachi native vaults via public endpoints.
+
+    Runs the Hibachi daily metrics pipeline: fetches vault metadata
+    and share price history from the public data API, stores in DuckDB,
+    and merges into the shared VaultDatabase pickle.
+
+    No authentication required.
+
+    :param db_path:
+        Path to the Hibachi DuckDB file.  ``None`` uses the default.
+    :param vault_db_path:
+        Path to the vault database pickle.
+    :return:
+        Scan result with vault count and duration.
+    """
+    from eth_defi.hibachi.constants import HIBACHI_DAILY_METRICS_DATABASE
+
+    if db_path is None:
+        db_path = HIBACHI_DAILY_METRICS_DATABASE
+
+    result = ChainResult(name="Hibachi", status="running")
+    start_time = time.time()
+
+    try:
+        db = hibachi_run_daily_scan(
+            db_path=db_path,
+        )
+
+        try:
+            vault_count = db.get_vault_count()
+            result.vault_count = vault_count
+            result.vault_scan_ok = True
+
+            hibachi_merge_vault_db(db, vault_db_path)
+            result.price_scan_ok = True
+        finally:
+            db.close()
+
+        result.status = "success"
+
+    except Exception as e:
+        logger.exception("Hibachi scan failed")
+        result.status = "failed"
+        result.error = str(e)
+        result.traceback_str = traceback.format_exc()
+
+    result.duration = time.time() - start_time
+    return result
+
+
 def _load_last_timestamps(uncleaned_price_path: Path | None = None) -> dict[str, str]:
     """Load the last data timestamp per chain from the uncleaned parquet.
 
@@ -1090,6 +1147,7 @@ def backup_pipeline_files(backup_files: list[Path] | None = None, backup_dir: Pa
             HYPERLIQUID_DAILY_METRICS_DATABASE,
             GRVT_DAILY_METRICS_DATABASE,
             LIGHTER_DAILY_METRICS_DATABASE,
+            HIBACHI_DAILY_METRICS_DATABASE,
         ]
 
     if backup_dir is None:
@@ -1137,6 +1195,7 @@ def run_scan_tick(
     scan_hypercore: bool,
     scan_grvt: bool,
     scan_lighter: bool,
+    scan_hibachi: bool,
     max_workers: int,
     frequency: str,
     retry_count: int,
@@ -1153,6 +1212,7 @@ def run_scan_tick(
     hyperliquid_hf_db_path: Path,
     grvt_db_path: Path,
     lighter_db_path: Path,
+    hibachi_db_path: Path,
     bkp_files: list[Path],
     bkp_dir: Path,
     cleaned_price_path: Path | None = None,
@@ -1302,6 +1362,22 @@ def run_scan_tick(
             logger.error("Lighter: FAILED - %s", r.error)
         print_dashboard(results, display_order, uncleaned_price_path=uncleaned_price_path)
 
+    if scan_hibachi and "Hibachi" in active_protocols:
+        logger.info("Scanning Hibachi (native vaults)")
+        try:
+            results["Hibachi"] = scan_hibachi_fn(db_path=hibachi_db_path, vault_db_path=vault_db_path)
+        except Exception as e:
+            logger.exception("Hibachi scan crashed with unhandled exception")
+            results["Hibachi"] = ChainResult(name="Hibachi", status="failed", error=str(e), traceback_str=traceback.format_exc())
+        r = results["Hibachi"]
+        if r.status == "success":
+            logger.info("Hibachi: SUCCESS - %d vaults", r.vault_count or 0)
+            if on_item_success:
+                on_item_success("Hibachi")
+        elif r.status == "failed":
+            logger.error("Hibachi: FAILED - %s", r.error)
+        print_dashboard(results, display_order, uncleaned_price_path=uncleaned_price_path)
+
     # Retry passes - retry failed EVM chains (native protocols are not retried)
     evm_chain_names = {c.name for c in chains}
     for attempt in range(1, retry_count + 1):
@@ -1346,6 +1422,7 @@ def run_scan_tick(
             scan_hypercore=scan_hypercore,
             scan_grvt=scan_grvt,
             scan_lighter=scan_lighter,
+            scan_hibachi=scan_hibachi,
             skip_cleaning=skip_cleaning,
             skip_top_vaults=skip_top_vaults,
             skip_sparklines=skip_sparklines,
@@ -1356,6 +1433,7 @@ def run_scan_tick(
             hyperliquid_hf_db_path=hyperliquid_hf_db_path,
             grvt_db_path=grvt_db_path,
             lighter_db_path=lighter_db_path,
+            hibachi_db_path=hibachi_db_path,
             vault_db_path=vault_db_path,
             cleaned_path=cleaned_price_path,
         )
@@ -1432,6 +1510,7 @@ def main():
     scan_hypercore = os.environ.get("SCAN_HYPERCORE", "false").lower() == "true"
     scan_grvt = os.environ.get("SCAN_GRVT", "false").lower() == "true"
     scan_lighter = os.environ.get("SCAN_LIGHTER", "false").lower() == "true"
+    scan_hibachi = os.environ.get("SCAN_HIBACHI", "false").lower() == "true"
     force_rescan = os.environ.get("FORCE_RESCAN", "false").lower() == "true"
     max_workers = int(os.environ.get("MAX_WORKERS", "50"))
     frequency = os.environ.get("FREQUENCY", "1h")
@@ -1473,12 +1552,13 @@ def main():
     pipeline_lock_path = data_dir / "scan-pipeline"
     backup_dir = data_dir / "backups"
     lighter_db_path = data_dir / "lighter-pools.duckdb"
+    hibachi_db_path = data_dir / "hibachi-vaults.duckdb"
     hypercore_mode = os.environ.get("HYPERCORE_MODE", "daily").strip().lower()
     hyperliquid_db_path = data_dir / "hyperliquid-vaults.duckdb"
     hyperliquid_hf_db_path = data_dir / "hyperliquid-vaults-hf.duckdb"
     grvt_db_path = data_dir / "grvt-vaults.duckdb"
 
-    bkp_files = [uncleaned_price_path, reader_state_path, vault_db_path, hyperliquid_db_path, hyperliquid_hf_db_path, grvt_db_path, lighter_db_path]
+    bkp_files = [uncleaned_price_path, reader_state_path, vault_db_path, hyperliquid_db_path, hyperliquid_hf_db_path, grvt_db_path, lighter_db_path, hibachi_db_path]
 
     # Test mode - filter chains if TEST_CHAINS is set
     disable_chains_str = os.environ.get("DISABLE_CHAINS")
@@ -1491,7 +1571,7 @@ def main():
 
     logger.debug("=" * 80)
     logger.info("Starting multi-chain vault scan")
-    logger.info("SCAN_PRICES: %s, SCAN_HYPERCORE: %s, SCAN_GRVT: %s, SCAN_LIGHTER: %s, RETRY_COUNT: %d, MAX_WORKERS: %d, FREQUENCY: %s", scan_prices, scan_hypercore, scan_grvt, scan_lighter, retry_count, max_workers, frequency)
+    logger.info("SCAN_PRICES: %s, SCAN_HYPERCORE: %s, SCAN_GRVT: %s, SCAN_LIGHTER: %s, SCAN_HIBACHI: %s, RETRY_COUNT: %d, MAX_WORKERS: %d, FREQUENCY: %s", scan_prices, scan_hypercore, scan_grvt, scan_lighter, scan_hibachi, retry_count, max_workers, frequency)
     logger.info("PIPELINE_DATA_DIR: %s", data_dir)
     if skip_post_processing:
         logger.info("SKIP_POST_PROCESSING: true")
@@ -1558,6 +1638,8 @@ def main():
         all_protocols.append("GRVT")
     if scan_lighter:
         all_protocols.append("Lighter")
+    if scan_hibachi:
+        all_protocols.append("Hibachi")
 
     # Pre-compute human-readable cycle intervals for all items
     if looped_mode:
@@ -1578,6 +1660,7 @@ def main():
         scan_hypercore=scan_hypercore,
         scan_grvt=scan_grvt,
         scan_lighter=scan_lighter,
+        scan_hibachi=scan_hibachi,
         max_workers=max_workers,
         frequency=frequency,
         retry_count=retry_count,
@@ -1594,6 +1677,7 @@ def main():
         hyperliquid_hf_db_path=hyperliquid_hf_db_path,
         grvt_db_path=grvt_db_path,
         lighter_db_path=lighter_db_path,
+        hibachi_db_path=hibachi_db_path,
         bkp_files=bkp_files,
         bkp_dir=backup_dir,
         cleaned_price_path=cleaned_price_path,

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -59,12 +59,13 @@ poetry run python scripts/erc-4626/scan-vaults-all-chains.py
 | `LOG_LEVEL` | Optional. Default: WARNING. |
 | `PIPELINE_DATA_DIR` | Optional. Directory for all pipeline files (parquet, pickle, DuckDB, state). Default: `~/.tradingstrategy/vaults`. |
 | `LOOP_INTERVAL_SECONDS` | Optional. When >0, enables looped mode — ticks every N seconds. Default: 0 (single run). |
-| `SCAN_CYCLES` | Optional. Per-item cycle intervals, e.g. `Lighter=4h,GRVT=4h,Hypercore=4h`. |
+| `SCAN_CYCLES` | Optional. Per-item cycle intervals, e.g. `Lighter=4h,GRVT=4h,Hypercore=4h,Hibachi=4h`. |
 | `DEFAULT_CYCLE` | Optional. Default cycle for items not in `SCAN_CYCLES`. Default: `24h`. |
 | `MAX_CYCLES` | Optional. Exit after N cycles (for testing). Default: 0 (unlimited). |
 | `SCAN_HYPERCORE` | Optional. Enable Hyperliquid native vault scanning. Default: false. |
 | `SCAN_GRVT` | Optional. Enable GRVT native vault scanning. Default: false. |
 | `SCAN_LIGHTER` | Optional. Enable Lighter native pool scanning. Default: false. |
+| `SCAN_HIBACHI` | Optional. Enable Hibachi native vault scanning. Default: false. |
 
 ### scan-prices.py
 

--- a/scripts/erc-4626/post-process-prices.py
+++ b/scripts/erc-4626/post-process-prices.py
@@ -1,6 +1,6 @@
 """Standalone post-processing pipeline for vault price data.
 
-Merges native protocol data (Hypercore, GRVT, Lighter) into the
+Merges native protocol data (Hypercore, GRVT, Lighter, Hibachi) into the
 uncleaned parquet, cleans the data, generates the top-vaults JSON,
 and uploads to R2. Each step reports success/failure and the script
 exits with code 1 if any step fails.
@@ -24,9 +24,9 @@ Usage:
     # Skip native protocol merges (just clean + export)
     source .local-test.env && poetry run python scripts/erc-4626/post-process-prices.py
 
-    # Include Hypercore, GRVT, Lighter merges
+    # Include Hypercore, GRVT, Lighter, Hibachi merges
     source .local-test.env && \\
-    MERGE_HYPERCORE=true MERGE_GRVT=true MERGE_LIGHTER=true \\
+    MERGE_HYPERCORE=true MERGE_GRVT=true MERGE_LIGHTER=true MERGE_HIBACHI=true \\
     poetry run python scripts/erc-4626/post-process-prices.py
 
     # Only merge and clean, skip all R2 uploads
@@ -49,6 +49,7 @@ Pipeline control:
 - ``MERGE_HYPERCORE``: Merge Hyperliquid native vault data (default: ``false``)
 - ``MERGE_GRVT``: Merge GRVT native vault data (default: ``false``)
 - ``MERGE_LIGHTER``: Merge Lighter native pool data (default: ``false``)
+- ``MERGE_HIBACHI``: Merge Hibachi native vault data (default: ``false``)
 - ``SKIP_CLEANING``: Skip price cleaning step (default: ``false``)
 - ``SKIP_TOP_VAULTS``: Skip top-vaults JSON generation and R2 upload (default: ``false``)
 - ``SKIP_SPARKLINES``: Skip sparkline image export to R2 (default: ``false``)
@@ -116,6 +117,7 @@ def main():
     merge_hypercore = os.environ.get("MERGE_HYPERCORE", "false").lower() == "true"
     merge_grvt = os.environ.get("MERGE_GRVT", "false").lower() == "true"
     merge_lighter = os.environ.get("MERGE_LIGHTER", "false").lower() == "true"
+    merge_hibachi = os.environ.get("MERGE_HIBACHI", "false").lower() == "true"
     skip_cleaning = os.environ.get("SKIP_CLEANING", "false").lower() == "true"
     skip_top_vaults = os.environ.get("SKIP_TOP_VAULTS", "false").lower() == "true"
     skip_sparklines = os.environ.get("SKIP_SPARKLINES", "false").lower() == "true"
@@ -139,10 +141,11 @@ def main():
     hyperliquid_hf_db_path = data_dir / "hyperliquid-vaults-hf.duckdb"
     grvt_db_path = data_dir / "grvt-vaults.duckdb"
     lighter_db_path = data_dir / "lighter-pools.duckdb"
+    hibachi_db_path = data_dir / "hibachi-vaults.duckdb"
 
     logger.info("Pipeline data directory: %s", data_dir)
-    if not any([merge_hypercore, merge_grvt, merge_lighter]):
-        logger.info("No native protocol merges requested (set MERGE_HYPERCORE/MERGE_GRVT/MERGE_LIGHTER=true)")
+    if not any([merge_hypercore, merge_grvt, merge_lighter, merge_hibachi]):
+        logger.info("No native protocol merges requested (set MERGE_HYPERCORE/MERGE_GRVT/MERGE_LIGHTER/MERGE_HIBACHI=true)")
 
     # run_post_processing() uses scan_hypercore/scan_grvt/scan_lighter for
     # the "merge this native protocol's data" flags. We keep the
@@ -152,6 +155,7 @@ def main():
         scan_hypercore=merge_hypercore,
         scan_grvt=merge_grvt,
         scan_lighter=merge_lighter,
+        scan_hibachi=merge_hibachi,
         skip_cleaning=skip_cleaning,
         skip_top_vaults=skip_top_vaults,
         skip_sparklines=skip_sparklines,
@@ -162,6 +166,7 @@ def main():
         hyperliquid_hf_db_path=hyperliquid_hf_db_path,
         grvt_db_path=grvt_db_path,
         lighter_db_path=lighter_db_path,
+        hibachi_db_path=hibachi_db_path,
         vault_db_path=vault_db_path,
         cleaned_path=cleaned_price_path,
     )

--- a/scripts/erc-4626/scan-vaults-all-chains.py
+++ b/scripts/erc-4626/scan-vaults-all-chains.py
@@ -28,6 +28,9 @@ Usage:
     # Include Lighter native pools
     SCAN_LIGHTER=true python scripts/erc-4626/scan-vaults-all-chains.py
 
+    # Include Hibachi native vaults
+    SCAN_HIBACHI=true python scripts/erc-4626/scan-vaults-all-chains.py
+
     # Custom retry count
     RETRY_COUNT=2 python scripts/erc-4626/scan-vaults-all-chains.py
 
@@ -42,9 +45,9 @@ Usage:
 
     # Looped mode: tick every 1h, Lighter/GRVT/Hypercore on 4h cycle, EVM chains on 24h
     LOOP_INTERVAL_SECONDS=3600 \\
-    SCAN_CYCLES="Hypercore=4h,GRVT=4h,Lighter=4h" \\
+    SCAN_CYCLES="Hypercore=4h,GRVT=4h,Lighter=4h,Hibachi=4h" \\
     DEFAULT_CYCLE=24h \\
-    SCAN_HYPERCORE=true SCAN_GRVT=true SCAN_LIGHTER=true \\
+    SCAN_HYPERCORE=true SCAN_GRVT=true SCAN_LIGHTER=true SCAN_HIBACHI=true \\
     python scripts/erc-4626/scan-vaults-all-chains.py
 
 Manual testing:

--- a/scripts/hibachi/README-hibachi-vaults.md
+++ b/scripts/hibachi/README-hibachi-vaults.md
@@ -1,0 +1,57 @@
+# Hibachi native vault metrics pipeline
+
+This pipeline fetches vault metadata and daily share price history
+from the Hibachi public data API, stores it in DuckDB, and merges
+the data into the unified ERC-4626 vault pipeline.
+
+## Architecture
+
+```
+Hibachi data API → DuckDB → VaultDatabase pickle → uncleaned Parquet → cleaning pipeline → JSON export
+```
+
+The pipeline follows the same pattern as GRVT and Lighter native vault integrations.
+
+## API documentation
+
+See [eth_defi/hibachi/README.md](../../eth_defi/hibachi/README.md) for reverse-engineered
+API endpoint documentation.
+
+## Running the standalone pipeline
+
+```shell
+# Basic usage
+poetry run python scripts/hibachi/daily-vault-metrics.py
+
+# With debug logging
+LOG_LEVEL=info poetry run python scripts/hibachi/daily-vault-metrics.py
+
+# Scan specific vaults
+VAULT_IDS=2,3 poetry run python scripts/hibachi/daily-vault-metrics.py
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `LOG_LEVEL` | `warning` | Logging level |
+| `DB_PATH` | `~/.tradingstrategy/vaults/hibachi-vaults.duckdb` | DuckDB database path |
+| `VAULT_IDS` | (all) | Comma-separated vault IDs to scan |
+| `VAULT_DB_PATH` | `~/.tradingstrategy/vaults/vault-metadata-db.pickle` | VaultDatabase pickle path |
+| `PARQUET_PATH` | `~/.tradingstrategy/vaults/vault-prices-1h.parquet` | Uncleaned Parquet path |
+
+## Production usage
+
+In the production scanner (`scan-vaults-all-chains.py`), Hibachi is
+enabled via the `SCAN_HIBACHI=true` environment variable. It can also
+be scheduled via `SCAN_CYCLES="...,Hibachi=4h"`.
+
+## Known vaults (as of 2026-04-30)
+
+| vaultId | Symbol | Name | Strategy |
+|---|---|---|---|
+| 2 | GAV | Growi Alpha Vault | Mean-reversion on crypto perps |
+| 3 | FLP | Fire Liquidity Provider | Market making across all markets |
+
+Both vaults are denominated in USDT. Chain ID 9997 is a synthetic
+in-house identifier (not an EVM JSON-RPC chain ID).

--- a/scripts/hibachi/daily-vault-metrics.py
+++ b/scripts/hibachi/daily-vault-metrics.py
@@ -1,0 +1,126 @@
+"""Daily Hibachi vault metrics pipeline.
+
+Fetches vault metadata and share price history from the Hibachi
+public data API, stores metrics in DuckDB, and merges the data
+into the existing ERC-4626 vault pipeline files (VaultDatabase
+pickle and cleaned Parquet).
+
+No authentication is required — all data comes from public endpoints.
+
+After this script runs, the existing ``vault-analysis-json.py`` will
+produce a combined JSON with ERC-4626, Hyperliquid, GRVT, Lighter,
+and Hibachi vaults.
+
+Usage:
+
+.. code-block:: shell
+
+    # Basic usage with defaults
+    poetry run python scripts/hibachi/daily-vault-metrics.py
+
+    # With debug logging
+    LOG_LEVEL=info poetry run python scripts/hibachi/daily-vault-metrics.py
+
+    # Scan specific vaults by ID
+    VAULT_IDS=2,3 \\
+      poetry run python scripts/hibachi/daily-vault-metrics.py
+
+Environment variables:
+
+- ``LOG_LEVEL``: Logging level (debug, info, warning, error). Default: warning
+- ``DB_PATH``: Path to DuckDB database file. Default: ~/.tradingstrategy/vaults/hibachi-vaults.duckdb
+- ``VAULT_IDS``: Comma-separated list of vault IDs (integers) to scan. Default: all vaults
+- ``VAULT_DB_PATH``: Path to existing ERC-4626 VaultDatabase pickle to merge into.
+  Default: ~/.tradingstrategy/vaults/vault-metadata-db.pickle
+- ``PARQUET_PATH``: Path to uncleaned Parquet to merge into.
+  Default: ~/.tradingstrategy/vaults/vault-prices-1h.parquet
+
+"""
+
+import logging
+import os
+from pathlib import Path
+
+from eth_defi.hibachi.constants import HIBACHI_CHAIN_ID, HIBACHI_DAILY_METRICS_DATABASE
+from eth_defi.hibachi.daily_metrics import run_daily_scan
+from eth_defi.hibachi.vault_data_export import (
+    merge_into_uncleaned_parquet,
+    merge_into_vault_database,
+)
+from eth_defi.research.wrangle_vault_prices import generate_cleaned_vault_datasets
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.vaultdb import DEFAULT_UNCLEANED_PRICE_DATABASE, DEFAULT_VAULT_DATABASE
+
+logger = logging.getLogger(__name__)
+
+
+def main():
+    # Configuration from environment
+    default_log_level = os.environ.get("LOG_LEVEL", "warning")
+    setup_console_logging(
+        default_log_level=default_log_level,
+        log_file=Path("logs/hibachi-daily-vault-metrics.log"),
+    )
+
+    db_path_str = os.environ.get("DB_PATH")
+    db_path = Path(db_path_str).expanduser() if db_path_str else HIBACHI_DAILY_METRICS_DATABASE
+
+    vault_ids_str = os.environ.get("VAULT_IDS", "").strip()
+    vault_ids = [int(v.strip()) for v in vault_ids_str.split(",") if v.strip()] or None
+
+    vault_db_path_str = os.environ.get("VAULT_DB_PATH")
+    vault_db_path = Path(vault_db_path_str).expanduser() if vault_db_path_str else DEFAULT_VAULT_DATABASE
+
+    uncleaned_path_str = os.environ.get("PARQUET_PATH")
+    uncleaned_path = Path(uncleaned_path_str).expanduser() if uncleaned_path_str else DEFAULT_UNCLEANED_PRICE_DATABASE
+
+    print("Hibachi daily vault metrics pipeline")
+    print(f"DuckDB path: {db_path}")
+    if vault_ids:
+        print(f"Vault IDs: {', '.join(str(v) for v in vault_ids)}")
+    else:
+        print("Scanning all vaults")
+    print(f"VaultDB path: {vault_db_path}")
+    print(f"Uncleaned parquet path: {uncleaned_path}")
+
+    # Step 1: Scan and store in DuckDB
+    print("\nStep 1: Scanning Hibachi vaults...")
+    db = run_daily_scan(
+        db_path=db_path,
+        vault_ids=vault_ids,
+    )
+
+    try:
+        vault_count = db.get_vault_count()
+        print(f"Stored metrics for {vault_count} vaults in DuckDB")
+
+        # Step 2: Merge into VaultDatabase pickle
+        print(f"\nStep 2: Merging into VaultDatabase at {vault_db_path}...")
+        vault_db = merge_into_vault_database(db, vault_db_path)
+        print(f"VaultDatabase now has {len(vault_db)} total vaults")
+
+        # Step 3: Merge into uncleaned Parquet
+        print(f"\nStep 3: Merging into uncleaned Parquet at {uncleaned_path}...")
+        combined_df = merge_into_uncleaned_parquet(db, uncleaned_path)
+        hibachi_rows = combined_df[combined_df["chain"] == HIBACHI_CHAIN_ID] if len(combined_df) > 0 else combined_df
+        print(f"Uncleaned parquet now has {len(combined_df):,} total rows ({len(hibachi_rows):,} Hibachi)")
+
+    finally:
+        db.close()
+
+    # Step 4: Run the cleaning pipeline
+    print("\nStep 4: Running cleaning pipeline...")
+    generate_cleaned_vault_datasets(
+        vault_db_path=vault_db_path,
+        price_df_path=uncleaned_path,
+    )
+
+    print("\nAll ok")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        logger.exception("Fatal error: %s", e, exc_info=e)
+        raise e

--- a/tests/hibachi/test_hibachi_vault.py
+++ b/tests/hibachi/test_hibachi_vault.py
@@ -1,0 +1,386 @@
+"""Test Hibachi vault data parsing, DuckDB storage, and pipeline integration.
+
+Unit tests only — no live API calls, no Anvil fork.
+Tests cover:
+
+1. Parsing ``/vault/info`` JSON into ``HibachiVaultInfo`` dataclass
+2. Parsing ``/vault/performance`` JSON with UTC date conversion
+3. Synthetic address format validation
+4. DuckDB upsert roundtrip
+5. Raw prices DataFrame schema for Parquet compatibility
+6. VaultSpec creation via ``create_hibachi_vault_row``
+7. Post-processing pipeline wiring (``run_post_processing`` → ``merge_native_protocols``)
+"""
+
+import datetime
+from pathlib import Path
+
+import pytest
+
+from eth_defi.hibachi.constants import HIBACHI_CHAIN_ID
+from eth_defi.hibachi.daily_metrics import HibachiDailyMetricsDatabase
+from eth_defi.hibachi.vault import (
+    HibachiVaultInfo,
+    _parse_vault_info,
+    _parse_vault_performance,
+)
+from eth_defi.hibachi.vault_data_export import (
+    build_raw_prices_dataframe,
+    create_hibachi_vault_row,
+)
+from eth_defi.utils import is_good_multichain_address
+
+
+#: Hardcoded ``/vault/info`` fixture matching the live API shape
+VAULT_INFO_FIXTURE = [
+    {
+        "vaultId": 2,
+        "symbol": "GAV",
+        "shortDescription": "Growi Alpha Vault",
+        "description": "Mean-reversion strategy on crypto perps.",
+        "perSharePrice": "1.030186",
+        "30dSharePrice": "0.999923",
+        "outstandingShares": "1501004.254809",
+        "managementFees": "0.00000000",
+        "depositFees": "0.00000000",
+        "withdrawalFees": "0.00000000",
+        "performanceFees": "0.00000000",
+        "marginingAssetId": 1,
+        "vaultAssetId": 131073,
+        "vaultPubKey": "92f2d3ac73037b5a635b1aef77452b2c847e6e8a",
+        "minUnlockHours": 0,
+        "resolutionDecimals": 6,
+        "maxDrawdown": "0",
+        "sharpeRatio": "0",
+    },
+]
+
+#: Hardcoded ``/vault/performance`` fixture.
+#: Second timestamp ends in 999 to exercise the UTC date-shift edge case.
+VAULT_PERFORMANCE_FIXTURE = {
+    "vaultPerformanceIntervals": [
+        {
+            "interval": "1d",
+            "timestamp": 1773226800,
+            "perSharePrice": "1.000017",
+            "totalValueLocked": "74925.281546",
+        },
+        {
+            "interval": "1d",
+            "timestamp": 1773313199,  # ends in 999 ms boundary — must not shift date
+            "perSharePrice": "1.023197",
+            "totalValueLocked": "76662.074599",
+        },
+        {
+            "interval": "1d",
+            "timestamp": 1773399600,
+            "perSharePrice": "1.054465",
+            "totalValueLocked": "79004.798135",
+        },
+    ],
+}
+
+
+def test_parse_vault_info_response():
+    """Parse hardcoded ``/vault/info`` JSON into ``HibachiVaultInfo``.
+
+    1. Call ``_parse_vault_info`` with the fixture
+    2. Assert dataclass fields match the fixture values
+    3. Assert ``tvl`` property equals ``perSharePrice × outstandingShares``
+    4. Assert ``address`` property returns ``hibachi-vault-2``
+    """
+    # 1. Parse
+    vaults = _parse_vault_info(VAULT_INFO_FIXTURE)
+
+    assert len(vaults) == 1
+    v = vaults[0]
+
+    # 2. Field checks
+    assert isinstance(v, HibachiVaultInfo)
+    assert v.vault_id == 2
+    assert v.symbol == "GAV"
+    assert v.short_description == "Growi Alpha Vault"
+    assert v.description == "Mean-reversion strategy on crypto perps."
+    assert v.per_share_price == pytest.approx(1.030186)
+    assert v.outstanding_shares == pytest.approx(1501004.254809)
+    assert v.min_unlock_hours == 0
+    assert v.vault_pub_key == "92f2d3ac73037b5a635b1aef77452b2c847e6e8a"
+    assert v.vault_asset_id == 131073
+
+    # 3. TVL property
+    expected_tvl = 1.030186 * 1501004.254809
+    assert v.tvl == pytest.approx(expected_tvl, rel=1e-6)
+
+    # 4. Address property
+    assert v.address == "hibachi-vault-2"
+
+
+def test_parse_vault_performance_response():
+    """Parse hardcoded ``/vault/performance`` JSON with UTC date conversion.
+
+    1. Call ``_parse_vault_performance`` with the fixture
+    2. Assert rows are sorted by date ascending
+    3. Assert first row has ``daily_return is None``
+    4. Assert second row ``daily_return`` matches expected value
+    5. Assert timestamp ending in 999 does not cause a date shift
+    """
+    # 1. Parse
+    prices = _parse_vault_performance(VAULT_PERFORMANCE_FIXTURE, vault_id=3)
+
+    assert len(prices) == 3
+
+    # 2. Sorted ascending
+    assert prices[0].date <= prices[1].date <= prices[2].date
+
+    # 3. First row has no daily return
+    assert prices[0].daily_return is None
+
+    # 4. Second row daily return
+    expected_return = (1.023197 - 1.000017) / 1.000017
+    assert prices[1].daily_return == pytest.approx(expected_return, rel=1e-6)
+
+    # 5. Date is consistent (timestamp 1773313199 should not shift date)
+    assert isinstance(prices[1].date, datetime.date)
+    # All three dates should be different consecutive days
+    assert prices[0].date < prices[1].date < prices[2].date
+
+
+def test_synthetic_address_is_valid():
+    """Verify ``hibachi-vault-`` prefix passes address validation.
+
+    1. Check ``is_good_multichain_address`` returns ``True``
+    """
+    assert is_good_multichain_address("hibachi-vault-2") is True
+    assert is_good_multichain_address("hibachi-vault-3") is True
+    assert is_good_multichain_address("HIBACHI-VAULT-2") is True
+
+
+def test_duckdb_upsert_roundtrip(tmp_path: Path):
+    """Create DuckDB, upsert metadata + prices, read back and verify.
+
+    1. Create ``HibachiDailyMetricsDatabase`` at ``tmp_path``
+    2. Upsert one vault's metadata
+    3. Upsert two daily price rows
+    4. Read back via ``get_all_vault_metadata()`` and ``get_all_daily_prices()``
+    5. Assert shapes and values match
+    """
+    from eth_defi.compat import native_datetime_utc_now
+
+    # 1. Create database
+    db = HibachiDailyMetricsDatabase(tmp_path / "test.duckdb")
+
+    try:
+        # 2. Upsert metadata
+        db.upsert_vault_metadata(
+            vault_id=2,
+            symbol="GAV",
+            short_description="Growi Alpha Vault",
+            description="Mean-reversion strategy.",
+            per_share_price=1.03,
+            outstanding_shares=1500000.0,
+            tvl=1545000.0,
+            min_unlock_hours=0,
+            vault_pub_key="abc123",
+            vault_asset_id=131073,
+        )
+
+        # 3. Upsert daily prices
+        now = native_datetime_utc_now()
+        rows = [
+            (2, datetime.date(2025, 6, 1), 1.0, 1500000.0, None, now),
+            (2, datetime.date(2025, 6, 2), 1.01, 1515000.0, 0.01, now),
+        ]
+        db.upsert_daily_prices(rows)
+
+        # 4. Read back
+        meta_df = db.get_all_vault_metadata()
+        prices_df = db.get_all_daily_prices()
+
+        # 5. Assert
+        assert len(meta_df) == 1
+        assert meta_df.iloc[0]["vault_id"] == 2
+        assert meta_df.iloc[0]["symbol"] == "GAV"
+        assert meta_df.iloc[0]["vault_pub_key"] == "abc123"
+
+        assert len(prices_df) == 2
+        assert db.get_vault_count() == 1
+    finally:
+        db.close()
+
+
+def test_raw_prices_dataframe_schema(tmp_path: Path):
+    """Verify ``build_raw_prices_dataframe()`` output matches uncleaned Parquet schema.
+
+    1. Create and populate a test DuckDB
+    2. Call ``build_raw_prices_dataframe()``
+    3. Assert column names, dtypes, and address format
+    """
+    from eth_defi.compat import native_datetime_utc_now
+
+    # 1. Create and populate
+    db = HibachiDailyMetricsDatabase(tmp_path / "test.duckdb")
+    try:
+        now = native_datetime_utc_now()
+        rows = [
+            (2, datetime.date(2025, 6, 1), 1.0, 1500000.0, None, now),
+            (3, datetime.date(2025, 6, 1), 1.2, 500000.0, None, now),
+        ]
+        db.upsert_daily_prices(rows)
+
+        # 2. Build DataFrame
+        df = build_raw_prices_dataframe(db)
+    finally:
+        db.close()
+
+    # 3. Assert schema
+    expected_columns = {
+        "chain",
+        "address",
+        "block_number",
+        "timestamp",
+        "share_price",
+        "total_assets",
+        "total_supply",
+        "performance_fee",
+        "management_fee",
+        "errors",
+        "written_at",
+    }
+    assert set(df.columns) == expected_columns
+    assert df["chain"].dtype.name == "int32"
+    assert df["block_number"].dtype.name == "int64"
+    assert str(df["timestamp"].dtype).startswith("datetime64")
+
+    # Address format
+    assert all(addr.startswith("hibachi-vault-") for addr in df["address"])
+    assert (df["chain"] == HIBACHI_CHAIN_ID).all()
+
+
+def test_vault_spec_creation():
+    """Verify ``create_hibachi_vault_row`` produces valid VaultSpec.
+
+    1. Call ``create_hibachi_vault_row`` with test data
+    2. Assert VaultSpec has correct chain_id and vault_address
+    3. Assert VaultRow has correct Protocol and Denomination
+    """
+    # 1. Create
+    spec, row = create_hibachi_vault_row(
+        vault_id=2,
+        symbol="GAV",
+        name="Growi Alpha Vault",
+        description="Test description",
+        tvl=1500000.0,
+    )
+
+    # 2. VaultSpec checks
+    assert spec.chain_id == 9997
+    assert spec.vault_address == "hibachi-vault-2"
+
+    # 3. VaultRow checks
+    assert row["Protocol"] == "Hibachi"
+    assert row["Denomination"] == "USDT"
+    assert row["Link"] == "https://hibachi.xyz/vaults"
+    assert row["Mgmt fee"] == 0.0
+    assert row["Perf fee"] == 0.0
+
+
+def test_run_post_processing_wiring(tmp_path: Path):
+    """Verify ``run_post_processing`` passes ``scan_hibachi`` through to ``merge_native_protocols``.
+
+    1. Create a valid empty Hibachi DuckDB
+    2. Call ``run_post_processing`` with ``scan_hibachi=True`` and all skips enabled
+    3. Assert ``hibachi-price-merge`` key appears in the returned steps dict
+
+    We mock nothing — we just verify the parameter plumbing works
+    end-to-end with an empty database.
+    """
+    from eth_defi.vault.post_processing import run_post_processing
+
+    # 1. Create valid empty DuckDB
+    hibachi_db_path = tmp_path / "hibachi.duckdb"
+    db = HibachiDailyMetricsDatabase(hibachi_db_path)
+    db.close()
+
+    # 2. Call run_post_processing
+    steps = run_post_processing(
+        scan_hibachi=True,
+        hibachi_db_path=hibachi_db_path,
+        skip_cleaning=True,
+        skip_top_vaults=True,
+        skip_sparklines=True,
+        skip_metadata=True,
+        skip_data=True,
+        uncleaned_parquet_path=tmp_path / "prices.parquet",
+    )
+
+    # 3. Assert hibachi-price-merge appeared
+    assert "hibachi-price-merge" in steps
+
+
+def test_hibachi_live_scan_single_vault(tmp_path: Path):
+    """Smoke integration test: scan a single Hibachi vault from the live API.
+
+    Exercises the full pipeline end-to-end against the real
+    ``data-api.hibachi.xyz`` endpoint, using isolated tmp databases.
+
+    1. Run ``run_daily_scan`` for vault 3 (FLP) into an isolated DuckDB
+    2. Assert DuckDB has exactly 1 vault with daily price history
+    3. Merge into a fresh VaultDatabase pickle
+    4. Assert VaultDatabase contains the Hibachi vault with correct metadata
+    5. Merge into an isolated uncleaned Parquet
+    6. Assert Parquet has Hibachi rows with correct schema
+    """
+    from eth_defi.hibachi.daily_metrics import run_daily_scan
+    from eth_defi.hibachi.vault_data_export import (
+        merge_into_uncleaned_parquet,
+        merge_into_vault_database,
+    )
+    from eth_defi.vault.vaultdb import VaultDatabase
+
+    db_path = tmp_path / "hibachi-test.duckdb"
+    vault_db_path = tmp_path / "vault-db.pickle"
+    parquet_path = tmp_path / "prices.parquet"
+
+    # 1. Scan single vault (FLP, vaultId=3)
+    db = run_daily_scan(
+        db_path=db_path,
+        vault_ids=[3],
+    )
+
+    try:
+        # 2. DuckDB assertions
+        assert db.get_vault_count() == 1
+
+        meta_df = db.get_all_vault_metadata()
+        assert len(meta_df) == 1
+        assert meta_df.iloc[0]["symbol"] == "FLP"
+        assert meta_df.iloc[0]["vault_id"] == 3
+        assert meta_df.iloc[0]["vault_pub_key"] != ""
+        assert meta_df.iloc[0]["tvl"] > 0
+
+        prices_df = db.get_all_daily_prices()
+        assert len(prices_df) > 10, f"Expected >10 daily prices, got {len(prices_df)}"
+        assert (prices_df["per_share_price"] > 0).all()
+
+        # 3. Merge into VaultDatabase
+        vault_db = merge_into_vault_database(db, vault_db_path)
+
+        # 4. VaultDatabase assertions
+        assert len(vault_db) == 1
+        spec, row = next(iter(vault_db.rows.items()))
+        assert spec.chain_id == HIBACHI_CHAIN_ID
+        assert spec.vault_address == "hibachi-vault-3"
+        assert row["Protocol"] == "Hibachi"
+        assert row["Denomination"] == "USDT"
+
+        # 5. Merge into Parquet
+        combined_df = merge_into_uncleaned_parquet(db, parquet_path)
+
+        # 6. Parquet assertions
+        hibachi_rows = combined_df[combined_df["chain"] == HIBACHI_CHAIN_ID]
+        assert len(hibachi_rows) > 10
+        assert (hibachi_rows["address"] == "hibachi-vault-3").all()
+        assert hibachi_rows["share_price"].dtype.name == "float64"
+        assert hibachi_rows["chain"].dtype.name == "int32"
+    finally:
+        db.close()


### PR DESCRIPTION
## Why

Hibachi is a stablecoin-native FX / crypto perpetuals exchange with investment vaults (GAV, FLP). Adding it to the native vault metrics pipeline (alongside Hyperliquid, GRVT, Lighter) so Hibachi vaults appear in the unified vault scanner output (VaultDatabase pickle + cleaned Parquet + JSON export).

## Lessons learnt

- Hibachi data API (`data-api.hibachi.xyz`) is public with no auth or rate limiting observed
- Only `timeRange=All` works for performance data; sub-daily granularity parameters (`interval`, `granularity`, `resolution`) are silently ignored — daily is the only available resolution
- Vault-level fees are all zero (management, performance, deposit, withdrawal); the platform charges trading taker fees (0.045%) and deposit/withdrawal fees separately at the exchange level
- Currently 2 vaults: GAV (mean-reversion perps) and FLP (market making), both USDT-denominated

## Summary

**New `eth_defi/hibachi/` module:**
- `session.py` — `HibachiSession` subclass with retry logic
- `vault.py` — `HibachiVaultInfo` / `HibachiVaultDailyPrice` dataclasses, `fetch_vault_info()`, `fetch_vault_performance()` with UTC-safe date conversion
- `daily_metrics.py` — `HibachiDailyMetricsDatabase` (DuckDB) + `run_daily_scan()`
- `vault_data_export.py` — `create_hibachi_vault_row()`, `build_raw_prices_dataframe()`, VaultDatabase + Parquet merge functions
- `constants.py` — synthetic chain ID 9997, API URL, fee mode, lockup

**Pipeline wiring:**
- `scan_all_chains.py` — `scan_hibachi_fn()`, `SCAN_HIBACHI` env var, `run_scan_tick()`, `backup_pipeline_files()` defaults
- `post_processing.py` — `merge_hibachi` / `scan_hibachi` in `merge_native_protocols()` and `run_post_processing()`
- `post-process-prices.py` — `MERGE_HIBACHI` env var

**Infrastructure changes:**
- `utils.py` — `hibachi-vault-` prefix in `is_good_multichain_address()`
- `vault/base.py` — updated `VaultSpec` assertion message
- `erc_4626/core.py` — `ERC4626Feature.hibachi_native` + `get_vault_protocol_name()`
- `chain.py` — `CHAIN_NAMES[9997]` + `CHAIN_HOMEPAGES[9997]`
- `vault/fee.py` — `"Hibachi": VaultFeeMode.feeless`
- `vault/risk.py` — `"Hibachi": VaultTechnicalRisk.severe`
- `vault_metrics.py` — `"hibachi"` in `SPECIAL_VAULT_PROTOCOL_SLUGS`

**Tests:** 7 offline unit tests + 1 live integration smoke test (all passing)

**Docs:** Sphinx API stub, pipeline README, protocol metadata YAML, API reverse-engineering notes


🤖 Generated with [Claude Code](https://claude.com/claude-code)