### PR TITLE
fix: use loan contract address for Accountable vault links

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/accountable/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/offchain_metadata.py
@@ -74,6 +74,10 @@ class AccountableVaultMetadata(TypedDict):
     #: Source of yield, or None if not specified
     yield_source: str | None
 
+    #: Loan/strategy contract address used in the yield app URL
+    #: (distinct from the ERC-4626 vault/share token address)
+    loan_address: str | None
+
 
 def _fetch_vault_listing(
     api_base_url: str = DEFAULT_API_BASE_URL,
@@ -164,6 +168,7 @@ def _parse_vault_metadata(listing_item: dict, detail: dict | None) -> Accountabl
         net_apy=listing_item.get("net_apy"),
         performance_fee=performance_fee,
         yield_source=loan.get("yield_source"),
+        loan_address=listing_item.get("loan_address"),
     )
 
 

--- a/eth_defi/erc_4626/vault_protocol/accountable/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/vault.py
@@ -286,5 +286,13 @@ class AccountableVault(ERC4626Vault):
         return None
 
     def get_link(self, referral: str | None = None) -> str:
-        """Return the yield app link."""
+        """Return the yield app link.
+
+        Accountable's yield app URLs use the loan/strategy contract address,
+        not the ERC-4626 vault (share token) address.
+        Falls back to the vault address if metadata is unavailable.
+        """
+        meta = self.accountable_metadata
+        if meta and meta.get("loan_address"):
+            return f"https://yield.accountable.capital/vaults/{meta['loan_address']}"
         return f"https://yield.accountable.capital/vaults/{self.vault_address}"


### PR DESCRIPTION
## Why

Accountable's yield app SPA builds vault detail URLs as `/vaults/{loan_address}`, using the loan/strategy contract address from the listing API. Our `get_link()` was incorrectly using the ERC-4626 vault (share token) address, producing links that don't resolve to the correct vault page.

Confirmed by reverse-engineering the minified SPA JS: the listing component destructures `loan_address:d` and navigates to `/vaults/${d}`.

## Lessons learnt

- Accountable has two contract addresses per vault: the **loan/strategy contract** (used in URLs and API) and the **ERC-4626 share token** (the actual vault). The listing API's `loan_address` field is the one used in the SPA routing.

## Summary

- Added `loan_address` field to `AccountableVaultMetadata` TypedDict
- Stored `loan_address` from listing API when parsing metadata
- Updated `get_link()` to use the loan address, with fallback to vault address if metadata unavailable