### PR TITLE
feat: Scan Ethereum, Base, Arbitrum vaults every 8h

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,7 +141,7 @@ services:
       - ${HOME}/.cache:/root/.cache:rw
 
   # Persistent: looped vault scanner, ticks every 1h, scans chains on configurable cycles.
-  # Hyperliquid/GRVT/Lighter/Hibachi default to 4h, EVM chains default to 24h.
+  # Ethereum/Base/Arbitrum on 8h, Hyperliquid/GRVT/Lighter/Hibachi on 4h, other EVM chains on 24h.
   # Uses a pipeline lock to prevent overlap with the single-run vault-scanner.
   # Started by `docker compose up -d`.
   vault-scanner-looped:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,7 +151,7 @@ services:
     entrypoint: [ "python", "scripts/erc-4626/scan-vaults-all-chains.py" ]
     environment:
       LOOP_INTERVAL_SECONDS: ${LOOP_INTERVAL_SECONDS:-3600}
-      SCAN_CYCLES: ${SCAN_CYCLES:-Hypercore=4h,GRVT=4h,Lighter=4h,Hibachi=4h}
+      SCAN_CYCLES: ${SCAN_CYCLES:-Ethereum=8h,Base=8h,Arbitrum=8h,Hypercore=4h,GRVT=4h,Lighter=4h,Hibachi=4h}
       DEFAULT_CYCLE: ${DEFAULT_CYCLE:-24h}
 
       CHAIN_ORDER: ${CHAIN_ORDER:-}

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -75,7 +75,7 @@ poetry run python scripts/erc-4626/scan-vaults-all-chains.py
 | `LOG_LEVEL` | Optional. Default: WARNING. |
 | `PIPELINE_DATA_DIR` | Optional. Directory for all pipeline files (parquet, pickle, DuckDB, state). Default: `~/.tradingstrategy/vaults`. |
 | `LOOP_INTERVAL_SECONDS` | Optional. When >0, enables looped mode — ticks every N seconds. Default: 0 (single run). |
-| `SCAN_CYCLES` | Optional. Per-item cycle intervals, e.g. `Lighter=4h,GRVT=4h,Hypercore=4h,Hibachi=4h`. |
+| `SCAN_CYCLES` | Optional. Per-item cycle intervals, e.g. `Ethereum=8h,Base=8h,Arbitrum=8h,Lighter=4h,GRVT=4h,Hypercore=4h,Hibachi=4h`. |
 | `DEFAULT_CYCLE` | Optional. Default cycle for items not in `SCAN_CYCLES`. Default: `24h`. |
 | `MAX_CYCLES` | Optional. Exit after N cycles (for testing). Default: 0 (unlimited). |
 | `SCAN_HYPERCORE` | Optional. Enable Hyperliquid native vault scanning. Default: false. |

--- a/scripts/erc-4626/scan-vaults-all-chains.py
+++ b/scripts/erc-4626/scan-vaults-all-chains.py
@@ -43,9 +43,9 @@ Usage:
     # Disable specific chains (skip them)
     DISABLE_CHAINS=Plasma,Katana python scripts/erc-4626/scan-vaults-all-chains.py
 
-    # Looped mode: tick every 1h, Lighter/GRVT/Hypercore on 4h cycle, EVM chains on 24h
+    # Looped mode: tick every 1h, major EVM chains on 8h, native protocols on 4h, rest on 24h
     LOOP_INTERVAL_SECONDS=3600 \\
-    SCAN_CYCLES="Hypercore=4h,GRVT=4h,Lighter=4h,Hibachi=4h" \\
+    SCAN_CYCLES="Ethereum=8h,Base=8h,Arbitrum=8h,Hypercore=4h,GRVT=4h,Lighter=4h,Hibachi=4h" \\
     DEFAULT_CYCLE=24h \\
     SCAN_HYPERCORE=true SCAN_GRVT=true SCAN_LIGHTER=true SCAN_HIBACHI=true \\
     python scripts/erc-4626/scan-vaults-all-chains.py
@@ -99,7 +99,7 @@ Environment variables:
     - SKIP_DATA: "true" to skip data file (parquet, pickle) export to R2 (default: "false")
     - JSON_RPC_<CHAIN>: RPC URL for each chain (required per chain)
     - LOOP_INTERVAL_SECONDS: Seconds between ticks in looped mode (default: "0" = single run)
-    - SCAN_CYCLES: Per-chain/protocol cycle overrides, e.g. "Hypercore=4h,GRVT=4h,Lighter=4h"
+    - SCAN_CYCLES: Per-chain/protocol cycle overrides, e.g. "Ethereum=8h,Base=8h,Arbitrum=8h,Hypercore=4h,GRVT=4h,Lighter=4h"
     - DEFAULT_CYCLE: Default cycle interval for items not in SCAN_CYCLES (default: "24h")
     - MAX_CYCLES: Exit after N cycles in looped mode, for testing (default: "0" = unlimited)
     - FORCE_RESCAN: "true" to ignore cycle state and rescan all items on the first cycle (default: "false")


### PR DESCRIPTION
## Why

Ethereum, Base, and Arbitrum are the highest-traffic EVM chains for vault activity. The previous 24h default scan cycle meant TVL and price data could be stale for up to a day. Scanning every 8h keeps data fresher for these key chains while leaving smaller chains on the 24h default.

## Lessons learnt

- `SCAN_CYCLES` env var supports per-chain overrides — no code changes needed, just config
- `DEFAULT_CYCLE` still applies to all chains not explicitly listed

## Summary

- Added `Ethereum=8h,Base=8h,Arbitrum=8h` to the default `SCAN_CYCLES` in `docker-compose.yml`
- Updated script docstring and README examples to reflect the new defaults