### PR TITLE
fix: Add ThrottledHypersyncClient with SQLite-backed rate limiting

### DIFF
--- a/eth_defi/aave_v3/liquidation.py
+++ b/eth_defi/aave_v3/liquidation.py
@@ -22,6 +22,7 @@ from tqdm_loggable.auto import tqdm
 from eth_defi.chain import get_chain_name
 from eth_defi.compat import native_datetime_utc_fromtimestamp
 from eth_defi.event_reader.conversion import convert_uint256_bytes_to_address
+from eth_defi.hypersync.session import is_hypersync_client
 from eth_defi.token import fetch_erc20_details, TokenDetails
 from eth_defi.utils import addr
 
@@ -76,7 +77,7 @@ class AaveLiquidationReader:
         web3: Web3,
         hypersync_read_timeout: float = 90,
     ):
-        assert isinstance(client, hypersync.HypersyncClient), f"Expected HypersyncClient, got {type(client)}"
+        assert is_hypersync_client(client), f"Expected HypersyncClient or ThrottledHypersyncClient, got {type(client)}"
         assert isinstance(web3, Web3), f"Expected Web3, got {type(web3)}"
         self.client = client
         self.web3 = web3

--- a/eth_defi/erc_4626/lead_scan_core.py
+++ b/eth_defi/erc_4626/lead_scan_core.py
@@ -113,16 +113,11 @@ def scan_leads(
     max_getlogs_range: int | None = None,
     reset_leads=False,
     hypersync_api_key: str | None = None,
-    hypersync_limiter=None,
 ) -> LeadScanReport:
     """Core loop to discover new vaults on a chain.
 
     - Use Hypersync if available, otherwise fall back to JSON-RPC only scanning
     - Resume for the last known block
-
-    :param hypersync_limiter:
-        Optional shared :py:class:`pyrate_limiter.Limiter` for
-        Hypersync API rate coordination.
     """
 
     from eth_defi.erc_4626.hypersync_discovery import HypersyncVaultDiscover
@@ -136,7 +131,7 @@ def scan_leads(
     name = get_chain_name(chain_id)
     rpcs = get_provider_name(web3.provider)
 
-    hypersync_config = configure_hypersync_from_env(web3, hypersync_api_key=hypersync_api_key, limiter=hypersync_limiter)
+    hypersync_config = configure_hypersync_from_env(web3, hypersync_api_key=hypersync_api_key)
     printer(f"Scanning ERC-4626 vaults on chain {web3.eth.chain_id}: {name}, using rpcs: {rpcs}, using event backend {backend}, HyperSync: {hypersync_config.hypersync_url or '<not avail>'}, and {max_workers} workers")
 
     if not vault_db_file.exists():

--- a/eth_defi/erc_4626/lead_scan_core.py
+++ b/eth_defi/erc_4626/lead_scan_core.py
@@ -113,11 +113,16 @@ def scan_leads(
     max_getlogs_range: int | None = None,
     reset_leads=False,
     hypersync_api_key: str | None = None,
+    hypersync_limiter=None,
 ) -> LeadScanReport:
     """Core loop to discover new vaults on a chain.
 
     - Use Hypersync if available, otherwise fall back to JSON-RPC only scanning
     - Resume for the last known block
+
+    :param hypersync_limiter:
+        Optional shared :py:class:`pyrate_limiter.Limiter` for
+        Hypersync API rate coordination.
     """
 
     from eth_defi.erc_4626.hypersync_discovery import HypersyncVaultDiscover
@@ -131,7 +136,7 @@ def scan_leads(
     name = get_chain_name(chain_id)
     rpcs = get_provider_name(web3.provider)
 
-    hypersync_config = configure_hypersync_from_env(web3, hypersync_api_key=hypersync_api_key)
+    hypersync_config = configure_hypersync_from_env(web3, hypersync_api_key=hypersync_api_key, limiter=hypersync_limiter)
     printer(f"Scanning ERC-4626 vaults on chain {web3.eth.chain_id}: {name}, using rpcs: {rpcs}, using event backend {backend}, HyperSync: {hypersync_config.hypersync_url or '<not avail>'}, and {max_workers} workers")
 
     if not vault_db_file.exists():

--- a/eth_defi/hypersync/hypersync_timestamp.py
+++ b/eth_defi/hypersync/hypersync_timestamp.py
@@ -39,6 +39,7 @@ from tqdm_loggable.auto import tqdm
 
 from eth_defi.event_reader.block_header import BlockHeader
 from eth_defi.event_reader.timestamp_cache import load_timestamp_cache, BlockTimestampDatabase, DEFAULT_TIMESTAMP_CACHE_FOLDER, BlockTimestampSlicer
+from eth_defi.hypersync.session import is_hypersync_client
 from eth_defi.utils import from_unix_timestamp
 
 logger = logging.getLogger(__name__)
@@ -118,7 +119,7 @@ async def get_block_timestamps_using_hypersync_async(
 
     """
 
-    assert isinstance(client, hypersync.HypersyncClient), f"Expected HypersyncClient, got {type(client)}"
+    assert is_hypersync_client(client), f"Expected HypersyncClient or ThrottledHypersyncClient, got {type(client)}"
     assert type(chain_id) == int
     assert start_block >= 0
     assert end_block >= start_block, f"end_block {end_block} must be >= start_block {start_block}"
@@ -322,7 +323,7 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
     if needs_head or needs_tail:
         # Validate chain_id only when we actually need to fetch from Hypersync.
         # Skipped on warm cache hits to avoid wasting API quota.
-        if isinstance(client, hypersync.HypersyncClient):
+        if is_hypersync_client(client):
             await _validate_hypersync_chain_id_async(client, chain_id, reason="timestamp-cache-validate")
 
         iter = get_block_timestamps_using_hypersync_async(
@@ -360,6 +361,16 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
             gaps = [(s, e, n) for s, e, n in gaps if s >= scan_start and e <= end_block]
             if not gaps:
                 break
+
+            # Back off before each healing pass to let Hypersync rate limits
+            # recover.  Without this, gap healing immediately re-hammers the
+            # API after a 429-induced drop, turning a transient rate limit
+            # into a cascading failure.
+            if heal_attempt > 0:
+                heal_backoff = 30 * (2**heal_attempt)  # 60s, 120s
+                logger.info("Backing off %d seconds before gap-heal attempt %d/%d", heal_backoff, heal_attempt + 1, max_heal_attempts)
+                await asyncio.sleep(heal_backoff)
+
             total_missing = sum(g[2] for g in gaps)
             logger.warning(
                 "HyperSync dropped %d blocks across %d gaps in range %d-%d (heal attempt %d/%d), re-fetching",

--- a/eth_defi/hypersync/session.py
+++ b/eth_defi/hypersync/session.py
@@ -24,6 +24,7 @@ Usage::
 
 import asyncio
 import logging
+import os
 from pathlib import Path
 
 import hypersync
@@ -151,6 +152,22 @@ def _create_limiter(
         bucket_class=SQLiteBucket,
         bucket_kwargs={"path": str(db_path)},
     )
+
+
+def get_hypersync_rpm_from_env() -> int:
+    """Read ``HYPERSYNC_RPM`` from the environment.
+
+    Returns :py:data:`DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE` when the
+    variable is unset or blank.  Raises :py:class:`ValueError` with a
+    clear message when a non-empty value cannot be parsed as an integer.
+    """
+    raw = os.environ.get("HYPERSYNC_RPM", "").strip()
+    if not raw:
+        return DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE
+    try:
+        return int(raw)
+    except ValueError:
+        raise ValueError(f"HYPERSYNC_RPM must be an integer, got: {raw!r}") from None
 
 
 def create_throttled_hypersync_client(

--- a/eth_defi/hypersync/session.py
+++ b/eth_defi/hypersync/session.py
@@ -1,0 +1,191 @@
+"""Throttle-aware Hypersync client wrapper.
+
+Provides a drop-in replacement for :py:class:`hypersync.HypersyncClient`
+that rate-limits every API call (``stream``, ``recv``, ``get_chain_id``,
+``get_height``) through a shared SQLite-backed token bucket.
+
+This follows the same ``pyrate_limiter`` + ``SQLiteBucket`` throttling
+pattern used for Hyperliquid, GRVT, Lighter and Derive sessions (see
+e.g. :py:mod:`eth_defi.hyperliquid.session`), adapted for the async
+Rust FFI client instead of ``requests.Session``.
+
+Usage::
+
+    from eth_defi.hypersync.session import create_throttled_hypersync_client
+
+    client = create_throttled_hypersync_client(
+        hypersync.ClientConfig(url=url, bearer_token=api_key),
+    )
+
+    # Use exactly like a regular HypersyncClient — throttling is transparent
+    receiver = await client.stream(query, config)
+    res = await receiver.recv()
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+
+import hypersync
+from pyrate_limiter import BucketFullException, Duration, Limiter, RequestRate, SQLiteBucket
+
+logger = logging.getLogger(__name__)
+
+#: Default SQLite database path for Hypersync rate limiting state.
+#:
+#: Using SQLite ensures thread/process-safe rate limiting across
+#: parallel workers and scanner instances that share the same API key.
+HYPERSYNC_RATE_LIMIT_SQLITE_DATABASE = Path("~/.tradingstrategy/hypersync/rate-limit.sqlite").expanduser()
+
+#: Conservative default: 150 RPM leaves 25% headroom below Hypersync's
+#: 200 RPM limit, accounting for internal Rust client retries that also
+#: consume quota.
+DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE = 150
+
+
+async def _acquire_async(limiter: Limiter, reason: str = "") -> None:
+    """Acquire a rate limit slot, sleeping asynchronously if over budget.
+
+    Uses ``asyncio.sleep`` instead of blocking ``time.sleep`` so the
+    event loop is not blocked.
+    """
+    while True:
+        try:
+            limiter.try_acquire("hypersync")
+            return
+        except BucketFullException as e:
+            delay = e.meta_info["remaining_time"]
+            logger.info(
+                "Hypersync throttle: waiting %.1fs before next request [%s]",
+                delay,
+                reason,
+            )
+            await asyncio.sleep(delay)
+
+
+class ThrottledReceiver:
+    """Wraps a Hypersync stream receiver with per-``recv()`` rate limiting.
+
+    Each ``recv()`` call consumes one or more HTTP requests against the
+    Hypersync API quota.  This wrapper acquires a rate-limit slot
+    before each ``recv()`` to stay within the configured budget.
+    """
+
+    def __init__(self, receiver, limiter: Limiter):
+        self._receiver = receiver
+        self._limiter = limiter
+
+    async def recv(self):
+        """Receive the next batch, throttled."""
+        await _acquire_async(self._limiter, "recv")
+        return await self._receiver.recv()
+
+
+class ThrottledHypersyncClient:
+    """Drop-in wrapper for :py:class:`hypersync.HypersyncClient` with
+    built-in rate limiting.
+
+    Delegates all calls to the underlying Rust client after acquiring
+    a slot from the shared :py:class:`pyrate_limiter.Limiter`.  The
+    limiter uses an SQLite-backed token bucket, giving thread-safe and
+    cross-process coordination of the per-API-key rate limit.
+
+    The ``stream()`` method returns a :py:class:`ThrottledReceiver`
+    so that ``recv()`` calls within the stream are also throttled.
+
+    .. note::
+
+       This class intentionally does **not** subclass
+       ``hypersync.HypersyncClient`` (a Rust-backed PyO3 class).
+       It relies on duck typing — callers that accept
+       ``HypersyncClient`` should also accept this wrapper.
+       Use :py:func:`is_hypersync_client` for ``isinstance``-style
+       checks that accept both types.
+    """
+
+    def __init__(
+        self,
+        client: hypersync.HypersyncClient,
+        limiter: Limiter,
+    ):
+        self._client = client
+        self._limiter = limiter
+
+    async def stream(self, query, config):
+        """Open a throttled stream."""
+        await _acquire_async(self._limiter, "stream-setup")
+        receiver = await self._client.stream(query, config)
+        return ThrottledReceiver(receiver, self._limiter)
+
+    async def get_chain_id(self):
+        """Get chain ID, throttled."""
+        await _acquire_async(self._limiter, "get-chain-id")
+        return await self._client.get_chain_id()
+
+    async def get_height(self):
+        """Get latest block height, throttled."""
+        await _acquire_async(self._limiter, "get-height")
+        return await self._client.get_height()
+
+    def __repr__(self) -> str:
+        return f"ThrottledHypersyncClient(rpm={self._limiter})"
+
+
+def is_hypersync_client(obj) -> bool:
+    """Check if *obj* is a Hypersync client (native or throttled).
+
+    Use instead of ``isinstance(obj, hypersync.HypersyncClient)`` so that
+    :py:class:`ThrottledHypersyncClient` wrappers are also accepted.
+    """
+    return isinstance(obj, (hypersync.HypersyncClient, ThrottledHypersyncClient))
+
+
+def _create_limiter(
+    requests_per_minute: int = DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE,
+    db_path: Path = HYPERSYNC_RATE_LIMIT_SQLITE_DATABASE,
+) -> Limiter:
+    """Create a ``pyrate_limiter.Limiter`` with an SQLite-backed bucket."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    return Limiter(
+        RequestRate(requests_per_minute, Duration.MINUTE),
+        bucket_class=SQLiteBucket,
+        bucket_kwargs={"path": str(db_path)},
+    )
+
+
+def create_throttled_hypersync_client(
+    config: hypersync.ClientConfig,
+    requests_per_minute: int = DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE,
+    limiter: Limiter | None = None,
+) -> ThrottledHypersyncClient:
+    """Create a Hypersync client with built-in SQLite-backed rate limiting.
+
+    :param config:
+        Hypersync client configuration (URL, bearer token, etc.).
+
+    :param requests_per_minute:
+        Maximum API requests per minute.  Defaults to 150 (75% of the
+        Hypersync free-tier 200 RPM limit).  Ignored when *limiter*
+        is provided.
+
+    :param limiter:
+        Optional pre-existing :py:class:`pyrate_limiter.Limiter` to
+        share across multiple clients (e.g. lead discovery + price
+        scanning on the same API key).  When ``None``, a new limiter
+        is created.
+
+    :return:
+        A :py:class:`ThrottledHypersyncClient` wrapping a native
+        ``HypersyncClient``.
+    """
+    client = hypersync.HypersyncClient(config)
+
+    if limiter is None:
+        limiter = _create_limiter(requests_per_minute)
+
+    logger.info(
+        "Created throttled Hypersync client: url=%s, rpm=%d",
+        config.url,
+        requests_per_minute,
+    )
+    return ThrottledHypersyncClient(client, limiter)

--- a/eth_defi/hypersync/session.py
+++ b/eth_defi/hypersync/session.py
@@ -165,9 +165,12 @@ def get_hypersync_rpm_from_env() -> int:
     if not raw:
         return DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE
     try:
-        return int(raw)
+        rpm = int(raw)
     except ValueError:
-        raise ValueError(f"HYPERSYNC_RPM must be an integer, got: {raw!r}") from None
+        raise ValueError(f"HYPERSYNC_RPM must be a positive integer, got: {raw!r}") from None
+    if rpm <= 0:
+        raise ValueError(f"HYPERSYNC_RPM must be a positive integer, got: {rpm}")
+    return rpm
 
 
 def create_throttled_hypersync_client(

--- a/eth_defi/hypersync/utils.py
+++ b/eth_defi/hypersync/utils.py
@@ -6,13 +6,15 @@ from dataclasses import dataclass
 from web3 import Web3
 
 import hypersync
+from pyrate_limiter import Limiter
 
 from eth_defi.hypersync.server import get_hypersync_server
+from eth_defi.hypersync.session import ThrottledHypersyncClient, create_throttled_hypersync_client, _create_limiter
 
 
 @dataclass(slots=True, frozen=True)
 class HypersyncBackendConfig:
-    hypersync_client: "hypersync.HypersyncClient | None"
+    hypersync_client: "hypersync.HypersyncClient | ThrottledHypersyncClient | None"
     hypersync_url: "str | None"
     scan_backend: str
 
@@ -20,13 +22,25 @@ class HypersyncBackendConfig:
 def configure_hypersync_from_env(
     web3: Web3,
     hypersync_api_key: str | None = None,
+    limiter: Limiter | None = None,
 ) -> HypersyncBackendConfig:
     """Helper for scan-vaults and scan-prices scripts to configure Hypersync client from environment variables.
 
     - Some chains support HyperSync, others don't - autodetect support
+    - When a *limiter* is provided, the returned client is a
+      :py:class:`~eth_defi.hypersync.session.ThrottledHypersyncClient`
+      that rate-limits every API call through the shared limiter.
+      When ``None`` and the environment variable ``HYPERSYNC_RPM`` is
+      set, a limiter is created automatically.
 
     :param hypersync_api_key:
-        Use given API key, instead of reading from env.\
+        Use given API key, instead of reading from env.
+
+    :param limiter:
+        Optional shared :py:class:`pyrate_limiter.Limiter`.  Pass the
+        same instance to multiple ``configure_hypersync_from_env`` calls
+        (e.g. lead discovery + price scanning) so they coordinate rate
+        limits via one SQLite bucket.
 
     :return:
         A valid Hypersync config if the chain supports HyperSync
@@ -39,19 +53,30 @@ def configure_hypersync_from_env(
     if scan_backend == "auto":
         assert hypersync_api_key, f"HYPERSYNC_API_KEY must be set to use auto scan backend"
 
+    # Auto-create limiter from env if not provided
+    rpm_env = os.environ.get("HYPERSYNC_RPM")
+    if limiter is None and rpm_env:
+        limiter = _create_limiter(requests_per_minute=int(rpm_env))
+
+    def _make_client(url: str) -> "hypersync.HypersyncClient | ThrottledHypersyncClient":
+        config = hypersync.ClientConfig(url=url, bearer_token=hypersync_api_key)
+        if limiter is not None:
+            return create_throttled_hypersync_client(config, limiter=limiter)
+        return hypersync.HypersyncClient(config)
+
     match scan_backend:
         case "auto":
             hypersync_url = get_hypersync_server(web3, allow_missing=True)
             assert hypersync_api_key, "HYPERSYNC_API_KEY must be set to use HyperSync backend"
             if hypersync_url:
-                hypersync_client = hypersync.HypersyncClient(hypersync.ClientConfig(url=hypersync_url, bearer_token=hypersync_api_key))
+                hypersync_client = _make_client(hypersync_url)
             else:
                 hypersync_client = None
         case "hypersync":
             hypersync_url = get_hypersync_server(web3)
             assert hypersync_url, f"No HyperSync server available for chain {web3.eth.chain_id}"
             assert hypersync_api_key, "HYPERSYNC_API_KEY must be set to use HyperSync backend"
-            hypersync_client = hypersync.HypersyncClient(hypersync.ClientConfig(url=hypersync_url, bearer_token=hypersync_api_key))
+            hypersync_client = _make_client(hypersync_url)
         case "rpc":
             hypersync_client = None
             hypersync_url = None

--- a/eth_defi/hypersync/utils.py
+++ b/eth_defi/hypersync/utils.py
@@ -53,12 +53,11 @@ def configure_hypersync_from_env(
     if scan_backend == "auto":
         assert hypersync_api_key, f"HYPERSYNC_API_KEY must be set to use auto scan backend"
 
-    # Always throttle by default.  HYPERSYNC_RPM overrides the default;
-    # an explicit limiter= argument takes precedence over both.
-    if limiter is None:
-        limiter = _create_limiter(requests_per_minute=get_hypersync_rpm_from_env())
-
     def _make_client(url: str) -> ThrottledHypersyncClient:
+        """Create a throttled client, lazily building the limiter on first use."""
+        nonlocal limiter
+        if limiter is None:
+            limiter = _create_limiter(requests_per_minute=get_hypersync_rpm_from_env())
         config = hypersync.ClientConfig(url=url, bearer_token=hypersync_api_key)
         return create_throttled_hypersync_client(config, limiter=limiter)
 

--- a/eth_defi/hypersync/utils.py
+++ b/eth_defi/hypersync/utils.py
@@ -9,7 +9,7 @@ import hypersync
 from pyrate_limiter import Limiter
 
 from eth_defi.hypersync.server import get_hypersync_server
-from eth_defi.hypersync.session import ThrottledHypersyncClient, create_throttled_hypersync_client, _create_limiter, DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE
+from eth_defi.hypersync.session import ThrottledHypersyncClient, create_throttled_hypersync_client, _create_limiter, get_hypersync_rpm_from_env
 
 
 @dataclass(slots=True, frozen=True)
@@ -56,8 +56,7 @@ def configure_hypersync_from_env(
     # Always throttle by default.  HYPERSYNC_RPM overrides the default;
     # an explicit limiter= argument takes precedence over both.
     if limiter is None:
-        rpm = int(os.environ.get("HYPERSYNC_RPM", "0")) or DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE
-        limiter = _create_limiter(requests_per_minute=rpm)
+        limiter = _create_limiter(requests_per_minute=get_hypersync_rpm_from_env())
 
     def _make_client(url: str) -> ThrottledHypersyncClient:
         config = hypersync.ClientConfig(url=url, bearer_token=hypersync_api_key)

--- a/eth_defi/hypersync/utils.py
+++ b/eth_defi/hypersync/utils.py
@@ -9,12 +9,12 @@ import hypersync
 from pyrate_limiter import Limiter
 
 from eth_defi.hypersync.server import get_hypersync_server
-from eth_defi.hypersync.session import ThrottledHypersyncClient, create_throttled_hypersync_client, _create_limiter
+from eth_defi.hypersync.session import ThrottledHypersyncClient, create_throttled_hypersync_client, _create_limiter, DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE
 
 
 @dataclass(slots=True, frozen=True)
 class HypersyncBackendConfig:
-    hypersync_client: "hypersync.HypersyncClient | ThrottledHypersyncClient | None"
+    hypersync_client: "ThrottledHypersyncClient | None"
     hypersync_url: "str | None"
     scan_backend: str
 
@@ -27,11 +27,11 @@ def configure_hypersync_from_env(
     """Helper for scan-vaults and scan-prices scripts to configure Hypersync client from environment variables.
 
     - Some chains support HyperSync, others don't - autodetect support
-    - When a *limiter* is provided, the returned client is a
+    - The returned client is always a
       :py:class:`~eth_defi.hypersync.session.ThrottledHypersyncClient`
-      that rate-limits every API call through the shared limiter.
-      When ``None`` and the environment variable ``HYPERSYNC_RPM`` is
-      set, a limiter is created automatically.
+      that rate-limits every API call.  The rate defaults to 150 RPM
+      and can be overridden with the ``HYPERSYNC_RPM`` environment
+      variable or by passing an explicit *limiter*.
 
     :param hypersync_api_key:
         Use given API key, instead of reading from env.
@@ -53,16 +53,15 @@ def configure_hypersync_from_env(
     if scan_backend == "auto":
         assert hypersync_api_key, f"HYPERSYNC_API_KEY must be set to use auto scan backend"
 
-    # Auto-create limiter from env if not provided
-    rpm_env = os.environ.get("HYPERSYNC_RPM")
-    if limiter is None and rpm_env:
-        limiter = _create_limiter(requests_per_minute=int(rpm_env))
+    # Always throttle by default.  HYPERSYNC_RPM overrides the default;
+    # an explicit limiter= argument takes precedence over both.
+    if limiter is None:
+        rpm = int(os.environ.get("HYPERSYNC_RPM", "0")) or DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE
+        limiter = _create_limiter(requests_per_minute=rpm)
 
-    def _make_client(url: str) -> "hypersync.HypersyncClient | ThrottledHypersyncClient":
+    def _make_client(url: str) -> ThrottledHypersyncClient:
         config = hypersync.ClientConfig(url=url, bearer_token=hypersync_api_key)
-        if limiter is not None:
-            return create_throttled_hypersync_client(config, limiter=limiter)
-        return hypersync.HypersyncClient(config)
+        return create_throttled_hypersync_client(config, limiter=limiter)
 
     match scan_backend:
         case "auto":

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -41,7 +41,7 @@ from eth_defi.hyperliquid.daily_metrics import HyperliquidDailyMetricsDatabase
 from eth_defi.hyperliquid.daily_metrics import run_daily_scan as hyperliquid_run_daily_scan
 from eth_defi.hyperliquid.session import create_hyperliquid_session
 from eth_defi.hyperliquid.vault_data_export import merge_into_vault_database as hyperliquid_merge_vault_db
-from eth_defi.hypersync.session import _create_limiter
+from eth_defi.hypersync.session import _create_limiter, get_hypersync_rpm_from_env
 from eth_defi.hypersync.utils import configure_hypersync_from_env
 from eth_defi.lighter.constants import LIGHTER_CHAIN_ID
 from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase
@@ -496,9 +496,7 @@ def scan_chain(
     # Create a shared Hypersync rate limiter for this chain scan so that
     # vault lead discovery and price scanning coordinate their API
     # request rate through one SQLite-backed bucket.
-    # Honour HYPERSYNC_RPM env var so operators can lower the limit after 429s.
-    rpm = int(os.environ.get("HYPERSYNC_RPM", "0")) or None
-    hypersync_limiter = _create_limiter(requests_per_minute=rpm) if rpm else _create_limiter()
+    hypersync_limiter = _create_limiter(requests_per_minute=get_hypersync_rpm_from_env())
 
     # Verify RPC providers and filter out broken ones
     try:

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -35,6 +35,7 @@ from eth_defi.hyperliquid.daily_metrics import HyperliquidDailyMetricsDatabase
 from eth_defi.hyperliquid.daily_metrics import run_daily_scan as hyperliquid_run_daily_scan
 from eth_defi.hyperliquid.session import create_hyperliquid_session
 from eth_defi.hyperliquid.vault_data_export import merge_into_vault_database as hyperliquid_merge_vault_db
+from eth_defi.hypersync.session import _create_limiter
 from eth_defi.hypersync.utils import configure_hypersync_from_env
 from eth_defi.lighter.constants import LIGHTER_CHAIN_ID
 from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase
@@ -313,12 +314,18 @@ def build_chain_configs() -> list[ChainConfig]:
     ]
 
 
-def scan_vaults_for_chain(rpc_url: str, max_workers: int, vault_db_path: Path = DEFAULT_VAULT_DATABASE) -> tuple[bool, dict]:
+def scan_vaults_for_chain(
+    rpc_url: str,
+    max_workers: int,
+    vault_db_path: Path = DEFAULT_VAULT_DATABASE,
+    hypersync_limiter: "Limiter | None" = None,
+) -> tuple[bool, dict]:
     """Scan vaults for a single chain by calling scan_leads() directly.
 
     :param rpc_url: RPC URL for the chain
     :param max_workers: Number of parallel workers
     :param vault_db_path: Path to the vault database pickle
+    :param hypersync_limiter: Shared Hypersync rate limiter
     :return: Tuple of (success, metrics_dict)
     """
     try:
@@ -329,6 +336,7 @@ def scan_vaults_for_chain(rpc_url: str, max_workers: int, vault_db_path: Path = 
             backend="auto",
             hypersync_api_key=os.environ.get("HYPERSYNC_API_KEY"),
             printer=lambda msg: None,  # Suppress output to keep logs clean
+            hypersync_limiter=hypersync_limiter,
         )
 
         return True, {
@@ -350,6 +358,7 @@ def scan_prices_for_chain(
     vault_db_path: Path = DEFAULT_VAULT_DATABASE,
     uncleaned_price_path: Path = DEFAULT_UNCLEANED_PRICE_DATABASE,
     reader_state_path: Path = DEFAULT_READER_STATE_DATABASE,
+    hypersync_limiter: "Limiter | None" = None,
 ) -> tuple[bool, dict]:
     """Scan historical prices for a single chain.
 
@@ -359,6 +368,7 @@ def scan_prices_for_chain(
     :param vault_db_path: Path to the vault database pickle
     :param uncleaned_price_path: Path to the uncleaned price parquet
     :param reader_state_path: Path to the reader state pickle
+    :param hypersync_limiter: Shared Hypersync rate limiter
     :return: Tuple of (success, metrics_dict)
     """
     try:
@@ -407,8 +417,8 @@ def scan_prices_for_chain(
             logger.info("No vaults to scan on chain %d after filtering", chain_id)
             return True, {"rows_written": 0}
 
-        # Configure HyperSync
-        hypersync_config = configure_hypersync_from_env(web3)
+        # Configure HyperSync (shares throttle with vault lead discovery)
+        hypersync_config = configure_hypersync_from_env(web3, limiter=hypersync_limiter)
 
         # Scan historical prices
         result = scan_historical_prices_to_parquet(
@@ -477,6 +487,11 @@ def scan_chain(
     logger.info("%s: Starting scan (retry %d)", config.name, retry_attempt)
     start_time = time.time()
 
+    # Create a shared Hypersync rate limiter for this chain scan so that
+    # vault lead discovery and price scanning coordinate their API
+    # request rate through one SQLite-backed bucket.
+    hypersync_limiter = _create_limiter()
+
     # Verify RPC providers and filter out broken ones
     try:
         rpc_url, latest_block = verify_archive_node(rpc_url, config.name)
@@ -490,7 +505,7 @@ def scan_chain(
 
     # Scan vaults
     if config.scan_vaults:
-        vault_success, vault_metrics = scan_vaults_for_chain(rpc_url, max_workers, vault_db_path=vault_db_path)
+        vault_success, vault_metrics = scan_vaults_for_chain(rpc_url, max_workers, vault_db_path=vault_db_path, hypersync_limiter=hypersync_limiter)
         result.vault_scan_ok = vault_success
 
         if vault_success:
@@ -508,6 +523,7 @@ def scan_chain(
             rpc_url,
             max_workers,
             frequency,
+            hypersync_limiter=hypersync_limiter,
             vault_db_path=vault_db_path,
             uncleaned_price_path=uncleaned_price_path,
             reader_state_path=reader_state_path,

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -4,6 +4,12 @@ Multi-chain vault scanning pipeline with retry logic, native protocol
 support (Hypercore, GRVT, Lighter), looped scheduling, and
 post-processing.  Extracted from the
 ``scripts/erc-4626/scan-vaults-all-chains.py`` CLI wrapper.
+
+Hypersync rate limiting is controlled by the ``HYPERSYNC_RPM``
+environment variable (default: 150 requests per minute, 75% of the
+free-tier 200 RPM limit).  All scan phases within a chain share
+one SQLite-backed rate limiter so that vault lead discovery and
+price scanning coordinate their API quota.
 """
 
 import datetime

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -318,7 +318,7 @@ def scan_vaults_for_chain(
     rpc_url: str,
     max_workers: int,
     vault_db_path: Path = DEFAULT_VAULT_DATABASE,
-    hypersync_limiter: "Limiter | None" = None,
+    hypersync_limiter=None,
 ) -> tuple[bool, dict]:
     """Scan vaults for a single chain by calling scan_leads() directly.
 
@@ -358,7 +358,7 @@ def scan_prices_for_chain(
     vault_db_path: Path = DEFAULT_VAULT_DATABASE,
     uncleaned_price_path: Path = DEFAULT_UNCLEANED_PRICE_DATABASE,
     reader_state_path: Path = DEFAULT_READER_STATE_DATABASE,
-    hypersync_limiter: "Limiter | None" = None,
+    hypersync_limiter=None,
 ) -> tuple[bool, dict]:
     """Scan historical prices for a single chain.
 
@@ -490,7 +490,9 @@ def scan_chain(
     # Create a shared Hypersync rate limiter for this chain scan so that
     # vault lead discovery and price scanning coordinate their API
     # request rate through one SQLite-backed bucket.
-    hypersync_limiter = _create_limiter()
+    # Honour HYPERSYNC_RPM env var so operators can lower the limit after 429s.
+    rpm = int(os.environ.get("HYPERSYNC_RPM", "0")) or None
+    hypersync_limiter = _create_limiter(requests_per_minute=rpm) if rpm else _create_limiter()
 
     # Verify RPC providers and filter out broken ones
     try:

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -41,7 +41,6 @@ from eth_defi.hyperliquid.daily_metrics import HyperliquidDailyMetricsDatabase
 from eth_defi.hyperliquid.daily_metrics import run_daily_scan as hyperliquid_run_daily_scan
 from eth_defi.hyperliquid.session import create_hyperliquid_session
 from eth_defi.hyperliquid.vault_data_export import merge_into_vault_database as hyperliquid_merge_vault_db
-from eth_defi.hypersync.session import _create_limiter, get_hypersync_rpm_from_env
 from eth_defi.hypersync.utils import configure_hypersync_from_env
 from eth_defi.lighter.constants import LIGHTER_CHAIN_ID
 from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase
@@ -320,18 +319,12 @@ def build_chain_configs() -> list[ChainConfig]:
     ]
 
 
-def scan_vaults_for_chain(
-    rpc_url: str,
-    max_workers: int,
-    vault_db_path: Path = DEFAULT_VAULT_DATABASE,
-    hypersync_limiter=None,
-) -> tuple[bool, dict]:
+def scan_vaults_for_chain(rpc_url: str, max_workers: int, vault_db_path: Path = DEFAULT_VAULT_DATABASE) -> tuple[bool, dict]:
     """Scan vaults for a single chain by calling scan_leads() directly.
 
     :param rpc_url: RPC URL for the chain
     :param max_workers: Number of parallel workers
     :param vault_db_path: Path to the vault database pickle
-    :param hypersync_limiter: Shared Hypersync rate limiter
     :return: Tuple of (success, metrics_dict)
     """
     try:
@@ -342,7 +335,6 @@ def scan_vaults_for_chain(
             backend="auto",
             hypersync_api_key=os.environ.get("HYPERSYNC_API_KEY"),
             printer=lambda msg: None,  # Suppress output to keep logs clean
-            hypersync_limiter=hypersync_limiter,
         )
 
         return True, {
@@ -364,7 +356,6 @@ def scan_prices_for_chain(
     vault_db_path: Path = DEFAULT_VAULT_DATABASE,
     uncleaned_price_path: Path = DEFAULT_UNCLEANED_PRICE_DATABASE,
     reader_state_path: Path = DEFAULT_READER_STATE_DATABASE,
-    hypersync_limiter=None,
 ) -> tuple[bool, dict]:
     """Scan historical prices for a single chain.
 
@@ -374,7 +365,6 @@ def scan_prices_for_chain(
     :param vault_db_path: Path to the vault database pickle
     :param uncleaned_price_path: Path to the uncleaned price parquet
     :param reader_state_path: Path to the reader state pickle
-    :param hypersync_limiter: Shared Hypersync rate limiter
     :return: Tuple of (success, metrics_dict)
     """
     try:
@@ -424,7 +414,7 @@ def scan_prices_for_chain(
             return True, {"rows_written": 0}
 
         # Configure HyperSync (shares throttle with vault lead discovery)
-        hypersync_config = configure_hypersync_from_env(web3, limiter=hypersync_limiter)
+        hypersync_config = configure_hypersync_from_env(web3)
 
         # Scan historical prices
         result = scan_historical_prices_to_parquet(
@@ -493,10 +483,9 @@ def scan_chain(
     logger.info("%s: Starting scan (retry %d)", config.name, retry_attempt)
     start_time = time.time()
 
-    # Create a shared Hypersync rate limiter for this chain scan so that
-    # vault lead discovery and price scanning coordinate their API
-    # request rate through one SQLite-backed bucket.
-    hypersync_limiter = _create_limiter(requests_per_minute=get_hypersync_rpm_from_env())
+    # No explicit limiter — configure_hypersync_from_env() creates one
+    # lazily only when a Hypersync client is actually needed.  Multiple
+    # callers coordinate via the same SQLite database file.
 
     # Verify RPC providers and filter out broken ones
     try:
@@ -511,7 +500,7 @@ def scan_chain(
 
     # Scan vaults
     if config.scan_vaults:
-        vault_success, vault_metrics = scan_vaults_for_chain(rpc_url, max_workers, vault_db_path=vault_db_path, hypersync_limiter=hypersync_limiter)
+        vault_success, vault_metrics = scan_vaults_for_chain(rpc_url, max_workers, vault_db_path=vault_db_path)
         result.vault_scan_ok = vault_success
 
         if vault_success:
@@ -529,7 +518,6 @@ def scan_chain(
             rpc_url,
             max_workers,
             frequency,
-            hypersync_limiter=hypersync_limiter,
             vault_db_path=vault_db_path,
             uncleaned_price_path=uncleaned_price_path,
             reader_state_path=reader_state_path,

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -26,7 +26,7 @@ JSON_RPC_URL=$JSON_RPC_BASE poetry run python scripts/erc-4626/scan-vaults.py
 | `END_BLOCK` | Optional. Stop scanning at this block. |
 | `RESET_LEADS` | Optional. Rescan discovery events from block 1. Existing vault database rows are not deleted before the scan; new results are merged back in and matching rows may be overwritten with freshly detected metadata. Use when new protocol event support has been added and historical events need to be re-discovered. Very slow on large chains like Ethereum mainnet (~24M+ blocks). |
 | `HYPERSYNC_API_KEY` | Optional. Required when using `auto` scan backend. |
-| `HYPERSYNC_RPM` | Optional. Hypersync API requests-per-minute limit. Default: 150 (75% of the 200 RPM free-tier limit). Lower this after persistent 429 errors. |
+| `HYPERSYNC_RPM` | Optional. Hypersync API requests-per-minute limit. Default: 150 (75% of the 200 RPM free-tier limit). Throttling is always on; set this to lower the limit after persistent 429 errors. |
 
 #### Re-discovering vaults after adding new protocol support
 

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -24,19 +24,35 @@ JSON_RPC_URL=$JSON_RPC_BASE poetry run python scripts/erc-4626/scan-vaults.py
 | `MAX_GETLOGS_RANGE` | Optional. Max block range for getLogs. |
 | `SCAN_BACKEND` | Optional. Event reader backend (`auto`, `hypersync`, `rpc`). |
 | `END_BLOCK` | Optional. Stop scanning at this block. |
-| `RESET_LEADS` | Optional. Rescan from block 1, discarding existing leads. Use when new protocol event support has been added and historical events need to be re-discovered. Very slow on large chains like Ethereum mainnet (~24M+ blocks). |
+| `RESET_LEADS` | Optional. Rescan discovery events from block 1. Existing vault database rows are not deleted before the scan; new results are merged back in and matching rows may be overwritten with freshly detected metadata. Use when new protocol event support has been added and historical events need to be re-discovered. Very slow on large chains like Ethereum mainnet (~24M+ blocks). |
 | `HYPERSYNC_API_KEY` | Optional. Required when using `auto` scan backend. |
+| `HYPERSYNC_RPM` | Optional. Hypersync API requests-per-minute limit. Default: 150 (75% of the 200 RPM free-tier limit). Lower this after persistent 429 errors. |
 
 #### Re-discovering vaults after adding new protocol support
 
 The vault scanner is incremental — it only scans new blocks since the last run.
 When support for a new protocol's custom events is added (e.g. Ember's `VaultDeposit`),
 vaults that emitted events before the code change will not be discovered because the scanner
-has already passed those blocks. Use `RESET_LEADS` to rescan from the beginning:
+has already passed those blocks. Use `RESET_LEADS` to rescan from the beginning.
+
+`RESET_LEADS` does **not** truncate the existing vault database before scanning. The scanner
+builds a fresh in-memory lead set from block 1, then merges those leads and metadata rows back
+into the existing pickle. Existing leads that are found again are refreshed; unrelated existing
+rows remain in the database. Because matching rows may be overwritten, take a backup before a
+large production rescan:
+
+```shell
+cp ~/.tradingstrategy/vaults/vault-metadata-db.pickle \
+   ~/.tradingstrategy/vaults/vault-metadata-db.before-reset-leads.pickle
+```
+
+The scanner currently cannot limit discovery to only the newly added custom event topics. A
+historical custom-event backfill, such as TokenGateway/ForgeYields support, still re-queries all
+configured vault discovery events for the block range.
 
 ```shell
 # Re-discover all vaults on Ethereum from block 1
-# Works with both Hypersync and RPC backends
+# Works with both HyperSync and RPC backends
 RESET_LEADS=1 LOG_LEVEL=info JSON_RPC_URL=$JSON_RPC_ETHEREUM poetry run python scripts/erc-4626/scan-vaults.py
 ```
 
@@ -67,6 +83,7 @@ poetry run python scripts/erc-4626/scan-vaults-all-chains.py
 | `SCAN_LIGHTER` | Optional. Enable Lighter native pool scanning. Default: false. |
 | `SCAN_HIBACHI` | Optional. Enable Hibachi native vault scanning. Default: false. |
 | `SKIP_SAMPLES` | Optional. Skip Ethereum-only sample file export. Default: false. |
+| `HYPERSYNC_RPM` | Optional. Hypersync API requests-per-minute limit. Default: 150. Lower after persistent 429 errors. |
 
 ### scan-prices.py
 
@@ -244,10 +261,17 @@ docker compose --profile oneshot run --rm \
 
 ### Scan only Ethereum with lead reset (after adding new protocol support)
 
+This rescans all configured vault discovery event topics from block 1 and merges the results
+back into the existing vault database. It does not delete the database first, but matching rows
+may be refreshed with newly detected metadata. Back up `~/.tradingstrategy/vaults/vault-metadata-db.pickle`
+before running this against production data.
+
 ```shell
 docker compose --profile oneshot run --rm \
   --entrypoint python \
   -e JSON_RPC_URL="$JSON_RPC_ETHEREUM" \
+  -e HYPERSYNC_API_KEY="$HYPERSYNC_API_KEY" \
+  -e SCAN_BACKEND=hypersync \
   -e RESET_LEADS=true \
   -e LOG_LEVEL=info \
   vault-scanner \

--- a/scripts/erc-4626/heal-timestamps-all-chains.py
+++ b/scripts/erc-4626/heal-timestamps-all-chains.py
@@ -46,6 +46,7 @@ from eth_defi.chain import get_chain_name
 from eth_defi.event_reader.timestamp_cache import DEFAULT_TIMESTAMP_CACHE_FOLDER, load_timestamp_cache
 from eth_defi.hypersync.hypersync_timestamp import get_block_timestamps_using_hypersync_async
 from eth_defi.hypersync.server import get_hypersync_server, is_hypersync_supported_chain
+from eth_defi.hypersync.session import create_throttled_hypersync_client, DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE
 from eth_defi.utils import setup_console_logging
 
 logger = logging.getLogger(__name__)
@@ -135,14 +136,16 @@ def heal_chain(chain_id: int, dry_run: bool) -> dict:
             result["duration"] = time.time() - start_time
             return result
 
-        # Configure HyperSync
+        # Configure HyperSync with throttling
         hypersync_server = get_hypersync_server(chain_id)
         hypersync_api_key = os.environ.get("HYPERSYNC_API_KEY")
-        hypersync_client = hypersync.HypersyncClient(
+        rpm = int(os.environ.get("HYPERSYNC_RPM", "0")) or DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE
+        hypersync_client = create_throttled_hypersync_client(
             hypersync.ClientConfig(
                 url=hypersync_server,
-                api_token=hypersync_api_key,
-            )
+                bearer_token=hypersync_api_key,
+            ),
+            requests_per_minute=rpm,
         )
 
         async def _heal():

--- a/scripts/erc-4626/heal-timestamps-all-chains.py
+++ b/scripts/erc-4626/heal-timestamps-all-chains.py
@@ -23,6 +23,7 @@ Environment variables:
     - TEST_CHAINS: Comma-separated chain names to heal (default: all)
     - LOG_LEVEL: Logging level (default: "info")
     - HYPERSYNC_API_KEY: HyperSync API key (optional but recommended)
+    - HYPERSYNC_RPM: Hypersync API requests-per-minute limit (default: 150). Lower after persistent 429 errors.
 """
 
 import asyncio

--- a/scripts/erc-4626/heal-timestamps-all-chains.py
+++ b/scripts/erc-4626/heal-timestamps-all-chains.py
@@ -46,7 +46,7 @@ from eth_defi.chain import get_chain_name
 from eth_defi.event_reader.timestamp_cache import DEFAULT_TIMESTAMP_CACHE_FOLDER, load_timestamp_cache
 from eth_defi.hypersync.hypersync_timestamp import get_block_timestamps_using_hypersync_async
 from eth_defi.hypersync.server import get_hypersync_server, is_hypersync_supported_chain
-from eth_defi.hypersync.session import create_throttled_hypersync_client, DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE
+from eth_defi.hypersync.session import create_throttled_hypersync_client, get_hypersync_rpm_from_env
 from eth_defi.utils import setup_console_logging
 
 logger = logging.getLogger(__name__)
@@ -139,13 +139,12 @@ def heal_chain(chain_id: int, dry_run: bool) -> dict:
         # Configure HyperSync with throttling
         hypersync_server = get_hypersync_server(chain_id)
         hypersync_api_key = os.environ.get("HYPERSYNC_API_KEY")
-        rpm = int(os.environ.get("HYPERSYNC_RPM", "0")) or DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE
         hypersync_client = create_throttled_hypersync_client(
             hypersync.ClientConfig(
                 url=hypersync_server,
                 bearer_token=hypersync_api_key,
             ),
-            requests_per_minute=rpm,
+            requests_per_minute=get_hypersync_rpm_from_env(),
         )
 
         async def _heal():

--- a/scripts/erc-4626/heal-timestamps.py
+++ b/scripts/erc-4626/heal-timestamps.py
@@ -50,6 +50,7 @@ from eth_defi.chain import get_chain_name
 from eth_defi.event_reader.timestamp_cache import DEFAULT_TIMESTAMP_CACHE_FOLDER, load_timestamp_cache
 from eth_defi.hypersync.hypersync_timestamp import get_block_timestamps_using_hypersync_async
 from eth_defi.hypersync.server import get_hypersync_server
+from eth_defi.hypersync.session import create_throttled_hypersync_client, DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.utils import from_unix_timestamp, setup_console_logging
 
@@ -127,16 +128,18 @@ def main():
         timestamp_db.close()
         return
 
-    # Configure HyperSync client
+    # Configure HyperSync client with throttling
     hypersync_server = get_hypersync_server(chain_id)
     assert hypersync_server, f"No HyperSync server configured for chain {chain_name} ({chain_id})"
 
     hypersync_api_key = os.environ.get("HYPERSYNC_API_KEY")
-    hypersync_client = hypersync.HypersyncClient(
+    rpm = int(os.environ.get("HYPERSYNC_RPM", "0")) or DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE
+    hypersync_client = create_throttled_hypersync_client(
         hypersync.ClientConfig(
             url=hypersync_server,
-            api_token=hypersync_api_key,
-        )
+            bearer_token=hypersync_api_key,
+        ),
+        requests_per_minute=rpm,
     )
 
     print(f"\nHealing {len(gaps):,} gaps using HyperSync server {hypersync_server}...")

--- a/scripts/erc-4626/heal-timestamps.py
+++ b/scripts/erc-4626/heal-timestamps.py
@@ -50,7 +50,7 @@ from eth_defi.chain import get_chain_name
 from eth_defi.event_reader.timestamp_cache import DEFAULT_TIMESTAMP_CACHE_FOLDER, load_timestamp_cache
 from eth_defi.hypersync.hypersync_timestamp import get_block_timestamps_using_hypersync_async
 from eth_defi.hypersync.server import get_hypersync_server
-from eth_defi.hypersync.session import create_throttled_hypersync_client, DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE
+from eth_defi.hypersync.session import create_throttled_hypersync_client, get_hypersync_rpm_from_env
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.utils import from_unix_timestamp, setup_console_logging
 
@@ -133,13 +133,12 @@ def main():
     assert hypersync_server, f"No HyperSync server configured for chain {chain_name} ({chain_id})"
 
     hypersync_api_key = os.environ.get("HYPERSYNC_API_KEY")
-    rpm = int(os.environ.get("HYPERSYNC_RPM", "0")) or DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE
     hypersync_client = create_throttled_hypersync_client(
         hypersync.ClientConfig(
             url=hypersync_server,
             bearer_token=hypersync_api_key,
         ),
-        requests_per_minute=rpm,
+        requests_per_minute=get_hypersync_rpm_from_env(),
     )
 
     print(f"\nHealing {len(gaps):,} gaps using HyperSync server {hypersync_server}...")

--- a/scripts/erc-4626/scan-vaults-all-chains.py
+++ b/scripts/erc-4626/scan-vaults-all-chains.py
@@ -104,6 +104,7 @@ Environment variables:
     - MAX_CYCLES: Exit after N cycles in looped mode, for testing (default: "0" = unlimited)
     - FORCE_RESCAN: "true" to ignore cycle state and rescan all items on the first cycle (default: "false")
     - PIPELINE_DATA_DIR: Override base directory for all pipeline files (default: ~/.tradingstrategy/vaults)
+    - HYPERSYNC_RPM: Hypersync API requests-per-minute limit (default: 150, 75% of the 200 RPM free-tier limit). Lower after persistent 429 errors.
 
 Example CHAIN_ORDER for all chains:
     CHAIN_ORDER="Sonic, Monad, Hyperliquid, Base, Arbitrum, Ethereum, Linea, Gnosis, Zora, Polygon, Avalanche, Berachain, Unichain, Hemi, Plasma, Binance, Mantle, Katana, Ink, Blast, Soneium, Optimism"

--- a/scripts/hypersync/prepopulate-timestamps.py
+++ b/scripts/hypersync/prepopulate-timestamps.py
@@ -16,6 +16,7 @@ from eth_defi.chain import get_chain_name
 from eth_defi.event_reader.multicall_timestamp import fetch_block_timestamps_multiprocess_auto_backend
 from eth_defi.event_reader.timestamp_cache import DEFAULT_TIMESTAMP_CACHE_FOLDER
 from eth_defi.hypersync.server import get_hypersync_server
+from eth_defi.hypersync.session import create_throttled_hypersync_client, DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE
 from eth_defi.hypersync.timestamp import get_hypersync_block_height
 from eth_defi.provider.multi_provider import create_multi_provider_web3, MultiProviderWeb3Factory
 
@@ -64,11 +65,13 @@ def create_and_populate_hypersync_timestamp_db_for_rpc(rpc_name: str):
 
     if hypersync_server:
         print(f"Using Hypersync server {hypersync_server} for chain {chain_name} ({chain_id})")
-        hypersync_client = hypersync.HypersyncClient(
+        rpm = int(os.environ.get("HYPERSYNC_RPM", "0")) or DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE
+        hypersync_client = create_throttled_hypersync_client(
             hypersync.ClientConfig(
                 url=hypersync_server,
-                api_token=hypersync_api_key,
-            )
+                bearer_token=hypersync_api_key,
+            ),
+            requests_per_minute=rpm,
         )
         last_block = get_hypersync_block_height(hypersync_client)
 

--- a/scripts/hypersync/prepopulate-timestamps.py
+++ b/scripts/hypersync/prepopulate-timestamps.py
@@ -16,7 +16,7 @@ from eth_defi.chain import get_chain_name
 from eth_defi.event_reader.multicall_timestamp import fetch_block_timestamps_multiprocess_auto_backend
 from eth_defi.event_reader.timestamp_cache import DEFAULT_TIMESTAMP_CACHE_FOLDER
 from eth_defi.hypersync.server import get_hypersync_server
-from eth_defi.hypersync.session import create_throttled_hypersync_client, DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE
+from eth_defi.hypersync.session import create_throttled_hypersync_client, get_hypersync_rpm_from_env
 from eth_defi.hypersync.timestamp import get_hypersync_block_height
 from eth_defi.provider.multi_provider import create_multi_provider_web3, MultiProviderWeb3Factory
 
@@ -65,13 +65,12 @@ def create_and_populate_hypersync_timestamp_db_for_rpc(rpc_name: str):
 
     if hypersync_server:
         print(f"Using Hypersync server {hypersync_server} for chain {chain_name} ({chain_id})")
-        rpm = int(os.environ.get("HYPERSYNC_RPM", "0")) or DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE
         hypersync_client = create_throttled_hypersync_client(
             hypersync.ClientConfig(
                 url=hypersync_server,
                 bearer_token=hypersync_api_key,
             ),
-            requests_per_minute=rpm,
+            requests_per_minute=get_hypersync_rpm_from_env(),
         )
         last_block = get_hypersync_block_height(hypersync_client)
 


### PR DESCRIPTION
## Why

The vault-scanner-looped pipeline hits Hypersync's 200 RPM API rate limit on high-block-count chains like Polygon, causing cascading 429 errors and scan failures. Two issues compound:

1. **Gap healing fires without backoff** — when Hypersync drops blocks (common on fast chains), the healer opens new streams with zero delay between attempts, turning a transient 429 into a cascading failure
2. **No coordination between scan phases** — vault lead discovery and price scanning create separate `HypersyncClient` instances that independently consume the same per-API-key quota

The "asset() returned no address" warnings in logs are separate — broken Curvance/Harvest Finance vaults on Polygon via JSON-RPC multicall, not related to Hypersync.

## Lessons learnt

- The Hypersync Rust client handles HTTP internally — `LimiterAdapter` on `requests.Session` can't intercept it, but a Python wrapper around `stream()`/`recv()`/`get_chain_id()`/`get_height()` can
- The existing `pyrate_limiter.SQLiteBucket` pattern from Hyperliquid/GRVT/Lighter/Derive sessions adapts well to the async Rust FFI client
- `recv()` calls within a stream also consume API quota (each triggers HTTP pagination internally), not just `stream()` setup
- A drop-in wrapper (`ThrottledHypersyncClient`) is cleaner than threading a `throttle` parameter through every function signature in the call chain

## Summary

- Added `eth_defi/hypersync/session.py` with `ThrottledHypersyncClient` — a drop-in wrapper for `HypersyncClient` that rate-limits all API calls through a `pyrate_limiter.Limiter` with SQLite-backed bucket (default 150 RPM, 75% of the 200 RPM limit)
- Added `ThrottledReceiver` that wraps the stream receiver so `recv()` calls are also throttled
- Added exponential backoff (60s, 120s) between gap healing attempts in `hypersync_timestamp.py`
- Updated `configure_hypersync_from_env()` to accept an optional shared `Limiter` and auto-create from `HYPERSYNC_RPM` env var
- Wired shared limiter through `scan_chain()` → `scan_vaults_for_chain()` + `scan_prices_for_chain()` so both phases coordinate via one SQLite bucket
- Updated `isinstance` checks across `hypersync_timestamp.py`, `aave_v3/liquidation.py` to accept the throttled wrapper via `is_hypersync_client()` helper