### PR TITLE
notes: flag Silo SiloId 149 USDC vault on Arbitrum as illiquid

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -448,6 +448,8 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0xaf68a0f0d2d4f82e671578ae6dd6a99de0e84cc6": (VaultFlag.malicious, MALICIOUS_VAULT),
     # Borrowable USDC Deposit, SiloId: 138
     "0x20abecf84ce707c3650b4e8afcf7ea1e22bbcd0c": (VaultFlag.illiquid, XUSD_MESSAGE),
+    # Borrowable USDC Deposit, SiloId: 149 (Arbitrum)
+    "0xa9a4bd976dbcfc2b89f554467ac85e2c758e2618": (VaultFlag.illiquid, XUSD_MESSAGE),
 }
 
 for addr in VAULT_FLAGS_AND_NOTES.keys():


### PR DESCRIPTION
## Why

Borrowable USDC Deposit, SiloId: 149 (`0xa9a4bd976dbcfc2b89f554467ac85e2c758e2618`) on Arbitrum is illiquid due to xUSD exposure, consistent with the many other Silo Finance USDC vaults already flagged in the blacklist.

## Lessons learnt

Silo Finance USDC vaults with xUSD exposure follow a recurring pattern — the same `XUSD_MESSAGE` and `VaultFlag.illiquid` applies.

## Summary

- Added `0xa9a4bd976dbcfc2b89f554467ac85e2c758e2618` to `VAULT_FLAGS_AND_NOTES` in `eth_defi/vault/flag.py` with `VaultFlag.illiquid` and `XUSD_MESSAGE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)