### PR TITLE
fix: Handle Lagoon v0.6.0 vault version in scanner

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/lagoon/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/vault.py
@@ -105,6 +105,7 @@ class LagoonVersion(enum.Enum):
     legacy = "legacy"
     v_0_5_0 = "v0.5.0"
     v_0_4_0 = "v0.4.0"
+    v_0_6_0 = "v0.6.0"
 
 
 class AutomatedSafe:
@@ -432,6 +433,8 @@ class LagoonVault(ERC7540Vault, AutomatedSafe):
                 return LagoonVersion.v_0_4_0
             elif decoded_version == "v0.5.0":
                 return LagoonVersion.v_0_5_0
+            elif decoded_version == "v0.6.0":
+                return LagoonVersion.v_0_6_0
             else:
                 raise NotImplementedError(f"Unknown Lagoon version {decoded_version} for vault {self.spec.vault_address}")
         except (ValueError, ContractLogicError, InsufficientDataBytes) as e:
@@ -629,7 +632,7 @@ class LagoonVault(ERC7540Vault, AutomatedSafe):
         # Lagoon team removed pendingSilo() function
         # as they hit the contract size limit
         vault_contract = self.vault_contract
-        if self.version in (LagoonVersion.v_0_5_0, LagoonVersion.v_0_4_0):
+        if self.version in (LagoonVersion.v_0_5_0, LagoonVersion.v_0_4_0, LagoonVersion.v_0_6_0):
             web3 = self.web3
             # Magic storage slot for Silo address
             slot = "0x5c74d456014b1c0eb4368d944667a568313858a3029a650ff0cb7b56f8b57a08"

--- a/eth_defi/utils.py
+++ b/eth_defi/utils.py
@@ -326,7 +326,7 @@ def setup_console_logging(
         fmt = "%(message)s"
         date_fmt = "%H:%M:%S"
     else:
-        fmt = "%(asctime)s %(name)-44s [%(threadName)s] %(message)s"
+        fmt = "%(asctime)s %(name)-44s %(levelname)-8s [%(threadName)s] %(message)s"
         date_fmt = "%Y-%m-%d %H:%M:%S"
 
     def _wrap_thread_colours(handler: logging.Handler):

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -1498,7 +1498,7 @@ def main():
         encoding="utf-8",
     )
     rotating_handler.setLevel(logging.INFO)
-    rotating_handler.setFormatter(logging.Formatter("%(asctime)s %(name)-44s [%(threadName)s] %(message)s", "%Y-%m-%d %H:%M:%S"))
+    rotating_handler.setFormatter(logging.Formatter("%(asctime)s %(name)-44s %(levelname)-8s [%(threadName)s] %(message)s", "%Y-%m-%d %H:%M:%S"))
 
     root = logging.getLogger()
     root.addHandler(rotating_handler)

--- a/tests/lagoon/test_lagoon_version.py
+++ b/tests/lagoon/test_lagoon_version.py
@@ -1,0 +1,72 @@
+"""Test Lagoon vault version detection.
+
+- Lagoon deploys new contract versions over time (v0.4.0, v0.5.0, v0.6.0, ...)
+- Our scanner must handle each known version without crashing
+- v0.6.0 was first seen on Ethereum mainnet (9Summits Flagship EURC)
+  and caused NotImplementedError in production (scan_all_chains)
+"""
+
+import os
+
+import flaky
+import pytest
+from web3 import Web3
+
+from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault, LagoonVersion
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.vault.base import VaultSpec
+
+JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
+
+pytestmark = pytest.mark.skipif(
+    JSON_RPC_ETHEREUM is None,
+    reason="JSON_RPC_ETHEREUM needed to run these tests",
+)
+
+#: 9Summits Flagship EURC — first known Lagoon v0.6.0 vault on Ethereum mainnet
+LAGOON_V060_VAULT = "0xd0c4c9386f7509c44987f43136be7d4349ccddc9"
+
+
+@pytest.fixture(scope="module")
+def anvil_ethereum_fork() -> AnvilLaunch:
+    """Fork Ethereum mainnet."""
+    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=25_121_000)
+    try:
+        yield launch
+    finally:
+        launch.close()
+
+
+@pytest.fixture(scope="module")
+def web3(anvil_ethereum_fork) -> Web3:
+    """Create web3 connection to the forked Ethereum."""
+    return create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url)
+
+
+@flaky.flaky
+def test_lagoon_v060_version_detection(web3: Web3):
+    """Lagoon v0.6.0 vaults must be detected without crashing.
+
+    Previously, the scanner raised NotImplementedError for unknown Lagoon
+    versions, which broke the entire scan_all_chains pipeline.
+
+    1. Create a LagoonVault for the known v0.6.0 contract
+    2. Verify the version is correctly detected as v_0_6_0
+    3. Verify the vault ABI is loaded (uses v0.5.0 ABI as a compatible fallback)
+    4. Verify basic vault properties are readable
+    """
+    # 1. Create a LagoonVault for the known v0.6.0 contract
+    spec = VaultSpec(1, LAGOON_V060_VAULT)
+    vault = LagoonVault(web3, spec)
+
+    # 2. Verify the version is correctly detected as v_0_6_0
+    assert vault.version == LagoonVersion.v_0_6_0
+
+    # 3. Verify the vault ABI is loaded (uses v0.5.0 ABI as a compatible fallback)
+    assert vault.vault_abi == "lagoon/v0.5.0/Vault.json"
+
+    # 4. Verify basic vault properties are readable
+    assert vault.name == "9Summits Flagship EURC"
+    assert vault.symbol == "9SEURC"
+    assert vault.denomination_token.symbol == "EURC"


### PR DESCRIPTION
## Why

The vault scanner crashed with `NotImplementedError` when encountering Lagoon v0.6.0 contracts (e.g. 9Summits Flagship EURC at `0xd0c4c9386f7509c44987f43136be7d4349ccddc9` on Ethereum), breaking the entire `scan_all_chains` pipeline. Lagoon deployed new v0.6.0 contracts that our version detection code didn't recognise.

Additionally, log output (both file and console) was missing the log level field, making it hard to distinguish INFO/WARNING/ERROR lines when reading log files.

## Lessons learnt

- Lagoon version checks are almost entirely `legacy` vs `non-legacy` — new versions just need an enum entry and a string match
- The `silo_address` property has an explicit version tuple that must be updated (unlike other checks that use `!= legacy`)
- The v0.5.0 ABI is compatible with v0.6.0 contracts

## Summary

- Added `v_0_6_0` member to `LagoonVersion` enum
- Added `"v0.6.0"` handling in `fetch_version()`
- Updated `silo_address` version tuple to include `v_0_6_0`
- Added test that forks Ethereum mainnet and verifies v0.6.0 detection, ABI loading, and basic vault properties
- Added `%(levelname)-8s` to log format in `setup_console_logging()` and `scan_all_chains.py` file handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)