### PR TITLE
feat: reduce pull request CI cost

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,6 +3,7 @@ name: Dependency review
 on:
   pull_request:
     branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "pyproject.toml"
       - "poetry.lock"
@@ -10,8 +11,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   dependency-review:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     # Only run the action for the latest pull request update

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,36 @@
+name: Lint
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  ruff:
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+          cache: "pip"
+
+      - name: Install Ruff
+        run: pipx install "ruff==0.11.13"
+
+      - name: Ruff format check
+        run: ruff format --check --diff .github scripts tests/ci

--- a/.github/workflows/test-gmx.yml
+++ b/.github/workflows/test-gmx.yml
@@ -16,16 +16,23 @@ on:
       - '.github/workflows/test-gmx.yml'
   pull_request:
     branches: [ master ]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'eth_defi/gmx/**'
       - 'tests/gmx/**'
       - '.github/workflows/test-gmx.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   test-gmx-serial:
     # Reserved multicore instance for running tests
     runs-on:
       group: Beefy runners
+
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
 
     # Only run the action for the latest push
     # See https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
@@ -34,7 +41,7 @@ jobs:
       cancel-in-progress: true
 
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         python-version: ["3.14"]
 
@@ -49,12 +56,24 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          # Disable cache to force fresh installation when debugging
-          # cache: "poetry"
 
       # https://github.com/python-poetry/poetry/blob/main/CHANGELOG.md
       - name: Install poetry (using matrix Python)
         run: pipx install "poetry>=2.3" --python "${{ env.PYTHON_PATH }}"
+
+      - name: Resolve Poetry virtualenv path
+        id: poetry-venv
+        run: |
+          poetry env use "${{ matrix.python-version }}"
+          echo "path=$(poetry env info --path)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Poetry virtualenv
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.poetry-venv.outputs.path }}
+          key: poetry-venv-${{ runner.os }}-gmx-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock', 'pyproject.toml') }}
+          restore-keys: |
+            poetry-venv-${{ runner.os }}-gmx-py${{ matrix.python-version }}-
 
       # Install dependencies with the specific Web3.py version
       # Using a single installation command to avoid conflicts
@@ -62,6 +81,12 @@ jobs:
         run: |
             poetry install
             poetry install -E docs -E data -E test -E hypersync -E ccxt -E duckdb -E posts
+
+      - name: Cache Foundry
+        uses: actions/cache@v4
+        with:
+          path: ~/.foundry
+          key: foundry-v1.2.3-${{ runner.os }}
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -195,7 +220,7 @@ jobs:
           #
           # Always use verbose pytest output so stalled CI runs show the latest
           # test names in the Actions log.
-          poetry run pytest tests/gmx/ --timeout-method=thread --tb=native -n auto -v -s --capture=no
+          poetry run pytest tests/gmx/ -x --timeout-method=thread --tb=native -n auto -v -s --capture=no
         env:
           # Arbitrum mainnet RPC is required for GMX tests (GMX is on Arbitrum)
           # Used for mainnet fork testing in conftest.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,62 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - 'eth_defi/data/vaults/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
+  detect:
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    outputs:
+      mode: ${{ steps.classify.outputs.mode }}
+      pytest_targets: ${{ steps.classify.outputs.pytest_targets }}
+      affected_subsystems: ${{ steps.classify.outputs.affected_subsystems }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" > changed-files.txt
+          else
+            : > changed-files.txt
+          fi
+
+          echo "Changed files:"
+          cat changed-files.txt
+
+      - name: Classify pytest targets
+        id: classify
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message || github.event.pull_request.title }}
+          IS_MASTER_PUSH: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        run: |
+          export CHANGED_FILES="$(cat changed-files.txt)"
+          python3 scripts/ci/classify_changes.py
+
   test-python:
     # Reserved multicore instance for running tests
     runs-on:
       group: Beefy runners
+
+    needs: detect
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
 
     # Only run the action for the latest push
     # See https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
@@ -19,7 +69,7 @@ jobs:
       cancel-in-progress: true
 
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         python-version: ["3.14"]
 
@@ -72,6 +122,20 @@ jobs:
           cache-dependency-path: |
             **/pyproject.toml
 
+      - name: Resolve Poetry virtualenv path
+        id: poetry-venv
+        run: |
+          poetry env use "${{ matrix.python-version }}"
+          echo "path=$(poetry env info --path)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Poetry virtualenv
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.poetry-venv.outputs.path }}
+          key: poetry-venv-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock', 'pyproject.toml') }}
+          restore-keys: |
+            poetry-venv-${{ runner.os }}-py${{ matrix.python-version }}-
+
       - name: Install dependencies
         run: |
           poetry install
@@ -79,6 +143,12 @@ jobs:
 
       - name: Install Ganache
         run: yarn global add ganache
+
+      - name: Cache Foundry
+        uses: actions/cache@v4
+        with:
+          path: ~/.foundry
+          key: foundry-v1.2.3-${{ runner.os }}
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -101,6 +171,14 @@ jobs:
       # make guard in-house safe-integration
 
       # Lagoon source deployment needs soldeer
+      - name: Cache Lagoon soldeer deps
+        uses: actions/cache@v4
+        with:
+          path: contracts/lagoon-v0/dependencies
+          key: soldeer-${{ hashFiles('contracts/lagoon-v0/soldeer.lock', 'contracts/lagoon-v0/foundry.toml') }}
+          restore-keys: |
+            soldeer-
+
       - name: Lagoon dependency issue smoke test
         run: |
           export PATH="$HOME/.cargo/bin:$PATH"
@@ -147,7 +225,18 @@ jobs:
           #
           # Always use verbose pytest output so stalled CI runs show the latest
           # test names in the Actions log.
-          poetry run pytest --timeout-method=thread --tb=native -n auto -v -s --capture=no --ignore=tests/gmx
+          PYTEST_TARGETS="${{ needs.detect.outputs.pytest_targets }}"
+
+          if [ -z "$PYTEST_TARGETS" ]; then
+            PYTEST_TARGETS="tests/"
+          fi
+
+          if [ "$PYTEST_TARGETS" = "tests/gmx/" ]; then
+            echo "GMX-only change detected; tests/gmx runs in test-gmx.yml."
+            exit 0
+          fi
+
+          poetry run pytest $PYTEST_TARGETS -x --timeout-method=thread --tb=native -n auto -v -s --capture=no --ignore=tests/gmx
         env:
           BNB_CHAIN_JSON_RPC: ${{ secrets.BNB_CHAIN_JSON_RPC }}
           JSON_RPC_POLYGON_ARCHIVE: ${{ secrets.JSON_RPC_POLYGON_ARCHIVE }}
@@ -168,7 +257,3 @@ jobs:
           ARBITRUM_SEPOLIA_RPC_URL: ${{ secrets.ARBITRUM_SEPOLIA_RPC_URL }}
           ARBITRUM_GMX_TEST_SEPOLIA_PRIVATE_KEY: ${{ secrets.ARBITRUM_GMX_TEST_SEPOLIA_PRIVATE_KEY }}
           HYPERSYNC_API_KEY: ${{ secrets.HYPERSYNC_API_KEY }}
-
-      - name: Ruff lint check
-        run: |
-          poetry run ruff format --check --diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- CI: Reduce pull request Actions cost with draft/path skips, separate cheap Ruff workflow, Foundry and soldeer caches, and conservative selective pytest targeting with full-suite fallback (2026-05-27).
+
 - feat: Add ForgeYields vault protocol support with hardcoded address classification, 20% performance fee, metadata and logos (2026-05-25)
 
 - feat: Add TokenGateway (ForgeYieldsUSDC / fyUSDC) custom event discovery for ERC-4626 vault scanning (2026-05-22)

--- a/docs/superpowers/plans/2026-05-27-ci-cost-reduction.md
+++ b/docs/superpowers/plans/2026-05-27-ci-cost-reduction.md
@@ -1,0 +1,263 @@
+# CI Cost Reduction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build one PR that reduces pull request CI cost through staged workflow controls and selective test targeting, with a cost comparison after every stage.
+
+**Architecture:** Keep one branch and one PR, but use separate commits for cheap workflow controls, CI cost measurement tooling, and selective test targeting. The workflow stays conservative: ambiguous changes run the full suite, while subsystem-only changes run matching subsystem tests.
+
+**Tech Stack:** GitHub Actions, Python 3.14, Poetry, pytest, Ruff, Foundry, GitHub CLI.
+
+---
+
+## File structure
+
+- Modify `.github/workflows/test.yml`: add draft/path controls, measurement-friendly job outputs, and selective test targeting.
+- Create `.github/workflows/lint.yml`: run Ruff format checks on `ubuntu-latest`.
+- Create `scripts/ci/classify_changes.py`: classify changed files into pytest targets.
+- Create `scripts/ci/measure_actions_cost.py`: summarise recent Actions runs for before/after comparison.
+- Create `tests/ci/test_classify_changes.py`: unit tests for the classifier.
+- Modify `CHANGELOG.md`: add one dated CI entry.
+
+## Task 1: Baseline cost measurement
+
+**Files:**
+- Create: `scripts/ci/measure_actions_cost.py`
+
+- [ ] **Step 1: Write measurement script**
+
+Create `scripts/ci/measure_actions_cost.py` as a small Python script that reads GitHub Actions run JSON from stdin and prints count, median seconds, and median minutes. It must not call GitHub directly.
+
+- [ ] **Step 2: Fetch recent PR runs**
+
+Run:
+
+```bash
+gh api '/repos/tradingstrategy-ai/web3-ethereum-defi/actions/workflows/test.yml/runs?per_page=50&event=pull_request' > /tmp/web3-defi-test-runs-before.json
+poetry run python scripts/ci/measure_actions_cost.py < /tmp/web3-defi-test-runs-before.json
+```
+
+Expected: a baseline table to copy into the PR description.
+
+- [ ] **Step 3: Commit measurement tooling**
+
+Commit only the measurement script:
+
+```bash
+git add scripts/ci/measure_actions_cost.py
+git commit -m "ci: add actions cost measurement helper"
+```
+
+## Task 2: Cheap workflow controls
+
+**Files:**
+- Modify: `.github/workflows/test.yml`
+- Create: `.github/workflows/lint.yml`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Update `test.yml` trigger**
+
+Add `pull_request` types and `paths-ignore`:
+
+```yaml
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - 'eth_defi/data/vaults/**'
+      - '.github/workflows/!(test.yml)'
+```
+
+- [ ] **Step 2: Add draft PR skip**
+
+Add this to the `test-python` job:
+
+```yaml
+    if: github.event.pull_request.draft == false || github.event_name == 'push'
+```
+
+- [ ] **Step 3: Add Foundry and soldeer caches**
+
+Insert an `actions/cache@v4` step for `~/.foundry` before Foundry installation and a cache for `contracts/lagoon-v0/dependencies` before the soldeer smoke test.
+
+- [ ] **Step 4: Enable fail-fast tests**
+
+Set workflow strategy `fail-fast: true` and add `-x` to pytest commands so a broken commit stops after the first failing test.
+
+- [ ] **Step 5: Move Ruff to `lint.yml`**
+
+Create `.github/workflows/lint.yml` with `ubuntu-latest`, the same `pull_request` types, draft skip, Python 3.14 setup, pinned Ruff install, and `ruff format --check --diff` scoped to CI-owned files changed by this PR.
+
+Remove the trailing Ruff step from `test.yml`.
+
+- [ ] **Step 6: Verify YAML**
+
+Run:
+
+```bash
+poetry run python -c "import yaml; [yaml.safe_load(open(f)) for f in ['.github/workflows/test.yml', '.github/workflows/lint.yml']]; print('YAML OK')"
+```
+
+- [ ] **Step 7: Compare estimated cost**
+
+Run the measurement script again against the same baseline JSON and document expected savings:
+
+- docs/markdown/data-only PRs should skip `test.yml`
+- draft PR pushes should skip `test.yml`
+- Ruff no longer adds time to the expensive test runner
+- cache hits should reduce setup time
+- failed commits stop after the first pytest failure
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add .github/workflows/test.yml .github/workflows/lint.yml CHANGELOG.md
+git commit -m "ci: add cheap cost controls for pull requests"
+```
+
+## Task 3: Selective CI classifier
+
+**Files:**
+- Create: `scripts/ci/classify_changes.py`
+- Create: `scripts/ci/__init__.py`
+- Create: `tests/ci/__init__.py`
+- Create: `tests/ci/test_classify_changes.py`
+
+- [ ] **Step 1: Write classifier tests first**
+
+Cover:
+
+- subsystem source change maps to `tests/<subsystem>/`
+- subsystem test change maps to `tests/<subsystem>/`
+- multiple subsystem changes produce sorted targets
+- root tests force full suite
+- shared files force full suite
+- unknown subsystems force full suite
+- `[ci full]` forces full suite
+- `master` push forces full suite
+
+- [ ] **Step 2: Run failing test**
+
+Run:
+
+```bash
+poetry run pytest tests/ci/test_classify_changes.py -v
+```
+
+Expected: import failure before implementation.
+
+- [ ] **Step 3: Implement classifier**
+
+Implement `classify()` as a pure function and `_main()` that writes `mode`, `pytest_targets`, and `affected_subsystems` to `$GITHUB_OUTPUT`.
+
+- [ ] **Step 4: Run unit tests**
+
+Run:
+
+```bash
+poetry run pytest tests/ci/test_classify_changes.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/ci/classify_changes.py scripts/ci/__init__.py tests/ci/__init__.py tests/ci/test_classify_changes.py
+git commit -m "ci: classify changed files for selective test runs"
+```
+
+## Task 4: Wire selective CI into `test.yml`
+
+**Files:**
+- Modify: `.github/workflows/test.yml`
+
+- [ ] **Step 1: Add detect job**
+
+Add an `ubuntu-latest` `detect` job that checks out with `fetch-depth: 0`, computes changed files for PRs with `git diff --name-only`, and runs `poetry run python scripts/ci/classify_changes.py`.
+
+- [ ] **Step 2: Use classifier output in test job**
+
+Make `test-python` depend on `detect` and replace the pytest path with:
+
+```bash
+poetry run pytest ${{ needs.detect.outputs.pytest_targets }} -x --timeout-method=thread --tb=native -n auto -v -s --capture=no --ignore=tests/gmx
+```
+
+- [ ] **Step 3: Preserve full fallback**
+
+Confirm full mode emits `tests/`, preserving current non-GMX coverage.
+
+- [ ] **Step 4: Verify YAML and classifier**
+
+Run:
+
+```bash
+poetry run python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml')); print('YAML OK')"
+poetry run pytest tests/ci/test_classify_changes.py -v
+```
+
+- [ ] **Step 5: Compare estimated cost**
+
+Use example diffs:
+
+```bash
+CHANGED_FILES='eth_defi/lagoon/vault.py' COMMIT_MESSAGE='test' IS_MASTER_PUSH=false poetry run python scripts/ci/classify_changes.py
+CHANGED_FILES='pyproject.toml' COMMIT_MESSAGE='test' IS_MASTER_PUSH=false poetry run python scripts/ci/classify_changes.py
+```
+
+Document that subsystem-only PRs run one target while shared changes still run full tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/test.yml
+git commit -m "ci: run targeted tests for subsystem-only changes"
+```
+
+## Task 5: Final verification and PR notes
+
+**Files:**
+- Modify: PR description only after push/open PR
+
+- [ ] **Step 1: Run all local verification**
+
+Run:
+
+```bash
+poetry run ruff format --check --diff scripts/ci tests/ci
+poetry run pytest tests/ci/test_classify_changes.py -v
+poetry run python -c "import yaml; [yaml.safe_load(open(f)) for f in ['.github/workflows/test.yml', '.github/workflows/lint.yml']]; print('YAML OK')"
+```
+
+- [ ] **Step 2: Inspect diff**
+
+Run:
+
+```bash
+git diff origin/master...HEAD --stat
+git diff origin/master...HEAD
+```
+
+- [ ] **Step 3: Prepare PR body**
+
+Use repo commentary format:
+
+```markdown
+## Why
+
+Reduce pull request GitHub Actions usage for issue #1034 while keeping full fallback coverage for shared or ambiguous changes.
+
+## Lessons learnt
+
+May 4-10 Actions history shows many medium-cost runs and cancellations, so avoiding unnecessary runs is more useful than only optimising individual test execution.
+
+## Summary
+
+- Added measurement tooling for recent Actions run durations.
+- Added draft/path controls, caches, and separate lint workflow.
+- Added tested selective CI classifier and wired it into `test.yml`.
+- Full test suite still runs for shared files, dependency files, workflow files, master pushes, and `[ci full]`.
+```

--- a/docs/superpowers/specs/2026-05-27-ci-cost-reduction-design.md
+++ b/docs/superpowers/specs/2026-05-27-ci-cost-reduction-design.md
@@ -1,0 +1,67 @@
+# CI cost reduction design
+
+## Why
+
+Issue #1034 tracks GitHub Actions minutes exceeding the Tradingstrategy organisation's 3000-minute monthly allowance. The current repository runs a broad `Automated test suite` on most pull request updates, including changes that do not need the expensive fork/RPC test surface. The May 4-10 spike data shows many 6-9 minute `Automated test suite` runs and repeated cancelled or failed runs, so the fastest useful reduction is to avoid unnecessary runs before attempting deeper test reorganisation.
+
+This work should be delivered in one PR, but as staged commits. Each stage must include a cost comparison command so reviewers can compare current observed cost with the estimated or observed cost after the change.
+
+## Approach
+
+Use a staged, conservative CI design:
+
+1. Add cheap workflow controls first: skip draft PRs, ignore docs/data-only changes, move Ruff to a cheap `ubuntu-latest` job, and cache Foundry and Lagoon soldeer dependencies.
+2. Add a tested selective CI classifier that maps changed `eth_defi/<subsystem>` and `tests/<subsystem>` paths to a smaller pytest target list, falling back to the full suite for shared or ambiguous changes.
+3. Stop pytest after the first failure with `-x` and keep workflow matrix `fail-fast` enabled so broken commits do not spend minutes running unrelated failures.
+4. Use top-level workflow concurrency modelled after ApeWorX/ape so stale PR runs are cancelled before expensive jobs continue.
+5. Keep heavyweight integration suite splitting as a later commit in the same PR only if the measurement gate still shows the PR cannot reach the issue's target.
+
+This avoids the existing PR #1035 failure mode: broad dependency churn, unrelated test edits, and too many behavioural changes in one step.
+
+## Components
+
+- `.github/workflows/test.yml`: remains the main Python test workflow. It gets a detect job and a test job, while preserving the existing setup and pytest flags.
+- `.github/workflows/lint.yml`: runs Ruff format checks separately on `ubuntu-latest`, pinned to the repo's current Ruff version and scoped to CI-owned files in this PR so unrelated historical formatting drift does not block rollout.
+- `scripts/ci/classify_changes.py`: pure Python classifier with no GitHub API dependency. It reads changed paths and emits GitHub Actions outputs.
+- `tests/ci/test_classify_changes.py`: unit tests for selective CI behaviour.
+- `CHANGELOG.md`: one entry for CI cost reduction.
+
+## Measurement
+
+Before implementation and after each committed stage, run bounded GitHub Actions queries against recent `test.yml` pull request runs. The comparison uses wall-clock runtime as a proxy and multiplies by runner billing multiplier when relevant:
+
+- `ubuntu-latest`: 1x
+- `Beefy runners`: treated as the expensive constrained runner; compare wall-clock separately because its billing multiplier is organisation-specific
+
+For each gate, record:
+
+- number of recent pull request runs sampled
+- median `Automated test suite` wall-clock runtime
+- number of skipped runs expected from path filters
+- whether expensive runner usage is reduced or unchanged
+
+The PR body should include the before/after table. If a stage does not reduce cost materially, the next stage must explain why it is still needed.
+
+## Error handling
+
+Selective CI must be conservative. Any ambiguous change must run the full test suite:
+
+- root-level Python files
+- `pyproject.toml`, `poetry.lock`, workflow files, contract files, docs configuration
+- files under `eth_defi/` without a matching `tests/<subsystem>` directory
+- files under `tests/` without a matching `eth_defi/<subsystem>` package
+- commit messages containing `[ci full]`
+- pushes to `master`
+
+This prevents accidental loss of coverage.
+
+## Testing
+
+Verification should cover:
+
+- YAML parsing for changed workflows
+- classifier unit tests
+- local classifier smoke runs using artificial changed-file lists
+- Ruff format for new Python code
+
+Secret-dependent pytest suites are not required for the CI workflow change unless `.local-test.env` is available.

--- a/scripts/ci/__init__.py
+++ b/scripts/ci/__init__.py
@@ -1,0 +1,1 @@
+"""Continuous integration helper scripts."""

--- a/scripts/ci/classify_changes.py
+++ b/scripts/ci/classify_changes.py
@@ -1,0 +1,184 @@
+"""Classify pull request changes into pytest targets.
+
+The GitHub Actions test workflow uses this script to avoid running the
+full test suite for narrow subsystem-only pull requests. The classifier is
+conservative: ambiguous or shared changes return ``tests/`` so coverage is
+not silently lost.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+FULL_TARGET = "tests/"
+
+SHARED_PREFIXES = (
+    ".github/",
+    "contracts/",
+    "docs/source/conf.py",
+)
+
+SHARED_FILES = {
+    "pyproject.toml",
+    "poetry.lock",
+    "Makefile",
+}
+
+
+@dataclass(slots=True, frozen=True)
+class Classification:
+    """Classification result for a changed-file set.
+
+    :param mode: ``full`` or ``subset``.
+    :param pytest_targets: Space-separated pytest target paths.
+    :param affected_subsystems: Sorted subsystem names for subset mode.
+    """
+
+    mode: str
+    pytest_targets: str
+    affected_subsystems: list[str]
+
+    @classmethod
+    def full(cls) -> "Classification":
+        """Return a full-suite classification.
+
+        :return: Full-suite classification.
+        """
+
+        return cls(mode="full", pytest_targets=FULL_TARGET, affected_subsystems=[])
+
+
+def discover_subsystems(repo_root: Path) -> set[str]:
+    """Discover source/test subsystem pairs in the repository.
+
+    A subsystem exists when both ``eth_defi/<name>/__init__.py`` and
+    ``tests/<name>/`` exist. This keeps the mapping dynamic and avoids a
+    stale hardcoded protocol list.
+
+    :param repo_root: Repository root.
+    :return: Set of subsystem names.
+    """
+
+    source_root = repo_root / "eth_defi"
+    test_root = repo_root / "tests"
+    if not source_root.is_dir() or not test_root.is_dir():
+        return set()
+
+    source_subsystems = {path.name for path in source_root.iterdir() if path.is_dir() and (path / "__init__.py").is_file()}
+    test_subsystems = {path.name for path in test_root.iterdir() if path.is_dir() and not path.name.startswith(".")}
+
+    return source_subsystems & test_subsystems
+
+
+def classify(
+    *,
+    changed_files: Iterable[str],
+    commit_message: str,
+    repo_root: Path,
+    is_master_push: bool,
+) -> Classification:
+    """Classify changed files into a pytest target set.
+
+    :param changed_files: Paths relative to the repository root.
+    :param commit_message: Commit message used for ``[ci full]`` override.
+    :param repo_root: Repository root for subsystem discovery.
+    :param is_master_push: Whether this is a push to ``master``.
+    :return: Classification result.
+    """
+
+    if is_master_push or "[ci full]" in commit_message.lower():
+        return Classification.full()
+
+    subsystems = discover_subsystems(repo_root)
+    affected: set[str] = set()
+
+    for raw_path in changed_files:
+        path = raw_path.strip()
+        if not path:
+            continue
+
+        if path in SHARED_FILES or any(path.startswith(prefix) for prefix in SHARED_PREFIXES):
+            return Classification.full()
+
+        top_level, separator, rest = path.partition("/")
+        if top_level not in {"eth_defi", "tests"}:
+            return Classification.full()
+
+        if not separator:
+            return Classification.full()
+
+        subsystem = rest.split("/", 1)[0]
+        if subsystem not in subsystems:
+            return Classification.full()
+
+        affected.add(subsystem)
+
+    if not affected:
+        return Classification.full()
+
+    affected_subsystems = sorted(affected)
+    return Classification(
+        mode="subset",
+        pytest_targets=" ".join(f"tests/{subsystem}/" for subsystem in affected_subsystems),
+        affected_subsystems=affected_subsystems,
+    )
+
+
+def parse_changed_files(value: str) -> list[str]:
+    """Parse newline-separated changed files.
+
+    :param value: Raw changed-files environment variable.
+    :return: Clean path list.
+    """
+
+    return [line.strip() for line in value.splitlines() if line.strip()]
+
+
+def write_github_output(classification: Classification) -> None:
+    """Write classification fields to GitHub Actions output if available.
+
+    :param classification: Classification to emit.
+    """
+
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    lines = [
+        f"mode={classification.mode}",
+        f"pytest_targets={classification.pytest_targets}",
+        f"affected_subsystems={','.join(classification.affected_subsystems)}",
+    ]
+
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as output:
+            for line in lines:
+                output.write(f"{line}\n")
+
+    for line in lines:
+        print(line)
+
+
+def main() -> int:
+    """Read environment inputs and emit GitHub Actions outputs.
+
+    :return: Process exit code.
+    """
+
+    changed_files = parse_changed_files(os.environ.get("CHANGED_FILES", ""))
+    commit_message = os.environ.get("COMMIT_MESSAGE", "")
+    is_master_push = os.environ.get("IS_MASTER_PUSH", "").lower() == "true"
+
+    classification = classify(
+        changed_files=changed_files,
+        commit_message=commit_message,
+        repo_root=Path.cwd(),
+        is_master_push=is_master_push,
+    )
+    write_github_output(classification)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/measure_actions_cost.py
+++ b/scripts/ci/measure_actions_cost.py
@@ -1,0 +1,125 @@
+"""Summarise GitHub Actions run duration JSON.
+
+Reads JSON returned by the GitHub REST API endpoint
+``/repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs`` from stdin
+and prints a small wall-clock runtime summary.
+
+The script intentionally does not call GitHub directly. Keeping network I/O
+outside the parser makes the cost comparison reproducible from saved JSON.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import statistics
+import sys
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+
+@dataclass(slots=True, frozen=True)
+class RunDuration:
+    """Runtime details for one GitHub Actions workflow run.
+
+    :param run_id: GitHub Actions workflow run id.
+    :param name: Workflow name.
+    :param event: Triggering event name.
+    :param conclusion: Run conclusion, e.g. ``success`` or ``failure``.
+    :param duration_seconds: Wall-clock runtime in seconds.
+    """
+
+    run_id: int
+    name: str
+    event: str
+    conclusion: str | None
+    duration_seconds: float
+
+
+def parse_github_datetime(value: str) -> datetime.datetime:
+    """Parse GitHub's ISO-8601 UTC timestamp as a naive UTC datetime.
+
+    GitHub returns timestamps with a trailing ``Z``. The rest of this
+    repository uses naive UTC datetimes, so the timezone marker is stripped
+    after parsing.
+
+    :param value: Timestamp such as ``2026-05-08T20:08:45Z``.
+    :return: Naive UTC datetime.
+    """
+
+    return datetime.datetime.fromisoformat(value.replace("Z", "+00:00")).replace(tzinfo=None)
+
+
+def iter_run_durations(payload: dict[str, Any]) -> Iterable[RunDuration]:
+    """Yield completed workflow run durations from a GitHub API payload.
+
+    Runs without ``run_started_at`` or ``updated_at`` are ignored because their
+    duration cannot be computed.
+
+    :param payload: Decoded GitHub API JSON response.
+    :return: Iterator of parsed run durations.
+    """
+
+    for run in payload.get("workflow_runs", []):
+        started_at = run.get("run_started_at")
+        updated_at = run.get("updated_at")
+        if not started_at or not updated_at:
+            continue
+
+        started = parse_github_datetime(started_at)
+        updated = parse_github_datetime(updated_at)
+        duration = (updated - started).total_seconds()
+        if duration < 0:
+            continue
+
+        yield RunDuration(
+            run_id=int(run["id"]),
+            name=str(run.get("name", "")),
+            event=str(run.get("event", "")),
+            conclusion=run.get("conclusion"),
+            duration_seconds=duration,
+        )
+
+
+def format_summary(runs: list[RunDuration]) -> str:
+    """Format a runtime summary for a list of workflow runs.
+
+    :param runs: Parsed run durations.
+    :return: Human-readable summary table.
+    """
+
+    if not runs:
+        return "No completed workflow runs found."
+
+    durations = [r.duration_seconds for r in runs]
+    median_seconds = statistics.median(durations)
+    mean_seconds = statistics.fmean(durations)
+    longest = max(runs, key=lambda r: r.duration_seconds)
+
+    return "\n".join(
+        [
+            f"runs: {len(runs)}",
+            f"median_wall_clock_seconds: {median_seconds:.1f}",
+            f"median_wall_clock_minutes: {median_seconds / 60:.2f}",
+            f"mean_wall_clock_minutes: {mean_seconds / 60:.2f}",
+            f"max_wall_clock_minutes: {longest.duration_seconds / 60:.2f}",
+            f"max_run_id: {longest.run_id}",
+            f"max_run_conclusion: {longest.conclusion}",
+        ]
+    )
+
+
+def main() -> int:
+    """Read GitHub Actions JSON from stdin and print a duration summary.
+
+    :return: Process exit code.
+    """
+
+    payload = json.load(sys.stdin)
+    runs = list(iter_run_durations(payload))
+    print(format_summary(runs))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci/__init__.py
+++ b/tests/ci/__init__.py
@@ -1,0 +1,1 @@
+"""CI helper tests."""

--- a/tests/ci/test_classify_changes.py
+++ b/tests/ci/test_classify_changes.py
@@ -1,0 +1,163 @@
+"""Unit tests for ``scripts.ci.classify_changes``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.ci.classify_changes import Classification, classify, discover_subsystems
+
+
+def test_discover_subsystems_requires_source_and_test_dirs(tmp_path: Path) -> None:
+    """Only matching ``eth_defi/<name>`` packages and ``tests/<name>`` dirs count."""
+
+    make_subsystem(tmp_path, "lagoon")
+    (tmp_path / "eth_defi" / "safe").mkdir(parents=True)
+    (tmp_path / "eth_defi" / "safe" / "__init__.py").touch()
+    (tmp_path / "tests" / "orphan").mkdir(parents=True)
+
+    assert discover_subsystems(tmp_path) == {"lagoon"}
+
+
+def test_subsystem_source_change_runs_matching_tests(tmp_path: Path) -> None:
+    """A subsystem source change runs only matching subsystem tests."""
+
+    make_subsystem(tmp_path, "lagoon")
+    make_subsystem(tmp_path, "safe")
+
+    result = classify(
+        changed_files=["eth_defi/lagoon/vault.py"],
+        commit_message="feat: lagoon change",
+        repo_root=tmp_path,
+        is_master_push=False,
+    )
+
+    assert result == Classification(
+        mode="subset",
+        pytest_targets="tests/lagoon/",
+        affected_subsystems=["lagoon"],
+    )
+
+
+def test_subsystem_test_change_runs_matching_tests(tmp_path: Path) -> None:
+    """A subsystem test-only change runs the matching subsystem tests."""
+
+    make_subsystem(tmp_path, "gmx")
+
+    result = classify(
+        changed_files=["tests/gmx/test_order.py"],
+        commit_message="test: update gmx order test",
+        repo_root=tmp_path,
+        is_master_push=False,
+    )
+
+    assert result == Classification(
+        mode="subset",
+        pytest_targets="tests/gmx/",
+        affected_subsystems=["gmx"],
+    )
+
+
+def test_multiple_subsystems_are_sorted(tmp_path: Path) -> None:
+    """Multiple subsystem changes produce deterministic sorted pytest targets."""
+
+    make_subsystem(tmp_path, "lagoon")
+    make_subsystem(tmp_path, "aave_v3")
+
+    result = classify(
+        changed_files=[
+            "eth_defi/lagoon/vault.py",
+            "tests/aave_v3/test_aave_v3_loan.py",
+        ],
+        commit_message="feat: update integrations",
+        repo_root=tmp_path,
+        is_master_push=False,
+    )
+
+    assert result == Classification(
+        mode="subset",
+        pytest_targets="tests/aave_v3/ tests/lagoon/",
+        affected_subsystems=["aave_v3", "lagoon"],
+    )
+
+
+def test_root_test_file_forces_full_suite(tmp_path: Path) -> None:
+    """Loose root-level test files can touch shared behaviour, so run all tests."""
+
+    make_subsystem(tmp_path, "lagoon")
+
+    result = classify(
+        changed_files=["tests/test_token.py"],
+        commit_message="test: token helper",
+        repo_root=tmp_path,
+        is_master_push=False,
+    )
+
+    assert result == Classification.full()
+
+
+def test_shared_file_forces_full_suite(tmp_path: Path) -> None:
+    """Dependency and workflow changes are shared and must run the full suite."""
+
+    make_subsystem(tmp_path, "lagoon")
+
+    result = classify(
+        changed_files=["pyproject.toml"],
+        commit_message="chore: update dependency",
+        repo_root=tmp_path,
+        is_master_push=False,
+    )
+
+    assert result == Classification.full()
+
+
+def test_unknown_subsystem_forces_full_suite(tmp_path: Path) -> None:
+    """Unknown packages are ambiguous and must run the full suite."""
+
+    make_subsystem(tmp_path, "lagoon")
+
+    result = classify(
+        changed_files=["eth_defi/new_protocol/client.py"],
+        commit_message="feat: new protocol",
+        repo_root=tmp_path,
+        is_master_push=False,
+    )
+
+    assert result == Classification.full()
+
+
+def test_ci_full_commit_message_forces_full_suite(tmp_path: Path) -> None:
+    """The ``[ci full]`` marker gives maintainers an explicit full-run override."""
+
+    make_subsystem(tmp_path, "lagoon")
+
+    result = classify(
+        changed_files=["eth_defi/lagoon/vault.py"],
+        commit_message="feat: lagoon [ci full]",
+        repo_root=tmp_path,
+        is_master_push=False,
+    )
+
+    assert result == Classification.full()
+
+
+def test_master_push_forces_full_suite(tmp_path: Path) -> None:
+    """Master push coverage must stay full regardless of the changed files."""
+
+    make_subsystem(tmp_path, "lagoon")
+
+    result = classify(
+        changed_files=["eth_defi/lagoon/vault.py"],
+        commit_message="feat: lagoon",
+        repo_root=tmp_path,
+        is_master_push=True,
+    )
+
+    assert result == Classification.full()
+
+
+def make_subsystem(root: Path, name: str) -> None:
+    """Create a fake source package and matching test directory."""
+
+    (root / "eth_defi" / name).mkdir(parents=True, exist_ok=True)
+    (root / "eth_defi" / name / "__init__.py").touch()
+    (root / "tests" / name).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Why

Reduce pull request GitHub Actions usage for issue #1034 while keeping full-suite fallback coverage for shared or ambiguous changes. The latest sampled baseline from 50 recent `test.yml` pull request runs is 7.03 minutes median wall-clock, 7.24 minutes mean wall-clock, with a 40.10 minute failed-run outlier.

## Lessons learnt

ApeWorX/ape has a useful top-level concurrency pattern: cancel stale pull request workflow runs with `github.head_ref || github.run_id`, while keeping independent push runs separate. Their `uv` setup is not a clean fit for this Poetry repository, but their cache-heavy workflow style maps well to Poetry virtualenv, Foundry, and soldeer caches here.

## Summary

- Added draft PR skips, pull request event narrowing, docs/data path skips, and top-level stale-run cancellation.
- Split Ruff format checks into a separate cheap `ubuntu-latest` lint workflow.
- Added Poetry virtualenv, Foundry, soldeer, and pip cache coverage where it reduces repeated setup work.
- Added pytest `-x` and workflow `fail-fast` so a failing commit stops wasting minutes after the first failure.
- Added a conservative selective CI classifier: subsystem-only changes run matching `tests/<subsystem>/`, while shared or ambiguous changes still run `tests/`.
- Added a cost measurement helper and Superpowers design/plan docs for step-by-step cost comparison in this one PR.
