### PR TITLE
fix: wait for receipt visibility on all read providers

### DIFF
--- a/docs/source/api/core3/index.rst
+++ b/docs/source/api/core3/index.rst
@@ -21,6 +21,9 @@ Features:
    :recursive:
 
    eth_defi.core3.session
+   eth_defi.core3.api
    eth_defi.core3.database
    eth_defi.core3.scanner
    eth_defi.core3.constants
+   eth_defi.core3.mappings
+   eth_defi.core3.vault_protocol

--- a/docs/source/api/provider/index.rst
+++ b/docs/source/api/provider/index.rst
@@ -19,6 +19,7 @@ This submodule offers functionality to connect and enhance robustness of various
    eth_defi.provider.multi_provider
    eth_defi.provider.mev_blocker
    eth_defi.provider.fallback
+   eth_defi.provider.receipt
    eth_defi.provider.broken_provider
    eth_defi.provider.ankr
    eth_defi.provider.llamanodes
@@ -31,4 +32,3 @@ This submodule offers functionality to connect and enhance robustness of various
    eth_defi.provider.rpc_proxy
    eth_defi.provider.rpc_monitoring_adapter
    eth_defi.provider.tenderly
-

--- a/eth_defi/core3/vault_protocol.py
+++ b/eth_defi/core3/vault_protocol.py
@@ -14,7 +14,7 @@ Example::
     db = Core3Database(CORE3_DATABASE_PATH)
     record = get_core3_protocol_record(db, "morpho")
     if record:
-        print(f"PoL score: {record['pol_score']}")
+        print(f"PoL score: {record['pol']['score']}")
         print(f"Top risks: {len(record['top_risks'])}")
     db.close()
 """

--- a/eth_defi/erc_4626/vault_protocol/lagoon/testing.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/testing.py
@@ -14,6 +14,7 @@ from eth_defi.event_reader.conversion import convert_uint256_string_to_int, conv
 from eth_defi.event_reader.multicall_batcher import EncodedCall
 from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
 from eth_defi.hotwallet import HotWallet
+from eth_defi.provider.receipt import wait_for_transaction_receipt_robust
 from eth_defi.token import TokenDiskCache
 from eth_defi.trace import assert_transaction_success_with_explanation
 
@@ -124,6 +125,7 @@ def fund_lagoon_vault(
         else:
             tx_hash = bound_func.transact({"from": test_account_with_balance, "gas": gas})
         assert_transaction_success_with_explanation(web3, tx_hash)
+        return tx_hash
 
     def _send_as_manager(bound_func, description: str, gas: int = 1_000_000):
         """Sign and broadcast as asset manager."""
@@ -133,14 +135,17 @@ def fund_lagoon_vault(
         else:
             tx_hash = bound_func.transact({"from": asset_manager, "gas": gas})
         assert_transaction_success_with_explanation(web3, tx_hash)
+        return tx_hash
 
     # 1. Post initial valuation (needed for fresh vaults)
     _send_as_manager(vault.post_new_valuation(Decimal(0)), "Post initial valuation")
 
     # 2. Approve denomination token for vault deposit
-    _send(denomination_token.approve(vault.address, amount), f"Approve {amount} for vault deposit")
-    # Live RPC read providers can lag behind the sequencer/write provider.
-    time.sleep(5)
+    approval_tx_hash = _send(
+        denomination_token.approve(vault.address, amount),
+        f"Approve {amount} for vault deposit",
+    )
+    wait_for_transaction_receipt_robust(web3, approval_tx_hash)
 
     # 3. Put to deposit queue
     deposit_func = vault.request_deposit(test_account_with_balance, raw_amount)
@@ -148,7 +153,8 @@ def fund_lagoon_vault(
 
     # 4. Update NAV and settle
     _send_as_manager(vault.post_new_valuation(nav), "Post valuation for settlement")
-    _send_as_manager(vault.settle_via_trading_strategy_module(nav), "Settle vault deposits")
+    settle_tx_hash = _send_as_manager(vault.settle_via_trading_strategy_module(nav), "Settle vault deposits")
+    wait_for_transaction_receipt_robust(web3, settle_tx_hash)
 
     # 5. Claim shares (ERC-7540: settlement mints shares to the vault contract,
     #    depositor must call deposit() to transfer them to their wallet)
@@ -162,11 +168,14 @@ def fund_lagoon_vault(
     #    On live chains this helper is often used with a MultiProviderWeb3 setup
     #    where writes go to the sequencer / transaction provider and reads go to
     #    one or more public RPC providers. These read providers can trail the
-    #    sequencer by a few seconds. If we call finalise_deposit() during this
-    #    window, it internally reads maxDeposit(depositor). A stale read returns
-    #    zero or an unclaimable epoch, then the transaction builder estimates gas
-    #    for deposit(0, depositor). Lagoon rejects that path with the custom error
-    #    RequestIdNotClaimable() (selector 0x912d1a73).
+    #    sequencer by a few seconds. We first wait until all configured read
+    #    providers can see the settlement receipt, but this still does not prove
+    #    every future eth_call will hit a backend with fresh Lagoon epoch state.
+    #    If we call finalise_deposit() during this window, it internally reads
+    #    maxDeposit(depositor). A stale read returns zero or an unclaimable epoch,
+    #    then the transaction builder estimates gas for deposit(0, depositor).
+    #    Lagoon rejects that path with the custom error RequestIdNotClaimable()
+    #    (selector 0x912d1a73).
     #
     #    Poll for an actually claimable deposit before building the final claim
     #    transaction. We also pass the raw claimable amount explicitly to
@@ -191,7 +200,10 @@ def fund_lagoon_vault(
         time.sleep(claim_retry_delay)
 
     if claimable_raw_amount == 0:
-        raise RuntimeError(f"Lagoon deposit settlement was mined, but maxDeposit({test_account_with_balance}) stayed 0 after {claim_attempts * claim_retry_delay} seconds. The deposit request is not yet claimable on the read RPC, or settlement did not mark it claimable.")
+        raise RuntimeError(
+            f"Lagoon deposit settlement was mined, but maxDeposit({test_account_with_balance}) stayed 0 after {claim_attempts * claim_retry_delay} seconds. "
+            "The deposit request is not yet claimable on the read RPC, or settlement did not mark it claimable."
+        )
 
     finalise_func = vault.finalise_deposit(test_account_with_balance, raw_amount=claimable_raw_amount)
     _send(finalise_func, f"Claim shares for {test_account_with_balance}")

--- a/eth_defi/provider/receipt.py
+++ b/eth_defi/provider/receipt.py
@@ -1,0 +1,456 @@
+"""Transaction receipt visibility helpers for multi-provider Web3 setups."""
+
+import logging
+import time
+
+from hexbytes import HexBytes
+from requests.exceptions import RequestException
+from web3 import Web3
+from web3.exceptions import (
+    CannotHandleRequest,
+    MultipleFailedRequests,
+    ProviderConnectionError,
+    RequestTimedOut,
+    TransactionNotFound,
+    TooManyRequests,
+    Web3RPCError,
+)
+from web3.providers import BaseProvider
+from web3.types import TxReceipt
+
+from eth_defi.provider.anvil import is_anvil
+from eth_defi.provider.fallback import FallbackProvider
+from eth_defi.provider.named import get_provider_name
+
+
+logger = logging.getLogger(__name__)
+
+
+PROVIDER_READ_EXCEPTIONS = (
+    CannotHandleRequest,
+    MultipleFailedRequests,
+    ProviderConnectionError,
+    RequestException,
+    RequestTimedOut,
+    TransactionNotFound,
+    TooManyRequests,
+    Web3RPCError,
+)
+"""Exceptions raised by unavailable or read-restricted JSON-RPC providers."""
+
+
+class ReceiptVisibilityTimedOut(TimeoutError):
+    """Timed out before all read providers could see a transaction receipt."""
+
+
+class ReceiptVisibilityMismatch(RuntimeError):
+    """Read providers returned conflicting receipt data for the same transaction."""
+
+
+def _is_anvil(web3: Web3) -> bool:
+    """Check Anvil without letting read-restricted providers crash the caller."""
+    try:
+        return is_anvil(web3)
+    except PROVIDER_READ_EXCEPTIONS:
+        return False
+
+
+def _get_active_read_provider(provider: BaseProvider) -> BaseProvider:
+    """Get the active read provider from direct, fallback, or MEV-wrapped providers."""
+    call_provider = getattr(provider, "call_provider", None)
+    if call_provider is not None:
+        provider = call_provider
+
+    if isinstance(provider, FallbackProvider):
+        return provider.get_active_provider()
+
+    return provider
+
+
+def get_read_providers(web3: Web3) -> list[BaseProvider]:
+    """Get JSON-RPC providers used for read calls.
+
+    MEV/sequencer transaction providers are intentionally excluded because some
+    sequencers are write-only and do not support receipt or state reads.
+    """
+    provider = web3.provider
+
+    if _is_anvil(web3):
+        return [_get_active_read_provider(provider)]
+
+    call_provider = getattr(provider, "call_provider", None)
+    if call_provider is not None:
+        provider = call_provider
+
+    if isinstance(provider, FallbackProvider):
+        return provider.providers
+
+    return [provider]
+
+
+def _get_provider_label(index: int, provider: BaseProvider) -> str:
+    """Get a stable provider label for diagnostics."""
+    return f"{index}:{get_provider_name(provider)}"
+
+
+def _fetch_raw_receipt(provider: BaseProvider, tx_hash_hex: str) -> dict | None:
+    """Fetch raw JSON-RPC receipt data from a provider."""
+    response = provider.make_request("eth_getTransactionReceipt", [tx_hash_hex])
+    return response.get("result")
+
+
+def _fetch_raw_block_number(provider: BaseProvider) -> int:
+    """Fetch raw JSON-RPC block number from a provider."""
+    response = provider.make_request("eth_blockNumber", [])
+    result = response.get("result")
+    if result is None:
+        raise ValueError(f"Provider returned no eth_blockNumber result: {response}")
+    return int(result, 16)
+
+
+def _is_failed_receipt_status(status) -> bool:
+    """Check raw or typed receipt status for a failed transaction."""
+    if status is None:
+        return False
+    if isinstance(status, str):
+        return status.lower() == "0x0"
+    return status == 0 or status is False
+
+
+def _log_raw_receipt_statuses(tx_hash_hex: str, receipts: dict[str, dict]) -> None:
+    """Log failed transaction status from raw provider receipts."""
+    for label, receipt in receipts.items():
+        status = receipt.get("status")
+        if _is_failed_receipt_status(status):
+            logger.error(
+                "Transaction %s has failed receipt status %s on read provider %s, blockNumber=%s, blockHash=%s",
+                tx_hash_hex,
+                status,
+                label,
+                receipt.get("blockNumber"),
+                receipt.get("blockHash"),
+            )
+
+
+def _log_typed_receipt_status(tx_hash_hex: str, receipt: TxReceipt) -> None:
+    """Log failed transaction status from the final typed Web3 receipt."""
+    status = receipt.get("status")
+    if _is_failed_receipt_status(status):
+        logger.error(
+            "Transaction %s has failed typed receipt status %s from original Web3 provider",
+            tx_hash_hex,
+            status,
+        )
+
+
+def _assert_receipts_match(receipts: dict[str, dict], tx_hash_hex: str) -> None:
+    """Check all raw JSON-RPC receipts describe the same transaction inclusion."""
+    expected_tx_hash = tx_hash_hex.lower()
+    reference_label = None
+    reference_block_hash = None
+
+    for label, receipt in receipts.items():
+        receipt_tx_hash = receipt.get("transactionHash", "").lower()
+        block_hash = receipt.get("blockHash", "").lower()
+
+        if receipt_tx_hash != expected_tx_hash:
+            raise ReceiptVisibilityMismatch(
+                f"Provider {label} returned receipt for transaction {receipt_tx_hash}, expected {expected_tx_hash}"
+            )
+
+        if reference_block_hash is None:
+            reference_label = label
+            reference_block_hash = block_hash
+        elif block_hash != reference_block_hash:
+            raise ReceiptVisibilityMismatch(
+                f"Provider {label} returned blockHash {block_hash}, but provider {reference_label} returned {reference_block_hash}"
+            )
+
+
+def _get_insufficient_confirmations(
+    provider_entries: list[tuple[int, BaseProvider]],
+    receipts: dict[str, dict],
+    confirmation_block_count: int,
+) -> list[str]:
+    """Return providers whose block height does not yet give enough confirmations.
+
+    This check is best-effort: provider block numbers are read sequentially, so a
+    new block may arrive between receipt and block number reads.
+    """
+    if confirmation_block_count <= 0:
+        return []
+
+    insufficient = []
+    for index, provider in provider_entries:
+        label = _get_provider_label(index, provider)
+        receipt = receipts[label]
+        receipt_block = int(receipt["blockNumber"], 16)
+        try:
+            current_block = _fetch_raw_block_number(provider)
+        except PROVIDER_READ_EXCEPTIONS as e:
+            logger.warning(
+                "Could not fetch current block number from read provider while checking transaction confirmations, provider=%s",
+                label,
+                exc_info=True,
+            )
+            insufficient.append(f"{label} (block number unavailable: {e})")
+            continue
+        confirmations = current_block - receipt_block
+        if confirmations < confirmation_block_count:
+            insufficient.append(f"{label} ({confirmations}/{confirmation_block_count})")
+
+    return insufficient
+
+
+def wait_for_transaction_receipt_robust(
+    web3: Web3,
+    tx_hash: HexBytes | str,
+    timeout: float = 120.0,
+    poll_delay: float = 1.0,
+    max_poll_delay: float = 5.0,
+    confirmation_block_count: int = 0,
+    extra_sleep: float = 0.0,
+) -> TxReceipt:
+    """Wait until a transaction receipt is visible through all read RPC providers.
+
+    This is stricter than :py:meth:`web3.eth.wait_for_transaction_receipt` for
+    live multi-RPC setups. Receipt values fetched directly from providers are raw
+    JSON-RPC objects, so comparisons use raw hex strings. For Anvil we use the
+    normal Web3 receipt wait path because Anvil has one coherent local state view.
+    This helper is safe to call after the transaction is already confirmed
+    through the primary provider; it checks read-provider visibility separately.
+
+    :param web3:
+        Web3 instance, optionally backed by FallbackProvider or MEVBlockerProvider.
+    :param tx_hash:
+        Transaction hash to wait for.
+    :param timeout:
+        Maximum seconds to wait.
+    :param poll_delay:
+        Initial delay between polling rounds.
+    :param max_poll_delay:
+        Maximum adaptive delay between polling rounds.
+    :param confirmation_block_count:
+        How many confirmations each read provider should see. This is best-effort
+        because provider block numbers are fetched sequentially.
+    :param extra_sleep:
+        Extra seconds to sleep once after all read providers have seen the
+        matching receipt and enough confirmations.
+    :return:
+        Typed receipt from the original Web3 instance, preserving middleware behaviour.
+    """
+    assert timeout > 0, f"timeout must be positive, got {timeout}"
+    assert poll_delay > 0, f"poll_delay must be positive, got {poll_delay}"
+    assert max_poll_delay >= poll_delay, f"max_poll_delay must be >= poll_delay, got {max_poll_delay} < {poll_delay}"
+    assert confirmation_block_count >= 0, f"confirmation_block_count must be non-negative, got {confirmation_block_count}"
+    assert extra_sleep >= 0, f"extra_sleep must be non-negative, got {extra_sleep}"
+
+    tx_hash_bytes = HexBytes(tx_hash)
+    tx_hash_hex = "0x" + tx_hash_bytes.hex()
+
+    if _is_anvil(web3):
+        logger.info(
+            "Waiting for transaction receipt on Anvil, tx_hash=%s, timeout=%s",
+            tx_hash_hex,
+            timeout,
+        )
+        try:
+            receipt = web3.eth.wait_for_transaction_receipt(tx_hash_bytes, timeout=timeout)
+        except PROVIDER_READ_EXCEPTIONS:
+            logger.error(
+                "Failed to wait for transaction receipt on Anvil, tx_hash=%s",
+                tx_hash_hex,
+                exc_info=True,
+            )
+            raise
+        _log_typed_receipt_status(tx_hash_hex, receipt)
+        if extra_sleep > 0:
+            logger.info(
+                "Sleeping after Anvil transaction receipt confirmation, tx_hash=%s, sleep=%s",
+                tx_hash_hex,
+                extra_sleep,
+            )
+            time.sleep(extra_sleep)
+        logger.info(
+            "Transaction receipt is visible on Anvil, tx_hash=%s, status=%s, blockNumber=%s",
+            tx_hash_hex,
+            receipt.get("status"),
+            receipt.get("blockNumber"),
+        )
+        return receipt
+
+    providers = get_read_providers(web3)
+    provider_entries = list(enumerate(providers))
+    deadline = time.monotonic() + timeout
+    current_delay = poll_delay
+    last_missing: list[str] = []
+    last_errors: dict[str, str] = {}
+    last_insufficient_confirmations: list[str] = []
+    last_mismatch: ReceiptVisibilityMismatch | None = None
+    extra_sleep_done = False
+    provider_labels = [_get_provider_label(index, provider) for index, provider in provider_entries]
+
+    logger.info(
+        "Waiting for transaction receipt visibility on all read providers, tx_hash=%s, providers=%s, timeout=%s, poll_delay=%s, max_poll_delay=%s, confirmation_block_count=%d",
+        tx_hash_hex,
+        provider_labels,
+        timeout,
+        poll_delay,
+        max_poll_delay,
+        confirmation_block_count,
+    )
+
+    poll_round = 0
+    while time.monotonic() < deadline:
+        poll_round += 1
+        receipts: dict[str, dict] = {}
+        missing = []
+        errors = {}
+
+        logger.debug(
+            "Polling transaction receipt visibility, tx_hash=%s, round=%d, provider_count=%d",
+            tx_hash_hex,
+            poll_round,
+            len(provider_entries),
+        )
+
+        for index, provider in provider_entries:
+            label = _get_provider_label(index, provider)
+            logger.debug(
+                "Requesting transaction receipt from read provider, tx_hash=%s, provider=%s",
+                tx_hash_hex,
+                label,
+            )
+            try:
+                receipt = _fetch_raw_receipt(provider, tx_hash_hex)
+            except PROVIDER_READ_EXCEPTIONS as e:
+                errors[label] = str(e)
+                missing.append(label)
+                logger.warning(
+                    "Could not fetch transaction receipt from read provider, tx_hash=%s, provider=%s",
+                    tx_hash_hex,
+                    label,
+                    exc_info=True,
+                )
+                continue
+
+            if receipt is None:
+                missing.append(label)
+                logger.debug(
+                    "Read provider does not yet see transaction receipt, tx_hash=%s, provider=%s",
+                    tx_hash_hex,
+                    label,
+                )
+            else:
+                receipts[label] = receipt
+                logger.debug(
+                    "Read provider sees transaction receipt, tx_hash=%s, provider=%s, blockNumber=%s, blockHash=%s, status=%s",
+                    tx_hash_hex,
+                    label,
+                    receipt.get("blockNumber"),
+                    receipt.get("blockHash"),
+                    receipt.get("status"),
+                )
+
+        if not missing and len(receipts) == len(provider_entries):
+            try:
+                _assert_receipts_match(receipts, tx_hash_hex)
+            except ReceiptVisibilityMismatch as e:
+                last_mismatch = e
+                logger.warning(
+                    "Transaction receipt data mismatch across read providers, retrying until timeout, tx_hash=%s",
+                    tx_hash_hex,
+                    exc_info=True,
+                )
+            else:
+                last_mismatch = None
+                _log_raw_receipt_statuses(tx_hash_hex, receipts)
+                last_insufficient_confirmations = _get_insufficient_confirmations(
+                    provider_entries,
+                    receipts,
+                    confirmation_block_count,
+                )
+                if not last_insufficient_confirmations:
+                    if extra_sleep > 0 and not extra_sleep_done:
+                        logger.info(
+                            "Sleeping after transaction receipt visibility on all read providers, tx_hash=%s, sleep=%s",
+                            tx_hash_hex,
+                            extra_sleep,
+                        )
+                        time.sleep(extra_sleep)
+                        extra_sleep_done = True
+
+                    # Return through the original Web3 instance so callers get the
+                    # typed receipt and any middleware transformations they expect.
+                    logger.info(
+                        "Transaction receipt is visible on all read providers, fetching typed receipt through original Web3, tx_hash=%s",
+                        tx_hash_hex,
+                    )
+                    try:
+                        typed_receipt = web3.eth.get_transaction_receipt(tx_hash_bytes)
+                    except PROVIDER_READ_EXCEPTIONS as e:
+                        errors["original-web3"] = str(e)
+                        missing.append("original-web3")
+                        logger.warning(
+                            "Failed to fetch typed transaction receipt through original Web3 after raw provider checks, retrying until timeout, tx_hash=%s",
+                            tx_hash_hex,
+                            exc_info=True,
+                        )
+                    else:
+                        _log_typed_receipt_status(tx_hash_hex, typed_receipt)
+                        logger.info(
+                            "Transaction receipt robust wait complete, tx_hash=%s, status=%s, blockNumber=%s",
+                            tx_hash_hex,
+                            typed_receipt.get("status"),
+                            typed_receipt.get("blockNumber"),
+                        )
+                        return typed_receipt
+                else:
+                    logger.debug(
+                        "Transaction receipt is visible on all read providers but confirmations are insufficient, tx_hash=%s, insufficient_confirmations=%s",
+                        tx_hash_hex,
+                        last_insufficient_confirmations,
+                    )
+
+        last_missing = missing
+        last_errors = errors
+
+        sleep_for = min(current_delay, max(0, deadline - time.monotonic()))
+        if sleep_for > 0:
+            logger.debug(
+                "Transaction receipt not ready on all read providers, tx_hash=%s, missing_providers=%s, provider_errors=%s, insufficient_confirmations=%s, sleep=%s",
+                tx_hash_hex,
+                last_missing,
+                last_errors,
+                last_insufficient_confirmations,
+                sleep_for,
+            )
+            time.sleep(sleep_for)
+        current_delay = min(max_poll_delay, current_delay * 1.5)
+
+    detail = ", ".join(last_missing) if last_missing else "none"
+    error_detail = "; ".join(f"{label}: {error}" for label, error in last_errors.items())
+    confirmation_detail = ", ".join(last_insufficient_confirmations)
+    extra = ""
+    if error_detail:
+        extra += f" Last errors: {error_detail}."
+    if confirmation_detail:
+        extra += f" Insufficient confirmations: {confirmation_detail}."
+    if last_mismatch is not None:
+        logger.error(
+            "Timed out with persistent transaction receipt mismatch across read providers, tx_hash=%s, timeout=%s",
+            tx_hash_hex,
+            timeout,
+        )
+        raise last_mismatch
+    logger.error(
+        "Timed out waiting for transaction receipt visibility on all read providers, tx_hash=%s, timeout=%s, missing_providers=%s, provider_errors=%s, insufficient_confirmations=%s",
+        tx_hash_hex,
+        timeout,
+        last_missing,
+        last_errors,
+        last_insufficient_confirmations,
+    )
+    raise ReceiptVisibilityTimedOut(
+        f"Timed out after {timeout} seconds waiting for receipt {tx_hash_hex} on all read providers. Missing providers: {detail}.{extra}"
+    )

--- a/tests/rpc/test_receipt.py
+++ b/tests/rpc/test_receipt.py
@@ -1,0 +1,516 @@
+"""Robust receipt visibility helper tests."""
+
+import shutil
+
+import pytest
+from web3 import Web3
+from web3.exceptions import ProviderConnectionError, TransactionNotFound
+
+from eth_defi.abi import ZERO_ADDRESS
+from eth_defi.compat import clear_middleware, create_http_provider
+from eth_defi.provider import receipt as receipt_module
+from eth_defi.provider.anvil import AnvilLaunch, launch_anvil
+from eth_defi.provider.fallback import FallbackProvider
+from eth_defi.provider.receipt import (
+    ReceiptVisibilityMismatch,
+    ReceiptVisibilityTimedOut,
+    get_read_providers,
+    wait_for_transaction_receipt_robust,
+)
+
+
+TX_HASH = "0x" + "12" * 32
+BLOCK_HASH = "0x" + "34" * 32
+
+
+def _raw_receipt(
+    tx_hash: str = TX_HASH,
+    block_hash: str = BLOCK_HASH,
+    block_number: str = "0x1",
+) -> dict:
+    """Create a minimal raw JSON-RPC transaction receipt."""
+    return {
+        "transactionHash": tx_hash,
+        "blockHash": block_hash,
+        "blockNumber": block_number,
+        "status": "0x1",
+    }
+
+
+class FakeProvider:
+    """Minimal provider supporting direct raw JSON-RPC calls."""
+
+    def __init__(
+        self,
+        name: str,
+        receipts: list[dict | None] | None = None,
+        block_number: str | list[str | BaseException] = "0x2",
+    ):
+        self.endpoint_uri = f"https://{name}.example"
+        self.receipts = receipts or [_raw_receipt()]
+        self.block_numbers = block_number if isinstance(block_number, list) else [block_number]
+        self.calls: list[str] = []
+
+    def make_request(self, method: str, params: list) -> dict:
+        self.calls.append(method)
+        if method == "eth_getTransactionReceipt":
+            if len(self.receipts) > 1:
+                result = self.receipts.pop(0)
+            else:
+                result = self.receipts[0]
+            return {"jsonrpc": "2.0", "id": 1, "result": result}
+        if method == "eth_blockNumber":
+            if len(self.block_numbers) > 1:
+                result = self.block_numbers.pop(0)
+            else:
+                result = self.block_numbers[0]
+            if isinstance(result, BaseException):
+                raise result
+            return {"jsonrpc": "2.0", "id": 1, "result": result}
+        raise NotImplementedError(method)
+
+
+class FakeEth:
+    """Minimal eth namespace for returning a typed Web3 receipt."""
+
+    def __init__(self, receipt: dict | list[dict | BaseException] | None = None):
+        self.receipts = receipt if isinstance(receipt, list) else [receipt or {"status": 1}]
+        self.waited = False
+        self.get_receipt_calls = 0
+
+    def _next_receipt(self):
+        if len(self.receipts) > 1:
+            receipt = self.receipts.pop(0)
+        else:
+            receipt = self.receipts[0]
+        if isinstance(receipt, BaseException):
+            raise receipt
+        return receipt
+
+    def get_transaction_receipt(self, tx_hash):
+        self.get_receipt_calls += 1
+        return self._next_receipt()
+
+    def wait_for_transaction_receipt(self, tx_hash, timeout: float = 120.0):
+        self.waited = True
+        return self._next_receipt()
+
+
+class FakeWeb3:
+    """Minimal Web3-like object for provider receipt tests."""
+
+    def __init__(self, provider, eth: FakeEth | None = None):
+        self.provider = provider
+        self.eth = eth or FakeEth()
+        self.client_version = "fake-web3"
+
+
+class FakeMEVProvider:
+    """Minimal MEV-style wrapper with a separate read provider."""
+
+    def __init__(self, call_provider):
+        self.call_provider = call_provider
+
+
+@pytest.fixture(scope="module")
+def anvil() -> AnvilLaunch:
+    """Launch Anvil for the test backend."""
+    anvil = launch_anvil()
+    try:
+        yield anvil
+    finally:
+        anvil.close()
+
+
+def test_get_read_providers_plain(monkeypatch: pytest.MonkeyPatch):
+    """Get read providers from a plain Web3 provider.
+
+    1. Create a plain fake provider.
+    2. Disable Anvil detection for the fake Web3.
+    3. Check the provider is returned unchanged.
+    """
+
+    # 1. Create a plain fake provider.
+    provider = FakeProvider("plain")
+    web3 = FakeWeb3(provider)
+
+    # 2. Disable Anvil detection for the fake Web3.
+    monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
+
+    # 3. Check the provider is returned unchanged.
+    assert get_read_providers(web3) == [provider]
+
+
+def test_get_read_providers_fallback(monkeypatch: pytest.MonkeyPatch):
+    """Get all read providers from a direct fallback provider.
+
+    1. Create two fake read providers.
+    2. Wrap them in a fallback provider.
+    3. Check both providers are returned.
+    """
+
+    # 1. Create two fake read providers.
+    provider_1 = FakeProvider("read-1")
+    provider_2 = FakeProvider("read-2")
+
+    # 2. Wrap them in a fallback provider.
+    fallback_provider = FallbackProvider([provider_1, provider_2])
+    web3 = FakeWeb3(fallback_provider)
+    monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
+
+    # 3. Check both providers are returned.
+    assert get_read_providers(web3) == [provider_1, provider_2]
+
+
+def test_get_read_providers_mev_wrapper(monkeypatch: pytest.MonkeyPatch):
+    """Get read providers from a MEV-style wrapped provider.
+
+    1. Create two fake read providers behind a fallback provider.
+    2. Wrap the fallback provider in an object with call_provider.
+    3. Check transaction providers are ignored and read providers are returned.
+    """
+
+    # 1. Create two fake read providers behind a fallback provider.
+    provider_1 = FakeProvider("read-1")
+    provider_2 = FakeProvider("read-2")
+    fallback_provider = FallbackProvider([provider_1, provider_2])
+
+    # 2. Wrap the fallback provider in an object with call_provider.
+    web3 = FakeWeb3(FakeMEVProvider(fallback_provider))
+    monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
+
+    # 3. Check transaction providers are ignored and read providers are returned.
+    assert get_read_providers(web3) == [provider_1, provider_2]
+
+
+def test_get_read_providers_anvil_active_only(monkeypatch: pytest.MonkeyPatch):
+    """Get only the active read provider on Anvil.
+
+    1. Create a fallback provider with two fake providers.
+    2. Mark the fake Web3 as Anvil and switch the active provider.
+    3. Check only the active provider is returned.
+    """
+
+    # 1. Create a fallback provider with two fake providers.
+    provider_1 = FakeProvider("read-1")
+    provider_2 = FakeProvider("read-2")
+    fallback_provider = FallbackProvider([provider_1, provider_2])
+
+    # 2. Mark the fake Web3 as Anvil and switch the active provider.
+    fallback_provider.currently_active_provider = 1
+    web3 = FakeWeb3(fallback_provider)
+    monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: True)
+
+    # 3. Check only the active provider is returned.
+    assert get_read_providers(web3) == [provider_2]
+
+
+def test_wait_for_transaction_receipt_robust_immediate(monkeypatch: pytest.MonkeyPatch):
+    """Wait for an immediately visible receipt on all read providers.
+
+    1. Create two fake providers that already see the receipt.
+    2. Wait for robust receipt visibility.
+    3. Check the original Web3 receipt is returned.
+    """
+
+    # 1. Create two fake providers that already see the receipt.
+    provider_1 = FakeProvider("read-1")
+    provider_2 = FakeProvider("read-2")
+    web3 = FakeWeb3(FallbackProvider([provider_1, provider_2]), FakeEth({"status": 1, "source": "original-web3"}))
+    monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
+
+    # 2. Wait for robust receipt visibility.
+    receipt = wait_for_transaction_receipt_robust(web3, TX_HASH, timeout=1, poll_delay=0.001, max_poll_delay=0.002)
+
+    # 3. Check the original Web3 receipt is returned.
+    assert receipt == {"status": 1, "source": "original-web3"}
+
+
+def test_wait_for_transaction_receipt_robust_lagging_provider(monkeypatch: pytest.MonkeyPatch):
+    """Wait until a lagging read provider can see the receipt.
+
+    1. Create one immediate provider and one lagging provider.
+    2. Wait for robust receipt visibility.
+    3. Check the lagging provider was polled more than once.
+    """
+
+    # 1. Create one immediate provider and one lagging provider.
+    provider_1 = FakeProvider("read-1")
+    provider_2 = FakeProvider("read-2", receipts=[None, _raw_receipt()])
+    web3 = FakeWeb3(FallbackProvider([provider_1, provider_2]))
+    monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
+
+    # 2. Wait for robust receipt visibility.
+    wait_for_transaction_receipt_robust(web3, TX_HASH, timeout=1, poll_delay=0.001, max_poll_delay=0.002)
+
+    # 3. Check the lagging provider was polled more than once.
+    assert provider_2.calls.count("eth_getTransactionReceipt") == 2
+
+
+def test_wait_for_transaction_receipt_robust_extra_sleep_after_visibility(monkeypatch: pytest.MonkeyPatch):
+    """Sleep once after all read providers can see the receipt.
+
+    1. Create one immediate provider and one lagging provider.
+    2. Wait with an extra sleep and record sleep calls.
+    3. Check the extra sleep happens after the lagging provider is retried.
+    """
+
+    # 1. Create one immediate provider and one lagging provider.
+    sleep_calls = []
+    provider_1 = FakeProvider("read-1")
+    provider_2 = FakeProvider("read-2", receipts=[None, _raw_receipt()])
+    web3 = FakeWeb3(FallbackProvider([provider_1, provider_2]))
+    monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
+    monkeypatch.setattr(receipt_module.time, "sleep", sleep_calls.append)
+
+    # 2. Wait with an extra sleep and record sleep calls.
+    wait_for_transaction_receipt_robust(
+        web3,
+        TX_HASH,
+        timeout=1,
+        poll_delay=0.001,
+        max_poll_delay=0.002,
+        extra_sleep=0.123,
+    )
+
+    # 3. Check the extra sleep happens after the lagging provider is retried.
+    assert provider_2.calls.count("eth_getTransactionReceipt") == 2
+    assert sleep_calls == [0.001, 0.123]
+
+
+def test_wait_for_transaction_receipt_robust_timeout(monkeypatch: pytest.MonkeyPatch):
+    """Fail when a read provider never sees the receipt.
+
+    1. Create one visible provider and one permanently missing provider.
+    2. Wait for robust receipt visibility with a short timeout.
+    3. Check the timeout names the missing provider.
+    """
+
+    # 1. Create one visible provider and one permanently missing provider.
+    provider_1 = FakeProvider("read-1")
+    provider_2 = FakeProvider("read-2", receipts=[None])
+    web3 = FakeWeb3(FallbackProvider([provider_1, provider_2]))
+    monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
+
+    # 2. Wait for robust receipt visibility with a short timeout.
+    with pytest.raises(ReceiptVisibilityTimedOut) as exc_info:
+        wait_for_transaction_receipt_robust(web3, TX_HASH, timeout=0.01, poll_delay=0.001, max_poll_delay=0.002)
+
+    # 3. Check the timeout names the missing provider.
+    assert "read-2.example" in str(exc_info.value)
+
+
+def test_wait_for_transaction_receipt_robust_mismatch(monkeypatch: pytest.MonkeyPatch):
+    """Fail when read providers keep disagreeing on the receipt block hash.
+
+    1. Create two providers with different block hashes for the same tx.
+    2. Wait for robust receipt visibility until the timeout.
+    3. Check a persistent receipt mismatch is raised.
+    """
+
+    # 1. Create two providers with different block hashes for the same tx.
+    provider_1 = FakeProvider("read-1", receipts=[_raw_receipt(block_hash="0x" + "aa" * 32)])
+    provider_2 = FakeProvider("read-2", receipts=[_raw_receipt(block_hash="0x" + "bb" * 32)])
+    web3 = FakeWeb3(FallbackProvider([provider_1, provider_2]))
+    monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
+
+    # 2. Wait for robust receipt visibility until the timeout.
+    with pytest.raises(ReceiptVisibilityMismatch):
+        wait_for_transaction_receipt_robust(web3, TX_HASH, timeout=0.01, poll_delay=0.001, max_poll_delay=0.002)
+
+    # 3. Check a persistent receipt mismatch is raised.
+    assert provider_1.calls.count("eth_getTransactionReceipt") > 1
+
+
+def test_wait_for_transaction_receipt_robust_transient_mismatch(monkeypatch: pytest.MonkeyPatch):
+    """Retry when read providers temporarily disagree on the receipt block hash.
+
+    1. Create two providers that first disagree and then return the same receipt.
+    2. Wait for robust receipt visibility.
+    3. Check the original Web3 receipt is returned after retrying.
+    """
+
+    # 1. Create two providers that first disagree and then return the same receipt.
+    final_receipt = _raw_receipt(block_hash="0x" + "cc" * 32)
+    provider_1 = FakeProvider(
+        "read-1",
+        receipts=[_raw_receipt(block_hash="0x" + "aa" * 32), final_receipt],
+    )
+    provider_2 = FakeProvider(
+        "read-2",
+        receipts=[_raw_receipt(block_hash="0x" + "bb" * 32), final_receipt],
+    )
+    web3 = FakeWeb3(FallbackProvider([provider_1, provider_2]), FakeEth({"status": 1, "source": "original-web3"}))
+    monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
+
+    # 2. Wait for robust receipt visibility.
+    receipt = wait_for_transaction_receipt_robust(web3, TX_HASH, timeout=1, poll_delay=0.001, max_poll_delay=0.002)
+
+    # 3. Check the original Web3 receipt is returned after retrying.
+    assert receipt == {"status": 1, "source": "original-web3"}
+    assert provider_1.calls.count("eth_getTransactionReceipt") == 2
+
+
+def test_wait_for_transaction_receipt_robust_confirmation_success(monkeypatch: pytest.MonkeyPatch):
+    """Wait until all providers have enough receipt confirmations.
+
+    1. Create one provider that needs one more block for confirmation.
+    2. Wait for robust receipt visibility with one required confirmation.
+    3. Check block numbers were polled until confirmations were high enough.
+    """
+
+    # 1. Create one provider that needs one more block for confirmation.
+    provider_1 = FakeProvider("read-1", block_number=["0x1", "0x2"])
+    provider_2 = FakeProvider("read-2", block_number="0x2")
+    web3 = FakeWeb3(FallbackProvider([provider_1, provider_2]))
+    monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
+
+    # 2. Wait for robust receipt visibility with one required confirmation.
+    wait_for_transaction_receipt_robust(
+        web3,
+        TX_HASH,
+        timeout=1,
+        poll_delay=0.001,
+        max_poll_delay=0.002,
+        confirmation_block_count=1,
+    )
+
+    # 3. Check block numbers were polled until confirmations were high enough.
+    assert provider_1.calls.count("eth_blockNumber") == 2
+
+
+def test_wait_for_transaction_receipt_robust_confirmation_block_number_error(monkeypatch: pytest.MonkeyPatch):
+    """Treat a transient block number read error as insufficient confirmations.
+
+    1. Create one provider whose first block number read fails.
+    2. Wait for robust receipt visibility with one required confirmation.
+    3. Check the provider is retried instead of crashing the wait loop.
+    """
+
+    # 1. Create one provider whose first block number read fails.
+    provider_1 = FakeProvider(
+        "read-1",
+        block_number=[ProviderConnectionError("temporary block number error"), "0x2"],
+    )
+    provider_2 = FakeProvider("read-2", block_number="0x2")
+    web3 = FakeWeb3(FallbackProvider([provider_1, provider_2]))
+    monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
+
+    # 2. Wait for robust receipt visibility with one required confirmation.
+    wait_for_transaction_receipt_robust(
+        web3,
+        TX_HASH,
+        timeout=1,
+        poll_delay=0.001,
+        max_poll_delay=0.002,
+        confirmation_block_count=1,
+    )
+
+    # 3. Check the provider is retried instead of crashing the wait loop.
+    assert provider_1.calls.count("eth_blockNumber") == 2
+
+
+def test_wait_for_transaction_receipt_robust_confirmation_timeout(monkeypatch: pytest.MonkeyPatch):
+    """Time out when providers never have enough receipt confirmations.
+
+    1. Create providers that stay on the receipt block.
+    2. Wait for robust receipt visibility with one required confirmation.
+    3. Check timeout details mention insufficient confirmations.
+    """
+
+    # 1. Create providers that stay on the receipt block.
+    provider_1 = FakeProvider("read-1", block_number="0x1")
+    provider_2 = FakeProvider("read-2", block_number="0x1")
+    web3 = FakeWeb3(FallbackProvider([provider_1, provider_2]))
+    monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
+
+    # 2. Wait for robust receipt visibility with one required confirmation.
+    with pytest.raises(ReceiptVisibilityTimedOut) as exc_info:
+        wait_for_transaction_receipt_robust(
+            web3,
+            TX_HASH,
+            timeout=0.01,
+            poll_delay=0.001,
+            max_poll_delay=0.002,
+            confirmation_block_count=1,
+        )
+
+    # 3. Check timeout details mention insufficient confirmations.
+    assert "Insufficient confirmations" in str(exc_info.value)
+
+
+def test_wait_for_transaction_receipt_robust_final_typed_receipt_retry(monkeypatch: pytest.MonkeyPatch):
+    """Retry the final typed receipt fetch after raw providers see the receipt.
+
+    1. Create providers that already see the raw receipt.
+    2. Make the original Web3 receipt fetch fail once.
+    3. Check the typed receipt is retried and returned.
+    """
+
+    # 1. Create providers that already see the raw receipt.
+    provider_1 = FakeProvider("read-1")
+    provider_2 = FakeProvider("read-2")
+    eth = FakeEth(
+        [
+            TransactionNotFound("typed receipt not yet visible"),
+            {"status": 1, "source": "typed-retry"},
+        ]
+    )
+    web3 = FakeWeb3(FallbackProvider([provider_1, provider_2]), eth)
+    monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
+
+    # 2. Make the original Web3 receipt fetch fail once.
+    receipt = wait_for_transaction_receipt_robust(web3, TX_HASH, timeout=1, poll_delay=0.001, max_poll_delay=0.002)
+
+    # 3. Check the typed receipt is retried and returned.
+    assert receipt == {"status": 1, "source": "typed-retry"}
+    assert eth.get_receipt_calls == 2
+
+
+def test_wait_for_transaction_receipt_robust_anvil_path(monkeypatch: pytest.MonkeyPatch):
+    """Use normal Web3 receipt waiting on Anvil.
+
+    1. Create a fake Anvil Web3.
+    2. Wait for robust receipt visibility.
+    3. Check the normal Web3 wait path was used.
+    """
+
+    # 1. Create a fake Anvil Web3.
+    provider = FakeProvider("anvil")
+    eth = FakeEth({"status": 1})
+    web3 = FakeWeb3(provider, eth)
+    monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: True)
+
+    # 2. Wait for robust receipt visibility.
+    receipt = wait_for_transaction_receipt_robust(web3, TX_HASH, timeout=1)
+
+    # 3. Check the normal Web3 wait path was used.
+    assert receipt == {"status": 1}
+    assert eth.waited
+    assert provider.calls == []
+
+
+@pytest.mark.skipif(shutil.which("anvil") is None, reason="Install anvil to run this test")
+def test_wait_for_transaction_receipt_robust_real_fallback_provider(anvil: AnvilLaunch, monkeypatch: pytest.MonkeyPatch):
+    """Wait for a real transaction receipt through a real fallback provider.
+
+    1. Create two real HTTP providers pointing at the same Anvil instance.
+    2. Send a transaction through the fallback Web3.
+    3. Force the live robust path and check receipt visibility succeeds.
+    """
+
+    # 1. Create two real HTTP providers pointing at the same Anvil instance.
+    provider_1 = create_http_provider(anvil.json_rpc_url, exception_retry_configuration=None)
+    provider_2 = create_http_provider(anvil.json_rpc_url, exception_retry_configuration=None)
+    clear_middleware(provider_1)
+    clear_middleware(provider_2)
+    web3 = Web3(FallbackProvider([provider_1, provider_2], sleep=0.1, backoff=1))
+
+    # 2. Send a transaction through the fallback Web3.
+    account = web3.eth.accounts[0]
+    tx_hash = web3.eth.send_transaction({"from": account, "to": ZERO_ADDRESS, "value": 1})
+
+    # 3. Force the live robust path and check receipt visibility succeeds.
+    monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
+    receipt = wait_for_transaction_receipt_robust(web3, tx_hash, timeout=10, poll_delay=0.01, max_poll_delay=0.05)
+    assert receipt["status"] == 1


### PR DESCRIPTION
## Why

Multi-RPC setups can mine a settlement transaction through one provider while other read providers still cannot see its receipt. Lagoon funding can then build follow-up calls against stale RPC state and hit `RequestIdNotClaimable`.

## Lessons learnt

Receipt visibility across all read providers is a useful lower-level readiness check, but it still does not guarantee protocol state is fresh for later `eth_call` requests. Lagoon therefore keeps its existing `maxDeposit()` polling after the robust receipt wait.

## Summary

- Add `eth_defi.provider.receipt` with read-provider discovery and robust all-read-provider receipt waiting.
- Add Anvil and MEV/read-provider handling without importing MEV-specific provider classes.
- Hook the helper into Lagoon test vault funding before the existing `maxDeposit()` polling.
- Add unit coverage for provider discovery, lagging providers, timeouts, mismatched receipts, and a real Anvil/FallbackProvider path.