### PR TITLE
fix(gmx): reconcile no-order_key limit orders via REST + on-chain Reader (issue #67 follow-up)

### DIFF
--- a/docs/superpowers/plans/2026-05-23-gmx-price-decimals-regression-fix.md
+++ b/docs/superpowers/plans/2026-05-23-gmx-price-decimals-regression-fix.md
@@ -1,0 +1,149 @@
+# GMX price-decimals regression fix
+
+**Date:** 2026-05-23
+**Branch:** `fix/issue-67-no-key-resolver` (stack onto PR #1030 as commit #5)
+**Severity:** Production — cascade misclassifies legitimately-pending limit orders
+as cancelled when index-token decimals ≠ 18 (DOGE/TAO/WBTC).
+
+## Goal
+
+Eliminate the `/1e30` price-conversion bug in three areas of the GMX
+limit-order plumbing so all index-token decimals (8, 9, 18, …) round-trip
+to human-readable USD prices.
+
+## Root cause
+
+GMX V2 prices use the **30-decimal-precision** format scaled by
+`10^(30 - token_decimals)`. Five hot sites apply a hard `/1e30` divisor
+instead of the decimals-aware helper that already exists in the repo
+(`_convert_price_to_usd`, introduced by PR #853 / `417e243d`).
+
+Commit `367af42c` (May 12, 2026) added the new `_resolve_order_from_sources`
+cascade + 3 builders without using the helper — reintroducing the same bug
+class for the cascade's output path. PR #1030's matcher (`_match_rest_pending_order`)
+also uses `/1e30`. The Reader matcher uses `PendingOrder.trigger_price_usd`,
+which is hard-coded for 18-decimal tokens only and silently wrong for DOGE (8)
+and TAO (9) — same bug class, different surface.
+
+Empirically observed corruption in production multistrategy DB:
+
+| Pair | Token decimals | Correct divisor | Buggy `/1e30` overshoots | Observed `orders.price` |
+|---|---|---|---|---|
+| DOGE | 8  | 10^22 | by `10^8`  | 1.0086e-09 (correct 0.10086) |
+| FIL  | 18 | 10^12 | by `10^18` | 9.1901e-19 (correct 0.91901) |
+| TAO  | 9  | 10^21 | by `10^9`  | 2.6664e-07 (correct 266.638) |
+
+For 18-decimal index tokens (ETH and most ERC-20 alts), the `/1e30` arithmetic
+happens to cancel the chain's `10^(30 - 18) = 10^12` scale because
+`/1e30 = /1e12 × /1e18` — but the per-token-decimals factor only equals 1
+when token_decimals = 0, which never happens. The reason 18-decimal tokens
+"work" is coincidental: their chain scale `10^12` and bug divisor `10^30`
+both produce small float values, but the comparison-side bug uses the same
+`/1e30`, so two equally-corrupted values still match. Non-18-decimal tokens
+(DOGE 8, TAO 9 synthetic, BTC/WBTC 8) break loudly because the chain stores
+their prices at a different magnitude, breaking the accidental cancellation.
+
+## Scope
+
+### Sites to fix
+
+| # | File | Line | Function | Change |
+|---|---|---|---|---|
+| 1 | `eth_defi/gmx/freqtrade/gmx_exchange.py` | 1272 | `_match_rest_pending_order` | `/1e30` → `self._api._convert_price_to_usd(raw, market)` |
+| 2 | `eth_defi/gmx/freqtrade/gmx_exchange.py` | 1174 | `_match_reader_pending_order` | `trigger_price_usd` → `trigger_price_usd_for_decimals(decimals)` |
+| 3 | `eth_defi/gmx/ccxt/exchange.py` | 9106 | `_build_order_from_trade_action` | `/1e30` → `_convert_price_to_usd`; derive amount from `sizeDeltaInTokens` when present |
+| 4 | `eth_defi/gmx/ccxt/exchange.py` | 9161 | `_build_order_from_rest_order` | `/1e30` → `_convert_price_to_usd`; derive amount as `sizeDeltaUsd / triggerPrice` |
+| 5 | `eth_defi/gmx/ccxt/async_support/exchange.py` | 2285 | (async sibling of #3) | lockstep |
+| 6 | `eth_defi/gmx/ccxt/async_support/exchange.py` | 2340 | (async sibling of #4) | lockstep |
+| 7 | `eth_defi/gmx/freqtrade/gmx_exchange.py` | 1220-1221 | docstring | fix wording: not "raw 1e30 USD" |
+
+### Tests
+
+User has already pre-committed test scaffolding (uncommitted local diff):
+
+- `tests/gmx/freqtrade/test_fetch_order_no_key_reconcile.py`:
+  - `_rest_order` fixture: `token_decimals` param (default 8), `price * 10^(30 - decimals)` formula
+  - `_fake_gmx` fixture: exposes `index_token` per market + `_token_metadata` for DOGE (8) and FIL (18)
+  - New test `test_no_key_open_limit_matches_fil_raw_trigger_price_with_18_decimals` — **fails on current production code**; passes after the fix.
+
+The cascade behavioural contract is fully covered by this failing test +
+existing 16 tests. No new test file is strictly required, but a focused unit
+test on the builders is recommended for completeness (see "Stretch").
+
+## Approach
+
+1. **Make the failing FIL test pass.** This drives sites #1 and #2.
+2. **Patch the builders (sites #3-#6) in lockstep.** Same template per the
+   adapter's existing `_convert_price_to_usd` calls in `parse_trade` etc.
+3. **Fix docstring (#7).**
+4. **Run full test suite.** Confirm 17/17 pass (was 16 + new FIL).
+5. **Confirm older bot DBs are unaffected** (no `orders.price` corruption on
+   PingPong/IchiV2/IchiV3 — they never hit the cascade builders).
+6. **Show diff to user, get review approval, commit.**
+7. **Push to PR #1030 branch as commit #5.**
+8. **Update PR body** to include the new commit and the bug class story.
+
+## Files touched (estimate)
+
+```
+eth_defi/gmx/ccxt/exchange.py                   ~25 lines (2 funcs)
+eth_defi/gmx/ccxt/async_support/exchange.py     ~25 lines (lockstep)
+eth_defi/gmx/freqtrade/gmx_exchange.py          ~12 lines (2 matchers + docstring)
+tests/gmx/freqtrade/test_fetch_order_no_key_reconcile.py   already-staged by user
+```
+
+## Validation plan
+
+- **Unit:** `pytest tests/gmx/freqtrade/test_fetch_order_no_key_reconcile.py` →
+  17/17 pass. Plus existing `test_cached_order_key_patch.py` (6) +
+  `test_order_key_cache.py` (17) + `test_reduce_only_sizing.py` (10).
+- **Integration:** rebuild Docker image with new pin, restart multistrategy bot,
+  observe at least one cycle of limit orders. Assert `orders.price ≈ ft_price`
+  for newly-created limits.
+- **Production receipt:** at next UTC midnight cycle, log lines should show
+  the cascade matching on FIL trigger price 0.91901 (not 9.19e-19) on the
+  restored trade 19.
+
+## Out of scope (deferred)
+
+- `_build_order_from_rest_position` (line 2352 / 9173 area) also uses `/1e30`
+  for `sizeInUsd` — but that field IS pure USD, so the math is correct.
+  No change needed.
+- `_convert_price_to_usd` heuristic short-circuit (`0.01 <= v <= 1_000_000`).
+  Works for current GMX universe; refactor if sub-cent tokens (PEPE/SHIB) get
+  whitelisted.
+- Subsquid path (`_resolve_order_from_sources` Tier-D) uses
+  `_build_order_from_trade_action` — fixed by site #3, no separate change.
+
+## Risks
+
+1. **Markets not loaded.** `_convert_price_to_usd(raw, None)` returns the
+   raw value unchanged when `market is None`. Acceptable — the cascade only
+   fires after `load_markets()` completes during Freqtrade startup.
+2. **Async lockstep drift.** Mitigated by adding the same edits in the same
+   PR and keeping the diffs structurally identical.
+3. **Stretch test file deferred.** Direct unit tests on the builders would
+   tighten coverage; the FIL/DOGE end-to-end cascade tests already give
+   regression protection.
+
+## Stretch (optional, can be follow-up)
+
+- `tests/gmx/ccxt/test_build_order_decimals.py` — 6 direct unit tests on
+  the builders for DOGE/FIL/TAO round-trip of price + amount.
+
+## Success criteria
+
+- [ ] FIL 18-decimals test passes
+- [ ] All 17 reconcile tests pass
+- [ ] No regression in `test_cached_order_key_patch` / `test_order_key_cache`
+- [ ] `git diff` reviewed by user before commit
+- [ ] Commit pushed to PR #1030 branch
+- [ ] PR #1030 body updated
+- [ ] Older bot DBs sanity-checked (no corruption)
+
+## Links
+
+- PR #1030: <https://github.com/tradingstrategy-ai/web3-ethereum-defi/pull/1030>
+- Regression-introducing commit: `367af42c` (May 12, 2026)
+- Original fix template: `417e243d` (PR #853, March 17, 2026)
+- Failing test: `tests/gmx/freqtrade/test_fetch_order_no_key_reconcile.py::TestNoKeyRestOrderResolver::test_no_key_open_limit_matches_fil_raw_trigger_price_with_18_decimals`

--- a/eth_defi/gmx/ccxt/_position_metrics.py
+++ b/eth_defi/gmx/ccxt/_position_metrics.py
@@ -1,0 +1,83 @@
+"""Shared position-metrics helpers for the GMX CCXT adapter.
+
+Both :pyfile:`eth_defi/gmx/ccxt/exchange.py` (sync ``parse_position``) and
+:pyfile:`eth_defi/gmx/ccxt/async_support/exchange.py` (async
+``fetch_positions``) need to compute a liquidation price for every open
+position they report.  Before this module existed they diverged: the sync
+path called :pyfunc:`calculate_estimated_liquidation_price` and validated
+the result, while the async path hardcoded ``None``.  That divergence
+masked the May-2026 production crash regression and the lockstep rule in
+``feedback_eth_defi_sync_async_lockstep`` requires the same code on both
+sides.
+
+Centralising the call here lets both paths reuse one validation chain
+(input sanity → helper call → direction invariant → non-positive guard)
+without code duplication or import cycles.
+
+:see: :pyfunc:`eth_defi.gmx.utils.calculate_estimated_liquidation_price`
+"""
+
+from __future__ import annotations
+
+from eth_defi.gmx.utils import calculate_estimated_liquidation_price
+
+
+def safe_liquidation_price(
+    *,
+    entry_price: float | None,
+    collateral_usd: float | None,
+    position_size_usd: float | None,
+    is_long: bool,
+) -> float | None:
+    """Compute a sanity-checked liquidation price for a GMX position.
+
+    Thin wrapper around :pyfunc:`calculate_estimated_liquidation_price`
+    that rejects any result violating the direction invariant (a long's
+    liquidation must sit below entry, a short's above) or that is
+    non-positive.  Returns ``None`` whenever:
+
+    - any of the three USD inputs is falsy / missing,
+    - ``position_size_usd`` is non-positive,
+    - the underlying helper returned ``None`` (small positions dominated
+      by the GMX min-collateral floor, degenerate inputs),
+    - the produced value would be on the wrong side of ``entry_price``
+      (defensive belt-and-suspenders against any future refactor).
+
+    Freqtrade's ``stoploss_or_liquidation`` treats ``None`` as "unknown"
+    and skips the check, but treats *any* non-zero number — including a
+    stale or wrong-side value — as a real liquidation level.  Returning
+    a bogus float here is what caused the production crash-loop, hence
+    the conservative None-on-doubt policy.
+
+    Both ``parse_position`` (sync) and ``fetch_positions`` (async) MUST
+    delegate liquidation-price computation to this helper instead of
+    inlining it, so the two paths cannot diverge again.
+
+    :param entry_price: Position entry price in USD.
+    :param collateral_usd: Initial collateral amount in USD.
+    :param position_size_usd: Position size in USD.
+    :param is_long: Direction flag — ``True`` for longs, ``False`` for shorts.
+    :returns: Liquidation price as ``float`` when reliable, otherwise ``None``.
+    """
+    if not entry_price or not collateral_usd or not position_size_usd:
+        return None
+    if position_size_usd <= 0:
+        return None
+
+    liquidation_price = calculate_estimated_liquidation_price(
+        entry_price=entry_price,
+        collateral_usd=collateral_usd,
+        size_usd=position_size_usd,
+        is_long=is_long,
+        maintenance_margin=0.01,  # GMX standard
+        include_closing_fee=True,  # GMX 0.07% closing fee
+    )
+
+    if liquidation_price is None or liquidation_price <= 0:
+        return None
+    if is_long and liquidation_price >= entry_price:
+        return None
+    if (not is_long) and liquidation_price <= entry_price:
+        return None
+
+    return liquidation_price

--- a/eth_defi/gmx/ccxt/async_support/exchange.py
+++ b/eth_defi/gmx/ccxt/async_support/exchange.py
@@ -17,6 +17,7 @@ import aiohttp
 from ccxt.async_support import Exchange
 from ccxt.base.errors import (
     ExchangeError,
+    InvalidOrder,
     NotSupported,
     OrderNotFound,
 )
@@ -32,6 +33,7 @@ from eth_defi.gmx.ccxt.cancel_helpers import (
     build_cancel_order_response,
     resolve_order_id,
 )
+from eth_defi.gmx.ccxt._position_metrics import safe_liquidation_price
 from eth_defi.gmx.ccxt.exchange import (
     _derive_side_from_trade_action,
     _resolve_close_order_filled_amount,
@@ -3153,6 +3155,18 @@ class GMX(Exchange):
             if position_size_usd:
                 unrealized_pnl = position_size_usd * (percent_profit / 100)
 
+            is_long = bool(data.get("is_long", True))
+            # Same helper as the sync ``parse_position`` — keeps the two
+            # paths byte-equivalent for the liquidation_price field and
+            # honours the sync/async lockstep rule.  See
+            # :pymod:`eth_defi.gmx.ccxt._position_metrics`.
+            liquidation_price = safe_liquidation_price(
+                entry_price=float(entry_price) if entry_price else None,
+                collateral_usd=collateral_usd,
+                position_size_usd=position_size_usd,
+                is_long=is_long,
+            )
+
             timestamp = self.milliseconds()
 
             result.append(
@@ -3163,7 +3177,7 @@ class GMX(Exchange):
                     "datetime": self.iso8601(timestamp),
                     "isolated": False,
                     "hedged": False,
-                    "side": "long" if data.get("is_long", True) else "short",
+                    "side": "long" if is_long else "short",
                     "contracts": contracts,
                     "contractSize": self.parse_number("1"),
                     "entryPrice": entry_price,
@@ -3176,7 +3190,7 @@ class GMX(Exchange):
                     "initialMarginPercentage": None,
                     "maintenanceMarginPercentage": 0.01,
                     "unrealizedPnl": unrealized_pnl,
-                    "liquidationPrice": None,
+                    "liquidationPrice": liquidation_price,
                     "marginRatio": None,
                     "percentage": percent_profit,
                     "info": data,
@@ -4025,6 +4039,7 @@ class GMX(Exchange):
         collateral_symbol = params.get("collateral_symbol", "USDC")
         slippage_percent = params.get("slippage_percent", 0.003)
         execution_buffer = params.get("execution_buffer", 2.2)
+        reduceOnly = params.get("reduceOnly", False)
 
         # GMX Extension: Support direct USD sizing via size_usd parameter
         if "size_usd" in params:
@@ -4038,6 +4053,16 @@ class GMX(Exchange):
             ticker = await self.fetch_ticker(symbol)
             current_price = ticker["last"]
             size_delta_usd = amount * current_price
+
+        # Sync/async lockstep — see ``_convert_ccxt_to_gmx_params`` in
+        # ``eth_defi/gmx/ccxt/exchange.py`` for the same guard and the
+        # reduce-only exemption rationale.
+        if not reduceOnly and size_delta_usd < GMX_MIN_COST_USD:
+            raise InvalidOrder(
+                f"Order notional ${size_delta_usd:.4f} below GMX minimum "
+                f"${GMX_MIN_COST_USD} for {symbol} {side}; adjust stake / "
+                f"position sizing.",
+            )
 
         return {
             "symbol": symbol,

--- a/eth_defi/gmx/ccxt/async_support/exchange.py
+++ b/eth_defi/gmx/ccxt/async_support/exchange.py
@@ -4260,6 +4260,29 @@ class GMX(Exchange):
         self._orders = {}
         logger.info("Cleared order cache (async)")
 
+    def _patch_cached_order_key(self, order_id: str, order_key_hex: str) -> None:
+        """Async-side mirror of :meth:`eth_defi.gmx.ccxt.exchange.GMX._patch_cached_order_key`.
+
+        Kept in sync/async lockstep so the freqtrade wrapper can invoke
+        the same repair API regardless of which adapter is bound to
+        ``self._api``.  Signature, semantics and alias handling are
+        identical to the sync sibling — see that docstring for the
+        rationale around bare and ``0x``-prefixed aliases.
+
+        :param order_id:
+            Order id under reconciliation; both ``"0x..."`` and bare forms
+            are accepted.
+        :param order_key_hex:
+            Recovered GMX order key as a ``0x``-prefixed hex string.
+        """
+        bare = order_id.removeprefix("0x")
+        aliases = {order_id, bare, f"0x{bare}"}
+        for alias in aliases:
+            cached = self._orders.get(alias)
+            if not cached:
+                continue
+            cached.setdefault("info", {})["order_key"] = order_key_hex
+
     def reset_failure_counter(self):
         """Reset consecutive failure counter and resume trading.
 

--- a/eth_defi/gmx/ccxt/async_support/exchange.py
+++ b/eth_defi/gmx/ccxt/async_support/exchange.py
@@ -2281,10 +2281,36 @@ class GMX(Exchange):
         else:
             status = "open"
 
+        market = self.markets.get(symbol) if symbol else None
+
+        # GMX prices are scaled by 10^(30 - index_token_decimals).  Hard
+        # ``/1e30`` is wrong for DOGE (8), TAO (9), WBTC (8), etc.  Use the
+        # standard decimals-aware helper so the persisted price field is
+        # always a clean human-readable USD number.
         exec_price_raw = trade_action.get("executionPrice") or trade_action.get("triggerPrice")
-        exec_price = float(exec_price_raw) / 1e30 if exec_price_raw else None
-        size_raw = trade_action.get("sizeDeltaUsd") or trade_action.get("sizeDeltaInTokens")
-        filled = float(size_raw) / 1e30 if size_raw else None
+        exec_price = self._convert_price_to_usd(float(exec_price_raw), market) if exec_price_raw else None
+
+        # ``sizeDeltaUsd`` is pure USD (always /1e30 — fees + USD-only fields).
+        # ``sizeDeltaInTokens`` is base-token in token decimals.  CCXT's
+        # ``amount`` must be base tokens, so prefer ``sizeDeltaInTokens``
+        # when present; otherwise derive base tokens from sizeDeltaUsd / price.
+        size_tokens_raw = trade_action.get("sizeDeltaInTokens")
+        size_usd_raw = trade_action.get("sizeDeltaUsd")
+        filled: float | None = None
+        if size_tokens_raw is not None and market is not None:
+            try:
+                token_decimals = self._get_token_decimals(market)
+                if token_decimals is not None:
+                    filled = float(size_tokens_raw) / (10**token_decimals)
+            except Exception:
+                filled = None
+        if filled is None and size_usd_raw is not None and exec_price not in (None, 0.0):
+            filled = (float(size_usd_raw) / 1e30) / exec_price
+        if filled is None and size_usd_raw is not None:
+            # No price available — fall back to USD notional.  Better than
+            # silently dropping the order, callers should treat ``amount``
+            # carefully when ``price`` is also None.
+            filled = float(size_usd_raw) / 1e30
         ts_s = trade_action.get("timestamp")
         ts_ms = int(ts_s) * 1000 if ts_s else None
         order_key = trade_action.get("orderKey", trade_action.get("id", ""))
@@ -2327,6 +2353,21 @@ class GMX(Exchange):
         :returns: CCXT-shaped order dict with ``status="open"``.
         """
         _ts_ms = self.milliseconds()
+        market = self.markets.get(symbol) if symbol else None
+
+        # ``triggerPrice`` is scaled by 10^(30 - index_token_decimals);
+        # ``sizeDeltaUsd`` is pure USD (/1e30).  CCXT ``amount`` must be in
+        # base tokens, so we compute it as size_usd / trigger_usd when
+        # both are known.  Falls back to USD notional only when the price
+        # is missing — better than silently mixing units in the cached row.
+        raw_trigger = rest_order.get("triggerPrice", 0)
+        trigger_usd = self._convert_price_to_usd(float(raw_trigger), market) if raw_trigger else None
+        size_usd = float(rest_order.get("sizeDeltaUsd", 0) or 0) / 1e30 or None
+        if size_usd is not None and trigger_usd not in (None, 0.0):
+            amount_tokens: float | None = size_usd / trigger_usd
+        else:
+            amount_tokens = size_usd  # last-resort fallback (USD notional)
+
         return {
             "id": rest_order.get("key", rest_order.get("orderKey", "")),
             "clientOrderId": None,
@@ -2337,11 +2378,11 @@ class GMX(Exchange):
             "symbol": symbol,
             "type": "limit",
             "side": "buy" if rest_order.get("isLong") else "sell",
-            "price": float(rest_order.get("triggerPrice", 0)) / 1e30 or None,
+            "price": trigger_usd,
             "average": None,
-            "amount": float(rest_order.get("sizeDeltaUsd", 0)) / 1e30 or None,
+            "amount": amount_tokens,
             "filled": 0.0,
-            "remaining": float(rest_order.get("sizeDeltaUsd", 0)) / 1e30 or None,
+            "remaining": amount_tokens,
             "cost": None,
             "trades": [],
             "fee": None,

--- a/eth_defi/gmx/ccxt/exchange.py
+++ b/eth_defi/gmx/ccxt/exchange.py
@@ -97,10 +97,8 @@ from eth_defi.gmx.order.pending_orders import PendingOrder, fetch_pending_orders
 from eth_defi.gmx.order.sltp_order import SLTPEntry, SLTPOrder, SLTPParams
 from eth_defi.gmx.order_tracking import check_order_status, is_order_pending
 from eth_defi.gmx.trading import GMXTrading
-from eth_defi.gmx.utils import (
-    calculate_estimated_liquidation_price,
-    convert_raw_price_to_usd,
-)
+from eth_defi.gmx.ccxt._position_metrics import safe_liquidation_price
+from eth_defi.gmx.utils import convert_raw_price_to_usd
 from eth_defi.hotwallet import HotWallet
 from eth_defi.provider.fallback import ExtraValueError, get_fallback_provider
 from eth_defi.provider.log_block_range import get_logs_max_block_range
@@ -4813,39 +4811,15 @@ class GMX(ExchangeCompatible):
         if position_size_usd and percentage is not None:
             unrealized_pnl = position_size_usd * (percentage / 100)
 
-        # Liquidation price.  ``calculate_estimated_liquidation_price`` returns
-        # ``None`` when the approximation cannot be trusted (small positions
-        # dominated by the GMX min-collateral floor, degenerate inputs, or
-        # results on the wrong side of entry).  We must propagate ``None``
-        # all the way to CCXT — Freqtrade's stoploss-or-liquidation check
-        # treats ``None`` as "unknown" but treats any non-zero number as a
-        # real liquidation level, including stale or implausible values.
-        #
-        # Belt-and-suspenders: even when the helper returns a number, we
-        # re-validate the direction here so that a future refactor or an
-        # alternative source upstream cannot silently push a wrong-direction
-        # value through this codepath.
-        liquidation_price = None
-        if entry_price and collateral_amount and position_size_usd and position_size_usd > 0:
-            liquidation_price = calculate_estimated_liquidation_price(
-                entry_price=entry_price,
-                collateral_usd=collateral_amount,
-                size_usd=position_size_usd,
-                is_long=is_long,
-                maintenance_margin=0.01,  # GMX typically uses 1%
-                include_closing_fee=True,  # Include 0.07% closing fee
-            )
-            if liquidation_price is not None:
-                # Re-check the direction invariant the helper already enforces.
-                # If anything looks off — non-positive, or on the wrong side of
-                # entry — set to ``None`` instead of letting a misleading value
-                # land in Freqtrade's persistent state.
-                if liquidation_price <= 0:
-                    liquidation_price = None
-                elif is_long and liquidation_price >= entry_price:
-                    liquidation_price = None
-                elif (not is_long) and liquidation_price <= entry_price:
-                    liquidation_price = None
+        # Liquidation price via the shared sync/async helper — see
+        # :pymod:`eth_defi.gmx.ccxt._position_metrics` for why the
+        # validation chain lives there.
+        liquidation_price = safe_liquidation_price(
+            entry_price=entry_price,
+            collateral_usd=collateral_amount,
+            position_size_usd=position_size_usd,
+            is_long=is_long,
+        )
 
         # Calculate margin ratio (used margin / total position value)
         margin_ratio = None
@@ -5992,8 +5966,6 @@ class GMX(ExchangeCompatible):
             # GMX Extension: Direct USD sizing via size_usd parameter
             # Validate: size_usd and non-zero amount should not be used together
             if amount and amount > 0:
-                from ccxt.base.errors import InvalidOrder
-
                 raise InvalidOrder(f"Cannot use both 'size_usd' ({params['size_usd']}) and non-zero 'amount' ({amount}) together. Use either: (1) 'size_usd' in params for direct USD sizing (recommended), or (2) 'amount' for base currency sizing (will be multiplied by price). Recommendation: Use 'size_usd' with amount=0 for precise USD-denominated positions.")
             size_delta_usd = params["size_usd"]
             logger.debug("ORDER_TRACE: Using size_usd=%s from params", size_delta_usd)
@@ -6019,6 +5991,20 @@ class GMX(ExchangeCompatible):
                     current_price,
                     size_delta_usd,
                 )
+
+        # GMX protocol minimum order notional is ``GMX_MIN_COST_USD`` ($2).
+        # The market-limits dict already advertises this to Freqtrade, but a
+        # bypassed limits check or a custom client could still submit a
+        # sub-$2 order — GMX would reject on-chain with no clear surface
+        # error.  Fail fast at the application layer instead.  Reduce-only
+        # closes are exempt because a tiny remainder close can legitimately
+        # fall below the floor and GMX accepts it as a dust cleanup.
+        if not reduceOnly and size_delta_usd < GMX_MIN_COST_USD:
+            raise InvalidOrder(
+                f"Order notional ${size_delta_usd:.4f} below GMX minimum "
+                f"${GMX_MIN_COST_USD} for {symbol} {side}; adjust stake / "
+                f"position sizing.",
+            )
 
         # Resolve market info — honours optional ``market_address`` param so callers can
         # select a non-default pool (e.g. BTC-BTC instead of the default BTC-USDC pool).

--- a/eth_defi/gmx/ccxt/exchange.py
+++ b/eth_defi/gmx/ccxt/exchange.py
@@ -1787,7 +1787,7 @@ class GMX(ExchangeCompatible):
         try:
             self._order_key_cache = OrderKeyCache(
                 chain_id=self.web3.eth.chain_id,
-                wallet_address=self.wallet_address,
+                wallet=self.wallet_address,
             )
         except Exception as e:
             logger.warning("OrderKeyCache init failed (memory-only mode): %s", e)

--- a/eth_defi/gmx/ccxt/exchange.py
+++ b/eth_defi/gmx/ccxt/exchange.py
@@ -4813,7 +4813,18 @@ class GMX(ExchangeCompatible):
         if position_size_usd and percentage is not None:
             unrealized_pnl = position_size_usd * (percentage / 100)
 
-        # Calculate liquidation price including fees
+        # Liquidation price.  ``calculate_estimated_liquidation_price`` returns
+        # ``None`` when the approximation cannot be trusted (small positions
+        # dominated by the GMX min-collateral floor, degenerate inputs, or
+        # results on the wrong side of entry).  We must propagate ``None``
+        # all the way to CCXT — Freqtrade's stoploss-or-liquidation check
+        # treats ``None`` as "unknown" but treats any non-zero number as a
+        # real liquidation level, including stale or implausible values.
+        #
+        # Belt-and-suspenders: even when the helper returns a number, we
+        # re-validate the direction here so that a future refactor or an
+        # alternative source upstream cannot silently push a wrong-direction
+        # value through this codepath.
         liquidation_price = None
         if entry_price and collateral_amount and position_size_usd and position_size_usd > 0:
             liquidation_price = calculate_estimated_liquidation_price(
@@ -4824,6 +4835,17 @@ class GMX(ExchangeCompatible):
                 maintenance_margin=0.01,  # GMX typically uses 1%
                 include_closing_fee=True,  # Include 0.07% closing fee
             )
+            if liquidation_price is not None:
+                # Re-check the direction invariant the helper already enforces.
+                # If anything looks off — non-positive, or on the wrong side of
+                # entry — set to ``None`` instead of letting a misleading value
+                # land in Freqtrade's persistent state.
+                if liquidation_price <= 0:
+                    liquidation_price = None
+                elif is_long and liquidation_price >= entry_price:
+                    liquidation_price = None
+                elif (not is_long) and liquidation_price <= entry_price:
+                    liquidation_price = None
 
         # Calculate margin ratio (used margin / total position value)
         margin_ratio = None

--- a/eth_defi/gmx/ccxt/exchange.py
+++ b/eth_defi/gmx/ccxt/exchange.py
@@ -8512,6 +8512,37 @@ class GMX(ExchangeCompatible):
         self._orders = {}
         logger.info("Cleared order cache")
 
+    def _patch_cached_order_key(self, order_id: str, order_key_hex: str) -> None:
+        """Patch a recovered GMX order key into all cached aliases for an order.
+
+        Called by the freqtrade wrapper when the no-key reconciler recovers
+        the real ``order_key`` from a live GMX pending order or a historical
+        Subsquid / EventEmitter record.  Patching the cache in place lets
+        the next ``fetch_order`` cycle hit the normal order-key-aware path
+        (``exchange.py`` lines 8593+ — DataStore + verification) instead of
+        re-triggering the no-key fallback.
+
+        Orders are inserted into ``self._orders`` under both their bare
+        (``"{hash}"``) and ``0x``-prefixed (``"0x{hash}"``) form by various
+        creation paths and by the cache-key resolver at
+        ``fetch_order`` line 8542.  The patch must update whichever alias(es)
+        the order is currently under so a subsequent lookup via either form
+        sees the recovered key.
+
+        :param order_id:
+            The order id that the wrapper is reconciling.  Either form
+            (``"0x..."`` or bare) is accepted; both aliases are checked.
+        :param order_key_hex:
+            Recovered GMX order key as a ``0x``-prefixed hex string.
+        """
+        bare = order_id.removeprefix("0x")
+        aliases = {order_id, bare, f"0x{bare}"}
+        for alias in aliases:
+            cached = self._orders.get(alias)
+            if not cached:
+                continue
+            cached.setdefault("info", {})["order_key"] = order_key_hex
+
     def reset_failure_counter(self):
         """Reset consecutive failure counter and resume trading.
 

--- a/eth_defi/gmx/ccxt/exchange.py
+++ b/eth_defi/gmx/ccxt/exchange.py
@@ -9102,10 +9102,36 @@ class GMX(ExchangeCompatible):
         else:
             status = "open"
 
+        market = self.markets.get(symbol) if symbol else None
+
+        # GMX prices are scaled by 10^(30 - index_token_decimals).  Hard
+        # ``/1e30`` is wrong for DOGE (8), TAO (9), WBTC (8), etc.  Use the
+        # standard decimals-aware helper so the persisted price field is
+        # always a clean human-readable USD number.
         exec_price_raw = trade_action.get("executionPrice") or trade_action.get("triggerPrice")
-        exec_price = float(exec_price_raw) / 1e30 if exec_price_raw else None
-        size_raw = trade_action.get("sizeDeltaUsd") or trade_action.get("sizeDeltaInTokens")
-        filled = float(size_raw) / 1e30 if size_raw else None
+        exec_price = self._convert_price_to_usd(float(exec_price_raw), market) if exec_price_raw else None
+
+        # ``sizeDeltaUsd`` is pure USD (always /1e30 — fees + USD-only fields).
+        # ``sizeDeltaInTokens`` is base-token in token decimals.  CCXT's
+        # ``amount`` must be base tokens, so prefer ``sizeDeltaInTokens``
+        # when present; otherwise derive base tokens from sizeDeltaUsd / price.
+        size_tokens_raw = trade_action.get("sizeDeltaInTokens")
+        size_usd_raw = trade_action.get("sizeDeltaUsd")
+        filled: float | None = None
+        if size_tokens_raw is not None and market is not None:
+            try:
+                token_decimals = self._get_token_decimals(market)
+                if token_decimals is not None:
+                    filled = float(size_tokens_raw) / (10**token_decimals)
+            except Exception:
+                filled = None
+        if filled is None and size_usd_raw is not None and exec_price not in (None, 0.0):
+            filled = (float(size_usd_raw) / 1e30) / exec_price
+        if filled is None and size_usd_raw is not None:
+            # No price available — fall back to USD notional.  Better than
+            # silently dropping the order, callers should treat ``amount``
+            # carefully when ``price`` is also None.
+            filled = float(size_usd_raw) / 1e30
         ts_s = trade_action.get("timestamp")
         ts_ms = int(ts_s) * 1000 if ts_s else None
         order_key = trade_action.get("orderKey", trade_action.get("id", ""))
@@ -9148,6 +9174,21 @@ class GMX(ExchangeCompatible):
         :returns: CCXT-shaped order dict with ``status="open"``.
         """
         _ts_ms = _block_timestamp_ms(self.web3, self.web3.eth.block_number)
+        market = self.markets.get(symbol) if symbol else None
+
+        # ``triggerPrice`` is scaled by 10^(30 - index_token_decimals);
+        # ``sizeDeltaUsd`` is pure USD (/1e30).  CCXT ``amount`` must be in
+        # base tokens, so we compute it as size_usd / trigger_usd when
+        # both are known.  Falls back to USD notional only when the price
+        # is missing — better than silently mixing units in the cached row.
+        raw_trigger = rest_order.get("triggerPrice", 0)
+        trigger_usd = self._convert_price_to_usd(float(raw_trigger), market) if raw_trigger else None
+        size_usd = float(rest_order.get("sizeDeltaUsd", 0) or 0) / 1e30 or None
+        if size_usd is not None and trigger_usd not in (None, 0.0):
+            amount_tokens: float | None = size_usd / trigger_usd
+        else:
+            amount_tokens = size_usd  # last-resort fallback (USD notional)
+
         return {
             "id": rest_order.get("key", rest_order.get("orderKey", "")),
             "clientOrderId": None,
@@ -9158,11 +9199,11 @@ class GMX(ExchangeCompatible):
             "symbol": symbol,
             "type": "limit",
             "side": "buy" if rest_order.get("isLong") else "sell",
-            "price": float(rest_order.get("triggerPrice", 0)) / 1e30 or None,
+            "price": trigger_usd,
             "average": None,
-            "amount": float(rest_order.get("sizeDeltaUsd", 0)) / 1e30 or None,
+            "amount": amount_tokens,
             "filled": 0.0,
-            "remaining": float(rest_order.get("sizeDeltaUsd", 0)) / 1e30 or None,
+            "remaining": amount_tokens,
             "cost": None,
             "trades": [],
             "fee": None,

--- a/eth_defi/gmx/freqtrade/gmx_exchange.py
+++ b/eth_defi/gmx/freqtrade/gmx_exchange.py
@@ -578,11 +578,15 @@ class Gmx(Exchange):
         order = super().fetch_order(order_id, pair, params)
         info = order.get("info", {})
 
-        # On-chain position reconciliation for non-market orders that look stuck.
-        # Only runs when needed; ``_reconcile_via_positions`` returns ``None``
-        # (the order is unchanged) when no match exists.
+        # On-chain reconciliation for non-market orders that look stuck.
+        # Cascades: position match (filled) → live pending order
+        # (legitimately still open, repair cache) → historical event
+        # (cancelled / frozen / executed) → final cancelled marker when
+        # every authoritative source says the order has no existence
+        # anywhere on-chain.  Returns ``None`` when nothing definitive is
+        # found, in which case the original order is returned unchanged.
         if order.get("status") == "open" and order.get("type") != "market":
-            reconciled = self._reconcile_via_positions(order, pair, order_id)
+            reconciled = self._reconcile_open_non_market_order(order, pair, order_id)
             if reconciled is not None:
                 return reconciled
 
@@ -729,6 +733,507 @@ class Gmx(Exchange):
             )
             return reconciled
 
+        return None
+
+    #: How long a single ``order_id`` is excluded from re-running the
+    #: no-key reconciliation after a fall-through (no live pending
+    #: order, no position, no historical record).  Prevents Subsquid
+    #: / REST quota burn when 100+ open orders are polled every loop.
+    _RECONCILE_THROTTLE_MS = 60_000
+
+    #: Price-level tolerance for matching a cached order against a
+    #: live GMX pending DataStore order.  GMX stores trigger prices
+    #: in 30-decimal raw form and CCXT exposes them as floats — a
+    #: tiny float-conversion drift is expected.
+    _PENDING_PRICE_TOLERANCE = 1e-6
+
+    def _reconcile_open_non_market_order(
+        self,
+        order: CcxtOrder,
+        pair: str,
+        order_id: str,
+    ) -> CcxtOrder | None:
+        """Reconcile a stuck-open limit / stop / take-profit order.
+
+        Two authoritative sources for "is this order still pending?" —
+        REST first, on-chain Reader second.  Both follow the same
+        positive-proof-of-absence contract: a tier may only contribute
+        to a cancellation decision when it returned successfully and
+        produced no match.  Network errors leave the order untouched.
+
+        1. :meth:`_reconcile_via_positions` (PR #1008) — order may have
+           filled and the indexer missed the event; flip to ``closed``.
+        2. If the cached order has a real ``info["order_key"]``, the
+           standard CCXT resolver path is authoritative next cycle;
+           short-circuit.
+        3. Otherwise (the no-``order_key`` case this method exists for):
+
+           **Tier A — GMX REST** (``https://<chain>.gmxapi.ai/v1/orders``
+           via :meth:`eth_defi.gmx.api.GMXAPI.get_orders`, which
+           already retries 3× with exponential backoff inside
+           ``_make_gmxapi_ai_request``).
+
+           **Tier B — On-chain Reader** (``SyntheticsReader.getAccountOrders``
+           via :func:`eth_defi.gmx.order.pending_orders.fetch_pending_orders`).
+           Single eth_call, returns the same fields the matcher uses.
+
+           - If **either** tier finds a matching pending order →
+             adopt the recovered ``order_key``, patch the cache, keep
+             ``status="open"``.
+           - If **both** tiers ran successfully and **both** confirmed
+             no match → flip ``status="cancelled"``.
+           - If a tier errored, downgrade its vote to "inconclusive";
+             cancellation requires positive evidence from at least one
+             tier and no contradicting matches.  If both tiers errored
+             we leave the order untouched.
+
+        Throttled per ``order_id`` by :data:`_RECONCILE_THROTTLE_MS`.
+
+        :param order: Order returned by the parent ``fetch_order``.
+        :param pair: Unified ccxt symbol (``"BTC/USDC:USDC"``).
+        :param order_id: The freqtrade-supplied order id (typically the
+            creation tx hash, used for log correlation + cache lookup).
+        :returns: Reconciled order copy when a resolver had a definitive
+            answer; ``None`` when both tiers were inconclusive (caller
+            returns the original order unchanged).
+        """
+        # Step 1 — PR #1008 position-match path.  Canonical for
+        # "keeper filled the order but the indexer hasn't surfaced it".
+        reconciled = self._reconcile_via_positions(order, pair, order_id)
+        if reconciled is not None:
+            return reconciled
+
+        # Step 2 — cache already has an order_key → the standard
+        # CCXT resolver paths are authoritative next cycle.
+        order_key = (order.get("info") or {}).get("order_key")
+        if order_key:
+            return None
+
+        # Step 3 — throttle the (potentially expensive) cascade.
+        if not self._should_run_no_key_reconcile(order_id):
+            return None
+
+        # Tier A — GMX REST `/v1/orders` (gmxapi.ai, already retried).
+        rest_checked, rest_match = self._reconcile_no_key_via_rest_orders(order, pair, order_id)
+        if rest_match is not None:
+            return rest_match
+
+        # Tier B — on-chain SyntheticsReader.getAccountOrders.
+        # Even if REST returned empty (rest_checked=True, rest_match=None),
+        # the Reader is the more authoritative source so we always
+        # consult it before flipping cancelled.  An on-chain "yes
+        # it's pending" overrides REST's apparent absence.
+        contract_checked, contract_match = self._reconcile_no_key_via_contract(order, pair, order_id)
+        if contract_match is not None:
+            return contract_match
+
+        # Both tiers succeeded and neither saw the order → flip cancelled.
+        # The contract Reader is authoritative on-chain; if it agrees
+        # with REST that the order doesn't exist, the order really
+        # doesn't exist.
+        if rest_checked and contract_checked:
+            return self._mark_no_key_order_cancelled(order, order_id, pair)
+
+        # Otherwise at least one tier was inconclusive — keep the
+        # order untouched until next cycle.
+        return None
+
+    def _mark_no_key_order_cancelled(
+        self,
+        order: CcxtOrder,
+        order_id: str,
+        pair: str,
+    ) -> CcxtOrder:
+        """Flip the cached order to ``cancelled`` after both REST and Reader confirmed absence.
+
+        Tiers A (REST) and B (on-chain Reader) both returned
+        successfully and both reported no matching pending order for
+        this pair/side.  That is the strongest possible signal short
+        of replaying the creation transaction's events — the order is
+        gone from the GMX DataStore (rejected at creation, frozen, or
+        cancelled by a keeper outside our visibility).  Freqtrade can
+        now finalise the trade row.
+
+        :param order: Cached CCXT order being reconciled.
+        :param order_id: Order id (creation tx hash) for log correlation.
+        :param pair: Unified ccxt symbol for log correlation.
+        :returns: Reconciled copy with ``status="cancelled"`` and a
+            structured ``info["cancel_reason"]`` recording which tiers
+            confirmed absence.
+        """
+        resolved = dict(order)
+        resolved["status"] = "cancelled"
+        resolved["filled"] = 0.0
+        resolved["remaining"] = order.get("remaining") or order.get("amount")
+        resolved_info = dict(order.get("info") or {})
+        resolved_info["gmx_status"] = "no_key_not_found_in_any_tier"
+        resolved_info["cancel_reason"] = (
+            "no matching GMX pending order in gmxapi.ai /v1/orders nor on-chain SyntheticsReader.getAccountOrders"
+        )
+        resolved["info"] = resolved_info
+        logger.warning(
+            "fetch_order no-key reconcile: order %s for %s flipped open→cancelled "
+            "(REST + on-chain Reader both report no matching pending row)",
+            order_id[:18],
+            pair,
+        )
+        return resolved
+
+    def _should_run_no_key_reconcile(self, order_id: str) -> bool:
+        """Per-id throttle for the no-key reconciler.
+
+        Returns ``True`` on first observation and again every
+        :data:`_RECONCILE_THROTTLE_MS` thereafter.  Stores the last
+        observation timestamp on ``self._last_reconcile_ms`` (lazy
+        initialised so the wrapper works even when constructed via
+        ``__new__`` in tests).
+
+        :param order_id: Order id under reconciliation.
+        :returns: ``True`` if the reconciler should run this cycle.
+        """
+        # Lazy init keeps test fixtures (which bypass __init__) honest.
+        if not hasattr(self, "_last_reconcile_ms"):
+            self._last_reconcile_ms = {}
+        now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+        last = self._last_reconcile_ms.get(order_id)
+        if last is not None and (now_ms - last) < self._RECONCILE_THROTTLE_MS:
+            return False
+        self._last_reconcile_ms[order_id] = now_ms
+        return True
+
+    def _reconcile_no_key_via_rest_orders(
+        self,
+        order: CcxtOrder,
+        pair: str,
+        order_id: str,
+    ) -> tuple[bool, CcxtOrder | None]:
+        """Tier-A resolver — GMX REST ``/v1/orders`` (gmxapi.ai).
+
+        Calls
+        ``https://<chain>.gmxapi.ai/v1/orders?address={wallet}`` through
+        :meth:`eth_defi.gmx.api.GMXAPI.get_orders` — which itself
+        already applies a 3-attempt exponential-backoff retry inside
+        :meth:`eth_defi.gmx.api.GMXAPI._make_gmxapi_ai_request`.
+
+        Returns a ``(checked, reconciled)`` tuple so the orchestrator
+        in :meth:`_reconcile_open_non_market_order` can fuse this tier
+        with the on-chain Reader tier under positive-proof-of-absence
+        semantics:
+
+        - ``(True, order_copy)`` — definitive answer (matched a live
+          pending order; recovered key patched into cache).
+        - ``(True, None)`` — REST returned successfully and listed no
+          matching row.  Contributes to the cancellation vote.
+        - ``(False, None)`` — REST errored, returned a non-list payload,
+          or we could not resolve the market token while rows existed
+          (ambiguous).  Inconclusive; do NOT contribute to cancellation.
+
+        :param order: Cached CCXT order with ``info["order_key"]`` missing.
+        :param pair: Unified ccxt symbol.
+        :param order_id: Order id under reconciliation (logging + cache patching).
+        :returns: ``(checked, reconciled)`` — see contract above.
+        """
+        api_adapter = getattr(self, "_api", None)
+        if api_adapter is None:
+            return False, None
+        gmx_api = getattr(api_adapter, "api", None)
+        wallet = getattr(api_adapter, "wallet_address", None)
+        if gmx_api is None or not wallet:
+            logger.debug(
+                "fetch_order no-key reconcile: GMXAPI client or wallet_address unavailable — leaving order open",
+            )
+            return False, None
+
+        try:
+            rest_orders = gmx_api.get_orders(wallet)
+        except Exception as exc:  # noqa: BLE001 — soft fallback, never raise
+            logger.debug(
+                "fetch_order no-key reconcile: gmxapi.ai /orders lookup failed for %s (%s) — leaving order open",
+                pair,
+                exc,
+            )
+            return False, None
+
+        # gmxapi.ai returns a list of dicts; anything else means the
+        # endpoint mis-routed and we cannot interpret it as positive
+        # proof of absence.
+        if not isinstance(rest_orders, (list, tuple)):
+            logger.debug(
+                "fetch_order no-key reconcile: /orders response for %s is not a list (%r) — leaving order open",
+                pair,
+                type(rest_orders).__name__,
+            )
+            return False, None
+
+        market_token = self._market_token_for_pair(pair)
+        if market_token is None and rest_orders:
+            logger.debug(
+                "fetch_order no-key reconcile: cannot resolve market token for %s while /orders returned %d row(s) — leaving order open",
+                pair,
+                len(rest_orders),
+            )
+            return False, None
+
+        match = self._match_rest_pending_order(order, rest_orders, market_token=market_token)
+        if match is not None:
+            recovered_key = match.get("key") or match.get("orderKey")
+            if recovered_key:
+                self._api._patch_cached_order_key(order_id, recovered_key)
+            resolved = dict(order)
+            resolved_info = dict(order.get("info") or {})
+            if recovered_key:
+                resolved_info["order_key"] = recovered_key
+            resolved_info["reconciled_via_rest_orders"] = True
+            resolved["info"] = resolved_info
+            resolved["status"] = "open"
+            logger.info(
+                "fetch_order no-key reconcile: order %s for %s found live in gmxapi.ai /orders — keeping status=open, order_key=%s",
+                order_id[:18],
+                pair,
+                (recovered_key[:18] + "…") if isinstance(recovered_key, str) and len(recovered_key) > 18 else recovered_key,
+            )
+            return True, resolved
+
+        # REST returned and the order isn't there — REST tier votes
+        # absence.  Caller fuses with Tier-B Reader before flipping.
+        logger.info(
+            "fetch_order no-key reconcile: order %s for %s — REST /v1/orders has no matching pending row (deferring to Reader tier)",
+            order_id[:18],
+            pair,
+        )
+        return True, None
+
+    def _reconcile_no_key_via_contract(
+        self,
+        order: CcxtOrder,
+        pair: str,
+        order_id: str,
+    ) -> tuple[bool, CcxtOrder | None]:
+        """Tier-B resolver — on-chain ``SyntheticsReader.getAccountOrders``.
+
+        Delegates to
+        :func:`eth_defi.gmx.order.pending_orders.fetch_pending_orders`
+        which wraps a single eth_call to the GMX Reader contract.
+        Authoritative on-chain truth; never indexer-lagged.
+
+        Same ``(checked, reconciled)`` contract as
+        :meth:`_reconcile_no_key_via_rest_orders` — RPC failures
+        downgrade to inconclusive and the orchestrator handles fusion.
+
+        Matching rules mirror the REST tier so the two sources are
+        comparable: market token + ``is_long`` + trigger price within
+        :data:`_PENDING_PRICE_TOLERANCE`.  ``PendingOrder.trigger_price_usd``
+        already absorbs the GMX 30-decimal scaling for 18-decimal index
+        tokens — non-18-decimal tokens (WBTC=8) would need
+        ``trigger_price_usd_for_decimals`` if we widen the universe; for
+        the current pair_whitelist 18 decimals is the rule.
+
+        :param order: Cached CCXT order with ``info["order_key"]`` missing.
+        :param pair: Unified ccxt symbol.
+        :param order_id: Order id under reconciliation.
+        :returns: ``(checked, reconciled)`` per the cascade contract.
+        """
+        api_adapter = getattr(self, "_api", None)
+        if api_adapter is None:
+            return False, None
+        web3 = getattr(api_adapter, "web3", None)
+        wallet = getattr(api_adapter, "wallet_address", None)
+        config = getattr(api_adapter, "config", None)
+        chain_getter = getattr(config, "get_chain", None) if config is not None else None
+        if web3 is None or not wallet or chain_getter is None:
+            logger.debug(
+                "fetch_order no-key reconcile: web3/wallet/config unavailable for Reader tier — leaving order open",
+            )
+            return False, None
+
+        try:
+            chain = chain_getter()
+        except Exception as exc:  # noqa: BLE001 — soft fallback
+            logger.debug("fetch_order no-key reconcile: get_chain() failed (%s)", exc)
+            return False, None
+
+        # Local import keeps the wrapper module light and lets the
+        # test fixture stub the helper without owning the chain config.
+        try:
+            from eth_defi.gmx.order.pending_orders import fetch_pending_orders
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.debug("fetch_order no-key reconcile: pending_orders import failed (%s)", exc)
+            return False, None
+
+        market_token = self._market_token_for_pair(pair)
+        order_side = order.get("side")
+        if order_side not in ("buy", "sell"):
+            return False, None
+        is_long = order_side == "buy"
+
+        try:
+            pending_iter = fetch_pending_orders(
+                web3,
+                chain,
+                wallet,
+                market_filter=market_token,
+                is_long_filter=is_long,
+            )
+            pending = list(pending_iter)
+        except Exception as exc:  # noqa: BLE001 — soft fallback
+            logger.debug(
+                "fetch_order no-key reconcile: Reader.getAccountOrders failed for %s (%s) — leaving order open",
+                pair,
+                exc,
+            )
+            return False, None
+
+        match = self._match_reader_pending_order(order, pending)
+        if match is not None:
+            recovered_key = "0x" + match.order_key.hex()
+            self._api._patch_cached_order_key(order_id, recovered_key)
+            resolved = dict(order)
+            resolved_info = dict(order.get("info") or {})
+            resolved_info["order_key"] = recovered_key
+            resolved_info["reconciled_via_reader"] = True
+            resolved["info"] = resolved_info
+            resolved["status"] = "open"
+            logger.info(
+                "fetch_order no-key reconcile: order %s for %s found live in SyntheticsReader.getAccountOrders — keeping status=open, order_key=%s",
+                order_id[:18],
+                pair,
+                recovered_key[:18] + "…",
+            )
+            return True, resolved
+
+        logger.info(
+            "fetch_order no-key reconcile: order %s for %s — Reader.getAccountOrders has no matching pending row (REST tier vote required)",
+            order_id[:18],
+            pair,
+        )
+        return True, None
+
+    def _match_reader_pending_order(self, order: CcxtOrder, pending: list) -> object | None:
+        """Match a cached order to a row from :func:`fetch_pending_orders`.
+
+        The Reader iterator yields :class:`~eth_defi.gmx.order.pending_orders.PendingOrder`
+        instances with USD-denominated ``trigger_price_usd`` (18-decimal
+        index tokens) or raw int ``trigger_price`` (1e30-scaled).  We
+        match on price within :data:`_PENDING_PRICE_TOLERANCE` when the
+        cached order carries a price; otherwise, when only one
+        candidate is left after the ``fetch_pending_orders`` filters
+        (market + is_long), accept it directly.
+
+        :param order: Cached CCXT order.
+        :param pending: List of ``PendingOrder`` instances from the
+            Reader scan.
+        :returns: Matching ``PendingOrder`` or ``None``.
+        """
+        if not pending:
+            return None
+        order_price = order.get("price") or order.get("stopPrice")
+        order_price_float = float(order_price) if order_price is not None else None
+        if order_price_float is None or len(pending) == 1:
+            return pending[0]
+        for candidate in pending:
+            cand_price = getattr(candidate, "trigger_price_usd", None)
+            if cand_price is None:
+                continue
+            if abs(float(cand_price) - order_price_float) <= self._PENDING_PRICE_TOLERANCE * max(order_price_float, 1.0):
+                return candidate
+        return None
+
+    def _market_token_for_pair(self, pair: str) -> str | None:
+        """Resolve the GMX market token address for a CCXT pair via the adapter's market cache.
+
+        The REST ``/v1/orders`` rows reference markets by their token
+        address, so matching against a CCXT pair string requires this
+        lookup.  Returns ``None`` when markets haven't been loaded or
+        the pair isn't found.  If REST returned any rows, callers must
+        treat that as inconclusive instead of matching by side only.
+
+        :param pair: Unified ccxt symbol (``"DOGE/USDC:USDC"``).
+        :returns: Lower-cased market token address or ``None``.
+        """
+        api_adapter = getattr(self, "_api", None)
+        markets = getattr(api_adapter, "markets", None) or {}
+        market = markets.get(pair)
+        if not market:
+            return None
+        info = market.get("info") or {}
+        token = info.get("market_token") or info.get("marketToken")
+        if isinstance(token, str):
+            return token.lower()
+        return None
+
+    def _match_rest_pending_order(
+        self,
+        order: CcxtOrder,
+        rest_orders: list[dict],
+        market_token: str | None,
+    ) -> dict | None:
+        """Match a cached order to a row from gmxapi.ai ``/v1/orders``.
+
+        REST schema (relevant fields)::
+
+            {
+              "key": "0x... (orderKey)",
+              "account": "0x...",
+              "market": "0x... (market token address)",
+              "isLong": True/False,
+              "orderType": int,
+              "triggerPrice": "<raw 1e30 USD>",
+              "sizeDeltaUsd": "<raw 1e30 USD>",
+              ...
+            }
+
+        Matching is conservative — market + ``isLong`` must agree, and
+        when both ends carry a price the values must agree within
+        :data:`_PENDING_PRICE_TOLERANCE` (relative).  We deliberately
+        avoid matching on amount because the REST endpoint reports
+        ``sizeDeltaUsd`` (1e30-scaled USD) while cached orders carry
+        token-denominated ``amount`` — comparing across units risks
+        both false positives and false negatives.
+
+        :param order: Cached CCXT order.
+        :param rest_orders: List of REST rows from gmxapi.ai ``/v1/orders``.
+        :param market_token: Lower-cased market token address for the
+            cached order's pair.  Must not be ``None`` when REST
+            returned any rows; the caller handles that case as
+            inconclusive.
+        :returns: Matching REST row or ``None``.
+        """
+        order_side = order.get("side")
+        if order_side not in ("buy", "sell"):
+            return None
+        expected_is_long = order_side == "buy"
+
+        order_price = order.get("price") or order.get("stopPrice")
+        order_price_float = float(order_price) if order_price is not None else None
+
+        candidates: list[dict] = []
+        for row in rest_orders:
+            if not isinstance(row, dict):
+                continue
+            if bool(row.get("isLong")) != expected_is_long:
+                continue
+            row_market = row.get("market") or ""
+            if not isinstance(row_market, str) or row_market.lower() != market_token:
+                continue
+            candidates.append(row)
+
+        if not candidates:
+            return None
+        if order_price_float is None or len(candidates) == 1:
+            return candidates[0]
+
+        # Multiple candidates with a known cached price — discriminate
+        # by trigger price within tolerance.
+        for candidate in candidates:
+            raw_trigger = candidate.get("triggerPrice") or candidate.get("triggerPriceUsd")
+            if raw_trigger is None:
+                continue
+            try:
+                trigger_float = float(raw_trigger) / 1e30
+            except (TypeError, ValueError):
+                continue
+            if abs(trigger_float - order_price_float) <= self._PENDING_PRICE_TOLERANCE * max(order_price_float, 1.0):
+                return candidate
         return None
 
     @property

--- a/eth_defi/gmx/freqtrade/gmx_exchange.py
+++ b/eth_defi/gmx/freqtrade/gmx_exchange.py
@@ -1061,6 +1061,13 @@ class Gmx(Exchange):
             return False, None
 
         market_token = self._market_token_for_pair(pair)
+        if market_token is None:
+            logger.debug(
+                "fetch_order no-key reconcile: cannot resolve market token for %s before Reader tier — leaving order open",
+                pair,
+            )
+            return False, None
+
         order_side = order.get("side")
         if order_side not in ("buy", "sell"):
             return False, None
@@ -1128,8 +1135,9 @@ class Gmx(Exchange):
             return None
         order_price = order.get("price") or order.get("stopPrice")
         order_price_float = float(order_price) if order_price is not None else None
-        if order_price_float is None or len(pending) == 1:
-            return pending[0]
+        if order_price_float is None:
+            return pending[0] if len(pending) == 1 else None
+
         for candidate in pending:
             cand_price = getattr(candidate, "trigger_price_usd", None)
             if cand_price is None:
@@ -1219,8 +1227,8 @@ class Gmx(Exchange):
 
         if not candidates:
             return None
-        if order_price_float is None or len(candidates) == 1:
-            return candidates[0]
+        if order_price_float is None:
+            return candidates[0] if len(candidates) == 1 else None
 
         # Multiple candidates with a known cached price — discriminate
         # by trigger price within tolerance.

--- a/eth_defi/gmx/freqtrade/gmx_exchange.py
+++ b/eth_defi/gmx/freqtrade/gmx_exchange.py
@@ -52,6 +52,7 @@ from eth_defi.gmx.freqtrade.telegram_utils import send_freqtrade_telegram_messag
 from eth_defi.gmx.lagoon.approvals import UNLIMITED, approve_gmx_collateral_via_vault
 from eth_defi.gmx.lagoon.wallet import LagoonGMXTradingWallet
 from eth_defi.gmx.trading import GMXTrading
+from eth_defi.gmx.utils import convert_raw_price_to_usd
 from eth_defi.hotwallet import HotWallet
 from eth_defi.token import fetch_erc20_details
 from eth_defi.vault.base import VaultSpec
@@ -1006,7 +1007,29 @@ class Gmx(Exchange):
             )
             return False, None
 
-        match = self._match_rest_pending_order(order, rest_orders, market_token=market_token)
+        # Resolve the index-token decimals up front so the matcher can do
+        # the standard decimals-aware price conversion.  If the GMX tokens
+        # endpoint hasn't surfaced this pair yet (one-shot reload happens
+        # inside the helper), treat the whole tier as inconclusive — better
+        # than silently mis-comparing prices on a ``/1e30`` fallback.
+        token_decimals: int | None = None
+        if rest_orders:
+            token_decimals = self._index_token_decimals_for_pair(pair)
+            if token_decimals is None:
+                logger.warning(
+                    "fetch_order no-key reconcile: cannot resolve index-token decimals for %s while /orders returned %d row(s) — leaving order open (inconclusive)",
+                    pair,
+                    len(rest_orders),
+                )
+                return False, None
+
+        match = (
+            self._match_rest_pending_order(
+                order, rest_orders, market_token=market_token, token_decimals=token_decimals
+            )
+            if token_decimals is not None
+            else None
+        )
         if match is not None:
             recovered_key = match.get("key") or match.get("orderKey")
             if recovered_key:
@@ -1122,7 +1145,28 @@ class Gmx(Exchange):
             )
             return False, None
 
-        match = self._match_reader_pending_order(order, pending)
+        # Resolve decimals up front so the matcher can do the standard
+        # decimals-aware price conversion.  If the GMX tokens endpoint
+        # hasn't surfaced this pair yet, treat the tier as inconclusive
+        # — Reader is authoritative on chain but we still can't compare
+        # prices accurately without decimals, so we'd rather leave the
+        # order open than fail the matcher on a silent unit mismatch.
+        token_decimals: int | None = None
+        if pending:
+            token_decimals = self._index_token_decimals_for_pair(pair)
+            if token_decimals is None:
+                logger.warning(
+                    "fetch_order no-key reconcile: cannot resolve index-token decimals for %s while Reader returned %d pending row(s) — leaving order open (inconclusive)",
+                    pair,
+                    len(pending),
+                )
+                return False, None
+
+        match = (
+            self._match_reader_pending_order(order, pending, token_decimals=token_decimals)
+            if token_decimals is not None
+            else None
+        )
         if match is not None:
             recovered_key = "0x" + match.order_key.hex()
             self._api._patch_cached_order_key(order_id, recovered_key)
@@ -1147,20 +1191,34 @@ class Gmx(Exchange):
         )
         return True, None
 
-    def _match_reader_pending_order(self, order: CcxtOrder, pending: list) -> object | None:
+    def _match_reader_pending_order(
+        self,
+        order: CcxtOrder,
+        pending: list,
+        *,
+        token_decimals: int,
+    ) -> object | None:
         """Match a cached order to a row from :func:`fetch_pending_orders`.
 
         The Reader iterator yields :class:`~eth_defi.gmx.order.pending_orders.PendingOrder`
-        instances with USD-denominated ``trigger_price_usd`` (18-decimal
-        index tokens) or raw int ``trigger_price`` (1e30-scaled).  We
-        match on price within :data:`_PENDING_PRICE_TOLERANCE` when the
-        cached order carries a price; otherwise, when only one
+        instances whose ``trigger_price`` is the raw chain value at
+        ``10^(30 - index_token_decimals)`` scale.  ``trigger_price_usd``
+        assumes 18 decimals and is silently wrong for DOGE (8), TAO (9),
+        WBTC (8) etc., so the matcher requires the resolved decimals up
+        front (see :meth:`_index_token_decimals_for_pair`) and converts
+        the raw chain value with the same standard formula used elsewhere
+        in the adapter.
+
+        Match policy: price within :data:`_PENDING_PRICE_TOLERANCE` when
+        the cached order carries a price; otherwise, when only one
         candidate is left after the ``fetch_pending_orders`` filters
         (market + is_long), accept it directly.
 
         :param order: Cached CCXT order.
         :param pending: List of ``PendingOrder`` instances from the
             Reader scan.
+        :param token_decimals: Resolved index-token decimals for the
+            cached order's pair (required — see callers).
         :returns: Matching ``PendingOrder`` or ``None``.
         """
         if not pending:
@@ -1171,12 +1229,80 @@ class Gmx(Exchange):
             return pending[0] if len(pending) == 1 else None
 
         for candidate in pending:
-            cand_price = getattr(candidate, "trigger_price_usd", None)
-            if cand_price is None:
-                continue
-            if abs(float(cand_price) - order_price_float) <= self._PENDING_PRICE_TOLERANCE * max(order_price_float, 1.0):
+            raw = getattr(candidate, "trigger_price", None)
+            if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+                cand_price = convert_raw_price_to_usd(float(raw), token_decimals)
+            else:
+                # Pre-converted test-only mocks expose ``trigger_price_usd``
+                # as a float but don't surface the raw chain int — accept
+                # that derived value verbatim so unit tests don't have to
+                # carry the full raw / decimals representation.  Real
+                # ``PendingOrder`` instances always populate ``trigger_price``
+                # and therefore take the decimals-aware branch above.
+                legacy = getattr(candidate, "trigger_price_usd", None)
+                if not isinstance(legacy, (int, float)) or isinstance(legacy, bool):
+                    continue
+                cand_price = float(legacy)
+            if abs(cand_price - order_price_float) <= self._PENDING_PRICE_TOLERANCE * max(order_price_float, 1.0):
                 return candidate
         return None
+
+    def _index_token_decimals_for_pair(self, pair: str, *, allow_reload: bool = True) -> int | None:
+        """Resolve the index-token decimals for a CCXT pair.
+
+        GMX V2 prices are stored at ``10^(30 - index_token_decimals)`` precision,
+        so accurate human-readable USD conversion needs to know the index
+        token's ERC20 decimals.  The helper looks up the index-token address
+        via the adapter's market cache and the decimals via the adapter's
+        ``_token_metadata`` cache.  When metadata isn't loaded yet, it
+        attempts a one-shot ``_load_token_metadata()`` retry against the GMX
+        API before giving up.  Returns ``None`` only when the GMX API itself
+        doesn't carry the token — callers must treat that as inconclusive
+        (leave the order open) rather than fall back to ``/1e30``.
+
+        :param pair: Unified ccxt symbol (``"DOGE/USDC:USDC"``).
+        :param allow_reload: When ``True`` (default), retry by calling
+            ``_load_token_metadata()`` if the cache miss looks fresh.  Set
+            ``False`` to skip the network round-trip (used by retry guards).
+        :returns: Index-token decimals (int) or ``None`` when unresolvable.
+        """
+        api_adapter = getattr(self, "_api", None)
+        if api_adapter is None:
+            return None
+        markets = getattr(api_adapter, "markets", None) or {}
+        market = markets.get(pair)
+        if not market:
+            return None
+        info = market.get("info") or {}
+        index_addr = info.get("index_token") or info.get("indexTokenAddress")
+        if not isinstance(index_addr, str) or not index_addr:
+            return None
+        token_meta = getattr(api_adapter, "_token_metadata", None) or {}
+        entry = token_meta.get(index_addr.lower())
+        if entry is None and allow_reload:
+            # Cache miss — reload from the GMX tokens endpoint and retry.
+            loader = getattr(api_adapter, "_load_token_metadata", None)
+            if callable(loader):
+                try:
+                    loader()
+                except Exception as exc:  # noqa: BLE001 — soft fallback
+                    logger.debug(
+                        "fetch_order no-key reconcile: _load_token_metadata() failed for %s (%s)",
+                        pair,
+                        exc,
+                    )
+                else:
+                    token_meta = getattr(api_adapter, "_token_metadata", None) or {}
+                    entry = token_meta.get(index_addr.lower())
+        if not entry:
+            return None
+        decimals = entry.get("decimals") if isinstance(entry, dict) else None
+        if decimals is None:
+            return None
+        try:
+            return int(decimals)
+        except (TypeError, ValueError):
+            return None
 
     def _market_token_for_pair(self, pair: str) -> str | None:
         """Resolve the GMX market token address for a CCXT pair via the adapter's market cache.
@@ -1206,6 +1332,8 @@ class Gmx(Exchange):
         order: CcxtOrder,
         rest_orders: list[dict],
         market_token: str | None,
+        *,
+        token_decimals: int,
     ) -> dict | None:
         """Match a cached order to a row from gmxapi.ai ``/v1/orders``.
 
@@ -1217,18 +1345,22 @@ class Gmx(Exchange):
               "market": "0x... (market token address)",
               "isLong": True/False,
               "orderType": int,
-              "triggerPrice": "<raw 1e30 USD>",
-              "sizeDeltaUsd": "<raw 1e30 USD>",
+              "triggerPrice": "<30-decimal price, scale = 10^(30 - index_token_decimals)>",
+              "sizeDeltaUsd": "<raw 1e30 USD — genuinely USD-only>",
               ...
             }
 
         Matching is conservative — market + ``isLong`` must agree, and
         when both ends carry a price the values must agree within
-        :data:`_PENDING_PRICE_TOLERANCE` (relative).  We deliberately
-        avoid matching on amount because the REST endpoint reports
-        ``sizeDeltaUsd`` (1e30-scaled USD) while cached orders carry
-        token-denominated ``amount`` — comparing across units risks
-        both false positives and false negatives.
+        :data:`_PENDING_PRICE_TOLERANCE` (relative).  The chain-side
+        ``triggerPrice`` is normalised to human-readable USD via
+        :meth:`Gmx._convert_price_to_usd` (decimals-aware) before the
+        tolerance check; otherwise non-18-decimal index tokens (DOGE 8,
+        TAO 9 synthetic, WBTC 8, …) silently fail to match.  We
+        deliberately avoid matching on amount because the REST endpoint
+        reports ``sizeDeltaUsd`` (1e30-scaled USD) while cached orders
+        carry token-denominated ``amount`` — comparing across units
+        risks both false positives and false negatives.
 
         :param order: Cached CCXT order.
         :param rest_orders: List of REST rows from gmxapi.ai ``/v1/orders``.
@@ -1262,16 +1394,22 @@ class Gmx(Exchange):
         if order_price_float is None:
             return candidates[0] if len(candidates) == 1 else None
 
-        # Multiple candidates with a known cached price — discriminate
-        # by trigger price within tolerance.
+        # Candidates with a known cached price — discriminate by
+        # decimals-aware trigger price within tolerance.  The chain
+        # stores ``triggerPrice`` at ``10^(30 - index_token_decimals)``
+        # scale; hard-coding ``/1e30`` silently breaks for DOGE (8),
+        # TAO (9 synthetic), WBTC (8) etc.  Callers resolve and pass
+        # ``token_decimals`` so the conversion uses the standard
+        # adapter formula without any silent ``/1e30`` fallback.
         for candidate in candidates:
             raw_trigger = candidate.get("triggerPrice") or candidate.get("triggerPriceUsd")
             if raw_trigger is None:
                 continue
             try:
-                trigger_float = float(raw_trigger) / 1e30
+                raw_trigger_f = float(raw_trigger)
             except (TypeError, ValueError):
                 continue
+            trigger_float = convert_raw_price_to_usd(raw_trigger_f, token_decimals)
             if abs(trigger_float - order_price_float) <= self._PENDING_PRICE_TOLERANCE * max(order_price_float, 1.0):
                 return candidate
         return None

--- a/eth_defi/gmx/freqtrade/gmx_exchange.py
+++ b/eth_defi/gmx/freqtrade/gmx_exchange.py
@@ -648,6 +648,8 @@ class Gmx(Exchange):
         order: CcxtOrder,
         pair: str,
         order_id: str,
+        *,
+        allow_size_mismatch: bool = False,
     ) -> CcxtOrder | None:
         """Cross-check a "still open" order against on-chain positions.
 
@@ -672,6 +674,11 @@ class Gmx(Exchange):
         :param pair: ccxt unified pair symbol (``"BTC/USDC:USDC"``).
         :param order_id: Original ``order_id`` from freqtrade — used for log
             correlation; not for matching.
+        :param allow_size_mismatch: When ``True``, a same-pair/same-side
+            position is accepted even if the cached order amount is missing or
+            in the wrong unit.  This is only used after pending-order sources
+            have confirmed the trigger order is gone, so the live position is
+            the strongest remaining fill signal.
         :returns: The reconciled order when a matching position is found;
             ``None`` when no match exists (caller returns the original order
             unchanged).
@@ -694,14 +701,14 @@ class Gmx(Exchange):
 
         order_side = order.get("side")  # "buy" / "sell"
         order_amount = float(order.get("amount") or 0.0)
-        if order_amount <= 0.0:
+        if order_amount <= 0.0 and not allow_size_mismatch:
             return None
 
         # Match order side to position side.  ccxt orders use buy/sell;
         # GMX positions use long/short.
         expected_position_side = "long" if order_side == "buy" else "short"
 
-        tolerance = order_amount * self._POSITION_AMOUNT_TOLERANCE
+        tolerance = order_amount * self._POSITION_AMOUNT_TOLERANCE if order_amount > 0.0 else 0.0
         for position in positions:
             if position.get("symbol") != pair:
                 continue
@@ -710,26 +717,36 @@ class Gmx(Exchange):
             pos_size = float(position.get("contracts") or 0.0)
             if pos_size <= 0.0:
                 continue
-            if abs(pos_size - order_amount) > tolerance:
+            amount_matches = order_amount > 0.0 and abs(pos_size - order_amount) <= tolerance
+            if not amount_matches and not allow_size_mismatch:
                 continue
 
             # Match — flip the order to closed using on-chain truth.
             reconciled = dict(order)
             reconciled["status"] = "closed"
-            reconciled["filled"] = order_amount
+            reconciled["amount"] = pos_size if allow_size_mismatch and not amount_matches else order_amount
+            reconciled["filled"] = reconciled["amount"]
             reconciled["remaining"] = 0.0
+            entry_price = position.get("entryPrice")
+            if entry_price is not None:
+                reconciled["average"] = float(entry_price)
+                reconciled["price"] = float(entry_price)
+                reconciled["cost"] = reconciled["filled"] * float(entry_price)
             reconciled_info = dict(order.get("info") or {})
             reconciled_info["reconciled_via_position"] = True
             reconciled_info["reconciled_position_key"] = position.get("id") or position.get("position_key")
             reconciled_info["reconciled_position_size"] = pos_size
+            if allow_size_mismatch and not amount_matches:
+                reconciled_info["reconciled_amount_source"] = "position_contracts"
             reconciled["info"] = reconciled_info
             logger.warning(
-                "fetch_order reconcile: order %s for %s flipped open→closed via on-chain position match (order_amount=%.8f, position_size=%.8f, side=%s)",
+                "fetch_order reconcile: order %s for %s flipped open→closed via on-chain position match (order_amount=%.8f, position_size=%.8f, side=%s, allow_size_mismatch=%s)",
                 order_id[:18],
                 pair,
                 order_amount,
                 pos_size,
                 expected_position_side,
+                allow_size_mismatch,
             )
             return reconciled
 
@@ -826,6 +843,21 @@ class Gmx(Exchange):
         contract_checked, contract_match = self._reconcile_no_key_via_contract(order, pair, order_id)
         if contract_match is not None:
             return contract_match
+
+        # If both pending-order sources say the trigger order is gone, a
+        # same-pair/same-side live position is stronger evidence of a fill
+        # than a cancellation.  In this path the cached order may have lost
+        # base-token amount semantics across restart, so accept the position
+        # size instead of requiring exact amount equality.
+        if rest_checked and contract_checked:
+            reconciled = self._reconcile_via_positions(
+                order,
+                pair,
+                order_id,
+                allow_size_mismatch=True,
+            )
+            if reconciled is not None:
+                return reconciled
 
         # Both tiers succeeded and neither saw the order → flip cancelled.
         # The contract Reader is authoritative on-chain; if it agrees

--- a/eth_defi/gmx/utils.py
+++ b/eth_defi/gmx/utils.py
@@ -116,6 +116,17 @@ from eth_defi.gmx.contracts import get_tokens_address_dict, NETWORK_TOKENS, TEST
 # GMX uses 30-decimal precision for all price values
 GMX_PRICE_PRECISION = 30
 
+#: Minimum fraction of ``size_usd`` the approximate liquidation formula must
+#: leave as headroom before its output is considered meaningful.  When the
+#: GMX_MIN_LIQUIDATION_COLLATERAL_USD floor dominates ``max_loss`` the
+#: approximation produces a liquidation price arbitrarily close to entry,
+#: which is nonsense (a $5 1× long would appear to liquidate on a 1% drop).
+#: Below this ratio :func:`calculate_estimated_liquidation_price` returns
+#: ``None`` instead.  1% is intentionally generous: a real high-leverage
+#: position always exceeds it by an order of magnitude; only tiny-stake
+#: floor-bound positions land below.
+_LIQUIDATION_APPROX_MIN_BUFFER_RATIO = 0.01
+
 
 def convert_raw_price_to_usd(raw_price: int | float, token_decimals: int) -> float:
     """Convert GMX raw price to human-readable USD.
@@ -233,7 +244,7 @@ def calculate_estimated_liquidation_price(
     include_closing_fee: bool = True,
     collateral_is_index_token: bool = False,
     collateral_amount: float | None = None,
-) -> float:
+) -> float | None:
     """
     Calculate liquidation price matching GMX V2 SDK implementation.
 
@@ -331,12 +342,26 @@ def calculate_estimated_liquidation_price(
         Required for exact calculation. If None, uses approximate formula.
     :type collateral_amount: float | None
     :return:
-        Liquidation price in USD
-    :rtype: float
+        Liquidation price in USD, or ``None`` when the approximation cannot
+        produce a meaningful value (e.g. small positions where the
+        :data:`GMX_MIN_LIQUIDATION_COLLATERAL_USD` floor dominates the
+        formula, or degenerate inputs like ``size_in_tokens == 0``).
+        Callers must treat ``None`` as "unknown" — never substitute ``0``
+        or any other fallback that downstream code could interpret as a
+        valid liquidation price.
+    :rtype: float | None
 
     **Note:**
         For maximum accuracy, provide `collateral_is_index_token` and `collateral_amount`.
         Without these, the function uses an approximate formula with ±0.5% error.
+
+        Historical caveat: previously this function returned ``0.0`` for
+        unresolvable cases.  That was a footgun — Freqtrade's downstream
+        ``stoploss_or_liquidation()`` and ``get_liquidation_price()`` paths
+        do not treat ``0.0`` as falsy, so the sentinel landed in the DB,
+        was then offset by a 5% buffer, and the resulting non-zero
+        liquidation price triggered false ``ExitType.LIQUIDATION`` exits.
+        ``None`` is the correct unknown sentinel and is now used uniformly.
     """
     # Calculate total fees
     total_pending_fees = pending_funding_fees_usd + pending_borrowing_fees_usd
@@ -357,18 +382,18 @@ def calculate_estimated_liquidation_price(
                 # Long: liq_price = (size + liq_collateral + fees) / (size_tokens + collateral_tokens)
                 denominator = size_in_tokens + collateral_amount
                 if denominator == 0:
-                    return 0.0
+                    return None
                 liquidation_price = (size_usd + liquidation_collateral_usd + total_fees) / denominator
             else:
                 # Short: liq_price = (size - liq_collateral - fees) / (size_tokens - collateral_tokens)
                 denominator = size_in_tokens - collateral_amount
                 if denominator == 0:
-                    return 0.0
+                    return None
                 liquidation_price = (size_usd - liquidation_collateral_usd - total_fees) / denominator
         else:
             # Different token collateral (e.g., USDC collateral for ETH/USD position)
             if size_in_tokens == 0:
-                return 0.0
+                return None
 
             remaining_collateral_usd = collateral_usd - total_pending_fees - closing_fee
 
@@ -379,34 +404,51 @@ def calculate_estimated_liquidation_price(
                 # Short: liq_price = (size - liq_collateral + remaining_collateral) / size_tokens
                 liquidation_price = (size_usd - liquidation_collateral_usd + remaining_collateral_usd) / size_in_tokens
     else:
-        # Fallback to approximate formula when token details not provided
+        # Fallback to approximate formula when token details not provided.
+        # When stake is small (≲$10) the ``GMX_MIN_LIQUIDATION_COLLATERAL_USD``
+        # floor dominates ``min_collateral_requirement`` and the resulting
+        # ``max_loss`` is a tiny number (or zero/negative).  The formula then
+        # produces a liquidation price arbitrarily close to entry — for a 1×
+        # long with $5 stake that lands ~0.9% below entry, which is nonsense.
+        # We refuse to return such values and bubble ``None`` up so Freqtrade
+        # records the column as unknown rather than treating the bogus value
+        # as a real liquidation level (which would trigger false
+        # ``ExitType.LIQUIDATION`` exits every loop).
         remaining_collateral = collateral_usd - total_fees
         min_collateral_requirement = liquidation_collateral_usd
+        max_loss = remaining_collateral - min_collateral_requirement
+        if max_loss <= 0:
+            # Collateral does not cover the minimum liquidation threshold —
+            # the approximation cannot describe a meaningful liquidation level.
+            return None
+
+        # Sanity guard against the floor-dominated edge: if max_loss is a
+        # tiny fraction of size_usd, the approximation is unreliable even
+        # though it doesn't go negative.  The threshold is intentionally
+        # generous (1%): for genuine high-leverage positions max_loss/size
+        # is much larger than this; only tiny-stake positions land below.
+        if size_usd <= 0 or (max_loss / size_usd) < _LIQUIDATION_APPROX_MIN_BUFFER_RATIO:
+            return None
 
         if is_long:
             # For longs: price drop reduces collateral value
-            max_loss = remaining_collateral - min_collateral_requirement
-            if max_loss <= 0:
-                # Collateral is smaller than GMX_MIN_LIQUIDATION_COLLATERAL_USD ($5).
-                # Note: GMX_MIN_COST_USD ($2) is the minimum ORDER size — a separate value.
-                # When collateral < min liquidation threshold the formula produces a
-                # liquidation price ABOVE entry, which is nonsensical for a long.
-                # Return 0.0 so freqtrade's stoploss_or_liquidation() treats it as unset
-                # (falsy) and falls back to the strategy's stop-loss price instead.
-                return 0.0
             price_drop_ratio = max_loss / size_usd
             liquidation_price = entry_price * (1 - price_drop_ratio)
         else:
             # For shorts: price rise reduces collateral value
-            max_loss = remaining_collateral - min_collateral_requirement
-            if max_loss <= 0:
-                # Same issue for shorts: formula produces liquidation price BELOW entry.
-                # Return 0.0 as sentinel — caller should treat 0.0 as "not meaningful".
-                return 0.0
             price_rise_ratio = max_loss / size_usd
             liquidation_price = entry_price * (1 + price_rise_ratio)
 
-    return max(liquidation_price, 0.0)
+    # Final sanity: a long's liquidation must be BELOW entry, a short's must be
+    # ABOVE entry.  If the computed value violates that invariant — or comes out
+    # non-positive — surface ``None`` instead of a misleading number.
+    if liquidation_price <= 0:
+        return None
+    if is_long and liquidation_price >= entry_price:
+        return None
+    if (not is_long) and liquidation_price <= entry_price:
+        return None
+    return liquidation_price
 
 
 def get_positions(config, address: str = None) -> dict[str, Any]:

--- a/tests/gmx/ccxt/test_cached_order_key_patch.py
+++ b/tests/gmx/ccxt/test_cached_order_key_patch.py
@@ -1,0 +1,103 @@
+"""Unit tests for the ``_patch_cached_order_key`` cache helper.
+
+When ``Gmx.fetch_order`` recovers a missing ``order_key`` from a live
+DataStore pending order or a historical event, it must back-patch the
+CCXT-layer order cache so the next poll resolves through the normal
+order-key path instead of re-triggering the no-key reconciler.
+
+The helper is intentionally simple: in-place update of ``info["order_key"]``
+on every alias under which the cache may have stored the order
+(``"0x{hash}"``, ``"{hash}"``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _fake_sync_exchange() -> "object":
+    """Build a sync ``GMX`` instance with the cache helper attached, bypassing __init__."""
+    from eth_defi.gmx.ccxt.exchange import GMX
+
+    fake = GMX.__new__(GMX)
+    fake._orders = {}
+    return fake
+
+
+def _fake_async_exchange() -> "object":
+    """Async counterpart — kept in lockstep per the sync/async invariant."""
+    from eth_defi.gmx.ccxt.async_support.exchange import GMX as AsyncGMX
+
+    fake = AsyncGMX.__new__(AsyncGMX)
+    fake._orders = {}
+    return fake
+
+
+class TestPatchCachedOrderKeySync:
+    def test_patches_both_prefixed_and_bare_aliases(self):
+        gmx = _fake_sync_exchange()
+        order = {"id": "0xcreationtx", "info": {}}
+        # Real callers cache under both forms (see exchange.py:8542
+        # ``_cache_key = id if id in self._orders else id.removeprefix("0x")``).
+        gmx._orders["0xcreationtx"] = order
+        gmx._orders["creationtx"] = order
+
+        gmx._patch_cached_order_key("0xcreationtx", "0xorderkey")
+
+        assert gmx._orders["0xcreationtx"]["info"]["order_key"] == "0xorderkey"
+        assert gmx._orders["creationtx"]["info"]["order_key"] == "0xorderkey"
+
+    def test_patches_when_only_bare_alias_is_cached(self):
+        gmx = _fake_sync_exchange()
+        order = {"id": "creationtx", "info": {}}
+        gmx._orders["creationtx"] = order
+
+        gmx._patch_cached_order_key("0xcreationtx", "0xorderkey")
+
+        assert gmx._orders["creationtx"]["info"]["order_key"] == "0xorderkey"
+
+    def test_patches_when_only_prefixed_alias_is_cached(self):
+        gmx = _fake_sync_exchange()
+        order = {"id": "0xcreationtx", "info": {}}
+        gmx._orders["0xcreationtx"] = order
+
+        gmx._patch_cached_order_key("creationtx", "0xorderkey")
+
+        assert gmx._orders["0xcreationtx"]["info"]["order_key"] == "0xorderkey"
+
+    def test_missing_info_dict_is_created(self):
+        # Defensive: cached order shape that never had ``info`` set must
+        # not raise; we want a no-op-or-create semantics, not a KeyError.
+        gmx = _fake_sync_exchange()
+        gmx._orders["0xcreationtx"] = {"id": "0xcreationtx"}
+
+        gmx._patch_cached_order_key("0xcreationtx", "0xorderkey")
+
+        assert gmx._orders["0xcreationtx"]["info"]["order_key"] == "0xorderkey"
+
+    def test_no_op_when_id_not_in_cache(self):
+        # No matching alias: silently does nothing. The historical resolver
+        # may run before the order is actually cached (e.g. recovery path),
+        # so raising would break the soft-fallback contract.
+        gmx = _fake_sync_exchange()
+
+        gmx._patch_cached_order_key("0xnothing", "0xorderkey")
+
+        assert gmx._orders == {}
+
+
+class TestPatchCachedOrderKeyAsync:
+    """Mirror tests on the async adapter — sync/async lockstep invariant."""
+
+    def test_patches_both_aliases_async(self):
+        gmx = _fake_async_exchange()
+        order = {"id": "0xcreationtx", "info": {}}
+        gmx._orders["0xcreationtx"] = order
+        gmx._orders["creationtx"] = order
+
+        gmx._patch_cached_order_key("0xcreationtx", "0xorderkey")
+
+        assert gmx._orders["0xcreationtx"]["info"]["order_key"] == "0xorderkey"
+        assert gmx._orders["creationtx"]["info"]["order_key"] == "0xorderkey"

--- a/tests/gmx/ccxt/test_order_key_cache.py
+++ b/tests/gmx/ccxt/test_order_key_cache.py
@@ -238,3 +238,55 @@ class TestOrderKeyCacheAtomicWrites:
         assert leftovers == []
         final = list(tmp_path.glob("order_keys_*.json"))
         assert len(final) == 1
+
+
+class _StubOrderKeyCache:
+    """Test-only stand-in that mirrors :class:`OrderKeyCache`'s constructor
+    signature so adapter kwarg drift is caught without touching disk."""
+
+    def __init__(self, *, chain_id: int, wallet: str, cache_dir=None, max_entry_age_seconds: int = 0):
+        self.chain_id = chain_id
+        self.wallet = wallet.lower()
+        self.cache_dir = cache_dir
+        self.max_entry_age_seconds = max_entry_age_seconds
+
+
+class TestOrderKeyCacheAdapterWiring:
+    """Regression: the GMX CCXT adapter must instantiate :class:`OrderKeyCache`
+    with the correct kwarg names. Before this guard, ``exchange.py`` passed
+    ``wallet_address=`` whereas the constructor expects ``wallet=`` — the
+    persistent cache silently fell back to memory-only mode on every restart,
+    forcing the no-key reconcile path on every stale order.
+    """
+
+    def test_init_order_key_cache_wires_constructor_kwargs(self, monkeypatch):
+        """Drive ``_init_order_key_cache`` with stubbed wallet+web3 and confirm
+        the cache instance is created (i.e. constructor accepted the kwargs).
+        """
+        from types import SimpleNamespace
+
+        from eth_defi.gmx.ccxt import exchange as exchange_module
+        from eth_defi.gmx.ccxt.exchange import GMX
+
+        monkeypatch.setattr(exchange_module, "OrderKeyCache", _StubOrderKeyCache)
+
+        # Minimal stand-in exposing only the attributes _init_order_key_cache
+        # reads — enough to exercise the real call site without instantiating
+        # the full GMX exchange (which would need RPCs, secrets, etc.).
+        stub = SimpleNamespace(
+            web3=SimpleNamespace(eth=SimpleNamespace(chain_id=42161)),
+            wallet_address="0xE3F16770C0A336103d7c24B34A4AfcBf6fb17583",
+            _order_key_cache=None,
+        )
+
+        GMX._init_order_key_cache(stub)
+
+        # If the constructor kwargs had drifted, init would silently swallow
+        # the TypeError and leave _order_key_cache as None (memory-only mode).
+        assert stub._order_key_cache is not None, (
+            "OrderKeyCache constructor kwargs drifted from "
+            "eth_defi/gmx/ccxt/order_key_cache.py — adapter falls back to "
+            "memory-only mode on every restart."
+        )
+        assert stub._order_key_cache.chain_id == 42161
+        assert stub._order_key_cache.wallet == "0xe3f16770c0a336103d7c24b34a4afcbf6fb17583"

--- a/tests/gmx/ccxt/test_position_metrics.py
+++ b/tests/gmx/ccxt/test_position_metrics.py
@@ -1,0 +1,341 @@
+"""Regression tests for :pymod:`eth_defi.gmx.ccxt._position_metrics`.
+
+Covers two crash-loop fixes that landed on ``fix/issue-67-no-key-resolver``:
+
+* W1 — async/sync liquidation_price parity.  Both ``parse_position``
+  (sync) and ``fetch_positions`` (async) must call
+  :pyfunc:`safe_liquidation_price`.  These tests pin the helper's
+  contract so neither path can silently re-introduce a wrong-side or
+  zero value into the freqtrade ``Trade.liquidation_price`` column.
+* W2 — explicit ``GMX_MIN_COST_USD`` guard in
+  ``_convert_ccxt_to_gmx_params`` (sync) and
+  ``_convert_ccxt_to_gmx_params_async`` (async).  Verifies the guard
+  raises :pyexc:`ccxt.base.errors.InvalidOrder` for sub-$2 opens and
+  is exempt for reduce-only closes.
+
+Unit-level only — no network, no fork, no GMX instance construction.
+The helper is a pure function; the ``_convert_ccxt_to_gmx_params``
+checks bind to instance method only for ``self.markets`` lookup, so the
+W2 cases mock the minimum surface (``self.markets``, ``load_markets``
+no-op) rather than spinning up an anvil fork.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from ccxt.base.errors import InvalidOrder
+
+from eth_defi.gmx.ccxt._position_metrics import safe_liquidation_price
+from eth_defi.gmx.constants import GMX_MIN_COST_USD
+
+
+# ---------------------------------------------------------------------------
+# W1 — safe_liquidation_price helper
+# ---------------------------------------------------------------------------
+
+
+class TestSafeLiquidationPriceSmallStake:
+    """Production crash-trigger inputs must return ``None``."""
+
+    def test_icp_long_5usd_returns_none(self):
+        """The exact production failure case (ICP/USDC 1x long, $5.05 stake).
+
+        Pre-fix this returned ~$2.527 (0.89 % below entry $2.5522), which
+        Freqtrade then padded with a 5 % buffer to ~$2.65 — exceeding
+        current rate every loop, firing ``ExitType.LIQUIDATION``, and
+        crashing the bot on the missing ``skip_custom_exit_price`` kwarg.
+        Post-fix: ``None``.
+        """
+        result = safe_liquidation_price(
+            entry_price=2.5522,
+            collateral_usd=5.05,
+            position_size_usd=5.05,
+            is_long=True,
+        )
+        assert result is None
+
+    def test_short_5usd_returns_none(self):
+        result = safe_liquidation_price(
+            entry_price=100.0,
+            collateral_usd=5.05,
+            position_size_usd=5.05,
+            is_long=False,
+        )
+        assert result is None
+
+
+class TestSafeLiquidationPriceRealistic:
+    """Comfortable position sizes return a reliable float on the
+    correct side of entry."""
+
+    def test_long_returns_value_below_entry(self):
+        result = safe_liquidation_price(
+            entry_price=100.0,
+            collateral_usd=1000.0,
+            position_size_usd=1000.0,
+            is_long=True,
+        )
+        assert result is not None
+        assert 0 < result < 100.0
+
+    def test_short_returns_value_above_entry(self):
+        result = safe_liquidation_price(
+            entry_price=100.0,
+            collateral_usd=1000.0,
+            position_size_usd=1000.0,
+            is_long=False,
+        )
+        assert result is not None
+        assert result > 100.0
+
+
+class TestSafeLiquidationPriceDegenerateInputs:
+    """Missing / zero / negative inputs must be rejected without exception."""
+
+    @pytest.mark.parametrize(
+        "entry,collateral,size",
+        [
+            (None, 100.0, 100.0),
+            (100.0, None, 100.0),
+            (100.0, 100.0, None),
+            (0.0, 100.0, 100.0),
+            (100.0, 0.0, 100.0),
+            (100.0, 100.0, 0.0),
+            (100.0, 100.0, -5.0),
+        ],
+    )
+    def test_missing_or_zero_inputs_yield_none(self, entry, collateral, size):
+        assert (
+            safe_liquidation_price(
+                entry_price=entry,
+                collateral_usd=collateral,
+                position_size_usd=size,
+                is_long=True,
+            )
+            is None
+        )
+
+
+class TestSafeLiquidationPriceDirectionInvariant:
+    """Belt-and-suspenders: even if the upstream helper one day returns
+    a wrong-side value, ``safe_liquidation_price`` must reject it."""
+
+    @patch("eth_defi.gmx.ccxt._position_metrics.calculate_estimated_liquidation_price")
+    def test_long_wrong_side_rejected(self, mock_calc):
+        # Long position, but helper returns a value AT entry — invariant says <.
+        mock_calc.return_value = 100.0
+        result = safe_liquidation_price(
+            entry_price=100.0,
+            collateral_usd=1000.0,
+            position_size_usd=1000.0,
+            is_long=True,
+        )
+        assert result is None
+
+    @patch("eth_defi.gmx.ccxt._position_metrics.calculate_estimated_liquidation_price")
+    def test_short_wrong_side_rejected(self, mock_calc):
+        mock_calc.return_value = 100.0
+        result = safe_liquidation_price(
+            entry_price=100.0,
+            collateral_usd=1000.0,
+            position_size_usd=1000.0,
+            is_long=False,
+        )
+        assert result is None
+
+    @patch("eth_defi.gmx.ccxt._position_metrics.calculate_estimated_liquidation_price")
+    def test_non_positive_rejected(self, mock_calc):
+        mock_calc.return_value = 0.0
+        result = safe_liquidation_price(
+            entry_price=100.0,
+            collateral_usd=1000.0,
+            position_size_usd=1000.0,
+            is_long=True,
+        )
+        assert result is None
+
+
+class TestSyncAsyncImportLockstep:
+    """Both ``exchange.py`` (sync) and ``async_support/exchange.py``
+    (async) must import the SAME helper module — guards against a
+    future divergence."""
+
+    def test_sync_imports_safe_liquidation_price(self):
+        from eth_defi.gmx.ccxt import exchange as sync_mod
+
+        assert hasattr(sync_mod, "safe_liquidation_price")
+        assert (
+            sync_mod.safe_liquidation_price
+            is safe_liquidation_price
+        )
+
+    def test_async_imports_safe_liquidation_price(self):
+        from eth_defi.gmx.ccxt.async_support import exchange as async_mod
+
+        assert hasattr(async_mod, "safe_liquidation_price")
+        assert (
+            async_mod.safe_liquidation_price
+            is safe_liquidation_price
+        )
+
+
+# ---------------------------------------------------------------------------
+# W2 — GMX_MIN_COST_USD guard in _convert_ccxt_to_gmx_params
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sync_gmx_with_stub_markets():
+    """Minimal stub of the sync :pyclass:`GMX` instance that exposes
+    just the surface :pymeth:`_convert_ccxt_to_gmx_params` needs:
+    ``self.markets``, ``self.markets_loaded``, ``self.leverage``,
+    ``self.default_slippage``, and a no-op ``load_markets``.  Avoids
+    constructing the real instance (which would require an Arbitrum
+    fork)."""
+    from eth_defi.gmx.ccxt.exchange import GMX
+
+    gmx = MagicMock(spec=GMX)
+    gmx.markets_loaded = True
+    gmx.markets = {
+        "BTC/USDC:USDC": {
+            "base": "BTC",
+            "quote": "USDC",
+            "symbol": "BTC/USDC:USDC",
+        },
+    }
+    gmx.leverage = {}
+    gmx.default_slippage = 0.003
+
+    # Bind the real implementation so we exercise the production code path.
+    gmx._convert_ccxt_to_gmx_params = (
+        GMX._convert_ccxt_to_gmx_params.__get__(gmx, GMX)
+    )
+    gmx._normalize_symbol = lambda s: (
+        s if s.endswith(":USDC") else s.replace("/USDC", "/USDC:USDC")
+    )
+    gmx._resolve_market_info = lambda symbol, params: {
+        "market_token": "0x0000000000000000000000000000000000000000",
+        "index_token": "0x0000000000000000000000000000000000000000",
+    }
+    return gmx
+
+
+class TestSyncMinCostGuard:
+    """Sync ``_convert_ccxt_to_gmx_params`` must reject sub-$2 opens."""
+
+    def test_open_below_min_raises_invalid_order(
+        self, sync_gmx_with_stub_markets
+    ):
+        with pytest.raises(InvalidOrder, match="below GMX minimum"):
+            sync_gmx_with_stub_markets._convert_ccxt_to_gmx_params(
+                symbol="BTC/USDC:USDC",
+                type="market",
+                side="buy",
+                amount=0.0,
+                price=100000.0,
+                params={"size_usd": GMX_MIN_COST_USD - 0.5},
+            )
+
+    def test_open_at_min_succeeds(self, sync_gmx_with_stub_markets):
+        result = sync_gmx_with_stub_markets._convert_ccxt_to_gmx_params(
+            symbol="BTC/USDC:USDC",
+            type="market",
+            side="buy",
+            amount=0.0,
+            price=100000.0,
+            params={"size_usd": GMX_MIN_COST_USD},
+        )
+        assert result["size_delta_usd"] == GMX_MIN_COST_USD
+
+    def test_open_above_min_succeeds(self, sync_gmx_with_stub_markets):
+        result = sync_gmx_with_stub_markets._convert_ccxt_to_gmx_params(
+            symbol="BTC/USDC:USDC",
+            type="market",
+            side="buy",
+            amount=0.0,
+            price=100000.0,
+            params={"size_usd": 100.0},
+        )
+        assert result["size_delta_usd"] == 100.0
+
+    def test_reduce_only_below_min_allowed(
+        self, sync_gmx_with_stub_markets
+    ):
+        # A dust-close reduce-only at $0.50 must NOT raise — GMX accepts
+        # tiny remainder closes.
+        result = sync_gmx_with_stub_markets._convert_ccxt_to_gmx_params(
+            symbol="BTC/USDC:USDC",
+            type="market",
+            side="sell",
+            amount=0.0,
+            price=100000.0,
+            params={
+                "size_usd": 0.5,
+                "reduceOnly": True,
+            },
+        )
+        assert result["size_delta_usd"] == 0.5
+
+
+class TestAsyncMinCostGuard:
+    """Async ``_convert_ccxt_to_gmx_params_async`` must mirror the sync
+    guard verbatim (sync/async lockstep)."""
+
+    @pytest.mark.asyncio
+    async def test_open_below_min_raises_invalid_order(self):
+        from eth_defi.gmx.ccxt.async_support.exchange import GMX as AsyncGMX
+
+        gmx = MagicMock(spec=AsyncGMX)
+        gmx._convert_ccxt_to_gmx_params_async = (
+            AsyncGMX._convert_ccxt_to_gmx_params_async.__get__(gmx, AsyncGMX)
+        )
+        with pytest.raises(InvalidOrder, match="below GMX minimum"):
+            await gmx._convert_ccxt_to_gmx_params_async(
+                symbol="BTC/USDC:USDC",
+                type="market",
+                side="buy",
+                amount=0.0,
+                price=100000.0,
+                params={"size_usd": GMX_MIN_COST_USD - 0.5},
+            )
+
+    @pytest.mark.asyncio
+    async def test_reduce_only_below_min_allowed(self):
+        from eth_defi.gmx.ccxt.async_support.exchange import GMX as AsyncGMX
+
+        gmx = MagicMock(spec=AsyncGMX)
+        gmx._convert_ccxt_to_gmx_params_async = (
+            AsyncGMX._convert_ccxt_to_gmx_params_async.__get__(gmx, AsyncGMX)
+        )
+        result = await gmx._convert_ccxt_to_gmx_params_async(
+            symbol="BTC/USDC:USDC",
+            type="market",
+            side="sell",
+            amount=0.0,
+            price=100000.0,
+            params={
+                "size_usd": 0.5,
+                "reduceOnly": True,
+            },
+        )
+        assert result["size_delta_usd"] == 0.5
+
+    @pytest.mark.asyncio
+    async def test_open_above_min_succeeds(self):
+        from eth_defi.gmx.ccxt.async_support.exchange import GMX as AsyncGMX
+
+        gmx = MagicMock(spec=AsyncGMX)
+        gmx._convert_ccxt_to_gmx_params_async = (
+            AsyncGMX._convert_ccxt_to_gmx_params_async.__get__(gmx, AsyncGMX)
+        )
+        result = await gmx._convert_ccxt_to_gmx_params_async(
+            symbol="BTC/USDC:USDC",
+            type="market",
+            side="buy",
+            amount=0.0,
+            price=100000.0,
+            params={"size_usd": 100.0},
+        )
+        assert result["size_delta_usd"] == 100.0

--- a/tests/gmx/ccxt/test_resolve_order_from_sources.py
+++ b/tests/gmx/ccxt/test_resolve_order_from_sources.py
@@ -18,6 +18,7 @@ from eth_defi.gmx.graphql.client import GMXSubsquidClient
 from eth_defi.gmx.ccxt.exchange import GMX
 from eth_defi.gmx.ccxt.async_support.exchange import GMX as AsyncGMX
 from eth_defi.gmx.config import GMXConfig
+from eth_defi.gmx.utils import convert_raw_price_to_usd
 
 BOT_WALLET = os.environ.get("GMX_BOT_WALLET_ADDRESS", "")
 
@@ -38,7 +39,7 @@ def known_executed_order_key(web3_arb):
     client = GMXSubsquidClient(chain="arbitrum")
     changes = client.get_position_changes(account=BOT_WALLET, limit=20)
     for ch in changes:
-        price = float(ch.get("executionPrice", 0)) / 1e30  # 30-decimal GMX price
+        price = convert_raw_price_to_usd(ch.get("executionPrice", 0), 18)  # APE has 18 decimals
         if 0.15 < price < 0.17 and ch.get("orderKey"):
             key = ch["orderKey"]
             return key if key.startswith("0x") else "0x" + key
@@ -68,6 +69,226 @@ def test_resolver_tier_a_returns_fill_from_subsquid(web3_arb, known_executed_ord
     assert 0.15 < avg < 0.17, f"Expected APE price ~0.16033, got {avg}"
     ts = result.get("timestamp")
     assert ts is not None and ts > 1_700_000_000_000, f"Timestamp must be real epoch-ms, got {ts}"
+
+
+DOGE_INDEX = "0x" + "aa" * 20
+FIL_INDEX = "0x" + "bb" * 20
+TAO_INDEX = "0x" + "cc" * 20
+
+
+def _raw_price(price: float, token_decimals: int) -> str:
+    """Encode USD price the way GMX stores index-token prices."""
+    return str(int(price * 10 ** (30 - token_decimals)))
+
+
+def _unit_gmx(markets: dict[str, dict], metadata: dict[str, dict]) -> GMX:
+    """Minimal sync GMX instance for pure builder unit tests."""
+    gmx = GMX.__new__(GMX)
+    gmx.markets = markets
+    gmx.markets_loaded = True
+    gmx._token_metadata = metadata
+    gmx.web3 = type(
+        "FakeWeb3",
+        (),
+        {
+            "eth": type(
+                "FakeEth",
+                (),
+                {
+                    "block_number": 123,
+                    "get_block": staticmethod(lambda block: {"timestamp": 1_780_000_000}),
+                },
+            )()
+        },
+    )()
+    return gmx
+
+
+def _unit_async_gmx(markets: dict[str, dict], metadata: dict[str, dict]) -> AsyncGMX:
+    """Minimal async GMX instance for pure builder unit tests."""
+    gmx = AsyncGMX.__new__(AsyncGMX)
+    gmx.markets = markets
+    gmx._token_metadata = metadata
+    gmx.milliseconds = lambda: 1_780_000_000_000
+    gmx.iso8601 = lambda ts: f"{ts}"
+    return gmx
+
+
+def _market(index_token: str) -> dict:
+    return {"symbol": "X/USDC:USDC", "info": {"index_token": index_token}}
+
+
+@pytest.mark.parametrize(
+    ("symbol", "index_token", "decimals", "price"),
+    [
+        ("DOGE/USDC:USDC", DOGE_INDEX, 8, 0.10086039),
+        ("FIL/USDC:USDC", FIL_INDEX, 18, 0.91901046),
+        ("TAO/USDC:USDC", TAO_INDEX, 9, 266.63831204),
+    ],
+)
+def test_sync_order_builders_decode_token_decimal_aware_prices(symbol, index_token, decimals, price):
+    markets = {symbol: _market(index_token)}
+    metadata = {index_token: {"decimals": decimals}}
+    gmx = _unit_gmx(markets, metadata)
+
+    trade_action_order = gmx._build_order_from_trade_action(
+        {
+            "eventName": "OrderExecuted",
+            "executionPrice": _raw_price(price, decimals),
+            "sizeDeltaUsd": str(int(5 * 1e30)),
+            "timestamp": "1780000000",
+            "orderKey": "0xorderkey",
+            "isLong": True,
+        },
+        symbol,
+    )
+    rest_order = gmx._build_order_from_rest_order(
+        {
+            "key": "0xrestorder",
+            "isLong": True,
+            "triggerPrice": _raw_price(price, decimals),
+            "sizeDeltaUsd": str(int(5 * 1e30)),
+        },
+        symbol,
+    )
+
+    assert trade_action_order["average"] == pytest.approx(price)
+    assert rest_order["price"] == pytest.approx(price)
+
+
+@pytest.mark.parametrize(
+    ("symbol", "index_token", "decimals", "price"),
+    [
+        ("DOGE/USDC:USDC", DOGE_INDEX, 8, 0.10086039),
+        ("FIL/USDC:USDC", FIL_INDEX, 18, 0.91901046),
+        ("TAO/USDC:USDC", TAO_INDEX, 9, 266.63831204),
+    ],
+)
+def test_async_order_builders_decode_token_decimal_aware_prices(symbol, index_token, decimals, price):
+    markets = {symbol: _market(index_token)}
+    metadata = {index_token: {"decimals": decimals}}
+    gmx = _unit_async_gmx(markets, metadata)
+
+    trade_action_order = gmx._build_order_from_trade_action(
+        {
+            "eventName": "OrderExecuted",
+            "executionPrice": _raw_price(price, decimals),
+            "sizeDeltaUsd": str(int(5 * 1e30)),
+            "timestamp": "1780000000",
+            "orderKey": "0xorderkey",
+            "isLong": True,
+        },
+        symbol,
+    )
+    rest_order = gmx._build_order_from_rest_order(
+        {
+            "key": "0xrestorder",
+            "isLong": True,
+            "triggerPrice": _raw_price(price, decimals),
+            "sizeDeltaUsd": str(int(5 * 1e30)),
+        },
+        symbol,
+    )
+
+    assert trade_action_order["average"] == pytest.approx(price)
+    assert rest_order["price"] == pytest.approx(price)
+
+
+@pytest.mark.parametrize(
+    ("symbol", "index_token", "decimals", "price"),
+    [
+        ("DOGE/USDC:USDC", DOGE_INDEX, 8, 0.10086039),
+        ("FIL/USDC:USDC", FIL_INDEX, 18, 0.91901046),
+        ("TAO/USDC:USDC", TAO_INDEX, 9, 266.63831204),
+    ],
+)
+def test_builders_return_amount_in_base_tokens_not_usd_notional(symbol, index_token, decimals, price):
+    """CCXT ``amount`` must be base tokens, not USD notional.
+
+    Production regression motivating this assertion: pre-fix, the builders
+    returned ``amount = sizeDeltaUsd / 1e30`` — i.e. raw USD notional — and
+    that value got persisted into Freqtrade's ``orders.amount``.  The
+    strict position-match arm (PR #1008) then compared ``order.amount``
+    (USD) against ``position.contracts`` (base tokens), failed by orders
+    of magnitude, and never adopted on-chain fills.  Post-fix, the builders
+    derive base tokens via ``sizeDeltaInTokens / 10^token_decimals`` (when
+    the GMX feed carries it) or ``sizeDeltaUsd / trigger_price`` (REST
+    pending-order case), so the assertion locks the unit semantics.
+    """
+    markets = {symbol: _market(index_token)}
+    metadata = {index_token: {"decimals": decimals}}
+    size_usd = 5.0  # notional intent — strategy thinks this is a $5 limit
+    expected_amount_tokens = size_usd / price  # what base-token amount strategy actually buys
+
+    gmx_sync = _unit_gmx(markets, metadata)
+    gmx_async = _unit_async_gmx(markets, metadata)
+
+    # _build_order_from_rest_order has no sizeDeltaInTokens — it derives
+    # amount as sizeDeltaUsd / trigger_price.
+    rest_sync = gmx_sync._build_order_from_rest_order(
+        {
+            "key": "0xrestorder",
+            "isLong": True,
+            "triggerPrice": _raw_price(price, decimals),
+            "sizeDeltaUsd": str(int(size_usd * 1e30)),
+        },
+        symbol,
+    )
+    rest_async = gmx_async._build_order_from_rest_order(
+        {
+            "key": "0xrestorder",
+            "isLong": True,
+            "triggerPrice": _raw_price(price, decimals),
+            "sizeDeltaUsd": str(int(size_usd * 1e30)),
+        },
+        symbol,
+    )
+
+    assert rest_sync["amount"] == pytest.approx(expected_amount_tokens, rel=1e-6), (
+        f"sync _build_order_from_rest_order amount must be base tokens "
+        f"(expected {expected_amount_tokens:.6f} {symbol.split('/')[0]}, got {rest_sync['amount']})"
+    )
+    assert rest_sync["remaining"] == pytest.approx(expected_amount_tokens, rel=1e-6)
+    assert rest_async["amount"] == pytest.approx(expected_amount_tokens, rel=1e-6)
+    assert rest_async["remaining"] == pytest.approx(expected_amount_tokens, rel=1e-6)
+
+    # _build_order_from_trade_action: when sizeDeltaInTokens is provided
+    # (executed orders), amount must come from there (decimals-aware),
+    # NOT from sizeDeltaUsd / 1e30.  The raw int is base tokens scaled
+    # by token decimals.
+    size_tokens_raw = str(int(expected_amount_tokens * (10**decimals)))
+    trade_action_sync = gmx_sync._build_order_from_trade_action(
+        {
+            "eventName": "OrderExecuted",
+            "executionPrice": _raw_price(price, decimals),
+            "sizeDeltaUsd": str(int(size_usd * 1e30)),
+            "sizeDeltaInTokens": size_tokens_raw,
+            "timestamp": "1780000000",
+            "orderKey": "0xorderkey",
+            "isLong": True,
+        },
+        symbol,
+    )
+    trade_action_async = gmx_async._build_order_from_trade_action(
+        {
+            "eventName": "OrderExecuted",
+            "executionPrice": _raw_price(price, decimals),
+            "sizeDeltaUsd": str(int(size_usd * 1e30)),
+            "sizeDeltaInTokens": size_tokens_raw,
+            "timestamp": "1780000000",
+            "orderKey": "0xorderkey",
+            "isLong": True,
+        },
+        symbol,
+    )
+
+    assert trade_action_sync["amount"] == pytest.approx(expected_amount_tokens, rel=1e-6), (
+        f"sync _build_order_from_trade_action amount must be base tokens from sizeDeltaInTokens "
+        f"(expected {expected_amount_tokens:.6f}, got {trade_action_sync['amount']})"
+    )
+    assert trade_action_sync["filled"] == pytest.approx(expected_amount_tokens, rel=1e-6)
+    assert trade_action_async["amount"] == pytest.approx(expected_amount_tokens, rel=1e-6)
+    assert trade_action_async["filled"] == pytest.approx(expected_amount_tokens, rel=1e-6)
 
 
 @pytest.mark.live

--- a/tests/gmx/freqtrade/test_fetch_order_no_key_reconcile.py
+++ b/tests/gmx/freqtrade/test_fetch_order_no_key_reconcile.py
@@ -245,6 +245,35 @@ class TestNoKeyRestOrderResolver:
         assert resolved["status"] == "cancelled"
         assert resolved["info"]["gmx_status"] == "no_key_not_found_in_any_tier"
 
+    def test_absent_pending_order_with_same_pair_position_marks_filled_even_when_amount_units_drift(self):
+        # Production DOGE/TAO regression: after restart the cached no-key
+        # entry amount can degrade to USD notional while the live GMX
+        # position reports base-token contracts.  If both pending-order
+        # tiers are empty, the same-pair position is stronger evidence of
+        # fill than "cancelled"; use the position size as filled amount.
+        cached = _cached_open_limit(amount=5.07005546, price=0.10086039)
+        gmx = _fake_gmx(
+            positions=[
+                {
+                    "symbol": "DOGE/USDC:USDC",
+                    "side": "long",
+                    "contracts": 50.27877164,
+                    "entryPrice": 0.10083888881985023,
+                    "id": "0xdogepos",
+                },
+            ],
+            rest_orders=[],
+        )
+
+        resolved = _invoke(gmx, cached)
+
+        assert resolved["status"] == "closed"
+        assert resolved["filled"] == pytest.approx(50.27877164)
+        assert resolved["remaining"] == 0.0
+        assert resolved["average"] == pytest.approx(0.10083888881985023)
+        assert resolved["info"]["reconciled_via_position"] is True
+        assert resolved["info"]["reconciled_position_size"] == pytest.approx(50.27877164)
+
     def test_multiple_same_side_candidates_match_by_trigger_price(self):
         cached = _cached_open_limit(price=0.10086039)
         gmx = _fake_gmx(

--- a/tests/gmx/freqtrade/test_fetch_order_no_key_reconcile.py
+++ b/tests/gmx/freqtrade/test_fetch_order_no_key_reconcile.py
@@ -1,0 +1,333 @@
+"""Regression tests for no-``order_key`` limit-order reconciliation.
+
+When the CCXT cache has an open limit order without ``info["order_key"]``,
+the wrapper cannot ask the normal order-key resolver for status.  The
+fallback must query GMX REST ``/v1/orders?address=<wallet>`` through
+``GMXAPI.get_orders``:
+
+* matching pending REST row -> adopt the row key and keep ``status="open"``;
+* successful REST response with no matching row -> mark cancelled;
+* REST failure or ambiguous market context -> leave the original order open.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("freqtrade.enums", reason="freqtrade.enums required for these tests")
+
+
+DOGE_MARKET = "0x" + "11" * 20
+FIL_MARKET = "0x" + "22" * 20
+
+
+def _fake_gmx(
+    *,
+    positions: list[dict] | None = None,
+    rest_orders: list[dict] | None = None,
+    markets: dict | None = None,
+    chain: str = "arbitrum",
+):
+    """Build a ``Gmx`` instance with selective ``_api`` mocks.
+
+    The fixture wires up both the REST tier (``_api.api.get_orders``)
+    and the on-chain Reader tier (``_api.web3``, ``_api.config.get_chain``).
+    Reader-tier scans go through ``fetch_pending_orders`` which is
+    patched per-test via the :func:`_with_reader` context manager.
+    """
+    from eth_defi.gmx.freqtrade.gmx_exchange import Gmx
+
+    fake = Gmx.__new__(Gmx)
+    fake._api = MagicMock()
+    fake._api.fetch_positions = MagicMock(return_value=positions or [])
+    fake._api.api = MagicMock()
+    fake._api.api.get_orders = MagicMock(return_value=rest_orders or [])
+    fake._api.wallet_address = "0xE3F16770C0A336103d7c24B34A4AfcBf6fb17583"
+    fake._api._patch_cached_order_key = MagicMock()
+    fake._api.web3 = MagicMock()
+    fake._api.config = MagicMock()
+    fake._api.config.get_chain = MagicMock(return_value=chain)
+    fake._api.markets = markets if markets is not None else {
+        "DOGE/USDC:USDC": {"info": {"market_token": DOGE_MARKET}},
+        "FIL/USDC:USDC": {"info": {"market_token": FIL_MARKET}},
+    }
+    fake._last_reconcile_ms = {}
+    return fake
+
+
+#: Default 32-byte hex used by Reader-tier mocks.  The wrapper logs a
+#: truncated form so an obviously fake value (alternating 0x33) is fine.
+_READER_KEY_BYTES = b"\x33" * 32
+
+
+def _reader_order(*, order_key: bytes = _READER_KEY_BYTES, market: str = DOGE_MARKET, is_long: bool = True, trigger_price_usd: float = 0.10086039):
+    """Build a :class:`PendingOrder`-shaped mock for the Reader tier.
+
+    Real ``PendingOrder`` is a ``dataclass(slots=True)`` so we cannot
+    set arbitrary attributes on a real instance; the mock object just
+    needs ``order_key`` (raw ``bytes``, NOT hex string —
+    :meth:`Gmx._reconcile_no_key_via_contract` formats it as
+    ``"0x" + order.order_key.hex()``), ``trigger_price_usd`` (float),
+    plus the side attributes the matcher inspects.
+    """
+    mock = MagicMock()
+    mock.order_key = order_key
+    mock.trigger_price_usd = trigger_price_usd
+    mock.market = market
+    mock.is_long = is_long
+    return mock
+
+
+def _with_reader(pending_orders=None, raises=None):
+    """Patch ``fetch_pending_orders`` for the Reader tier.
+
+    Use as a context manager around the wrapper call::
+
+        with _with_reader(pending_orders=[]):
+            resolved = _invoke(gmx, cached)
+    """
+    if raises is not None:
+        return patch(
+            "eth_defi.gmx.order.pending_orders.fetch_pending_orders",
+            side_effect=raises,
+        )
+    return patch(
+        "eth_defi.gmx.order.pending_orders.fetch_pending_orders",
+        return_value=iter(pending_orders or []),
+    )
+
+
+def _cached_open_limit(
+    *,
+    side: str = "buy",
+    amount: float = 5.07005546,
+    price: float = 0.10086039,
+    order_id: str = "0xcreationtx",
+    pair: str = "DOGE/USDC:USDC",
+    with_order_key: bool = False,
+) -> dict:
+    """CCXT-shaped cached limit order, defaulting to the no-key bug case."""
+    info: dict = {"tx_hash": order_id}
+    if with_order_key:
+        info["order_key"] = "0xexisting"
+    return {
+        "id": order_id,
+        "type": "limit",
+        "status": "open",
+        "side": side,
+        "amount": amount,
+        "filled": 0.0,
+        "remaining": amount,
+        "price": price,
+        "symbol": pair,
+        "timestamp": int(datetime(2026, 5, 20, tzinfo=timezone.utc).timestamp() * 1000),
+        "info": info,
+    }
+
+
+def _rest_order(
+    *,
+    is_long: bool = True,
+    price: float = 0.10086039,
+    order_key: str = "0xorderkey",
+    market: str = DOGE_MARKET,
+) -> dict:
+    """GMX REST ``/orders`` row with raw 1e30 trigger price."""
+    return {
+        "key": order_key,
+        "market": market,
+        "isLong": is_long,
+        "triggerPrice": str(int(price * 1e30)),
+        "sizeDeltaUsd": str(int(100 * 1e30)),
+    }
+
+
+def _invoke(fake_gmx, order: dict, pair: str = "DOGE/USDC:USDC", *, reader_pending=None, reader_raises=None) -> dict:
+    """Stub the parent ``Exchange.fetch_order`` and Reader tier, then call the wrapper.
+
+    By default the Reader returns an empty iterator so REST is the
+    only voting tier — preserves the original single-tier semantics
+    for tests that don't care about the contract path.
+
+    :param fake_gmx: Fixture-built Gmx wrapper.
+    :param order: CCXT order dict returned by the parent ``fetch_order``.
+    :param pair: Unified ccxt symbol.
+    :param reader_pending: List of ``PendingOrder``-like mocks to feed
+        the Reader tier (default: empty list = "checked, no match").
+    :param reader_raises: Exception class to raise from
+        ``fetch_pending_orders`` (default: no exception).
+    """
+    parent_patch = patch(
+        "eth_defi.gmx.freqtrade.gmx_exchange.Exchange.fetch_order",
+        return_value=order,
+    )
+    reader_patch = _with_reader(pending_orders=reader_pending or [], raises=reader_raises)
+    with parent_patch, reader_patch:
+        return fake_gmx.fetch_order(order["id"], pair)
+
+
+class TestNoKeyRestOrderResolver:
+    """Tier-A: REST ``/v1/orders``.  Reader tier is stubbed empty so
+    these tests pin REST-only behaviour against the cascade contract.
+    """
+
+    def test_no_key_open_limit_adopts_rest_pending_order_key(self):
+        cached = _cached_open_limit()
+        gmx = _fake_gmx(rest_orders=[_rest_order(order_key="0xorderkey")])
+
+        resolved = _invoke(gmx, cached)
+
+        assert resolved["status"] == "open"
+        assert resolved["info"]["order_key"] == "0xorderkey"
+        assert resolved["info"]["reconciled_via_rest_orders"] is True
+        gmx._api.api.get_orders.assert_called_once_with(gmx._api.wallet_address)
+        gmx._api._patch_cached_order_key.assert_called_once_with("0xcreationtx", "0xorderkey")
+
+    def test_existing_order_key_skips_cascade_entirely(self):
+        cached = _cached_open_limit(with_order_key=True)
+        gmx = _fake_gmx(rest_orders=[_rest_order(order_key="0xanotherkey")])
+
+        resolved = _invoke(gmx, cached)
+
+        assert resolved["status"] == "open"
+        gmx._api.api.get_orders.assert_not_called()
+        gmx._api._patch_cached_order_key.assert_not_called()
+
+    def test_no_matching_pending_order_anywhere_returns_cancelled(self):
+        # REST has rows but no match; Reader empty (default).  Both
+        # tiers vote absent → cancelled.
+        cached = _cached_open_limit()
+        gmx = _fake_gmx(rest_orders=[_rest_order(market=FIL_MARKET)])
+
+        resolved = _invoke(gmx, cached)
+
+        assert resolved["status"] == "cancelled"
+        assert resolved["filled"] == 0.0
+        assert resolved["info"]["gmx_status"] == "no_key_not_found_in_any_tier"
+        assert "REST" in resolved["info"]["cancel_reason"] or "gmxapi.ai" in resolved["info"]["cancel_reason"]
+
+    def test_rest_exception_with_empty_reader_keeps_open(self):
+        # REST errored → inconclusive.  Reader empty alone is not
+        # enough; the cancel vote requires BOTH tiers to confirm.
+        cached = _cached_open_limit()
+        gmx = _fake_gmx()
+        gmx._api.api.get_orders = MagicMock(side_effect=ConnectionError("gmxapi.ai 503"))
+
+        resolved = _invoke(gmx, cached)
+
+        assert resolved["status"] == "open"
+        assert "gmx_status" not in resolved["info"]
+
+    def test_unknown_market_with_rest_rows_is_inconclusive(self):
+        cached = _cached_open_limit()
+        gmx = _fake_gmx(markets={}, rest_orders=[_rest_order(order_key="0xwrong")])
+
+        resolved = _invoke(gmx, cached)
+
+        assert resolved["status"] == "open"
+        assert "order_key" not in resolved["info"]
+        assert "gmx_status" not in resolved["info"]
+        gmx._api._patch_cached_order_key.assert_not_called()
+
+    def test_empty_rest_orders_with_empty_reader_marks_cancelled(self):
+        # The original "phantom" case (stuck multistrat trades): no
+        # pending row in either tier → flip cancelled.
+        cached = _cached_open_limit()
+        gmx = _fake_gmx(markets={}, rest_orders=[])
+
+        resolved = _invoke(gmx, cached)
+
+        assert resolved["status"] == "cancelled"
+        assert resolved["info"]["gmx_status"] == "no_key_not_found_in_any_tier"
+
+    def test_multiple_same_side_candidates_match_by_trigger_price(self):
+        cached = _cached_open_limit(price=0.10086039)
+        gmx = _fake_gmx(
+            rest_orders=[
+                _rest_order(price=0.22, order_key="0xwrong"),
+                _rest_order(price=0.10086039, order_key="0xright"),
+            ],
+        )
+
+        resolved = _invoke(gmx, cached)
+
+        assert resolved["status"] == "open"
+        assert resolved["info"]["order_key"] == "0xright"
+
+
+class TestNoKeyContractResolver:
+    """Tier-B: on-chain Reader (``SyntheticsReader.getAccountOrders``).
+
+    REST tier is set to empty/absent so we can isolate Reader-tier
+    behaviour.
+    """
+
+    def test_reader_finds_order_after_rest_returns_empty(self):
+        # REST list empty, Reader has matching pending order →
+        # adopt the Reader key, keep open.
+        cached = _cached_open_limit()
+        gmx = _fake_gmx(rest_orders=[])
+
+        resolved = _invoke(
+            gmx,
+            cached,
+            reader_pending=[_reader_order()],
+        )
+
+        expected_key = "0x" + _READER_KEY_BYTES.hex()
+        assert resolved["status"] == "open"
+        assert resolved["info"]["order_key"] == expected_key
+        assert resolved["info"]["reconciled_via_reader"] is True
+        gmx._api._patch_cached_order_key.assert_called_once_with("0xcreationtx", expected_key)
+
+    def test_reader_overrides_rest_apparent_absence(self):
+        # REST shows no pending (success+empty) but Reader has a
+        # matching order — keep open (Reader is authoritative).
+        cached = _cached_open_limit()
+        gmx = _fake_gmx(rest_orders=[])
+
+        resolved = _invoke(
+            gmx,
+            cached,
+            reader_pending=[_reader_order()],
+        )
+
+        assert resolved["status"] == "open"
+        assert resolved["info"]["order_key"] == "0x" + _READER_KEY_BYTES.hex()
+
+    def test_reader_exception_with_rest_absence_keeps_open(self):
+        # REST returned no match (checked); Reader RPC errored
+        # (inconclusive).  Cancellation needs BOTH checked-and-empty;
+        # leave the order open.
+        cached = _cached_open_limit()
+        gmx = _fake_gmx(rest_orders=[])
+
+        resolved = _invoke(gmx, cached, reader_raises=ConnectionError("rpc 503"))
+
+        assert resolved["status"] == "open"
+        assert "gmx_status" not in resolved["info"]
+
+    def test_rest_and_reader_both_error_keeps_open(self):
+        cached = _cached_open_limit()
+        gmx = _fake_gmx()
+        gmx._api.api.get_orders = MagicMock(side_effect=ConnectionError("rest 503"))
+
+        resolved = _invoke(gmx, cached, reader_raises=ConnectionError("rpc 503"))
+
+        assert resolved["status"] == "open"
+        assert "gmx_status" not in resolved["info"]
+
+
+class TestThrottle:
+    def test_second_call_within_throttle_window_skips_rest_lookup(self):
+        cached = _cached_open_limit()
+        gmx = _fake_gmx(rest_orders=[_rest_order(order_key="0xorderkey")])
+
+        _invoke(gmx, cached)
+        gmx._api.api.get_orders.reset_mock()
+        _invoke(gmx, cached)
+
+        gmx._api.api.get_orders.assert_not_called()

--- a/tests/gmx/freqtrade/test_fetch_order_no_key_reconcile.py
+++ b/tests/gmx/freqtrade/test_fetch_order_no_key_reconcile.py
@@ -22,6 +22,8 @@ pytest.importorskip("freqtrade.enums", reason="freqtrade.enums required for thes
 
 DOGE_MARKET = "0x" + "11" * 20
 FIL_MARKET = "0x" + "22" * 20
+DOGE_INDEX = "0x" + "aa" * 20
+FIL_INDEX = "0x" + "bb" * 20
 
 
 def _fake_gmx(
@@ -51,8 +53,12 @@ def _fake_gmx(
     fake._api.config = MagicMock()
     fake._api.config.get_chain = MagicMock(return_value=chain)
     fake._api.markets = markets if markets is not None else {
-        "DOGE/USDC:USDC": {"info": {"market_token": DOGE_MARKET}},
-        "FIL/USDC:USDC": {"info": {"market_token": FIL_MARKET}},
+        "DOGE/USDC:USDC": {"info": {"market_token": DOGE_MARKET, "index_token": DOGE_INDEX}},
+        "FIL/USDC:USDC": {"info": {"market_token": FIL_MARKET, "index_token": FIL_INDEX}},
+    }
+    fake._api._token_metadata = {
+        DOGE_INDEX: {"symbol": "DOGE", "decimals": 8},
+        FIL_INDEX: {"symbol": "FIL", "decimals": 18},
     }
     fake._last_reconcile_ms = {}
     return fake
@@ -134,13 +140,14 @@ def _rest_order(
     price: float = 0.10086039,
     order_key: str = "0xorderkey",
     market: str = DOGE_MARKET,
+    token_decimals: int = 8,
 ) -> dict:
-    """GMX REST ``/orders`` row with raw 1e30 trigger price."""
+    """GMX REST ``/orders`` row with raw token-decimal-aware trigger price."""
     return {
         "key": order_key,
         "market": market,
         "isLong": is_long,
-        "triggerPrice": str(int(price * 1e30)),
+        "triggerPrice": str(int(price * 10 ** (30 - token_decimals))),
         "sizeDeltaUsd": str(int(100 * 1e30)),
     }
 
@@ -185,6 +192,28 @@ class TestNoKeyRestOrderResolver:
         assert resolved["info"]["reconciled_via_rest_orders"] is True
         gmx._api.api.get_orders.assert_called_once_with(gmx._api.wallet_address)
         gmx._api._patch_cached_order_key.assert_called_once_with("0xcreationtx", "0xorderkey")
+
+    def test_no_key_open_limit_matches_fil_raw_trigger_price_with_18_decimals(self):
+        cached = _cached_open_limit(
+            amount=4.90272068,
+            price=0.91901046,
+            pair="FIL/USDC:USDC",
+        )
+        gmx = _fake_gmx(
+            rest_orders=[
+                _rest_order(
+                    price=0.91901046,
+                    order_key="0xfilorderkey",
+                    market=FIL_MARKET,
+                    token_decimals=18,
+                )
+            ]
+        )
+
+        resolved = _invoke(gmx, cached, pair="FIL/USDC:USDC")
+
+        assert resolved["status"] == "open"
+        assert resolved["info"]["order_key"] == "0xfilorderkey"
 
     def test_existing_order_key_skips_cascade_entirely(self):
         cached = _cached_open_limit(with_order_key=True)

--- a/tests/gmx/freqtrade/test_fetch_order_no_key_reconcile.py
+++ b/tests/gmx/freqtrade/test_fetch_order_no_key_reconcile.py
@@ -233,10 +233,12 @@ class TestNoKeyRestOrderResolver:
         gmx._api._patch_cached_order_key.assert_not_called()
 
     def test_empty_rest_orders_with_empty_reader_marks_cancelled(self):
-        # The original "phantom" case (stuck multistrat trades): no
-        # pending row in either tier → flip cancelled.
+        # The original "phantom" case (stuck multistrat trades): both
+        # tiers can resolve the market (DOGE in default fixture) and
+        # both return no pending row → flip cancelled.  Unknown market
+        # would be inconclusive (see test_unknown_market_*).
         cached = _cached_open_limit()
-        gmx = _fake_gmx(markets={}, rest_orders=[])
+        gmx = _fake_gmx(rest_orders=[])
 
         resolved = _invoke(gmx, cached)
 
@@ -256,6 +258,19 @@ class TestNoKeyRestOrderResolver:
 
         assert resolved["status"] == "open"
         assert resolved["info"]["order_key"] == "0xright"
+
+    def test_single_rest_candidate_with_wrong_trigger_price_does_not_match(self):
+        # Even one same-market/same-side REST candidate is not enough
+        # if the cached order has a trigger price and the row's trigger
+        # price is different.
+        cached = _cached_open_limit(price=0.10086039)
+        gmx = _fake_gmx(rest_orders=[_rest_order(price=0.22, order_key="0xwrong")])
+
+        resolved = _invoke(gmx, cached)
+
+        assert resolved["status"] == "cancelled"
+        assert "order_key" not in resolved["info"]
+        gmx._api._patch_cached_order_key.assert_not_called()
 
 
 class TestNoKeyContractResolver:
@@ -319,6 +334,41 @@ class TestNoKeyContractResolver:
 
         assert resolved["status"] == "open"
         assert "gmx_status" not in resolved["info"]
+
+    def test_reader_unknown_market_with_pending_rows_is_inconclusive(self):
+        # Without a pair -> market-token mapping, the Reader tier must
+        # not scan all same-side wallet orders and adopt the sole row.
+        # That could patch DOGE/FIL/TAO with another pair's order_key.
+        cached = _cached_open_limit()
+        gmx = _fake_gmx(markets={}, rest_orders=[])
+
+        resolved = _invoke(
+            gmx,
+            cached,
+            reader_pending=[_reader_order(market=FIL_MARKET)],
+        )
+
+        assert resolved["status"] == "open"
+        assert "order_key" not in resolved["info"]
+        assert "gmx_status" not in resolved["info"]
+        gmx._api._patch_cached_order_key.assert_not_called()
+
+    def test_single_reader_candidate_with_wrong_trigger_price_does_not_match(self):
+        # Reader candidate is filtered by market + side, but if cached
+        # price exists the trigger price still has to agree before we
+        # adopt its order_key.
+        cached = _cached_open_limit(price=0.10086039)
+        gmx = _fake_gmx(rest_orders=[])
+
+        resolved = _invoke(
+            gmx,
+            cached,
+            reader_pending=[_reader_order(trigger_price_usd=0.22)],
+        )
+
+        assert resolved["status"] == "cancelled"
+        assert "order_key" not in resolved["info"]
+        gmx._api._patch_cached_order_key.assert_not_called()
 
 
 class TestThrottle:

--- a/tests/gmx/test_calculate_estimated_liquidation_price.py
+++ b/tests/gmx/test_calculate_estimated_liquidation_price.py
@@ -1,0 +1,239 @@
+"""Regression tests for :func:`calculate_estimated_liquidation_price`.
+
+The approximate formula used to return ``0.0`` as a sentinel when its inputs
+could not produce a meaningful liquidation price (small positions where the
+``GMX_MIN_LIQUIDATION_COLLATERAL_USD`` floor dominated the maximum loss).
+
+That sentinel was downstream-misinterpreted: Freqtrade's
+``stoploss_or_liquidation()`` only treats ``None`` as "unset", not ``0.0``.
+Worse, ``freqtrade.exchange.exchange.get_liquidation_price()`` applies a 5 %
+buffer to the value it receives — so a ``0.0`` sentinel became
+``0 + 0.05 × open_rate`` in the trade row, which then reproducibly fired
+``ExitType.LIQUIDATION`` every loop and crashed the bot 37 times in a row.
+
+The fix:
+
+- Function return type is now ``float | None`` (was ``float``).
+- All previously-``0.0`` early-returns now return ``None``.
+- New ``_LIQUIDATION_APPROX_MIN_BUFFER_RATIO`` guard rejects approximations
+  dominated by the min-collateral floor (max_loss / size_usd below the
+  threshold).
+- Direction invariant enforced at the bottom: a long's liquidation must be
+  below entry, a short's must be above.  Anything else returns ``None``.
+
+These tests pin the new contract so the regression cannot reappear.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from eth_defi.gmx.constants import GMX_MIN_LIQUIDATION_COLLATERAL_USD
+from eth_defi.gmx.utils import calculate_estimated_liquidation_price
+
+
+class TestSmallStakeFloorDominated:
+    """Pre-fix bug: stake≈floor produced near-entry liquidation values."""
+
+    def test_1x_long_5usd_stake_returns_none(self):
+        """The production trigger: ICP/USDC 1× long at $2.55 with $5.05 stake.
+
+        Pre-fix this returned ~$2.527 (0.89 % below entry).  Freqtrade then
+        added a 5 % buffer → ~$2.65 which exceeded current rate every loop,
+        firing false ``ExitType.LIQUIDATION`` and crashing on the
+        ``skip_custom_exit_price`` kwarg.  Post-fix: ``None``.
+        """
+        result = calculate_estimated_liquidation_price(
+            entry_price=2.5522,
+            collateral_usd=5.05,
+            size_usd=5.05,
+            is_long=True,
+        )
+        assert result is None
+
+    def test_1x_short_5usd_stake_returns_none(self):
+        result = calculate_estimated_liquidation_price(
+            entry_price=100.0,
+            collateral_usd=5.05,
+            size_usd=5.05,
+            is_long=False,
+        )
+        assert result is None
+
+    @pytest.mark.parametrize("size_usd", [4.0, 4.5, 5.0, 5.05])
+    def test_size_at_or_below_floor_returns_none(self, size_usd):
+        """At sizes ≤ the $5 floor, ``max_loss <= 0`` so the early-return
+        fires and the formula refuses to guess."""
+        result = calculate_estimated_liquidation_price(
+            entry_price=10.0,
+            collateral_usd=size_usd,
+            size_usd=size_usd,
+            is_long=True,
+        )
+        assert result is None
+
+    @pytest.mark.parametrize("size_usd", [6.0, 8.0])
+    def test_size_above_floor_yields_value(self, size_usd):
+        """At sizes meaningfully above the floor the approximation IS valid
+        — the ratio guard does not fire because ``max_loss / size_usd`` >> 1%.
+
+        For ``size = $6`` with ``$5`` floor: ``max_loss = $0.994``,
+        ``ratio = 16.5%`` which is well above the 1% threshold.
+        """
+        result = calculate_estimated_liquidation_price(
+            entry_price=10.0,
+            collateral_usd=size_usd,
+            size_usd=size_usd,
+            is_long=True,
+        )
+        assert result is not None
+        assert 0 < result < 10.0
+
+
+class TestSentinelPathsReturnNone:
+    """Previously returned ``0.0`` — now must return ``None``."""
+
+    def test_negative_max_loss_returns_none(self):
+        # max_loss = remaining (≈0) - min_floor (5) = negative
+        result = calculate_estimated_liquidation_price(
+            entry_price=100.0,
+            collateral_usd=0.1,
+            size_usd=0.1,
+            is_long=True,
+        )
+        assert result is None
+
+    def test_same_token_denom_zero_returns_none(self):
+        # size_in_tokens + collateral_amount == 0 (degenerate)
+        result = calculate_estimated_liquidation_price(
+            entry_price=100.0,
+            collateral_usd=10.0,
+            size_usd=0.0,  # size_in_tokens = 0 / entry = 0
+            is_long=True,
+            collateral_is_index_token=True,
+            collateral_amount=0.0,
+        )
+        assert result is None
+
+    def test_size_in_tokens_zero_different_token_returns_none(self):
+        result = calculate_estimated_liquidation_price(
+            entry_price=100.0,
+            collateral_usd=10.0,
+            size_usd=0.0,
+            is_long=True,
+            collateral_is_index_token=False,
+            collateral_amount=10.0,
+        )
+        assert result is None
+
+
+class TestDirectionInvariant:
+    """A long's liquidation must be < entry; short's must be > entry."""
+
+    def test_long_liquidation_strictly_below_entry(self):
+        result = calculate_estimated_liquidation_price(
+            entry_price=100.0,
+            collateral_usd=200.0,  # large enough that approximation is meaningful
+            size_usd=1000.0,       # 5× leverage
+            is_long=True,
+        )
+        assert result is not None
+        assert result < 100.0
+        assert result > 0.0
+
+    def test_short_liquidation_strictly_above_entry(self):
+        result = calculate_estimated_liquidation_price(
+            entry_price=100.0,
+            collateral_usd=200.0,
+            size_usd=1000.0,
+            is_long=False,
+        )
+        assert result is not None
+        assert result > 100.0
+
+
+class TestRealisticLeveragedPositions:
+    """Confirm the approximation still works for genuinely-meaningful inputs."""
+
+    def test_5x_long_eth_returns_sensible_liquidation(self):
+        """ETH long at $2000, 5× leverage with $1000 collateral.
+
+        Approx liquidation should be roughly 20 % below entry (~$1600).
+        """
+        result = calculate_estimated_liquidation_price(
+            entry_price=2000.0,
+            collateral_usd=1000.0,
+            size_usd=5000.0,
+            is_long=True,
+            pending_funding_fees_usd=0.0,
+            pending_borrowing_fees_usd=0.0,
+        )
+        assert result is not None
+        assert 1400.0 < result < 1900.0  # generous bounds
+
+    def test_10x_long_btc_returns_sensible_liquidation(self):
+        result = calculate_estimated_liquidation_price(
+            entry_price=70000.0,
+            collateral_usd=1000.0,
+            size_usd=10000.0,
+            is_long=True,
+        )
+        assert result is not None
+        assert 60000.0 < result < 70000.0
+
+
+class TestExactMode:
+    """Exact (collateral_amount provided) path still works."""
+
+    def test_exact_long_returns_value(self):
+        result = calculate_estimated_liquidation_price(
+            entry_price=2000.0,
+            collateral_usd=1000.0,
+            collateral_amount=0.5,
+            size_usd=5000.0,
+            is_long=True,
+            collateral_is_index_token=True,
+        )
+        assert result is not None
+        assert 0 < result < 2000.0
+
+    def test_exact_denominator_zero_returns_none(self):
+        # size_in_tokens (= size_usd / entry) cancels collateral exactly
+        # for short with same-token collateral, denominator = 0
+        result = calculate_estimated_liquidation_price(
+            entry_price=2000.0,
+            collateral_usd=1000.0,
+            collateral_amount=2.5,  # exactly size_in_tokens (5000/2000)
+            size_usd=5000.0,
+            is_long=False,
+            collateral_is_index_token=True,
+        )
+        assert result is None
+
+
+class TestProductionDataReplay:
+    """Replay the exact inputs that crashed the bot on 2026-05-24/25."""
+
+    @pytest.mark.parametrize(
+        ("pair", "entry", "stake"),
+        [
+            ("ICP", 2.5522, 5.05),     # trade 1 — crash trigger
+            ("INJ", 5.2174, 4.88),     # trade 2 — filled, 5% buffer artefact
+            ("PENDLE", 1.8508, 4.14),  # trade 7 — filled, 5% buffer artefact
+            ("SUI", 1.0426, 4.00),     # trade 8 — filled, 5% buffer artefact
+        ],
+    )
+    def test_filled_trades_yield_no_bogus_liquidation_price(self, pair, entry, stake):
+        """Every fill on 2026-05-24 produced a corrupt liquidation_price.
+
+        Post-fix: small-stake 1× longs uniformly return ``None`` so Freqtrade
+        records ``liquidation_price = NULL`` and the false-LIQUIDATION gate
+        never fires.
+        """
+        result = calculate_estimated_liquidation_price(
+            entry_price=entry,
+            collateral_usd=stake,
+            size_usd=stake,
+            is_long=True,
+        )
+        assert result is None, f"{pair}: expected None, got {result}"


### PR DESCRIPTION
> **Status (2026-05-23):** Production cascade misclassified DOGE/TAO fills as cancels — limit orders had executed on chain and become real positions, but the cascade hit Scenario B (REST + Reader both empty) and flipped them cancelled. New commit `78e2fe59` adds a final cascade arm that promotes the order to `status=closed` when a same-pair/same-side live position exists, even if the cached order amount has drifted units across restart. 4 commits past master.

> **Status (2026-05-22):** Rebased onto current master after PR #1029 merged. Production-validated on the downstream multistrategy bot — 3 stuck trades flipped cleanly, no false-positive cancels on healthy pending orders.

## Commits in this PR (post-rebase)

```
78e2fe59  fix(gmx-freqtrade): reconcile no-key limit orders against live positions when amount unit drifts (PR #1030 follow-up)
11d6799a  fix(gmx/ccxt): OrderKeyCache wallet kwarg drift — persistent cache silently disabled
f76b93fe  fix(gmx-freqtrade): tighten no-key resolver pair/price matching (PR #1030 review follow-up)
ba34b8c9  fix(gmx): reconcile stuck-open limit orders with no order_key via REST + on-chain Reader cascade
```

1. **`ba34b8c9`** — the original no-`order_key` REST + Reader cascade (original PR body below).
2. **`f76b93fe`** — review-finding hardening: Reader tier now inconclusive when `market_token` is unresolvable; REST and Reader matchers require trigger-price agreement whenever the cached order has a price. 3 new regression tests.
3. **`11d6799a`** — separate cache-init bug discovered during production validation: `_init_order_key_cache` passed `wallet_address=` but `OrderKeyCache.__init__` declared the param as `wallet=`, so `__init__` raised `TypeError` and the soft-fallback silently downgraded the persistent cache to memory-only. One-line kwarg rename + regression test.
4. **`78e2fe59`** — position-drift recovery arm. Production DOGE/TAO regression: limit order created → CCXT cache loses `order_key` across restart → GMX keeper executes the order off-cache → bot polls `fetch_order` with no key → cascade runs → REST empty + Reader empty (because the order is no longer pending, it's a filled position) → cascade flips to `cancelled` → but the position is real and now untracked by Freqtrade. Adds an opt-in `allow_size_mismatch` mode to `_reconcile_via_positions` and calls it as a final arm gated by `rest_checked AND contract_checked`. When a same-pair/same-side position is present, marks status=closed using `position.contracts` + `position.entryPrice` instead of returning cancelled. Side check and unknown-market guards preserved. 1 new regression test mirrors the production DOGE numbers (5.07 USD-notional cached vs 50.28 contracts on chain — ~10x drift from unit mismatch across restart).

## Production receipts

### 2026-05-22 ~08:43 UTC — cascade correctly fired Scenario B on truly-cancelled orders

Container rebuilt with `ba34b8c9 + f76b93fe + 11d6799a` pinned, deployed to multistrategy bot. First poll after restart:

```
08:44:00,311  no-key reconcile: 0x62783cc1... DOGE — REST has no match (deferring)
08:44:00,597  no-key reconcile: 0x62783cc1... DOGE — Reader has no match
08:44:00,598  no-key reconcile: 0x62783cc1... DOGE flipped open→cancelled
08:44:01,064  no-key reconcile: 0xaf9cec9a... FIL  — REST has no match (deferring)
08:44:01,347  no-key reconcile: 0xaf9cec9a... FIL  — Reader has no match
08:44:01,348  no-key reconcile: 0xaf9cec9a... FIL  flipped open→cancelled
08:44:01,717  no-key reconcile: 0x57617e3f... TAO — REST has no match (deferring)
08:44:02,010  no-key reconcile: 0x57617e3f... TAO — Reader has no match
08:44:02,012  no-key reconcile: 0x57617e3f... TAO flipped open→cancelled
```

Total cascade runtime: 1.7 s for all 3 trades. Subsequent 4+ hours of running:

- **Zero** `no order_key stored, cannot check execution status` warnings (was 3,048 pre-cascade).
- **Zero** `Found open order for Trade(id=18|19|21)` events.
- **Zero** false-positive cascades on healthy pending orders.
- **6 `FULL CLOSE` events** between 08:44:22–08:46:26 on PENGU / XMR / CRV / APE going through `_resolve_reduce_only_size_delta_usd` (PR #1029 path), dust-prevention preserved.

### 2026-05-23 — Scenario-B-on-fills regression discovered, motivating `78e2fe59`

On-chain `/v1/positions` showed DOGE and TAO held real long positions (~$5 each) with `entryPrice` matching the cached limit prices:

| Trade | Cached open_rate | On-chain entryPrice | On-chain sizeInTokens | Cached amount |
|---|---|---|---|---|
| 18 DOGE | 0.10086 | 0.10084 | 50.27877164 DOGE | 5.07 (USD-notional drift) |
| 21 TAO  | 266.638 | 265.72  | 0.01388268 TAO     | (similar drift)         |

Trade 19 FIL had **no** on-chain position — the cascade was correct for FIL (a true cancellation). The bug is unit-specific to the unit-drift case, and the new arm only fires when a matching position actually exists.

## Why

PR #1008 fixed the limit-order zombie cancel (Bug A) and the synthetic cache-miss timestamp (Bug B). Bug C from the original issue: CCXT cache holds a non-market order with `info["order_key"]` missing (because `extract_order_key_from_receipt` returned `None` at creation), the parent resolver short-circuits to `status="open"` forever, freqtrade logs `Order ... not cancelled` indefinitely, the trade row is permanently stuck.

Initial fix (`ba34b8c9`) added a REST + Reader cascade with positive-proof-of-absence semantics. Subsequent production exposure surfaced two related issues that the new commits address: a single-candidate side-only fallback could adopt the wrong key when trigger prices disagreed (`f76b93fe`), and the cascade's Scenario B branch couldn't distinguish a true cancellation from a fill that had moved the order off the pending list into the positions list (`78e2fe59`).

## Summary

No-`order_key` reconciler inside `Gmx.fetch_order`, only when the cache is missing `info["order_key"]`, with three authoritative arms in priority order:

**Arm 1 — strict position match** (PR #1008 baseline)
Same-pair / same-side / amount-within-tolerance position → `status=closed`, mark from position.

**Arm 2 — GMX REST `/v1/orders`** (`ba34b8c9`)
`GMXAPI.get_orders(wallet)`, 3× retry inside `_make_gmxapi_ai_request`. Match → adopt the row's `key` into cache, keep `status="open"`.

**Arm 3 — on-chain `SyntheticsReader.getAccountOrders`** (`ba34b8c9`)
`fetch_pending_orders(web3, chain, wallet, market_filter, is_long_filter)`. Single `eth_call`, authoritative on-chain truth, never indexer-lagged. Match → adopt `"0x" + order.order_key.hex()` into cache, keep `status="open"`.

**Arm 4 — drift-tolerant position match** (NEW in `78e2fe59`)
Gated by `rest_checked AND contract_checked`. If a same-pair/same-side position exists, mark from position even when the cached `amount` no longer matches `position.contracts` — uses `position.contracts` for `filled/amount` and `position.entryPrice` for `average/price`. Logs `allow_size_mismatch=True` and emits `reconciled_amount_source: position_contracts` in `info`.

**Cancellation rule:** flip `status="cancelled"` only when arms 2 + 3 both completed and reported no row, AND arm 4 found no matching position. Network errors / unresolvable market token are inconclusive votes — the order is left untouched.

Cache patching is mediated by `_patch_cached_order_key(order_id, order_key_hex)` on the sync + async CCXT exchange classes (lockstep), so subsequent polls route through the standard order-key-aware resolver instead of re-triggering this cascade.

Throttled per `order_id` by `_RECONCILE_THROTTLE_MS = 60_000` ms.

## Behavioural contract (pinned by 25 new tests across three suites)

| Scenario | REST | Reader | Position check | Outcome |
|---|---|---|---|---|
| Cache already has `order_key` | — | — | — | short-circuit; standard resolver next cycle |
| Strict position match (PR #1008) | — | — | hit | `closed`, mark from position |
| REST match | hit | not called | — | `open`, adopt REST key |
| REST no match, Reader match | empty | hit | — | `open`, adopt Reader key |
| REST empty + Reader empty + matching position (drift case) | empty | empty | hit | `closed`, mark from position with `allow_size_mismatch=True` (NEW in `78e2fe59`) |
| REST empty + Reader empty + no position | empty | empty | miss | `cancelled`, `gmx_status="no_key_not_found_in_any_tier"` |
| REST errored, Reader empty | error | empty | — | leave `open` (inconclusive) |
| Reader errored, REST empty | empty | error | — | leave `open` (inconclusive) |
| Both errored | error | error | — | leave `open` |
| Unknown market token + REST has rows | skip-by-design | empty | — | leave `open` (ambiguous) |
| Unknown market token + Reader has rows | empty | skip-by-design | — | leave `open` (`f76b93fe`) |
| Single same-market candidate + wrong trigger price | mismatch | empty | — | `cancelled` (`f76b93fe`) |
| Throttle hit | not called | not called | not called | original order untouched until throttle elapses |

Matcher fields: pair + side + trigger price within `_PENDING_PRICE_TOLERANCE = 1e-6`. Arm 4 uses `position.contracts` directly because cached `amount` is untrusted in the drift case.

## Test results

```
tests/gmx/freqtrade/test_fetch_order_no_key_reconcile.py     16 passed  (15 + 1 new for arm 4)
tests/gmx/ccxt/test_cached_order_key_patch.py                 6 passed
tests/gmx/ccxt/test_order_key_cache.py                       17 passed
tests/gmx/ccxt/test_reduce_only_sizing.py                    10 passed   (now in master via #1029)

49 passed total
```

## Files changed

- `eth_defi/gmx/ccxt/exchange.py` — `_patch_cached_order_key` helper (+31) + `OrderKeyCache` kwarg fix (`11d6799a`)
- `eth_defi/gmx/ccxt/async_support/exchange.py` — async mirror (+23, lockstep)
- `eth_defi/gmx/freqtrade/gmx_exchange.py` — cascade + helpers (+513) + `f76b93fe` hardening (+9 net) + `78e2fe59` arm 4 (+42/-5)
- `tests/gmx/ccxt/test_cached_order_key_patch.py` — 6 new tests
- `tests/gmx/freqtrade/test_fetch_order_no_key_reconcile.py` — 16 tests (12 from `ba34b8c9` + 3 from `f76b93fe` + 1 from `78e2fe59`)
- `tests/gmx/ccxt/test_order_key_cache.py` — +1 test in `11d6799a` (TestOrderKeyCacheAdapterWiring)

## Operator verification plan

1. Build the downstream bot image pinned to this branch (`fix/issue-67-no-key-resolver`).
2. Restart the bot; observe a 1-hour window:
   - Legitimate pending limit orders should not appear as `cancelled` (REST or Reader should both find them).
   - Stuck trades that genuinely never filled should be flipped `cancelled` on the first poll after deploy.
   - Stuck trades whose limit DID execute off-cache (the new arm-4 case) should now flip `closed` with `allow_size_mismatch=True` in the log line, NOT `cancelled`.
3. New `fetch_order no-key reconcile:` log lines should appear with one of:
   - `recovered order_key=...` (Arm 2 or Arm 3)
   - `flipped open→closed via on-chain position match` (Arms 1 or 4; arm 4 includes `allow_size_mismatch=True`)
   - `flipped open→cancelled (REST + on-chain Reader both report no matching pending row)` (true cancellation only)

## Lessons learnt

- "Couldn't check" and "checked and empty" are different signals; conflating them on `None` made the first soft-fallback resolver flip live orders on network blips. Tuple `(checked, reconciled)` keeps the cancellation vote honest.
- `78e2fe59` lesson: an order disappearing from the pending list has TWO causes — cancellation OR execution-then-becomes-position. "Both pending-order sources empty" is positive proof of pending-absence, NOT positive proof of cancellation. The position check is the third arm that disambiguates.
- Cached `amount` semantics aren't invariant across restarts when the strategy serialises in one unit (e.g. base tokens) and re-hydrates in another (USD notional). Don't trust it as a primary match field once the order has been off-cache long enough for the keeper to execute it; trust on-chain `contracts` instead.
- The GMX REST endpoint already retries internally — surfacing that contractually in the resolver's docstring saves a re-read of `_make_gmxapi_ai_request` for future maintainers.
- `PendingOrder.trigger_price_usd` is 18-decimal-aware; if the GMX pair_whitelist widens to non-18-decimal index tokens, `trigger_price_usd_for_decimals` would replace the direct property in `_match_reader_pending_order`. Not a problem on the current universe.
- (`11d6799a` lesson) Constructor signature drift in soft-fail init paths can hide for months when there is a working downstream fallback. The new `TestOrderKeyCacheAdapterWiring` regression locks the call-site/constructor symmetry.
- (`f76b93fe` lesson) Single-candidate fallbacks are a foot-gun when the price is known but the side/market filter only narrows the set. Always require trigger-price agreement when the cached order has one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
