### PR TITLE
fix: correct 40acres Base vault contract address typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- fix: 40acres Aerodrome USDC vault on Base had a typo in the contract address (duplicated `d`), causing vault detection to fail; correct address is `0xb99b6df96d4d5448cc0a5b3e0ef7896df9507cf5` (2026-05-05)
+
 - feat: Twitter list collector falls back to individual user timeline for handles with zero list results, ensuring last_post_published_at is always populated (2026-05-05)
 
 - feat: Logos added for 67 vault curators — 256×256 RGBA PNG assets sourced from official brand kits, GitHub repos, website SVGs, CDN assets, and Twitter avatars; one curator (Tanken) documented as logo-unavailable (2026-05-05)

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -1877,8 +1877,8 @@ HARDCODED_PROTOCOLS = {
     # https://optimistic.etherscan.io/address/0x08dCDBf7baDe91Ccd42CB2a4EA8e5D199d285957
     "0x08dcdbf7bade91ccd42cb2a4ea8e5d199d285957": {ERC4626Feature.forty_acres_like},
     # 40acres - Aerodrome USDC vault on Base
-    # https://basescan.org/address/0xB99B6dDF96d4d5448cC0a5B3e0ef7896df9507Cf5
-    "0xb99b6ddf96d4d5448cc0a5b3e0ef7896df9507cf5": {ERC4626Feature.forty_acres_like},
+    # https://basescan.org/address/0xb99b6df96d4d5448cc0a5b3e0ef7896df9507cf5
+    "0xb99b6df96d4d5448cc0a5b3e0ef7896df9507cf5": {ERC4626Feature.forty_acres_like},
 }
 
 for a in HARDCODED_PROTOCOLS.keys():

--- a/eth_defi/erc_4626/vault_protocol/forty_acres/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/forty_acres/vault.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 #: Used to override the cryptic on-chain ``name()`` return values.
 VAULT_NAMES: dict[str, str] = {
     # Aerodrome USDC vault on Base
-    "0xb99b6ddf96d4d5448cc0a5b3e0ef7896df9507cf5": "Aerodrome USDC",
+    "0xb99b6df96d4d5448cc0a5b3e0ef7896df9507cf5": "Aerodrome USDC",
     # Velodrome USDC vault on Optimism
     "0x08dcdbf7bade91ccd42cb2a4ea8e5d199d285957": "Velodrome USDC",
     # Pharaoh USDC vault on Avalanche
@@ -94,7 +94,7 @@ class FortyAcresVault(ERC4626Vault):
     - `Blackhole vault on Avalanche <https://snowtrace.io/address/0xc0485c4bafb594ae1457820fb6e5b67e8a04bcfd>`__
     - `Pharaoh vault on Avalanche <https://snowtrace.io/address/0x124d00b1ce4453ffc5a5f65ce83af13a7709bac7>`__
     - `Velodrome vault on Optimism <https://optimistic.etherscan.io/address/0x08dCDBf7baDe91Ccd42CB2a4EA8e5D199d285957>`__
-    - `Aerodrome vault on Base <https://basescan.org/address/0xB99B6dDF96d4d5448cC0a5B3e0ef7896df9507Cf5>`__
+    - `Aerodrome vault on Base <https://basescan.org/address/0xb99b6df96d4d5448cc0a5b3e0ef7896df9507cf5>`__
     """
 
     @property


### PR DESCRIPTION
## Why

The 40acres Aerodrome USDC vault on Base (`0xb99b6df96d4d5448cc0a5b3e0ef7896df9507cf5`) was not appearing in the vault listing because the contract address stored in our codebase had a duplicated `d` — `b99b6**dd**f` instead of `b99b6**d**f` — making it 41 hex characters. Web3.py's `to_checksum_address` rejected this at runtime, so the vault could be detected (exact dict key match in `HARDCODED_PROTOCOLS`) but could not be instantiated or read.

## Lessons learnt

Ethereum addresses are exactly 40 hex characters after `0x`. Our existing address validation (`assert a == a.lower()`) only checks casing, not length — a length assertion would catch this class of typo earlier.

## Summary

- Fix `0xb99b6**dd**f...` → `0xb99b6**d**f...` in `classification.py` and `forty_acres/vault.py` (VAULT_NAMES dict + docstring link)
- CHANGELOG entry added