### PR TITLE
fix: Add backoff delay between multicall retries for eRPC consensus failures

### DIFF
--- a/eth_defi/event_reader/multicall_batcher.py
+++ b/eth_defi/event_reader/multicall_batcher.py
@@ -1223,7 +1223,13 @@ class MultiprocessMulticallReader:
                         logger.warning("Received HTTP 429: sleeping %f, cause %s", self.too_many_requets_sleep, cause)
                         time.sleep(self.too_many_requets_sleep)
                     else:
-                        logger.warning("Received no-throttle status %s: %s, cause: %s, multicall target addresses: %s...", status_code, pformat(headers), cause, multicall_addresses[0:12])
+                        # Sleep between retries to give RPC nodes time to converge.
+                        # Without this delay, all retries fire within milliseconds and
+                        # transient issues like eRPC consensus failures
+                        # ("not enough agreement among responses") never resolve.
+                        retry_sleep = 2.0 * (i + 1)
+                        logger.warning("Received no-throttle status %s, sleeping %f seconds: %s, cause: %s, multicall target addresses: %s...", status_code, retry_sleep, pformat(headers), cause, multicall_addresses[0:12])
+                        time.sleep(retry_sleep)
 
                     fallback_provider.switch_provider(
                         log_level=logging.WARNING,


### PR DESCRIPTION
## Why

The Hyperliquid vault scanner was consistently failing with:

```
Out of multicall retries, even after dropping multicall batch size to 1 and switching providers, bailing out.
```

The underlying error was `{'code': -32603, 'message': 'not enough agreement among responses'}` — an eRPC consensus failure where upstream HyperEVM nodes disagreed on the multicall result at a recent block.

The error was already correctly classified as retryable (`WTF_RETRY_EXCEPTIONS_MESSAGE_CLUES`), and the retry loop switched providers and reduced batch sizes. However, for non-429 errors there was **no delay between retries** — all 5 attempts fired within milliseconds, before the upstream nodes had time to converge on the same state.

Confirmed by replaying the exact `curl` command from the error log ~30 minutes later — it succeeded, proving the error is transient and just needs time to resolve.

## Lessons learnt

- eRPC consensus mode (`x-erpc-consensus-slots: 5`) compares responses from multiple upstream nodes. On HyperEVM, nodes can briefly disagree on state at recent blocks, causing transient failures that resolve within seconds.
- The multicall retry loop already handled batch size reduction and provider switching, but lacked the one thing consensus errors actually need: time.
- All three configured HyperEVM providers (Alchemy, Goldsky, DRPC) route through eRPC, so switching providers doesn't help — only waiting does.

## Summary

- Added exponential backoff delay (2s, 4s, 6s, 8s, 10s) between non-429 multicall retries in `MultiprocessMulticallReader.process_calls()`
- Total worst-case delay across 5 retries: 30 seconds, acceptable for a scanner running on multi-minute cycles
- Previously, the non-429 retry path only logged and immediately retried with no sleep
