### PR TITLE
fix(gmx): bounded markets cache + on-chain liveness check (issue #67 Bug C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- fix: GMX market cache — bounded caching + on-chain liveness check. `Markets._process_markets` no longer drops markets whose index token is momentarily missing from the oracle snapshot; the oracle-snapshot filter is replaced with a Multicall3 `IS_MARKET_DISABLED` check (mirroring the existing CCXT-side pattern). Cache now carries a 5-minute TTL and exposes `Markets.invalidate_cache(chain)`. `OrderArgumentParser._handle_missing_market_key` invalidates and retries once before raising `ValueError`. Redundant `_MARKETS_CACHE` in `order_argument_parser.py` removed. New `GMX.get_on_chain_index_tokens()` enumerator gives downstream consumers a structural ("is this market listed?") answer that's decoupled from oracle staleness. Resolves a class of failures where new GMX listings or oracle hiccups produced spurious `ValueError: No GMX market found for index_token_address=...` crashes. See tradingstrategy-ai/gmx-strategies#67 (2026-05-11)
+
 - feat: Ethereum-only sample vault data files (`vault-historical.sample.parquet`, `vault-metadata.sample.json`) generated during post-processing and uploaded to the public R2 bucket for free download; skip with `SKIP_SAMPLES=true` (2026-05-08)
 
 - fix: 40acres Aerodrome USDC vault on Base had a typo in the contract address (duplicated `d`), causing vault detection to fail; correct address is `0xb99b6df96d4d5448cc0a5b3e0ef7896df9507cf5` (2026-05-05)

--- a/eth_defi/gmx/ccxt/exchange.py
+++ b/eth_defi/gmx/ccxt/exchange.py
@@ -1260,6 +1260,35 @@ class GMX(ExchangeCompatible):
             )
             return markets
 
+    def get_on_chain_index_tokens(self) -> set[str]:
+        """Return the set of index-token addresses currently listed on GMX V2.
+
+        Bypasses the oracle-snapshot filter that
+        :meth:`Markets.get_available_markets` historically applied and gives
+        the **structural** answer to "is this token a GMX market right now?".
+        That structural view is the correct input for startup whitelist
+        validation — it must not drop pairs whose oracle feed is momentarily
+        unavailable.  This is the decoupling pin called out in the
+        issue-#67 deep-dive: a transient oracle gap must never silently
+        shrink the production whitelist again.
+
+        :returns: EIP-55 checksummed Ethereum addresses of every listed index
+            token on the configured chain.  Zero-address sentinels (used by
+            swap-only markets / the wstETH special-case) are filtered out.
+        :raises: Propagates any RPC error from the underlying reader call.
+            Callers performing startup validation should treat a raise as
+            "no validation possible — keep whitelist as-is" and log loudly.
+        """
+        from eth_defi.gmx.core.markets import Markets
+
+        raw_markets = Markets(self.config)._get_available_markets_raw()
+        zero = "0x" + "0" * 40
+        return {
+            to_checksum_address(row[1])
+            for row in raw_markets
+            if row[1] and row[1].lower() != zero
+        }
+
     def _fetch_position_close_from_event_logs(
         self,
         market_address: str,

--- a/eth_defi/gmx/core/markets.py
+++ b/eth_defi/gmx/core/markets.py
@@ -5,24 +5,55 @@ This module provides access to GMX protocol market information and trading pairs
 """
 
 import logging
+import time
 from dataclasses import dataclass
 from typing import Any, Optional
 
 from eth_typing import HexAddress
 from eth_utils import to_checksum_address
 
+from eth_defi.event_reader.multicall_batcher import get_multicall_contract
 from eth_defi.gmx.config import GMXConfig
 from eth_defi.gmx.contracts import get_contract_addresses, get_datastore_contract, get_reader_contract, get_tokens_metadata_dict
-from eth_defi.gmx.keys import MARKET_LIST
+from eth_defi.gmx.keys import MARKET_LIST, is_market_disabled_key
 from eth_defi.gmx.core.oracle import OraclePrices
 from eth_defi.gmx.types import MarketData, MarketSymbol
 from eth_defi.gmx.symbols import SYMBOL_NORMALISE
 
 logger = logging.getLogger(__name__)
 
-# Class-level cache for markets data, shared across all Markets instances
-# Keyed by chain name to avoid re-fetching for the same network
-_CLASS_MARKETS_CACHE: dict[str, dict] = {}
+
+@dataclass(slots=True)
+class _MarketsCacheEntry:
+    """A cached chain-wide markets map plus metadata for staleness/partial detection.
+
+    :ivar markets: Processed markets dict, keyed by market contract address.
+    :ivar fetched_at_ms: Epoch milliseconds when this entry was built.
+    :ivar partial: ``True`` when ``len(markets) < on_chain_market_count`` — forces
+        a re-fetch on every miss so a single-call shortfall cannot permanently
+        shrink the cached set.
+    """
+
+    #: Processed markets dict, keyed by market contract address.
+    markets: dict
+    #: Epoch milliseconds when this entry was built.
+    fetched_at_ms: int
+    #: True when ``len(markets) < on_chain_market_count``. Forces re-fetch on every miss.
+    partial: bool
+
+
+# Class-level cache for markets data, shared across all Markets instances.
+# Keyed by chain name to avoid re-fetching for the same network.  Each entry
+# is wrapped in :class:`_MarketsCacheEntry` so we can apply a TTL and detect
+# partial builds.
+_CLASS_MARKETS_CACHE: dict[str, _MarketsCacheEntry] = {}
+
+#: 5 minutes — long enough to keep order-path latency low, short enough for a
+#: poisoned cache to self-heal within a single 1h candle.  Issue #67 saw 56
+#: identical crash signatures over 24h precisely because the previous cache had
+#: no expiry; this bound caps the blast radius of any future filter regression
+#: at 5 minutes per process.
+_CLASS_MARKETS_CACHE_TTL_MS: int = 5 * 60 * 1000
 
 
 @dataclass(slots=True)
@@ -63,6 +94,23 @@ class Markets:
         """
         self.config = config
         self._special_wsteth_address = to_checksum_address("0x0Cf1fb4d1FF67A3D8Ca92c9d6643F8F9be8e03E5")
+
+    @classmethod
+    def invalidate_cache(cls, chain: str | None = None) -> None:
+        """Explicitly invalidate the class-level markets cache.
+
+        Use this when a caller suspects the cached snapshot is stale — for
+        example, when an order-builder fails to resolve a token that *should*
+        be present (see :meth:`OrderArgumentParser._handle_missing_market_key`).
+
+        :param chain: When provided, invalidate only this chain's entry.
+            When ``None``, invalidate every chain entry currently in the
+            cache.  Passing an unknown chain name is a no-op.
+        """
+        if chain is None:
+            _CLASS_MARKETS_CACHE.clear()
+        else:
+            _CLASS_MARKETS_CACHE.pop(chain, None)
 
     def _get_token_metadata_dict(self) -> dict[HexAddress, dict]:
         """Get token metadata dictionary with correct decimals from GMX API.
@@ -231,41 +279,158 @@ class Markets:
             market_count + 1,
         ).call()
 
+    def _get_on_chain_market_count(self) -> int:
+        """Read the live ``MARKET_LIST`` length from the DataStore.
+
+        Used by :meth:`_process_markets` for partial-build detection — if the
+        processed-markets count is strictly less than this value, the cache
+        entry is marked ``partial=True`` so the next call refetches instead of
+        permanently shadowing dropped markets.
+
+        :return: Number of markets currently registered on-chain.
+        :raises Exception: Propagates any RPC error from the DataStore call.
+        """
+        datastore_contract = get_datastore_contract(self.config.web3, self.config.chain)
+        return datastore_contract.functions.getAddressCount(MARKET_LIST).call()
+
+    def _check_markets_disabled_onchain(self, market_addresses: list[str]) -> dict[str, bool]:
+        """Batch-check ``IS_MARKET_DISABLED`` for the supplied market addresses.
+
+        Mirrors the proven Multicall3 pattern in
+        :meth:`eth_defi.gmx.ccxt.exchange.GMX._filter_datastore_disabled_markets`.
+        All ``DataStore.getBool(IS_MARKET_DISABLED)`` calls are batched into a
+        single ``aggregate3`` round-trip with up to two attempts; an entry that
+        still fails after two attempts is treated as **enabled** (conservative —
+        the market goes through and a later trade attempt will surface any
+        ground-truth disabled status).
+
+        :param market_addresses: Checksummed GMX market token addresses.
+        :return: Mapping of ``market_address`` -> ``True`` if the market is
+            disabled on-chain, ``False`` otherwise.  All input addresses
+            appear as keys in the returned dict.
+        """
+        result: dict[str, bool] = {addr: False for addr in market_addresses}
+        if not market_addresses:
+            return result
+
+        try:
+            chain = self.config.chain
+            datastore = get_datastore_contract(self.config.web3, chain)
+            multicall = get_multicall_contract(self.config.web3)
+
+            # Encode one getBool() calldata per market.
+            batch: list[tuple[str, bytes]] = []
+            for market_addr in market_addresses:
+                key = is_market_disabled_key(market_addr)
+                calldata = bytes.fromhex(
+                    datastore.encode_abi(abi_element_identifier="getBool", args=[key])[2:]
+                )
+                batch.append((market_addr, calldata))
+
+            datastore_addr = datastore.address
+            pending = batch
+            for attempt in range(1, 3):
+                mc_calls = [(datastore_addr, True, data) for (_a, data) in pending]
+                mc_results = multicall.functions.aggregate3(mc_calls).call()
+                retry: list[tuple[str, bytes]] = []
+                for (market_addr, calldata), (success, return_data) in zip(pending, mc_results):
+                    if not success or not return_data:
+                        if attempt < 2:
+                            retry.append((market_addr, calldata))
+                        else:
+                            # Two attempts failed — treat conservatively as enabled.
+                            logger.warning(
+                                "IS_MARKET_DISABLED check failed for market %s after 2 attempts — treating as enabled",
+                                market_addr,
+                            )
+                            result[market_addr] = False
+                        continue
+                    disabled = bool(int(return_data.hex(), 16))
+                    result[market_addr] = disabled
+                if not retry:
+                    break
+                pending = retry
+        except Exception as e:
+            # If Multicall3 itself blows up, log loudly and report every market as
+            # enabled.  Better to let a disabled market through (the trade will
+            # revert on-chain with a clear error) than to silently shrink the
+            # cached set the way the oracle filter used to.
+            logger.warning(
+                "_check_markets_disabled_onchain failed, treating all markets as enabled: %s",
+                e,
+            )
+            return {addr: False for addr in market_addresses}
+
+        return result
+
     def _process_markets(self) -> dict:
         """
         Process the raw market data and return the results.
 
-        :return: Dictionary of processed markets
+        Build pipeline (issue #67 redesign):
+
+        1. **TTL fast path** — if a non-partial cache entry exists for this
+           chain and was built within :data:`_CLASS_MARKETS_CACHE_TTL_MS`,
+           return it without any RPC traffic.
+        2. **Fetch + structural build** — read raw markets from the on-chain
+           reader contract and synthesise metadata.  The oracle REST snapshot
+           is fetched but **never used as an exclusion filter** — issue #67
+           proved that filtering on oracle availability causes spurious
+           ``ValueError: No GMX market found`` crashes whenever Pyth feeds
+           lag a new listing.
+        3. **On-chain liveness** — batch-check ``IS_MARKET_DISABLED`` via
+           Multicall3 and drop markets that the DataStore says are disabled.
+        4. **Partial-build detection** — compare the processed count to
+           ``DataStore.MARKET_LIST`` size.  If the new build is partial *and*
+           a prior complete entry exists, return the prior entry (logged as a
+           warning) so a transient gap cannot permanently shrink the cached
+           set.  Otherwise mark the new entry ``partial=True`` so it will
+           refresh on every subsequent call.
+
+        :return: Dictionary of processed markets, keyed by checksummed market
+            contract address.
         :rtype: dict
+        :raises ValueError: When the build produces an empty result and no
+            usable prior cache entry exists (preserves the PR-#722 guard).
         """
-        # Return cached data if available — only use a non-empty cache entry so that a
-        # previous transient API failure cannot poison this call.
         chain_key = self.config.chain
-        if chain_key in _CLASS_MARKETS_CACHE and _CLASS_MARKETS_CACHE[chain_key]:
-            logger.debug("Returning cached markets data for chain %s", chain_key)
-            return _CLASS_MARKETS_CACHE[chain_key]
+        now_ms = int(time.time() * 1000)
+
+        # 1. TTL fast path — non-partial, fresh entries skip the rebuild entirely.
+        cached_entry = _CLASS_MARKETS_CACHE.get(chain_key)
+        if (
+            cached_entry is not None
+            and not cached_entry.partial
+            and cached_entry.markets
+            and (now_ms - cached_entry.fetched_at_ms) < _CLASS_MARKETS_CACHE_TTL_MS
+        ):
+            logger.debug("Returning cached markets data for chain %s (fresh)", chain_key)
+            return cached_entry.markets
 
         logger.debug("Processing GMX markets data for chain %s...", chain_key)
 
-        # Pre-load necessary data
+        # 2. Pre-load necessary data.
         token_metadata_dict = self._get_token_metadata_dict()
-        oracle_prices = self._get_oracle_prices()
-
-        # Testnets use different token addresses, so skip oracle validation for them
-        is_testnet = self.config.chain in ["arbitrum_sepolia", "avalanche_fuji"]
+        # NOTE: oracle_prices is still fetched for downstream consumers that may
+        # rely on it (e.g. price warm-up), but it is intentionally NOT used to
+        # exclude markets — see issue #67 for the failure mode the old filter
+        # produced.
+        try:
+            self._get_oracle_prices()
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.debug("Oracle prices fetch failed (non-fatal under new design): %s", exc)
 
         # Use token metadata for testnets from contracts module
         if self.config.chain == "arbitrum_sepolia":
-            # Get token metadata from contracts module
             arbitrum_sepolia_token_metadata = get_tokens_metadata_dict(self.config.chain)
             token_metadata_dict.update(arbitrum_sepolia_token_metadata)
 
-        # Get raw market data
+        # Get raw market data.
         raw_markets = self._get_available_markets_raw()
         logger.debug("Retrieved %s raw markets from contract", len(raw_markets))
 
-        # Process markets in bulk
-        processed_markets = {}
+        # 3. Synthesise metadata for every raw market — no oracle filtering.
+        processed_markets: dict[str, dict] = {}
 
         for raw_market in raw_markets:
             try:
@@ -284,31 +449,21 @@ class Markets:
                         logger.debug("Skipping market %s with zero index token address", market_address)
                         continue
 
-                # Check if index token is available in oracle prices (skip for testnets due to address mismatch)
-                if not is_testnet and oracle_prices and index_token_address not in oracle_prices:
-                    # Special case for wstETH market
-                    if market_address == self._special_wsteth_address:
-                        pass  # Continue processing
-                    else:
-                        logger.debug("Skipping market %s: index token %s not in oracle prices", market_address, index_token_address)
-                        continue
-
-                # Get metadata for all tokens
+                # Get metadata for all tokens.
                 index_token_meta = token_metadata_dict.get(index_token_address)
                 long_token_meta = token_metadata_dict.get(long_token_address)
                 short_token_meta = token_metadata_dict.get(short_token_address)
 
-                # Handle swap markets (when index token metadata is missing)
+                # Handle swap markets (when index token metadata is missing).
                 if not index_token_meta:
-                    # Skip swap markets - they don't have price data we can safely convert
                     logger.debug("Skipping market %s: no index token metadata (likely a swap market)", market_address)
                     continue
 
-                # Verify index token has decimals
+                # Verify index token has decimals.
                 if "decimals" not in index_token_meta:
                     raise ValueError(f"Index token {index_token_address} missing decimals in GMX API response. Cannot safely process market {market_address}.")
 
-                # Determine market symbol
+                # Determine market symbol.
                 market_symbol = index_token_meta["symbol"]
                 if long_token_address == short_token_address:
                     market_symbol = f"{market_symbol}2"
@@ -316,10 +471,10 @@ class Markets:
                 # Normalise versioned symbols to canonical names (e.g. "XAUT.v2" -> "XAUT").
                 market_symbol = SYMBOL_NORMALISE.get(market_symbol, market_symbol)
 
-                # Set synthetic flag for BTC2/ETH2 markets
+                # Set synthetic flag for BTC2/ETH2 markets.
                 index_token_meta["synthetic"] = long_token_address == short_token_address
 
-                # Special case for wstETH market
+                # Special case for wstETH market.
                 if market_address == self._special_wsteth_address:
                     market_symbol = "wstETH"
                     index_token_address = to_checksum_address("0x5979D7b546E38E414F7E9822514be443A4800529")
@@ -327,13 +482,13 @@ class Markets:
                     if not index_token_meta or "decimals" not in index_token_meta:
                         raise ValueError(f"wstETH token {index_token_address} not found in GMX API or missing decimals.")
 
-                # Ensure metadata exists for all tokens (long/short tokens need decimals for collateral)
+                # Ensure metadata exists for all tokens (long/short tokens need decimals for collateral).
                 if not long_token_meta or "decimals" not in long_token_meta:
                     raise ValueError(f"Long token {long_token_address} missing metadata or decimals for market {market_address}.")
                 if not short_token_meta or "decimals" not in short_token_meta:
                     raise ValueError(f"Short token {short_token_address} missing metadata or decimals for market {market_address}.")
 
-                # Store processed market
+                # Store processed market.
                 processed_markets[market_address] = {
                     "gmx_market_address": market_address,
                     "market_symbol": market_symbol,
@@ -349,15 +504,58 @@ class Markets:
                 logger.debug("Skipping market %s: %s", raw_market[0], e)
                 continue
 
-        logger.debug("Processed %s markets successfully for chain %s", len(processed_markets), chain_key)
+        logger.debug("Built %d markets for chain %s (pre-disabled-check)", len(processed_markets), chain_key)
 
-        # Guard: never cache an empty result — an empty dict means the GMX API or
-        # token-metadata endpoint returned nothing (transient saturation during parallel
-        # tests).  Caching it would poison every subsequent call on this worker.
+        # 4. On-chain liveness — drop markets the DataStore reports as disabled.
+        if processed_markets:
+            disabled_map = self._check_markets_disabled_onchain(list(processed_markets.keys()))
+            disabled_addrs = [addr for addr, is_disabled in disabled_map.items() if is_disabled]
+            for addr in disabled_addrs:
+                logger.warning("Market %s is disabled on-chain (IS_MARKET_DISABLED=true) — excluding", addr)
+                processed_markets.pop(addr, None)
+
+        # 5. Empty-result guard — preserve the PR-#722 invariant.
         if not processed_markets:
-            raise ValueError(f"Markets resolved to empty dict for chain {chain_key!r}. raw_markets count: {len(raw_markets)}, token_metadata_dict count: {len(token_metadata_dict)}. Likely a transient GMX API timeout or saturation — do not cache.")
+            raise ValueError(
+                f"Markets resolved to empty dict for chain {chain_key!r}. "
+                f"raw_markets count: {len(raw_markets)}, "
+                f"token_metadata_dict count: {len(token_metadata_dict)}. "
+                "Likely a transient GMX API timeout or saturation — do not cache."
+            )
 
-        # Cache the results for future calls (class-level cache shared across all instances)
-        _CLASS_MARKETS_CACHE[chain_key] = processed_markets
+        # 6. Partial-build detection — compare to on-chain MARKET_LIST count.
+        partial = False
+        try:
+            on_chain_count = self._get_on_chain_market_count()
+            partial = len(processed_markets) < on_chain_count
+            if partial:
+                logger.warning(
+                    "Partial build for chain %s: processed=%d on_chain=%d — entry will refresh on next call",
+                    chain_key,
+                    len(processed_markets),
+                    on_chain_count,
+                )
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.debug("On-chain market count check failed (assuming complete): %s", exc)
+
+        # 7. Partial-rebuild protection — keep a complete prior entry if the new
+        # build is smaller.  Without this, a single mid-flight RPC blip could
+        # poison the cache for the next 5 minutes.
+        if partial and cached_entry is not None and not cached_entry.partial and len(cached_entry.markets) > len(processed_markets):
+            logger.warning(
+                "Keeping prior complete cache entry for %s (%d markets) over new partial build (%d markets)",
+                chain_key,
+                len(cached_entry.markets),
+                len(processed_markets),
+            )
+            return cached_entry.markets
+
+        # 8. Store the new entry.
+        _CLASS_MARKETS_CACHE[chain_key] = _MarketsCacheEntry(
+            markets=processed_markets,
+            fetched_at_ms=now_ms,
+            partial=partial,
+        )
+        logger.debug("Cached %d markets for chain %s (partial=%s)", len(processed_markets), chain_key, partial)
 
         return processed_markets

--- a/eth_defi/gmx/order/order_argument_parser.py
+++ b/eth_defi/gmx/order/order_argument_parser.py
@@ -18,8 +18,11 @@ from eth_defi.gmx.contracts import get_tokens_metadata_dict
 
 logger = logging.getLogger(__name__)
 
-# Module-level caches to avoid repeated expensive calls
-_MARKETS_CACHE: dict[str, dict] = {}  # Key: chain name
+# Module-level cache for token metadata only.  The previous ``_MARKETS_CACHE``
+# was removed in the issue-#67 fix — :class:`Markets` now owns a TTL'd cache
+# that is invalidated centrally via :meth:`Markets.invalidate_cache`, so a
+# parallel cache here would defeat the cache-coherence guarantee that the
+# refresh-on-miss path depends on.
 _TOKEN_METADATA_CACHE: dict[tuple[int, str], dict] = {}  # Key: (chain_id, chain_name)
 
 
@@ -110,20 +113,21 @@ class OrderArgumentParser:
             # GMXConfigManager has get_chain() method
             chain = config.get_chain()
 
-        # Check if markets are cached — skip an empty cache entry so a previous transient
-        # API failure cannot poison this call (Markets.get_available_markets() now raises
-        # ValueError on empty rather than returning {}, so this guard handles any legacy
-        # empty entry that may exist in the cache from a prior run).
-        if chain not in _MARKETS_CACHE or not _MARKETS_CACHE[chain]:
-            # Get user wallet address - handle both types
-            user_wallet_address = getattr(config, "user_wallet_address", None) or getattr(config, "_user_wallet_address", None)
+        # Resolve markets via :class:`Markets`.  The class-level cache inside
+        # ``Markets`` carries its own 5-minute TTL and invalidation surface
+        # (see ``Markets.invalidate_cache``), so we do NOT layer a second
+        # cache here — having two caches with independent staleness was
+        # exactly the failure mode behind issue #67.
+        user_wallet_address = getattr(config, "user_wallet_address", None) or getattr(config, "_user_wallet_address", None)
+        gmx_config = GMXConfig(self.web3, user_wallet_address=user_wallet_address)
+        self._gmx_config_for_refresh = gmx_config  # Held so the miss-retry path can re-resolve.
+        self.markets = Markets(gmx_config).get_available_markets()
 
-            gmx_config = GMXConfig(self.web3, user_wallet_address=user_wallet_address)
-
-            # Get markets info - Markets expects GMXConfig, not GMXConfigManager
-            _MARKETS_CACHE[chain] = Markets(gmx_config).get_available_markets()
-
-        self.markets = _MARKETS_CACHE[chain]
+        #: True once :meth:`_handle_missing_market_key` has performed its
+        #: one allowed cache-refresh retry.  Bounding the retry per parser
+        #: instance prevents an infinite loop when the index token is
+        #: structurally absent from GMX.
+        self._market_key_refresh_attempted: bool = False
 
         if is_increase:
             self.required_keys = [
@@ -258,14 +262,35 @@ class OrderArgumentParser:
         all_matches = self.find_all_market_keys_by_index_address(self.markets, index_token_address)
 
         if not all_matches:
-            available = [v.get("index_token_address") for v in self.markets.values()]
-            logger.info(
-                "_handle_missing_market_key: NOT FOUND for index_token_address=%s — available=%s",
-                index_token_address,
-                available,
-            )
-            msg = f"No GMX market found for index_token_address={index_token_address!r}. Available index_token_addresses: {available}"
-            raise ValueError(msg)
+            # Force a cache refresh once per parser instance before giving up.
+            # The class-level Markets cache may be stale (e.g. a new GMX
+            # listing happened since the parser was constructed); a single
+            # forced refresh covers that case without risking an infinite
+            # retry loop when the token is genuinely absent.
+            if not self._market_key_refresh_attempted:
+                self._market_key_refresh_attempted = True
+                chain = self.parameters_dict.get("chain")
+                logger.warning(
+                    "_handle_missing_market_key: index_token_address=%s not in cached markets — invalidating cache for chain=%s and retrying once",
+                    index_token_address,
+                    chain,
+                )
+                Markets.invalidate_cache(chain)
+                self.markets = Markets(self._gmx_config_for_refresh).get_available_markets()
+                all_matches = self.find_all_market_keys_by_index_address(self.markets, index_token_address)
+
+            if not all_matches:
+                available = [v.get("index_token_address") for v in self.markets.values()]
+                logger.info(
+                    "_handle_missing_market_key: NOT FOUND for index_token_address=%s — available=%s",
+                    index_token_address,
+                    available,
+                )
+                msg = (
+                    f"No GMX market found for index_token_address={index_token_address!r} "
+                    f"after forced cache refresh. Available index_token_addresses: {available}"
+                )
+                raise ValueError(msg)
 
         if len(all_matches) == 1:
             market_key = all_matches[0]

--- a/tests/gmx/test_borrow_apr.py
+++ b/tests/gmx/test_borrow_apr.py
@@ -35,10 +35,19 @@ def test_get_data_processing(get_borrow_apr):
 
 def test_get_data_processing_empty_markets(get_borrow_apr):
     """Test _get_data_processing with empty markets."""
-    # Temporarily replace markets cache with empty dict
+    # Temporarily replace markets cache with an empty (non-partial) entry.
+    # Note: ``_CLASS_MARKETS_CACHE`` is now keyed to
+    # :class:`eth_defi.gmx.core.markets._MarketsCacheEntry` rather than a raw
+    # dict (issue-#67 redesign — see CHANGELOG entry for 2026-05-11).
+    import time as _time
+
     chain_key = get_borrow_apr.markets.config.chain
-    original_markets_cache = markets._CLASS_MARKETS_CACHE.get(chain_key, {})
-    markets._CLASS_MARKETS_CACHE[chain_key] = {}
+    original_markets_cache = markets._CLASS_MARKETS_CACHE.get(chain_key)
+    markets._CLASS_MARKETS_CACHE[chain_key] = markets._MarketsCacheEntry(
+        markets={},
+        fetched_at_ms=int(_time.time() * 1000),
+        partial=False,
+    )
 
     result = get_borrow_apr.get_data()
 
@@ -49,7 +58,10 @@ def test_get_data_processing_empty_markets(get_borrow_apr):
     assert "short" in result
 
     # Restore original markets
-    markets._CLASS_MARKETS_CACHE[chain_key] = original_markets_cache
+    if original_markets_cache is None:
+        markets._CLASS_MARKETS_CACHE.pop(chain_key, None)
+    else:
+        markets._CLASS_MARKETS_CACHE[chain_key] = original_markets_cache
 
 
 def test_output_format(get_borrow_apr):

--- a/tests/gmx/test_get_on_chain_index_tokens.py
+++ b/tests/gmx/test_get_on_chain_index_tokens.py
@@ -1,0 +1,142 @@
+"""Whitelist-decoupled enumeration of GMX index tokens.
+
+These tests pin the new ``GMX.get_on_chain_index_tokens()`` enumerator —
+the decoupling point that lets startup whitelist validation answer the
+*structural* question ("is this token a GMX market right now?") instead
+of relying on :meth:`Markets.get_available_markets`, whose result can
+shrink whenever the oracle REST snapshot is momentarily stale.
+
+The decoupling pin (``test_does_not_apply_oracle_filter``) is the most
+important assertion: a market that exists on-chain but is missing from
+``OraclePrices.get_recent_prices()`` MUST still appear in the returned
+set, otherwise a transient oracle hiccup would silently shrink the
+production whitelist again — exactly the failure mode that produced
+issue #67.
+
+See ``tradingstrategy-ai/gmx-strategies#67`` deep-dive
+(``2026-05-11-gmx-market-cache-permanent-fix.md``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from web3 import Web3
+
+
+_ETH_INDEX = "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1"
+_BTC_INDEX = "0x47904963fc8b2340414262125aF798B9655E58Cd"
+_CHZ_INDEX = "0x5dB4692926C8ceebF6Da0995358Bbc438F3fd80C"
+_USDC = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+_ETH_MARKET_ADDR = "0x70d95587d40A2caf56bd97485aB3Eec10Bee6336"
+_BTC_MARKET_ADDR = "0x47c031236e19d024b42f8AE6780E44A573170703"
+_CHZ_MARKET_ADDR = "0x4fDd333FF9cA409df583f306B6F5a7fFdC9573d1"
+
+
+def _raw_market(market: str, index: str) -> tuple[str, str, str, str]:
+    return (market, index, _USDC, _USDC)
+
+
+def _build_gmx_stub(raw_markets: list[tuple[str, str, str, str]]):
+    """Build a barely-instantiated ``GMX`` whose ``get_on_chain_index_tokens``
+    can be called against a mocked ``Markets`` instance."""
+    from eth_defi.gmx.ccxt.exchange import GMX
+    from eth_defi.gmx.core import markets as markets_mod
+
+    gmx = GMX.__new__(GMX)  # bypass __init__ to avoid RPC
+    gmx.config = MagicMock()
+    gmx.config.get_chain.return_value = "arbitrum"
+    gmx.config.chain = "arbitrum"
+    gmx.config.web3 = MagicMock()
+
+    # Patch the Markets._get_available_markets_raw used inside the method.
+    def _fake_raw(_self):
+        return list(raw_markets)
+
+    markets_mod.Markets._get_available_markets_raw = _fake_raw  # type: ignore[assignment]
+    return gmx
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    from eth_defi.gmx.core.markets import Markets
+
+    Markets.invalidate_cache()
+    yield
+    Markets.invalidate_cache()
+
+
+def test_method_exists_on_gmx():
+    """The new method must be on the ``GMX`` class itself, not a helper."""
+    from eth_defi.gmx.ccxt.exchange import GMX
+
+    assert hasattr(GMX, "get_on_chain_index_tokens"), (
+        "GMX.get_on_chain_index_tokens() is missing — issue #67 fix not applied"
+    )
+
+
+def test_returns_set_of_checksum_addresses(monkeypatch):
+    """The returned set must contain only EIP-55 checksum addresses."""
+    raw = [
+        _raw_market(_ETH_MARKET_ADDR, _ETH_INDEX),
+        _raw_market(_BTC_MARKET_ADDR, _BTC_INDEX),
+    ]
+    gmx = _build_gmx_stub(raw)
+
+    result = gmx.get_on_chain_index_tokens()
+
+    assert isinstance(result, set)
+    assert Web3.to_checksum_address(_ETH_INDEX) in result
+    assert Web3.to_checksum_address(_BTC_INDEX) in result
+    # Every address must round-trip through to_checksum_address unchanged.
+    for addr in result:
+        assert addr == Web3.to_checksum_address(addr)
+
+
+def test_does_not_apply_oracle_filter(monkeypatch):
+    """Decoupling pin — markets missing from oracle prices are STILL returned.
+
+    This is the exact failure mode that produced issue #67: the oracle
+    snapshot for a newly-listed (or momentarily-stale) token is empty
+    for a few seconds while Pyth updates, and the old
+    :meth:`Markets.get_available_markets` dropped the market entirely.
+    The enumerator must NOT consult ``OraclePrices`` at all.
+    """
+    from eth_defi.gmx.core import markets as markets_mod
+
+    raw = [
+        _raw_market(_ETH_MARKET_ADDR, _ETH_INDEX),
+        _raw_market(_CHZ_MARKET_ADDR, _CHZ_INDEX),
+    ]
+    gmx = _build_gmx_stub(raw)
+
+    # Mock oracle to return empty — the issue #67 scenario.
+    with patch.object(markets_mod.OraclePrices, "get_recent_prices", return_value={}):
+        result = gmx.get_on_chain_index_tokens()
+
+    assert Web3.to_checksum_address(_CHZ_INDEX) in result, (
+        "Oracle-missing token must still appear in the structural enumeration"
+    )
+    assert Web3.to_checksum_address(_ETH_INDEX) in result
+
+
+def test_skips_zero_address_index_tokens(monkeypatch):
+    """A market with a zero index token (e.g. wstETH special-case) is filtered out.
+
+    The enumerator's job is to return *real* index tokens — the zero address
+    is a wstETH-special-case sentinel from the reader contract.  Returning it
+    would corrupt whitelist validation by suggesting that ``0x0`` is a valid
+    GMX market.
+    """
+    zero = "0x" + "0" * 40
+    raw = [
+        _raw_market(_ETH_MARKET_ADDR, _ETH_INDEX),
+        _raw_market("0xfeed" + "0" * 36, zero),  # a swap-only market
+    ]
+    gmx = _build_gmx_stub(raw)
+
+    result = gmx.get_on_chain_index_tokens()
+    assert Web3.to_checksum_address(_ETH_INDEX) in result
+    assert zero not in result
+    assert Web3.to_checksum_address(zero) not in result

--- a/tests/gmx/test_markets_cache_ttl.py
+++ b/tests/gmx/test_markets_cache_ttl.py
@@ -1,0 +1,328 @@
+"""Bounded markets cache: TTL, invalidation, partial-build protection.
+
+These tests pin the redesign of the class-level GMX markets cache
+(``eth_defi.gmx.core.markets._CLASS_MARKETS_CACHE``):
+
+* The cache must expire after a bounded TTL so a recently-listed token
+  becomes visible within a single 1-hour candle without any process
+  restart.
+* The cache must support explicit ``Markets.invalidate_cache(chain)``
+  invalidation for caller-driven force-refresh on lookup miss.
+* A partial build (``len(processed_markets) < on_chain_count``) must
+  never permanently shadow a previously-complete cache entry — partial
+  results are either stored only when no better entry exists, and never
+  served from the TTL fast path.
+
+See ``tradingstrategy-ai/gmx-strategies#67`` deep-dive
+(``2026-05-11-gmx-market-cache-permanent-fix.md``).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# Token addresses used as fixtures throughout the suite.  These are real
+# Arbitrum addresses but the tests do not touch any RPC — every test
+# mocks the raw-fetch and on-chain calls so the suite is fully offline.
+_BTC_INDEX = "0x47904963fc8b2340414262125aF798B9655E58Cd"
+_ETH_INDEX = "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1"
+_USDC_LONG = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+_USDC_SHORT = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+_BTC_MARKET_ADDR = "0x47c031236e19d024b42f8AE6780E44A573170703"
+_ETH_MARKET_ADDR = "0x70d95587d40A2caf56bd97485aB3Eec10Bee6336"
+
+
+def _build_raw_market_tuple(
+    market_address: str,
+    index_token: str,
+    long_token: str = _USDC_LONG,
+    short_token: str = _USDC_SHORT,
+) -> tuple[str, str, str, str]:
+    """Return a tuple shaped like one row of ``MarketReader.getMarkets()``."""
+    return (market_address, index_token, long_token, short_token)
+
+
+def _build_token_metadata(addresses: list[str]) -> dict[str, dict[str, Any]]:
+    """Return a token-metadata dict covering the supplied addresses."""
+    return {addr: {"symbol": "TKN", "decimals": 18} for addr in addresses}
+
+
+def _build_config(chain: str = "arbitrum") -> MagicMock:
+    """Build a minimal mock that mimics :class:`GMXConfig` for cache tests."""
+    config = MagicMock()
+    config.chain = chain
+    config.web3 = MagicMock()
+    return config
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    """Reset the class-level cache around every test."""
+    from eth_defi.gmx.core.markets import Markets
+
+    Markets.invalidate_cache()
+    yield
+    Markets.invalidate_cache()
+
+
+def _install_mocks(
+    monkeypatch,
+    raw_markets: list[tuple[str, str, str, str]],
+    token_metadata: dict[str, dict[str, Any]] | None = None,
+    disabled_addresses: set[str] | None = None,
+    on_chain_count: int | None = None,
+):
+    """Patch the network surfaces ``_process_markets`` depends on."""
+    from eth_defi.gmx.core import markets as markets_mod
+
+    token_meta = token_metadata or _build_token_metadata([t for row in raw_markets for t in row[1:]])
+    disabled = disabled_addresses or set()
+    count = on_chain_count if on_chain_count is not None else len(raw_markets)
+
+    raw_call = MagicMock(return_value=list(raw_markets))
+    monkeypatch.setattr(markets_mod.Markets, "_get_available_markets_raw", raw_call)
+    monkeypatch.setattr(markets_mod.Markets, "_get_token_metadata_dict", lambda self: dict(token_meta))
+    monkeypatch.setattr(markets_mod.Markets, "_get_oracle_prices", lambda self: {})
+
+    disabled_check = MagicMock(return_value={addr: (addr in disabled) for addr in [row[0] for row in raw_markets]})
+    monkeypatch.setattr(markets_mod.Markets, "_check_markets_disabled_onchain", disabled_check, raising=False)
+
+    count_call = MagicMock(return_value=count)
+    monkeypatch.setattr(markets_mod.Markets, "_get_on_chain_market_count", count_call, raising=False)
+
+    return {"raw_call": raw_call, "disabled_check": disabled_check, "count_call": count_call}
+
+
+def test_cache_entry_under_ttl_returns_cached(monkeypatch):
+    """Within TTL, ``_process_markets`` must NOT rebuild — RPC calls happen once only."""
+    from eth_defi.gmx.core.markets import Markets
+
+    raw = [_build_raw_market_tuple(_ETH_MARKET_ADDR, _ETH_INDEX)]
+    mocks = _install_mocks(monkeypatch, raw)
+
+    config = _build_config()
+    markets = Markets(config)
+
+    first = markets._process_markets()
+    second = markets._process_markets()
+
+    assert first is second or first == second
+    # Raw fetch should happen exactly once even though we called twice.
+    assert mocks["raw_call"].call_count == 1
+
+
+def test_cache_entry_over_ttl_refetches(monkeypatch):
+    """After TTL elapses, next call rebuilds."""
+    from eth_defi.gmx.core import markets as markets_mod
+    from eth_defi.gmx.core.markets import Markets
+
+    raw = [_build_raw_market_tuple(_ETH_MARKET_ADDR, _ETH_INDEX)]
+    mocks = _install_mocks(monkeypatch, raw)
+
+    config = _build_config()
+    markets = Markets(config)
+
+    # First call seeds the cache.
+    markets._process_markets()
+    assert mocks["raw_call"].call_count == 1
+
+    # Reach into the cache and rewind ``fetched_at_ms`` past the TTL.
+    entry = markets_mod._CLASS_MARKETS_CACHE["arbitrum"]
+    entry.fetched_at_ms = entry.fetched_at_ms - markets_mod._CLASS_MARKETS_CACHE_TTL_MS - 1
+
+    markets._process_markets()
+    assert mocks["raw_call"].call_count == 2, "Stale entry must trigger a rebuild"
+
+
+def test_invalidate_cache_clears_chain_entry():
+    """Per-chain invalidation removes only that chain's entry."""
+    from eth_defi.gmx.core.markets import (
+        _CLASS_MARKETS_CACHE,
+        Markets,
+        _MarketsCacheEntry,
+    )
+
+    _CLASS_MARKETS_CACHE["arbitrum"] = _MarketsCacheEntry(
+        markets={"0xabc": {"index_token_address": "0x123"}},
+        fetched_at_ms=int(time.time() * 1000),
+        partial=False,
+    )
+    _CLASS_MARKETS_CACHE["avalanche"] = _MarketsCacheEntry(
+        markets={"0xdef": {"index_token_address": "0x456"}},
+        fetched_at_ms=int(time.time() * 1000),
+        partial=False,
+    )
+
+    Markets.invalidate_cache("arbitrum")
+    assert "arbitrum" not in _CLASS_MARKETS_CACHE
+    assert "avalanche" in _CLASS_MARKETS_CACHE
+
+
+def test_invalidate_cache_clears_all_when_chain_none():
+    """``invalidate_cache()`` with no argument wipes every chain."""
+    from eth_defi.gmx.core.markets import (
+        _CLASS_MARKETS_CACHE,
+        Markets,
+        _MarketsCacheEntry,
+    )
+
+    _CLASS_MARKETS_CACHE["arbitrum"] = _MarketsCacheEntry(
+        markets={"0xabc": {}}, fetched_at_ms=0, partial=False
+    )
+    _CLASS_MARKETS_CACHE["avalanche"] = _MarketsCacheEntry(
+        markets={"0xdef": {}}, fetched_at_ms=0, partial=False
+    )
+    Markets.invalidate_cache()
+    assert _CLASS_MARKETS_CACHE == {}
+
+
+def test_invalidate_cache_unknown_chain_is_noop():
+    """Calling invalidate for a chain that was never cached must not raise."""
+    from eth_defi.gmx.core.markets import Markets
+
+    # Should be a no-op rather than KeyError.
+    Markets.invalidate_cache("base_sepolia")
+
+
+def test_partial_build_marked_partial(monkeypatch):
+    """When processed_count < on_chain_count, the entry has partial=True."""
+    from eth_defi.gmx.core import markets as markets_mod
+    from eth_defi.gmx.core.markets import Markets
+
+    raw = [_build_raw_market_tuple(_ETH_MARKET_ADDR, _ETH_INDEX)]
+    # Tell the partial-detection helper there are *2* on-chain markets but the
+    # raw fetch only returned 1 — this simulates a transient gap (e.g. a
+    # mid-flight RPC error inside _process_markets that drops a market).
+    _install_mocks(monkeypatch, raw, on_chain_count=2)
+
+    config = _build_config()
+    markets = Markets(config)
+    result = markets._process_markets()
+
+    entry = markets_mod._CLASS_MARKETS_CACHE["arbitrum"]
+    assert entry.partial is True
+    assert result  # The (partial) result is still returned for this call.
+
+
+def test_partial_build_never_returned_from_ttl_fast_path(monkeypatch):
+    """A partial entry forces a rebuild on every subsequent call."""
+    from eth_defi.gmx.core import markets as markets_mod
+    from eth_defi.gmx.core.markets import Markets
+
+    raw = [_build_raw_market_tuple(_ETH_MARKET_ADDR, _ETH_INDEX)]
+    mocks = _install_mocks(monkeypatch, raw, on_chain_count=2)
+
+    config = _build_config()
+    markets = Markets(config)
+
+    markets._process_markets()
+    assert mocks["raw_call"].call_count == 1
+
+    # Even within TTL, the partial entry must be re-evaluated.
+    markets._process_markets()
+    assert mocks["raw_call"].call_count == 2
+
+    # And confirm the entry on disk is still partial.
+    entry = markets_mod._CLASS_MARKETS_CACHE["arbitrum"]
+    assert entry.partial is True
+
+
+def test_partial_build_does_not_overwrite_complete_prior(monkeypatch):
+    """A complete prior entry beats a partial new build (no oracle-race poisoning)."""
+    from eth_defi.gmx.core import markets as markets_mod
+    from eth_defi.gmx.core.markets import Markets, _MarketsCacheEntry
+
+    # Seed cache with a *complete* 2-market entry from a prior call.
+    complete_markets = {
+        _ETH_MARKET_ADDR: {"index_token_address": _ETH_INDEX, "market_symbol": "ETH"},
+        _BTC_MARKET_ADDR: {"index_token_address": _BTC_INDEX, "market_symbol": "BTC"},
+    }
+    markets_mod._CLASS_MARKETS_CACHE["arbitrum"] = _MarketsCacheEntry(
+        markets=complete_markets,
+        fetched_at_ms=int(time.time() * 1000)
+        - markets_mod._CLASS_MARKETS_CACHE_TTL_MS
+        - 1,  # past TTL → would normally rebuild
+        partial=False,
+    )
+
+    # The rebuild only sees ONE market but on-chain still reports 2 — partial.
+    raw = [_build_raw_market_tuple(_ETH_MARKET_ADDR, _ETH_INDEX)]
+    _install_mocks(monkeypatch, raw, on_chain_count=2)
+
+    config = _build_config()
+    markets = Markets(config)
+    result = markets._process_markets()
+
+    # The complete prior cache MUST be preserved when the new build is partial.
+    assert _BTC_MARKET_ADDR in result, "Complete prior entry must shadow a partial rebuild"
+    assert _ETH_MARKET_ADDR in result
+    # And the stored entry should still be the original complete one, not partial.
+    entry = markets_mod._CLASS_MARKETS_CACHE["arbitrum"]
+    assert entry.partial is False
+    assert _BTC_MARKET_ADDR in entry.markets
+
+
+def test_disabled_market_filtered_via_onchain_check(monkeypatch):
+    """A market flagged as disabled by ``IS_MARKET_DISABLED`` is excluded."""
+    from eth_defi.gmx.core.markets import Markets
+
+    raw = [
+        _build_raw_market_tuple(_ETH_MARKET_ADDR, _ETH_INDEX),
+        _build_raw_market_tuple(_BTC_MARKET_ADDR, _BTC_INDEX),
+    ]
+    _install_mocks(
+        monkeypatch,
+        raw,
+        disabled_addresses={_BTC_MARKET_ADDR},
+        on_chain_count=2,
+    )
+
+    config = _build_config()
+    markets = Markets(config)
+    result = markets._process_markets()
+
+    assert _ETH_MARKET_ADDR in result
+    assert _BTC_MARKET_ADDR not in result, "Disabled market must be filtered out"
+
+
+def test_oracle_snapshot_does_not_exclude_markets(monkeypatch):
+    """Markets missing from the oracle snapshot must STILL be included.
+
+    This is the structural fix for issue #67 — the previous code skipped any
+    market whose ``index_token_address`` was absent from the oracle REST
+    snapshot, which crashed live bots whenever a newly-listed token (or one
+    whose Pyth feed was momentarily unavailable) was on the whitelist.
+    """
+    from eth_defi.gmx.core import markets as markets_mod
+    from eth_defi.gmx.core.markets import Markets
+
+    raw = [_build_raw_market_tuple(_ETH_MARKET_ADDR, _ETH_INDEX)]
+    _install_mocks(monkeypatch, raw)
+    # Override the oracle stub to be empty *and* still expect the market to
+    # come through.
+    monkeypatch.setattr(markets_mod.Markets, "_get_oracle_prices", lambda self: {})
+
+    config = _build_config()
+    markets = Markets(config)
+    result = markets._process_markets()
+
+    assert _ETH_MARKET_ADDR in result, "Oracle-missing markets must NOT be filtered out"
+
+
+def test_empty_processed_markets_still_raises(monkeypatch):
+    """Preserve the existing PR-#722 guard: an empty result must raise."""
+    from eth_defi.gmx.core.markets import Markets
+
+    # All markets have zero-address index tokens, so all get skipped.
+    raw = [_build_raw_market_tuple(_ETH_MARKET_ADDR, "0x" + "0" * 40)]
+    _install_mocks(monkeypatch, raw, on_chain_count=1)
+
+    config = _build_config()
+    markets = Markets(config)
+    with pytest.raises(ValueError, match="empty dict"):
+        markets._process_markets()

--- a/tests/gmx/test_order_argument_parser_refresh_on_miss.py
+++ b/tests/gmx/test_order_argument_parser_refresh_on_miss.py
@@ -1,0 +1,201 @@
+"""Force-refresh on market_key miss inside ``OrderArgumentParser``.
+
+These tests pin the second leg of the issue #67 fix: when
+``_handle_missing_market_key`` cannot resolve an index token, instead of
+raising immediately it must:
+
+1. Log a warning, invalidate the class-level markets cache, and re-fetch.
+2. Retry the lookup once.
+3. Raise a ``ValueError`` *only* if the retry also fails — with a message
+   that includes ``after forced cache refresh`` so on-call operators can
+   distinguish a structural miss from a stale-cache miss.
+4. Bound the retry to one refresh per parser instance — never loop.
+
+See ``tradingstrategy-ai/gmx-strategies#67`` deep-dive
+(``2026-05-11-gmx-market-cache-permanent-fix.md``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# Reused fixture addresses (the same checksum addresses pinned in
+# ``test_markets_cache_ttl.py``).
+_BTC_INDEX = "0x47904963fc8b2340414262125aF798B9655E58Cd"
+_CHZ_INDEX = "0x5dB4692926C8ceebF6Da0995358Bbc438F3fd80C"  # the issue-#67 token
+_USDC = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+_BTC_MARKET_ADDR = "0x47c031236e19d024b42f8AE6780E44A573170703"
+_CHZ_MARKET_ADDR = "0x4fDd333FF9cA409df583f306B6F5a7fFdC9573d1"
+
+
+def _markets_with_btc_only() -> dict:
+    return {
+        _BTC_MARKET_ADDR: {
+            "gmx_market_address": _BTC_MARKET_ADDR,
+            "market_symbol": "BTC",
+            "index_token_address": _BTC_INDEX,
+            "long_token_address": _USDC,
+            "short_token_address": _USDC,
+            "market_metadata": {"symbol": "BTC", "decimals": 8},
+            "long_token_metadata": {"symbol": "USDC", "decimals": 6},
+            "short_token_metadata": {"symbol": "USDC", "decimals": 6},
+        },
+    }
+
+
+def _markets_with_btc_and_chz() -> dict:
+    return {
+        _BTC_MARKET_ADDR: {
+            "gmx_market_address": _BTC_MARKET_ADDR,
+            "market_symbol": "BTC",
+            "index_token_address": _BTC_INDEX,
+            "long_token_address": _USDC,
+            "short_token_address": _USDC,
+            "market_metadata": {"symbol": "BTC", "decimals": 8},
+            "long_token_metadata": {"symbol": "USDC", "decimals": 6},
+            "short_token_metadata": {"symbol": "USDC", "decimals": 6},
+        },
+        _CHZ_MARKET_ADDR: {
+            "gmx_market_address": _CHZ_MARKET_ADDR,
+            "market_symbol": "CHZ",
+            "index_token_address": _CHZ_INDEX,
+            "long_token_address": _USDC,
+            "short_token_address": _USDC,
+            "market_metadata": {"symbol": "CHZ", "decimals": 8},
+            "long_token_metadata": {"symbol": "USDC", "decimals": 6},
+            "short_token_metadata": {"symbol": "USDC", "decimals": 6},
+        },
+    }
+
+
+def _build_config() -> MagicMock:
+    config = MagicMock()
+    config.chain = "arbitrum"
+    config.web3 = MagicMock()
+    config.web3.eth.chain_id = 42161
+    config.user_wallet_address = None
+    return config
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    """Reset the class-level markets cache around every test."""
+    from eth_defi.gmx.core.markets import Markets
+
+    Markets.invalidate_cache()
+    yield
+    Markets.invalidate_cache()
+
+
+def _build_parser(monkeypatch, initial_markets: dict):
+    """Build an ``OrderArgumentParser`` whose initial ``self.markets`` snapshot
+    is the provided dict.  Returns ``(parser, get_available_markets_mock)``."""
+    from eth_defi.gmx.order import order_argument_parser as parser_mod
+    from eth_defi.gmx.order.order_argument_parser import OrderArgumentParser
+
+    # Patch the Markets.get_available_markets so __init__ uses our snapshot.
+    mock_get_available_markets = MagicMock(return_value=initial_markets)
+    monkeypatch.setattr(
+        parser_mod.Markets,
+        "get_available_markets",
+        lambda self: mock_get_available_markets(),
+    )
+
+    # Avoid triggering an actual GMXConfig construction.
+    monkeypatch.setattr(parser_mod, "GMXConfig", MagicMock())
+
+    config = _build_config()
+    parser = OrderArgumentParser(config, is_increase=True)
+    return parser, mock_get_available_markets
+
+
+def test_first_miss_invalidates_and_retries_then_succeeds(monkeypatch):
+    """First lookup misses CHZ; after refresh CHZ is present and resolves."""
+    from eth_defi.gmx.core.markets import Markets
+
+    parser, mock_get_available_markets = _build_parser(
+        monkeypatch, _markets_with_btc_only()
+    )
+
+    # Now arrange that the next call returns the *expanded* market set.
+    mock_get_available_markets.return_value = _markets_with_btc_and_chz()
+
+    # Spy on Markets.invalidate_cache to confirm the parser actually invokes it.
+    with patch.object(Markets, "invalidate_cache", wraps=Markets.invalidate_cache) as inv:
+        parser.parameters_dict = {
+            "chain": "arbitrum",
+            "index_token_address": _CHZ_INDEX,
+        }
+        parser._handle_missing_market_key()
+
+    assert parser.parameters_dict["market_key"] == _CHZ_MARKET_ADDR
+    assert inv.called, "invalidate_cache must be called on the first miss"
+
+
+def test_second_miss_after_refresh_raises_value_error(monkeypatch):
+    """When CHZ is structurally absent, the retry also misses and raises."""
+    parser, mock_get_available_markets = _build_parser(
+        monkeypatch, _markets_with_btc_only()
+    )
+    # Even after the refresh, CHZ is not present anywhere.
+    mock_get_available_markets.return_value = _markets_with_btc_only()
+
+    parser.parameters_dict = {
+        "chain": "arbitrum",
+        "index_token_address": _CHZ_INDEX,
+    }
+    with pytest.raises(ValueError, match="after forced cache refresh"):
+        parser._handle_missing_market_key()
+
+
+def test_refresh_is_bounded_one_attempt_per_parser_instance(monkeypatch):
+    """Two consecutive structural misses must NOT cause two cache refreshes."""
+    from eth_defi.gmx.core.markets import Markets
+
+    parser, mock_get_available_markets = _build_parser(
+        monkeypatch, _markets_with_btc_only()
+    )
+    mock_get_available_markets.return_value = _markets_with_btc_only()
+
+    with patch.object(Markets, "invalidate_cache", wraps=Markets.invalidate_cache) as inv:
+        # First miss: refresh once, raise.
+        parser.parameters_dict = {
+            "chain": "arbitrum",
+            "index_token_address": _CHZ_INDEX,
+        }
+        with pytest.raises(ValueError):
+            parser._handle_missing_market_key()
+        first_refresh_count = inv.call_count
+
+        # Second miss on the SAME parser instance: must not refresh again.
+        parser.parameters_dict = {
+            "chain": "arbitrum",
+            "index_token_address": _CHZ_INDEX,
+        }
+        with pytest.raises(ValueError):
+            parser._handle_missing_market_key()
+        second_refresh_count = inv.call_count
+
+    assert second_refresh_count == first_refresh_count, (
+        "A second miss on the same parser must not trigger another refresh"
+    )
+
+
+def test_initial_hit_does_not_invalidate_cache(monkeypatch):
+    """When the lookup hits on the first try, no cache refresh should occur."""
+    from eth_defi.gmx.core.markets import Markets
+
+    parser, _ = _build_parser(monkeypatch, _markets_with_btc_and_chz())
+
+    with patch.object(Markets, "invalidate_cache", wraps=Markets.invalidate_cache) as inv:
+        parser.parameters_dict = {
+            "chain": "arbitrum",
+            "index_token_address": _CHZ_INDEX,
+        }
+        parser._handle_missing_market_key()
+
+    assert parser.parameters_dict["market_key"] == _CHZ_MARKET_ADDR
+    assert not inv.called, "invalidate_cache must NOT be called on a hit"


### PR DESCRIPTION
## Why

Bug C in [tradingstrategy-ai/gmx-strategies#67](https://github.com/tradingstrategy-ai/gmx-strategies/issues/67): a live GMX freqtrade bot crashed 56 times in a 24h window on `ValueError: No GMX market found for index_token_address='0x5dB46...'` (Chiliz/CHZ).

Root cause was a class-level markets cache (`_CLASS_MARKETS_CACHE`) with **no TTL, no invalidation, and an oracle-snapshot exclusion filter** that dropped any market whose index token was momentarily missing from the GMX REST `/signed_prices/latest` response. Four prior PRs (#609, #722, #853, #862) each patched a different filter (enumeration window, empty-dict, scope) without removing the oracle one — every new GMX listing exposed a fresh subset of latent tokens to the same race.

A cross-check of the production whitelist against the bot's runtime cache identified **12 latent crash tokens** beyond CHZ: AR, CC, DASH, IP, JTO, LIT, MET, MON, SKY, SYRUP, ZEC. Each was waiting for its first signal to crash the bot.

## Summary

- `Markets._process_markets` no longer applies the oracle-snapshot exclusion filter. The oracle is still fetched (downstream consumers may read it) but it is never used as an exclude predicate.
- New Multicall3-backed `IS_MARKET_DISABLED` check filters genuinely disabled markets, mirroring the proven pattern already in `GMX._filter_datastore_disabled_markets`. Single `aggregate3` round-trip with one retry; conservative fall-back to \"enabled\" on total Multicall3 failure.
- `_CLASS_MARKETS_CACHE` now stores `_MarketsCacheEntry(markets, fetched_at_ms, partial)` dataclass instances. Entries expire after 5 minutes; partial entries (`len(markets) < on-chain MARKET_LIST size`) never enter the TTL fast path and never overwrite a strictly-larger complete prior entry.
- Public `Markets.invalidate_cache(chain=None)` classmethod for caller-driven force-refresh.
- `OrderArgumentParser._handle_missing_market_key` now invalidates the cache and re-fetches **once** before raising `ValueError`. Bounded to one attempt per parser instance. Error message now contains \"after forced cache refresh\" so operators can distinguish a structural miss from a stale-cache miss.
- Redundant module-level `_MARKETS_CACHE` in `order_argument_parser.py` removed — the new TTL'd cache in `Markets` is the single source of truth.
- New `GMX.get_on_chain_index_tokens()` enumerator returns the structural set of listed index tokens directly from the reader contract (oracle-independent). This is the decoupling pin: downstream startup whitelist validators must not silently shrink the production whitelist whenever an oracle feed lags.
- Existing PR-#722 empty-dict guard preserved.

## Property coverage

Tests pin the four contracts the deep-dive design required:

| # | Contract | Tests |
|---|---|---|
| 1 | TTL + explicit invalidation | `test_cache_entry_under_ttl_returns_cached`, `test_cache_entry_over_ttl_refetches`, `test_invalidate_cache_clears_chain_entry`, `test_invalidate_cache_clears_all_when_chain_none` |
| 2 | Force-refresh on lookup miss | `test_first_miss_invalidates_and_retries_then_succeeds`, `test_second_miss_after_refresh_raises_value_error`, `test_refresh_is_bounded_one_attempt_per_parser_instance`, `test_initial_hit_does_not_invalidate_cache` |
| 3 | No partial-build poisoning | `test_partial_build_marked_partial`, `test_partial_build_never_returned_from_ttl_fast_path`, `test_partial_build_does_not_overwrite_complete_prior`, `test_empty_processed_markets_still_raises` (PR-#722 regression), `test_disabled_market_filtered_via_onchain_check`, `test_oracle_snapshot_does_not_exclude_markets` |
| 4 | Whitelist enumerator decoupled from oracle | `test_method_exists_on_gmx`, `test_returns_set_of_checksum_addresses`, `test_does_not_apply_oracle_filter`, `test_skips_zero_address_index_tokens` |

19/19 new tests PASS. 50/50 PASS across offline `tests/gmx/` runs.

## Lessons learnt

- Cache safety is a property of three things together: bounded staleness (TTL), explicit invalidation, and shape-aware refresh. Any cache missing one of those three is a future bug.
- When a build pipeline depends on two independent data sources (here: on-chain market list + oracle REST snapshot), filter on the **authoritative** one only. Oracle availability is the wrong gate for *structural* market existence — disabled-status on-chain is the right one.
- Test seams matter. Exposing `_get_on_chain_market_count` and `_check_markets_disabled_onchain` as named helpers on `Markets` let the tests pin the partial-build and disabled-filter behaviour without standing up a fork environment.

## Companion PRs

This is the third of three PRs that together resolve issue #67:

- #1000 — Bug A (limit orders no longer zombie-cancelled at 10 min)
- #1001 — Bug B (synthetic timestamp = `block.timestamp * 1000` not `block.number * 1000`)
- **this PR — Bug C** (bounded markets cache + on-chain liveness)

Downstream work in `gmx-strategies-livebt` (filter helper + `bot_start` wiring + `confirm_trade_entry` safety net) tracked separately.

## Test plan

- [ ] CI green
- [ ] Smoke against Arbitrum mainnet: instantiate `Markets("arbitrum").get_available_markets()`, confirm CHZ (`0x5dB4...`), ZEC, SKY, JTO are present.
- [ ] `Markets.invalidate_cache("arbitrum")` followed by a second `get_available_markets()` triggers a fresh on-chain enumeration (log the count change).
- [ ] After merge: bump the pin in `gmx-strategies` and restart the production bot; confirm no new `ValueError: No GMX market found...` in the next 24h.