### PR TITLE
fix: Mitigate Hypersync 429 rate limiting in timestamp streaming

### DIFF
--- a/eth_defi/gmx/ccxt/async_support/exchange.py
+++ b/eth_defi/gmx/ccxt/async_support/exchange.py
@@ -4059,9 +4059,7 @@ class GMX(Exchange):
         # reduce-only exemption rationale.
         if not reduceOnly and size_delta_usd < GMX_MIN_COST_USD:
             raise InvalidOrder(
-                f"Order notional ${size_delta_usd:.4f} below GMX minimum "
-                f"${GMX_MIN_COST_USD} for {symbol} {side}; adjust stake / "
-                f"position sizing.",
+                f"Order notional ${size_delta_usd:.4f} below GMX minimum ${GMX_MIN_COST_USD} for {symbol} {side}; adjust stake / position sizing.",
             )
 
         return {

--- a/eth_defi/gmx/ccxt/exchange.py
+++ b/eth_defi/gmx/ccxt/exchange.py
@@ -5939,8 +5939,7 @@ class GMX(ExchangeCompatible):
             # operators can grep for unexpected full closes in 5-min logs.
             if isinstance(size_delta_usd, int) and size_delta_usd > 10**20:
                 logger.info(
-                    "FULL CLOSE: Using exact GMX position size %.2f USD (raw=%s, "
-                    "requested %.2f USD ≥ %.1f%% of actual — substituting raw int to prevent dust)",
+                    "FULL CLOSE: Using exact GMX position size %.2f USD (raw=%s, requested %.2f USD ≥ %.1f%% of actual — substituting raw int to prevent dust)",
                     actual_size_usd,
                     size_delta_usd,
                     requested_size_usd,
@@ -5954,8 +5953,7 @@ class GMX(ExchangeCompatible):
                 )
             else:
                 logger.info(
-                    "PARTIAL CLOSE: size_delta_usd=%.2f (requested %.2f, actual position %.2f, "
-                    "source=%s)",
+                    "PARTIAL CLOSE: size_delta_usd=%.2f (requested %.2f, actual position %.2f, source=%s)",
                     size_delta_usd,
                     requested_size_usd,
                     actual_size_usd,
@@ -6001,9 +5999,7 @@ class GMX(ExchangeCompatible):
         # fall below the floor and GMX accepts it as a dust cleanup.
         if not reduceOnly and size_delta_usd < GMX_MIN_COST_USD:
             raise InvalidOrder(
-                f"Order notional ${size_delta_usd:.4f} below GMX minimum "
-                f"${GMX_MIN_COST_USD} for {symbol} {side}; adjust stake / "
-                f"position sizing.",
+                f"Order notional ${size_delta_usd:.4f} below GMX minimum ${GMX_MIN_COST_USD} for {symbol} {side}; adjust stake / position sizing.",
             )
 
         # Resolve market info — honours optional ``market_address`` param so callers can

--- a/eth_defi/gmx/core/liquidation.py
+++ b/eth_defi/gmx/core/liquidation.py
@@ -21,11 +21,7 @@ Key Differences from Simplified Estimates:
     config = GMXConfig(web3, user_wallet_address="0x...")
     positions = get_positions(config)
 
-    liq_price = get_liquidation_price(
-        config=config,
-        position_dict=positions["ETH_long"],
-        wallet_address="0x..."
-    )
+    liq_price = get_liquidation_price(config=config, position_dict=positions["ETH_long"], wallet_address="0x...")
     print(f"Liquidation price: ${liq_price:.2f}")
 """
 

--- a/eth_defi/gmx/errors.py
+++ b/eth_defi/gmx/errors.py
@@ -55,7 +55,6 @@ class GmxError(NamedTuple):
     params: tuple[str, ...]
 
 
-
 _GMX_ERROR_REGISTRY: dict[str, GmxError] = {
     "0xb244a107": GmxError(
         selector="0xb244a107",

--- a/eth_defi/gmx/freqtrade/gmx_exchange.py
+++ b/eth_defi/gmx/freqtrade/gmx_exchange.py
@@ -900,13 +900,10 @@ class Gmx(Exchange):
         resolved["remaining"] = order.get("remaining") or order.get("amount")
         resolved_info = dict(order.get("info") or {})
         resolved_info["gmx_status"] = "no_key_not_found_in_any_tier"
-        resolved_info["cancel_reason"] = (
-            "no matching GMX pending order in gmxapi.ai /v1/orders nor on-chain SyntheticsReader.getAccountOrders"
-        )
+        resolved_info["cancel_reason"] = "no matching GMX pending order in gmxapi.ai /v1/orders nor on-chain SyntheticsReader.getAccountOrders"
         resolved["info"] = resolved_info
         logger.warning(
-            "fetch_order no-key reconcile: order %s for %s flipped open→cancelled "
-            "(REST + on-chain Reader both report no matching pending row)",
+            "fetch_order no-key reconcile: order %s for %s flipped open→cancelled (REST + on-chain Reader both report no matching pending row)",
             order_id[:18],
             pair,
         )
@@ -1023,13 +1020,7 @@ class Gmx(Exchange):
                 )
                 return False, None
 
-        match = (
-            self._match_rest_pending_order(
-                order, rest_orders, market_token=market_token, token_decimals=token_decimals
-            )
-            if token_decimals is not None
-            else None
-        )
+        match = self._match_rest_pending_order(order, rest_orders, market_token=market_token, token_decimals=token_decimals) if token_decimals is not None else None
         if match is not None:
             recovered_key = match.get("key") or match.get("orderKey")
             if recovered_key:
@@ -1162,11 +1153,7 @@ class Gmx(Exchange):
                 )
                 return False, None
 
-        match = (
-            self._match_reader_pending_order(order, pending, token_decimals=token_decimals)
-            if token_decimals is not None
-            else None
-        )
+        match = self._match_reader_pending_order(order, pending, token_decimals=token_decimals) if token_decimals is not None else None
         if match is not None:
             recovered_key = "0x" + match.order_key.hex()
             self._api._patch_cached_order_key(order_id, recovered_key)

--- a/eth_defi/hypersync/hypersync_timestamp.py
+++ b/eth_defi/hypersync/hypersync_timestamp.py
@@ -61,10 +61,15 @@ async def _validate_hypersync_chain_id_async(client: hypersync.HypersyncClient, 
     """Validate that the Hypersync client is connected to the expected chain.
 
     Guards against poisoning persistent caches with wrong-chain data.
-    Must be called inside an async context so it participates in the
-    retry/backoff loop when rate-limited.
+    Wraps 429 errors as :py:class:`HypersyncFlaky` so the caller's
+    retry/backoff loop handles rate limits.
     """
-    connected = await client.get_chain_id()
+    try:
+        connected = await client.get_chain_id()
+    except RuntimeError as e:
+        if _is_hypersync_rate_limit_error(e):
+            raise HypersyncFlaky(f"Hypersync rate limited during chain_id validation: {e}") from e
+        raise
     assert connected == expected_chain_id, f"Hypersync client connected to chain {connected}, but expected {expected_chain_id}"
 
 
@@ -76,6 +81,7 @@ async def get_block_timestamps_using_hypersync_async(
     timeout: float = 120.0,
     display_progress: bool = True,
     progress_throttle=10_000,
+    validate_chain_id: bool = True,
 ) -> AsyncIterable[BlockHeader]:
     """Read block timestamps using Hypersync API.
 
@@ -83,9 +89,8 @@ async def get_block_timestamps_using_hypersync_async(
     get block timestamps using Hypersync API 1000x faster.
 
     :param chain_id:
-        Verify HyperSync client is connected to the correct chain ID.
-
-        (Not actually used in request because client is per-chain)
+        Expected chain ID. Validated against the client unless
+        ``validate_chain_id`` is ``False``.
 
     :param start_block:
         Start block, inclusive
@@ -96,12 +101,20 @@ async def get_block_timestamps_using_hypersync_async(
     :param client:
         Hypersync client to use
 
+    :param validate_chain_id:
+        When ``True`` (default), verify the client is connected to
+        the expected chain before streaming. Set to ``False`` when the
+        caller has already validated (e.g. the cached path).
+
     """
 
     assert isinstance(client, hypersync.HypersyncClient), f"Expected HypersyncClient, got {type(client)}"
     assert type(chain_id) == int
     assert start_block >= 0
     assert end_block >= start_block, f"end_block {end_block} must be >= start_block {start_block}"
+
+    if validate_chain_id:
+        await _validate_hypersync_chain_id_async(client, chain_id)
 
     if display_progress:
         progress_bar = tqdm(
@@ -192,7 +205,6 @@ def get_block_timestamps_using_hypersync(
 
     # Don't leak async colored interface, as it is an implementation detail
     async def _hypersync_asyncio_wrapper():
-        await _validate_hypersync_chain_id_async(client, chain_id)
         iter = get_block_timestamps_using_hypersync_async(
             client,
             chain_id,
@@ -292,6 +304,7 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
             start_block=scan_start,
             end_block=end_block,
             display_progress=display_progress,
+            validate_chain_id=False,  # Already validated above
         )
 
         async for block_header in iter:
@@ -338,6 +351,7 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
                     start_block=gap_start + 1,
                     end_block=gap_end - 1,
                     display_progress=False,
+                    validate_chain_id=False,  # Already validated above
                 ):
                     heal_index.append(bh.block_number)
                     heal_values.append(bh.timestamp)

--- a/eth_defi/hypersync/hypersync_timestamp.py
+++ b/eth_defi/hypersync/hypersync_timestamp.py
@@ -57,18 +57,15 @@ def _is_hypersync_rate_limit_error(e: Exception) -> bool:
     return isinstance(e, RuntimeError) and "429" in str(e)
 
 
-def _validate_hypersync_chain_id(client: hypersync.HypersyncClient, expected_chain_id: int) -> None:
+async def _validate_hypersync_chain_id_async(client: hypersync.HypersyncClient, expected_chain_id: int) -> None:
     """Validate that the Hypersync client is connected to the expected chain.
 
-    Called once per public entry point (before any retry loop) to guard
-    against poisoning persistent caches with wrong-chain data.
+    Guards against poisoning persistent caches with wrong-chain data.
+    Must be called inside an async context so it participates in the
+    retry/backoff loop when rate-limited.
     """
-
-    async def _check():
-        connected = await client.get_chain_id()
-        assert connected == expected_chain_id, f"Hypersync client connected to chain {connected}, but expected {expected_chain_id}"
-
-    asyncio.run(_check())
+    connected = await client.get_chain_id()
+    assert connected == expected_chain_id, f"Hypersync client connected to chain {connected}, but expected {expected_chain_id}"
 
 
 async def get_block_timestamps_using_hypersync_async(
@@ -193,10 +190,9 @@ def get_block_timestamps_using_hypersync(
         Block number -> header mapping
     """
 
-    _validate_hypersync_chain_id(client, chain_id)
-
     # Don't leak async colored interface, as it is an implementation detail
     async def _hypersync_asyncio_wrapper():
+        await _validate_hypersync_chain_id_async(client, chain_id)
         iter = get_block_timestamps_using_hypersync_async(
             client,
             chain_id,
@@ -285,6 +281,11 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
     needs_tail = end_block > last_read_block
 
     if needs_head or needs_tail:
+        # Validate chain_id only when we actually need to fetch from Hypersync.
+        # Skipped on warm cache hits to avoid wasting API quota.
+        if isinstance(client, hypersync.HypersyncClient):
+            await _validate_hypersync_chain_id_async(client, chain_id)
+
         iter = get_block_timestamps_using_hypersync_async(
             client,
             chain_id,
@@ -372,10 +373,6 @@ def fetch_block_timestamps_using_hypersync_cached(
     :param attempts:
         Work around Hypersync timeout issues
     """
-
-    # Validate once before entering the retry loop so a 429 from
-    # get_chain_id() does not bypass the backoff path.
-    _validate_hypersync_chain_id(client, chain_id)
 
     async def _hypersync_asyncio_wrapper():
         for attempt in range(attempts):

--- a/eth_defi/hypersync/hypersync_timestamp.py
+++ b/eth_defi/hypersync/hypersync_timestamp.py
@@ -83,9 +83,6 @@ async def get_block_timestamps_using_hypersync_async(
     assert start_block >= 0
     assert end_block >= start_block, f"end_block {end_block} must be >= start_block {start_block}"
 
-    connected_chain_id = await client.get_chain_id()
-    assert chain_id == connected_chain_id, f"Connected to chain {connected_chain_id}, but expected {chain_id}"
-
     if display_progress:
         progress_bar = tqdm(
             total=(end_block - start_block),
@@ -230,11 +227,12 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
         if start_block < first_read_block:
             scan_start = start_block
         else:
-            scan_start = last_read_block
+            # +1 to avoid re-fetching the last cached block
+            scan_start = last_read_block + 1
     else:
         scan_start = start_block
 
-    logger.info(f"Adjusted timestamp scan range for chain {chain_id}: blocks {scan_start} - {end_block}")
+    logger.info(f"Adjusted timestamp scan range for chain {chain_id}: blocks {scan_start:,} - {end_block:,} (delta {end_block - scan_start:,} blocks)")
 
     def _save():
         series = pd.Series(data=values, index=index)
@@ -249,7 +247,10 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
     index = []
     values = []
 
-    if end_block > last_read_block or start_block < first_read_block:
+    needs_head = start_block < first_read_block
+    needs_tail = end_block > last_read_block
+
+    if needs_head or needs_tail:
         iter = get_block_timestamps_using_hypersync_async(
             client,
             chain_id,
@@ -309,6 +310,13 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
                     heal_series = pd.Series(data=heal_values, index=heal_index)
                     timestamp_db.import_chain_data(chain_id, heal_series)
                     logger.info("Healed gap %d-%d: inserted %d timestamps", gap_start + 1, gap_end - 1, len(heal_index))
+    else:
+        logger.info(
+            "Timestamp cache fully covers requested range %d-%d for chain %d, skipping Hypersync fetch",
+            start_block,
+            end_block,
+            chain_id,
+        )
 
     # Drop unnecessary blocks from memory
     return timestamp_db.get_slicer()
@@ -347,5 +355,10 @@ def fetch_block_timestamps_using_hypersync_cached(
                 if attempt + 1 >= attempts:
                     logger.error("Exceeded maximum Hypersync attempts, failing: %s", e)
                     raise
+                # Exponential backoff: 30s, 60s, 120s, 240s to avoid hammering
+                # a rate-limited Hypersync endpoint
+                backoff = 30 * (2**attempt)
+                logger.info("Backing off %d seconds before retry", backoff)
+                await asyncio.sleep(backoff)
 
     return asyncio.run(_hypersync_asyncio_wrapper())

--- a/eth_defi/hypersync/hypersync_timestamp.py
+++ b/eth_defi/hypersync/hypersync_timestamp.py
@@ -45,7 +45,16 @@ logger = logging.getLogger(__name__)
 
 
 class HypersyncFlaky(Exception):
-    """Hypersync stream flaky error, e.g. timeout."""
+    """Hypersync stream flaky error, e.g. timeout or rate limit."""
+
+
+def _is_hypersync_rate_limit_error(e: Exception) -> bool:
+    """Check if a Hypersync RuntimeError is a 429 rate limit error.
+
+    The Rust client raises ``RuntimeError`` with the HTTP status in the message
+    after exhausting its internal retries.
+    """
+    return isinstance(e, RuntimeError) and "429" in str(e)
 
 
 async def get_block_timestamps_using_hypersync_async(
@@ -108,7 +117,12 @@ async def get_block_timestamps_using_hypersync_async(
         ),
     )
 
-    receiver = await client.stream(query, hypersync.StreamConfig())
+    try:
+        receiver = await client.stream(query, hypersync.StreamConfig())
+    except RuntimeError as e:
+        if _is_hypersync_rate_limit_error(e):
+            raise HypersyncFlaky(f"Hypersync rate limited during stream setup: {e}") from e
+        raise
 
     while True:
         try:
@@ -116,6 +130,10 @@ async def get_block_timestamps_using_hypersync_async(
         except asyncio.TimeoutError as e:
             logger.error("HyperSync receiver timed out, cannot recover")
             raise HypersyncFlaky(f"Cannot recover from HyperSync stream timeout after {timeout} seconds") from e
+        except RuntimeError as e:
+            if _is_hypersync_rate_limit_error(e):
+                raise HypersyncFlaky(f"Hypersync rate limited during streaming: {e}") from e
+            raise
 
         # exit if the stream finished
         if res is None:
@@ -212,6 +230,13 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
     :return:
         Block number -> datetime mapping
     """
+
+    # Validate chain_id once per sync call to guard against poisoning
+    # the persistent timestamp cache with data from the wrong chain.
+    # This is checked here (not per-stream) to avoid wasting API quota.
+    if isinstance(client, hypersync.HypersyncClient):
+        connected_chain_id = await client.get_chain_id()
+        assert chain_id == connected_chain_id, f"Hypersync client connected to chain {connected_chain_id}, but expected {chain_id}"
 
     if cache_path.exists():
         timestamp_db = load_timestamp_cache(chain_id, cache_path)

--- a/eth_defi/hypersync/hypersync_timestamp.py
+++ b/eth_defi/hypersync/hypersync_timestamp.py
@@ -57,6 +57,20 @@ def _is_hypersync_rate_limit_error(e: Exception) -> bool:
     return isinstance(e, RuntimeError) and "429" in str(e)
 
 
+def _validate_hypersync_chain_id(client: hypersync.HypersyncClient, expected_chain_id: int) -> None:
+    """Validate that the Hypersync client is connected to the expected chain.
+
+    Called once per public entry point (before any retry loop) to guard
+    against poisoning persistent caches with wrong-chain data.
+    """
+
+    async def _check():
+        connected = await client.get_chain_id()
+        assert connected == expected_chain_id, f"Hypersync client connected to chain {connected}, but expected {expected_chain_id}"
+
+    asyncio.run(_check())
+
+
 async def get_block_timestamps_using_hypersync_async(
     client: hypersync.HypersyncClient,
     chain_id: int,
@@ -179,6 +193,8 @@ def get_block_timestamps_using_hypersync(
         Block number -> header mapping
     """
 
+    _validate_hypersync_chain_id(client, chain_id)
+
     # Don't leak async colored interface, as it is an implementation detail
     async def _hypersync_asyncio_wrapper():
         iter = get_block_timestamps_using_hypersync_async(
@@ -230,13 +246,6 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
     :return:
         Block number -> datetime mapping
     """
-
-    # Validate chain_id once per sync call to guard against poisoning
-    # the persistent timestamp cache with data from the wrong chain.
-    # This is checked here (not per-stream) to avoid wasting API quota.
-    if isinstance(client, hypersync.HypersyncClient):
-        connected_chain_id = await client.get_chain_id()
-        assert chain_id == connected_chain_id, f"Hypersync client connected to chain {connected_chain_id}, but expected {chain_id}"
 
     if cache_path.exists():
         timestamp_db = load_timestamp_cache(chain_id, cache_path)
@@ -363,6 +372,10 @@ def fetch_block_timestamps_using_hypersync_cached(
     :param attempts:
         Work around Hypersync timeout issues
     """
+
+    # Validate once before entering the retry loop so a 429 from
+    # get_chain_id() does not bypass the backoff path.
+    _validate_hypersync_chain_id(client, chain_id)
 
     async def _hypersync_asyncio_wrapper():
         for attempt in range(attempts):

--- a/tests/gmx/ccxt/test_close_order_full_close.py
+++ b/tests/gmx/ccxt/test_close_order_full_close.py
@@ -75,10 +75,7 @@ def test_full_close_returns_requested_amount_not_token_derived() -> None:
 
     token_derived = size_delta_usd / execution_price
     assert filled == requested_amount
-    assert filled != token_derived, (
-        f"Full-close path must return requested amount ({requested_amount}), "
-        f"not the token-derived value ({token_derived})"
-    )
+    assert filled != token_derived, f"Full-close path must return requested amount ({requested_amount}), not the token-derived value ({token_derived})"
 
 
 def test_partial_close_returns_token_derived_amount() -> None:

--- a/tests/gmx/ccxt/test_order_key_cache.py
+++ b/tests/gmx/ccxt/test_order_key_cache.py
@@ -283,10 +283,6 @@ class TestOrderKeyCacheAdapterWiring:
 
         # If the constructor kwargs had drifted, init would silently swallow
         # the TypeError and leave _order_key_cache as None (memory-only mode).
-        assert stub._order_key_cache is not None, (
-            "OrderKeyCache constructor kwargs drifted from "
-            "eth_defi/gmx/ccxt/order_key_cache.py — adapter falls back to "
-            "memory-only mode on every restart."
-        )
+        assert stub._order_key_cache is not None, "OrderKeyCache constructor kwargs drifted from eth_defi/gmx/ccxt/order_key_cache.py — adapter falls back to memory-only mode on every restart."
         assert stub._order_key_cache.chain_id == 42161
         assert stub._order_key_cache.wallet == "0xe3f16770c0a336103d7c24b34a4afcbf6fb17583"

--- a/tests/gmx/ccxt/test_position_metrics.py
+++ b/tests/gmx/ccxt/test_position_metrics.py
@@ -166,19 +166,13 @@ class TestSyncAsyncImportLockstep:
         from eth_defi.gmx.ccxt import exchange as sync_mod
 
         assert hasattr(sync_mod, "safe_liquidation_price")
-        assert (
-            sync_mod.safe_liquidation_price
-            is safe_liquidation_price
-        )
+        assert sync_mod.safe_liquidation_price is safe_liquidation_price
 
     def test_async_imports_safe_liquidation_price(self):
         from eth_defi.gmx.ccxt.async_support import exchange as async_mod
 
         assert hasattr(async_mod, "safe_liquidation_price")
-        assert (
-            async_mod.safe_liquidation_price
-            is safe_liquidation_price
-        )
+        assert async_mod.safe_liquidation_price is safe_liquidation_price
 
 
 # ---------------------------------------------------------------------------
@@ -209,12 +203,8 @@ def sync_gmx_with_stub_markets():
     gmx.default_slippage = 0.003
 
     # Bind the real implementation so we exercise the production code path.
-    gmx._convert_ccxt_to_gmx_params = (
-        GMX._convert_ccxt_to_gmx_params.__get__(gmx, GMX)
-    )
-    gmx._normalize_symbol = lambda s: (
-        s if s.endswith(":USDC") else s.replace("/USDC", "/USDC:USDC")
-    )
+    gmx._convert_ccxt_to_gmx_params = GMX._convert_ccxt_to_gmx_params.__get__(gmx, GMX)
+    gmx._normalize_symbol = lambda s: (s if s.endswith(":USDC") else s.replace("/USDC", "/USDC:USDC"))
     gmx._resolve_market_info = lambda symbol, params: {
         "market_token": "0x0000000000000000000000000000000000000000",
         "index_token": "0x0000000000000000000000000000000000000000",
@@ -225,9 +215,7 @@ def sync_gmx_with_stub_markets():
 class TestSyncMinCostGuard:
     """Sync ``_convert_ccxt_to_gmx_params`` must reject sub-$2 opens."""
 
-    def test_open_below_min_raises_invalid_order(
-        self, sync_gmx_with_stub_markets
-    ):
+    def test_open_below_min_raises_invalid_order(self, sync_gmx_with_stub_markets):
         with pytest.raises(InvalidOrder, match="below GMX minimum"):
             sync_gmx_with_stub_markets._convert_ccxt_to_gmx_params(
                 symbol="BTC/USDC:USDC",
@@ -260,9 +248,7 @@ class TestSyncMinCostGuard:
         )
         assert result["size_delta_usd"] == 100.0
 
-    def test_reduce_only_below_min_allowed(
-        self, sync_gmx_with_stub_markets
-    ):
+    def test_reduce_only_below_min_allowed(self, sync_gmx_with_stub_markets):
         # A dust-close reduce-only at $0.50 must NOT raise — GMX accepts
         # tiny remainder closes.
         result = sync_gmx_with_stub_markets._convert_ccxt_to_gmx_params(
@@ -288,9 +274,7 @@ class TestAsyncMinCostGuard:
         from eth_defi.gmx.ccxt.async_support.exchange import GMX as AsyncGMX
 
         gmx = MagicMock(spec=AsyncGMX)
-        gmx._convert_ccxt_to_gmx_params_async = (
-            AsyncGMX._convert_ccxt_to_gmx_params_async.__get__(gmx, AsyncGMX)
-        )
+        gmx._convert_ccxt_to_gmx_params_async = AsyncGMX._convert_ccxt_to_gmx_params_async.__get__(gmx, AsyncGMX)
         with pytest.raises(InvalidOrder, match="below GMX minimum"):
             await gmx._convert_ccxt_to_gmx_params_async(
                 symbol="BTC/USDC:USDC",
@@ -306,9 +290,7 @@ class TestAsyncMinCostGuard:
         from eth_defi.gmx.ccxt.async_support.exchange import GMX as AsyncGMX
 
         gmx = MagicMock(spec=AsyncGMX)
-        gmx._convert_ccxt_to_gmx_params_async = (
-            AsyncGMX._convert_ccxt_to_gmx_params_async.__get__(gmx, AsyncGMX)
-        )
+        gmx._convert_ccxt_to_gmx_params_async = AsyncGMX._convert_ccxt_to_gmx_params_async.__get__(gmx, AsyncGMX)
         result = await gmx._convert_ccxt_to_gmx_params_async(
             symbol="BTC/USDC:USDC",
             type="market",
@@ -327,9 +309,7 @@ class TestAsyncMinCostGuard:
         from eth_defi.gmx.ccxt.async_support.exchange import GMX as AsyncGMX
 
         gmx = MagicMock(spec=AsyncGMX)
-        gmx._convert_ccxt_to_gmx_params_async = (
-            AsyncGMX._convert_ccxt_to_gmx_params_async.__get__(gmx, AsyncGMX)
-        )
+        gmx._convert_ccxt_to_gmx_params_async = AsyncGMX._convert_ccxt_to_gmx_params_async.__get__(gmx, AsyncGMX)
         result = await gmx._convert_ccxt_to_gmx_params_async(
             symbol="BTC/USDC:USDC",
             type="market",

--- a/tests/gmx/ccxt/test_resolve_order_from_sources.py
+++ b/tests/gmx/ccxt/test_resolve_order_from_sources.py
@@ -244,10 +244,7 @@ def test_builders_return_amount_in_base_tokens_not_usd_notional(symbol, index_to
         symbol,
     )
 
-    assert rest_sync["amount"] == pytest.approx(expected_amount_tokens, rel=1e-6), (
-        f"sync _build_order_from_rest_order amount must be base tokens "
-        f"(expected {expected_amount_tokens:.6f} {symbol.split('/')[0]}, got {rest_sync['amount']})"
-    )
+    assert rest_sync["amount"] == pytest.approx(expected_amount_tokens, rel=1e-6), f"sync _build_order_from_rest_order amount must be base tokens (expected {expected_amount_tokens:.6f} {symbol.split('/')[0]}, got {rest_sync['amount']})"
     assert rest_sync["remaining"] == pytest.approx(expected_amount_tokens, rel=1e-6)
     assert rest_async["amount"] == pytest.approx(expected_amount_tokens, rel=1e-6)
     assert rest_async["remaining"] == pytest.approx(expected_amount_tokens, rel=1e-6)
@@ -282,10 +279,7 @@ def test_builders_return_amount_in_base_tokens_not_usd_notional(symbol, index_to
         symbol,
     )
 
-    assert trade_action_sync["amount"] == pytest.approx(expected_amount_tokens, rel=1e-6), (
-        f"sync _build_order_from_trade_action amount must be base tokens from sizeDeltaInTokens "
-        f"(expected {expected_amount_tokens:.6f}, got {trade_action_sync['amount']})"
-    )
+    assert trade_action_sync["amount"] == pytest.approx(expected_amount_tokens, rel=1e-6), f"sync _build_order_from_trade_action amount must be base tokens from sizeDeltaInTokens (expected {expected_amount_tokens:.6f}, got {trade_action_sync['amount']})"
     assert trade_action_sync["filled"] == pytest.approx(expected_amount_tokens, rel=1e-6)
     assert trade_action_async["amount"] == pytest.approx(expected_amount_tokens, rel=1e-6)
     assert trade_action_async["filled"] == pytest.approx(expected_amount_tokens, rel=1e-6)

--- a/tests/gmx/freqtrade/test_fetch_order_no_key_reconcile.py
+++ b/tests/gmx/freqtrade/test_fetch_order_no_key_reconcile.py
@@ -52,10 +52,14 @@ def _fake_gmx(
     fake._api.web3 = MagicMock()
     fake._api.config = MagicMock()
     fake._api.config.get_chain = MagicMock(return_value=chain)
-    fake._api.markets = markets if markets is not None else {
-        "DOGE/USDC:USDC": {"info": {"market_token": DOGE_MARKET, "index_token": DOGE_INDEX}},
-        "FIL/USDC:USDC": {"info": {"market_token": FIL_MARKET, "index_token": FIL_INDEX}},
-    }
+    fake._api.markets = (
+        markets
+        if markets is not None
+        else {
+            "DOGE/USDC:USDC": {"info": {"market_token": DOGE_MARKET, "index_token": DOGE_INDEX}},
+            "FIL/USDC:USDC": {"info": {"market_token": FIL_MARKET, "index_token": FIL_INDEX}},
+        }
+    )
     fake._api._token_metadata = {
         DOGE_INDEX: {"symbol": "DOGE", "decimals": 8},
         FIL_INDEX: {"symbol": "FIL", "decimals": 18},

--- a/tests/gmx/test_calculate_estimated_liquidation_price.py
+++ b/tests/gmx/test_calculate_estimated_liquidation_price.py
@@ -134,7 +134,7 @@ class TestDirectionInvariant:
         result = calculate_estimated_liquidation_price(
             entry_price=100.0,
             collateral_usd=200.0,  # large enough that approximation is meaningful
-            size_usd=1000.0,       # 5× leverage
+            size_usd=1000.0,  # 5× leverage
             is_long=True,
         )
         assert result is not None
@@ -217,10 +217,10 @@ class TestProductionDataReplay:
     @pytest.mark.parametrize(
         ("pair", "entry", "stake"),
         [
-            ("ICP", 2.5522, 5.05),     # trade 1 — crash trigger
-            ("INJ", 5.2174, 4.88),     # trade 2 — filled, 5% buffer artefact
+            ("ICP", 2.5522, 5.05),  # trade 1 — crash trigger
+            ("INJ", 5.2174, 4.88),  # trade 2 — filled, 5% buffer artefact
             ("PENDLE", 1.8508, 4.14),  # trade 7 — filled, 5% buffer artefact
-            ("SUI", 1.0426, 4.00),     # trade 8 — filled, 5% buffer artefact
+            ("SUI", 1.0426, 4.00),  # trade 8 — filled, 5% buffer artefact
         ],
     )
     def test_filled_trades_yield_no_bogus_liquidation_price(self, pair, entry, stake):

--- a/tests/gmx/test_errors_decoder.py
+++ b/tests/gmx/test_errors_decoder.py
@@ -156,9 +156,7 @@ def test_curated_descriptions_cover_operational_errors():
         "DisabledMarket",
         "InsufficientExecutionFee",
     }
-    described = {
-        v.name for v in _GMX_ERROR_REGISTRY.values() if v.description
-    }
+    described = {v.name for v in _GMX_ERROR_REGISTRY.values() if v.description}
     missing = operational_errors - described
     assert not missing, f"Operational errors missing descriptions: {missing}"
 
@@ -186,11 +184,7 @@ def test_adapter_keeper_cancel_message_includes_decoded_name():
             _desc = f" — {_named.description}" if _named.description else ""
             decoded_error = f"{_named.name}{_desc} (selector: {_named.selector})"
 
-    assert decoded_error == (
-        "InvalidCollateralTokenForMarket — "
-        "The collateral token is not accepted by this market "
-        "(selector: 0x839c693e)"
-    )
+    assert decoded_error == ("InvalidCollateralTokenForMarket — The collateral token is not accepted by this market (selector: 0x839c693e)")
 
 
 def test_adapter_keeper_cancel_message_falls_through_for_unknown_selector():

--- a/tests/hypersync/test_hypersync_gap_healing.py
+++ b/tests/hypersync/test_hypersync_gap_healing.py
@@ -41,7 +41,7 @@ def test_hypersync_gap_healing(tmp_path):
 
     call_count = 0
 
-    async def mock_get_timestamps(client, chain_id, start_block, end_block, timeout=120.0, display_progress=True, progress_throttle=10_000):
+    async def mock_get_timestamps(client, chain_id, start_block, end_block, timeout=120.0, display_progress=True, progress_throttle=10_000, validate_chain_id=True):
         nonlocal call_count
         call_count += 1
         current_call = call_count
@@ -98,7 +98,7 @@ def test_hypersync_gap_healing_no_gaps(tmp_path):
 
     call_count = 0
 
-    async def mock_get_timestamps(client, chain_id, start_block, end_block, timeout=120.0, display_progress=True, progress_throttle=10_000):
+    async def mock_get_timestamps(client, chain_id, start_block, end_block, timeout=120.0, display_progress=True, progress_throttle=10_000, validate_chain_id=True):
         nonlocal call_count
         call_count += 1
 
@@ -150,7 +150,7 @@ def test_hypersync_gap_healing_persistent_gap(tmp_path):
 
     call_count = 0
 
-    async def mock_get_timestamps(client, chain_id, start_block, end_block, timeout=120.0, display_progress=True, progress_throttle=10_000):
+    async def mock_get_timestamps(client, chain_id, start_block, end_block, timeout=120.0, display_progress=True, progress_throttle=10_000, validate_chain_id=True):
         nonlocal call_count
         call_count += 1
 


### PR DESCRIPTION
## Why

The vault price scanner hits Hypersync's 200 RPM API rate limit on high-block-count chains like Polygon, causing cascading 429 errors and scan failures. Three issues compound:

1. A redundant `get_chain_id()` API call fires on every stream opening — including each gap-healing sub-range — wasting quota
2. The flaky retry loop retries immediately on failure with no backoff, turning a transient 429 into a retry storm
3. The cache boundary has an off-by-one overlap, re-fetching the last cached block on every incremental run

## Lessons learnt

- Hypersync's Rust client retries 429s internally but surfaces them as errors when retries are exhausted — the Python layer needs its own backoff on top
- The `get_chain_id()` call is purely a sanity check (chain ID is already baked into the client URL) but counts against the rate limit
- On incremental runs where the DuckDB cache fully covers the requested range, a log message confirming the skip is valuable for debugging

## Summary

- Removed the redundant `await client.get_chain_id()` call from `get_block_timestamps_using_hypersync_async()` — saves one API request per stream opening
- Added exponential backoff (30s → 60s → 120s → 240s) in `fetch_block_timestamps_using_hypersync_cached()` between flaky retry attempts
- Fixed off-by-one: changed `scan_start = last_read_block` to `last_read_block + 1` to avoid re-fetching the cached boundary block
- Added log message when timestamp cache fully covers the requested range (Hypersync fetch skipped entirely)
- Improved log format to include delta block count for easier debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)