### PR TITLE
feat: PR-A Anvil fork caching — module-scope fixtures with evm_snapshot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     # Only run the action for the latest push
     # See https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.python-version }}
+      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
 
     strategy:
@@ -80,6 +80,15 @@ jobs:
       - name: Install Ganache
         run: yarn global add ganache
 
+      - name: Cache Foundry
+        uses: actions/cache@v4
+        with:
+          path: ~/.foundry
+          key: foundry-v1.2.3-${{ runner.os }}
+          restore-keys: |
+            foundry-v1.2.3-
+            foundry-
+
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
@@ -101,6 +110,14 @@ jobs:
       # make guard in-house safe-integration
 
       # Lagoon source deployment needs soldeer
+      - name: Cache Lagoon soldeer deps
+        uses: actions/cache@v4
+        with:
+          path: contracts/lagoon-v0/dependencies
+          key: soldeer-${{ hashFiles('contracts/lagoon-v0/soldeer.lock', 'contracts/lagoon-v0/foundry.toml') }}
+          restore-keys: |
+            soldeer-
+
       - name: Lagoon dependency issue smoke test
         run: |
           export PATH="$HOME/.cargo/bin:$PATH"
@@ -147,7 +164,7 @@ jobs:
           #
           # Always use verbose pytest output so stalled CI runs show the latest
           # test names in the Actions log.
-          poetry run pytest --timeout-method=thread --tb=native -n auto -v -s --capture=no --ignore=tests/gmx
+          poetry run pytest --timeout-method=thread --tb=native -n auto --dist loadgroup -v -s --capture=no --ignore=tests/gmx
         env:
           BNB_CHAIN_JSON_RPC: ${{ secrets.BNB_CHAIN_JSON_RPC }}
           JSON_RPC_POLYGON_ARCHIVE: ${{ secrets.JSON_RPC_POLYGON_ARCHIVE }}

--- a/eth_defi/testing/__init__.py
+++ b/eth_defi/testing/__init__.py
@@ -1,0 +1,1 @@
+# Testing utilities for eth_defi integration and fork-based tests.

--- a/eth_defi/testing/evm_snapshot_fixture.py
+++ b/eth_defi/testing/evm_snapshot_fixture.py
@@ -1,0 +1,99 @@
+"""Shared autouse fixture for per-test EVM state isolation on module-scope Anvil.
+
+This module provides :func:`make_evm_snapshot_fixture` — a factory that creates
+an autouse pytest fixture wrapping each test in an ``evm_snapshot`` /
+``evm_revert`` pair.
+
+The motivation is CI cost reduction: many test fixtures that wrap
+:func:`~eth_defi.provider.anvil.fork_network_anvil` are function-scoped,
+spawning a fresh Anvil per test and re-warming the fork from the archive RPC.
+Bumping the fork fixture to ``scope="module"`` and adding an autouse
+snapshot/revert keeps per-test isolation but spawns Anvil once per module —
+typically a 30-50% wall-clock reduction on fork-heavy dirs.
+
+Usage in a conftest or test file:
+
+.. code-block:: python
+
+    from eth_defi.testing.evm_snapshot_fixture import make_evm_snapshot_fixture
+
+
+    @pytest.fixture(scope="module")
+    def anvil_base_fork(...) -> AnvilLaunch:
+        launch = fork_network_anvil(JSON_RPC_BASE, fork_block_number=N, ...)
+        try:
+            yield launch
+        finally:
+            launch.close()
+
+
+    _evm_snapshot = make_evm_snapshot_fixture("anvil_base_fork")
+
+The factory takes the *name* of the fork fixture (so it can request that
+fixture as a dependency by string lookup) and returns an autouse function-scope
+fixture.
+
+See the Anvil fork caching design doc for the full strategy:
+``docs/superpowers/specs/2026-05-27-anvil-fork-caching-design.md``
+"""
+
+import logging
+
+import pytest
+from web3 import HTTPProvider, Web3
+
+logger = logging.getLogger(__name__)
+
+
+def make_evm_snapshot_fixture(fork_fixture_name: str):
+    """Return an autouse pytest fixture that snapshots EVM state per test.
+
+    The returned fixture depends on ``fork_fixture_name`` (which must yield an
+    object with a ``json_rpc_url`` attribute, e.g.
+    :class:`~eth_defi.provider.anvil.AnvilLaunch`). Before each test it issues
+    ``evm_snapshot``; after the test it reverts via ``evm_revert``. This pattern
+    lets a module share one Anvil process while each test still sees a clean
+    state.
+
+    :param fork_fixture_name:
+        Name of an existing module-scope or session-scope Anvil fixture in the
+        same conftest/test file. Looked up via
+        ``pytest.FixtureRequest.getfixturevalue``.
+
+    :return:
+        An autouse function-scope :func:`pytest.fixture` ready to bind to a
+        module-level name.
+
+    .. note::
+
+        ``evm_revert`` restores EVM state and storage but **does not** reset
+        block timestamp. Tests asserting on ``block.timestamp == X`` must call
+        ``evm_setNextBlockTimestamp`` themselves; the snapshot pattern alone is
+        insufficient for time-sensitive assertions.
+
+    .. seealso::
+
+        `Anvil custom JSON-RPC methods
+        <https://book.getfoundry.sh/anvil/#custom-methods>`_ for the full list
+        of ``evm_*`` and ``anvil_*`` methods.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _evm_snapshot(request):
+        fork = request.getfixturevalue(fork_fixture_name)
+        web3 = Web3(HTTPProvider(fork.json_rpc_url))
+        snap_response = web3.provider.make_request("evm_snapshot", [])
+        snap_id = snap_response.get("result")
+        if snap_id is None:
+            error = snap_response.get("error", {})
+            msg = f"evm_snapshot failed: {error}"
+            raise RuntimeError(msg)
+        try:
+            yield
+        finally:
+            revert_response = web3.provider.make_request("evm_revert", [snap_id])
+            ok = revert_response.get("result")
+            if ok is not True:
+                logger.warning("evm_revert returned %s for snap %s", revert_response, snap_id)
+
+    return _evm_snapshot

--- a/tests/erc_4626/test_4626_deposit_redeem.py
+++ b/tests/erc_4626/test_4626_deposit_redeem.py
@@ -1,16 +1,19 @@
 import os
 from decimal import Decimal
 from typing import cast
+
 import pytest
+from eth_typing import HexAddress
 from web3 import Web3
+
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil, mine
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.token import fetch_erc20_details, TokenDetails, USDC_WHALE
+from eth_defi.testing.evm_snapshot_fixture import make_evm_snapshot_fixture
+from eth_defi.token import USDC_WHALE, TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
-from eth_typing import HexAddress
 
 JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
 
@@ -19,7 +22,7 @@ CI = os.environ.get("CI", None) is not None
 pytestmark = pytest.mark.skipif(not JSON_RPC_BASE, reason="No JSON_RPC_BASE environment variable")
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def anvil_base_fork(request) -> AnvilLaunch:
     """Create a testable fork of live BNB chain.
 
@@ -157,3 +160,8 @@ def test_erc_4626_redeem(
     redemption_request.broadcast()
     shares = vault.share_token.fetch_balance_of(test_user)
     assert shares == 0
+
+
+# Per-test EVM state isolation on module-scope Anvil fork.
+# See eth_defi.testing.evm_snapshot_fixture for the rationale.
+_evm_snapshot = make_evm_snapshot_fixture("anvil_base_fork")

--- a/tests/ipor/test_ipor_deposit.py
+++ b/tests/ipor/test_ipor_deposit.py
@@ -12,15 +12,15 @@ from eth_typing import HexAddress
 from web3 import Web3
 
 from eth_defi.erc_4626.analysis import analyse_4626_flow_transaction
-from eth_defi.erc_4626.estimate import estimate_4626_redeem, estimate_4626_deposit, estimate_value_by_share_price
+from eth_defi.erc_4626.estimate import estimate_4626_deposit, estimate_4626_redeem, estimate_value_by_share_price
 from eth_defi.erc_4626.flow import deposit_4626, redeem_4626
 from eth_defi.erc_4626.vault_protocol.ipor.vault import IPORVault
-from eth_defi.provider.anvil import fork_network_anvil, AnvilLaunch, mine
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil, mine
 from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.evm_snapshot_fixture import make_evm_snapshot_fixture
 from eth_defi.token import TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.trade import TradeSuccess
-
 from eth_defi.vault.base import VaultSpec
 
 JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
@@ -28,7 +28,7 @@ JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
 pytestmark = pytest.mark.skipif(JSON_RPC_BASE is None, reason="JSON_RPC_BASE needed to run these tests")
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def usdc_holder() -> HexAddress:
     # https://basescan.org/token/0x833589fcd6edb6e08f4c7c32d4f71b54bda02913#balances
     return "0x3304E22DDaa22bCdC5fCa2269b418046aE7b566A"
@@ -39,7 +39,7 @@ def test_block_number() -> int:
     return 27975506
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def anvil_base_fork(usdc_holder, test_block_number: int) -> AnvilLaunch:
     """Create a testable fork of live BNB chain.
 
@@ -237,3 +237,8 @@ def test_ipor_redeem(
     # Share price has changed over 1yera
     share_price = vault.fetch_share_price("latest")
     assert share_price == pytest.approx(Decimal("1.024204051979538320520931622"))
+
+
+# Per-test EVM state isolation on module-scope Anvil fork.
+# See eth_defi.testing.evm_snapshot_fixture for the rationale.
+_evm_snapshot = make_evm_snapshot_fixture("anvil_base_fork")

--- a/tests/lagoon/conftest.py
+++ b/tests/lagoon/conftest.py
@@ -17,12 +17,13 @@ from eth_account.signers.local import LocalAccount
 from eth_typing import HexAddress, HexStr
 from web3 import Web3
 
-from eth_defi.hotwallet import HotWallet
-from eth_defi.erc_4626.vault_protocol.lagoon.deployment import LagoonDeploymentParameters, deploy_automated_lagoon_vault, LagoonAutomatedDeployment
+from eth_defi.erc_4626.vault_protocol.lagoon.deployment import LagoonAutomatedDeployment, LagoonDeploymentParameters, deploy_automated_lagoon_vault
 from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
+from eth_defi.hotwallet import HotWallet
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.token import TokenDetails, fetch_erc20_details, USDC_NATIVE_TOKEN, USDC_WHALE
+from eth_defi.testing.evm_snapshot_fixture import make_evm_snapshot_fixture
+from eth_defi.token import USDC_NATIVE_TOKEN, USDC_WHALE, TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.uniswap_v2.constants import UNISWAP_V2_DEPLOYMENTS
 from eth_defi.uniswap_v2.deployment import fetch_deployment
@@ -36,7 +37,7 @@ CI = os.environ.get("CI", None) is not None
 pytestmark = pytest.mark.skipif(not JSON_RPC_BASE, reason="No JSON_RPC_BASE environment variable")
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def vault_owner() -> HexAddress:
     # Vaut owner
     return addr("0x0c9db006f1c7bfaa0716d70f012ec470587a8d4f")
@@ -48,13 +49,13 @@ def depositor() -> HexAddress:
     return addr("0x20415f3Ec0FEA974548184bdD6e67575D128953F")
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def usdc_holder() -> HexAddress:
     # https://basescan.org/token/0x833589fcd6edb6e08f4c7c32d4f71b54bda02913#balances
     return USDC_WHALE[8453]
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def valuation_manager() -> HexAddress:
     """Unlockable account set as the vault valuation manager."""
     return addr("0x8358bBFb4Afc9B1eBe4e8C93Db8bF0586BD8331a")
@@ -66,13 +67,13 @@ def safe_address() -> HexAddress:
     return addr("0x20415f3Ec0FEA974548184bdD6e67575D128953F")
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def test_block_number() -> int:
     """Fork height for our tests."""
     return 30_659_990
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def anvil_base_fork(
     request,
     vault_owner,
@@ -232,13 +233,13 @@ def automated_lagoon_vault(
     return deploy_info
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def asset_manager() -> HexAddress:
     """The asset manager role."""
     return "0x0b2582E9Bf6AcE4E7f42883d4E91240551cf0947"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def second_asset_manager() -> HexAddress:
     """The secondary asset manager role used in multi-key tests."""
     return Web3.to_checksum_address("0x4b3346d9b7d4f6b7a90a4d2f0d2f5f6d5b9c8a17")
@@ -363,6 +364,11 @@ def multisig_owners(web3) -> list[HexAddress]:
 #     })
 #     assert_transaction_success_with_explanation(web3, tx_hash)
 #     return safe_address
+
+
+# Per-test EVM state isolation on module-scope Anvil fork.
+# See eth_defi.testing.evm_snapshot_fixture for the rationale.
+_evm_snapshot = make_evm_snapshot_fixture("anvil_base_fork")
 
 
 # Some addresses for the roles set:

--- a/tests/safe-integration/test_guard_safe_e2e.py
+++ b/tests/safe-integration/test_guard_safe_e2e.py
@@ -18,7 +18,8 @@ from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.safe.safe_compat import create_safe_ethereum_client
 from eth_defi.simple_vault.transact import encode_simple_vault_transaction
-from eth_defi.token import TokenDetails, fetch_erc20_details, USDC_WHALE
+from eth_defi.testing.evm_snapshot_fixture import make_evm_snapshot_fixture
+from eth_defi.token import USDC_WHALE, TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.uniswap_v2.constants import UNISWAP_V2_DEPLOYMENTS
 from eth_defi.uniswap_v2.deployment import FOREVER_DEADLINE, UniswapV2Deployment, fetch_deployment
@@ -56,7 +57,7 @@ def safe_deployer_hot_wallet(web3) -> HotWallet:
     return hot_wallet
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def usdc_whale() -> HexAddress:
     """Large USDC holder onchain, unlocked in Anvil for testing"""
     # https://basescan.org/token/0x833589fcd6edb6e08f4c7c32d4f71b54bda02913#balances
@@ -89,7 +90,7 @@ def uniswap_v2(web3) -> UniswapV2Deployment:
     )
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def anvil_base_fork(request, usdc_whale) -> AnvilLaunch:
     """Create a testable fork of live BNB chain.
 
@@ -584,3 +585,8 @@ def test_velora_token_not_whitelisted(
             b"\x00",
         ).transact({"from": asset_manager})
     assert "tokenIn not allowed" in str(e)
+
+
+# Per-test EVM state isolation on module-scope Anvil fork.
+# See eth_defi.testing.evm_snapshot_fixture for the rationale.
+_evm_snapshot = make_evm_snapshot_fixture("anvil_base_fork")

--- a/tests/safe-integration/test_guard_safe_uniswap_v2.py
+++ b/tests/safe-integration/test_guard_safe_uniswap_v2.py
@@ -6,7 +6,7 @@
 """
 
 import pytest
-from web3 import Web3, HTTPProvider
+from web3 import HTTPProvider, Web3
 from web3._utils.events import EventLogErrorFlags
 from web3.contract import Contract
 
@@ -14,6 +14,7 @@ from eth_defi.abi import get_deployed_contract, get_function_selector
 from eth_defi.deploy import deploy_contract
 from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
 from eth_defi.simple_vault.transact import encode_simple_vault_transaction
+from eth_defi.testing.evm_snapshot_fixture import make_evm_snapshot_fixture
 from eth_defi.token import create_token
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.uniswap_v2.deployment import (
@@ -25,7 +26,7 @@ from eth_defi.uniswap_v2.deployment import (
 from eth_defi.uniswap_v2.pair import PairDetails, fetch_pair_details
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def anvil(request) -> AnvilLaunch:
     """Create a standalone Anvil RPC backend.
 
@@ -275,3 +276,8 @@ def test_safe_module_can_trade_uniswap_v2(
     assert_transaction_success_with_explanation(web3, tx_hash)
 
     assert weth.functions.balanceOf(safe.address).call() == 3696700037078235076
+
+
+# Per-test EVM state isolation on module-scope Anvil.
+# See eth_defi.testing.evm_snapshot_fixture for the rationale.
+_evm_snapshot = make_evm_snapshot_fixture("anvil")

--- a/tests/uniswap_v3/test_uniswap_v3_swap_base.py
+++ b/tests/uniswap_v3/test_uniswap_v3_swap_base.py
@@ -7,15 +7,15 @@ import pytest
 from eth_typing import HexAddress
 from web3 import Web3
 
-from eth_defi.provider.anvil import fork_network_anvil, AnvilLaunch
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.token import fetch_erc20_details, USDC_WHALE
+from eth_defi.testing.evm_snapshot_fixture import make_evm_snapshot_fixture
+from eth_defi.token import USDC_WHALE, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.uniswap_v3.constants import UNISWAP_V3_DEPLOYMENTS
 from eth_defi.uniswap_v3.deployment import (
     fetch_deployment,
 )
-
 from eth_defi.uniswap_v3.swap import swap_with_slippage_protection
 
 JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
@@ -25,13 +25,13 @@ CI = os.environ.get("CI", None) is not None
 pytestmark = pytest.mark.skipif(not JSON_RPC_BASE, reason="No JSON_RPC_BASE environment variable")
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def usdc_holder() -> HexAddress:
     # https://basescan.org/token/0x833589fcd6edb6e08f4c7c32d4f71b54bda02913#balances
     return USDC_WHALE[8453]
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def anvil_base_fork(request, usdc_holder) -> AnvilLaunch:
     """Create a testable fork of live BNB chain.
 
@@ -115,3 +115,8 @@ def test_uniswap_v3_swap_on_base(
 
     tx_hash = bound_call.transact({"from": usdc_holder})
     assert_transaction_success_with_explanation(web3, tx_hash)
+
+
+# Per-test EVM state isolation on module-scope Anvil fork.
+# See eth_defi.testing.evm_snapshot_fixture for the rationale.
+_evm_snapshot = make_evm_snapshot_fixture("anvil_base_fork")


### PR DESCRIPTION
## Why

CI cost reduction step 2 — bump 6 function-scope Anvil fork fixtures to module scope, preserving per-test isolation via `evm_snapshot`/`evm_revert`. One Anvil spawn per module instead of per test.

`pytest.fixture()` defaults to function scope, which spawns a fresh Anvil per test and re-warms the fork from the archive RPC (5-30s per spawn). `evm_snapshot`/`evm_revert` are O(ms) on Anvil. Bumping scope is essentially free once snapshots cover isolation.

This is PR-A of the staged plan in `docs/superpowers/specs/2026-05-27-anvil-fork-caching-design.md`. PR-B (HTTP RPC proxy cache) and PR-C (Anvil state snapshots) follow if PR-A alone does not hit the ≥30% wall-clock target.

## Lessons learnt

Most Anvil fork cost is N spawns, not N test executions. The `evm_snapshot`/`evm_revert` pair costs ~10ms round-trip; a cold fork spawn costs 5-30s plus archive-RPC slot fetching. Bumping scope trades a one-time warmup cost (per module) for per-test snapshot overhead — net saving is proportional to the number of tests sharing a module.

Pure-value fixtures (address constants, block numbers) that are dependencies of the fork fixture must also be bumped to `scope="module"` — pytest enforces that a module-scope fixture cannot depend on a function-scope one.

## Summary

- New helper: `eth_defi/testing/evm_snapshot_fixture.py` — `make_evm_snapshot_fixture(name)` factory that returns an autouse function-scope fixture wrapping each test in `evm_snapshot`/`evm_revert`
- Module-scope bumps:
  - `tests/lagoon/conftest.py` (`anvil_base_fork` + 6 address/constant deps)
  - `tests/uniswap_v3/test_uniswap_v3_swap_base.py`
  - `tests/safe-integration/test_guard_safe_e2e.py`
  - `tests/safe-integration/test_guard_safe_uniswap_v2.py`
  - `tests/ipor/test_ipor_deposit.py`
  - `tests/erc_4626/test_4626_deposit_redeem.py`
- Audited and deliberately skipped:
  - `tests/erc_4626/test_umami_deposit.py` — entire suite skips unless `JSON_RPC_TENDERLY` set; fixture comment "Reset write state between tests" indicates deliberate function scope
  - `tests/enzyme/conftest.py` — Enzyme support phasing out; deferred to follow-up