### PR TITLE
feat: add 40acres vaults on Optimism and Base, improve vault names

### DIFF
--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -1873,6 +1873,12 @@ HARDCODED_PROTOCOLS = {
     # 40acres - Pharaoh USDC vault on Avalanche
     # https://snowtrace.io/address/0x124d00b1ce4453ffc5a5f65ce83af13a7709bac7
     "0x124d00b1ce4453ffc5a5f65ce83af13a7709bac7": {ERC4626Feature.forty_acres_like},
+    # 40acres - Velodrome USDC vault on Optimism
+    # https://optimistic.etherscan.io/address/0x08dCDBf7baDe91Ccd42CB2a4EA8e5D199d285957
+    "0x08dcdbf7bade91ccd42cb2a4ea8e5d199d285957": {ERC4626Feature.forty_acres_like},
+    # 40acres - Aerodrome USDC vault on Base
+    # https://basescan.org/address/0xB99B6dDF96d4d5448cC0a5B3e0ef7896df9507Cf5
+    "0xb99b6ddf96d4d5448cc0a5b3e0ef7896df9507cf5": {ERC4626Feature.forty_acres_like},
 }
 
 for a in HARDCODED_PROTOCOLS.keys():

--- a/eth_defi/erc_4626/vault_protocol/forty_acres/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/forty_acres/vault.py
@@ -25,6 +25,7 @@ import logging
 
 from eth_typing import BlockIdentifier
 
+from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.vault import ERC4626Vault
 
 logger = logging.getLogger(__name__)
@@ -78,7 +79,19 @@ class FortyAcresVault(ERC4626Vault):
 
     - `Blackhole vault on Avalanche <https://snowtrace.io/address/0xc0485c4bafb594ae1457820fb6e5b67e8a04bcfd>`__
     - `Pharaoh vault on Avalanche <https://snowtrace.io/address/0x124d00b1ce4453ffc5a5f65ce83af13a7709bac7>`__
+    - `Velodrome vault on Optimism <https://optimistic.etherscan.io/address/0x08dCDBf7baDe91Ccd42CB2a4EA8e5D199d285957>`__
+    - `Aerodrome vault on Base <https://basescan.org/address/0xB99B6dDF96d4d5448cC0a5B3e0ef7896df9507Cf5>`__
     """
+
+    @property
+    def name(self) -> str:
+        """Return a human-readable name based on the chain.
+
+        On-chain ``name()`` returns cryptic strings like ``40op-USDC-Vault``.
+        We override to produce a consistent ``40acres on <Chain>`` format.
+        """
+        chain = get_chain_name(self.chain_id)
+        return f"40acres on {chain}"
 
     def get_management_fee(self, block_identifier: BlockIdentifier) -> float | None:
         """No explicit management fee on the vault contract.


### PR DESCRIPTION
## Why

40acres has deployed USDC supply vaults on two new chains — Velodrome on Optimism and Aerodrome on Base — which were missing from our hardcoded vault registry. Without the `forty_acres_like` feature flag these vaults would not be classified correctly.

Additionally, the on-chain `name()` for these vaults returns cryptic strings (e.g. `40op-USDC-Vault`) which are unhelpful for display. We override `name` in `FortyAcresVault` to produce a consistent `"40acres on <Chain>"` format using the existing `get_chain_name()` helper.

## Lessons learnt

- 40acres vaults on non-Avalanche chains need hardcoding just like the existing Avalanche ones — the auto-detection probe doesn't pick them up.
- On-chain vault names are protocol-specific and often cryptic; protocol subclasses should override `name` when the on-chain string is not user-facing.
- `@property` is preferable to `@cached_property` for trivial derived values (pure dict lookups) — no I/O means no caching benefit.

## Summary

- Added `0x08dcdbf7...` (Velodrome USDC vault, Optimism) and `0xb99b6ddf...` (Aerodrome USDC vault, Base) to `HARDCODED_PROTOCOLS` in `classification.py`
- Added `FortyAcresVault.name` property that returns `"40acres on {chain}"` (e.g. `"40acres on Base"`, `"40acres on Optimism"`, `"40acres on Avalanche"`)
- Updated class docstring to list all four known vaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)