### PR TITLE
ci: reduce PR cost — docs-only ignores, draft-skip, concurrency

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,53 @@
+name: Lint
+
+on:
+  push:
+    branches: [master]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+  pull_request:
+    branches: [master]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.14
+
+      - name: Cache Poetry & Pip
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pypoetry
+            ~/.cache/pip
+          key: poetry-lint-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            poetry-lint-${{ runner.os }}-
+
+      - name: Install poetry
+        run: pipx install "poetry>=2.3" --python "${{ env.PYTHON_PATH }}"
+
+      - name: Install lint dependencies
+        run: |
+          poetry install --no-root
+
+      - name: Ruff lint check
+        run: |
+          poetry run ruff format --check --diff

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,13 +7,14 @@ on:
       - 'docs/**'
       - '**/*.md'
   pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
     branches: [master]
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test-gmx.yml
+++ b/.github/workflows/test-gmx.yml
@@ -64,6 +64,16 @@ jobs:
           # Disable cache to force fresh installation when debugging
           # cache: "poetry"
 
+      - name: Cache Poetry & Pip
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pypoetry
+            ~/.cache/pip
+          key: poetry-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            poetry-${{ runner.os }}-
+
       # https://github.com/python-poetry/poetry/blob/main/CHANGELOG.md
       - name: Install poetry (using matrix Python)
         run: pipx install "poetry>=2.3" --python "${{ env.PYTHON_PATH }}"
@@ -74,6 +84,14 @@ jobs:
         run: |
             poetry install
             poetry install -E docs -E data -E test -E hypersync -E ccxt -E duckdb -E posts
+
+      - name: Cache Foundry
+        uses: actions/cache@v4
+        with:
+          path: ~/.foundry
+          key: foundry-${{ runner.os }}-${{ hashFiles('foundry.toml') }}
+          restore-keys: |
+            foundry-${{ runner.os }}-
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/test-gmx.yml
+++ b/.github/workflows/test-gmx.yml
@@ -14,15 +14,27 @@ on:
       - 'eth_defi/gmx/**'
       - 'tests/gmx/**'
       - '.github/workflows/test-gmx.yml'
+    # Ignore docs-only changes to avoid firing heavy GMX tests
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
   pull_request:
     branches: [ master ]
     paths:
       - 'eth_defi/gmx/**'
       - 'tests/gmx/**'
       - '.github/workflows/test-gmx.yml'
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-gmx-serial:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     # Reserved multicore instance for running tests
     runs-on:
       group: Beefy runners

--- a/.github/workflows/test-gmx.yml
+++ b/.github/workflows/test-gmx.yml
@@ -19,6 +19,7 @@ on:
       - 'docs/**'
       - '**/*.md'
   pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
     branches: [ master ]
     paths:
       - 'eth_defi/gmx/**'
@@ -29,7 +30,7 @@ on:
       - '**/*.md'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,14 @@ jobs:
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
           echo $PNPM_HOME >> $GITHUB_PATH
 
+      - name: Cache PNPM store
+        uses: actions/cache@v4
+        with:
+          path: ~/.pnpm-store
+          key: pnpm-${{ runner.os }}-${{ hashFiles('contracts/aave-v3-deploy/package-lock.json') }}
+          restore-keys: |
+            pnpm-${{ runner.os }}-
+
       - name: Install poetry (using matrix Python)
         run: pipx install "poetry>=2.3" --python "${{ env.PYTHON_PATH }}"
 
@@ -85,6 +93,16 @@ jobs:
           cache-dependency-path: |
             **/pyproject.toml
 
+      - name: Cache Poetry & Pip
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pypoetry
+            ~/.cache/pip
+          key: poetry-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: |
+            poetry-${{ runner.os }}-
+
       - name: Install dependencies
         run: |
           poetry install
@@ -92,6 +110,14 @@ jobs:
 
       - name: Install Ganache
         run: yarn global add ganache
+
+      - name: Cache Foundry
+        uses: actions/cache@v4
+        with:
+          path: ~/.foundry
+          key: foundry-${{ runner.os }}-${{ hashFiles('foundry.toml') }}
+          restore-keys: |
+            foundry-${{ runner.os }}-
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -182,6 +208,3 @@ jobs:
           ARBITRUM_GMX_TEST_SEPOLIA_PRIVATE_KEY: ${{ secrets.ARBITRUM_GMX_TEST_SEPOLIA_PRIVATE_KEY }}
           HYPERSYNC_API_KEY: ${{ secrets.HYPERSYNC_API_KEY }}
 
-      - name: Ruff lint check
-        run: |
-          poetry run ruff format --check --diff

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,24 @@ name: Automated test suite
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'docs/**/**'
   pull_request:
     branches: [master]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - 'docs/**/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-python:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     # Reserved multicore instance for running tests
     runs-on:
       group: Beefy runners

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,16 +6,15 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
-      - 'docs/**/**'
   pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
     branches: [master]
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
-      - 'docs/**/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Why
The org-wide GitHub Actions budget is being exceeded. This PR reduces per-PR CI cost by skipping heavy workflows for docs-only changes, adding cancel-in-progress concurrency, and preventing draft PRs from firing tests.

## Summary
- Added `paths-ignore` for `docs/**` and `**/*.md` in `.github/workflows/test.yml` and `.github/workflows/test-gmx.yml`
- Added `concurrency` with `cancel-in-progress` to both workflows
- Skipped workflow runs on draft PRs

## Notes
- This is a fresh cleanup branch starting from `origin/master`; it ignores the existing PR #1035 branch.
- No test code or package changes were included, only CI workflow controls.
