### PR TITLE
feat: Add Ostium V1.5 async settlement-based deposit/withdrawal support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- feat: Add Ostium V1.5 async settlement-based deposit/withdrawal support with version auto-detection, settlement-price analysis, and full test coverage for both V1 and V1.5 (2026-06-05)
+
 - feat: Add Royco senior/junior tranche vault support with custom Redeem event discovery, tuple-aware current and historical NAV readers, stored ABIs, and Royco offchain metadata fetching (2026-06-05)
 
 - feat: Add CrystalClear vault protocol — algorithmic trading vaults on HyperEVM that trade perpetuals on HyperCore, with hardcoded address detection, metadata, and Sphinx docs (2026-06-05)

--- a/eth_defi/abi/gains/OstiumVaultV1_5.json
+++ b/eth_defi/abi/gains/OstiumVaultV1_5.json
@@ -1,0 +1,3547 @@
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "AboveBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AboveMaxDeposit",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AboveMaxMint",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AboveWithdrawAmount",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      }
+    ],
+    "name": "AddressEmptyCode",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAssetsIn",
+        "type": "uint256"
+      }
+    ],
+    "name": "AssetsInTooLow",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      }
+    ],
+    "name": "DepositNotClaimable",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      }
+    ],
+    "name": "DepositNotReclaimable",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "DepositNotUnlocked",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "allowance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "needed",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC20InsufficientAllowance",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "needed",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC20InsufficientBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "approver",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20InvalidApprover",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20InvalidReceiver",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20InvalidSender",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20InvalidSpender",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "max",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC4626ExceededMaxDeposit",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "max",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC4626ExceededMaxMint",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "max",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC4626ExceededMaxRedeem",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "max",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC4626ExceededMaxWithdraw",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FailedCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FunctionDisabled",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "a",
+        "type": "address"
+      }
+    ],
+    "name": "HasAlreadyRole",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InsufficientBuffer",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidInitialization",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "MaxDailyPnlReached",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NoDiscount",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "a",
+        "type": "address"
+      }
+    ],
+    "name": "NotAllowed",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "a",
+        "type": "address"
+      }
+    ],
+    "name": "NotCallbacks",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "a",
+        "type": "address"
+      }
+    ],
+    "name": "NotDev",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotEnoughAssets",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "a",
+        "type": "address"
+      }
+    ],
+    "name": "NotGov",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotInitializing",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "a",
+        "type": "address"
+      }
+    ],
+    "name": "NotMM",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "a",
+        "type": "address"
+      }
+    ],
+    "name": "NotOpenPnl",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "a",
+        "type": "address"
+      }
+    ],
+    "name": "NotTimelock",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NullAddr",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NullAmount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NullPrice",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "PendingWithdrawal",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "bits",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "SafeCastOverflowedUintDowncast",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "SafeCastOverflowedUintToInt",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "SafeERC20FailedOperation",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxSharesOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "SharesOutTooHigh",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      }
+    ],
+    "name": "WithdrawNotClaimable",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      }
+    ],
+    "name": "WithdrawNotReclaimable",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "duration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minLock",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxLock",
+        "type": "uint256"
+      }
+    ],
+    "name": "WrongLockDuration",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "WrongParams",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ZeroAmount",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "newEpoch",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "prevPositiveOpenPnl",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newPositiveOpenPnl",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newEpochPositiveOpenPnl",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "newAccPnlPerTokenUsed",
+        "type": "int256"
+      }
+    ],
+    "name": "AccPnlPerTokenUsedUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "prevOpenPnl",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "newOpenPnl",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "settlementOpenPnl",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "accPnlPerTokenUsed",
+        "type": "int256"
+      }
+    ],
+    "name": "AccPnlPerTokenUsedUpdatedV2",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "value",
+        "type": "address"
+      }
+    ],
+    "name": "AddressParamUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "AssetsReceived",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "AssetsSent",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "deltaShares",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalAssetsToDeposit",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalSharesToWithdraw",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shareToAssetsPrice",
+        "type": "uint256"
+      }
+    ],
+    "name": "AsyncDepositWithdrawExecuted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "CurrentMaxSupplyUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "DailyAccPnlDeltaReset",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "Deposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "DepositClaimedV2",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "depositId",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "shares",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "assetsDeposited",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "assetsDiscount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint32",
+            "name": "atTimestamp",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "lockDuration",
+            "type": "uint32"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct IOstiumVault.LockedDeposit",
+        "name": "d",
+        "type": "tuple"
+      }
+    ],
+    "name": "DepositLocked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "refundedAssets",
+        "type": "uint256"
+      }
+    ],
+    "name": "DepositPartiallyRefunded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "DepositReclaimedV2",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "DepositRequestedV2",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "depositId",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "shares",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "assetsDeposited",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "assetsDiscount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint32",
+            "name": "atTimestamp",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "lockDuration",
+            "type": "uint32"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct IOstiumVault.LockedDeposit",
+        "name": "d",
+        "type": "tuple"
+      }
+    ],
+    "name": "DepositUnlocked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "version",
+        "type": "uint64"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "mm",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "MMDeposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "mm",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "MMWithdraw",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "oldMM",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newMM",
+        "type": "address"
+      }
+    ],
+    "name": "MarketMakerUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "MaxAccOpenPnlDeltaPerTokenUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "MaxDailyAccPnlDeltaPerTokenUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "MaxDiscountPUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "MaxDiscountThresholdPUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "maxDeltaId",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "delta",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "maxDelta",
+        "type": "int256"
+      }
+    ],
+    "name": "MaxOpenPnlDeltaUsed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "newValue",
+        "type": "uint32"
+      }
+    ],
+    "name": "MaxSettlementIntervalUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "MaxSupplyIncreaseDailyPUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint16",
+        "name": "newEpoch",
+        "type": "uint16"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "newEpochTs",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      }
+    ],
+    "name": "NewEpoch",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "OpenPnlCallFailed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "RequestDepositCanceledV2",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "RequestWithdrawCanceledV2",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "accRewardsPerToken",
+        "type": "uint256"
+      }
+    ],
+    "name": "RewardDistributed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "settlementTs",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "settlementOpenPnl",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum IOstiumVault.SettlementType",
+        "name": "settlementType",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "accPnlPerTokenUsed",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "accRewardsPerToken",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shareToAssetsPrice",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "totalClosedPnl",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalSupply",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalAssets",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "bufferSize",
+        "type": "int256"
+      }
+    ],
+    "name": "SettlementExecuted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "ShareToAssetsPriceUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "SupplyCapUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalAssetsToDeposit",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxAssets",
+        "type": "uint256"
+      }
+    ],
+    "name": "TotalAssetsToDepositAboveMax",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "requestedAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "allocatedAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "TotalAssetsToDepositCapped",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalSharesToWithdraw",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxShares",
+        "type": "uint256"
+      }
+    ],
+    "name": "TotalSharesToWithdrawAboveMax",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "Withdraw",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "currEpoch",
+        "type": "uint16"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint16",
+        "name": "unlockEpoch",
+        "type": "uint16"
+      }
+    ],
+    "name": "WithdrawCanceled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawClaimedV2",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint16[2]",
+        "name": "value",
+        "type": "uint16[2]"
+      }
+    ],
+    "name": "WithdrawLockThresholdsPUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawReclaimedV2",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "currEpoch",
+        "type": "uint16"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint16",
+        "name": "unlockEpoch",
+        "type": "uint16"
+      }
+    ],
+    "name": "WithdrawRequested",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "WithdrawRequestedV2",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint32",
+        "name": "value",
+        "type": "uint32"
+      }
+    ],
+    "name": "WithdrawSettlementDelayUpdated",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "__DEPRECATED_currentEpochPositiveOpenPnl",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "__DEPRECATED_currentMaxSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "__DEPRECATED_lastMaxSupplyUpdateTs",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "__DEPRECATED_maxDiscountP",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "",
+        "type": "uint16"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "__DEPRECATED_maxDiscountThresholdP",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "",
+        "type": "uint16"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "__DEPRECATED_maxSupplyIncreaseDailyP",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "",
+        "type": "uint16"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "__DEPRECATED_totalDeposited",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "__DEPRECATED_totalLiability",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "__DEPRECATED_totalRewards",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "__DEPRECATED_withdrawLockThresholdsP",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "",
+        "type": "uint16"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "trader",
+        "type": "address"
+      },
+      {
+        "internalType": "uint16",
+        "name": "withdrawEpoch",
+        "type": "uint16"
+      }
+    ],
+    "name": "__DEPRECATED_withdrawRequests",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "accPnlPerToken",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "accPnlPerTokenThreshold",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "accPnlPerTokenUsed",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "accRewardsPerToken",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "asset",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "availableAssets",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "cancelRequestDeposit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "cancelRequestWithdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      }
+    ],
+    "name": "claimDeposit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      }
+    ],
+    "name": "claimWithdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "convertToAssets",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_shareToAssetsPrice",
+        "type": "uint256"
+      }
+    ],
+    "name": "convertToAssetsWithPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "convertToShares",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_shareToAssetsPrice",
+        "type": "uint256"
+      }
+    ],
+    "name": "convertToSharesWithPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "currentBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "currentEpoch",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "",
+        "type": "uint16"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "currentEpochStart",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "dailyAccPnlDeltaPerToken",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "deposit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "distributeReward",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "effectiveAccPnlPerTokenUsed",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "forceResetDailyAccPnlDelta",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "forceSettlement",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBufferSize",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      }
+    ],
+    "name": "getDepositStatus",
+    "outputs": [
+      {
+        "internalType": "enum IOstiumVault.RequestStatus",
+        "name": "requestStatus",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "depositId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getLockedDeposit",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "shares",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "assetsDeposited",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "assetsDiscount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint32",
+            "name": "atTimestamp",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "lockDuration",
+            "type": "uint32"
+          }
+        ],
+        "internalType": "struct IOstiumVault.LockedDeposit",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      }
+    ],
+    "name": "getWithdrawStatus",
+    "outputs": [
+      {
+        "internalType": "enum IOstiumVault.RequestStatus",
+        "name": "requestStatus",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_asset",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_registry",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxAccOpenPnlDeltaPerToken",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxDailyAccPnlDeltaPerToken",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint16",
+        "name": "_maxSupplyIncreaseDailyP",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16",
+        "name": "_maxDiscountP",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16",
+        "name": "_maxDiscountThresholdP",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16[2]",
+        "name": "_withdrawLockThresholdsP",
+        "type": "uint16[2]"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "initializeV2",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "initializeV3",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_marketMaker",
+        "type": "address"
+      }
+    ],
+    "name": "initializeV4",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isBufferPositive",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastDailyAccPnlDeltaResetTs",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastSettlementId",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastSettlementOpenPnl",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastSettlementTs",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "depositId",
+        "type": "uint256"
+      }
+    ],
+    "name": "lockedDeposits",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "assetsDeposited",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "assetsDiscount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint32",
+        "name": "atTimestamp",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "lockDuration",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lockedDepositsCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "marketCap",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "marketMaker",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxAccOpenPnlDeltaPerToken",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxAccPnlPerToken",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxDailyAccPnlDeltaPerToken",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "maxDeposit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "maxMint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "maxRedeem",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxSettlementInterval",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "maxWithdraw",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "mint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "mmDeposit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "mmWithdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "data",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "multicall",
+    "outputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "results",
+        "type": "bytes[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      }
+    ],
+    "name": "pendingDepositRequest",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      }
+    ],
+    "name": "pendingWithdrawRequest",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "previewDeposit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "previewMint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "previewRedeem",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "previewWithdraw",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      }
+    ],
+    "name": "receiveAssets",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      }
+    ],
+    "name": "reclaimDeposit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      }
+    ],
+    "name": "reclaimWithdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "redeem",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "registry",
+    "outputs": [
+      {
+        "internalType": "contract IOstiumRegistry",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      }
+    ],
+    "name": "requestDeposit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "requestWithdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "sendAssets",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_mm",
+        "type": "address"
+      }
+    ],
+    "name": "setMarketMaker",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      }
+    ],
+    "name": "settlementAllocationScaleP",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      }
+    ],
+    "name": "settlementShareToAssetsPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "shareToAssetsPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "supplyCap",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "isDeposit",
+        "type": "bool"
+      }
+    ],
+    "name": "targetSettlementId",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalAssets",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      }
+    ],
+    "name": "totalAssetsToDeposit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalClosedPnl",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalDiscounts",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalLockedDiscounts",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "settlementId",
+        "type": "uint32"
+      }
+    ],
+    "name": "totalSharesToWithdraw",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "tryNewSettlement",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "tryResetDailyAccPnlDelta",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "tvl",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "depositId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "unlockDeposit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateMaxAccOpenPnlDeltaPerToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateMaxDailyAccPnlDeltaPerToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "newValue",
+        "type": "uint32"
+      }
+    ],
+    "name": "updateMaxSettlementInterval",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateSupplyCap",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "newValue",
+        "type": "uint32"
+      }
+    ],
+    "name": "updateWithdrawSettlementDelay",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "withdraw",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "withdrawSettlementDelay",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/eth_defi/erc_4626/vault_protocol/gains/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/gains/deposit_redeem.py
@@ -1,4 +1,7 @@
-"""Deposit and redeem flow for GToken-like vaults."""
+"""Deposit and redeem flow for GToken-like vaults.
+
+Supports both Gains V1 (epoch-based) and Ostium V1.5 (settlement-based) flows.
+"""
 
 import datetime
 import logging
@@ -6,7 +9,17 @@ from dataclasses import dataclass
 from decimal import Decimal
 
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
-from eth_defi.vault.deposit_redeem import RedemptionTicket, RedemptionRequest, CannotParseRedemptionTransaction
+from eth_defi.timestamp import get_block_timestamp
+from eth_defi.utils import from_unix_timestamp
+from eth_defi.vault.deposit_redeem import (
+    DepositRedeemEventAnalysis,
+    DepositRedeemEventFailure,
+    DepositRequest,
+    DepositTicket,
+    RedemptionTicket,
+    RedemptionRequest,
+    CannotParseRedemptionTransaction,
+)
 from hexbytes import HexBytes
 from web3._utils.events import EventLogErrorFlags
 from eth_typing import HexAddress
@@ -192,3 +205,483 @@ class GainsDepositManager(ERC4626DepositManager):
     def is_redemption_in_progress(self, owner: HexAddress) -> bool:
         contract = self.vault.vault_contract
         return contract.functions.totalSharesBeingWithdrawn(owner).call() > 0
+
+
+# ---------------------------------------------------------------------------
+# Ostium V1.5 async settlement-based deposit/redemption
+# ---------------------------------------------------------------------------
+
+
+class OstiumSettlementFailed(Exception):
+    """Raised when an Ostium V1.5 settlement resulted in RECLAIMABLE status.
+
+    The user should call ``reclaimDeposit(settlementId)`` or
+    ``reclaimWithdraw(settlementId)`` to recover their funds.
+    """
+
+
+#: Ostium V1.5 RequestStatus enum values
+OSTIUM_REQUEST_STATUS_NONE = 0
+OSTIUM_REQUEST_STATUS_PENDING = 1
+OSTIUM_REQUEST_STATUS_CLAIMABLE = 2
+OSTIUM_REQUEST_STATUS_RECLAIMABLE = 3
+
+
+@dataclass(slots=True)
+class OstiumDepositTicket(DepositTicket):
+    """Tracks an in-progress Ostium V1.5 async deposit request.
+
+    The ``settlement_id`` is extracted from the ``DepositRequestedV2`` event.
+    """
+
+    #: Settlement ID for this deposit request
+    settlement_id: int
+
+
+@dataclass(slots=True)
+class OstiumRedemptionTicket(RedemptionTicket):
+    """Tracks an in-progress Ostium V1.5 async withdrawal request.
+
+    The ``settlement_id`` is extracted from the ``WithdrawRequestedV2`` event.
+    """
+
+    #: Settlement ID for this withdrawal request
+    settlement_id: int
+
+    def get_request_id(self) -> int:
+        return self.settlement_id
+
+
+class OstiumDepositRequest(DepositRequest):
+    """Wraps Ostium V1.5 ``requestDeposit(uint256 assets)`` call.
+
+    After broadcasting, parse the transaction to extract the ``settlement_id``
+    from the ``DepositRequestedV2`` event.
+    """
+
+    def parse_deposit_transaction(self, tx_hashes: list[HexBytes]) -> OstiumDepositTicket:
+        """Parse the ``DepositRequestedV2`` event from ``requestDeposit()`` transaction.
+
+        ``DepositRequestedV2(address indexed owner, uint32 indexed settlementId, uint256 assets)``
+        """
+        tx_hash = tx_hashes[-1]
+        assert isinstance(tx_hash, HexBytes)
+
+        receipt = self.vault.web3.eth.get_transaction_receipt(tx_hash)
+        assert receipt is not None, f"Transaction is not yet mined: {tx_hash.hex()}"
+        assert receipt["status"] == 1, f"Transaction reverted: {tx_hash.hex()}"
+
+        logs = self.vault.vault_contract.events.DepositRequestedV2().process_receipt(receipt, errors=EventLogErrorFlags.Discard)
+        if len(logs) != 1:
+            raise CannotParseRedemptionTransaction(f"Expected exactly one DepositRequestedV2 event, got {len(logs)} at {tx_hash.hex()}")
+
+        log = logs[0]
+
+        gas_used = sum(self.vault.web3.eth.get_transaction_receipt(h)["gasUsed"] for h in tx_hashes)
+        block_number = receipt["blockNumber"]
+        block_timestamp = get_block_timestamp(self.vault.web3, block_number)
+
+        return OstiumDepositTicket(
+            vault_address=self.vault.address,
+            owner=self.owner,
+            to=self.to,
+            raw_amount=self.raw_amount,
+            tx_hash=tx_hash,
+            gas_used=gas_used,
+            block_number=block_number,
+            block_timestamp=block_timestamp,
+            settlement_id=log["args"]["settlementId"],
+        )
+
+
+class OstiumRedemptionRequest(RedemptionRequest):
+    """Wraps Ostium V1.5 ``requestWithdraw(uint256 shares)`` call.
+
+    After broadcasting, parse the transaction to extract the ``settlement_id``
+    from the ``WithdrawRequestedV2`` event.
+    """
+
+    def parse_redeem_transaction(self, tx_hashes: list[HexBytes]) -> OstiumRedemptionTicket:
+        """Parse the ``WithdrawRequestedV2`` event from ``requestWithdraw()`` transaction.
+
+        ``WithdrawRequestedV2(address indexed owner, uint32 indexed settlementId, uint256 shares)``
+        """
+        tx_hash = tx_hashes[-1]
+        assert isinstance(tx_hash, HexBytes)
+
+        receipt = self.vault.web3.eth.get_transaction_receipt(tx_hash)
+        assert receipt is not None, f"Transaction is not yet mined: {tx_hash.hex()}"
+        assert receipt["status"] == 1, f"Transaction reverted: {tx_hash.hex()}"
+
+        logs = self.vault.vault_contract.events.WithdrawRequestedV2().process_receipt(receipt, errors=EventLogErrorFlags.Discard)
+        if len(logs) != 1:
+            raise CannotParseRedemptionTransaction(f"Expected exactly one WithdrawRequestedV2 event, got {len(logs)} at {tx_hash.hex()}")
+
+        log = logs[0]
+
+        return OstiumRedemptionTicket(
+            vault_address=self.vault.address,
+            owner=self.owner,
+            to=self.to,
+            raw_shares=log["args"]["shares"],
+            tx_hash=tx_hash,
+            settlement_id=log["args"]["settlementId"],
+        )
+
+
+class OstiumV15DepositManager(ERC4626DepositManager):
+    """Async deposit/redemption manager for Ostium V1.5 settlement-based flow.
+
+    V1.5 disables ERC-4626 ``deposit()``, ``mint()``, ``withdraw()``, ``redeem()``
+    and replaces them with:
+
+    - Deposits: ``requestDeposit(assets)`` -> settlement -> ``claimDeposit(settlementId)``
+    - Withdrawals: ``requestWithdraw(shares)`` -> settlement -> ``claimWithdraw(settlementId)``
+
+    Settlement happens daily via ``tryNewSettlement()`` (public, permissionless)
+    once ``maxSettlementInterval`` has elapsed.
+
+    The ``is_deposit_in_progress()`` / ``is_redemption_in_progress()`` methods only
+    check the current ``targetSettlementId``. For checking specific tickets regardless
+    of the current settlement, use ``get_deposit_ticket_status()`` /
+    ``get_redemption_ticket_status()``.
+    """
+
+    def __init__(self, vault: "eth_defi.erc_4626.vault_protocol.gains.vault.OstiumVault"):
+        from eth_defi.erc_4626.vault_protocol.gains.vault import OstiumVault, OstiumVersion
+
+        assert isinstance(vault, OstiumVault), f"Got {type(vault)}"
+        assert vault.version == OstiumVersion.v1_5, f"OstiumV15DepositManager requires V1.5 vault, got {vault.version}"
+        self.vault = vault
+
+    def has_synchronous_deposit(self) -> bool:
+        return False
+
+    def has_synchronous_redemption(self) -> bool:
+        return False
+
+    def create_deposit_request(
+        self,
+        owner: HexAddress,
+        to: HexAddress = None,
+        amount: Decimal = None,
+        raw_amount: int = None,
+        check_max_deposit=True,
+        check_enough_token=True,
+    ) -> OstiumDepositRequest:
+        """Create an async deposit request via ``requestDeposit(assets)``.
+
+        1. USDC is transferred to the vault immediately
+        2. Request is queued for the next settlement
+        3. After settlement, shares can be claimed via ``claimDeposit(settlementId)``
+
+        :param owner:
+            Address depositing USDC.
+
+        :param amount:
+            USDC amount in human-readable decimal.
+
+        :param raw_amount:
+            USDC amount in raw token units.
+        """
+        vault = self.vault
+
+        if not raw_amount:
+            assert vault.denomination_token is not None, "Vault denomination token data missing"
+            raw_amount = vault.denomination_token.convert_to_raw(amount)
+
+        assert type(raw_amount) == int, f"Got {raw_amount} {type(raw_amount)}"
+        assert to is None or to == owner, f"Ostium V1.5 requestDeposit() acts on msg.sender only, cannot specify a different receiver (to={to}, owner={owner})"
+
+        func = vault.vault_contract.functions.requestDeposit(raw_amount)
+
+        return OstiumDepositRequest(
+            vault=vault,
+            owner=owner,
+            to=owner,
+            funcs=[func],
+            amount=amount,
+            raw_amount=raw_amount,
+        )
+
+    def create_redemption_request(
+        self,
+        owner: HexAddress,
+        to: HexAddress = None,
+        shares: Decimal = None,
+        raw_shares: int = None,
+        check_max_deposit=True,
+        check_enough_token=True,
+    ) -> OstiumRedemptionRequest:
+        """Create an async withdrawal request via ``requestWithdraw(shares)``.
+
+        1. OLP shares are transferred to the vault immediately
+        2. Request is queued for settlement
+        3. After settlement, USDC can be claimed via ``claimWithdraw(settlementId)``
+
+        :param owner:
+            Address withdrawing shares.
+
+        :param shares:
+            Share amount in human-readable decimal.
+
+        :param raw_shares:
+            Share amount in raw token units.
+        """
+        assert raw_shares or shares
+        vault = self.vault
+
+        if not raw_shares:
+            raw_amount = vault.share_token.convert_to_raw(shares)
+        else:
+            raw_amount = raw_shares
+
+        assert type(raw_amount) == int, f"Got {raw_amount} {type(raw_amount)}"
+
+        share_token = vault.share_token
+        human_amount = share_token.convert_to_decimals(raw_amount)
+
+        assert to is None or to == owner, f"Ostium V1.5 requestWithdraw() acts on msg.sender only, cannot specify a different receiver (to={to}, owner={owner})"
+
+        logger.info("Setting up V1.5 withdrawal request for %s %s shares, for %s", human_amount, share_token.symbol, owner)
+
+        func = vault.vault_contract.functions.requestWithdraw(raw_amount)
+
+        return OstiumRedemptionRequest(
+            vault=vault,
+            owner=owner,
+            to=owner,
+            shares=human_amount,
+            raw_shares=raw_amount,
+            funcs=[func],
+        )
+
+    def can_finish_deposit(self, deposit_ticket: OstiumDepositTicket) -> bool:
+        """Check if a deposit can be claimed after settlement.
+
+        :raises OstiumSettlementFailed:
+            If the settlement resulted in RECLAIMABLE status.
+            Call ``reclaim_deposit()`` to recover funds.
+        """
+        assert isinstance(deposit_ticket, OstiumDepositTicket)
+        status = self.vault.vault_contract.functions.getDepositStatus(deposit_ticket.owner, deposit_ticket.settlement_id).call()
+        if status == OSTIUM_REQUEST_STATUS_RECLAIMABLE:
+            raise OstiumSettlementFailed(f"Deposit settlement {deposit_ticket.settlement_id} failed for {deposit_ticket.owner}. Call reclaimDeposit({deposit_ticket.settlement_id}) to recover funds.")
+        return status == OSTIUM_REQUEST_STATUS_CLAIMABLE
+
+    def can_finish_redeem(self, redemption_ticket: OstiumRedemptionTicket) -> bool:
+        """Check if a withdrawal can be claimed after settlement.
+
+        :raises OstiumSettlementFailed:
+            If the settlement resulted in RECLAIMABLE status.
+            Call ``reclaim_withdrawal()`` to recover shares.
+        """
+        assert isinstance(redemption_ticket, OstiumRedemptionTicket)
+        status = self.vault.vault_contract.functions.getWithdrawStatus(redemption_ticket.owner, redemption_ticket.settlement_id).call()
+        if status == OSTIUM_REQUEST_STATUS_RECLAIMABLE:
+            raise OstiumSettlementFailed(f"Withdrawal settlement {redemption_ticket.settlement_id} failed for {redemption_ticket.owner}. Call reclaimWithdraw({redemption_ticket.settlement_id}) to recover shares.")
+        return status == OSTIUM_REQUEST_STATUS_CLAIMABLE
+
+    def finish_deposit(self, deposit_ticket: OstiumDepositTicket) -> ContractFunction:
+        """Return ``claimDeposit(settlementId)`` bound function."""
+        assert isinstance(deposit_ticket, OstiumDepositTicket)
+        return self.vault.vault_contract.functions.claimDeposit(deposit_ticket.settlement_id)
+
+    def finish_redemption(self, redemption_ticket: OstiumRedemptionTicket) -> ContractFunction:
+        """Return ``claimWithdraw(settlementId)`` bound function."""
+        assert isinstance(redemption_ticket, OstiumRedemptionTicket)
+        return self.vault.vault_contract.functions.claimWithdraw(redemption_ticket.settlement_id)
+
+    def can_create_deposit_request(self, owner: HexAddress) -> bool:
+        """V1.5 deposits are always accepted (caps enforced at settlement, not request)."""
+        return True
+
+    def can_create_redemption_request(self, owner: HexAddress) -> bool:
+        """V1.5 withdrawals can be requested any time (no epoch window restriction)."""
+        return True
+
+    def is_deposit_in_progress(self, owner: HexAddress) -> bool:
+        """Check if owner has a pending deposit for the current target settlement.
+
+        Only checks the current ``targetSettlementId(true)``. For checking a specific
+        ticket's settlement, use ``get_deposit_ticket_status()``.
+        """
+        vault = self.vault
+        target_id = vault.vault_contract.functions.targetSettlementId(True).call()
+        status = vault.vault_contract.functions.getDepositStatus(owner, target_id).call()
+        return status == OSTIUM_REQUEST_STATUS_PENDING
+
+    def is_redemption_in_progress(self, owner: HexAddress) -> bool:
+        """Check if owner has a pending withdrawal for the current target settlement.
+
+        Only checks the current ``targetSettlementId(false)``. For checking a specific
+        ticket's settlement, use ``get_redemption_ticket_status()``.
+        """
+        vault = self.vault
+        target_id = vault.vault_contract.functions.targetSettlementId(False).call()
+        status = vault.vault_contract.functions.getWithdrawStatus(owner, target_id).call()
+        return status == OSTIUM_REQUEST_STATUS_PENDING
+
+    def estimate_redemption_delay(self) -> datetime.timedelta:
+        """Estimate how long until a withdrawal request can be claimed.
+
+        Uses ``(targetSettlementId(false) - lastSettlementId) * maxSettlementInterval``
+        to account for ``withdrawSettlementDelay``.
+        """
+        vault = self.vault
+        target_id = vault.vault_contract.functions.targetSettlementId(False).call()
+        last_id = vault.vault_contract.functions.lastSettlementId().call()
+        interval = vault.vault_contract.functions.maxSettlementInterval().call()
+        settlements_to_wait = max(target_id - last_id, 1)
+        return datetime.timedelta(seconds=settlements_to_wait * interval)
+
+    def get_redemption_delay_over(self, address: HexAddress | str) -> datetime.datetime:
+        """Estimate when the next withdrawal settlement will occur."""
+        vault = self.vault
+        target_id = vault.vault_contract.functions.targetSettlementId(False).call()
+        last_id = vault.vault_contract.functions.lastSettlementId().call()
+        last_ts = vault.vault_contract.functions.lastSettlementTs().call()
+        interval = vault.vault_contract.functions.maxSettlementInterval().call()
+        settlements_to_wait = max(target_id - last_id, 1)
+        return from_unix_timestamp(last_ts + settlements_to_wait * interval)
+
+    def analyse_deposit(
+        self,
+        claim_tx_hash: HexBytes | str,
+        deposit_ticket: DepositTicket | None,
+    ) -> DepositRedeemEventAnalysis | DepositRedeemEventFailure:
+        """Analyse a ``claimDeposit()`` transaction.
+
+        Parses ``DepositClaimedV2(address indexed owner, uint32 indexed settlementId, uint256 shares)``
+        and uses the settlement price for accurate denomination amount calculation.
+        """
+        assert isinstance(deposit_ticket, OstiumDepositTicket), f"Ostium V1.5 analyse_deposit requires OstiumDepositTicket, got {type(deposit_ticket)}"
+        vault = self.vault
+        receipt = vault.web3.eth.get_transaction_receipt(claim_tx_hash)
+
+        if receipt["status"] != 1:
+            return DepositRedeemEventFailure(tx_hash=HexBytes(claim_tx_hash), revert_reason="Transaction reverted")
+
+        logs = vault.vault_contract.events.DepositClaimedV2().process_receipt(receipt, errors=EventLogErrorFlags.Discard)
+        logs = [log for log in logs if log["address"].lower() == vault.vault_address.lower()]
+
+        if len(logs) != 1:
+            return DepositRedeemEventFailure(tx_hash=HexBytes(claim_tx_hash), revert_reason=f"Expected 1 DepositClaimedV2 event, got {len(logs)}")
+
+        log = logs[0]
+        raw_shares = log["args"]["shares"]
+        settlement_id = log["args"]["settlementId"]
+
+        # Use settlement price for accurate denomination amount
+        settlement_price = vault.vault_contract.functions.settlementShareToAssetsPrice(settlement_id).call()
+        raw_assets = vault.vault_contract.functions.convertToAssetsWithPrice(raw_shares, settlement_price).call()
+
+        # Log partial refunds if the deposit was capped/scaled at settlement
+        refund_logs = vault.vault_contract.events.DepositPartiallyRefunded().process_receipt(receipt, errors=EventLogErrorFlags.Discard)
+        refund_logs = [log for log in refund_logs if log["address"].lower() == vault.vault_address.lower()]
+        if refund_logs:
+            refunded_assets = refund_logs[0]["args"]["refundedAssets"]
+            logger.info(
+                "Deposit partially refunded: %s raw assets returned to %s at settlement %d",
+                refunded_assets,
+                deposit_ticket.owner if deposit_ticket else "unknown",
+                settlement_id,
+            )
+
+        share_count = vault.share_token.convert_to_decimals(raw_shares)
+        denomination_amount = vault.denomination_token.convert_to_decimals(raw_assets)
+
+        tx = vault.web3.eth.get_transaction(claim_tx_hash)
+        block_number = tx["blockNumber"]
+        block_timestamp = get_block_timestamp(vault.web3, block_number)
+
+        return DepositRedeemEventAnalysis(
+            from_=deposit_ticket.owner,
+            to=deposit_ticket.to,
+            tx_hash=HexBytes(claim_tx_hash),
+            block_number=block_number,
+            block_timestamp=block_timestamp,
+            share_count=share_count,
+            denomination_amount=denomination_amount,
+        )
+
+    def analyse_redemption(
+        self,
+        claim_tx_hash: HexBytes | str,
+        redemption_ticket: RedemptionTicket | None,
+    ) -> DepositRedeemEventAnalysis | DepositRedeemEventFailure:
+        """Analyse a ``claimWithdraw()`` transaction.
+
+        Parses ``WithdrawClaimedV2(address indexed owner, uint32 indexed settlementId, uint256 assets)``
+        and uses the settlement price for accurate share price reconstruction.
+        """
+        assert isinstance(redemption_ticket, OstiumRedemptionTicket), f"Ostium V1.5 analyse_redemption requires OstiumRedemptionTicket, got {type(redemption_ticket)}"
+        vault = self.vault
+        receipt = vault.web3.eth.get_transaction_receipt(claim_tx_hash)
+
+        if receipt["status"] != 1:
+            return DepositRedeemEventFailure(tx_hash=HexBytes(claim_tx_hash), revert_reason="Transaction reverted")
+
+        logs = vault.vault_contract.events.WithdrawClaimedV2().process_receipt(receipt, errors=EventLogErrorFlags.Discard)
+        logs = [log for log in logs if log["address"].lower() == vault.vault_address.lower()]
+
+        if len(logs) != 1:
+            return DepositRedeemEventFailure(tx_hash=HexBytes(claim_tx_hash), revert_reason=f"Expected 1 WithdrawClaimedV2 event, got {len(logs)}")
+
+        log = logs[0]
+        raw_assets = log["args"]["assets"]
+
+        denomination_amount = vault.denomination_token.convert_to_decimals(raw_assets)
+        share_count = vault.share_token.convert_to_decimals(redemption_ticket.raw_shares)
+
+        tx = vault.web3.eth.get_transaction(claim_tx_hash)
+        block_number = tx["blockNumber"]
+        block_timestamp = get_block_timestamp(vault.web3, block_number)
+
+        return DepositRedeemEventAnalysis(
+            from_=redemption_ticket.owner,
+            to=redemption_ticket.to,
+            tx_hash=HexBytes(claim_tx_hash),
+            block_number=block_number,
+            block_timestamp=block_timestamp,
+            share_count=share_count,
+            denomination_amount=denomination_amount,
+        )
+
+    # --- Ticket-based status helpers ---
+
+    def get_deposit_ticket_status(self, ticket: OstiumDepositTicket) -> int:
+        """Query deposit status for a specific ticket's settlement ID.
+
+        :return:
+            One of ``OSTIUM_REQUEST_STATUS_*`` constants:
+            NONE(0), PENDING(1), CLAIMABLE(2), RECLAIMABLE(3)
+        """
+        return self.vault.vault_contract.functions.getDepositStatus(ticket.owner, ticket.settlement_id).call()
+
+    def get_redemption_ticket_status(self, ticket: OstiumRedemptionTicket) -> int:
+        """Query withdrawal status for a specific ticket's settlement ID.
+
+        :return:
+            One of ``OSTIUM_REQUEST_STATUS_*`` constants:
+            NONE(0), PENDING(1), CLAIMABLE(2), RECLAIMABLE(3)
+        """
+        return self.vault.vault_contract.functions.getWithdrawStatus(ticket.owner, ticket.settlement_id).call()
+
+    # --- Reclaim/cancel convenience methods ---
+
+    def reclaim_deposit(self, ticket: OstiumDepositTicket) -> ContractFunction:
+        """Return ``reclaimDeposit(settlementId)`` to recover funds after a failed settlement."""
+        return self.vault.vault_contract.functions.reclaimDeposit(ticket.settlement_id)
+
+    def reclaim_withdrawal(self, ticket: OstiumRedemptionTicket) -> ContractFunction:
+        """Return ``reclaimWithdraw(settlementId)`` to recover shares after a failed settlement."""
+        return self.vault.vault_contract.functions.reclaimWithdraw(ticket.settlement_id)
+
+    def cancel_deposit(self, ticket: OstiumDepositTicket, raw_assets: int) -> ContractFunction:
+        """Return ``cancelRequestDeposit(settlementId, assets)`` to cancel a pending deposit."""
+        return self.vault.vault_contract.functions.cancelRequestDeposit(ticket.settlement_id, raw_assets)
+
+    def cancel_withdrawal(self, ticket: OstiumRedemptionTicket, raw_shares: int) -> ContractFunction:
+        """Return ``cancelRequestWithdraw(settlementId, shares)`` to cancel a pending withdrawal."""
+        return self.vault.vault_contract.functions.cancelRequestWithdraw(ticket.settlement_id, raw_shares)

--- a/eth_defi/erc_4626/vault_protocol/gains/testing.py
+++ b/eth_defi/erc_4626/vault_protocol/gains/testing.py
@@ -62,3 +62,62 @@ def force_next_gains_epoch(
 
     tx_hash = vault.open_pnl_contract.functions.forceNewEpoch().transact({"from": any_account, "gas": gas_limit})
     assert_transaction_success_with_explanation(web3, tx_hash)
+
+
+def force_ostium_v15_settlement(
+    vault: "eth_defi.erc_4626.vault_protocol.gains.vault.OstiumVault",
+    any_account: HexAddress,
+    padding_seconds: int = 1,
+    gas_limit: int = 3_000_000,
+):
+    """Force a settlement on Ostium V1.5 by advancing Anvil time and calling ``tryNewSettlement()``.
+
+    ``tryNewSettlement()`` is public and permissionless — it executes when
+    ``block.timestamp >= lastSettlementTs + maxSettlementInterval``.
+
+    :param vault:
+        Ostium V1.5 vault instance.
+
+    :param any_account:
+        Any account to pay gas for the transaction.
+
+    :param padding_seconds:
+        Extra seconds past the settlement threshold.
+    """
+    from eth_defi.erc_4626.vault_protocol.gains.vault import OstiumVault, OstiumVersion
+
+    assert isinstance(vault, OstiumVault), f"Expected OstiumVault, got {type(vault)}"
+    assert vault.version == OstiumVersion.v1_5, f"Expected V1.5 vault, got {vault.version}"
+
+    web3 = vault.web3
+    contract = vault.vault_contract
+
+    last_settlement_ts = contract.functions.lastSettlementTs().call()
+    max_interval = contract.functions.maxSettlementInterval().call()
+    last_settlement_id = contract.functions.lastSettlementId().call()
+
+    target_ts = last_settlement_ts + max_interval + padding_seconds
+
+    # Ensure we advance past current block time
+    current_block_time = web3.eth.get_block("latest")["timestamp"]
+    if current_block_time >= target_ts:
+        target_ts = current_block_time + 1
+
+    logger.info(
+        "Forcing V1.5 settlement: lastSettlementId=%d, lastSettlementTs=%s, maxInterval=%ds, advancing to %s",
+        last_settlement_id,
+        from_unix_timestamp(last_settlement_ts),
+        max_interval,
+        from_unix_timestamp(target_ts),
+    )
+
+    mine(
+        web3,
+        timestamp=target_ts,
+    )
+
+    tx_hash = contract.functions.tryNewSettlement().transact({"from": any_account, "gas": gas_limit})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+
+    new_settlement_id = contract.functions.lastSettlementId().call()
+    logger.info("Settlement completed: lastSettlementId %d -> %d", last_settlement_id, new_settlement_id)

--- a/eth_defi/erc_4626/vault_protocol/gains/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/gains/vault.py
@@ -213,7 +213,7 @@ class OstiumV15HistoricalReader(ERC4626HistoricalReader):
             performance_fee=None,
             management_fee=None,
             errors=errors or None,
-            max_deposit=max_deposit,
+            max_deposit=None,  # V1.5 maxDeposit() returns max uint (ERC-4626 spec violation)
             deposits_open=True,
             redemption_open=True,
         )

--- a/eth_defi/erc_4626/vault_protocol/gains/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/gains/vault.py
@@ -20,10 +20,12 @@ Notes:
 """
 
 import datetime
+import enum
 import logging
 from functools import cached_property
 from typing import Iterable
 
+import eth_abi
 from web3 import Web3
 from web3.contract.contract import Contract
 from web3.exceptions import BadFunctionCallOutput, ContractLogicError
@@ -48,6 +50,20 @@ from eth_typing import BlockIdentifier
 from eth_defi.vault.risk import VaultTechnicalRisk
 
 logger = logging.getLogger(__name__)
+
+
+class OstiumVersion(enum.Enum):
+    """Ostium vault implementation version.
+
+    - V1: legacy epoch-based deposit/withdrawal (synchronous ``deposit()``, ``makeWithdrawRequest()``/``redeem()``)
+    - V1.5: async settlement-based flow (``requestDeposit()``/``claimDeposit()``, ``requestWithdraw()``/``claimWithdraw()``)
+    """
+
+    #: Legacy epoch-based deposit and withdrawal
+    v1 = "v1"
+
+    #: Settlement-based async deposit and withdrawal (upgraded 2026-04-28)
+    v1_5 = "v1_5"
 
 
 class GainsHistoricalReader(ERC4626HistoricalReader):
@@ -163,6 +179,43 @@ class GainsHistoricalReader(ERC4626HistoricalReader):
             max_deposit=max_deposit,
             deposits_open=deposits_open,
             redemption_open=redemption_open,
+        )
+
+
+class OstiumV15HistoricalReader(ERC4626HistoricalReader):
+    """Read Ostium V1.5 vault data using only core ERC-4626 multicalls.
+
+    V1.5 deprecates ``currentMaxSupply()`` and ``nextEpochValuesRequestCount()``,
+    so the Gains-specific epoch calls are skipped. In V1.5, ``requestDeposit()``
+    and ``requestWithdraw()`` are always available (caps enforced at settlement),
+    so both deposits and redemptions are reported as open.
+    """
+
+    def construct_multicalls(self) -> Iterable[EncodedCall]:
+        yield from self.construct_core_erc_4626_multicall()
+
+    def process_result(
+        self,
+        block_number: int,
+        timestamp: datetime.datetime,
+        call_results: list[EncodedCallResult],
+    ) -> VaultHistoricalRead:
+        call_by_name = self.dictify_multicall_results(block_number, call_results)
+        share_price, total_supply, total_assets, errors, max_deposit = self.process_core_erc_4626_result(call_by_name)
+
+        return VaultHistoricalRead(
+            vault=self.vault,
+            block_number=block_number,
+            timestamp=timestamp,
+            share_price=share_price,
+            total_assets=total_assets,
+            total_supply=total_supply,
+            performance_fee=None,
+            management_fee=None,
+            errors=errors or None,
+            max_deposit=max_deposit,
+            deposits_open=True,
+            redemption_open=True,
         )
 
 
@@ -518,8 +571,12 @@ class DominationFinanceVault(GainsVault):
 class OstiumVault(GainsVault):
     """Ostium vault is a Gains-like vault.
 
-    - OstiumVault.sol https://github.com/0xOstium/smart-contracts-public/blob/da3b944623bef814285b7f418d43e6a95f4ad4b1/src/OstiumVault.sol#L243
-    - OstiumVault on Arbitrum
+    Supports both V1 (legacy epoch-based) and V1.5 (async settlement-based) versions.
+    Version is auto-detected by probing ``targetSettlementId(bool)`` which only exists in V1.5.
+
+    - `OstiumVault V1.5 source <https://github.com/0xOstium/smart-contracts-public/blob/main/src/OstiumVault.sol>`__
+    - `OstiumVault V1 source <https://github.com/0xOstium/smart-contracts-public/blob/da3b944623bef814285b7f418d43e6a95f4ad4b1/src/OstiumVault.sol#L243>`__
+    - OstiumVault on Arbitrum https://arbiscan.io/address/0x20d419a8e12c45f88fda7c5760bb6923cee27f98
     - OstiumOpenPnl https://arbiscan.io/address/0xe607ac9ff58697c5978afa1fc1c5c437a6d1858c
 
     What Ostium says:
@@ -529,15 +586,46 @@ class OstiumVault(GainsVault):
 
     @property
     def name(self) -> str:
-        return f"Ostium Liquidity Pool Vault"
+        return "Ostium Liquidity Pool Vault"
+
+    @cached_property
+    def version(self) -> OstiumVersion:
+        """Detect Ostium vault implementation version.
+
+        Probes ``targetSettlementId(bool)`` which only exists in V1.5.
+        Uses raw keccak call to avoid ABI dependency (since ABI selection depends on version).
+
+        Respects ``default_block_identifier`` so that archive-backed instances
+        created at a pre-upgrade block correctly detect V1.
+        """
+        target_settlement_call = EncodedCall.from_keccak_signature(
+            address=self.address,
+            signature=Web3.keccak(text="targetSettlementId(bool)")[0:4],
+            function="targetSettlementId",
+            data=eth_abi.encode(["bool"], [True]),
+            extra_data=None,
+        )
+
+        try:
+            target_settlement_call.call(
+                web3=self.web3,
+                block_identifier=self._get_block_identifier(),
+            )
+            return OstiumVersion.v1_5
+        except (ValueError, BadFunctionCallOutput):
+            return OstiumVersion.v1
 
     @cached_property
     def vault_contract(self) -> Contract:
-        """Get vault deployment."""
+        """Get vault deployment with version-appropriate ABI."""
+        if self.version == OstiumVersion.v1_5:
+            abi_fname = "gains/OstiumVaultV1_5.json"
+        else:
+            abi_fname = "gains/OstiumVault.json"
         return get_deployed_erc_4626_contract(
             self.web3,
             self.spec.vault_address,
-            abi_fname="gains/OstiumVault.json",
+            abi_fname=abi_fname,
         )
 
     @cached_property
@@ -545,12 +633,11 @@ class OstiumVault(GainsVault):
         """Get Ostium registry contract.
 
         - https://github.com/0xOstium/smart-contracts-public/blob/da3b944623bef814285b7f418d43e6a95f4ad4b1/src/OstiumRegistry.sol
-        -
         """
 
-        # OstiumVault has `registry()` call to get the registry address
+        # Use self.address (not self.vault_contract.address) to avoid ABI-loading dependency
         registry_call = EncodedCall.from_keccak_signature(
-            address=self.vault_contract.address,
+            address=self.address,
             signature=Web3.keccak(text="registry()")[0:4],
             function="registry",
             data=b"",
@@ -577,7 +664,7 @@ class OstiumVault(GainsVault):
     def open_pnl_contract(self) -> Contract:
         """Get OpenPNL contract.
 
-        - Needed for epoch calls
+        - Needed for epoch calls (V1 only)
         """
 
         ostium_registry = self.ostium_registry
@@ -590,7 +677,54 @@ class OstiumVault(GainsVault):
                 open_pnl_address,
             )
 
-        raise NotImplementedError(f"Does not know this Gains-like vault structure")
+        raise NotImplementedError("Does not know this Gains-like vault structure")
+
+    def get_deposit_manager(self):
+        """Return version-appropriate deposit manager."""
+        if self.version == OstiumVersion.v1_5:
+            from eth_defi.erc_4626.vault_protocol.gains.deposit_redeem import OstiumV15DepositManager
+
+            return OstiumV15DepositManager(self)
+
+        from eth_defi.erc_4626.vault_protocol.gains.deposit_redeem import GainsDepositManager
+
+        return GainsDepositManager(self)
+
+    def get_historical_reader(self, stateful) -> VaultHistoricalReader:
+        """Return version-appropriate historical reader."""
+        if self.version == OstiumVersion.v1_5:
+            return OstiumV15HistoricalReader(self, stateful)
+        return GainsHistoricalReader(self, stateful)
+
+    def fetch_deposit_closed_reason(self) -> str | None:
+        """Check if deposits are closed.
+
+        V1.5: ``deposit()`` always reverts with ``FunctionDisabled``, but deposits
+        are open via ``requestDeposit()``. The ``FunctionDisabled`` revert is expected
+        and should not be reported as closed.
+
+        V1: checks ``maxDeposit()`` and probes ``deposit()`` for ``FunctionDisabled``.
+        """
+        if self.version == OstiumVersion.v1_5:
+            # V1.5: deposits are always available via requestDeposit()
+            # maxDeposit() returns max uint (ERC-4626 spec violation) so no cap check
+            return None
+
+        return super().fetch_deposit_closed_reason()
+
+    def fetch_redemption_closed_reason(self) -> str | None:
+        """Check if redemptions are closed.
+
+        V1.5: ``requestWithdraw()`` can be called any time (settlement is separate).
+        The epoch-based ``nextEpochValuesRequestCount`` check no longer applies.
+
+        V1: epoch-based check via ``nextEpochValuesRequestCount``.
+        """
+        if self.version == OstiumVersion.v1_5:
+            # V1.5: requestWithdraw() is always available
+            return None
+
+        return super().fetch_redemption_closed_reason()
 
     @property
     def short_description(self) -> str | None:
@@ -598,4 +732,6 @@ class OstiumVault(GainsVault):
 
     @property
     def description(self) -> str | None:
+        if self.version == OstiumVersion.v1_5:
+            return "Users deposit USDC to mint OLP tokens via an async settlement flow. Deposits are queued via requestDeposit() and settled daily, after which shares can be claimed. Withdrawals follow the same pattern via requestWithdraw()/claimWithdraw(). Returns come from trading fees and trader PnL exposure. See [Ostium docs](https://docs.ostium.com) for details."
         return "Users deposit USDC to mint OLP tokens, representing a stake in a fund that generates returns through trading fees and trader PnL exposure. The vault operates on an epoch-based system (currently 3-day cycles) with two states: when undercollateralised (c-ratio < 100%), OLP holders act as direct counterparties to traders with higher fee capture but more volatility; when overcollateralised (c-ratio >= 100%), a buffer absorbs trader PnL first, insulating OLP from volatility. Fees include 30% of opening fees (continuous) and 100% of rollover/liquidation fees (end-of-epoch). Withdrawals require a request during the first 48 hours of an epoch, followed by a cool-off period before USDC redemption. See [Ostium vault documentation](https://ostium-labs.gitbook.io/ostium-docs/vault/overview) for more details."

--- a/tests/gains/test_ostium_v15.py
+++ b/tests/gains/test_ostium_v15.py
@@ -1,0 +1,313 @@
+"""Ostium vault V1.5 async deposit/withdraw tests.
+
+Tests the settlement-based async flow introduced in the V1.5 upgrade
+(Arbitrum block 457,238,658). Uses a post-upgrade fork block.
+"""
+
+import datetime
+import logging
+import os
+from decimal import Decimal
+
+import pytest
+
+from web3 import Web3
+
+from eth_defi.erc_4626.classification import create_vault_instance_autodetect, detect_vault_features
+from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.erc_4626.vault_protocol.gains.deposit_redeem import (
+    OstiumDepositRequest,
+    OstiumDepositTicket,
+    OstiumRedemptionRequest,
+    OstiumRedemptionTicket,
+    OstiumV15DepositManager,
+    OSTIUM_REQUEST_STATUS_CLAIMABLE,
+    OSTIUM_REQUEST_STATUS_PENDING,
+)
+from eth_defi.erc_4626.vault_protocol.gains.testing import force_ostium_v15_settlement
+from eth_defi.erc_4626.vault_protocol.gains.vault import (
+    OstiumV15HistoricalReader,
+    OstiumVault,
+    OstiumVersion,
+)
+from eth_defi.provider.anvil import fork_network_anvil, AnvilLaunch
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.token import TokenDetails, fetch_erc20_details, USDC_NATIVE_TOKEN, USDC_WHALE
+from eth_defi.trace import assert_transaction_success_with_explanation
+
+
+JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
+CI = os.environ.get("CI") == "true"
+pytestmark = pytest.mark.skipif(not JSON_RPC_ARBITRUM, reason="Set JSON_RPC_ARBITRUM to run this test")
+
+#: Post-upgrade fork block (V1.5 was deployed at block 457,238,658)
+FORK_BLOCK = 470_000_000
+
+
+@pytest.fixture(scope="module")
+def anvil_arbitrum_fork(request) -> AnvilLaunch:
+    launch = fork_network_anvil(JSON_RPC_ARBITRUM, fork_block_number=FORK_BLOCK)
+    try:
+        yield launch
+    finally:
+        launch.close()
+
+
+@pytest.fixture(scope="module")
+def web3(anvil_arbitrum_fork):
+    web3 = create_multi_provider_web3(anvil_arbitrum_fork.json_rpc_url)
+    return web3
+
+
+@pytest.fixture()
+def anvil_arbitrum_fork_write(request) -> AnvilLaunch:
+    """Fresh fork for each write test."""
+    usdc_whale = USDC_WHALE[42161]
+    launch = fork_network_anvil(
+        JSON_RPC_ARBITRUM,
+        fork_block_number=FORK_BLOCK,
+        unlocked_addresses=[usdc_whale],
+    )
+    try:
+        yield launch
+    finally:
+        launch.close(log_level=logging.ERROR)
+
+
+@pytest.fixture()
+def web3_write(anvil_arbitrum_fork_write):
+    web3 = create_multi_provider_web3(anvil_arbitrum_fork_write.json_rpc_url, retries=1)
+    return web3
+
+
+@pytest.fixture()
+def usdc(web3_write) -> TokenDetails:
+    web3 = web3_write
+    return fetch_erc20_details(web3, USDC_NATIVE_TOKEN[42161])
+
+
+@pytest.fixture()
+def test_user(web3_write, usdc):
+    web3 = web3_write
+    account = web3.eth.accounts[0]
+    tx_hash = usdc.transfer(account, Decimal(10_000)).transact({"from": USDC_WHALE[42161]})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+    assert web3.eth.get_balance(account) > 10**18
+    return account
+
+
+@pytest.fixture(scope="module")
+def vault(web3) -> OstiumVault:
+    """Ostium LP vault on Arbitrum at post-upgrade block."""
+    vault_address = "0x20d419a8e12c45f88fda7c5760bb6923cee27f98"
+    vault = create_vault_instance_autodetect(web3, vault_address)
+    assert isinstance(vault, OstiumVault)
+    return vault
+
+
+def test_ostium_v15_version_detection(web3):
+    """Verify version detection returns V1.5 at post-upgrade block.
+
+    1. Create vault instance via autodetect
+    2. Assert version is V1.5
+    3. Assert correct ABI is loaded
+    """
+    vault_address = "0x20d419a8e12c45f88fda7c5760bb6923cee27f98"
+    vault = create_vault_instance_autodetect(web3, vault_address)
+    assert isinstance(vault, OstiumVault)
+    assert vault.version == OstiumVersion.v1_5
+
+
+def test_ostium_v15_features(web3):
+    """Verify feature detection still works at post-upgrade block.
+
+    1. Detect vault features
+    2. Assert ostium_like feature present
+    """
+    vault_address = "0x20d419a8e12c45f88fda7c5760bb6923cee27f98"
+    features = detect_vault_features(web3, vault_address, verbose=True)
+    assert ERC4626Feature.ostium_like in features, f"Got features: {features}"
+
+
+@pytest.mark.skipif(CI, reason="Skipped on CI due to RPC inconsistencies")
+def test_ostium_v15_read_data(web3, vault: OstiumVault):
+    """Read vault metadata and historical state at V1.5 block.
+
+    1. Verify basic vault properties
+    2. Get historical reader (should be OstiumV15HistoricalReader)
+    3. Run multicalls and process results
+    4. Assert deposits_open and redemption_open are True
+    5. Verify deposit/redemption closed reason methods work
+    """
+    assert vault.name == "Ostium Liquidity Pool Vault"
+    assert vault.version == OstiumVersion.v1_5
+
+    # V1.5 historical reader
+    reader = vault.get_historical_reader(stateful=False)
+    assert isinstance(reader, OstiumV15HistoricalReader)
+
+    block_number = web3.eth.block_number
+    block = web3.eth.get_block(block_number)
+    timestamp = datetime.datetime.fromtimestamp(block["timestamp"], tz=datetime.timezone.utc).replace(tzinfo=None)
+
+    calls = list(reader.construct_multicalls())
+    call_results = [c.call_as_result(web3=web3, block_identifier=block_number) for c in calls]
+    vault_read = reader.process_result(block_number, timestamp, call_results)
+
+    assert vault_read.block_number == block_number
+    assert vault_read.share_price > 0
+    assert vault_read.total_assets > 0
+    assert vault_read.total_supply > 0
+
+    # V1.5: both always open
+    assert vault_read.deposits_open is True
+    assert vault_read.redemption_open is True
+
+    # V1.5: deposit/redemption not closed
+    assert vault.fetch_deposit_closed_reason() is None
+    assert vault.fetch_redemption_closed_reason() is None
+
+    # V1.5 deposit manager
+    deposit_manager = vault.get_deposit_manager()
+    assert isinstance(deposit_manager, OstiumV15DepositManager)
+    assert deposit_manager.has_synchronous_deposit() is False
+    assert deposit_manager.has_synchronous_redemption() is False
+
+
+@pytest.mark.skipif(CI, reason="Skipped on CI due to RPC inconsistencies")
+def test_ostium_v15_async_deposit_withdraw(
+    web3_write: Web3,
+    test_user,
+    usdc: TokenDetails,
+):
+    """Full async deposit -> settlement -> claim -> withdraw -> settlement -> claim cycle.
+
+    1. Approve USDC to vault
+    2. Create deposit request via requestDeposit
+    3. Broadcast and parse DepositRequestedV2 event for settlement_id
+    4. Assert deposit status is PENDING
+    5. Assert is_deposit_in_progress is True
+    6. Force settlement via tryNewSettlement
+    7. Assert deposit status is CLAIMABLE
+    8. Claim deposit and broadcast claimDeposit
+    9. Run analyse_deposit on claim tx
+    10. Verify OLP share balance
+    11. Create redemption request via requestWithdraw
+    12. Broadcast and parse WithdrawRequestedV2 event
+    13. Assert withdrawal status is PENDING
+    14. Force settlement(s) for withdrawal
+    15. Assert withdrawal status is CLAIMABLE
+    16. Claim withdrawal and broadcast claimWithdraw
+    17. Run analyse_redemption on claim tx
+    18. Verify USDC received back
+    """
+    web3 = web3_write
+    vault: OstiumVault = create_vault_instance_autodetect(web3, "0x20d419a8e12c45f88fda7c5760bb6923cee27f98")
+    assert vault.version == OstiumVersion.v1_5
+
+    deposit_manager = vault.get_deposit_manager()
+    assert isinstance(deposit_manager, OstiumV15DepositManager)
+
+    amount = Decimal(100)
+
+    # 1. Approve USDC
+    tx_hash = usdc.approve(vault.address, amount).transact({"from": test_user})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+
+    # 2. Create deposit request
+    deposit_request = deposit_manager.create_deposit_request(test_user, amount=amount)
+    assert isinstance(deposit_request, OstiumDepositRequest)
+
+    # 3. Broadcast requestDeposit
+    tx_hashes = []
+    for func in deposit_request.funcs:
+        tx_hash = func.transact({"from": test_user, "gas": 1_000_000})
+        assert_transaction_success_with_explanation(web3, tx_hash)
+        tx_hashes.append(tx_hash)
+
+    deposit_ticket = deposit_request.parse_deposit_transaction(tx_hashes)
+    assert isinstance(deposit_ticket, OstiumDepositTicket)
+    assert deposit_ticket.settlement_id > 0
+    assert deposit_ticket.owner == test_user
+
+    # 4. Check PENDING status
+    status = deposit_manager.get_deposit_ticket_status(deposit_ticket)
+    assert status == OSTIUM_REQUEST_STATUS_PENDING
+
+    # 5. Check in-progress
+    assert deposit_manager.is_deposit_in_progress(test_user) is True
+
+    # 6. Force settlement
+    force_ostium_v15_settlement(vault, test_user)
+
+    # 7. Check CLAIMABLE status
+    status = deposit_manager.get_deposit_ticket_status(deposit_ticket)
+    assert status == OSTIUM_REQUEST_STATUS_CLAIMABLE
+    assert deposit_manager.can_finish_deposit(deposit_ticket) is True
+
+    # 8. Claim deposit
+    claim_func = deposit_manager.finish_deposit(deposit_ticket)
+    claim_tx_hash = claim_func.transact({"from": test_user, "gas": 1_000_000})
+    assert_transaction_success_with_explanation(web3, claim_tx_hash)
+
+    # 9. Analyse deposit claim
+    analysis = deposit_manager.analyse_deposit(claim_tx_hash, deposit_ticket)
+    assert analysis.share_count > 0
+    assert analysis.denomination_amount > 0
+
+    # 10. Verify OLP shares received
+    share_token = vault.share_token
+    shares = share_token.fetch_balance_of(test_user)
+    assert shares > 0
+
+    # 11. Create redemption request
+    redemption_request = deposit_manager.create_redemption_request(
+        owner=test_user,
+        shares=shares,
+    )
+    assert isinstance(redemption_request, OstiumRedemptionRequest)
+
+    # 12. Broadcast requestWithdraw
+    tx_hashes = []
+    for func in redemption_request.funcs:
+        tx_hash = func.transact({"from": test_user, "gas": 1_000_000})
+        assert_transaction_success_with_explanation(web3, tx_hash)
+        tx_hashes.append(tx_hash)
+
+    redemption_ticket = redemption_request.parse_redeem_transaction(tx_hashes)
+    assert isinstance(redemption_ticket, OstiumRedemptionTicket)
+    assert redemption_ticket.settlement_id > 0
+
+    # 13. Check PENDING status
+    status = deposit_manager.get_redemption_ticket_status(redemption_ticket)
+    assert status == OSTIUM_REQUEST_STATUS_PENDING
+
+    # 14. Force settlement(s) for withdrawal
+    # withdrawSettlementDelay may require multiple settlements
+    withdraw_target = vault.vault_contract.functions.targetSettlementId(False).call()
+    last_id = vault.vault_contract.functions.lastSettlementId().call()
+    settlements_needed = max(withdraw_target - last_id, 1)
+    for _ in range(settlements_needed):
+        force_ostium_v15_settlement(vault, test_user)
+
+    # 15. Check CLAIMABLE status
+    status = deposit_manager.get_redemption_ticket_status(redemption_ticket)
+    assert status == OSTIUM_REQUEST_STATUS_CLAIMABLE
+    assert deposit_manager.can_finish_redeem(redemption_ticket) is True
+
+    # 16. Claim withdrawal
+    claim_func = deposit_manager.finish_redemption(redemption_ticket)
+    claim_tx_hash = claim_func.transact({"from": test_user, "gas": 1_000_000})
+    assert_transaction_success_with_explanation(web3, claim_tx_hash)
+
+    # 17. Analyse redemption claim
+    analysis = deposit_manager.analyse_redemption(claim_tx_hash, redemption_ticket)
+    assert analysis.denomination_amount > 0
+
+    # 18. Verify USDC received and shares gone
+    remaining_shares = share_token.fetch_balance_of(test_user)
+    assert remaining_shares == 0
+
+    usdc_balance = usdc.fetch_balance_of(test_user)
+    # Should get back approximately what we deposited (minus any fees/slippage)
+    assert usdc_balance > Decimal(9_900)  # Started with 10k, deposited 100, should get ~100 back

--- a/tests/gains/test_ostium_v15.py
+++ b/tests/gains/test_ostium_v15.py
@@ -159,9 +159,10 @@ def test_ostium_v15_read_data(web3, vault: OstiumVault):
     assert vault_read.total_assets > 0
     assert vault_read.total_supply > 0
 
-    # V1.5: both always open
+    # V1.5: both always open, max_deposit is None (V1.5 maxDeposit returns max uint)
     assert vault_read.deposits_open is True
     assert vault_read.redemption_open is True
+    assert vault_read.max_deposit is None
 
     # V1.5: deposit/redemption not closed
     assert vault.fetch_deposit_closed_reason() is None


### PR DESCRIPTION
## Why

On 2026-04-28 Ostium upgraded their OLP vault proxy (`0x20D419a8e12C45f88fDA7c5760bb6923Cee27F98`) at Arbitrum block 457,238,658 to V1.5, which disables ERC-4626 `deposit()`/`mint()`/`withdraw()`/`redeem()` (all revert with `FunctionDisabled()`). Deposits and withdrawals now use an async settlement-based request/settle/claim flow. Our existing code could detect the disabled deposit but could not trade Ostium positions on V1.5.

## Lessons learnt

- Ostium V1.5 `maxDeposit()` returns max uint even though `deposit()` reverts — an ERC-4626 spec violation that required version-aware handling in `fetch_deposit_closed_reason()`
- V1.5 deprecates `currentMaxSupply()` (renamed to `__DEPRECATED_currentMaxSupply`), breaking the `GainsHistoricalReader` multicalls. A separate `OstiumV15HistoricalReader` that skips epoch calls was needed.
- `claimDeposit()` / `claimWithdraw()` emit `DepositClaimedV2` / `WithdrawClaimedV2` instead of standard ERC-4626 `Deposit`/`Withdraw` events, requiring custom analysis methods
- Settlement price must be read from `settlementShareToAssetsPrice(settlementId)` — using current `convertToAssets()` would misprice delayed claims
- `tryNewSettlement()` is public and permissionless, making test settlement forcing straightforward (no governance unlock needed)
- `requestDeposit()`/`requestWithdraw()`/`claimDeposit()`/`claimWithdraw()` all act on `msg.sender` only — the `to` parameter is not supported

## Summary

- **Version detection**: `OstiumVersion` enum (`v1`, `v1_5`) with auto-detection via `targetSettlementId(bool)` probe using `_get_block_identifier()` for archive compatibility
- **ABI**: `OstiumVaultV1_5.json` (205 entries) extracted from Arbiscan, loaded when V1.5 detected
- **Deposit manager**: `OstiumV15DepositManager` with `requestDeposit`/`claimDeposit` and `requestWithdraw`/`claimWithdraw` flows, settlement-price-based trade analysis, RECLAIMABLE error handling, ticket-based status helpers, reclaim/cancel convenience methods
- **Historical reader**: `OstiumV15HistoricalReader` skips deprecated `currentMaxSupply()` and `nextEpochValuesRequestCount()` calls, reports deposits/redemptions as always open
- **Test helper**: `force_ostium_v15_settlement()` using public `tryNewSettlement()` after Anvil time advance
- **Tests**: 4 new V1.5 tests at post-upgrade fork block (version detection, features, read data, full async deposit→settle→claim→withdraw→settle→claim cycle). All 13 Gains/Ostium tests pass (V1 + V1.5 + gTrade + Domination Finance).

### Files changed

| File | Change |
|------|--------|
| `eth_defi/abi/gains/OstiumVaultV1_5.json` | New V1.5 ABI |
| `eth_defi/erc_4626/vault_protocol/gains/vault.py` | `OstiumVersion`, version detection, `OstiumV15HistoricalReader`, vault overrides |
| `eth_defi/erc_4626/vault_protocol/gains/deposit_redeem.py` | `OstiumV15DepositManager` and supporting data classes |
| `eth_defi/erc_4626/vault_protocol/gains/testing.py` | `force_ostium_v15_settlement()` |
| `tests/gains/test_ostium_v15.py` | V1.5 integration tests |
| `CHANGELOG.md` | Changelog entry |