### PR TITLE
fix: blacklist Morpho vaults missing from API

### DIFF
--- a/eth_defi/erc_4626/scan.py
+++ b/eth_defi/erc_4626/scan.py
@@ -43,6 +43,7 @@ def create_vault_scan_record(
         detection.address,
         detection.features,
         token_cache=token_cache,
+        default_block_identifier=block_identifier,
     )
 
     empty_record = {
@@ -95,7 +96,10 @@ def create_vault_scan_record(
         # aggregator), fall back to fetch_nav() which may return denomination-token
         # TVL from an external API.
         if total_assets is None:
-            total_assets = vault.fetch_nav()
+            try:
+                total_assets = vault.fetch_nav(block_identifier)
+            except (AttributeError, ValueError):
+                total_assets = None
 
         try:
             total_supply = vault.fetch_total_supply(block_identifier)

--- a/eth_defi/erc_4626/vault_protocol/morpho/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/offchain_metadata.py
@@ -1,10 +1,10 @@
 """Morpho Blue offchain vault metadata.
 
-- Morpho Blue exposes a public GraphQL API that reports vault-level governance
+- Morpho exposes a public GraphQL API that reports vault-level governance
   warnings (e.g. ``short_timelock``) and market-level risk warnings
   (e.g. ``bad_debt_unrealized``)
-- We reverse-engineered the warning schema from the Morpho Blue GraphQL API at
-  ``blue-api.morpho.org``
+- We reverse-engineered the warning schema from the Morpho GraphQL API at
+  ``api.morpho.org``
 - Vault-level warnings cover governance risk; market-level warnings cover
   financial risk in underlying market allocations
 - Two-level caching: disk (24h TTL) + in-process dictionary keyed by
@@ -28,16 +28,18 @@ Warning types observed from the API:
 - ``not_whitelisted`` (YELLOW) — market not curated
 - ``unrecognized_collateral_asset`` / ``unrecognized_loan_asset`` (YELLOW)
 
-Morpho Blue API documentation:
-- `Morpho Blue GraphQL API <https://blue-api.morpho.org/graphql>`__
+Morpho API documentation:
+- `Morpho GraphQL API <https://api.morpho.org/graphql>`__
 - `Morpho documentation <https://docs.morpho.org/>`__
 """
 
 import datetime
+import enum
 import json
 import logging
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TypedDict
+from typing import Literal, TypedDict
 
 import requests
 from eth_typing import HexAddress
@@ -51,8 +53,8 @@ from eth_defi.utils import wait_other_writers
 #: Where we cache fetched Morpho vault data files
 DEFAULT_CACHE_PATH = DEFAULT_CACHE_ROOT / "morpho"
 
-#: Morpho Blue public GraphQL API endpoint
-MORPHO_BLUE_GRAPHQL_URL = "https://blue-api.morpho.org/graphql"
+#: Morpho public GraphQL API endpoint
+MORPHO_BLUE_GRAPHQL_URL = "https://api.morpho.org/graphql"
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +100,53 @@ query MorphoVaultWarnings($address: String!, $chainId: Int!) {
 }
 """
 
+#: GraphQL query to fetch V2 vault-level warnings for a single vault.
+_VAULT_V2_WARNINGS_QUERY = """
+query MorphoVaultV2Warnings($address: String!, $chainId: Int!) {
+  vaultV2ByAddress(address: $address, chainId: $chainId) {
+    address
+    warnings {
+      type
+      level
+    }
+  }
+}
+"""
+
+MorphoVaultAPIVersion = Literal["v1", "v2"]
+
+
+class MorphoVaultAPIStatus(str, enum.Enum):
+    """Status of a Morpho API vault lookup."""
+
+    #: The vault was found and warning data is present.
+    found = "found"
+
+    #: Morpho returned a definitive ``NOT_FOUND`` or null address lookup.
+    not_found = "not_found"
+
+    #: The lookup failed due to a retryable network/API issue.
+    transient_error = "transient_error"
+
+
+@dataclass(slots=True)
+class MorphoVaultAPIResult:
+    """Three-way Morpho API result for a vault lookup.
+
+    :ivar status:
+        Lookup status.
+    :ivar data:
+        Warning payload when :py:attr:`status` is :py:attr:`MorphoVaultAPIStatus.found`.
+    """
+
+    status: MorphoVaultAPIStatus
+    data: "MorphoVaultData | None" = None
+
+    @property
+    def is_not_found(self) -> bool:
+        """Does the result mean Morpho API does not know this vault."""
+        return self.status == MorphoVaultAPIStatus.not_found
+
 
 class MorphoMarketWarning(TypedDict):
     """A warning on a Morpho Blue market that a vault is allocated to.
@@ -105,7 +154,7 @@ class MorphoMarketWarning(TypedDict):
     Market warnings indicate financial risk in the underlying market allocations.
     The most critical are ``bad_debt_unrealized`` (RED) and ``bad_debt_realized`` (YELLOW).
 
-    - `Morpho Blue market warning types <https://blue-api.morpho.org/graphql>`__
+    - `Morpho market warning types <https://api.morpho.org/graphql>`__
     """
 
     #: Warning type identifier, snake_case.
@@ -135,15 +184,15 @@ class MorphoMarketWarning(TypedDict):
 
 
 class MorphoVaultData(TypedDict):
-    """Offchain warning data for a Morpho vault from the Morpho Blue GraphQL API.
+    """Offchain warning data for a Morpho vault from the Morpho GraphQL API.
 
-    Fetched from ``https://blue-api.morpho.org/graphql`` via the ``vaultByAddress`` query.
+    Fetched from ``https://api.morpho.org/graphql`` via the ``vaultByAddress`` query.
 
     - ``vault_warnings`` covers vault-level governance risk
     - ``market_warnings`` covers financial risk in underlying market allocations
 
-    Note: for Morpho V2 vaults, the API currently returns ``NOT_FOUND`` so
-    ``market_warnings`` will always be empty for those vaults.
+    Note: Morpho V2 vault responses do not expose V1-style market allocation
+    warnings, so ``market_warnings`` will be empty for those vaults.
     """
 
     #: Vault-level governance warnings.
@@ -168,8 +217,13 @@ _cached_vault_data: dict[str, MorphoVaultData] = {}
 #: Sentinel to distinguish transient API failures from definitively-not-found
 _TRANSIENT_ERROR = object()
 
+#: Sentinel for legacy empty-dict cache files that represented ``NOT_FOUND``.
+#:
+#: TODO: Remove after production Morpho cache files have rotated past their old 24h TTL.
+_NOT_FOUND_CACHE_MARKER = object()
 
-def _parse_cached_json(file: Path) -> MorphoVaultData | object | None:
+
+def _parse_cached_json(file: Path) -> MorphoVaultData | object:
     """Read and validate a Morpho vault data JSON cache file.
 
     :param file:
@@ -177,7 +231,8 @@ def _parse_cached_json(file: Path) -> MorphoVaultData | object | None:
 
     :return:
         - :py:class:`MorphoVaultData` on a valid cache hit
-        - ``None`` if the file is an empty-dict NOT_FOUND marker
+        - :py:data:`_NOT_FOUND_CACHE_MARKER` if the file is a legacy empty-dict
+          NOT_FOUND marker
         - :py:data:`_TRANSIENT_ERROR` if the file cannot be parsed or has unexpected shape
     """
     try:
@@ -187,8 +242,7 @@ def _parse_cached_json(file: Path) -> MorphoVaultData | object | None:
         logger.warning("Corrupted Morpho cache file %s: %s - ignoring", file, e)
         return _TRANSIENT_ERROR
     if not raw:
-        # Empty dict marker written when vault is definitively NOT_FOUND
-        return None
+        return _NOT_FOUND_CACHE_MARKER
     if not isinstance(raw, dict):
         logger.warning("Unexpected Morpho cache shape in %s (%s) - ignoring", file, type(raw).__name__)
         return _TRANSIENT_ERROR
@@ -246,16 +300,31 @@ def _build_vault_data_from_api_response(raw_vault: dict) -> MorphoVaultData:
     )
 
 
-def fetch_morpho_vault_data(
+def _get_cache_key(cache_path: Path, chain_id: int, address_lower: str, api_version: MorphoVaultAPIVersion) -> str:
+    """Build an in-process cache key for Morpho API data."""
+    if api_version == "v1":
+        return f"{cache_path}:{chain_id}:{address_lower}"
+    return f"{cache_path}:{api_version}:{chain_id}:{address_lower}"
+
+
+def _get_cache_file(cache_path: Path, chain_id: int, address_lower: str, api_version: MorphoVaultAPIVersion) -> Path:
+    """Build a disk cache file path for Morpho API data."""
+    if api_version == "v1":
+        return (cache_path / f"morpho_{chain_id}_{address_lower}.json").resolve()
+    return (cache_path / f"morpho_{api_version}_{chain_id}_{address_lower}.json").resolve()
+
+
+def fetch_morpho_vault_api_result(  # noqa: PLR0917
     web3: Web3,
     vault_address: HexAddress,
     cache_path: Path = DEFAULT_CACHE_PATH,
     now_: datetime.datetime | None = None,
     max_cache_duration: datetime.timedelta = datetime.timedelta(hours=24),
-) -> MorphoVaultData | None:
-    """Fetch and cache Morpho Blue API offchain warning data for a vault.
+    api_version: MorphoVaultAPIVersion = "v1",
+) -> MorphoVaultAPIResult:
+    """Fetch and cache Morpho API offchain warning data for a vault.
 
-    Queries the Morpho Blue public GraphQL API at ``blue-api.morpho.org`` to
+    Queries the Morpho public GraphQL API at ``api.morpho.org`` to
     retrieve vault-level governance warnings and market-level risk warnings for
     the vault's underlying market allocations.
 
@@ -267,13 +336,11 @@ def fetch_morpho_vault_data(
     Caching policy:
 
     - **Found**: Full :py:class:`MorphoVaultData` written to disk and in-process cache.
-    - **Not found** (``NOT_FOUND`` GraphQL error or null ``vaultByAddress``): empty marker
-      ``{}`` written to disk so we don't re-query for 24h.
-    - **Transient error** (network failure, rate limit, unexpected GraphQL error): returns
-      ``None`` without writing cache so the next call retries.
-
-    Note: Morpho V2 vaults are currently not indexed by the ``vaultByAddress`` query
-    and will return ``None`` (NOT_FOUND).
+    - **Not found** (``NOT_FOUND`` GraphQL error or null address lookup): no disk
+      or in-process cache is written, so unofficial vaults are rechecked on every
+      scan cycle.
+    - **Transient error** (network failure, rate limit, unexpected GraphQL error):
+      no cache is written so the next call retries.
 
     :param web3:
         Web3 instance (used to determine chain ID and checksum the address).
@@ -290,28 +357,30 @@ def fetch_morpho_vault_data(
     :param max_cache_duration:
         Cache TTL. Default 24 hours (shorter than Euler/Lagoon's 2 days because
         bad-debt warnings can appear and resolve more quickly).
+    :param api_version:
+        Morpho vault API family. V1 uses ``vaultByAddress`` and V2 uses
+        ``vaultV2ByAddress``.
 
     :return:
-        Vault warning data, or ``None`` if the vault is not indexed by the Morpho
-        Blue API or if a transient error occurred.
+        Three-way Morpho API lookup result.
     """
     chain_id = web3.eth.chain_id
     address_lower = vault_address.lower()
     checksum_address = Web3.to_checksum_address(vault_address)
-    cache_key = f"{cache_path}:{chain_id}:{address_lower}"
+    cache_key = _get_cache_key(cache_path, chain_id, address_lower, api_version)
 
     logger.info("Resolving Morpho GraphQL data for vault %s on chain %d", checksum_address, chain_id)
 
     # 1. In-process cache hit
     if cache_key in _cached_vault_data:
-        return _cached_vault_data[cache_key]
+        return MorphoVaultAPIResult(MorphoVaultAPIStatus.found, _cached_vault_data[cache_key])
 
     # 2. Disk cache
     if not now_:
         now_ = native_datetime_utc_now()
 
     cache_path.mkdir(parents=True, exist_ok=True)
-    file = (cache_path / f"morpho_{chain_id}_{address_lower}.json").resolve()
+    file = _get_cache_file(cache_path, chain_id, address_lower, api_version)
 
     with wait_other_writers(file):
         if file.exists() and file.stat().st_size > 0:
@@ -325,43 +394,84 @@ def fetch_morpho_vault_data(
                     age,
                 )
                 cached = _parse_cached_json(file)
-                if cached is None:
-                    # Empty-dict NOT_FOUND marker
-                    return None
+                if cached is _NOT_FOUND_CACHE_MARKER:
+                    logger.info("Ignoring legacy Morpho NOT_FOUND cache marker %s", file)
+                    file.unlink(missing_ok=True)
+                    cached = _TRANSIENT_ERROR
                 if cached is not _TRANSIENT_ERROR:
                     _cached_vault_data[cache_key] = cached  # type: ignore[assignment]
-                    return cached  # type: ignore[return-value]
+                    return MorphoVaultAPIResult(MorphoVaultAPIStatus.found, cached)  # type: ignore[arg-type]
 
         # 3. Fetch from API
         logger.info("Fetching Morpho vault warnings for %s on chain %d", checksum_address, chain_id)
-        result = _query_morpho_api(chain_id, checksum_address)
+        result = _query_morpho_api(chain_id, checksum_address, api_version=api_version)
 
-        if result is _TRANSIENT_ERROR:
-            # Transient failure — do not cache, let the next call retry
-            return None
+        if result.status == MorphoVaultAPIStatus.transient_error:
+            return result
 
-        if result is None:
-            # Definitively NOT_FOUND — cache empty marker so we don't re-query
+        if result.status == MorphoVaultAPIStatus.not_found:
             logger.info("Morpho API: vault %s on chain %d is not indexed (NOT_FOUND)", checksum_address, chain_id)
-            with file.open("wt") as f:
-                json.dump({}, f)
-            return None
+            file.unlink(missing_ok=True)
+            return result
 
         # Successful fetch — write to disk and populate in-process cache
+        assert result.data is not None
         serialisable = {
-            "vault_warnings": result["vault_warnings"],
-            "market_warnings": [dict(w) for w in result["market_warnings"]],
+            "vault_warnings": result.data["vault_warnings"],
+            "market_warnings": [dict(w) for w in result.data["market_warnings"]],
         }
         with file.open("wt") as f:
             json.dump(serialisable, f, indent=2)
-        logger.info("Wrote Morpho vault data cache %s (%d vault warnings, %d market warnings)", file, len(result["vault_warnings"]), len(result["market_warnings"]))
+        logger.info("Wrote Morpho vault data cache %s (%d vault warnings, %d market warnings)", file, len(result.data["vault_warnings"]), len(result.data["market_warnings"]))
 
-        _cached_vault_data[cache_key] = result
+        _cached_vault_data[cache_key] = result.data
         return result
 
 
-def _query_morpho_api(chain_id: int, address: str) -> MorphoVaultData | object | None:
-    """Execute the GraphQL query against the Morpho Blue API.
+def fetch_morpho_vault_data(  # noqa: PLR0917
+    web3: Web3,
+    vault_address: HexAddress,
+    cache_path: Path = DEFAULT_CACHE_PATH,
+    now_: datetime.datetime | None = None,
+    max_cache_duration: datetime.timedelta = datetime.timedelta(hours=24),
+    api_version: MorphoVaultAPIVersion = "v1",
+) -> MorphoVaultData | None:
+    """Fetch and cache Morpho API offchain warning data for a vault.
+
+    Backwards-compatible data-only wrapper around
+    :py:func:`fetch_morpho_vault_api_result`. Returns ``None`` for both
+    ``NOT_FOUND`` and transient API failures.
+
+    :param web3:
+        Web3 instance.
+    :param vault_address:
+        Vault contract address.
+    :param cache_path:
+        Directory for cache files.
+    :param now_:
+        Override current UTC time for cache TTL checks.
+    :param max_cache_duration:
+        Cache TTL.
+    :param api_version:
+        Morpho vault API family.
+
+    :return:
+        Vault warning data, or ``None`` if the vault is not indexed by the Morpho
+        API or if a transient error occurred.
+    """
+    result = fetch_morpho_vault_api_result(
+        web3=web3,
+        vault_address=vault_address,
+        cache_path=cache_path,
+        now_=now_,
+        max_cache_duration=max_cache_duration,
+        api_version=api_version,
+    )
+    return result.data if result.status == MorphoVaultAPIStatus.found else None
+
+
+def _query_morpho_api(chain_id: int, address: str, api_version: MorphoVaultAPIVersion = "v1") -> MorphoVaultAPIResult:
+    """Execute the GraphQL query against the Morpho API.
 
     :param chain_id:
         EVM chain ID.
@@ -369,13 +479,15 @@ def _query_morpho_api(chain_id: int, address: str) -> MorphoVaultData | object |
     :param address:
         Checksummed vault address.
 
+    :param api_version:
+        Morpho vault API family.
+
     :return:
-        - :py:class:`MorphoVaultData` on success
-        - ``None`` when the vault is definitively not found (NOT_FOUND error or null data)
-        - :py:data:`_TRANSIENT_ERROR` sentinel on transient failures (network, rate limit, etc.)
+        Three-way Morpho API lookup result.
     """
+    query = _VAULT_WARNINGS_QUERY if api_version == "v1" else _VAULT_V2_WARNINGS_QUERY
     payload = {
-        "query": _VAULT_WARNINGS_QUERY,
+        "query": query,
         "variables": {"address": address, "chainId": chain_id},
     }
     try:
@@ -389,30 +501,34 @@ def _query_morpho_api(chain_id: int, address: str) -> MorphoVaultData | object |
         body = resp.json()
     except requests.RequestException as e:
         logger.warning("Morpho API request failed for %s on chain %d: %s", address, chain_id, e)
-        return _TRANSIENT_ERROR
+        return MorphoVaultAPIResult(MorphoVaultAPIStatus.transient_error)
     except json.JSONDecodeError as e:
         logger.warning("Morpho API returned invalid JSON for %s on chain %d: %s", address, chain_id, e)
-        return _TRANSIENT_ERROR
+        return MorphoVaultAPIResult(MorphoVaultAPIStatus.transient_error)
 
     # Check for GraphQL-level errors
     errors = body.get("errors")
     if errors:
         # Only treat NOT_FOUND as definitively absent; everything else is a transient error
         if any(str(err.get("status", "")).upper() == "NOT_FOUND" for err in errors):
-            return None
+            return MorphoVaultAPIResult(MorphoVaultAPIStatus.not_found)
         logger.warning(
             "Morpho API returned unexpected GraphQL errors for %s on chain %d: %s",
             address,
             chain_id,
             errors,
         )
-        return _TRANSIENT_ERROR
+        return MorphoVaultAPIResult(MorphoVaultAPIStatus.transient_error)
 
     data = body.get("data") or {}
-    raw_vault = data.get("vaultByAddress")
+    response_key = "vaultByAddress" if api_version == "v1" else "vaultV2ByAddress"
+    raw_vault = data.get(response_key)
 
     if raw_vault is None:
-        # data.vaultByAddress is null — vault not indexed
-        return None
+        # Address lookup returned null — vault not indexed
+        return MorphoVaultAPIResult(MorphoVaultAPIStatus.not_found)
 
-    return _build_vault_data_from_api_response(raw_vault)
+    return MorphoVaultAPIResult(
+        status=MorphoVaultAPIStatus.found,
+        data=_build_vault_data_from_api_response(raw_vault),
+    )

--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v1.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v1.py
@@ -20,11 +20,16 @@ from web3 import Web3
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.morpho.flag_analytics import analyze_morpho_flags
-from eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata import MorphoVaultData, fetch_morpho_vault_data
+from eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata import (
+    MorphoVaultAPIResult,
+    MorphoVaultAPIStatus,
+    MorphoVaultData,
+    fetch_morpho_vault_api_result,
+)
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.types import Percent
 from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
-from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.flag import NOT_IN_MORPHO_API, VaultFlag
 
 logger = logging.getLogger(__name__)
 
@@ -157,22 +162,34 @@ class MorphoV1Vault(ERC4626Vault):
     """
 
     @cached_property
+    def morpho_api_result(self) -> MorphoVaultAPIResult:
+        """Vault lookup result from the Morpho GraphQL API.
+
+        Unlike :py:attr:`morpho_offchain_data`, this property preserves the
+        difference between ``NOT_FOUND`` and transient API failures.
+
+        :return:
+            Three-way Morpho API lookup result.
+        """
+        return fetch_morpho_vault_api_result(self.web3, self.vault_address, api_version="v1")
+
+    @cached_property
     def morpho_offchain_data(self) -> MorphoVaultData | None:
-        """Vault and market warnings from the Morpho Blue GraphQL API (24h cached).
+        """Vault and market warnings from the Morpho GraphQL API (24h cached).
 
         Fetches vault-level governance warnings (e.g. ``short_timelock``) and
         market-level risk warnings (e.g. ``bad_debt_unrealized``) for this vault
         and its underlying market allocations.
 
         - Results are cached in-process and on disk for 24 hours.
-        - Returns ``None`` if the vault is not indexed by the Morpho Blue API or if
+        - Returns ``None`` if the vault is not indexed by the Morpho API or if
           a transient network error occurred.
 
         :return:
             :py:class:`~eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata.MorphoVaultData`
             or ``None``.
         """
-        return fetch_morpho_vault_data(self.web3, self.vault_address)
+        return self.morpho_api_result.data if self.morpho_api_result.status == MorphoVaultAPIStatus.found else None
 
     def get_morpho_vault_flags(self) -> set[str]:
         """Return warning type strings from vault-level Morpho API warnings.
@@ -210,7 +227,7 @@ class MorphoV1Vault(ERC4626Vault):
         """Return a human-readable note about RED-level Morpho warnings, if any.
 
         Checks the hardcoded flag table first (via the base class), then falls back
-        to a dynamically generated note from the Morpho Blue GraphQL API when RED
+        to a dynamically generated note from the Morpho GraphQL API when RED
         warnings are present.
 
         The generated text follows the form::
@@ -223,6 +240,8 @@ class MorphoV1Vault(ERC4626Vault):
         note = super().get_notes()
         if note:
             return note
+        if self.morpho_api_result.is_not_found:
+            return NOT_IN_MORPHO_API
         data = self.morpho_offchain_data
         if data is not None:
             return analyze_morpho_flags(data).note
@@ -231,7 +250,7 @@ class MorphoV1Vault(ERC4626Vault):
     def get_flags(self) -> set[VaultFlag]:
         """Get vault flags, adding ``morpho_issues`` when RED warnings are detected.
 
-        Calls the Morpho Blue GraphQL API (24h cached) to check for RED-level
+        Calls the Morpho GraphQL API (24h cached) to check for RED-level
         vault or market warnings. If any are found, adds
         :py:attr:`~eth_defi.vault.flag.VaultFlag.morpho_issues` to the flag set.
 
@@ -239,6 +258,10 @@ class MorphoV1Vault(ERC4626Vault):
             Set of :py:class:`~eth_defi.vault.flag.VaultFlag` values.
         """
         flags = super().get_flags()
+        if self.morpho_api_result.is_not_found:
+            flags = set(flags)
+            flags.add(VaultFlag.not_in_morpho_api)
+            return flags
         data = self.morpho_offchain_data
         if data:
             has_red = any(w.get("level") == "RED" for w in data.get("vault_warnings", []) + data.get("market_warnings", []))

--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
@@ -29,7 +29,12 @@ from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.morpho.flag_analytics import analyze_morpho_flags
-from eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata import MorphoVaultData, fetch_morpho_vault_data
+from eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata import (
+    MorphoVaultAPIResult,
+    MorphoVaultAPIStatus,
+    MorphoVaultData,
+    fetch_morpho_vault_api_result,
+)
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.types import Percent
 from eth_defi.vault.base import (
@@ -38,7 +43,7 @@ from eth_defi.vault.base import (
     VaultHistoricalRead,
     VaultHistoricalReader,
 )
-from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.flag import NOT_IN_MORPHO_API, VaultFlag
 
 logger = logging.getLogger(__name__)
 
@@ -207,29 +212,37 @@ class MorphoV2Vault(ERC4626Vault):
     """
 
     @cached_property
+    def morpho_api_result(self) -> MorphoVaultAPIResult:
+        """Vault lookup result from the Morpho GraphQL API.
+
+        V2 vaults use ``vaultV2ByAddress`` so valid V2 vaults are not mistaken
+        for missing V1 vaults.
+
+        :return:
+            Three-way Morpho API lookup result.
+        """
+        return fetch_morpho_vault_api_result(self.web3, self.vault_address, api_version="v2")
+
+    @cached_property
     def morpho_offchain_data(self) -> MorphoVaultData | None:
-        """Vault and market warnings from the Morpho Blue GraphQL API (24h cached).
+        """Vault and market warnings from the Morpho GraphQL API (24h cached).
 
-        Fetches vault-level governance warnings and market-level risk warnings via the
-        Morpho Blue public GraphQL API.
-
-        Note: the Morpho Blue ``vaultByAddress`` query currently returns ``NOT_FOUND``
-        for V2 vault addresses — V2 vaults use an adapter-based architecture and are
-        not yet indexed by this API endpoint. This method will return ``None`` for
-        all current V2 vaults and is included for future compatibility.
+        Fetches vault-level governance warnings via the Morpho public GraphQL API.
+        V2 vaults do not expose V1-style market allocation warnings, so
+        ``market_warnings`` is expected to be empty.
 
         :return:
             :py:class:`~eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata.MorphoVaultData`
             or ``None``.
         """
-        return fetch_morpho_vault_data(self.web3, self.vault_address)
+        return self.morpho_api_result.data if self.morpho_api_result.status == MorphoVaultAPIStatus.found else None
 
     def get_morpho_vault_flags(self) -> set[str]:
         """Return warning type strings from vault-level Morpho API warnings.
 
         :return:
             Set of warning type strings, e.g. ``{"short_timelock", "not_whitelisted"}``.
-            Empty set if no data available (expected for V2 vaults currently).
+            Empty set if no data available.
         """
         data = self.morpho_offchain_data
         if not data:
@@ -241,7 +254,7 @@ class MorphoV2Vault(ERC4626Vault):
 
         :return:
             Set of warning type strings, e.g. ``{"bad_debt_unrealized"}``.
-            Empty set if no data available (expected for V2 vaults currently).
+            Empty set if no data available.
         """
         data = self.morpho_offchain_data
         if not data:
@@ -252,11 +265,8 @@ class MorphoV2Vault(ERC4626Vault):
         """Return a human-readable note about RED-level Morpho warnings, if any.
 
         Checks the hardcoded flag table first (via the base class), then falls back
-        to a dynamically generated note from the Morpho Blue GraphQL API when RED
+        to a dynamically generated note from the Morpho GraphQL API when RED
         warnings are present.
-
-        For current V2 vaults the Morpho Blue API returns ``NOT_FOUND``, so this
-        will typically return ``None`` unless a hardcoded note exists.
 
         :return:
             Note string, or ``None`` if no hardcoded note and no RED warnings.
@@ -264,6 +274,8 @@ class MorphoV2Vault(ERC4626Vault):
         note = super().get_notes()
         if note:
             return note
+        if self.morpho_api_result.is_not_found:
+            return NOT_IN_MORPHO_API
         data = self.morpho_offchain_data
         if data is not None:
             return analyze_morpho_flags(data).note
@@ -272,17 +284,18 @@ class MorphoV2Vault(ERC4626Vault):
     def get_flags(self) -> set[VaultFlag]:
         """Get vault flags, adding ``morpho_issues`` when RED warnings are detected.
 
-        Calls the Morpho Blue GraphQL API (24h cached) to check for RED-level
+        Calls the Morpho GraphQL API (24h cached) to check for RED-level
         vault or market warnings. If any are found, adds
         :py:attr:`~eth_defi.vault.flag.VaultFlag.morpho_issues` to the flag set.
-
-        For current V2 vaults this will return the base ERC-4626 flags only,
-        as the Morpho Blue API does not yet index V2 vault addresses.
 
         :return:
             Set of :py:class:`~eth_defi.vault.flag.VaultFlag` values.
         """
         flags = super().get_flags()
+        if self.morpho_api_result.is_not_found:
+            flags = set(flags)
+            flags.add(VaultFlag.not_in_morpho_api)
+            return flags
         data = self.morpho_offchain_data
         if data:
             has_red = any(w.get("level") == "RED" for w in data.get("vault_warnings", []) + data.get("market_warnings", []))

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -25,16 +25,23 @@ from tqdm_loggable.auto import tqdm
 
 from eth_defi.chain import get_chain_name
 from eth_defi.compat import native_datetime_utc_now
+from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS
 from eth_defi.erc_4626.core import ERC4262VaultDetection
 from eth_defi.erc_4626.vault_protocol.morpho.flag_analytics import MorphoFlagAnalytics, analyze_morpho_flags
 from eth_defi.research.value_table import format_grouped_series_as_multi_column_grid, format_series_as_multi_column_grid
 from eth_defi.research.wrangle_vault_prices import forward_fill_vault
 from eth_defi.token import is_stablecoin_like, normalise_token_symbol
-from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS
 from eth_defi.vault.base import VaultSpec
-from eth_defi.vault.fee import FeeData, VaultFeeMode, get_vault_fee_mode
 from eth_defi.vault.curator import get_curator_name, identify_curator, is_protocol_curator
-from eth_defi.vault.flag import ABNORMAL_SHARE_PRICE, ABNORMAL_TVL, ABNORMAL_VOLATILITY, VaultFlag, get_notes
+from eth_defi.vault.fee import FeeData, VaultFeeMode, get_vault_fee_mode
+from eth_defi.vault.flag import (
+    ABNORMAL_SHARE_PRICE,
+    ABNORMAL_TVL,
+    ABNORMAL_VOLATILITY,
+    NOT_IN_MORPHO_API,
+    VaultFlag,
+    get_notes,
+)
 from eth_defi.vault.risk import VaultTechnicalRisk, get_vault_risk
 from eth_defi.vault.vaultdb import VaultDatabase, VaultRow
 
@@ -1122,6 +1129,35 @@ def apply_abnormal_value_checks(
     return risk, notes, flags
 
 
+def apply_morpho_not_in_api_check(
+    risk: VaultTechnicalRisk | None,
+    notes: str | None,
+    flags: set[VaultFlag],
+) -> tuple[VaultTechnicalRisk | None, str | None, set[VaultFlag]]:
+    """Blacklist Morpho vaults missing from Morpho API.
+
+    Dynamic scan flags are not visible to :py:func:`get_vault_risk`, because
+    that helper only reads the static manual flag table. This helper handles the
+    Morpho-specific dynamic blacklist flag before metrics export.
+
+    :param risk:
+        Current risk classification.
+    :param notes:
+        Current note, if any. Existing notes have priority.
+    :param flags:
+        Dynamic flags collected during vault scan.
+
+    :return:
+        Updated risk, notes, and flags.
+    """
+    if VaultFlag.not_in_morpho_api in flags:
+        risk = VaultTechnicalRisk.blacklisted
+        if not notes:
+            notes = NOT_IN_MORPHO_API
+
+    return risk, notes, flags
+
+
 def calculate_vault_record(
     prices_df: pd.DataFrame,
     vault_metadata_rows: dict[VaultSpec, VaultRow],
@@ -1217,6 +1253,11 @@ def calculate_vault_record(
         flags=flags,
         current_nav=current_nav,
         current_share_price=current_share_price,
+    )
+    risk, notes, flags = apply_morpho_not_in_api_check(
+        risk=risk,
+        notes=notes,
+        flags=flags,
     )
 
     vault_slug = vault_metadata["vault_slug"]

--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -75,6 +75,9 @@ class VaultFlag(str, enum.Enum):
     #: ``other_data["morpho_market_flags"]`` in the metrics Series for the specific flag types.
     morpho_issues = "morpho_issues"
 
+    #: Morpho API does not return this vault by address.
+    not_in_morpho_api = "not_in_morpho_api"
+
 
 #: Don't touch vaults with these flags
 BAD_FLAGS = {
@@ -88,6 +91,7 @@ BAD_FLAGS = {
     VaultFlag.abnormal_volatility,
     VaultFlag.subvault,
     VaultFlag.irregular_reporting,
+    VaultFlag.not_in_morpho_api,
 }
 
 
@@ -169,6 +173,8 @@ LOW_TVL_ABNORMAL_PRICE = "Low-TVL vault with abnormal price behaviour"
 ILLIQUID_ABNORMAL_SHARE_PRICE = "Vault likely illiquid. Share price chart has abnormal high returns while deposits are still enabled."
 
 MISSING_IN_PROTOCOL_FRONTEND = "This vault is missing in the protocol's primary website and cannot be verified."
+
+NOT_IN_MORPHO_API = "This vault does not appear on Morpho website."
 
 TEST_VAULT = "This appears to be a test vault and should not be shown to end users."
 
@@ -416,6 +422,8 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0xcca902f2d3d265151f123d8ce8fdac38ba9745ed": (VaultFlag.unofficial, MISSING_IN_PROTOCOL_FRONTEND),
     # Blue Chip USDC Vault (Prime) on Ethereum - Morpho
     "0x74847d0d124ce5c89ca8f4e7547aecd09e86b2e0": (VaultFlag.unofficial, MISSING_IN_PROTOCOL_FRONTEND),
+    # VaultMorpho on Ethereum - Morpho
+    "0x21ed44c18c926c60092b1b2985e2c999421a5a69": (VaultFlag.unofficial, MISSING_IN_PROTOCOL_FRONTEND),
     # Borrowable USDC Deposit, SiloId: 125 on Avalanche
     "0xe0345f66318f482acccd67244a921c7fdc410957": (VaultFlag.illiquid, XUSD_MESSAGE),
     # Peapods Interest Bearing USDC - 22 (Arbitrum)

--- a/tests/morpho/test_morpho_offchain_metadata.py
+++ b/tests/morpho/test_morpho_offchain_metadata.py
@@ -59,17 +59,22 @@ from pathlib import Path
 
 import flaky
 import pytest
+import requests
 from web3 import Web3
 
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata import (
+    MorphoVaultAPIResult,
+    MorphoVaultAPIStatus,
     MorphoVaultData,
     _cached_vault_data,  # noqa: PLC2701
+    fetch_morpho_vault_api_result,
     fetch_morpho_vault_data,
 )
 from eth_defi.erc_4626.vault_protocol.morpho.vault_v1 import MorphoV1Vault
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.flag import NOT_IN_MORPHO_API, VaultFlag
 
 JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
@@ -87,6 +92,71 @@ YELLOW_ONLY_USDC_ETHEREUM = "0xbEeFCe6c76C7D7A8066562Fe9FF0e343a52dD92F"
 #: Gauntlet USDC Prime on Ethereum — clean vault, no warnings
 GAUNTLET_USDC_PRIME_ETHEREUM = "0xdd0f28e19C1780eb6396170735D45153D261490d"
 
+NOT_FOUND_TEST_VAULT = "0x000000000000000000000000000000000000dead"
+
+
+class _FakeEth:
+    """Minimal fake Web3.eth object for Morpho API tests."""
+
+    chain_id = 1
+
+
+class _FakeWeb3:
+    """Minimal fake Web3 object for Morpho API tests."""
+
+    eth = _FakeEth()
+
+
+class _FakeResponse:
+    """Minimal requests response for Morpho API tests."""
+
+    def __init__(self, body: dict):
+        self.body = body
+
+    def raise_for_status(self) -> None:
+        """No-op for successful fake responses."""
+
+    def json(self) -> dict:
+        """Return the fake JSON body."""
+        return self.body
+
+
+def _patch_morpho_api(monkeypatch: pytest.MonkeyPatch, responses: list[dict]) -> list[dict]:
+    """Patch Morpho API HTTP calls and return captured payloads."""
+    calls: list[dict] = []
+
+    def fake_post(url: str, json: dict, timeout: int, headers: dict) -> _FakeResponse:
+        calls.append(
+            {
+                "url": url,
+                "json": json,
+                "timeout": timeout,
+                "headers": headers,
+            }
+        )
+        return _FakeResponse(responses.pop(0))
+
+    monkeypatch.setattr("eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata.requests.post", fake_post)
+    return calls
+
+
+def _make_morpho_v1_vault(address: str) -> MorphoV1Vault:
+    """Create a Morpho V1 vault with only offchain API dependencies populated."""
+    return MorphoV1Vault(
+        web3=_FakeWeb3(),  # type: ignore[arg-type]
+        spec=VaultSpec(chain_id=1, vault_address=address),
+        token_cache={},
+    )
+
+
+def _patch_base_vault_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Avoid onchain ERC-4626 flag reads in pure Morpho API unit tests."""
+
+    def fake_get_flags(_self) -> set[VaultFlag]:
+        return set()
+
+    monkeypatch.setattr("eth_defi.erc_4626.vault.ERC4626Vault.get_flags", fake_get_flags)
+
 
 @pytest.fixture(scope="module")
 def web3_arbitrum() -> Web3:
@@ -98,6 +168,130 @@ def web3_arbitrum() -> Web3:
 def web3_ethereum() -> Web3:
     """Web3 connection to Ethereum mainnet."""
     return create_multi_provider_web3(JSON_RPC_ETHEREUM)
+
+
+# ---------------------------------------------------------------------------
+# Mocked API status tests
+# ---------------------------------------------------------------------------
+
+
+def test_morpho_not_found_adds_dynamic_flag_and_note(monkeypatch: pytest.MonkeyPatch):
+    """A definitive Morpho ``NOT_FOUND`` adds the dynamic blacklist flag and note."""
+    _patch_base_vault_flags(monkeypatch)
+
+    def fake_fetch_morpho_vault_api_result(*_args, **_kwargs) -> MorphoVaultAPIResult:
+        return MorphoVaultAPIResult(MorphoVaultAPIStatus.not_found)
+
+    monkeypatch.setattr(
+        "eth_defi.erc_4626.vault_protocol.morpho.vault_v1.fetch_morpho_vault_api_result",
+        fake_fetch_morpho_vault_api_result,
+    )
+
+    vault = _make_morpho_v1_vault(NOT_FOUND_TEST_VAULT)
+
+    assert vault.get_flags() == {VaultFlag.not_in_morpho_api}
+    assert vault.get_notes() == NOT_IN_MORPHO_API
+    assert VaultFlag.morpho_issues not in vault.get_flags()
+
+
+def test_morpho_not_found_is_not_cached(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """A definitive Morpho ``NOT_FOUND`` is queried again by a fresh vault instance."""
+    calls = _patch_morpho_api(
+        monkeypatch,
+        [
+            {
+                "errors": [
+                    {
+                        "message": "No results matching given parameters",
+                        "status": "NOT_FOUND",
+                        "extensions": {},
+                    }
+                ],
+                "data": None,
+            },
+            {
+                "errors": [
+                    {
+                        "message": "No results matching given parameters",
+                        "status": "NOT_FOUND",
+                        "extensions": {},
+                    }
+                ],
+                "data": None,
+            },
+        ],
+    )
+
+    vault_1 = _make_morpho_v1_vault(NOT_FOUND_TEST_VAULT)
+    vault_2 = _make_morpho_v1_vault(NOT_FOUND_TEST_VAULT)
+
+    assert fetch_morpho_vault_api_result(vault_1.web3, vault_1.vault_address, cache_path=tmp_path).is_not_found
+    assert fetch_morpho_vault_api_result(vault_2.web3, vault_2.vault_address, cache_path=tmp_path).is_not_found
+
+    cache_file = tmp_path / f"morpho_1_{NOT_FOUND_TEST_VAULT.lower()}.json"
+    assert not cache_file.exists()
+    expected_call_count = 2
+    assert len(calls) == expected_call_count
+
+
+def test_morpho_transient_error_does_not_add_not_found_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Transient Morpho API errors are not treated as definitive missing-vault results."""
+    _patch_base_vault_flags(monkeypatch)
+
+    def fake_post(_url: str, **_kwargs) -> _FakeResponse:
+        message = "temporary timeout"
+        raise requests.Timeout(message)
+
+    monkeypatch.setattr("eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata.requests.post", fake_post)
+
+    vault = _make_morpho_v1_vault(NOT_FOUND_TEST_VAULT)
+    result = fetch_morpho_vault_api_result(vault.web3, vault.vault_address, cache_path=tmp_path)
+
+    def fake_fetch_morpho_vault_api_result(*_args, **_kwargs) -> MorphoVaultAPIResult:
+        return MorphoVaultAPIResult(MorphoVaultAPIStatus.transient_error)
+
+    monkeypatch.setattr(
+        "eth_defi.erc_4626.vault_protocol.morpho.vault_v1.fetch_morpho_vault_api_result",
+        fake_fetch_morpho_vault_api_result,
+    )
+
+    assert result.status == MorphoVaultAPIStatus.transient_error
+    assert VaultFlag.not_in_morpho_api not in vault.get_flags()
+    assert vault.get_notes() is None
+
+    cache_file = tmp_path / f"morpho_1_{NOT_FOUND_TEST_VAULT.lower()}.json"
+    assert not cache_file.exists()
+
+
+def test_morpho_found_data_uses_disk_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Successful Morpho warning data still uses the existing disk cache."""
+    calls = _patch_morpho_api(
+        monkeypatch,
+        [
+            {
+                "data": {
+                    "vaultByAddress": {
+                        "address": Web3.to_checksum_address(DUNE_USDC_ETHEREUM),
+                        "warnings": [{"type": "short_timelock", "level": "RED"}],
+                        "state": {"allocation": []},
+                    }
+                }
+            }
+        ],
+    )
+
+    web3 = _FakeWeb3()  # type: ignore[assignment]
+    result_1 = fetch_morpho_vault_data(web3, DUNE_USDC_ETHEREUM, cache_path=tmp_path)
+    assert result_1 is not None
+    assert result_1["vault_warnings"] == [{"type": "short_timelock", "level": "RED"}]
+
+    cache_key = f"{tmp_path}:1:{DUNE_USDC_ETHEREUM.lower()}"
+    _cached_vault_data.pop(cache_key, None)
+
+    result_2 = fetch_morpho_vault_data(web3, DUNE_USDC_ETHEREUM, cache_path=tmp_path)
+
+    assert result_2 == result_1
+    assert len(calls) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -12,12 +12,38 @@ from plotly.graph_objects import Figure
 
 from eth_defi.research.sparkline import export_sparkline_as_png, export_sparkline_as_svg, extract_vault_price_data, render_sparkline_simple
 from eth_defi.research.vault_benchmark import visualise_vault_return_benchmark
-from eth_defi.research.vault_metrics import PeriodMetrics, apply_abnormal_value_checks, calculate_lifetime_metrics, calculate_period_metrics, display_vault_chart_and_tearsheet, export_lifetime_row, format_lifetime_table
-from eth_defi.vault.flag import VaultFlag
+from eth_defi.research.vault_metrics import PeriodMetrics, apply_abnormal_value_checks, apply_morpho_not_in_api_check, calculate_lifetime_metrics, calculate_period_metrics, display_vault_chart_and_tearsheet, export_lifetime_row, format_lifetime_table
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.fee import FeeData, VaultFeeMode
+from eth_defi.vault.flag import NOT_IN_MORPHO_API, VaultFlag
 from eth_defi.vault.risk import VaultTechnicalRisk
 from eth_defi.vault.vaultdb import VaultDatabase
+
+
+def test_apply_morpho_not_in_api_check_blacklists_vault():
+    """Morpho API missing flag blacklists the vault in metrics."""
+    risk, notes, flags = apply_morpho_not_in_api_check(
+        risk=VaultTechnicalRisk.negligible,
+        notes=None,
+        flags={VaultFlag.not_in_morpho_api},
+    )
+
+    assert risk == VaultTechnicalRisk.blacklisted
+    assert notes == NOT_IN_MORPHO_API
+    assert flags == {VaultFlag.not_in_morpho_api}
+
+
+def test_apply_morpho_not_in_api_check_preserves_existing_note():
+    """Morpho API missing flag does not replace higher-priority notes."""
+    risk, notes, flags = apply_morpho_not_in_api_check(
+        risk=VaultTechnicalRisk.negligible,
+        notes="Existing manual note",
+        flags={VaultFlag.not_in_morpho_api},
+    )
+
+    assert risk == VaultTechnicalRisk.blacklisted
+    assert notes == "Existing manual note"
+    assert flags == {VaultFlag.not_in_morpho_api}
 
 
 @pytest.fixture(scope="module")

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -6,6 +6,11 @@ from eth_defi.vault.flag import BAD_FLAGS, VaultFlag, get_notes, get_vault_speci
 from eth_defi.vault.risk import VaultTechnicalRisk, get_vault_risk
 
 
+def test_not_in_morpho_api_is_bad_flag():
+    """Morpho API missing vaults are blacklisted."""
+    assert VaultFlag.not_in_morpho_api in BAD_FLAGS
+
+
 @pytest.mark.parametrize(
     ("address", "protocol", "expected_flag", "expected_note"),
     [


### PR DESCRIPTION
## Why

Morpho vaults that are not returned by the official Morpho API should be treated as unavailable from the Morpho website and blacklisted automatically instead of relying only on manual notes. The scan should also recheck missing vaults every cycle, so stale NOT_FOUND cache markers must not hide later API changes.

## Lessons learnt

The old Morpho warning lookup collapsed NOT_FOUND and transient failures into None. Splitting the API response into found, not_found, and transient_error lets us blacklist definitive missing vaults without punishing temporary API failures. Dynamic scan flags also need explicit metrics handling because the static risk helper only reads manual flag entries.

## Summary

- Added VaultFlag.not_in_morpho_api and the note: This vault does not appear on Morpho website.
- Added a three-way Morpho API result and stopped caching NOT_FOUND responses while preserving successful response caching.
- Wired Morpho V1/V2 flags and notes to the new API status, using the correct V1/V2 GraphQL address lookups.
- Added metrics handling so the dynamic missing-API flag blacklists exported vault metrics.
- Added targeted mocked API, flag, and metrics-helper tests.

Verified with source .local-test.env && poetry run pytest tests/morpho/test_morpho_offchain_metadata.py tests/vault/test_flag.py tests/research/test_vault_metrics.py -q.