### PR TITLE
feat: Add AlphaGrowth Euler metadata labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- feat: AlphaGrowth Monad Euler EVK vaults now use AlphaGrowth's Euler Light label metadata for display names, descriptions, and curator attribution (2026-05-14)
+
 - feat: AlphaGrowth curator metadata added, and AlphaGrowth Monad Euler EVK vaults with custom Balancer LP collateral now link to AlphaGrowth's Euler Light frontend instead of Euler's official frontend (2026-05-13)
 
 - feat: IPOR Fusion vault descriptions fetched from the offchain customisation API at `api.ipor.io/fusion/vaults-customization-list`, with prospectus links appended as markdown (2026-05-13)

--- a/eth_defi/erc_4626/vault_protocol/euler/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/euler/vault.py
@@ -49,12 +49,26 @@ ALPHAGROWTH_EULER_LIGHT_BASE_URL = "https://euler.alphagrowth.io"
 #: AlphaGrowth curates its Euler vaults with governorAdmin
 #: ``0x4f894Bfc9481110278C356adE1473eBe2127Fd3C``, but only these two Monad
 #: vaults currently need this custom frontend link.
-ALPHAGROWTH_EULER_LIGHT_MONAD_VAULTS = frozenset(
-    {
-        "0x438cedce647491b1d93a73d491ec19a50194c222",
-        "0x75b6c392f778b8bcf9bdb676f8f128b4dd49ac19",
-    }
-)
+ALPHAGROWTH_EULER_LIGHT_MONAD_METADATA: dict[str, EulerVaultMetadata] = {
+    "0x438cedce647491b1d93a73d491ec19a50194c222": {
+        "name": "AlphaGrowth AUSD Borrow Vault",
+        "description": "Borrow AUSD against Balancer BPT collateral.",
+        "entity": "alphagrowth",
+        "entities": ["alphagrowth", "balancer", "euler"],
+        "product": "ausd-bpt-leverage",
+        "product_name": "Stablecoin BPT Leverage",
+    },
+    "0x75b6c392f778b8bcf9bdb676f8f128b4dd49ac19": {
+        "name": "AlphaGrowth WMON Borrow Vault",
+        "description": "Borrow WMON against Balancer BPT collateral.",
+        "entity": "alphagrowth",
+        "entities": ["alphagrowth", "balancer", "euler"],
+        "product": "wmon-bpt-leverage",
+        "product_name": "WMON BPT Leverage",
+    },
+}
+
+ALPHAGROWTH_EULER_LIGHT_MONAD_VAULTS = frozenset(ALPHAGROWTH_EULER_LIGHT_MONAD_METADATA.keys())
 
 
 def is_alphagrowth_euler_light_vault(chain_id: int, vault_address: str) -> bool:
@@ -77,6 +91,34 @@ def is_alphagrowth_euler_light_vault(chain_id: int, vault_address: str) -> bool:
         ``True`` if the vault should use the AlphaGrowth Euler Light frontend.
     """
     return chain_id == MONAD_CHAIN_ID and vault_address.lower() in ALPHAGROWTH_EULER_LIGHT_MONAD_VAULTS
+
+
+def get_alphagrowth_euler_light_metadata(chain_id: int, vault_address: str) -> EulerVaultMetadata | None:
+    """Get AlphaGrowth-specific metadata for Monad Euler Light vaults.
+
+    AlphaGrowth maintains labels for its Euler Light frontend in
+    ``alphagrowth/ag-euler-balancer-labels``.  The source labels identify the
+    AUSD vault as ``AUSD Borrow Vault`` and the WMON vault as
+    ``WMON Borrow Vault`` with ``alphagrowth`` as the entity.  We prefix the
+    display names with ``AlphaGrowth`` so our current curator detection, which
+    matches against vault names, can recognise these vaults without a separate
+    on-chain governorAdmin lookup.
+
+    Source:
+    https://github.com/alphagrowth/ag-euler-balancer-labels/tree/main/143
+
+    :param chain_id:
+        EVM chain id for the vault.
+
+    :param vault_address:
+        ERC-4626 vault contract address.
+
+    :return:
+        Metadata override for AlphaGrowth Euler Light vaults, or ``None``.
+    """
+    if chain_id != MONAD_CHAIN_ID:
+        return None
+    return ALPHAGROWTH_EULER_LIGHT_MONAD_METADATA.get(vault_address.lower())
 
 
 class EulerVaultHistoricalReader(ERC4626HistoricalReader):
@@ -228,6 +270,9 @@ class EulerVault(ERC4626Vault):
 
     @property
     def name(self) -> str:
+        if alphagrowth_metadata := get_alphagrowth_euler_light_metadata(self.chain_id, self.vault_address):
+            return alphagrowth_metadata["name"]
+
         if self.euler_metadata:
             # Euler metadata might not have an entry for this vault yet
             return self.euler_metadata.get("name", super().name)
@@ -235,12 +280,18 @@ class EulerVault(ERC4626Vault):
 
     @property
     def description(self) -> str | None:
+        if alphagrowth_metadata := get_alphagrowth_euler_light_metadata(self.chain_id, self.vault_address):
+            return alphagrowth_metadata.get("description")
+
         if self.euler_metadata:
             return self.euler_metadata.get("description")
         return None
 
     @property
     def entity(self) -> str | None:
+        if alphagrowth_metadata := get_alphagrowth_euler_light_metadata(self.chain_id, self.vault_address):
+            return alphagrowth_metadata.get("entity")
+
         if self.euler_metadata:
             return self.euler_metadata.get("entity")
         return None

--- a/tests/erc_4626/vault_protocol/test_euler_links.py
+++ b/tests/erc_4626/vault_protocol/test_euler_links.py
@@ -35,6 +35,16 @@ def test_euler_alphagrowth_ausd_vault_uses_light_frontend() -> None:
     assert vault.get_link() == f"{ALPHAGROWTH_EULER_LIGHT_BASE_URL}/lend/{Web3.to_checksum_address(vault_address)}"
 
 
+def test_euler_alphagrowth_ausd_vault_uses_light_metadata() -> None:
+    """AlphaGrowth AUSD vault uses metadata from AlphaGrowth's label repository."""
+    vault_address = "0x438cedcE647491B1d93a73d491eC19A50194c222"
+    vault = create_euler_vault(chain_id=143, vault_address=vault_address)
+
+    assert vault.name == "AlphaGrowth AUSD Borrow Vault"
+    assert vault.description == "Borrow AUSD against Balancer BPT collateral."
+    assert vault.entity == "alphagrowth"
+
+
 def test_euler_alphagrowth_wmon_vault_uses_light_frontend() -> None:
     """AlphaGrowth WMON vault links to its Euler Light lend route."""
     vault_address = "0x75b6c392f778b8bcf9bdb676f8f128b4dd49ac19"


### PR DESCRIPTION
## Why

AlphaGrowth's Monad Euler EVK vaults are not labelled in Euler's public metadata, so the AUSD vault appears as the generic on-chain name `EVK Vault eAUSD-11` and curator attribution does not resolve to AlphaGrowth.

AlphaGrowth's Euler Light frontend points to their own label repository, `alphagrowth/ag-euler-balancer-labels`, which provides names, descriptions, and entity metadata for these custom Balancer BPT vaults.

## Lessons learnt

The previous frontend-link override fixed the protocol URL but did not affect display metadata. The generated vault listing still needs a branded name for the existing curator matcher to recognise AlphaGrowth.

## Summary

- Add AlphaGrowth Euler Light metadata overrides for the AUSD and WMON Monad vaults from AlphaGrowth's label repository.
- Prefix the display names with AlphaGrowth so curator detection can resolve them through the existing name matcher.
- Cover the AUSD metadata override with a regression test.
- Add a changelog entry for the new metadata labels.