### PR TITLE
feat: add Ethereum-only sample vault data files for free download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- feat: Ethereum-only sample vault data files (`vault-historical.sample.parquet`, `vault-metadata.sample.json`) generated during post-processing and uploaded to the public R2 bucket for free download; skip with `SKIP_SAMPLES=true` (2026-05-08)
+
 - fix: 40acres Aerodrome USDC vault on Base had a typo in the contract address (duplicated `d`), causing vault detection to fail; correct address is `0xb99b6df96d4d5448cc0a5b3e0ef7896df9507cf5` (2026-05-05)
 
 - feat: Twitter list collector falls back to individual user timeline for handles with zero list results, ensuring last_post_published_at is always populated (2026-05-05)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,7 @@ services:
       R2_TOP_VAULTS_PUBLIC_URL: ${R2_TOP_VAULTS_PUBLIC_URL:-}
       R2_TOP_VAULTS_ALTERNATIVE_BUCKET_NAME: ${R2_TOP_VAULTS_ALTERNATIVE_BUCKET_NAME:-}
       SKIP_TOP_VAULTS: ${SKIP_TOP_VAULTS:-false}
+      SKIP_SAMPLES: ${SKIP_SAMPLES:-false}
 
       # General workers per script
       MAX_WORKERS: ${MAX_WORKERS:-50}
@@ -221,6 +222,7 @@ services:
       R2_TOP_VAULTS_PUBLIC_URL: ${R2_TOP_VAULTS_PUBLIC_URL:-}
       R2_TOP_VAULTS_ALTERNATIVE_BUCKET_NAME: ${R2_TOP_VAULTS_ALTERNATIVE_BUCKET_NAME:-}
       SKIP_TOP_VAULTS: ${SKIP_TOP_VAULTS:-false}
+      SKIP_SAMPLES: ${SKIP_SAMPLES:-false}
 
       # Hyperliquid manual vault review Google Sheet sync — same
       # contract as the one-shot vault-scanner service above.

--- a/eth_defi/vault/post_processing.py
+++ b/eth_defi/vault/post_processing.py
@@ -409,14 +409,10 @@ def export_sample_files(
     :return: True if export succeeded
     """
     try:
+        from eth_defi.vault.sample_export import export_sample_files_to_r2
+
         logger.info("Exporting sample data files")
-        spec = importlib.util.spec_from_file_location(
-            "export_sample_files",
-            "scripts/erc-4626/export-sample-files.py",
-        )
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        module.main(
+        export_sample_files_to_r2(
             skip_parquet_sample=skip_parquet_sample,
             skip_json_sample=skip_json_sample,
         )

--- a/eth_defi/vault/post_processing.py
+++ b/eth_defi/vault/post_processing.py
@@ -387,6 +387,46 @@ def export_data_files() -> bool:
         return False
 
 
+def export_sample_files(
+    skip_parquet_sample: bool = False,
+    skip_json_sample: bool = False,
+) -> bool:
+    """Export Ethereum-only sample data files to R2.
+
+    Generates filtered sample versions of the cleaned parquet and
+    top-vaults JSON for free download, then uploads to the primary
+    (public) R2 bucket only — deliberately skips the alternative
+    (private) bucket.
+
+    :param skip_parquet_sample:
+        Skip the parquet sample generation (e.g. when the
+        cleaned parquet was not generated this run).
+
+    :param skip_json_sample:
+        Skip the JSON sample generation (e.g. when the
+        top-vaults JSON was not generated this run).
+
+    :return: True if export succeeded
+    """
+    try:
+        logger.info("Exporting sample data files")
+        spec = importlib.util.spec_from_file_location(
+            "export_sample_files",
+            "scripts/erc-4626/export-sample-files.py",
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        module.main(
+            skip_parquet_sample=skip_parquet_sample,
+            skip_json_sample=skip_json_sample,
+        )
+        logger.info("Sample data file export complete")
+        return True
+    except Exception:
+        logger.exception("Export sample files failed")
+        return False
+
+
 def validate_top_vaults_config(skip_top_vaults: bool = False) -> None:
     """Fail-fast pre-flight check for the top-vaults JSON R2 upload.
 
@@ -546,6 +586,7 @@ def run_post_processing(
     skip_sparklines: bool = False,
     skip_metadata: bool = False,
     skip_data: bool = False,
+    skip_samples: bool = False,
     uncleaned_parquet_path: Path | None = None,
     hyperliquid_db_path: Path | None = None,
     hyperliquid_hf_db_path: Path | None = None,
@@ -564,6 +605,7 @@ def run_post_processing(
     4. Export sparklines to R2
     5. Export protocol metadata to R2
     6. Export data files (parquet, pickle) to R2
+    7. Export Ethereum-only sample files to R2 (public bucket only)
 
     :param scan_hypercore: Whether to merge Hypercore data
     :param scan_grvt: Whether to merge GRVT data
@@ -574,6 +616,7 @@ def run_post_processing(
     :param skip_sparklines: Skip sparkline image export to R2
     :param skip_metadata: Skip protocol/stablecoin metadata export to R2
     :param skip_data: Skip data file (parquet, pickle) export to R2
+    :param skip_samples: Skip Ethereum-only sample file export to R2
     :param uncleaned_parquet_path: Override for the uncleaned parquet path
     :param hyperliquid_db_path: Override for the daily Hyperliquid DuckDB path
     :param hyperliquid_hf_db_path: Override for the HF Hyperliquid DuckDB path
@@ -637,5 +680,34 @@ def run_post_processing(
         logger.info("Skipping data file export (SKIP_DATA=true)")
     else:
         steps["export-data-files"] = export_data_files()
+
+    # Step 7: Export Ethereum-only sample files (public bucket only)
+    if skip_samples:
+        logger.info("Skipping sample file export (SKIP_SAMPLES=true)")
+    else:
+        # Parquet sample requires clean-prices to have succeeded this run.
+        # If cleaning was explicitly skipped (SKIP_CLEANING=true), the operator
+        # asserts the existing cleaned parquet is valid, so samples are allowed.
+        parquet_ok = steps.get("clean-prices", True) if not skip_cleaning else True
+
+        # JSON sample requires BOTH a fresh cleaned parquet (top-vaults JSON is
+        # derived from cleaned data) AND a successful top-vaults export.
+        # This prevents sampling a JSON built from stale cleaned data after a
+        # cleaning failure.
+        json_ok = (parquet_ok and steps.get("export-top-vaults-json", False)) if not skip_top_vaults else False
+
+        # If neither sample type is eligible, skip the step entirely
+        # rather than recording a misleading "OK" for zero work.
+        if not parquet_ok and not json_ok:
+            logger.warning(
+                "Skipping sample export — no eligible source data (clean-prices=%s, export-top-vaults-json=%s)",
+                steps.get("clean-prices"),
+                steps.get("export-top-vaults-json"),
+            )
+        else:
+            steps["export-sample-files"] = export_sample_files(
+                skip_parquet_sample=not parquet_ok,
+                skip_json_sample=not json_ok,
+            )
 
     return steps

--- a/eth_defi/vault/sample_export.py
+++ b/eth_defi/vault/sample_export.py
@@ -1,0 +1,201 @@
+"""Export Ethereum-only sample vault data files to Cloudflare R2.
+
+Generates free-download sample versions of the cleaned parquet and
+top-vaults JSON filtered to Ethereum mainnet (chain_id=1) only.
+
+These sample files are uploaded to the primary (public) R2 bucket only,
+NOT to the alternative (private) bucket.
+"""
+
+import json
+import logging
+import os
+from pathlib import Path
+
+import pandas as pd
+
+from eth_defi.cloudflare_r2 import create_r2_client, upload_file_to_r2
+from eth_defi.vault.vaultdb import get_pipeline_data_dir
+
+logger = logging.getLogger(__name__)
+
+#: Only include Ethereum mainnet in the sample files
+ETHEREUM_CHAIN_ID = 1
+
+
+def generate_sample_parquet(cleaned_path: Path, output_path: Path) -> int:
+    """Filter the cleaned vault prices parquet to Ethereum only.
+
+    Reads the full multi-chain cleaned parquet and writes an
+    Ethereum-only subset for free download.
+
+    :param cleaned_path:
+        Path to the full ``cleaned-vault-prices-1h.parquet``.
+
+    :param output_path:
+        Destination path for the sample parquet.
+
+    :return:
+        Number of rows in the sample.
+
+    :raise FileNotFoundError:
+        If the source parquet does not exist.
+
+    :raise ValueError:
+        If the filtered result has zero Ethereum rows.
+    """
+    if not cleaned_path.exists():
+        raise FileNotFoundError(f"Cleaned parquet not found: {cleaned_path}")
+
+    df = pd.read_parquet(cleaned_path)
+    sample_df = df[df["chain"] == ETHEREUM_CHAIN_ID]
+
+    if len(sample_df) == 0:
+        raise ValueError(f"No Ethereum (chain_id={ETHEREUM_CHAIN_ID}) rows found in {cleaned_path}")
+
+    sample_df.to_parquet(output_path, compression="zstd")
+    logger.info(
+        "Generated sample parquet: %d Ethereum rows out of %d total -> %s",
+        len(sample_df),
+        len(df),
+        output_path,
+    )
+    return len(sample_df)
+
+
+def generate_sample_json(json_path: Path, output_path: Path) -> int:
+    """Filter the top-vaults JSON to Ethereum only.
+
+    Reads the full multi-chain top-vaults JSON and writes an
+    Ethereum-only subset for free download.
+
+    :param json_path:
+        Path to the full ``top_vaults_by_chain.json``.
+
+    :param output_path:
+        Destination path for the sample JSON.
+
+    :return:
+        Number of vaults in the sample.
+
+    :raise FileNotFoundError:
+        If the source JSON does not exist.
+
+    :raise ValueError:
+        If the filtered result has zero Ethereum vaults.
+    """
+    if not json_path.exists():
+        raise FileNotFoundError(f"Top vaults JSON not found: {json_path}")
+
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    filtered_vaults = [v for v in data["vaults"] if v.get("chain_id") == ETHEREUM_CHAIN_ID]
+
+    if len(filtered_vaults) == 0:
+        raise ValueError(f"No Ethereum (chain_id={ETHEREUM_CHAIN_ID}) vaults found in {json_path}")
+
+    sample_data = {
+        "generated_at": data["generated_at"],
+        "vaults": filtered_vaults,
+    }
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(sample_data, f, indent=2, ensure_ascii=False, allow_nan=False)
+
+    logger.info(
+        "Generated sample JSON: %d Ethereum vaults out of %d total -> %s",
+        len(filtered_vaults),
+        len(data["vaults"]),
+        output_path,
+    )
+    return len(filtered_vaults)
+
+
+def export_sample_files_to_r2(
+    skip_parquet_sample: bool = False,
+    skip_json_sample: bool = False,
+) -> None:
+    """Generate and upload Ethereum-only sample data files.
+
+    Produces ``vault-historical.sample.parquet`` and
+    ``vault-metadata.sample.json`` filtered to Ethereum
+    mainnet (chain_id=1) only, then uploads them to the primary
+    (public) R2 bucket.
+
+    :param skip_parquet_sample:
+        Skip the parquet sample generation (e.g. when
+        the cleaned parquet was not generated this run).
+
+    :param skip_json_sample:
+        Skip the JSON sample generation (e.g. when the
+        top-vaults JSON was not generated this run).
+    """
+    if skip_parquet_sample and skip_json_sample:
+        logger.info("No sample files eligible — both parquet and JSON samples skipped")
+        return
+
+    # R2 credentials — same env vars as export-data-files.py
+    bucket_name = os.environ.get("R2_DATA_BUCKET_NAME") or os.environ.get("R2_VAULT_METADATA_BUCKET_NAME")
+    access_key_id = os.environ.get("R2_DATA_ACCESS_KEY_ID") or os.environ.get("R2_VAULT_METADATA_ACCESS_KEY_ID")
+    secret_access_key = os.environ.get("R2_DATA_SECRET_ACCESS_KEY") or os.environ.get("R2_VAULT_METADATA_SECRET_ACCESS_KEY")
+    endpoint_url = os.environ.get("R2_DATA_ENDPOINT_URL") or os.environ.get("R2_VAULT_METADATA_ENDPOINT_URL")
+    public_url = os.environ.get("R2_DATA_PUBLIC_URL") or os.environ.get("R2_VAULT_METADATA_PUBLIC_URL")
+    upload_prefix = os.environ.get("UPLOAD_PREFIX", "")
+
+    assert bucket_name, "R2_DATA_BUCKET_NAME (or R2_VAULT_METADATA_BUCKET_NAME) environment variable is required"
+
+    base_path = get_pipeline_data_dir()
+
+    # Generate sample files
+    sample_files: list[Path] = []
+
+    if not skip_parquet_sample:
+        cleaned_path = base_path / "cleaned-vault-prices-1h.parquet"
+        parquet_sample_path = base_path / "vault-historical.sample.parquet"
+        row_count = generate_sample_parquet(cleaned_path, parquet_sample_path)
+        sample_files.append(parquet_sample_path)
+        print(f"  Parquet sample: {row_count:,} Ethereum rows")
+    else:
+        logger.info("Skipping parquet sample generation")
+
+    if not skip_json_sample:
+        json_path = base_path / "top_vaults_by_chain.json"
+        json_sample_path = base_path / "vault-metadata.sample.json"
+        vault_count = generate_sample_json(json_path, json_sample_path)
+        sample_files.append(json_sample_path)
+        print(f"  JSON sample: {vault_count:,} Ethereum vaults")
+    else:
+        logger.info("Skipping JSON sample generation")
+
+    if not sample_files:
+        return
+
+    # Upload to primary (public) bucket only — deliberately skip alternative bucket
+    print("\nExporting sample files to R2 (public bucket only)")
+    print(f"  Bucket: {bucket_name}")
+    print(f"  Endpoint: {endpoint_url}")
+    print(f"  Key prefix: '{upload_prefix}'" if upload_prefix else "  Key prefix: (none)")
+
+    s3_client = create_r2_client(
+        endpoint_url=endpoint_url,
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
+    )
+
+    for file_path in sample_files:
+        s3_key = f"{upload_prefix}{file_path.name}"
+        uploaded = upload_file_to_r2(
+            s3_client=s3_client,
+            file_path=file_path,
+            bucket_name=bucket_name,
+            object_name=s3_key,
+            skip_if_current=True,
+        )
+        if uploaded:
+            logger.info("Uploaded %s to s3://%s/%s", file_path, bucket_name, s3_key)
+        else:
+            logger.info("Skipped unchanged %s for s3://%s/%s", file_path, bucket_name, s3_key)
+
+        if public_url and uploaded:
+            final_url = f"{public_url.rstrip('/')}/{s3_key}"
+            print(f"  -> {final_url}")

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -1205,6 +1205,7 @@ def run_scan_tick(
     skip_sparklines: bool,
     skip_metadata: bool,
     skip_data: bool,
+    skip_samples: bool,
     vault_db_path: Path,
     uncleaned_price_path: Path,
     reader_state_path: Path,
@@ -1428,6 +1429,7 @@ def run_scan_tick(
             skip_sparklines=skip_sparklines,
             skip_metadata=skip_metadata,
             skip_data=skip_data,
+            skip_samples=skip_samples,
             uncleaned_parquet_path=uncleaned_price_path,
             hyperliquid_db_path=hyperliquid_db_path,
             hyperliquid_hf_db_path=hyperliquid_hf_db_path,
@@ -1520,6 +1522,7 @@ def main():
     skip_sparklines = os.environ.get("SKIP_SPARKLINES", "false").lower() == "true"
     skip_metadata = os.environ.get("SKIP_METADATA", "false").lower() == "true"
     skip_data = os.environ.get("SKIP_DATA", "false").lower() == "true"
+    skip_samples = os.environ.get("SKIP_SAMPLES", "false").lower() == "true"
 
     # Fail-fast: refuse to start the scan loop if the top-vaults R2 upload
     # is not configured. Discovering at the end of a multi-hour scan that
@@ -1670,6 +1673,7 @@ def main():
         skip_sparklines=skip_sparklines,
         skip_metadata=skip_metadata,
         skip_data=skip_data,
+        skip_samples=skip_samples,
         vault_db_path=vault_db_path,
         uncleaned_price_path=uncleaned_price_path,
         reader_state_path=reader_state_path,

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -66,6 +66,7 @@ poetry run python scripts/erc-4626/scan-vaults-all-chains.py
 | `SCAN_GRVT` | Optional. Enable GRVT native vault scanning. Default: false. |
 | `SCAN_LIGHTER` | Optional. Enable Lighter native pool scanning. Default: false. |
 | `SCAN_HIBACHI` | Optional. Enable Hibachi native vault scanning. Default: false. |
+| `SKIP_SAMPLES` | Optional. Skip Ethereum-only sample file export. Default: false. |
 
 ### scan-prices.py
 
@@ -125,6 +126,7 @@ MERGE_HYPERCORE=true MERGE_GRVT=true MERGE_LIGHTER=true \
 | `MERGE_GRVT` | Optional. Merge GRVT native vault data. Default: false. |
 | `MERGE_LIGHTER` | Optional. Merge Lighter native pool data. Default: false. |
 | `SKIP_EXPORT` | Optional. Skip sparkline and metadata export to R2. Default: false. |
+| `SKIP_SAMPLES` | Optional. Skip Ethereum-only sample file export. Default: false. |
 | `LOG_LEVEL` | Optional. Default: info. |
 
 ### clean-prices.py
@@ -168,6 +170,31 @@ poetry run python scripts/erc-4626/export-protocol-metadata.py
 | `R2_VAULT_METADATA_PUBLIC_URL` | Required. R2 public URL. |
 | `R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME` | Optional. Alternative R2 bucket for the upcoming private commercial professional vault data bucket. Uses same credentials as primary. |
 | `MAX_WORKERS` | Optional. Default: 20. |
+
+### export-sample-files.py
+
+Export Ethereum-only sample versions of cleaned vault data files to Cloudflare R2.
+Generates `vault-historical.sample.parquet` and `vault-metadata.sample.json`
+filtered to Ethereum mainnet (chain_id=1) only, for free download.
+
+Sample files are uploaded to the primary (public) R2 bucket only, not the alternative bucket.
+
+```shell
+source .local-test.env && poetry run python scripts/erc-4626/export-sample-files.py
+```
+
+| Variable | Description |
+|----------|-------------|
+| `R2_DATA_BUCKET_NAME` | R2 bucket for data files (falls back to `R2_VAULT_METADATA_BUCKET_NAME`). |
+| `R2_DATA_ACCESS_KEY_ID` | R2 access key (falls back to `R2_VAULT_METADATA_ACCESS_KEY_ID`). |
+| `R2_DATA_SECRET_ACCESS_KEY` | R2 secret (falls back to `R2_VAULT_METADATA_SECRET_ACCESS_KEY`). |
+| `R2_DATA_ENDPOINT_URL` | R2 endpoint (falls back to `R2_VAULT_METADATA_ENDPOINT_URL`). |
+| `R2_DATA_PUBLIC_URL` | Public base URL (falls back to `R2_VAULT_METADATA_PUBLIC_URL`). |
+| `UPLOAD_PREFIX` | Optional. Prefix for S3 keys. |
+
+Public download URLs:
+- `https://vault-protocol-metadata.tradingstrategy.ai/vault-historical.sample.parquet`
+- `https://vault-protocol-metadata.tradingstrategy.ai/vault-metadata.sample.json`
 
 ### scan-vault-posts.py
 

--- a/scripts/erc-4626/export-sample-files.py
+++ b/scripts/erc-4626/export-sample-files.py
@@ -1,10 +1,6 @@
 """Export Ethereum-only sample vault data files to Cloudflare R2.
 
-Generates free-download sample versions of the cleaned parquet and
-top-vaults JSON filtered to Ethereum mainnet (chain_id=1) only.
-
-These sample files are uploaded to the primary (public) R2 bucket only,
-NOT to the alternative (private) bucket.
+Thin CLI wrapper around :py:func:`eth_defi.vault.sample_export.export_sample_files_to_r2`.
 
 Example:
 
@@ -22,205 +18,19 @@ Environment variables:
     - PIPELINE_DATA_DIR: Override pipeline data directory (default: ~/.tradingstrategy/vaults)
 """
 
-import json
-import logging
-import os
 from pathlib import Path
 
-import pandas as pd
-
-from eth_defi.cloudflare_r2 import create_r2_client, upload_file_to_r2
 from eth_defi.utils import setup_console_logging
-from eth_defi.vault.vaultdb import get_pipeline_data_dir
-
-logger = logging.getLogger(__name__)
-
-#: Only include Ethereum mainnet in the sample files
-ETHEREUM_CHAIN_ID = 1
+from eth_defi.vault.sample_export import export_sample_files_to_r2
 
 
-def generate_sample_parquet(cleaned_path: Path, output_path: Path) -> int:
-    """Filter the cleaned vault prices parquet to Ethereum only.
-
-    Reads the full multi-chain cleaned parquet and writes an
-    Ethereum-only subset for free download.
-
-    :param cleaned_path:
-        Path to the full ``cleaned-vault-prices-1h.parquet``.
-
-    :param output_path:
-        Destination path for the sample parquet.
-
-    :return:
-        Number of rows in the sample.
-
-    :raise FileNotFoundError:
-        If the source parquet does not exist.
-
-    :raise ValueError:
-        If the filtered result has zero Ethereum rows.
-    """
-    if not cleaned_path.exists():
-        raise FileNotFoundError(f"Cleaned parquet not found: {cleaned_path}")
-
-    df = pd.read_parquet(cleaned_path)
-    sample_df = df[df["chain"] == ETHEREUM_CHAIN_ID]
-
-    if len(sample_df) == 0:
-        raise ValueError(f"No Ethereum (chain_id={ETHEREUM_CHAIN_ID}) rows found in {cleaned_path}")
-
-    sample_df.to_parquet(output_path, compression="zstd")
-    logger.info(
-        "Generated sample parquet: %d Ethereum rows out of %d total -> %s",
-        len(sample_df),
-        len(df),
-        output_path,
-    )
-    return len(sample_df)
-
-
-def generate_sample_json(json_path: Path, output_path: Path) -> int:
-    """Filter the top-vaults JSON to Ethereum only.
-
-    Reads the full multi-chain top-vaults JSON and writes an
-    Ethereum-only subset for free download.
-
-    :param json_path:
-        Path to the full ``top_vaults_by_chain.json``.
-
-    :param output_path:
-        Destination path for the sample JSON.
-
-    :return:
-        Number of vaults in the sample.
-
-    :raise FileNotFoundError:
-        If the source JSON does not exist.
-
-    :raise ValueError:
-        If the filtered result has zero Ethereum vaults.
-    """
-    if not json_path.exists():
-        raise FileNotFoundError(f"Top vaults JSON not found: {json_path}")
-
-    data = json.loads(json_path.read_text(encoding="utf-8"))
-    filtered_vaults = [v for v in data["vaults"] if v.get("chain_id") == ETHEREUM_CHAIN_ID]
-
-    if len(filtered_vaults) == 0:
-        raise ValueError(f"No Ethereum (chain_id={ETHEREUM_CHAIN_ID}) vaults found in {json_path}")
-
-    sample_data = {
-        "generated_at": data["generated_at"],
-        "vaults": filtered_vaults,
-    }
-
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, "w", encoding="utf-8") as f:
-        json.dump(sample_data, f, indent=2, ensure_ascii=False, allow_nan=False)
-
-    logger.info(
-        "Generated sample JSON: %d Ethereum vaults out of %d total -> %s",
-        len(filtered_vaults),
-        len(data["vaults"]),
-        output_path,
-    )
-    return len(filtered_vaults)
-
-
-def main(
-    skip_parquet_sample: bool = False,
-    skip_json_sample: bool = False,
-):
-    """Generate and upload Ethereum-only sample data files.
-
-    Produces ``vault-historical.sample.parquet`` and
-    ``vault-metadata.sample.json`` filtered to Ethereum
-    mainnet (chain_id=1) only, then uploads them to the primary
-    (public) R2 bucket.
-
-    :param skip_parquet_sample:
-        Skip the parquet sample generation (e.g. when
-        the cleaned parquet was not generated this run).
-
-    :param skip_json_sample:
-        Skip the JSON sample generation (e.g. when the
-        top-vaults JSON was not generated this run).
-    """
+def main():
     setup_console_logging(
         log_file=Path("logs/export-sample-files.log"),
         only_log_file=False,
         clear_log_file=False,
     )
-
-    if skip_parquet_sample and skip_json_sample:
-        logger.info("No sample files eligible — both parquet and JSON samples skipped")
-        return
-
-    # R2 credentials — same env vars as export-data-files.py
-    bucket_name = os.environ.get("R2_DATA_BUCKET_NAME") or os.environ.get("R2_VAULT_METADATA_BUCKET_NAME")
-    access_key_id = os.environ.get("R2_DATA_ACCESS_KEY_ID") or os.environ.get("R2_VAULT_METADATA_ACCESS_KEY_ID")
-    secret_access_key = os.environ.get("R2_DATA_SECRET_ACCESS_KEY") or os.environ.get("R2_VAULT_METADATA_SECRET_ACCESS_KEY")
-    endpoint_url = os.environ.get("R2_DATA_ENDPOINT_URL") or os.environ.get("R2_VAULT_METADATA_ENDPOINT_URL")
-    public_url = os.environ.get("R2_DATA_PUBLIC_URL") or os.environ.get("R2_VAULT_METADATA_PUBLIC_URL")
-    upload_prefix = os.environ.get("UPLOAD_PREFIX", "")
-
-    assert bucket_name, "R2_DATA_BUCKET_NAME (or R2_VAULT_METADATA_BUCKET_NAME) environment variable is required"
-
-    base_path = get_pipeline_data_dir()
-
-    # Generate sample files
-    sample_files: list[Path] = []
-
-    if not skip_parquet_sample:
-        cleaned_path = base_path / "cleaned-vault-prices-1h.parquet"
-        parquet_sample_path = base_path / "vault-historical.sample.parquet"
-        row_count = generate_sample_parquet(cleaned_path, parquet_sample_path)
-        sample_files.append(parquet_sample_path)
-        print(f"  Parquet sample: {row_count:,} Ethereum rows")
-    else:
-        logger.info("Skipping parquet sample generation")
-
-    if not skip_json_sample:
-        json_path = base_path / "top_vaults_by_chain.json"
-        json_sample_path = base_path / "vault-metadata.sample.json"
-        vault_count = generate_sample_json(json_path, json_sample_path)
-        sample_files.append(json_sample_path)
-        print(f"  JSON sample: {vault_count:,} Ethereum vaults")
-    else:
-        logger.info("Skipping JSON sample generation")
-
-    if not sample_files:
-        return
-
-    # Upload to primary (public) bucket only — deliberately skip alternative bucket
-    print(f"\nExporting sample files to R2 (public bucket only)")
-    print(f"  Bucket: {bucket_name}")
-    print(f"  Endpoint: {endpoint_url}")
-    print(f"  Key prefix: '{upload_prefix}'" if upload_prefix else "  Key prefix: (none)")
-
-    s3_client = create_r2_client(
-        endpoint_url=endpoint_url,
-        access_key_id=access_key_id,
-        secret_access_key=secret_access_key,
-    )
-
-    for file_path in sample_files:
-        s3_key = f"{upload_prefix}{file_path.name}"
-        uploaded = upload_file_to_r2(
-            s3_client=s3_client,
-            file_path=file_path,
-            bucket_name=bucket_name,
-            object_name=s3_key,
-            skip_if_current=True,
-        )
-        if uploaded:
-            logger.info("Uploaded %s to s3://%s/%s", file_path, bucket_name, s3_key)
-        else:
-            logger.info("Skipped unchanged %s for s3://%s/%s", file_path, bucket_name, s3_key)
-
-        if public_url and uploaded:
-            final_url = f"{public_url.rstrip('/')}/{s3_key}"
-            print(f"  -> {final_url}")
+    export_sample_files_to_r2()
 
 
 if __name__ == "__main__":

--- a/scripts/erc-4626/export-sample-files.py
+++ b/scripts/erc-4626/export-sample-files.py
@@ -1,0 +1,227 @@
+"""Export Ethereum-only sample vault data files to Cloudflare R2.
+
+Generates free-download sample versions of the cleaned parquet and
+top-vaults JSON filtered to Ethereum mainnet (chain_id=1) only.
+
+These sample files are uploaded to the primary (public) R2 bucket only,
+NOT to the alternative (private) bucket.
+
+Example:
+
+.. code-block:: shell
+
+    source .local-test.env && poetry run python scripts/erc-4626/export-sample-files.py
+
+Environment variables:
+    - R2_DATA_BUCKET_NAME: R2 bucket for data files (falls back to R2_VAULT_METADATA_BUCKET_NAME)
+    - R2_DATA_ACCESS_KEY_ID: R2 access key ID (falls back to R2_VAULT_METADATA_ACCESS_KEY_ID)
+    - R2_DATA_SECRET_ACCESS_KEY: R2 secret access key (falls back to R2_VAULT_METADATA_SECRET_ACCESS_KEY)
+    - R2_DATA_ENDPOINT_URL: R2 endpoint URL (falls back to R2_VAULT_METADATA_ENDPOINT_URL)
+    - R2_DATA_PUBLIC_URL: Public base URL for data files (falls back to R2_VAULT_METADATA_PUBLIC_URL)
+    - UPLOAD_PREFIX: Prefix for S3 keys, e.g. "test-" (default: "")
+    - PIPELINE_DATA_DIR: Override pipeline data directory (default: ~/.tradingstrategy/vaults)
+"""
+
+import json
+import logging
+import os
+from pathlib import Path
+
+import pandas as pd
+
+from eth_defi.cloudflare_r2 import create_r2_client, upload_file_to_r2
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.vaultdb import get_pipeline_data_dir
+
+logger = logging.getLogger(__name__)
+
+#: Only include Ethereum mainnet in the sample files
+ETHEREUM_CHAIN_ID = 1
+
+
+def generate_sample_parquet(cleaned_path: Path, output_path: Path) -> int:
+    """Filter the cleaned vault prices parquet to Ethereum only.
+
+    Reads the full multi-chain cleaned parquet and writes an
+    Ethereum-only subset for free download.
+
+    :param cleaned_path:
+        Path to the full ``cleaned-vault-prices-1h.parquet``.
+
+    :param output_path:
+        Destination path for the sample parquet.
+
+    :return:
+        Number of rows in the sample.
+
+    :raise FileNotFoundError:
+        If the source parquet does not exist.
+
+    :raise ValueError:
+        If the filtered result has zero Ethereum rows.
+    """
+    if not cleaned_path.exists():
+        raise FileNotFoundError(f"Cleaned parquet not found: {cleaned_path}")
+
+    df = pd.read_parquet(cleaned_path)
+    sample_df = df[df["chain"] == ETHEREUM_CHAIN_ID]
+
+    if len(sample_df) == 0:
+        raise ValueError(f"No Ethereum (chain_id={ETHEREUM_CHAIN_ID}) rows found in {cleaned_path}")
+
+    sample_df.to_parquet(output_path, compression="zstd")
+    logger.info(
+        "Generated sample parquet: %d Ethereum rows out of %d total -> %s",
+        len(sample_df),
+        len(df),
+        output_path,
+    )
+    return len(sample_df)
+
+
+def generate_sample_json(json_path: Path, output_path: Path) -> int:
+    """Filter the top-vaults JSON to Ethereum only.
+
+    Reads the full multi-chain top-vaults JSON and writes an
+    Ethereum-only subset for free download.
+
+    :param json_path:
+        Path to the full ``top_vaults_by_chain.json``.
+
+    :param output_path:
+        Destination path for the sample JSON.
+
+    :return:
+        Number of vaults in the sample.
+
+    :raise FileNotFoundError:
+        If the source JSON does not exist.
+
+    :raise ValueError:
+        If the filtered result has zero Ethereum vaults.
+    """
+    if not json_path.exists():
+        raise FileNotFoundError(f"Top vaults JSON not found: {json_path}")
+
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    filtered_vaults = [v for v in data["vaults"] if v.get("chain_id") == ETHEREUM_CHAIN_ID]
+
+    if len(filtered_vaults) == 0:
+        raise ValueError(f"No Ethereum (chain_id={ETHEREUM_CHAIN_ID}) vaults found in {json_path}")
+
+    sample_data = {
+        "generated_at": data["generated_at"],
+        "vaults": filtered_vaults,
+    }
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(sample_data, f, indent=2, ensure_ascii=False, allow_nan=False)
+
+    logger.info(
+        "Generated sample JSON: %d Ethereum vaults out of %d total -> %s",
+        len(filtered_vaults),
+        len(data["vaults"]),
+        output_path,
+    )
+    return len(filtered_vaults)
+
+
+def main(
+    skip_parquet_sample: bool = False,
+    skip_json_sample: bool = False,
+):
+    """Generate and upload Ethereum-only sample data files.
+
+    Produces ``vault-historical.sample.parquet`` and
+    ``vault-metadata.sample.json`` filtered to Ethereum
+    mainnet (chain_id=1) only, then uploads them to the primary
+    (public) R2 bucket.
+
+    :param skip_parquet_sample:
+        Skip the parquet sample generation (e.g. when
+        the cleaned parquet was not generated this run).
+
+    :param skip_json_sample:
+        Skip the JSON sample generation (e.g. when the
+        top-vaults JSON was not generated this run).
+    """
+    setup_console_logging(
+        log_file=Path("logs/export-sample-files.log"),
+        only_log_file=False,
+        clear_log_file=False,
+    )
+
+    if skip_parquet_sample and skip_json_sample:
+        logger.info("No sample files eligible — both parquet and JSON samples skipped")
+        return
+
+    # R2 credentials — same env vars as export-data-files.py
+    bucket_name = os.environ.get("R2_DATA_BUCKET_NAME") or os.environ.get("R2_VAULT_METADATA_BUCKET_NAME")
+    access_key_id = os.environ.get("R2_DATA_ACCESS_KEY_ID") or os.environ.get("R2_VAULT_METADATA_ACCESS_KEY_ID")
+    secret_access_key = os.environ.get("R2_DATA_SECRET_ACCESS_KEY") or os.environ.get("R2_VAULT_METADATA_SECRET_ACCESS_KEY")
+    endpoint_url = os.environ.get("R2_DATA_ENDPOINT_URL") or os.environ.get("R2_VAULT_METADATA_ENDPOINT_URL")
+    public_url = os.environ.get("R2_DATA_PUBLIC_URL") or os.environ.get("R2_VAULT_METADATA_PUBLIC_URL")
+    upload_prefix = os.environ.get("UPLOAD_PREFIX", "")
+
+    assert bucket_name, "R2_DATA_BUCKET_NAME (or R2_VAULT_METADATA_BUCKET_NAME) environment variable is required"
+
+    base_path = get_pipeline_data_dir()
+
+    # Generate sample files
+    sample_files: list[Path] = []
+
+    if not skip_parquet_sample:
+        cleaned_path = base_path / "cleaned-vault-prices-1h.parquet"
+        parquet_sample_path = base_path / "vault-historical.sample.parquet"
+        row_count = generate_sample_parquet(cleaned_path, parquet_sample_path)
+        sample_files.append(parquet_sample_path)
+        print(f"  Parquet sample: {row_count:,} Ethereum rows")
+    else:
+        logger.info("Skipping parquet sample generation")
+
+    if not skip_json_sample:
+        json_path = base_path / "top_vaults_by_chain.json"
+        json_sample_path = base_path / "vault-metadata.sample.json"
+        vault_count = generate_sample_json(json_path, json_sample_path)
+        sample_files.append(json_sample_path)
+        print(f"  JSON sample: {vault_count:,} Ethereum vaults")
+    else:
+        logger.info("Skipping JSON sample generation")
+
+    if not sample_files:
+        return
+
+    # Upload to primary (public) bucket only — deliberately skip alternative bucket
+    print(f"\nExporting sample files to R2 (public bucket only)")
+    print(f"  Bucket: {bucket_name}")
+    print(f"  Endpoint: {endpoint_url}")
+    print(f"  Key prefix: '{upload_prefix}'" if upload_prefix else "  Key prefix: (none)")
+
+    s3_client = create_r2_client(
+        endpoint_url=endpoint_url,
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
+    )
+
+    for file_path in sample_files:
+        s3_key = f"{upload_prefix}{file_path.name}"
+        uploaded = upload_file_to_r2(
+            s3_client=s3_client,
+            file_path=file_path,
+            bucket_name=bucket_name,
+            object_name=s3_key,
+            skip_if_current=True,
+        )
+        if uploaded:
+            logger.info("Uploaded %s to s3://%s/%s", file_path, bucket_name, s3_key)
+        else:
+            logger.info("Skipped unchanged %s for s3://%s/%s", file_path, bucket_name, s3_key)
+
+        if public_url and uploaded:
+            final_url = f"{public_url.rstrip('/')}/{s3_key}"
+            print(f"  -> {final_url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/erc-4626/post-process-prices.py
+++ b/scripts/erc-4626/post-process-prices.py
@@ -55,6 +55,7 @@ Pipeline control:
 - ``SKIP_SPARKLINES``: Skip sparkline image export to R2 (default: ``false``)
 - ``SKIP_METADATA``: Skip protocol/stablecoin metadata export to R2 (default: ``false``)
 - ``SKIP_DATA``: Skip data file (parquet, pickle) export to R2 (default: ``false``)
+- ``SKIP_SAMPLES``: Skip Ethereum-only sample file export to R2 (default: ``false``)
 - ``UPLOAD_PREFIX``: Prefix for uploaded data file keys, e.g. ``test-`` (default: ``""``). Applies to all R2 uploads including the top-vaults JSON.
 - ``MAX_WORKERS``: Number of parallel workers for rendering/uploading (default: ``20``)
 
@@ -123,6 +124,7 @@ def main():
     skip_sparklines = os.environ.get("SKIP_SPARKLINES", "false").lower() == "true"
     skip_metadata = os.environ.get("SKIP_METADATA", "false").lower() == "true"
     skip_data = os.environ.get("SKIP_DATA", "false").lower() == "true"
+    skip_samples = os.environ.get("SKIP_SAMPLES", "false").lower() == "true"
 
     # Fail-fast: crash with a clear error before we touch anything if the
     # top-vaults R2 upload is not configured. Matches scan-vaults-all-chains.py.
@@ -161,6 +163,7 @@ def main():
         skip_sparklines=skip_sparklines,
         skip_metadata=skip_metadata,
         skip_data=skip_data,
+        skip_samples=skip_samples,
         uncleaned_parquet_path=uncleaned_price_path,
         hyperliquid_db_path=hyperliquid_db_path,
         hyperliquid_hf_db_path=hyperliquid_hf_db_path,


### PR DESCRIPTION
## Why

Provide free-download sample versions of vault data files so users can evaluate the data without needing access to the full commercial dataset. The samples contain only Ethereum mainnet (chain_id=1) data.

## Lessons learnt

- The top-vaults JSON sample must depend on both the cleaning step AND the top-vaults export step succeeding — otherwise stale data from a previous run could be sampled and uploaded as "fresh".
- `SKIP_SAMPLES` must be wired through both `scan_all_chains.py` (production) and `post-process-prices.py` (debug), not just one.
- Sample files deliberately go to the `R2_DATA_*` bucket (`vault-protocol-metadata.tradingstrategy.ai`) rather than the `R2_TOP_VAULTS_*` bucket, giving a single public URL namespace for all sample downloads.

## Summary

- New script `scripts/erc-4626/export-sample-files.py` that generates:
  - `vault-historical.sample.parquet` — cleaned vault prices filtered to Ethereum
  - `vault-metadata.sample.json` — top vaults JSON filtered to Ethereum
- Uploads to the primary (public) R2 bucket only, deliberately skips the alternative (private) bucket
- Integrated as step 7 in `run_post_processing()` with `SKIP_SAMPLES` env var
- Wired through `scan_all_chains.py` and `post-process-prices.py`
- Freshness guards: parquet sample requires `clean-prices` success; JSON sample requires both `clean-prices` and `export-top-vaults-json` success
- Hard failure on empty results (zero Ethereum rows/vaults)
- Documented in `README-vault-scripts.md` with public download URLs

Public URLs:
- https://vault-protocol-metadata.tradingstrategy.ai/vault-historical.sample.parquet
- https://vault-protocol-metadata.tradingstrategy.ai/vault-metadata.sample.json