### PR TITLE
fix: avoid duplicate Hibachi short descriptions

### DIFF
--- a/eth_defi/hibachi/vault_data_export.py
+++ b/eth_defi/hibachi/vault_data_export.py
@@ -43,6 +43,36 @@ from eth_defi.vault.vaultdb import VaultDatabase, VaultRow
 logger = logging.getLogger(__name__)
 
 
+def _create_short_description(name: str | None, description: str | None) -> str | None:
+    """Create a listing description that does not duplicate the vault name.
+
+    Hibachi's ``shortDescription`` API field is the vault display name, so
+    using it for both ``Name`` and ``_short_description`` repeats the title
+    in vault listings. Use the first sentence of the strategy description
+    instead, and return ``None`` if the source text is missing or still
+    matches the name.
+
+    :param name:
+        Vault display name.
+    :param description:
+        Long vault strategy description from the Hibachi API.
+    :return:
+        First strategy sentence, or ``None`` if no distinct short
+        description is available.
+    """
+    if not description:
+        return None
+
+    first_sentence = description.split(".", maxsplit=1)[0].strip()
+    if not first_sentence:
+        return None
+
+    if name and first_sentence.casefold() == name.strip().casefold():
+        return None
+
+    return f"{first_sentence}."
+
+
 def create_hibachi_vault_row(
     vault_id: int,
     symbol: str,
@@ -120,7 +150,7 @@ def create_hibachi_vault_row(
         "_flags": flags,
         "_lockup": HIBACHI_VAULT_LOCKUP,
         "_description": description,
-        "_short_description": name,
+        "_short_description": _create_short_description(name, description),
         "_available_liquidity": None,
         "_utilisation": None,
         "_deposit_closed_reason": None,

--- a/tests/hibachi/test_hibachi_vault.py
+++ b/tests/hibachi/test_hibachi_vault.py
@@ -282,6 +282,44 @@ def test_vault_spec_creation():
     assert row["Link"] == "https://hibachi.xyz/vaults"
     assert row["Mgmt fee"] == 0.0
     assert row["Perf fee"] == 0.0
+    assert row["Name"] == "Growi Alpha Vault"
+    assert row["_description"] == "Test description"
+    assert row["_short_description"] == "Test description."
+    assert row["_short_description"] != row["Name"]
+
+
+def test_vault_short_description_not_title_duplicate():
+    """Verify Hibachi vault listing description does not duplicate title.
+
+    1. Call ``create_hibachi_vault_row`` with a title-like name and longer
+       strategy description
+    2. Assert ``_short_description`` uses the strategy description
+    3. Assert ``_short_description`` is omitted when only duplicate text is
+       available
+    """
+    # 1. Create with distinct long description
+    _, row = create_hibachi_vault_row(
+        vault_id=3,
+        symbol="FLP",
+        name="Fire Liquidity Provider",
+        description="Market making across all Hibachi markets. Operated by Kappa Lab.",
+        tvl=750000.0,
+    )
+
+    # 2. Short description comes from the first strategy sentence, not title
+    assert row["Name"] == "Fire Liquidity Provider"
+    assert row["_short_description"] == "Market making across all Hibachi markets."
+    assert row["_short_description"] != row["Name"]
+
+    # 3. Duplicate-only source text is not repeated in the listing
+    _, duplicate_row = create_hibachi_vault_row(
+        vault_id=4,
+        symbol="DUP",
+        name="Duplicate Vault",
+        description="Duplicate Vault",
+        tvl=10.0,
+    )
+    assert duplicate_row["_short_description"] is None
 
 
 def test_run_post_processing_wiring(tmp_path: Path):


### PR DESCRIPTION
## Why

Hibachi vault metadata uses `shortDescription` as the vault display title. Exporting that same value as `_short_description` made vault listings repeat the title in the description slot.

## Lessons learnt

Hibachi's public API field names are slightly misleading: `shortDescription` is better treated as the vault name, while the first sentence of `description` is the useful listing summary.

## Summary

- Derive Hibachi `_short_description` from the first sentence of the strategy description.
- Suppress the short description when the available text still duplicates the title.
- Add regression coverage for distinct and duplicate short-description handling.