### PR TITLE
feat: Core3 risk intelligence in vault lifetime metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- feat: Core3 risk intelligence in vault lifetime metrics — `calculate_lifetime_metrics()` accepts optional `Core3Database`, pre-computes per-protocol cache, and exports Core3 PoL score, rating, top risks in `other_data["core3"]`; standardised `CORE3_DATABASE_PATH` env var across all Core3 scripts; moved default database to `~/.tradingstrategy/vaults/core3/core3.duckdb` (2026-06-03)
+
 - feat: Core3 vault protocol mapping — `CORE3_MAPPINGS` dict mapping 21 of our 75 vault protocol slugs to Core3 project slugs, with `update-core3-mappings.py` discovery script using heuristics (exact slug, website domain, DeFi Llama, name similarity) (2026-06-03)
 
 - feat: Core3 risk intelligence DuckDB pipeline — scan ~1,400 crypto projects for Probability of Loss (PoL) scores, store snapshots and time-series in DuckDB with incremental sync, parallel fetching, and raw JSON payload storage (2026-06-03)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,9 @@ services:
       SKIP_TOP_VAULTS: ${SKIP_TOP_VAULTS:-false}
       SKIP_SAMPLES: ${SKIP_SAMPLES:-false}
 
+      # Core3 risk intelligence DuckDB path override
+      CORE3_DATABASE_PATH: ${CORE3_DATABASE_PATH:-}
+
       # General workers per script
       MAX_WORKERS: ${MAX_WORKERS:-50}
 
@@ -223,6 +226,9 @@ services:
       R2_TOP_VAULTS_ALTERNATIVE_BUCKET_NAME: ${R2_TOP_VAULTS_ALTERNATIVE_BUCKET_NAME:-}
       SKIP_TOP_VAULTS: ${SKIP_TOP_VAULTS:-false}
       SKIP_SAMPLES: ${SKIP_SAMPLES:-false}
+
+      # Core3 risk intelligence DuckDB path override
+      CORE3_DATABASE_PATH: ${CORE3_DATABASE_PATH:-}
 
       # Hyperliquid manual vault review Google Sheet sync — same
       # contract as the one-shot vault-scanner service above.

--- a/eth_defi/core3/README-core3.md
+++ b/eth_defi/core3/README-core3.md
@@ -23,12 +23,12 @@ and centralised exchanges, scoring risk on a 0-100 scale where 0 = Exceptional a
 
 ## Database files
 
-Default location: `~/.tradingstrategy/core3/`
+Default location: `~/.tradingstrategy/vaults/core3/`
 
 | File | Description |
 |------|-------------|
-| `risk-data.duckdb` | Main DuckDB database with all project snapshots and time-series data |
-| `risk-data.duckdb.wal` | DuckDB write-ahead log (automatically managed) |
+| `core3.duckdb` | Main DuckDB database with all project snapshots and time-series data |
+| `core3.duckdb.wal` | DuckDB write-ahead log (automatically managed) |
 | `rate-limit.sqlite` | SQLite database for thread-safe rate limiting state across `joblib` workers |
 
 ### Database tables
@@ -60,7 +60,7 @@ source .local-test.env && poetry run python scripts/core3/scan-core3.py
 |---------------------|---------|-------------|
 | `CORE3_API_KEY` | (required) | Core3 API key (prefixed `core3_`) |
 | `LOG_LEVEL` | `warning` | Logging level: debug, info, warning, error |
-| `DB_PATH` | `~/.tradingstrategy/core3/risk-data.duckdb` | Path to DuckDB database file |
+| `CORE3_DATABASE_PATH` | `~/.tradingstrategy/vaults/core3/core3.duckdb` | Path to DuckDB database file |
 | `LIMIT` | (none) | Limit number of projects to scan (for testing) |
 | `MAX_WORKERS` | `8` | Maximum number of parallel workers for API fetching |
 | `FETCH_SECTIONS` | `false` | Set to `true` to also fetch section detail endpoints (5 extra API calls per project) |
@@ -76,7 +76,7 @@ poetry run python scripts/core3/core3-overview.py
 
 | Environment variable | Default | Description |
 |---------------------|---------|-------------|
-| `DB_PATH` | `~/.tradingstrategy/core3/risk-data.duckdb` | Path to DuckDB database file |
+| `CORE3_DATABASE_PATH` | `~/.tradingstrategy/vaults/core3/core3.duckdb` | Path to DuckDB database file |
 
 ### update-core3-mappings.py — vault protocol mapping updater
 
@@ -105,7 +105,7 @@ source .local-test.env && PYTHONPATH="$(pwd):$PYTHONPATH" poetry run python scri
 
 | Environment variable | Default | Description |
 |---------------------|---------|-------------|
-| `DB_PATH` | `~/.tradingstrategy/core3/risk-data.duckdb` | Path to DuckDB database file |
+| `CORE3_DATABASE_PATH` | `~/.tradingstrategy/vaults/core3/core3.duckdb` | Path to DuckDB database file |
 | `LOG_LEVEL` | `warning` | Logging level |
 
 ### reproduce-duckdb-crash.py — crash reproducer

--- a/eth_defi/core3/constants.py
+++ b/eth_defi/core3/constants.py
@@ -13,13 +13,13 @@ from pathlib import Path
 CORE3_API_URL: str = "https://api.core3.io/projects_data"
 
 #: Default DuckDB path for Core3 risk data.
-CORE3_DATABASE_PATH: Path = Path("~/.tradingstrategy/core3/risk-data.duckdb").expanduser()
+CORE3_DATABASE_PATH: Path = Path("~/.tradingstrategy/vaults/core3/core3.duckdb").expanduser()
 
 #: Default SQLite database path for rate limiting state.
 #:
 #: Using SQLite ensures thread-safe rate limiting across multiple threads
 #: when using ``joblib.Parallel`` or similar parallel processing.
-CORE3_RATE_LIMIT_SQLITE_DATABASE: Path = Path("~/.tradingstrategy/core3/rate-limit.sqlite").expanduser()
+CORE3_RATE_LIMIT_SQLITE_DATABASE: Path = Path("~/.tradingstrategy/vaults/core3/rate-limit.sqlite").expanduser()
 
 #: Default requests per second.
 #:

--- a/eth_defi/core3/database.py
+++ b/eth_defi/core3/database.py
@@ -24,7 +24,7 @@ run in parallel while database writes are serialised.
 Storage location
 ----------------
 
-Default: ``~/.tradingstrategy/core3/risk-data.duckdb``
+Default: ``~/.tradingstrategy/vaults/core3/core3.duckdb``
 
 Example::
 

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -25,6 +25,7 @@ from tqdm_loggable.auto import tqdm
 
 from eth_defi.chain import get_chain_name
 from eth_defi.compat import native_datetime_utc_now
+from eth_defi.core3.vault_protocol import get_core3_protocol_record
 from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS
 from eth_defi.erc_4626.core import ERC4262VaultDetection
 from eth_defi.erc_4626.vault_protocol.morpho.flag_analytics import MorphoFlagAnalytics, analyze_morpho_flags
@@ -1717,8 +1718,6 @@ def calculate_lifetime_metrics(
     # unique protocol slug once and cache the result for the per-vault loop.
     core3_cache: dict | None = None
     if core3_db is not None:
-        from eth_defi.core3.vault_protocol import get_core3_protocol_record
-
         unique_slugs = {v.get("protocol_slug") for v in vaults_by_id.values() if v.get("protocol_slug")}
         core3_cache = {slug: get_core3_protocol_record(core3_db, slug) for slug in unique_slugs}
 

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -1164,6 +1164,7 @@ def calculate_vault_record(
     month_ago: pd.Timestamp,
     three_months_ago: pd.Timestamp,
     vault_id: str | None = None,
+    core3_cache: dict | None = None,
 ) -> pd.Series:
     """Process a single vault metadata + prices to calculate its full data.
 
@@ -1184,6 +1185,12 @@ def calculate_vault_record(
 
     :param vault_id:
         Vault ID string. If not provided, extracted from prices_df["id"].
+
+    :param core3_cache:
+        Pre-computed dict mapping protocol slugs to
+        :py:class:`~eth_defi.core3.vault_protocol.Core3Record` or ``None``.
+        Built by :py:func:`calculate_lifetime_metrics` before the per-vault loop.
+        When ``None``, ``other_data["core3"]`` is set to ``None``.
 
     :return:
         Series with calculated metrics
@@ -1386,7 +1393,8 @@ def calculate_vault_record(
                 notes = morpho_analytics.note
 
     # ``other_data`` is a protocol-specific extension dict included in the metrics Series.
-    # Currently populated for Morpho vaults; all other protocols return empty lists.
+    # Currently populated for Morpho warnings and Core3 risk intelligence;
+    # all other protocols return empty lists / None.
     # Future protocols should add their own keys here rather than adding top-level Series fields.
     other_data: dict = {
         # Vault-level governance warning types from the Morpho Blue API.
@@ -1403,6 +1411,11 @@ def calculate_vault_record(
         # Combined YELLOW-level warning types across vault and market warnings.
         # YELLOW flags do not trigger VaultFlag.morpho_issues. Example: ["bad_debt_realized", "not_whitelisted"]
         "morpho_yellow_flags": morpho_yellow_flags,
+        # Core3 risk intelligence record for this vault's protocol.
+        # A :py:class:`~eth_defi.core3.vault_protocol.Core3Record` TypedDict with PoL score,
+        # rating, top risks, seals, etc. ``None`` when Core3 DB is not available or
+        # the protocol has no Core3 mapping.
+        "core3": core3_cache.get(protocol_slug) if core3_cache else None,
     }
 
     # Manual review decision from the Hyperliquid review Google Sheet.
@@ -1651,6 +1664,7 @@ def calculate_lifetime_metrics(
     df: pd.DataFrame,
     vault_db: VaultDatabase | dict[VaultSpec, VaultRow],
     returns_column: str = "returns_1h",
+    core3_db: "Core3Database | None" = None,
 ) -> pd.DataFrame:
     """Calculate lifetime metrics for each vault in the provided DataFrame.
 
@@ -1668,6 +1682,12 @@ def calculate_lifetime_metrics(
 
     :param vault_db:
         Pass all vaults or subset of vaults as VaultRows, or full VaultDatabase
+
+    :param core3_db:
+        Optional open :py:class:`~eth_defi.core3.database.Core3Database` connection.
+        When provided, Core3 risk intelligence records are looked up per protocol
+        and included in each vault's ``other_data["core3"]``. When ``None``,
+        ``other_data["core3"]`` is set to ``None`` for all vaults.
 
     :return:
         DataFrame, one row per vault.
@@ -1692,11 +1712,21 @@ def calculate_lifetime_metrics(
         vaults=vaults_by_id,
     )
 
+    # Pre-compute Core3 risk records per protocol slug.
+    # Core3 data is per-protocol (not per-vault), so we look up each
+    # unique protocol slug once and cache the result for the per-vault loop.
+    core3_cache: dict | None = None
+    if core3_db is not None:
+        from eth_defi.core3.vault_protocol import get_core3_protocol_record
+
+        unique_slugs = {v.get("protocol_slug") for v in vaults_by_id.values() if v.get("protocol_slug")}
+        core3_cache = {slug: get_core3_protocol_record(core3_db, slug) for slug in unique_slugs}
+
     # Use progress_apply instead of the for loop
     # Sort is needed for slug stability
     # We pass include_groups=False to avoid FutureWarning, and pass id via group.name
     def _apply_vault_record(group):
-        return calculate_vault_record(group, vaults_by_id, month_ago, three_months_ago, vault_id=group.name)
+        return calculate_vault_record(group, vaults_by_id, month_ago, three_months_ago, vault_id=group.name, core3_cache=core3_cache)
 
     results_df = df.groupby("id", group_keys=False, sort=True).progress_apply(
         _apply_vault_record,

--- a/eth_defi/vault/post_processing.py
+++ b/eth_defi/vault/post_processing.py
@@ -480,6 +480,7 @@ def export_top_vaults_json(
     vault_db_path: Path | None = None,
     cleaned_path: Path | None = None,
     output_path: Path | None = None,
+    core3_db_path: Path | None = None,
 ) -> bool:
     """Generate the top-vaults lifetime-metrics JSON and upload to R2.
 
@@ -511,6 +512,11 @@ def export_top_vaults_json(
         ``get_pipeline_data_dir() / "top_vaults_by_chain.json"``. The
         filename is intentionally kept identical to the existing public
         URL ``https://top-defi-vaults.tradingstrategy.ai/top_vaults_by_chain.json``.
+
+    :param core3_db_path:
+        Override for the Core3 risk intelligence DuckDB path. When ``None``,
+        ``vault-analysis-json.main()`` auto-discovers from
+        ``CORE3_DATABASE_PATH`` env var or the default constant.
 
     :return:
         ``True`` if the JSON was generated and uploaded, ``False`` on
@@ -545,6 +551,7 @@ def export_top_vaults_json(
             vault_db_path=vault_db_path,
             parquet_path=cleaned_path,
             output_path=output_path,
+            core3_db_path=core3_db_path,
         )
 
         bucket_name = os.environ["R2_TOP_VAULTS_BUCKET_NAME"]
@@ -611,6 +618,7 @@ def run_post_processing(
     hibachi_db_path: Path | None = None,
     vault_db_path: Path | None = None,
     cleaned_path: Path | None = None,
+    core3_db_path: Path | None = None,
 ) -> dict[str, bool]:
     """Run full post-processing pipeline after chain scans complete.
 
@@ -641,6 +649,7 @@ def run_post_processing(
     :param hibachi_db_path: Override for the Hibachi DuckDB path
     :param vault_db_path: Override for the vault database pickle path
     :param cleaned_path: Override for the cleaned parquet output path
+    :param core3_db_path: Override for the Core3 risk intelligence DuckDB path
     :return: Dictionary mapping step name to success boolean
     """
     steps = {}
@@ -687,6 +696,7 @@ def run_post_processing(
         steps["export-top-vaults-json"] = export_top_vaults_json(
             vault_db_path=vault_db_path,
             cleaned_path=cleaned_path,
+            core3_db_path=core3_db_path,
         )
 
     # Step 4: Export sparklines

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -1232,6 +1232,7 @@ def run_scan_tick(
     not_due_items: dict[str, float] | None = None,
     cycle_intervals: dict[str, str] | None = None,
     on_item_success: Callable[[str], None] | None = None,
+    core3_db_path: Path | None = None,
 ) -> dict[str, ChainResult]:
     """Execute one scan tick: EVM chains + native protocols + post-processing.
 
@@ -1244,6 +1245,10 @@ def run_scan_tick(
         an interrupted scan does not re-fetch already-completed items on
         restart.  Not related to post-processing — post-processing always
         runs after all data fetches complete.
+
+    :param core3_db_path:
+        Path to the Core3 risk intelligence DuckDB. Forwarded to
+        :py:func:`~eth_defi.vault.post_processing.run_post_processing`.
     """
     # Back up critical pipeline files before any scanning
     backup_pipeline_files(backup_files=bkp_files, backup_dir=bkp_dir)
@@ -1448,6 +1453,7 @@ def run_scan_tick(
             hibachi_db_path=hibachi_db_path,
             vault_db_path=vault_db_path,
             cleaned_path=cleaned_price_path,
+            core3_db_path=core3_db_path,
         )
         for step, success in post_results.items():
             logger.info("Post-processing %s: %s", step, "SUCCESS" if success else "FAILED")
@@ -1570,6 +1576,13 @@ def main():
     hyperliquid_db_path = data_dir / "hyperliquid-vaults.duckdb"
     hyperliquid_hf_db_path = data_dir / "hyperliquid-vaults-hf.duckdb"
     grvt_db_path = data_dir / "grvt-vaults.duckdb"
+
+    # Core3 risk intelligence database — lives under data_dir/core3/ alongside
+    # the vault pipeline data rather than the old standalone location.
+    from eth_defi.core3.constants import CORE3_DATABASE_PATH
+
+    core3_db_path_env = os.environ.get("CORE3_DATABASE_PATH")
+    core3_db_path = Path(core3_db_path_env).expanduser() if core3_db_path_env else CORE3_DATABASE_PATH
 
     bkp_files = [uncleaned_price_path, reader_state_path, vault_db_path, hyperliquid_db_path, hyperliquid_hf_db_path, grvt_db_path, lighter_db_path, hibachi_db_path]
 
@@ -1697,6 +1710,7 @@ def main():
         cleaned_price_path=cleaned_price_path,
         excluded_chains=[c.name for c in skipped_by_order + disabled_chains],
         hypercore_mode=hypercore_mode,
+        core3_db_path=core3_db_path,
     )
 
     # Clear cycle state on disc so the first tick rescans everything.

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -52,6 +52,7 @@ from eth_defi.hibachi.daily_metrics import run_daily_scan as hibachi_run_daily_s
 from eth_defi.hibachi.vault_data_export import merge_into_vault_database as hibachi_merge_vault_db
 from eth_defi.provider.broken_provider import verify_archive_node
 from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
+from eth_defi.core3.constants import CORE3_DATABASE_PATH
 from eth_defi.token import TokenDiskCache
 from eth_defi.utils import setup_console_logging, wait_other_writers
 from eth_defi.vault.historical import scan_historical_prices_to_parquet
@@ -1577,10 +1578,7 @@ def main():
     hyperliquid_hf_db_path = data_dir / "hyperliquid-vaults-hf.duckdb"
     grvt_db_path = data_dir / "grvt-vaults.duckdb"
 
-    # Core3 risk intelligence database — lives under data_dir/core3/ alongside
-    # the vault pipeline data rather than the old standalone location.
-    from eth_defi.core3.constants import CORE3_DATABASE_PATH
-
+    # Core3 risk intelligence database path — resolved from env var or default constant.
     core3_db_path_env = os.environ.get("CORE3_DATABASE_PATH")
     core3_db_path = Path(core3_db_path_env).expanduser() if core3_db_path_env else CORE3_DATABASE_PATH
 

--- a/scripts/core3/core3-overview.py
+++ b/scripts/core3/core3-overview.py
@@ -10,11 +10,11 @@ Usage:
     poetry run python scripts/core3/core3-overview.py
 
     # Custom database path
-    DB_PATH=~/my-core3.duckdb poetry run python scripts/core3/core3-overview.py
+    CORE3_DATABASE_PATH=~/my-core3.duckdb poetry run python scripts/core3/core3-overview.py
 
 Environment variables:
 
-- ``DB_PATH``: Path to DuckDB database file. Default: ~/.tradingstrategy/core3/risk-data.duckdb
+- ``CORE3_DATABASE_PATH``: Path to DuckDB database file. Default: ~/.tradingstrategy/vaults/core3/core3.duckdb
 """
 
 import os
@@ -37,7 +37,7 @@ def _fmt_market_cap(x) -> str:
 
 
 def main():
-    db_path_str = os.environ.get("DB_PATH")
+    db_path_str = os.environ.get("CORE3_DATABASE_PATH")
     if db_path_str:
         db_path = Path(db_path_str).expanduser()
     else:

--- a/scripts/core3/scan-core3.py
+++ b/scripts/core3/scan-core3.py
@@ -24,7 +24,7 @@ Environment variables:
 
 - ``CORE3_API_KEY``: Core3 API key (required, prefixed ``core3_``)
 - ``LOG_LEVEL``: Logging level (debug, info, warning, error). Default: warning
-- ``DB_PATH``: Path to DuckDB database file. Default: ~/.tradingstrategy/core3/risk-data.duckdb
+- ``CORE3_DATABASE_PATH``: Path to DuckDB database file. Default: ~/.tradingstrategy/vaults/core3/core3.duckdb
 - ``LIMIT``: Limit the number of projects to scan (for testing). Default: None (scan all)
 - ``MAX_WORKERS``: Maximum number of parallel workers. Default: 8
 - ``FETCH_SECTIONS``: Set to ``true`` to also fetch section detail endpoints. Default: false
@@ -53,7 +53,7 @@ def main():
 
     logger.info("Using log level: %s", default_log_level)
 
-    db_path_str = os.environ.get("DB_PATH")
+    db_path_str = os.environ.get("CORE3_DATABASE_PATH")
     if db_path_str:
         db_path = Path(db_path_str).expanduser()
     else:

--- a/scripts/core3/update-core3-mappings.py
+++ b/scripts/core3/update-core3-mappings.py
@@ -22,7 +22,7 @@ Usage:
 
 Environment variables:
 
-- ``DB_PATH``: Path to DuckDB database file. Default: ~/.tradingstrategy/core3/risk-data.duckdb
+- ``CORE3_DATABASE_PATH``: Path to DuckDB database file. Default: ~/.tradingstrategy/vaults/core3/core3.duckdb
 - ``LOG_LEVEL``: Logging level. Default: warning
 """
 
@@ -343,7 +343,7 @@ def main():
     default_log_level = os.environ.get("LOG_LEVEL", "warning")
     setup_console_logging(default_log_level=default_log_level)
 
-    db_path_str = os.environ.get("DB_PATH")
+    db_path_str = os.environ.get("CORE3_DATABASE_PATH")
     db_path = Path(db_path_str).expanduser() if db_path_str else CORE3_DATABASE_PATH
 
     if not db_path.exists():

--- a/scripts/erc-4626/post-process-prices.py
+++ b/scripts/erc-4626/post-process-prices.py
@@ -104,6 +104,7 @@ from pathlib import Path
 
 from tabulate import tabulate
 
+from eth_defi.core3.constants import CORE3_DATABASE_PATH
 from eth_defi.utils import setup_console_logging
 from eth_defi.vault.post_processing import run_post_processing, validate_top_vaults_config
 from eth_defi.vault.vaultdb import get_pipeline_data_dir
@@ -146,9 +147,7 @@ def main():
     lighter_db_path = data_dir / "lighter-pools.duckdb"
     hibachi_db_path = data_dir / "hibachi-vaults.duckdb"
 
-    # Core3 risk intelligence database
-    from eth_defi.core3.constants import CORE3_DATABASE_PATH
-
+    # Core3 risk intelligence database path — resolved from env var or default constant.
     core3_db_path_env = os.environ.get("CORE3_DATABASE_PATH")
     core3_db_path = Path(core3_db_path_env).expanduser() if core3_db_path_env else CORE3_DATABASE_PATH
 

--- a/scripts/erc-4626/post-process-prices.py
+++ b/scripts/erc-4626/post-process-prices.py
@@ -100,6 +100,7 @@ Top-vaults JSON R2 bucket (required unless ``SKIP_TOP_VAULTS=true``):
 import logging
 import os
 import sys
+from pathlib import Path
 
 from tabulate import tabulate
 
@@ -145,6 +146,12 @@ def main():
     lighter_db_path = data_dir / "lighter-pools.duckdb"
     hibachi_db_path = data_dir / "hibachi-vaults.duckdb"
 
+    # Core3 risk intelligence database
+    from eth_defi.core3.constants import CORE3_DATABASE_PATH
+
+    core3_db_path_env = os.environ.get("CORE3_DATABASE_PATH")
+    core3_db_path = Path(core3_db_path_env).expanduser() if core3_db_path_env else CORE3_DATABASE_PATH
+
     logger.info("Pipeline data directory: %s", data_dir)
     if not any([merge_hypercore, merge_grvt, merge_lighter, merge_hibachi]):
         logger.info("No native protocol merges requested (set MERGE_HYPERCORE/MERGE_GRVT/MERGE_LIGHTER/MERGE_HIBACHI=true)")
@@ -172,6 +179,7 @@ def main():
         hibachi_db_path=hibachi_db_path,
         vault_db_path=vault_db_path,
         cleaned_path=cleaned_price_path,
+        core3_db_path=core3_db_path,
     )
 
     # Summary

--- a/scripts/erc-4626/vault-analysis-json.py
+++ b/scripts/erc-4626/vault-analysis-json.py
@@ -33,6 +33,8 @@ import pandas as pd
 import datetime
 from pathlib import Path
 
+from eth_defi.core3.constants import CORE3_DATABASE_PATH
+from eth_defi.core3.database import Core3Database
 from eth_defi.token import is_stablecoin_like
 
 # Import core TradingStrategy / eth_defi modules
@@ -222,12 +224,8 @@ def main(
         if db_path_env:
             core3_db_path = Path(db_path_env).expanduser()
         else:
-            from eth_defi.core3.constants import CORE3_DATABASE_PATH
-
             core3_db_path = CORE3_DATABASE_PATH
     if core3_db_path.exists():
-        from eth_defi.core3.database import Core3Database
-
         core3_db = Core3Database(core3_db_path)
         print(f"Opened Core3 risk database at {core3_db_path} with {core3_db.get_project_count()} projects")
 

--- a/scripts/erc-4626/vault-analysis-json.py
+++ b/scripts/erc-4626/vault-analysis-json.py
@@ -131,6 +131,7 @@ def main(
     vault_db_path: Path | None = None,
     parquet_path: Path | None = None,
     output_path: Path | None = None,
+    core3_db_path: Path | None = None,
 ):
     """Main execution function for vault analysis and JSON export.
 
@@ -162,6 +163,12 @@ def main(
         ``__main__`` entrypoint, not by :py:func:`main` itself, so
         in-process callers get deterministic path anchoring with no env
         var surprises.
+
+    :param core3_db_path:
+        Path to the Core3 risk intelligence DuckDB database.
+        When ``None``, resolved from ``CORE3_DATABASE_PATH`` env var,
+        then the default constant. The database is only opened if the
+        resolved file exists on disk.
     """
     defaults = _resolve_defaults_from_env()
     if data_dir is None:
@@ -205,7 +212,30 @@ def main(
 
     raw_returns_df = returns_df = calculate_hourly_returns_for_all_vaults(prices_df)
 
-    lifetime_data_df = calculate_lifetime_metrics(returns_df, vault_db)
+    # Open Core3 risk intelligence database if locally available.
+    # Resolved from explicit argument, CORE3_DATABASE_PATH env var, or the default constant.
+    # Only opened if the file exists — constructing Core3Database on a non-existent
+    # path would create an empty database rather than being truly optional.
+    core3_db = None
+    if core3_db_path is None:
+        db_path_env = os.getenv("CORE3_DATABASE_PATH")
+        if db_path_env:
+            core3_db_path = Path(db_path_env).expanduser()
+        else:
+            from eth_defi.core3.constants import CORE3_DATABASE_PATH
+
+            core3_db_path = CORE3_DATABASE_PATH
+    if core3_db_path.exists():
+        from eth_defi.core3.database import Core3Database
+
+        core3_db = Core3Database(core3_db_path)
+        print(f"Opened Core3 risk database at {core3_db_path} with {core3_db.get_project_count()} projects")
+
+    try:
+        lifetime_data_df = calculate_lifetime_metrics(returns_df, vault_db, core3_db=core3_db)
+    finally:
+        if core3_db is not None:
+            core3_db.close()
 
     print(f"Calculated lifetime metrics for {len(lifetime_data_df):,} vaults with {len(lifetime_data_df.columns):,} columns")
 

--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -1,5 +1,6 @@
 """Test vault metrics calculations and charts."""
 
+import datetime
 import json
 import os.path
 import pickle
@@ -10,6 +11,7 @@ import pytest
 import zstandard as zstd
 from plotly.graph_objects import Figure
 
+from eth_defi.core3.database import Core3Database
 from eth_defi.research.sparkline import export_sparkline_as_png, export_sparkline_as_svg, extract_vault_price_data, render_sparkline_simple
 from eth_defi.research.vault_benchmark import visualise_vault_return_benchmark
 from eth_defi.research.vault_metrics import PeriodMetrics, apply_abnormal_value_checks, apply_morpho_not_in_api_check, calculate_lifetime_metrics, calculate_period_metrics, display_vault_chart_and_tearsheet, export_lifetime_row, format_lifetime_table
@@ -533,3 +535,123 @@ def test_export_lifetime_row_nat_serialization():
     # Verify other fields are still properly serialized
     assert parsed["name"] == "Test Vault"
     assert parsed["current_nav"] == 1000.0
+
+
+def _make_core3_project_json(slug: str, name: str, rank: int, pol_score: float) -> dict:
+    """Build a Core3 project JSON matching the full API payload shape.
+
+    Local helper — not imported from ``tests/core3/`` to avoid
+    cross-test-tree imports.
+    """
+    return {
+        "slug": slug,
+        "name": name,
+        "description": f"{name} is a DeFi protocol.",
+        "rank": rank,
+        "pol": {"score": pol_score, "rating": "BB", "confidence": "High"},
+        "ticker": slug.upper(),
+        "coingecko_id": slug,
+        "logo": f"https://example.com/{slug}.png",
+        "link": f"https://core3.io{slug}",
+        "launched_at": None,
+        "category": {"name": "Decentralized Finance"},
+        "data_coverage": {"percentage": 76.7},
+        "market_cap": {"in_usd": "1000000", "change_24h_percentage": -0.5, "change_24h_in_usd": "-5000"},
+        "chains": [{"name": "Ethereum"}, {"name": "Base"}],
+        "links": {
+            "website": f"https://{slug}.org/",
+            "legal": None,
+            "whitepaper": None,
+            "socials": [{"name": "Twitter", "link": f"https://twitter.com/{slug}"}],
+        },
+        "tags": [],
+        "top_risks": [{"content": "Example risk finding.", "date": "2026-01-01T00:00:00.000Z"}],
+        "recent_changes": [],
+        "seals": {
+            "security_measures": {"value": False, "logo": None},
+            "independent_certificates": {"value": False, "logo": None},
+            "self_regulation": {"value": False, "logo": None},
+        },
+    }
+
+
+def test_core3_integration_in_lifetime_metrics(
+    vault_db: VaultDatabase,
+    price_df: pd.DataFrame,
+    tmp_path: Path,
+):
+    """Core3 risk data flows through calculate_lifetime_metrics into JSON export.
+
+    The Hemi test fixture contains Morpho vaults (protocol_slug == "morpho").
+    We insert a synthetic Core3 snapshot for "morpho" and verify:
+
+    1. Create a temp Core3 DuckDB and insert a "morpho" project snapshot
+    2. Call calculate_lifetime_metrics with core3_db
+    3. Verify Morpho vaults have other_data["core3"] populated with PoL score
+    4. Verify non-Morpho vaults have other_data["core3"] as None
+    5. Run export_lifetime_row + json.dumps to verify full serialisation path
+    6. Assert fetched_at becomes an ISO 8601 string, not a raw datetime
+    """
+    # 1. Create temp Core3 DuckDB with a morpho snapshot
+    core3_db = Core3Database(tmp_path / "test-core3.duckdb")
+    t_fetch = datetime.datetime(2025, 7, 1, 12, 0, 0)
+    raw = _make_core3_project_json("morpho", "Morpho", rank=96, pol_score=32.15)
+    core3_db.insert_project_snapshot("morpho", t_fetch, raw)
+
+    try:
+        # 2. Calculate lifetime metrics with Core3 DB
+        metrics = calculate_lifetime_metrics(
+            price_df,
+            vault_db,
+            core3_db=core3_db,
+        )
+    finally:
+        core3_db.close()
+
+    assert len(metrics) == 3
+
+    # 3. Morpho vault should have Core3 data populated
+    morpho_row = metrics.set_index("id").loc["43111-0x05c2e246156d37b39a825a25dd08d5589e3fd883"]
+    assert morpho_row["protocol_slug"] == "morpho"
+    core3_data = morpho_row["other_data"]["core3"]
+    assert core3_data is not None
+    assert core3_data["slug"] == "morpho"
+    assert core3_data["pol"]["score"] == pytest.approx(32.15)
+    assert core3_data["rank"] == 96
+    assert len(core3_data["top_risks"]) == 1
+    assert isinstance(core3_data["fetched_at"], datetime.datetime)
+
+    # 4. Non-Morpho vaults should have core3 as None
+    non_morpho_rows = metrics[metrics["protocol_slug"] != "morpho"]
+    for _, row in non_morpho_rows.iterrows():
+        assert row["other_data"]["core3"] is None
+
+    # 5. Full serialisation path: export_lifetime_row + json.dumps
+    exported = export_lifetime_row(morpho_row)
+    json_str = json.dumps(exported)
+    parsed = json.loads(json_str)
+
+    # 6. fetched_at must be an ISO 8601 string after serialisation
+    assert parsed["other_data"]["core3"]["fetched_at"] == "2025-07-01T12:00:00"
+    assert parsed["other_data"]["core3"]["pol"]["score"] == pytest.approx(32.15)
+    assert parsed["other_data"]["core3"]["rank"] == 96
+
+
+def test_core3_none_when_db_not_provided(
+    vault_db: VaultDatabase,
+    price_df: pd.DataFrame,
+):
+    """Without Core3 DB, all vaults have other_data["core3"] as None.
+
+    1. Call calculate_lifetime_metrics without core3_db
+    2. Verify all rows have other_data["core3"] as None
+    """
+    # 1. No core3_db argument
+    metrics = calculate_lifetime_metrics(
+        price_df,
+        vault_db,
+    )
+
+    # 2. All rows should have core3 as None
+    for _, row in metrics.iterrows():
+        assert row["other_data"]["core3"] is None


### PR DESCRIPTION
## Why

Core3 risk intelligence data (PoL scores, ratings, top risks, seals) was being collected into a local DuckDB database but not surfaced in the vault JSON output consumed by the frontend. This change wires the Core3 data through `calculate_lifetime_metrics()` so downstream consumers can display protocol-level risk alongside vault performance metrics.

Additionally, the generic `DB_PATH` env var was ambiguous when multiple databases exist in the vault metrics pipeline. Standardised all Core3 scripts to use `CORE3_DATABASE_PATH`, and relocated the default database path under `~/.tradingstrategy/vaults/core3/` to co-locate with other vault pipeline data.

## Lessons learnt

- Core3 data is per-protocol not per-vault — caching the lookup result per unique `protocol_slug` before the per-vault `groupby().progress_apply()` loop avoids redundant DuckDB queries
- `Core3Database` constructor creates parent dirs and initialises schema, so checking file existence before constructing is essential for truly optional behaviour
- `export_lifetime_row()` already handles dict recursion and `datetime.datetime` serialisation, so `Core3Record` (TypedDict = dict) serialises automatically with no exporter changes

## Summary

- `calculate_lifetime_metrics()` accepts optional `core3_db: Core3Database`, pre-computes per-protocol cache, passes to `calculate_vault_record()` which injects into `other_data["core3"]`
- `vault-analysis-json.py` auto-discovers Core3 DB (explicit arg > `CORE3_DATABASE_PATH` env > constant), opens only if file exists
- Migrated all Core3 scripts from `DB_PATH` to `CORE3_DATABASE_PATH` env var
- Moved default database path to `~/.tradingstrategy/vaults/core3/core3.duckdb`
- Two integration tests: happy path (Morpho vault with Core3 data through full JSON export pipeline) and `None` path (no Core3 DB)