### PR TITLE
fix: Thread HotWallet nonce through Safe operations to prevent stale-nonce crashes

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/lagoon/deployment.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/deployment.py
@@ -1169,12 +1169,16 @@ def deploy_safe_trading_strategy_module(
 
         safe_tx = safe.build_multisig_tx(safe.address, 0, tx["data"])
         safe_tx.sign(_deployer_account._private_key.hex())
+        # Pass HotWallet so nonce comes from the internal counter
+        # instead of a potentially stale RPC read.
+        _hot_wallet = deployer if isinstance(deployer, HotWallet) else None
         tx_hash, tx = execute_safe_tx(
             safe_tx,
             tx_sender_private_key=_deployer_account._private_key.hex(),
             tx_gas=1_500_000,
             # eip1559_speed=TxSpeed.NORMAL,
             gas_fee=gas_estimate,
+            hot_wallet=_hot_wallet,
         )
         assert_transaction_success_with_explanation(web3, tx_hash)
 
@@ -1804,6 +1808,8 @@ def deploy_automated_lagoon_vault(
         vault_label = f" with vault {vault_contract.address}" if vault_contract is not None else ""
         raise AssertionError(f"Cannot find TradingStrategyModuleV0 on Safe {safe.address}{vault_label}, modules {modules}")
 
+    _hot_wallet = deployer if isinstance(deployer, HotWallet) else None
+
     if not existing_safe_address:
         # Deploy a Safe multisig that forms the core of Lagoon vault
         with big_blocks_for_deployment(web3, _private_key_hex) if _need_big_blocks_for_proxy else nullcontext():
@@ -1815,6 +1821,7 @@ def deploy_automated_lagoon_vault(
                     threshold=1,
                     salt_nonce=safe_salt_nonce,
                     proxy_factory_address=safe_proxy_factory_address or "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",
+                    hot_wallet=_hot_wallet,
                 )
             else:
                 safe = deploy_safe(
@@ -1827,10 +1834,12 @@ def deploy_automated_lagoon_vault(
         parameters.safe = safe.address
         logger.info("Deployed new Safe: %s", safe.address)
 
-        # Safe deployment bypasses HotWallet nonce tracking (uses LocalAccount
-        # directly via safe-eth-py). Sync so subsequent forge deploys use the
-        # correct on-chain nonce.
-        if isinstance(deployer, HotWallet):
+        # When no HotWallet is available, Safe deployment bypasses nonce
+        # tracking (uses LocalAccount directly via safe-eth-py).  Sync so
+        # subsequent deploys use the correct on-chain nonce.
+        # When HotWallet IS available, nonce was already allocated via
+        # hot_wallet.allocate_nonce() inside deploy_safe_with_deterministic_address.
+        if isinstance(deployer, HotWallet) and safe_salt_nonce is None:
             deployer.sync_nonce(web3)
     else:
         safe = fetch_safe_deployment(
@@ -2011,6 +2020,7 @@ def deploy_automated_lagoon_vault(
             tx_sender_private_key=deployer_local_account._private_key.hex(),
             tx_gas=1_500_000,
             gas_fee=gas_estimate,
+            hot_wallet=_hot_wallet,
         )
         assert_transaction_success_with_explanation(web3, tx_hash)
 
@@ -2027,6 +2037,7 @@ def deploy_automated_lagoon_vault(
             deployer_local_account,
             owners=safe_owners,
             threshold=safe_threshold,
+            hot_wallet=_hot_wallet,
         )
     elif satellite_chain:
         # Satellite chains still need Safe owners set up
@@ -2036,6 +2047,7 @@ def deploy_automated_lagoon_vault(
             deployer_local_account,
             owners=safe_owners,
             threshold=safe_threshold,
+            hot_wallet=_hot_wallet,
         )
 
     if satellite_chain:

--- a/eth_defi/safe/deployment.py
+++ b/eth_defi/safe/deployment.py
@@ -7,8 +7,11 @@ Safe source code:
 - https://github.com/safe-global/safe-smart-account/blob/main/contracts/Safe.sol
 """
 
+from __future__ import annotations
+
 import logging
 import time
+from typing import TYPE_CHECKING
 
 from eth_account.signers.local import LocalAccount
 from eth_typing import HexAddress
@@ -28,6 +31,9 @@ from eth_defi.provider.anvil import is_anvil
 from eth_defi.safe.execute import execute_safe_tx
 from eth_defi.safe.safe_compat import create_safe_ethereum_client
 from eth_defi.trace import TransactionAssertionError, assert_transaction_success_with_explanation
+
+if TYPE_CHECKING:
+    from eth_defi.hotwallet import HotWallet
 
 
 logger = logging.getLogger(__name__)
@@ -204,6 +210,7 @@ def deploy_safe_with_deterministic_address(
     master_copy_address: HexAddress | str = SAFE_L2_MASTER_COPY_ADDRESS,
     proxy_factory_address: HexAddress | str = SAFE_PROXY_FACTORY_ADDRESS,
     post_deploy_delay_seconds: float = 10.0,
+    hot_wallet: HotWallet | None = None,
 ) -> Safe:
     """Deploy a new Safe wallet at a deterministic address using CREATE2.
 
@@ -238,6 +245,11 @@ def deploy_safe_with_deterministic_address(
 
     :param post_deploy_delay_seconds:
         Sleep after deployment on non-Anvil networks to let state propagate.
+
+    :param hot_wallet:
+        When provided, allocate the transaction nonce from the wallet's
+        internal counter instead of letting ``safe_eth`` read from the
+        RPC node.  Avoids stale-nonce errors on load-balanced endpoints.
     """
     assert len(owners) >= 1, "Safe must have at least one owner"
     assert isinstance(deployer, LocalAccount), "Safe can be only deployed using LocalAccount"
@@ -269,11 +281,15 @@ def deploy_safe_with_deterministic_address(
     logger.info("Expected deterministic Safe address: %s", expected_address)
 
     # Deploy via ProxyFactory.createProxyWithNonce (CREATE2)
+    # When a HotWallet is provided, use its nonce counter instead of
+    # letting safe_eth read from the (potentially stale) RPC node.
+    deploy_nonce = hot_wallet.allocate_nonce() if hot_wallet is not None else None
     tx_sent = proxy_factory.deploy_proxy_contract_with_nonce(
         deployer_account=deployer,
         master_copy=master_copy_address,
         initializer=initializer,
         salt_nonce=salt_nonce,
+        nonce=deploy_nonce,
     )
 
     assert_transaction_success_with_explanation(web3, tx_sent.tx_hash)
@@ -302,6 +318,7 @@ def add_new_safe_owners(
     threshold: int,
     gas_per_tx=500_000,
     gnosis_safe_state_safety_sleep=12,
+    hot_wallet: HotWallet | None = None,
 ):
     """Update Safe owners and threshold list.
 
@@ -319,6 +336,10 @@ def add_new_safe_owners(
     :param between_calls_sleep:
         Deployer hack
 
+    :param hot_wallet:
+        When provided, allocate transaction nonces from the wallet's
+        internal counter instead of letting ``safe_eth`` read from the
+        RPC node.  Avoids stale-nonce errors on load-balanced endpoints.
 
     More info:
 
@@ -363,6 +384,7 @@ def add_new_safe_owners(
                     tx_sender_private_key=deployer._private_key.hex(),
                     tx_gas=1_000_000,
                     gas_fee=gas_estimate,
+                    hot_wallet=hot_wallet,
                 )
                 assert_transaction_success_with_explanation(web3, tx_hash)
                 break  # Success
@@ -402,6 +424,7 @@ def add_new_safe_owners(
                 tx_sender_private_key=deployer._private_key.hex(),
                 tx_gas=1_000_000,
                 gas_fee=gas_estimate,
+                hot_wallet=hot_wallet,
             )
             assert_transaction_success_with_explanation(web3, tx_hash)
             break

--- a/eth_defi/safe/execute.py
+++ b/eth_defi/safe/execute.py
@@ -1,7 +1,22 @@
-"""Fix broken Safe Python SDK stuff."""
+"""Fix broken Safe Python SDK stuff.
+
+The upstream ``safe_eth`` library manages transaction nonces internally
+by reading from the RPC node.  On load-balanced endpoints this often
+returns stale values, causing "nonce too low" errors when multiple
+transactions are sent in quick succession (e.g. during multichain
+vault deployment).
+
+All functions in this module accept an optional
+:class:`~eth_defi.hotwallet.HotWallet` parameter.  When provided the
+nonce is allocated from the wallet's internal counter instead of
+querying the RPC, keeping it in sync with other ``HotWallet``-managed
+transactions in the same deployment flow.
+"""
+
+from __future__ import annotations
 
 import logging
-from typing import Optional, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from eth_account import Account
 from hexbytes import HexBytes
@@ -11,6 +26,9 @@ from safe_eth.eth.ethereum_client import TxSpeed
 from safe_eth.safe.safe_tx import SafeTx
 
 from ..gas import GasPriceSuggestion, apply_gas
+
+if TYPE_CHECKING:
+    from eth_defi.hotwallet import HotWallet
 
 
 logger = logging.getLogger(__name__)
@@ -25,19 +43,29 @@ def execute_safe_tx(
     block_identifier: Optional[BlockIdentifier] = "latest",
     eip1559_speed: Optional[TxSpeed] = None,
     gas_fee: GasPriceSuggestion = None,
+    hot_wallet: HotWallet | None = None,
 ) -> Tuple[HexBytes, TxParams]:
-    """Fixex broken SafeTx.execute().
+    """Fixed version of ``SafeTx.execute()``.
 
-    - See the orignal as :py:meth:`safe_eth.safe.safe_tx.SafeTx.execute()`
+    - See the original as :py:meth:`safe_eth.safe.safe_tx.SafeTx.execute()`
 
     - Handle gas fees correctly, don't fail randomly
 
     :param gas_fee:
         Gas fee to apply to the transaction, don't try to use broken Safe logic to get gas fee filled in,
         as it will result to broken transactions rejected by the node.
+
+    :param hot_wallet:
+        When provided, allocate the transaction nonce from the wallet's
+        internal counter instead of reading from the RPC node.  This
+        avoids stale-nonce errors on load-balanced endpoints.
+        Takes precedence over ``tx_nonce``.
     """
 
     assert isinstance(self, SafeTx), f"execute_safe_tx() must be called on SafeTx instance, got {type(self)}"
+
+    if hot_wallet is not None:
+        tx_nonce = hot_wallet.allocate_nonce()
 
     sender_account = Account.from_key(tx_sender_private_key)
     if eip1559_speed and self.ethereum_client.is_eip1559_supported():


### PR DESCRIPTION
## Why

During parallel multichain vault deployment, `safe_eth` library functions (`execute_safe_tx`, `deploy_safe_with_deterministic_address`, `add_new_safe_owners`) read transaction nonces from load-balanced RPC endpoints independently, while the rest of the deployment uses `HotWallet`'s internal counter. On load-balanced endpoints the RPC can return stale nonce values, causing the two nonce counters to diverge and resulting in fatal `nonce too low` crashes.

The specific failure mode:
1. `HotWallet` sends tx with nonce N via `deploy_contract` / `_broadcast`
2. `safe_eth`'s `send_unsigned_transaction` queries RPC for nonce — gets stale value N (should be N+1)
3. `safe_eth` sends with nonce N → `ReplacementTransactionUnderpriced`
4. `safe_eth` retry loop re-reads nonce from RPC — still stale → crash

## Lessons learnt

- `safe_eth`'s `send_unsigned_transaction` has its own nonce management with a retry loop that re-reads from RPC on failure. When the RPC consistently returns stale values, retries make things worse.
- When `tx_nonce` is explicitly passed to `execute_safe_tx`, `retry` is automatically set to `False` (existing logic), which is correct — the caller should own nonce management.
- The `HotWallet.sync_nonce()` method already has a guard against stale reads (`if new_nonce < self.current_nonce: return`), making it safe to call even on flaky RPCs. But `safe_eth` has no such guard.

## Summary

Added an optional `hot_wallet: HotWallet | None` parameter to all Safe operations that send transactions:

- **`execute_safe_tx()`** — when `hot_wallet` is provided, allocates nonce from the wallet's internal counter instead of letting `safe_eth` query the RPC
- **`deploy_safe_with_deterministic_address()`** — passes `hot_wallet.allocate_nonce()` to `ProxyFactory.deploy_proxy_contract_with_nonce(nonce=...)`
- **`add_new_safe_owners()`** — threads `hot_wallet` through to all `execute_safe_tx` calls (add owner + change threshold)
- **`deploy_safe_trading_strategy_module()`** — passes `HotWallet` to `execute_safe_tx` for `enableModule`
- **`deploy_automated_lagoon_vault()`** — threads `HotWallet` through to Safe deployment, USDC approve, and owner management on both source and satellite chains

All parameters are optional and backward-compatible — existing callers without a `HotWallet` continue to use `safe_eth`'s RPC-based nonce management.

### Test results
- `test_safe_deterministic_deploy.py` — 2/2 passed
- `test_deploy_base.py` — 4/4 passed