### PR TITLE
fix: Chunk Hypersync timestamp cache fills to avoid 429 rate limit cascades

### DIFF
--- a/eth_defi/hypersync/hypersync_timestamp.py
+++ b/eth_defi/hypersync/hypersync_timestamp.py
@@ -353,23 +353,30 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
                 f"{end_block - tail_start + 1:,}",
             )
 
-        # Check for interior gaps within the requested range.
+        # Check for interior gaps that overlap the requested range.
         # A partial head-backfill followed by a 429 can leave holes
         # (e.g. cache has 1-99 + 1000-2000, blocks 100-999 are missing).
         # MIN/MAX look fully covered but find_gaps() detects the holes.
+        # Gaps may only partially overlap the requested range, so we clip
+        # them to the intersection rather than requiring full containment.
         interior_gaps = timestamp_db.find_gaps()
-        interior_gaps = [(s, e, n) for s, e, n in interior_gaps if s >= start_block and e <= end_block]
-        if interior_gaps:
-            for gap_start, gap_end, gap_size in interior_gaps:
-                fetch_ranges.append((gap_start + 1, gap_end - 1))
+        for gap_start, gap_end, gap_size in interior_gaps:
+            # gap_start/gap_end are the boundary blocks that DO exist;
+            # the missing blocks are gap_start+1 .. gap_end-1
+            clip_start = max(start_block, gap_start + 1)
+            clip_end = min(end_block, gap_end - 1)
+            if clip_start <= clip_end:
+                fetch_ranges.append((clip_start, clip_end))
                 logger.info(
-                    "Chain %d: interior gap detected — blocks %s - %s (%s missing blocks)",
+                    "Chain %d: interior gap detected — blocks %s - %s (%s missing blocks, clipped from full gap %s - %s)",
                     chain_id,
+                    f"{clip_start:,}",
+                    f"{clip_end:,}",
+                    f"{clip_end - clip_start + 1:,}",
                     f"{gap_start + 1:,}",
                     f"{gap_end - 1:,}",
-                    f"{gap_size:,}",
                 )
-        elif not needs_head and not needs_tail:
+        if not fetch_ranges:
             logger.info(
                 "Chain %d: cache fully covers requested range %s - %s (cache has %s - %s), no gaps",
                 chain_id,
@@ -484,8 +491,11 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
         max_heal_attempts = 3
         for heal_attempt in range(max_heal_attempts):
             gaps = timestamp_db.find_gaps()
-            # Only heal gaps within our scan range
-            gaps = [(s, e, n) for s, e, n in gaps if s >= scan_start and e <= scan_end]
+            # Only heal gaps that overlap our scan range.
+            # find_gaps() returns (boundary_start, boundary_end, count) where
+            # boundary blocks exist but everything between them is missing.
+            # Filter to gaps that overlap scan_start..scan_end.
+            gaps = [(s, e, n) for s, e, n in gaps if s + 1 <= scan_end and e - 1 >= scan_start]
             if not gaps:
                 logger.info(
                     "Chain %d: no gaps found in scan range (heal check %d/%d)",

--- a/eth_defi/hypersync/hypersync_timestamp.py
+++ b/eth_defi/hypersync/hypersync_timestamp.py
@@ -274,51 +274,88 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
     cache_path=DEFAULT_TIMESTAMP_CACHE_FOLDER,
     display_progress: bool = True,
     checkpoint_freq: int = 1_250_000_000,
+    chunk_size: int = 100_000,
 ) -> BlockTimestampSlicer:
     """Quickly get block timestamps using Hypersync API and a local cache file.
 
     - Ultra fast, used optimised Hypersync streaming and DuckDB local cache.
+    - Large ranges are split into chunks of *chunk_size* blocks so that
+      each chunk opens a separate Hypersync ``stream()`` call.  This keeps
+      individual requests small, lets the Python-side rate limiter pace
+      them, and — crucially — saves progress after each chunk so that a
+      429 failure only loses the current chunk, not all prior work.
+
+    :param chunk_size:
+        Maximum number of blocks per Hypersync streaming request.
+        Defaults to 100 000 (~2 days on Polygon, ~3 days on Binance).
 
     :return:
         Block number -> datetime mapping
     """
 
+    logger.info(
+        "Timestamp cache fill requested for chain %d: caller wants blocks %d - %d, cache_path=%s, chunk_size=%d",
+        chain_id,
+        start_block,
+        end_block,
+        cache_path,
+        chunk_size,
+    )
+
     if cache_path.exists():
         timestamp_db = load_timestamp_cache(chain_id, cache_path)
     else:
+        logger.info("Timestamp cache does not exist yet for chain %d, creating new database at %s", chain_id, cache_path)
         timestamp_db = BlockTimestampDatabase.create(chain_id, cache_path)
 
     first_read_block, last_read_block = timestamp_db.get_first_and_last_block()
+    cached_count = timestamp_db.get_count()
 
-    logger.info(f"Timestamp cache {cache_path} for chain {chain_id}: blocks {first_read_block} - {last_read_block}")
+    logger.info(
+        "Timestamp cache state for chain %d: cached blocks %s - %s (%s entries in DB)",
+        chain_id,
+        f"{first_read_block:,}" if first_read_block else "None",
+        f"{last_read_block:,}" if last_read_block else "None",
+        f"{cached_count:,}" if cached_count else "0",
+    )
 
     if last_read_block:
         # Check the range we need to map out, we might ask earlier blocks than before
         if start_block < first_read_block:
             scan_start = start_block
+            logger.info(
+                "Chain %d: caller needs blocks earlier than cache (caller start %d < cache start %d), backfilling from %d",
+                chain_id,
+                start_block,
+                first_read_block,
+                scan_start,
+            )
         else:
             # +1 to avoid re-fetching the last cached block
             scan_start = last_read_block + 1
+            logger.info(
+                "Chain %d: cache covers up to block %d, will fetch new blocks from %d onwards",
+                chain_id,
+                last_read_block,
+                scan_start,
+            )
     else:
         scan_start = start_block
+        logger.info("Chain %d: empty cache, starting from block %d", chain_id, scan_start)
 
-    logger.info(f"Adjusted timestamp scan range for chain {chain_id}: blocks {scan_start:,} - {end_block:,} (delta {end_block - scan_start:,} blocks)")
-
-    def _save():
-        series = pd.Series(data=values, index=index)
-        timestamp_db.import_chain_data(
-            chain_id,
-            series,
-        )
-
-    # Check if we have anything to read
-    checkpoint_count = 0
-
-    index = []
-    values = []
-
+    total_delta = end_block - scan_start
     needs_head = start_block < first_read_block
     needs_tail = end_block > last_read_block
+
+    logger.info(
+        "Timestamp fetch decision for chain %d: needs_head=%s, needs_tail=%s, scan_start=%s, end_block=%s, delta=%s blocks to fetch",
+        chain_id,
+        needs_head,
+        needs_tail,
+        f"{scan_start:,}",
+        f"{end_block:,}",
+        f"{total_delta:,}",
+    )
 
     if needs_head or needs_tail:
         # Validate chain_id only when we actually need to fetch from Hypersync.
@@ -326,30 +363,81 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
         if is_hypersync_client(client):
             await _validate_hypersync_chain_id_async(client, chain_id, reason="timestamp-cache-validate")
 
-        iter = get_block_timestamps_using_hypersync_async(
-            client,
+        # Split the range into chunks so each opens a fresh stream() call.
+        # This lets the Python-side throttle pace requests and saves
+        # progress after each chunk — a 429 only loses the current chunk.
+        chunk_starts = list(range(scan_start, end_block + 1, chunk_size))
+        n_chunks = len(chunk_starts)
+
+        logger.info(
+            "Chain %d: streaming %s blocks from Hypersync in %d chunk(s) of up to %s blocks each",
             chain_id,
-            start_block=scan_start,
-            end_block=end_block,
-            display_progress=display_progress,
-            validate_chain_id=False,  # Already validated above
-            reason="timestamp-cache-fill",
+            f"{total_delta:,}",
+            n_chunks,
+            f"{chunk_size:,}",
         )
 
-        async for block_header in iter:
-            index.append(block_header.block_number)
-            values.append(block_header.timestamp)
+        for chunk_idx, chunk_start in enumerate(chunk_starts):
+            chunk_end = min(chunk_start + chunk_size - 1, end_block)
+            chunk_block_count = chunk_end - chunk_start + 1
 
-            # result[block_header.block_number] = pd.to_datetime(block_header.timestamp, unit="s")
-            checkpoint_count += 1
+            logger.info(
+                "Chain %d: starting chunk %d/%d — requesting blocks %s - %s (%s blocks)",
+                chain_id,
+                chunk_idx + 1,
+                n_chunks,
+                f"{chunk_start:,}",
+                f"{chunk_end:,}",
+                f"{chunk_block_count:,}",
+            )
 
-            if checkpoint_count % checkpoint_freq == 0:
-                _save()
-                # Reset buffer
-                index = []
-                values = []
+            index = []
+            values = []
 
-        _save()
+            iter = get_block_timestamps_using_hypersync_async(
+                client,
+                chain_id,
+                start_block=chunk_start,
+                end_block=chunk_end,
+                display_progress=display_progress,
+                validate_chain_id=False,  # Already validated above
+                reason=f"timestamp-cache-fill chunk {chunk_idx + 1}/{n_chunks}",
+            )
+
+            async for block_header in iter:
+                index.append(block_header.block_number)
+                values.append(block_header.timestamp)
+
+            # Save after each chunk so progress is durable
+            if index:
+                series = pd.Series(data=values, index=index)
+                timestamp_db.import_chain_data(chain_id, series)
+                logger.info(
+                    "Chain %d: chunk %d/%d complete — saved %s blocks (%s - %s) to cache",
+                    chain_id,
+                    chunk_idx + 1,
+                    n_chunks,
+                    f"{len(index):,}",
+                    f"{chunk_start:,}",
+                    f"{chunk_end:,}",
+                )
+            else:
+                logger.info(
+                    "Chain %d: chunk %d/%d returned 0 blocks for range %s - %s",
+                    chain_id,
+                    chunk_idx + 1,
+                    n_chunks,
+                    f"{chunk_start:,}",
+                    f"{chunk_end:,}",
+                )
+
+        logger.info(
+            "Chain %d: all %d chunk(s) streamed, checking for gaps in range %s - %s",
+            chain_id,
+            n_chunks,
+            f"{scan_start:,}",
+            f"{end_block:,}",
+        )
 
         # Detect and heal any gaps left by silently dropped HyperSync batches.
         # On fast chains like Monad, HyperSync can skip entire ~9,000-block
@@ -360,6 +448,12 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
             # Only heal gaps within our scan range
             gaps = [(s, e, n) for s, e, n in gaps if s >= scan_start and e <= end_block]
             if not gaps:
+                logger.info(
+                    "Chain %d: no gaps found in scan range (heal check %d/%d)",
+                    chain_id,
+                    heal_attempt + 1,
+                    max_heal_attempts,
+                )
                 break
 
             # Back off before each healing pass to let Hypersync rate limits
@@ -373,7 +467,8 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
 
             total_missing = sum(g[2] for g in gaps)
             logger.warning(
-                "HyperSync dropped %d blocks across %d gaps in range %d-%d (heal attempt %d/%d), re-fetching",
+                "Chain %d: HyperSync dropped %d blocks across %d gaps in range %d-%d (heal attempt %d/%d), re-fetching",
+                chain_id,
                 total_missing,
                 len(gaps),
                 scan_start,
@@ -381,7 +476,16 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
                 heal_attempt + 1,
                 max_heal_attempts,
             )
-            for gap_start, gap_end, gap_size in gaps:
+            for gap_idx, (gap_start, gap_end, gap_size) in enumerate(gaps):
+                logger.info(
+                    "Chain %d: healing gap %d/%d — blocks %d - %d (%d missing blocks)",
+                    chain_id,
+                    gap_idx + 1,
+                    len(gaps),
+                    gap_start + 1,
+                    gap_end - 1,
+                    gap_size,
+                )
                 heal_index = []
                 heal_values = []
                 async for bh in get_block_timestamps_using_hypersync_async(
@@ -398,13 +502,32 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
                 if heal_index:
                     heal_series = pd.Series(data=heal_values, index=heal_index)
                     timestamp_db.import_chain_data(chain_id, heal_series)
-                    logger.info("Healed gap %d-%d: inserted %d timestamps", gap_start + 1, gap_end - 1, len(heal_index))
+                    logger.info(
+                        "Chain %d: healed gap %d/%d — inserted %d timestamps for blocks %d - %d",
+                        chain_id,
+                        gap_idx + 1,
+                        len(gaps),
+                        len(heal_index),
+                        gap_start + 1,
+                        gap_end - 1,
+                    )
+                else:
+                    logger.warning(
+                        "Chain %d: gap heal %d/%d returned 0 blocks for %d - %d",
+                        chain_id,
+                        gap_idx + 1,
+                        len(gaps),
+                        gap_start + 1,
+                        gap_end - 1,
+                    )
     else:
         logger.info(
-            "Timestamp cache fully covers requested range %d-%d for chain %d, skipping Hypersync fetch",
-            start_block,
-            end_block,
+            "Chain %d: timestamp cache fully covers requested range %s - %s (cache has %s - %s), no Hypersync fetch needed",
             chain_id,
+            f"{start_block:,}",
+            f"{end_block:,}",
+            f"{first_read_block:,}" if first_read_block else "None",
+            f"{last_read_block:,}" if last_read_block else "None",
         )
 
     # Drop unnecessary blocks from memory
@@ -428,9 +551,25 @@ def fetch_block_timestamps_using_hypersync_cached(
         Work around Hypersync timeout issues
     """
 
+    logger.info(
+        "Timestamp cache sync wrapper: chain %d, blocks %d - %d, max %d attempts",
+        chain_id,
+        start_block,
+        end_block,
+        attempts,
+    )
+
     async def _hypersync_asyncio_wrapper():
         for attempt in range(attempts):
             try:
+                logger.info(
+                    "Chain %d: timestamp cache attempt %d/%d starting (blocks %d - %d)",
+                    chain_id,
+                    attempt + 1,
+                    attempts,
+                    start_block,
+                    end_block,
+                )
                 return await fetch_block_timestamps_using_hypersync_cached_async(
                     client=client,
                     chain_id=chain_id,
@@ -440,14 +579,31 @@ def fetch_block_timestamps_using_hypersync_cached(
                     display_progress=display_progress,
                 )
             except HypersyncFlaky as e:
-                logger.warning(f"Hypersync flaky error on attempt {attempt + 1}/{attempts}: {e}")
+                logger.warning(
+                    "Chain %d: Hypersync flaky error on attempt %d/%d: %s",
+                    chain_id,
+                    attempt + 1,
+                    attempts,
+                    e,
+                )
                 if attempt + 1 >= attempts:
-                    logger.error("Exceeded maximum Hypersync attempts, failing: %s", e)
+                    logger.error(
+                        "Chain %d: exceeded maximum %d Hypersync attempts, giving up: %s",
+                        chain_id,
+                        attempts,
+                        e,
+                    )
                     raise
                 # Exponential backoff: 30s, 60s, 120s, 240s to avoid hammering
                 # a rate-limited Hypersync endpoint
                 backoff = 30 * (2**attempt)
-                logger.info("Backing off %d seconds before retry", backoff)
+                logger.info(
+                    "Chain %d: backing off %d seconds before retry attempt %d/%d",
+                    chain_id,
+                    backoff,
+                    attempt + 2,
+                    attempts,
+                )
                 await asyncio.sleep(backoff)
 
     return asyncio.run(_hypersync_asyncio_wrapper())

--- a/eth_defi/hypersync/hypersync_timestamp.py
+++ b/eth_defi/hypersync/hypersync_timestamp.py
@@ -319,66 +319,101 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
         f"{cached_count:,}" if cached_count else "0",
     )
 
+    # Build a list of (range_start, range_end) pairs to fetch.
+    # We compute head and tail ranges separately so that a partial
+    # backfill before an existing cache doesn't leave permanent holes.
+    # Using a single scan_start derived from MIN/MAX would miss interior
+    # gaps created when a head-backfill chunk saves, then a 429 kills
+    # the stream — on retry MIN/MAX would look fully covered.
+    fetch_ranges: list[tuple[int, int]] = []
+
     if last_read_block:
-        # Check the range we need to map out, we might ask earlier blocks than before
-        if start_block < first_read_block:
-            scan_start = start_block
+        needs_head = start_block < first_read_block
+        needs_tail = end_block > last_read_block
+
+        if needs_head:
+            head_end = first_read_block - 1
+            fetch_ranges.append((start_block, head_end))
             logger.info(
-                "Chain %d: caller needs blocks earlier than cache (caller start %d < cache start %d), backfilling from %d",
+                "Chain %d: head backfill needed — blocks %s - %s (%s blocks before existing cache)",
                 chain_id,
-                start_block,
-                first_read_block,
-                scan_start,
+                f"{start_block:,}",
+                f"{head_end:,}",
+                f"{head_end - start_block + 1:,}",
             )
-        else:
-            # +1 to avoid re-fetching the last cached block
-            scan_start = last_read_block + 1
+
+        if needs_tail:
+            tail_start = last_read_block + 1
+            fetch_ranges.append((tail_start, end_block))
             logger.info(
-                "Chain %d: cache covers up to block %d, will fetch new blocks from %d onwards",
+                "Chain %d: tail append needed — blocks %s - %s (%s new blocks after cache)",
                 chain_id,
-                last_read_block,
-                scan_start,
+                f"{tail_start:,}",
+                f"{end_block:,}",
+                f"{end_block - tail_start + 1:,}",
+            )
+
+        # Check for interior gaps within the requested range.
+        # A partial head-backfill followed by a 429 can leave holes
+        # (e.g. cache has 1-99 + 1000-2000, blocks 100-999 are missing).
+        # MIN/MAX look fully covered but find_gaps() detects the holes.
+        interior_gaps = timestamp_db.find_gaps()
+        interior_gaps = [(s, e, n) for s, e, n in interior_gaps if s >= start_block and e <= end_block]
+        if interior_gaps:
+            for gap_start, gap_end, gap_size in interior_gaps:
+                fetch_ranges.append((gap_start + 1, gap_end - 1))
+                logger.info(
+                    "Chain %d: interior gap detected — blocks %s - %s (%s missing blocks)",
+                    chain_id,
+                    f"{gap_start + 1:,}",
+                    f"{gap_end - 1:,}",
+                    f"{gap_size:,}",
+                )
+        elif not needs_head and not needs_tail:
+            logger.info(
+                "Chain %d: cache fully covers requested range %s - %s (cache has %s - %s), no gaps",
+                chain_id,
+                f"{start_block:,}",
+                f"{end_block:,}",
+                f"{first_read_block:,}",
+                f"{last_read_block:,}",
             )
     else:
-        scan_start = start_block
-        logger.info("Chain %d: empty cache, starting from block %d", chain_id, scan_start)
+        fetch_ranges.append((start_block, end_block))
+        logger.info("Chain %d: empty cache, fetching full range %s - %s", chain_id, f"{start_block:,}", f"{end_block:,}")
 
-    total_delta = end_block - scan_start
-    needs_head = start_block < first_read_block
-    needs_tail = end_block > last_read_block
+    total_blocks_to_fetch = sum(e - s + 1 for s, e in fetch_ranges)
 
     logger.info(
-        "Timestamp fetch decision for chain %d: needs_head=%s, needs_tail=%s, scan_start=%s, end_block=%s, delta=%s blocks to fetch",
+        "Timestamp fetch plan for chain %d: %d range(s), %s total blocks to fetch",
         chain_id,
-        needs_head,
-        needs_tail,
-        f"{scan_start:,}",
-        f"{end_block:,}",
-        f"{total_delta:,}",
+        len(fetch_ranges),
+        f"{total_blocks_to_fetch:,}",
     )
 
-    if needs_head or needs_tail:
+    if fetch_ranges:
         # Validate chain_id only when we actually need to fetch from Hypersync.
         # Skipped on warm cache hits to avoid wasting API quota.
         if is_hypersync_client(client):
             await _validate_hypersync_chain_id_async(client, chain_id, reason="timestamp-cache-validate")
 
-        # Split the range into chunks so each opens a fresh stream() call.
-        # This lets the Python-side throttle pace requests and saves
-        # progress after each chunk — a 429 only loses the current chunk.
-        chunk_starts = list(range(scan_start, end_block + 1, chunk_size))
-        n_chunks = len(chunk_starts)
+        # Build chunks across all ranges
+        all_chunks: list[tuple[int, int]] = []
+        for range_start, range_end in fetch_ranges:
+            for cs in range(range_start, range_end + 1, chunk_size):
+                ce = min(cs + chunk_size - 1, range_end)
+                all_chunks.append((cs, ce))
 
+        n_chunks = len(all_chunks)
         logger.info(
             "Chain %d: streaming %s blocks from Hypersync in %d chunk(s) of up to %s blocks each",
             chain_id,
-            f"{total_delta:,}",
+            f"{total_blocks_to_fetch:,}",
             n_chunks,
             f"{chunk_size:,}",
         )
 
-        for chunk_idx, chunk_start in enumerate(chunk_starts):
-            chunk_end = min(chunk_start + chunk_size - 1, end_block)
+        for chunk_idx, (chunk_start, chunk_end) in enumerate(all_chunks):
             chunk_block_count = chunk_end - chunk_start + 1
 
             logger.info(
@@ -431,12 +466,16 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
                     f"{chunk_end:,}",
                 )
 
+        # Compute the full scan extent for gap healing below
+        scan_start = min(s for s, _ in fetch_ranges)
+        scan_end = max(e for _, e in fetch_ranges)
+
         logger.info(
             "Chain %d: all %d chunk(s) streamed, checking for gaps in range %s - %s",
             chain_id,
             n_chunks,
             f"{scan_start:,}",
-            f"{end_block:,}",
+            f"{scan_end:,}",
         )
 
         # Detect and heal any gaps left by silently dropped HyperSync batches.
@@ -446,7 +485,7 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
         for heal_attempt in range(max_heal_attempts):
             gaps = timestamp_db.find_gaps()
             # Only heal gaps within our scan range
-            gaps = [(s, e, n) for s, e, n in gaps if s >= scan_start and e <= end_block]
+            gaps = [(s, e, n) for s, e, n in gaps if s >= scan_start and e <= scan_end]
             if not gaps:
                 logger.info(
                     "Chain %d: no gaps found in scan range (heal check %d/%d)",
@@ -472,7 +511,7 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
                 total_missing,
                 len(gaps),
                 scan_start,
-                end_block,
+                scan_end,
                 heal_attempt + 1,
                 max_heal_attempts,
             )

--- a/eth_defi/hypersync/hypersync_timestamp.py
+++ b/eth_defi/hypersync/hypersync_timestamp.py
@@ -359,6 +359,7 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
         len(fetch_ranges),
     )
 
+    empty_chunks = 0
     for chunk_idx, (chunk_start, chunk_end) in enumerate(all_chunks):
         index = []
         values = []
@@ -387,6 +388,15 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
                 f"{chunk_start:,}",
                 f"{chunk_end:,}",
             )
+        else:
+            empty_chunks += 1
+
+    # If Hypersync returned zero rows for any chunk, the blocks are
+    # still missing but find_gaps() cannot detect head/tail gaps
+    # (no boundary blocks to define them). Treat this as a flaky
+    # error so the retry loop re-enters with a fresh cache check.
+    if empty_chunks:
+        raise HypersyncFlaky(f"Chain {chain_id}: Hypersync returned 0 rows for {empty_chunks}/{n_chunks} chunks")
 
     # Heal gaps left by silently dropped HyperSync batches.
     # On fast chains like Monad, HyperSync can skip entire ~9,000-block
@@ -397,9 +407,15 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
 
     for heal_attempt in range(max_heal_attempts):
         gaps = timestamp_db.find_gaps()
-        # Only heal gaps that overlap our scan range
-        gaps = [(s, e, n) for s, e, n in gaps if s + 1 <= scan_end and e - 1 >= scan_start]
-        if not gaps:
+        # Clip gaps to our scan range — don't heal the full database
+        # gap when we only need a subset.
+        clipped_gaps: list[tuple[int, int]] = []
+        for s, e, _n in gaps:
+            clip_start = max(scan_start, s + 1)
+            clip_end = min(scan_end, e - 1)
+            if clip_start <= clip_end:
+                clipped_gaps.append((clip_start, clip_end))
+        if not clipped_gaps:
             break
 
         # Back off before re-heal to let rate limits recover
@@ -408,33 +424,36 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
             logger.info("Chain %d: backing off %ds before gap-heal attempt %d/%d", chain_id, heal_backoff, heal_attempt + 1, max_heal_attempts)
             await asyncio.sleep(heal_backoff)
 
-        total_missing = sum(g[2] for g in gaps)
+        total_missing = sum(e - s + 1 for s, e in clipped_gaps)
         logger.warning(
             "Chain %d: %d blocks dropped across %d gaps (heal attempt %d/%d)",
             chain_id,
             total_missing,
-            len(gaps),
+            len(clipped_gaps),
             heal_attempt + 1,
             max_heal_attempts,
         )
 
-        for gap_start, gap_end, _gap_size in gaps:
-            heal_index = []
-            heal_values = []
-            async for bh in get_block_timestamps_using_hypersync_async(
-                client,
-                chain_id,
-                start_block=gap_start + 1,
-                end_block=gap_end - 1,
-                display_progress=False,
-                validate_chain_id=False,
-                reason=f"gap-heal-{heal_attempt + 1}/{max_heal_attempts}",
-            ):
-                heal_index.append(bh.block_number)
-                heal_values.append(bh.timestamp)
-            if heal_index:
-                timestamp_db.import_chain_data(chain_id, pd.Series(data=heal_values, index=heal_index))
-                logger.info("Chain %d: healed gap %d-%d (%d blocks)", chain_id, gap_start + 1, gap_end - 1, len(heal_index))
+        # Chunk heal ranges the same way as initial fetches
+        for heal_start, heal_end in clipped_gaps:
+            for hs in range(heal_start, heal_end + 1, chunk_size):
+                he = min(hs + chunk_size - 1, heal_end)
+                heal_index = []
+                heal_values = []
+                async for bh in get_block_timestamps_using_hypersync_async(
+                    client,
+                    chain_id,
+                    start_block=hs,
+                    end_block=he,
+                    display_progress=False,
+                    validate_chain_id=False,
+                    reason=f"gap-heal-{heal_attempt + 1}/{max_heal_attempts}",
+                ):
+                    heal_index.append(bh.block_number)
+                    heal_values.append(bh.timestamp)
+                if heal_index:
+                    timestamp_db.import_chain_data(chain_id, pd.Series(data=heal_values, index=heal_index))
+                    logger.info("Chain %d: healed %d-%d (%d blocks)", chain_id, hs, he, len(heal_index))
 
     return timestamp_db.get_slicer()
 

--- a/eth_defi/hypersync/hypersync_timestamp.py
+++ b/eth_defi/hypersync/hypersync_timestamp.py
@@ -273,7 +273,6 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
     end_block: int,
     cache_path=DEFAULT_TIMESTAMP_CACHE_FOLDER,
     display_progress: bool = True,
-    checkpoint_freq: int = 1_250_000_000,
     chunk_size: int = 100_000,
 ) -> BlockTimestampSlicer:
     """Quickly get block timestamps using Hypersync API and a local cache file.
@@ -293,293 +292,150 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
         Block number -> datetime mapping
     """
 
-    logger.info(
-        "Timestamp cache fill requested for chain %d: caller wants blocks %d - %d, cache_path=%s, chunk_size=%d",
-        chain_id,
-        start_block,
-        end_block,
-        cache_path,
-        chunk_size,
-    )
-
     if cache_path.exists():
         timestamp_db = load_timestamp_cache(chain_id, cache_path)
     else:
-        logger.info("Timestamp cache does not exist yet for chain %d, creating new database at %s", chain_id, cache_path)
         timestamp_db = BlockTimestampDatabase.create(chain_id, cache_path)
 
     first_read_block, last_read_block = timestamp_db.get_first_and_last_block()
-    cached_count = timestamp_db.get_count()
 
     logger.info(
-        "Timestamp cache state for chain %d: cached blocks %s - %s (%s entries in DB)",
+        "Chain %d: timestamp cache has blocks %s - %s (%s entries), caller wants %s - %s",
         chain_id,
         f"{first_read_block:,}" if first_read_block else "None",
         f"{last_read_block:,}" if last_read_block else "None",
-        f"{cached_count:,}" if cached_count else "0",
+        f"{timestamp_db.get_count():,}",
+        f"{start_block:,}",
+        f"{end_block:,}",
     )
 
-    # Build a list of (range_start, range_end) pairs to fetch.
-    # We compute head and tail ranges separately so that a partial
-    # backfill before an existing cache doesn't leave permanent holes.
-    # Using a single scan_start derived from MIN/MAX would miss interior
-    # gaps created when a head-backfill chunk saves, then a 429 kills
-    # the stream — on retry MIN/MAX would look fully covered.
+    # Build (start, end) pairs for blocks we need to fetch.
+    # Head and tail are computed separately so a partial backfill
+    # followed by a 429 doesn't leave permanent holes on retry.
     fetch_ranges: list[tuple[int, int]] = []
 
     if last_read_block:
-        needs_head = start_block < first_read_block
-        needs_tail = end_block > last_read_block
+        if start_block < first_read_block:
+            fetch_ranges.append((start_block, first_read_block - 1))
+        if end_block > last_read_block:
+            fetch_ranges.append((last_read_block + 1, end_block))
 
-        if needs_head:
-            head_end = first_read_block - 1
-            fetch_ranges.append((start_block, head_end))
-            logger.info(
-                "Chain %d: head backfill needed — blocks %s - %s (%s blocks before existing cache)",
-                chain_id,
-                f"{start_block:,}",
-                f"{head_end:,}",
-                f"{head_end - start_block + 1:,}",
-            )
-
-        if needs_tail:
-            tail_start = last_read_block + 1
-            fetch_ranges.append((tail_start, end_block))
-            logger.info(
-                "Chain %d: tail append needed — blocks %s - %s (%s new blocks after cache)",
-                chain_id,
-                f"{tail_start:,}",
-                f"{end_block:,}",
-                f"{end_block - tail_start + 1:,}",
-            )
-
-        # Check for interior gaps that overlap the requested range.
-        # A partial head-backfill followed by a 429 can leave holes
-        # (e.g. cache has 1-99 + 1000-2000, blocks 100-999 are missing).
-        # MIN/MAX look fully covered but find_gaps() detects the holes.
-        # Gaps may only partially overlap the requested range, so we clip
-        # them to the intersection rather than requiring full containment.
-        interior_gaps = timestamp_db.find_gaps()
-        for gap_start, gap_end, gap_size in interior_gaps:
-            # gap_start/gap_end are the boundary blocks that DO exist;
-            # the missing blocks are gap_start+1 .. gap_end-1
+        # Detect interior gaps (e.g. from a partial backfill that saved
+        # blocks 1-99 then got a 429, leaving a hole at 100-999).
+        # Clip each gap to the requested range since we only care about
+        # the intersection.
+        for gap_start, gap_end, _count in timestamp_db.find_gaps():
             clip_start = max(start_block, gap_start + 1)
             clip_end = min(end_block, gap_end - 1)
             if clip_start <= clip_end:
                 fetch_ranges.append((clip_start, clip_end))
-                logger.info(
-                    "Chain %d: interior gap detected — blocks %s - %s (%s missing blocks, clipped from full gap %s - %s)",
-                    chain_id,
-                    f"{clip_start:,}",
-                    f"{clip_end:,}",
-                    f"{clip_end - clip_start + 1:,}",
-                    f"{gap_start + 1:,}",
-                    f"{gap_end - 1:,}",
-                )
-        if not fetch_ranges:
-            logger.info(
-                "Chain %d: cache fully covers requested range %s - %s (cache has %s - %s), no gaps",
-                chain_id,
-                f"{start_block:,}",
-                f"{end_block:,}",
-                f"{first_read_block:,}",
-                f"{last_read_block:,}",
-            )
     else:
         fetch_ranges.append((start_block, end_block))
-        logger.info("Chain %d: empty cache, fetching full range %s - %s", chain_id, f"{start_block:,}", f"{end_block:,}")
 
-    total_blocks_to_fetch = sum(e - s + 1 for s, e in fetch_ranges)
+    total_to_fetch = sum(e - s + 1 for s, e in fetch_ranges)
 
+    if not fetch_ranges:
+        logger.info("Chain %d: cache fully covers requested range, nothing to fetch", chain_id)
+        return timestamp_db.get_slicer()
+
+    # Validate chain_id once before streaming
+    if is_hypersync_client(client):
+        await _validate_hypersync_chain_id_async(client, chain_id, reason="timestamp-cache-validate")
+
+    # Split ranges into chunks — each opens a separate stream() call
+    # so the Python-side throttle can pace requests, and progress is
+    # saved after each chunk.
+    all_chunks: list[tuple[int, int]] = []
+    for range_start, range_end in fetch_ranges:
+        for cs in range(range_start, range_end + 1, chunk_size):
+            all_chunks.append((cs, min(cs + chunk_size - 1, range_end)))
+
+    n_chunks = len(all_chunks)
     logger.info(
-        "Timestamp fetch plan for chain %d: %d range(s), %s total blocks to fetch",
+        "Chain %d: fetching %s blocks in %d chunk(s) across %d range(s)",
         chain_id,
+        f"{total_to_fetch:,}",
+        n_chunks,
         len(fetch_ranges),
-        f"{total_blocks_to_fetch:,}",
     )
 
-    if fetch_ranges:
-        # Validate chain_id only when we actually need to fetch from Hypersync.
-        # Skipped on warm cache hits to avoid wasting API quota.
-        if is_hypersync_client(client):
-            await _validate_hypersync_chain_id_async(client, chain_id, reason="timestamp-cache-validate")
+    for chunk_idx, (chunk_start, chunk_end) in enumerate(all_chunks):
+        index = []
+        values = []
 
-        # Build chunks across all ranges
-        all_chunks: list[tuple[int, int]] = []
-        for range_start, range_end in fetch_ranges:
-            for cs in range(range_start, range_end + 1, chunk_size):
-                ce = min(cs + chunk_size - 1, range_end)
-                all_chunks.append((cs, ce))
-
-        n_chunks = len(all_chunks)
-        logger.info(
-            "Chain %d: streaming %s blocks from Hypersync in %d chunk(s) of up to %s blocks each",
+        async for block_header in get_block_timestamps_using_hypersync_async(
+            client,
             chain_id,
-            f"{total_blocks_to_fetch:,}",
-            n_chunks,
-            f"{chunk_size:,}",
-        )
+            start_block=chunk_start,
+            end_block=chunk_end,
+            display_progress=display_progress,
+            validate_chain_id=False,
+            reason=f"timestamp-cache-fill chunk {chunk_idx + 1}/{n_chunks}",
+        ):
+            index.append(block_header.block_number)
+            values.append(block_header.timestamp)
 
-        for chunk_idx, (chunk_start, chunk_end) in enumerate(all_chunks):
-            chunk_block_count = chunk_end - chunk_start + 1
-
+        # Save after each chunk so progress is durable
+        if index:
+            timestamp_db.import_chain_data(chain_id, pd.Series(data=values, index=index))
             logger.info(
-                "Chain %d: starting chunk %d/%d — requesting blocks %s - %s (%s blocks)",
+                "Chain %d: chunk %d/%d saved %s blocks (%s - %s)",
                 chain_id,
                 chunk_idx + 1,
                 n_chunks,
+                f"{len(index):,}",
                 f"{chunk_start:,}",
                 f"{chunk_end:,}",
-                f"{chunk_block_count:,}",
             )
 
-            index = []
-            values = []
+    # Heal gaps left by silently dropped HyperSync batches.
+    # On fast chains like Monad, HyperSync can skip entire ~9,000-block
+    # streaming batches without raising errors.
+    scan_start = min(s for s, _ in fetch_ranges)
+    scan_end = max(e for _, e in fetch_ranges)
+    max_heal_attempts = 3
 
-            iter = get_block_timestamps_using_hypersync_async(
+    for heal_attempt in range(max_heal_attempts):
+        gaps = timestamp_db.find_gaps()
+        # Only heal gaps that overlap our scan range
+        gaps = [(s, e, n) for s, e, n in gaps if s + 1 <= scan_end and e - 1 >= scan_start]
+        if not gaps:
+            break
+
+        # Back off before re-heal to let rate limits recover
+        if heal_attempt > 0:
+            heal_backoff = 30 * (2**heal_attempt)
+            logger.info("Chain %d: backing off %ds before gap-heal attempt %d/%d", chain_id, heal_backoff, heal_attempt + 1, max_heal_attempts)
+            await asyncio.sleep(heal_backoff)
+
+        total_missing = sum(g[2] for g in gaps)
+        logger.warning(
+            "Chain %d: %d blocks dropped across %d gaps (heal attempt %d/%d)",
+            chain_id,
+            total_missing,
+            len(gaps),
+            heal_attempt + 1,
+            max_heal_attempts,
+        )
+
+        for gap_start, gap_end, _gap_size in gaps:
+            heal_index = []
+            heal_values = []
+            async for bh in get_block_timestamps_using_hypersync_async(
                 client,
                 chain_id,
-                start_block=chunk_start,
-                end_block=chunk_end,
-                display_progress=display_progress,
-                validate_chain_id=False,  # Already validated above
-                reason=f"timestamp-cache-fill chunk {chunk_idx + 1}/{n_chunks}",
-            )
+                start_block=gap_start + 1,
+                end_block=gap_end - 1,
+                display_progress=False,
+                validate_chain_id=False,
+                reason=f"gap-heal-{heal_attempt + 1}/{max_heal_attempts}",
+            ):
+                heal_index.append(bh.block_number)
+                heal_values.append(bh.timestamp)
+            if heal_index:
+                timestamp_db.import_chain_data(chain_id, pd.Series(data=heal_values, index=heal_index))
+                logger.info("Chain %d: healed gap %d-%d (%d blocks)", chain_id, gap_start + 1, gap_end - 1, len(heal_index))
 
-            async for block_header in iter:
-                index.append(block_header.block_number)
-                values.append(block_header.timestamp)
-
-            # Save after each chunk so progress is durable
-            if index:
-                series = pd.Series(data=values, index=index)
-                timestamp_db.import_chain_data(chain_id, series)
-                logger.info(
-                    "Chain %d: chunk %d/%d complete — saved %s blocks (%s - %s) to cache",
-                    chain_id,
-                    chunk_idx + 1,
-                    n_chunks,
-                    f"{len(index):,}",
-                    f"{chunk_start:,}",
-                    f"{chunk_end:,}",
-                )
-            else:
-                logger.info(
-                    "Chain %d: chunk %d/%d returned 0 blocks for range %s - %s",
-                    chain_id,
-                    chunk_idx + 1,
-                    n_chunks,
-                    f"{chunk_start:,}",
-                    f"{chunk_end:,}",
-                )
-
-        # Compute the full scan extent for gap healing below
-        scan_start = min(s for s, _ in fetch_ranges)
-        scan_end = max(e for _, e in fetch_ranges)
-
-        logger.info(
-            "Chain %d: all %d chunk(s) streamed, checking for gaps in range %s - %s",
-            chain_id,
-            n_chunks,
-            f"{scan_start:,}",
-            f"{scan_end:,}",
-        )
-
-        # Detect and heal any gaps left by silently dropped HyperSync batches.
-        # On fast chains like Monad, HyperSync can skip entire ~9,000-block
-        # streaming batches without raising errors.
-        max_heal_attempts = 3
-        for heal_attempt in range(max_heal_attempts):
-            gaps = timestamp_db.find_gaps()
-            # Only heal gaps that overlap our scan range.
-            # find_gaps() returns (boundary_start, boundary_end, count) where
-            # boundary blocks exist but everything between them is missing.
-            # Filter to gaps that overlap scan_start..scan_end.
-            gaps = [(s, e, n) for s, e, n in gaps if s + 1 <= scan_end and e - 1 >= scan_start]
-            if not gaps:
-                logger.info(
-                    "Chain %d: no gaps found in scan range (heal check %d/%d)",
-                    chain_id,
-                    heal_attempt + 1,
-                    max_heal_attempts,
-                )
-                break
-
-            # Back off before each healing pass to let Hypersync rate limits
-            # recover.  Without this, gap healing immediately re-hammers the
-            # API after a 429-induced drop, turning a transient rate limit
-            # into a cascading failure.
-            if heal_attempt > 0:
-                heal_backoff = 30 * (2**heal_attempt)  # 60s, 120s
-                logger.info("Backing off %d seconds before gap-heal attempt %d/%d", heal_backoff, heal_attempt + 1, max_heal_attempts)
-                await asyncio.sleep(heal_backoff)
-
-            total_missing = sum(g[2] for g in gaps)
-            logger.warning(
-                "Chain %d: HyperSync dropped %d blocks across %d gaps in range %d-%d (heal attempt %d/%d), re-fetching",
-                chain_id,
-                total_missing,
-                len(gaps),
-                scan_start,
-                scan_end,
-                heal_attempt + 1,
-                max_heal_attempts,
-            )
-            for gap_idx, (gap_start, gap_end, gap_size) in enumerate(gaps):
-                logger.info(
-                    "Chain %d: healing gap %d/%d — blocks %d - %d (%d missing blocks)",
-                    chain_id,
-                    gap_idx + 1,
-                    len(gaps),
-                    gap_start + 1,
-                    gap_end - 1,
-                    gap_size,
-                )
-                heal_index = []
-                heal_values = []
-                async for bh in get_block_timestamps_using_hypersync_async(
-                    client,
-                    chain_id,
-                    start_block=gap_start + 1,
-                    end_block=gap_end - 1,
-                    display_progress=False,
-                    validate_chain_id=False,  # Already validated above
-                    reason=f"gap-heal-{heal_attempt + 1}/{max_heal_attempts}",
-                ):
-                    heal_index.append(bh.block_number)
-                    heal_values.append(bh.timestamp)
-                if heal_index:
-                    heal_series = pd.Series(data=heal_values, index=heal_index)
-                    timestamp_db.import_chain_data(chain_id, heal_series)
-                    logger.info(
-                        "Chain %d: healed gap %d/%d — inserted %d timestamps for blocks %d - %d",
-                        chain_id,
-                        gap_idx + 1,
-                        len(gaps),
-                        len(heal_index),
-                        gap_start + 1,
-                        gap_end - 1,
-                    )
-                else:
-                    logger.warning(
-                        "Chain %d: gap heal %d/%d returned 0 blocks for %d - %d",
-                        chain_id,
-                        gap_idx + 1,
-                        len(gaps),
-                        gap_start + 1,
-                        gap_end - 1,
-                    )
-    else:
-        logger.info(
-            "Chain %d: timestamp cache fully covers requested range %s - %s (cache has %s - %s), no Hypersync fetch needed",
-            chain_id,
-            f"{start_block:,}",
-            f"{end_block:,}",
-            f"{first_read_block:,}" if first_read_block else "None",
-            f"{last_read_block:,}" if last_read_block else "None",
-        )
-
-    # Drop unnecessary blocks from memory
     return timestamp_db.get_slicer()
 
 
@@ -592,7 +448,7 @@ def fetch_block_timestamps_using_hypersync_cached(
     display_progress: bool = True,
     attempts=5,
 ) -> BlockTimestampSlicer:
-    """Sync wrapper.
+    """Sync wrapper with retry and exponential backoff.
 
     See :py:func:`fetch_block_timestamps_using_hypersync_cached_async` for documentation.
 
@@ -600,25 +456,9 @@ def fetch_block_timestamps_using_hypersync_cached(
         Work around Hypersync timeout issues
     """
 
-    logger.info(
-        "Timestamp cache sync wrapper: chain %d, blocks %d - %d, max %d attempts",
-        chain_id,
-        start_block,
-        end_block,
-        attempts,
-    )
-
     async def _hypersync_asyncio_wrapper():
         for attempt in range(attempts):
             try:
-                logger.info(
-                    "Chain %d: timestamp cache attempt %d/%d starting (blocks %d - %d)",
-                    chain_id,
-                    attempt + 1,
-                    attempts,
-                    start_block,
-                    end_block,
-                )
                 return await fetch_block_timestamps_using_hypersync_cached_async(
                     client=client,
                     chain_id=chain_id,
@@ -628,31 +468,11 @@ def fetch_block_timestamps_using_hypersync_cached(
                     display_progress=display_progress,
                 )
             except HypersyncFlaky as e:
-                logger.warning(
-                    "Chain %d: Hypersync flaky error on attempt %d/%d: %s",
-                    chain_id,
-                    attempt + 1,
-                    attempts,
-                    e,
-                )
+                logger.warning("Chain %d: Hypersync flaky on attempt %d/%d: %s", chain_id, attempt + 1, attempts, e)
                 if attempt + 1 >= attempts:
-                    logger.error(
-                        "Chain %d: exceeded maximum %d Hypersync attempts, giving up: %s",
-                        chain_id,
-                        attempts,
-                        e,
-                    )
                     raise
-                # Exponential backoff: 30s, 60s, 120s, 240s to avoid hammering
-                # a rate-limited Hypersync endpoint
                 backoff = 30 * (2**attempt)
-                logger.info(
-                    "Chain %d: backing off %d seconds before retry attempt %d/%d",
-                    chain_id,
-                    backoff,
-                    attempt + 2,
-                    attempts,
-                )
+                logger.info("Chain %d: backing off %ds before retry %d/%d", chain_id, backoff, attempt + 2, attempts)
                 await asyncio.sleep(backoff)
 
     return asyncio.run(_hypersync_asyncio_wrapper())

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -460,6 +460,47 @@ source .local-test.env && poetry run python scripts/erc-4626/heal-broken-vaults.
 | `JSON_RPC_<CHAIN>` | Required per chain with broken vaults. |
 | `LOG_LEVEL` | Optional. Default: info. |
 
+### prepopulate-timestamps.py
+
+Prepopulate the Hypersync block timestamp DuckDB cache for all scanner chains.
+Use this to recover chains stuck in a 429 rate-limit spiral — when a chain's
+timestamp cache falls behind, each scan cycle needs more blocks, making it more
+likely to hit 429 again. Running this script during a quiet period (with the
+looped scanner stopped) lets the cache catch up without competing for API quota.
+
+The script uses the same chain list as `scan-vaults-all-chains.py` and only
+fetches the delta since the last cached block — it never re-downloads data that
+is already in the cache. Large ranges are chunked into 100k-block pieces with
+durable saves after each chunk.
+
+```shell
+# All chains (skips those without JSON_RPC_* or Hypersync support)
+source .local-test.env && poetry run python scripts/hypersync/prepopulate-timestamps.py
+
+# Specific stuck chains only
+CHAIN_FILTER="Polygon,Binance,Plasma" \
+  source .local-test.env && poetry run python scripts/hypersync/prepopulate-timestamps.py
+```
+
+Inside the Docker container:
+
+```shell
+docker compose --profile oneshot run --rm \
+  --entrypoint python \
+  -e CHAIN_FILTER="Polygon,Binance,Plasma" \
+  -e LOG_LEVEL=info \
+  vault-scanner \
+  scripts/hypersync/prepopulate-timestamps.py
+```
+
+| Variable | Description |
+|----------|-------------|
+| `CHAIN_FILTER` | Optional. Comma-separated chain names to process. Default: all chains. |
+| `HYPERSYNC_API_KEY` | Required. Envio Hypersync API key. |
+| `HYPERSYNC_RPM` | Optional. Requests-per-minute limit. Default: 150. Lower after persistent 429 errors. |
+| `JSON_RPC_<CHAIN>` | Required per chain. Same env vars as docker-compose. |
+| `LOG_LEVEL` | Optional. Default: info. |
+
 ### heal-timestamps.py
 
 Heal gaps in the block timestamp DuckDB cache populated by HyperSync.

--- a/scripts/hypersync/prepopulate-timestamps.py
+++ b/scripts/hypersync/prepopulate-timestamps.py
@@ -1,13 +1,35 @@
-"""Create a multichain timesstamp database and prepopulate it with data from Hypersync.
+"""Prepopulate the Hypersync block timestamp cache for all scanner chains.
 
-To run a single chain:
+Fills the DuckDB-backed timestamp cache used by the vault scanner pipeline.
+Chains that already have a warm cache only fetch the delta since the last
+cached block — this is safe to run repeatedly without re-downloading data.
+
+Uses the same chain list as the main vault scanner
+(:py:func:`eth_defi.vault.scan_all_chains.build_chain_configs`),
+reads the same ``JSON_RPC_*`` environment variables, and respects
+``HYPERSYNC_API_KEY`` and ``HYPERSYNC_RPM``.
+
+Usage:
 
 .. code-block:: shell
 
-    RPC_NAMES=JSON_RPC_ARBITRUM python scripts/hypersync/prepopulate-timestamps.py
+    # All chains (reads JSON_RPC_* env vars, skips unconfigured ones)
+    source .local-test.env && poetry run python scripts/hypersync/prepopulate-timestamps.py
 
+    # Specific chains only
+    CHAIN_FILTER="Polygon,Binance,Plasma" \\
+    source .local-test.env && poetry run python scripts/hypersync/prepopulate-timestamps.py
+
+Environment variables:
+
+    - ``JSON_RPC_<CHAIN>``: RPC URL for each chain (same as docker-compose)
+    - ``HYPERSYNC_API_KEY``: Envio Hypersync API key (required)
+    - ``HYPERSYNC_RPM``: Requests-per-minute limit (default: 150)
+    - ``CHAIN_FILTER``: Comma-separated chain names to process (default: all)
+    - ``LOG_LEVEL``: Logging level (default: "info")
 """
 
+import logging
 import os
 
 import hypersync
@@ -15,69 +37,59 @@ import hypersync
 from eth_defi.chain import get_chain_name
 from eth_defi.event_reader.multicall_timestamp import fetch_block_timestamps_multiprocess_auto_backend
 from eth_defi.event_reader.timestamp_cache import DEFAULT_TIMESTAMP_CACHE_FOLDER
+from eth_defi.hypersync.hypersync_timestamp import get_hypersync_block_height
 from eth_defi.hypersync.server import get_hypersync_server
 from eth_defi.hypersync.session import create_throttled_hypersync_client, get_hypersync_rpm_from_env
-from eth_defi.hypersync.timestamp import get_hypersync_block_height
 from eth_defi.provider.multi_provider import create_multi_provider_web3, MultiProviderWeb3Factory
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.scan_all_chains import build_chain_configs
 
-RPC_NAMES = [
-    "JSON_RPC_UNICHAIN",
-    "JSON_RPC_SONIC",
-    "JSON_RPC_HYPERLIQUID",
-    "JSON_RPC_AVALANCHE",
-    "JSON_RPC_ARBITRUM",
-    "JSON_RPC_MODE",
-    "JSON_RPC_MANTLE",
-    "JSON_RPC_MANTLE_2",
-    "JSON_RPC_BINANCE",
-    "JSON_RPC_OPTIMISM",
-    "JSON_RPC_ABSTRACT",
-    "JSON_RPC_CELO",
-    "JSON_RPC_SONEIUM",
-    "JSON_RPC_ZKSYNC",
-    "JSON_RPC_GNOSIS",
-    "JSON_RPC_BLAST",
-    "JSON_RPC_ZORA",
-    "JSON_RPC_INK",
-    "JSON_RPC_BASE",
-    "JSON_RPC_POLYGON",
-    "JSON_RPC_HEMI",
-    "JSON_RPC_LINEA",
-    # "JSON_RPC_TAC",
-    "JSON_RPC_PLASMA",
-    "JSON_RPC_KATANA",
-]
+logger = logging.getLogger(__name__)
 
 
-def create_and_populate_hypersync_timestamp_db_for_rpc(rpc_name: str):
-    rpc_url = os.environ.get(rpc_name)
-    assert rpc_url, f"Environment variable {rpc_name} not set"
+def prepopulate_chain(env_var: str, chain_name: str, hypersync_api_key: str):
+    """Prepopulate timestamp cache for a single chain.
+
+    - Reads the RPC URL from the given environment variable
+    - Skips chains without Hypersync support
+    - Only fetches the delta since the last cached block
+
+    :param env_var:
+        Environment variable name for the RPC URL (e.g. ``JSON_RPC_POLYGON``)
+
+    :param chain_name:
+        Human-readable chain name for logging
+
+    :param hypersync_api_key:
+        Envio Hypersync API key
+    """
+
+    rpc_url = os.environ.get(env_var)
+    if not rpc_url:
+        logger.info("%s: skipped — %s not set", chain_name, env_var)
+        return
+
     web3 = create_multi_provider_web3(rpc_url)
     web3factory = MultiProviderWeb3Factory(rpc_url)
     chain_id = web3.eth.chain_id
-    chain_name = get_chain_name(chain_id)
-    hypersync_server = get_hypersync_server(chain_id, allow_missing=True)
-    if hypersync_server is None:
-        print(f"No Hypersync server configured for chain {chain_name} ({chain_id}), skipping...")
+
+    hypersync_url = get_hypersync_server(chain_id, allow_missing=True)
+    if not hypersync_url:
+        logger.info("%s (chain %d): skipped — no Hypersync server configured", chain_name, chain_id)
         return
 
-    hypersync_api_key = os.environ.get("HYPERSYNC_API_KEY")
+    logger.info("%s (chain %d): using Hypersync server %s", chain_name, chain_id, hypersync_url)
 
-    if hypersync_server:
-        print(f"Using Hypersync server {hypersync_server} for chain {chain_name} ({chain_id})")
-        hypersync_client = create_throttled_hypersync_client(
-            hypersync.ClientConfig(
-                url=hypersync_server,
-                bearer_token=hypersync_api_key,
-            ),
-            requests_per_minute=get_hypersync_rpm_from_env(),
-        )
-        last_block = get_hypersync_block_height(hypersync_client)
+    hypersync_client = create_throttled_hypersync_client(
+        hypersync.ClientConfig(
+            url=hypersync_url,
+            bearer_token=hypersync_api_key,
+        ),
+        requests_per_minute=get_hypersync_rpm_from_env(),
+    )
 
-    else:
-        print(f"No Hypersync server configured for chain {chain_name} ({chain_id}), skipping...")
-        last_block = web3.eth.block_number
-        hypersync_client = None
+    last_block = get_hypersync_block_height(hypersync_client)
+    logger.info("%s (chain %d): Hypersync head at block %s", chain_name, chain_id, f"{last_block:,}")
 
     timestamps = fetch_block_timestamps_multiprocess_auto_backend(
         web3factory=web3factory,
@@ -87,24 +99,59 @@ def create_and_populate_hypersync_timestamp_db_for_rpc(rpc_name: str):
         step=1,
         hypersync_client=hypersync_client,
     )
-    print("Fetched timestamps for", len(timestamps), "blocks on chain", chain_name)
+
+    logger.info("%s (chain %d): done — cache covers %s blocks", chain_name, chain_id, f"{len(timestamps):,}")
 
 
 def main():
-    print(f"Prepopulating timestamp cache file {DEFAULT_TIMESTAMP_CACHE_FOLDER}")
+    setup_console_logging(
+        default_log_level=os.environ.get("LOG_LEVEL", "info"),
+    )
 
-    rpc_names = os.environ.get("RPC_NAMES")
-    if rpc_names:
-        rpc_names = rpc_names.split(" ")
+    hypersync_api_key = os.environ.get("HYPERSYNC_API_KEY")
+    if not hypersync_api_key:
+        logger.error("HYPERSYNC_API_KEY environment variable is required")
+        raise SystemExit(1)
+
+    # Build chain list from the same source as the vault scanner
+    all_chains = build_chain_configs()
+
+    # Optional filter
+    chain_filter = os.environ.get("CHAIN_FILTER", "").strip()
+    if chain_filter:
+        filter_names = {name.strip() for name in chain_filter.split(",")}
+        chains = [c for c in all_chains if c.name in filter_names]
+        unknown = filter_names - {c.name for c in chains}
+        if unknown:
+            logger.warning("CHAIN_FILTER contains unknown chain names: %s", ", ".join(sorted(unknown)))
     else:
-        rpc_names = RPC_NAMES
+        chains = all_chains
 
-    for rpc in rpc_names:
-        print(f"Prepopulating timestamps for RPC {rpc}...")
-        create_and_populate_hypersync_timestamp_db_for_rpc(rpc)
-        print(f"Done prepopulating timestamps for RPC {rpc}.")
+    logger.info(
+        "Prepopulating timestamp cache at %s for %d chain(s): %s",
+        DEFAULT_TIMESTAMP_CACHE_FOLDER,
+        len(chains),
+        ", ".join(c.name for c in chains),
+    )
 
-    print("All done.")
+    succeeded = []
+    failed = []
+
+    for chain_config in chains:
+        try:
+            prepopulate_chain(chain_config.env_var, chain_config.name, hypersync_api_key)
+            succeeded.append(chain_config.name)
+        except Exception:
+            logger.exception("%s: prepopulation failed", chain_config.name)
+            failed.append(chain_config.name)
+
+    logger.info(
+        "Prepopulation complete: %d succeeded, %d failed. Succeeded: %s. Failed: %s",
+        len(succeeded),
+        len(failed),
+        ", ".join(succeeded) or "(none)",
+        ", ".join(failed) or "(none)",
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/hypersync/prepopulate-timestamps.py
+++ b/scripts/hypersync/prepopulate-timestamps.py
@@ -153,6 +153,9 @@ def main():
         ", ".join(failed) or "(none)",
     )
 
+    if failed:
+        raise SystemExit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/tests/hypersync/test_hypersync_gap_healing.py
+++ b/tests/hypersync/test_hypersync_gap_healing.py
@@ -1,7 +1,11 @@
-"""Test that HyperSync timestamp gap healing works correctly.
+"""Test that HyperSync timestamp gap healing and backfill work correctly.
 
 Simulates HyperSync silently dropping blocks (as observed on fast chains
 like Monad) and verifies the gap-healing loop detects and re-fetches them.
+
+Also tests head-backfill scenarios where the caller requests blocks before
+an existing cache, verifying that partial progress followed by retry does
+not leave permanent holes.
 
 No live HyperSync connection needed — uses mocked async generators.
 """
@@ -189,5 +193,174 @@ def test_hypersync_gap_healing_persistent_gap(tmp_path):
 
     # 1 initial fetch + 3 heal attempts (max_heal_attempts)
     assert call_count == 4
+
+    slicer.close()
+
+
+def test_hypersync_head_backfill_no_holes(tmp_path):
+    """Verify that head-backfill followed by retry does not leave permanent holes.
+
+    Reproduces the scenario where:
+
+    1. Cache already has blocks 1000-2000
+    2. Caller requests blocks 1-1200 (needs head backfill)
+    3. First attempt saves chunk 1-99, then fails
+    4. On retry, blocks 100-999 must still be fetched despite
+       MIN=1 and MAX=2000 looking fully covered
+
+    Without separate head/tail ranges this would leave blocks 100-999
+    permanently missing because MIN/MAX suggest full coverage.
+    """
+
+    chain_id = 1
+
+    # Pre-populate cache with blocks 1000-2000
+    from eth_defi.event_reader.timestamp_cache import BlockTimestampDatabase
+
+    import pandas as pd
+
+    db = BlockTimestampDatabase.create(chain_id, tmp_path)
+    existing_index = list(range(1000, 2001))
+    existing_values = [1_700_000_000 + b for b in existing_index]
+    db.import_chain_data(chain_id, pd.Series(data=existing_values, index=existing_index))
+    first, last = db.get_first_and_last_block()
+    assert first == 1000
+    assert last == 2000
+    db.close()
+
+    attempt = 0
+
+    async def mock_get_timestamps(client, chain_id, start_block, end_block, timeout=120.0, display_progress=True, progress_throttle=10_000, validate_chain_id=True, reason=None):
+        nonlocal attempt
+        attempt += 1
+        for block_num in range(start_block, end_block + 1):
+            yield _make_block_header(block_num)
+
+    async def _run():
+        mock_client = MagicMock()
+
+        with patch(
+            "eth_defi.hypersync.hypersync_timestamp.get_block_timestamps_using_hypersync_async",
+            side_effect=mock_get_timestamps,
+        ):
+            # Simulate: caller wants blocks 1-1200, cache has 1000-2000.
+            # Head range should be 1-999, tail is not needed (1200 <= 2000).
+            slicer = await fetch_block_timestamps_using_hypersync_cached_async(
+                client=mock_client,
+                chain_id=chain_id,
+                start_block=1,
+                end_block=1200,
+                cache_path=tmp_path,
+                display_progress=False,
+                chunk_size=100_000,
+            )
+
+        return slicer
+
+    slicer = asyncio.run(_run())
+
+    # All blocks 1-2000 should be present (head backfill 1-999 + existing 1000-2000)
+    assert len(slicer) == 2000
+
+    # Verify no holes — every block from 1 to 1200 (the requested range) is accessible
+    for block_num in range(1, 1201):
+        ts = slicer[block_num]
+        expected = datetime.datetime(2023, 11, 14, 22, 13, 20) + datetime.timedelta(seconds=block_num)
+        assert ts == expected, f"Block {block_num}: expected {expected}, got {ts}"
+
+    # Only one fetch range (head: 1-999), served as a single chunk
+    assert attempt == 1
+
+    slicer.close()
+
+
+def test_hypersync_head_backfill_retry_after_partial(tmp_path):
+    """Verify that partial head-backfill followed by retry fills the remaining gap.
+
+    1. Cache has blocks 1000-2000
+    2. First call: fetch head range 1-999 with chunk_size=100, saves chunk 1-99,
+       then 429 kills chunk 100-199
+    3. Second call: cache now has 1-99 + 1000-2000. The function must detect
+       the gap 100-999 and fetch it.
+
+    This is the exact P1 bug scenario.
+    """
+
+    chain_id = 1
+
+    from eth_defi.event_reader.timestamp_cache import BlockTimestampDatabase
+    from eth_defi.hypersync.hypersync_timestamp import HypersyncFlaky
+
+    import pandas as pd
+
+    # Pre-populate cache with blocks 1000-2000
+    db = BlockTimestampDatabase.create(chain_id, tmp_path)
+    existing_index = list(range(1000, 2001))
+    existing_values = [1_700_000_000 + b for b in existing_index]
+    db.import_chain_data(chain_id, pd.Series(data=existing_values, index=existing_index))
+    db.close()
+
+    call_log = []
+
+    async def mock_get_timestamps_fail_second_chunk(client, chain_id, start_block, end_block, timeout=120.0, display_progress=True, progress_throttle=10_000, validate_chain_id=True, reason=None):
+        call_log.append((start_block, end_block))
+        # On the very first call stream succeeds (chunk 1-99).
+        # On the second call (chunk 100-199), simulate a 429.
+        if len(call_log) == 2:
+            raise HypersyncFlaky("Simulated 429 for testing")
+        for block_num in range(start_block, end_block + 1):
+            yield _make_block_header(block_num)
+
+    async def mock_get_timestamps_ok(client, chain_id, start_block, end_block, timeout=120.0, display_progress=True, progress_throttle=10_000, validate_chain_id=True, reason=None):
+        call_log.append((start_block, end_block))
+        for block_num in range(start_block, end_block + 1):
+            yield _make_block_header(block_num)
+
+    async def _run():
+        mock_client = MagicMock()
+
+        # First attempt: chunk 1-99 saves, chunk 100-199 fails with 429
+        with patch(
+            "eth_defi.hypersync.hypersync_timestamp.get_block_timestamps_using_hypersync_async",
+            side_effect=mock_get_timestamps_fail_second_chunk,
+        ):
+            with pytest.raises(HypersyncFlaky):
+                await fetch_block_timestamps_using_hypersync_cached_async(
+                    client=mock_client,
+                    chain_id=chain_id,
+                    start_block=1,
+                    end_block=1200,
+                    cache_path=tmp_path,
+                    display_progress=False,
+                    chunk_size=100,
+                )
+
+        # Retry: should detect that 100-999 is still missing and fetch it
+        with patch(
+            "eth_defi.hypersync.hypersync_timestamp.get_block_timestamps_using_hypersync_async",
+            side_effect=mock_get_timestamps_ok,
+        ):
+            slicer = await fetch_block_timestamps_using_hypersync_cached_async(
+                client=mock_client,
+                chain_id=chain_id,
+                start_block=1,
+                end_block=1200,
+                cache_path=tmp_path,
+                display_progress=False,
+                chunk_size=100,
+            )
+
+        return slicer
+
+    slicer = asyncio.run(_run())
+
+    # All blocks 1-2000 must be present — no holes
+    assert len(slicer) == 2000
+
+    # Verify the previously-vulnerable range is filled
+    for block_num in range(100, 1000):
+        ts = slicer[block_num]
+        expected = datetime.datetime(2023, 11, 14, 22, 13, 20) + datetime.timedelta(seconds=block_num)
+        assert ts == expected, f"Block {block_num}: expected {expected}, got {ts}"
 
     slicer.close()

--- a/tests/hypersync/test_hypersync_gap_healing.py
+++ b/tests/hypersync/test_hypersync_gap_healing.py
@@ -198,18 +198,12 @@ def test_hypersync_gap_healing_persistent_gap(tmp_path):
 
 
 def test_hypersync_head_backfill_no_holes(tmp_path):
-    """Verify that head-backfill followed by retry does not leave permanent holes.
-
-    Reproduces the scenario where:
+    """Verify that head-backfill correctly fetches only the missing head range.
 
     1. Cache already has blocks 1000-2000
     2. Caller requests blocks 1-1200 (needs head backfill)
-    3. First attempt saves chunk 1-99, then fails
-    4. On retry, blocks 100-999 must still be fetched despite
-       MIN=1 and MAX=2000 looking fully covered
-
-    Without separate head/tail ranges this would leave blocks 100-999
-    permanently missing because MIN/MAX suggest full coverage.
+    3. The function should fetch only blocks 1-999 (the head gap)
+    4. All requested blocks 1-1200 must be accessible
     """
 
     chain_id = 1
@@ -228,11 +222,10 @@ def test_hypersync_head_backfill_no_holes(tmp_path):
     assert last == 2000
     db.close()
 
-    attempt = 0
+    fetch_calls = []
 
     async def mock_get_timestamps(client, chain_id, start_block, end_block, timeout=120.0, display_progress=True, progress_throttle=10_000, validate_chain_id=True, reason=None):
-        nonlocal attempt
-        attempt += 1
+        fetch_calls.append((start_block, end_block))
         for block_num in range(start_block, end_block + 1):
             yield _make_block_header(block_num)
 
@@ -243,8 +236,6 @@ def test_hypersync_head_backfill_no_holes(tmp_path):
             "eth_defi.hypersync.hypersync_timestamp.get_block_timestamps_using_hypersync_async",
             side_effect=mock_get_timestamps,
         ):
-            # Simulate: caller wants blocks 1-1200, cache has 1000-2000.
-            # Head range should be 1-999, tail is not needed (1200 <= 2000).
             slicer = await fetch_block_timestamps_using_hypersync_cached_async(
                 client=mock_client,
                 chain_id=chain_id,
@@ -252,7 +243,6 @@ def test_hypersync_head_backfill_no_holes(tmp_path):
                 end_block=1200,
                 cache_path=tmp_path,
                 display_progress=False,
-                chunk_size=100_000,
             )
 
         return slicer
@@ -268,77 +258,57 @@ def test_hypersync_head_backfill_no_holes(tmp_path):
         expected = datetime.datetime(2023, 11, 14, 22, 13, 20) + datetime.timedelta(seconds=block_num)
         assert ts == expected, f"Block {block_num}: expected {expected}, got {ts}"
 
-    # Only one fetch range (head: 1-999), served as a single chunk
-    assert attempt == 1
+    # Should have fetched head range only (possibly as multiple chunks)
+    assert len(fetch_calls) >= 1
+    # First fetch must start at 1, last fetch must end at or before 999
+    assert fetch_calls[0][0] == 1
+    assert all(end <= 999 for _, end in fetch_calls)
 
     slicer.close()
 
 
-def test_hypersync_head_backfill_retry_after_partial(tmp_path):
-    """Verify that partial head-backfill followed by retry fills the remaining gap.
+def test_hypersync_interior_gap_detected_on_retry(tmp_path):
+    """Verify that interior gaps from partial backfill are detected and filled on retry.
 
-    1. Cache has blocks 1000-2000
-    2. First call: fetch head range 1-999 with chunk_size=100, saves chunk 1-99,
-       then 429 kills chunk 100-199
-    3. Second call: cache now has 1-99 + 1000-2000. The function must detect
-       the gap 100-999 and fetch it.
+    Simulates the state after a failed partial head-backfill:
 
-    This is the exact P1 bug scenario.
+    1. Cache has blocks 1-99 + 1000-2000 (partial backfill left a hole at 100-999)
+    2. Caller requests blocks 1-1200
+    3. MIN=1, MAX=2000 look fully covered, but blocks 100-999 are missing
+    4. The function must detect the interior gap and fetch it
     """
 
     chain_id = 1
 
     from eth_defi.event_reader.timestamp_cache import BlockTimestampDatabase
-    from eth_defi.hypersync.hypersync_timestamp import HypersyncFlaky
 
     import pandas as pd
 
-    # Pre-populate cache with blocks 1000-2000
+    # Pre-populate cache simulating partial backfill state:
+    # blocks 1-99 (saved before 429) + blocks 1000-2000 (original cache)
     db = BlockTimestampDatabase.create(chain_id, tmp_path)
-    existing_index = list(range(1000, 2001))
-    existing_values = [1_700_000_000 + b for b in existing_index]
-    db.import_chain_data(chain_id, pd.Series(data=existing_values, index=existing_index))
+    partial_index = list(range(1, 100)) + list(range(1000, 2001))
+    partial_values = [1_700_000_000 + b for b in partial_index]
+    db.import_chain_data(chain_id, pd.Series(data=partial_values, index=partial_index))
+    first, last = db.get_first_and_last_block()
+    assert first == 1
+    assert last == 2000
+    assert db.get_count() == 1100  # 99 + 1001, gap at 100-999
     db.close()
 
-    call_log = []
+    fetch_calls = []
 
-    async def mock_get_timestamps_fail_second_chunk(client, chain_id, start_block, end_block, timeout=120.0, display_progress=True, progress_throttle=10_000, validate_chain_id=True, reason=None):
-        call_log.append((start_block, end_block))
-        # On the very first call stream succeeds (chunk 1-99).
-        # On the second call (chunk 100-199), simulate a 429.
-        if len(call_log) == 2:
-            raise HypersyncFlaky("Simulated 429 for testing")
-        for block_num in range(start_block, end_block + 1):
-            yield _make_block_header(block_num)
-
-    async def mock_get_timestamps_ok(client, chain_id, start_block, end_block, timeout=120.0, display_progress=True, progress_throttle=10_000, validate_chain_id=True, reason=None):
-        call_log.append((start_block, end_block))
+    async def mock_get_timestamps(client, chain_id, start_block, end_block, timeout=120.0, display_progress=True, progress_throttle=10_000, validate_chain_id=True, reason=None):
+        fetch_calls.append((start_block, end_block))
         for block_num in range(start_block, end_block + 1):
             yield _make_block_header(block_num)
 
     async def _run():
         mock_client = MagicMock()
 
-        # First attempt: chunk 1-99 saves, chunk 100-199 fails with 429
         with patch(
             "eth_defi.hypersync.hypersync_timestamp.get_block_timestamps_using_hypersync_async",
-            side_effect=mock_get_timestamps_fail_second_chunk,
-        ):
-            with pytest.raises(HypersyncFlaky):
-                await fetch_block_timestamps_using_hypersync_cached_async(
-                    client=mock_client,
-                    chain_id=chain_id,
-                    start_block=1,
-                    end_block=1200,
-                    cache_path=tmp_path,
-                    display_progress=False,
-                    chunk_size=100,
-                )
-
-        # Retry: should detect that 100-999 is still missing and fetch it
-        with patch(
-            "eth_defi.hypersync.hypersync_timestamp.get_block_timestamps_using_hypersync_async",
-            side_effect=mock_get_timestamps_ok,
+            side_effect=mock_get_timestamps,
         ):
             slicer = await fetch_block_timestamps_using_hypersync_cached_async(
                 client=mock_client,
@@ -347,7 +317,6 @@ def test_hypersync_head_backfill_retry_after_partial(tmp_path):
                 end_block=1200,
                 cache_path=tmp_path,
                 display_progress=False,
-                chunk_size=100,
             )
 
         return slicer
@@ -357,10 +326,18 @@ def test_hypersync_head_backfill_retry_after_partial(tmp_path):
     # All blocks 1-2000 must be present — no holes
     assert len(slicer) == 2000
 
-    # Verify the previously-vulnerable range is filled
+    # Verify the previously-missing range is filled
     for block_num in range(100, 1000):
         ts = slicer[block_num]
         expected = datetime.datetime(2023, 11, 14, 22, 13, 20) + datetime.timedelta(seconds=block_num)
         assert ts == expected, f"Block {block_num}: expected {expected}, got {ts}"
+
+    # Must have fetched the gap range (100-999)
+    assert len(fetch_calls) >= 1
+    fetched_blocks = set()
+    for s, e in fetch_calls:
+        fetched_blocks.update(range(s, e + 1))
+    # All gap blocks must have been requested
+    assert all(b in fetched_blocks for b in range(100, 1000))
 
     slicer.close()


### PR DESCRIPTION
## Why

The vault scanner's timestamp cache fill has been failing with Hypersync 429 rate limit errors on Polygon, Binance, and Plasma for days/weeks. Each failure prevents the cache from advancing, making the next cycle's catch-up range even larger — a vicious cycle.

The root cause: when the cache is behind by millions of blocks, the entire range is streamed in a single `stream()` call. The Rust client paginates internally with hundreds of HTTP requests that are invisible to the Python-side `ThrottledHypersyncClient` rate limiter. These unthrottled requests exhaust the 200 RPM API limit, and a 429 failure loses all progress.

## Summary

- **Chunked streaming**: Split large timestamp fetches into 100k-block chunks. Each chunk opens a separate `stream()` call (throttled by the Python limiter) and saves to the DuckDB cache immediately. A 429 failure only loses the current chunk — all prior chunks are persisted.
- **Automatic recovery**: On retry (via the sync wrapper's exponential backoff), the async function re-reads the cache (now warm up to the last saved chunk) and only fetches the remaining blocks.
- **Comprehensive INFO logging**: Added detailed logging throughout the timestamp cache path so operators can see:
  - What the cache currently covers and how many entries it has
  - Whether the cache hit or missed (and why)
  - Exactly how many blocks need fetching and how many chunks will be used
  - Per-chunk progress (start, complete, block counts)
  - Gap detection and healing status

## Lessons learnt

- The `ThrottledHypersyncClient` only throttles `stream()` setup, not the Rust client's internal HTTP pagination within an active stream. Large streaming ranges bypass Python-side rate limiting entirely.
- When chains fail repeatedly, the catch-up gap grows, making the next attempt more likely to fail — a cascading failure pattern that requires chunked progress to break.
- Extensive logging is essential for production scanners — without it, operators can't tell whether the cache is warm (delta = 1,500 blocks) or cold (delta = 1,000,000 blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)