### PR TITLE
fix: review broken RSS feeds

### DIFF
--- a/eth_defi/data/feeds/RSS-review.md
+++ b/eth_defi/data/feeds/RSS-review.md
@@ -1,0 +1,72 @@
+# RSS review
+
+Reviewed on 2026-05-05.
+
+This continues the broken RSS review started in `updated-tracking.md`.  The
+scope was YAML files carrying `rss-failure-at`, with special attention to
+whether the project is dead, the feed moved, or the failure is caused by the
+feed host returning non-RSS HTML/rate limits.
+
+Before this pass there were 69 YAML files with RSS failure stamps.  After the
+feed fixes there were 44 remaining Medium-style rate-limit stamps.  These were
+reset on 2026-05-05, because the URL often works on retry but Medium rate
+limits automated collection.
+
+## Updated feeds
+
+| Files | Finding | Change |
+|-------|---------|--------|
+| `stablecoins/usde.yaml`, `stablecoins/usdtb.yaml`, `stablecoins/susde.yaml` | Ethena is active.  The old Mirror feed now redirects to Paragraph and can return 429 through the redirect path. | Replaced Mirror URL with direct Paragraph RSS: `https://api.paragraph.com/blogs/rss/@ethena-labs`. |
+| `stablecoins/pyusd.yaml` | PayPal USD is active.  The old PayPal newsroom query URL now returns HTML. | Replaced with the current cryptocurrency newsroom RSS: `https://newsroom.paypal-corp.com/news-cryptocurrency?pagetemplate=rss`. |
+| `stablecoins/ageur.yaml`, `stablecoins/eura.yaml`, `stablecoins/stusd.yaml`, `stablecoins/usda.yaml` | Angle is winding down the stablecoins, but its blog feed moved from stale Medium entries to Paragraph. | Replaced Medium RSS with `https://api.paragraph.com/blogs/rss/@angleprotocol`. |
+| `stablecoins/cdai.yaml`, `stablecoins/cusdc.yaml`, `stablecoins/cusdt.yaml` | Compound is active.  Medium is stale; active updates are on the governance forum. | Replaced Medium RSS with `https://www.comp.xyz/latest.rss`. |
+| `stablecoins/adai.yaml`, `stablecoins/gho.yaml` | Aave is active.  Medium is stale; active updates are on governance/forum RSS. | Replaced Medium RSS with `https://governance.aave.com/latest.rss`. |
+| `protocols/gains-network.yaml`, `stablecoins/gdai.yaml` | Gains Network is active.  Medium is stale; active updates are on governance/forum RSS. | Replaced Medium RSS with `https://gov.gains.trade/latest.rss`. |
+| `stablecoins/eusd-reserve.yaml` | Reserve blog RSS is alive.  The stored 429 was transient. | Removed stale RSS failure fields. |
+| `stablecoins/csusd.yaml` | cSigma is active.  Medium RSS still parses; the official website blog has no RSS endpoint. | Removed stale RSS failure fields and added a note. |
+| `stablecoins/vbusdc.yaml`, `stablecoins/vbusdt.yaml` | Katana is active.  Official blog is active but no RSS endpoint was found; Medium remains the only RSS source. | Removed stale RSS failure fields and added a note. |
+
+## Disabled feeds
+
+| Files | Finding | Change |
+|-------|---------|--------|
+| `curators/pareto-technologies.yaml` | Project is not dead.  Beehiiv archive and company site are live, but `/feed.xml` returns an HTML 404 page with HTTP 200. | Commented out RSS and added a note. |
+| `protocols/euler.yaml` | Euler is active.  `newsletter.euler.finance/feed` redirects to the Euler homepage HTML; current blog has no advertised RSS. | Commented out RSS and added a note. |
+| `stablecoins/rusd-ipor.yaml` | Reservoir is not dead.  Beehiiv archive is live, but `/feed` returns an HTML 404 page with HTTP 200. | Commented out RSS and added a note. |
+| `stablecoins/usdxl.yaml` | HypurrFi is not dead.  Beehiiv archive is live, including 2026 posts, but `/feed` returns an HTML 404 page with HTTP 200. | Commented out RSS and added a note. |
+| `stablecoins/gyen.yaml`, `stablecoins/zusd.yaml` | GMO Trust pages are active, but Medium is stale and the official press page has no RSS endpoint. | Commented out stale Medium RSS and added notes. |
+| `stablecoins/jchf.yaml`, `stablecoins/jeur.yaml` | Jarvis Medium is historical and the project appears inactive. | Kept `rss-dead-at`, removed stale failure fields, and added notes. |
+
+## Reset rate limits
+
+The remaining `rss-failure-at` fields were reset on 2026-05-05.  They were
+mostly Medium feeds that previously returned HTTP 429.  A live batch check
+showed many of these return valid XML when not rate limited, and some return
+HTTP 403 after a burst of requests from the same client.  Treat future 429/403
+errors from these hosts as platform/rate-limit failures unless another pass
+finds a clear replacement feed or a dead project.
+
+Examples that still need individual judgement:
+
+- `protocols/ipor-fusion.yaml`: Medium source appears alive/rate-limited.
+- `protocols/morpho.yaml`: Medium is historical; Morpho has an active blog but
+  no RSS endpoint was found.
+- `stablecoins/usdm.yaml`: Mountain Protocol is winding down, but the old
+  Medium feed failure is still a Medium rate-limit case.
+- `stablecoins/musd.yaml`, `stablecoins/rai.yaml`, `stablecoins/ousd.yaml`,
+  `stablecoins/usdr.yaml`: likely inactive or historical projects, but these
+  need a separate dead-project pass before disabling RSS.
+
+## Evidence checked
+
+- `https://api.paragraph.com/blogs/rss/@ethena-labs`
+- `https://api.paragraph.com/blogs/rss/@angleprotocol`
+- `https://newsroom.paypal-corp.com/news-cryptocurrency?pagetemplate=rss`
+- `https://www.comp.xyz/latest.rss`
+- `https://governance.aave.com/latest.rss`
+- `https://gov.gains.trade/latest.rss`
+- `https://blog.reserve.org/feed`
+- `https://paretotechnologies.beehiiv.com/feed.xml`
+- `https://reservoir.beehiiv.com/feed`
+- `https://hypurrfi.beehiiv.com/feed`
+- `https://newsletter.euler.finance/feed`

--- a/eth_defi/data/feeds/curators/ignight-capital.yaml
+++ b/eth_defi/data/feeds/curators/ignight-capital.yaml
@@ -6,6 +6,3 @@ twitter: IgnightCapital
 linkedin: ignightcapital
 rss: https://medium.com/feed/@ignightcapital
 linkedin-rss-hub-disabled-at: 2026-04-04
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/@ignightcapital"

--- a/eth_defi/data/feeds/curators/pareto-technologies.yaml
+++ b/eth_defi/data/feeds/curators/pareto-technologies.yaml
@@ -3,6 +3,4 @@ name: Pareto Technologies
 role: curator
 website: https://paretotechnologies.com
 linkedin: pareto-technologies-llc
-rss: https://paretotechnologies.beehiiv.com/feed.xml
-rss-failure-at: 2026-04-30
-rss-failure-exception-message: "Feed parse failed for https://paretotechnologies.beehiiv.com/feed.xml: <unknown>:109:918: not well-formed (invalid token)"
+# rss: https://paretotechnologies.beehiiv.com/feed.xml  # Beehiiv archive is active, but /feed and /feed.xml return HTML 404 pages as of 2026-05.

--- a/eth_defi/data/feeds/curators/sentora.yaml
+++ b/eth_defi/data/feeds/curators/sentora.yaml
@@ -5,6 +5,3 @@ website: https://sentora.com
 twitter: SentoraHQ
 linkedin: sentorahq
 rss: https://medium.com/feed/sentora
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/sentora"

--- a/eth_defi/data/feeds/protocols/aarna.yaml
+++ b/eth_defi/data/feeds/protocols/aarna.yaml
@@ -6,6 +6,3 @@ twitter: aarnasays
 linkedin: aarna-finance
 rss: https://medium.com/feed/@aarna_finance
 linkedin-rss-hub-disabled-at: 2026-04-04
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/@aarna_finance"

--- a/eth_defi/data/feeds/protocols/d2-finance.yaml
+++ b/eth_defi/data/feeds/protocols/d2-finance.yaml
@@ -6,6 +6,3 @@ twitter: D2_Finance
 linkedin: d2finance
 rss: https://medium.com/feed/@D2.Finance
 linkedin-rss-hub-disabled-at: 2026-04-04
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/@D2.Finance"

--- a/eth_defi/data/feeds/protocols/decentralized-usd.yaml
+++ b/eth_defi/data/feeds/protocols/decentralized-usd.yaml
@@ -4,6 +4,3 @@ role: protocol
 website: https://usdd.io/
 twitter: usddio
 rss: https://medium.com/feed/@usddio
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/@usddio"

--- a/eth_defi/data/feeds/protocols/dolomite.yaml
+++ b/eth_defi/data/feeds/protocols/dolomite.yaml
@@ -6,6 +6,3 @@ twitter: dolomite_io
 linkedin: dolomiteio
 rss: https://medium.com/feed/dolomite-official
 linkedin-rss-hub-disabled-at: 2026-04-04
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/dolomite-official"

--- a/eth_defi/data/feeds/protocols/euler.yaml
+++ b/eth_defi/data/feeds/protocols/euler.yaml
@@ -4,6 +4,4 @@ role: protocol
 website: https://www.euler.finance/
 twitter: eulerfinance
 linkedin: euler-xyz
-rss: https://newsletter.euler.finance/feed
-rss-failure-at: 2026-04-30
-rss-failure-exception-message: "Feed parse failed for https://newsletter.euler.finance/feed: <unknown>:2:219721: not well-formed (invalid token)"
+# rss: https://newsletter.euler.finance/feed  # Redirects to euler.finance HTML; active website blog has no RSS endpoint as of 2026-05.

--- a/eth_defi/data/feeds/protocols/foxify.yaml
+++ b/eth_defi/data/feeds/protocols/foxify.yaml
@@ -5,6 +5,3 @@ website: https://www.foxify.trade/
 twitter: foxifytrade
 # linkedin: not found
 rss: https://medium.com/feed/@foxifytrade
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/@foxifytrade"

--- a/eth_defi/data/feeds/protocols/gains-network.yaml
+++ b/eth_defi/data/feeds/protocols/gains-network.yaml
@@ -4,7 +4,5 @@ role: protocol
 website: https://gains.trade/
 twitter: GainsNetwork_io
 # linkedin: not found
-rss: https://medium.com/feed/gains-network
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/gains-network"
+# Gains Medium is stale; use the active governance/forum RSS.
+rss: https://gov.gains.trade/latest.rss

--- a/eth_defi/data/feeds/protocols/harvest-finance.yaml
+++ b/eth_defi/data/feeds/protocols/harvest-finance.yaml
@@ -6,6 +6,3 @@ twitter: harvest_finance
 linkedin: harvestdotfinance
 rss: https://medium.com/feed/harvest-finance
 linkedin-rss-hub-disabled-at: 2026-04-04
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/harvest-finance"

--- a/eth_defi/data/feeds/protocols/hyperlend.yaml
+++ b/eth_defi/data/feeds/protocols/hyperlend.yaml
@@ -5,6 +5,3 @@ website: https://hyperlend.finance/
 twitter: hyperlendx
 # linkedin: not found
 rss: https://medium.com/feed/@hyperlendx
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/@hyperlendx"

--- a/eth_defi/data/feeds/protocols/ipor-fusion.yaml
+++ b/eth_defi/data/feeds/protocols/ipor-fusion.yaml
@@ -5,6 +5,3 @@ website: https://www.ipor.io/
 twitter: ipor_io
 linkedin: iporlabs
 rss: https://medium.com/feed/ipor-labs
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/ipor-labs"

--- a/eth_defi/data/feeds/protocols/plutus.yaml
+++ b/eth_defi/data/feeds/protocols/plutus.yaml
@@ -4,6 +4,3 @@ role: protocol
 website: https://plutus.fi/
 twitter: plutus_fi_x
 rss: https://medium.com/feed/@plutus.fi
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/@plutus.fi"

--- a/eth_defi/data/feeds/protocols/secured-finance.yaml
+++ b/eth_defi/data/feeds/protocols/secured-finance.yaml
@@ -5,6 +5,3 @@ website: https://secured.finance/
 twitter: Secured_Fi
 linkedin: securedfinance
 rss: https://medium.com/feed/secured-finance
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/secured-finance"

--- a/eth_defi/data/feeds/protocols/silo-finance.yaml
+++ b/eth_defi/data/feeds/protocols/silo-finance.yaml
@@ -4,6 +4,3 @@ role: protocol
 website: https://silo.finance/
 twitter: SiloFinance
 rss: https://silofinance.medium.com/feed
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://silofinance.medium.com/feed"

--- a/eth_defi/data/feeds/protocols/superform.yaml
+++ b/eth_defi/data/feeds/protocols/superform.yaml
@@ -5,6 +5,3 @@ website: https://www.superform.xyz/
 twitter: Superformxyz
 linkedin: superformxyz
 rss: https://medium.com/feed/@superformco
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/@superformco"

--- a/eth_defi/data/feeds/protocols/yieldfi.yaml
+++ b/eth_defi/data/feeds/protocols/yieldfi.yaml
@@ -5,6 +5,3 @@ website: https://yield.fi/
 twitter: getyieldfi
 linkedin: yieldfi
 rss: https://medium.com/feed/@YieldFi
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/@YieldFi"

--- a/eth_defi/data/feeds/protocols/yuzu-money.yaml
+++ b/eth_defi/data/feeds/protocols/yuzu-money.yaml
@@ -5,6 +5,3 @@ website: https://yuzu.money/
 twitter: YuzuMoneyX
 linkedin: yuzu-money
 rss: https://yuzumoney.medium.com/feed
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://yuzumoney.medium.com/feed"

--- a/eth_defi/data/feeds/stablecoins/adai.yaml
+++ b/eth_defi/data/feeds/stablecoins/adai.yaml
@@ -4,9 +4,6 @@ role: stablecoin
 website: https://aave.com/
 twitter: aave
 linkedin: aaveaave
-rss: https://medium.com/feed/aave
+# Aave Medium is stale; use the active governance/forum RSS.
+rss: https://governance.aave.com/latest.rss
 linkedin-rss-hub-disabled-at: 2026-04-04
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/aave"
-rss-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/stablecoins/ageur.yaml
+++ b/eth_defi/data/feeds/stablecoins/ageur.yaml
@@ -4,8 +4,5 @@ role: stablecoin
 website: https://www.angle.money/
 twitter: AngleProtocol
 linkedin: angle-labs
-rss: https://medium.com/feed/angle-protocol
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/angle-protocol"
-rss-dead-at: 2026-04-06
+# Angle blog moved from Medium to Paragraph.
+rss: https://api.paragraph.com/blogs/rss/@angleprotocol

--- a/eth_defi/data/feeds/stablecoins/alusd.yaml
+++ b/eth_defi/data/feeds/stablecoins/alusd.yaml
@@ -4,6 +4,3 @@ role: stablecoin
 website: https://alchemix.fi/
 twitter: AlchemixFi
 rss: https://medium.com/feed/@alchemixfi
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/@alchemixfi"

--- a/eth_defi/data/feeds/stablecoins/bean.yaml
+++ b/eth_defi/data/feeds/stablecoins/bean.yaml
@@ -4,8 +4,5 @@ role: stablecoin
 website: https://bean.money/
 twitter: BeanstalkFarms
 rss: https://medium.com/feed/beanstalkfarms
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/beanstalkfarms"
 rss-dead-at: 2026-04-06
 twitter-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/stablecoins/cadc.yaml
+++ b/eth_defi/data/feeds/stablecoins/cadc.yaml
@@ -5,7 +5,4 @@ website: https://paytrie.com/
 twitter: Paytrie
 linkedin: paytrie
 rss: https://medium.com/feed/paytrie
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/paytrie"
 rss-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/stablecoins/cdai.yaml
+++ b/eth_defi/data/feeds/stablecoins/cdai.yaml
@@ -4,10 +4,7 @@ role: stablecoin
 website: https://compound.finance/
 twitter: compoundfinance
 linkedin: compound-labs
-rss: https://medium.com/feed/compound-finance
+# Compound Medium is stale; use the active governance/forum RSS.
+rss: https://www.comp.xyz/latest.rss
 linkedin-rss-hub-disabled-at: 2026-04-04
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/compound-finance"
-rss-dead-at: 2026-04-06
 twitter-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/stablecoins/csusd.yaml
+++ b/eth_defi/data/feeds/stablecoins/csusd.yaml
@@ -4,8 +4,6 @@ role: stablecoin
 website: https://www.csigma.finance/
 twitter: csigmafinance
 linkedin: csigma-finance-inc
+# Medium feed is still the working RSS source; official website blog has no RSS endpoint as of 2026-05.
 rss: https://medium.com/feed/@csigma
 linkedin-rss-hub-disabled-at: 2026-04-04
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/@csigma"

--- a/eth_defi/data/feeds/stablecoins/cusdc.yaml
+++ b/eth_defi/data/feeds/stablecoins/cusdc.yaml
@@ -4,10 +4,7 @@ role: stablecoin
 website: https://compound.finance/
 twitter: compoundfinance
 linkedin: compound-labs
-rss: https://medium.com/feed/compound-finance
+# Compound Medium is stale; use the active governance/forum RSS.
+rss: https://www.comp.xyz/latest.rss
 linkedin-rss-hub-disabled-at: 2026-04-04
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/compound-finance"
-rss-dead-at: 2026-04-06
 twitter-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/stablecoins/cusdt.yaml
+++ b/eth_defi/data/feeds/stablecoins/cusdt.yaml
@@ -4,10 +4,7 @@ role: stablecoin
 website: https://compound.finance/
 twitter: compoundfinance
 linkedin: compound-labs
-rss: https://medium.com/feed/compound-finance
+# Compound Medium is stale; use the active governance/forum RSS.
+rss: https://www.comp.xyz/latest.rss
 linkedin-rss-hub-disabled-at: 2026-04-04
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/compound-finance"
-rss-dead-at: 2026-04-06
 twitter-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/stablecoins/djed.yaml
+++ b/eth_defi/data/feeds/stablecoins/djed.yaml
@@ -5,6 +5,3 @@ website: https://djed.xyz/
 twitter: DjedStablecoin
 linkedin: coti-ltd
 rss: https://medium.com/feed/cotinetwork
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/cotinetwork"

--- a/eth_defi/data/feeds/stablecoins/eosdt.yaml
+++ b/eth_defi/data/feeds/stablecoins/eosdt.yaml
@@ -6,8 +6,5 @@ twitter: EquilibriumDeFi
 linkedin: equilibrium-eosdt
 rss: https://medium.com/feed/equilibrium-eosdt
 linkedin-rss-hub-disabled-at: 2026-04-04
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/equilibrium-eosdt"
 rss-dead-at: 2026-04-06
 twitter-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/stablecoins/eura.yaml
+++ b/eth_defi/data/feeds/stablecoins/eura.yaml
@@ -4,8 +4,5 @@ role: stablecoin
 website: https://www.angle.money/
 twitter: AngleProtocol
 linkedin: angle-labs
-rss: https://medium.com/feed/angle-protocol
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/angle-protocol"
-rss-dead-at: 2026-04-06
+# Angle blog moved from Medium to Paragraph.
+rss: https://api.paragraph.com/blogs/rss/@angleprotocol

--- a/eth_defi/data/feeds/stablecoins/eurs.yaml
+++ b/eth_defi/data/feeds/stablecoins/eurs.yaml
@@ -5,9 +5,6 @@ website: https://stasis.net/
 twitter: stasisnet
 linkedin: stasisnet
 rss: https://medium.com/feed/stasis-blog
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/stasis-blog"
 rss-dead-at: 2026-04-06
 twitter-dead-at: 2026-04-06
 linkedin-rss-hub-disabled-at: 2026-04-22

--- a/eth_defi/data/feeds/stablecoins/eusd-reserve.yaml
+++ b/eth_defi/data/feeds/stablecoins/eusd-reserve.yaml
@@ -5,6 +5,3 @@ website: https://app.reserve.org/
 twitter: reserveprotocol
 linkedin: reserveprotocol
 rss: https://blog.reserve.org/feed
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://blog.reserve.org/feed"

--- a/eth_defi/data/feeds/stablecoins/eusd.yaml
+++ b/eth_defi/data/feeds/stablecoins/eusd.yaml
@@ -6,7 +6,4 @@ twitter: LybraFinance
 linkedin: lybra
 rss: https://medium.com/feed/@Lybra_Finance
 linkedin-rss-hub-disabled-at: 2026-04-04
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/@Lybra_Finance"
 rss-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/stablecoins/gdai.yaml
+++ b/eth_defi/data/feeds/stablecoins/gdai.yaml
@@ -4,8 +4,6 @@ role: stablecoin
 website: https://gains.trade/
 twitter: GainsNetwork_io
 linkedin: gains-network
-rss: https://medium.com/feed/gains-network
+# Gains Medium is stale; use the active governance/forum RSS.
+rss: https://gov.gains.trade/latest.rss
 linkedin-rss-hub-disabled-at: 2026-04-04
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/gains-network"

--- a/eth_defi/data/feeds/stablecoins/gho.yaml
+++ b/eth_defi/data/feeds/stablecoins/gho.yaml
@@ -4,8 +4,5 @@ role: stablecoin
 website: https://aave.com/
 twitter: aave
 linkedin: aavelabs
-rss: https://medium.com/feed/aave
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/aave"
-rss-dead-at: 2026-04-06
+# Aave Medium is stale; use the active governance/forum RSS.
+rss: https://governance.aave.com/latest.rss

--- a/eth_defi/data/feeds/stablecoins/gyd.yaml
+++ b/eth_defi/data/feeds/stablecoins/gyd.yaml
@@ -5,6 +5,3 @@ website: https://www.gyro.finance/
 twitter: GyroscopeFi
 rss: https://medium.com/feed/gyroscope-protocol
 twitter-dead-at: 2026-04-06
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/gyroscope-protocol"

--- a/eth_defi/data/feeds/stablecoins/gyen.yaml
+++ b/eth_defi/data/feeds/stablecoins/gyen.yaml
@@ -4,7 +4,4 @@ role: stablecoin
 website: https://stablecoin.z.com/gyen
 twitter: GMOTrust
 linkedin: gmo-z-com-trust-company
-rss: https://medium.com/feed/gmo-z-com-trust-company
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/gmo-z-com-trust-company"
+# rss: https://medium.com/feed/gmo-z-com-trust-company  # Medium is stale; official press page is active but has no RSS endpoint as of 2026-05.

--- a/eth_defi/data/feeds/stablecoins/jchf.yaml
+++ b/eth_defi/data/feeds/stablecoins/jchf.yaml
@@ -4,9 +4,7 @@ role: stablecoin
 website: https://www.jarvis.network/
 twitter: Jarvis_Network
 linkedin: jarvis-network
+# Jarvis Medium is historical and the project appears inactive; keep RSS disabled.
 rss: https://medium.com/feed/jarvis-network
 linkedin-rss-hub-disabled-at: 2026-04-04
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/jarvis-network"
 rss-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/stablecoins/jeur.yaml
+++ b/eth_defi/data/feeds/stablecoins/jeur.yaml
@@ -4,9 +4,7 @@ role: stablecoin
 website: https://www.jarvis.network/
 twitter: Jarvis_Network
 linkedin: jarvis-network
+# Jarvis Medium is historical and the project appears inactive; keep RSS disabled.
 rss: https://medium.com/feed/jarvis-network
 linkedin-rss-hub-disabled-at: 2026-04-04
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/jarvis-network"
 rss-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/stablecoins/lisusd.yaml
+++ b/eth_defi/data/feeds/stablecoins/lisusd.yaml
@@ -4,6 +4,3 @@ role: stablecoin
 website: https://lista.org/
 twitter: lista_dao
 rss: https://medium.com/feed/listadao
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/listadao"

--- a/eth_defi/data/feeds/stablecoins/mimatic.yaml
+++ b/eth_defi/data/feeds/stablecoins/mimatic.yaml
@@ -4,7 +4,4 @@ role: stablecoin
 website: https://www.mai.finance/
 twitter: QiDaoProtocol
 rss: https://qidaoprotocol.medium.com/feed
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://qidaoprotocol.medium.com/feed"
 rss-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/stablecoins/musd.yaml
+++ b/eth_defi/data/feeds/stablecoins/musd.yaml
@@ -6,6 +6,3 @@ twitter: mstable_
 linkedin: stability-labs
 rss: https://medium.com/feed/mstable
 linkedin-rss-hub-disabled-at: 2026-04-04
-rss-failure-at: 2026-04-10
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/mstable"

--- a/eth_defi/data/feeds/stablecoins/ousd.yaml
+++ b/eth_defi/data/feeds/stablecoins/ousd.yaml
@@ -5,7 +5,4 @@ website: https://www.originprotocol.com/ousd
 twitter: OriginProtocol
 linkedin: originprotocol
 rss: https://medium.com/feed/originprotocol
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/originprotocol"
 rss-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/stablecoins/pyusd.yaml
+++ b/eth_defi/data/feeds/stablecoins/pyusd.yaml
@@ -4,6 +4,5 @@ role: stablecoin
 website: https://www.paypal.com/pyusd
 twitter: PayPal
 linkedin: paypal
-rss: https://newsroom.paypal-corp.com/index.php?s=20324&rsspage=20325
-rss-failure-at: 2026-04-30
-rss-failure-exception-message: "Feed parse failed for https://newsroom.paypal-corp.com/index.php?s=20324&rsspage=20325: <unknown>:3:0: syntax error"
+# PayPal newsroom RSS moved from the old index.php query endpoint to pagetemplate=rss.
+rss: https://newsroom.paypal-corp.com/news-cryptocurrency?pagetemplate=rss

--- a/eth_defi/data/feeds/stablecoins/rai.yaml
+++ b/eth_defi/data/feeds/stablecoins/rai.yaml
@@ -6,7 +6,4 @@ twitter: reflexerfinance
 linkedin: reflexer-labs
 rss: https://medium.com/feed/reflexer-labs
 linkedin-rss-hub-disabled-at: 2026-04-04
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/reflexer-labs"
 rss-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/stablecoins/rusd-ipor.yaml
+++ b/eth_defi/data/feeds/stablecoins/rusd-ipor.yaml
@@ -4,8 +4,6 @@ role: stablecoin
 website: https://reservoir.xyz/
 twitter: __reservoir
 linkedin: fortunafi
-rss: https://reservoir.beehiiv.com/feed
 linkedin-rss-hub-disabled-at: 2026-04-04
 twitter-dead-at: 2026-04-06
-rss-failure-at: 2026-04-30
-rss-failure-exception-message: "Feed parse failed for https://reservoir.beehiiv.com/feed: <unknown>:109:918: not well-formed (invalid token)"
+# rss: https://reservoir.beehiiv.com/feed  # Beehiiv archive is active, but /feed returns an HTML 404 page as of 2026-05.

--- a/eth_defi/data/feeds/stablecoins/stusd.yaml
+++ b/eth_defi/data/feeds/stablecoins/stusd.yaml
@@ -4,8 +4,5 @@ role: stablecoin
 website: https://www.angle.money/
 twitter: AngleProtocol
 linkedin: angle-labs
-rss: https://medium.com/feed/angle-protocol
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/angle-protocol"
-rss-dead-at: 2026-04-06
+# Angle blog moved from Medium to Paragraph.
+rss: https://api.paragraph.com/blogs/rss/@angleprotocol

--- a/eth_defi/data/feeds/stablecoins/susde.yaml
+++ b/eth_defi/data/feeds/stablecoins/susde.yaml
@@ -1,9 +1,9 @@
 # Twitter handle changed from ethena_labs to ethena (website footer links to x.com/ethena)
-# Blog moved from ethena.fi/blog/feed (broken HTML, not RSS) to Mirror.xyz/Paragraph
+# Blog moved from ethena.fi/blog/feed (broken HTML, not RSS) to Paragraph.
 feeder-id: susde
 name: Ethena Staked USDe
 role: stablecoin
 website: https://ethena.fi/
 twitter: ethena
 linkedin: ethena-labs
-rss: https://mirror.xyz/0xF99d0E4E3435cc9C9868D1C6274DfaB3e2721341/feed/atom
+rss: https://api.paragraph.com/blogs/rss/@ethena-labs

--- a/eth_defi/data/feeds/stablecoins/susg.yaml
+++ b/eth_defi/data/feeds/stablecoins/susg.yaml
@@ -4,7 +4,4 @@ role: stablecoin
 website: https://www.tangent.finance/
 twitter: Tangent_fi
 rss: https://medium.com/feed/tangent-finance
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/tangent-finance"
 rss-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/stablecoins/usc.yaml
+++ b/eth_defi/data/feeds/stablecoins/usc.yaml
@@ -4,7 +4,4 @@ role: stablecoin
 website: https://orby.network/
 twitter: OrbyNetwork
 rss: https://orbynetwork.medium.com/feed
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://orbynetwork.medium.com/feed"
 rss-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/stablecoins/usd-plus.yaml
+++ b/eth_defi/data/feeds/stablecoins/usd-plus.yaml
@@ -5,6 +5,3 @@ website: https://overnight.fi/
 twitter: overnight_fi
 linkedin: overnightfi
 rss: https://overnightdefi.medium.com/feed
-rss-failure-at: 2026-04-10
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://overnightdefi.medium.com/feed"

--- a/eth_defi/data/feeds/stablecoins/usda.yaml
+++ b/eth_defi/data/feeds/stablecoins/usda.yaml
@@ -2,7 +2,7 @@
 # Redemption at 1:1 until March 2027, protocol ceasing operations after
 # Team now focuses on Merkl incentive platform
 # blog.angle.money custom domain DNS is dead, but Medium publication still exists
-# RSS feed available at medium.com/feed/angle-protocol (last posts from 2022)
+# RSS feed moved from Medium to Paragraph.
 # Twitter @AngleProtocol confirmed active and correct
 feeder-id: usda
 name: Angle USDA
@@ -10,5 +10,4 @@ role: stablecoin
 website: https://www.angle.money/
 twitter: AngleProtocol
 linkedin: angle-labs
-rss: https://medium.com/feed/angle-protocol
-rss-dead-at: 2026-04-06
+rss: https://api.paragraph.com/blogs/rss/@angleprotocol

--- a/eth_defi/data/feeds/stablecoins/usdd.yaml
+++ b/eth_defi/data/feeds/stablecoins/usdd.yaml
@@ -5,6 +5,3 @@ website: https://usdd.io/
 twitter: usddio
 linkedin: trondao
 rss: https://trondao.medium.com/feed
-rss-failure-at: 2026-04-10
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://trondao.medium.com/feed"

--- a/eth_defi/data/feeds/stablecoins/usde.yaml
+++ b/eth_defi/data/feeds/stablecoins/usde.yaml
@@ -1,12 +1,9 @@
 # Twitter handle changed from ethena_labs to ethena (website footer links to x.com/ethena)
-# Blog moved from ethena.fi/blog/feed (broken HTML, not RSS) to Mirror.xyz/Paragraph
+# Blog moved from ethena.fi/blog/feed (broken HTML, not RSS) to Paragraph.
 feeder-id: usde
 name: Ethena USDe
 role: stablecoin
 website: https://ethena.fi/
 twitter: ethena
 linkedin: ethena-labs
-rss: https://mirror.xyz/0xF99d0E4E3435cc9C9868D1C6274DfaB3e2721341/feed/atom
-rss-failure-at: 2026-04-30
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://mirror.xyz/0xF99d0E4E3435cc9C9868D1C6274DfaB3e2721341/feed/atom"
+rss: https://api.paragraph.com/blogs/rss/@ethena-labs

--- a/eth_defi/data/feeds/stablecoins/usdm.yaml
+++ b/eth_defi/data/feeds/stablecoins/usdm.yaml
@@ -7,6 +7,3 @@ twitter: MountainUSDM
 linkedin: mountain-protocol
 rss: https://medium.com/feed/@MountainUSDM
 twitter-dead-at: 2026-04-06
-rss-failure-at: 2026-04-10
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/@MountainUSDM"

--- a/eth_defi/data/feeds/stablecoins/usdr.yaml
+++ b/eth_defi/data/feeds/stablecoins/usdr.yaml
@@ -5,6 +5,3 @@ website: https://www.re.al/
 twitter: tangibleDAO
 rss: https://medium.com/feed/tangible
 twitter-dead-at: 2026-04-06
-rss-failure-at: 2026-04-10
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/tangible"

--- a/eth_defi/data/feeds/stablecoins/usds-sperax.yaml
+++ b/eth_defi/data/feeds/stablecoins/usds-sperax.yaml
@@ -5,7 +5,4 @@ website: https://sperax.io/
 twitter: SperaxUSD
 linkedin: sperax
 rss: https://medium.com/feed/sperax
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/sperax"
 rss-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/stablecoins/usdtb.yaml
+++ b/eth_defi/data/feeds/stablecoins/usdtb.yaml
@@ -1,12 +1,9 @@
 # Twitter handle changed from ethena_labs to ethena (website footer links to x.com/ethena)
-# Blog moved from ethena.fi/blog/feed (broken HTML, not RSS) to Mirror.xyz/Paragraph
+# Blog moved from ethena.fi/blog/feed (broken HTML, not RSS) to Paragraph.
 feeder-id: usdtb
 name: Ethena USDtb
 role: stablecoin
 website: https://usdtb.money/
 twitter: ethena
 linkedin: ethena-labs
-rss: https://mirror.xyz/0xF99d0E4E3435cc9C9868D1C6274DfaB3e2721341/feed/atom
-rss-failure-at: 2026-04-30
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://mirror.xyz/0xF99d0E4E3435cc9C9868D1C6274DfaB3e2721341/feed/atom"
+rss: https://api.paragraph.com/blogs/rss/@ethena-labs

--- a/eth_defi/data/feeds/stablecoins/usdxl.yaml
+++ b/eth_defi/data/feeds/stablecoins/usdxl.yaml
@@ -3,6 +3,4 @@ name: HypurrFi Last USD
 role: stablecoin
 website: https://hypurr.fi/
 twitter: HypurrFi
-rss: https://hypurrfi.beehiiv.com/feed
-rss-failure-at: 2026-04-30
-rss-failure-exception-message: "Feed parse failed for https://hypurrfi.beehiiv.com/feed: <unknown>:109:918: not well-formed (invalid token)"
+# rss: https://hypurrfi.beehiiv.com/feed  # Beehiiv archive is active, but /feed returns an HTML 404 page as of 2026-05.

--- a/eth_defi/data/feeds/stablecoins/usk.yaml
+++ b/eth_defi/data/feeds/stablecoins/usk.yaml
@@ -4,8 +4,5 @@ role: stablecoin
 website: https://kujira.app/
 twitter: TeamKujira
 rss: https://medium.com/feed/team-kujira
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/team-kujira"
 rss-dead-at: 2026-04-06
 twitter-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/stablecoins/usx.yaml
+++ b/eth_defi/data/feeds/stablecoins/usx.yaml
@@ -6,6 +6,3 @@ twitter: dForcenet
 linkedin: dforce-network
 rss: https://medium.com/feed/dforcenet
 linkedin-rss-hub-disabled-at: 2026-04-04
-rss-failure-at: 2026-04-10
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/dforcenet"

--- a/eth_defi/data/feeds/stablecoins/uusd.yaml
+++ b/eth_defi/data/feeds/stablecoins/uusd.yaml
@@ -4,6 +4,3 @@ role: stablecoin
 website: https://u.is/
 twitter: UtopiaP2P
 rss: https://utopiap2p.medium.com/feed
-rss-failure-at: 2026-04-10
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://utopiap2p.medium.com/feed"

--- a/eth_defi/data/feeds/stablecoins/vai.yaml
+++ b/eth_defi/data/feeds/stablecoins/vai.yaml
@@ -5,7 +5,4 @@ website: https://venus.io/
 twitter: VenusProtocol
 linkedin: venusdefi
 rss: https://medium.com/feed/venusprotocol
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/venusprotocol"
 rss-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/stablecoins/vbusdc.yaml
+++ b/eth_defi/data/feeds/stablecoins/vbusdc.yaml
@@ -4,7 +4,5 @@ role: stablecoin
 website: https://katana.network/
 twitter: katana
 linkedin: katananetwork
+# Official blog is active, but no RSS endpoint was found as of 2026-05; keep Medium as the only RSS source.
 rss: https://medium.com/feed/@katananetwork
-rss-failure-at: 2026-04-10
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/@katananetwork"

--- a/eth_defi/data/feeds/stablecoins/vbusdt.yaml
+++ b/eth_defi/data/feeds/stablecoins/vbusdt.yaml
@@ -4,7 +4,5 @@ role: stablecoin
 website: https://katana.network/
 twitter: katana
 linkedin: katananetwork
+# Official blog is active, but no RSS endpoint was found as of 2026-05; keep Medium as the only RSS source.
 rss: https://medium.com/feed/@katananetwork
-rss-failure-at: 2026-04-10
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/@katananetwork"

--- a/eth_defi/data/feeds/stablecoins/vst.yaml
+++ b/eth_defi/data/feeds/stablecoins/vst.yaml
@@ -5,7 +5,4 @@ website: https://vestafinance.xyz/
 twitter: vestafinance
 linkedin: usevesta
 rss: https://medium.com/feed/@VestaFinance
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/@VestaFinance"
 rss-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/stablecoins/vusd-vesper.yaml
+++ b/eth_defi/data/feeds/stablecoins/vusd-vesper.yaml
@@ -6,6 +6,3 @@ twitter: VesperFi
 linkedin: vesperfinance
 rss: https://medium.com/feed/vesperfinance
 linkedin-rss-hub-disabled-at: 2026-04-04
-rss-failure-at: 2026-04-10
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/vesperfinance"

--- a/eth_defi/data/feeds/stablecoins/vusd.yaml
+++ b/eth_defi/data/feeds/stablecoins/vusd.yaml
@@ -4,7 +4,4 @@ role: stablecoin
 website: https://veno.finance/
 twitter: VenoFinance
 rss: https://medium.com/feed/@VenoFinance
-rss-failure-at: 2026-04-06
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/@VenoFinance"
 rss-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/stablecoins/xstusd.yaml
+++ b/eth_defi/data/feeds/stablecoins/xstusd.yaml
@@ -5,6 +5,3 @@ website: https://sora.org/
 twitter: sora_xor
 linkedin: sora-xor
 rss: https://medium.com/feed/sora-xor
-rss-failure-at: 2026-04-10
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/sora-xor"

--- a/eth_defi/data/feeds/stablecoins/zusd.yaml
+++ b/eth_defi/data/feeds/stablecoins/zusd.yaml
@@ -4,7 +4,4 @@ role: stablecoin
 website: https://stablecoin.z.com/zusd/
 twitter: GMOTrust
 linkedin: gmo-z-com-trust-company
-rss: https://medium.com/feed/gmo-z-com-trust-company
-rss-failure-at: 2026-04-10
-rss-failure-status-code: 429
-rss-failure-exception-message: "429 Client Error: Too Many Requests for url: https://medium.com/feed/gmo-z-com-trust-company"
+# rss: https://medium.com/feed/gmo-z-com-trust-company  # Medium is stale; official press page is active but has no RSS endpoint as of 2026-05.


### PR DESCRIPTION
## Why

RSS source metadata had a mix of stale rate-limit failures, moved feeds, and endpoints that returned HTML instead of RSS. This makes scanner output noisy and hides the feeds that are genuinely unavailable.

## Lessons learnt

Medium and some hosted newsletter platforms often fail because of platform throttling or HTML fallback pages, not because the underlying project is dead. For recurring 429s, the YAML should not keep stale failure stamps once the feed is known to work on retry.

## Summary

- Added `eth_defi/data/feeds/RSS-review.md` with the RSS review findings.
- Updated moved RSS URLs for Ethena, PayPal USD, Angle, Compound, Aave, and Gains.
- Commented out RSS URLs that now return HTML or have no exposed feed.
- Reset stored RSS rate-limit failure fields across feed YAML files.