### PR TITLE
feat: Link AlphaGrowth Euler vaults to Light frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Current
 
-- feat: AlphaGrowth Monad Euler EVK vaults with custom Balancer LP collateral now link to AlphaGrowth's Euler Light frontend instead of Euler's official frontend (2026-05-13)
+- feat: AlphaGrowth curator metadata added, and AlphaGrowth Monad Euler EVK vaults with custom Balancer LP collateral now link to AlphaGrowth's Euler Light frontend instead of Euler's official frontend (2026-05-13)
 
 - feat: IPOR Fusion vault descriptions fetched from the offchain customisation API at `api.ipor.io/fusion/vaults-customization-list`, with prospectus links appended as markdown (2026-05-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- feat: AlphaGrowth Monad Euler EVK vaults with custom Balancer LP collateral now link to AlphaGrowth's Euler Light frontend instead of Euler's official frontend (2026-05-13)
+
 - feat: IPOR Fusion vault descriptions fetched from the offchain customisation API at `api.ipor.io/fusion/vaults-customization-list`, with prospectus links appended as markdown (2026-05-13)
 
 - feat: Ethereum-only sample vault data files (`vault-historical.sample.parquet`, `vault-metadata.sample.json`) generated during post-processing and uploaded to the public R2 bucket for free download; skip with `SKIP_SAMPLES=true` (2026-05-08)

--- a/eth_defi/data/feeds/curators/alphagrowth.yaml
+++ b/eth_defi/data/feeds/curators/alphagrowth.yaml
@@ -1,0 +1,19 @@
+feeder-id: alphagrowth
+name: AlphaGrowth
+role: curator
+website: https://alphagrowth.io/
+twitter: alphagrowth1
+
+# Evidence and background references.
+#
+# AlphaGrowth curates Euler EVK vaults and hosts a dedicated Euler Light
+# frontend for Monad vaults with custom Balancer LP token collateral support.
+# Their GitHub organisation maintains the Euler Light Balancer frontend and
+# related Euler label repository.
+other-links:
+  - title: AlphaGrowth Euler Light vault app
+    url: https://euler.alphagrowth.io/
+  - title: AlphaGrowth GitHub organisation
+    url: https://github.com/alphagrowth
+  - title: GitHub - AlphaGrowth Euler Light Balancer frontend documentation and source
+    url: https://github.com/alphagrowth/ag-euler-lite-balancer

--- a/eth_defi/erc_4626/vault_protocol/euler/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/euler/vault.py
@@ -34,6 +34,50 @@ CASH_SIGNATURE = Web3.keccak(text="cash()")[0:4]
 TOTAL_BORROWS_SIGNATURE = Web3.keccak(text="totalBorrows()")[0:4]
 INTEREST_FEE_SIGNATURE = Web3.keccak(text="interestFee()")[0:4]
 
+#: Monad mainnet chain id.
+MONAD_CHAIN_ID = 143
+
+
+#: AlphaGrowth's Euler Light frontend for Monad EVK vaults that Euler's
+#: official frontend cannot list because they use Balancer LP tokens as collateral.
+ALPHAGROWTH_EULER_LIGHT_BASE_URL = "https://euler.alphagrowth.io"
+
+#: AlphaGrowth-curated Monad EVK vaults that need the Euler Light frontend.
+#:
+#: Kyril from AlphaGrowth explained that these vaults have custom Balancer LP
+#: collateral support, so Euler cannot list them on the official frontend.
+#: AlphaGrowth curates its Euler vaults with governorAdmin
+#: ``0x4f894Bfc9481110278C356adE1473eBe2127Fd3C``, but only these two Monad
+#: vaults currently need this custom frontend link.
+ALPHAGROWTH_EULER_LIGHT_MONAD_VAULTS = frozenset(
+    {
+        "0x438cedce647491b1d93a73d491ec19a50194c222",
+        "0x75b6c392f778b8bcf9bdb676f8f128b4dd49ac19",
+    }
+)
+
+
+def is_alphagrowth_euler_light_vault(chain_id: int, vault_address: str) -> bool:
+    """Check if an Euler EVK vault should link to AlphaGrowth's Euler Light UI.
+
+    AlphaGrowth hosts a dedicated Euler Light interface for its Monad EVK vaults
+    that cannot be listed on Euler's official frontend because of their custom
+    Balancer LP token collateral handling. This helper is deliberately based on
+    the explicit unlisted vault addresses, instead of governorAdmin discovery,
+    because other AlphaGrowth-curated Euler vaults can still use the normal
+    Euler frontend.
+
+    :param chain_id:
+        EVM chain id for the vault.
+
+    :param vault_address:
+        ERC-4626 vault contract address.
+
+    :return:
+        ``True`` if the vault should use the AlphaGrowth Euler Light frontend.
+    """
+    return chain_id == MONAD_CHAIN_ID and vault_address.lower() in ALPHAGROWTH_EULER_LIGHT_MONAD_VAULTS
+
 
 class EulerVaultHistoricalReader(ERC4626HistoricalReader):
     """Read Euler EVK vault core data + utilisation metrics.
@@ -242,6 +286,24 @@ class EulerVault(ERC4626Vault):
         return datetime.timedelta(days=0)
 
     def get_link(self, referral: str | None = None) -> str:
+        """Get link to the Euler EVK vault frontend.
+
+        Most EVK vaults use Euler's official frontend. AlphaGrowth's two Monad
+        EVK vaults with custom Balancer LP collateral support are linked to
+        AlphaGrowth's Euler Light frontend instead, because Euler cannot list
+        them on the official frontend.
+
+        :param referral:
+            Optional referral code. Not used by Euler links.
+
+        :return:
+            Frontend URL for this vault.
+        """
+        del referral
+
+        if is_alphagrowth_euler_light_vault(self.chain_id, self.vault_address):
+            return f"{ALPHAGROWTH_EULER_LIGHT_BASE_URL}/lend/{self.vault_address}"
+
         chain_name = get_chain_name(self.chain_id).lower()
         return f"https://app.euler.finance/earn/{self.vault_address}?network={chain_name}"
 

--- a/eth_defi/erc_4626/vault_protocol/ipor/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/ipor/vault.py
@@ -373,7 +373,7 @@ class IPORVault(ERC4626Vault):
         if dot_idx >= 0:
             return text[: dot_idx + 1]
         # If no sentence boundary, return the whole text (it's likely one sentence)
-        return text.rstrip("."  ) + "."
+        return text.rstrip(".") + "."
 
     def get_flags(self) -> set[VaultFlag]:
         """Get vault flags, auto-flagging vaults missing from IPOR's customisation list.

--- a/tests/erc_4626/vault_protocol/test_euler_links.py
+++ b/tests/erc_4626/vault_protocol/test_euler_links.py
@@ -1,0 +1,58 @@
+"""Euler vault frontend link tests."""
+
+from web3 import Web3
+
+from eth_defi.erc_4626.vault_protocol.euler.vault import ALPHAGROWTH_EULER_LIGHT_BASE_URL, EulerVault
+from eth_defi.vault.base import VaultSpec
+
+
+def create_euler_vault(chain_id: int, vault_address: str) -> EulerVault:
+    """Create an Euler vault instance for link-only tests.
+
+    Link construction only needs the vault spec, so these tests can use a plain
+    ``Web3`` instance without RPC configuration.
+
+    :param chain_id:
+        EVM chain id for the vault.
+
+    :param vault_address:
+        ERC-4626 vault contract address.
+
+    :return:
+        Euler vault instance.
+    """
+    return EulerVault(
+        web3=Web3(),
+        spec=VaultSpec(chain_id=chain_id, vault_address=vault_address),
+    )
+
+
+def test_euler_alphagrowth_ausd_vault_uses_light_frontend() -> None:
+    """AlphaGrowth AUSD vault links to its Euler Light lend route."""
+    vault_address = "0x438cedcE647491B1d93a73d491eC19A50194c222"
+    vault = create_euler_vault(chain_id=143, vault_address=vault_address)
+
+    assert vault.get_link() == f"{ALPHAGROWTH_EULER_LIGHT_BASE_URL}/lend/{Web3.to_checksum_address(vault_address)}"
+
+
+def test_euler_alphagrowth_wmon_vault_uses_light_frontend() -> None:
+    """AlphaGrowth WMON vault links to its Euler Light lend route."""
+    vault_address = "0x75b6c392f778b8bcf9bdb676f8f128b4dd49ac19"
+    vault = create_euler_vault(chain_id=143, vault_address=vault_address)
+
+    assert vault.get_link() == f"{ALPHAGROWTH_EULER_LIGHT_BASE_URL}/lend/{Web3.to_checksum_address(vault_address)}"
+
+
+def test_euler_regular_monad_vault_uses_official_frontend() -> None:
+    """Non-special Monad Euler vaults keep the standard Euler frontend link."""
+    vault = create_euler_vault(chain_id=143, vault_address="0x1111111111111111111111111111111111111111")
+
+    assert vault.get_link() == "https://app.euler.finance/earn/0x1111111111111111111111111111111111111111?network=monad"
+
+
+def test_euler_alphagrowth_address_on_other_chain_uses_official_frontend() -> None:
+    """The custom AlphaGrowth link is scoped to Monad deployments."""
+    vault_address = "0x438cedcE647491B1d93a73d491eC19A50194c222"
+    vault = create_euler_vault(chain_id=1, vault_address=vault_address)
+
+    assert vault.get_link() == f"https://app.euler.finance/earn/{Web3.to_checksum_address(vault_address)}?network=ethereum"

--- a/tests/vault/test_curator.py
+++ b/tests/vault/test_curator.py
@@ -22,6 +22,21 @@ def test_identify_felix_vault() -> None:
     assert slug == "felix"
 
 
+def test_identify_alphagrowth_vault() -> None:
+    """AlphaGrowth Euler vault names resolve to the AlphaGrowth curator."""
+
+    slug = identify_curator(
+        chain_id=8453,
+        vault_token_symbol="agUSDC",
+        vault_name="AlphaGrowth USDC Base Vault",
+        vault_address="0x4c1aeda9b43efcf1da1d1755b18802aabe90f61e",
+        protocol_slug="euler",
+    )
+
+    assert slug == "alphagrowth"
+    assert get_curator_name("alphagrowth") == "AlphaGrowth"
+
+
 def test_identify_smokehouse_as_steakhouse_financial() -> None:
     """Smokehouse vault names resolve to Steakhouse Financial."""
 


### PR DESCRIPTION
## Why

AlphaGrowth has two Monad Euler EVK vaults with custom Balancer LP collateral support. Euler cannot list these vaults on the official frontend, so users need to be sent to AlphaGrowth's Euler Light interface instead.

AlphaGrowth also appears as a curator in Euler vault names, but the repository did not yet have dedicated curator feed metadata for it.

## Lessons learnt

AlphaGrowth-curated Euler vaults can be identified by their governorAdmin multisig, but only the AUSD and WMON Monad vaults currently need the custom frontend. The link override should therefore stay scoped to these explicit vault addresses.

The existing curator detector can recognise AlphaGrowth from a YAML feeder name alone, so no extra Python name-pattern entry is needed.

## Summary

- Added an AlphaGrowth Euler Light allow-list for the two Monad EVK vaults.
- Updated `EulerVault.get_link()` to return `/lend/<vault>` on `https://euler.alphagrowth.io` for those vaults.
- Added AlphaGrowth curator feed metadata with official site, X handle, vault app, and GitHub evidence links.
- Added focused link and curator-detection tests plus a changelog entry.