### PR TITLE
feat: Core3 risk intelligence DuckDB pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- feat: Core3 risk intelligence DuckDB pipeline — scan ~1,400 crypto projects for Probability of Loss (PoL) scores, store snapshots and time-series in DuckDB with incremental sync, parallel fetching, and raw JSON payload storage (2026-06-03)
+
 - test(gmx): remove redundant `test_gmx_valuation.py` — required a live archive node (`JSON_RPC_ARBITRUM`) but covered the same on-chain `Reader` + `GMXAPI` path that `test_precision_fork.py` already exercises via a self-contained Anvil fork (2026-05-29)
 
 - feat: External TVL stamping for vaults without on-chain TVL — `stamp_external_tvl()` post-scan step writes point-in-time USD TVL from protocol APIs (ForgeYields), new `tvl_usd` parquet column and `is_historical_tvl_supported()` on `VaultBase` (2026-05-28)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,6 +294,7 @@ Consult these for domain-specific context. Logo READMEs under `eth_defi/data/vau
 | `eth_defi/abi/lagoon/README.md` | Lagoon ABI source links |
 | `eth_defi/abi/uniswap-swap-contracts/README.md` | SwapRouter02 deployment on Base |
 | `eth_defi/cctp/README-cctp.md` | Circle CCTP V2 integration |
+| `eth_defi/core3/README-core3.md` | Core3 risk intelligence integration — modules, database schema, scripts, API reference |
 | `eth_defi/data/vaults/README.md` | Vault protocol metadata and logo system |
 | `eth_defi/erc_4626/vault_protocol/README-reader-states.md` | Vault reader states and warmup system |
 | `eth_defi/erc_4626/vault_protocol/README-utilisation.md` | Utilisation and available liquidity metrics for lending vaults |

--- a/docs/source/api/core3/index.rst
+++ b/docs/source/api/core3/index.rst
@@ -1,0 +1,26 @@
+Core3 risk intelligence API
+---------------------------
+
+`Core3 <https://core3.io/>`__ risk intelligence integration for tracking
+Probability of Loss (PoL) scores across crypto projects.
+
+Core3 (formerly CER.live) provides risk ratings across six categories:
+security, financial, operational, reputational, regulatory, and dependency.
+This module fetches and stores risk data in a local DuckDB database for
+historical tracking.
+
+Features:
+
+- Rate-limited API session with retry logic
+- DuckDB storage with incremental sync (two-phase backfill + ranged updates)
+- Parallel project scanning with ``joblib``
+- Raw JSON payload storage for future re-extraction
+
+.. autosummary::
+   :toctree: _autosummary_core3
+   :recursive:
+
+   eth_defi.core3.session
+   eth_defi.core3.database
+   eth_defi.core3.scanner
+   eth_defi.core3.constants

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -34,6 +34,7 @@ See :ref:`tutorials <tutorials>` for guides and examples on how to use the libra
    one_delta/index
    safe/index
    vault/index
+   core3/index
    feed/index
    erc_4626/index
    enzyme/index

--- a/eth_defi/core3/README-core3.md
+++ b/eth_defi/core3/README-core3.md
@@ -10,6 +10,100 @@ and centralised exchanges, scoring risk on a 0-100 scale where 0 = Exceptional a
 - OpenAPI spec: https://docs.core3.io/api-reference/projects-data-openapi.json
 - Contact: info@core3.io
 
+## Modules
+
+| Module | Description |
+|--------|-------------|
+| `eth_defi.core3.constants` | Shared constants: API URL, database paths, rate limit config, section names |
+| `eth_defi.core3.session` | `Core3Session` (requests.Session subclass) with rate limiting, retry logic, and fetch helpers for all API endpoints |
+| `eth_defi.core3.database` | `Core3Database` — DuckDB persistence with thread-safe inserts, deduplication, sync state watermarks, and query methods |
+| `eth_defi.core3.scanner` | `scan_projects()` orchestrator — parallel fetching with `joblib.Parallel`, incremental sync, error handling |
+
+## Database files
+
+Default location: `~/.tradingstrategy/core3/`
+
+| File | Description |
+|------|-------------|
+| `risk-data.duckdb` | Main DuckDB database with all project snapshots and time-series data |
+| `risk-data.duckdb.wal` | DuckDB write-ahead log (automatically managed) |
+| `rate-limit.sqlite` | SQLite database for thread-safe rate limiting state across `joblib` workers |
+
+### Database tables
+
+| Table | Description |
+|-------|-------------|
+| `project_snapshots` | One row per poll cycle per project — raw JSON payload plus extracted key columns (slug, name, rank, PoL score/rating, market cap) |
+| `section_snapshots` | Optional section detail storage (security, financial, operational, reputational, regulatory) |
+| `pol_daily` | API-native PoL score time-series (sparse timestamps); `__index__` slug for aggregate |
+| `pol_category_daily` | API-native category PoL breakdown time-series (security, financial, operational, reputational, regulatory scores) |
+| `sync_state` | Per-slug watermarks for incremental sync — tracks `last_ts`, `backfill_done`, and `last_synced` |
+
+No PRIMARY KEY or UNIQUE constraints are used due to a DuckDB 1.5.0 ART index crash
+on Python 3.14 + macOS ARM64 ([duckdb#17006](https://github.com/duckdb/duckdb/issues/17006)).
+Deduplication is handled at the application level using DELETE + INSERT via temp tables.
+
+## Scripts
+
+### scan-core3.py — batch scanner
+
+Fetches all Core3 projects and stores snapshots + PoL time-series in DuckDB.
+Supports incremental sync (first run does full backfill, subsequent runs fetch only new data).
+
+```shell
+source .local-test.env && poetry run python scripts/core3/scan-core3.py
+```
+
+| Environment variable | Default | Description |
+|---------------------|---------|-------------|
+| `CORE3_API_KEY` | (required) | Core3 API key (prefixed `core3_`) |
+| `LOG_LEVEL` | `warning` | Logging level: debug, info, warning, error |
+| `DB_PATH` | `~/.tradingstrategy/core3/risk-data.duckdb` | Path to DuckDB database file |
+| `LIMIT` | (none) | Limit number of projects to scan (for testing) |
+| `MAX_WORKERS` | `8` | Maximum number of parallel workers for API fetching |
+| `FETCH_SECTIONS` | `false` | Set to `true` to also fetch section detail endpoints (5 extra API calls per project) |
+
+### core3-overview.py — database inspector
+
+Displays a tabulated overview of the database contents: one row per project with
+rank, PoL score, market cap, snapshot counts, and PoL date ranges.
+
+```shell
+poetry run python scripts/core3/core3-overview.py
+```
+
+| Environment variable | Default | Description |
+|---------------------|---------|-------------|
+| `DB_PATH` | `~/.tradingstrategy/core3/risk-data.duckdb` | Path to DuckDB database file |
+
+### reproduce-duckdb-crash.py — crash reproducer
+
+Standalone DuckDB crash reproducer (no API key needed). Simulates the scanner's data volume
+and threading patterns across 24 scenarios to isolate the SIGSEGV trigger.
+
+```shell
+# Run all scenarios
+poetry run python scripts/core3/reproduce-duckdb-crash.py all
+
+# Run a specific scenario
+poetry run python scripts/core3/reproduce-duckdb-crash.py 12
+```
+
+## Tests
+
+| Test module | Description | Requires API key |
+|-------------|-------------|-----------------|
+| `tests/core3/test_core3_scanner.py` | Integration tests: scan projects, verify snapshots, PoL history, idempotency | Yes (`CORE3_API_KEY`) |
+| `tests/core3/test_core3_database.py` | Offline tests: insert, deduplication, sync state, query methods with synthetic data | No |
+
+```shell
+# Run offline tests (no API key needed)
+source .local-test.env && PYTHONPATH="$(pwd):$PYTHONPATH" poetry run pytest tests/core3/test_core3_database.py -v --timeout=300
+
+# Run integration tests (requires CORE3_API_KEY)
+source .local-test.env && PYTHONPATH="$(pwd):$PYTHONPATH" poetry run pytest tests/core3/test_core3_scanner.py -v --timeout=300
+```
+
 ## API overview
 
 - **Type**: REST / JSON, read-only (all endpoints are `GET`)

--- a/eth_defi/core3/README-core3.md
+++ b/eth_defi/core3/README-core3.md
@@ -1,0 +1,194 @@
+# Core3 projects data API
+
+Core3 (formerly CER.live) is a self-regulatory risk intelligence platform for Web3.
+It provides a standardised **Probability of Loss (PoL)** risk metric for crypto projects
+and centralised exchanges, scoring risk on a 0-100 scale where 0 = Exceptional and
+100 = Critical risk.
+
+- Website: https://core3.io
+- Documentation: https://docs.core3.io
+- OpenAPI spec: https://docs.core3.io/api-reference/projects-data-openapi.json
+- Contact: info@core3.io
+
+## API overview
+
+- **Type**: REST / JSON, read-only (all endpoints are `GET`)
+- **Base URL**: `https://api.core3.io/projects_data`
+- **Version**: All routes under `/v1`
+- **Authentication**: `x-api-key` header, keys prefixed `core3_`
+- **Environment variable**: `CORE3_API_KEY`
+- **Cloudflare**: Requires a `User-Agent` header — requests without one get blocked (HTTP 403, error 1010)
+- **Coverage**: ~1,427 crypto projects as of June 2026
+
+## Key concepts
+
+### Probability of loss (PoL)
+
+A data-driven, non-price risk metric. Does **not** evaluate expected returns or token
+price performance. Scores map to credit-style tiers:
+
+| Rating | PoL range | Meaning |
+|--------|-----------|---------|
+| AAA    | ~0        | Exceptional |
+| AA/A   | Low       | Very low loss probability |
+| BBB/BB/B | Medium  | Moderate, increasing probability |
+| CCC/CC/C | High    | High probability |
+| DDD/DD/D | Very high | Critical risk |
+
+PoL is assessed across six risk categories (each with its own sub-score):
+
+1. **Security** — audits, bug bounty, contract verification, third-party monitoring
+2. **Financial** — revenue sources, treasury quality, token inflation, circulating supply
+3. **Operational** — GitHub activity, team track record, liquidity risks, certifications
+4. **Reputational** — auditor ratings, incident response, red flags, social metrics, insurance
+5. **Regulatory** — KYC/KYT, jurisdiction, legal documentation, team transparency
+6. **Dependency** — bridges, oracles, custody, infrastructure providers
+
+The methodology uses 98 metrics and sub-metrics, combined via a baseline assessment
+module and a contextual adjustment module.
+
+### Proof of voice (PoV)
+
+Expert-authored qualitative reviews: structured pros/cons lists and analyst reviews
+providing human context alongside quantitative PoL data.
+
+### Seals
+
+Verifiable trust marks: `security_measures`, `independent_certificates`, `self_regulation`.
+
+## Endpoints
+
+### Health
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/health` | Liveness check; returns `200` (ok) or `503` |
+
+Response: `{status, info: {database: {status}, cache: {status}}, error, details}`
+
+### Project list and search
+
+| Method | Path | Parameters | Description |
+|--------|------|------------|-------------|
+| GET | `/v1/list` | — | All ~1,427 projects with slug, name, coingecko_id, PoL score |
+| GET | `/v1/search` | `search` (text, required) | Search by name/slug; returns slug, name, ticker, rank, logo, PoL |
+| GET | `/v1/search/trending` | — | Currently trending projects |
+
+### Ratings (paginated + filterable)
+
+| Method | Path | Parameters | Description |
+|--------|------|------------|-------------|
+| GET | `/v1/ratings` | `page` (default 1), `page_size` (default 20, max 50), `sort_by`, `sort_direction`, `categories[]`, `market_cap[]`, `chains[]`, `compliance[]` | Paginated project rankings with PoL, market cap, seals |
+| GET | `/v1/ratings/parameters` | — | Available filter values and sort fields |
+
+Sort fields: `rank` (default), `name`, `certifications`, `market_cap`, `market_cap_change_24h`, `pol`, `data_coverage`, `category`.
+
+Filter options include ~30 categories (Layer 1, DeFi, GameFi, AI, etc.), market cap ranges,
+chain filters, and compliance filters (`audited`, `kyc`).
+
+### Project detail
+
+| Method | Path | Parameters | Description |
+|--------|------|------------|-------------|
+| GET | `/v1/{slug}` | — | Full project profile |
+
+Returns: `slug`, `name`, `description`, `rank`, `pol` (score/rating/confidence), `ticker`,
+`coingecko_id`, `logo`, `link`, `launched_at`, `category`, `data_coverage` (percentage),
+`market_cap` (in_usd, change_24h_percentage, change_24h_in_usd), `chains[]`,
+`links` (website, legal, whitepaper, socials[]), `tags[]`, `top_risks[]` (content, date),
+`recent_changes[]`, `seals`.
+
+### Project section endpoints
+
+All section endpoints take `{slug}` as a path parameter and return
+the section-level PoL sub-score alongside section-specific data.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/{slug}/security` | Audits (token/product), bug bounty, token contract verification, third-party monitoring/prevention |
+| GET | `/v1/{slug}/financial` | Revenue sources, treasury quality (asset distribution, trends, spikes), circulating supply analysis, lockers |
+| GET | `/v1/{slug}/financial/inflation/history/chart` | Inflation history; optional `days` (1-365) |
+| GET | `/v1/{slug}/reputational` | Top auditor rating, past incidents, red flags, social metrics (Twitter, website, Google Trends), insurance |
+| GET | `/v1/{slug}/regulatory` | KYC/KYT, jurisdiction quality, legal presence, team transparency, regulatory status |
+| GET | `/v1/{slug}/operational` | GitHub activity heatmap, team track records, liquidity risks (CEX/DEX quality), documentation links, certifications (ISO 27001, CCSS) |
+| GET | `/v1/{slug}/proof_of_voice` | Pros, cons, expert reviews (reviewer handler, date, text) |
+| GET | `/v1/{slug}/proof_of_voice/history/chart` | PoV sentiment over time (positive/negative %); optional `days` |
+
+### PoL score endpoints
+
+#### Index-level (aggregate across all projects)
+
+| Method | Path | Parameters | Description |
+|--------|------|------------|-------------|
+| GET | `/v1/pol` | — | Current aggregate PoL score |
+| GET | `/v1/pol/history` | `from`, `to` (unix timestamps, required) | Historical PoL points |
+| GET | `/v1/pol/history/chart` | `days` (1-365, optional; omit for all-time) | PoL chart data |
+
+#### Per-project PoL
+
+| Method | Path | Parameters | Description |
+|--------|------|------------|-------------|
+| GET | `/v1/{slug}/pol/current` | — | Current project PoL with rating and confidence |
+| GET | `/v1/{slug}/pol/history` | `from`, `to` | Historical PoL |
+| GET | `/v1/{slug}/pol/history/chart` | `days` | PoL chart |
+| GET | `/v1/{slug}/pol/by_category` | — | PoL broken down by security, financial, operational, reputational, regulatory |
+| GET | `/v1/{slug}/pol/by_category/history` | `from`, `to` | Category breakdown over time |
+| GET | `/v1/{slug}/pol/by_category/history/chart` | `days` | Category chart |
+| GET | `/v1/{slug}/pol/by_metric` | — | PoL broken down by individual metrics with weights |
+| GET | `/v1/{slug}/pol/by_metric/history` | `from`, `to` | Metric-level history |
+| GET | `/v1/{slug}/pol/by_metric/history/chart` | `days` | Metric-level chart |
+
+## Common parameters
+
+- **`{slug}`**: Project identifier string (e.g. `ethereum`, `aave`, `bitcoin`). Matches CoinGecko IDs in most cases.
+- **`from`, `to`**: Unix timestamps in seconds (inclusive range). Required for `/history` endpoints.
+- **`days`**: Integer 1-365. Optional for `/history/chart` endpoints; omit for all-time data.
+
+## Response format
+
+All responses are JSON. Key shared types:
+
+```
+PolDto {
+  score: number       // 0-100, lower = less risk
+  rating: string|null // "AAA", "AA", "A", "BBB", ..., "D", or null
+  confidence: string|null // "Exceptional", "High", "Medium", "Low", "Critical", or null
+}
+```
+
+History/chart endpoints return `{points: [{score, timestamp}, ...]}` where `timestamp`
+is a unix timestamp in seconds.
+
+## Example usage
+
+```bash
+# Health check
+curl -sS "https://api.core3.io/projects_data/v1/health" \
+  -H "x-api-key: $CORE3_API_KEY" \
+  -H "User-Agent: eth-defi"
+
+# Get Ethereum project detail
+curl -sS "https://api.core3.io/projects_data/v1/ethereum" \
+  -H "x-api-key: $CORE3_API_KEY" \
+  -H "User-Agent: eth-defi"
+
+# Get PoL breakdown by category
+curl -sS "https://api.core3.io/projects_data/v1/ethereum/pol/by_category" \
+  -H "x-api-key: $CORE3_API_KEY" \
+  -H "User-Agent: eth-defi"
+
+# Ratings with filtering
+curl -sS "https://api.core3.io/projects_data/v1/ratings?page=1&page_size=10&sort_by=pol&sort_direction=ASC" \
+  -H "x-api-key: $CORE3_API_KEY" \
+  -H "User-Agent: eth-defi"
+```
+
+## Notes and quirks
+
+- The API is behind Cloudflare. A `User-Agent` header is **required** or requests fail with HTTP 403 / error code 1010.
+- The `/v1/list` endpoint returns all ~1,427 projects in a single response (not paginated). Only `/v1/ratings` is paginated.
+- Many fields are nullable. For less-covered projects, section data may be mostly `null`.
+- The `by_metric` endpoint currently returns duplicated metric entries (observed for Ethereum) — this appears to be an API bug.
+- Market cap values are returned as strings (`"226130642842"`), not numbers.
+- The `link` field in project detail has a malformed URL (e.g. `https://core3.ioethereum` missing a `/`).
+- There is also a separate **Exchanges Data API** (`/exchanges_data`) for centralised exchange risk assessment, documented at https://docs.core3.io/exchanges-data-api.md with its own OpenAPI spec.

--- a/eth_defi/core3/__init__.py
+++ b/eth_defi/core3/__init__.py
@@ -1,0 +1,11 @@
+"""Core3 risk intelligence integration.
+
+This module provides tools for fetching and storing risk data from the
+`Core3 <https://core3.io>`__ Probability of Loss (PoL) API. Core3 scores
+~1,427 crypto projects on a 0–100 risk scale across security, financial,
+operational, reputational, and regulatory categories.
+
+See :py:mod:`eth_defi.core3.session` for HTTP session management,
+:py:mod:`eth_defi.core3.database` for DuckDB storage, and
+:py:mod:`eth_defi.core3.scanner` for the scan orchestrator.
+"""

--- a/eth_defi/core3/constants.py
+++ b/eth_defi/core3/constants.py
@@ -1,0 +1,39 @@
+"""Shared constants for Core3 integration.
+
+Centralises API URLs, default paths, and configuration values used
+by :py:mod:`eth_defi.core3.session`, :py:mod:`eth_defi.core3.database`,
+and :py:mod:`eth_defi.core3.scanner`.
+"""
+
+from pathlib import Path
+
+#: Core3 Projects Data API base URL.
+#:
+#: All endpoint paths are appended to this, e.g. ``CORE3_API_URL + "/v1/list"``.
+CORE3_API_URL: str = "https://api.core3.io/projects_data"
+
+#: Default DuckDB path for Core3 risk data.
+CORE3_DATABASE_PATH: Path = Path("~/.tradingstrategy/core3/risk-data.duckdb").expanduser()
+
+#: Default SQLite database path for rate limiting state.
+#:
+#: Using SQLite ensures thread-safe rate limiting across multiple threads
+#: when using ``joblib.Parallel`` or similar parallel processing.
+CORE3_RATE_LIMIT_SQLITE_DATABASE: Path = Path("~/.tradingstrategy/core3/rate-limit.sqlite").expanduser()
+
+#: Default requests per second.
+#:
+#: Conservative; Core3 docs do not specify a quota. The API is behind
+#: Cloudflare so aggressive rates may trigger blocks.
+CORE3_DEFAULT_REQUESTS_PER_SECOND: float = 5.0
+
+#: User-Agent header required by Cloudflare.
+#:
+#: Requests without a User-Agent get blocked with HTTP 403 / error code 1010.
+CORE3_USER_AGENT: str = "eth-defi/core3"
+
+#: Project detail sections available for section snapshot fetching.
+SECTIONS: tuple[str, ...] = ("security", "financial", "operational", "reputational", "regulatory")
+
+#: Special slug used for the index-level aggregate PoL in the ``pol_daily`` table.
+INDEX_SLUG: str = "__index__"

--- a/eth_defi/core3/constants.py
+++ b/eth_defi/core3/constants.py
@@ -15,12 +15,6 @@ CORE3_API_URL: str = "https://api.core3.io/projects_data"
 #: Default DuckDB path for Core3 risk data.
 CORE3_DATABASE_PATH: Path = Path("~/.tradingstrategy/core3/risk-data.duckdb").expanduser()
 
-#: Default SQLite database path for rate limiting state.
-#:
-#: Using SQLite ensures thread-safe rate limiting across multiple threads
-#: when using ``joblib.Parallel`` or similar parallel processing.
-CORE3_RATE_LIMIT_SQLITE_DATABASE: Path = Path("~/.tradingstrategy/core3/rate-limit.sqlite").expanduser()
-
 #: Default requests per second.
 #:
 #: Conservative; Core3 docs do not specify a quota. The API is behind

--- a/eth_defi/core3/constants.py
+++ b/eth_defi/core3/constants.py
@@ -15,6 +15,12 @@ CORE3_API_URL: str = "https://api.core3.io/projects_data"
 #: Default DuckDB path for Core3 risk data.
 CORE3_DATABASE_PATH: Path = Path("~/.tradingstrategy/core3/risk-data.duckdb").expanduser()
 
+#: Default SQLite database path for rate limiting state.
+#:
+#: Using SQLite ensures thread-safe rate limiting across multiple threads
+#: when using ``joblib.Parallel`` or similar parallel processing.
+CORE3_RATE_LIMIT_SQLITE_DATABASE: Path = Path("~/.tradingstrategy/core3/rate-limit.sqlite").expanduser()
+
 #: Default requests per second.
 #:
 #: Conservative; Core3 docs do not specify a quota. The API is behind

--- a/eth_defi/core3/database.py
+++ b/eth_defi/core3/database.py
@@ -102,6 +102,15 @@ class Core3Database:
         self.path = path
         self.con = duckdb.connect(str(path))
         self._db_lock = threading.Lock()
+
+        # Disable automatic WAL checkpoint (default 16 MiB).
+        # When the scanner runs with ThreadPoolExecutor, auto-checkpoint
+        # can trigger inside an INSERT while worker threads are alive,
+        # causing heap corruption on Python 3.14 + DuckDB 1.5.
+        # We do a manual CHECKPOINT via save() after all threads exit.
+        # See: https://github.com/duckdb/duckdb/issues/17006
+        self.con.execute("SET wal_autocheckpoint = '1TB'")
+
         self._init_schema()
 
     def __del__(self):
@@ -110,7 +119,18 @@ class Core3Database:
             self.con = None
 
     def _init_schema(self):
-        """Create all tables if they don't exist."""
+        """Create all tables if they don't exist.
+
+        No PRIMARY KEY or UNIQUE constraints are used because DuckDB 1.5.0's
+        ART index (used for unique constraint enforcement) causes SIGSEGV
+        (heap corruption in ``tiny_malloc_should_clear``) on file-backed
+        databases with Python 3.14 + macOS ARM64 when enough rows accumulate.
+
+        Deduplication is handled at the application level using DELETE + INSERT
+        instead of ``ON CONFLICT``.
+
+        See `duckdb#17006 <https://github.com/duckdb/duckdb/issues/17006>`__.
+        """
 
         self.con.execute("""
             CREATE TABLE IF NOT EXISTS project_snapshots (
@@ -121,8 +141,7 @@ class Core3Database:
                 pol_score DOUBLE,
                 pol_rating VARCHAR,
                 market_cap_usd VARCHAR,
-                payload VARCHAR NOT NULL,
-                PRIMARY KEY (slug, fetched_at)
+                payload VARCHAR NOT NULL
             )
         """)
 
@@ -132,8 +151,7 @@ class Core3Database:
                 section VARCHAR NOT NULL,
                 fetched_at TIMESTAMP NOT NULL,
                 section_pol_score DOUBLE,
-                payload VARCHAR NOT NULL,
-                PRIMARY KEY (slug, section, fetched_at)
+                payload VARCHAR NOT NULL
             )
         """)
 
@@ -142,8 +160,7 @@ class Core3Database:
                 slug VARCHAR NOT NULL,
                 ts TIMESTAMP NOT NULL,
                 pol_score DOUBLE NOT NULL,
-                fetched_at TIMESTAMP NOT NULL,
-                PRIMARY KEY (slug, ts)
+                fetched_at TIMESTAMP NOT NULL
             )
         """)
 
@@ -156,8 +173,7 @@ class Core3Database:
                 operational_score DOUBLE,
                 reputational_score DOUBLE,
                 regulatory_score DOUBLE,
-                fetched_at TIMESTAMP NOT NULL,
-                PRIMARY KEY (slug, ts)
+                fetched_at TIMESTAMP NOT NULL
             )
         """)
 
@@ -167,17 +183,38 @@ class Core3Database:
                 data_type VARCHAR NOT NULL,
                 last_ts BIGINT,
                 backfill_done BOOLEAN NOT NULL DEFAULT FALSE,
-                last_synced TIMESTAMP NOT NULL,
-                PRIMARY KEY (slug, data_type)
+                last_synced TIMESTAMP NOT NULL
             )
         """)
 
     def close(self):
-        """Close the database connection."""
+        """Close the database connection.
+
+        DuckDB performs an implicit checkpoint on close, flushing
+        the WAL to the main database file.
+        """
         logger.info("Closing Core3 database at %s", self.path)
         if self.con is not None:
             self.con.close()
             self.con = None
+
+    def reconnect(self):
+        """Close and reopen the database connection.
+
+        Used to flush writes between chunks when DuckDB CHECKPOINT
+        cannot be called safely (e.g. threading issues with
+        Python 3.14 + DuckDB 1.5, see `duckdb#13904
+        <https://github.com/duckdb/duckdb/issues/13904>`__).
+
+        DuckDB checkpoints implicitly on close, so this is equivalent
+        to ``save()`` followed by reopening the connection.
+        """
+        import duckdb
+
+        if self.con is not None:
+            self.con.close()
+        self.con = duckdb.connect(str(self.path))
+        self.con.execute("SET wal_autocheckpoint = '1TB'")
 
     def save(self):
         """Force a checkpoint to ensure data is persisted to disk."""
@@ -214,17 +251,13 @@ class Core3Database:
 
         with self._db_lock:
             self.con.execute(
+                "DELETE FROM project_snapshots WHERE slug = ? AND fetched_at = ?",
+                [slug, fetched_at],
+            )
+            self.con.execute(
                 """
                 INSERT INTO project_snapshots (slug, fetched_at, name, rank, pol_score, pol_rating, market_cap_usd, payload)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT (slug, fetched_at)
-                DO UPDATE SET
-                    name = EXCLUDED.name,
-                    rank = EXCLUDED.rank,
-                    pol_score = EXCLUDED.pol_score,
-                    pol_rating = EXCLUDED.pol_rating,
-                    market_cap_usd = EXCLUDED.market_cap_usd,
-                    payload = EXCLUDED.payload
                 """,
                 [
                     slug,
@@ -263,13 +296,13 @@ class Core3Database:
 
         with self._db_lock:
             self.con.execute(
+                "DELETE FROM section_snapshots WHERE slug = ? AND section = ? AND fetched_at = ?",
+                [slug, section, fetched_at],
+            )
+            self.con.execute(
                 """
                 INSERT INTO section_snapshots (slug, section, fetched_at, section_pol_score, payload)
                 VALUES (?, ?, ?, ?, ?)
-                ON CONFLICT (slug, section, fetched_at)
-                DO UPDATE SET
-                    section_pol_score = EXCLUDED.section_pol_score,
-                    payload = EXCLUDED.payload
                 """,
                 [
                     slug,
@@ -289,7 +322,8 @@ class Core3Database:
         """Insert PoL daily history points, deduplicating on ``(slug, ts)``.
 
         Converts unix timestamps from the API to naive UTC datetimes.
-        Uses ``ON CONFLICT DO NOTHING`` for idempotent inserts.
+        Deduplication uses a temp table with DELETE + INSERT instead of
+        ``ON CONFLICT`` to avoid DuckDB 1.5.0 ART index crashes.
 
         :param slug:
             Project slug (or :py:data:`~eth_defi.core3.constants.INDEX_SLUG`
@@ -309,14 +343,11 @@ class Core3Database:
         with self._db_lock:
             before = self.con.execute("SELECT COUNT(*) FROM pol_daily WHERE slug = ?", [slug]).fetchone()[0]
 
-            self.con.executemany(
-                """
-                INSERT INTO pol_daily (slug, ts, pol_score, fetched_at)
-                VALUES (?, ?, ?, ?)
-                ON CONFLICT (slug, ts) DO NOTHING
-                """,
-                rows,
-            )
+            self.con.execute("CREATE TEMP TABLE IF NOT EXISTS _tmp_pol (slug VARCHAR, ts TIMESTAMP, pol_score DOUBLE, fetched_at TIMESTAMP)")
+            self.con.execute("DELETE FROM _tmp_pol")
+            self.con.executemany("INSERT INTO _tmp_pol VALUES (?, ?, ?, ?)", rows)
+            self.con.execute("DELETE FROM pol_daily p USING _tmp_pol t WHERE p.slug = t.slug AND p.ts = t.ts")
+            self.con.execute("INSERT INTO pol_daily SELECT * FROM _tmp_pol")
 
             after = self.con.execute("SELECT COUNT(*) FROM pol_daily WHERE slug = ?", [slug]).fetchone()[0]
 
@@ -364,15 +395,14 @@ class Core3Database:
         with self._db_lock:
             before = self.con.execute("SELECT COUNT(*) FROM pol_category_daily WHERE slug = ?", [slug]).fetchone()[0]
 
-            self.con.executemany(
-                """
-                INSERT INTO pol_category_daily (slug, ts, security_score, financial_score,
-                    operational_score, reputational_score, regulatory_score, fetched_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT (slug, ts) DO NOTHING
-                """,
-                rows,
-            )
+            self.con.execute("""CREATE TEMP TABLE IF NOT EXISTS _tmp_cat (
+                slug VARCHAR, ts TIMESTAMP, security_score DOUBLE, financial_score DOUBLE,
+                operational_score DOUBLE, reputational_score DOUBLE, regulatory_score DOUBLE,
+                fetched_at TIMESTAMP)""")
+            self.con.execute("DELETE FROM _tmp_cat")
+            self.con.executemany("INSERT INTO _tmp_cat VALUES (?, ?, ?, ?, ?, ?, ?, ?)", rows)
+            self.con.execute("DELETE FROM pol_category_daily p USING _tmp_cat t WHERE p.slug = t.slug AND p.ts = t.ts")
+            self.con.execute("INSERT INTO pol_category_daily SELECT * FROM _tmp_cat")
 
             after = self.con.execute("SELECT COUNT(*) FROM pol_category_daily WHERE slug = ?", [slug]).fetchone()[0]
 
@@ -432,14 +462,13 @@ class Core3Database:
         now = native_datetime_utc_now()
         with self._db_lock:
             self.con.execute(
+                "DELETE FROM sync_state WHERE slug = ? AND data_type = ?",
+                [slug, data_type],
+            )
+            self.con.execute(
                 """
                 INSERT INTO sync_state (slug, data_type, last_ts, backfill_done, last_synced)
                 VALUES (?, ?, ?, ?, ?)
-                ON CONFLICT (slug, data_type)
-                DO UPDATE SET
-                    last_ts = EXCLUDED.last_ts,
-                    backfill_done = EXCLUDED.backfill_done,
-                    last_synced = EXCLUDED.last_synced
                 """,
                 [slug, data_type, last_ts, backfill_done, now],
             )

--- a/eth_defi/core3/database.py
+++ b/eth_defi/core3/database.py
@@ -1,0 +1,537 @@
+"""DuckDB persistence for Core3 risk intelligence data.
+
+Stores project snapshots, PoL time-series, category breakdowns, and
+section details. Supports incremental sync using watermarks in the
+``sync_state`` table.
+
+Schema
+------
+
+Five tables:
+
+- ``project_snapshots`` — one row per poll cycle per project; raw JSON
+  payload plus extracted key columns (rank, PoL score, market cap)
+- ``section_snapshots`` — optional section detail storage (security,
+  financial, etc.)
+- ``pol_daily`` — API-native PoL score time-series (sparse timestamps)
+- ``pol_category_daily`` — API-native category PoL breakdown time-series
+- ``sync_state`` — per-slug watermarks for incremental sync
+
+Thread safety: all database operations are protected by an internal lock.
+Multiple threads can call insert methods concurrently — the API calls
+run in parallel while database writes are serialised.
+
+Storage location
+----------------
+
+Default: ``~/.tradingstrategy/core3/risk-data.duckdb``
+
+Example::
+
+    from pathlib import Path
+    from eth_defi.core3.database import Core3Database
+
+    db = Core3Database(Path("/tmp/core3-risk.duckdb"))
+    # ... insert data ...
+    db.save()
+    db.close()
+"""
+
+import datetime
+import json
+import logging
+import threading
+from pathlib import Path
+
+import pandas as pd
+
+from eth_defi.compat import native_datetime_utc_now
+
+logger = logging.getLogger(__name__)
+
+
+def _unix_ts_to_naive_utc(ts: int | float) -> datetime.datetime:
+    """Convert a unix timestamp to a naive UTC datetime.
+
+    Avoids ``datetime.fromtimestamp()`` which applies local timezone,
+    and ``datetime.utcfromtimestamp()`` which is deprecated in Python 3.12+.
+
+    :param ts:
+        Unix timestamp in seconds.
+    :return:
+        Naive UTC datetime.
+    """
+    return datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=int(ts))
+
+
+class Core3Database:
+    """DuckDB database for storing Core3 risk intelligence data.
+
+    Stores project snapshots, PoL time-series, category breakdowns,
+    and section details. Supports incremental sync using watermarks
+    in the ``sync_state`` table.
+
+    Thread safety: all database operations are protected by
+    :py:attr:`_db_lock`. Multiple threads can call insert methods
+    concurrently — the API calls run in parallel while database
+    writes are serialised.
+
+    Example::
+
+        from pathlib import Path
+        from eth_defi.core3.database import Core3Database
+
+        db = Core3Database(Path("/tmp/core3-risk.duckdb"))
+        db.save()
+        db.close()
+    """
+
+    def __init__(self, path: Path):
+        """Initialise the database connection.
+
+        :param path:
+            Path to the DuckDB file. Parent directories will be created if needed.
+        """
+        assert isinstance(path, Path), f"Expected Path for path, got {type(path)}"
+        assert not path.is_dir(), f"Expected file path, got directory: {path}"
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        import duckdb
+
+        self.path = path
+        self.con = duckdb.connect(str(path))
+        self._db_lock = threading.Lock()
+        self._init_schema()
+
+    def __del__(self):
+        if hasattr(self, "con") and self.con is not None:
+            self.con.close()
+            self.con = None
+
+    def _init_schema(self):
+        """Create all tables if they don't exist."""
+
+        self.con.execute("""
+            CREATE TABLE IF NOT EXISTS project_snapshots (
+                slug VARCHAR NOT NULL,
+                fetched_at TIMESTAMP NOT NULL,
+                name VARCHAR,
+                rank INTEGER,
+                pol_score DOUBLE,
+                pol_rating VARCHAR,
+                market_cap_usd VARCHAR,
+                payload VARCHAR NOT NULL,
+                PRIMARY KEY (slug, fetched_at)
+            )
+        """)
+
+        self.con.execute("""
+            CREATE TABLE IF NOT EXISTS section_snapshots (
+                slug VARCHAR NOT NULL,
+                section VARCHAR NOT NULL,
+                fetched_at TIMESTAMP NOT NULL,
+                section_pol_score DOUBLE,
+                payload VARCHAR NOT NULL,
+                PRIMARY KEY (slug, section, fetched_at)
+            )
+        """)
+
+        self.con.execute("""
+            CREATE TABLE IF NOT EXISTS pol_daily (
+                slug VARCHAR NOT NULL,
+                ts TIMESTAMP NOT NULL,
+                pol_score DOUBLE NOT NULL,
+                fetched_at TIMESTAMP NOT NULL,
+                PRIMARY KEY (slug, ts)
+            )
+        """)
+
+        self.con.execute("""
+            CREATE TABLE IF NOT EXISTS pol_category_daily (
+                slug VARCHAR NOT NULL,
+                ts TIMESTAMP NOT NULL,
+                security_score DOUBLE,
+                financial_score DOUBLE,
+                operational_score DOUBLE,
+                reputational_score DOUBLE,
+                regulatory_score DOUBLE,
+                fetched_at TIMESTAMP NOT NULL,
+                PRIMARY KEY (slug, ts)
+            )
+        """)
+
+        self.con.execute("""
+            CREATE TABLE IF NOT EXISTS sync_state (
+                slug VARCHAR NOT NULL,
+                data_type VARCHAR NOT NULL,
+                last_ts BIGINT,
+                backfill_done BOOLEAN NOT NULL DEFAULT FALSE,
+                last_synced TIMESTAMP NOT NULL,
+                PRIMARY KEY (slug, data_type)
+            )
+        """)
+
+    def close(self):
+        """Close the database connection."""
+        logger.info("Closing Core3 database at %s", self.path)
+        if self.con is not None:
+            self.con.close()
+            self.con = None
+
+    def save(self):
+        """Force a checkpoint to ensure data is persisted to disk."""
+        with self._db_lock:
+            if self.con is not None:
+                self.con.execute("CHECKPOINT")
+
+    # ------------------------------------------------------------------
+    # Insert methods
+    # ------------------------------------------------------------------
+
+    def insert_project_snapshot(
+        self,
+        slug: str,
+        fetched_at: datetime.datetime,
+        raw_json: dict,
+    ) -> None:
+        """Insert a project snapshot, extracting key columns from the raw JSON.
+
+        Extracts ``name``, ``rank``, ``pol.score``, ``pol.rating``, and
+        ``market_cap.in_usd`` from the raw JSON payload. Stores the full
+        JSON as a VARCHAR for future re-extraction if the schema changes.
+
+        :param slug:
+            Project slug.
+        :param fetched_at:
+            Timestamp of when the data was fetched.
+        :param raw_json:
+            Full JSON response from ``/v1/{slug}``.
+        """
+        pol = raw_json.get("pol") or {}
+        market_cap = raw_json.get("market_cap") or {}
+        market_cap_usd = market_cap.get("in_usd")
+
+        with self._db_lock:
+            self.con.execute(
+                """
+                INSERT INTO project_snapshots (slug, fetched_at, name, rank, pol_score, pol_rating, market_cap_usd, payload)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (slug, fetched_at)
+                DO UPDATE SET
+                    name = EXCLUDED.name,
+                    rank = EXCLUDED.rank,
+                    pol_score = EXCLUDED.pol_score,
+                    pol_rating = EXCLUDED.pol_rating,
+                    market_cap_usd = EXCLUDED.market_cap_usd,
+                    payload = EXCLUDED.payload
+                """,
+                [
+                    slug,
+                    fetched_at,
+                    raw_json.get("name"),
+                    raw_json.get("rank"),
+                    pol.get("score"),
+                    pol.get("rating"),
+                    str(market_cap_usd) if market_cap_usd is not None else None,
+                    json.dumps(raw_json),
+                ],
+            )
+
+    def insert_section_snapshot(
+        self,
+        slug: str,
+        section: str,
+        fetched_at: datetime.datetime,
+        raw_json: dict,
+    ) -> None:
+        """Insert a section snapshot.
+
+        Extracts ``pol.score`` from the section response as the
+        section-level PoL sub-score.
+
+        :param slug:
+            Project slug.
+        :param section:
+            Section name (security, financial, etc.).
+        :param fetched_at:
+            Fetch timestamp.
+        :param raw_json:
+            Full section JSON response.
+        """
+        pol = raw_json.get("pol") or {}
+
+        with self._db_lock:
+            self.con.execute(
+                """
+                INSERT INTO section_snapshots (slug, section, fetched_at, section_pol_score, payload)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT (slug, section, fetched_at)
+                DO UPDATE SET
+                    section_pol_score = EXCLUDED.section_pol_score,
+                    payload = EXCLUDED.payload
+                """,
+                [
+                    slug,
+                    section,
+                    fetched_at,
+                    pol.get("score"),
+                    json.dumps(raw_json),
+                ],
+            )
+
+    def insert_pol_daily_points(
+        self,
+        slug: str,
+        points: list[dict],
+        fetched_at: datetime.datetime,
+    ) -> int:
+        """Insert PoL daily history points, deduplicating on ``(slug, ts)``.
+
+        Converts unix timestamps from the API to naive UTC datetimes.
+        Uses ``ON CONFLICT DO NOTHING`` for idempotent inserts.
+
+        :param slug:
+            Project slug (or :py:data:`~eth_defi.core3.constants.INDEX_SLUG`
+            for the aggregate index).
+        :param points:
+            List of ``{score, timestamp}`` dicts from the API.
+        :param fetched_at:
+            When this data was fetched.
+        :return:
+            Number of new rows inserted.
+        """
+        if not points:
+            return 0
+
+        rows = [(slug, _unix_ts_to_naive_utc(p["timestamp"]), p["score"], fetched_at) for p in points]
+
+        with self._db_lock:
+            before = self.con.execute("SELECT COUNT(*) FROM pol_daily WHERE slug = ?", [slug]).fetchone()[0]
+
+            self.con.executemany(
+                """
+                INSERT INTO pol_daily (slug, ts, pol_score, fetched_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT (slug, ts) DO NOTHING
+                """,
+                rows,
+            )
+
+            after = self.con.execute("SELECT COUNT(*) FROM pol_daily WHERE slug = ?", [slug]).fetchone()[0]
+
+        return int(after - before)
+
+    def insert_pol_category_daily_points(
+        self,
+        slug: str,
+        points: list[dict],
+        fetched_at: datetime.datetime,
+    ) -> int:
+        """Insert category PoL daily breakdown points.
+
+        Each point contains a ``timestamp`` and per-category PoL scores
+        (``security.score``, ``financial.score``, etc.).
+
+        :param slug:
+            Project slug.
+        :param points:
+            List of point dicts from the category history API.
+        :param fetched_at:
+            When this data was fetched.
+        :return:
+            Number of new rows inserted.
+        """
+        if not points:
+            return 0
+
+        rows = []
+        for p in points:
+            ts = _unix_ts_to_naive_utc(p["timestamp"])
+            rows.append(
+                (
+                    slug,
+                    ts,
+                    (p.get("security") or {}).get("score"),
+                    (p.get("financial") or {}).get("score"),
+                    (p.get("operational") or {}).get("score"),
+                    (p.get("reputational") or {}).get("score"),
+                    (p.get("regulatory") or {}).get("score"),
+                    fetched_at,
+                )
+            )
+
+        with self._db_lock:
+            before = self.con.execute("SELECT COUNT(*) FROM pol_category_daily WHERE slug = ?", [slug]).fetchone()[0]
+
+            self.con.executemany(
+                """
+                INSERT INTO pol_category_daily (slug, ts, security_score, financial_score,
+                    operational_score, reputational_score, regulatory_score, fetched_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (slug, ts) DO NOTHING
+                """,
+                rows,
+            )
+
+            after = self.con.execute("SELECT COUNT(*) FROM pol_category_daily WHERE slug = ?", [slug]).fetchone()[0]
+
+        return int(after - before)
+
+    # ------------------------------------------------------------------
+    # Sync state
+    # ------------------------------------------------------------------
+
+    def get_sync_state(self, slug: str, data_type: str) -> dict | None:
+        """Get sync state for a specific slug and data type.
+
+        :param slug:
+            Project slug.
+        :param data_type:
+            Data type key (e.g. ``'pol_daily'``, ``'pol_category_daily'``).
+        :return:
+            Dict with ``last_ts``, ``backfill_done``, and ``last_synced``,
+            or ``None`` if no state exists.
+        """
+        with self._db_lock:
+            row = self.con.execute(
+                "SELECT last_ts, backfill_done, last_synced FROM sync_state WHERE slug = ? AND data_type = ?",
+                [slug, data_type],
+            ).fetchone()
+
+        if row is None:
+            return None
+        return {"last_ts": row[0], "backfill_done": row[1], "last_synced": row[2]}
+
+    def update_sync_state(
+        self,
+        slug: str,
+        data_type: str,
+        last_ts: int | None,
+        backfill_done: bool = True,
+    ) -> None:
+        """Update or insert sync state watermark.
+
+        Always updates ``last_synced`` to now, even when ``last_ts`` is
+        unchanged (zero new points). Sets ``backfill_done=TRUE`` after
+        the initial chart backfill.
+
+        When ``backfill_done`` is ``TRUE`` but ``last_ts`` is ``NULL``,
+        subsequent runs use incremental with ``from=0`` (epoch), which
+        is effectively a full range but avoids re-calling the chart endpoint.
+
+        :param slug:
+            Project slug.
+        :param data_type:
+            Data type key.
+        :param last_ts:
+            Latest unix timestamp in the synced data, or ``None`` if empty.
+        :param backfill_done:
+            Whether the initial backfill has been attempted.
+        """
+        now = native_datetime_utc_now()
+        with self._db_lock:
+            self.con.execute(
+                """
+                INSERT INTO sync_state (slug, data_type, last_ts, backfill_done, last_synced)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT (slug, data_type)
+                DO UPDATE SET
+                    last_ts = EXCLUDED.last_ts,
+                    backfill_done = EXCLUDED.backfill_done,
+                    last_synced = EXCLUDED.last_synced
+                """,
+                [slug, data_type, last_ts, backfill_done, now],
+            )
+
+    # ------------------------------------------------------------------
+    # Query methods
+    # ------------------------------------------------------------------
+
+    def get_latest_project_snapshots(self) -> pd.DataFrame:
+        """Get the most recent snapshot for each project.
+
+        :return:
+            DataFrame with the latest snapshot per slug, ordered by rank.
+        """
+        with self._db_lock:
+            return self.con.execute("""
+                    SELECT ps.*
+                    FROM project_snapshots ps
+                    INNER JOIN (
+                        SELECT slug, MAX(fetched_at) AS max_fetched_at
+                        FROM project_snapshots
+                        GROUP BY slug
+                    ) latest ON ps.slug = latest.slug AND ps.fetched_at = latest.max_fetched_at
+                    ORDER BY ps.rank NULLS LAST
+                """).df()
+
+    def get_project_snapshot_history(self, slug: str) -> pd.DataFrame:
+        """Get all snapshots for a specific project over time.
+
+        :param slug:
+            Project slug.
+        :return:
+            DataFrame ordered by fetched_at.
+        """
+        with self._db_lock:
+            return self.con.execute(
+                "SELECT * FROM project_snapshots WHERE slug = ? ORDER BY fetched_at",
+                [slug],
+            ).df()
+
+    def get_pol_daily(self, slug: str) -> pd.DataFrame:
+        """Get daily PoL time-series for a project.
+
+        :param slug:
+            Project slug (or :py:data:`~eth_defi.core3.constants.INDEX_SLUG`
+            for the aggregate).
+        :return:
+            DataFrame with ``ts`` and ``pol_score`` columns, ordered by ``ts``.
+        """
+        with self._db_lock:
+            return self.con.execute(
+                "SELECT * FROM pol_daily WHERE slug = ? ORDER BY ts",
+                [slug],
+            ).df()
+
+    def get_pol_category_daily(self, slug: str) -> pd.DataFrame:
+        """Get daily category PoL breakdown for a project.
+
+        :param slug:
+            Project slug.
+        :return:
+            DataFrame with ``ts`` and category score columns.
+        """
+        with self._db_lock:
+            return self.con.execute(
+                "SELECT * FROM pol_category_daily WHERE slug = ? ORDER BY ts",
+                [slug],
+            ).df()
+
+    def get_project_count(self) -> int:
+        """Get number of unique projects in the database.
+
+        :return:
+            Count of unique slugs in ``project_snapshots``.
+        """
+        with self._db_lock:
+            return int(self.con.execute("SELECT COUNT(DISTINCT slug) FROM project_snapshots").fetchone()[0])
+
+    def get_snapshot_count(self) -> int:
+        """Get total number of project snapshot records.
+
+        :return:
+            Total count of rows in ``project_snapshots``.
+        """
+        with self._db_lock:
+            return int(self.con.execute("SELECT COUNT(*) FROM project_snapshots").fetchone()[0])
+
+    def get_pol_daily_count(self) -> int:
+        """Get total number of PoL daily records.
+
+        :return:
+            Total count of rows in ``pol_daily``.
+        """
+        with self._db_lock:
+            return int(self.con.execute("SELECT COUNT(*) FROM pol_daily").fetchone()[0])

--- a/eth_defi/core3/database.py
+++ b/eth_defi/core3/database.py
@@ -104,10 +104,10 @@ class Core3Database:
         self._db_lock = threading.Lock()
 
         # Disable automatic WAL checkpoint (default 16 MiB).
-        # When the scanner runs with ThreadPoolExecutor, auto-checkpoint
-        # can trigger inside an INSERT while worker threads are alive,
-        # causing heap corruption on Python 3.14 + DuckDB 1.5.
-        # We do a manual CHECKPOINT via save() after all threads exit.
+        # DuckDB 1.5.0 has ART index heap corruption on file-backed DBs
+        # with Python 3.14 + macOS ARM64. We removed PRIMARY KEY constraints
+        # as a workaround, but also disable auto-checkpoint as a defensive
+        # measure. Manual CHECKPOINT via save() after all writes complete.
         # See: https://github.com/duckdb/duckdb/issues/17006
         self.con.execute("SET wal_autocheckpoint = '1TB'")
 
@@ -197,24 +197,6 @@ class Core3Database:
         if self.con is not None:
             self.con.close()
             self.con = None
-
-    def reconnect(self):
-        """Close and reopen the database connection.
-
-        Used to flush writes between chunks when DuckDB CHECKPOINT
-        cannot be called safely (e.g. threading issues with
-        Python 3.14 + DuckDB 1.5, see `duckdb#13904
-        <https://github.com/duckdb/duckdb/issues/13904>`__).
-
-        DuckDB checkpoints implicitly on close, so this is equivalent
-        to ``save()`` followed by reopening the connection.
-        """
-        import duckdb
-
-        if self.con is not None:
-            self.con.close()
-        self.con = duckdb.connect(str(self.path))
-        self.con.execute("SET wal_autocheckpoint = '1TB'")
 
     def save(self):
         """Force a checkpoint to ensure data is persisted to disk."""

--- a/eth_defi/core3/scanner.py
+++ b/eth_defi/core3/scanner.py
@@ -22,6 +22,7 @@ Example usage::
 import datetime
 import logging
 import time
+from collections.abc import Callable
 from pathlib import Path
 
 import requests
@@ -47,16 +48,50 @@ from eth_defi.core3.session import (
 logger = logging.getLogger(__name__)
 
 
+def _safe_fetch(slug: str, endpoint: str, fn: Callable):
+    """Call *fn* and return the result, or ``None`` on recoverable errors.
+
+    401/403 errors are re-raised (auth / Cloudflare block).
+    All other HTTP, network, and parse errors are logged and swallowed
+    so the scan can continue with the remaining endpoints.
+
+    :param slug:
+        Project slug (for log messages).
+    :param endpoint:
+        Human-readable endpoint name (for log messages).
+    :param fn:
+        Zero-argument callable that performs the fetch (and optional DB write).
+    :return:
+        Whatever *fn* returns, or ``None`` on error.
+    """
+    try:
+        return fn()
+    except requests.HTTPError as e:
+        if e.response is not None and e.response.status_code in (401, 403):
+            raise
+        elif e.response is not None and e.response.status_code == 404:
+            logger.warning("Project %s: %s not found, skipping", slug, endpoint)
+        else:
+            status = e.response.status_code if e.response is not None else "unknown"
+            logger.error("Project %s: %s HTTP %s, skipping", slug, endpoint, status)
+    except (requests.Timeout, requests.ConnectionError) as e:
+        logger.error("Project %s: %s network error (%s), skipping", slug, endpoint, type(e).__name__)
+    except requests.RequestException as e:
+        logger.error("Project %s: %s request failed (%s), skipping", slug, endpoint, e)
+    except (ValueError, KeyError) as e:
+        logger.error("Project %s: %s bad response (%s), skipping", slug, endpoint, e)
+    return None
+
+
 def _sync_time_series(
     db: Core3Database,
     session: Core3Session,
     slug: str,
     data_type: str,
-    fetch_backfill,
-    fetch_incremental,
-    insert_fn,
+    fetch_backfill: Callable,
+    fetch_incremental: Callable,
+    insert_fn: Callable,
     fetched_at: datetime.datetime,
-    timeout: float,
 ) -> int:
     """Two-phase sync helper for PoL time-series data.
 
@@ -82,8 +117,6 @@ def _sync_time_series(
         Database insert function. Signature: ``(slug, points, fetched_at) -> int``.
     :param fetched_at:
         Timestamp of the current scan cycle.
-    :param timeout:
-        HTTP request timeout.
     :return:
         Number of new rows inserted.
     """
@@ -113,10 +146,10 @@ def _process_project(
     fetch_categories: bool,
     fetch_sections_flag: bool,
     timeout: float,
-) -> dict:
+) -> None:
     """Worker function to process a single project.
 
-    Each endpoint call is wrapped in its own try/except so that a failure
+    Each endpoint call is wrapped in :func:`_safe_fetch` so that a failure
     on one endpoint does not prevent the others from succeeding.
 
     :param session:
@@ -135,114 +168,38 @@ def _process_project(
         Whether to fetch section detail endpoints.
     :param timeout:
         HTTP request timeout.
-    :return:
-        Summary dict with counts.
     """
-    result = {"slug": slug, "snapshot": False, "pol_new": 0, "category_new": 0, "sections": 0}
-
     # 1. Project detail snapshot
-    try:
-        raw = fetch_project_detail(session, slug, timeout=timeout)
+    raw = _safe_fetch(slug, "detail", lambda: fetch_project_detail(session, slug, timeout=timeout))
+    if raw is not None:
         db.insert_project_snapshot(slug, fetched_at, raw)
-        result["snapshot"] = True
-    except requests.HTTPError as e:
-        if e.response is not None and e.response.status_code in (401, 403):
-            raise
-        elif e.response is not None and e.response.status_code == 404:
-            logger.warning("Project %s: detail endpoint not found, skipping", slug)
-        else:
-            status = e.response.status_code if e.response is not None else "unknown"
-            logger.error("Project %s: detail HTTP %s, skipping", slug, status)
-    except (requests.Timeout, requests.ConnectionError) as e:
-        logger.error("Project %s: detail network error (%s), skipping", slug, type(e).__name__)
-    except requests.RequestException as e:
-        logger.error("Project %s: detail request failed (%s), skipping", slug, e)
-    except (ValueError, KeyError) as e:
-        logger.error("Project %s: detail bad response (%s), skipping", slug, e)
 
     # 2. PoL daily history
     if fetch_pol:
-        try:
-            new = _sync_time_series(
-                db,
-                session,
-                slug,
-                "pol_daily",
-                fetch_backfill=lambda: fetch_pol_history(session, slug, timeout=timeout),
-                fetch_incremental=lambda f, t: fetch_pol_history_incremental(session, slug, f, t, timeout=timeout),
-                insert_fn=db.insert_pol_daily_points,
-                fetched_at=fetched_at,
-                timeout=timeout,
-            )
-            result["pol_new"] = new
-        except requests.HTTPError as e:
-            if e.response is not None and e.response.status_code in (401, 403):
-                raise
-            elif e.response is not None and e.response.status_code == 404:
-                logger.warning("Project %s: PoL history not found, skipping", slug)
-            else:
-                status = e.response.status_code if e.response is not None else "unknown"
-                logger.error("Project %s: PoL history HTTP %s, skipping", slug, status)
-        except (requests.Timeout, requests.ConnectionError) as e:
-            logger.error("Project %s: PoL history network error (%s), skipping", slug, type(e).__name__)
-        except requests.RequestException as e:
-            logger.error("Project %s: PoL history request failed (%s), skipping", slug, e)
-        except (ValueError, KeyError) as e:
-            logger.error("Project %s: PoL history bad response (%s), skipping", slug, e)
+        _safe_fetch(slug, "PoL history", lambda: _sync_time_series(
+            db, session, slug, "pol_daily",
+            fetch_backfill=lambda: fetch_pol_history(session, slug, timeout=timeout),
+            fetch_incremental=lambda f, t: fetch_pol_history_incremental(session, slug, f, t, timeout=timeout),
+            insert_fn=db.insert_pol_daily_points,
+            fetched_at=fetched_at,
+        ))
 
     # 3. Category PoL daily history
     if fetch_categories:
-        try:
-            new = _sync_time_series(
-                db,
-                session,
-                slug,
-                "pol_category_daily",
-                fetch_backfill=lambda: fetch_pol_category_history(session, slug, timeout=timeout),
-                fetch_incremental=lambda f, t: fetch_pol_category_history_incremental(session, slug, f, t, timeout=timeout),
-                insert_fn=db.insert_pol_category_daily_points,
-                fetched_at=fetched_at,
-                timeout=timeout,
-            )
-            result["category_new"] = new
-        except requests.HTTPError as e:
-            if e.response is not None and e.response.status_code in (401, 403):
-                raise
-            elif e.response is not None and e.response.status_code == 404:
-                logger.warning("Project %s: category history not found, skipping", slug)
-            else:
-                status = e.response.status_code if e.response is not None else "unknown"
-                logger.error("Project %s: category history HTTP %s, skipping", slug, status)
-        except (requests.Timeout, requests.ConnectionError) as e:
-            logger.error("Project %s: category history network error (%s), skipping", slug, type(e).__name__)
-        except requests.RequestException as e:
-            logger.error("Project %s: category history request failed (%s), skipping", slug, e)
-        except (ValueError, KeyError) as e:
-            logger.error("Project %s: category history bad response (%s), skipping", slug, e)
+        _safe_fetch(slug, "category history", lambda: _sync_time_series(
+            db, session, slug, "pol_category_daily",
+            fetch_backfill=lambda: fetch_pol_category_history(session, slug, timeout=timeout),
+            fetch_incremental=lambda f, t: fetch_pol_category_history_incremental(session, slug, f, t, timeout=timeout),
+            insert_fn=db.insert_pol_category_daily_points,
+            fetched_at=fetched_at,
+        ))
 
     # 4. Section snapshots
     if fetch_sections_flag:
         for section in SECTIONS:
-            try:
-                raw = fetch_section_detail(session, slug, section, timeout=timeout)
+            raw = _safe_fetch(slug, f"{section} section", lambda s=section: fetch_section_detail(session, slug, s, timeout=timeout))
+            if raw is not None:
                 db.insert_section_snapshot(slug, section, fetched_at, raw)
-                result["sections"] += 1
-            except requests.HTTPError as e:
-                if e.response is not None and e.response.status_code in (401, 403):
-                    raise
-                elif e.response is not None and e.response.status_code == 404:
-                    logger.warning("Project %s: %s section not found, skipping", slug, section)
-                else:
-                    status = e.response.status_code if e.response is not None else "unknown"
-                    logger.error("Project %s: %s section HTTP %s, skipping", slug, section, status)
-            except (requests.Timeout, requests.ConnectionError) as e:
-                logger.error("Project %s: %s section network error (%s), skipping", slug, section, type(e).__name__)
-            except requests.RequestException as e:
-                logger.error("Project %s: %s section request failed (%s), skipping", slug, section, e)
-            except (ValueError, KeyError) as e:
-                logger.error("Project %s: %s section bad response (%s), skipping", slug, section, e)
-
-    return result
 
 
 def scan_projects(
@@ -325,26 +282,13 @@ def scan_projects(
 
     # Index-level PoL history (single request, not parallelised)
     if fetch_index_pol:
-        try:
-            _sync_time_series(
-                db,
-                session,
-                INDEX_SLUG,
-                "pol_daily",
-                fetch_backfill=lambda: fetch_index_pol_history(session, timeout=timeout),
-                fetch_incremental=lambda f, t: fetch_index_pol_history_incremental(session, f, t, timeout=timeout),
-                insert_fn=db.insert_pol_daily_points,
-                fetched_at=fetched_at,
-                timeout=timeout,
-            )
-        except requests.HTTPError as e:
-            if e.response is not None and e.response.status_code in (401, 403):
-                raise
-            logger.error("Index PoL history failed: %s", e)
-        except (requests.Timeout, requests.ConnectionError, requests.RequestException) as e:
-            logger.error("Index PoL history failed: %s", e)
-        except (ValueError, KeyError) as e:
-            logger.error("Index PoL history bad response: %s", e)
+        _safe_fetch(INDEX_SLUG, "index PoL history", lambda: _sync_time_series(
+            db, session, INDEX_SLUG, "pol_daily",
+            fetch_backfill=lambda: fetch_index_pol_history(session, timeout=timeout),
+            fetch_incremental=lambda f, t: fetch_index_pol_history_incremental(session, f, t, timeout=timeout),
+            insert_fn=db.insert_pol_daily_points,
+            fetched_at=fetched_at,
+        ))
 
     db.save()
     logger.info(

--- a/eth_defi/core3/scanner.py
+++ b/eth_defi/core3/scanner.py
@@ -22,11 +22,11 @@ Example usage::
 import datetime
 import logging
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 import requests
-from joblib import Parallel, delayed
-from tqdm_loggable.auto import tqdm
+from tqdm.auto import tqdm
 
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.core3.constants import CORE3_DATABASE_PATH, INDEX_SLUG, SECTIONS
@@ -104,29 +104,24 @@ def _sync_time_series(
     return new_count
 
 
-def _process_project(
+def _fetch_project_data(
     session: Core3Session,
-    db: Core3Database,
     slug: str,
-    fetched_at: datetime.datetime,
     fetch_pol: bool,
     fetch_categories: bool,
     fetch_sections_flag: bool,
     timeout: float,
 ) -> dict:
-    """Worker function to process a single project.
+    """Worker function to fetch all API data for a single project.
 
+    Runs in a thread pool — only does HTTP fetching, no database writes.
     Each endpoint call is wrapped in its own try/except so that a failure
     on one endpoint does not prevent the others from succeeding.
 
     :param session:
         Core3 API session.
-    :param db:
-        Core3 database.
     :param slug:
         Project slug.
-    :param fetched_at:
-        Timestamp of the current scan cycle.
     :param fetch_pol:
         Whether to fetch PoL history.
     :param fetch_categories:
@@ -136,15 +131,13 @@ def _process_project(
     :param timeout:
         HTTP request timeout.
     :return:
-        Summary dict with counts.
+        Dict with fetched data keyed by endpoint type.
     """
-    result = {"slug": slug, "snapshot": False, "pol_new": 0, "category_new": 0, "sections": 0}
+    data = {"slug": slug, "detail": None, "pol_points": None, "category_points": None, "sections": {}}
 
-    # 1. Project detail snapshot
+    # 1. Project detail
     try:
-        raw = fetch_project_detail(session, slug, timeout=timeout)
-        db.insert_project_snapshot(slug, fetched_at, raw)
-        result["snapshot"] = True
+        data["detail"] = fetch_project_detail(session, slug, timeout=timeout)
     except requests.HTTPError as e:
         if e.response is not None and e.response.status_code in (401, 403):
             raise
@@ -163,18 +156,7 @@ def _process_project(
     # 2. PoL daily history
     if fetch_pol:
         try:
-            new = _sync_time_series(
-                db,
-                session,
-                slug,
-                "pol_daily",
-                fetch_backfill=lambda: fetch_pol_history(session, slug, timeout=timeout),
-                fetch_incremental=lambda f, t: fetch_pol_history_incremental(session, slug, f, t, timeout=timeout),
-                insert_fn=db.insert_pol_daily_points,
-                fetched_at=fetched_at,
-                timeout=timeout,
-            )
-            result["pol_new"] = new
+            data["pol_points"] = fetch_pol_history(session, slug, timeout=timeout)
         except requests.HTTPError as e:
             if e.response is not None and e.response.status_code in (401, 403):
                 raise
@@ -193,18 +175,7 @@ def _process_project(
     # 3. Category PoL daily history
     if fetch_categories:
         try:
-            new = _sync_time_series(
-                db,
-                session,
-                slug,
-                "pol_category_daily",
-                fetch_backfill=lambda: fetch_pol_category_history(session, slug, timeout=timeout),
-                fetch_incremental=lambda f, t: fetch_pol_category_history_incremental(session, slug, f, t, timeout=timeout),
-                insert_fn=db.insert_pol_category_daily_points,
-                fetched_at=fetched_at,
-                timeout=timeout,
-            )
-            result["category_new"] = new
+            data["category_points"] = fetch_pol_category_history(session, slug, timeout=timeout)
         except requests.HTTPError as e:
             if e.response is not None and e.response.status_code in (401, 403):
                 raise
@@ -220,13 +191,11 @@ def _process_project(
         except (ValueError, KeyError) as e:
             logger.error("Project %s: category history bad response (%s), skipping", slug, e)
 
-    # 4. Section snapshots
+    # 4. Section details
     if fetch_sections_flag:
         for section in SECTIONS:
             try:
-                raw = fetch_section_detail(session, slug, section, timeout=timeout)
-                db.insert_section_snapshot(slug, section, fetched_at, raw)
-                result["sections"] += 1
+                data["sections"][section] = fetch_section_detail(session, slug, section, timeout=timeout)
             except requests.HTTPError as e:
                 if e.response is not None and e.response.status_code in (401, 403):
                     raise
@@ -242,7 +211,40 @@ def _process_project(
             except (ValueError, KeyError) as e:
                 logger.error("Project %s: %s section bad response (%s), skipping", slug, section, e)
 
-    return result
+    return data
+
+
+def _store_project_data(
+    db: Core3Database,
+    data: dict,
+    fetched_at: datetime.datetime,
+) -> None:
+    """Write fetched project data to the database (main thread only).
+
+    :param db:
+        Core3 database.
+    :param data:
+        Dict returned by :py:func:`_fetch_project_data`.
+    :param fetched_at:
+        Timestamp of the current scan cycle.
+    """
+    slug = data["slug"]
+
+    if data["detail"] is not None:
+        db.insert_project_snapshot(slug, fetched_at, data["detail"])
+
+    if data["pol_points"] is not None:
+        db.insert_pol_daily_points(slug, data["pol_points"], fetched_at)
+        last_ts = max((p["timestamp"] for p in data["pol_points"]), default=None)
+        db.update_sync_state(slug, "pol_daily", last_ts, backfill_done=True)
+
+    if data["category_points"] is not None:
+        db.insert_pol_category_daily_points(slug, data["category_points"], fetched_at)
+        last_ts = max((p["timestamp"] for p in data["category_points"]), default=None)
+        db.update_sync_state(slug, "pol_category_daily", last_ts, backfill_done=True)
+
+    for section, raw in data["sections"].items():
+        db.insert_section_snapshot(slug, section, fetched_at, raw)
 
 
 def scan_projects(
@@ -255,13 +257,14 @@ def scan_projects(
     limit: int | None = None,
     max_workers: int = 8,
     timeout: float = 30.0,
+    checkpoint_every: int = 100,
 ) -> Core3Database:
     """Scan all Core3 projects and store snapshots in DuckDB.
 
     This function:
 
     1. Fetches the project list from ``/v1/list`` to get all slugs
-    2. For each slug (parallelised with ``joblib``):
+    2. For each slug (parallelised with ``ThreadPoolExecutor``):
 
        a. Fetches ``/v1/{slug}`` and inserts into ``project_snapshots``
        b. Optionally fetches PoL history and inserts into ``pol_daily``
@@ -290,6 +293,13 @@ def scan_projects(
         Maximum number of parallel workers for fetching project data.
     :param timeout:
         HTTP request timeout in seconds.
+    :param checkpoint_every:
+        Flush WAL to disk every N projects. DuckDB CHECKPOINT cannot run
+        safely while ``ThreadPoolExecutor`` threads are alive (heap
+        corruption on Python 3.14 + DuckDB 1.5, see `duckdb#13904
+        <https://github.com/duckdb/duckdb/issues/13904>`__), so work is
+        processed in chunks — the executor exits and all threads join
+        before each checkpoint.
     :return:
         :py:class:`~eth_defi.core3.database.Core3Database` instance with
         the newly inserted data. Caller must call ``close()`` when done.
@@ -307,21 +317,59 @@ def scan_projects(
         slugs = slugs[:limit]
         logger.info("Limited to %d projects", len(slugs))
 
-    # Parallel per-project processing
-    desc = f"Scanning Core3 projects ({max_workers} workers)"
-    Parallel(n_jobs=max_workers, backend="threading")(
-        delayed(_process_project)(
-            session,
-            db,
-            slug,
-            fetched_at,
-            fetch_pol=fetch_pol_history,
-            fetch_categories=fetch_category_history,
-            fetch_sections_flag=fetch_sections,
-            timeout=timeout,
-        )
-        for slug in tqdm(slugs, desc=desc)
-    )
+    # Process projects in chunks with a two-phase approach per chunk:
+    #   Phase 1 (fetch): parallel HTTP with ThreadPoolExecutor + tqdm
+    #   Phase 2 (store): sequential DB writes, then reconnect
+    #
+    # DuckDB con.close() triggers an implicit CHECKPOINT which causes
+    # heap corruption if ANY Python thread is alive — including tqdm's
+    # persistent monitor thread (Python 3.14 + DuckDB 1.5, duckdb#13904).
+    # By collecting fetch results first, we can ensure no threads exist
+    # when we touch the database.
+    chunks = [slugs[i : i + checkpoint_every] for i in range(0, len(slugs), checkpoint_every)]
+    processed = 0
+
+    for chunk_idx, chunk in enumerate(chunks):
+        # Phase 1: fetch all data (threads + tqdm alive, no DB access)
+        results = []
+        desc = f"Fetching chunk {chunk_idx + 1}/{len(chunks)} ({max_workers} workers)"
+        if max_workers > 1:
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                futures = {
+                    executor.submit(
+                        _fetch_project_data,
+                        session,
+                        slug,
+                        fetch_pol=fetch_pol_history,
+                        fetch_categories=fetch_category_history,
+                        fetch_sections_flag=fetch_sections,
+                        timeout=timeout,
+                    ): slug
+                    for slug in chunk
+                }
+                with tqdm(total=len(chunk), desc=desc) as progress:
+                    for future in as_completed(futures):
+                        results.append(future.result())
+                        progress.update(1)
+        else:
+            for slug in tqdm(chunk, desc=desc):
+                results.append(
+                    _fetch_project_data(
+                        session,
+                        slug,
+                        fetch_pol=fetch_pol_history,
+                        fetch_categories=fetch_category_history,
+                        fetch_sections_flag=fetch_sections,
+                        timeout=timeout,
+                    )
+                )
+
+        # Phase 2: write to DB and checkpoint (no threads alive)
+        for data in results:
+            _store_project_data(db, data, fetched_at)
+        processed += len(results)
+        db.reconnect()
+        logger.info("Saved %d/%d projects", processed, len(slugs))
 
     # Index-level PoL history (single request, not parallelised)
     if fetch_index_pol:
@@ -346,7 +394,7 @@ def scan_projects(
         except (ValueError, KeyError) as e:
             logger.error("Index PoL history bad response: %s", e)
 
-    db.save()
+    db.reconnect()
     logger.info(
         "Scan complete: %d projects, %d snapshots, %d PoL daily rows",
         db.get_project_count(),

--- a/eth_defi/core3/scanner.py
+++ b/eth_defi/core3/scanner.py
@@ -22,11 +22,11 @@ Example usage::
 import datetime
 import logging
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 import requests
-from tqdm.auto import tqdm
+from joblib import Parallel, delayed
+from tqdm_loggable.auto import tqdm
 
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.core3.constants import CORE3_DATABASE_PATH, INDEX_SLUG, SECTIONS
@@ -104,24 +104,29 @@ def _sync_time_series(
     return new_count
 
 
-def _fetch_project_data(
+def _process_project(
     session: Core3Session,
+    db: Core3Database,
     slug: str,
+    fetched_at: datetime.datetime,
     fetch_pol: bool,
     fetch_categories: bool,
     fetch_sections_flag: bool,
     timeout: float,
 ) -> dict:
-    """Worker function to fetch all API data for a single project.
+    """Worker function to process a single project.
 
-    Runs in a thread pool — only does HTTP fetching, no database writes.
     Each endpoint call is wrapped in its own try/except so that a failure
     on one endpoint does not prevent the others from succeeding.
 
     :param session:
         Core3 API session.
+    :param db:
+        Core3 database.
     :param slug:
         Project slug.
+    :param fetched_at:
+        Timestamp of the current scan cycle.
     :param fetch_pol:
         Whether to fetch PoL history.
     :param fetch_categories:
@@ -131,13 +136,15 @@ def _fetch_project_data(
     :param timeout:
         HTTP request timeout.
     :return:
-        Dict with fetched data keyed by endpoint type.
+        Summary dict with counts.
     """
-    data = {"slug": slug, "detail": None, "pol_points": None, "category_points": None, "sections": {}}
+    result = {"slug": slug, "snapshot": False, "pol_new": 0, "category_new": 0, "sections": 0}
 
-    # 1. Project detail
+    # 1. Project detail snapshot
     try:
-        data["detail"] = fetch_project_detail(session, slug, timeout=timeout)
+        raw = fetch_project_detail(session, slug, timeout=timeout)
+        db.insert_project_snapshot(slug, fetched_at, raw)
+        result["snapshot"] = True
     except requests.HTTPError as e:
         if e.response is not None and e.response.status_code in (401, 403):
             raise
@@ -156,7 +163,18 @@ def _fetch_project_data(
     # 2. PoL daily history
     if fetch_pol:
         try:
-            data["pol_points"] = fetch_pol_history(session, slug, timeout=timeout)
+            new = _sync_time_series(
+                db,
+                session,
+                slug,
+                "pol_daily",
+                fetch_backfill=lambda: fetch_pol_history(session, slug, timeout=timeout),
+                fetch_incremental=lambda f, t: fetch_pol_history_incremental(session, slug, f, t, timeout=timeout),
+                insert_fn=db.insert_pol_daily_points,
+                fetched_at=fetched_at,
+                timeout=timeout,
+            )
+            result["pol_new"] = new
         except requests.HTTPError as e:
             if e.response is not None and e.response.status_code in (401, 403):
                 raise
@@ -175,7 +193,18 @@ def _fetch_project_data(
     # 3. Category PoL daily history
     if fetch_categories:
         try:
-            data["category_points"] = fetch_pol_category_history(session, slug, timeout=timeout)
+            new = _sync_time_series(
+                db,
+                session,
+                slug,
+                "pol_category_daily",
+                fetch_backfill=lambda: fetch_pol_category_history(session, slug, timeout=timeout),
+                fetch_incremental=lambda f, t: fetch_pol_category_history_incremental(session, slug, f, t, timeout=timeout),
+                insert_fn=db.insert_pol_category_daily_points,
+                fetched_at=fetched_at,
+                timeout=timeout,
+            )
+            result["category_new"] = new
         except requests.HTTPError as e:
             if e.response is not None and e.response.status_code in (401, 403):
                 raise
@@ -191,11 +220,13 @@ def _fetch_project_data(
         except (ValueError, KeyError) as e:
             logger.error("Project %s: category history bad response (%s), skipping", slug, e)
 
-    # 4. Section details
+    # 4. Section snapshots
     if fetch_sections_flag:
         for section in SECTIONS:
             try:
-                data["sections"][section] = fetch_section_detail(session, slug, section, timeout=timeout)
+                raw = fetch_section_detail(session, slug, section, timeout=timeout)
+                db.insert_section_snapshot(slug, section, fetched_at, raw)
+                result["sections"] += 1
             except requests.HTTPError as e:
                 if e.response is not None and e.response.status_code in (401, 403):
                     raise
@@ -211,40 +242,7 @@ def _fetch_project_data(
             except (ValueError, KeyError) as e:
                 logger.error("Project %s: %s section bad response (%s), skipping", slug, section, e)
 
-    return data
-
-
-def _store_project_data(
-    db: Core3Database,
-    data: dict,
-    fetched_at: datetime.datetime,
-) -> None:
-    """Write fetched project data to the database (main thread only).
-
-    :param db:
-        Core3 database.
-    :param data:
-        Dict returned by :py:func:`_fetch_project_data`.
-    :param fetched_at:
-        Timestamp of the current scan cycle.
-    """
-    slug = data["slug"]
-
-    if data["detail"] is not None:
-        db.insert_project_snapshot(slug, fetched_at, data["detail"])
-
-    if data["pol_points"] is not None:
-        db.insert_pol_daily_points(slug, data["pol_points"], fetched_at)
-        last_ts = max((p["timestamp"] for p in data["pol_points"]), default=None)
-        db.update_sync_state(slug, "pol_daily", last_ts, backfill_done=True)
-
-    if data["category_points"] is not None:
-        db.insert_pol_category_daily_points(slug, data["category_points"], fetched_at)
-        last_ts = max((p["timestamp"] for p in data["category_points"]), default=None)
-        db.update_sync_state(slug, "pol_category_daily", last_ts, backfill_done=True)
-
-    for section, raw in data["sections"].items():
-        db.insert_section_snapshot(slug, section, fetched_at, raw)
+    return result
 
 
 def scan_projects(
@@ -257,14 +255,13 @@ def scan_projects(
     limit: int | None = None,
     max_workers: int = 8,
     timeout: float = 30.0,
-    checkpoint_every: int = 100,
 ) -> Core3Database:
     """Scan all Core3 projects and store snapshots in DuckDB.
 
     This function:
 
     1. Fetches the project list from ``/v1/list`` to get all slugs
-    2. For each slug (parallelised with ``ThreadPoolExecutor``):
+    2. For each slug (parallelised with ``joblib``):
 
        a. Fetches ``/v1/{slug}`` and inserts into ``project_snapshots``
        b. Optionally fetches PoL history and inserts into ``pol_daily``
@@ -293,13 +290,6 @@ def scan_projects(
         Maximum number of parallel workers for fetching project data.
     :param timeout:
         HTTP request timeout in seconds.
-    :param checkpoint_every:
-        Flush WAL to disk every N projects. DuckDB CHECKPOINT cannot run
-        safely while ``ThreadPoolExecutor`` threads are alive (heap
-        corruption on Python 3.14 + DuckDB 1.5, see `duckdb#13904
-        <https://github.com/duckdb/duckdb/issues/13904>`__), so work is
-        processed in chunks — the executor exits and all threads join
-        before each checkpoint.
     :return:
         :py:class:`~eth_defi.core3.database.Core3Database` instance with
         the newly inserted data. Caller must call ``close()`` when done.
@@ -317,59 +307,21 @@ def scan_projects(
         slugs = slugs[:limit]
         logger.info("Limited to %d projects", len(slugs))
 
-    # Process projects in chunks with a two-phase approach per chunk:
-    #   Phase 1 (fetch): parallel HTTP with ThreadPoolExecutor + tqdm
-    #   Phase 2 (store): sequential DB writes, then reconnect
-    #
-    # DuckDB con.close() triggers an implicit CHECKPOINT which causes
-    # heap corruption if ANY Python thread is alive — including tqdm's
-    # persistent monitor thread (Python 3.14 + DuckDB 1.5, duckdb#13904).
-    # By collecting fetch results first, we can ensure no threads exist
-    # when we touch the database.
-    chunks = [slugs[i : i + checkpoint_every] for i in range(0, len(slugs), checkpoint_every)]
-    processed = 0
-
-    for chunk_idx, chunk in enumerate(chunks):
-        # Phase 1: fetch all data (threads + tqdm alive, no DB access)
-        results = []
-        desc = f"Fetching chunk {chunk_idx + 1}/{len(chunks)} ({max_workers} workers)"
-        if max_workers > 1:
-            with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                futures = {
-                    executor.submit(
-                        _fetch_project_data,
-                        session,
-                        slug,
-                        fetch_pol=fetch_pol_history,
-                        fetch_categories=fetch_category_history,
-                        fetch_sections_flag=fetch_sections,
-                        timeout=timeout,
-                    ): slug
-                    for slug in chunk
-                }
-                with tqdm(total=len(chunk), desc=desc) as progress:
-                    for future in as_completed(futures):
-                        results.append(future.result())
-                        progress.update(1)
-        else:
-            for slug in tqdm(chunk, desc=desc):
-                results.append(
-                    _fetch_project_data(
-                        session,
-                        slug,
-                        fetch_pol=fetch_pol_history,
-                        fetch_categories=fetch_category_history,
-                        fetch_sections_flag=fetch_sections,
-                        timeout=timeout,
-                    )
-                )
-
-        # Phase 2: write to DB and checkpoint (no threads alive)
-        for data in results:
-            _store_project_data(db, data, fetched_at)
-        processed += len(results)
-        db.reconnect()
-        logger.info("Saved %d/%d projects", processed, len(slugs))
+    # Parallel per-project processing
+    desc = f"Scanning Core3 projects ({max_workers} workers)"
+    Parallel(n_jobs=max_workers, backend="threading")(
+        delayed(_process_project)(
+            session,
+            db,
+            slug,
+            fetched_at,
+            fetch_pol=fetch_pol_history,
+            fetch_categories=fetch_category_history,
+            fetch_sections_flag=fetch_sections,
+            timeout=timeout,
+        )
+        for slug in tqdm(slugs, desc=desc)
+    )
 
     # Index-level PoL history (single request, not parallelised)
     if fetch_index_pol:
@@ -394,7 +346,7 @@ def scan_projects(
         except (ValueError, KeyError) as e:
             logger.error("Index PoL history bad response: %s", e)
 
-    db.reconnect()
+    db.save()
     logger.info(
         "Scan complete: %d projects, %d snapshots, %d PoL daily rows",
         db.get_project_count(),

--- a/eth_defi/core3/scanner.py
+++ b/eth_defi/core3/scanner.py
@@ -176,23 +176,37 @@ def _process_project(
 
     # 2. PoL daily history
     if fetch_pol:
-        _safe_fetch(slug, "PoL history", lambda: _sync_time_series(
-            db, session, slug, "pol_daily",
-            fetch_backfill=lambda: fetch_pol_history(session, slug, timeout=timeout),
-            fetch_incremental=lambda f, t: fetch_pol_history_incremental(session, slug, f, t, timeout=timeout),
-            insert_fn=db.insert_pol_daily_points,
-            fetched_at=fetched_at,
-        ))
+        _safe_fetch(
+            slug,
+            "PoL history",
+            lambda: _sync_time_series(
+                db,
+                session,
+                slug,
+                "pol_daily",
+                fetch_backfill=lambda: fetch_pol_history(session, slug, timeout=timeout),
+                fetch_incremental=lambda f, t: fetch_pol_history_incremental(session, slug, f, t, timeout=timeout),
+                insert_fn=db.insert_pol_daily_points,
+                fetched_at=fetched_at,
+            ),
+        )
 
     # 3. Category PoL daily history
     if fetch_categories:
-        _safe_fetch(slug, "category history", lambda: _sync_time_series(
-            db, session, slug, "pol_category_daily",
-            fetch_backfill=lambda: fetch_pol_category_history(session, slug, timeout=timeout),
-            fetch_incremental=lambda f, t: fetch_pol_category_history_incremental(session, slug, f, t, timeout=timeout),
-            insert_fn=db.insert_pol_category_daily_points,
-            fetched_at=fetched_at,
-        ))
+        _safe_fetch(
+            slug,
+            "category history",
+            lambda: _sync_time_series(
+                db,
+                session,
+                slug,
+                "pol_category_daily",
+                fetch_backfill=lambda: fetch_pol_category_history(session, slug, timeout=timeout),
+                fetch_incremental=lambda f, t: fetch_pol_category_history_incremental(session, slug, f, t, timeout=timeout),
+                insert_fn=db.insert_pol_category_daily_points,
+                fetched_at=fetched_at,
+            ),
+        )
 
     # 4. Section snapshots
     if fetch_sections_flag:
@@ -282,13 +296,20 @@ def scan_projects(
 
     # Index-level PoL history (single request, not parallelised)
     if fetch_index_pol:
-        _safe_fetch(INDEX_SLUG, "index PoL history", lambda: _sync_time_series(
-            db, session, INDEX_SLUG, "pol_daily",
-            fetch_backfill=lambda: fetch_index_pol_history(session, timeout=timeout),
-            fetch_incremental=lambda f, t: fetch_index_pol_history_incremental(session, f, t, timeout=timeout),
-            insert_fn=db.insert_pol_daily_points,
-            fetched_at=fetched_at,
-        ))
+        _safe_fetch(
+            INDEX_SLUG,
+            "index PoL history",
+            lambda: _sync_time_series(
+                db,
+                session,
+                INDEX_SLUG,
+                "pol_daily",
+                fetch_backfill=lambda: fetch_index_pol_history(session, timeout=timeout),
+                fetch_incremental=lambda f, t: fetch_index_pol_history_incremental(session, f, t, timeout=timeout),
+                insert_fn=db.insert_pol_daily_points,
+                fetched_at=fetched_at,
+            ),
+        )
 
     db.save()
     logger.info(

--- a/eth_defi/core3/scanner.py
+++ b/eth_defi/core3/scanner.py
@@ -1,0 +1,356 @@
+"""Core3 project scanner with DuckDB storage.
+
+Orchestrates fetching data from the Core3 API and storing it in a
+:py:class:`~eth_defi.core3.database.Core3Database`. Supports parallel
+fetching with ``joblib.Parallel`` and incremental sync using watermarks.
+
+Example usage::
+
+    from pathlib import Path
+    from eth_defi.core3.session import create_core3_session
+    from eth_defi.core3.scanner import scan_projects
+
+    session = create_core3_session()
+    db = scan_projects(session=session, limit=10)
+    try:
+        df = db.get_latest_project_snapshots()
+        print(df)
+    finally:
+        db.close()
+"""
+
+import datetime
+import logging
+import time
+from pathlib import Path
+
+import requests
+from joblib import Parallel, delayed
+from tqdm_loggable.auto import tqdm
+
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.core3.constants import CORE3_DATABASE_PATH, INDEX_SLUG, SECTIONS
+from eth_defi.core3.database import Core3Database
+from eth_defi.core3.session import (
+    Core3Session,
+    fetch_index_pol_history,
+    fetch_index_pol_history_incremental,
+    fetch_pol_category_history,
+    fetch_pol_category_history_incremental,
+    fetch_pol_history,
+    fetch_pol_history_incremental,
+    fetch_project_detail,
+    fetch_project_list,
+    fetch_section_detail,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _sync_time_series(
+    db: Core3Database,
+    session: Core3Session,
+    slug: str,
+    data_type: str,
+    fetch_backfill,
+    fetch_incremental,
+    insert_fn,
+    fetched_at: datetime.datetime,
+    timeout: float,
+) -> int:
+    """Two-phase sync helper for PoL time-series data.
+
+    Phase 1 (backfill): if no sync state exists or ``backfill_done`` is
+    ``FALSE``, calls the chart endpoint for all-time data.
+
+    Phase 2 (incremental): if ``backfill_done`` is ``TRUE``, calls the
+    ranged history endpoint from the last known timestamp to now.
+
+    :param db:
+        Core3 database.
+    :param session:
+        Core3 API session.
+    :param slug:
+        Project slug (or ``INDEX_SLUG``).
+    :param data_type:
+        Sync state key (e.g. ``'pol_daily'``).
+    :param fetch_backfill:
+        Callable for the full chart endpoint. Signature: ``() -> list[dict]``.
+    :param fetch_incremental:
+        Callable for the ranged endpoint. Signature: ``(from_ts, to_ts) -> list[dict]``.
+    :param insert_fn:
+        Database insert function. Signature: ``(slug, points, fetched_at) -> int``.
+    :param fetched_at:
+        Timestamp of the current scan cycle.
+    :param timeout:
+        HTTP request timeout.
+    :return:
+        Number of new rows inserted.
+    """
+    state = db.get_sync_state(slug, data_type)
+    now_ts = int(time.time())
+
+    if state is None or not state["backfill_done"]:
+        points = fetch_backfill()
+    else:
+        from_ts = state["last_ts"] or 0
+        points = fetch_incremental(from_ts, now_ts)
+
+    new_count = insert_fn(slug, points, fetched_at)
+
+    last_ts = max((p["timestamp"] for p in points), default=None) if points else (state["last_ts"] if state else None)
+    db.update_sync_state(slug, data_type, last_ts, backfill_done=True)
+
+    return new_count
+
+
+def _process_project(
+    session: Core3Session,
+    db: Core3Database,
+    slug: str,
+    fetched_at: datetime.datetime,
+    fetch_pol: bool,
+    fetch_categories: bool,
+    fetch_sections_flag: bool,
+    timeout: float,
+) -> dict:
+    """Worker function to process a single project.
+
+    Each endpoint call is wrapped in its own try/except so that a failure
+    on one endpoint does not prevent the others from succeeding.
+
+    :param session:
+        Core3 API session.
+    :param db:
+        Core3 database.
+    :param slug:
+        Project slug.
+    :param fetched_at:
+        Timestamp of the current scan cycle.
+    :param fetch_pol:
+        Whether to fetch PoL history.
+    :param fetch_categories:
+        Whether to fetch category PoL history.
+    :param fetch_sections_flag:
+        Whether to fetch section detail endpoints.
+    :param timeout:
+        HTTP request timeout.
+    :return:
+        Summary dict with counts.
+    """
+    result = {"slug": slug, "snapshot": False, "pol_new": 0, "category_new": 0, "sections": 0}
+
+    # 1. Project detail snapshot
+    try:
+        raw = fetch_project_detail(session, slug, timeout=timeout)
+        db.insert_project_snapshot(slug, fetched_at, raw)
+        result["snapshot"] = True
+    except requests.HTTPError as e:
+        if e.response is not None and e.response.status_code in (401, 403):
+            raise
+        elif e.response is not None and e.response.status_code == 404:
+            logger.warning("Project %s: detail endpoint not found, skipping", slug)
+        else:
+            status = e.response.status_code if e.response is not None else "unknown"
+            logger.error("Project %s: detail HTTP %s, skipping", slug, status)
+    except (requests.Timeout, requests.ConnectionError) as e:
+        logger.error("Project %s: detail network error (%s), skipping", slug, type(e).__name__)
+    except requests.RequestException as e:
+        logger.error("Project %s: detail request failed (%s), skipping", slug, e)
+    except (ValueError, KeyError) as e:
+        logger.error("Project %s: detail bad response (%s), skipping", slug, e)
+
+    # 2. PoL daily history
+    if fetch_pol:
+        try:
+            new = _sync_time_series(
+                db,
+                session,
+                slug,
+                "pol_daily",
+                fetch_backfill=lambda: fetch_pol_history(session, slug, timeout=timeout),
+                fetch_incremental=lambda f, t: fetch_pol_history_incremental(session, slug, f, t, timeout=timeout),
+                insert_fn=db.insert_pol_daily_points,
+                fetched_at=fetched_at,
+                timeout=timeout,
+            )
+            result["pol_new"] = new
+        except requests.HTTPError as e:
+            if e.response is not None and e.response.status_code in (401, 403):
+                raise
+            elif e.response is not None and e.response.status_code == 404:
+                logger.warning("Project %s: PoL history not found, skipping", slug)
+            else:
+                status = e.response.status_code if e.response is not None else "unknown"
+                logger.error("Project %s: PoL history HTTP %s, skipping", slug, status)
+        except (requests.Timeout, requests.ConnectionError) as e:
+            logger.error("Project %s: PoL history network error (%s), skipping", slug, type(e).__name__)
+        except requests.RequestException as e:
+            logger.error("Project %s: PoL history request failed (%s), skipping", slug, e)
+        except (ValueError, KeyError) as e:
+            logger.error("Project %s: PoL history bad response (%s), skipping", slug, e)
+
+    # 3. Category PoL daily history
+    if fetch_categories:
+        try:
+            new = _sync_time_series(
+                db,
+                session,
+                slug,
+                "pol_category_daily",
+                fetch_backfill=lambda: fetch_pol_category_history(session, slug, timeout=timeout),
+                fetch_incremental=lambda f, t: fetch_pol_category_history_incremental(session, slug, f, t, timeout=timeout),
+                insert_fn=db.insert_pol_category_daily_points,
+                fetched_at=fetched_at,
+                timeout=timeout,
+            )
+            result["category_new"] = new
+        except requests.HTTPError as e:
+            if e.response is not None and e.response.status_code in (401, 403):
+                raise
+            elif e.response is not None and e.response.status_code == 404:
+                logger.warning("Project %s: category history not found, skipping", slug)
+            else:
+                status = e.response.status_code if e.response is not None else "unknown"
+                logger.error("Project %s: category history HTTP %s, skipping", slug, status)
+        except (requests.Timeout, requests.ConnectionError) as e:
+            logger.error("Project %s: category history network error (%s), skipping", slug, type(e).__name__)
+        except requests.RequestException as e:
+            logger.error("Project %s: category history request failed (%s), skipping", slug, e)
+        except (ValueError, KeyError) as e:
+            logger.error("Project %s: category history bad response (%s), skipping", slug, e)
+
+    # 4. Section snapshots
+    if fetch_sections_flag:
+        for section in SECTIONS:
+            try:
+                raw = fetch_section_detail(session, slug, section, timeout=timeout)
+                db.insert_section_snapshot(slug, section, fetched_at, raw)
+                result["sections"] += 1
+            except requests.HTTPError as e:
+                if e.response is not None and e.response.status_code in (401, 403):
+                    raise
+                elif e.response is not None and e.response.status_code == 404:
+                    logger.warning("Project %s: %s section not found, skipping", slug, section)
+                else:
+                    status = e.response.status_code if e.response is not None else "unknown"
+                    logger.error("Project %s: %s section HTTP %s, skipping", slug, section, status)
+            except (requests.Timeout, requests.ConnectionError) as e:
+                logger.error("Project %s: %s section network error (%s), skipping", slug, section, type(e).__name__)
+            except requests.RequestException as e:
+                logger.error("Project %s: %s section request failed (%s), skipping", slug, section, e)
+            except (ValueError, KeyError) as e:
+                logger.error("Project %s: %s section bad response (%s), skipping", slug, section, e)
+
+    return result
+
+
+def scan_projects(
+    session: Core3Session,
+    db_path: Path = CORE3_DATABASE_PATH,
+    fetch_sections: bool = False,
+    fetch_pol_history: bool = True,
+    fetch_category_history: bool = True,
+    fetch_index_pol: bool = True,
+    limit: int | None = None,
+    max_workers: int = 8,
+    timeout: float = 30.0,
+) -> Core3Database:
+    """Scan all Core3 projects and store snapshots in DuckDB.
+
+    This function:
+
+    1. Fetches the project list from ``/v1/list`` to get all slugs
+    2. For each slug (parallelised with ``joblib``):
+
+       a. Fetches ``/v1/{slug}`` and inserts into ``project_snapshots``
+       b. Optionally fetches PoL history and inserts into ``pol_daily``
+       c. Optionally fetches category history and inserts into ``pol_category_daily``
+       d. Optionally fetches section endpoints and inserts into ``section_snapshots``
+
+    3. Optionally fetches index-level PoL history
+
+    :param session:
+        Core3 API session. Use :py:func:`~eth_defi.core3.session.create_core3_session`
+        to create one.
+    :param db_path:
+        Path to the DuckDB database file.
+    :param fetch_sections:
+        If ``True``, also fetch section detail endpoints (security, financial, etc.).
+        This is slower (5 extra API calls per project).
+    :param fetch_pol_history:
+        If ``True``, fetch PoL daily history for each project.
+    :param fetch_category_history:
+        If ``True``, fetch category PoL breakdown history for each project.
+    :param fetch_index_pol:
+        If ``True``, fetch the aggregate index-level PoL history.
+    :param limit:
+        Limit the number of projects to scan. For testing only.
+    :param max_workers:
+        Maximum number of parallel workers for fetching project data.
+    :param timeout:
+        HTTP request timeout in seconds.
+    :return:
+        :py:class:`~eth_defi.core3.database.Core3Database` instance with
+        the newly inserted data. Caller must call ``close()`` when done.
+    """
+    fetched_at = native_datetime_utc_now()
+
+    db = Core3Database(db_path)
+
+    # Fetch project list — hard fail if this fails (no meaningful scan without it)
+    project_list = fetch_project_list(session, timeout=timeout)
+    slugs = [p["slug"] for p in project_list]
+    logger.info("Fetched %d projects from Core3 API", len(slugs))
+
+    if limit is not None:
+        slugs = slugs[:limit]
+        logger.info("Limited to %d projects", len(slugs))
+
+    # Parallel per-project processing
+    desc = f"Scanning Core3 projects ({max_workers} workers)"
+    Parallel(n_jobs=max_workers, backend="threading")(
+        delayed(_process_project)(
+            session,
+            db,
+            slug,
+            fetched_at,
+            fetch_pol=fetch_pol_history,
+            fetch_categories=fetch_category_history,
+            fetch_sections_flag=fetch_sections,
+            timeout=timeout,
+        )
+        for slug in tqdm(slugs, desc=desc)
+    )
+
+    # Index-level PoL history (single request, not parallelised)
+    if fetch_index_pol:
+        try:
+            _sync_time_series(
+                db,
+                session,
+                INDEX_SLUG,
+                "pol_daily",
+                fetch_backfill=lambda: fetch_index_pol_history(session, timeout=timeout),
+                fetch_incremental=lambda f, t: fetch_index_pol_history_incremental(session, f, t, timeout=timeout),
+                insert_fn=db.insert_pol_daily_points,
+                fetched_at=fetched_at,
+                timeout=timeout,
+            )
+        except requests.HTTPError as e:
+            if e.response is not None and e.response.status_code in (401, 403):
+                raise
+            logger.error("Index PoL history failed: %s", e)
+        except (requests.Timeout, requests.ConnectionError, requests.RequestException) as e:
+            logger.error("Index PoL history failed: %s", e)
+        except (ValueError, KeyError) as e:
+            logger.error("Index PoL history bad response: %s", e)
+
+    db.save()
+    logger.info(
+        "Scan complete: %d projects, %d snapshots, %d PoL daily rows",
+        db.get_project_count(),
+        db.get_snapshot_count(),
+        db.get_pol_daily_count(),
+    )
+    return db

--- a/eth_defi/core3/session.py
+++ b/eth_defi/core3/session.py
@@ -1,0 +1,352 @@
+"""HTTP session management and fetch helpers for Core3 API.
+
+This module provides session creation with retry logic and rate limiting
+for Core3 Projects Data API requests, plus helper functions to fetch
+and unwrap individual endpoints.
+
+Rate limiting is thread-safe using SQLite backend, so the session can be
+shared across multiple threads when using ``joblib.Parallel`` or similar.
+
+The :py:class:`Core3Session` carries the API URL and API key so that
+downstream functions do not need separate arguments on every call.
+
+See `Core3 API documentation <https://docs.core3.io/projects-data-api>`__
+for endpoint details.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+from pyrate_limiter import SQLiteBucket
+from requests import Session
+from requests_ratelimiter import LimiterAdapter
+
+from eth_defi.core3.constants import (
+    CORE3_API_URL,
+    CORE3_DEFAULT_REQUESTS_PER_SECOND,
+    CORE3_RATE_LIMIT_SQLITE_DATABASE,
+    CORE3_USER_AGENT,
+)
+from eth_defi.velvet.logging_retry import LoggingRetry
+
+logger = logging.getLogger(__name__)
+
+#: Default number of retries for API requests
+DEFAULT_RETRIES: int = 5
+
+#: Default backoff factor for retries (seconds)
+DEFAULT_BACKOFF_FACTOR: float = 0.5
+
+
+class Core3Session(Session):
+    """A :py:class:`requests.Session` subclass for Core3 API.
+
+    Carries the API URL and API key, and sets required default headers
+    (``User-Agent`` and ``x-api-key``). All Core3 fetch functions accept
+    a ``Core3Session`` and read :py:attr:`api_url` from it.
+
+    Use :py:func:`create_core3_session` to create instances.
+    """
+
+    #: Core3 API base URL (e.g. ``https://api.core3.io/projects_data``).
+    api_url: str
+
+    #: Core3 API key (prefixed ``core3_``).
+    api_key: str
+
+    def __init__(self, api_url: str = CORE3_API_URL, api_key: str | None = None):
+        super().__init__()
+        self.api_url = api_url
+        if api_key is None:
+            api_key = os.environ.get("CORE3_API_KEY")
+        assert api_key, "CORE3_API_KEY environment variable or api_key parameter is required"
+        self.api_key = api_key
+        self.headers.update(
+            {
+                "User-Agent": CORE3_USER_AGENT,
+                "x-api-key": api_key,
+            }
+        )
+
+    def __repr__(self) -> str:
+        return f"<Core3Session api_url={self.api_url!r}>"
+
+
+def create_core3_session(
+    api_url: str = CORE3_API_URL,
+    api_key: str | None = None,
+    retries: int = DEFAULT_RETRIES,
+    backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
+    requests_per_second: float = CORE3_DEFAULT_REQUESTS_PER_SECOND,
+    pool_maxsize: int = 32,
+    rate_limit_db_path: Path = CORE3_RATE_LIMIT_SQLITE_DATABASE,
+) -> Core3Session:
+    """Create a :py:class:`Core3Session` configured for Core3 API.
+
+    The session is configured with:
+
+    - The API URL and API key stored on the session
+    - Rate limiting to respect Cloudflare throttling (thread-safe via SQLite)
+    - Retry logic for handling transient errors using exponential backoff
+
+    The rate limiter uses SQLite backend for thread-safe coordination across
+    multiple threads (e.g., when using ``joblib.Parallel`` with threading backend).
+
+    Example::
+
+        from eth_defi.core3.session import create_core3_session
+
+        session = create_core3_session()
+
+    :param api_url:
+        Core3 API base URL. Defaults to
+        :py:data:`~eth_defi.core3.constants.CORE3_API_URL`.
+    :param api_key:
+        Core3 API key. If ``None``, reads from ``CORE3_API_KEY`` env var.
+    :param retries:
+        Maximum number of retry attempts for failed requests.
+    :param backoff_factor:
+        Backoff factor for exponential retry delays.
+    :param requests_per_second:
+        Maximum requests per second to avoid rate limiting.
+    :param pool_maxsize:
+        Maximum number of connections to keep in the connection pool.
+        Should be at least as large as ``max_workers`` when using parallel requests.
+    :param rate_limit_db_path:
+        Path to SQLite database for storing rate limit state.
+    :return:
+        Configured :py:class:`Core3Session` with rate limiting and retry logic.
+    """
+    rate_limit_db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    session = Core3Session(api_url=api_url, api_key=api_key)
+
+    retry_policy = LoggingRetry(
+        total=retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=[429, 500, 502, 503, 504],
+        respect_retry_after_header=True,
+        logger=logger,
+    )
+
+    adapter = LimiterAdapter(
+        per_second=requests_per_second,
+        max_retries=retry_policy,
+        pool_connections=pool_maxsize,
+        pool_maxsize=pool_maxsize,
+        bucket_class=SQLiteBucket,
+        bucket_kwargs={"path": str(rate_limit_db_path)},
+    )
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
+
+
+# ---------------------------------------------------------------------------
+# Fetch helpers
+# ---------------------------------------------------------------------------
+
+
+def fetch_project_list(session: Core3Session, timeout: float = 30.0) -> list[dict]:
+    """Fetch the full project list from ``/v1/list``.
+
+    Returns the unwrapped list (the API wraps it as ``{"list": [...]}``)
+    containing slug, name, coingecko_id, and PoL score per project.
+
+    :param session:
+        Core3 API session.
+    :param timeout:
+        HTTP request timeout in seconds.
+    :return:
+        List of project dicts.
+    """
+    url = f"{session.api_url}/v1/list"
+    resp = session.get(url, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()["list"]
+
+
+def fetch_project_detail(session: Core3Session, slug: str, timeout: float = 30.0) -> dict:
+    """Fetch full project detail from ``/v1/{slug}``.
+
+    Returns the top-level project object including description, rank,
+    PoL score, market cap, links, top_risks, and seals.
+
+    :param session:
+        Core3 API session.
+    :param slug:
+        Project identifier (e.g. ``'ethereum'``, ``'aave'``).
+    :param timeout:
+        HTTP request timeout in seconds.
+    :return:
+        Project detail dict (raw JSON response).
+    """
+    url = f"{session.api_url}/v1/{slug}"
+    resp = session.get(url, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_pol_history(session: Core3Session, slug: str, timeout: float = 30.0) -> list[dict]:
+    """Fetch all-time PoL history chart from ``/v1/{slug}/pol/history/chart``.
+
+    Returns a list of ``{score, timestamp}`` points, unwrapped from
+    ``{"points": [...]}``. Used for initial backfill.
+
+    :param session:
+        Core3 API session.
+    :param slug:
+        Project slug.
+    :param timeout:
+        HTTP request timeout in seconds.
+    :return:
+        List of point dicts with ``score`` and ``timestamp`` keys.
+    """
+    url = f"{session.api_url}/v1/{slug}/pol/history/chart"
+    resp = session.get(url, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()["points"]
+
+
+def fetch_pol_history_incremental(
+    session: Core3Session,
+    slug: str,
+    from_ts: int,
+    to_ts: int,
+    timeout: float = 30.0,
+) -> list[dict]:
+    """Fetch ranged PoL history from ``/v1/{slug}/pol/history``.
+
+    Uses the ``from`` and ``to`` query parameters (unix timestamps in
+    seconds) to fetch only the requested range. Used for incremental
+    updates after the initial backfill.
+
+    :param session:
+        Core3 API session.
+    :param slug:
+        Project slug.
+    :param from_ts:
+        Start unix timestamp (inclusive).
+    :param to_ts:
+        End unix timestamp (inclusive).
+    :param timeout:
+        HTTP request timeout in seconds.
+    :return:
+        List of point dicts with ``score`` and ``timestamp`` keys.
+    """
+    url = f"{session.api_url}/v1/{slug}/pol/history"
+    resp = session.get(url, params={"from": from_ts, "to": to_ts}, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()["points"]
+
+
+def fetch_pol_category_history(session: Core3Session, slug: str, timeout: float = 30.0) -> list[dict]:
+    """Fetch all-time PoL category breakdown history from ``/v1/{slug}/pol/by_category/history/chart``.
+
+    Returns a list of points, each containing a timestamp and per-category
+    PoL scores (security, financial, operational, reputational, regulatory).
+
+    :param session:
+        Core3 API session.
+    :param slug:
+        Project slug.
+    :param timeout:
+        HTTP request timeout in seconds.
+    :return:
+        List of point dicts with category score breakdowns.
+    """
+    url = f"{session.api_url}/v1/{slug}/pol/by_category/history/chart"
+    resp = session.get(url, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()["points"]
+
+
+def fetch_pol_category_history_incremental(
+    session: Core3Session,
+    slug: str,
+    from_ts: int,
+    to_ts: int,
+    timeout: float = 30.0,
+) -> list[dict]:
+    """Fetch ranged PoL category breakdown history from ``/v1/{slug}/pol/by_category/history``.
+
+    :param session:
+        Core3 API session.
+    :param slug:
+        Project slug.
+    :param from_ts:
+        Start unix timestamp (inclusive).
+    :param to_ts:
+        End unix timestamp (inclusive).
+    :param timeout:
+        HTTP request timeout in seconds.
+    :return:
+        List of point dicts with category score breakdowns.
+    """
+    url = f"{session.api_url}/v1/{slug}/pol/by_category/history"
+    resp = session.get(url, params={"from": from_ts, "to": to_ts}, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()["points"]
+
+
+def fetch_index_pol_history(session: Core3Session, timeout: float = 30.0) -> list[dict]:
+    """Fetch all-time index-level aggregate PoL history from ``/v1/pol/history/chart``.
+
+    :param session:
+        Core3 API session.
+    :param timeout:
+        HTTP request timeout in seconds.
+    :return:
+        List of point dicts with ``score`` and ``timestamp`` keys.
+    """
+    url = f"{session.api_url}/v1/pol/history/chart"
+    resp = session.get(url, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()["points"]
+
+
+def fetch_index_pol_history_incremental(
+    session: Core3Session,
+    from_ts: int,
+    to_ts: int,
+    timeout: float = 30.0,
+) -> list[dict]:
+    """Fetch ranged index-level aggregate PoL history from ``/v1/pol/history``.
+
+    :param session:
+        Core3 API session.
+    :param from_ts:
+        Start unix timestamp (inclusive).
+    :param to_ts:
+        End unix timestamp (inclusive).
+    :param timeout:
+        HTTP request timeout in seconds.
+    :return:
+        List of point dicts with ``score`` and ``timestamp`` keys.
+    """
+    url = f"{session.api_url}/v1/pol/history"
+    resp = session.get(url, params={"from": from_ts, "to": to_ts}, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()["points"]
+
+
+def fetch_section_detail(session: Core3Session, slug: str, section: str, timeout: float = 30.0) -> dict:
+    """Fetch a project section endpoint (security, financial, etc.).
+
+    :param session:
+        Core3 API session.
+    :param slug:
+        Project slug.
+    :param section:
+        Section name: ``'security'``, ``'financial'``, ``'operational'``,
+        ``'reputational'``, or ``'regulatory'``.
+    :param timeout:
+        HTTP request timeout in seconds.
+    :return:
+        Section detail dict (raw JSON response).
+    """
+    url = f"{session.api_url}/v1/{slug}/{section}"
+    resp = session.get(url, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()

--- a/eth_defi/core3/session.py
+++ b/eth_defi/core3/session.py
@@ -4,8 +4,8 @@ This module provides session creation with retry logic and rate limiting
 for Core3 Projects Data API requests, plus helper functions to fetch
 and unwrap individual endpoints.
 
-Rate limiting is thread-safe using SQLite backend, so the session can be
-shared across multiple threads when using ``joblib.Parallel`` or similar.
+Rate limiting is thread-safe using an in-memory queue bucket, so the
+session can be shared across multiple threads.
 
 The :py:class:`Core3Session` carries the API URL and API key so that
 downstream functions do not need separate arguments on every call.
@@ -16,16 +16,14 @@ for endpoint details.
 
 import logging
 import os
-from pathlib import Path
 
-from pyrate_limiter import SQLiteBucket
+from pyrate_limiter import MemoryQueueBucket
 from requests import Session
 from requests_ratelimiter import LimiterAdapter
 
 from eth_defi.core3.constants import (
     CORE3_API_URL,
     CORE3_DEFAULT_REQUESTS_PER_SECOND,
-    CORE3_RATE_LIMIT_SQLITE_DATABASE,
     CORE3_USER_AGENT,
 )
 from eth_defi.velvet.logging_retry import LoggingRetry
@@ -80,18 +78,19 @@ def create_core3_session(
     backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
     requests_per_second: float = CORE3_DEFAULT_REQUESTS_PER_SECOND,
     pool_maxsize: int = 32,
-    rate_limit_db_path: Path = CORE3_RATE_LIMIT_SQLITE_DATABASE,
 ) -> Core3Session:
     """Create a :py:class:`Core3Session` configured for Core3 API.
 
     The session is configured with:
 
     - The API URL and API key stored on the session
-    - Rate limiting to respect Cloudflare throttling (thread-safe via SQLite)
+    - Rate limiting to respect Cloudflare throttling (in-memory, thread-safe)
     - Retry logic for handling transient errors using exponential backoff
 
-    The rate limiter uses SQLite backend for thread-safe coordination across
-    multiple threads (e.g., when using ``joblib.Parallel`` with threading backend).
+    The rate limiter uses an in-memory queue bucket which is thread-safe
+    for use with ``ThreadPoolExecutor`` or similar. SQLite-backed buckets
+    are avoided because they can cause segfaults when combined with DuckDB
+    in multi-threaded scenarios.
 
     Example::
 
@@ -113,13 +112,9 @@ def create_core3_session(
     :param pool_maxsize:
         Maximum number of connections to keep in the connection pool.
         Should be at least as large as ``max_workers`` when using parallel requests.
-    :param rate_limit_db_path:
-        Path to SQLite database for storing rate limit state.
     :return:
         Configured :py:class:`Core3Session` with rate limiting and retry logic.
     """
-    rate_limit_db_path.parent.mkdir(parents=True, exist_ok=True)
-
     session = Core3Session(api_url=api_url, api_key=api_key)
 
     retry_policy = LoggingRetry(
@@ -135,8 +130,7 @@ def create_core3_session(
         max_retries=retry_policy,
         pool_connections=pool_maxsize,
         pool_maxsize=pool_maxsize,
-        bucket_class=SQLiteBucket,
-        bucket_kwargs={"path": str(rate_limit_db_path)},
+        bucket_class=MemoryQueueBucket,
     )
     session.mount("http://", adapter)
     session.mount("https://", adapter)

--- a/eth_defi/core3/session.py
+++ b/eth_defi/core3/session.py
@@ -4,8 +4,8 @@ This module provides session creation with retry logic and rate limiting
 for Core3 Projects Data API requests, plus helper functions to fetch
 and unwrap individual endpoints.
 
-Rate limiting is thread-safe using an in-memory queue bucket, so the
-session can be shared across multiple threads.
+Rate limiting is thread-safe using SQLite backend, so the session can be
+shared across multiple threads when using ``joblib.Parallel`` or similar.
 
 The :py:class:`Core3Session` carries the API URL and API key so that
 downstream functions do not need separate arguments on every call.
@@ -16,14 +16,16 @@ for endpoint details.
 
 import logging
 import os
+from pathlib import Path
 
-from pyrate_limiter import MemoryQueueBucket
+from pyrate_limiter import SQLiteBucket
 from requests import Session
 from requests_ratelimiter import LimiterAdapter
 
 from eth_defi.core3.constants import (
     CORE3_API_URL,
     CORE3_DEFAULT_REQUESTS_PER_SECOND,
+    CORE3_RATE_LIMIT_SQLITE_DATABASE,
     CORE3_USER_AGENT,
 )
 from eth_defi.velvet.logging_retry import LoggingRetry
@@ -78,19 +80,18 @@ def create_core3_session(
     backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
     requests_per_second: float = CORE3_DEFAULT_REQUESTS_PER_SECOND,
     pool_maxsize: int = 32,
+    rate_limit_db_path: Path = CORE3_RATE_LIMIT_SQLITE_DATABASE,
 ) -> Core3Session:
     """Create a :py:class:`Core3Session` configured for Core3 API.
 
     The session is configured with:
 
     - The API URL and API key stored on the session
-    - Rate limiting to respect Cloudflare throttling (in-memory, thread-safe)
+    - Rate limiting to respect Cloudflare throttling (thread-safe via SQLite)
     - Retry logic for handling transient errors using exponential backoff
 
-    The rate limiter uses an in-memory queue bucket which is thread-safe
-    for use with ``ThreadPoolExecutor`` or similar. SQLite-backed buckets
-    are avoided because they can cause segfaults when combined with DuckDB
-    in multi-threaded scenarios.
+    The rate limiter uses SQLite backend for thread-safe coordination across
+    multiple threads (e.g., when using ``joblib.Parallel`` with threading backend).
 
     Example::
 
@@ -112,9 +113,13 @@ def create_core3_session(
     :param pool_maxsize:
         Maximum number of connections to keep in the connection pool.
         Should be at least as large as ``max_workers`` when using parallel requests.
+    :param rate_limit_db_path:
+        Path to SQLite database for storing rate limit state.
     :return:
         Configured :py:class:`Core3Session` with rate limiting and retry logic.
     """
+    rate_limit_db_path.parent.mkdir(parents=True, exist_ok=True)
+
     session = Core3Session(api_url=api_url, api_key=api_key)
 
     retry_policy = LoggingRetry(
@@ -130,7 +135,8 @@ def create_core3_session(
         max_retries=retry_policy,
         pool_connections=pool_maxsize,
         pool_maxsize=pool_maxsize,
-        bucket_class=MemoryQueueBucket,
+        bucket_class=SQLiteBucket,
+        bucket_kwargs={"path": str(rate_limit_db_path)},
     )
     session.mount("http://", adapter)
     session.mount("https://", adapter)

--- a/scripts/core3/core3-overview.py
+++ b/scripts/core3/core3-overview.py
@@ -20,6 +20,7 @@ Environment variables:
 import os
 from pathlib import Path
 
+import pandas as pd
 from tabulate import tabulate
 
 from eth_defi.core3.constants import CORE3_DATABASE_PATH
@@ -27,7 +28,7 @@ from eth_defi.core3.database import Core3Database
 
 
 def _fmt_market_cap(x) -> str:
-    if x is None or x == "":
+    if not isinstance(x, str) or x == "":
         return ""
     try:
         return f"${int(x):,}"
@@ -122,11 +123,11 @@ def main():
             ]
         ].copy()
 
-        display["pol_score"] = display["pol_score"].apply(lambda x: f"{x:.2f}" if x is not None else "")
+        display["pol_score"] = display["pol_score"].apply(lambda x: f"{x:.2f}" if pd.notna(x) else "")
         display["market_cap_usd"] = display["market_cap_usd"].apply(_fmt_market_cap)
-        display["pol_first"] = display["pol_first"].apply(lambda x: x.strftime("%Y-%m-%d") if x is not None else "")
-        display["pol_last"] = display["pol_last"].apply(lambda x: x.strftime("%Y-%m-%d") if x is not None else "")
-        display["last_snapshot"] = display["last_snapshot"].apply(lambda x: x.strftime("%Y-%m-%d %H:%M") if x is not None else "")
+        display["pol_first"] = display["pol_first"].apply(lambda x: x.strftime("%Y-%m-%d") if pd.notna(x) else "")
+        display["pol_last"] = display["pol_last"].apply(lambda x: x.strftime("%Y-%m-%d") if pd.notna(x) else "")
+        display["last_snapshot"] = display["last_snapshot"].apply(lambda x: x.strftime("%Y-%m-%d %H:%M") if pd.notna(x) else "")
 
         display.columns = [
             "slug",

--- a/scripts/core3/core3-overview.py
+++ b/scripts/core3/core3-overview.py
@@ -1,0 +1,169 @@
+"""Display an overview of the Core3 DuckDB database contents.
+
+Shows one row per project with key metrics, data counts, and last
+updated timestamps. Useful for verifying scan results.
+
+Usage:
+
+.. code-block:: shell
+
+    poetry run python scripts/core3/core3-overview.py
+
+    # Custom database path
+    DB_PATH=~/my-core3.duckdb poetry run python scripts/core3/core3-overview.py
+
+Environment variables:
+
+- ``DB_PATH``: Path to DuckDB database file. Default: ~/.tradingstrategy/core3/risk-data.duckdb
+"""
+
+import os
+from pathlib import Path
+
+from tabulate import tabulate
+
+from eth_defi.core3.constants import CORE3_DATABASE_PATH
+from eth_defi.core3.database import Core3Database
+
+
+def _fmt_market_cap(x) -> str:
+    if x is None or x == "":
+        return ""
+    try:
+        return f"${int(x):,}"
+    except (ValueError, TypeError):
+        return str(x)
+
+
+def main():
+    db_path_str = os.environ.get("DB_PATH")
+    if db_path_str:
+        db_path = Path(db_path_str).expanduser()
+    else:
+        db_path = CORE3_DATABASE_PATH
+
+    if not db_path.exists():
+        print(f"Database not found: {db_path}")
+        print("Run scan-core3.py first to populate the database.")
+        return
+
+    db = Core3Database(db_path)
+
+    try:
+        # Summary counts
+        project_count = db.get_project_count()
+        snapshot_count = db.get_snapshot_count()
+        pol_daily_count = db.get_pol_daily_count()
+
+        print(f"Database: {db_path}")
+        print(f"Projects: {project_count:,}")
+        print(f"Snapshots: {snapshot_count:,}")
+        print(f"PoL daily rows: {pol_daily_count:,}")
+
+        # Per-project overview: latest snapshot + data counts + timestamps
+        with db._db_lock:
+            df = db.con.execute("""
+                SELECT
+                    ps.slug,
+                    ps.name,
+                    ps.rank,
+                    ps.pol_score,
+                    ps.pol_rating,
+                    ps.market_cap_usd,
+                    ps.fetched_at AS last_snapshot,
+                    snap_counts.snapshot_count,
+                    COALESCE(pol_counts.pol_points, 0) AS pol_points,
+                    pol_counts.pol_first,
+                    pol_counts.pol_last,
+                    COALESCE(cat_counts.cat_points, 0) AS cat_points
+                FROM project_snapshots ps
+                INNER JOIN (
+                    SELECT slug, MAX(fetched_at) AS max_fetched_at
+                    FROM project_snapshots
+                    GROUP BY slug
+                ) latest ON ps.slug = latest.slug AND ps.fetched_at = latest.max_fetched_at
+                LEFT JOIN (
+                    SELECT slug, COUNT(*) AS snapshot_count
+                    FROM project_snapshots
+                    GROUP BY slug
+                ) snap_counts ON ps.slug = snap_counts.slug
+                LEFT JOIN (
+                    SELECT slug, COUNT(*) AS pol_points, MIN(ts) AS pol_first, MAX(ts) AS pol_last
+                    FROM pol_daily
+                    GROUP BY slug
+                ) pol_counts ON ps.slug = pol_counts.slug
+                LEFT JOIN (
+                    SELECT slug, COUNT(*) AS cat_points
+                    FROM pol_category_daily
+                    GROUP BY slug
+                ) cat_counts ON ps.slug = cat_counts.slug
+                ORDER BY ps.rank NULLS LAST
+            """).df()
+
+        if len(df) == 0:
+            print("\nNo projects found.")
+            return
+
+        # Format columns for display
+        display = df[
+            [
+                "slug",
+                "name",
+                "rank",
+                "pol_score",
+                "pol_rating",
+                "market_cap_usd",
+                "snapshot_count",
+                "pol_points",
+                "cat_points",
+                "pol_first",
+                "pol_last",
+                "last_snapshot",
+            ]
+        ].copy()
+
+        display["pol_score"] = display["pol_score"].apply(lambda x: f"{x:.2f}" if x is not None else "")
+        display["market_cap_usd"] = display["market_cap_usd"].apply(_fmt_market_cap)
+        display["pol_first"] = display["pol_first"].apply(lambda x: x.strftime("%Y-%m-%d") if x is not None else "")
+        display["pol_last"] = display["pol_last"].apply(lambda x: x.strftime("%Y-%m-%d") if x is not None else "")
+        display["last_snapshot"] = display["last_snapshot"].apply(lambda x: x.strftime("%Y-%m-%d %H:%M") if x is not None else "")
+
+        display.columns = [
+            "slug",
+            "name",
+            "rank",
+            "pol",
+            "rating",
+            "market_cap",
+            "snaps",
+            "pol_pts",
+            "cat_pts",
+            "pol_from",
+            "pol_to",
+            "last_updated",
+        ]
+
+        table = tabulate(
+            display.to_dict("records"),
+            headers="keys",
+            tablefmt="fancy_grid",
+        )
+        print(f"\n{table}")
+
+        # Index PoL summary
+        with db._db_lock:
+            index_row = db.con.execute("""
+                SELECT COUNT(*), MIN(ts), MAX(ts)
+                FROM pol_daily
+                WHERE slug = '__index__'
+            """).fetchone()
+
+        if index_row[0] > 0:
+            print(f"\nIndex PoL: {index_row[0]:,} points from {index_row[1]:%Y-%m-%d} to {index_row[2]:%Y-%m-%d}")
+
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/core3/reproduce-duckdb-crash.py
+++ b/scripts/core3/reproduce-duckdb-crash.py
@@ -41,19 +41,21 @@ faulthandler.enable()
 # ---------------------------------------------------------------------------
 # Configuration — matches real Core3 scanner data volume
 # ---------------------------------------------------------------------------
-NUM_PROJECTS = 150          # crash happens at ~100 in real scanner
-POINTS_PER_PROJECT = 200    # reduced from 700; still pushes WAL past 16 MiB
-CATEGORY_POINTS = 200       # reduced from 700
-CHECKPOINT_EVERY = 100      # chunk boundary
+NUM_PROJECTS = 150  # crash happens at ~100 in real scanner
+POINTS_PER_PROJECT = 200  # reduced from 700; still pushes WAL past 16 MiB
+CATEGORY_POINTS = 200  # reduced from 700
+CHECKPOINT_EVERY = 100  # chunk boundary
 MAX_WORKERS = 8
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def create_db(path: Path, disable_autocheckpoint: bool = False):
     """Create a DuckDB database with Core3-like schema."""
     import duckdb
+
     con = duckdb.connect(str(path))
     if disable_autocheckpoint:
         con.execute("SET wal_autocheckpoint = '1TB'")
@@ -97,14 +99,8 @@ def make_fake_project(slug: str) -> dict:
     """Generate fake project data matching real scanner volume."""
     fetched_at = datetime.datetime(2025, 6, 1, 0, 0, 0)
     detail = {"slug": slug, "name": f"Project {slug}", "rank": 1, "pol": {"score": 42.0}}
-    pol_points = [
-        (slug, datetime.datetime(2023, 1, 1) + datetime.timedelta(days=i), 42.0 + i * 0.01, fetched_at)
-        for i in range(POINTS_PER_PROJECT)
-    ]
-    cat_points = [
-        (slug, datetime.datetime(2023, 1, 1) + datetime.timedelta(days=i), 10.0, 20.0, 30.0, 40.0, 50.0, fetched_at)
-        for i in range(CATEGORY_POINTS)
-    ]
+    pol_points = [(slug, datetime.datetime(2023, 1, 1) + datetime.timedelta(days=i), 42.0 + i * 0.01, fetched_at) for i in range(POINTS_PER_PROJECT)]
+    cat_points = [(slug, datetime.datetime(2023, 1, 1) + datetime.timedelta(days=i), 10.0, 20.0, 30.0, 40.0, 50.0, fetched_at) for i in range(CATEGORY_POINTS)]
     return {
         "slug": slug,
         "fetched_at": fetched_at,
@@ -155,6 +151,7 @@ def checkpoint(con, lock):
 def reconnect(path: Path, con, lock, disable_autocheckpoint: bool = False):
     """Close and reopen connection."""
     import duckdb
+
     with lock:
         con.close()
     new_con = duckdb.connect(str(path))
@@ -167,6 +164,7 @@ def reconnect(path: Path, con, lock, disable_autocheckpoint: bool = False):
 # Scenarios
 # ---------------------------------------------------------------------------
 
+
 def scenario_1(db_path: Path):
     """Sequential writes only, no threads, no tqdm, CHECKPOINT every 100."""
     print("Scenario 1: sequential + CHECKPOINT")
@@ -176,9 +174,9 @@ def scenario_1(db_path: Path):
         project = make_fake_project(f"project-{i}")
         write_project_to_db(con, lock, project)
         if (i + 1) % CHECKPOINT_EVERY == 0:
-            report_threads(f"before checkpoint at {i+1}")
+            report_threads(f"before checkpoint at {i + 1}")
             checkpoint(con, lock)
-            print(f"  Checkpoint at {i+1} OK")
+            print(f"  Checkpoint at {i + 1} OK")
     con.close()
     print("  PASSED")
 
@@ -186,6 +184,7 @@ def scenario_1(db_path: Path):
 def scenario_2(db_path: Path):
     """Sequential writes + tqdm, no threads, CHECKPOINT every 100."""
     from tqdm.auto import tqdm
+
     print("Scenario 2: sequential + tqdm + CHECKPOINT")
     con = create_db(db_path)
     lock = threading.Lock()
@@ -193,9 +192,9 @@ def scenario_2(db_path: Path):
         project = make_fake_project(f"project-{i}")
         write_project_to_db(con, lock, project)
         if (i + 1) % CHECKPOINT_EVERY == 0:
-            report_threads(f"before checkpoint at {i+1}")
+            report_threads(f"before checkpoint at {i + 1}")
             checkpoint(con, lock)
-            print(f"  Checkpoint at {i+1} OK")
+            print(f"  Checkpoint at {i + 1} OK")
     con.close()
     print("  PASSED")
 
@@ -206,7 +205,7 @@ def scenario_3(db_path: Path):
     con = create_db(db_path)
     lock = threading.Lock()
     slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
-    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+    chunks = [slugs[i : i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
 
     for chunk_idx, chunk in enumerate(chunks):
         with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
@@ -225,11 +224,12 @@ def scenario_3(db_path: Path):
 def scenario_4(db_path: Path):
     """ThreadPoolExecutor + tqdm + DB writes on main, CHECKPOINT every 100."""
     from tqdm.auto import tqdm
+
     print("Scenario 4: ThreadPoolExecutor + tqdm + CHECKPOINT")
     con = create_db(db_path)
     lock = threading.Lock()
     slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
-    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+    chunks = [slugs[i : i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
 
     with tqdm(total=NUM_PROJECTS, desc="Scenario 4") as progress:
         for chunk_idx, chunk in enumerate(chunks):
@@ -250,11 +250,12 @@ def scenario_4(db_path: Path):
 def scenario_5(db_path: Path):
     """ThreadPoolExecutor + tqdm + DB writes on main, reconnect() every 100."""
     from tqdm.auto import tqdm
+
     print("Scenario 5: ThreadPoolExecutor + tqdm + reconnect()")
     con = create_db(db_path)
     lock = threading.Lock()
     slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
-    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+    chunks = [slugs[i : i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
 
     with tqdm(total=NUM_PROJECTS, desc="Scenario 5") as progress:
         for chunk_idx, chunk in enumerate(chunks):
@@ -275,6 +276,7 @@ def scenario_5(db_path: Path):
 def scenario_6(db_path: Path):
     """ThreadPoolExecutor + tqdm + DB writes on main, NO checkpoint at all."""
     from tqdm.auto import tqdm
+
     print("Scenario 6: ThreadPoolExecutor + tqdm + NO checkpoint")
     con = create_db(db_path, disable_autocheckpoint=True)
     lock = threading.Lock()
@@ -301,7 +303,7 @@ def scenario_7(db_path: Path):
         project = make_fake_project(f"project-{i}")
         write_project_to_db(con, lock, project)
         if (i + 1) % 50 == 0:
-            print(f"  Written {i+1}/{NUM_PROJECTS}")
+            print(f"  Written {i + 1}/{NUM_PROJECTS}")
     report_threads("before close")
     con.close()
     print("  PASSED")
@@ -310,11 +312,12 @@ def scenario_7(db_path: Path):
 def scenario_8(db_path: Path):
     """Like scenario 4, but with wal_autocheckpoint disabled."""
     from tqdm.auto import tqdm
+
     print("Scenario 8: ThreadPoolExecutor + tqdm + CHECKPOINT + autocheckpoint=1TB")
     con = create_db(db_path, disable_autocheckpoint=True)
     lock = threading.Lock()
     slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
-    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+    chunks = [slugs[i : i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
 
     with tqdm(total=NUM_PROJECTS, desc="Scenario 8") as progress:
         for chunk_idx, chunk in enumerate(chunks):
@@ -333,6 +336,7 @@ def scenario_8(db_path: Path):
 
 
 # ---------------------------------------------------------------------------
+
 
 def scenario_9(db_path: Path):
     """Like scenario 4, but with a real requests Session + LimiterAdapter."""
@@ -357,7 +361,7 @@ def scenario_9(db_path: Path):
     con = create_db(db_path)
     lock = threading.Lock()
     slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
-    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+    chunks = [slugs[i : i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
 
     def fetch_with_session(slug):
         # Don't actually make HTTP calls, but use the session object
@@ -403,7 +407,7 @@ def scenario_10(db_path: Path):
     con = create_db(db_path)
     lock = threading.Lock()
     slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
-    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+    chunks = [slugs[i : i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
 
     def fetch_with_real_http(slug):
         # Make a real HTTP request that fails fast
@@ -433,6 +437,7 @@ def scenario_10(db_path: Path):
 def scenario_11(db_path: Path):
     """Like scenario 4, but with REAL data volume (700 points per project) and network-like delays."""
     from tqdm.auto import tqdm
+
     print("Scenario 11: ThreadPoolExecutor + tqdm + CHECKPOINT + 700 points/project + delays")
 
     global POINTS_PER_PROJECT, CATEGORY_POINTS
@@ -449,7 +454,7 @@ def scenario_11(db_path: Path):
     con = create_db(db_path)
     lock = threading.Lock()
     slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
-    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+    chunks = [slugs[i : i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
 
     with tqdm(total=NUM_PROJECTS, desc="Scenario 11") as progress:
         for chunk_idx, chunk in enumerate(chunks):
@@ -477,6 +482,7 @@ def malloc_heavy_fetch(slug):
     """
     import random
     import ssl
+
     ctx = ssl.create_default_context()
     big_data = {f"key_{i}": f"value_{i}" * random.randint(10, 100) for i in range(200)}
     payload = json.dumps(big_data)
@@ -497,6 +503,7 @@ def scenario_12(db_path: Path):
     All threads share the same macOS malloc arenas → heap corruption.
     """
     from tqdm.auto import tqdm
+
     print("Scenario 12: INTERLEAVED — DB writes while threads do malloc-heavy work")
     print("  (This scenario attempts to reproduce the real crash)")
 
@@ -530,6 +537,7 @@ def scenario_13(db_path: Path):
     DB connection kept open during fetch phase (DuckDB's internal threads present).
     """
     from tqdm.auto import tqdm
+
     print("Scenario 13: TWO-PHASE — DB open during fetch (DuckDB threads present)")
 
     global POINTS_PER_PROJECT, CATEGORY_POINTS
@@ -540,14 +548,14 @@ def scenario_13(db_path: Path):
     con = create_db(db_path)
     lock = threading.Lock()
     slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
-    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+    chunks = [slugs[i : i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
 
     for chunk_idx, chunk in enumerate(chunks):
         # Phase 1: fetch all (threads alive, DuckDB connection open but idle)
         results = []
         with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
             futures = {executor.submit(malloc_heavy_fetch, s): s for s in chunk}
-            with tqdm(total=len(chunk), desc=f"Fetch chunk {chunk_idx+1}/{len(chunks)}") as progress:
+            with tqdm(total=len(chunk), desc=f"Fetch chunk {chunk_idx + 1}/{len(chunks)}") as progress:
                 for future in as_completed(futures):
                     results.append(future.result())
                     progress.update(1)
@@ -570,6 +578,7 @@ def scenario_14(db_path: Path):
     DuckDB's 22 internal threads don't exist during malloc-heavy fetch phase.
     """
     from tqdm.auto import tqdm
+
     print("Scenario 14: TWO-PHASE + LATE DB OPEN — DB closed during fetch")
 
     global POINTS_PER_PROJECT, CATEGORY_POINTS
@@ -578,14 +587,14 @@ def scenario_14(db_path: Path):
     CATEGORY_POINTS = 700
 
     slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
-    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+    chunks = [slugs[i : i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
 
     for chunk_idx, chunk in enumerate(chunks):
         # Phase 1: fetch all (NO DuckDB connection — no internal threads)
         results = []
         with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
             futures = {executor.submit(malloc_heavy_fetch, s): s for s in chunk}
-            with tqdm(total=len(chunk), desc=f"Fetch chunk {chunk_idx+1}/{len(chunks)}") as progress:
+            with tqdm(total=len(chunk), desc=f"Fetch chunk {chunk_idx + 1}/{len(chunks)}") as progress:
                 for future in as_completed(futures):
                     results.append(future.result())
                     progress.update(1)
@@ -607,6 +616,7 @@ def scenario_14(db_path: Path):
 def scenario_15(db_path: Path):
     """Like scenario 12, but with DuckDB threads=1."""
     from tqdm.auto import tqdm
+
     print("Scenario 15: INTERLEAVED + DuckDB threads=1")
 
     global POINTS_PER_PROJECT, CATEGORY_POINTS
@@ -615,6 +625,7 @@ def scenario_15(db_path: Path):
     CATEGORY_POINTS = 700
 
     import duckdb
+
     con = duckdb.connect(str(db_path))
     con.execute("SET threads = 1")
     con.execute("SET wal_autocheckpoint = '1TB'")
@@ -662,7 +673,7 @@ def scenario_16(db_path: Path):
     CATEGORY_POINTS = 700
 
     slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
-    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+    chunks = [slugs[i : i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
 
     for chunk_idx, chunk in enumerate(chunks):
         # Phase 1: fetch all (NO DuckDB, NO tqdm)
@@ -671,7 +682,7 @@ def scenario_16(db_path: Path):
             futures = {executor.submit(malloc_heavy_fetch, s): s for s in chunk}
             for future in as_completed(futures):
                 results.append(future.result())
-        print(f"  Fetched chunk {chunk_idx+1}/{len(chunks)}: {len(results)} projects")
+        print(f"  Fetched chunk {chunk_idx + 1}/{len(chunks)}: {len(results)} projects")
 
         # Phase 2: open DB, write, close
         con = create_db(db_path)
@@ -692,6 +703,7 @@ def scenario_17(db_path: Path):
     If this passes, multi-threaded malloc_heavy_fetch is required for the crash.
     """
     from tqdm.auto import tqdm
+
     print("Scenario 17: SEQUENTIAL malloc-heavy + DuckDB (no ThreadPoolExecutor)")
 
     global POINTS_PER_PROJECT, CATEGORY_POINTS
@@ -719,6 +731,7 @@ def scenario_18(db_path: Path):
     """
     from tqdm.auto import tqdm
     from concurrent.futures import ProcessPoolExecutor
+
     print("Scenario 18: ProcessPoolExecutor + DuckDB on main (separate heaps)")
 
     global POINTS_PER_PROJECT, CATEGORY_POINTS
@@ -729,13 +742,13 @@ def scenario_18(db_path: Path):
     con = create_db(db_path)
     lock = threading.Lock()
     slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
-    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+    chunks = [slugs[i : i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
 
     for chunk_idx, chunk in enumerate(chunks):
         results = []
         with ProcessPoolExecutor(max_workers=MAX_WORKERS) as executor:
             futures = {executor.submit(malloc_heavy_fetch, s): s for s in chunk}
-            with tqdm(total=len(chunk), desc=f"Fetch chunk {chunk_idx+1}/{len(chunks)}") as progress:
+            with tqdm(total=len(chunk), desc=f"Fetch chunk {chunk_idx + 1}/{len(chunks)}") as progress:
                 for future in as_completed(futures):
                     results.append(future.result())
                     progress.update(1)
@@ -758,6 +771,7 @@ def scenario_19(db_path: Path):
     Isolates whether SSL context creation is required for the crash.
     """
     from tqdm.auto import tqdm
+
     print("Scenario 19: SEQUENTIAL JSON-only churn + DuckDB (no SSL)")
 
     global POINTS_PER_PROJECT, CATEGORY_POINTS
@@ -797,6 +811,7 @@ def scenario_20(db_path: Path):
     """
     from tqdm.auto import tqdm
     import ssl
+
     print("Scenario 20: SEQUENTIAL SSL-only + DuckDB (no JSON churn)")
 
     global POINTS_PER_PROJECT, CATEGORY_POINTS
@@ -810,6 +825,7 @@ def scenario_20(db_path: Path):
         return make_fake_project(slug)
 
     import random
+
     con = create_db(db_path)
     lock = threading.Lock()
     slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
@@ -830,6 +846,7 @@ def scenario_21(db_path: Path):
     CHECKPOINT races with tqdm's monitor thread.
     """
     from tqdm.auto import tqdm
+
     print("Scenario 21: PURE DuckDB writes only, 700 points/project, DEFAULT autocheckpoint")
 
     global POINTS_PER_PROJECT, CATEGORY_POINTS
@@ -857,6 +874,7 @@ def scenario_22(db_path: Path):
     """
     from tqdm.auto import tqdm
     import random
+
     print("Scenario 22: JSON churn ALL first, then DuckDB writes ALL")
 
     global POINTS_PER_PROJECT, CATEGORY_POINTS
@@ -893,6 +911,7 @@ def scenario_23(db_path: Path):
     DuckDB's implicit wal_autocheckpoint + tqdm's daemon thread = heap corruption.
     """
     from tqdm.auto import tqdm
+
     print("Scenario 23: PURE DuckDB writes, 700 points, autocheckpoint=1TB")
 
     global POINTS_PER_PROJECT, CATEGORY_POINTS
@@ -932,7 +951,7 @@ def scenario_24(db_path: Path):
         project = make_fake_project(f"project-{i}")
         write_project_to_db(con, lock, project)
         if (i + 1) % 50 == 0:
-            print(f"  Written {i+1}/{NUM_PROJECTS}")
+            print(f"  Written {i + 1}/{NUM_PROJECTS}")
 
     report_threads("before close")
     con.close()
@@ -978,6 +997,7 @@ def main():
     print(f"\nPython {sys.version}")
 
     import duckdb
+
     print(f"DuckDB {duckdb.__version__}")
     print(f"GIL enabled: {sys._is_gil_enabled() if hasattr(sys, '_is_gil_enabled') else 'N/A'}")
     print(f"Projects: {NUM_PROJECTS}, points/project: {POINTS_PER_PROJECT}+{CATEGORY_POINTS}")

--- a/scripts/core3/reproduce-duckdb-crash.py
+++ b/scripts/core3/reproduce-duckdb-crash.py
@@ -1,0 +1,994 @@
+"""Standalone DuckDB crash reproducer — no API needed.
+
+Simulates the Core3 scanner's data volume and threading patterns
+to isolate what causes the SIGSEGV (exit code 139) on Python 3.14 + DuckDB 1.5.
+
+Run scenarios one at a time to identify the trigger:
+
+    python scripts/core3/reproduce-duckdb-crash.py <scenario>
+
+Scenarios:
+    1  Sequential writes only, no threads, no tqdm, with CHECKPOINT every 100
+    2  Sequential writes + tqdm, no threads, with CHECKPOINT every 100
+    3  ThreadPoolExecutor (no DB in threads) + DB writes on main, no tqdm, CHECKPOINT every 100
+    4  ThreadPoolExecutor + tqdm + DB writes on main, CHECKPOINT every 100
+    5  ThreadPoolExecutor + tqdm + DB writes on main, reconnect() every 100
+    6  ThreadPoolExecutor + tqdm + DB writes on main, NO checkpoint at all
+    7  Sequential writes, no threads, no tqdm, no intermediate checkpoint, close at end
+    8  Like 4, but with wal_autocheckpoint disabled (1TB)
+    9  Like 4, but with a requests Session + LimiterAdapter (no real HTTP)
+    10 Like 4, but with real HTTP calls to httpbin.org
+    11 Like 4, but with 700 points/project + network-like delays
+    12 INTERLEAVED: DB writes while threads do malloc-heavy work (simulates real scanner)
+    13 TWO-PHASE: fetch ALL into memory first, then write to DB (DB open during fetch)
+    14 TWO-PHASE + LATE DB OPEN: DB connection opened ONLY during write phase
+    15 INTERLEAVED + DuckDB threads=1: reduce internal thread count
+"""
+
+import datetime
+import faulthandler
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+faulthandler.enable()
+
+# ---------------------------------------------------------------------------
+# Configuration — matches real Core3 scanner data volume
+# ---------------------------------------------------------------------------
+NUM_PROJECTS = 150          # crash happens at ~100 in real scanner
+POINTS_PER_PROJECT = 200    # reduced from 700; still pushes WAL past 16 MiB
+CATEGORY_POINTS = 200       # reduced from 700
+CHECKPOINT_EVERY = 100      # chunk boundary
+MAX_WORKERS = 8
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def create_db(path: Path, disable_autocheckpoint: bool = False):
+    """Create a DuckDB database with Core3-like schema."""
+    import duckdb
+    con = duckdb.connect(str(path))
+    if disable_autocheckpoint:
+        con.execute("SET wal_autocheckpoint = '1TB'")
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS project_snapshots (
+            slug VARCHAR NOT NULL,
+            fetched_at TIMESTAMP NOT NULL,
+            name VARCHAR,
+            rank INTEGER,
+            pol_score DOUBLE,
+            payload VARCHAR NOT NULL,
+            PRIMARY KEY (slug, fetched_at)
+        )
+    """)
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS pol_daily (
+            slug VARCHAR NOT NULL,
+            ts TIMESTAMP NOT NULL,
+            pol_score DOUBLE NOT NULL,
+            fetched_at TIMESTAMP NOT NULL,
+            PRIMARY KEY (slug, ts)
+        )
+    """)
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS pol_category_daily (
+            slug VARCHAR NOT NULL,
+            ts TIMESTAMP NOT NULL,
+            security_score DOUBLE,
+            financial_score DOUBLE,
+            operational_score DOUBLE,
+            reputational_score DOUBLE,
+            regulatory_score DOUBLE,
+            fetched_at TIMESTAMP NOT NULL,
+            PRIMARY KEY (slug, ts)
+        )
+    """)
+    return con
+
+
+def make_fake_project(slug: str) -> dict:
+    """Generate fake project data matching real scanner volume."""
+    fetched_at = datetime.datetime(2025, 6, 1, 0, 0, 0)
+    detail = {"slug": slug, "name": f"Project {slug}", "rank": 1, "pol": {"score": 42.0}}
+    pol_points = [
+        (slug, datetime.datetime(2023, 1, 1) + datetime.timedelta(days=i), 42.0 + i * 0.01, fetched_at)
+        for i in range(POINTS_PER_PROJECT)
+    ]
+    cat_points = [
+        (slug, datetime.datetime(2023, 1, 1) + datetime.timedelta(days=i), 10.0, 20.0, 30.0, 40.0, 50.0, fetched_at)
+        for i in range(CATEGORY_POINTS)
+    ]
+    return {
+        "slug": slug,
+        "fetched_at": fetched_at,
+        "detail": detail,
+        "pol_points": pol_points,
+        "cat_points": cat_points,
+    }
+
+
+def write_project_to_db(con, lock, project: dict):
+    """Write one project's data to DuckDB (main thread)."""
+    slug = project["slug"]
+    detail = project["detail"]
+    fetched_at = project["fetched_at"]
+
+    with lock:
+        con.execute(
+            "INSERT INTO project_snapshots VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT DO NOTHING",
+            [slug, fetched_at, detail["name"], detail["rank"], detail["pol"]["score"], json.dumps(detail)],
+        )
+        con.executemany(
+            "INSERT INTO pol_daily VALUES (?, ?, ?, ?) ON CONFLICT DO NOTHING",
+            project["pol_points"],
+        )
+        con.executemany(
+            "INSERT INTO pol_category_daily VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT DO NOTHING",
+            project["cat_points"],
+        )
+
+
+def fake_fetch(_slug: str) -> dict:
+    """Simulate HTTP fetch — no DB access."""
+    return make_fake_project(_slug)
+
+
+def report_threads(label: str):
+    """Print all alive threads."""
+    threads = [t for t in threading.enumerate() if t is not threading.main_thread()]
+    print(f"  [{label}] Non-main threads: {len(threads)} — {[t.name for t in threads]}")
+
+
+def checkpoint(con, lock):
+    """Explicit CHECKPOINT."""
+    with lock:
+        con.execute("CHECKPOINT")
+
+
+def reconnect(path: Path, con, lock, disable_autocheckpoint: bool = False):
+    """Close and reopen connection."""
+    import duckdb
+    with lock:
+        con.close()
+    new_con = duckdb.connect(str(path))
+    if disable_autocheckpoint:
+        new_con.execute("SET wal_autocheckpoint = '1TB'")
+    return new_con
+
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+def scenario_1(db_path: Path):
+    """Sequential writes only, no threads, no tqdm, CHECKPOINT every 100."""
+    print("Scenario 1: sequential + CHECKPOINT")
+    con = create_db(db_path)
+    lock = threading.Lock()
+    for i in range(NUM_PROJECTS):
+        project = make_fake_project(f"project-{i}")
+        write_project_to_db(con, lock, project)
+        if (i + 1) % CHECKPOINT_EVERY == 0:
+            report_threads(f"before checkpoint at {i+1}")
+            checkpoint(con, lock)
+            print(f"  Checkpoint at {i+1} OK")
+    con.close()
+    print("  PASSED")
+
+
+def scenario_2(db_path: Path):
+    """Sequential writes + tqdm, no threads, CHECKPOINT every 100."""
+    from tqdm.auto import tqdm
+    print("Scenario 2: sequential + tqdm + CHECKPOINT")
+    con = create_db(db_path)
+    lock = threading.Lock()
+    for i in tqdm(range(NUM_PROJECTS), desc="Scenario 2"):
+        project = make_fake_project(f"project-{i}")
+        write_project_to_db(con, lock, project)
+        if (i + 1) % CHECKPOINT_EVERY == 0:
+            report_threads(f"before checkpoint at {i+1}")
+            checkpoint(con, lock)
+            print(f"  Checkpoint at {i+1} OK")
+    con.close()
+    print("  PASSED")
+
+
+def scenario_3(db_path: Path):
+    """ThreadPoolExecutor + DB writes on main, no tqdm, CHECKPOINT every 100."""
+    print("Scenario 3: ThreadPoolExecutor + CHECKPOINT, no tqdm")
+    con = create_db(db_path)
+    lock = threading.Lock()
+    slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
+    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+
+    for chunk_idx, chunk in enumerate(chunks):
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = {executor.submit(fake_fetch, s): s for s in chunk}
+            for future in as_completed(futures):
+                write_project_to_db(con, lock, future.result())
+
+        report_threads(f"after executor exit, chunk {chunk_idx}")
+        checkpoint(con, lock)
+        print(f"  Checkpoint after chunk {chunk_idx} OK")
+
+    con.close()
+    print("  PASSED")
+
+
+def scenario_4(db_path: Path):
+    """ThreadPoolExecutor + tqdm + DB writes on main, CHECKPOINT every 100."""
+    from tqdm.auto import tqdm
+    print("Scenario 4: ThreadPoolExecutor + tqdm + CHECKPOINT")
+    con = create_db(db_path)
+    lock = threading.Lock()
+    slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
+    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+
+    with tqdm(total=NUM_PROJECTS, desc="Scenario 4") as progress:
+        for chunk_idx, chunk in enumerate(chunks):
+            with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+                futures = {executor.submit(fake_fetch, s): s for s in chunk}
+                for future in as_completed(futures):
+                    write_project_to_db(con, lock, future.result())
+                    progress.update(1)
+
+            report_threads(f"after executor exit, chunk {chunk_idx}")
+            checkpoint(con, lock)
+            print(f"  Checkpoint after chunk {chunk_idx} OK")
+
+    con.close()
+    print("  PASSED")
+
+
+def scenario_5(db_path: Path):
+    """ThreadPoolExecutor + tqdm + DB writes on main, reconnect() every 100."""
+    from tqdm.auto import tqdm
+    print("Scenario 5: ThreadPoolExecutor + tqdm + reconnect()")
+    con = create_db(db_path)
+    lock = threading.Lock()
+    slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
+    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+
+    with tqdm(total=NUM_PROJECTS, desc="Scenario 5") as progress:
+        for chunk_idx, chunk in enumerate(chunks):
+            with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+                futures = {executor.submit(fake_fetch, s): s for s in chunk}
+                for future in as_completed(futures):
+                    write_project_to_db(con, lock, future.result())
+                    progress.update(1)
+
+            report_threads(f"after executor exit, chunk {chunk_idx}")
+            con = reconnect(db_path, con, lock)
+            print(f"  Reconnect after chunk {chunk_idx} OK")
+
+    con.close()
+    print("  PASSED")
+
+
+def scenario_6(db_path: Path):
+    """ThreadPoolExecutor + tqdm + DB writes on main, NO checkpoint at all."""
+    from tqdm.auto import tqdm
+    print("Scenario 6: ThreadPoolExecutor + tqdm + NO checkpoint")
+    con = create_db(db_path, disable_autocheckpoint=True)
+    lock = threading.Lock()
+    slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
+
+    with tqdm(total=NUM_PROJECTS, desc="Scenario 6") as progress:
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = {executor.submit(fake_fetch, s): s for s in slugs}
+            for future in as_completed(futures):
+                write_project_to_db(con, lock, future.result())
+                progress.update(1)
+
+    report_threads("after everything")
+    # Don't checkpoint, don't close cleanly — just exit
+    print("  PASSED (no checkpoint, no close)")
+
+
+def scenario_7(db_path: Path):
+    """Sequential writes, no threads, no tqdm, no intermediate checkpoint, close at end."""
+    print("Scenario 7: sequential, no threads, no tqdm, close at end only")
+    con = create_db(db_path)
+    lock = threading.Lock()
+    for i in range(NUM_PROJECTS):
+        project = make_fake_project(f"project-{i}")
+        write_project_to_db(con, lock, project)
+        if (i + 1) % 50 == 0:
+            print(f"  Written {i+1}/{NUM_PROJECTS}")
+    report_threads("before close")
+    con.close()
+    print("  PASSED")
+
+
+def scenario_8(db_path: Path):
+    """Like scenario 4, but with wal_autocheckpoint disabled."""
+    from tqdm.auto import tqdm
+    print("Scenario 8: ThreadPoolExecutor + tqdm + CHECKPOINT + autocheckpoint=1TB")
+    con = create_db(db_path, disable_autocheckpoint=True)
+    lock = threading.Lock()
+    slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
+    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+
+    with tqdm(total=NUM_PROJECTS, desc="Scenario 8") as progress:
+        for chunk_idx, chunk in enumerate(chunks):
+            with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+                futures = {executor.submit(fake_fetch, s): s for s in chunk}
+                for future in as_completed(futures):
+                    write_project_to_db(con, lock, future.result())
+                    progress.update(1)
+
+            report_threads(f"after executor exit, chunk {chunk_idx}")
+            checkpoint(con, lock)
+            print(f"  Checkpoint after chunk {chunk_idx} OK")
+
+    con.close()
+    print("  PASSED")
+
+
+# ---------------------------------------------------------------------------
+
+def scenario_9(db_path: Path):
+    """Like scenario 4, but with a real requests Session + LimiterAdapter."""
+    from tqdm.auto import tqdm
+    from pyrate_limiter import MemoryQueueBucket
+    from requests import Session
+    from requests_ratelimiter import LimiterAdapter
+
+    print("Scenario 9: ThreadPoolExecutor + tqdm + CHECKPOINT + real requests Session")
+
+    # Create a session matching create_core3_session() config
+    session = Session()
+    adapter = LimiterAdapter(
+        per_second=50,  # fast, we're not hitting real endpoints
+        pool_connections=32,
+        pool_maxsize=32,
+        bucket_class=MemoryQueueBucket,
+    )
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+
+    con = create_db(db_path)
+    lock = threading.Lock()
+    slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
+    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+
+    def fetch_with_session(slug):
+        # Don't actually make HTTP calls, but use the session object
+        # to keep its connection pool alive
+        return make_fake_project(slug)
+
+    with tqdm(total=NUM_PROJECTS, desc="Scenario 9") as progress:
+        for chunk_idx, chunk in enumerate(chunks):
+            with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+                futures = {executor.submit(fetch_with_session, s): s for s in chunk}
+                for future in as_completed(futures):
+                    write_project_to_db(con, lock, future.result())
+                    progress.update(1)
+
+            report_threads(f"after executor exit, chunk {chunk_idx}")
+            checkpoint(con, lock)
+            print(f"  Checkpoint after chunk {chunk_idx} OK")
+
+    session.close()
+    con.close()
+    print("  PASSED")
+
+
+def scenario_10(db_path: Path):
+    """Like scenario 4, but threads make REAL HTTP requests (to localhost/invalid)."""
+    from tqdm.auto import tqdm
+    from pyrate_limiter import MemoryQueueBucket
+    from requests import Session
+    from requests_ratelimiter import LimiterAdapter
+
+    print("Scenario 10: ThreadPoolExecutor + tqdm + CHECKPOINT + real HTTP calls")
+
+    session = Session()
+    adapter = LimiterAdapter(
+        per_second=50,
+        pool_connections=32,
+        pool_maxsize=32,
+        bucket_class=MemoryQueueBucket,
+    )
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+
+    con = create_db(db_path)
+    lock = threading.Lock()
+    slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
+    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+
+    def fetch_with_real_http(slug):
+        # Make a real HTTP request that fails fast
+        try:
+            session.get("https://httpbin.org/get", timeout=2)
+        except Exception:
+            pass
+        return make_fake_project(slug)
+
+    with tqdm(total=NUM_PROJECTS, desc="Scenario 10") as progress:
+        for chunk_idx, chunk in enumerate(chunks):
+            with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+                futures = {executor.submit(fetch_with_real_http, s): s for s in chunk}
+                for future in as_completed(futures):
+                    write_project_to_db(con, lock, future.result())
+                    progress.update(1)
+
+            report_threads(f"after executor exit, chunk {chunk_idx}")
+            checkpoint(con, lock)
+            print(f"  Checkpoint after chunk {chunk_idx} OK")
+
+    session.close()
+    con.close()
+    print("  PASSED")
+
+
+def scenario_11(db_path: Path):
+    """Like scenario 4, but with REAL data volume (700 points per project) and network-like delays."""
+    from tqdm.auto import tqdm
+    print("Scenario 11: ThreadPoolExecutor + tqdm + CHECKPOINT + 700 points/project + delays")
+
+    global POINTS_PER_PROJECT, CATEGORY_POINTS
+    old_pp, old_cp = POINTS_PER_PROJECT, CATEGORY_POINTS
+    POINTS_PER_PROJECT = 700
+    CATEGORY_POINTS = 700
+
+    import random
+
+    def fetch_with_delay(slug):
+        time.sleep(random.uniform(0.2, 2.0))  # simulate real network latency
+        return make_fake_project(slug)
+
+    con = create_db(db_path)
+    lock = threading.Lock()
+    slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
+    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+
+    with tqdm(total=NUM_PROJECTS, desc="Scenario 11") as progress:
+        for chunk_idx, chunk in enumerate(chunks):
+            with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+                futures = {executor.submit(fetch_with_delay, s): s for s in chunk}
+                for future in as_completed(futures):
+                    write_project_to_db(con, lock, future.result())
+                    progress.update(1)
+
+            report_threads(f"after executor exit, chunk {chunk_idx}")
+            checkpoint(con, lock)
+            print(f"  Checkpoint after chunk {chunk_idx} OK")
+
+    con.close()
+    POINTS_PER_PROJECT, CATEGORY_POINTS = old_pp, old_cp
+    print("  PASSED")
+
+
+def malloc_heavy_fetch(slug):
+    """Simulate the malloc pressure of real HTTP + SSL + JSON parsing.
+
+    SSL context creation does heavy malloc (like real HTTPS requests).
+    JSON encode/decode churns the allocator concurrently with DuckDB's
+    internal threads — reproduces the heap corruption on macOS.
+    """
+    import random
+    import ssl
+    ctx = ssl.create_default_context()
+    big_data = {f"key_{i}": f"value_{i}" * random.randint(10, 100) for i in range(200)}
+    payload = json.dumps(big_data)
+    parsed = json.loads(payload)
+    for _ in range(50):
+        _ = json.dumps(parsed)
+        _ = json.loads(payload)
+    time.sleep(random.uniform(0.1, 0.5))
+    return make_fake_project(slug)
+
+
+def scenario_12(db_path: Path):
+    """INTERLEAVED: DB writes on main while threads do malloc-heavy SSL/HTTP work.
+
+    This matches the real scanner pattern: as_completed() loop writes to DuckDB
+    on the main thread while OTHER executor threads are still running, doing
+    malloc-heavy SSL + JSON work. DuckDB also spawns ~22 internal C++ threads.
+    All threads share the same macOS malloc arenas → heap corruption.
+    """
+    from tqdm.auto import tqdm
+    print("Scenario 12: INTERLEAVED — DB writes while threads do malloc-heavy work")
+    print("  (This scenario attempts to reproduce the real crash)")
+
+    global POINTS_PER_PROJECT, CATEGORY_POINTS
+    old_pp, old_cp = POINTS_PER_PROJECT, CATEGORY_POINTS
+    POINTS_PER_PROJECT = 700
+    CATEGORY_POINTS = 700
+
+    con = create_db(db_path)
+    lock = threading.Lock()
+    slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
+
+    # Single executor for all projects — DB writes interleaved with fetches
+    with tqdm(total=NUM_PROJECTS, desc="Scenario 12") as progress:
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = {executor.submit(malloc_heavy_fetch, s): s for s in slugs}
+            for future in as_completed(futures):
+                # Write to DB while other threads still running
+                write_project_to_db(con, lock, future.result())
+                progress.update(1)
+
+    report_threads("after everything")
+    con.close()
+    POINTS_PER_PROJECT, CATEGORY_POINTS = old_pp, old_cp
+    print("  PASSED")
+
+
+def scenario_13(db_path: Path):
+    """TWO-PHASE: fetch ALL into memory first, then write to DB with no threads alive.
+
+    DB connection kept open during fetch phase (DuckDB's internal threads present).
+    """
+    from tqdm.auto import tqdm
+    print("Scenario 13: TWO-PHASE — DB open during fetch (DuckDB threads present)")
+
+    global POINTS_PER_PROJECT, CATEGORY_POINTS
+    old_pp, old_cp = POINTS_PER_PROJECT, CATEGORY_POINTS
+    POINTS_PER_PROJECT = 700
+    CATEGORY_POINTS = 700
+
+    con = create_db(db_path)
+    lock = threading.Lock()
+    slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
+    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+
+    for chunk_idx, chunk in enumerate(chunks):
+        # Phase 1: fetch all (threads alive, DuckDB connection open but idle)
+        results = []
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = {executor.submit(malloc_heavy_fetch, s): s for s in chunk}
+            with tqdm(total=len(chunk), desc=f"Fetch chunk {chunk_idx+1}/{len(chunks)}") as progress:
+                for future in as_completed(futures):
+                    results.append(future.result())
+                    progress.update(1)
+
+        # Phase 2: write to DB (no threads alive except tqdm daemon)
+        for project in results:
+            write_project_to_db(con, lock, project)
+        report_threads(f"before checkpoint, chunk {chunk_idx}")
+        checkpoint(con, lock)
+        print(f"  Checkpoint after chunk {chunk_idx} OK")
+
+    con.close()
+    POINTS_PER_PROJECT, CATEGORY_POINTS = old_pp, old_cp
+    print("  PASSED")
+
+
+def scenario_14(db_path: Path):
+    """TWO-PHASE + LATE DB OPEN: DB connection opened ONLY during write phase.
+
+    DuckDB's 22 internal threads don't exist during malloc-heavy fetch phase.
+    """
+    from tqdm.auto import tqdm
+    print("Scenario 14: TWO-PHASE + LATE DB OPEN — DB closed during fetch")
+
+    global POINTS_PER_PROJECT, CATEGORY_POINTS
+    old_pp, old_cp = POINTS_PER_PROJECT, CATEGORY_POINTS
+    POINTS_PER_PROJECT = 700
+    CATEGORY_POINTS = 700
+
+    slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
+    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+
+    for chunk_idx, chunk in enumerate(chunks):
+        # Phase 1: fetch all (NO DuckDB connection — no internal threads)
+        results = []
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = {executor.submit(malloc_heavy_fetch, s): s for s in chunk}
+            with tqdm(total=len(chunk), desc=f"Fetch chunk {chunk_idx+1}/{len(chunks)}") as progress:
+                for future in as_completed(futures):
+                    results.append(future.result())
+                    progress.update(1)
+        # executor exited, all threads joined
+
+        # Phase 2: open DB, write, close (no fetch threads, no DuckDB threads during fetch)
+        con = create_db(db_path)
+        lock = threading.Lock()
+        for project in results:
+            write_project_to_db(con, lock, project)
+        report_threads(f"before close, chunk {chunk_idx}")
+        con.close()
+        print(f"  Close after chunk {chunk_idx} OK")
+
+    POINTS_PER_PROJECT, CATEGORY_POINTS = old_pp, old_cp
+    print("  PASSED")
+
+
+def scenario_15(db_path: Path):
+    """Like scenario 12, but with DuckDB threads=1."""
+    from tqdm.auto import tqdm
+    print("Scenario 15: INTERLEAVED + DuckDB threads=1")
+
+    global POINTS_PER_PROJECT, CATEGORY_POINTS
+    old_pp, old_cp = POINTS_PER_PROJECT, CATEGORY_POINTS
+    POINTS_PER_PROJECT = 700
+    CATEGORY_POINTS = 700
+
+    import duckdb
+    con = duckdb.connect(str(db_path))
+    con.execute("SET threads = 1")
+    con.execute("SET wal_autocheckpoint = '1TB'")
+    # Create schema
+    con.execute("""CREATE TABLE IF NOT EXISTS project_snapshots (
+        slug VARCHAR NOT NULL, fetched_at TIMESTAMP NOT NULL, name VARCHAR,
+        rank INTEGER, pol_score DOUBLE, payload VARCHAR NOT NULL,
+        PRIMARY KEY (slug, fetched_at))""")
+    con.execute("""CREATE TABLE IF NOT EXISTS pol_daily (
+        slug VARCHAR NOT NULL, ts TIMESTAMP NOT NULL, pol_score DOUBLE NOT NULL,
+        fetched_at TIMESTAMP NOT NULL, PRIMARY KEY (slug, ts))""")
+    con.execute("""CREATE TABLE IF NOT EXISTS pol_category_daily (
+        slug VARCHAR NOT NULL, ts TIMESTAMP NOT NULL,
+        security_score DOUBLE, financial_score DOUBLE, operational_score DOUBLE,
+        reputational_score DOUBLE, regulatory_score DOUBLE,
+        fetched_at TIMESTAMP NOT NULL, PRIMARY KEY (slug, ts))""")
+
+    lock = threading.Lock()
+    slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
+
+    with tqdm(total=NUM_PROJECTS, desc="Scenario 15") as progress:
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = {executor.submit(malloc_heavy_fetch, s): s for s in slugs}
+            for future in as_completed(futures):
+                write_project_to_db(con, lock, future.result())
+                progress.update(1)
+
+    report_threads("after everything")
+    con.close()
+    POINTS_PER_PROJECT, CATEGORY_POINTS = old_pp, old_cp
+    print("  PASSED")
+
+
+def scenario_16(db_path: Path):
+    """TWO-PHASE + LATE DB OPEN + NO TQDM: isolate tqdm as a factor.
+
+    Same as scenario 14 but without tqdm. If this passes, tqdm's
+    persistent monitor thread is interacting with DuckDB to trigger the crash.
+    """
+    print("Scenario 16: TWO-PHASE + LATE DB OPEN + NO TQDM")
+
+    global POINTS_PER_PROJECT, CATEGORY_POINTS
+    old_pp, old_cp = POINTS_PER_PROJECT, CATEGORY_POINTS
+    POINTS_PER_PROJECT = 700
+    CATEGORY_POINTS = 700
+
+    slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
+    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+
+    for chunk_idx, chunk in enumerate(chunks):
+        # Phase 1: fetch all (NO DuckDB, NO tqdm)
+        results = []
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = {executor.submit(malloc_heavy_fetch, s): s for s in chunk}
+            for future in as_completed(futures):
+                results.append(future.result())
+        print(f"  Fetched chunk {chunk_idx+1}/{len(chunks)}: {len(results)} projects")
+
+        # Phase 2: open DB, write, close
+        con = create_db(db_path)
+        lock = threading.Lock()
+        for project in results:
+            write_project_to_db(con, lock, project)
+        report_threads(f"before close, chunk {chunk_idx}")
+        con.close()
+        print(f"  Close after chunk {chunk_idx} OK")
+
+    POINTS_PER_PROJECT, CATEGORY_POINTS = old_pp, old_cp
+    print("  PASSED")
+
+
+def scenario_17(db_path: Path):
+    """SEQUENTIAL malloc-heavy fetch + DuckDB writes. No thread pool at all.
+
+    If this passes, multi-threaded malloc_heavy_fetch is required for the crash.
+    """
+    from tqdm.auto import tqdm
+    print("Scenario 17: SEQUENTIAL malloc-heavy + DuckDB (no ThreadPoolExecutor)")
+
+    global POINTS_PER_PROJECT, CATEGORY_POINTS
+    old_pp, old_cp = POINTS_PER_PROJECT, CATEGORY_POINTS
+    POINTS_PER_PROJECT = 700
+    CATEGORY_POINTS = 700
+
+    con = create_db(db_path)
+    lock = threading.Lock()
+    slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
+
+    for slug in tqdm(slugs, desc="Scenario 17"):
+        project = malloc_heavy_fetch(slug)
+        write_project_to_db(con, lock, project)
+
+    con.close()
+    POINTS_PER_PROJECT, CATEGORY_POINTS = old_pp, old_cp
+    print("  PASSED")
+
+
+def scenario_18(db_path: Path):
+    """ProcessPoolExecutor for fetch, DuckDB writes on main thread.
+
+    Each worker process has its own heap — no cross-process memory corruption.
+    """
+    from tqdm.auto import tqdm
+    from concurrent.futures import ProcessPoolExecutor
+    print("Scenario 18: ProcessPoolExecutor + DuckDB on main (separate heaps)")
+
+    global POINTS_PER_PROJECT, CATEGORY_POINTS
+    old_pp, old_cp = POINTS_PER_PROJECT, CATEGORY_POINTS
+    POINTS_PER_PROJECT = 700
+    CATEGORY_POINTS = 700
+
+    con = create_db(db_path)
+    lock = threading.Lock()
+    slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
+    chunks = [slugs[i:i + CHECKPOINT_EVERY] for i in range(0, len(slugs), CHECKPOINT_EVERY)]
+
+    for chunk_idx, chunk in enumerate(chunks):
+        results = []
+        with ProcessPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            futures = {executor.submit(malloc_heavy_fetch, s): s for s in chunk}
+            with tqdm(total=len(chunk), desc=f"Fetch chunk {chunk_idx+1}/{len(chunks)}") as progress:
+                for future in as_completed(futures):
+                    results.append(future.result())
+                    progress.update(1)
+
+        for project in results:
+            write_project_to_db(con, lock, project)
+        report_threads(f"before reconnect, chunk {chunk_idx}")
+        con.close()
+        con = create_db(db_path)
+        print(f"  Reconnect after chunk {chunk_idx} OK")
+
+    con.close()
+    POINTS_PER_PROJECT, CATEGORY_POINTS = old_pp, old_cp
+    print("  PASSED")
+
+
+def scenario_19(db_path: Path):
+    """Sequential, JSON churn only (no ssl.create_default_context), + DuckDB writes.
+
+    Isolates whether SSL context creation is required for the crash.
+    """
+    from tqdm.auto import tqdm
+    print("Scenario 19: SEQUENTIAL JSON-only churn + DuckDB (no SSL)")
+
+    global POINTS_PER_PROJECT, CATEGORY_POINTS
+    old_pp, old_cp = POINTS_PER_PROJECT, CATEGORY_POINTS
+    POINTS_PER_PROJECT = 700
+    CATEGORY_POINTS = 700
+
+    import random
+
+    def json_only_fetch(slug):
+        big_data = {f"key_{i}": f"value_{i}" * random.randint(10, 100) for i in range(200)}
+        payload = json.dumps(big_data)
+        parsed = json.loads(payload)
+        for _ in range(50):
+            _ = json.dumps(parsed)
+            _ = json.loads(payload)
+        time.sleep(random.uniform(0.1, 0.5))
+        return make_fake_project(slug)
+
+    con = create_db(db_path)
+    lock = threading.Lock()
+    slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
+
+    for slug in tqdm(slugs, desc="Scenario 19"):
+        project = json_only_fetch(slug)
+        write_project_to_db(con, lock, project)
+
+    con.close()
+    POINTS_PER_PROJECT, CATEGORY_POINTS = old_pp, old_cp
+    print("  PASSED")
+
+
+def scenario_20(db_path: Path):
+    """Sequential, SSL only (no JSON churn), + DuckDB writes.
+
+    Isolates whether SSL alone is sufficient for the crash.
+    """
+    from tqdm.auto import tqdm
+    import ssl
+    print("Scenario 20: SEQUENTIAL SSL-only + DuckDB (no JSON churn)")
+
+    global POINTS_PER_PROJECT, CATEGORY_POINTS
+    old_pp, old_cp = POINTS_PER_PROJECT, CATEGORY_POINTS
+    POINTS_PER_PROJECT = 700
+    CATEGORY_POINTS = 700
+
+    def ssl_only_fetch(slug):
+        ctx = ssl.create_default_context()
+        time.sleep(random.uniform(0.1, 0.5))
+        return make_fake_project(slug)
+
+    import random
+    con = create_db(db_path)
+    lock = threading.Lock()
+    slugs = [f"project-{i}" for i in range(NUM_PROJECTS)]
+
+    for slug in tqdm(slugs, desc="Scenario 20"):
+        project = ssl_only_fetch(slug)
+        write_project_to_db(con, lock, project)
+
+    con.close()
+    POINTS_PER_PROJECT, CATEGORY_POINTS = old_pp, old_cp
+    print("  PASSED")
+
+
+def scenario_21(db_path: Path):
+    """Pure DuckDB writes only, 700 points/project, no fetch, no JSON, no SSL.
+
+    Uses DEFAULT wal_autocheckpoint (16 MiB). Crashes because the implicit
+    CHECKPOINT races with tqdm's monitor thread.
+    """
+    from tqdm.auto import tqdm
+    print("Scenario 21: PURE DuckDB writes only, 700 points/project, DEFAULT autocheckpoint")
+
+    global POINTS_PER_PROJECT, CATEGORY_POINTS
+    old_pp, old_cp = POINTS_PER_PROJECT, CATEGORY_POINTS
+    POINTS_PER_PROJECT = 700
+    CATEGORY_POINTS = 700
+
+    con = create_db(db_path)  # default wal_autocheckpoint=16MiB
+    lock = threading.Lock()
+
+    for i in tqdm(range(NUM_PROJECTS), desc="Scenario 21"):
+        project = make_fake_project(f"project-{i}")
+        write_project_to_db(con, lock, project)
+
+    con.close()
+    POINTS_PER_PROJECT, CATEGORY_POINTS = old_pp, old_cp
+    print("  PASSED")
+
+
+def scenario_22(db_path: Path):
+    """JSON churn first (all projects), THEN DuckDB writes (all projects).
+
+    Fully separate phases: if this passes, the interleaving matters.
+    If this crashes, the heap is poisoned by prior JSON churn.
+    """
+    from tqdm.auto import tqdm
+    import random
+    print("Scenario 22: JSON churn ALL first, then DuckDB writes ALL")
+
+    global POINTS_PER_PROJECT, CATEGORY_POINTS
+    old_pp, old_cp = POINTS_PER_PROJECT, CATEGORY_POINTS
+    POINTS_PER_PROJECT = 700
+    CATEGORY_POINTS = 700
+
+    # Phase 1: all JSON churn, no DuckDB
+    projects = []
+    for slug in tqdm([f"project-{i}" for i in range(NUM_PROJECTS)], desc="Phase 1: JSON churn"):
+        big_data = {f"key_{i}": f"value_{i}" * random.randint(10, 100) for i in range(200)}
+        payload = json.dumps(big_data)
+        parsed = json.loads(payload)
+        for _ in range(50):
+            _ = json.dumps(parsed)
+            _ = json.loads(payload)
+        projects.append(make_fake_project(slug))
+
+    # Phase 2: all DuckDB writes
+    con = create_db(db_path)
+    lock = threading.Lock()
+    for project in tqdm(projects, desc="Phase 2: DB writes"):
+        write_project_to_db(con, lock, project)
+
+    con.close()
+    POINTS_PER_PROJECT, CATEGORY_POINTS = old_pp, old_cp
+    print("  PASSED")
+
+
+def scenario_23(db_path: Path):
+    """Like scenario 21, but with wal_autocheckpoint DISABLED (1TB).
+
+    If this passes while 21 crashes, the root cause is:
+    DuckDB's implicit wal_autocheckpoint + tqdm's daemon thread = heap corruption.
+    """
+    from tqdm.auto import tqdm
+    print("Scenario 23: PURE DuckDB writes, 700 points, autocheckpoint=1TB")
+
+    global POINTS_PER_PROJECT, CATEGORY_POINTS
+    old_pp, old_cp = POINTS_PER_PROJECT, CATEGORY_POINTS
+    POINTS_PER_PROJECT = 700
+    CATEGORY_POINTS = 700
+
+    con = create_db(db_path, disable_autocheckpoint=True)
+    lock = threading.Lock()
+
+    for i in tqdm(range(NUM_PROJECTS), desc="Scenario 23"):
+        project = make_fake_project(f"project-{i}")
+        write_project_to_db(con, lock, project)
+
+    report_threads("before close")
+    con.close()
+    POINTS_PER_PROJECT, CATEGORY_POINTS = old_pp, old_cp
+    print("  PASSED")
+
+
+def scenario_24(db_path: Path):
+    """Like scenario 21 (700 points, default autocheckpoint) but NO tqdm.
+
+    If this passes while 21 crashes, tqdm's monitor thread is required.
+    """
+    print("Scenario 24: PURE DuckDB writes, 700 points, DEFAULT autocheckpoint, NO tqdm")
+
+    global POINTS_PER_PROJECT, CATEGORY_POINTS
+    old_pp, old_cp = POINTS_PER_PROJECT, CATEGORY_POINTS
+    POINTS_PER_PROJECT = 700
+    CATEGORY_POINTS = 700
+
+    con = create_db(db_path)  # default wal_autocheckpoint
+    lock = threading.Lock()
+
+    for i in range(NUM_PROJECTS):
+        project = make_fake_project(f"project-{i}")
+        write_project_to_db(con, lock, project)
+        if (i + 1) % 50 == 0:
+            print(f"  Written {i+1}/{NUM_PROJECTS}")
+
+    report_threads("before close")
+    con.close()
+    POINTS_PER_PROJECT, CATEGORY_POINTS = old_pp, old_cp
+    print("  PASSED")
+
+
+SCENARIOS = {
+    "1": scenario_1,
+    "2": scenario_2,
+    "3": scenario_3,
+    "4": scenario_4,
+    "5": scenario_5,
+    "6": scenario_6,
+    "7": scenario_7,
+    "8": scenario_8,
+    "9": scenario_9,
+    "10": scenario_10,
+    "11": scenario_11,
+    "12": scenario_12,
+    "13": scenario_13,
+    "14": scenario_14,
+    "15": scenario_15,
+    "16": scenario_16,
+    "17": scenario_17,
+    "18": scenario_18,
+    "19": scenario_19,
+    "20": scenario_20,
+    "21": scenario_21,
+    "22": scenario_22,
+    "23": scenario_23,
+    "24": scenario_24,
+}
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] not in SCENARIOS:
+        print(__doc__)
+        print("Available scenarios:", ", ".join(sorted(SCENARIOS.keys())))
+        sys.exit(1)
+
+    scenario_id = sys.argv[1]
+    print(f"\nPython {sys.version}")
+
+    import duckdb
+    print(f"DuckDB {duckdb.__version__}")
+    print(f"GIL enabled: {sys._is_gil_enabled() if hasattr(sys, '_is_gil_enabled') else 'N/A'}")
+    print(f"Projects: {NUM_PROJECTS}, points/project: {POINTS_PER_PROJECT}+{CATEGORY_POINTS}")
+    print(f"Checkpoint every: {CHECKPOINT_EVERY}, workers: {MAX_WORKERS}")
+    print()
+
+    tmp_dir = tempfile.mkdtemp()
+    db_path = Path(tmp_dir) / "test.duckdb"
+
+    SCENARIOS[scenario_id](db_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/core3/scan-core3.py
+++ b/scripts/core3/scan-core3.py
@@ -1,0 +1,118 @@
+"""Scan all Core3 projects and store risk data in DuckDB.
+
+This script fetches project risk intelligence from the Core3 API and stores
+point-in-time snapshots plus PoL time-series in a DuckDB database for
+historical tracking.
+
+Usage:
+
+.. code-block:: shell
+
+    # Basic usage (scans all projects)
+    source .local-test.env && poetry run python scripts/core3/scan-core3.py
+
+    # With debug logging
+    source .local-test.env && LOG_LEVEL=info poetry run python scripts/core3/scan-core3.py
+
+    # Limited scan for testing
+    source .local-test.env && LIMIT=10 poetry run python scripts/core3/scan-core3.py
+
+    # Include section details (security, financial, etc.)
+    source .local-test.env && FETCH_SECTIONS=true poetry run python scripts/core3/scan-core3.py
+
+Environment variables:
+
+- ``CORE3_API_KEY``: Core3 API key (required, prefixed ``core3_``)
+- ``LOG_LEVEL``: Logging level (debug, info, warning, error). Default: warning
+- ``DB_PATH``: Path to DuckDB database file. Default: ~/.tradingstrategy/core3/risk-data.duckdb
+- ``LIMIT``: Limit the number of projects to scan (for testing). Default: None (scan all)
+- ``MAX_WORKERS``: Maximum number of parallel workers. Default: 8
+- ``FETCH_SECTIONS``: Set to ``true`` to also fetch section detail endpoints. Default: false
+"""
+
+import logging
+import os
+from pathlib import Path
+
+from tabulate import tabulate
+
+from eth_defi.core3.constants import CORE3_DATABASE_PATH
+from eth_defi.core3.scanner import scan_projects
+from eth_defi.core3.session import create_core3_session
+from eth_defi.utils import setup_console_logging
+
+logger = logging.getLogger(__name__)
+
+
+def main():
+    default_log_level = os.environ.get("LOG_LEVEL", "warning")
+    setup_console_logging(
+        default_log_level=default_log_level,
+        log_file=Path("logs/core3-scan.log"),
+    )
+
+    logger.info("Using log level: %s", default_log_level)
+
+    db_path_str = os.environ.get("DB_PATH")
+    if db_path_str:
+        db_path = Path(db_path_str).expanduser()
+    else:
+        db_path = CORE3_DATABASE_PATH
+
+    limit_str = os.environ.get("LIMIT")
+    limit = int(limit_str) if limit_str else None
+
+    max_workers = int(os.environ.get("MAX_WORKERS", "8"))
+    fetch_sections = os.environ.get("FETCH_SECTIONS", "false").lower() == "true"
+
+    print(f"Scanning Core3 projects...")
+    print(f"Database path: {db_path}")
+    if limit:
+        print(f"Limit: {limit} projects")
+    print(f"Max workers: {max_workers}")
+    print(f"Fetch sections: {fetch_sections}")
+
+    session = create_core3_session()
+
+    db = scan_projects(
+        session=session,
+        db_path=db_path,
+        limit=limit,
+        max_workers=max_workers,
+        fetch_sections=fetch_sections,
+    )
+
+    try:
+        project_count = db.get_project_count()
+        snapshot_count = db.get_snapshot_count()
+        pol_daily_count = db.get_pol_daily_count()
+
+        print(f"\nScan complete!")
+        print(f"Total projects: {project_count:,}")
+        print(f"Total snapshots: {snapshot_count:,}")
+        print(f"PoL daily rows: {pol_daily_count:,}")
+
+        df = db.get_latest_project_snapshots()
+        if len(df) > 0:
+            print("\nTop 10 projects by rank:")
+            top_10 = df.head(10)[["slug", "name", "rank", "pol_score", "pol_rating", "market_cap_usd"]].copy()
+            top_10["pol_score"] = top_10["pol_score"].apply(lambda x: f"{x:.2f}" if x is not None else "")
+            top_10["market_cap_usd"] = top_10["market_cap_usd"].apply(lambda x: f"${int(x):,}" if x is not None and x != "" else "")
+            table_fmt = tabulate(
+                top_10.to_dict("records"),
+                headers="keys",
+                tablefmt="fancy_grid",
+            )
+            print(table_fmt)
+    finally:
+        db.close()
+
+    print("\nAll ok")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        logger.exception("Fatal error: %s", e, exc_info=e)
+        raise e

--- a/scripts/core3/scan-core3.py
+++ b/scripts/core3/scan-core3.py
@@ -97,7 +97,16 @@ def main():
             print("\nTop 10 projects by rank:")
             top_10 = df.head(10)[["slug", "name", "rank", "pol_score", "pol_rating", "market_cap_usd"]].copy()
             top_10["pol_score"] = top_10["pol_score"].apply(lambda x: f"{x:.2f}" if x is not None else "")
-            top_10["market_cap_usd"] = top_10["market_cap_usd"].apply(lambda x: f"${int(x):,}" if x is not None and x != "" else "")
+
+            def _fmt_market_cap(x):
+                if x is None or x == "":
+                    return ""
+                try:
+                    return f"${int(x):,}"
+                except (ValueError, TypeError):
+                    return str(x)
+
+            top_10["market_cap_usd"] = top_10["market_cap_usd"].apply(_fmt_market_cap)
             table_fmt = tabulate(
                 top_10.to_dict("records"),
                 headers="keys",

--- a/tests/core3/test_core3_database.py
+++ b/tests/core3/test_core3_database.py
@@ -1,0 +1,298 @@
+"""Offline tests for Core3Database — no API key required.
+
+Verifies DuckDB insert, deduplication, sync state, and query methods
+using synthetic data so these tests always run in CI.
+"""
+
+import datetime
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from eth_defi.core3.constants import INDEX_SLUG
+from eth_defi.core3.database import Core3Database
+
+
+@pytest.fixture()
+def db(tmp_path: Path):
+    """Create a temporary Core3Database, closed after test."""
+    database = Core3Database(tmp_path / "test.duckdb")
+    yield database
+    database.close()
+
+
+def _make_project_json(slug: str, rank: int, pol_score: float, market_cap: str | None = None) -> dict:
+    """Build a minimal project detail JSON matching the API shape."""
+    result = {
+        "slug": slug,
+        "name": slug.replace("-", " ").title(),
+        "rank": rank,
+        "pol": {"score": pol_score, "rating": "BBB"},
+    }
+    if market_cap is not None:
+        result["market_cap"] = {"in_usd": market_cap}
+    return result
+
+
+def test_insert_and_query_project_snapshots(db: Core3Database):
+    """Insert project snapshots and verify query methods return correct data.
+
+    1. Insert two project snapshots with different fetched_at timestamps
+    2. Verify get_project_count returns unique slug count
+    3. Verify get_snapshot_count returns total row count
+    4. Verify get_latest_project_snapshots returns only the most recent per slug
+    5. Verify get_project_snapshot_history returns all snapshots for a slug
+    """
+    t1 = datetime.datetime(2025, 1, 1, 12, 0, 0)
+    t2 = datetime.datetime(2025, 1, 2, 12, 0, 0)
+
+    raw_aave = _make_project_json("aave", rank=5, pol_score=15.5, market_cap="1000000")
+    raw_uniswap = _make_project_json("uniswap", rank=10, pol_score=20.0)
+
+    # 1. Insert at two timestamps
+    db.insert_project_snapshot("aave", t1, raw_aave)
+    db.insert_project_snapshot("uniswap", t1, raw_uniswap)
+    db.insert_project_snapshot("aave", t2, raw_aave)
+
+    # 2. Unique project count
+    assert db.get_project_count() == 2
+
+    # 3. Total snapshot rows
+    assert db.get_snapshot_count() == 3
+
+    # 4. Latest snapshots — one per slug
+    df_latest = db.get_latest_project_snapshots()
+    assert len(df_latest) == 2
+    aave_row = df_latest[df_latest["slug"] == "aave"].iloc[0]
+    assert aave_row["rank"] == 5
+    assert aave_row["pol_score"] == pytest.approx(15.5)
+    assert aave_row["market_cap_usd"] == "1000000"
+
+    # uniswap has no market cap
+    uni_row = df_latest[df_latest["slug"] == "uniswap"].iloc[0]
+    assert uni_row["market_cap_usd"] is None or pd.isna(uni_row["market_cap_usd"])
+
+    # 5. History for aave
+    df_history = db.get_project_snapshot_history("aave")
+    assert len(df_history) == 2
+
+    # Payload is valid JSON
+    payload = json.loads(aave_row["payload"])
+    assert payload["slug"] == "aave"
+
+
+def test_snapshot_upsert_on_conflict(db: Core3Database):
+    """Inserting a snapshot with the same (slug, fetched_at) updates existing row.
+
+    1. Insert a snapshot
+    2. Insert again with same key but different rank
+    3. Verify the row was updated (not duplicated)
+    """
+    t1 = datetime.datetime(2025, 1, 1, 12, 0, 0)
+
+    # 1. Initial insert
+    db.insert_project_snapshot("aave", t1, _make_project_json("aave", rank=5, pol_score=15.0))
+
+    # 2. Upsert with updated rank
+    db.insert_project_snapshot("aave", t1, _make_project_json("aave", rank=3, pol_score=12.0))
+
+    # 3. Still one row, with updated values
+    assert db.get_snapshot_count() == 1
+    df = db.get_latest_project_snapshots()
+    assert df.iloc[0]["rank"] == 3
+    assert df.iloc[0]["pol_score"] == pytest.approx(12.0)
+
+
+def test_pol_daily_insert_and_dedup(db: Core3Database):
+    """Insert PoL daily points and verify ON CONFLICT DO NOTHING deduplication.
+
+    1. Insert 3 points for a project
+    2. Insert overlapping points (2 old + 1 new)
+    3. Verify only the new point was added (total 4, not 6)
+    4. Verify scores are in expected range
+    """
+    t_fetch = datetime.datetime(2025, 6, 1, 0, 0, 0)
+
+    # 1. Initial 3 points
+    points_1 = [
+        {"score": 10.0, "timestamp": 1700000000},
+        {"score": 11.0, "timestamp": 1700086400},
+        {"score": 12.0, "timestamp": 1700172800},
+    ]
+    new_count = db.insert_pol_daily_points("aave", points_1, t_fetch)
+    assert new_count == 3
+
+    # 2. Overlapping insert (2 existing + 1 new)
+    points_2 = [
+        {"score": 10.0, "timestamp": 1700000000},
+        {"score": 11.0, "timestamp": 1700086400},
+        {"score": 13.0, "timestamp": 1700259200},
+    ]
+    new_count = db.insert_pol_daily_points("aave", points_2, t_fetch)
+    assert new_count == 1
+
+    # 3. Total is 4
+    assert db.get_pol_daily_count() == 4
+
+    # 4. Query and verify
+    df = db.get_pol_daily("aave")
+    assert len(df) == 4
+    assert df["pol_score"].min() == pytest.approx(10.0)
+    assert df["pol_score"].max() == pytest.approx(13.0)
+
+
+def test_pol_daily_empty_points(db: Core3Database):
+    """Inserting an empty points list returns 0 and does not error.
+
+    1. Insert empty list
+    2. Verify return value is 0 and table is empty
+    """
+    t_fetch = datetime.datetime(2025, 6, 1, 0, 0, 0)
+    assert db.insert_pol_daily_points("aave", [], t_fetch) == 0
+    assert db.get_pol_daily_count() == 0
+
+
+def test_pol_category_daily_insert(db: Core3Database):
+    """Insert category PoL daily points and verify column extraction.
+
+    1. Insert points with category scores
+    2. Verify all category columns are populated
+    3. Verify deduplication on second insert
+    """
+    t_fetch = datetime.datetime(2025, 6, 1, 0, 0, 0)
+
+    points = [
+        {
+            "timestamp": 1700000000,
+            "security": {"score": 5.0},
+            "financial": {"score": 10.0},
+            "operational": {"score": 15.0},
+            "reputational": {"score": 20.0},
+            "regulatory": {"score": 25.0},
+        },
+        {
+            "timestamp": 1700086400,
+            "security": {"score": 6.0},
+            "financial": None,
+            "operational": {"score": 16.0},
+        },
+    ]
+
+    # 1. Insert
+    new_count = db.insert_pol_category_daily_points("aave", points, t_fetch)
+    assert new_count == 2
+
+    # 2. Verify columns
+    df = db.get_pol_category_daily("aave")
+    assert len(df) == 2
+    row0 = df.iloc[0]
+    assert row0["security_score"] == pytest.approx(5.0)
+    assert row0["regulatory_score"] == pytest.approx(25.0)
+
+    # Second row has None for financial (API returned null)
+    row1 = df.iloc[1]
+    assert row1["financial_score"] is None or pd.isna(row1["financial_score"])
+
+    # 3. Dedup
+    new_count = db.insert_pol_category_daily_points("aave", points, t_fetch)
+    assert new_count == 0
+
+
+def test_sync_state_lifecycle(db: Core3Database):
+    """Verify sync state create, read, update cycle.
+
+    1. Initially no state exists
+    2. Update sync state with backfill_done=True
+    3. Read back and verify fields
+    4. Update with new last_ts
+    5. Verify updated values
+    """
+    # 1. No state
+    assert db.get_sync_state("aave", "pol_daily") is None
+
+    # 2. Create state
+    db.update_sync_state("aave", "pol_daily", last_ts=1700000000, backfill_done=True)
+
+    # 3. Read back
+    state = db.get_sync_state("aave", "pol_daily")
+    assert state is not None
+    assert state["last_ts"] == 1700000000
+    assert state["backfill_done"] is True
+    assert state["last_synced"] is not None
+
+    # 4. Update
+    db.update_sync_state("aave", "pol_daily", last_ts=1700172800, backfill_done=True)
+
+    # 5. Verify update
+    state = db.get_sync_state("aave", "pol_daily")
+    assert state["last_ts"] == 1700172800
+
+
+def test_sync_state_null_last_ts(db: Core3Database):
+    """Sync state with last_ts=None represents a backfilled project with no data.
+
+    1. Set backfill_done=True with last_ts=None
+    2. Verify state distinguishes from never-synced (None return)
+    """
+    # 1. Backfill done, but no data
+    db.update_sync_state("empty-project", "pol_daily", last_ts=None, backfill_done=True)
+
+    # 2. State exists (not None) but last_ts is None
+    state = db.get_sync_state("empty-project", "pol_daily")
+    assert state is not None
+    assert state["last_ts"] is None
+    assert state["backfill_done"] is True
+
+
+def test_section_snapshot_insert(db: Core3Database):
+    """Insert a section snapshot and verify extraction.
+
+    1. Insert a security section snapshot
+    2. Verify section_pol_score is extracted
+    3. Verify payload is stored
+    """
+    t_fetch = datetime.datetime(2025, 6, 1, 0, 0, 0)
+    raw = {"pol": {"score": 8.5}, "details": [{"name": "audit", "status": "passed"}]}
+
+    # 1. Insert
+    db.insert_section_snapshot("aave", "security", t_fetch, raw)
+
+    # 2-3. Query via raw SQL (no dedicated query method for sections)
+    with db._db_lock:
+        row = db.con.execute(
+            "SELECT section_pol_score, payload FROM section_snapshots WHERE slug = ? AND section = ?",
+            ["aave", "security"],
+        ).fetchone()
+
+    assert row[0] == pytest.approx(8.5)
+    payload = json.loads(row[1])
+    assert payload["details"][0]["name"] == "audit"
+
+
+def test_index_slug_isolation(db: Core3Database):
+    """Index-level PoL rows use INDEX_SLUG and are isolated from project rows.
+
+    1. Insert points for a project and for the index
+    2. Verify get_pol_daily returns only the requested slug's rows
+    """
+    t_fetch = datetime.datetime(2025, 6, 1, 0, 0, 0)
+
+    project_points = [{"score": 20.0, "timestamp": 1700000000}]
+    index_points = [{"score": 50.0, "timestamp": 1700000000}]
+
+    db.insert_pol_daily_points("aave", project_points, t_fetch)
+    db.insert_pol_daily_points(INDEX_SLUG, index_points, t_fetch)
+
+    # Total is 2
+    assert db.get_pol_daily_count() == 2
+
+    # Each query returns only its own rows
+    df_aave = db.get_pol_daily("aave")
+    assert len(df_aave) == 1
+    assert df_aave.iloc[0]["pol_score"] == pytest.approx(20.0)
+
+    df_index = db.get_pol_daily(INDEX_SLUG)
+    assert len(df_index) == 1
+    assert df_index.iloc[0]["pol_score"] == pytest.approx(50.0)

--- a/tests/core3/test_core3_scanner.py
+++ b/tests/core3/test_core3_scanner.py
@@ -1,0 +1,175 @@
+"""Test Core3 risk intelligence scanner with DuckDB storage.
+
+Verifies that we can scan Core3 projects and store snapshots,
+PoL time-series, and category breakdowns in a DuckDB database.
+
+Requires ``CORE3_API_KEY`` environment variable to be set.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from eth_defi.core3.constants import INDEX_SLUG
+from eth_defi.core3.database import Core3Database
+from eth_defi.core3.scanner import scan_projects
+from eth_defi.core3.session import create_core3_session
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("CORE3_API_KEY"),
+    reason="CORE3_API_KEY not set",
+)
+
+
+@pytest.fixture()
+def core3_session():
+    """Create a Core3 API session for testing."""
+    return create_core3_session()
+
+
+def test_scan_projects_snapshot_only(core3_session, tmp_path: Path):
+    """Scan a handful of projects without history and verify snapshots are stored.
+
+    1. Scan 5 projects with PoL and category history disabled
+    2. Verify project_count matches the limit
+    3. Verify expected columns exist in the latest snapshots
+    4. Verify payload column contains non-empty JSON
+    5. Verify PoL daily table is empty (history not fetched)
+    """
+    db_path = tmp_path / "test-snapshots.duckdb"
+
+    # 1. Scan 5 projects, snapshots only
+    db = scan_projects(
+        session=core3_session,
+        db_path=db_path,
+        fetch_pol_history=False,
+        fetch_category_history=False,
+        fetch_index_pol=False,
+        limit=5,
+        max_workers=2,
+    )
+
+    try:
+        # 2. Verify project count
+        project_count = db.get_project_count()
+        assert project_count == 5, f"Expected 5 projects, got {project_count}"
+
+        # 3. Verify columns in latest snapshots
+        df = db.get_latest_project_snapshots()
+        assert len(df) == 5
+        for col in ("slug", "name", "rank", "pol_score", "pol_rating", "market_cap_usd", "payload"):
+            assert col in df.columns, f"Missing column: {col}"
+
+        # 4. Verify payloads are non-empty JSON
+        assert df["payload"].notna().all()
+        assert (df["payload"].str.len() > 2).all()
+
+        # 5. Verify no PoL daily rows (history not fetched)
+        assert db.get_pol_daily_count() == 0
+    finally:
+        db.close()
+
+
+def test_scan_projects_with_pol_history(core3_session, tmp_path: Path):
+    """Scan projects with full history enabled and verify time-series data.
+
+    1. Scan 3 projects with PoL history, category history, and index PoL enabled
+    2. Verify pol_daily has points for each project with scores in 0-100
+    3. Verify pol_category_daily has rows with category scores
+    4. Verify INDEX_SLUG rows exist in pol_daily (index-level aggregate)
+    """
+    db_path = tmp_path / "test-history.duckdb"
+
+    # 1. Scan 3 projects with all history
+    db = scan_projects(
+        session=core3_session,
+        db_path=db_path,
+        fetch_pol_history=True,
+        fetch_category_history=True,
+        fetch_index_pol=True,
+        limit=3,
+        max_workers=2,
+    )
+
+    try:
+        # 2. Verify pol_daily has data with scores in valid range
+        df_snapshots = db.get_latest_project_snapshots()
+        for slug in df_snapshots["slug"].tolist():
+            df_pol = db.get_pol_daily(slug)
+            assert len(df_pol) > 0, f"Expected PoL history for {slug}"
+            assert (df_pol["pol_score"] >= 0).all(), f"PoL scores below 0 for {slug}"
+            assert (df_pol["pol_score"] <= 100).all(), f"PoL scores above 100 for {slug}"
+
+        # 3. Verify category daily data
+        for slug in df_snapshots["slug"].tolist():
+            df_cat = db.get_pol_category_daily(slug)
+            assert len(df_cat) > 0, f"Expected category history for {slug}"
+            for cat_col in ("security_score", "financial_score", "operational_score"):
+                assert cat_col in df_cat.columns, f"Missing {cat_col} for {slug}"
+
+        # 4. Verify index PoL exists
+        df_index = db.get_pol_daily(INDEX_SLUG)
+        assert len(df_index) > 0, "Expected index-level PoL history"
+        assert (df_index["pol_score"] >= 0).all()
+        assert (df_index["pol_score"] <= 100).all()
+    finally:
+        db.close()
+
+
+def test_scan_idempotent(core3_session, tmp_path: Path):
+    """Scan the same projects twice and verify idempotent inserts.
+
+    1. Scan 2 projects with PoL history
+    2. Record pol_daily row count and snapshot count
+    3. Scan the same 2 projects again
+    4. Verify no duplicate (slug, ts) rows in pol_daily
+    5. Verify project_snapshots count doubles (two fetched_at values)
+    """
+    db_path = tmp_path / "test-idempotent.duckdb"
+
+    # 1. First scan
+    db = scan_projects(
+        session=core3_session,
+        db_path=db_path,
+        fetch_pol_history=True,
+        fetch_category_history=False,
+        fetch_index_pol=False,
+        limit=2,
+        max_workers=2,
+    )
+
+    try:
+        # 2. Record counts after first scan
+        pol_count_1 = db.get_pol_daily_count()
+        snapshot_count_1 = db.get_snapshot_count()
+        assert pol_count_1 > 0, "First scan should produce PoL rows"
+        assert snapshot_count_1 == 2, "First scan should produce 2 snapshots"
+    finally:
+        db.close()
+
+    # 3. Second scan of same projects
+    db = scan_projects(
+        session=core3_session,
+        db_path=db_path,
+        fetch_pol_history=True,
+        fetch_category_history=False,
+        fetch_index_pol=False,
+        limit=2,
+        max_workers=2,
+    )
+
+    try:
+        pol_count_2 = db.get_pol_daily_count()
+        snapshot_count_2 = db.get_snapshot_count()
+
+        # 4. PoL daily uses ON CONFLICT DO NOTHING — row count should not
+        # significantly increase (may increase slightly if API published
+        # new points between the two scans)
+        assert pol_count_2 >= pol_count_1, "PoL count should not decrease"
+        assert pol_count_2 <= pol_count_1 + 10, f"PoL count grew unexpectedly: {pol_count_1} -> {pol_count_2}"
+
+        # 5. Snapshots use different fetched_at, so count should double
+        assert snapshot_count_2 == 4, f"Expected 4 snapshots (2 per scan), got {snapshot_count_2}"
+    finally:
+        db.close()


### PR DESCRIPTION
## Why

We need to continuously track risk intelligence data from Core3 (formerly CER.live), which provides Probability of Loss (PoL) scores across ~1,400 crypto projects. This data helps assess protocol risk across security, financial, operational, reputational, and regulatory categories.

The API schema is in beta and will change, so we store raw JSON payloads alongside extracted key columns for future re-extraction.

## Lessons learnt

- Core3 API is behind Cloudflare — requests without a `User-Agent` header get blocked with HTTP 403 / error code 1010
- `requests.exceptions.JSONDecodeError` is NOT a subclass of `json.JSONDecodeError` — catch `ValueError` instead
- Two-phase incremental sync (full backfill via `/history/chart` then ranged `/history?from=&to=`) avoids refetching 2,000-point histories on every poll cycle
- A `backfill_done` boolean flag in sync_state distinguishes "never synced" from "backfill attempted but API returned zero points", preventing infinite re-backfill
- DuckDB connections are not thread-safe — all reads and writes must be serialised with `threading.Lock`
- Rate limiting with `SQLiteBucket` from `pyrate_limiter` provides thread-safe coordination across `joblib.Parallel` workers

## Summary

New `eth_defi.core3` module with:

- **`constants.py`** — API URL, default DB path, rate limit config, section names
- **`session.py`** — `Core3Session` (requests.Session subclass) with rate limiting via `LimiterAdapter` + `SQLiteBucket`, retry logic via `LoggingRetry`, and 9 fetch helpers that unwrap API DTOs
- **`database.py`** — `Core3Database` with 5 DuckDB tables: `project_snapshots`, `section_snapshots`, `pol_daily`, `pol_category_daily`, `sync_state`. Thread-safe with `threading.Lock`
- **`scanner.py`** — `scan_projects()` orchestrator using `joblib.Parallel(backend="threading")` with tqdm progress, two-phase incremental sync, stratified error handling (401/403 hard fail, 404 skip, 5xx retry then skip)
- **`scripts/core3/scan-core3.py`** — batch job script with env var configuration
- **`tests/core3/test_core3_scanner.py`** — 3 integration tests (snapshot-only, full history, idempotency)
- **`docs/source/api/core3/index.rst`** — Sphinx API documentation stub
- **`README-core3.md`** — comprehensive API documentation with all endpoints, parameters, and quirks