### PR TITLE
fix(gmx-ccxt): reduce-only sizing respects requested Trade.amount for logical per-trade closes

### DIFF
--- a/eth_defi/gmx/ccxt/async_support/exchange.py
+++ b/eth_defi/gmx/ccxt/async_support/exchange.py
@@ -54,6 +54,7 @@ from eth_defi.gmx.keys import is_market_disabled_key
 from eth_defi.gmx.core import Markets
 from eth_defi.gmx.core.open_positions import GetOpenPositions
 from eth_defi.gmx.core.oracle import OraclePrices
+from eth_defi.gmx.errors import decode_gmx_revert_selector  # noqa: F401  -- sync/async lockstep with eth_defi.gmx.ccxt.exchange
 from eth_defi.gmx.events import (
     GMX_USD_PRECISION,
     decode_gmx_event,

--- a/eth_defi/gmx/ccxt/async_support/exchange.py
+++ b/eth_defi/gmx/ccxt/async_support/exchange.py
@@ -34,6 +34,7 @@ from eth_defi.gmx.ccxt.cancel_helpers import (
 )
 from eth_defi.gmx.ccxt.exchange import (
     _derive_side_from_trade_action,
+    _resolve_close_order_filled_amount,
     _resolve_reduce_only_size_delta_usd,
 )
 from eth_defi.gmx.ccxt.properties import describe_gmx

--- a/eth_defi/gmx/ccxt/async_support/exchange.py
+++ b/eth_defi/gmx/ccxt/async_support/exchange.py
@@ -32,7 +32,10 @@ from eth_defi.gmx.ccxt.cancel_helpers import (
     build_cancel_order_response,
     resolve_order_id,
 )
-from eth_defi.gmx.ccxt.exchange import _derive_side_from_trade_action
+from eth_defi.gmx.ccxt.exchange import (
+    _derive_side_from_trade_action,
+    _resolve_reduce_only_size_delta_usd,
+)
 from eth_defi.gmx.ccxt.properties import describe_gmx
 from eth_defi.gmx.ccxt.validation import _validate_ohlcv_data_sufficiency
 from eth_defi.gmx.api import GMXAPI

--- a/eth_defi/gmx/ccxt/exchange.py
+++ b/eth_defi/gmx/ccxt/exchange.py
@@ -355,6 +355,64 @@ def _block_timestamp_ms(web3: "Web3", block_number: int | None) -> int | None:
         return None
 
 
+def _resolve_reduce_only_size_delta_usd(
+    *,
+    requested_size_usd: float,
+    gmx_position: dict,
+    full_close_tolerance: float = 0.995,
+) -> float | int:
+    """Resolve the GMX ``sizeDeltaUsd`` for a reduce-only close.
+
+    Background. Freqtrade's stock ``execute_trade_exit`` calls
+    ``exchange.create_order(..., amount=Trade.amount, reduceOnly=True, ...)``
+    without forwarding a ``sub_trade_amt`` CCXT parameter. The GMX adapter
+    therefore must decide the on-chain decrease size from the ``amount``
+    Freqtrade passes (translated to USD by the caller before this helper is
+    invoked), NOT from the external GMX net position size — otherwise a
+    logical per-trade close flattens the entire on-chain position when
+    multiple Freqtrade trades share a single GMX market position (the
+    same-pair NT-HEDGING parity case shipped in the
+    ``feat/orchestrator-live-independent-same-pair`` work upstream of this
+    fix).
+
+    Three cases.
+
+    * ``actual_size_usd <= 0`` (invalid / closed) — return ``requested_size_usd``
+      unchanged; the calling create_order path will surface the
+      ``InvalidDecreaseOrderSize`` revert if it really is invalid.
+    * ``requested_size_usd >= actual_size_usd * full_close_tolerance`` (the
+      caller is effectively asking for the whole position) — return the
+      raw uint256 ``position_size_usd_raw`` if available, else
+      ``actual_size_usd``. Preserves the historical dust-prevention behaviour
+      for true full closes (avoids ``int(float * 10^30)`` overshoot causing
+      GMX ``InvalidDecreaseOrderSize`` reverts).
+    * Otherwise — return ``min(requested_size_usd, actual_size_usd)``. The
+      ``min`` caps the request at the actual on-chain size so a bug in the
+      caller can never over-reduce a position; ``cap_size_delta_to_position``
+      later in ``create_order`` keeps a final safety net.
+
+    :param requested_size_usd: The amount the Freqtrade caller asked to
+        decrease, already translated to USD (``amount * price``).
+    :param gmx_position: Dict from ``GetOpenPositions`` with at least
+        ``position_size`` (float USD) and optionally
+        ``position_size_usd_raw`` (uint256 with 30 decimals).
+    :param full_close_tolerance: Fraction of ``actual_size_usd`` at or above
+        which the request is treated as a full close. Default ``0.995`` —
+        ie. the caller must request at least 99.5% of the on-chain size to
+        get the dust-preventing raw int substitution.
+    :returns: The ``sizeDeltaUsd`` value the GMX order builder should use.
+        May be a ``float`` (USD) or a ``int`` (raw uint256, 30 decimals);
+        downstream ``_format_size_info`` already handles both.
+    """
+    actual_size_usd = float(gmx_position.get("position_size", 0.0) or 0.0)
+    actual_size_usd_raw = int(gmx_position.get("position_size_usd_raw", 0) or 0)
+    if actual_size_usd <= 0:
+        return requested_size_usd
+    if requested_size_usd >= actual_size_usd * full_close_tolerance:
+        return actual_size_usd_raw if actual_size_usd_raw > 0 else actual_size_usd
+    return min(requested_size_usd, actual_size_usd)
+
+
 class GMX(ExchangeCompatible):
     """
     CCXT-compatible wrapper for GMX protocol market data and trading.
@@ -5762,60 +5820,57 @@ class GMX(ExchangeCompatible):
 
         # Only proceed with GMX position logic if we still have a valid position
         if reduceOnly and gmx_position:
-            # Check if this is a partial close (sub_trade_amt provided)
+            # The CCXT caller's authoritative close size is whichever of these
+            # is set: an explicit ``sub_trade_amt`` (Freqtrade DCA partial-exit
+            # path) OR the ``amount`` argument itself (Freqtrade's stock
+            # ``execute_trade_exit`` — the same-pair logical-trade case). Pre
+            # this fix the ``sub_trade_amt is None`` branch substituted the
+            # external net GMX position size, which silently flattened sibling
+            # logical Trades sharing one GMX position. Make ``amount``
+            # authoritative; the historical dust-prevention behaviour for true
+            # full closes is preserved by
+            # :func:`_resolve_reduce_only_size_delta_usd`'s
+            # ``full_close_tolerance`` branch.
             sub_trade_amt = params.get("sub_trade_amt")
+            close_amount = sub_trade_amt if sub_trade_amt is not None else amount
 
-            if sub_trade_amt is None:
-                # ============================================
-                # FULL CLOSE: Use GMX's exact raw position size
-                # ============================================
-                # Pass the raw 30-decimal int so _format_size_info() uses it
-                # as-is (isinstance(int) and > 10^20 branch) without the
-                # lossy int(float * 10^30) multiplication.
-                size_delta_usd = actual_size_usd_raw if actual_size_usd_raw > 0 else actual_size_usd
-
-                logger.info(
-                    "FULL CLOSE: Using exact GMX position size %.2f USD (raw=%s, freqtrade amount %.2f tokens ignored to prevent remnants)",
-                    actual_size_usd,
-                    actual_size_usd_raw,
-                    amount,
-                )
-
+            if price:
+                requested_size_usd = close_amount * price
             else:
-                # ============================================
-                # PARTIAL CLOSE: Calculate requested, clamp to actual
-                # ============================================
-                if price:
-                    requested_size_usd = sub_trade_amt * price
-                else:
-                    ticker = self.fetch_ticker(symbol)
-                    current_price = ticker["last"]
-                    requested_size_usd = sub_trade_amt * current_price
+                ticker = self.fetch_ticker(symbol)
+                current_price = ticker["last"]
+                requested_size_usd = close_amount * current_price
 
-                # Clamp to actual position size (float comparison fine for partial amounts)
-                size_delta_usd = min(requested_size_usd, actual_size_usd)
+            size_delta_usd = _resolve_reduce_only_size_delta_usd(
+                requested_size_usd=requested_size_usd,
+                gmx_position=gmx_position,
+            )
 
-                if size_delta_usd < requested_size_usd:
-                    logger.warning(
-                        "PARTIAL CLOSE: Clamping size from %.2f to %.2f USD (actual GMX position)",
-                        requested_size_usd,
-                        size_delta_usd,
-                    )
-
-                # If clamped to full position size, use the raw int to avoid
-                # float precision dust (same logic as full close path)
-                if size_delta_usd >= actual_size_usd and actual_size_usd_raw > 0:
-                    size_delta_usd = actual_size_usd_raw
-                    logger.info(
-                        "PARTIAL CLOSE: Clamped to full position — using raw int to avoid dust (raw=%s)",
-                        actual_size_usd_raw,
-                    )
-
+            # Diagnostic log distinguishes the three resolved paths so prod
+            # operators can grep for unexpected full closes in 5-min logs.
+            if isinstance(size_delta_usd, int) and size_delta_usd > 10**20:
                 logger.info(
-                    "PARTIAL CLOSE: size_delta_usd=%s (requested %.2f, actual position %.2f)",
+                    "FULL CLOSE: Using exact GMX position size %.2f USD (raw=%s, "
+                    "requested %.2f USD ≥ %.1f%% of actual — substituting raw int to prevent dust)",
+                    actual_size_usd,
+                    size_delta_usd,
+                    requested_size_usd,
+                    99.5,
+                )
+            elif size_delta_usd < requested_size_usd:
+                logger.warning(
+                    "PARTIAL CLOSE: Clamping size from %.2f to %.2f USD (actual GMX position)",
+                    requested_size_usd,
+                    size_delta_usd,
+                )
+            else:
+                logger.info(
+                    "PARTIAL CLOSE: size_delta_usd=%.2f (requested %.2f, actual position %.2f, "
+                    "source=%s)",
                     size_delta_usd,
                     requested_size_usd,
                     actual_size_usd,
+                    "sub_trade_amt" if sub_trade_amt is not None else "amount",
                 )
 
         elif "size_usd" in params:

--- a/eth_defi/gmx/ccxt/exchange.py
+++ b/eth_defi/gmx/ccxt/exchange.py
@@ -413,6 +413,98 @@ def _resolve_reduce_only_size_delta_usd(
     return min(requested_size_usd, actual_size_usd)
 
 
+def _resolve_close_order_filled_amount(
+    *,
+    requested_amount: float,
+    size_delta_usd: float | None,
+    execution_price: float | None,
+    gmx_position: dict | None,
+    full_close_tolerance: float = 0.995,
+) -> float:
+    """Resolve the ``filled`` / ``amount`` value reported in a close-order CCXT response.
+
+    Background. The GMX close-order response previously reported
+    ``size_delta_usd / execution_price`` for both ``filled`` and ``amount``.
+    That value is the *post-execution* base-currency amount derived from
+    on-chain ``sizeInTokens``, which differs from the Freqtrade-requested
+    ``amount`` by a few wei because GMX price impact + integer rounding
+    shift the fill price slightly relative to the signal price the caller
+    used to size the trade.
+
+    For partial closes that token-derived value is correct — Freqtrade
+    needs the accurate base-currency delta to keep its wallet view aligned
+    with the on-chain position.
+
+    For full closes it is destructive. Freqtrade's
+    :func:`freqtrade.persistence.trade_model.Trade.update_trade` calls
+    ``isclose(filled, amount, abs_tol=1e-14)`` to decide whether the close
+    was full or partial. The wei-level gap blows that tolerance — Freqtrade
+    marks the successful full close as a PARTIAL fill, keeps
+    ``Trade.is_open = True`` with a dust residual base amount, and
+    re-fires ``should_exit`` on the next tick, triggering a 6-minute
+    dust-close retry via the Subsquid event-scanner fallback. Live
+    evidence: LINK trade #8 on 2026-05-22 closed at 01:37 for 0.30608767
+    LINK then again at 01:43 for 0.00107856 LINK dust.
+
+    Decision matrix.
+
+    * ``size_delta_usd`` falsy or ``execution_price`` falsy / None →
+      return ``requested_amount``. No token-derived value possible.
+    * ``gmx_position`` is None or ``position_size`` ≤ 0 →
+      return ``requested_amount``. We can't compare against actual size.
+    * Full close (``size_delta_usd >= actual_size_usd × full_close_tolerance``) →
+      return ``requested_amount``. Keeps ``filled == amount`` exactly so
+      Freqtrade sees a full fill.
+    * Partial close → return ``size_delta_usd / execution_price``
+      (token-derived). Preserves the wallet-sync behaviour.
+
+    Complement to :func:`_resolve_reduce_only_size_delta_usd` — that helper
+    fixes the *sizing* (entry into ``create_order``), this one fixes the
+    *reporting* (close-order response). Both are required for correct
+    same-pair NT-HEDGING parity behaviour in the
+    ``feat/orchestrator-live-independent-same-pair`` work upstream of this
+    fix.
+
+    :param requested_amount: The Freqtrade-requested ``amount`` (in base
+        currency). For DCA closes, callers should pass
+        ``params.get("sub_trade_amt") or amount`` so the authoritative
+        partial value flows through.
+    :param size_delta_usd: The USD size delta of the executed close, as
+        reported by the keeper trade-action event (post price-impact).
+        May be ``0.0`` / ``None`` when the order was already closed via
+        the Subsquid fallback paths (synthetic responses).
+    :param execution_price: The on-chain executed price in USD per base
+        currency. May be ``None`` when no execution event was found.
+    :param gmx_position: The ``GetOpenPositions`` dict for the position
+        being closed, or ``None`` if the position was already gone. Must
+        contain at least ``position_size`` (float USD) when not None.
+    :param full_close_tolerance: Fraction of ``actual_size_usd`` at or
+        above which the close is treated as full. Default ``0.995``
+        mirrors :func:`_resolve_reduce_only_size_delta_usd`.
+    :returns: The base-currency amount to report in the CCXT response's
+        ``filled`` and ``amount`` fields.
+    """
+    # Fallback: no token-derived value possible.
+    if not size_delta_usd or not execution_price:
+        return requested_amount
+
+    # Fallback: no comparable on-chain position.
+    if gmx_position is None:
+        return requested_amount
+
+    actual_size_usd = float(gmx_position.get("position_size", 0.0) or 0.0)
+    if actual_size_usd <= 0:
+        return requested_amount
+
+    # Full-close path: return the FT-requested amount so Freqtrade's
+    # isclose(filled, amount) check sees an exact match.
+    if size_delta_usd >= actual_size_usd * full_close_tolerance:
+        return requested_amount
+
+    # Partial-close path: return the token-derived value (wallet-sync).
+    return size_delta_usd / execution_price
+
+
 class GMX(ExchangeCompatible):
     """
     CCXT-compatible wrapper for GMX protocol market data and trading.
@@ -8182,6 +8274,20 @@ class GMX(ExchangeCompatible):
             )
 
             timestamp = self.milliseconds()
+            # Compute the reportable filled/amount once so close-order responses
+            # report the FT-requested amount on a full close (avoids the wei-level
+            # gap between token-derived and requested amounts blowing Freqtrade's
+            # isclose(filled, amount, abs_tol=1e-14) check → dust-residual retry).
+            # See :func:`_resolve_close_order_filled_amount` for the full rationale.
+            # For opens, `_gmx_position` is popped from gmx_params at line ~7333
+            # so the helper hits its `gmx_position is None` fallback and returns
+            # `amount` unchanged — preserving open-order behaviour exactly.
+            _reportable_amount = _resolve_close_order_filled_amount(
+                requested_amount=(params.get("sub_trade_amt") if params else None) or amount,
+                size_delta_usd=size_delta_usd,
+                execution_price=execution_price,
+                gmx_position=gmx_params.get("_gmx_position") if isinstance(gmx_params, dict) else None,
+            )
             order = {
                 "id": tx_hash,
                 "clientOrderId": None,
@@ -8192,15 +8298,17 @@ class GMX(ExchangeCompatible):
                 "type": type,
                 "side": side,
                 "price": execution_price,
-                # Use actual executed token amount derived from on-chain size_delta_usd / execution_price.
-                # The original `amount` parameter is a pre-execution estimate based on signal price;
-                # GMX price impact shifts the fill price slightly, producing a different sizeInTokens
-                # on-chain. Using the post-execution value here avoids the Freqtrade wallet-sync
-                # mismatch warning "Wallet shows X but trade has Y".
-                "amount": size_delta_usd / execution_price if (size_delta_usd and execution_price) else amount,
+                # On a full close (requested >= 99.5% × actual on-chain position) we
+                # report the Freqtrade-requested amount so update_trade's
+                # isclose(filled, amount) sees an exact match and marks the trade
+                # closed. On a partial close we keep the post-execution token-derived
+                # value (size_delta_usd / execution_price) so the Freqtrade wallet
+                # view stays aligned with the on-chain position (avoids the
+                # "Wallet shows X but trade has Y" warning).
+                "amount": _reportable_amount,
                 "cost": size_delta_usd if size_delta_usd else ((execution_price or 0) * amount if execution_price else None),
                 "average": execution_price,
-                "filled": size_delta_usd / execution_price if (size_delta_usd and execution_price) else amount,
+                "filled": _reportable_amount,
                 "remaining": 0.0,
                 "status": "closed",
                 "fee": fee_dict,

--- a/eth_defi/gmx/ccxt/exchange.py
+++ b/eth_defi/gmx/ccxt/exchange.py
@@ -77,6 +77,7 @@ from eth_defi.gmx.core.markets import Markets
 from eth_defi.gmx.core.open_positions import GetOpenPositions
 from eth_defi.gmx.core.oracle import OraclePrices
 from eth_defi.gmx.precision import cap_size_delta_to_position, is_raw_usd_amount
+from eth_defi.gmx.errors import decode_gmx_revert_selector
 from eth_defi.gmx.events import (
     _get_event_emitter_contract,
     decode_error_reason,
@@ -8185,6 +8186,21 @@ class GMX(ExchangeCompatible):
                         decoded_error = decode_error_reason(_reason_bytes)
                     except Exception:
                         pass
+                # If the legacy events.py registry only produced a bare
+                # "Unknown error (selector: 0x...)" string, consult the
+                # comprehensive GMX V2 selector registry in eth_defi.gmx.errors
+                # to surface the human-readable error name + description.
+                # Example uplift:
+                #   "Unknown error (selector: 0x839c693e)"
+                #     -> "InvalidCollateralTokenForMarket — The collateral
+                #         token is not accepted by this market
+                #         (selector: 0x839c693e)"
+                if decoded_error and decoded_error.startswith("Unknown error (selector: 0x"):
+                    _selector_hex = decoded_error.split("0x", 1)[1].rstrip(")")
+                    _named = decode_gmx_revert_selector(_selector_hex)
+                    if _named is not None:
+                        _desc = f" — {_named.description}" if _named.description else ""
+                        decoded_error = f"{_named.name}{_desc} (selector: {_named.selector})"
                 error_reason = decoded_error or trade_action.get("reason") or f"Order {event_name.lower()}"
                 logger.warning(
                     "ORDER_TRACE: create_order() - Order %s by keeper for %s - decoded=%s, raw_reason=%s, tx=%s, order_key=%s",

--- a/eth_defi/gmx/errors.py
+++ b/eth_defi/gmx/errors.py
@@ -1,0 +1,2197 @@
+"""GMX V2 custom error selector decoder.
+
+GMX V2 contracts revert with Solidity custom errors. The on-chain log
+records only the 4-byte function selector — keccak256 of the error
+signature, e.g. ``keccak256("InvalidCollateralTokenForMarket(address,address)")[:4]``.
+
+This module maps known selectors back to a human-readable error name +
+description so operators see real failure reasons instead of opaque hex
+(e.g. ``0x839c693e``).
+
+The selector registry is generated from
+`gmx-io/gmx-synthetics/contracts/error/Errors.sol`_ — every
+``error Name(...);`` declaration is hashed to produce its 4-byte selector.
+Curated human descriptions are attached to the operationally-relevant
+errors (collateral, position, order, price, pool, oracle, fee categories).
+
+.. _gmx-io/gmx-synthetics/contracts/error/Errors.sol:
+    https://github.com/gmx-io/gmx-synthetics/blob/main/contracts/error/Errors.sol
+
+:see: :mod:`eth_defi.gmx.ccxt.exchange` — uses :func:`decode_gmx_revert_selector`
+    when constructing keeper-cancel error messages so logs read e.g.
+    ``"InvalidCollateralTokenForMarket — The collateral token is not
+    accepted by this market (selector: 0x839c693e)"`` instead of
+    ``"Unknown error (selector: 0x839c693e)"``.
+
+Sub-investigation flag (2026-05-22): the live ``0x839c693e`` revert on
+``BTC/USDC:USDC`` long with USDC collateral suggests the adapter may be
+selecting a BTC ``market_token_address`` whose accepted-collateral set
+excludes USDC. This module only improves the diagnostic surface —
+investigating and fixing the market-selection logic is tracked as a
+follow-up in the multi-sleeve plan
+(``docs/superpowers/plans/2026-05-22-orchestrator-multi-sleeve-followups.md``).
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+
+class GmxError(NamedTuple):
+    """A decoded GMX V2 custom error.
+
+    :ivar selector: 4-byte hex string with ``0x`` prefix, lowercase
+        (e.g. ``"0x839c693e"``).
+    :ivar name: Solidity error name (e.g. ``"InvalidCollateralTokenForMarket"``).
+    :ivar description: Plain-English description of when this error is raised.
+        Empty string for errors without a curated description.
+    :ivar params: Solidity parameter type signature
+        (e.g. ``("address", "address")``).
+    """
+
+    selector: str
+    name: str
+    description: str
+    params: tuple[str, ...]
+
+
+
+_GMX_ERROR_REGISTRY: dict[str, GmxError] = {
+    "0xb244a107": GmxError(
+        selector="0xb244a107",
+        name="ActionAlreadySignalled",
+        description="",
+        params=(),
+    ),
+    "0x94fdaea2": GmxError(
+        selector="0x94fdaea2",
+        name="ActionNotSignalled",
+        description="",
+        params=(),
+    ),
+    "0x3285dc57": GmxError(
+        selector="0x3285dc57",
+        name="AdlNotEnabled",
+        description="",
+        params=(),
+    ),
+    "0xd06ed8be": GmxError(
+        selector="0xd06ed8be",
+        name="AdlNotRequired",
+        description="",
+        params=("int256", "uint256"),
+    ),
+    "0x70657e04": GmxError(
+        selector="0x70657e04",
+        name="ArrayOutOfBoundsBytes",
+        description="",
+        params=("bytes[]", "uint256", "string"),
+    ),
+    "0x9d18e63b": GmxError(
+        selector="0x9d18e63b",
+        name="ArrayOutOfBoundsUint256",
+        description="",
+        params=("uint256[]", "uint256", "string"),
+    ),
+    "0x97a3eeff": GmxError(
+        selector="0x97a3eeff",
+        name="AttemptedBridgeAmountTooHigh",
+        description="",
+        params=("uint256", "uint256", "uint256"),
+    ),
+    "0x60c5e472": GmxError(
+        selector="0x60c5e472",
+        name="AvailableFeeAmountIsZero",
+        description="",
+        params=("address", "address", "uint256"),
+    ),
+    "0x11aeaf6b": GmxError(
+        selector="0x11aeaf6b",
+        name="BlockNumbersNotSorted",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x4708f070": GmxError(
+        selector="0x4708f070",
+        name="BridgeOutNotSupportedDuringShift",
+        description="",
+        params=(),
+    ),
+    "0xa5123802": GmxError(
+        selector="0xa5123802",
+        name="BridgedAmountNotSufficient",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xbd3b23af": GmxError(
+        selector="0xbd3b23af",
+        name="BridgingBalanceArrayMismatch",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x98984b37": GmxError(
+        selector="0x98984b37",
+        name="BridgingTransactionFailed",
+        description="",
+        params=("bytes",),
+    ),
+    "0xec775484": GmxError(
+        selector="0xec775484",
+        name="BuybackAndFeeTokenAreEqual",
+        description="",
+        params=("address", "address"),
+    ),
+    "0xd6b52b60": GmxError(
+        selector="0xd6b52b60",
+        name="ChainlinkPriceFeedNotUpdated",
+        description="",
+        params=("address", "uint256", "uint256"),
+    ),
+    "0xec6d89c8": GmxError(
+        selector="0xec6d89c8",
+        name="CollateralAlreadyClaimed",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xbdec9c0d": GmxError(
+        selector="0xbdec9c0d",
+        name="CompactedArrayOutOfBounds",
+        description="",
+        params=("uint256[]", "uint256", "uint256", "string"),
+    ),
+    "0x5ebb87c9": GmxError(
+        selector="0x5ebb87c9",
+        name="ConfigValueExceedsAllowedRange",
+        description="",
+        params=("bytes32", "uint256"),
+    ),
+    "0xc92f6438": GmxError(
+        selector="0xc92f6438",
+        name="DataListLengthExceeded",
+        description="",
+        params=(),
+    ),
+    "0x413f9a54": GmxError(
+        selector="0x413f9a54",
+        name="DataStreamIdAlreadyExistsForToken",
+        description="",
+        params=("address",),
+    ),
+    "0x83f2ba20": GmxError(
+        selector="0x83f2ba20",
+        name="DeadlinePassed",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x43e30ca8": GmxError(
+        selector="0x43e30ca8",
+        name="DepositNotFound",
+        description="",
+        params=("bytes32",),
+    ),
+    "0xdd70e0c9": GmxError(
+        selector="0xdd70e0c9",
+        name="DisabledFeature",
+        description="",
+        params=("bytes32",),
+    ),
+    "0x09f8c937": GmxError(
+        selector="0x09f8c937",
+        name="DisabledMarket",
+        description="The market is disabled (paused or delisted)",
+        params=("address",),
+    ),
+    "0xfd795fc1": GmxError(
+        selector="0xfd795fc1",
+        name="DuplicateClaimTerms",
+        description="",
+        params=("uint256",),
+    ),
+    "0xd4064737": GmxError(
+        selector="0xd4064737",
+        name="DuplicatedIndex",
+        description="",
+        params=("uint256", "string"),
+    ),
+    "0x91c78b78": GmxError(
+        selector="0x91c78b78",
+        name="DuplicatedMarketInSwapPath",
+        description="Same market appears more than once in the swap path",
+        params=("address",),
+    ),
+    "0x3f677c2e": GmxError(
+        selector="0x3f677c2e",
+        name="EdgeDataStreamIdAlreadyExistsForToken",
+        description="",
+        params=("address",),
+    ),
+    "0xdd7016a2": GmxError(
+        selector="0xdd7016a2",
+        name="EmptyAccount",
+        description="Account address is the zero address",
+        params=(),
+    ),
+    "0xe474a425": GmxError(
+        selector="0xe474a425",
+        name="EmptyAddressInMarketTokenBalanceValidation",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x0d143458": GmxError(
+        selector="0x0d143458",
+        name="EmptyAmount",
+        description="",
+        params=(),
+    ),
+    "0x8db88ccf": GmxError(
+        selector="0x8db88ccf",
+        name="EmptyChainlinkPriceFeed",
+        description="",
+        params=("address",),
+    ),
+    "0xb86fffef": GmxError(
+        selector="0xb86fffef",
+        name="EmptyChainlinkPriceFeedMultiplier",
+        description="",
+        params=("address",),
+    ),
+    "0x616daf1f": GmxError(
+        selector="0x616daf1f",
+        name="EmptyClaimFeesMarket",
+        description="",
+        params=(),
+    ),
+    "0x7c8cdbf9": GmxError(
+        selector="0x7c8cdbf9",
+        name="EmptyClaimableAmount",
+        description="",
+        params=("address",),
+    ),
+    "0x62e402cc": GmxError(
+        selector="0x62e402cc",
+        name="EmptyDataStreamFeedId",
+        description="",
+        params=("address",),
+    ),
+    "0x088405c6": GmxError(
+        selector="0x088405c6",
+        name="EmptyDataStreamMultiplier",
+        description="",
+        params=("address",),
+    ),
+    "0x95b66fe9": GmxError(
+        selector="0x95b66fe9",
+        name="EmptyDeposit",
+        description="",
+        params=(),
+    ),
+    "0x01af8c24": GmxError(
+        selector="0x01af8c24",
+        name="EmptyDepositAmounts",
+        description="",
+        params=(),
+    ),
+    "0xd1c3d5bd": GmxError(
+        selector="0xd1c3d5bd",
+        name="EmptyDepositAmountsAfterSwap",
+        description="",
+        params=(),
+    ),
+    "0x9ab5d127": GmxError(
+        selector="0x9ab5d127",
+        name="EmptyFundingAccount",
+        description="",
+        params=(),
+    ),
+    "0xa14e1b3d": GmxError(
+        selector="0xa14e1b3d",
+        name="EmptyGlv",
+        description="",
+        params=("address",),
+    ),
+    "0xbd192971": GmxError(
+        selector="0xbd192971",
+        name="EmptyGlvDeposit",
+        description="",
+        params=(),
+    ),
+    "0x03251ce6": GmxError(
+        selector="0x03251ce6",
+        name="EmptyGlvDepositAmounts",
+        description="",
+        params=(),
+    ),
+    "0x94409f52": GmxError(
+        selector="0x94409f52",
+        name="EmptyGlvMarketAmount",
+        description="",
+        params=(),
+    ),
+    "0x93856b1a": GmxError(
+        selector="0x93856b1a",
+        name="EmptyGlvTokenSupply",
+        description="",
+        params=(),
+    ),
+    "0x0e5be78f": GmxError(
+        selector="0x0e5be78f",
+        name="EmptyGlvWithdrawal",
+        description="",
+        params=(),
+    ),
+    "0x402a866f": GmxError(
+        selector="0x402a866f",
+        name="EmptyGlvWithdrawalAmount",
+        description="",
+        params=(),
+    ),
+    "0xe9b78bd4": GmxError(
+        selector="0xe9b78bd4",
+        name="EmptyHoldingAddress",
+        description="",
+        params=(),
+    ),
+    "0x05fbc1ae": GmxError(
+        selector="0x05fbc1ae",
+        name="EmptyMarket",
+        description="",
+        params=(),
+    ),
+    "0xeb1947dd": GmxError(
+        selector="0xeb1947dd",
+        name="EmptyMarketPrice",
+        description="",
+        params=("address",),
+    ),
+    "0x2ee3d69c": GmxError(
+        selector="0x2ee3d69c",
+        name="EmptyMarketTokenSupply",
+        description="",
+        params=(),
+    ),
+    "0x14c35d93": GmxError(
+        selector="0x14c35d93",
+        name="EmptyMultichainTransferInAmount",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x7a29de11": GmxError(
+        selector="0x7a29de11",
+        name="EmptyMultichainTransferOutAmount",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x16307797": GmxError(
+        selector="0x16307797",
+        name="EmptyOrder",
+        description="The order is empty or has been removed",
+        params=(),
+    ),
+    "0xb2db7048": GmxError(
+        selector="0xb2db7048",
+        name="EmptyPeer",
+        description="",
+        params=("uint32",),
+    ),
+    "0x4dfbbff3": GmxError(
+        selector="0x4dfbbff3",
+        name="EmptyPosition",
+        description="The position does not exist or has zero size",
+        params=(),
+    ),
+    "0x0d1bbc95": GmxError(
+        selector="0x0d1bbc95",
+        name="EmptyPositionImpactWithdrawalAmount",
+        description="",
+        params=(),
+    ),
+    "0xcd64a025": GmxError(
+        selector="0xcd64a025",
+        name="EmptyPrimaryPrice",
+        description="Oracle has no primary price for the token",
+        params=("address",),
+    ),
+    "0xd551823d": GmxError(
+        selector="0xd551823d",
+        name="EmptyReceiver",
+        description="Receiver address is the zero address",
+        params=(),
+    ),
+    "0xb3d35539": GmxError(
+        selector="0xb3d35539",
+        name="EmptyReduceLentAmount",
+        description="",
+        params=(),
+    ),
+    "0x64174bbc": GmxError(
+        selector="0x64174bbc",
+        name="EmptyRelayFeeAddress",
+        description="",
+        params=(),
+    ),
+    "0x6af5e96f": GmxError(
+        selector="0x6af5e96f",
+        name="EmptyShift",
+        description="",
+        params=(),
+    ),
+    "0x60d5e84a": GmxError(
+        selector="0x60d5e84a",
+        name="EmptyShiftAmount",
+        description="",
+        params=(),
+    ),
+    "0x3df42531": GmxError(
+        selector="0x3df42531",
+        name="EmptySizeDeltaInTokens",
+        description="Size delta in tokens is zero",
+        params=(),
+    ),
+    "0x9cdc6daa": GmxError(
+        selector="0x9cdc6daa",
+        name="EmptyTarget",
+        description="",
+        params=(),
+    ),
+    "0x066f53b1": GmxError(
+        selector="0x066f53b1",
+        name="EmptyToken",
+        description="",
+        params=(),
+    ),
+    "0x9fc297fa": GmxError(
+        selector="0x9fc297fa",
+        name="EmptyTokenTranferGasLimit",
+        description="",
+        params=("address",),
+    ),
+    "0x9231be69": GmxError(
+        selector="0x9231be69",
+        name="EmptyValidatedPrices",
+        description="",
+        params=(),
+    ),
+    "0x6d4bb5e9": GmxError(
+        selector="0x6d4bb5e9",
+        name="EmptyWithdrawal",
+        description="",
+        params=(),
+    ),
+    "0x01d6f7b1": GmxError(
+        selector="0x01d6f7b1",
+        name="EmptyWithdrawalAmount",
+        description="",
+        params=(),
+    ),
+    "0x4e48dcda": GmxError(
+        selector="0x4e48dcda",
+        name="EndOfOracleSimulation",
+        description="",
+        params=(),
+    ),
+    "0xeeadc89d": GmxError(
+        selector="0xeeadc89d",
+        name="EventItemNotFound",
+        description="",
+        params=("string",),
+    ),
+    "0x59afd6c6": GmxError(
+        selector="0x59afd6c6",
+        name="ExternalCallFailed",
+        description="",
+        params=("bytes",),
+    ),
+    "0x2df6dc23": GmxError(
+        selector="0x2df6dc23",
+        name="FeeBatchNotFound",
+        description="",
+        params=("bytes32",),
+    ),
+    "0x53d1caca": GmxError(
+        selector="0x53d1caca",
+        name="FeeDistributionAlreadyCompleted",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xe44992d0": GmxError(
+        selector="0xe44992d0",
+        name="GlvAlreadyExists",
+        description="",
+        params=("bytes32", "address"),
+    ),
+    "0x057058b6": GmxError(
+        selector="0x057058b6",
+        name="GlvDepositNotFound",
+        description="",
+        params=("bytes32",),
+    ),
+    "0x30b8a225": GmxError(
+        selector="0x30b8a225",
+        name="GlvDisabledMarket",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x8da31161": GmxError(
+        selector="0x8da31161",
+        name="GlvEnabledMarket",
+        description="",
+        params=("address", "address"),
+    ),
+    "0xc8b70b2c": GmxError(
+        selector="0xc8b70b2c",
+        name="GlvInsufficientMarketTokenBalance",
+        description="",
+        params=("address", "address", "uint256", "uint256"),
+    ),
+    "0x80ad6831": GmxError(
+        selector="0x80ad6831",
+        name="GlvInvalidLongToken",
+        description="",
+        params=("address", "address", "address"),
+    ),
+    "0x9673a10b": GmxError(
+        selector="0x9673a10b",
+        name="GlvInvalidShortToken",
+        description="",
+        params=("address", "address", "address"),
+    ),
+    "0x3aa9fc91": GmxError(
+        selector="0x3aa9fc91",
+        name="GlvMarketAlreadyExists",
+        description="",
+        params=("address", "address"),
+    ),
+    "0xaf7d3787": GmxError(
+        selector="0xaf7d3787",
+        name="GlvMaxMarketCountExceeded",
+        description="",
+        params=("address", "uint256"),
+    ),
+    "0xd859f947": GmxError(
+        selector="0xd859f947",
+        name="GlvMaxMarketTokenBalanceAmountExceeded",
+        description="",
+        params=("address", "address", "uint256", "uint256"),
+    ),
+    "0x66560e7d": GmxError(
+        selector="0x66560e7d",
+        name="GlvMaxMarketTokenBalanceUsdExceeded",
+        description="",
+        params=("address", "address", "uint256", "uint256"),
+    ),
+    "0x155712e1": GmxError(
+        selector="0x155712e1",
+        name="GlvNameTooLong",
+        description="",
+        params=(),
+    ),
+    "0x2e3780e5": GmxError(
+        selector="0x2e3780e5",
+        name="GlvNegativeMarketPoolValue",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x3afc5e65": GmxError(
+        selector="0x3afc5e65",
+        name="GlvNonZeroMarketBalance",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x6c00ed8a": GmxError(
+        selector="0x6c00ed8a",
+        name="GlvNotFound",
+        description="",
+        params=("address",),
+    ),
+    "0x232d7165": GmxError(
+        selector="0x232d7165",
+        name="GlvShiftIntervalNotYetPassed",
+        description="",
+        params=("uint256", "uint256", "uint256"),
+    ),
+    "0xf4dfe85d": GmxError(
+        selector="0xf4dfe85d",
+        name="GlvShiftMaxLossExceeded",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xde45e162": GmxError(
+        selector="0xde45e162",
+        name="GlvShiftNotFound",
+        description="",
+        params=("bytes32",),
+    ),
+    "0x9cb4f5c5": GmxError(
+        selector="0x9cb4f5c5",
+        name="GlvSymbolTooLong",
+        description="",
+        params=(),
+    ),
+    "0x07e9c4d5": GmxError(
+        selector="0x07e9c4d5",
+        name="GlvUnsupportedMarket",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x20dcb068": GmxError(
+        selector="0x20dcb068",
+        name="GlvWithdrawalNotFound",
+        description="",
+        params=("bytes32",),
+    ),
+    "0xd90abe06": GmxError(
+        selector="0xd90abe06",
+        name="GmEmptySigner",
+        description="",
+        params=("uint256",),
+    ),
+    "0xee6e8ecf": GmxError(
+        selector="0xee6e8ecf",
+        name="GmInvalidBlockNumber",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xb8aaa455": GmxError(
+        selector="0xb8aaa455",
+        name="GmInvalidMinMaxBlockNumber",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xc7b44b28": GmxError(
+        selector="0xc7b44b28",
+        name="GmMaxOracleSigners",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x0f885e52": GmxError(
+        selector="0x0f885e52",
+        name="GmMaxPricesNotSorted",
+        description="",
+        params=("address", "uint256", "uint256"),
+    ),
+    "0x5b1250e7": GmxError(
+        selector="0x5b1250e7",
+        name="GmMaxSignerIndex",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xdc2a99e7": GmxError(
+        selector="0xdc2a99e7",
+        name="GmMinOracleSigners",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xcc7bbd5b": GmxError(
+        selector="0xcc7bbd5b",
+        name="GmMinPricesNotSorted",
+        description="",
+        params=("address", "uint256", "uint256"),
+    ),
+    "0xa581f648": GmxError(
+        selector="0xa581f648",
+        name="InsufficientBuybackOutputAmount",
+        description="",
+        params=("address", "address", "uint256", "uint256"),
+    ),
+    "0x74cc815b": GmxError(
+        selector="0x74cc815b",
+        name="InsufficientCollateralAmount",
+        description="Collateral amount is below the minimum required",
+        params=("uint256", "int256"),
+    ),
+    "0x2159b161": GmxError(
+        selector="0x2159b161",
+        name="InsufficientCollateralUsd",
+        description="Remaining collateral USD is below the minimum required",
+        params=("int256",),
+    ),
+    "0x5dac504d": GmxError(
+        selector="0x5dac504d",
+        name="InsufficientExecutionFee",
+        description="Execution fee provided is below the required minimum",
+        params=("uint256", "uint256"),
+    ),
+    "0xbb416f93": GmxError(
+        selector="0xbb416f93",
+        name="InsufficientExecutionGas",
+        description="Caller did not forward enough gas to execute the handler",
+        params=("uint256", "uint256", "uint256"),
+    ),
+    "0x79293964": GmxError(
+        selector="0x79293964",
+        name="InsufficientExecutionGasForErrorHandling",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xa458261b": GmxError(
+        selector="0xa458261b",
+        name="InsufficientFee",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x9fc47b77": GmxError(
+        selector="0x9fc47b77",
+        name="InsufficientFunds",
+        description="",
+        params=("address",),
+    ),
+    "0x19d50093": GmxError(
+        selector="0x19d50093",
+        name="InsufficientFundsToPayForCosts",
+        description="",
+        params=("uint256", "string"),
+    ),
+    "0xe73a05d5": GmxError(
+        selector="0xe73a05d5",
+        name="InsufficientGasForAutoCancellation",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xd3dacaac": GmxError(
+        selector="0xd3dacaac",
+        name="InsufficientGasForCancellation",
+        description="Caller did not forward enough gas to cancel the order on error",
+        params=("uint256", "uint256"),
+    ),
+    "0xf50ce733": GmxError(
+        selector="0xf50ce733",
+        name="InsufficientGasLeft",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x79a2abad": GmxError(
+        selector="0x79a2abad",
+        name="InsufficientGasLeftForCallback",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x3083b9e5": GmxError(
+        selector="0x3083b9e5",
+        name="InsufficientHandleExecutionErrorGas",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x8643d20a": GmxError(
+        selector="0x8643d20a",
+        name="InsufficientImpactPoolValueForWithdrawal",
+        description="",
+        params=("uint256", "uint256", "int256"),
+    ),
+    "0x82c8828a": GmxError(
+        selector="0x82c8828a",
+        name="InsufficientMarketTokens",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x4ac6d095": GmxError(
+        selector="0x4ac6d095",
+        name="InsufficientMultichainBalance",
+        description="",
+        params=("address", "address", "uint256", "uint256"),
+    ),
+    "0x77f8f169": GmxError(
+        selector="0x77f8f169",
+        name="InsufficientMultichainNativeFee",
+        description="",
+        params=("uint256",),
+    ),
+    "0xb5749baf": GmxError(
+        selector="0xb5749baf",
+        name="InsufficientNativeTokenAmount",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xd28d3eb5": GmxError(
+        selector="0xd28d3eb5",
+        name="InsufficientOutputAmount",
+        description="Output amount is below the minimum acceptable",
+        params=("uint256", "uint256"),
+    ),
+    "0x23090a31": GmxError(
+        selector="0x23090a31",
+        name="InsufficientPoolAmount",
+        description="Pool does not have enough tokens to fill the order",
+        params=("uint256", "uint256"),
+    ),
+    "0x9cd76295": GmxError(
+        selector="0x9cd76295",
+        name="InsufficientRelayFee",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x315276c9": GmxError(
+        selector="0x315276c9",
+        name="InsufficientReserve",
+        description="Reserve is insufficient to back the open interest",
+        params=("uint256", "uint256"),
+    ),
+    "0xb98c6179": GmxError(
+        selector="0xb98c6179",
+        name="InsufficientReserveForOpenInterest",
+        description="Reserve is insufficient relative to open interest",
+        params=("uint256", "uint256"),
+    ),
+    "0xa7aebadc": GmxError(
+        selector="0xa7aebadc",
+        name="InsufficientSwapOutputAmount",
+        description="Swap output is below the minimum acceptable",
+        params=("uint256", "uint256"),
+    ),
+    "0x3a78cd7e": GmxError(
+        selector="0x3a78cd7e",
+        name="InsufficientWntAmountForExecutionFee",
+        description="WNT (wrapped ETH) provided for execution fee is insufficient",
+        params=("uint256", "uint256"),
+    ),
+    "0x1d4fc3c0": GmxError(
+        selector="0x1d4fc3c0",
+        name="InvalidAdl",
+        description="",
+        params=("int256", "int256"),
+    ),
+    "0x8ac146e6": GmxError(
+        selector="0x8ac146e6",
+        name="InvalidAmountInForFeeBatch",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xeb19d3f5": GmxError(
+        selector="0xeb19d3f5",
+        name="InvalidBaseKey",
+        description="",
+        params=("bytes32",),
+    ),
+    "0x25e5dc07": GmxError(
+        selector="0x25e5dc07",
+        name="InvalidBlockRangeSet",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x2877599b": GmxError(
+        selector="0x2877599b",
+        name="InvalidBridgeOutToken",
+        description="",
+        params=("address",),
+    ),
+    "0x752fdb63": GmxError(
+        selector="0x752fdb63",
+        name="InvalidBuybackToken",
+        description="",
+        params=("address",),
+    ),
+    "0x89736584": GmxError(
+        selector="0x89736584",
+        name="InvalidCancellationReceiverForSubaccountOrder",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x5b3043dd": GmxError(
+        selector="0x5b3043dd",
+        name="InvalidClaimAffiliateRewardsInput",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x42c0d1f2": GmxError(
+        selector="0x42c0d1f2",
+        name="InvalidClaimCollateralInput",
+        description="",
+        params=("uint256", "uint256", "uint256"),
+    ),
+    "0x7363cfa5": GmxError(
+        selector="0x7363cfa5",
+        name="InvalidClaimFundingFeesInput",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x6ac60b4a": GmxError(
+        selector="0x6ac60b4a",
+        name="InvalidClaimTermsSignature",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x500016f0": GmxError(
+        selector="0x500016f0",
+        name="InvalidClaimTermsSignatureForContract",
+        description="",
+        params=("address",),
+    ),
+    "0x74cee48d": GmxError(
+        selector="0x74cee48d",
+        name="InvalidClaimUiFeesInput",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x6c2738d3": GmxError(
+        selector="0x6c2738d3",
+        name="InvalidClaimableFactor",
+        description="",
+        params=("uint256",),
+    ),
+    "0x7cf9eb07": GmxError(
+        selector="0x7cf9eb07",
+        name="InvalidClaimableReductionFactor",
+        description="",
+        params=("uint256",),
+    ),
+    "0x839c693e": GmxError(
+        selector="0x839c693e",
+        name="InvalidCollateralTokenForMarket",
+        description="The collateral token is not accepted by this market",
+        params=("address", "address"),
+    ),
+    "0x4a591309": GmxError(
+        selector="0x4a591309",
+        name="InvalidContributorToken",
+        description="",
+        params=("address",),
+    ),
+    "0x8d56bea1": GmxError(
+        selector="0x8d56bea1",
+        name="InvalidDataStreamBidAsk",
+        description="",
+        params=("address", "int192", "int192"),
+    ),
+    "0xa4949e25": GmxError(
+        selector="0xa4949e25",
+        name="InvalidDataStreamFeedId",
+        description="",
+        params=("address", "bytes32", "bytes32"),
+    ),
+    "0x2a74194d": GmxError(
+        selector="0x2a74194d",
+        name="InvalidDataStreamPrices",
+        description="",
+        params=("address", "int192", "int192"),
+    ),
+    "0x6e0c29ed": GmxError(
+        selector="0x6e0c29ed",
+        name="InvalidDataStreamSpreadReductionFactor",
+        description="",
+        params=("address", "uint256"),
+    ),
+    "0x9fbe2cbc": GmxError(
+        selector="0x9fbe2cbc",
+        name="InvalidDecreaseOrderSize",
+        description="Decrease order size exceeds the remaining position size",
+        params=("uint256", "uint256"),
+    ),
+    "0x751951f9": GmxError(
+        selector="0x751951f9",
+        name="InvalidDecreasePositionSwapType",
+        description="",
+        params=("uint256",),
+    ),
+    "0xc3776a2c": GmxError(
+        selector="0xc3776a2c",
+        name="InvalidDestinationChainId",
+        description="",
+        params=("uint256",),
+    ),
+    "0x8695f464": GmxError(
+        selector="0x8695f464",
+        name="InvalidDistributionState",
+        description="",
+        params=("uint256",),
+    ),
+    "0xe75fc463": GmxError(
+        selector="0xe75fc463",
+        name="InvalidEdgeDataStreamBidAsk",
+        description="",
+        params=("address", "uint256", "uint256"),
+    ),
+    "0x8bb5c4bf": GmxError(
+        selector="0x8bb5c4bf",
+        name="InvalidEdgeDataStreamExpo",
+        description="",
+        params=("int256",),
+    ),
+    "0x4234439c": GmxError(
+        selector="0x4234439c",
+        name="InvalidEdgeDataStreamPrices",
+        description="",
+        params=("address", "uint256", "uint256"),
+    ),
+    "0x545e155f": GmxError(
+        selector="0x545e155f",
+        name="InvalidEdgeSignature",
+        description="",
+        params=("uint256",),
+    ),
+    "0x8a1cc36b": GmxError(
+        selector="0x8a1cc36b",
+        name="InvalidEdgeSigner",
+        description="",
+        params=(),
+    ),
+    "0x3ee39805": GmxError(
+        selector="0x3ee39805",
+        name="InvalidEid",
+        description="",
+        params=("uint256",),
+    ),
+    "0x9b867f31": GmxError(
+        selector="0x9b867f31",
+        name="InvalidExecutionFee",
+        description="",
+        params=("uint256", "uint256", "uint256"),
+    ),
+    "0x99e26b44": GmxError(
+        selector="0x99e26b44",
+        name="InvalidExecutionFeeForMigration",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x831e9f11": GmxError(
+        selector="0x831e9f11",
+        name="InvalidExternalCallInput",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xbe55c895": GmxError(
+        selector="0xbe55c895",
+        name="InvalidExternalCallTarget",
+        description="",
+        params=("address",),
+    ),
+    "0xec7fd385": GmxError(
+        selector="0xec7fd385",
+        name="InvalidExternalCalls",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xe15f2701": GmxError(
+        selector="0xe15f2701",
+        name="InvalidExternalReceiversInput",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xfa804399": GmxError(
+        selector="0xfa804399",
+        name="InvalidFeeBatchTokenIndex",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xcb9339d5": GmxError(
+        selector="0xcb9339d5",
+        name="InvalidFeeReceiver",
+        description="",
+        params=("address",),
+    ),
+    "0xbe6514b6": GmxError(
+        selector="0xbe6514b6",
+        name="InvalidFeedPrice",
+        description="Oracle price feed returned an invalid (zero/negative) value",
+        params=("address", "int256"),
+    ),
+    "0xfc90fcc3": GmxError(
+        selector="0xfc90fcc3",
+        name="InvalidGlpAmount",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xbf16cb0a": GmxError(
+        selector="0xbf16cb0a",
+        name="InvalidGlvDepositInitialLongToken",
+        description="",
+        params=("address",),
+    ),
+    "0xdf0f9a23": GmxError(
+        selector="0xdf0f9a23",
+        name="InvalidGlvDepositInitialShortToken",
+        description="",
+        params=("address",),
+    ),
+    "0x055ab8b9": GmxError(
+        selector="0x055ab8b9",
+        name="InvalidGlvDepositSwapPath",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x993417d5": GmxError(
+        selector="0x993417d5",
+        name="InvalidGmMedianMinMaxPrice",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xa54d4339": GmxError(
+        selector="0xa54d4339",
+        name="InvalidGmOraclePrice",
+        description="",
+        params=("address",),
+    ),
+    "0x8d648a7f": GmxError(
+        selector="0x8d648a7f",
+        name="InvalidGmSignature",
+        description="",
+        params=("address", "address"),
+    ),
+    "0xb21c863e": GmxError(
+        selector="0xb21c863e",
+        name="InvalidGmSignerMinMaxPrice",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x7bb9d8f8": GmxError(
+        selector="0x7bb9d8f8",
+        name="InvalidHoldingAddress",
+        description="",
+        params=("address",),
+    ),
+    "0xadc06ae7": GmxError(
+        selector="0xadc06ae7",
+        name="InvalidInitializer",
+        description="",
+        params=(),
+    ),
+    "0xe5feddc0": GmxError(
+        selector="0xe5feddc0",
+        name="InvalidKeeperForFrozenOrder",
+        description="The caller is not authorized to execute frozen orders",
+        params=("address",),
+    ),
+    "0x33a1ea6b": GmxError(
+        selector="0x33a1ea6b",
+        name="InvalidMarketTokenBalance",
+        description="",
+        params=("address", "address", "uint256", "uint256"),
+    ),
+    "0x9dd026db": GmxError(
+        selector="0x9dd026db",
+        name="InvalidMarketTokenBalanceForClaimableFunding",
+        description="",
+        params=("address", "address", "uint256", "uint256"),
+    ),
+    "0x808c464f": GmxError(
+        selector="0x808c464f",
+        name="InvalidMarketTokenBalanceForCollateralAmount",
+        description="",
+        params=("address", "address", "uint256", "uint256"),
+    ),
+    "0xc08bb8a0": GmxError(
+        selector="0xc08bb8a0",
+        name="InvalidMinGlvTokensForFirstGlvDeposit",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x3f9c06ab": GmxError(
+        selector="0x3f9c06ab",
+        name="InvalidMinMarketTokensForFirstDeposit",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x1608d41a": GmxError(
+        selector="0x1608d41a",
+        name="InvalidMinMaxForPrice",
+        description="",
+        params=("address", "uint256", "uint256"),
+    ),
+    "0x9c9a99db": GmxError(
+        selector="0x9c9a99db",
+        name="InvalidMultichainEndpoint",
+        description="",
+        params=("address",),
+    ),
+    "0x2314a6e3": GmxError(
+        selector="0x2314a6e3",
+        name="InvalidMultichainProvider",
+        description="",
+        params=("address",),
+    ),
+    "0xe71a51be": GmxError(
+        selector="0xe71a51be",
+        name="InvalidNativeTokenSender",
+        description="",
+        params=("address",),
+    ),
+    "0x05d102a2": GmxError(
+        selector="0x05d102a2",
+        name="InvalidOracleProvider",
+        description="",
+        params=("address",),
+    ),
+    "0x68b49e6c": GmxError(
+        selector="0x68b49e6c",
+        name="InvalidOracleProviderForToken",
+        description="",
+        params=("address", "address"),
+    ),
+    "0xf9996e9f": GmxError(
+        selector="0xf9996e9f",
+        name="InvalidOracleSetPricesDataParam",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xdd51dc73": GmxError(
+        selector="0xdd51dc73",
+        name="InvalidOracleSetPricesProvidersParam",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xc1b14c91": GmxError(
+        selector="0xc1b14c91",
+        name="InvalidOracleSigner",
+        description="",
+        params=("address",),
+    ),
+    "0x0481a15a": GmxError(
+        selector="0x0481a15a",
+        name="InvalidOrderPrices",
+        description="Order price bounds are invalid for this order type",
+        params=("uint256", "uint256", "uint256", "uint256"),
+    ),
+    "0x253c8c02": GmxError(
+        selector="0x253c8c02",
+        name="InvalidOutputToken",
+        description="",
+        params=("address", "address"),
+    ),
+    "0xa8c278dd": GmxError(
+        selector="0xa8c278dd",
+        name="InvalidParams",
+        description="",
+        params=("string",),
+    ),
+    "0x3c0ac199": GmxError(
+        selector="0x3c0ac199",
+        name="InvalidPermitSpender",
+        description="",
+        params=("address", "address"),
+    ),
+    "0xadaa688d": GmxError(
+        selector="0xadaa688d",
+        name="InvalidPoolValueForDeposit",
+        description="",
+        params=("int256",),
+    ),
+    "0x90a6af3b": GmxError(
+        selector="0x90a6af3b",
+        name="InvalidPoolValueForWithdrawal",
+        description="",
+        params=("int256",),
+    ),
+    "0x15a1e249": GmxError(
+        selector="0x15a1e249",
+        name="InvalidPositionImpactPoolDistributionRate",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x182e30e3": GmxError(
+        selector="0x182e30e3",
+        name="InvalidPositionMarket",
+        description="The market is invalid for the position",
+        params=("address",),
+    ),
+    "0xbff65b3f": GmxError(
+        selector="0xbff65b3f",
+        name="InvalidPositionSizeValues",
+        description="Position size and collateral are inconsistent (e.g. size != 0 with zero collateral)",
+        params=("uint256", "uint256"),
+    ),
+    "0x663de023": GmxError(
+        selector="0x663de023",
+        name="InvalidPrimaryPricesForSimulation",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x9cfea583": GmxError(
+        selector="0x9cfea583",
+        name="InvalidReceiver",
+        description="",
+        params=("address",),
+    ),
+    "0x77e8e698": GmxError(
+        selector="0x77e8e698",
+        name="InvalidReceiverForFirstDeposit",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x6eedac2f": GmxError(
+        selector="0x6eedac2f",
+        name="InvalidReceiverForFirstGlvDeposit",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x4baab816": GmxError(
+        selector="0x4baab816",
+        name="InvalidReceiverForSubaccountOrder",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x2416afa9": GmxError(
+        selector="0x2416afa9",
+        name="InvalidRecoveredSigner",
+        description="",
+        params=("string", "address", "address", "address"),
+    ),
+    "0xbfb09088": GmxError(
+        selector="0xbfb09088",
+        name="InvalidReferralRewardToken",
+        description="",
+        params=("address",),
+    ),
+    "0x530b2590": GmxError(
+        selector="0x530b2590",
+        name="InvalidSetContributorPaymentInput",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x29a93dc4": GmxError(
+        selector="0x29a93dc4",
+        name="InvalidSetMaxTotalContributorTokenAmountInput",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x2a34f7fe": GmxError(
+        selector="0x2a34f7fe",
+        name="InvalidSignature",
+        description="",
+        params=("string",),
+    ),
+    "0x720bb461": GmxError(
+        selector="0x720bb461",
+        name="InvalidSizeDeltaForAdl",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x2c9bcbdd": GmxError(
+        selector="0x2c9bcbdd",
+        name="InvalidSrcChainId",
+        description="",
+        params=("uint256",),
+    ),
+    "0x7db6c745": GmxError(
+        selector="0x7db6c745",
+        name="InvalidSubaccountApprovalDesChainId",
+        description="",
+        params=("uint256",),
+    ),
+    "0x3044992f": GmxError(
+        selector="0x3044992f",
+        name="InvalidSubaccountApprovalNonce",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x545e8f2b": GmxError(
+        selector="0x545e8f2b",
+        name="InvalidSubaccountApprovalSubaccount",
+        description="",
+        params=(),
+    ),
+    "0xcb9bd134": GmxError(
+        selector="0xcb9bd134",
+        name="InvalidSwapMarket",
+        description="",
+        params=("address",),
+    ),
+    "0x6ba3dd8b": GmxError(
+        selector="0x6ba3dd8b",
+        name="InvalidSwapOutputToken",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x672e4fba": GmxError(
+        selector="0x672e4fba",
+        name="InvalidSwapPathForV1",
+        description="",
+        params=("address[]", "address"),
+    ),
+    "0xe6b0ddb6": GmxError(
+        selector="0xe6b0ddb6",
+        name="InvalidTimelockDelay",
+        description="",
+        params=("uint256",),
+    ),
+    "0x961c9a4f": GmxError(
+        selector="0x961c9a4f",
+        name="InvalidToken",
+        description="",
+        params=("address",),
+    ),
+    "0x53f81711": GmxError(
+        selector="0x53f81711",
+        name="InvalidTokenIn",
+        description="Swap input token is invalid for the chosen market",
+        params=("address", "address"),
+    ),
+    "0xb0731c3f": GmxError(
+        selector="0xb0731c3f",
+        name="InvalidTransferRequestsLength",
+        description="",
+        params=(),
+    ),
+    "0x9e5d5cf3": GmxError(
+        selector="0x9e5d5cf3",
+        name="InvalidTrustedSignerAddress",
+        description="",
+        params=(),
+    ),
+    "0x81468139": GmxError(
+        selector="0x81468139",
+        name="InvalidUiFeeFactor",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x1041c08a": GmxError(
+        selector="0x1041c08a",
+        name="InvalidUserDigest",
+        description="",
+        params=("bytes32",),
+    ),
+    "0x1de2bca4": GmxError(
+        selector="0x1de2bca4",
+        name="InvalidVersion",
+        description="",
+        params=("uint256",),
+    ),
+    "0x32aedc9f": GmxError(
+        selector="0x32aedc9f",
+        name="JitEmptyShiftParams",
+        description="",
+        params=(),
+    ),
+    "0xf5489e5e": GmxError(
+        selector="0xf5489e5e",
+        name="JitInvalidToMarket",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x262be6a6": GmxError(
+        selector="0x262be6a6",
+        name="JitUnsupportedOrderType",
+        description="",
+        params=("uint256",),
+    ),
+    "0x088e379a": GmxError(
+        selector="0x088e379a",
+        name="KeeperAmountMismatch",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x1f983722": GmxError(
+        selector="0x1f983722",
+        name="KeeperArrayLengthMismatch",
+        description="",
+        params=("uint256", "uint256", "uint256"),
+    ),
+    "0xbc121108": GmxError(
+        selector="0xbc121108",
+        name="LiquidatablePosition",
+        description="Position is liquidatable",
+        params=("string", "int256", "int256", "int256"),
+    ),
+    "0xa38dfb2a": GmxError(
+        selector="0xa38dfb2a",
+        name="LongTokensAreNotEqual",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x25e34fa1": GmxError(
+        selector="0x25e34fa1",
+        name="MarketAlreadyExists",
+        description="",
+        params=("bytes32", "address"),
+    ),
+    "0x6918f9bf": GmxError(
+        selector="0x6918f9bf",
+        name="MarketNotFound",
+        description="",
+        params=("address",),
+    ),
+    "0x143e2156": GmxError(
+        selector="0x143e2156",
+        name="MaskIndexOutOfBounds",
+        description="",
+        params=("uint256", "string"),
+    ),
+    "0xf0794a60": GmxError(
+        selector="0xf0794a60",
+        name="MaxAutoCancelOrdersExceeded",
+        description="Too many auto-cancel orders attached to this position",
+        params=("uint256", "uint256"),
+    ),
+    "0x4e3f62a8": GmxError(
+        selector="0x4e3f62a8",
+        name="MaxBuybackPriceAgeExceeded",
+        description="",
+        params=("uint256", "uint256", "uint256"),
+    ),
+    "0x10aeb692": GmxError(
+        selector="0x10aeb692",
+        name="MaxCallbackGasLimitExceeded",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xd1a942ab": GmxError(
+        selector="0xd1a942ab",
+        name="MaxCollateralSumExceeded",
+        description="Maximum collateral sum exceeded for this market",
+        params=("uint256", "uint256"),
+    ),
+    "0xa0629236": GmxError(
+        selector="0xa0629236",
+        name="MaxDataListLengthExceeded",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xb96d6372": GmxError(
+        selector="0xb96d6372",
+        name="MaxEsGmxReferralRewardsAmountExceeded",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x4f82a998": GmxError(
+        selector="0x4f82a998",
+        name="MaxFundingFactorPerSecondLimitExceeded",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xca42750e": GmxError(
+        selector="0xca42750e",
+        name="MaxLendableFactorForWithdrawalsExceeded",
+        description="",
+        params=("uint256", "uint256", "uint256"),
+    ),
+    "0x2bf127cf": GmxError(
+        selector="0x2bf127cf",
+        name="MaxOpenInterestExceeded",
+        description="Maximum total open interest exceeded for this market",
+        params=("uint256", "uint256"),
+    ),
+    "0xdd9c6b9a": GmxError(
+        selector="0xdd9c6b9a",
+        name="MaxOracleTimestampRangeExceeded",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x6429ff3f": GmxError(
+        selector="0x6429ff3f",
+        name="MaxPoolAmountExceeded",
+        description="Pool amount cap exceeded",
+        params=("uint256", "uint256"),
+    ),
+    "0x46169f04": GmxError(
+        selector="0x46169f04",
+        name="MaxPoolUsdForDepositExceeded",
+        description="Pool USD cap for deposits exceeded",
+        params=("uint256", "uint256"),
+    ),
+    "0x2b6e7c3f": GmxError(
+        selector="0x2b6e7c3f",
+        name="MaxPriceAgeExceeded",
+        description="Oracle price is too stale to be used",
+        params=("uint256", "uint256"),
+    ),
+    "0x3d1986f7": GmxError(
+        selector="0x3d1986f7",
+        name="MaxRefPriceDeviationExceeded",
+        description="",
+        params=("address", "uint256", "uint256", "uint256"),
+    ),
+    "0xc1fa6843": GmxError(
+        selector="0xc1fa6843",
+        name="MaxReferralRewardsExceeded",
+        description="",
+        params=("address", "uint256", "uint256"),
+    ),
+    "0xc0471bf8": GmxError(
+        selector="0xc0471bf8",
+        name="MaxRelayFeeSwapForSubaccountExceeded",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x519ba753": GmxError(
+        selector="0x519ba753",
+        name="MaxSubaccountActionCountExceeded",
+        description="",
+        params=("address", "address", "uint256", "uint256"),
+    ),
+    "0x9da36043": GmxError(
+        selector="0x9da36043",
+        name="MaxSwapPathLengthExceeded",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xfaf66f0c": GmxError(
+        selector="0xfaf66f0c",
+        name="MaxTimelockDelayExceeded",
+        description="",
+        params=("uint256",),
+    ),
+    "0xc10ceac7": GmxError(
+        selector="0xc10ceac7",
+        name="MaxTotalCallbackGasLimitForAutoCancelOrdersExceeded",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x043038f0": GmxError(
+        selector="0x043038f0",
+        name="MaxTotalContributorTokenAmountExceeded",
+        description="",
+        params=("address", "uint256", "uint256"),
+    ),
+    "0x89a90794": GmxError(
+        selector="0x89a90794",
+        name="MaxWntFromTreasuryExceeded",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xe6685115": GmxError(
+        selector="0xe6685115",
+        name="MaxWntReferralRewardsInUsdAmountExceeded",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x30ae0954": GmxError(
+        selector="0x30ae0954",
+        name="MaxWntReferralRewardsInUsdExceeded",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x961b4025": GmxError(
+        selector="0x961b4025",
+        name="MinContributorPaymentIntervalBelowAllowedRange",
+        description="",
+        params=("uint256",),
+    ),
+    "0xb9dc7b9d": GmxError(
+        selector="0xb9dc7b9d",
+        name="MinContributorPaymentIntervalNotYetPassed",
+        description="",
+        params=("uint256",),
+    ),
+    "0x966fea10": GmxError(
+        selector="0x966fea10",
+        name="MinGlvTokens",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xf442c0bc": GmxError(
+        selector="0xf442c0bc",
+        name="MinLongTokens",
+        description="Received long tokens below the minimum acceptable",
+        params=("uint256", "uint256"),
+    ),
+    "0x6ce23460": GmxError(
+        selector="0x6ce23460",
+        name="MinMarketTokens",
+        description="Received market tokens below the minimum acceptable",
+        params=("uint256", "uint256"),
+    ),
+    "0x85efb31a": GmxError(
+        selector="0x85efb31a",
+        name="MinPositionSize",
+        description="Position size delta is below the minimum allowed",
+        params=("uint256", "uint256"),
+    ),
+    "0xb4a196af": GmxError(
+        selector="0xb4a196af",
+        name="MinShortTokens",
+        description="Received short tokens below the minimum acceptable",
+        params=("uint256", "uint256"),
+    ),
+    "0xcc32db99": GmxError(
+        selector="0xcc32db99",
+        name="NegativeExecutionPrice",
+        description="Computed execution price went negative (price impact too large)",
+        params=("int256", "uint256", "uint256", "int256", "uint256"),
+    ),
+    "0x53410c43": GmxError(
+        selector="0x53410c43",
+        name="NonAtomicOracleProvider",
+        description="",
+        params=("address",),
+    ),
+    "0x28f773e9": GmxError(
+        selector="0x28f773e9",
+        name="NonEmptyExternalCallsForSubaccountOrder",
+        description="",
+        params=(),
+    ),
+    "0xef2df9b5": GmxError(
+        selector="0xef2df9b5",
+        name="NonEmptyTokensWithPrices",
+        description="",
+        params=("uint256",),
+    ),
+    "0x730293fd": GmxError(
+        selector="0x730293fd",
+        name="OpenInterestCannotBeUpdatedForSwapOnlyMarket",
+        description="",
+        params=("address",),
+    ),
+    "0x48afc38e": GmxError(
+        selector="0x48afc38e",
+        name="OraclePriceOutdated",
+        description="",
+        params=(),
+    ),
+    "0xa6013d30": GmxError(
+        selector="0xa6013d30",
+        name="OracleProviderAlreadyExistsForToken",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x73f9981d": GmxError(
+        selector="0x73f9981d",
+        name="OracleProviderMinChangeDelayNotYetPassed",
+        description="",
+        params=("address", "address"),
+    ),
+    "0xd84b8ee8": GmxError(
+        selector="0xd84b8ee8",
+        name="OracleTimestampsAreLargerThanRequestExpirationTime",
+        description="",
+        params=("uint256", "uint256", "uint256"),
+    ),
+    "0x7d677abf": GmxError(
+        selector="0x7d677abf",
+        name="OracleTimestampsAreSmallerThanRequired",
+        description="Oracle timestamps are older than the required floor",
+        params=("uint256", "uint256"),
+    ),
+    "0x730d44b1": GmxError(
+        selector="0x730d44b1",
+        name="OrderAlreadyFrozen",
+        description="The order is already in the frozen state",
+        params=(),
+    ),
+    "0x59485ed9": GmxError(
+        selector="0x59485ed9",
+        name="OrderNotFound",
+        description="No order found for the given key",
+        params=("bytes32",),
+    ),
+    "0xe09ad0e9": GmxError(
+        selector="0xe09ad0e9",
+        name="OrderNotFulfillableAtAcceptablePrice",
+        description="Execution price exceeds the acceptable price slippage bound",
+        params=("uint256", "uint256"),
+    ),
+    "0x9aba92cb": GmxError(
+        selector="0x9aba92cb",
+        name="OrderNotUpdatable",
+        description="",
+        params=("uint256",),
+    ),
+    "0x8a4bd513": GmxError(
+        selector="0x8a4bd513",
+        name="OrderTypeCannotBeCreated",
+        description="",
+        params=("uint256",),
+    ),
+    "0xcf9319d6": GmxError(
+        selector="0xcf9319d6",
+        name="OrderValidFromTimeNotReached",
+        description="Order validFrom timestamp has not been reached yet",
+        params=("uint256", "uint256"),
+    ),
+    "0xef84cb99": GmxError(
+        selector="0xef84cb99",
+        name="OutdatedReadResponse",
+        description="",
+        params=("uint256",),
+    ),
+    "0xb92fb250": GmxError(
+        selector="0xb92fb250",
+        name="PnlFactorExceededForLongs",
+        description="",
+        params=("int256", "uint256"),
+    ),
+    "0xb0010694": GmxError(
+        selector="0xb0010694",
+        name="PnlFactorExceededForShorts",
+        description="",
+        params=("int256", "uint256"),
+    ),
+    "0x9f0bc7de": GmxError(
+        selector="0x9f0bc7de",
+        name="PnlOvercorrected",
+        description="",
+        params=("int256", "uint256"),
+    ),
+    "0x426cfff0": GmxError(
+        selector="0x426cfff0",
+        name="PositionNotFound",
+        description="No position found for the given key",
+        params=("bytes32",),
+    ),
+    "0xee919dd9": GmxError(
+        selector="0xee919dd9",
+        name="PositionShouldNotBeLiquidated",
+        description="Position should not be liquidated",
+        params=("string", "int256", "int256", "int256"),
+    ),
+    "0xded099de": GmxError(
+        selector="0xded099de",
+        name="PriceAlreadySet",
+        description="",
+        params=("address", "uint256", "uint256"),
+    ),
+    "0xd4141298": GmxError(
+        selector="0xd4141298",
+        name="PriceFeedAlreadyExistsForToken",
+        description="",
+        params=("address",),
+    ),
+    "0xf0641c92": GmxError(
+        selector="0xf0641c92",
+        name="PriceImpactLargerThanOrderSize",
+        description="Price impact exceeds the order size",
+        params=("int256", "uint256"),
+    ),
+    "0xeef4e171": GmxError(
+        selector="0xeef4e171",
+        name="ReductionExceedsLentAmount",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x519e91bb": GmxError(
+        selector="0x519e91bb",
+        name="ReferralCodeAlreadyExists",
+        description="",
+        params=("bytes32",),
+    ),
+    "0xb09ace9a": GmxError(
+        selector="0xb09ace9a",
+        name="RelayCalldataTooLong",
+        description="",
+        params=("uint256",),
+    ),
+    "0x25eeb47a": GmxError(
+        selector="0x25eeb47a",
+        name="RelayEmptyBatch",
+        description="",
+        params=(),
+    ),
+    "0x7290c82f": GmxError(
+        selector="0x7290c82f",
+        name="RemovalShouldNotBeSkipped",
+        description="",
+        params=("bytes32", "bytes32"),
+    ),
+    "0xe8266438": GmxError(
+        selector="0xe8266438",
+        name="RequestNotYetCancellable",
+        description="",
+        params=("uint256", "uint256", "string"),
+    ),
+    "0xe70f9152": GmxError(
+        selector="0xe70f9152",
+        name="SelfTransferNotSupported",
+        description="",
+        params=("address",),
+    ),
+    "0xf0b8da75": GmxError(
+        selector="0xf0b8da75",
+        name="SendEthToKeeperFailed",
+        description="",
+        params=("address", "uint256", "bytes"),
+    ),
+    "0x032b3d00": GmxError(
+        selector="0x032b3d00",
+        name="SequencerDown",
+        description="",
+        params=(),
+    ),
+    "0x113cfc03": GmxError(
+        selector="0x113cfc03",
+        name="SequencerGraceDurationNotYetPassed",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x950227bb": GmxError(
+        selector="0x950227bb",
+        name="ShiftFromAndToMarketAreEqual",
+        description="",
+        params=("address",),
+    ),
+    "0xb611f297": GmxError(
+        selector="0xb611f297",
+        name="ShiftNotFound",
+        description="",
+        params=("bytes32",),
+    ),
+    "0xf54d8776": GmxError(
+        selector="0xf54d8776",
+        name="ShortTokensAreNotEqual",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x20b23584": GmxError(
+        selector="0x20b23584",
+        name="SignalTimeNotYetPassed",
+        description="",
+        params=("uint256",),
+    ),
+    "0x26025b4e": GmxError(
+        selector="0x26025b4e",
+        name="SubaccountApprovalDeadlinePassed",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x9b539f07": GmxError(
+        selector="0x9b539f07",
+        name="SubaccountApprovalExpired",
+        description="",
+        params=("address", "address", "uint256", "uint256"),
+    ),
+    "0x34e5c9e2": GmxError(
+        selector="0x34e5c9e2",
+        name="SubaccountIntegrationIdDisabled",
+        description="",
+        params=("bytes32",),
+    ),
+    "0x9be0a43c": GmxError(
+        selector="0x9be0a43c",
+        name="SubaccountNotAuthorized",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x75885d69": GmxError(
+        selector="0x75885d69",
+        name="SwapPriceImpactExceedsAmountIn",
+        description="Swap price impact exceeds the input amount",
+        params=("uint256", "int256"),
+    ),
+    "0xd2e229e6": GmxError(
+        selector="0xd2e229e6",
+        name="SwapsNotAllowedForAtomicWithdrawal",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x7bf8d2b3": GmxError(
+        selector="0x7bf8d2b3",
+        name="SyncConfigInvalidInputLengths",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0x624b5b13": GmxError(
+        selector="0x624b5b13",
+        name="SyncConfigInvalidMarketFromData",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x8b3d4655": GmxError(
+        selector="0x8b3d4655",
+        name="SyncConfigUpdatesDisabledForMarket",
+        description="",
+        params=("address",),
+    ),
+    "0x0798d283": GmxError(
+        selector="0x0798d283",
+        name="SyncConfigUpdatesDisabledForMarketParameter",
+        description="",
+        params=("address", "string"),
+    ),
+    "0x8ea7eb18": GmxError(
+        selector="0x8ea7eb18",
+        name="SyncConfigUpdatesDisabledForParameter",
+        description="",
+        params=("string",),
+    ),
+    "0xb783c88a": GmxError(
+        selector="0xb783c88a",
+        name="ThereMustBeAtLeastOneRoleAdmin",
+        description="",
+        params=(),
+    ),
+    "0x282b5b70": GmxError(
+        selector="0x282b5b70",
+        name="ThereMustBeAtLeastOneTimelockMultiSig",
+        description="",
+        params=(),
+    ),
+    "0x7344d981": GmxError(
+        selector="0x7344d981",
+        name="TokenPermitsNotAllowedForMultichain",
+        description="",
+        params=(),
+    ),
+    "0x979dc780": GmxError(
+        selector="0x979dc780",
+        name="TokenTransferError",
+        description="",
+        params=("address", "address", "uint256"),
+    ),
+    "0x0e92b837": GmxError(
+        selector="0x0e92b837",
+        name="Uint256AsBytesLengthExceeds32Bytes",
+        description="",
+        params=("uint256",),
+    ),
+    "0x6afad778": GmxError(
+        selector="0x6afad778",
+        name="UnableToGetBorrowingFactorEmptyPoolUsd",
+        description="",
+        params=(),
+    ),
+    "0xbe4729a2": GmxError(
+        selector="0xbe4729a2",
+        name="UnableToGetCachedTokenPrice",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x11423d95": GmxError(
+        selector="0x11423d95",
+        name="UnableToGetFundingFactorEmptyOpenInterest",
+        description="",
+        params=(),
+    ),
+    "0x7a0ca681": GmxError(
+        selector="0x7a0ca681",
+        name="UnableToGetOppositeToken",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x68fb0fed": GmxError(
+        selector="0x68fb0fed",
+        name="UnableToPayOrderFee",
+        description="",
+        params=(),
+    ),
+    "0xde27e626": GmxError(
+        selector="0xde27e626",
+        name="UnableToPayOrderFeeFromCollateral",
+        description="",
+        params=(),
+    ),
+    "0x3a61a4a9": GmxError(
+        selector="0x3a61a4a9",
+        name="UnableToWithdrawCollateral",
+        description="Cannot withdraw the requested collateral amount",
+        params=("int256",),
+    ),
+    "0xa35b150b": GmxError(
+        selector="0xa35b150b",
+        name="Unauthorized",
+        description="Caller is not authorized to perform this action",
+        params=("address", "string"),
+    ),
+    "0x99b2d582": GmxError(
+        selector="0x99b2d582",
+        name="UnexpectedBorrowingFactor",
+        description="",
+        params=("uint256", "uint256"),
+    ),
+    "0xcc3459ff": GmxError(
+        selector="0xcc3459ff",
+        name="UnexpectedMarket",
+        description="",
+        params=(),
+    ),
+    "0x3b42e952": GmxError(
+        selector="0x3b42e952",
+        name="UnexpectedPoolValue",
+        description="",
+        params=("int256",),
+    ),
+    "0x814991c3": GmxError(
+        selector="0x814991c3",
+        name="UnexpectedPositionState",
+        description="",
+        params=(),
+    ),
+    "0xe949114e": GmxError(
+        selector="0xe949114e",
+        name="UnexpectedRelayFeeToken",
+        description="",
+        params=("address", "address"),
+    ),
+    "0xa9721241": GmxError(
+        selector="0xa9721241",
+        name="UnexpectedRelayFeeTokenAfterSwap",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x785ee469": GmxError(
+        selector="0x785ee469",
+        name="UnexpectedTokenForVirtualInventory",
+        description="",
+        params=("address", "address"),
+    ),
+    "0x3af14617": GmxError(
+        selector="0x3af14617",
+        name="UnexpectedValidFromTime",
+        description="",
+        params=("uint256",),
+    ),
+    "0x3784f834": GmxError(
+        selector="0x3784f834",
+        name="UnsupportedOrderType",
+        description="Order type is not supported",
+        params=("uint256",),
+    ),
+    "0x31f47690": GmxError(
+        selector="0x31f47690",
+        name="UnsupportedOrderTypeForAutoCancellation",
+        description="",
+        params=("uint256",),
+    ),
+    "0x0d0fcc0b": GmxError(
+        selector="0x0d0fcc0b",
+        name="UnsupportedRelayFeeToken",
+        description="",
+        params=("address", "address"),
+    ),
+    "0xeadaf93a": GmxError(
+        selector="0xeadaf93a",
+        name="UsdDeltaExceedsLongOpenInterest",
+        description="",
+        params=("int256", "uint256"),
+    ),
+    "0x2e949409": GmxError(
+        selector="0x2e949409",
+        name="UsdDeltaExceedsPoolValue",
+        description="",
+        params=("int256", "uint256"),
+    ),
+    "0x8af0d140": GmxError(
+        selector="0x8af0d140",
+        name="UsdDeltaExceedsShortOpenInterest",
+        description="",
+        params=("int256", "uint256"),
+    ),
+    "0x60737bc0": GmxError(
+        selector="0x60737bc0",
+        name="WithdrawalNotFound",
+        description="",
+        params=("bytes32",),
+    ),
+    "0xa3b900da": GmxError(
+        selector="0xa3b900da",
+        name="ZeroTreasuryAddress",
+        description="",
+        params=(),
+    ),
+}
+
+
+def decode_gmx_revert_selector(selector: str | None) -> GmxError | None:
+    """Decode a 4-byte GMX V2 revert selector to its named error.
+
+    Looks up the 4-byte selector in :data:`_GMX_ERROR_REGISTRY` and returns
+    the matching :class:`GmxError`. The input may be either:
+
+    * A bare selector hex string with or without ``0x`` prefix
+      (``"0x839c693e"``, ``"839c693e"``).
+    * A longer revert-data hex string — only the first 4 bytes after the
+      optional ``0x`` are inspected (the rest is ABI-encoded parameters).
+    * Mixed case (``"0x839C693E"``) — input is lower-cased before lookup.
+
+    :param selector: 4-byte hex string, case-insensitive. May also be a
+        longer revert-data hex string; only the first 4 bytes after the
+        optional ``0x`` are inspected.
+    :returns: :class:`GmxError` if the selector is known; ``None`` for any
+        unknown / falsy / malformed input.
+    """
+    if not selector:
+        return None
+    s = selector.lower()
+    if s.startswith("0x"):
+        s = s[2:]
+    if len(s) < 8:
+        return None
+    return _GMX_ERROR_REGISTRY.get("0x" + s[:8])
+
+
+__all__ = ["GmxError", "decode_gmx_revert_selector"]

--- a/tests/gmx/ccxt/test_close_order_full_close.py
+++ b/tests/gmx/ccxt/test_close_order_full_close.py
@@ -1,0 +1,218 @@
+"""Tests for :func:`eth_defi.gmx.ccxt.exchange._resolve_close_order_filled_amount`.
+
+The helper decides what value the GMX adapter reports in the close-order
+CCXT response's ``filled`` and ``amount`` fields. Prior to its introduction,
+the sync adapter returned ``size_delta_usd / execution_price`` — a
+token-derived value computed from the on-chain execution. On a FULL close,
+that value differs from the Freqtrade-requested ``amount`` by a few wei
+because GMX price impact + ``sizeInTokens`` rounding shift the on-chain
+fill price slightly relative to the signal price.
+
+Freqtrade's :func:`freqtrade.persistence.trade_model.Trade.update_trade`
+(at ``trade_model.py:926-936``) uses ``isclose(filled, amount, abs_tol=1e-14)``
+to decide partial-vs-full. The token-derived gap blows that tolerance →
+Freqtrade flagged the successful full close as a PARTIAL fill, kept the
+``Trade`` row open with a tiny residual base amount, and re-fired the exit
+signal on the next bot loop. Live evidence: LINK trade #8 on 2026-05-22
+closed at 01:37 for 0.30608767 LINK then again at 01:43 for 0.00107856 LINK
+dust via the 6-minute Subsquid event-scanner retry path.
+
+These tests pin both halves of the contract:
+
+1. Full close (requested ≥ 99.5% × actual) ⇒ helper returns the
+   Freqtrade-requested amount (``params['sub_trade_amt']`` or ``amount``).
+   Keeps ``filled == amount`` exactly so ``update_trade`` sees a full fill.
+2. Partial close (requested < 99.5% × actual) ⇒ helper returns the
+   token-derived ``size_delta_usd / execution_price``. Preserves the
+   pre-existing wallet-sync behaviour that avoids
+   "Wallet shows X but trade has Y" warnings for partial closes where
+   Freqtrade actually needs the accurate base-currency delta.
+
+This is a complement to :func:`_resolve_reduce_only_size_delta_usd` (sized
+on entry to ``create_order``) — that helper fixes the *sizing*, this one
+fixes the *reporting*. Both are required for correct same-pair NT-HEDGING
+parity behaviour shipped in ``feat/orchestrator-live-independent-same-pair``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from eth_defi.gmx.ccxt.exchange import _resolve_close_order_filled_amount
+
+
+def _position(size_usd: float) -> dict:
+    """Build a ``GetOpenPositions``-shaped dict with both float and raw uint256 size."""
+    return {
+        "position_size": size_usd,
+        "position_size_usd_raw": int(size_usd * 10**30),
+    }
+
+
+def test_full_close_returns_requested_amount_not_token_derived() -> None:
+    """Full close (requested ≥ 99.5% × actual) returns the FT-requested amount.
+
+    Live LINK trade #8 reproducer: Freqtrade requested ``amount = 0.30716623``
+    LINK, GMX executed at a slightly different price → ``size_delta_usd /
+    execution_price = 0.30608767``. The few-wei gap (~0.00108) exceeded
+    ``isclose(..., abs_tol=1e-14)`` → Freqtrade treated the full close as
+    partial → 6-minute dust-retry storm. Post-fix the helper returns
+    0.30716623 so ``filled == amount`` exactly.
+    """
+    actual_position = _position(1000.0)  # $1000 LINK position
+
+    # Freqtrade asks to close the full position.
+    requested_amount = 0.30716623
+    size_delta_usd = 999.5  # actual on-chain ≈ 99.95% of $1000 → full-close
+    execution_price = 3.2667  # produces token-derived 0.30608767 (different from requested)
+
+    filled = _resolve_close_order_filled_amount(
+        requested_amount=requested_amount,
+        size_delta_usd=size_delta_usd,
+        execution_price=execution_price,
+        gmx_position=actual_position,
+    )
+
+    token_derived = size_delta_usd / execution_price
+    assert filled == requested_amount
+    assert filled != token_derived, (
+        f"Full-close path must return requested amount ({requested_amount}), "
+        f"not the token-derived value ({token_derived})"
+    )
+
+
+def test_partial_close_returns_token_derived_amount() -> None:
+    """Partial close (requested < 99.5% × actual) returns token-derived value.
+
+    Preserves the historical wallet-sync behaviour that avoids the
+    "Wallet shows X but trade has Y" warning when Freqtrade needs the
+    accurate base-currency delta for a logical partial exit.
+    """
+    actual_position = _position(3000.0)  # $3000 position
+
+    # Freqtrade asks to close ~1/3 of the position.
+    requested_amount = 0.30716623  # what Freqtrade thinks based on signal price
+    size_delta_usd = 1000.0  # ~33% of $3000 → well below 99.5% tolerance
+    execution_price = 3.2667
+    token_derived = size_delta_usd / execution_price  # 306.16 / 1000 ≈ 0.30612
+
+    filled = _resolve_close_order_filled_amount(
+        requested_amount=requested_amount,
+        size_delta_usd=size_delta_usd,
+        execution_price=execution_price,
+        gmx_position=actual_position,
+    )
+
+    assert filled == pytest.approx(token_derived, rel=1e-12)
+    assert filled != requested_amount
+
+
+def test_boundary_at_995_pct_uses_full_close_path() -> None:
+    """At exactly the 99.5% tolerance threshold, behave as full close."""
+    actual_position = _position(1000.0)
+
+    requested_amount = 0.30716623
+    size_delta_usd = 995.0  # exactly 99.5% — full-close path
+    execution_price = 3.2667
+
+    filled = _resolve_close_order_filled_amount(
+        requested_amount=requested_amount,
+        size_delta_usd=size_delta_usd,
+        execution_price=execution_price,
+        gmx_position=actual_position,
+    )
+
+    assert filled == requested_amount
+
+
+def test_just_under_995_pct_uses_partial_close_path() -> None:
+    """One dollar below the threshold stays in partial-close (token-derived) path."""
+    actual_position = _position(1000.0)
+
+    requested_amount = 0.30716623
+    size_delta_usd = 994.0  # 99.4% — under tolerance
+    execution_price = 3.2667
+    token_derived = size_delta_usd / execution_price
+
+    filled = _resolve_close_order_filled_amount(
+        requested_amount=requested_amount,
+        size_delta_usd=size_delta_usd,
+        execution_price=execution_price,
+        gmx_position=actual_position,
+    )
+
+    assert filled == pytest.approx(token_derived, rel=1e-12)
+
+
+def test_missing_gmx_position_falls_back_to_requested_amount() -> None:
+    """When ``gmx_position`` is None, fall back to requested amount.
+
+    The close path always tries to fetch the position before this code
+    executes; when the position has already been closed by stop-loss /
+    keeper / Subsquid fallback, the position dict may be ``None``. In
+    that case the on-chain decrease has already happened — Freqtrade's
+    requested amount is the correct reportable value.
+    """
+    filled = _resolve_close_order_filled_amount(
+        requested_amount=0.30716623,
+        size_delta_usd=1000.0,
+        execution_price=3.2667,
+        gmx_position=None,
+    )
+
+    assert filled == 0.30716623
+
+
+def test_zero_position_size_falls_back_to_requested_amount() -> None:
+    """``position_size <= 0`` means there's no live position to compare against."""
+    invalid_position = {"position_size": 0.0, "position_size_usd_raw": 0}
+
+    filled = _resolve_close_order_filled_amount(
+        requested_amount=0.30716623,
+        size_delta_usd=1000.0,
+        execution_price=3.2667,
+        gmx_position=invalid_position,
+    )
+
+    assert filled == 0.30716623
+
+
+def test_missing_execution_price_falls_back_to_requested_amount() -> None:
+    """No execution_price → no token-derived value possible → return requested."""
+    actual_position = _position(1000.0)
+
+    filled = _resolve_close_order_filled_amount(
+        requested_amount=0.30716623,
+        size_delta_usd=1000.0,
+        execution_price=None,
+        gmx_position=actual_position,
+    )
+
+    assert filled == 0.30716623
+
+
+def test_missing_size_delta_usd_falls_back_to_requested_amount() -> None:
+    """No size_delta_usd → no token-derived value possible → return requested."""
+    actual_position = _position(1000.0)
+
+    filled = _resolve_close_order_filled_amount(
+        requested_amount=0.30716623,
+        size_delta_usd=0.0,
+        execution_price=3.2667,
+        gmx_position=actual_position,
+    )
+
+    assert filled == 0.30716623
+
+
+def test_async_adapter_imports_same_helper() -> None:
+    """Sync/async lockstep — both adapter modules expose the same helper.
+
+    Mirrors the lockstep contract from
+    :func:`test_async_adapter_imports_same_helper` in
+    ``test_reduce_only_sizing.py``. Any future async close path will use
+    identical reporting semantics.
+    """
+    from eth_defi.gmx.ccxt.async_support import exchange as async_exchange
+
+    assert async_exchange._resolve_close_order_filled_amount is _resolve_close_order_filled_amount

--- a/tests/gmx/ccxt/test_reduce_only_sizing.py
+++ b/tests/gmx/ccxt/test_reduce_only_sizing.py
@@ -1,0 +1,189 @@
+"""Tests for :func:`eth_defi.gmx.ccxt.exchange._resolve_reduce_only_size_delta_usd`.
+
+The helper is the load-bearing decision point for reduce-only close sizing.
+Prior to its introduction, the sync adapter substituted the external GMX net
+position size whenever ``params['sub_trade_amt']`` was absent — which made it
+impossible to close a single logical Freqtrade ``Trade`` row when multiple
+trades shared one GMX market position (the NT-HEDGING parity case in
+``feat/orchestrator-live-independent-same-pair`` downstream of this fix).
+
+These tests pin both halves of the contract:
+
+1. Partial requested close ⇒ helper returns the request (capped at actual size
+   by ``min`` for defence in depth).
+2. Effectively-full requested close (≥ 99.5% of actual) ⇒ helper returns the
+   raw uint256 size for dust prevention — preserving the historical behaviour
+   for true full closes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from eth_defi.gmx.ccxt.exchange import _resolve_reduce_only_size_delta_usd
+
+
+def _position(size_usd: float) -> dict:
+    """Build a ``GetOpenPositions`` dict with both float and raw uint256 size."""
+    return {
+        "position_size": size_usd,
+        "position_size_usd_raw": int(size_usd * 10**30),
+    }
+
+
+def test_reduce_only_close_uses_requested_trade_amount_when_less_than_net_position() -> None:
+    """Logical per-trade close (1/3 of the on-chain position) must NOT flatten the position.
+
+    Pre-fix behaviour: with ``sub_trade_amt`` absent, the sync adapter
+    substituted the external net GMX position size — silently flattening
+    sibling logical trades. Post-fix the helper returns the requested amount.
+    """
+    actual_position = _position(3000.0)
+
+    size_delta_usd = _resolve_reduce_only_size_delta_usd(
+        requested_size_usd=1000.0,
+        gmx_position=actual_position,
+    )
+
+    assert size_delta_usd == 1000.0
+    assert size_delta_usd != actual_position["position_size_usd_raw"]
+    assert size_delta_usd != actual_position["position_size"]
+
+
+def test_reduce_only_close_uses_raw_position_size_when_request_matches_full_position() -> None:
+    """A request within the full-close tolerance band still uses the raw uint256.
+
+    Preserves the historical dust-prevention behaviour: closing the full
+    position via ``Trade.amount`` (which translates to ~100% of actual size)
+    must use the raw int to avoid ``int(float * 10^30)`` overshooting and
+    triggering a GMX ``InvalidDecreaseOrderSize`` revert.
+    """
+    actual_position = _position(3000.0)
+
+    size_delta_usd = _resolve_reduce_only_size_delta_usd(
+        requested_size_usd=2999.0,  # 99.97% — well above default 0.995 tolerance
+        gmx_position=actual_position,
+    )
+
+    assert size_delta_usd == actual_position["position_size_usd_raw"]
+    assert isinstance(size_delta_usd, int)
+
+
+def test_reduce_only_close_exactly_full_request_returns_raw_int() -> None:
+    """Requesting exactly the actual position size returns the raw uint256."""
+    actual_position = _position(3000.0)
+
+    size_delta_usd = _resolve_reduce_only_size_delta_usd(
+        requested_size_usd=3000.0,
+        gmx_position=actual_position,
+    )
+
+    assert size_delta_usd == actual_position["position_size_usd_raw"]
+
+
+def test_reduce_only_close_request_above_actual_caps_at_raw_int() -> None:
+    """Even if the caller over-asks, helper never returns > actual position size.
+
+    A buggy caller passing more than the on-chain size must NOT cause GMX to
+    revert with ``InvalidDecreaseOrderSize`` from float overshoot — the raw
+    int substitution kicks in once the request crosses the tolerance band.
+    """
+    actual_position = _position(3000.0)
+
+    size_delta_usd = _resolve_reduce_only_size_delta_usd(
+        requested_size_usd=4500.0,
+        gmx_position=actual_position,
+    )
+
+    assert size_delta_usd == actual_position["position_size_usd_raw"]
+
+
+def test_reduce_only_close_at_tolerance_boundary_returns_raw_int() -> None:
+    """At exactly the tolerance threshold (default 0.995), behave as full close."""
+    actual_position = _position(3000.0)
+    boundary_request = 3000.0 * 0.995  # 2985.0
+
+    size_delta_usd = _resolve_reduce_only_size_delta_usd(
+        requested_size_usd=boundary_request,
+        gmx_position=actual_position,
+    )
+
+    assert size_delta_usd == actual_position["position_size_usd_raw"]
+
+
+def test_reduce_only_close_just_under_tolerance_returns_requested() -> None:
+    """One bp below the tolerance threshold stays in partial-close path."""
+    actual_position = _position(3000.0)
+    just_below = 3000.0 * 0.995 - 1.0  # 2984.0
+
+    size_delta_usd = _resolve_reduce_only_size_delta_usd(
+        requested_size_usd=just_below,
+        gmx_position=actual_position,
+    )
+
+    assert size_delta_usd == just_below
+    assert isinstance(size_delta_usd, float)
+
+
+def test_reduce_only_close_invalid_position_returns_requested_unchanged() -> None:
+    """``position_size <= 0`` (already closed / invalid) returns request as-is.
+
+    The calling ``create_order`` path will surface the resulting
+    ``InvalidDecreaseOrderSize`` revert if the position really is gone — this
+    helper's job is sizing, not gating.
+    """
+    invalid_position = {"position_size": 0.0, "position_size_usd_raw": 0}
+
+    size_delta_usd = _resolve_reduce_only_size_delta_usd(
+        requested_size_usd=500.0,
+        gmx_position=invalid_position,
+    )
+
+    assert size_delta_usd == 500.0
+
+
+def test_reduce_only_close_missing_raw_uses_float_actual_as_full_close() -> None:
+    """When ``position_size_usd_raw`` is absent, full-close path returns the float.
+
+    Older GMX SDK paths may not populate ``position_size_usd_raw``; the helper
+    must still satisfy the full-close contract using the float field.
+    """
+    legacy_position = {"position_size": 3000.0}  # no _raw field
+
+    size_delta_usd = _resolve_reduce_only_size_delta_usd(
+        requested_size_usd=3000.0,
+        gmx_position=legacy_position,
+    )
+
+    assert size_delta_usd == 3000.0
+
+
+def test_reduce_only_close_custom_tolerance_band() -> None:
+    """The tolerance band is parameterised — tighter band keeps partial-close active longer."""
+    actual_position = _position(3000.0)
+
+    # With default 0.995, a 99% close (2970) would still be partial.
+    size_default = _resolve_reduce_only_size_delta_usd(
+        requested_size_usd=2970.0,
+        gmx_position=actual_position,
+    )
+    assert size_default == 2970.0
+
+    # With a looser 0.95 tolerance, the same request crosses into full-close.
+    size_loose = _resolve_reduce_only_size_delta_usd(
+        requested_size_usd=2970.0,
+        gmx_position=actual_position,
+        full_close_tolerance=0.95,
+    )
+    assert size_loose == actual_position["position_size_usd_raw"]
+
+
+def test_async_adapter_imports_same_helper() -> None:
+    """Sync/async lockstep — both adapter modules expose the same helper.
+
+    The eth_defi.gmx.ccxt.async_support.exchange module must import the same
+    helper so a future async close path uses identical sizing semantics.
+    """
+    from eth_defi.gmx.ccxt.async_support import exchange as async_exchange
+
+    assert async_exchange._resolve_reduce_only_size_delta_usd is _resolve_reduce_only_size_delta_usd

--- a/tests/gmx/test_errors_decoder.py
+++ b/tests/gmx/test_errors_decoder.py
@@ -1,0 +1,206 @@
+"""Unit tests for the GMX V2 custom-error selector decoder.
+
+Covers :func:`eth_defi.gmx.errors.decode_gmx_revert_selector` and the
+integration point in :mod:`eth_defi.gmx.ccxt.exchange` where the decoder
+augments keeper-cancel error messages.
+
+The anchor case is the live 2026-05-22 observation: a BTC long open was
+keeper-cancelled with selector ``0x839c693e`` (= the keccak prefix of
+``InvalidCollateralTokenForMarket(address,address)`` in the
+gmx-synthetics ``Errors.sol``).
+"""
+
+from __future__ import annotations
+
+from eth_utils import keccak
+
+from eth_defi.gmx.errors import (
+    GmxError,
+    _GMX_ERROR_REGISTRY,
+    decode_gmx_revert_selector,
+)
+
+
+# ---------------------------------------------------------------------------
+# decode_gmx_revert_selector — happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_decode_known_selector_invalid_collateral_token():
+    """0x839c693e is the live-observed selector for InvalidCollateralTokenForMarket."""
+    err = decode_gmx_revert_selector("0x839c693e")
+    assert err is not None
+    assert err.name == "InvalidCollateralTokenForMarket"
+    assert err.selector == "0x839c693e"
+    assert err.params == ("address", "address")
+    # Curated description must mention "collateral token" so operators can grep.
+    assert "collateral token" in err.description.lower()
+
+
+def test_decode_handles_long_revert_data():
+    """A real on-chain revert blob has selector + ABI-encoded params.
+
+    The decoder must only inspect the first 4 bytes (8 hex chars after 0x).
+    """
+    # Selector + 2 address params (32 bytes each, ABI-encoded).
+    payload = "0x839c693e" + "00" * 64
+    err = decode_gmx_revert_selector(payload)
+    assert err is not None
+    assert err.name == "InvalidCollateralTokenForMarket"
+
+
+def test_decode_handles_uppercase_input():
+    """Selectors are sometimes uppercased; lookup must be case-insensitive."""
+    err = decode_gmx_revert_selector("0x839C693E")
+    assert err is not None
+    assert err.name == "InvalidCollateralTokenForMarket"
+
+
+def test_decode_handles_missing_prefix():
+    """Selector without leading ``0x`` should still resolve."""
+    err = decode_gmx_revert_selector("839c693e")
+    assert err is not None
+    assert err.name == "InvalidCollateralTokenForMarket"
+
+
+def test_decode_handles_mixed_case_with_long_payload():
+    """Combination of mixed case + ABI payload trailing bytes."""
+    err = decode_gmx_revert_selector("0x839C693E" + "DEADBEEF" * 16)
+    assert err is not None
+    assert err.name == "InvalidCollateralTokenForMarket"
+
+
+# ---------------------------------------------------------------------------
+# decode_gmx_revert_selector — unknown / malformed inputs return None
+# ---------------------------------------------------------------------------
+
+
+def test_decode_unknown_selector_returns_none():
+    """An invented selector must produce ``None`` rather than raising."""
+    assert decode_gmx_revert_selector("0xdeadbeef") is None
+
+
+def test_decode_none_returns_none():
+    """``None`` input must short-circuit to ``None``."""
+    assert decode_gmx_revert_selector(None) is None
+
+
+def test_decode_empty_string_returns_none():
+    """An empty string must produce ``None``."""
+    assert decode_gmx_revert_selector("") is None
+
+
+def test_decode_too_short_returns_none():
+    """A hex string shorter than 4 bytes cannot be a selector."""
+    assert decode_gmx_revert_selector("0x12") is None
+    assert decode_gmx_revert_selector("0x1234") is None  # only 2 bytes
+    assert decode_gmx_revert_selector("12") is None
+
+
+# ---------------------------------------------------------------------------
+# Registry invariants
+# ---------------------------------------------------------------------------
+
+
+def test_registry_has_at_least_20_entries():
+    """Plan acceptance: registry must cover the top ~20 GMX V2 errors.
+
+    The auto-generated registry is sourced from the full Errors.sol so
+    actual size is in the hundreds, but pin the >= 20 floor explicitly.
+    """
+    assert len(_GMX_ERROR_REGISTRY) >= 20
+
+
+def test_registry_keys_are_canonical_4byte_selectors():
+    """Every key must be a lowercase 0x-prefixed 4-byte hex string."""
+    for key in _GMX_ERROR_REGISTRY:
+        assert key.startswith("0x")
+        assert len(key) == 10  # "0x" + 8 hex chars
+        assert key == key.lower()
+        # Body must be valid hex.
+        int(key, 16)
+
+
+def test_registry_values_are_gmx_errors_with_matching_selector():
+    """Every stored ``GmxError`` must agree with its dict key."""
+    for key, value in _GMX_ERROR_REGISTRY.items():
+        assert isinstance(value, GmxError)
+        assert value.selector == key
+        assert value.name  # non-empty
+
+
+def test_anchor_selector_matches_keccak_locally():
+    """Anchor selector is reproducible from keccak — no copy-paste hazard.
+
+    This guards against silently regenerating the registry with a buggy
+    parser: if anyone changes how the selector is computed and forgets to
+    update the registry, this test fails immediately on the known anchor.
+    """
+    sig = "InvalidCollateralTokenForMarket(address,address)"
+    computed = "0x" + keccak(text=sig)[:4].hex()
+    assert computed == "0x839c693e"
+    assert _GMX_ERROR_REGISTRY[computed].name == "InvalidCollateralTokenForMarket"
+
+
+def test_curated_descriptions_cover_operational_errors():
+    """The most operationally-important errors must have descriptions.
+
+    These are the errors operators see daily and need to grep for.
+    """
+    operational_errors = {
+        "InvalidCollateralTokenForMarket",
+        "InsufficientCollateralAmount",
+        "OrderNotFulfillableAtAcceptablePrice",
+        "InsufficientPoolAmount",
+        "MaxOpenInterestExceeded",
+        "DisabledMarket",
+        "InsufficientExecutionFee",
+    }
+    described = {
+        v.name for v in _GMX_ERROR_REGISTRY.values() if v.description
+    }
+    missing = operational_errors - described
+    assert not missing, f"Operational errors missing descriptions: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Integration: adapter exception-message construction
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_keeper_cancel_message_includes_decoded_name():
+    """Mimic the exchange.py keeper-cancel path.
+
+    When the legacy ``decode_error_reason`` returns
+    ``"Unknown error (selector: 0x839c693e)"``, the adapter must upgrade
+    that to a human-readable name+description before raising
+    ``InvalidOrder``.
+    """
+    # Inline the small fragment from exchange.py so the test is hermetic
+    # (no need to spin up the full Exchange class).
+    decoded_error = "Unknown error (selector: 0x839c693e)"
+    if decoded_error and decoded_error.startswith("Unknown error (selector: 0x"):
+        _selector_hex = decoded_error.split("0x", 1)[1].rstrip(")")
+        _named = decode_gmx_revert_selector(_selector_hex)
+        if _named is not None:
+            _desc = f" — {_named.description}" if _named.description else ""
+            decoded_error = f"{_named.name}{_desc} (selector: {_named.selector})"
+
+    assert decoded_error == (
+        "InvalidCollateralTokenForMarket — "
+        "The collateral token is not accepted by this market "
+        "(selector: 0x839c693e)"
+    )
+
+
+def test_adapter_keeper_cancel_message_falls_through_for_unknown_selector():
+    """For an unknown selector the message must be left untouched."""
+    decoded_error = "Unknown error (selector: 0xdeadbeef)"
+    original = decoded_error
+    if decoded_error and decoded_error.startswith("Unknown error (selector: 0x"):
+        _selector_hex = decoded_error.split("0x", 1)[1].rstrip(")")
+        _named = decode_gmx_revert_selector(_selector_hex)
+        if _named is not None:
+            _desc = f" — {_named.description}" if _named.description else ""
+            decoded_error = f"{_named.name}{_desc} (selector: {_named.selector})"
+    assert decoded_error == original


### PR DESCRIPTION
> **Updated 2026-05-22 (post-rebase):** branch rebased onto `master` tip `d422714c` (TokenGateway scan, PR #1031). All 3 commits replayed cleanly with new SHAs; no conflicts; 35/35 GMX tests green post-rebase. SHAs below reflect the rebased branch.

## Update 2026-05-22 — additional commits pushed

The branch now carries **three** related commits, not one. Tip: `9131d842`.

| SHA | Subject | Files | Tests |
|---|---|---|---|
| `10213444` | reduce-only sizing respects requested `Trade.amount` for logical per-trade closes (original PR commit) | sync + async adapter, 1 new helper module | 10 in `tests/gmx/ccxt/test_reduce_only_sizing.py` |
| `dbb075c0` | report `filled = requested amount` on full close to avoid freqtrade residual retry | sync + async adapter, new helper `_resolve_close_order_filled_amount` | 9 in `tests/gmx/ccxt/test_close_order_full_close.py` |
| `9131d842` | decode GMX revert selectors to human-readable error names | sync + async adapter, new `eth_defi/gmx/errors.py` (351 selectors) | 16 in `tests/gmx/test_errors_decoder.py` |

All three commits address downstream NT-HEDGING parity blockers identified during live validation of `tradingstrategy-ai/gmx-strategies` PR #104:

- `10213444` — sibling-flatten on per-trade close (the core bug)
- `dbb075c0` — dust-residual retry on full close (LINK #8 on 2026-05-22: 0.30608767 then 0.00107856 dust 6 min later)
- `9131d842` — opaque keeper-cancel reasons (BTC `0x839c693e` = `InvalidCollateralTokenForMarket`; previously surfaced as "Unknown error (selector: ...)")

### Known follow-ups (post-merge, NOT blocking this PR)

1. **Registry reproducibility (Medium):** `eth_defi/gmx/errors.py` ships 351 selectors as a hand-curated dict. A generator script or a checked-in source snapshot (gmx-io/gmx-synthetics commit hash) would make the mapping reproducible. Tests cover the anchor selector (`0x839c693e`) + dict invariants + curated descriptions but cannot regenerate the full mapping.
2. **Adapter integration tests (Low):** both `dbb075c0` and `9131d842` test the helpers; one mocked adapter-level test per fix would prevent future refactors from bypassing the helper/decoder wiring.
3. **BTC InvalidCollateralTokenForMarket sub-investigation:** the live keeper-cancel selector `0x839c693e` on BTC/USDC:USDC long with USDC collateral suggests the adapter may pick a BTC `market_token_address` whose accepted-collateral set excludes USDC. Documented in `errors.py` module docstring. Not in scope for this PR.

### CI

The Python 3.14 broader test suite failure on the original commit predates these additions and is unrelated to the GMX adapter changes; GMX Tests pass green on all three commits.

---

## Why

Downstream `tradingstrategy-ai/gmx-strategies` is shipping NT-HEDGING parity for the orchestrator (`feat/orchestrator-live-independent-same-pair`): multiple Freqtrade `Trade` rows now share a single GMX market position when sibling sleeves signal on the same pair. Closing one logical `Trade` must reduce only that trade's `amount` — not flatten the entire on-chain position and silently close sibling trades.

The verification trace (downstream Task 8c) found that with installed `web3-ethereum-defi==1.1` the sync GMX CCXT adapter at `eth_defi/gmx/ccxt/exchange.py` substitutes the external GMX net position size whenever `params['sub_trade_amt']` is absent. Freqtrade's stock `execute_trade_exit` does NOT forward `sub_trade_amt` — it calls `exchange.create_order(..., amount=Trade.amount, reduceOnly=True, ...)` — so a normal logical close reaches the adapter as `reduceOnly=True` with no `sub_trade_amt` and the adapter flattens A+B+C on-chain when only A was meant to close.

## Summary

Adds a pure module-level helper:

```python
def _resolve_reduce_only_size_delta_usd(
    *,
    requested_size_usd: float,
    gmx_position: dict,
    full_close_tolerance: float = 0.995,
) -> float | int:
    ...
```

Three resolved paths:

* `actual_size_usd <= 0` (invalid / already closed) → return `requested_size_usd` unchanged. Caller's `create_order` will surface any `InvalidDecreaseOrderSize` revert.
* `requested_size_usd >= actual_size_usd * full_close_tolerance` (effectively a full close) → return the raw uint256 `position_size_usd_raw` if available, else `actual_size_usd`. **Preserves the existing dust-prevention behaviour** for true full closes (avoids `int(float * 10^30)` overshoot causing GMX `InvalidDecreaseOrderSize` reverts).
* Otherwise → `min(requested_size_usd, actual_size_usd)`. The `min` caps over-asks at the actual position size; `cap_size_delta_to_position` later in `create_order` is the final safety net.

The sync adapter's reduce-only branch in `_convert_ccxt_to_gmx_params` is rewritten around the helper. `close_amount = sub_trade_amt if sub_trade_amt is not None else amount` makes the Freqtrade `amount` argument authoritative for per-trade closes while keeping `sub_trade_amt` as the explicit DCA partial-exit override. The diagnostic log distinguishes the three resolved paths (FULL CLOSE / PARTIAL CLOSE clamped / PARTIAL CLOSE normal) and notes whether the source was `amount` or `sub_trade_amt`.

The async adapter (`eth_defi/gmx/ccxt/async_support/exchange.py`) imports the same helper for sync/async lockstep. Standard async `create_order` still raises `NotSupported` upstream of the close path, but the symmetric import means a future async close implementation will use identical sizing semantics — and the new test `test_async_adapter_imports_same_helper` regresses against drift.

Tests: 10 new pytest cases in `tests/gmx/ccxt/test_reduce_only_sizing.py`:

* `test_reduce_only_close_uses_requested_trade_amount_when_less_than_net_position` — the per-trade close path that flat-out failed pre-fix.
* `test_reduce_only_close_uses_raw_position_size_when_request_matches_full_position` — full-close dust prevention preserved.
* `test_reduce_only_close_exactly_full_request_returns_raw_int` — boundary at exactly actual size.
* `test_reduce_only_close_request_above_actual_caps_at_raw_int` — over-ask defence.
* `test_reduce_only_close_at_tolerance_boundary_returns_raw_int` — boundary at exactly 0.995 × actual.
* `test_reduce_only_close_just_under_tolerance_returns_requested` — boundary just below 0.995.
* `test_reduce_only_close_invalid_position_returns_requested_unchanged` — already-closed / invalid path.
* `test_reduce_only_close_missing_raw_uses_float_actual_as_full_close` — legacy GMX SDK paths without `position_size_usd_raw`.
* `test_reduce_only_close_custom_tolerance_band` — helper is parameterised.
* `test_async_adapter_imports_same_helper` — sync/async drift regression.

All 10 PASS. Existing GMX CCXT initialization / features / monkeypatch tests unaffected.

## Lessons learnt

* GMX has one on-chain position per (market, account). Any abstraction that lets the application layer manage multiple logical positions per market (Freqtrade DCA layers, NT HEDGING, this orchestrator's same-pair sibling sleeves) MUST decide reduce-only sizing from the application-layer per-trade amount, not from the external net position. The dust-prevention substitution to raw uint256 was correct for the single-trade-per-pair case it shipped under, but it had no `requested_size_usd / actual_size_usd` discriminator. Adding the 0.995 tolerance band keeps the dust-prevention benefit while opening the per-trade close path that the downstream parity work needs.
* Sync/async adapter lockstep is now enforced by an import-cross-check test, so future divergence at the close path produces a deterministic test failure instead of a silent runtime bug downstream.

## Verification

Downstream gmx-strategies dry-run with this branch editable-installed produced:

* 3 simultaneous open trades per pair (BTC / ETH / SOL each have `driver_a` + `driver_b` + `driver_c` rows).
* 6 `secondary_independent_trade opened` audit rows.
* 8 `secondary_layer skip live_independent_mode` rows.
* **0** `queued_net_add` rows.
* Backtest parity byte-identical to the pre-fix baseline (569 trades / 851.873 USDC / 5.27% MaxDD).

DO NOT MERGE until downstream parity validation completes — this PR is the upstream half of a two-repo coordinated change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

