### PR TITLE
feat: Add estimate_max_withdrawal_commission() for Hyperliquid vault withdrawals

### DIFF
--- a/eth_defi/hyperliquid/api.py
+++ b/eth_defi/hyperliquid/api.py
@@ -79,7 +79,15 @@ class UserVaultEquity:
     #: Hypercore vault address
     vault_address: HexAddress
 
-    #: USDC equity in the vault
+    #: USDC equity in the vault (gross, before withdrawal commission).
+    #:
+    #: The vault leader's performance fee (typically 10% of profits) is
+    #: deducted at withdrawal time, not reflected in this value.  The net
+    #: withdrawal amount is ``equity`` minus the commission on the profit
+    #: portion.
+    #:
+    #: See :py:func:`~eth_defi.hyperliquid.vault.estimate_max_withdrawal_commission`
+    #: for worst-case estimation.
     equity: Decimal
 
     #: UTC datetime until which withdrawals are locked.

--- a/eth_defi/hyperliquid/vault.py
+++ b/eth_defi/hyperliquid/vault.py
@@ -162,6 +162,51 @@ class VaultInfo:
     parent: HexAddress | None = None
 
 
+def estimate_max_withdrawal_commission(
+    withdrawal_amount: Decimal,
+    commission_rate: Decimal | float | None,
+) -> Decimal:
+    """Estimate the worst-case vault leader commission for a withdrawal.
+
+    Hyperliquid vault leaders earn a performance fee (typically 10%) on
+    depositor profits.  The fee is deducted at withdrawal time from the
+    portion of the withdrawal that represents profit.
+
+    In the worst case — when the entire withdrawal consists of profit —
+    the commission equals ``commission_rate * withdrawal_amount``.  In
+    practice the commission is lower because only the profit portion is
+    taxed.
+
+    Protocol vaults (HLP and children) have no commission, so
+    ``commission_rate`` is ``None`` or zero for those.
+
+    The ``withdrawal_amount`` is always treated as a positive quantity.
+    Hyperliquid withdrawal events store outflows as negative values
+    (see :py:class:`~eth_defi.hyperliquid.deposit.VaultDepositEvent`),
+    so callers may pass a negative amount — ``abs()`` is applied
+    internally.
+
+    :param withdrawal_amount:
+        USDC amount being withdrawn.  Negative values are accepted and
+        treated as their absolute value.
+    :param commission_rate:
+        Leader commission rate as a fraction (e.g. ``0.1`` or
+        ``Decimal("0.1")`` for 10%).  Accepts both ``float`` (as
+        returned by :py:attr:`VaultInfo.commission_rate`) and
+        ``Decimal``.  ``None`` for protocol vaults with no fee.
+    :return:
+        Worst-case commission in USDC (always non-negative).  Returns
+        ``Decimal(0)`` when ``commission_rate`` is ``None`` or zero.
+
+    See https://hyperliquid.gitbook.io/hyperliquid-docs/hypercore/vaults
+    """
+    if commission_rate is None or commission_rate <= 0:
+        return Decimal(0)
+    if not isinstance(commission_rate, Decimal):
+        commission_rate = Decimal(str(commission_rate))
+    return abs(withdrawal_amount) * commission_rate
+
+
 @dataclass(slots=True)
 class VaultSummary:
     """Summary information for a Hyperliquid vault.

--- a/eth_defi/hyperliquid/vault.py
+++ b/eth_defi/hyperliquid/vault.py
@@ -143,7 +143,16 @@ class VaultInfo:
     allow_deposits: bool
     #: Vault relationship type (normal, child, parent)
     relationship_type: str
-    #: Commission rate for the vault leader (as decimal, e.g., 0.1 = 10%)
+    #: Leader performance fee as a fraction (e.g. ``0.1`` for 10%).
+    #:
+    #: Sourced from the ``vaultDetails`` API ``leaderCommission`` field.
+    #: Protocol vaults (HLP and children) have no commission, so this
+    #: is ``None`` for those.
+    #:
+    #: Use :py:func:`estimate_max_withdrawal_commission` to compute the
+    #: worst-case fee for a given withdrawal amount.
+    #:
+    #: See https://hyperliquid.gitbook.io/hyperliquid-docs/hypercore/vaults
     commission_rate: Percent | None = None
     #: Fraction of vault capital owned by the leader (e.g. 0.05 = 5%).
     #:
@@ -153,10 +162,8 @@ class VaultInfo:
     #:
     #: Source: https://hyperliquid.gitbook.io/hyperliquid-docs/hypercore/vaults/for-vault-leaders-legacy
     leader_fraction: Percent | None = None
-    #: Leader commission value from the ``vaultDetails`` API ``leaderCommission`` field.
-    #:
-    #: The exact semantics of this field are not yet fully understood — it may
-    #: represent accumulated commission in USD or an alternative commission metric.
+    #: Alias for :py:attr:`commission_rate`, kept for backward compatibility
+    #: with data pipelines that reference this field name.
     leader_commission: float | None = None
     #: Parent vault address if this is a child vault
     parent: HexAddress | None = None
@@ -191,9 +198,10 @@ def estimate_max_withdrawal_commission(
         treated as their absolute value.
     :param commission_rate:
         Leader commission rate as a fraction (e.g. ``0.1`` or
-        ``Decimal("0.1")`` for 10%).  Accepts both ``float`` (as
-        returned by :py:attr:`VaultInfo.commission_rate`) and
-        ``Decimal``.  ``None`` for protocol vaults with no fee.
+        ``Decimal("0.1")`` for 10%).  Accepts both ``float`` (as stored
+        in :py:attr:`VaultInfo.commission_rate` from the Hyperliquid
+        ``leaderCommission`` API field) and ``Decimal``.
+        ``None`` for protocol vaults with no fee.
     :return:
         Worst-case commission in USDC (always non-negative).  Returns
         ``Decimal(0)`` when ``commission_rate`` is ``None`` or zero.
@@ -370,7 +378,7 @@ class HyperliquidVault:
             is_closed=data.get("isClosed", False),
             allow_deposits=data.get("allowDeposits", True),
             relationship_type=relationship_type,
-            commission_rate=data.get("commissionRate"),
+            commission_rate=data.get("leaderCommission"),
             leader_fraction=data.get("leaderFraction"),
             leader_commission=data.get("leaderCommission"),
             parent=parent,

--- a/tests/hyperliquid/test_vault_commission.py
+++ b/tests/hyperliquid/test_vault_commission.py
@@ -1,0 +1,91 @@
+"""Tests for Hyperliquid vault withdrawal commission estimation.
+
+Tests that :py:func:`~eth_defi.hyperliquid.vault.estimate_max_withdrawal_commission`
+correctly computes worst-case vault leader commission for withdrawals.
+"""
+
+from decimal import Decimal
+
+from eth_defi.hyperliquid.vault import estimate_max_withdrawal_commission
+
+
+def test_estimate_max_withdrawal_commission_with_rate():
+    """Estimate worst-case commission with a 10% leader rate.
+
+    1. Compute commission for a 500 USDC withdrawal at 10% rate.
+    2. Verify the result is 50 USDC (worst case: 100% profit).
+    """
+    # 1. Compute commission for a 500 USDC withdrawal at 10% rate.
+    result = estimate_max_withdrawal_commission(
+        withdrawal_amount=Decimal("500"),
+        commission_rate=Decimal("0.10"),
+    )
+
+    # 2. Verify the result is 50 USDC (worst case: 100% profit).
+    assert result == Decimal("50")
+
+
+def test_estimate_max_withdrawal_commission_none_rate():
+    """Protocol vaults (HLP) have no commission — rate is None.
+
+    1. Compute commission with None rate.
+    2. Verify the result is zero.
+    """
+    # 1. Compute commission with None rate.
+    result = estimate_max_withdrawal_commission(
+        withdrawal_amount=Decimal("500"),
+        commission_rate=None,
+    )
+
+    # 2. Verify the result is zero.
+    assert result == Decimal(0)
+
+
+def test_estimate_max_withdrawal_commission_zero_rate():
+    """Vault with explicit zero commission rate.
+
+    1. Compute commission with zero rate.
+    2. Verify the result is zero.
+    """
+    # 1. Compute commission with zero rate.
+    result = estimate_max_withdrawal_commission(
+        withdrawal_amount=Decimal("500"),
+        commission_rate=Decimal("0"),
+    )
+
+    # 2. Verify the result is zero.
+    assert result == Decimal(0)
+
+
+def test_estimate_max_withdrawal_commission_float_rate():
+    """VaultInfo.commission_rate is a float — must not raise TypeError.
+
+    1. Pass a float commission rate (as returned by VaultInfo).
+    2. Verify the result is correct and is a Decimal.
+    """
+    # 1. Float rate from VaultInfo.commission_rate.
+    result = estimate_max_withdrawal_commission(
+        withdrawal_amount=Decimal("500"),
+        commission_rate=0.1,
+    )
+
+    # 2. Correct result, returned as Decimal.
+    assert result == Decimal("50")
+    assert isinstance(result, Decimal)
+
+
+def test_estimate_max_withdrawal_commission_negative_withdrawal():
+    """Withdrawal events store outflows as negative — must return positive commission.
+
+    1. Pass a negative withdrawal amount (as in VaultDepositEvent.usdc).
+    2. Verify the commission is positive (abs applied internally).
+    """
+    # 1. Negative withdrawal amount.
+    result = estimate_max_withdrawal_commission(
+        withdrawal_amount=Decimal("-500"),
+        commission_rate=Decimal("0.10"),
+    )
+
+    # 2. Commission is positive.
+    assert result == Decimal("50")
+    assert result > 0


### PR DESCRIPTION
## Why

Hyperliquid vault leaders earn a performance fee (typically 10%) on depositor profits, deducted at withdrawal time. The `hyper-ai` strategy was hitting timeouts and shortfalls during vault withdrawals because the gross equity reported by the Hyperliquid API doesn't account for this commission. The trade executor needs a way to estimate the worst-case commission so it can budget for the shortfall when planning withdrawal amounts.

Additionally, `VaultInfo.commission_rate` was being parsed from the wrong API field (`commissionRate`, which is always `None` for real vaults) instead of `leaderCommission` — so even with the helper, the commission would always compute as zero.

## Lessons learnt

- The Hyperliquid `vaultDetails` API has two commission-related fields: `commissionRate` (always `None` for real vaults) and `leaderCommission` (the actual leader fee, e.g. `0.1` for 10%). Only `leaderCommission` is populated.
- `VaultInfo.commission_rate` is a `float` (from `_parse_vault_details()`), so any helper that accepts it must handle `float` — not just `Decimal`
- Hyperliquid withdrawal events store outflow amounts as negative values (`VaultDepositEvent.usdc`), so commission helpers must apply `abs()` to avoid returning negative results

## Summary

- Add `estimate_max_withdrawal_commission()` helper to `eth_defi/hyperliquid/vault.py` that computes worst-case vault leader commission for a withdrawal amount
  - Accepts both `float` (from `VaultInfo.commission_rate`) and `Decimal` inputs
  - Applies `abs()` internally so negative outflow values from withdrawal events work correctly
  - Returns `Decimal(0)` for protocol vaults (HLP) with no commission
- Fix `VaultInfo.commission_rate` parsing: source from `leaderCommission` API field instead of the always-`None` `commissionRate` field
- Document that `UserVaultEquity.equity` is gross (pre-commission) in `eth_defi/hyperliquid/api.py`
- Add 5 unit tests covering: standard rate, None rate, zero rate, float rate, and negative withdrawal amount

## Related issues and PRs

- Companion trade-executor PR will use this helper in `hypercore_routing.py` to apply commission-aware tolerance during withdrawal settlement
