### PR TITLE
Improve Anvil retry diagnostics

### DIFF
--- a/eth_defi/provider/anvil.py
+++ b/eth_defi/provider/anvil.py
@@ -72,6 +72,102 @@ logger = logging.getLogger(__name__)
 #: a flaky endpoint across multiple test fixtures.
 _anvil_rpc_state = threading.local()
 
+
+@dataclass(slots=True, frozen=True)
+class AnvilForkMetadata:
+    """Metadata for a locally running Anvil JSON-RPC endpoint.
+
+    This metadata lets later ``Web3`` objects created from only the local
+    Anvil URL still report which upstream fork RPC providers Anvil was
+    configured to use.
+
+    :ivar chain_id:
+        Chain id reported by the local Anvil instance after startup.
+
+    :ivar upstream_rpc_urls:
+        Original upstream RPC URLs passed to Anvil fork mode. If Anvil was
+        started as a standalone local backend, this is empty.
+
+    :ivar fork_block_number:
+        Explicit fork block used for Anvil, if any.
+
+    :ivar effective_fork_url:
+        URL passed to Anvil as ``--fork-url``. With multiple upstreams this can
+        be a local failover proxy URL instead of one of the upstream RPC URLs.
+    """
+
+    #: Chain id reported by the local Anvil instance after startup.
+    chain_id: int | None
+
+    #: Original upstream RPC URLs passed to Anvil fork mode.
+    upstream_rpc_urls: tuple[str, ...]
+
+    #: Explicit fork block used for Anvil, if any.
+    fork_block_number: int | None
+
+    #: URL passed to Anvil as ``--fork-url``.
+    effective_fork_url: str | None
+
+
+#: Protect the process-local Anvil metadata registry.
+_anvil_launch_metadata_lock = threading.Lock()
+
+#: Local Anvil JSON-RPC URL -> fork metadata.
+#:
+#: ``create_multi_provider_web3()`` often receives only
+#: ``AnvilLaunch.json_rpc_url``. Without this registry, retry logs can only
+#: show ``localhost:<port>`` and lose the upstream fork provider context.
+#:
+#: The returned :py:class:`AnvilLaunch` object is the canonical metadata source
+#: for callers. This registry is a process-local mirror used to recover the same
+#: metadata from a localhost URL later. HTTP providers receive a copied snapshot
+#: for logging only.
+_anvil_launch_metadata: dict[str, AnvilForkMetadata] = {}
+
+
+def _get_anvil_launch_metadata(json_rpc_url: str) -> AnvilForkMetadata | None:
+    """Return metadata for a locally launched Anvil endpoint.
+
+    :param json_rpc_url:
+        Local Anvil JSON-RPC URL.
+
+    :return:
+        Stored launch metadata, or ``None`` if this endpoint was not created by
+        :py:func:`launch_anvil` in the current Python process.
+    """
+
+    with _anvil_launch_metadata_lock:
+        return _anvil_launch_metadata.get(json_rpc_url)
+
+
+def _register_anvil_launch_metadata(
+    json_rpc_url: str,
+    metadata: AnvilForkMetadata,
+) -> None:
+    """Store metadata for a locally launched Anvil endpoint.
+
+    :param json_rpc_url:
+        Local Anvil JSON-RPC URL.
+
+    :param metadata:
+        Metadata copied from the canonical :py:class:`AnvilLaunch` values.
+    """
+
+    with _anvil_launch_metadata_lock:
+        _anvil_launch_metadata[json_rpc_url] = metadata
+
+
+def _unregister_anvil_launch_metadata(json_rpc_url: str) -> None:
+    """Remove metadata for a closed Anvil endpoint.
+
+    :param json_rpc_url:
+        Local Anvil JSON-RPC URL.
+    """
+
+    with _anvil_launch_metadata_lock:
+        _anvil_launch_metadata.pop(json_rpc_url, None)
+
+
 #: HyperEVM mainnet/testnet chain ids.
 #:
 #: HyperEVM RPCs are special when forking with Anvil: asking Anvil to fork the
@@ -278,6 +374,12 @@ class AnvilLaunch:
     """Control Anvil processes launched on background.
 
     Comes with a helpful :py:meth:`close` method when it is time to put Anvil rest.
+
+    The ``chain_id``, ``upstream_rpc_urls``, ``fork_block_number`` and
+    ``effective_fork_url`` fields are the canonical launch metadata exposed to
+    callers. The module-level metadata registry mirrors these values only so
+    that later ``create_multi_provider_web3(launch.json_rpc_url)`` calls can
+    attach the same context to retry diagnostics.
     """
 
     #: Which port was bound by the Anvil
@@ -291,6 +393,18 @@ class AnvilLaunch:
 
     #: UNIX process that we opened
     process: psutil.Popen
+
+    #: Chain id reported by the local Anvil instance after startup.
+    chain_id: int | None = None
+
+    #: Original upstream RPC URLs passed to Anvil fork mode.
+    upstream_rpc_urls: tuple[str, ...] = ()
+
+    #: Explicit fork block used for Anvil, if any.
+    fork_block_number: int | None = None
+
+    #: URL passed to Anvil as ``--fork-url``.
+    effective_fork_url: str | None = None
 
     #: Optional JSON-RPC failover proxy sitting between Anvil and upstream RPCs.
     #: Automatically started by :py:func:`launch_anvil` when multiple RPCs are
@@ -334,6 +448,7 @@ class AnvilLaunch:
             check_port=self.port,
         )
         logger.info("Anvil shutdown %s", self.json_rpc_url)
+        _unregister_anvil_launch_metadata(self.json_rpc_url)
         if self.proxy is not None and self._proxy_managed:
             self.proxy.close()
         return stdout, stderr
@@ -895,6 +1010,7 @@ def launch_anvil(
 
     proxy = None
     available_rpcs = []
+    upstream_rpc_urls: tuple[str, ...] = ()
     # Track whether we manage the proxy lifecycle (True) or the caller does (False)
     proxy_managed = True
 
@@ -906,6 +1022,7 @@ def launch_anvil(
         if not available_rpcs:
             # All endpoints are mev+, strip the prefix as a fallback
             available_rpcs = [u.replace("mev+", "", 1) for u in all_rpcs]
+        upstream_rpc_urls = tuple(available_rpcs)
 
         if len(available_rpcs) > 1 and proxy_multiple_upstream is not False:
             from eth_defi.provider.rpc_proxy import RPCProxy as RPCProxyClass
@@ -945,6 +1062,8 @@ def launch_anvil(
             logger.info("Using Anvil at RPC endpoint %d/%d: %s", rpc_index + 1, len(available_rpcs), cleaned_fork_url)
     else:
         cleaned_fork_url = fork_url if not fork_url or not fork_url.startswith("mev+") else fork_url.replace("mev+", "", 1)
+        if cleaned_fork_url:
+            upstream_rpc_urls = (cleaned_fork_url,)
 
     # Check given RPC works.
     # When a proxy is active, smoke-test one of the upstream URLs directly
@@ -1139,11 +1258,30 @@ def launch_anvil(
     # Use f-string for a thousand separator formatting
     logger.info(f"anvil forked network {chain_id}, the current block is {current_block:,}, Anvil JSON-RPC is {url}")
 
+    fork_metadata = AnvilForkMetadata(
+        chain_id=chain_id,
+        upstream_rpc_urls=upstream_rpc_urls,
+        fork_block_number=fork_block_number,
+        effective_fork_url=cleaned_fork_url,
+    )
+    _register_anvil_launch_metadata(url, fork_metadata)
+
     # Perform unlock accounts for all accounts
     for account in unlocked_addresses:
         unlock_account(web3, account)
 
-    return AnvilLaunch(port, final_cmd, url, process, proxy=proxy, _proxy_managed=proxy_managed)
+    return AnvilLaunch(
+        port,
+        final_cmd,
+        url,
+        process,
+        chain_id=fork_metadata.chain_id,
+        upstream_rpc_urls=fork_metadata.upstream_rpc_urls,
+        fork_block_number=fork_metadata.fork_block_number,
+        effective_fork_url=fork_metadata.effective_fork_url,
+        proxy=proxy,
+        _proxy_managed=proxy_managed,
+    )
 
 
 def unlock_account(web3: Web3, address: str):

--- a/eth_defi/provider/fallback.py
+++ b/eth_defi/provider/fallback.py
@@ -18,6 +18,7 @@ from web3.types import RPCEndpoint, RPCResponse
 from eth_defi.event_reader.fast_json_rpc import get_last_headers
 from eth_defi.middleware import DEFAULT_RETRYABLE_EXCEPTIONS, DEFAULT_RETRYABLE_HTTP_STATUS_CODES, DEFAULT_RETRYABLE_RPC_ERROR_CODES, ProbablyNodeHasNoBlock, is_retryable_http_exception, SomeCrappyRPCProviderException
 from eth_defi.provider.named import BaseNamedProvider, NamedProvider, get_provider_name
+from eth_defi.utils import get_url_domain
 
 logger = logging.getLogger(__name__)
 
@@ -327,6 +328,44 @@ class FallbackProvider(BaseNamedProvider):
         except IndexError as e:
             raise IndexProvider(f"Currently active provider index {self.currently_active_provider} is out of range for configured providers {len(self.providers)}") from e
 
+    def get_provider_context_for_log(self, provider: NamedProvider) -> dict[str, Any]:
+        """Get provider diagnostics suitable for warning logs.
+
+        The context includes Anvil launch metadata when the local Anvil
+        provider has metadata copied by :py:func:`create_multi_provider_web3`.
+        The metadata is registered by :py:func:`eth_defi.provider.anvil.launch_anvil`.
+        Upstream RPC URLs are reduced to domains to avoid leaking API keys.
+
+        :param provider:
+            Provider that handled the failing JSON-RPC request.
+
+        :return:
+            Dictionary safe to include in logs.
+        """
+
+        chain_id = getattr(provider, "anvil_chain_id", None)
+        if chain_id is None:
+            chain_id = self.expected_chain_id
+
+        context: dict[str, Any] = {
+            "provider": get_provider_name(provider),
+            "chain_id": chain_id,
+        }
+
+        upstream_rpc_urls = getattr(provider, "anvil_upstream_rpc_urls", ())
+        if upstream_rpc_urls:
+            context["anvil_upstream_rpc_providers"] = [get_url_domain(url) for url in upstream_rpc_urls]
+
+        effective_fork_url = getattr(provider, "anvil_effective_fork_url", None)
+        if effective_fork_url:
+            context["anvil_effective_fork_provider"] = get_url_domain(effective_fork_url)
+
+        fork_block_number = getattr(provider, "anvil_fork_block_number", None)
+        if fork_block_number is not None:
+            context["anvil_fork_block_number"] = fork_block_number
+
+        return context
+
     def get_total_api_call_counts(self) -> dict[str, int]:
         """Get API call coubst across all providers"""
         total = Counter()
@@ -429,18 +468,21 @@ class FallbackProvider(BaseNamedProvider):
                     if i < self.retries:
                         # Black messes up string new lines here
                         # See https://github.com/psf/black/issues/1837
-                        headers = get_last_headers()
-                        logger.log(
-                            self.switchover_noisiness,
-                            "Encountered JSON-RPC retryable error %s\nWhen calling RPC method: %s%s\nHeaders are: %s\nRetrying in %f seconds, retry #%d / %d",
-                            e,
-                            method,
-                            params,
-                            pformat(headers),
-                            current_sleep,
-                            i + 1,
-                            self.retries,
-                        )
+                        if logger.isEnabledFor(self.switchover_noisiness):
+                            headers = get_last_headers()
+                            provider_context = self.get_provider_context_for_log(provider)
+                            logger.log(
+                                self.switchover_noisiness,
+                                "Encountered JSON-RPC retryable error %s\nWhen calling RPC method: %s%s\nProvider context: %s\nHeaders are: %s\nRetrying in %f seconds, retry #%d / %d",
+                                e,
+                                method,
+                                params,
+                                pformat(provider_context),
+                                pformat(headers),
+                                current_sleep,
+                                i + 1,
+                                self.retries,
+                            )
                         time.sleep(current_sleep)
                         current_sleep *= self.backoff
                         self.retry_count += 1

--- a/eth_defi/provider/multi_provider.py
+++ b/eth_defi/provider/multi_provider.py
@@ -16,7 +16,7 @@ from eth_defi.chain import install_chain_middleware
 from eth_defi.compat import clear_middleware, create_http_provider
 from eth_defi.event_reader.fast_json_rpc import patch_provider, patch_web3
 from eth_defi.middleware import static_call_cache_middleware
-from eth_defi.provider.anvil import is_anvil
+from eth_defi.provider.anvil import _get_anvil_launch_metadata, is_anvil
 from eth_defi.provider.broken_provider import set_block_tip_latency
 from eth_defi.provider.fallback import ChainIdMismatch, FallbackProvider
 from eth_defi.provider.mev_blocker import MEVBlockerProvider
@@ -99,6 +99,27 @@ class MultiProviderWeb3(Web3):
             RPC endpoint name, call count dict
         """
         return self.get_fallback_provider().get_total_api_call_counts()
+
+
+def _apply_anvil_launch_metadata(provider: HTTPProvider) -> None:
+    """Attach Anvil launch metadata to a provider when available.
+
+    ``create_multi_provider_web3()`` often receives only the local Anvil
+    ``localhost`` URL. The provider itself needs launch metadata for retry logs
+    to show the original fork chain id and upstream RPC providers.
+
+    :param provider:
+        HTTP provider created for a JSON-RPC endpoint.
+    """
+
+    metadata = _get_anvil_launch_metadata(str(provider.endpoint_uri))
+    if metadata is None:
+        return
+
+    provider.anvil_chain_id = metadata.chain_id  # type: ignore[attr-defined]
+    provider.anvil_upstream_rpc_urls = metadata.upstream_rpc_urls  # type: ignore[attr-defined]
+    provider.anvil_fork_block_number = metadata.fork_block_number  # type: ignore[attr-defined]
+    provider.anvil_effective_fork_url = metadata.effective_fork_url  # type: ignore[attr-defined]
 
 
 def create_multi_provider_web3(
@@ -262,6 +283,7 @@ def create_multi_provider_web3(
             get_url_domain(url),
             request_kwargs.get("timeout"),
         )
+        _apply_anvil_launch_metadata(provider)
 
         call_providers.append(provider)
 
@@ -284,6 +306,7 @@ def create_multi_provider_web3(
     if len(transact_endpoints) > 0:
         transact_endpoint = transact_endpoints[0]
         transact_provider = HTTPProvider(transact_endpoint, request_kwargs=request_kwargs, session=session)
+        _apply_anvil_launch_metadata(transact_provider)
 
         _fix_provider(transact_provider)
 

--- a/tests/erc_4626/test_euler_metadata.py
+++ b/tests/erc_4626/test_euler_metadata.py
@@ -94,8 +94,8 @@ def test_euler_metadata_products_json(
 ):
     """Verify the new products.json metadata fields for a vault that IS listed.
 
-    Euler Prime WETH (0xD8b2...) is part of the "euler-prime" product.
-    The product has two entity curators: euler-dao and gauntlet.
+    Euler Prime WETH (0xD8b2...) is present in Euler's live products.json.
+    The upstream product assignment may change as vault curators are updated.
 
     Steps:
 
@@ -110,16 +110,18 @@ def test_euler_metadata_products_json(
 
     # 2. Backward-compatible fields.
     # No per-vault name override in products.json, so name falls back to the product name.
-    assert meta["name"] == "Euler Prime"
+    assert meta["name"] == meta["product_name"]
     assert meta["description"] is not None
     assert len(meta["description"]) > 0
     assert "lending" in meta["description"].lower()
     # entity is the first element of the product's entity list (backward compat)
-    assert meta["entity"] == "euler-dao"
+    assert meta["entity"] == meta["entities"][0]
 
     # 3. New fields from products.json
-    assert meta["entities"] == ["euler-dao"]
-    assert meta["product"] == "euler-prime"
-    assert meta["product_name"] == "Euler Prime"
+    expected_products = {
+        ("euler-prime", "Euler Prime", ("euler-dao",)),
+        ("k3-prime", "K3 Capital Prime Market", ("k3",)),
+    }
+    assert (meta["product"], meta["product_name"], tuple(meta["entities"])) in expected_products
     assert meta["deprecated"] is False
     assert meta["deprecation_reason"] is None

--- a/tests/rpc/test_multi_provider.py
+++ b/tests/rpc/test_multi_provider.py
@@ -5,13 +5,14 @@ import os
 import pytest
 from web3 import HTTPProvider, Web3
 
+from eth_defi.abi import ZERO_ADDRESS
 from eth_defi.chain import has_graphql_support
 from eth_defi.hotwallet import HotWallet
-from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
-from eth_defi.provider.multi_provider import create_multi_provider_web3, MultiProviderConfigurationError
+from eth_defi.provider import multi_provider as multi_provider_module
+from eth_defi.provider.anvil import AnvilForkMetadata, AnvilLaunch, launch_anvil
+from eth_defi.provider.multi_provider import MultiProviderConfigurationError, create_multi_provider_web3
 from eth_defi.provider.named import get_provider_name
 from eth_defi.trace import assert_transaction_success_with_explanation
-from eth_defi.abi import ZERO_ADDRESS
 from eth_defi.tx import get_tx_broadcast_data
 
 
@@ -132,3 +133,35 @@ def test_multi_provider_transact(anvil):
 
     mev_blocker = web3.get_configured_transact_provider()
     assert mev_blocker.provider_counter == {"call": 3, "transact": 1}
+
+
+def test_multi_provider_anvil_launch_metadata(anvil: AnvilLaunch, monkeypatch: pytest.MonkeyPatch):
+    """Anvil metadata is available in fallback provider diagnostics."""
+
+    metadata = AnvilForkMetadata(
+        chain_id=anvil.chain_id,
+        upstream_rpc_urls=("https://rpc.example.test/api-key",),
+        fork_block_number=12_345,
+        effective_fork_url="http://127.0.0.1:12345",
+    )
+
+    def mock_get_anvil_launch_metadata(json_rpc_url: str) -> AnvilForkMetadata | None:
+        """Return mocked launch metadata for the active local Anvil endpoint."""
+        if json_rpc_url == anvil.json_rpc_url:
+            return metadata
+        return None
+
+    monkeypatch.setattr(
+        multi_provider_module,
+        "_get_anvil_launch_metadata",
+        mock_get_anvil_launch_metadata,
+    )
+
+    web3 = create_multi_provider_web3(anvil.json_rpc_url)
+    provider = web3.get_active_call_provider()
+    context = web3.get_fallback_provider().get_provider_context_for_log(provider)
+
+    assert context["chain_id"] == anvil.chain_id
+    assert context["anvil_upstream_rpc_providers"] == ["rpc.example.test"]
+    assert context["anvil_fork_block_number"] == 12_345
+    assert context["anvil_effective_fork_provider"] == "127.0.0.1:12345"


### PR DESCRIPTION
## Why

Anvil retry warnings only showed the local localhost endpoint, which made it hard to tell which forked chain and upstream RPC providers were involved when a request timed out.

## Lessons learnt

When Web3 is later created from only `AnvilLaunch.json_rpc_url`, the original fork metadata needs to be preserved separately and copied onto the provider used by `FallbackProvider`.

## Summary

- Store Anvil fork metadata, including chain id, upstream RPC URLs, fork block, and effective fork URL.
- Attach stored Anvil metadata to providers created by `create_multi_provider_web3()`.
- Include provider context in retry warnings with sanitised upstream provider domains.
- Add a focused regression test for Anvil metadata in fallback provider diagnostics.
- Ran `source .local-test.env && poetry run pytest tests/rpc/test_multi_provider.py -k 'anvil_launch_metadata or multi_provider_transact'`.