### PR TITLE
docs: expand README-feed config reference for backfill and sync scripts

### DIFF
--- a/eth_defi/feed/README-feed.md
+++ b/eth_defi/feed/README-feed.md
@@ -529,7 +529,9 @@ Common errors and their causes:
 
 ## Configuration reference
 
-Environment variables accepted by the runner:
+### scan-vault-posts.py
+
+Environment variables accepted by the main scanner:
 
 - `DB_PATH`: DuckDB path, default `~/.tradingstrategy/vaults/vault-post-database.duckdb`
 - `MAPPINGS_DIR`: optional override for the feeder directory root, default
@@ -558,6 +560,36 @@ Environment variables accepted by the runner:
   default `1200`
 - `USE_X_LIST_TIMELINE`: use the X list timeline for Twitter reads when a list
   ID is available, default `true`
+
+### backfill-twitter-handles.py
+
+Environment variables accepted by the one-shot backfill script:
+
+- `TWITTER_BEARER_TOKEN`: **required** — X API v2 bearer token for reading
+  individual user timelines
+- `DB_PATH`: DuckDB path, default `~/.tradingstrategy/vaults/vault-post-database.duckdb`
+- `MAPPINGS_DIR`: feeder YAML root, default `eth_defi/data/feeds`
+- `LOG_LEVEL`: logging level, default `info`
+- `MAX_TWEETS_PER_HANDLE`: tweets to fetch per handle on first backfill, default `20`
+- `DELAY_BETWEEN_HANDLES`: seconds to sleep between X API calls, default `1`
+
+### sync-x-list.py
+
+Environment variables accepted by the X list membership sync script:
+
+- `TWITTER_BEARER_TOKEN`: **required** — X API v2 bearer token
+- `TWITTER_CONSUMER_KEY`: **required** — OAuth 1.0a consumer key
+- `TWITTER_SECRET_KEY`: **required** — OAuth 1.0a consumer secret
+- `TWITTER_ACCESS_TOKEN`: **required** — OAuth 1.0a user access token
+- `TWITTER_ACCESS_TOKEN_SECRET`: **required** — OAuth 1.0a user access token secret
+- `X_LIST_ID`: explicit X list ID override; otherwise the default list name is resolved
+- `X_LIST_NAME`: X list name to resolve, default `Best builders in DeFi`
+- `X_LIST_ADD_DELAY_SECONDS`: delay between list member writes, default `1`
+- `X_LIST_RATE_LIMIT_SLEEP_MAX_SECONDS`: maximum automatic rate-limit sleep,
+  default `1200`
+- `DB_PATH`: DuckDB path, default `~/.tradingstrategy/vaults/vault-post-database.duckdb`
+- `MAPPINGS_DIR`: feeder YAML root, default `eth_defi/data/feeds`
+- `LOG_LEVEL`: logging level, default `info`
 
 ## Main files
 


### PR DESCRIPTION
## Why

The configuration reference was a flat list that mixed env vars from three different scripts (`scan-vault-posts.py`, `backfill-twitter-handles.py`, `sync-x-list.py`). After adding the backfill script in the previous commit, two new env vars (`MAX_TWEETS_PER_HANDLE`, `DELAY_BETWEEN_HANDLES`) were missing from the reference entirely, and the sync-x-list vars were only documented in the running-the-scanner section, not the config reference.

## Summary

- Split the flat configuration reference into per-script subsections
- Added `backfill-twitter-handles.py` subsection with its two new env vars
- Added `sync-x-list.py` subsection consolidating its vars in the config reference
- Renamed the existing block to `scan-vault-posts.py` to match the pattern

## Lessons learnt

When a new standalone script is added, its env vars should be added to the configuration reference at the same time so operators have a single place to look them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)