### PR TITLE
fix: Preserve vault metadata when rescan fails with transient RPC errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- fix: Preserve vault metadata when rescan fails with transient RPC errors, add `heal-broken-vaults.py` healer script, atomic writes for Lagoon compatibility database (2026-06-04)
+
 - feat: Core3 risk intelligence in vault lifetime metrics — `calculate_lifetime_metrics()` accepts optional `Core3Database`, pre-computes per-protocol cache, and exports Core3 PoL score, rating, top risks in `other_data["core3"]`; standardised `CORE3_DATABASE_PATH` env var across all Core3 scripts; moved default database to `~/.tradingstrategy/vaults/core3/core3.duckdb` (2026-06-03)
 
 - feat: Core3 vault protocol mapping — `CORE3_MAPPINGS` dict mapping 21 of our 75 vault protocol slugs to Core3 project slugs, with `update-core3-mappings.py` discovery script using heuristics (exact slug, website domain, DeFi Llama, name similarity) (2026-06-03)

--- a/eth_defi/erc_4626/vault_protocol/lagoon/lagoon_compatibility.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/lagoon_compatibility.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from pprint import pformat
 from statistics import mean
 
+from atomicwrites import atomic_write
+
 from web3 import Web3
 from web3.contract.contract import ContractFunction
 from eth_typing import HexAddress
@@ -550,7 +552,7 @@ def check_lagoon_compatibility_with_database(
         database.report_by_token[base_token_address.lower()] = report
 
         # Because the operation is so slow, we want to resave after each iteration
-        with database_file.open("wb") as f:
+        with atomic_write(str(database_file), mode="wb", overwrite=True) as f:
             pickle.dump(database, f)
 
         anvil.close()

--- a/eth_defi/erc_4626/vault_protocol/lagoon/lagoon_compatibility.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/lagoon_compatibility.py
@@ -557,6 +557,6 @@ def check_lagoon_compatibility_with_database(
 
         anvil.close()
 
-    with database_file.open("wb") as f:
+    with atomic_write(str(database_file), mode="wb", overwrite=True) as f:
         pickle.dump(database, f)
     return database

--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -250,6 +250,8 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0xb739ae19620f7ecb4fb84727f205453aa5bc1ad2": (VaultFlag.illiquid, XUSD_MESSAGE),
     # Borrowable scUSD Deposit, SiloId: 125
     "0x0ab02dd08c1555d1a20c76a6ea30e3e36f3e06d4": (VaultFlag.illiquid, XUSD_MESSAGE),
+    # Borrowable frxUSD Deposit, SiloId: 37
+    "0xda14a41dbda731f03a94cb722191639dd22b35b2": (VaultFlag.illiquid, XUSD_MESSAGE),
     # Exposure to Elixir
     "0x94643e86aa5e38ddac6c7791c1297f4e40cd96c1": (VaultFlag.illiquid, XUSD_MESSAGE),
     # Exposure to xUSD - Silos

--- a/eth_defi/vault/vaultdb.py
+++ b/eth_defi/vault/vaultdb.py
@@ -1,6 +1,7 @@
 """Describe vault database pickle format."""
 
 import datetime
+import logging
 import os
 import pickle
 from dataclasses import dataclass, field
@@ -19,6 +20,8 @@ from eth_defi.erc_4626.discovery_base import PotentialVaultMatch
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.flag import VaultFlag
 from eth_defi.vault.risk import VaultTechnicalRisk
+
+logger = logging.getLogger(__name__)
 
 
 def get_pipeline_data_dir() -> Path:
@@ -131,6 +134,17 @@ class VaultRow(TypedDict):
 
 #: Legacy pickle format
 VaultDatabaseOld: TypeAlias = dict[VaultSpec, VaultRow]
+
+
+def _is_broken_row(row: VaultRow) -> bool:
+    """Check if a vault row represents a broken/failed scan result.
+
+    When the vault scanner encounters an RPC transient error (e.g. HTTP 400/500),
+    it creates a placeholder record with ``<broken: ...>`` as the name and empty
+    denomination.  Such records should not overwrite previously good metadata.
+    """
+    name = row.get("Name") or ""
+    return name.startswith("<broken") or (not name and not row.get("Denomination"))
 
 
 def has_good_fee_data(vault_row: VaultRow) -> bool:
@@ -246,7 +260,28 @@ class VaultDatabase:
         assert type(leads) == dict
         self.last_scanned_block[chain_id] = last_scanned_block
         self.leads.update({VaultSpec(chain_id, addr): lead for addr, lead in leads.items()})
-        self.rows.update(rows)
+        self._merge_rows(rows)
+
+    def _merge_rows(self, new_rows: dict[VaultSpec, VaultRow]):
+        """Merge new vault rows, preserving good data over broken rescans.
+
+        If a vault already has good metadata (name, denomination, NAV)
+        and the new scan produced a broken record (e.g. due to an RPC
+        transient failure), the existing good entry is kept instead of
+        being overwritten.
+        """
+        for spec, new_row in new_rows.items():
+            existing = self.rows.get(spec)
+            if existing is not None and _is_broken_row(new_row) and not _is_broken_row(existing):
+                logger.warning(
+                    "Skipping broken rescan for %s-%s (name=%s), keeping existing good data (name=%s)",
+                    spec.chain_id,
+                    spec.vault_address,
+                    new_row.get("Name"),
+                    existing.get("Name"),
+                )
+                continue
+            self.rows[spec] = new_row
 
     def limit_to_single_vault(self, vault_spec: VaultSpec) -> "VaultDatabase":
         """Limit results to a single vault.

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -441,6 +441,25 @@ poetry run python scripts/erc-4626/purge-stale-chain-ids.py
 | `DRY_RUN` | Optional. Report only, no changes. |
 | `LOG_LEVEL` | Optional. Default: info. |
 
+### heal-broken-vaults.py
+
+Heal broken vault metadata entries caused by transient RPC failures.
+When the vault scanner hits an HTTP error or timeout, it stores a placeholder
+record with `<broken: ...>` as the name. This script re-reads those vaults
+from the chain and replaces the broken records with fresh data.
+
+```shell
+source .local-test.env && poetry run python scripts/erc-4626/heal-broken-vaults.py
+```
+
+| Variable | Description |
+|----------|-------------|
+| `MAX_WORKERS` | Optional. Thread pool size. Default: 8. |
+| `DRY_RUN` | Optional. Report broken vaults without healing. Default: false. |
+| `HEAL_ALL` | Optional. Also attempt empty-name entries (likely false positives). Default: false. |
+| `JSON_RPC_<CHAIN>` | Required per chain with broken vaults. |
+| `LOG_LEVEL` | Optional. Default: info. |
+
 ### heal-timestamps.py
 
 Heal gaps in the block timestamp DuckDB cache populated by HyperSync.

--- a/scripts/erc-4626/heal-broken-vaults.py
+++ b/scripts/erc-4626/heal-broken-vaults.py
@@ -1,0 +1,208 @@
+"""Heal broken vault metadata entries in the vault database.
+
+When the vault scanner encounters a transient RPC error (HTTP 400/500,
+timeout, etc.) it stores a placeholder record with ``<broken: ...>`` as
+the name.  Because ``update_leads_and_rows()`` used to overwrite
+unconditionally, a single bad rescan could destroy previously good
+metadata for a vault.
+
+This script:
+
+1. Loads the vault-metadata-db.pickle (local or from R2).
+2. Finds all explicitly broken entries (``<broken: ...>``) across every chain.
+3. Re-reads each broken vault from the chain via JSON-RPC.
+4. Replaces the broken record with the freshly read good data.
+5. Writes the healed pickle back (and optionally uploads to R2).
+
+By default only targets entries whose name starts with ``<broken``
+(transient RPC failures).  Set ``HEAL_ALL=true`` to also attempt
+healing entries with empty names — these are usually false-positive
+Deposit event detections and unlikely to succeed.
+
+Environment variables:
+
+- ``MAX_WORKERS``: Thread pool size for parallel RPC reads (default: 8)
+- ``DRY_RUN``: Set to ``true`` to only report broken vaults without healing (default: false)
+- ``HEAL_ALL``: Set to ``true`` to also attempt empty-name entries (default: false)
+- ``JSON_RPC_<CHAIN>``: RPC URL per chain (required for chains that have broken vaults)
+
+Example:
+
+.. code-block:: shell
+
+    source .local-test.env && poetry run python scripts/erc-4626/heal-broken-vaults.py
+
+"""
+
+import logging
+import os
+from pathlib import Path
+
+from joblib import Parallel, delayed
+from tabulate import tabulate
+from tqdm_loggable.auto import tqdm
+
+from eth_defi.chain import CHAIN_NAMES, get_chain_name
+from eth_defi.erc_4626.scan import create_vault_scan_record
+from eth_defi.provider.env import read_json_rpc_url
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.token import TokenDiskCache
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.vaultdb import VaultDatabase, VaultRow, _is_broken_row, get_pipeline_data_dir
+
+logger = logging.getLogger(__name__)
+
+
+def heal_single_vault(
+    chain_id: int,
+    spec: VaultSpec,
+    broken_row: VaultRow,
+) -> tuple[VaultSpec, VaultRow | None]:
+    """Attempt to heal a single broken vault entry by re-reading from chain.
+
+    :return:
+        ``(spec, new_row)`` on success, ``(spec, None)`` on failure.
+    """
+    try:
+        json_rpc_url = read_json_rpc_url(chain_id)
+    except ValueError:
+        logger.warning(
+            "No RPC URL configured for chain %d (%s), skipping %s",
+            chain_id,
+            CHAIN_NAMES.get(chain_id, "unknown"),
+            spec.vault_address,
+        )
+        return spec, None
+
+    try:
+        web3 = create_multi_provider_web3(json_rpc_url)
+        block_number = web3.eth.block_number
+        detection = broken_row["_detection_data"]
+        token_cache = TokenDiskCache()
+
+        new_row = create_vault_scan_record(
+            web3,
+            detection,
+            block_number,
+            token_cache=token_cache,
+        )
+
+        if _is_broken_row(new_row):
+            logger.warning(
+                "Vault %s on chain %d still broken after re-read: %s",
+                spec.vault_address,
+                chain_id,
+                new_row.get("Name"),
+            )
+            return spec, None
+
+        return spec, new_row
+
+    except Exception as e:
+        logger.warning(
+            "Failed to heal vault %s on chain %d: %s",
+            spec.vault_address,
+            chain_id,
+            e,
+        )
+        return spec, None
+
+
+def main():
+    setup_console_logging(
+        default_log_level=os.environ.get("LOG_LEVEL", "info"),
+        log_file=Path("logs/heal-broken-vaults.log"),
+    )
+
+    max_workers = int(os.environ.get("MAX_WORKERS", "8"))
+    dry_run = os.environ.get("DRY_RUN", "false").lower() == "true"
+    heal_all = os.environ.get("HEAL_ALL", "false").lower() == "true"
+
+    vault_db_path = get_pipeline_data_dir() / "vault-metadata-db.pickle"
+    assert vault_db_path.exists(), f"Vault database not found at {vault_db_path}"
+
+    vault_db = VaultDatabase.read(vault_db_path)
+    print(f"Loaded {len(vault_db.rows):,} vault metadata entries from {vault_db_path}")
+
+    # Find broken entries
+    broken: list[tuple[VaultSpec, VaultRow]] = []
+    skipped_empty = 0
+    for spec, row in vault_db.rows.items():
+        if not _is_broken_row(row):
+            continue
+        name = row.get("Name") or ""
+        if name.startswith("<broken"):
+            # Explicit transient failure — always heal
+            broken.append((spec, row))
+        elif heal_all:
+            # Empty-name entries (likely false positives) — only with HEAL_ALL
+            broken.append((spec, row))
+        else:
+            skipped_empty += 1
+
+    if skipped_empty:
+        print(f"Skipped {skipped_empty:,} empty-name entries (likely false positives, use HEAL_ALL=true to include)")
+
+    if not broken:
+        print("No broken vault entries found.")
+        return
+
+    # Group by chain for reporting
+    by_chain: dict[int, list[tuple[VaultSpec, VaultRow]]] = {}
+    for spec, row in broken:
+        by_chain.setdefault(spec.chain_id, []).append((spec, row))
+
+    table_rows = []
+    for chain_id in sorted(by_chain.keys()):
+        chain_name = get_chain_name(chain_id) if chain_id in CHAIN_NAMES else str(chain_id)
+        entries = by_chain[chain_id]
+        for spec, row in entries:
+            table_rows.append(
+                [
+                    chain_name,
+                    spec.vault_address[:10] + "...",
+                    row.get("Name", ""),
+                    row.get("Protocol", ""),
+                ]
+            )
+
+    print(f"\nFound {len(broken)} broken vault entries across {len(by_chain)} chains:\n")
+    print(tabulate(table_rows, headers=["Chain", "Address", "Name", "Protocol"], tablefmt="simple"))
+
+    if dry_run:
+        print("\nDry run — no changes written.")
+        return
+
+    # Heal broken entries using thread pool
+    print(f"\nHealing {len(broken)} broken vaults using {max_workers} workers...")
+
+    results = Parallel(n_jobs=max_workers, backend="threading")(delayed(heal_single_vault)(spec.chain_id, spec, row) for spec, row in tqdm(broken, desc="Healing broken vaults"))
+
+    healed = 0
+    failed = 0
+    for spec, new_row in results:
+        if new_row is not None:
+            vault_db.rows[spec] = new_row
+            healed += 1
+            logger.info(
+                "Healed %s on chain %d: %s (%s)",
+                spec.vault_address,
+                spec.chain_id,
+                new_row.get("Name"),
+                new_row.get("Protocol"),
+            )
+        else:
+            failed += 1
+
+    print(f"\nResults: {healed} healed, {failed} still broken out of {len(broken)} total")
+
+    if healed > 0:
+        vault_db.write(vault_db_path)
+        print(f"Saved healed vault database to {vault_db_path}")
+    else:
+        print("No vaults were healed, database unchanged.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/erc-4626/heal-broken-vaults.py
+++ b/scripts/erc-4626/heal-broken-vaults.py
@@ -8,11 +8,14 @@ metadata for a vault.
 
 This script:
 
-1. Loads the vault-metadata-db.pickle (local or from R2).
+1. Loads the local vault-metadata-db.pickle.
 2. Finds all explicitly broken entries (``<broken: ...>``) across every chain.
 3. Re-reads each broken vault from the chain via JSON-RPC.
 4. Replaces the broken record with the freshly read good data.
-5. Writes the healed pickle back (and optionally uploads to R2).
+5. Writes the healed pickle back to the local pipeline data directory.
+
+To repair production data, run the normal ``export-data-files.py``
+script after healing to upload the fixed pickle to R2.
 
 By default only targets entries whose name starts with ``<broken``
 (transient RPC failures).  Set ``HEAL_ALL=true`` to also attempt


### PR DESCRIPTION
## Why

Vault `0xefe32813dba3a783059d50e5358b9e3661218dad` ("Senior ArcadiaV2 USD Coin") on Base disappeared from the vault database, breaking `trade-ui` with:

```
AssertionError: Expected 22 vaults, found 21, missing 1 (vault database has 4073 total vaults).
 - Missing vault 0xefe32813dba3a783059d50e5358b9e3661218dad on chain 8453
```

**Root cause**: During a production Base rescan, the RPC call failed with an `HTTPError`. The scan code stored a broken placeholder (`Name: <broken: HTTPError>`, empty denomination, NAV: 0). Then `update_leads_and_rows()` blindly overwrote the previously good metadata via `self.rows.update(rows)`. The stablecoin filter then excluded it from the exported JSON since `is_stablecoin_like("")` returns False.

The same vault address also exists on Optimism (Arcadia uses deterministic deployments), which was scanned successfully — so the Optimism entry survived while the Base entry was corrupted.

## Lessons learnt

- A single transient RPC failure during rescan can silently destroy months of accumulated good vault metadata.
- The `dict.update()` pattern is dangerous for incremental database merges — it overwrites unconditionally without checking data quality.
- Cross-chain vaults with identical addresses can mask the issue: one chain's entry survives while another silently disappears.
- Non-atomic pickle writes (`file.open("wb")` + `pickle.dump`) risk corruption if the process is interrupted mid-write.

## Summary

- **`eth_defi/vault/vaultdb.py`**: Replace `self.rows.update(rows)` with `_merge_rows()` that checks `_is_broken_row()` before overwriting — broken scan records no longer overwrite existing good metadata.
- **`scripts/erc-4626/heal-broken-vaults.py`**: New healer script that finds all explicitly broken entries (`<broken: ...>`) across all chains, re-reads each vault from the chain via JSON-RPC, and replaces broken records with fresh data. Supports `DRY_RUN`, `HEAL_ALL`, `MAX_WORKERS`.
- **`eth_defi/erc_4626/vault_protocol/lagoon/lagoon_compatibility.py`**: Switch both `pickle.dump` calls to use `atomic_write` — the only non-atomic pickle writes remaining in the production pipeline.
- **`scripts/erc-4626/README-vault-scripts.md`**: Document the healer script under "Data repair".

🤖 Generated with [Claude Code](https://claude.com/claude-code)