### PR TITLE
notes: flag Etherealm USDC as illiquid

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -186,6 +186,8 @@ MO_EARN_MAX_USDC_ILLIQUID = "Mo Earn Max USDC is illiquid"
 
 CLEARSTAR_YIELD_USDC_ILLIQUID = "Clearstar Yield USDC is illiquid"
 
+ETHEREALM_USDC_ILLIQUID = "Etherealm USDC is illiquid"
+
 YIELDNEST_YNRWAX = """ynRWAx: Tokenized Australian residential real estate credit earning 11% APY, allocated to mortgage-backed loans on verified house-and-land developments. Made safe in collaboration with a fully licensed and insured fund manager, [Kimber Capital](https://kimbercapital.au/) (AFS Licence No. 425278).
 
 Fees: 0%.
@@ -476,6 +478,8 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0xa9a4bd976dbcfc2b89f554467ac85e2c758e2618": (VaultFlag.illiquid, XUSD_MESSAGE),
     # Borrowable USDC Deposit, SiloId: 20 (Sonic)
     "0x322e1d5384aa4ed66aeca770b95686271de61dc3": (VaultFlag.illiquid, XUSD_MESSAGE),
+    # Etherealm USDC (Morpho on Ethereum)
+    "0xb7305d968ecd8a23a13ec01927e3f9588c7653b5": (VaultFlag.illiquid, ETHEREALM_USDC_ILLIQUID),
 }
 
 for addr in VAULT_FLAGS_AND_NOTES.keys():


### PR DESCRIPTION
## Why

Etherealm USDC vault on Ethereum (Morpho) is illiquid and should be flagged accordingly.

## Lessons learnt

N/A

## Summary

- Added `ETHEREALM_USDC_ILLIQUID` message constant and flagged vault `0xb7305d968ecd8a23a13ec01927e3f9588c7653b5` as illiquid in `VAULT_FLAGS_AND_NOTES`.