### PR TITLE
fix(gmx-ccxt): block.timestamp (not block.number) in fetch_order cache-miss synthetic orders (re-opens #1001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- fix: GMX CCXT adapter — `GMX.fetch_order` cache-miss path now uses the block's epoch-millisecond timestamp (`block.timestamp * 1000`) instead of `block.number * 1000`. The previous behaviour made the synthetic order's `timestamp` ~3 orders of magnitude too small; the freqtrade wrapper's age check then saw apparent ages of ~41 years and zombie-cancelled limit orders in memory on every bot restart, producing orphan on-chain positions. Fixed in both the sync and async adapters (3 sites each), via a new `_block_timestamp_ms` helper that returns `None` on RPC failure to keep `fetch_order` non-fatal. Companion to PR #1000. See tradingstrategy-ai/gmx-strategies#67 (2026-05-11)
+
 - feat: Ethereum-only sample vault data files (`vault-historical.sample.parquet`, `vault-metadata.sample.json`) generated during post-processing and uploaded to the public R2 bucket for free download; skip with `SKIP_SAMPLES=true` (2026-05-08)
 
 - fix: 40acres Aerodrome USDC vault on Base had a typo in the contract address (duplicated `d`), causing vault detection to fail; correct address is `0xb99b6df96d4d5448cc0a5b3e0ef7896df9507cf5` (2026-05-05)

--- a/eth_defi/gmx/ccxt/async_support/exchange.py
+++ b/eth_defi/gmx/ccxt/async_support/exchange.py
@@ -236,7 +236,7 @@ async def _async_scan_logs_chunked_for_trade_action(
     return None
 
 
-async def _block_timestamp_ms(web3, block_number: int | None) -> int | None:
+async def _block_timestamp_ms(web3: "AsyncWeb3", block_number: int | None) -> int | None:
     """Return block-creation epoch milliseconds for ``block_number``, or ``None``.
 
     Async mirror of the sync helper in :mod:`eth_defi.gmx.ccxt.exchange`. Used
@@ -248,7 +248,9 @@ async def _block_timestamp_ms(web3, block_number: int | None) -> int | None:
     :param web3: Connected :class:`web3.AsyncWeb3` instance.
     :param block_number: Block number to look up. ``None`` or ``0`` returns
         ``None`` without making an RPC call.
-    :returns: ``block.timestamp * 1000`` in epoch milliseconds, or ``None``.
+    :returns: ``block.timestamp * 1000`` in epoch milliseconds, or ``None`` if
+        ``block_number`` is falsy or the RPC call fails.
+    :raises: Never — RPC failures are logged at debug and return ``None``.
     """
     if not block_number:
         return None
@@ -256,7 +258,7 @@ async def _block_timestamp_ms(web3, block_number: int | None) -> int | None:
         block = await web3.eth.get_block(block_number)
         return int(block["timestamp"]) * 1000
     except Exception as e:  # noqa: BLE001 — fetch_order must never raise here
-        logging.getLogger(__name__).debug(
+        logger.debug(
             "_block_timestamp_ms: get_block(%s) failed: %s", block_number, e
         )
         return None

--- a/eth_defi/gmx/ccxt/async_support/exchange.py
+++ b/eth_defi/gmx/ccxt/async_support/exchange.py
@@ -236,6 +236,32 @@ async def _async_scan_logs_chunked_for_trade_action(
     return None
 
 
+async def _block_timestamp_ms(web3, block_number: int | None) -> int | None:
+    """Return block-creation epoch milliseconds for ``block_number``, or ``None``.
+
+    Async mirror of the sync helper in :mod:`eth_defi.gmx.ccxt.exchange`. Used
+    to build synthetic CCXT-order dicts in the cache-miss path of
+    :meth:`GMX.fetch_order` after a bot restart. Falling back to ``None`` on
+    any failure keeps the order construction non-fatal — downstream consumers
+    (e.g. the freqtrade wrapper) already handle ``timestamp=None`` safely.
+
+    :param web3: Connected :class:`web3.AsyncWeb3` instance.
+    :param block_number: Block number to look up. ``None`` or ``0`` returns
+        ``None`` without making an RPC call.
+    :returns: ``block.timestamp * 1000`` in epoch milliseconds, or ``None``.
+    """
+    if not block_number:
+        return None
+    try:
+        block = await web3.eth.get_block(block_number)
+        return int(block["timestamp"]) * 1000
+    except Exception as e:  # noqa: BLE001 — fetch_order must never raise here
+        logging.getLogger(__name__).debug(
+            "_block_timestamp_ms: get_block(%s) failed: %s", block_number, e
+        )
+        return None
+
+
 class GMX(Exchange):
     """Async GMX exchange with native async I/O.
 
@@ -2302,11 +2328,12 @@ class GMX(Exchange):
                 tx_success = receipt.get("status") == 1
                 if not tx_success:
                     # Transaction failed - return failed order
+                    _ts_ms = await _block_timestamp_ms(self.web3, tx.get("blockNumber"))
                     order = {
                         "id": id,
                         "clientOrderId": None,
-                        "datetime": self.iso8601(tx.get("blockNumber", 0) * 1000) if tx.get("blockNumber") else None,
-                        "timestamp": tx.get("blockNumber", 0) * 1000 if tx.get("blockNumber") else None,
+                        "datetime": self.iso8601(_ts_ms) if _ts_ms is not None else None,
+                        "timestamp": _ts_ms,
                         "lastTradeTimestamp": None,
                         "status": "failed",
                         "symbol": symbol if symbol else None,
@@ -2347,11 +2374,12 @@ class GMX(Exchange):
                 if not order_key:
                     # No order_key - can't verify execution, assume still pending
                     logger.warning("fetch_order(%s): no order_key, returning status=open", id)
+                    _ts_ms = await _block_timestamp_ms(self.web3, tx.get("blockNumber"))
                     order = {
                         "id": id,
                         "clientOrderId": None,
-                        "datetime": self.iso8601(tx.get("blockNumber", 0) * 1000) if tx.get("blockNumber") else None,
-                        "timestamp": tx.get("blockNumber", 0) * 1000 if tx.get("blockNumber") else None,
+                        "datetime": self.iso8601(_ts_ms) if _ts_ms is not None else None,
+                        "timestamp": _ts_ms,
                         "lastTradeTimestamp": None,
                         "status": "open",
                         "symbol": symbol if symbol else None,
@@ -2423,11 +2451,12 @@ class GMX(Exchange):
                         "ORDER_TRACE: fetch_order(%s) - NO EXECUTION FOUND (async, checked Subsquid + EventEmitter) - RETURNING status=open (might be lost/pending)",
                         id,
                     )
+                    _ts_ms = await _block_timestamp_ms(self.web3, tx.get("blockNumber"))
                     order = {
                         "id": id,
                         "clientOrderId": None,
-                        "datetime": self.iso8601(tx.get("blockNumber", 0) * 1000) if tx.get("blockNumber") else None,
-                        "timestamp": tx.get("blockNumber", 0) * 1000 if tx.get("blockNumber") else None,
+                        "datetime": self.iso8601(_ts_ms) if _ts_ms is not None else None,
+                        "timestamp": _ts_ms,
                         "lastTradeTimestamp": None,
                         "status": "open",
                         "symbol": symbol if symbol else None,

--- a/eth_defi/gmx/ccxt/exchange.py
+++ b/eth_defi/gmx/ccxt/exchange.py
@@ -328,7 +328,7 @@ def _derive_side_from_trade_action(trade_action: dict) -> str | None:
     return None
 
 
-def _block_timestamp_ms(web3, block_number: int | None) -> int | None:
+def _block_timestamp_ms(web3: "Web3", block_number: int | None) -> int | None:
     """Return block-creation epoch milliseconds for ``block_number``, or ``None``.
 
     Used to build synthetic CCXT-order dicts in the cache-miss path of
@@ -339,7 +339,9 @@ def _block_timestamp_ms(web3, block_number: int | None) -> int | None:
     :param web3: Connected :class:`web3.Web3` instance.
     :param block_number: Block number to look up. ``None`` or ``0`` returns
         ``None`` without making an RPC call.
-    :returns: ``block.timestamp * 1000`` in epoch milliseconds, or ``None``.
+    :returns: ``block.timestamp * 1000`` in epoch milliseconds, or ``None`` if
+        ``block_number`` is falsy or the RPC call fails.
+    :raises: Never — RPC failures are logged at debug and return ``None``.
     """
     if not block_number:
         return None
@@ -347,7 +349,7 @@ def _block_timestamp_ms(web3, block_number: int | None) -> int | None:
         block = web3.eth.get_block(block_number)
         return int(block["timestamp"]) * 1000
     except Exception as e:  # noqa: BLE001 — fetch_order must never raise here
-        logging.getLogger(__name__).debug(
+        logger.debug(
             "_block_timestamp_ms: get_block(%s) failed: %s", block_number, e
         )
         return None

--- a/eth_defi/gmx/ccxt/exchange.py
+++ b/eth_defi/gmx/ccxt/exchange.py
@@ -328,6 +328,31 @@ def _derive_side_from_trade_action(trade_action: dict) -> str | None:
     return None
 
 
+def _block_timestamp_ms(web3, block_number: int | None) -> int | None:
+    """Return block-creation epoch milliseconds for ``block_number``, or ``None``.
+
+    Used to build synthetic CCXT-order dicts in the cache-miss path of
+    :meth:`GMX.fetch_order` after a bot restart. Falling back to ``None`` on
+    any failure keeps the order construction non-fatal — downstream consumers
+    (e.g. the freqtrade wrapper) already handle ``timestamp=None`` safely.
+
+    :param web3: Connected :class:`web3.Web3` instance.
+    :param block_number: Block number to look up. ``None`` or ``0`` returns
+        ``None`` without making an RPC call.
+    :returns: ``block.timestamp * 1000`` in epoch milliseconds, or ``None``.
+    """
+    if not block_number:
+        return None
+    try:
+        block = web3.eth.get_block(block_number)
+        return int(block["timestamp"]) * 1000
+    except Exception as e:  # noqa: BLE001 — fetch_order must never raise here
+        logging.getLogger(__name__).debug(
+            "_block_timestamp_ms: get_block(%s) failed: %s", block_number, e
+        )
+        return None
+
+
 class GMX(ExchangeCompatible):
     """
     CCXT-compatible wrapper for GMX protocol market data and trading.
@@ -8716,11 +8741,12 @@ class GMX(ExchangeCompatible):
                 tx_success = receipt.get("status") == 1
                 if not tx_success:
                     # Transaction failed - return failed order
+                    _ts_ms = _block_timestamp_ms(self.web3, tx.get("blockNumber"))
                     order = {
                         "id": id,
                         "clientOrderId": None,
-                        "datetime": self.iso8601(tx.get("blockNumber", 0) * 1000) if tx.get("blockNumber") else None,
-                        "timestamp": tx.get("blockNumber", 0) * 1000 if tx.get("blockNumber") else None,
+                        "datetime": self.iso8601(_ts_ms) if _ts_ms is not None else None,
+                        "timestamp": _ts_ms,
                         "lastTradeTimestamp": None,
                         "status": "failed",
                         "symbol": symbol if symbol else None,
@@ -8757,11 +8783,12 @@ class GMX(ExchangeCompatible):
                 if not order_key:
                     # No order_key - can't verify execution, assume still pending
                     logger.warning("fetch_order(%s): no order_key, returning status=open", id)
+                    _ts_ms = _block_timestamp_ms(self.web3, tx.get("blockNumber"))
                     order = {
                         "id": id,
                         "clientOrderId": None,
-                        "datetime": self.iso8601(tx.get("blockNumber", 0) * 1000) if tx.get("blockNumber") else None,
-                        "timestamp": tx.get("blockNumber", 0) * 1000 if tx.get("blockNumber") else None,
+                        "datetime": self.iso8601(_ts_ms) if _ts_ms is not None else None,
+                        "timestamp": _ts_ms,
                         "lastTradeTimestamp": None,
                         "status": "open",
                         "symbol": symbol if symbol else None,
@@ -8833,11 +8860,12 @@ class GMX(ExchangeCompatible):
                         "ORDER_TRACE: fetch_order(%s) - NO EXECUTION FOUND (checked Subsquid + EventEmitter) - RETURNING status=open (might be lost/pending)",
                         id,
                     )
+                    _ts_ms = _block_timestamp_ms(self.web3, tx.get("blockNumber"))
                     order = {
                         "id": id,
                         "clientOrderId": None,
-                        "datetime": self.iso8601(tx.get("blockNumber", 0) * 1000) if tx.get("blockNumber") else None,
-                        "timestamp": tx.get("blockNumber", 0) * 1000 if tx.get("blockNumber") else None,
+                        "datetime": self.iso8601(_ts_ms) if _ts_ms is not None else None,
+                        "timestamp": _ts_ms,
                         "lastTradeTimestamp": None,
                         "status": "open",
                         "symbol": symbol if symbol else None,

--- a/tests/gmx/ccxt/test_fetch_order_cache_miss_timestamp.py
+++ b/tests/gmx/ccxt/test_fetch_order_cache_miss_timestamp.py
@@ -1,0 +1,52 @@
+"""Bug B regression: synthetic order from the cache-miss path must carry a real epoch-ms timestamp.
+
+See tradingstrategy-ai/gmx-strategies#67.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def fake_chain_state() -> dict:
+    """Block 400_000_000 on Arbitrum, occurred ~epoch second 1_780_000_000 (May 2026)."""
+    block_number = 400_000_000
+    block_timestamp_s = 1_780_000_000
+    receipt = {
+        "status": 0,  # tx failed — drives the failed-tx synthetic branch
+        "gasUsed": 100_000,
+        "blockNumber": block_number,
+        "logs": [],
+    }
+    tx = {"gasPrice": 100_000_000, "blockNumber": block_number}
+    return {"receipt": receipt, "tx": tx, "block_timestamp_s": block_timestamp_s, "block_number": block_number}
+
+
+def test_failed_tx_synthetic_uses_block_timestamp_not_block_number(fake_chain_state):
+    """The fix: synthetic order timestamp must equal block.timestamp * 1000, not block.number * 1000."""
+    from eth_defi.gmx.ccxt.exchange import GMX
+
+    ex = GMX.__new__(GMX)  # bypass __init__
+    ex._orders = {}
+    ex.web3 = MagicMock()
+    ex.web3.eth.get_transaction_receipt.return_value = fake_chain_state["receipt"]
+    ex.web3.eth.get_transaction.return_value = fake_chain_state["tx"]
+    ex.web3.eth.get_block.return_value = {"timestamp": fake_chain_state["block_timestamp_s"]}
+
+    # Build a 66-char tx hash so the cache-miss path runs
+    order = ex.fetch_order("0x" + "a" * 64, "BTC/USDC:USDC")
+
+    assert order["status"] == "failed"
+    expected_ms = fake_chain_state["block_timestamp_s"] * 1000
+    assert order["timestamp"] == expected_ms, (
+        f"timestamp should be block.timestamp*1000 = {expected_ms}, "
+        f"got {order['timestamp']} (likely block.number*1000 = {fake_chain_state['block_number'] * 1000})"
+    )
+    # Sanity bound: must be within ±50 years of "now"
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    fifty_years_ms = 50 * 365 * 24 * 60 * 60 * 1000
+    assert abs(now_ms - order["timestamp"]) < fifty_years_ms, "timestamp implausibly far from now"

--- a/tests/gmx/ccxt/test_fetch_order_cache_miss_timestamp.py
+++ b/tests/gmx/ccxt/test_fetch_order_cache_miss_timestamp.py
@@ -1,29 +1,124 @@
 """Bug B regression: synthetic order from the cache-miss path must carry a real epoch-ms timestamp.
 
 See tradingstrategy-ai/gmx-strategies#67.
+
+Two layers of coverage:
+
+1. Direct unit tests for ``_block_timestamp_ms`` (sync + async) — lock the
+   helper's contract: real epoch-ms on success, ``None`` on falsy block
+   number, ``None`` on any RPC failure (never raises).
+2. Integration test for the failed-tx synthetic branch inside
+   ``GMX.fetch_order`` — pins the helper to the call site and asserts the
+   resulting synthetic order's timestamp is real, not ``block.number * 1000``.
+
+The grep-level invariant ``"timestamp": tx.get("blockNumber", 0) * 1000`` →
+zero hits in both ``eth_defi/gmx/ccxt/exchange.py`` and
+``eth_defi/gmx/ccxt/async_support/exchange.py`` is enforced by code review
+and by the fact that all six wired sites now route through
+``_block_timestamp_ms``.
 """
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 
+# ---------------------------------------------------------------------------
+# Layer 1 — direct unit tests for the helper
+# ---------------------------------------------------------------------------
+
+
 @pytest.fixture
-def fake_chain_state() -> dict:
+def fake_block_number() -> int:
     """Block 400_000_000 on Arbitrum, occurred ~epoch second 1_780_000_000 (May 2026)."""
-    block_number = 400_000_000
-    block_timestamp_s = 1_780_000_000
+    return 400_000_000
+
+
+@pytest.fixture
+def fake_block_timestamp_s() -> int:
+    return 1_780_000_000
+
+
+def test_sync_helper_returns_block_timestamp_in_ms(fake_block_number, fake_block_timestamp_s):
+    from eth_defi.gmx.ccxt.exchange import _block_timestamp_ms
+
+    web3 = MagicMock()
+    web3.eth.get_block.return_value = {"timestamp": fake_block_timestamp_s}
+    assert _block_timestamp_ms(web3, fake_block_number) == fake_block_timestamp_s * 1000
+    web3.eth.get_block.assert_called_once_with(fake_block_number)
+
+
+@pytest.mark.parametrize("falsy", [None, 0])
+def test_sync_helper_returns_none_for_falsy_block_number(falsy):
+    from eth_defi.gmx.ccxt.exchange import _block_timestamp_ms
+
+    web3 = MagicMock()
+    assert _block_timestamp_ms(web3, falsy) is None
+    web3.eth.get_block.assert_not_called()
+
+
+def test_sync_helper_swallows_rpc_failures_and_returns_none(fake_block_number):
+    from eth_defi.gmx.ccxt.exchange import _block_timestamp_ms
+
+    web3 = MagicMock()
+    web3.eth.get_block.side_effect = ConnectionError("RPC down")
+    assert _block_timestamp_ms(web3, fake_block_number) is None
+
+
+@pytest.mark.asyncio
+async def test_async_helper_returns_block_timestamp_in_ms(fake_block_number, fake_block_timestamp_s):
+    from eth_defi.gmx.ccxt.async_support.exchange import _block_timestamp_ms
+
+    web3 = MagicMock()
+    web3.eth.get_block = AsyncMock(return_value={"timestamp": fake_block_timestamp_s})
+    assert await _block_timestamp_ms(web3, fake_block_number) == fake_block_timestamp_s * 1000
+    web3.eth.get_block.assert_awaited_once_with(fake_block_number)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("falsy", [None, 0])
+async def test_async_helper_returns_none_for_falsy_block_number(falsy):
+    from eth_defi.gmx.ccxt.async_support.exchange import _block_timestamp_ms
+
+    web3 = MagicMock()
+    web3.eth.get_block = AsyncMock()
+    assert await _block_timestamp_ms(web3, falsy) is None
+    web3.eth.get_block.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_helper_swallows_rpc_failures_and_returns_none(fake_block_number):
+    from eth_defi.gmx.ccxt.async_support.exchange import _block_timestamp_ms
+
+    web3 = MagicMock()
+    web3.eth.get_block = AsyncMock(side_effect=ConnectionError("RPC down"))
+    assert await _block_timestamp_ms(web3, fake_block_number) is None
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — integration test pinning the failed-tx synthetic branch in
+# GMX.fetch_order against block.timestamp * 1000 (not block.number * 1000).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_chain_state(fake_block_number, fake_block_timestamp_s) -> dict:
     receipt = {
         "status": 0,  # tx failed — drives the failed-tx synthetic branch
         "gasUsed": 100_000,
-        "blockNumber": block_number,
+        "blockNumber": fake_block_number,
         "logs": [],
     }
-    tx = {"gasPrice": 100_000_000, "blockNumber": block_number}
-    return {"receipt": receipt, "tx": tx, "block_timestamp_s": block_timestamp_s, "block_number": block_number}
+    tx = {"gasPrice": 100_000_000, "blockNumber": fake_block_number}
+    return {
+        "receipt": receipt,
+        "tx": tx,
+        "block_timestamp_s": fake_block_timestamp_s,
+        "block_number": fake_block_number,
+    }
 
 
 def test_failed_tx_synthetic_uses_block_timestamp_not_block_number(fake_chain_state):


### PR DESCRIPTION
## Re-opening #1001

PR #1001 was prematurely merged (admin override) before CI completed. That merge has been reverted via #1003. This PR carries the same content for a proper review cycle.

## Why

`GMX.fetch_order` cache-miss branch (sync + async) built synthetic CCXT-order dicts with `timestamp = blockNumber * 1000`. Arbitrum block numbers are ~4×10⁸; epoch milliseconds are ~1.78×10¹². So the synthetic `timestamp` ended up roughly 3 orders of magnitude too small.

The freqtrade wrapper then computed `age_ms = now_ms - timestamp` → ~41.76 years → triggered the zombie heuristic → force-resolved every limit order to `cancelled` in memory on every bot restart, producing orphan GMX positions.

Production log evidence (6 of 7 zombies in the 24h window):

```
GMX zombie order detected: 0x74a28f44a8d9231b for APE/USDC:USDC
has been open for 1317448383 seconds.   (= 41.76 years)
```

## Summary

- New `_block_timestamp_ms(web3, block_number) -> int | None` helper in both sync (`eth_defi/gmx/ccxt/exchange.py`) and async (`eth_defi/gmx/ccxt/async_support/exchange.py`) modules. Uses `web3.eth.get_block(block_number).timestamp * 1000`. Returns `None` on any RPC failure to keep `fetch_order` non-fatal.
- Replaces 3 buggy `timestamp` / `datetime` pairs in the sync adapter and 3 in the async mirror.
- 9 unit tests pinning the helper's contract (sync + async happy path, falsy block number, swallowed RPC failure) plus the failed-tx integration site.
- Companion to the re-opened Bug A PR.

## Test plan

- [ ] CI green
- [ ] Merge alongside the re-opened Bug A PR
- [ ] Bump the `web3-ethereum-defi` pin in `gmx-strategies` once both merge
- [ ] Restart bot; confirm no `has been open for 1XXXXXXXXX seconds` lines after restart