### PR TITLE
refactor: Add TODO to break whitelistERC4626 into per-protocol helpers

### DIFF
--- a/contracts/guard/src/GuardV0Base.sol
+++ b/contracts/guard/src/GuardV0Base.sol
@@ -781,6 +781,11 @@ abstract contract GuardV0Base is IGuard, Multicall {
      * - Any ERC-4626 extensions are not supported by this function, like special share tokens
      * - ERC-4626 withdrawal address must be always the Safe
      * - Because of non-standardisation the whitelisted function list is long
+     *
+     * TODO: Break this function into per-protocol helpers (e.g. _whitelistERC4626Core,
+     * _whitelistERC7540, _whitelistOstiumV15, _whitelistUmami) and compose them based
+     * on the actual vault type. Currently every vault gets every selector registered,
+     * which inflates callSiteCount and widens the call-site surface unnecessarily.
      */
     function whitelistERC4626(address vault, string calldata notes) external onlyGuardOwner {
         IERC4626 vault_ = IERC4626(vault);


### PR DESCRIPTION
## Why

Post-audit observation from the Ostium V1.5 guard PR (#1067): `whitelistERC4626()` is a kitchen-sink function that registers every protocol's selectors (ERC-4626, ERC-7540, Umami, Ostium V1.0, Ostium V1.5) for every vault, regardless of type. This inflates `callSiteCount` and widens the call-site surface unnecessarily.

No security vulnerability — each selector's validation logic handles receiver checks correctly — but it is a code hygiene issue worth addressing in a future refactor.

## Lessons learnt

- Ostium V1.5 functions are `msg.sender`-only (no receiver parameter), making them safe without payload validation in the guard
- The whitelisting function should be composed from per-protocol helpers to match the actual vault type

## Summary

- Added a `TODO` comment to `whitelistERC4626()` in `GuardV0Base.sol` to break it into per-protocol helpers (`_whitelistERC4626Core`, `_whitelistERC7540`, `_whitelistOstiumV15`, `_whitelistUmami`) composed based on actual vault type
