### PR TITLE
fix: set deposit_count to 0 for native protocols without event tracking

### DIFF
--- a/eth_defi/erc_4626/core.py
+++ b/eth_defi/erc_4626/core.py
@@ -939,10 +939,15 @@ class ERC4262VaultDetection:
     #: When this entry was scanned on chain
     updated_at: datetime.datetime
 
-    #: Event counts
+    #: Number of on-chain deposit events observed.
+    #:
+    #: Zero for native protocols (GRVT, Lighter, Hibachi) that do not
+    #: support on-chain deposit/redeem event tracking.
     deposit_count: int
 
-    #: Event counts
+    #: Number of on-chain redeem events observed.
+    #:
+    #: Zero for native protocols that do not support on-chain event tracking.
     redeem_count: int
 
     def get_spec(self) -> VaultSpec:

--- a/eth_defi/grvt/vault_data_export.py
+++ b/eth_defi/grvt/vault_data_export.py
@@ -101,7 +101,7 @@ def create_grvt_vault_row(
         first_seen_at=datetime.datetime(2025, 1, 1),
         features={ERC4626Feature.grvt_native},
         updated_at=native_datetime_utc_now(),
-        deposit_count=1,
+        deposit_count=0,
         redeem_count=0,
     )
 

--- a/eth_defi/hibachi/vault_data_export.py
+++ b/eth_defi/hibachi/vault_data_export.py
@@ -115,7 +115,7 @@ def create_hibachi_vault_row(
         first_seen_at=datetime.datetime(2025, 1, 1),
         features={ERC4626Feature.hibachi_native},
         updated_at=native_datetime_utc_now(),
-        deposit_count=1,
+        deposit_count=0,
         redeem_count=0,
     )
 

--- a/eth_defi/lighter/vault_data_export.py
+++ b/eth_defi/lighter/vault_data_export.py
@@ -98,7 +98,7 @@ def create_lighter_pool_row(
         first_seen_at=created_at or datetime.datetime(2025, 1, 1),
         features={ERC4626Feature.lighter_native},
         updated_at=native_datetime_utc_now(),
-        deposit_count=1,
+        deposit_count=0,
         redeem_count=0,
     )
 

--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -175,6 +175,9 @@ class CleanedVaultPriceRow(TypedDict, total=False):
 
     #: Total deposit + redeem events observed for this vault.
     #:
+    #: Zero if the protocol does not support on-chain deposit/redeem event tracking
+    #: (e.g. native vaults like GRVT, Lighter, Hibachi).
+    #:
     #: General — present for all protocols.
     event_count: int
 

--- a/tests/hyperliquid/test_vault_review_persistence.py
+++ b/tests/hyperliquid/test_vault_review_persistence.py
@@ -262,7 +262,7 @@ def test_calculate_vault_record_emits_manual_review_status() -> None:
         first_seen_at=datetime.datetime(2024, 1, 1),
         features={ERC4626Feature.hypercore_native},
         updated_at=datetime.datetime(2024, 1, 1),
-        deposit_count=1,
+        deposit_count=0,
         redeem_count=0,
     )
     fee_data = FeeData(


### PR DESCRIPTION
## Why

GRVT, Lighter, and Hibachi are native (non-EVM) protocols that do not emit on-chain deposit/redeem events. They used a synthetic `deposit_count=1` placeholder, which was misleading — it implied one deposit had occurred when in reality no deposits are tracked at all.

## Lessons learnt

Native protocol vaults should use 0 rather than 1 for unsupported metrics, with documentation clarifying the semantics.

## Summary

- Set `deposit_count=0` for GRVT, Lighter, and Hibachi vault data exports
- Documented on `ERC4262VaultDetection.deposit_count` and `redeem_count` that zero means the protocol does not support on-chain event tracking
- Documented on `CleanedVaultPriceRow.event_count` that zero means no deposit/redeem tracking
- Updated test fixture to match