### PR TITLE
docs: Update Ostium V1.5 fee/revenue model and canonical doc links

### DIFF
--- a/eth_defi/data/vaults/metadata/ostium.yaml
+++ b/eth_defi/data/vaults/metadata/ostium.yaml
@@ -17,18 +17,23 @@ long_description: |
   - ERC-4626 compatible vaults for perpetual futures liquidity provision
   - Self-custodial trading on real-world assets
   - Capital efficient automated market making for perpetual swaps
-  - Epoch-based withdrawal system for managing redemptions
+  - Async settlement-based deposit/withdrawal flow (V1.5)
   - Built on Arbitrum for fast and low-cost transactions
 fee_description: |
+  No management fees, performance fees, deposit fees, or withdrawal fees are charged to OLP holders.
+  OLP holders earn 30% of trader opening fees, allocated at each daily settlement.
+  The 30% allocation is a tunable protocol parameter, periodically reviewed by the protocol.
+  OLP holders have no direct trader PnL exposure in V1.5 (unlike V1 where they acted as
+  junior counterparty). APR depends solely on trading volume and opening fee generation.
 links:
   homepage: https://www.ostium.com
   app: https://ostium.app/vault
   twitter: https://twitter.com/ostiumlabs
   github: https://github.com/0xOstium/smart-contracts-public
-  documentation: https://ostium-labs.gitbook.io/ostium-docs
+  documentation: https://docs.ostium.com
   defillama: https://defillama.com/protocol/ostium
   audits: https://ostium-labs.gitbook.io/ostium-docs/security/smart-contract-audits
-  fees: https://ostium-labs.gitbook.io/ostium-docs/fee-breakdown
+  fees: https://docs.ostium.com/traders/reference/fees
   trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/ostium
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/gains/index.html
 example_smart_contracts:

--- a/eth_defi/erc_4626/vault_protocol/gains/README-Ostium.md
+++ b/eth_defi/erc_4626/vault_protocol/gains/README-Ostium.md
@@ -59,6 +59,25 @@ Deposit status is queryable via `getDepositStatus()` which returns an enum
 Withdrawals use the same pattern: `requestWithdraw` → settlement →
 `claimWithdraw`, with analogous cancel/reclaim paths.
 
+### Fee/revenue model change
+
+V1.5 fundamentally changed the OLP revenue model:
+
+| Aspect | V1 | V1.5 |
+|--------|----|----|
+| Opening fee share | 30% (continuous within epoch) | 30% (at daily settlement) |
+| Rollover/liquidation fees | 100% to OLP (end-of-epoch) | None — retained by protocol |
+| Trader PnL exposure | Yes (junior counterparty when undercollateralised) | None |
+| Management/performance fees | None | None |
+| APR characteristics | -4% to +50% (volatile, PnL-dependent) | Tighter, more stable (fee-only) |
+
+OLP holders no longer bear trader PnL risk. Returns come solely from
+the 30% opening fee allocation (a tunable protocol parameter). There
+are no management fees, performance fees, deposit fees, or withdrawal
+fees in either version.
+
+See: https://docs.ostium.com/vault/reference/olp-token
+
 ### ERC-4626 spec violation
 
 `maxDeposit()` still returns `type(uint256).max` even though `deposit()`
@@ -160,5 +179,7 @@ confirmation before broadcast.
 - [Vault proxy on Arbiscan](https://arbiscan.io/address/0x20d419a8e12c45f88fda7c5760bb6923cee27f98)
 - [V1.5.0 implementation on Arbiscan](https://arbiscan.io/address/0xd2619e2012a120504e043f61c8acb3ede2472bf7)
 - [Old implementation on Arbiscan](https://arbiscan.io/address/0x7912cf084eb45e7d2a2c10dda3e98136d12043fb)
-- [Ostium docs (new)](https://docs.ostium.com)
+- [Ostium docs — vault overview](https://docs.ostium.com/vault/overview)
+- [Ostium docs — OLP token and yield](https://docs.ostium.com/vault/reference/olp-token)
+- [Ostium docs — fee breakdown](https://docs.ostium.com/traders/reference/fees)
 - [Ostium docs (old, deprecated)](https://ostium-labs.gitbook.io/ostium-docs)

--- a/eth_defi/erc_4626/vault_protocol/gains/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/gains/vault.py
@@ -381,11 +381,23 @@ class GainsVault(ERC4626Vault):
         raise NotImplementedError(f"Does not know this Gains-like vault structure")
 
     def get_management_fee(self, block_identifier: BlockIdentifier) -> float:
-        """No management fee"""
+        """No management fee.
+
+        Ostium does not charge management fees to OLP holders.
+        Returns are generated from 30% of trader opening fees (V1.5)
+        or opening fees + rollover/liquidation fees + PnL exposure (V1).
+
+        See https://docs.ostium.com/vault/reference/olp-token
+        """
         return 0.0
 
     def get_performance_fee(self, block_identifier: BlockIdentifier) -> float:
-        """No performance fee"""
+        """No performance fee.
+
+        Ostium does not charge performance fees to OLP holders.
+
+        See https://docs.ostium.com/vault/reference/olp-token
+        """
         return 0.0
 
     def fetch_current_epoch(self) -> int:
@@ -728,10 +740,12 @@ class OstiumVault(GainsVault):
 
     @property
     def short_description(self) -> str | None:
+        if self.version == OstiumVersion.v1_5:
+            return "Ostium liquidity pool vault where depositors provide USDC via async settlement, earning a share of trading opening fees."
         return "Ostium liquidity pool vault where depositors provide USDC as counterparty liquidity to perpetual traders, earning trading fees and trader PnL exposure."
 
     @property
     def description(self) -> str | None:
         if self.version == OstiumVersion.v1_5:
-            return "Users deposit USDC to mint OLP tokens via an async settlement flow. Deposits are queued via requestDeposit() and settled daily, after which shares can be claimed. Withdrawals follow the same pattern via requestWithdraw()/claimWithdraw(). Returns come from trading fees and trader PnL exposure. See [Ostium docs](https://docs.ostium.com) for details."
-        return "Users deposit USDC to mint OLP tokens, representing a stake in a fund that generates returns through trading fees and trader PnL exposure. The vault operates on an epoch-based system (currently 3-day cycles) with two states: when undercollateralised (c-ratio < 100%), OLP holders act as direct counterparties to traders with higher fee capture but more volatility; when overcollateralised (c-ratio >= 100%), a buffer absorbs trader PnL first, insulating OLP from volatility. Fees include 30% of opening fees (continuous) and 100% of rollover/liquidation fees (end-of-epoch). Withdrawals require a request during the first 48 hours of an epoch, followed by a cool-off period before USDC redemption. See [Ostium vault documentation](https://ostium-labs.gitbook.io/ostium-docs/vault/overview) for more details."
+            return "Users deposit USDC to mint OLP tokens via an async settlement flow. Deposits are queued via requestDeposit() and settled daily (5-6 pm ET Mon-Fri), after which shares can be claimed. Withdrawals follow the same pattern via requestWithdraw()/claimWithdraw(). OLP holders earn 30% of opening fees paid by traders, allocated at each daily settlement. Unlike V1, OLP holders have no direct trader PnL exposure — returns come solely from opening fee revenue. The 30% allocation is a tunable protocol parameter. There are no management fees, performance fees, deposit fees, or withdrawal fees. See [Ostium vault docs](https://docs.ostium.com/vault/overview) for details."
+        return "Users deposit USDC to mint OLP tokens, representing a stake in a fund that generates returns through trading fees and trader PnL exposure. The vault operates on an epoch-based system (currently 3-day cycles) with two states: when undercollateralised (c-ratio < 100%), OLP holders act as direct counterparties to traders with higher fee capture but more volatility; when overcollateralised (c-ratio >= 100%), a buffer absorbs trader PnL first, insulating OLP from volatility. Fees include 30% of opening fees (continuous) and 100% of rollover/liquidation fees (end-of-epoch). Withdrawals require a request during the first 48 hours of an epoch, followed by a cool-off period before USDC redemption. See [Ostium vault documentation](https://docs.ostium.com/vault/overview) for more details."


### PR DESCRIPTION
## Why

Ostium V1.5 fundamentally changed the OLP revenue model: OLP holders no longer bear trader PnL risk and no longer receive rollover/liquidation fees. Returns now come solely from 30% of trader opening fees at daily settlement. Our descriptions incorrectly stated V1.5 still had "trader PnL exposure", and the `fee_description` metadata field was empty.

## Lessons learnt

- Ostium V1.5 smart contract has zero fee-related variables — all fees are implicit through share price changes
- The new canonical docs are at `docs.ostium.com` (the old gitbook at `ostium-labs.gitbook.io` is deprecated)
- V1.5 APR is tighter and more stable since it depends only on trading volume, not trader PnL outcomes

## Summary

- Fixed V1.5 `short_description` and `description` in `vault.py` to correctly state returns come from opening fees only (no PnL exposure)
- Filled in empty `fee_description` in `ostium.yaml` with the actual fee model
- Updated `long_description` in YAML: "Epoch-based withdrawal" → "Async settlement-based deposit/withdrawal flow"
- Updated documentation links from deprecated gitbook to canonical `docs.ostium.com`
- Added fee/revenue model comparison table to `README-Ostium.md`
- Expanded `get_management_fee()` / `get_performance_fee()` docstrings with canonical docs links