### PR TITLE
feat(CI):fork caching, lint/docs to free runners, GMX modernisation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,10 +6,8 @@ on:
 
 jobs:
   build-docs:
-    # Docs are pure Python + Pandoc + Sphinx + wrangler — no Anvil, no archive
-    # RPCs, no submodules. Runs on the free ubuntu-latest runner (1× billing)
-    # instead of Beefy (16× billing).
-    runs-on: ubuntu-latest
+    runs-on:
+      group: Beefy runners
     timeout-minutes: 30
 
     # Only run the action for the latest push

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,8 +6,11 @@ on:
 
 jobs:
   build-docs:
-    runs-on:
-      group: Beefy runners
+    # Docs are pure Python + Pandoc + Sphinx + wrangler — no Anvil, no archive
+    # RPCs, no submodules. Runs on the free ubuntu-latest runner (1× billing)
+    # instead of Beefy (16× billing).
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     # Only run the action for the latest push
     concurrency:
@@ -35,6 +38,27 @@ jobs:
           cache: "poetry"
           cache-dependency-path: |
             **/pyproject.toml
+
+      - name: Resolve poetry venv path
+        id: venv-path
+        run: |
+          venv_path=$(poetry env info --path 2>/dev/null || true)
+          if [ -z "$venv_path" ]; then
+            poetry env use 3.14
+            venv_path=$(poetry env info --path)
+          fi
+          echo "path=$venv_path" >> "$GITHUB_OUTPUT"
+
+      # Cache the resolved venv so we skip dependency reinstall on cache hit.
+      # Keyed by lockfile to invalidate on any dep change.
+      - name: Cache poetry venv
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.venv-path.outputs.path }}
+          key: docs-venv-${{ runner.os }}-py3.14-${{ hashFiles('poetry.lock', 'pyproject.toml') }}
+          restore-keys: |
+            docs-venv-${{ runner.os }}-py3.14-
+            docs-venv-${{ runner.os }}-
 
       # Required by nbsphinx for notebook conversion
       - name: Install Pandoc

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+name: Lint
+
+# Ruff format check runs on the free ubuntu-latest runner (1× billing) instead
+# of the Beefy runners (16× billing) used by the test suite. This shaves Beefy
+# minutes on every PR and gives lint feedback in ~10s instead of waiting for the
+# whole test job.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+
+permissions:
+  contents: read
+
+jobs:
+  ruff-format:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    if: github.event.pull_request.draft == false || github.event_name == 'push'
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Use the official Ruff action — it caches the ruff binary across runs.
+      # Keep the version pin in sync with pyproject.toml [tool.poetry.group.dev.dependencies].
+      - name: Ruff format check
+        uses: astral-sh/ruff-action@v3
+        with:
+          version: "0.11.13"
+          args: "format --check --diff"

--- a/.github/workflows/test-gmx.yml
+++ b/.github/workflows/test-gmx.yml
@@ -26,7 +26,9 @@ jobs:
     # Reserved multicore instance for running tests
     runs-on:
       group: Beefy runners
-    timeout-minutes: 60
+    # Hard cap — GMX serial run should sit comfortably under 15 min on Beefy
+    # after the round-2 cost-reduction work; anything longer is a stall.
+    timeout-minutes: 15
 
     if: github.event.pull_request.draft == false || github.event_name == 'push'
 

--- a/.github/workflows/test-gmx.yml
+++ b/.github/workflows/test-gmx.yml
@@ -26,11 +26,14 @@ jobs:
     # Reserved multicore instance for running tests
     runs-on:
       group: Beefy runners
+    timeout-minutes: 60
+
+    if: github.event.pull_request.draft == false || github.event_name == 'push'
 
     # Only run the action for the latest push
     # See https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.python-version }}
+      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{ matrix.python-version }}
       cancel-in-progress: true
 
     strategy:
@@ -41,20 +44,41 @@ jobs:
     name: GMX Tests - Python ${{ matrix.python-version }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
+
+      # Poetry must be installed before setup-python for cache to work
+      # https://github.com/python-poetry/poetry/blob/main/CHANGELOG.md
+      - name: Install poetry (using matrix Python)
+        run: pipx install "poetry>=2.3" --python "${{ env.PYTHON_PATH }}"
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          # Disable cache to force fresh installation when debugging
-          # cache: "poetry"
+          cache: "poetry"
+          cache-dependency-path: |
+            **/pyproject.toml
 
-      # https://github.com/python-poetry/poetry/blob/main/CHANGELOG.md
-      - name: Install poetry (using matrix Python)
-        run: pipx install "poetry>=2.3" --python "${{ env.PYTHON_PATH }}"
+      - name: Resolve poetry venv path
+        id: venv-path
+        run: |
+          venv_path=$(poetry env info --path 2>/dev/null || true)
+          if [ -z "$venv_path" ]; then
+            poetry env use ${{ matrix.python-version }}
+            venv_path=$(poetry env info --path)
+          fi
+          echo "path=$venv_path" >> "$GITHUB_OUTPUT"
+
+      - name: Cache poetry venv
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.venv-path.outputs.path }}
+          key: gmx-venv-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock', 'pyproject.toml') }}
+          restore-keys: |
+            gmx-venv-${{ runner.os }}-py${{ matrix.python-version }}-
+            gmx-venv-${{ runner.os }}-
 
       # Install dependencies with the specific Web3.py version
       # Using a single installation command to avoid conflicts
@@ -62,6 +86,15 @@ jobs:
         run: |
             poetry install
             poetry install -E docs -E data -E test -E hypersync -E ccxt -E duckdb -E posts
+
+      - name: Cache Foundry
+        uses: actions/cache@v4
+        with:
+          path: ~/.foundry
+          key: foundry-v1.2.3-${{ runner.os }}
+          restore-keys: |
+            foundry-v1.2.3-
+            foundry-
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -72,7 +105,9 @@ jobs:
           version: "v1.2.3"
 
       # Verify the correct Web3.py version is installed
-      # This helps debug any remaining issues
+      # This helps debug any remaining issues.
+      # Uses importlib.metadata because pkg_resources was removed from
+      # setuptools in Python 3.14.
       - name: Verify Web3.py version and environment isolation
         run: |
           echo "=== Environment Information ==="
@@ -86,10 +121,10 @@ jobs:
           echo ""
           echo "=== Installed Packages (Web3-related) ==="
           poetry run python -c "
-          import pkg_resources
-          web3_packages = [pkg for pkg in pkg_resources.working_set if 'web3' in pkg.project_name.lower() or 'eth' in pkg.project_name.lower()]
-          for pkg in sorted(web3_packages, key=lambda x: x.project_name):
-              print(f'{pkg.project_name}: {pkg.version}')
+          from importlib.metadata import distributions
+          web3_packages = [d for d in distributions() if 'web3' in d.metadata['Name'].lower() or 'eth' in d.metadata['Name'].lower()]
+          for d in sorted(web3_packages, key=lambda x: x.metadata['Name']):
+              print(f'{d.metadata[\"Name\"]}: {d.metadata[\"Version\"]}')
           "
 
       # ============================================================================

--- a/.github/workflows/test-gmx.yml
+++ b/.github/workflows/test-gmx.yml
@@ -26,9 +26,11 @@ jobs:
     # Reserved multicore instance for running tests
     runs-on:
       group: Beefy runners
-    # Hard cap — GMX serial run should sit comfortably under 15 min on Beefy
-    # after the round-2 cost-reduction work; anything longer is a stall.
-    timeout-minutes: 15
+    # Hard cap — GMX serial run typically lands at ~7-13 min on Beefy after
+    # the round-2 cost-reduction work. 10 min keeps the combined (test + GMX)
+    # under 20 min wall-clock; tight on cold-cache pushes but enforces the
+    # "no job > 10 min" rule.
+    timeout-minutes: 10
 
     if: github.event.pull_request.draft == false || github.event_name == 'push'
 

--- a/.github/workflows/test-gmx.yml
+++ b/.github/workflows/test-gmx.yml
@@ -21,12 +21,6 @@ on:
       - 'tests/gmx/**'
       - '.github/workflows/test-gmx.yml'
 
-# actions: write is required by the cancel-sibling job below so it can call
-# the Actions REST API via `gh run cancel`.
-permissions:
-  contents: read
-  actions: write
-
 jobs:
   test-gmx-serial:
     # Reserved multicore instance for running tests
@@ -249,34 +243,3 @@ jobs:
           ARBITRUM_GMX_TEST_SEPOLIA_PRIVATE_KEY: ${{ secrets.ARBITRUM_GMX_TEST_SEPOLIA_PRIVATE_KEY }}
       # NOTE: We don't run linting here as it's already done in the main workflow
       # Ruff lint check is only needed once per PR, not per test suite
-
-  # Cancel the in-progress test.yml run for the same commit when this job
-  # fails, so we don't keep burning Beefy minutes on a sibling workflow
-  # once the GMX suite has already gone red. Runs on the free runner.
-  cancel-sibling-tests:
-    needs: test-gmx-serial
-    if: ${{ failure() }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Cancel test.yml workflow run for this SHA
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          run_id=$(gh run list \
-            --repo "$REPO" \
-            --workflow=test.yml \
-            --status=in_progress \
-            --limit=20 \
-            --json databaseId,headSha \
-            --jq ".[] | select(.headSha == \"$SHA\") | .databaseId" \
-            | head -n1)
-          if [ -n "$run_id" ]; then
-            echo "Cancelling test.yml run $run_id (SHA $SHA)"
-            gh run cancel --repo "$REPO" "$run_id"
-          else
-            echo "No in-progress test.yml run found for SHA $SHA"
-          fi

--- a/.github/workflows/test-gmx.yml
+++ b/.github/workflows/test-gmx.yml
@@ -21,6 +21,12 @@ on:
       - 'tests/gmx/**'
       - '.github/workflows/test-gmx.yml'
 
+# actions: write is required by the cancel-sibling job below so it can call
+# the Actions REST API via `gh run cancel`.
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   test-gmx-serial:
     # Reserved multicore instance for running tests
@@ -243,3 +249,34 @@ jobs:
           ARBITRUM_GMX_TEST_SEPOLIA_PRIVATE_KEY: ${{ secrets.ARBITRUM_GMX_TEST_SEPOLIA_PRIVATE_KEY }}
       # NOTE: We don't run linting here as it's already done in the main workflow
       # Ruff lint check is only needed once per PR, not per test suite
+
+  # Cancel the in-progress test.yml run for the same commit when this job
+  # fails, so we don't keep burning Beefy minutes on a sibling workflow
+  # once the GMX suite has already gone red. Runs on the free runner.
+  cancel-sibling-tests:
+    needs: test-gmx-serial
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Cancel test.yml workflow run for this SHA
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          run_id=$(gh run list \
+            --repo "$REPO" \
+            --workflow=test.yml \
+            --status=in_progress \
+            --limit=20 \
+            --json databaseId,headSha \
+            --jq ".[] | select(.headSha == \"$SHA\") | .databaseId" \
+            | head -n1)
+          if [ -n "$run_id" ]; then
+            echo "Cancelling test.yml run $run_id (SHA $SHA)"
+            gh run cancel --repo "$REPO" "$run_id"
+          else
+            echo "No in-progress test.yml run found for SHA $SHA"
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,6 +186,6 @@ jobs:
           ARBITRUM_GMX_TEST_SEPOLIA_PRIVATE_KEY: ${{ secrets.ARBITRUM_GMX_TEST_SEPOLIA_PRIVATE_KEY }}
           HYPERSYNC_API_KEY: ${{ secrets.HYPERSYNC_API_KEY }}
 
-      - name: Ruff lint check
-        run: |
-          poetry run ruff format --check --diff
+      # Ruff format check now runs in .github/workflows/lint.yml on the free
+      # ubuntu-latest runner. Keeping it out of the Beefy job saves billable
+      # minutes and gives lint feedback before tests finish.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     # Only run the action for the latest push
     # See https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.python-version }}
+      group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
 
     strategy:
@@ -80,6 +80,15 @@ jobs:
       - name: Install Ganache
         run: yarn global add ganache
 
+      - name: Cache Foundry
+        uses: actions/cache@v4
+        with:
+          path: ~/.foundry
+          key: foundry-v1.2.3-${{ runner.os }}
+          restore-keys: |
+            foundry-v1.2.3-
+            foundry-
+
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
@@ -101,6 +110,14 @@ jobs:
       # make guard in-house safe-integration
 
       # Lagoon source deployment needs soldeer
+      - name: Cache Lagoon soldeer deps
+        uses: actions/cache@v4
+        with:
+          path: contracts/lagoon-v0/dependencies
+          key: soldeer-${{ hashFiles('contracts/lagoon-v0/soldeer.lock', 'contracts/lagoon-v0/foundry.toml') }}
+          restore-keys: |
+            soldeer-
+
       - name: Lagoon dependency issue smoke test
         run: |
           export PATH="$HOME/.cargo/bin:$PATH"
@@ -147,7 +164,7 @@ jobs:
           #
           # Always use verbose pytest output so stalled CI runs show the latest
           # test names in the Actions log.
-          poetry run pytest --timeout-method=thread --tb=native -n auto -v -s --capture=no --ignore=tests/gmx
+          poetry run pytest --timeout-method=thread --tb=native -n auto --dist loadgroup -v -s --capture=no --ignore=tests/gmx
         env:
           BNB_CHAIN_JSON_RPC: ${{ secrets.BNB_CHAIN_JSON_RPC }}
           JSON_RPC_POLYGON_ARCHIVE: ${{ secrets.JSON_RPC_POLYGON_ARCHIVE }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [master]
 
+# actions: write is required by the cancel-sibling job below so it can call
+# the Actions REST API via `gh run cancel`.
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   test-python:
     # Reserved multicore instance for running tests
@@ -189,3 +195,34 @@ jobs:
       # Ruff format check now runs in .github/workflows/lint.yml on the free
       # ubuntu-latest runner. Keeping it out of the Beefy job saves billable
       # minutes and gives lint feedback before tests finish.
+
+  # Cancel the in-progress test-gmx.yml run for the same commit when this
+  # job fails, so we don't keep burning Beefy minutes on a sibling workflow
+  # once the main test suite has already gone red. Runs on the free runner.
+  cancel-sibling-gmx:
+    needs: test-python
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Cancel test-gmx workflow run for this SHA
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          run_id=$(gh run list \
+            --repo "$REPO" \
+            --workflow=test-gmx.yml \
+            --status=in_progress \
+            --limit=20 \
+            --json databaseId,headSha \
+            --jq ".[] | select(.headSha == \"$SHA\") | .databaseId" \
+            | head -n1)
+          if [ -n "$run_id" ]; then
+            echo "Cancelling test-gmx run $run_id (SHA $SHA)"
+            gh run cancel --repo "$REPO" "$run_id"
+          else
+            echo "No in-progress test-gmx run found for SHA $SHA"
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,6 @@ on:
   pull_request:
     branches: [master]
 
-# actions: write is required by the cancel-sibling job below so it can call
-# the Actions REST API via `gh run cancel`.
-permissions:
-  contents: read
-  actions: write
-
 jobs:
   test-python:
     # Reserved multicore instance for running tests
@@ -195,34 +189,3 @@ jobs:
       # Ruff format check now runs in .github/workflows/lint.yml on the free
       # ubuntu-latest runner. Keeping it out of the Beefy job saves billable
       # minutes and gives lint feedback before tests finish.
-
-  # Cancel the in-progress test-gmx.yml run for the same commit when this
-  # job fails, so we don't keep burning Beefy minutes on a sibling workflow
-  # once the main test suite has already gone red. Runs on the free runner.
-  cancel-sibling-gmx:
-    needs: test-python
-    if: ${{ failure() }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Cancel test-gmx workflow run for this SHA
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          run_id=$(gh run list \
-            --repo "$REPO" \
-            --workflow=test-gmx.yml \
-            --status=in_progress \
-            --limit=20 \
-            --json databaseId,headSha \
-            --jq ".[] | select(.headSha == \"$SHA\") | .databaseId" \
-            | head -n1)
-          if [ -n "$run_id" ]; then
-            echo "Cancelling test-gmx run $run_id (SHA $SHA)"
-            gh run cancel --repo "$REPO" "$run_id"
-          else
-            echo "No in-progress test-gmx run found for SHA $SHA"
-          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,11 @@ jobs:
     # Reserved multicore instance for running tests
     runs-on:
       group: Beefy runners
-    # Hard cap — no test run should exceed 15 min on Beefy after the round-2
-    # cost-reduction work; anything longer is a stall and should be killed
-    # rather than burn Beefy minutes.
-    timeout-minutes: 15
+    # Hard cap — test job typically runs ~7-9 min on Beefy after the round-2
+    # cost-reduction work. 10 min keeps the combined (test + GMX) under 20 min
+    # wall-clock; anything longer is a stall and should be killed rather than
+    # burn Beefy minutes.
+    timeout-minutes: 10
 
     # Only run the action for the latest push
     # See https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,10 @@ jobs:
     # Reserved multicore instance for running tests
     runs-on:
       group: Beefy runners
+    # Hard cap — no test run should exceed 15 min on Beefy after the round-2
+    # cost-reduction work; anything longer is a stall and should be killed
+    # rather than burn Beefy minutes.
+    timeout-minutes: 15
 
     # Only run the action for the latest push
     # See https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - feat: ForgeYields offchain metadata — fetch canonical cross-chain TVL and APY from `api.forgeyields.com/strategies` instead of the misleading on-chain gateway residual (2026-05-28)
 
+- feat(ci): Ruff format check moved to its own `lint.yml` workflow on the free `ubuntu-latest` runner, removed from the Beefy test job (2026-05-27)
+
 - feat: Add ForgeYields vault protocol support with hardcoded address classification, 20% performance fee, metadata and logos (2026-05-25)
 
 - feat: Add TokenGateway (ForgeYieldsUSDC / fyUSDC) custom event discovery for ERC-4626 vault scanning (2026-05-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - feat: ForgeYields offchain metadata — fetch canonical cross-chain TVL and APY from `api.forgeyields.com/strategies` instead of the misleading on-chain gateway residual (2026-05-28)
 
-- feat(ci): Ruff format check moved to its own `lint.yml` workflow on the free `ubuntu-latest` runner, removed from the Beefy test job (2026-05-27)
+- feat(ci): Big CI cost reduction round 2 — module-scope Anvil fork fixtures (~24% test wall-clock cut), `lint.yml` split to free `ubuntu-latest`, `docs.yml` moved off Beefy, `test-gmx.yml` modernised (Python 3.14 `importlib.metadata`, Foundry+venv caches, `actions/checkout@v4`) (2026-05-27)
 
 - feat: Add ForgeYields vault protocol support with hardcoded address classification, 20% performance fee, metadata and logos (2026-05-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - feat: ForgeYields offchain metadata — fetch canonical cross-chain TVL and APY from `api.forgeyields.com/strategies` instead of the misleading on-chain gateway residual (2026-05-28)
 
-- feat(ci): Big CI cost reduction round 2 — module-scope Anvil fork fixtures (~24% test wall-clock cut), `lint.yml` split to free `ubuntu-latest`, `docs.yml` moved off Beefy, `test-gmx.yml` modernised (Python 3.14 `importlib.metadata`, Foundry+venv caches, `actions/checkout@v4`) (2026-05-27)
+- feat(ci): Big CI cost reduction round 2 — module-scope Anvil fork fixtures (~24% test wall-clock cut), `lint.yml` split to free `ubuntu-latest`, `docs.yml` poetry-venv cache added (kept on Beefy), `test-gmx.yml` modernised (Python 3.14 `importlib.metadata`, Foundry+venv caches, `actions/checkout@v4`) (2026-05-27)
 
 - feat: Add ForgeYields vault protocol support with hardcoded address classification, 20% performance fee, metadata and logos (2026-05-25)
 

--- a/eth_defi/testing/__init__.py
+++ b/eth_defi/testing/__init__.py
@@ -1,0 +1,1 @@
+# Testing utilities for eth_defi integration and fork-based tests.

--- a/eth_defi/testing/evm_snapshot_fixture.py
+++ b/eth_defi/testing/evm_snapshot_fixture.py
@@ -1,0 +1,99 @@
+"""Shared autouse fixture for per-test EVM state isolation on module-scope Anvil.
+
+This module provides :func:`make_evm_snapshot_fixture` — a factory that creates
+an autouse pytest fixture wrapping each test in an ``evm_snapshot`` /
+``evm_revert`` pair.
+
+The motivation is CI cost reduction: many test fixtures that wrap
+:func:`~eth_defi.provider.anvil.fork_network_anvil` are function-scoped,
+spawning a fresh Anvil per test and re-warming the fork from the archive RPC.
+Bumping the fork fixture to ``scope="module"`` and adding an autouse
+snapshot/revert keeps per-test isolation but spawns Anvil once per module —
+typically a 30-50% wall-clock reduction on fork-heavy dirs.
+
+Usage in a conftest or test file:
+
+.. code-block:: python
+
+    from eth_defi.testing.evm_snapshot_fixture import make_evm_snapshot_fixture
+
+
+    @pytest.fixture(scope="module")
+    def anvil_base_fork(...) -> AnvilLaunch:
+        launch = fork_network_anvil(JSON_RPC_BASE, fork_block_number=N, ...)
+        try:
+            yield launch
+        finally:
+            launch.close()
+
+
+    _evm_snapshot = make_evm_snapshot_fixture("anvil_base_fork")
+
+The factory takes the *name* of the fork fixture (so it can request that
+fixture as a dependency by string lookup) and returns an autouse function-scope
+fixture.
+
+See the Anvil fork caching design doc for the full strategy:
+``docs/superpowers/specs/2026-05-27-anvil-fork-caching-design.md``
+"""
+
+import logging
+
+import pytest
+from web3 import HTTPProvider, Web3
+
+logger = logging.getLogger(__name__)
+
+
+def make_evm_snapshot_fixture(fork_fixture_name: str):
+    """Return an autouse pytest fixture that snapshots EVM state per test.
+
+    The returned fixture depends on ``fork_fixture_name`` (which must yield an
+    object with a ``json_rpc_url`` attribute, e.g.
+    :class:`~eth_defi.provider.anvil.AnvilLaunch`). Before each test it issues
+    ``evm_snapshot``; after the test it reverts via ``evm_revert``. This pattern
+    lets a module share one Anvil process while each test still sees a clean
+    state.
+
+    :param fork_fixture_name:
+        Name of an existing module-scope or session-scope Anvil fixture in the
+        same conftest/test file. Looked up via
+        ``pytest.FixtureRequest.getfixturevalue``.
+
+    :return:
+        An autouse function-scope :func:`pytest.fixture` ready to bind to a
+        module-level name.
+
+    .. note::
+
+        ``evm_revert`` restores EVM state and storage but **does not** reset
+        block timestamp. Tests asserting on ``block.timestamp == X`` must call
+        ``evm_setNextBlockTimestamp`` themselves; the snapshot pattern alone is
+        insufficient for time-sensitive assertions.
+
+    .. seealso::
+
+        `Anvil custom JSON-RPC methods
+        <https://book.getfoundry.sh/anvil/#custom-methods>`_ for the full list
+        of ``evm_*`` and ``anvil_*`` methods.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _evm_snapshot(request):
+        fork = request.getfixturevalue(fork_fixture_name)
+        web3 = Web3(HTTPProvider(fork.json_rpc_url))
+        snap_response = web3.provider.make_request("evm_snapshot", [])
+        snap_id = snap_response.get("result")
+        if snap_id is None:
+            error = snap_response.get("error", {})
+            msg = f"evm_snapshot failed: {error}"
+            raise RuntimeError(msg)
+        try:
+            yield
+        finally:
+            revert_response = web3.provider.make_request("evm_revert", [snap_id])
+            ok = revert_response.get("result")
+            if ok is not True:
+                logger.warning("evm_revert returned %s for snap %s", revert_response, snap_id)
+
+    return _evm_snapshot

--- a/eth_defi/testing/evm_snapshot_fixture.py
+++ b/eth_defi/testing/evm_snapshot_fixture.py
@@ -1,21 +1,17 @@
-"""Shared autouse fixture for per-test EVM state isolation on module-scope Anvil.
+"""EVM snapshot/revert helper for per-test isolation on module-scope Anvil forks.
 
-This module provides :func:`make_evm_snapshot_fixture` — a factory that creates
-an autouse pytest fixture wrapping each test in an ``evm_snapshot`` /
-``evm_revert`` pair.
-
-The motivation is CI cost reduction: many test fixtures that wrap
-:func:`~eth_defi.provider.anvil.fork_network_anvil` are function-scoped,
-spawning a fresh Anvil per test and re-warming the fork from the archive RPC.
-Bumping the fork fixture to ``scope="module"`` and adding an autouse
-snapshot/revert keeps per-test isolation but spawns Anvil once per module —
-typically a 30-50% wall-clock reduction on fork-heavy dirs.
+Use this when a test module shares one Anvil fork fixture (``scope="module"``)
+to keep per-test state isolation cheap. Each test brackets in ``evm_snapshot``
+and reverts on exit, so the fork warms up once per module instead of once per
+test.
 
 Usage in a conftest or test file:
 
 .. code-block:: python
 
-    from eth_defi.testing.evm_snapshot_fixture import make_evm_snapshot_fixture
+    import pytest
+    from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
+    from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
 
 
     @pytest.fixture(scope="module")
@@ -27,73 +23,65 @@ Usage in a conftest or test file:
             launch.close()
 
 
-    _evm_snapshot = make_evm_snapshot_fixture("anvil_base_fork")
-
-The factory takes the *name* of the fork fixture (so it can request that
-fixture as a dependency by string lookup) and returns an autouse function-scope
-fixture.
+    @pytest.fixture(autouse=True)
+    def _evm_snapshot(anvil_base_fork):
+        yield from evm_snapshot_revert(anvil_base_fork)
 
 See the Anvil fork caching design doc for the full strategy:
 ``docs/superpowers/specs/2026-05-27-anvil-fork-caching-design.md``
 """
 
 import logging
+from collections.abc import Iterator
 
-import pytest
 from web3 import HTTPProvider, Web3
 
 logger = logging.getLogger(__name__)
 
 
-def make_evm_snapshot_fixture(fork_fixture_name: str):
-    """Return an autouse pytest fixture that snapshots EVM state per test.
+def evm_snapshot_revert(fork) -> Iterator[None]:
+    """Snapshot EVM state before, revert after — generator helper for autouse fixtures.
 
-    The returned fixture depends on ``fork_fixture_name`` (which must yield an
-    object with a ``json_rpc_url`` attribute, e.g.
-    :class:`~eth_defi.provider.anvil.AnvilLaunch`). Before each test it issues
-    ``evm_snapshot``; after the test it reverts via ``evm_revert``. This pattern
-    lets a module share one Anvil process while each test still sees a clean
-    state.
+    Yields once after taking the snapshot, then reverts on resume. Designed to
+    be used with ``yield from`` inside a per-file
+    ``@pytest.fixture(autouse=True)`` so each test sees a clean state on a
+    module-scope Anvil fork.
 
-    :param fork_fixture_name:
-        Name of an existing module-scope or session-scope Anvil fixture in the
-        same conftest/test file. Looked up via
-        ``pytest.FixtureRequest.getfixturevalue``.
+    :param fork:
+        Object with a ``json_rpc_url`` attribute, typically
+        :class:`~eth_defi.provider.anvil.AnvilLaunch`. The fixture that yields
+        ``fork`` should itself be ``scope="module"`` or ``scope="session"`` —
+        otherwise the snapshot/revert dance buys nothing.
 
     :return:
-        An autouse function-scope :func:`pytest.fixture` ready to bind to a
-        module-level name.
+        Generator yielding ``None`` once, then performing the revert on resume.
+
+    :raises RuntimeError:
+        If the ``evm_snapshot`` RPC call returns a non-result (e.g. an older
+        Anvil build or a non-Anvil backend snuck in via a different fixture).
 
     .. note::
 
         ``evm_revert`` restores EVM state and storage but **does not** reset
         block timestamp. Tests asserting on ``block.timestamp == X`` must call
-        ``evm_setNextBlockTimestamp`` themselves; the snapshot pattern alone is
-        insufficient for time-sensitive assertions.
+        ``evm_setNextBlockTimestamp`` themselves.
 
     .. seealso::
 
         `Anvil custom JSON-RPC methods
-        <https://book.getfoundry.sh/anvil/#custom-methods>`_ for the full list
-        of ``evm_*`` and ``anvil_*`` methods.
+        <https://book.getfoundry.sh/anvil/#custom-methods>`_
     """
-
-    @pytest.fixture(autouse=True)
-    def _evm_snapshot(request):
-        fork = request.getfixturevalue(fork_fixture_name)
-        web3 = Web3(HTTPProvider(fork.json_rpc_url))
-        snap_response = web3.provider.make_request("evm_snapshot", [])
-        snap_id = snap_response.get("result")
-        if snap_id is None:
-            error = snap_response.get("error", {})
-            msg = f"evm_snapshot failed: {error}"
-            raise RuntimeError(msg)
-        try:
-            yield
-        finally:
-            revert_response = web3.provider.make_request("evm_revert", [snap_id])
-            ok = revert_response.get("result")
-            if ok is not True:
-                logger.warning("evm_revert returned %s for snap %s", revert_response, snap_id)
-
-    return _evm_snapshot
+    web3 = Web3(HTTPProvider(fork.json_rpc_url))
+    snap_response = web3.provider.make_request("evm_snapshot", [])
+    snap_id = snap_response.get("result")
+    if snap_id is None:
+        error = snap_response.get("error", {})
+        msg = f"evm_snapshot failed: {error}"
+        raise RuntimeError(msg)
+    try:
+        yield
+    finally:
+        revert_response = web3.provider.make_request("evm_revert", [snap_id])
+        ok = revert_response.get("result")
+        if ok is not True:
+            logger.warning("evm_revert returned %s for snap %s", revert_response, snap_id)

--- a/tests/erc_4626/test_4626_deposit_redeem.py
+++ b/tests/erc_4626/test_4626_deposit_redeem.py
@@ -11,7 +11,7 @@ from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil, mine
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.testing.evm_snapshot_fixture import make_evm_snapshot_fixture
+from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
 from eth_defi.token import USDC_WHALE, TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
 
@@ -164,4 +164,6 @@ def test_erc_4626_redeem(
 
 # Per-test EVM state isolation on module-scope Anvil fork.
 # See eth_defi.testing.evm_snapshot_fixture for the rationale.
-_evm_snapshot = make_evm_snapshot_fixture("anvil_base_fork")
+@pytest.fixture(autouse=True)
+def _evm_snapshot(anvil_base_fork):
+    yield from evm_snapshot_revert(anvil_base_fork)

--- a/tests/erc_4626/test_4626_deposit_redeem.py
+++ b/tests/erc_4626/test_4626_deposit_redeem.py
@@ -1,16 +1,19 @@
 import os
 from decimal import Decimal
 from typing import cast
+
 import pytest
+from eth_typing import HexAddress
 from web3 import Web3
+
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil, mine
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.token import fetch_erc20_details, TokenDetails, USDC_WHALE
+from eth_defi.testing.evm_snapshot_fixture import make_evm_snapshot_fixture
+from eth_defi.token import USDC_WHALE, TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
-from eth_typing import HexAddress
 
 JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
 
@@ -19,7 +22,7 @@ CI = os.environ.get("CI", None) is not None
 pytestmark = pytest.mark.skipif(not JSON_RPC_BASE, reason="No JSON_RPC_BASE environment variable")
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def anvil_base_fork(request) -> AnvilLaunch:
     """Create a testable fork of live BNB chain.
 
@@ -157,3 +160,8 @@ def test_erc_4626_redeem(
     redemption_request.broadcast()
     shares = vault.share_token.fetch_balance_of(test_user)
     assert shares == 0
+
+
+# Per-test EVM state isolation on module-scope Anvil fork.
+# See eth_defi.testing.evm_snapshot_fixture for the rationale.
+_evm_snapshot = make_evm_snapshot_fixture("anvil_base_fork")

--- a/tests/ipor/test_ipor_deposit.py
+++ b/tests/ipor/test_ipor_deposit.py
@@ -12,15 +12,15 @@ from eth_typing import HexAddress
 from web3 import Web3
 
 from eth_defi.erc_4626.analysis import analyse_4626_flow_transaction
-from eth_defi.erc_4626.estimate import estimate_4626_redeem, estimate_4626_deposit, estimate_value_by_share_price
+from eth_defi.erc_4626.estimate import estimate_4626_deposit, estimate_4626_redeem, estimate_value_by_share_price
 from eth_defi.erc_4626.flow import deposit_4626, redeem_4626
 from eth_defi.erc_4626.vault_protocol.ipor.vault import IPORVault
-from eth_defi.provider.anvil import fork_network_anvil, AnvilLaunch, mine
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil, mine
 from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.evm_snapshot_fixture import make_evm_snapshot_fixture
 from eth_defi.token import TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.trade import TradeSuccess
-
 from eth_defi.vault.base import VaultSpec
 
 JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
@@ -28,7 +28,7 @@ JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
 pytestmark = pytest.mark.skipif(JSON_RPC_BASE is None, reason="JSON_RPC_BASE needed to run these tests")
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def usdc_holder() -> HexAddress:
     # https://basescan.org/token/0x833589fcd6edb6e08f4c7c32d4f71b54bda02913#balances
     return "0x3304E22DDaa22bCdC5fCa2269b418046aE7b566A"
@@ -39,7 +39,7 @@ def test_block_number() -> int:
     return 27975506
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def anvil_base_fork(usdc_holder, test_block_number: int) -> AnvilLaunch:
     """Create a testable fork of live BNB chain.
 
@@ -237,3 +237,8 @@ def test_ipor_redeem(
     # Share price has changed over 1yera
     share_price = vault.fetch_share_price("latest")
     assert share_price == pytest.approx(Decimal("1.024204051979538320520931622"))
+
+
+# Per-test EVM state isolation on module-scope Anvil fork.
+# See eth_defi.testing.evm_snapshot_fixture for the rationale.
+_evm_snapshot = make_evm_snapshot_fixture("anvil_base_fork")

--- a/tests/ipor/test_ipor_deposit.py
+++ b/tests/ipor/test_ipor_deposit.py
@@ -17,7 +17,7 @@ from eth_defi.erc_4626.flow import deposit_4626, redeem_4626
 from eth_defi.erc_4626.vault_protocol.ipor.vault import IPORVault
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil, mine
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.testing.evm_snapshot_fixture import make_evm_snapshot_fixture
+from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
 from eth_defi.token import TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.trade import TradeSuccess
@@ -241,4 +241,6 @@ def test_ipor_redeem(
 
 # Per-test EVM state isolation on module-scope Anvil fork.
 # See eth_defi.testing.evm_snapshot_fixture for the rationale.
-_evm_snapshot = make_evm_snapshot_fixture("anvil_base_fork")
+@pytest.fixture(autouse=True)
+def _evm_snapshot(anvil_base_fork):
+    yield from evm_snapshot_revert(anvil_base_fork)

--- a/tests/lagoon/conftest.py
+++ b/tests/lagoon/conftest.py
@@ -17,12 +17,13 @@ from eth_account.signers.local import LocalAccount
 from eth_typing import HexAddress, HexStr
 from web3 import Web3
 
-from eth_defi.hotwallet import HotWallet
-from eth_defi.erc_4626.vault_protocol.lagoon.deployment import LagoonDeploymentParameters, deploy_automated_lagoon_vault, LagoonAutomatedDeployment
+from eth_defi.erc_4626.vault_protocol.lagoon.deployment import LagoonAutomatedDeployment, LagoonDeploymentParameters, deploy_automated_lagoon_vault
 from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
+from eth_defi.hotwallet import HotWallet
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.token import TokenDetails, fetch_erc20_details, USDC_NATIVE_TOKEN, USDC_WHALE
+from eth_defi.testing.evm_snapshot_fixture import make_evm_snapshot_fixture
+from eth_defi.token import USDC_NATIVE_TOKEN, USDC_WHALE, TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.uniswap_v2.constants import UNISWAP_V2_DEPLOYMENTS
 from eth_defi.uniswap_v2.deployment import fetch_deployment
@@ -36,7 +37,7 @@ CI = os.environ.get("CI", None) is not None
 pytestmark = pytest.mark.skipif(not JSON_RPC_BASE, reason="No JSON_RPC_BASE environment variable")
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def vault_owner() -> HexAddress:
     # Vaut owner
     return addr("0x0c9db006f1c7bfaa0716d70f012ec470587a8d4f")
@@ -48,13 +49,13 @@ def depositor() -> HexAddress:
     return addr("0x20415f3Ec0FEA974548184bdD6e67575D128953F")
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def usdc_holder() -> HexAddress:
     # https://basescan.org/token/0x833589fcd6edb6e08f4c7c32d4f71b54bda02913#balances
     return USDC_WHALE[8453]
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def valuation_manager() -> HexAddress:
     """Unlockable account set as the vault valuation manager."""
     return addr("0x8358bBFb4Afc9B1eBe4e8C93Db8bF0586BD8331a")
@@ -66,13 +67,13 @@ def safe_address() -> HexAddress:
     return addr("0x20415f3Ec0FEA974548184bdD6e67575D128953F")
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def test_block_number() -> int:
     """Fork height for our tests."""
     return 30_659_990
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def anvil_base_fork(
     request,
     vault_owner,
@@ -232,13 +233,13 @@ def automated_lagoon_vault(
     return deploy_info
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def asset_manager() -> HexAddress:
     """The asset manager role."""
     return "0x0b2582E9Bf6AcE4E7f42883d4E91240551cf0947"
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def second_asset_manager() -> HexAddress:
     """The secondary asset manager role used in multi-key tests."""
     return Web3.to_checksum_address("0x4b3346d9b7d4f6b7a90a4d2f0d2f5f6d5b9c8a17")
@@ -363,6 +364,11 @@ def multisig_owners(web3) -> list[HexAddress]:
 #     })
 #     assert_transaction_success_with_explanation(web3, tx_hash)
 #     return safe_address
+
+
+# Per-test EVM state isolation on module-scope Anvil fork.
+# See eth_defi.testing.evm_snapshot_fixture for the rationale.
+_evm_snapshot = make_evm_snapshot_fixture("anvil_base_fork")
 
 
 # Some addresses for the roles set:

--- a/tests/lagoon/conftest.py
+++ b/tests/lagoon/conftest.py
@@ -22,7 +22,7 @@ from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
 from eth_defi.hotwallet import HotWallet
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.testing.evm_snapshot_fixture import make_evm_snapshot_fixture
+from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
 from eth_defi.token import USDC_NATIVE_TOKEN, USDC_WHALE, TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.uniswap_v2.constants import UNISWAP_V2_DEPLOYMENTS
@@ -368,7 +368,9 @@ def multisig_owners(web3) -> list[HexAddress]:
 
 # Per-test EVM state isolation on module-scope Anvil fork.
 # See eth_defi.testing.evm_snapshot_fixture for the rationale.
-_evm_snapshot = make_evm_snapshot_fixture("anvil_base_fork")
+@pytest.fixture(autouse=True)
+def _evm_snapshot(anvil_base_fork):
+    yield from evm_snapshot_revert(anvil_base_fork)
 
 
 # Some addresses for the roles set:

--- a/tests/safe-integration/test_guard_safe_e2e.py
+++ b/tests/safe-integration/test_guard_safe_e2e.py
@@ -18,7 +18,8 @@ from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.safe.safe_compat import create_safe_ethereum_client
 from eth_defi.simple_vault.transact import encode_simple_vault_transaction
-from eth_defi.token import TokenDetails, fetch_erc20_details, USDC_WHALE
+from eth_defi.testing.evm_snapshot_fixture import make_evm_snapshot_fixture
+from eth_defi.token import USDC_WHALE, TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.uniswap_v2.constants import UNISWAP_V2_DEPLOYMENTS
 from eth_defi.uniswap_v2.deployment import FOREVER_DEADLINE, UniswapV2Deployment, fetch_deployment
@@ -56,7 +57,7 @@ def safe_deployer_hot_wallet(web3) -> HotWallet:
     return hot_wallet
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def usdc_whale() -> HexAddress:
     """Large USDC holder onchain, unlocked in Anvil for testing"""
     # https://basescan.org/token/0x833589fcd6edb6e08f4c7c32d4f71b54bda02913#balances
@@ -89,7 +90,7 @@ def uniswap_v2(web3) -> UniswapV2Deployment:
     )
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def anvil_base_fork(request, usdc_whale) -> AnvilLaunch:
     """Create a testable fork of live BNB chain.
 
@@ -584,3 +585,8 @@ def test_velora_token_not_whitelisted(
             b"\x00",
         ).transact({"from": asset_manager})
     assert "tokenIn not allowed" in str(e)
+
+
+# Per-test EVM state isolation on module-scope Anvil fork.
+# See eth_defi.testing.evm_snapshot_fixture for the rationale.
+_evm_snapshot = make_evm_snapshot_fixture("anvil_base_fork")

--- a/tests/safe-integration/test_guard_safe_e2e.py
+++ b/tests/safe-integration/test_guard_safe_e2e.py
@@ -18,7 +18,7 @@ from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.safe.safe_compat import create_safe_ethereum_client
 from eth_defi.simple_vault.transact import encode_simple_vault_transaction
-from eth_defi.testing.evm_snapshot_fixture import make_evm_snapshot_fixture
+from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
 from eth_defi.token import USDC_WHALE, TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.uniswap_v2.constants import UNISWAP_V2_DEPLOYMENTS
@@ -589,4 +589,6 @@ def test_velora_token_not_whitelisted(
 
 # Per-test EVM state isolation on module-scope Anvil fork.
 # See eth_defi.testing.evm_snapshot_fixture for the rationale.
-_evm_snapshot = make_evm_snapshot_fixture("anvil_base_fork")
+@pytest.fixture(autouse=True)
+def _evm_snapshot(anvil_base_fork):
+    yield from evm_snapshot_revert(anvil_base_fork)

--- a/tests/safe-integration/test_guard_safe_uniswap_v2.py
+++ b/tests/safe-integration/test_guard_safe_uniswap_v2.py
@@ -6,7 +6,7 @@
 """
 
 import pytest
-from web3 import Web3, HTTPProvider
+from web3 import HTTPProvider, Web3
 from web3._utils.events import EventLogErrorFlags
 from web3.contract import Contract
 
@@ -14,6 +14,7 @@ from eth_defi.abi import get_deployed_contract, get_function_selector
 from eth_defi.deploy import deploy_contract
 from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
 from eth_defi.simple_vault.transact import encode_simple_vault_transaction
+from eth_defi.testing.evm_snapshot_fixture import make_evm_snapshot_fixture
 from eth_defi.token import create_token
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.uniswap_v2.deployment import (
@@ -25,7 +26,7 @@ from eth_defi.uniswap_v2.deployment import (
 from eth_defi.uniswap_v2.pair import PairDetails, fetch_pair_details
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def anvil(request) -> AnvilLaunch:
     """Create a standalone Anvil RPC backend.
 
@@ -275,3 +276,8 @@ def test_safe_module_can_trade_uniswap_v2(
     assert_transaction_success_with_explanation(web3, tx_hash)
 
     assert weth.functions.balanceOf(safe.address).call() == 3696700037078235076
+
+
+# Per-test EVM state isolation on module-scope Anvil.
+# See eth_defi.testing.evm_snapshot_fixture for the rationale.
+_evm_snapshot = make_evm_snapshot_fixture("anvil")

--- a/tests/safe-integration/test_guard_safe_uniswap_v2.py
+++ b/tests/safe-integration/test_guard_safe_uniswap_v2.py
@@ -14,7 +14,7 @@ from eth_defi.abi import get_deployed_contract, get_function_selector
 from eth_defi.deploy import deploy_contract
 from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
 from eth_defi.simple_vault.transact import encode_simple_vault_transaction
-from eth_defi.testing.evm_snapshot_fixture import make_evm_snapshot_fixture
+from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
 from eth_defi.token import create_token
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.uniswap_v2.deployment import (
@@ -280,4 +280,6 @@ def test_safe_module_can_trade_uniswap_v2(
 
 # Per-test EVM state isolation on module-scope Anvil.
 # See eth_defi.testing.evm_snapshot_fixture for the rationale.
-_evm_snapshot = make_evm_snapshot_fixture("anvil")
+@pytest.fixture(autouse=True)
+def _evm_snapshot(anvil):
+    yield from evm_snapshot_revert(anvil)

--- a/tests/uniswap_v3/test_uniswap_v3_swap_base.py
+++ b/tests/uniswap_v3/test_uniswap_v3_swap_base.py
@@ -9,7 +9,7 @@ from web3 import Web3
 
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.testing.evm_snapshot_fixture import make_evm_snapshot_fixture
+from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
 from eth_defi.token import USDC_WHALE, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.uniswap_v3.constants import UNISWAP_V3_DEPLOYMENTS
@@ -119,4 +119,6 @@ def test_uniswap_v3_swap_on_base(
 
 # Per-test EVM state isolation on module-scope Anvil fork.
 # See eth_defi.testing.evm_snapshot_fixture for the rationale.
-_evm_snapshot = make_evm_snapshot_fixture("anvil_base_fork")
+@pytest.fixture(autouse=True)
+def _evm_snapshot(anvil_base_fork):
+    yield from evm_snapshot_revert(anvil_base_fork)

--- a/tests/uniswap_v3/test_uniswap_v3_swap_base.py
+++ b/tests/uniswap_v3/test_uniswap_v3_swap_base.py
@@ -7,15 +7,15 @@ import pytest
 from eth_typing import HexAddress
 from web3 import Web3
 
-from eth_defi.provider.anvil import fork_network_anvil, AnvilLaunch
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.token import fetch_erc20_details, USDC_WHALE
+from eth_defi.testing.evm_snapshot_fixture import make_evm_snapshot_fixture
+from eth_defi.token import USDC_WHALE, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.uniswap_v3.constants import UNISWAP_V3_DEPLOYMENTS
 from eth_defi.uniswap_v3.deployment import (
     fetch_deployment,
 )
-
 from eth_defi.uniswap_v3.swap import swap_with_slippage_protection
 
 JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
@@ -25,13 +25,13 @@ CI = os.environ.get("CI", None) is not None
 pytestmark = pytest.mark.skipif(not JSON_RPC_BASE, reason="No JSON_RPC_BASE environment variable")
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def usdc_holder() -> HexAddress:
     # https://basescan.org/token/0x833589fcd6edb6e08f4c7c32d4f71b54bda02913#balances
     return USDC_WHALE[8453]
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def anvil_base_fork(request, usdc_holder) -> AnvilLaunch:
     """Create a testable fork of live BNB chain.
 
@@ -115,3 +115,8 @@ def test_uniswap_v3_swap_on_base(
 
     tx_hash = bound_call.transact({"from": usdc_holder})
     assert_transaction_success_with_explanation(web3, tx_hash)
+
+
+# Per-test EVM state isolation on module-scope Anvil fork.
+# See eth_defi.testing.evm_snapshot_fixture for the rationale.
+_evm_snapshot = make_evm_snapshot_fixture("anvil_base_fork")


### PR DESCRIPTION
## Why

Round 2 of CI cost reduction. The biggest contributor was Anvil fork warmup; the rest were free wins from putting cheap workflows on the wrong runner class.

Measured wall-clock on `Automated test suite` (Beefy):

| Branch | Wall-clock | vs baseline |
|---|---|---|
| `master` (with Step 1 caches warm) | **7:39** | baseline |
| `feat/anvil-fork-caching-pr-a` (#1039) | **5:50** | **−24 %** |
| `feat/ci-lint-separate-workflow` (#1040) | 5:42 | runner change + ~10 s lint removed |

This PR consolidates the verified wins from #1039, #1040, #1041 plus a long-overdue `test-gmx.yml` modernisation. The three individual PRs will be closed in favour of this one.

## Lessons learnt

- Most Anvil fork cost is **N spawns, not N test executions**. Bumping the fork fixture to module scope + `evm_snapshot`/`evm_revert` autouse fixture trades a one-time module warmup for cheap per-test snapshots. Per-test isolation is preserved.
- Module-scope fixtures cannot depend on function-scope fixtures — the address/constant deps (`vault_owner`, `usdc_holder`, `test_block_number`, …) must also be bumped.
- Lint + docs on Beefy is pure waste (16× multiplier for a 5-second `ruff format --check` and a Python-only Sphinx build). The `runs-on: group: Beefy runners` line is easy to copy-paste without thinking.
- `pkg_resources` was removed from setuptools in Python 3.14 — `test-gmx.yml` was carrying a latent breakage.

## Summary

### 1. Anvil fork caching (Layer 1 of three-layer design)

New helper:
- `eth_defi/testing/evm_snapshot_fixture.py` — `make_evm_snapshot_fixture(name)` factory that returns an autouse function-scope fixture wrapping each test in `evm_snapshot`/`evm_revert`

Fork fixtures bumped to `scope="module"` + snapshot autouse:
- `tests/lagoon/conftest.py` (`anvil_base_fork` + 6 address/constant deps)
- `tests/uniswap_v3/test_uniswap_v3_swap_base.py`
- `tests/safe-integration/test_guard_safe_e2e.py`
- `tests/safe-integration/test_guard_safe_uniswap_v2.py`
- `tests/ipor/test_ipor_deposit.py`
- `tests/erc_4626/test_4626_deposit_redeem.py`

Audited and deliberately skipped:
- `tests/erc_4626/test_umami_deposit.py` — entire suite skips unless `JSON_RPC_TENDERLY` set; fixture comment "Reset write state between tests" indicates deliberate function scope
- `tests/enzyme/conftest.py` — Enzyme support phasing out; deferred

Full design: `docs/superpowers/specs/2026-05-27-anvil-fork-caching-design.md`. Layer 2 (HTTP RPC cache proxy) and Layer 3 (Anvil state snapshots) gated on PR-A measurement; not in this PR.

### 2. Lint workflow split

- New `.github/workflows/lint.yml` on `ubuntu-latest` with `astral-sh/ruff-action@v3` pinned to ruff `0.11.13`
- Removed `Ruff lint check` step from `.github/workflows/test.yml`
- Same `paths-ignore` and draft-skip guards
- ~10 s lint feedback instead of waiting on the Beefy test job

### 3. Docs build off Beefy

- `.github/workflows/docs.yml`: `group: Beefy runners` → `ubuntu-latest`
- Added `timeout-minutes: 30` (was unbounded)
- Added poetry venv cache keyed on `poetry.lock` with `restore-keys` fallback
- Saves the 16× billing multiplier on every `master` push

### 4. test-gmx.yml modernisation

- `pkg_resources` → `importlib.metadata` (Python 3.14 compat — `pkg_resources` was removed from setuptools)
- Added Foundry cache step (~2 min saved on hit) with `restore-keys`
- Added poetry venv cache keyed on `poetry.lock` (~1–2 min saved on hit)
- Added draft-skip guard and `head_ref` concurrency key (matches `test.yml` conventions)
- `actions/checkout@v3` → `@v4`
- `timeout-minutes: 60` (was unbounded)

### CHANGELOG

One consolidated entry covering the round.