### PR TITLE
notes: Flag Borrowable USDC Deposit SiloId 20 as illiquid

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/ipor/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/ipor/vault.py
@@ -373,7 +373,7 @@ class IPORVault(ERC4626Vault):
         if dot_idx >= 0:
             return text[: dot_idx + 1]
         # If no sentence boundary, return the whole text (it's likely one sentence)
-        return text.rstrip("."  ) + "."
+        return text.rstrip(".") + "."
 
     def get_flags(self) -> set[VaultFlag]:
         """Get vault flags, auto-flagging vaults missing from IPOR's customisation list.

--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -466,6 +466,8 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0x61e175f91f017987c421e0731d6baa0594eca6eb": (VaultFlag.illiquid, GREENHOUSE_ILLIQUID),
     # Borrowable USDC Deposit, SiloId: 149 (Arbitrum)
     "0xa9a4bd976dbcfc2b89f554467ac85e2c758e2618": (VaultFlag.illiquid, XUSD_MESSAGE),
+    # Borrowable USDC Deposit, SiloId: 20 (Sonic)
+    "0x322e1d5384aa4ed66aeca770b95686271de61dc3": (VaultFlag.illiquid, XUSD_MESSAGE),
 }
 
 for addr in VAULT_FLAGS_AND_NOTES.keys():


### PR DESCRIPTION
## Why

Borrowable USDC Deposit SiloId 20 on Sonic (`0x322e1d5384aa4ed66aeca770b95686271de61dc3`) is illiquid.

## Lessons learnt

None.

## Summary

- Flagged Borrowable USDC Deposit SiloId 20 (Sonic) as `VaultFlag.illiquid` in `VAULT_FLAGS_AND_NOTES`

🤖 Generated with [Claude Code](https://claude.com/claude-code)