### PR TITLE
Add first batch curator metadata

### DIFF
--- a/eth_defi/data/feeds/curators/altura.yaml
+++ b/eth_defi/data/feeds/curators/altura.yaml
@@ -1,4 +1,12 @@
 # Altura curator - feeds provided by protocols/altura.yaml
+#
+# Alias rationale:
+# - The first curator discovery batch found Altura-branded,
+#   protocol-owned vaults.
+# - Altura already has canonical protocol feed metadata, so this
+#   curator alias exists only to make vault curator detection/export
+#   resolve to the same feeder.
+# - Official protocol site: https://altura.trade/
 feeder-id: altura
 name: Altura
 role: curator

--- a/eth_defi/data/feeds/curators/altura.yaml
+++ b/eth_defi/data/feeds/curators/altura.yaml
@@ -1,0 +1,5 @@
+# Altura curator - feeds provided by protocols/altura.yaml
+feeder-id: altura
+name: Altura
+role: curator
+canonical-feeder-id: altura

--- a/eth_defi/data/feeds/curators/cap.yaml
+++ b/eth_defi/data/feeds/curators/cap.yaml
@@ -1,0 +1,5 @@
+# CAP curator - feeds provided by protocols/cap.yaml
+feeder-id: cap
+name: CAP
+role: curator
+canonical-feeder-id: cap

--- a/eth_defi/data/feeds/curators/cap.yaml
+++ b/eth_defi/data/feeds/curators/cap.yaml
@@ -1,4 +1,11 @@
 # CAP curator - feeds provided by protocols/cap.yaml
+#
+# Alias rationale:
+# - The first curator discovery batch found the protocol-owned
+#   "cap USDC" vault surface.
+# - CAP already has canonical protocol feed metadata, so this curator
+#   alias avoids duplicating social/RSS sources.
+# - Official protocol site: https://cap.app/
 feeder-id: cap
 name: CAP
 role: curator

--- a/eth_defi/data/feeds/curators/curvance.yaml
+++ b/eth_defi/data/feeds/curators/curvance.yaml
@@ -1,0 +1,5 @@
+# Curvance curator - feeds provided by protocols/curvance.yaml
+feeder-id: curvance
+name: Curvance
+role: curator
+canonical-feeder-id: curvance

--- a/eth_defi/data/feeds/curators/curvance.yaml
+++ b/eth_defi/data/feeds/curators/curvance.yaml
@@ -1,4 +1,11 @@
 # Curvance curator - feeds provided by protocols/curvance.yaml
+#
+# Alias rationale:
+# - The first curator discovery batch found Curvance-branded,
+#   protocol-owned vaults.
+# - Curvance already has canonical protocol feed metadata, so this
+#   curator alias only preserves the curator identity for vault exports.
+# - Official protocol site: https://www.curvance.com/
 feeder-id: curvance
 name: Curvance
 role: curator

--- a/eth_defi/data/feeds/curators/gains-network.yaml
+++ b/eth_defi/data/feeds/curators/gains-network.yaml
@@ -1,4 +1,11 @@
 # Gains Network curator - feeds provided by protocols/gains-network.yaml
+#
+# Alias rationale:
+# - Gains vaults are protocol-managed rather than third-party curated.
+# - The exported protocol slug is gains-network; legacy gtrade inputs
+#   are normalised in eth_defi.vault.curator.identify_curator().
+# - Gains Network already has canonical protocol feed metadata.
+# - Official protocol site: https://gains.trade/
 feeder-id: gains-network
 name: Gains Network
 role: curator

--- a/eth_defi/data/feeds/curators/gains-network.yaml
+++ b/eth_defi/data/feeds/curators/gains-network.yaml
@@ -1,0 +1,5 @@
+# Gains Network curator - feeds provided by protocols/gains-network.yaml
+feeder-id: gains-network
+name: Gains Network
+role: curator
+canonical-feeder-id: gains-network

--- a/eth_defi/data/feeds/curators/grvt.yaml
+++ b/eth_defi/data/feeds/curators/grvt.yaml
@@ -1,4 +1,11 @@
 # GRVT curator - feeds provided by protocols/grvt.yaml
+#
+# Alias rationale:
+# - The first curator discovery batch found the GRVT Liquidity Provider
+#   native vault surface.
+# - GRVT already has canonical protocol feed metadata, so this alias
+#   reuses the protocol feeder and avoids duplicate source tracking.
+# - Official protocol site: https://grvt.io
 feeder-id: grvt
 name: GRVT
 role: curator

--- a/eth_defi/data/feeds/curators/grvt.yaml
+++ b/eth_defi/data/feeds/curators/grvt.yaml
@@ -1,0 +1,5 @@
+# GRVT curator - feeds provided by protocols/grvt.yaml
+feeder-id: grvt
+name: GRVT
+role: curator
+canonical-feeder-id: grvt

--- a/eth_defi/data/feeds/curators/janus-henderson-anemoy.yaml
+++ b/eth_defi/data/feeds/curators/janus-henderson-anemoy.yaml
@@ -1,0 +1,24 @@
+feeder-id: janus-henderson-anemoy
+name: Janus Henderson Anemoy
+role: curator
+website: https://www.anemoy.io/funds/jtrsy
+twitter: anemoycapital
+linkedin: anemoy
+
+# Evidence and background references.
+#
+# Local vault data contains Janus Henderson Anemoy Treasury Fund, AAA CLO
+# Fund, and S&P500 Fund vaults across Centrifuge/ERC-7540 chains.  The
+# Janus Henderson press release says Janus Henderson partnered with
+# Anemoy and Centrifuge to manage Anemoy's on-chain fund and serves as
+# sub-advisor.  Anemoy fund pages use the combined Janus Henderson
+# Anemoy product names.
+other-links:
+  - title: Janus Henderson press release - partnership with Anemoy and Centrifuge on tokenized fund
+    url: https://ir.janushenderson.com/News--Events/news/news-details/2024/Janus-Henderson-to-Partner-with-Anemoy-and-Centrifuge-on-Its-First-Tokenized-Fund/default.aspx
+  - title: Anemoy fund page - Janus Henderson Anemoy Treasury Fund
+    url: https://www.anemoy.io/funds/jtrsy
+  - title: Anemoy fund page - Janus Henderson Anemoy AAA CLO Fund
+    url: https://www.anemoy.io/funds/jaaa
+  - title: Anemoy fund page - Anemoy Janus Henderson S&P500 Index Fund
+    url: https://www.anemoy.io/funds/spxa

--- a/eth_defi/data/feeds/curators/k3-capital.yaml
+++ b/eth_defi/data/feeds/curators/k3-capital.yaml
@@ -1,4 +1,14 @@
 # K3 Capital curator — feeds provided by stablecoins/sbold.yaml
+#
+# Alias rationale:
+# - K3 Capital is the organisation-level curator/manager behind sBOLD
+#   and appears directly in several vault names.
+# - The canonical feed source is stablecoins/sbold.yaml because K3's
+#   tracked social and RSS metadata was already attached to the sBOLD
+#   stablecoin/product feeder.
+# - sBOLD itself has a separate curator alias for product/vault names
+#   that contain "sBOLD" but not "K3 Capital".
+# - K3 docs: https://k3-capital.gitbook.io/sbold/introducing-sbold
 feeder-id: k3-capital
 name: K3 Capital
 role: curator

--- a/eth_defi/data/feeds/curators/kappa-lab.yaml
+++ b/eth_defi/data/feeds/curators/kappa-lab.yaml
@@ -1,0 +1,17 @@
+feeder-id: kappa-lab
+name: Kappa Lab
+role: curator
+website: https://kappalab.io
+twitter: KappaLab_io
+linkedin: kappalab
+
+# Evidence and background references.
+#
+# Hibachi's public vault API describes the Fire Liquidity Provider
+# vault as operated by Kappa Lab.  Kappa Lab's own website identifies
+# the organisation as a digital assets market maker.
+other-links:
+  - title: Hibachi public vault API - Fire Liquidity Provider operated by Kappa Lab
+    url: https://data-api.hibachi.xyz/vault/info?vaultId=3
+  - title: Hibachi vaults page - official vault interface
+    url: https://hibachi.xyz/vaults

--- a/eth_defi/data/feeds/curators/sbold.yaml
+++ b/eth_defi/data/feeds/curators/sbold.yaml
@@ -1,0 +1,5 @@
+# sBOLD curator - feeds provided by stablecoins/sbold.yaml
+feeder-id: sbold
+name: sBOLD
+role: curator
+canonical-feeder-id: sbold

--- a/eth_defi/data/feeds/curators/sbold.yaml
+++ b/eth_defi/data/feeds/curators/sbold.yaml
@@ -1,4 +1,19 @@
 # sBOLD curator - feeds provided by stablecoins/sbold.yaml
+#
+# Alias rationale:
+# - sBOLD is both a yield-bearing stablecoin surface and an ERC-4626
+#   vault-name surface discovered in local vault exports.
+# - K3 Capital remains the organisation-level curator alias; this file
+#   covers the product/vault name "sBOLD" when it appears directly.
+# - K3 docs describe sBOLD as routing BOLD into Liquity V2 Stability
+#   Pools and K3 Capital actively managing the weights:
+#   https://k3-capital.gitbook.io/sbold/introducing-sbold
+# - Liquity docs describe sBOLD as an auto-compounding Stability Pool
+#   vault built and maintained by K3 Capital:
+#   https://docs.liquity.org/v2-faq/bold-and-earn
+# - ChainSecurity describes sBOLD as an ERC-4626 vault and asset
+#   allocation layer over Liquity V2 Stability Pool deposits:
+#   https://www.chainsecurity.com/security-audit/k3-sbold
 feeder-id: sbold
 name: sBOLD
 role: curator

--- a/eth_defi/data/feeds/curators/summer-fi.yaml
+++ b/eth_defi/data/feeds/curators/summer-fi.yaml
@@ -1,4 +1,11 @@
 # Summer.fi curator - feeds provided by protocols/summer-fi.yaml
+#
+# Alias rationale:
+# - The first curator discovery batch found Summer.fi-branded,
+#   protocol-owned vaults.
+# - Summer.fi already has canonical protocol feed metadata, so this
+#   curator alias only preserves the curator identity for vault exports.
+# - Official protocol site: https://summer.fi/
 feeder-id: summer-fi
 name: Summer.fi
 role: curator

--- a/eth_defi/data/feeds/curators/summer-fi.yaml
+++ b/eth_defi/data/feeds/curators/summer-fi.yaml
@@ -1,0 +1,5 @@
+# Summer.fi curator - feeds provided by protocols/summer-fi.yaml
+feeder-id: summer-fi
+name: Summer.fi
+role: curator
+canonical-feeder-id: summer-fi

--- a/eth_defi/data/feeds/curators/telosc.yaml
+++ b/eth_defi/data/feeds/curators/telosc.yaml
@@ -1,0 +1,22 @@
+feeder-id: telosc
+name: Telos Consilium
+role: curator
+website: https://telosc.com
+twitter: TelosConsilium
+linkedin: telosc
+
+# Evidence and background references.
+#
+# Telos Consilium uses the short form TelosC in Euler vault names.
+# The local vault export has multiple Euler vault descriptions stating
+# "Governed and curated by TelosC"; the links below preserve the
+# official identity and external vault-curator evidence trail.
+other-links:
+  - title: Official website - Telos Consilium Web3 accelerator with curation and non-custodial asset management services
+    url: https://telosc.com/
+  - title: Euler docs - Telos Consilium authored Maglev documentation as a Web3 service provider mandated by Euler
+    url: https://docs.euler.finance/creator-tools/maglev/overview/
+  - title: Trading Strategy vault page - TelosC Stream Euler vault described as governed and curated by TelosC
+    url: https://tradingstrategy.ai/trading-view/ethereum/vaults/telosc-stream-3
+  - title: SignalPlus coverage - TelosC acts as risk curator for Euler vaults
+    url: https://t.signalplus.com/crypto-news/detail/peckshield-27m-defi-risk-euler-telosc-vaults

--- a/eth_defi/data/feeds/curators/upshift.yaml
+++ b/eth_defi/data/feeds/curators/upshift.yaml
@@ -1,0 +1,5 @@
+# Upshift curator - feeds provided by protocols/upshift.yaml
+feeder-id: upshift
+name: Upshift
+role: curator
+canonical-feeder-id: upshift

--- a/eth_defi/data/feeds/curators/upshift.yaml
+++ b/eth_defi/data/feeds/curators/upshift.yaml
@@ -1,4 +1,11 @@
 # Upshift curator - feeds provided by protocols/upshift.yaml
+#
+# Alias rationale:
+# - The first curator discovery batch found Upshift-branded,
+#   protocol-owned vaults.
+# - Upshift already has canonical protocol feed metadata, so this
+#   curator alias avoids duplicating social/RSS sources.
+# - Official protocol site: https://www.upshift.finance/
 feeder-id: upshift
 name: Upshift
 role: curator

--- a/eth_defi/data/feeds/curators/yieldnest.yaml
+++ b/eth_defi/data/feeds/curators/yieldnest.yaml
@@ -1,4 +1,11 @@
 # YieldNest curator - feeds provided by protocols/yieldnest.yaml
+#
+# Alias rationale:
+# - The first curator discovery batch found the YieldNest RWA MAX
+#   vault-name surface.
+# - This points to the protocol feeder rather than the ynUSDx product
+#   feeder, because the discovered curator surface is YieldNest-branded.
+# - Official protocol site: https://www.yieldnest.finance
 feeder-id: yieldnest
 name: YieldNest
 role: curator

--- a/eth_defi/data/feeds/curators/yieldnest.yaml
+++ b/eth_defi/data/feeds/curators/yieldnest.yaml
@@ -1,0 +1,5 @@
+# YieldNest curator - feeds provided by protocols/yieldnest.yaml
+feeder-id: yieldnest
+name: YieldNest
+role: curator
+canonical-feeder-id: yieldnest

--- a/eth_defi/vault/curator.py
+++ b/eth_defi/vault/curator.py
@@ -16,7 +16,7 @@ This module provides:
   manages it using word-boundary regex matching against known curator
   names loaded from YAML feeder files
 - **Protocol-curated detection** — some vaults are operated by the
-  protocol itself (Ostium, gTrade, Hyperliquid HLP, Lighter LLP) rather
+  protocol itself (Ostium, Gains Network, Hyperliquid HLP, Lighter LLP) rather
   than a third-party curator; these are identified by address lookups
   against known system vault address sets
 - **Curator metadata loading** — load curator metadata from the shared
@@ -81,7 +81,7 @@ short patterns are registered in :py:data:`CURATOR_NAME_PATTERNS`.
 
 Protocol-curated vaults are identified before name matching:
 
-- **Ostium** and **gTrade** — all vaults on these protocols are
+- **Ostium** and **Gains Network** — all vaults on these protocols are
   protocol-curated (no external curator)
 - **Hyperliquid** — system vaults (HLP parent, HLP children, Liquidator)
   are identified by address against
@@ -122,8 +122,10 @@ import re
 from pathlib import Path
 from typing import TypedDict
 
+from eth_defi.feed.sources import load_feeder_metadata, resolve_canonical_feeder_yaml
 from eth_defi.hyperliquid.constants import HYPERLIQUID_SYSTEM_VAULT_ADDRESSES
 from eth_defi.lighter.constants import LIGHTER_SYSTEM_POOL_ADDRESSES
+from eth_defi.research.sparkline import upload_to_r2_compressed
 
 logger = logging.getLogger(__name__)
 
@@ -140,8 +142,14 @@ CURATORS_DATA_DIR: Path = Path(__file__).parent.parent / "data" / "feeds" / "cur
 #: itself operates every vault.  The slug values correspond to
 #: :py:func:`eth_defi.research.vault_metrics.slugify_protocol` output.
 PROTOCOL_CURATED_SLUGS: set[str] = {
+    "gains-network",
     "ostium",
-    "gtrade",
+}
+
+#: Legacy protocol slug aliases that should resolve to the canonical
+#: protocol-curator slug emitted by :py:func:`identify_curator`.
+PROTOCOL_CURATOR_SLUG_ALIASES: dict[str, str] = {
+    "gtrade": "gains-network",
 }
 
 #: Complete set of protocol slugs that can appear as curator slugs.
@@ -159,8 +167,8 @@ ALL_PROTOCOL_CURATOR_SLUGS: set[str] = PROTOCOL_CURATED_SLUGS | {
 #: These names are used by :py:func:`get_curator_name` when the curator
 #: slug matches a protocol rather than a third-party curator YAML file.
 PROTOCOL_CURATOR_NAMES: dict[str, str] = {
+    "gains-network": "Gains Network",
     "ostium": "Ostium",
-    "gtrade": "gTrade",
     "hyperliquid": "Hyperliquid",
     "lighter": "Lighter",
 }
@@ -176,7 +184,7 @@ PROTOCOL_CURATOR_NAMES: dict[str, str] = {
 #: ``"GammaSwap V1"``).
 CURATOR_NAME_PATTERNS: dict[str, list[str]] = {
     "re7-labs": ["RE7"],
-    "steakhouse-financial": ["Steakhouse"],
+    "steakhouse-financial": ["Steakhouse", "Smokehouse"],
     "block-analitica": ["B.Protocol"],
     "growi-finance": ["Growi"],
     "avantgarde-finance": ["Avantgarde"],
@@ -217,6 +225,8 @@ CURATOR_NAME_PATTERNS: dict[str, list[str]] = {
     "singularity": ["Singularity"],
     "fija": ["Fija"],
     "woo": ["Woo"],
+    "telosc": ["TelosC"],
+    "kappa-lab": ["Fire Liquidity Provider"],
 }
 
 
@@ -252,7 +262,7 @@ class CuratorInfo(TypedDict):
     #: Whether this is a protocol-native curator (the protocol itself
     #: acts as curator) rather than a third-party risk manager.
     #:
-    #: ``True`` for protocol-curated vaults (Ostium, gTrade, HLP, LLP).
+    #: ``True`` for protocol-curated vaults (Ostium, Gains Network, HLP, LLP).
     #: ``False`` for third-party curators (Gauntlet, RE7 Labs, etc.).
     protocol_curator: bool
 
@@ -295,7 +305,7 @@ class CuratorMetadata(TypedDict):
 
     #: Whether this curator is the protocol itself (not a third party).
     #:
-    #: ``True`` for protocol-curated vaults (e.g. Ostium, gTrade, HLP, LLP).
+    #: ``True`` for protocol-curated vaults (e.g. Ostium, Gains Network, HLP, LLP).
     #: ``False`` for third-party curators (e.g. Gauntlet, RE7 Labs).
     protocol_curator: bool
 
@@ -321,8 +331,6 @@ def _load_curator_yaml(yaml_path: Path) -> CuratorInfo:
     :param yaml_path:
         Path to a curator YAML file.
     """
-    from eth_defi.feed.sources import load_feeder_metadata
-
     parsed = load_feeder_metadata(yaml_path)
     return CuratorInfo(
         slug=parsed["feeder-id"],
@@ -331,7 +339,7 @@ def _load_curator_yaml(yaml_path: Path) -> CuratorInfo:
         twitter=parsed.get("twitter"),
         linkedin=parsed.get("linkedin"),
         rss=parsed.get("rss"),
-        protocol_curator=False,  # YAML curators are always third-party
+        protocol_curator=parsed["feeder-id"] in ALL_PROTOCOL_CURATOR_SLUGS,
         canonical_feeder_id=parsed.get("canonical-feeder-id"),
     )
 
@@ -346,7 +354,7 @@ def load_curator_map() -> dict[str, CuratorInfo]:
     :return:
         Dict keyed by curator slug.
     """
-    global _cached_curator_map
+    global _cached_curator_map  # noqa: PLW0603
 
     if _cached_curator_map is not None:
         return _cached_curator_map
@@ -372,7 +380,7 @@ def _build_matching_patterns() -> list[tuple[re.Pattern, str]]:
         List of ``(compiled_regex, curator_slug)`` pairs, longest
         pattern first.
     """
-    global _cached_patterns
+    global _cached_patterns  # noqa: PLW0603
 
     if _cached_patterns is not None:
         return _cached_patterns
@@ -437,6 +445,10 @@ def identify_curator(
         Use :py:func:`is_protocol_curator` to distinguish protocol-curated
         from third-party curators.
     """
+
+    del chain_id, vault_token_symbol
+
+    protocol_slug = PROTOCOL_CURATOR_SLUG_ALIASES.get(protocol_slug, protocol_slug)
 
     # 1. Blanket protocol-curated protocols (all vaults are protocol-operated)
     if protocol_slug in PROTOCOL_CURATED_SLUGS:
@@ -521,8 +533,6 @@ def build_curator_metadata_json(yaml_path: Path) -> CuratorMetadata:
     # If alias, inherit metadata from the canonical feeder.
     # Derive the feeds root from yaml_path: curators/foo.yaml -> parent.parent
     if info["canonical_feeder_id"]:
-        from eth_defi.feed.sources import load_feeder_metadata, resolve_canonical_feeder_yaml
-
         feeds_root = yaml_path.parent.parent
         canonical_yaml = resolve_canonical_feeder_yaml(
             info["canonical_feeder_id"],
@@ -560,33 +570,37 @@ def build_curator_metadata_json(yaml_path: Path) -> CuratorMetadata:
 
 
 def _build_protocol_curator_entries() -> list[CuratorMetadata]:
-    """Build synthetic curator metadata entries for protocol-curated slugs.
+    """Build metadata entries for protocol-curated slugs.
 
     One entry per protocol in :py:data:`PROTOCOL_CURATOR_NAMES` is
-    created so that frontend slug lookups always find metadata for
-    every slug that :py:func:`identify_curator` can emit.
+    created or loaded from YAML so that frontend slug lookups always
+    find metadata for every slug that :py:func:`identify_curator` can emit.
 
     :return:
-        List of synthetic :py:class:`CuratorMetadata` dicts.
+        List of :py:class:`CuratorMetadata` dicts.
     """
     entries: list[CuratorMetadata] = []
     for slug, name in sorted(PROTOCOL_CURATOR_NAMES.items()):
-        entries.append(
-            CuratorMetadata(
-                slug=slug,
-                name=name,
-                website=None,
-                twitter=None,
-                linkedin=None,
-                rss=None,
-                protocol_curator=True,
-                canonical_feeder_id=None,
+        yaml_path = CURATORS_DATA_DIR / f"{slug}.yaml"
+        if yaml_path.exists():
+            entries.append(build_curator_metadata_json(yaml_path))
+        else:
+            entries.append(
+                CuratorMetadata(
+                    slug=slug,
+                    name=name,
+                    website=None,
+                    twitter=None,
+                    linkedin=None,
+                    rss=None,
+                    protocol_curator=True,
+                    canonical_feeder_id=None,
+                )
             )
-        )
     return entries
 
 
-def process_and_upload_curator_metadata(
+def process_and_upload_curator_metadata(  # noqa: PLR0917
     yaml_path: Path,
     bucket_name: str,
     endpoint_url: str,
@@ -619,8 +633,6 @@ def process_and_upload_curator_metadata(
     :return:
         The processed :py:class:`CuratorMetadata`.
     """
-    from eth_defi.research.sparkline import upload_to_r2_compressed
-
     metadata = build_curator_metadata_json(yaml_path)
     slug = metadata["slug"]
 
@@ -671,8 +683,6 @@ def upload_protocol_curator_metadata(
     :return:
         List of uploaded :py:class:`CuratorMetadata` entries.
     """
-    from eth_defi.research.sparkline import upload_to_r2_compressed
-
     entries = _build_protocol_curator_entries()
 
     for metadata in entries:
@@ -712,8 +722,8 @@ def build_curator_index() -> list[CuratorMetadata]:
     for yaml_path in sorted(CURATORS_DATA_DIR.glob("*.yaml")):
         index.append(build_curator_metadata_json(yaml_path))
 
-    # Inject protocol-curator entries (Ostium, gTrade, Hyperliquid, Lighter)
-    index.extend(_build_protocol_curator_entries())
+    existing_slugs = {entry["slug"] for entry in index}
+    index.extend(entry for entry in _build_protocol_curator_entries() if entry["slug"] not in existing_slugs)
 
     return index
 
@@ -747,8 +757,6 @@ def upload_curator_index(
     :return:
         The full index list.
     """
-    from eth_defi.research.sparkline import upload_to_r2_compressed
-
     index = build_curator_index()
 
     json_bytes = json.dumps(index, indent=2).encode()

--- a/tests/vault/test_curator.py
+++ b/tests/vault/test_curator.py
@@ -1,6 +1,6 @@
 """Test vault curator detection."""
 
-from eth_defi.vault.curator import identify_curator
+from eth_defi.vault.curator import get_curator_name, identify_curator, is_protocol_curator
 
 
 def test_identify_anthias_labs_felix_vault() -> None:
@@ -20,3 +20,75 @@ def test_identify_anthias_labs_felix_vault() -> None:
     )
 
     assert slug == "anthias-labs"
+
+
+def test_identify_smokehouse_as_steakhouse_financial() -> None:
+    """Smokehouse vault names resolve to Steakhouse Financial."""
+
+    slug = identify_curator(
+        chain_id=1,
+        vault_token_symbol="smokeUSDC",
+        vault_name="Trust Wallet Morpho Smokehouse USDC",
+        vault_address="0x0000000000000000000000000000000000000001",
+        protocol_slug="morpho",
+    )
+
+    assert slug == "steakhouse-financial"
+
+
+def test_identify_telosc_short_name() -> None:
+    """TelosC vault names resolve to Telos Consilium."""
+
+    slug = identify_curator(
+        chain_id=1,
+        vault_token_symbol="eulerUSDC",
+        vault_name="TelosC Stream 3",
+        vault_address="0x0000000000000000000000000000000000000002",
+        protocol_slug="euler",
+    )
+
+    assert slug == "telosc"
+
+
+def test_identify_kappa_lab_fire_liquidity_provider() -> None:
+    """Fire Liquidity Provider vault names resolve to Kappa Lab."""
+
+    slug = identify_curator(
+        chain_id=9999,
+        vault_token_symbol="FLP",
+        vault_name="Fire Liquidity Provider",
+        vault_address="hibachi:vault:3",
+        protocol_slug="hibachi",
+    )
+
+    assert slug == "kappa-lab"
+
+
+def test_identify_gains_network_protocol_curator() -> None:
+    """Gains Network protocol vaults resolve to the exported protocol slug."""
+
+    slug = identify_curator(
+        chain_id=42161,
+        vault_token_symbol="gDAI",
+        vault_name="gDAI",
+        vault_address="0x0000000000000000000000000000000000000003",
+        protocol_slug="gains-network",
+    )
+
+    assert slug == "gains-network"
+    assert is_protocol_curator("gains-network")
+    assert get_curator_name("gains-network") == "Gains Network"
+
+
+def test_identify_legacy_gtrade_as_gains_network() -> None:
+    """Legacy gTrade protocol slug resolves to Gains Network."""
+
+    slug = identify_curator(
+        chain_id=42161,
+        vault_token_symbol="gDAI",
+        vault_name="gDAI",
+        vault_address="0x0000000000000000000000000000000000000004",
+        protocol_slug="gtrade",
+    )
+
+    assert slug == "gains-network"


### PR DESCRIPTION
## Why

The first curator discovery batch identified additional vault curators and protocol-owned curator surfaces that were not yet represented in feed metadata. Adding them improves curator attribution for vault exports while reusing canonical protocol or stablecoin feed sources where possible.

## Lessons learnt

Some discovered names are product or protocol surfaces rather than new independent feed sources. Smokehouse maps to Steakhouse Financial, sBOLD is distinct from the K3 Capital organisation alias, and the exported Gains Network slug needs to be preferred over the legacy gTrade slug.

## Summary

- Added source curator metadata for Janus Henderson Anemoy, Telos Consilium, and Kappa Lab.
- Added curator aliases for Altura, CAP, Curvance, Gains Network, GRVT, sBOLD, Summer.fi, Upshift, and YieldNest.
- Updated curator detection for Smokehouse, TelosC, Fire Liquidity Provider, and Gains Network/gTrade slug normalisation.
- Added focused curator detection tests for the new matching behaviour.