### PR TITLE
fix: Lagoon deterministic Safe test — switch Arbitrum to Ethereum

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/lagoon/deployment.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/deployment.py
@@ -2110,9 +2110,12 @@ LAGOON_BEACON_PROXY_FACTORIES = {
         "abi": "lagoon/BeaconProxyFactory.json",
         "address": "0xC953Fd298FdfA8Ed0D38ee73772D3e21Bf19c61b",
     },
-    # Arbitrum
-    # 42161: "0x9De724B0efEe0FbA07FE21a16B9Bf9bBb5204Fb4",
-    # Arbitrum new
+    # Arbitrum — currently non-functional for new vault deployments.
+    # The ProtocolRegistry at 0x6dA4D1859bA1d02D095D2246142CdAd52233e27C was upgraded
+    # to a new implementation with a different storage layout, but the existing storage
+    # was never migrated.  As a result defaultLogic() and protocolFeeReceiver() both
+    # revert, causing createVaultProxy() to fail.
+    # Old factory: 0x9De724B0efEe0FbA07FE21a16B9Bf9bBb5204Fb4 (same registry, also broken)
     # Impl https://arbiscan.io/address/0xbb2de8e36eb36dbc20d71c503711763a4be3b1b2#readContract
     # Proxy https://arbiscan.io/address/0xb1ee4f77a1691696a737ab9852e389cf4cb1f1f5#writeProxyContract#F1
     42161: {

--- a/tests/safe/test_safe_deterministic_deploy.py
+++ b/tests/safe/test_safe_deterministic_deploy.py
@@ -3,6 +3,16 @@
 Verifies that:
 1. The raw helper produces the same Safe address on Base and Arbitrum forks
 2. The Lagoon automated deployment produces the same Safe address when given a salt nonce
+
+.. note::
+
+    The Lagoon vault test uses Base + Ethereum rather than Base + Arbitrum.
+    The Arbitrum ``ProtocolRegistry`` at ``0x6dA4D1859bA1d02D095D2246142CdAd52233e27C``
+    was upgraded to a new implementation whose storage layout differs from the
+    original, but without migrating the existing storage.  As a result
+    ``defaultLogic()`` and ``protocolFeeReceiver()`` both revert on Arbitrum,
+    making ``createVaultProxy`` impossible.  Ethereum uses the same factory
+    pattern and its registry is correctly initialised.
 """
 
 import logging
@@ -31,6 +41,7 @@ logger = logging.getLogger(__name__)
 
 JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
 JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
+JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 
 pytestmark = pytest.mark.skipif(
     not JSON_RPC_BASE or not JSON_RPC_ARBITRUM,
@@ -92,6 +103,26 @@ def web3_arbitrum(anvil_arbitrum) -> Web3:
         default_http_timeout=(3, 250.0),
     )
     assert web3.eth.chain_id == 42161
+    return web3
+
+
+@pytest.fixture()
+def anvil_ethereum(request) -> AnvilLaunch:
+    """Ethereum mainnet fork."""
+    launch = fork_network_anvil(JSON_RPC_ETHEREUM)
+    try:
+        yield launch
+    finally:
+        launch.close(log_level=logging.ERROR)
+
+
+@pytest.fixture()
+def web3_ethereum(anvil_ethereum) -> Web3:
+    web3 = create_multi_provider_web3(
+        anvil_ethereum.json_rpc_url,
+        default_http_timeout=(3, 250.0),
+    )
+    assert web3.eth.chain_id == 1
     return web3
 
 
@@ -159,16 +190,29 @@ def test_deterministic_safe_same_address_base_and_arbitrum(
     assert safe_arbitrum.retrieve_owners() == [Web3.to_checksum_address(a) for a in owners]
 
 
-def test_lagoon_deterministic_safe_base_and_arbitrum(
+@pytest.mark.skipif(
+    not JSON_RPC_BASE or not JSON_RPC_ETHEREUM,
+    reason="JSON_RPC_BASE and JSON_RPC_ETHEREUM environment variables required",
+)
+def test_lagoon_deterministic_safe_base_and_ethereum(
     web3_base: Web3,
-    web3_arbitrum: Web3,
+    web3_ethereum: Web3,
     deployer: LocalAccount,
 ):
-    """Deploy Lagoon automated vaults on Base and Arbitrum with deterministic Safe.
+    """Deploy Lagoon automated vaults on Base and Ethereum with deterministic Safe.
 
     - Both deployments use the same salt nonce
     - Verify the Safe addresses from deploy_automated_lagoon_vault() are identical across chains
     - Verify the vault addresses are (expectedly) different
+
+    .. note::
+
+        Uses Base + Ethereum rather than Base + Arbitrum.
+        The Arbitrum ``ProtocolRegistry`` was upgraded to an implementation with a
+        different storage layout without migrating storage.  As a result
+        ``defaultLogic()`` reverts on Arbitrum, so ``createVaultProxy`` always
+        fails there.  Ethereum uses the same ``OptinProxyFactory`` pattern and its
+        registry is correctly initialised.
 
     .. note::
 
@@ -180,11 +224,11 @@ def test_lagoon_deterministic_safe_base_and_arbitrum(
     salt_nonce = 42
 
     deployer_wallet_base = HotWallet(deployer)
-    deployer_wallet_arb = HotWallet(deployer)
+    deployer_wallet_eth = HotWallet(deployer)
 
     # Fund deployer on both chains
     web3_base.provider.make_request("anvil_setBalance", [deployer.address, hex(100 * 10**18)])
-    web3_arbitrum.provider.make_request("anvil_setBalance", [deployer.address, hex(100 * 10**18)])
+    web3_ethereum.provider.make_request("anvil_setBalance", [deployer.address, hex(100 * 10**18)])
 
     asset_manager = deployer.address
     safe_owners = [OWNER_1, OWNER_2]
@@ -212,18 +256,18 @@ def test_lagoon_deterministic_safe_base_and_arbitrum(
     base_vault_address = base_deploy.vault.address
     logger.info("Base: Safe=%s, Vault=%s", base_safe_address, base_vault_address)
 
-    # Deploy on Arbitrum
-    deployer_wallet_arb.sync_nonce(web3_arbitrum)
-    arb_params = LagoonDeploymentParameters(
-        underlying=USDC_NATIVE_TOKEN[42161],
+    # Deploy on Ethereum
+    deployer_wallet_eth.sync_nonce(web3_ethereum)
+    eth_params = LagoonDeploymentParameters(
+        underlying=USDC_NATIVE_TOKEN[1],
         name="Test Vault",
         symbol="TV",
     )
-    arb_deploy = deploy_automated_lagoon_vault(
-        web3=web3_arbitrum,
-        deployer=deployer_wallet_arb,
+    eth_deploy = deploy_automated_lagoon_vault(
+        web3=web3_ethereum,
+        deployer=deployer_wallet_eth,
         asset_manager=asset_manager,
-        parameters=arb_params,
+        parameters=eth_params,
         safe_owners=safe_owners,
         safe_threshold=2,
         uniswap_v2=None,
@@ -231,12 +275,12 @@ def test_lagoon_deterministic_safe_base_and_arbitrum(
         any_asset=True,
         safe_salt_nonce=salt_nonce,
     )
-    arb_safe_address = arb_deploy.vault.safe_address
-    arb_vault_address = arb_deploy.vault.address
-    logger.info("Arbitrum: Safe=%s, Vault=%s", arb_safe_address, arb_vault_address)
+    eth_safe_address = eth_deploy.vault.safe_address
+    eth_vault_address = eth_deploy.vault.address
+    logger.info("Ethereum: Safe=%s, Vault=%s", eth_safe_address, eth_vault_address)
 
     # Safe addresses must be the same
-    assert base_safe_address == arb_safe_address, f"Safe addresses differ: Base={base_safe_address}, Arbitrum={arb_safe_address}"
+    assert base_safe_address == eth_safe_address, f"Safe addresses differ: Base={base_safe_address}, Ethereum={eth_safe_address}"
 
     # Vault addresses should be different (different chain, different init code)
-    assert base_vault_address != arb_vault_address, "Vault addresses unexpectedly identical across chains"
+    assert base_vault_address != eth_vault_address, "Vault addresses unexpectedly identical across chains"


### PR DESCRIPTION
## Why

The CI test `test_lagoon_deterministic_safe_base_and_arbitrum` has been failing because the Lagoon `ProtocolRegistry` contract on Arbitrum is in a broken state.

**Root cause — storage layout mismatch after an implementation upgrade**

The `ProtocolRegistry` proxy at `0x6dA4D1859bA1d02D095D2246142CdAd52233e27C` was upgraded to a new implementation (`0xd8c3dfb8e47b153913fe217d6ff4c9ecc4bb5544`) on Arbitrum. The new implementation uses a different [ERC-7201 namespaced storage](https://eips.ethereum.org/EIPS/eip-7201) slot for the `_defaultLogic` and fee-related fields.

The proxy's storage was populated using the *old* layout (namespace slot `0x1f7af4bd…00` for `defaultLogic`). After the upgrade, the new implementation reads from a *different* slot (`0xda29f9cc…00`), which is empty. As a result:

- `defaultLogic()` reverts — the new implementation reads an empty slot and reverts rather than returning `address(0)`.
- `protocolFeeReceiver()` similarly reverts.

Evidence gathered during debugging:

| Call | Base | Arbitrum |
|------|------|----------|
| `registry.defaultLogic()` | `0xE50554ec…` ✅ | **reverts** ❌ |
| `registry.protocolFeeReceiver()` | `0x9A408Dc0…` ✅ | **reverts** ❌ |
| Storage at old slot `0x1f7af4bd…00` | `0xe50554ec…` | `0xe50554ec…` (data still there but unused) |
| Storage at new slot `0xda29f9cc…00` | empty | **empty** ← impl reads here |

The `OptinProxyFactory.createVaultProxy()` call internally calls `registry.defaultLogic()` (via the `OptinProxy` constructor when `_logic == address(0)`) and then calls `vault.initialize()` which calls `__FeeManager_init(feeRegistry)` which calls `feeRegistry.protocolFeeReceiver()`. Both paths revert, making vault deployment impossible on Arbitrum.

Both Arbitrum factories (`0x9De724…` — old, and `0xb1ee4f77…` — new) point to the *same* broken registry, so neither can deploy vaults currently.

Ethereum uses the same `OptinProxyFactory` pattern with the same registry address (`0x6dA4D1859…`) but was never upgraded to the new implementation, so both `defaultLogic()` and `protocolFeeReceiver()` work correctly there.

## Lessons learnt

- Upgrading a transparent proxy to an implementation that uses a different ERC-7201 storage namespace silently breaks all reads unless the storage is explicitly migrated.  The initialisation check (`initialized == 1`) does not protect view functions from reading the wrong (empty) namespace slot.
- When a factory has zero on-chain deployments and another factory of the same type with two deployments is available, the newer factory may still be broken — always verify the registry it points to actually works before switching.
- Debugging strategy: read the actual bytecode constants (`PUSH32` opcodes) to find the namespace slots the implementation uses, then compare those slots against the proxy storage to detect layout mismatches.

## Summary

- **`tests/safe/test_safe_deterministic_deploy.py`** — Renamed `test_lagoon_deterministic_safe_base_and_arbitrum` → `test_lagoon_deterministic_safe_base_and_ethereum`. Uses Ethereum (chain 1) as the second chain instead of Arbitrum. Added `JSON_RPC_ETHEREUM` env variable, `anvil_ethereum` and `web3_ethereum` fixtures, and a per-test `skipif` so the Arbitrum-only Safe test is unaffected.
- **`eth_defi/erc_4626/vault_protocol/lagoon/deployment.py`** — Added a detailed comment to `LAGOON_BEACON_PROXY_FACTORIES[42161]` explaining why Arbitrum vault deployment is currently non-functional, referencing the storage layout issue and noting that the old factory has the same problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)