### PR TITLE
feat: Daily timestamped R2 backups for vault data files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- feat: Daily timestamped R2 backups for vault data files in private buckets using server-side `copy_object`, with skip-if-exists and opt-out via `R2_DAILY_BACKUP=false` (2026-05-18)
+
 - fix(gmx-freqtrade): remove pre-flight backtest data validator that aborted runs when any pair had short history; backtests now follow vanilla Freqtrade semantics (pairs start trading when their candles arrive) (2026-05-14)
 
 - feat: AlphaGrowth Monad Euler EVK vaults now use AlphaGrowth's Euler Light label metadata for display names, descriptions, and curator attribution (2026-05-14)

--- a/eth_defi/cloudflare_r2.py
+++ b/eth_defi/cloudflare_r2.py
@@ -210,7 +210,7 @@ def copy_r2_object_daily_backup(
         ``True`` if a backup copy was created, ``False`` if it was
         skipped (already exists) or if the copy failed.
     """
-    from botocore.exceptions import ClientError  # noqa: PLC0415
+    from botocore.exceptions import BotoCoreError, ClientError  # noqa: PLC0415
 
     from eth_defi.compat import native_datetime_utc_now  # noqa: PLC0415
 
@@ -246,6 +246,14 @@ def copy_r2_object_daily_backup(
             bucket_name,
             backup_key,
             enriched,
+        )
+        return False
+    except BotoCoreError as exc:
+        logger.warning(
+            "Daily backup copy failed for s3://%s/%s: %s",
+            bucket_name,
+            backup_key,
+            exc,
         )
         return False
 

--- a/eth_defi/cloudflare_r2.py
+++ b/eth_defi/cloudflare_r2.py
@@ -167,6 +167,98 @@ def _create_r2_operation_error(
     return R2OperationError(" ".join(detail_lines))
 
 
+def copy_r2_object_daily_backup(
+    s3_client: Any,
+    bucket_name: str,
+    source_key: str,
+    *,
+    backup_prefix: str = "daily",
+) -> bool:
+    """Create a daily timestamped backup copy of an R2 object.
+
+    Uses server-side ``copy_object()`` to create a dated snapshot within
+    the same bucket. The copy is skipped if a backup for today already
+    exists (cheap ``head_object()`` pre-flight check).
+
+    Failures are **non-fatal** — any ``ClientError`` is logged as a
+    warning and the function returns ``False``. The caller's primary
+    upload has already succeeded, so a backup copy failure should not
+    crash the pipeline.
+
+    Backup key layout::
+
+        {backup_prefix} / {YYYY - MM - DD} / {source_key}
+
+    The full ``source_key`` is preserved (including any upload prefix)
+    to avoid collisions.
+
+    :param s3_client:
+        Authenticated boto3 S3 client.
+
+    :param bucket_name:
+        Bucket containing the source object (backup is created in the
+        same bucket).
+
+    :param source_key:
+        Object key of the live file to back up.
+
+    :param backup_prefix:
+        Top-level prefix for backup copies. Defaults to ``daily``,
+        making it easy to target with R2 lifecycle rules.
+
+    :return:
+        ``True`` if a backup copy was created, ``False`` if it was
+        skipped (already exists) or if the copy failed.
+    """
+    from botocore.exceptions import ClientError  # noqa: PLC0415
+
+    from eth_defi.compat import native_datetime_utc_now  # noqa: PLC0415
+
+    today = native_datetime_utc_now().strftime("%Y-%m-%d")
+    backup_key = f"{backup_prefix}/{today}/{source_key}"
+
+    try:
+        head = fetch_r2_object_head(s3_client, bucket_name, backup_key)
+        if head is not None:
+            logger.info(
+                "Daily backup already exists, skipping: s3://%s/%s",
+                bucket_name,
+                backup_key,
+            )
+            return False
+    except R2OperationError:
+        logger.warning(
+            "Daily backup head check failed for s3://%s/%s, attempting copy anyway",
+            bucket_name,
+            backup_key,
+        )
+
+    try:
+        s3_client.copy_object(
+            Bucket=bucket_name,
+            Key=backup_key,
+            CopySource={"Bucket": bucket_name, "Key": source_key},
+        )
+    except ClientError as exc:
+        enriched = _create_r2_operation_error(exc, s3_client, bucket_name, backup_key)
+        logger.warning(
+            "Daily backup copy failed for s3://%s/%s: %s",
+            bucket_name,
+            backup_key,
+            enriched,
+        )
+        return False
+
+    logger.info(
+        "Created daily backup: s3://%s/%s -> s3://%s/%s",
+        bucket_name,
+        source_key,
+        bucket_name,
+        backup_key,
+    )
+    return True
+
+
 def create_r2_client(
     endpoint_url: str,
     access_key_id: str,

--- a/eth_defi/vault/post_processing.py
+++ b/eth_defi/vault/post_processing.py
@@ -14,7 +14,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from eth_defi.cloudflare_r2 import create_r2_client, upload_file_to_r2
+from eth_defi.cloudflare_r2 import copy_r2_object_daily_backup, create_r2_client, upload_file_to_r2
 from eth_defi.grvt.constants import GRVT_CHAIN_ID, GRVT_DAILY_METRICS_DATABASE
 from eth_defi.grvt.daily_metrics import GRVTDailyMetricsDatabase
 from eth_defi.grvt.vault_data_export import merge_into_uncleaned_parquet as grvt_merge_parquet
@@ -196,6 +196,14 @@ def _upload_top_vaults_json_to_configured_buckets(
             access_key_id=access_key_id,
             bucket_label="alternative",
         )
+
+        daily_backup_enabled = os.environ.get("R2_DAILY_BACKUP", "true").lower() != "false"
+        if daily_backup_enabled:
+            copied = copy_r2_object_daily_backup(s3_client, alt_bucket_name, object_key)
+            if copied:
+                logger.info("Created daily backup for top_vaults_by_chain.json in alternative bucket")
+            else:
+                logger.info("Daily backup skipped or failed for top_vaults_by_chain.json in alternative bucket")
 
     return primary_success and alternative_success
 

--- a/eth_defi/vault/post_processing.py
+++ b/eth_defi/vault/post_processing.py
@@ -198,7 +198,7 @@ def _upload_top_vaults_json_to_configured_buckets(
         )
 
         daily_backup_enabled = os.environ.get("R2_DAILY_BACKUP", "true").lower() != "false"
-        if daily_backup_enabled:
+        if alternative_success and daily_backup_enabled:
             copied = copy_r2_object_daily_backup(s3_client, alt_bucket_name, object_key)
             if copied:
                 logger.info("Created daily backup for top_vaults_by_chain.json in alternative bucket")

--- a/scripts/erc-4626/export-data-files.py
+++ b/scripts/erc-4626/export-data-files.py
@@ -26,7 +26,7 @@ from pathlib import Path
 
 from tqdm_loggable.auto import tqdm
 
-from eth_defi.cloudflare_r2 import create_r2_client, upload_file_to_r2
+from eth_defi.cloudflare_r2 import copy_r2_object_daily_backup, create_r2_client, upload_file_to_r2
 from eth_defi.utils import setup_console_logging
 from eth_defi.vault.vaultdb import get_pipeline_data_dir
 
@@ -165,6 +165,8 @@ def main():
         size = f"{p.stat().st_size / 1024 / 1024:.1f} MB" if exists else "MISSING"
         print(f"    - {p.name}: {size}")
 
+    daily_backup_enabled = os.environ.get("R2_DAILY_BACKUP", "true").lower() != "false"
+
     for current_bucket in bucket_names:
         if len(bucket_names) > 1:
             logger.info("Uploading data files to bucket: %s", current_bucket)
@@ -178,6 +180,30 @@ def main():
             key_prefix=upload_prefix,
             public_url=public_url,
         )
+
+        # Create daily timestamped backups in the alternative (private) bucket only.
+        if current_bucket == alt_bucket_name and daily_backup_enabled:
+            s3_client = create_r2_client(
+                endpoint_url=endpoint_url,
+                access_key_id=access_key_id,
+                secret_access_key=secret_access_key,
+            )
+            backup_created = 0
+            backup_skipped = 0
+            for file_path in paths:
+                if not file_path.exists():
+                    continue
+                source_key = f"{upload_prefix}{file_path.name}"
+                if copy_r2_object_daily_backup(s3_client, current_bucket, source_key):
+                    backup_created += 1
+                else:
+                    backup_skipped += 1
+            logger.info(
+                "Daily backup summary for bucket %s: %d created, %d skipped",
+                current_bucket,
+                backup_created,
+                backup_skipped,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/erc_4626/test_post_processing.py
+++ b/tests/erc_4626/test_post_processing.py
@@ -25,6 +25,7 @@ def test_upload_top_vaults_json_to_configured_buckets_continues_after_primary_fa
         return True
 
     monkeypatch.setattr(post_processing, "upload_file_to_r2", fake_upload_file_to_r2)
+    monkeypatch.setenv("R2_DAILY_BACKUP", "false")
 
     success = post_processing._upload_top_vaults_json_to_configured_buckets(
         s3_client=object(),

--- a/tests/test_cloudflare_r2.py
+++ b/tests/test_cloudflare_r2.py
@@ -14,10 +14,12 @@ from eth_defi.cloudflare_r2 import (
     R2AccessDeniedError,
     calculate_bytes_digest,
     calculate_file_digest,
+    copy_r2_object_daily_backup,
     fetch_r2_object_head,
     upload_bytes_to_r2,
     upload_file_to_r2,
 )
+from eth_defi.compat import native_datetime_utc_now
 
 try:
     from botocore.exceptions import ClientError
@@ -40,6 +42,7 @@ class FakeS3Client:
         self.head_exceptions: dict[tuple[str, str], Exception] = {}
         self.put_calls: list[dict] = []
         self.upload_calls: list[dict] = []
+        self.copy_calls: list[dict] = []
         self.meta = SimpleNamespace(endpoint_url=endpoint_url)
         self._request_signer = SimpleNamespace(_credentials=SimpleNamespace(access_key=access_key_id))
 
@@ -65,6 +68,20 @@ class FakeS3Client:
             "Metadata": kwargs.get("Metadata", {}),
             "ETag": f'"{_md5_hex(kwargs["Body"])}"',
         }
+
+    def copy_object(self, **kwargs) -> None:
+        """Record a copy-object call and duplicate the head state."""
+        bucket = kwargs["Bucket"]
+        key = kwargs["Key"]
+        copy_exc = self.head_exceptions.get(("copy", bucket, key))
+        if copy_exc is not None:
+            raise copy_exc
+        source = kwargs["CopySource"]
+        src_bucket = source["Bucket"]
+        src_key = source["Key"]
+        self.copy_calls.append(kwargs)
+        if (src_bucket, src_key) in self.head_responses:
+            self.head_responses[bucket, key] = dict(self.head_responses[src_bucket, src_key])
 
     def upload_fileobj(self, fileobj, bucket_name: str, object_name: str, **kwargs) -> None:
         """Record an upload-fileobj call and update the stored head state."""
@@ -267,3 +284,103 @@ def test_upload_file_to_r2_continues_after_head_access_denied(tmp_path: Path, ca
     assert uploaded is True
     assert len(s3_client.upload_calls) == 1
     assert "Proceeding with upload attempt anyway" in caplog.text
+
+
+def test_copy_r2_object_daily_backup_creates_copy() -> None:
+    """Server-side copy should be issued when no backup exists for today."""
+    s3_client = FakeS3Client()
+    # Simulate a live file already in the bucket.
+    s3_client.head_responses["bucket", "vault-prices-1h.parquet"] = {
+        "ContentLength": 100,
+        "Metadata": {},
+    }
+
+    copied = copy_r2_object_daily_backup(
+        s3_client=s3_client,
+        bucket_name="bucket",
+        source_key="vault-prices-1h.parquet",
+    )
+
+    today = native_datetime_utc_now().strftime("%Y-%m-%d")
+    expected_key = f"daily/{today}/vault-prices-1h.parquet"
+
+    assert copied is True
+    assert len(s3_client.copy_calls) == 1
+    assert s3_client.copy_calls[0]["Key"] == expected_key
+    assert s3_client.copy_calls[0]["CopySource"] == {"Bucket": "bucket", "Key": "vault-prices-1h.parquet"}
+
+
+def test_copy_r2_object_daily_backup_skips_when_exists() -> None:
+    """Backup should be skipped when today's copy already exists."""
+    s3_client = FakeS3Client()
+    today = native_datetime_utc_now().strftime("%Y-%m-%d")
+    backup_key = f"daily/{today}/vault-prices-1h.parquet"
+
+    # Pre-populate — backup already exists.
+    s3_client.head_responses["bucket", backup_key] = {
+        "ContentLength": 100,
+        "Metadata": {},
+    }
+
+    copied = copy_r2_object_daily_backup(
+        s3_client=s3_client,
+        bucket_name="bucket",
+        source_key="vault-prices-1h.parquet",
+    )
+
+    assert copied is False
+    assert s3_client.copy_calls == []
+
+
+def test_copy_r2_object_daily_backup_preserves_upload_prefix() -> None:
+    """Full source key including upload prefix should appear in backup key."""
+    s3_client = FakeS3Client()
+    source_key = "test-vault-prices-1h.parquet"
+    s3_client.head_responses["bucket", source_key] = {
+        "ContentLength": 50,
+        "Metadata": {},
+    }
+
+    copied = copy_r2_object_daily_backup(
+        s3_client=s3_client,
+        bucket_name="bucket",
+        source_key=source_key,
+    )
+
+    today = native_datetime_utc_now().strftime("%Y-%m-%d")
+    expected_key = f"daily/{today}/test-vault-prices-1h.parquet"
+
+    assert copied is True
+    assert len(s3_client.copy_calls) == 1
+    assert s3_client.copy_calls[0]["Key"] == expected_key
+
+
+def test_copy_r2_object_daily_backup_returns_false_on_error(caplog: pytest.LogCaptureFixture) -> None:
+    """Copy failure should log a warning and return False, never raise."""
+    s3_client = FakeS3Client()
+    s3_client.head_responses["bucket", "data.parquet"] = {
+        "ContentLength": 10,
+        "Metadata": {},
+    }
+
+    today = native_datetime_utc_now().strftime("%Y-%m-%d")
+    backup_key = f"daily/{today}/data.parquet"
+
+    # Force copy_object to raise.
+    s3_client.head_exceptions[("copy", "bucket", backup_key)] = ClientError(
+        {
+            "Error": {"Code": "AccessDenied", "Message": "Access Denied"},
+            "ResponseMetadata": {"HTTPStatusCode": 403},
+        },
+        "CopyObject",
+    )
+
+    with caplog.at_level(logging.WARNING):
+        copied = copy_r2_object_daily_backup(
+            s3_client=s3_client,
+            bucket_name="bucket",
+            source_key="data.parquet",
+        )
+
+    assert copied is False
+    assert "Daily backup copy failed" in caplog.text


### PR DESCRIPTION
## Why

The vault data pipeline overwrites 5 critical files in R2 on every run with no history. If a corrupted file is uploaded, there is no rollback mechanism. We need daily timestamped backup copies so operators can restore from a known-good snapshot.

## Lessons learnt

- R2 does not support S3 object versioning, so we use server-side `copy_object` (zero egress cost, near-instant) to create dated snapshots
- Backup key layout `daily/{YYYY-MM-DD}/{source_key}` preserves the full source key (including any `UPLOAD_PREFIX`) to avoid collisions, and keeps the `daily/` prefix at the bucket root for easy R2 lifecycle rule targeting
- Backup failures are non-fatal — log a warning and return `False`, matching the existing pattern where alternative bucket failures are isolated from the pipeline

## Summary

- Added `copy_r2_object_daily_backup()` to `eth_defi/cloudflare_r2.py` — server-side copy with skip-if-exists (`head_object` check) and non-fatal error handling
- Modified `scripts/erc-4626/export-data-files.py` — creates daily backups for all 4 data files (parquet + pickle) in the alternative (private) bucket after upload
- Modified `eth_defi/vault/post_processing.py` — creates daily backup for `top_vaults_by_chain.json` in the alternative bucket after upload
- Added 4 unit tests to `tests/test_cloudflare_r2.py` covering: copy creation, skip-when-exists, upload prefix preservation, and error handling
- Opt-out via `R2_DAILY_BACKUP=false` env var (enabled by default)