### PR TITLE
fix: Verify parquet files before atomic replace

### DIFF
--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -16,11 +16,11 @@ The output is a cleaned DataFrame conforming to
 
 import os
 import pickle
+import tempfile
 import warnings
 from pathlib import Path
 from typing import Callable, TypedDict
 
-from atomicwrites import atomic_write
 import numpy as np
 import pandas as pd
 from eth_typing import HexAddress
@@ -29,7 +29,7 @@ from tqdm_loggable.auto import tqdm
 
 from eth_defi.chain import get_chain_name
 from eth_defi.token import is_stablecoin_like
-from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.base import VaultSpec, verify_parquet_file
 from eth_defi.vault.vaultdb import DEFAULT_RAW_PRICE_DATABASE, DEFAULT_UNCLEANED_PRICE_DATABASE, DEFAULT_VAULT_DATABASE, VaultDatabase, VaultRow
 
 
@@ -1342,9 +1342,25 @@ def generate_cleaned_vault_datasets(
     # Sort for better compression
     enhanced_prices_df.sort_values(by=["id", "timestamp"], inplace=True)
 
-    # Atomic write with fsync + directory sync via atomicwrites
-    with atomic_write(str(cleaned_price_df_path), mode="wb", overwrite=True) as f:
-        enhanced_prices_df.to_parquet(f, compression="zstd")
+    # Write to a temp file, verify, then atomically replace the target.
+    # If verification fails, the original cleaned parquet is preserved.
+    temp_fd, temp_path = tempfile.mkstemp(
+        suffix=".parquet",
+        dir=str(cleaned_price_df_path.parent),
+    )
+    try:
+        os.close(temp_fd)
+        enhanced_prices_df.to_parquet(temp_path, compression="zstd")
+        verify_parquet_file(
+            temp_path,
+            expected_rows=len(enhanced_prices_df),
+            required_columns=["id", "share_price", "raw_share_price", "returns_1h", "timestamp"],
+        )
+        os.replace(temp_path, str(cleaned_price_df_path))
+    except BaseException:
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+        raise
 
     fsize = cleaned_price_df_path.stat().st_size
     logger(f"Saved cleaned vault prices to {cleaned_price_df_path}, total {len(enhanced_prices_df):,} rows, file size is {fsize / 1024 / 1024:.2f} MB")

--- a/eth_defi/vault/base.py
+++ b/eth_defi/vault/base.py
@@ -15,13 +15,16 @@
 
 import dataclasses
 import datetime
+import logging
+import os
+import pathlib
+import tempfile
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from decimal import Decimal
 from functools import cached_property
 from typing import Iterable, Tuple, TypedDict
 
-from atomicwrites import atomic_write
 from eth_typing import BlockIdentifier, BlockNumber, HexAddress
 from web3 import Web3
 
@@ -35,6 +38,8 @@ from eth_defi.vault.lower_case_dict import LowercaseDict
 from .fee import FeeData, VaultFeeMode, get_vault_fee_mode
 from .flag import VaultFlag, get_notes, get_vault_special_flags
 from .risk import VaultTechnicalRisk, get_vault_risk
+
+logger = logging.getLogger(__name__)
 
 BlockRange = Tuple[BlockNumber, BlockNumber]
 
@@ -52,6 +57,126 @@ REDEMPTION_CLOSED_FUNDS_CUSTODIED = "Funds custodied or epoch in progress"
 REDEMPTION_CLOSED_BY_ADMIN = "Redemptions closed by vault admin"
 REDEMPTION_CLOSED_INSUFFICIENT_LIQUIDITY = "Insufficient liquidity for redemption"
 REDEMPTION_CLOSED_PAUSED = "Vault paused by admin"
+
+
+class ParquetVerificationError(Exception):
+    """Raised when a parquet file fails post-write verification.
+
+    This is a hard failure — the operator must investigate and restore
+    from backup.  Never catch and swallow this exception.
+    """
+
+
+@dataclasses.dataclass(slots=True, frozen=True)
+class ParquetVerificationResult:
+    """Result of verifying a parquet file after writing.
+
+    Returned by :py:func:`verify_parquet_file` on success.
+    """
+
+    #: Path to the verified file.
+    path: pathlib.Path
+
+    #: Number of rows read back from the file metadata.
+    row_count: int
+
+    #: Number of columns in the file schema.
+    column_count: int
+
+    #: File size in bytes on disk.
+    file_size: int
+
+    #: Column names found in the file schema.
+    column_names: list[str]
+
+
+def verify_parquet_file(
+    path: pathlib.Path | str,
+    expected_rows: int | None = None,
+    expected_schema: "pyarrow.Schema | None" = None,
+    required_columns: list[str] | None = None,
+) -> ParquetVerificationResult:
+    """Read back a parquet file after writing and verify its integrity.
+
+    Performs a metadata read-back (not a full table load) to check:
+
+    1. The file can be opened and its metadata read without errors
+    2. Row count matches ``expected_rows`` if provided
+    3. All columns in ``expected_schema`` are present with correct types
+       (extra columns are permitted — e.g. native protocol columns)
+    4. All ``required_columns`` are present
+
+    Uses ``pq.read_metadata()`` and ``pq.read_schema()`` instead of
+    ``pq.read_table()`` to avoid loading the full dataset into memory.
+
+    This function should be called on a **temp file before the atomic
+    replace** so that the previous good file is preserved when
+    verification fails.
+
+    :param path:
+        Path to the parquet file to verify.
+    :param expected_rows:
+        If set, assert the file contains exactly this many rows.
+    :param expected_schema:
+        If set, verify that all columns in this schema are present with
+        the correct types.  Extra columns are permitted.
+    :param required_columns:
+        If set, verify these column names are present.
+    :return:
+        Verification result with metadata about the file.
+    :raises ParquetVerificationError:
+        If any verification check fails or the file cannot be read.
+    """
+    import pyarrow.parquet as pq
+
+    path = pathlib.Path(path)
+
+    # 1. Read metadata — catches truncation and footer corruption
+    try:
+        metadata = pq.read_metadata(path)
+        schema = pq.read_schema(path)
+    except Exception as e:
+        raise ParquetVerificationError(f"Cannot read parquet file {path}: {e}") from e
+
+    row_count = metadata.num_rows
+    column_names = schema.names
+    file_size = path.stat().st_size
+
+    # 2. Verify row count
+    if expected_rows is not None and row_count != expected_rows:
+        raise ParquetVerificationError(f"Row count mismatch in {path}: expected {expected_rows:,}, got {row_count:,}")
+
+    # 3. Verify schema fields (extra columns allowed)
+    if expected_schema is not None:
+        schema_by_name = {f.name: f for f in schema}
+        for field in expected_schema:
+            actual = schema_by_name.get(field.name)
+            if actual is None:
+                raise ParquetVerificationError(f"Missing column '{field.name}' in {path}. Expected schema has {len(expected_schema)} fields, file has columns: {column_names}")
+            if actual.type != field.type:
+                raise ParquetVerificationError(f"Type mismatch for column '{field.name}' in {path}: expected {field.type}, got {actual.type}")
+
+    # 4. Verify required columns
+    if required_columns is not None:
+        missing = set(required_columns) - set(column_names)
+        if missing:
+            raise ParquetVerificationError(f"Missing required columns in {path}: {sorted(missing)}. File has columns: {column_names}")
+
+    logger.info(
+        "Parquet verification passed for %s: %d rows, %d columns, %d bytes",
+        path,
+        row_count,
+        len(column_names),
+        file_size,
+    )
+
+    return ParquetVerificationResult(
+        path=path,
+        row_count=row_count,
+        column_count=len(column_names),
+        file_size=file_size,
+        column_names=column_names,
+    )
 
 
 @dataclass(slots=True)
@@ -637,8 +762,25 @@ class VaultHistoricalRead:
                     table.column(i).cast(target_field.type, safe=False),
                 )
 
-        with atomic_write(str(path), mode="wb", overwrite=True) as f:
-            pq.write_table(table, f, compression=compression)
+        # Write to a temp file, verify, then atomically replace the target.
+        # If verification fails, the original file is preserved.
+        temp_fd, temp_path = tempfile.mkstemp(
+            suffix=".parquet",
+            dir=str(path.parent),
+        )
+        try:
+            os.close(temp_fd)
+            pq.write_table(table, temp_path, compression=compression)
+            verify_parquet_file(
+                temp_path,
+                expected_rows=len(df),
+                expected_schema=table.schema,
+            )
+            os.replace(temp_path, str(path))
+        except BaseException:
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+            raise
 
 
 @dataclasses.dataclass(slots=True, frozen=True)

--- a/eth_defi/vault/historical.py
+++ b/eth_defi/vault/historical.py
@@ -38,7 +38,7 @@ from eth_defi.event_reader.web3factory import Web3Factory
 from eth_defi.provider.broken_provider import get_almost_latest_block_number
 from eth_defi.token import TokenDetails, TokenDiskCache, fetch_erc20_details
 from eth_defi.utils import chunked
-from eth_defi.vault.base import VaultBase, VaultHistoricalRead, VaultHistoricalReader, VaultSpec
+from eth_defi.vault.base import VaultBase, VaultHistoricalRead, VaultHistoricalReader, VaultSpec, verify_parquet_file
 from eth_defi.vault.risk import BROKEN_VAULT_CONTRACTS
 
 logger = logging.getLogger(__name__)
@@ -837,6 +837,13 @@ def scan_historical_prices_to_parquet(
             _proper_fsync(fd)
         finally:
             os.close(fd)
+        # Verify temp file before replacing the target so the
+        # previous good file is preserved if verification fails.
+        verify_parquet_file(
+            temp_fname,
+            expected_rows=existing_row_count + rows_written,
+            expected_schema=writer_schema,
+        )
         os.replace(temp_fname, output_fname)
         dir_fd = os.open(str(output_fname.parent), os.O_RDONLY)
         try:


### PR DESCRIPTION
## Why

The vault price pipeline writes critical parquet files that accumulate months of historical data. If a write produces a corrupted or truncated file and the atomic replace has already happened, the previous good version is gone. By verifying the temp file *before* the atomic replace, the old file survives if verification fails.

Closes #1024

## Lessons learnt

- `pq.read_metadata()` + `pq.read_schema()` is sufficient to detect truncation and schema issues without loading full data into memory
- `expected_schema` verification in `write_uncleaned_parquet()` should use the *written* table's schema (not the full canonical schema), because input DataFrames may have a subset of canonical columns
- The `atomicwrites` library doesn't expose the temp file path for pre-replace verification, so manual `tempfile.mkstemp` + `os.replace` is needed

## Summary

- Added `verify_parquet_file()`, `ParquetVerificationError`, and `ParquetVerificationResult` to `eth_defi/vault/base.py`
- Restructured all three automated pipeline write sites to verify-temp-before-replace:
  - **EVM scanner** (`historical.py`): verification inserted between fsync and `os.replace()`
  - **Native protocol merge** (`base.py:write_uncleaned_parquet()`): replaced `atomic_write` with temp → verify → replace
  - **Cleaned price writer** (`wrangle_vault_prices.py`): replaced `atomic_write` with temp → verify → replace
- Verification checks row count, schema types, and required columns via metadata-only reads
- Distinct `"Parquet verification passed"` log line at INFO level for each write
- Manual maintenance scripts excluded (operator-driven one-off tools)