### PR TITLE
fix: correct 40acres Base vault contract address typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- fix: 40acres Aerodrome USDC vault on Base had a typo in the contract address (duplicated `d`), causing vault detection to fail; correct address is `0xb99b6df96d4d5448cc0a5b3e0ef7896df9507cf5` (2026-05-05)
+
 - feat: Twitter list collector falls back to individual user timeline for handles with zero list results, ensuring last_post_published_at is always populated (2026-05-05)
 
 - feat: Logos added for 67 vault curators — 256×256 RGBA PNG assets sourced from official brand kits, GitHub repos, website SVGs, CDN assets, and Twitter avatars; one curator (Tanken) documented as logo-unavailable (2026-05-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- feat: Twitter list collector falls back to individual user timeline for handles with zero list results, ensuring last_post_published_at is always populated (2026-05-05)
+
 - feat: Logos added for 67 vault curators — 256×256 RGBA PNG assets sourced from official brand kits, GitHub repos, website SVGs, CDN assets, and Twitter avatars; one curator (Tanken) documented as logo-unavailable (2026-05-05)
 
 - feat: Feed Twitter collection uses the X list timeline by default when a list ID is available, reducing per-account API reads while falling back to individual timelines and RSS bridges if list reads fail (2026-05-05)

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -1877,8 +1877,8 @@ HARDCODED_PROTOCOLS = {
     # https://optimistic.etherscan.io/address/0x08dCDBf7baDe91Ccd42CB2a4EA8e5D199d285957
     "0x08dcdbf7bade91ccd42cb2a4ea8e5d199d285957": {ERC4626Feature.forty_acres_like},
     # 40acres - Aerodrome USDC vault on Base
-    # https://basescan.org/address/0xB99B6dDF96d4d5448cC0a5B3e0ef7896df9507Cf5
-    "0xb99b6ddf96d4d5448cc0a5b3e0ef7896df9507cf5": {ERC4626Feature.forty_acres_like},
+    # https://basescan.org/address/0xb99b6df96d4d5448cc0a5b3e0ef7896df9507cf5
+    "0xb99b6df96d4d5448cc0a5b3e0ef7896df9507cf5": {ERC4626Feature.forty_acres_like},
 }
 
 for a in HARDCODED_PROTOCOLS.keys():

--- a/eth_defi/erc_4626/vault_protocol/accountable/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/offchain_metadata.py
@@ -74,6 +74,10 @@ class AccountableVaultMetadata(TypedDict):
     #: Source of yield, or None if not specified
     yield_source: str | None
 
+    #: Loan/strategy contract address used in the yield app URL
+    #: (distinct from the ERC-4626 vault/share token address)
+    loan_address: str | None
+
 
 def _fetch_vault_listing(
     api_base_url: str = DEFAULT_API_BASE_URL,
@@ -164,6 +168,7 @@ def _parse_vault_metadata(listing_item: dict, detail: dict | None) -> Accountabl
         net_apy=listing_item.get("net_apy"),
         performance_fee=performance_fee,
         yield_source=loan.get("yield_source"),
+        loan_address=listing_item.get("loan_address"),
     )
 
 

--- a/eth_defi/erc_4626/vault_protocol/accountable/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/vault.py
@@ -286,5 +286,13 @@ class AccountableVault(ERC4626Vault):
         return None
 
     def get_link(self, referral: str | None = None) -> str:
-        """Return the yield app link."""
+        """Return the yield app link.
+
+        Accountable's yield app URLs use the loan/strategy contract address,
+        not the ERC-4626 vault (share token) address.
+        Falls back to the vault address if metadata is unavailable.
+        """
+        meta = self.accountable_metadata
+        if meta and meta.get("loan_address"):
+            return f"https://yield.accountable.capital/vaults/{meta['loan_address']}"
         return f"https://yield.accountable.capital/vaults/{self.vault_address}"

--- a/eth_defi/erc_4626/vault_protocol/forty_acres/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/forty_acres/vault.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 #: Used to override the cryptic on-chain ``name()`` return values.
 VAULT_NAMES: dict[str, str] = {
     # Aerodrome USDC vault on Base
-    "0xb99b6ddf96d4d5448cc0a5b3e0ef7896df9507cf5": "Aerodrome USDC",
+    "0xb99b6df96d4d5448cc0a5b3e0ef7896df9507cf5": "Aerodrome USDC",
     # Velodrome USDC vault on Optimism
     "0x08dcdbf7bade91ccd42cb2a4ea8e5d199d285957": "Velodrome USDC",
     # Pharaoh USDC vault on Avalanche
@@ -94,7 +94,7 @@ class FortyAcresVault(ERC4626Vault):
     - `Blackhole vault on Avalanche <https://snowtrace.io/address/0xc0485c4bafb594ae1457820fb6e5b67e8a04bcfd>`__
     - `Pharaoh vault on Avalanche <https://snowtrace.io/address/0x124d00b1ce4453ffc5a5f65ce83af13a7709bac7>`__
     - `Velodrome vault on Optimism <https://optimistic.etherscan.io/address/0x08dCDBf7baDe91Ccd42CB2a4EA8e5D199d285957>`__
-    - `Aerodrome vault on Base <https://basescan.org/address/0xB99B6dDF96d4d5448cC0a5B3e0ef7896df9507Cf5>`__
+    - `Aerodrome vault on Base <https://basescan.org/address/0xb99b6df96d4d5448cc0a5b3e0ef7896df9507cf5>`__
     """
 
     @property

--- a/eth_defi/feed/README-feed.md
+++ b/eth_defi/feed/README-feed.md
@@ -197,10 +197,12 @@ Twitter/X usernames are normalised to a handle.  In production, when
 X list timeline once and maps returned tweets back to the tracked member
 handles.  This avoids one API read per account.
 
-When a handle has no tweets in the list timeline — either because they have not
-posted recently or their recent posts were already in the database — the
-collector falls back to a single individual timeline read.  This ensures
-`last_post_published_at` is always populated, even for infrequent posters.
+When a handle has no tweets in the list timeline **and** has no stored
+`last_post_published_at`, the collector falls back to a single individual
+timeline read to seed the timestamp for that handle.  The fallback only fires
+for genuinely new handles; on steady-state runs the list fetch stops early at
+the first already-known tweet, which would otherwise trigger a per-account
+API call for every tracked handle and exhaust X API rate limits.
 
 If list timeline collection is unavailable or fails, the collector falls back
 to per-account X API timeline reads and then to RSS bridge URLs built from

--- a/eth_defi/feed/README-feed.md
+++ b/eth_defi/feed/README-feed.md
@@ -197,6 +197,11 @@ Twitter/X usernames are normalised to a handle.  In production, when
 X list timeline once and maps returned tweets back to the tracked member
 handles.  This avoids one API read per account.
 
+When a handle has no tweets in the list timeline — either because they have not
+posted recently or their recent posts were already in the database — the
+collector falls back to a single individual timeline read.  This ensures
+`last_post_published_at` is always populated, even for infrequent posters.
+
 If list timeline collection is unavailable or fails, the collector falls back
 to per-account X API timeline reads and then to RSS bridge URLs built from
 `TWITTER_RSS_BASE_URLS` and `TWITTER_FEED_URL_TEMPLATES`.

--- a/eth_defi/feed/collector.py
+++ b/eth_defi/feed/collector.py
@@ -704,10 +704,12 @@ def collect_twitter_list_posts(
     per tracked account while still storing posts under the account-specific
     tracked source rows.
 
-    When a handle has no tweets in the list timeline (either because they have
-    not posted recently or their posts were already known), the collector falls
-    back to a single individual timeline read to populate ``last_post_published_at``
-    and store a small number of recent posts.
+    When a handle has no tweets in the list timeline **and** has no stored
+    ``last_post_published_at`` (i.e. it is a brand-new handle whose first
+    scan returned nothing), the collector falls back to a single individual
+    timeline read.  This seeds the timestamp and stores a small number of
+    recent posts without firing per-account API calls on steady-state runs
+    where the list stopped early because all recent tweets were already known.
 
     :param db:
         Vault post database.
@@ -743,14 +745,23 @@ def collect_twitter_list_posts(
     )
     checked_at = native_datetime_utc_now()
 
+    # Pre-load stored timestamps so we only fall back for genuinely new handles.
+    # A source with last_post_published_at already set has been seen before; the
+    # list fetch simply had nothing newer for it and a per-account call would add
+    # no value while burning API quota.
+    stored_timestamps = db.get_source_last_post_timestamps(source_ids.values())
+
     for source in sources:
         source_id = source_ids[source.get_logical_key()]
         cached = twitter_user_cache.get(source.source_key)
         posts = posts_by_user_id.get(cached.user_id, []) if cached else []
 
-        # Fall back to individual timeline when the list returned zero tweets
-        # for this handle, so that last_post_published_at is always populated.
-        if not posts and cached:
+        # Fall back to individual timeline only when the source has no stored
+        # last_post_published_at (i.e. it is brand-new and has never had any
+        # tweets collected).  Skipping this check would fire one X API call per
+        # handle on every steady-state run because the list fetch stops at the
+        # first already-known tweet.
+        if not posts and cached and stored_timestamps.get(source_id) is None:
             try:
                 posts = fetch_user_tweets(
                     cached.user_id,
@@ -760,7 +771,7 @@ def collect_twitter_list_posts(
                 )
                 if posts:
                     logger.info(
-                        "Fetched %d fallback tweet(s) for @%s — handle had zero list timeline results",
+                        "Fetched %d fallback tweet(s) for @%s — new handle with no stored timestamp",
                         len(posts),
                         source.source_key,
                     )

--- a/eth_defi/feed/collector.py
+++ b/eth_defi/feed/collector.py
@@ -694,6 +694,7 @@ def collect_twitter_list_posts(
     bearer_token: str,
     twitter_user_cache: TwitterUserCache,
     max_tweets: int,
+    fallback_max_tweets: int = 5,
     label: str = "Twitter list",
 ) -> CollectorRunSummary:
     """Collect Twitter/X posts through a single X list timeline read.
@@ -702,6 +703,11 @@ def collect_twitter_list_posts(
     chronological order.  This lets production collection avoid one API call
     per tracked account while still storing posts under the account-specific
     tracked source rows.
+
+    When a handle has no tweets in the list timeline (either because they have
+    not posted recently or their posts were already known), the collector falls
+    back to a single individual timeline read to populate ``last_post_published_at``
+    and store a small number of recent posts.
 
     :param db:
         Vault post database.
@@ -715,6 +721,10 @@ def collect_twitter_list_posts(
         Cache containing handle-to-user-ID mappings.
     :param max_tweets:
         Maximum tweets to read from the list timeline.
+    :param fallback_max_tweets:
+        Maximum tweets to fetch per account when the list timeline returns
+        zero results for that handle.  Used to populate ``last_post_published_at``
+        for inactive accounts.  Defaults to 5.
     :param label:
         Dashboard label for this collection phase.
     :return:
@@ -737,6 +747,30 @@ def collect_twitter_list_posts(
         source_id = source_ids[source.get_logical_key()]
         cached = twitter_user_cache.get(source.source_key)
         posts = posts_by_user_id.get(cached.user_id, []) if cached else []
+
+        # Fall back to individual timeline when the list returned zero tweets
+        # for this handle, so that last_post_published_at is always populated.
+        if not posts and cached:
+            try:
+                posts = fetch_user_tweets(
+                    cached.user_id,
+                    bearer_token,
+                    source.source_key,
+                    max_tweets=fallback_max_tweets,
+                )
+                if posts:
+                    logger.info(
+                        "Fetched %d fallback tweet(s) for @%s — handle had zero list timeline results",
+                        len(posts),
+                        source.source_key,
+                    )
+            except Exception as e:
+                logger.warning(
+                    "Fallback individual timeline fetch failed for @%s: %s",
+                    source.source_key,
+                    e,
+                )
+
         latest_post_at = max((post.published_at for post in posts if post.published_at is not None), default=None)
         inserted = db.insert_posts(source_id, posts)
         db.mark_source_success(

--- a/eth_defi/feed/database.py
+++ b/eth_defi/feed/database.py
@@ -379,6 +379,31 @@ class VaultPostDatabase:
             rows = self.con.execute("SELECT external_post_id FROM posts").fetchall()
         return {row[0] for row in rows}
 
+    def get_source_last_post_timestamps(self, source_ids: Iterable[int]) -> dict[int, datetime.datetime | None]:
+        """Return the stored ``last_post_published_at`` for the given source IDs.
+
+        Used to gate backfill fallbacks: a source whose stored timestamp is
+        not ``None`` has already been seen before and does not need a fallback
+        individual timeline read.
+
+        :param source_ids:
+            Iterable of numeric source IDs to look up.
+
+        :return:
+            Mapping of ``source_id → last_post_published_at`` (``None`` when
+            the column has never been set for that row).
+        """
+
+        ids = list(source_ids)
+        if not ids:
+            return {}
+        placeholders = ", ".join("?" * len(ids))
+        rows = self.con.execute(
+            f"SELECT source_id, last_post_published_at FROM tracked_sources WHERE source_id IN ({placeholders})",
+            ids,
+        ).fetchall()
+        return {int(row[0]): row[1] for row in rows}
+
     def get_tracked_sources_df(self) -> pd.DataFrame:
         """Return tracked source rows for diagnostics."""
 

--- a/eth_defi/vault/curator.py
+++ b/eth_defi/vault/curator.py
@@ -129,6 +129,15 @@ from eth_defi.research.sparkline import upload_to_r2_compressed
 
 logger = logging.getLogger(__name__)
 
+#: Base directory for shared vault protocol and curator data.
+VAULTS_DATA_DIR: Path = Path(__file__).parent.parent / "data" / "vaults"
+
+#: Directory containing formatted 256x256 PNG logos.
+FORMATTED_LOGOS_DIR: Path = VAULTS_DATA_DIR / "formatted_logos"
+
+#: Logo variants supported by the shared vault logo folder.
+LOGO_VARIANTS: tuple[str, ...] = ("generic", "dark", "light")
+
 #: Path to the curator feeder YAML files.
 #:
 #: These files use the shared feeder schema from
@@ -275,6 +284,23 @@ class CuratorInfo(TypedDict):
     canonical_feeder_id: str | None
 
 
+class CuratorLogos(TypedDict):
+    """Logo URLs for a vault curator.
+
+    Logo URLs point to 256x256 PNG files in R2 storage.
+    ``None`` if the logo variant is not available.
+    """
+
+    #: Generic logo variant for neutral display contexts.
+    generic: str | None
+
+    #: Logo for dark background themes when available.
+    dark: str | None
+
+    #: Logo for light background themes when available.
+    light: str | None
+
+
 class CuratorMetadata(TypedDict):
     """Curator metadata as exported to JSON for R2 upload.
 
@@ -303,6 +329,9 @@ class CuratorMetadata(TypedDict):
 
     #: RSS or Atom feed URL, or ``None``.
     rss: str | None
+
+    #: Logo URLs for available 256x256 PNG variants.
+    logos: CuratorLogos
 
     #: Whether this curator is the protocol itself (not a third party).
     #:
@@ -516,7 +545,44 @@ def get_curator_name(slug: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def build_curator_metadata_json(yaml_path: Path) -> CuratorMetadata:
+def get_curator_available_logos(slug: str) -> dict[str, bool]:
+    """Check which logo variants are available for a curator.
+
+    Curator and vault protocol logos share
+    ``eth_defi/data/vaults/formatted_logos/{slug}/``.
+
+    :param slug:
+        Curator slug, e.g. ``"gauntlet"``.
+
+    :return:
+        Dictionary keyed by ``generic``, ``dark`` and ``light``.
+    """
+    logo_dir = FORMATTED_LOGOS_DIR / slug
+    return {variant: (logo_dir / f"{variant}.png").exists() for variant in LOGO_VARIANTS}
+
+
+def _build_curator_logo_urls(slug: str, public_url: str = "") -> CuratorLogos:
+    """Build public logo URLs for available curator logo variants.
+
+    :param slug:
+        Curator slug.
+
+    :param public_url:
+        Public base URL for constructing logo URLs.
+
+    :return:
+        Logo URL mapping for JSON export.
+    """
+    available_logos = get_curator_available_logos(slug)
+    public_url = public_url.rstrip("/") if public_url else ""
+    return CuratorLogos(
+        generic=f"{public_url}/curator-metadata/{slug}/generic.png" if available_logos["generic"] and public_url else None,
+        dark=f"{public_url}/curator-metadata/{slug}/dark.png" if available_logos["dark"] and public_url else None,
+        light=f"{public_url}/curator-metadata/{slug}/light.png" if available_logos["light"] and public_url else None,
+    )
+
+
+def build_curator_metadata_json(yaml_path: Path, public_url: str = "") -> CuratorMetadata:
     """Build a :py:class:`CuratorMetadata` dict from a curator YAML file.
 
     Twitter handles are expanded to full ``https://x.com/{handle}`` URLs.
@@ -526,10 +592,14 @@ def build_curator_metadata_json(yaml_path: Path) -> CuratorMetadata:
     :param yaml_path:
         Path to a curator YAML file.
 
+    :param public_url:
+        Public base URL for constructing logo URLs.
+
     :return:
         Metadata dict ready for JSON serialisation.
     """
     info = _load_curator_yaml(yaml_path)
+    slug = info["slug"]
 
     # If alias, inherit metadata from the canonical feeder.
     # Derive the feeds root from yaml_path: curators/foo.yaml -> parent.parent
@@ -559,23 +629,27 @@ def build_curator_metadata_json(yaml_path: Path) -> CuratorMetadata:
         linkedin_url = f"https://www.linkedin.com/company/{linkedin_id}"
 
     return CuratorMetadata(
-        slug=info["slug"],
+        slug=slug,
         name=info["name"],
         website=website,
         twitter=twitter_url,
         linkedin=linkedin_url,
         rss=rss,
+        logos=_build_curator_logo_urls(slug, public_url=public_url),
         protocol_curator=info["protocol_curator"],
         canonical_feeder_id=info["canonical_feeder_id"],
     )
 
 
-def _build_protocol_curator_entries() -> list[CuratorMetadata]:
+def _build_protocol_curator_entries(public_url: str = "") -> list[CuratorMetadata]:
     """Build metadata entries for protocol-curated slugs.
 
     One entry per protocol in :py:data:`PROTOCOL_CURATOR_NAMES` is
     created or loaded from YAML so that frontend slug lookups always
     find metadata for every slug that :py:func:`identify_curator` can emit.
+
+    :param public_url:
+        Public base URL for constructing logo URLs.
 
     :return:
         List of :py:class:`CuratorMetadata` dicts.
@@ -584,7 +658,7 @@ def _build_protocol_curator_entries() -> list[CuratorMetadata]:
     for slug, name in sorted(PROTOCOL_CURATOR_NAMES.items()):
         yaml_path = CURATORS_DATA_DIR / f"{slug}.yaml"
         if yaml_path.exists():
-            entries.append(build_curator_metadata_json(yaml_path))
+            entries.append(build_curator_metadata_json(yaml_path, public_url=public_url))
         else:
             entries.append(
                 CuratorMetadata(
@@ -594,6 +668,7 @@ def _build_protocol_curator_entries() -> list[CuratorMetadata]:
                     twitter=None,
                     linkedin=None,
                     rss=None,
+                    logos=_build_curator_logo_urls(slug, public_url=public_url),
                     protocol_curator=True,
                     canonical_feeder_id=None,
                 )
@@ -607,11 +682,15 @@ def process_and_upload_curator_metadata(  # noqa: PLR0917
     endpoint_url: str,
     access_key_id: str,
     secret_access_key: str,
+    public_url: str = "",
     key_prefix: str = "",
 ) -> CuratorMetadata:
-    """Process and upload a single curator's metadata to R2.
+    """Process and upload a single curator's metadata and logos to R2.
 
-    Uploads to ``curator-metadata/{key_prefix}{slug}/metadata.json``.
+    Uploads:
+
+    - ``curator-metadata/{key_prefix}{slug}/metadata.json`` — JSON metadata
+    - ``curator-metadata/{key_prefix}{slug}/{variant}.png`` — 256x256 logo
 
     :param yaml_path:
         Path to the curator YAML file.
@@ -628,13 +707,16 @@ def process_and_upload_curator_metadata(  # noqa: PLR0917
     :param secret_access_key:
         R2 secret access key.
 
+    :param public_url:
+        Public base URL for constructing logo URLs in metadata.
+
     :param key_prefix:
         Optional prefix for R2 keys (e.g. ``"test-"`` for testing).
 
     :return:
         The processed :py:class:`CuratorMetadata`.
     """
-    metadata = build_curator_metadata_json(yaml_path)
+    metadata = build_curator_metadata_json(yaml_path, public_url=public_url)
     slug = metadata["slug"]
 
     json_bytes = json.dumps(metadata, indent=2).encode()
@@ -650,14 +732,36 @@ def process_and_upload_curator_metadata(  # noqa: PLR0917
     )
     logger.info("%s curator metadata for: %s", "Uploaded" if metadata_uploaded else "Skipped unchanged", slug)
 
+    logo_dir = FORMATTED_LOGOS_DIR / slug
+    for variant in LOGO_VARIANTS:
+        logo_path = logo_dir / f"{variant}.png"
+        if logo_path.exists():
+            logo_uploaded = upload_to_r2_compressed(
+                payload=logo_path.read_bytes(),
+                bucket_name=bucket_name,
+                object_name=f"curator-metadata/{key_prefix}{slug}/{variant}.png",
+                endpoint_url=endpoint_url,
+                access_key_id=access_key_id,
+                secret_access_key=secret_access_key,
+                content_type="image/png",
+                skip_if_current=True,
+            )
+            logger.info(
+                "%s %s logo for curator: %s",
+                "Uploaded" if logo_uploaded else "Skipped unchanged",
+                variant,
+                slug,
+            )
+
     return metadata
 
 
-def upload_protocol_curator_metadata(
+def upload_protocol_curator_metadata(  # noqa: PLR0917
     bucket_name: str,
     endpoint_url: str,
     access_key_id: str,
     secret_access_key: str,
+    public_url: str = "",
     key_prefix: str = "",
 ) -> list[CuratorMetadata]:
     """Upload metadata entries for all protocol-curated slugs to R2.
@@ -678,13 +782,16 @@ def upload_protocol_curator_metadata(
     :param secret_access_key:
         R2 secret access key.
 
+    :param public_url:
+        Public base URL for constructing logo URLs in metadata.
+
     :param key_prefix:
         Optional prefix for R2 keys.
 
     :return:
         List of uploaded :py:class:`CuratorMetadata` entries.
     """
-    entries = _build_protocol_curator_entries()
+    entries = _build_protocol_curator_entries(public_url=public_url)
 
     for metadata in entries:
         slug = metadata["slug"]
@@ -706,34 +813,59 @@ def upload_protocol_curator_metadata(
             slug,
         )
 
+        logo_dir = FORMATTED_LOGOS_DIR / slug
+        for variant in LOGO_VARIANTS:
+            logo_path = logo_dir / f"{variant}.png"
+            if logo_path.exists():
+                logo_uploaded = upload_to_r2_compressed(
+                    payload=logo_path.read_bytes(),
+                    bucket_name=bucket_name,
+                    object_name=f"curator-metadata/{key_prefix}{slug}/{variant}.png",
+                    endpoint_url=endpoint_url,
+                    access_key_id=access_key_id,
+                    secret_access_key=secret_access_key,
+                    content_type="image/png",
+                    skip_if_current=True,
+                )
+                logger.info(
+                    "%s %s logo for protocol-curator: %s",
+                    "Uploaded" if logo_uploaded else "Skipped unchanged",
+                    variant,
+                    slug,
+                )
+
     return entries
 
 
-def build_curator_index() -> list[CuratorMetadata]:
+def build_curator_index(public_url: str = "") -> list[CuratorMetadata]:
     """Build the aggregate curator metadata index.
 
     Loads all curator YAML files and appends synthetic entries for
     protocol-curated slugs.  The result is suitable for JSON
     serialisation and R2 upload as ``curator-metadata/index.json``.
 
+    :param public_url:
+        Public base URL for constructing logo URLs.
+
     :return:
         List of :py:class:`CuratorMetadata` dicts for all known curators.
     """
     index: list[CuratorMetadata] = []
     for yaml_path in sorted(CURATORS_DATA_DIR.glob("*.yaml")):
-        index.append(build_curator_metadata_json(yaml_path))
+        index.append(build_curator_metadata_json(yaml_path, public_url=public_url))
 
     existing_slugs = {entry["slug"] for entry in index}
-    index.extend(entry for entry in _build_protocol_curator_entries() if entry["slug"] not in existing_slugs)
+    index.extend(entry for entry in _build_protocol_curator_entries(public_url=public_url) if entry["slug"] not in existing_slugs)
 
     return index
 
 
-def upload_curator_index(
+def upload_curator_index(  # noqa: PLR0917
     bucket_name: str,
     endpoint_url: str,
     access_key_id: str,
     secret_access_key: str,
+    public_url: str = "",
     key_prefix: str = "",
 ) -> list[CuratorMetadata]:
     """Build and upload the aggregate curator index to R2.
@@ -752,13 +884,16 @@ def upload_curator_index(
     :param secret_access_key:
         R2 secret access key.
 
+    :param public_url:
+        Public base URL for constructing logo URLs in metadata.
+
     :param key_prefix:
         Optional prefix for R2 keys.
 
     :return:
         The full index list.
     """
-    index = build_curator_index()
+    index = build_curator_index(public_url=public_url)
 
     json_bytes = json.dumps(index, indent=2).encode()
     index_uploaded = upload_to_r2_compressed(

--- a/scripts/erc-4626/export-protocol-metadata.py
+++ b/scripts/erc-4626/export-protocol-metadata.py
@@ -37,7 +37,7 @@ from eth_defi.vault.protocol_metadata import METADATA_DIR, get_available_logos, 
 logger = logging.getLogger(__name__)
 
 
-def main():
+def main():  # noqa: PLR0914
     setup_console_logging(
         log_file=Path("logs/export-protocol-metadata.log"),
         only_log_file=False,
@@ -111,6 +111,41 @@ def main():
             public_url=public_url,
         )
 
+        # Upload curator metadata
+        curator_files = list(CURATORS_DATA_DIR.glob("*.yaml"))
+        logger.info("Found %d curator metadata files", len(curator_files))
+
+        def _process_curator(yaml_path: Path, _bucket: str = current_bucket):
+            process_and_upload_curator_metadata(
+                yaml_path=yaml_path,
+                bucket_name=_bucket,
+                endpoint_url=endpoint_url,
+                access_key_id=access_key_id,
+                secret_access_key=secret_access_key,
+                public_url=public_url,
+            )
+
+        curator_tasks = (delayed(_process_curator)(f) for f in curator_files)
+        Parallel(n_jobs=max_workers, prefer="threads")(tqdm(curator_tasks, total=len(curator_files), desc="Checking curator metadata"))
+
+        # Upload protocol-curator entries (Ostium, gTrade, Hyperliquid, Lighter)
+        upload_protocol_curator_metadata(
+            bucket_name=current_bucket,
+            endpoint_url=endpoint_url,
+            access_key_id=access_key_id,
+            secret_access_key=secret_access_key,
+            public_url=public_url,
+        )
+
+        # Upload aggregate curator index
+        curator_index = upload_curator_index(
+            bucket_name=current_bucket,
+            endpoint_url=endpoint_url,
+            access_key_id=access_key_id,
+            secret_access_key=secret_access_key,
+            public_url=public_url,
+        )
+
     # Build summary table of exported protocols and logo availability
     table_data = []
     for slug in sorted(slugs):
@@ -133,38 +168,6 @@ def main():
     )
 
     print(f"\nStablecoin metadata export complete: {len(stablecoin_files)} stablecoins, {len(index)} index entries\n")
-
-    # Upload curator metadata
-    curator_files = list(CURATORS_DATA_DIR.glob("*.yaml"))
-    logger.info("Found %d curator metadata files", len(curator_files))
-
-    def _process_curator(yaml_path: Path):
-        process_and_upload_curator_metadata(
-            yaml_path=yaml_path,
-            bucket_name=bucket_name,
-            endpoint_url=endpoint_url,
-            access_key_id=access_key_id,
-            secret_access_key=secret_access_key,
-        )
-
-    curator_tasks = (delayed(_process_curator)(f) for f in curator_files)
-    Parallel(n_jobs=max_workers, prefer="threads")(tqdm(curator_tasks, total=len(curator_files), desc="Checking curator metadata"))
-
-    # Upload protocol-curator entries (Ostium, gTrade, Hyperliquid, Lighter)
-    upload_protocol_curator_metadata(
-        bucket_name=bucket_name,
-        endpoint_url=endpoint_url,
-        access_key_id=access_key_id,
-        secret_access_key=secret_access_key,
-    )
-
-    # Upload aggregate curator index
-    curator_index = upload_curator_index(
-        bucket_name=bucket_name,
-        endpoint_url=endpoint_url,
-        access_key_id=access_key_id,
-        secret_access_key=secret_access_key,
-    )
 
     print(f"\nCurator metadata export complete: {len(curator_files)} curators, {len(curator_index)} index entries\n")
 

--- a/scripts/logos/batch-post-process.py
+++ b/scripts/logos/batch-post-process.py
@@ -49,9 +49,7 @@ DARK_PRIORITY = [
     lambda slug, files: _find(files, f"{slug}.dark", ".png"),
     lambda slug, files: _find(files, f"{slug}.dark", ".jpg"),
     # Also match files with "dark" anywhere in stem (not wordmark)
-    lambda slug, files: next(
-        (f for f in files if "dark" in f.stem.lower() and "wordmark" not in f.stem.lower()), None
-    ),
+    lambda slug, files: next((f for f in files if "dark" in f.stem.lower() and "wordmark" not in f.stem.lower()), None),
 ]
 
 

--- a/tests/feed/test_canonical_feeder.py
+++ b/tests/feed/test_canonical_feeder.py
@@ -14,6 +14,7 @@ from eth_defi.feed.sources import (
     load_feeder_metadata,
     load_post_sources,
 )
+from eth_defi.vault import curator as curator_module
 
 
 def _write_yaml(path: Path, content: str) -> None:
@@ -64,8 +65,8 @@ def test_alias_loading(tmp_path: Path):
 
     # 6. Both aliases present
     alias_map = {(a.feeder_id, a.role): a.canonical_feeder_id for a in aliases}
-    assert alias_map[("usdt-e", "stablecoin")] == "usdt"
-    assert alias_map[("yo", "curator")] == "yo"
+    assert alias_map["usdt-e", "stablecoin"] == "usdt"
+    assert alias_map["yo", "curator"] == "yo"
 
     # 7. No aliases counted as skipped
     assert skipped == 0
@@ -89,7 +90,7 @@ def test_alias_validation_errors(tmp_path: Path):
         "feeder-id: bad-alias\nname: Bad\nrole: stablecoin\ncanonical-feeder-id: usdt\ntwitter: tether\n",
     )
 
-    with pytest.raises(ValueError, match="canonical-feeder-id.*twitter"):
+    with pytest.raises(ValueError, match=r"canonical-feeder-id.*twitter"):
         load_post_sources(tmp_path)
 
     # Clean up for next sub-test
@@ -101,7 +102,7 @@ def test_alias_validation_errors(tmp_path: Path):
         "feeder-id: ghost-alias\nname: Ghost\nrole: stablecoin\ncanonical-feeder-id: nonexistent\n",
     )
 
-    with pytest.raises(ValueError, match="nonexistent.*does not match any known feeder-id"):
+    with pytest.raises(ValueError, match=r"nonexistent.*does not match any known feeder-id"):
         load_post_sources(tmp_path)
 
     (tmp_path / "stablecoins" / "ghost-alias.yaml").unlink()
@@ -120,7 +121,7 @@ def test_alias_validation_errors(tmp_path: Path):
         "feeder-id: a\nname: Alias A\nrole: stablecoin\ncanonical-feeder-id: b\n",
     )
 
-    with pytest.raises(ValueError, match="alias.*chains are not allowed"):
+    with pytest.raises(ValueError, match=r"alias.*chains are not allowed"):
         load_post_sources(tmp_path)
 
 
@@ -132,26 +133,26 @@ def test_real_yaml_files_load_without_errors():
     3. Assert specific known aliases are present.
     """
 
-    sources, skipped, aliases = load_post_sources(FEEDS_DATA_DIR)
+    sources, _skipped, aliases = load_post_sources(FEEDS_DATA_DIR)
     assert len(sources) > 0
     assert len(aliases) > 0
 
     alias_map = {(a.feeder_id, a.role): a.canonical_feeder_id for a in aliases}
 
     # Same-role stablecoin aliases
-    assert alias_map[("usdt-e", "stablecoin")] == "usdt"
-    assert alias_map[("usdc-e", "stablecoin")] == "usdc"
-    assert alias_map[("sfrax", "stablecoin")] == "frax"
+    assert alias_map["usdt-e", "stablecoin"] == "usdt"
+    assert alias_map["usdc-e", "stablecoin"] == "usdc"
+    assert alias_map["sfrax", "stablecoin"] == "frax"
 
     # Cross-role curator -> stablecoin
-    assert alias_map[("ethena", "curator")] == "usde"
+    assert alias_map["ethena", "curator"] == "usde"
 
     # Cross-role curator -> protocol
-    assert alias_map[("spark", "curator")] == "spark"
-    assert alias_map[("ipor", "curator")] == "ipor-fusion"
+    assert alias_map["spark", "curator"] == "spark"
+    assert alias_map["ipor", "curator"] == "ipor-fusion"
 
     # Cross-role protocol -> stablecoin (sbold dedup)
-    assert alias_map[("sbold", "protocol")] == "sbold"
+    assert alias_map["sbold", "protocol"] == "sbold"
 
 
 def test_other_links_metadata_loads(tmp_path: Path):
@@ -188,8 +189,6 @@ def test_metadata_inheritance_in_curator_export(tmp_path: Path):
     5. Create a second alias whose canonical has no linkedin — assert linkedin is None.
     """
 
-    from eth_defi.vault.curator import build_curator_metadata_json
-
     # Full metadata canonical
     _write_yaml(
         tmp_path / "stablecoins" / "usde.yaml",
@@ -200,12 +199,13 @@ def test_metadata_inheritance_in_curator_export(tmp_path: Path):
         "feeder-id: ethena\nname: Ethena\nrole: curator\ncanonical-feeder-id: usde\n",
     )
 
-    metadata = build_curator_metadata_json(tmp_path / "curators" / "ethena.yaml")
+    metadata = curator_module.build_curator_metadata_json(tmp_path / "curators" / "ethena.yaml")
     assert metadata["slug"] == "ethena"
     assert metadata["name"] == "Ethena"
     assert metadata["website"] == "https://ethena.fi/"
     assert metadata["twitter"] == "https://x.com/ethena"
     assert metadata["linkedin"] == "https://www.linkedin.com/company/ethena-labs"
+    assert metadata["logos"] == {"generic": None, "dark": None, "light": None}
     assert metadata["canonical_feeder_id"] == "usde"
 
     # 5. Partial metadata canonical — no linkedin field
@@ -218,6 +218,76 @@ def test_metadata_inheritance_in_curator_export(tmp_path: Path):
         "feeder-id: abc-curator\nname: ABC Curator\nrole: curator\ncanonical-feeder-id: abc\n",
     )
 
-    meta2 = build_curator_metadata_json(tmp_path / "curators" / "abc-curator.yaml")
+    meta2 = curator_module.build_curator_metadata_json(tmp_path / "curators" / "abc-curator.yaml")
     assert meta2["twitter"] == "https://x.com/abctoken"
     assert meta2["linkedin"] is None
+
+
+def test_curator_metadata_export_includes_logo_urls(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Curator metadata export includes URLs for available logo variants.
+
+    1. Create a curator YAML file.
+    2. Point the curator logo directory to a temporary folder.
+    3. Create ``generic`` and ``dark`` PNG variants.
+    4. Assert the public metadata contains only available logo URLs.
+    """
+
+    _write_yaml(
+        tmp_path / "curators" / "gauntlet.yaml",
+        "feeder-id: gauntlet\nname: Gauntlet\nrole: curator\ntwitter: gauntlet_xyz\n",
+    )
+    logo_dir = tmp_path / "logos" / "gauntlet"
+    logo_dir.mkdir(parents=True)
+    (logo_dir / "generic.png").write_bytes(b"generic")
+    (logo_dir / "dark.png").write_bytes(b"dark")
+    monkeypatch.setattr(curator_module, "FORMATTED_LOGOS_DIR", tmp_path / "logos")
+
+    metadata = curator_module.build_curator_metadata_json(
+        tmp_path / "curators" / "gauntlet.yaml",
+        public_url="https://pub.example/",
+    )
+
+    assert metadata["logos"] == {
+        "generic": "https://pub.example/curator-metadata/gauntlet/generic.png",
+        "dark": "https://pub.example/curator-metadata/gauntlet/dark.png",
+        "light": None,
+    }
+
+
+def test_curator_metadata_uploads_logo_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Curator metadata upload includes JSON and available PNG logo variants."""
+
+    _write_yaml(
+        tmp_path / "curators" / "gauntlet.yaml",
+        "feeder-id: gauntlet\nname: Gauntlet\nrole: curator\ntwitter: gauntlet_xyz\n",
+    )
+    logo_dir = tmp_path / "logos" / "gauntlet"
+    logo_dir.mkdir(parents=True)
+    (logo_dir / "generic.png").write_bytes(b"generic")
+    (logo_dir / "light.png").write_bytes(b"light")
+    monkeypatch.setattr(curator_module, "FORMATTED_LOGOS_DIR", tmp_path / "logos")
+
+    uploads = []
+
+    def fake_upload_to_r2_compressed(**kwargs):
+        uploads.append(kwargs)
+        return True
+
+    monkeypatch.setattr(curator_module, "upload_to_r2_compressed", fake_upload_to_r2_compressed)
+
+    metadata = curator_module.process_and_upload_curator_metadata(
+        yaml_path=tmp_path / "curators" / "gauntlet.yaml",
+        bucket_name="bucket",
+        endpoint_url="https://endpoint.example",
+        access_key_id="key",
+        secret_access_key="secret",
+        public_url="https://pub.example/",
+        key_prefix="test-",
+    )
+
+    assert metadata["logos"]["generic"] == "https://pub.example/curator-metadata/gauntlet/generic.png"
+    assert {upload["object_name"] for upload in uploads} == {
+        "curator-metadata/test-gauntlet/metadata.json",
+        "curator-metadata/test-gauntlet/generic.png",
+        "curator-metadata/test-gauntlet/light.png",
+    }


### PR DESCRIPTION
## Why

The 40acres Aerodrome USDC vault on Base (`0xb99b6df96d4d5448cc0a5b3e0ef7896df9507cf5`) was not appearing in the vault listing because the contract address stored in our codebase had a duplicated `d` — `b99b6**dd**f` instead of `b99b6**d**f` — making it 41 hex characters. Web3.py's `to_checksum_address` rejected this at runtime, so the vault could be detected (exact dict key match) but could not be instantiated or read.

Also includes an Accountable vault fix: `get_link()` now correctly uses the `loan_address` field from the API (the yield app at `yield.accountable.capital` routes via loan/strategy contract addresses, not vault share token addresses).

## Lessons learnt

- Ethereum addresses are exactly 40 hex characters after `0x`; our address validation (`assert a == a.lower()`) only checks casing, not length — a length assertion would catch this class of typo earlier.

## Summary

- Fix `0xb99b6**dd**f...` → `0xb99b6**d**f...` in `classification.py` and `forty_acres/vault.py` (VAULT_NAMES dict + docstring link)
- Accountable: expose `loan_address` in `AccountableVaultMetadata` and use it in `get_link()`
- CHANGELOG entry added