### PR TITLE
refactor: Normalise Core3 data in JSON export, add brotli compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - fix: Preserve vault metadata when rescan fails with transient RPC errors, add `heal-broken-vaults.py` healer script, atomic writes for Lagoon compatibility database (2026-06-04)
 
+- refactor: Normalise Core3 data in JSON export — Core3 records moved from per-vault `other_data["core3"]` to top-level `core3_protocols` dict keyed by protocol slug; Core3 removed from `calculate_lifetime_metrics()` pipeline; added brotli-compressed `.json.br` R2 upload (2026-06-08)
+
 - feat: Core3 risk intelligence in vault lifetime metrics — `calculate_lifetime_metrics()` accepts optional `Core3Database`, pre-computes per-protocol cache, and exports Core3 PoL score, rating, top risks in `other_data["core3"]`; standardised `CORE3_DATABASE_PATH` env var across all Core3 scripts; moved default database to `~/.tradingstrategy/vaults/core3/core3.duckdb` (2026-06-03)
 
 

--- a/eth_defi/core3/vault_protocol.py
+++ b/eth_defi/core3/vault_protocol.py
@@ -21,10 +21,14 @@ Example::
 
 import datetime
 import json
+import logging
+from collections.abc import Iterable
 from typing import NotRequired, TypedDict
 
 from eth_defi.core3.database import Core3Database
 from eth_defi.core3.mappings import CORE3_MAPPINGS
+
+logger = logging.getLogger(__name__)
 
 
 class Core3Seal(TypedDict):
@@ -295,3 +299,117 @@ def get_core3_protocol_record(
     payload["fetched_at"] = fetched_at
 
     return payload
+
+
+class Core3ExportRecord(TypedDict):
+    """Serialised Core3 project record for JSON export.
+
+    Same structure as :class:`Core3Record` but with ``fetched_at``
+    as an ISO 8601 string instead of :class:`~datetime.datetime`,
+    since the JSON export cannot contain raw datetime objects.
+    """
+
+    #: Core3 project slug (CoinGecko-style), e.g. ``"morpho"``,
+    #: ``"instadapp"``, ``"syrup"``.
+    slug: str
+
+    #: Project display name, e.g. ``"Morpho"``, ``"Fluid"``.
+    name: str
+
+    #: Project description text from Core3 (may contain newlines).
+    description: str | None
+
+    #: Core3 global rank (1 = lowest risk). ``None`` if unranked.
+    rank: int | None
+
+    #: Probability of Loss score, rating, and confidence level.
+    pol: Core3PolScore
+
+    #: Token ticker symbol, e.g. ``"MORPHO"``, ``"EUL"``.
+    ticker: NotRequired[str | None]
+
+    #: CoinGecko ID for cross-referencing.
+    coingecko_id: NotRequired[str | None]
+
+    #: URL to the project logo image on CoinGecko CDN.
+    logo: str | None
+
+    #: Core3 project page link.
+    link: str | None
+
+    #: ISO 8601 launch date string, or ``None`` if unknown.
+    launched_at: str | None
+
+    #: Project category classification.
+    category: Core3Category | None
+
+    #: Data coverage percentage indicator.
+    data_coverage: Core3DataCoverage | None
+
+    #: Market capitalisation data.
+    market_cap: Core3MarketCap | None
+
+    #: Blockchain networks where the project is deployed.
+    chains: list[Core3Chain]
+
+    #: External links (website, legal, whitepaper, socials).
+    links: Core3Links | None
+
+    #: Project tags (often empty).
+    tags: list[str]
+
+    #: Top risk findings from Core3's assessment.
+    top_risks: list[Core3TopRisk]
+
+    #: Recent monitoring changes detected by Core3.
+    recent_changes: list[Core3RecentChange]
+
+    #: Trust seals status.
+    seals: Core3Seals | None
+
+    #: ISO 8601 timestamp when this snapshot was fetched.
+    fetched_at: str
+
+
+def build_core3_protocols_for_export(
+    db: Core3Database,
+    protocol_slugs: Iterable[str],
+) -> dict[str, Core3ExportRecord]:
+    """Build a protocol-slug-keyed dict of Core3 records for the JSON export.
+
+    Looks up each vault protocol slug in the Core3 database and returns
+    a dict suitable for embedding as the top-level ``core3_protocols``
+    key in the vault metrics JSON export. Records are keyed by our
+    internal protocol slugs (e.g. ``"fluid"``), not Core3's own slugs
+    (e.g. ``"instadapp"``).
+
+    :param db:
+        Open Core3 DuckDB database connection.
+
+    :param protocol_slugs:
+        Iterable of our vault protocol slugs to look up.
+
+    :return:
+        Dict mapping protocol slug to :class:`Core3ExportRecord`.
+        Slugs with no Core3 mapping or no database record are excluded.
+    """
+    result: dict[str, Core3ExportRecord] = {}
+    protocol_slugs = set(protocol_slugs)
+
+    for slug in protocol_slugs:
+        record = get_core3_protocol_record(db, slug)
+        if record is None:
+            continue
+
+        # Shallow copy to avoid mutating the original Core3Record in-place
+        export_record = {**record}
+
+        # Serialise fetched_at datetime to ISO 8601 string
+        fetched_at = export_record["fetched_at"]
+        if isinstance(fetched_at, datetime.datetime):
+            export_record["fetched_at"] = fetched_at.isoformat()
+
+        result[slug] = export_record
+
+    logger.info("Built Core3 export records for %d / %d protocol slugs", len(result), len(protocol_slugs))
+    return result

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -10,7 +10,7 @@ import math
 import warnings
 from dataclasses import asdict, dataclass, is_dataclass
 from enum import Enum
-from typing import Literal, Optional, TypeAlias
+from typing import Literal, Optional, TypeAlias, TypedDict
 
 import numpy as np
 import pandas as pd
@@ -25,7 +25,7 @@ from tqdm_loggable.auto import tqdm
 
 from eth_defi.chain import get_chain_name
 from eth_defi.compat import native_datetime_utc_now
-from eth_defi.core3.vault_protocol import get_core3_protocol_record
+from eth_defi.core3.vault_protocol import Core3ExportRecord
 from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS
 from eth_defi.erc_4626.core import ERC4262VaultDetection
 from eth_defi.erc_4626.vault_protocol.morpho.flag_analytics import MorphoFlagAnalytics, analyze_morpho_flags
@@ -184,6 +184,93 @@ LOOKBACK_AND_TOLERANCES: dict[Period, tuple[pd.DateOffset, pd.Timedelta]] = {
     "1Y": (pd.DateOffset(days=365), pd.Timedelta(days=365 + 45)),
     "lifetime": (pd.DateOffset(years=100), pd.Timedelta(days=100 * 365)),
 }
+
+
+class VaultMetricsRecord(TypedDict, total=False):
+    """Per-vault record in the JSON export.
+
+    Uses ``total=False`` so that only the most critical fields are typed
+    explicitly — remaining fields are still present but not enforced by
+    the type checker. This is an incremental approach; more fields can
+    be promoted to required as the schema stabilises.
+    """
+
+    #: Vault display name
+    name: str
+
+    #: Chain identifier (integer chain ID)
+    chain_id: int
+
+    #: Chain display name, e.g. ``"Ethereum"``
+    chain: str
+
+    #: Protocol display name, e.g. ``"Morpho"``
+    protocol: str
+
+    #: Protocol slug, e.g. ``"morpho"``
+    protocol_slug: str
+
+    #: Vault contract address (checksummed hex)
+    address: str
+
+    #: Unique vault slug for URLs
+    vault_slug: str
+
+    #: Compound Annual Growth Rate (lifetime)
+    cagr: float | None
+
+    #: Lifetime total return
+    lifetime_return: float | None
+
+    #: 3-month CAGR
+    three_months_cagr: float | None
+
+    #: 1-month CAGR
+    one_month_cagr: float | None
+
+    #: Annualised volatility
+    volatility: float | None
+
+    #: Sharpe ratio
+    sharpe: float | None
+
+    #: Technical risk classification
+    risk: str | None
+
+    #: Current net asset value in USD
+    current_nav: float | None
+
+    #: Peak net asset value in USD
+    peak_nav: float | None
+
+    #: Management fee percentage
+    management_fee: float | None
+
+    #: Performance fee percentage
+    performance_fee: float | None
+
+    #: Protocol-specific extension data (Morpho flags, etc.)
+    other_data: dict
+
+    #: Per-period tearsheet results
+    period_results: list[dict]
+
+
+class VaultMetricsExport(TypedDict):
+    """Top-level structure of the vault metrics JSON export.
+
+    Describes the shape of ``top_vaults_by_chain.json`` uploaded to R2.
+    """
+
+    #: ISO 8601 UTC timestamp when the export was generated
+    generated_at: str
+
+    #: Core3 risk intelligence keyed by protocol slug.
+    #: Only protocols present in the exported vaults are included.
+    core3_protocols: dict[str, Core3ExportRecord]
+
+    #: List of per-vault metric records
+    vaults: list[VaultMetricsRecord]
 
 
 def fmt_one_decimal_or_int(x: float | None) -> str:
@@ -1165,7 +1252,6 @@ def calculate_vault_record(
     month_ago: pd.Timestamp,
     three_months_ago: pd.Timestamp,
     vault_id: str | None = None,
-    core3_cache: dict | None = None,
 ) -> pd.Series:
     """Process a single vault metadata + prices to calculate its full data.
 
@@ -1186,12 +1272,6 @@ def calculate_vault_record(
 
     :param vault_id:
         Vault ID string. If not provided, extracted from prices_df["id"].
-
-    :param core3_cache:
-        Pre-computed dict mapping protocol slugs to
-        :py:class:`~eth_defi.core3.vault_protocol.Core3Record` or ``None``.
-        Built by :py:func:`calculate_lifetime_metrics` before the per-vault loop.
-        When ``None``, ``other_data["core3"]`` is set to ``None``.
 
     :return:
         Series with calculated metrics
@@ -1394,8 +1474,8 @@ def calculate_vault_record(
                 notes = morpho_analytics.note
 
     # ``other_data`` is a protocol-specific extension dict included in the metrics Series.
-    # Currently populated for Morpho warnings and Core3 risk intelligence;
-    # all other protocols return empty lists / None.
+    # Currently populated for Morpho warnings; Core3 risk intelligence is attached
+    # at JSON export time as a top-level ``core3_protocols`` dict (not per-vault).
     # Future protocols should add their own keys here rather than adding top-level Series fields.
     other_data: dict = {
         # Vault-level governance warning types from the Morpho Blue API.
@@ -1412,11 +1492,6 @@ def calculate_vault_record(
         # Combined YELLOW-level warning types across vault and market warnings.
         # YELLOW flags do not trigger VaultFlag.morpho_issues. Example: ["bad_debt_realized", "not_whitelisted"]
         "morpho_yellow_flags": morpho_yellow_flags,
-        # Core3 risk intelligence record for this vault's protocol.
-        # A :py:class:`~eth_defi.core3.vault_protocol.Core3Record` TypedDict with PoL score,
-        # rating, top risks, seals, etc. ``None`` when Core3 DB is not available or
-        # the protocol has no Core3 mapping.
-        "core3": core3_cache.get(protocol_slug) if core3_cache else None,
     }
 
     # Manual review decision from the Hyperliquid review Google Sheet.
@@ -1665,7 +1740,6 @@ def calculate_lifetime_metrics(
     df: pd.DataFrame,
     vault_db: VaultDatabase | dict[VaultSpec, VaultRow],
     returns_column: str = "returns_1h",
-    core3_db: "Core3Database | None" = None,
 ) -> pd.DataFrame:
     """Calculate lifetime metrics for each vault in the provided DataFrame.
 
@@ -1683,12 +1757,6 @@ def calculate_lifetime_metrics(
 
     :param vault_db:
         Pass all vaults or subset of vaults as VaultRows, or full VaultDatabase
-
-    :param core3_db:
-        Optional open :py:class:`~eth_defi.core3.database.Core3Database` connection.
-        When provided, Core3 risk intelligence records are looked up per protocol
-        and included in each vault's ``other_data["core3"]``. When ``None``,
-        ``other_data["core3"]`` is set to ``None`` for all vaults.
 
     :return:
         DataFrame, one row per vault.
@@ -1713,19 +1781,11 @@ def calculate_lifetime_metrics(
         vaults=vaults_by_id,
     )
 
-    # Pre-compute Core3 risk records per protocol slug.
-    # Core3 data is per-protocol (not per-vault), so we look up each
-    # unique protocol slug once and cache the result for the per-vault loop.
-    core3_cache: dict | None = None
-    if core3_db is not None:
-        unique_slugs = {v.get("protocol_slug") for v in vaults_by_id.values() if v.get("protocol_slug")}
-        core3_cache = {slug: get_core3_protocol_record(core3_db, slug) for slug in unique_slugs}
-
     # Use progress_apply instead of the for loop
     # Sort is needed for slug stability
     # We pass include_groups=False to avoid FutureWarning, and pass id via group.name
     def _apply_vault_record(group):
-        return calculate_vault_record(group, vaults_by_id, month_ago, three_months_ago, vault_id=group.name, core3_cache=core3_cache)
+        return calculate_vault_record(group, vaults_by_id, month_ago, three_months_ago, vault_id=group.name)
 
     results_df = df.groupby("id", group_keys=False, sort=True).progress_apply(
         _apply_vault_record,

--- a/eth_defi/vault/post_processing.py
+++ b/eth_defi/vault/post_processing.py
@@ -14,7 +14,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from eth_defi.cloudflare_r2 import copy_r2_object_daily_backup, create_r2_client, upload_file_to_r2
+from eth_defi.cloudflare_r2 import calculate_bytes_digest, copy_r2_object_daily_backup, create_r2_client, upload_bytes_to_r2, upload_file_to_r2
 from eth_defi.grvt.constants import GRVT_CHAIN_ID, GRVT_DAILY_METRICS_DATABASE
 from eth_defi.grvt.daily_metrics import GRVTDailyMetricsDatabase
 from eth_defi.grvt.vault_data_export import merge_into_uncleaned_parquet as grvt_merge_parquet
@@ -116,7 +116,6 @@ def _upload_top_vaults_json_to_bucket(
                 logger.info("  -> %s/%s", public_url.rstrip("/"), object_key)
         else:
             logger.info("Skipped unchanged %s for %s s3://%s/%s", output_path, bucket_label, bucket_name, object_key)
-        return True
     except Exception:
         logger.exception(
             "Top vaults JSON %s bucket upload failed — bucket=%s, endpoint=%s, object_key=%s, access_key_id=%s",
@@ -127,6 +126,46 @@ def _upload_top_vaults_json_to_bucket(
             _mask_access_key_id(access_key_id),
         )
         return False
+
+    # Upload brotli-compressed variant (.json.br) alongside raw JSON.
+    # Brotli is an optional dependency — if unavailable, raw upload still succeeds.
+    try:
+        import brotli
+
+        raw_bytes = output_path.read_bytes()
+        compressed = brotli.compress(raw_bytes, quality=11)
+        source_digest = calculate_bytes_digest(raw_bytes)
+
+        br_uploaded = upload_bytes_to_r2(
+            s3_client=s3_client,
+            payload=compressed,
+            bucket_name=bucket_name,
+            object_name=object_key + ".br",
+            content_type="application/json",
+            content_encoding="br",
+            source_digest=source_digest,
+            skip_if_current=True,
+        )
+        ratio = len(compressed) / len(raw_bytes) * 100 if raw_bytes else 0
+        if br_uploaded:
+            logger.info(
+                "Uploaded brotli %s.br to %s s3://%s/%s.br (%.1f%% of original)",
+                output_path.name,
+                bucket_label,
+                bucket_name,
+                object_key,
+                ratio,
+            )
+        else:
+            logger.info("Skipped unchanged brotli for %s s3://%s/%s.br", bucket_label, bucket_name, object_key)
+    except ImportError:
+        logger.warning("brotli package not installed — skipping .json.br upload for %s bucket", bucket_label)
+        return False
+    except Exception:
+        logger.exception("Brotli compression/upload failed for %s bucket — raw JSON already uploaded", bucket_label)
+        return False
+
+    return True
 
 
 def _upload_top_vaults_json_to_configured_buckets(

--- a/eth_defi/vault/sample_export.py
+++ b/eth_defi/vault/sample_export.py
@@ -93,8 +93,13 @@ def generate_sample_json(json_path: Path, output_path: Path) -> int:
     if len(filtered_vaults) == 0:
         raise ValueError(f"No Ethereum (chain_id={ETHEREUM_CHAIN_ID}) vaults found in {json_path}")
 
+    # Filter core3_protocols to only protocol slugs present in the sample vaults
+    sample_slugs = {v["protocol_slug"] for v in filtered_vaults if v.get("protocol_slug")}
+    core3 = {k: v for k, v in data.get("core3_protocols", {}).items() if k in sample_slugs}
+
     sample_data = {
         "generated_at": data["generated_at"],
+        "core3_protocols": core3,
         "vaults": filtered_vaults,
     }
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -662,6 +662,117 @@ urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >
 crt = ["awscrt (==0.31.2)"]
 
 [[package]]
+name = "brotli"
+version = "1.2.0"
+description = "Python bindings for the Brotli compression library"
+optional = true
+python-versions = "*"
+groups = ["main"]
+markers = "extra == \"cloudflare-r2\""
+files = [
+    {file = "brotli-1.2.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:99cfa69813d79492f0e5d52a20fd18395bc82e671d5d40bd5a91d13e75e468e8"},
+    {file = "brotli-1.2.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:3ebe801e0f4e56d17cd386ca6600573e3706ce1845376307f5d2cbd32149b69a"},
+    {file = "brotli-1.2.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:a387225a67f619bf16bd504c37655930f910eb03675730fc2ad69d3d8b5e7e92"},
+    {file = "brotli-1.2.0-cp27-cp27m-win32.whl", hash = "sha256:b908d1a7b28bc72dfb743be0d4d3f8931f8309f810af66c906ae6cd4127c93cb"},
+    {file = "brotli-1.2.0-cp27-cp27m-win_amd64.whl", hash = "sha256:d206a36b4140fbb5373bf1eb73fb9de589bb06afd0d22376de23c5e91d0ab35f"},
+    {file = "brotli-1.2.0-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7e9053f5fb4e0dfab89243079b3e217f2aea4085e4d58c5c06115fc34823707f"},
+    {file = "brotli-1.2.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:4735a10f738cb5516905a121f32b24ce196ab82cfc1e4ba2e3ad1b371085fd46"},
+    {file = "brotli-1.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3b90b767916ac44e93a8e28ce6adf8d551e43affb512f2377c732d486ac6514e"},
+    {file = "brotli-1.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6be67c19e0b0c56365c6a76e393b932fb0e78b3b56b711d180dd7013cb1fd984"},
+    {file = "brotli-1.2.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0bbd5b5ccd157ae7913750476d48099aaf507a79841c0d04a9db4415b14842de"},
+    {file = "brotli-1.2.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3f3c908bcc404c90c77d5a073e55271a0a498f4e0756e48127c35d91cf155947"},
+    {file = "brotli-1.2.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1b557b29782a643420e08d75aea889462a4a8796e9a6cf5621ab05a3f7da8ef2"},
+    {file = "brotli-1.2.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:81da1b229b1889f25adadc929aeb9dbc4e922bd18561b65b08dd9343cfccca84"},
+    {file = "brotli-1.2.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ff09cd8c5eec3b9d02d2408db41be150d8891c5566addce57513bf546e3d6c6d"},
+    {file = "brotli-1.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a1778532b978d2536e79c05dac2d8cd857f6c55cd0c95ace5b03740824e0e2f1"},
+    {file = "brotli-1.2.0-cp310-cp310-win32.whl", hash = "sha256:b232029d100d393ae3c603c8ffd7e3fe6f798c5e28ddca5feabb8e8fdb732997"},
+    {file = "brotli-1.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:ef87b8ab2704da227e83a246356a2b179ef826f550f794b2c52cddb4efbd0196"},
+    {file = "brotli-1.2.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:15b33fe93cedc4caaff8a0bd1eb7e3dab1c61bb22a0bf5bdfdfd97cd7da79744"},
+    {file = "brotli-1.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:898be2be399c221d2671d29eed26b6b2713a02c2119168ed914e7d00ceadb56f"},
+    {file = "brotli-1.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:350c8348f0e76fff0a0fd6c26755d2653863279d086d3aa2c290a6a7251135dd"},
+    {file = "brotli-1.2.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e1ad3fda65ae0d93fec742a128d72e145c9c7a99ee2fcd667785d99eb25a7fe"},
+    {file = "brotli-1.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:40d918bce2b427a0c4ba189df7a006ac0c7277c180aee4617d99e9ccaaf59e6a"},
+    {file = "brotli-1.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2a7f1d03727130fc875448b65b127a9ec5d06d19d0148e7554384229706f9d1b"},
+    {file = "brotli-1.2.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:9c79f57faa25d97900bfb119480806d783fba83cd09ee0b33c17623935b05fa3"},
+    {file = "brotli-1.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:844a8ceb8483fefafc412f85c14f2aae2fb69567bf2a0de53cdb88b73e7c43ae"},
+    {file = "brotli-1.2.0-cp311-cp311-win32.whl", hash = "sha256:aa47441fa3026543513139cb8926a92a8e305ee9c71a6209ef7a97d91640ea03"},
+    {file = "brotli-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:022426c9e99fd65d9475dce5c195526f04bb8be8907607e27e747893f6ee3e24"},
+    {file = "brotli-1.2.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:35d382625778834a7f3061b15423919aa03e4f5da34ac8e02c074e4b75ab4f84"},
+    {file = "brotli-1.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7a61c06b334bd99bc5ae84f1eeb36bfe01400264b3c352f968c6e30a10f9d08b"},
+    {file = "brotli-1.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:acec55bb7c90f1dfc476126f9711a8e81c9af7fb617409a9ee2953115343f08d"},
+    {file = "brotli-1.2.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:260d3692396e1895c5034f204f0db022c056f9e2ac841593a4cf9426e2a3faca"},
+    {file = "brotli-1.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:072e7624b1fc4d601036ab3f4f27942ef772887e876beff0301d261210bca97f"},
+    {file = "brotli-1.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adedc4a67e15327dfdd04884873c6d5a01d3e3b6f61406f99b1ed4865a2f6d28"},
+    {file = "brotli-1.2.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7a47ce5c2288702e09dc22a44d0ee6152f2c7eda97b3c8482d826a1f3cfc7da7"},
+    {file = "brotli-1.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:af43b8711a8264bb4e7d6d9a6d004c3a2019c04c01127a868709ec29962b6036"},
+    {file = "brotli-1.2.0-cp312-cp312-win32.whl", hash = "sha256:e99befa0b48f3cd293dafeacdd0d191804d105d279e0b387a32054c1180f3161"},
+    {file = "brotli-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:b35c13ce241abdd44cb8ca70683f20c0c079728a36a996297adb5334adfc1c44"},
+    {file = "brotli-1.2.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9e5825ba2c9998375530504578fd4d5d1059d09621a02065d1b6bfc41a8e05ab"},
+    {file = "brotli-1.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0cf8c3b8ba93d496b2fae778039e2f5ecc7cff99df84df337ca31d8f2252896c"},
+    {file = "brotli-1.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8565e3cdc1808b1a34714b553b262c5de5fbda202285782173ec137fd13709f"},
+    {file = "brotli-1.2.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:26e8d3ecb0ee458a9804f47f21b74845cc823fd1bb19f02272be70774f56e2a6"},
+    {file = "brotli-1.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67a91c5187e1eec76a61625c77a6c8c785650f5b576ca732bd33ef58b0dff49c"},
+    {file = "brotli-1.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4ecdb3b6dc36e6d6e14d3a1bdc6c1057c8cbf80db04031d566eb6080ce283a48"},
+    {file = "brotli-1.2.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3e1b35d56856f3ed326b140d3c6d9db91740f22e14b06e840fe4bb1923439a18"},
+    {file = "brotli-1.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:54a50a9dad16b32136b2241ddea9e4df159b41247b2ce6aac0b3276a66a8f1e5"},
+    {file = "brotli-1.2.0-cp313-cp313-win32.whl", hash = "sha256:1b1d6a4efedd53671c793be6dd760fcf2107da3a52331ad9ea429edf0902f27a"},
+    {file = "brotli-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:b63daa43d82f0cdabf98dee215b375b4058cce72871fd07934f179885aad16e8"},
+    {file = "brotli-1.2.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:6c12dad5cd04530323e723787ff762bac749a7b256a5bece32b2243dd5c27b21"},
+    {file = "brotli-1.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3219bd9e69868e57183316ee19c84e03e8f8b5a1d1f2667e1aa8c2f91cb061ac"},
+    {file = "brotli-1.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:963a08f3bebd8b75ac57661045402da15991468a621f014be54e50f53a58d19e"},
+    {file = "brotli-1.2.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9322b9f8656782414b37e6af884146869d46ab85158201d82bab9abbcb971dc7"},
+    {file = "brotli-1.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cf9cba6f5b78a2071ec6fb1e7bd39acf35071d90a81231d67e92d637776a6a63"},
+    {file = "brotli-1.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7547369c4392b47d30a3467fe8c3330b4f2e0f7730e45e3103d7d636678a808b"},
+    {file = "brotli-1.2.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:fc1530af5c3c275b8524f2e24841cbe2599d74462455e9bae5109e9ff42e9361"},
+    {file = "brotli-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d2d085ded05278d1c7f65560aae97b3160aeb2ea2c0b3e26204856beccb60888"},
+    {file = "brotli-1.2.0-cp314-cp314-win32.whl", hash = "sha256:832c115a020e463c2f67664560449a7bea26b0c1fdd690352addad6d0a08714d"},
+    {file = "brotli-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e7c0af964e0b4e3412a0ebf341ea26ec767fa0b4cf81abb5e897c9338b5ad6a3"},
+    {file = "brotli-1.2.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:82676c2781ecf0ab23833796062786db04648b7aae8be139f6b8065e5e7b1518"},
+    {file = "brotli-1.2.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c16ab1ef7bb55651f5836e8e62db1f711d55b82ea08c3b8083ff037157171a69"},
+    {file = "brotli-1.2.0-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e85190da223337a6b7431d92c799fca3e2982abd44e7b8dec69938dcc81c8e9e"},
+    {file = "brotli-1.2.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:d8c05b1dfb61af28ef37624385b0029df902ca896a639881f594060b30ffc9a7"},
+    {file = "brotli-1.2.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:465a0d012b3d3e4f1d6146ea019b5c11e3e87f03d1676da1cc3833462e672fb0"},
+    {file = "brotli-1.2.0-cp36-cp36m-musllinux_1_2_aarch64.whl", hash = "sha256:96fbe82a58cdb2f872fa5d87dedc8477a12993626c446de794ea025bbda625ea"},
+    {file = "brotli-1.2.0-cp36-cp36m-musllinux_1_2_i686.whl", hash = "sha256:1b71754d5b6eda54d16fbbed7fce2d8bc6c052a1b91a35c320247946ee103502"},
+    {file = "brotli-1.2.0-cp36-cp36m-musllinux_1_2_ppc64le.whl", hash = "sha256:66c02c187ad250513c2f4fce973ef402d22f80e0adce734ee4e4efd657b6cb64"},
+    {file = "brotli-1.2.0-cp36-cp36m-musllinux_1_2_x86_64.whl", hash = "sha256:ba76177fd318ab7b3b9bf6522be5e84c2ae798754b6cc028665490f6e66b5533"},
+    {file = "brotli-1.2.0-cp36-cp36m-win32.whl", hash = "sha256:c1702888c9f3383cc2f09eb3e88b8babf5965a54afb79649458ec7c3c7a63e96"},
+    {file = "brotli-1.2.0-cp36-cp36m-win_amd64.whl", hash = "sha256:f8d635cafbbb0c61327f942df2e3f474dde1cff16c3cd0580564774eaba1ee13"},
+    {file = "brotli-1.2.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e80a28f2b150774844c8b454dd288be90d76ba6109670fe33d7ff54d96eb5cb8"},
+    {file = "brotli-1.2.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50b1b799f45da91292ffaa21a473ab3a3054fa78560e8ff67082a185274431c8"},
+    {file = "brotli-1.2.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:29b7e6716ee4ea0c59e3b241f682204105f7da084d6254ec61886508efeb43bc"},
+    {file = "brotli-1.2.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:640fe199048f24c474ec6f3eae67c48d286de12911110437a36a87d7c89573a6"},
+    {file = "brotli-1.2.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:92edab1e2fd6cd5ca605f57d4545b6599ced5dea0fd90b2bcdf8b247a12bd190"},
+    {file = "brotli-1.2.0-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:7274942e69b17f9cef76691bcf38f2b2d4c8a5f5dba6ec10958363dcb3308a0a"},
+    {file = "brotli-1.2.0-cp37-cp37m-musllinux_1_2_i686.whl", hash = "sha256:a56ef534b66a749759ebd091c19c03ef81eb8cd96f0d1d16b59127eaf1b97a12"},
+    {file = "brotli-1.2.0-cp37-cp37m-musllinux_1_2_ppc64le.whl", hash = "sha256:5732eff8973dd995549a18ecbd8acd692ac611c5c0bb3f59fa3541ae27b33be3"},
+    {file = "brotli-1.2.0-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:598e88c736f63a0efec8363f9eb34e5b5536b7b6b1821e401afcb501d881f59a"},
+    {file = "brotli-1.2.0-cp37-cp37m-win32.whl", hash = "sha256:7ad8cec81f34edf44a1c6a7edf28e7b7806dfb8886e371d95dcf789ccd4e4982"},
+    {file = "brotli-1.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:865cedc7c7c303df5fad14a57bc5db1d4f4f9b2b4d0a7523ddd206f00c121a16"},
+    {file = "brotli-1.2.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:ac27a70bda257ae3f380ec8310b0a06680236bea547756c277b5dfe55a2452a8"},
+    {file = "brotli-1.2.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e813da3d2d865e9793ef681d3a6b66fa4b7c19244a45b817d0cceda67e615990"},
+    {file = "brotli-1.2.0-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9fe11467c42c133f38d42289d0861b6b4f9da31e8087ca2c0d7ebb4543625526"},
+    {file = "brotli-1.2.0-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c0d6770111d1879881432f81c369de5cde6e9467be7c682a983747ec800544e2"},
+    {file = "brotli-1.2.0-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:eda5a6d042c698e28bda2507a89b16555b9aa954ef1d750e1c20473481aff675"},
+    {file = "brotli-1.2.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:3173e1e57cebb6d1de186e46b5680afbd82fd4301d7b2465beebe83ed317066d"},
+    {file = "brotli-1.2.0-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:71a66c1c9be66595d628467401d5976158c97888c2c9379c034e1e2312c5b4f5"},
+    {file = "brotli-1.2.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:1e68cdf321ad05797ee41d1d09169e09d40fdf51a725bb148bff892ce04583d7"},
+    {file = "brotli-1.2.0-cp38-cp38-win32.whl", hash = "sha256:f16dace5e4d3596eaeb8af334b4d2c820d34b8278da633ce4a00020b2eac981c"},
+    {file = "brotli-1.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:14ef29fc5f310d34fc7696426071067462c9292ed98b5ff5a27ac70a200e5470"},
+    {file = "brotli-1.2.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8d4f47f284bdd28629481c97b5f29ad67544fa258d9091a6ed1fda47c7347cd1"},
+    {file = "brotli-1.2.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2881416badd2a88a7a14d981c103a52a23a276a553a8aacc1346c2ff47c8dc17"},
+    {file = "brotli-1.2.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d39b54b968f4b49b5e845758e202b1035f948b0561ff5e6385e855c96625971"},
+    {file = "brotli-1.2.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:95db242754c21a88a79e01504912e537808504465974ebb92931cfca2510469e"},
+    {file = "brotli-1.2.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bba6e7e6cfe1e6cb6eb0b7c2736a6059461de1fa2c0ad26cf845de6c078d16c8"},
+    {file = "brotli-1.2.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:88ef7d55b7bcf3331572634c3fd0ed327d237ceb9be6066810d39020a3ebac7a"},
+    {file = "brotli-1.2.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:7fa18d65a213abcfbb2f6cafbb4c58863a8bd6f2103d65203c520ac117d1944b"},
+    {file = "brotli-1.2.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:09ac247501d1909e9ee47d309be760c89c990defbb2e0240845c892ea5ff0de4"},
+    {file = "brotli-1.2.0-cp39-cp39-win32.whl", hash = "sha256:c25332657dee6052ca470626f18349fc1fe8855a56218e19bd7a8c6ad4952c49"},
+    {file = "brotli-1.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:1ce223652fd4ed3eb2b7f78fbea31c52314baecfac68db44037bb4167062a937"},
+    {file = "brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a"},
+]
+
+[[package]]
 name = "cached-property"
 version = "2.0.1"
 description = "A decorator for caching properties in classes."
@@ -10044,7 +10155,7 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 
 [extras]
 ccxt = ["ccxt"]
-cloudflare-r2 = ["boto3"]
+cloudflare-r2 = ["boto3", "brotli"]
 data = ["ffn", "gql", "jupyter", "kaleido", "matplotlib", "numpy", "plotly", "pyarrow", "tenacity", "tqdm"]
 docs = ["Sphinx", "furo", "nbsphinx", "sphinx-autodoc-typehints", "sphinx-rtd-theme", "sphinx-rtd-theme", "sphinx-sitemap", "sphinx-sitemap", "zope-dottedname"]
 duckdb = ["duckdb"]
@@ -10057,4 +10168,4 @@ test = ["pytest-xdist"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "c517d8cbdce997e296ddecec476dfd9d326128ff07858e29d3ce458e6da2c7ff"
+content-hash = "7b6d0094550334754ee88fe28478f9480cddd20a480f19ce2184c3e148929a78"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ cachetools = ">=4"
 eth-bloom = "^2.0.0" 
 futureproof = "^0.3.1" 
 orjson = ">=3.10.0" # Fast JSON decoding for JSON-RPC responses
+# Brotli compression for R2 JSON uploads (transparent browser decompression)
+brotli = {version = "^1.1.0", optional = true}
 psutil = "^5.9.0" 
 setuptools = {version = ">=63,<=70"} 
 #evm-trace = "^0.2.6"
@@ -183,7 +185,7 @@ docs = [
 test = ["pytest-xdist"]
 
 ccxt = ["ccxt"]
-cloudflare_r2 = ["boto3"]
+cloudflare_r2 = ["boto3", "brotli"]
 duckdb = ["duckdb"]
 posts = ["duckdb", "feedparser", "tweepy"]
 hyperliquid_backfill = ["boto3", "lz4", "duckdb"]

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -629,6 +629,42 @@ poetry run python scripts/erc-4626/identify-curators.py
 
 Multi-chain vault analysis with JSON export and lifetime metric analysis.
 
+Generates `top_vaults_by_chain.json` with the following top-level structure:
+
+```json
+{
+  "generated_at": "2026-06-08T12:00:00Z",
+  "core3_protocols": {
+    "morpho": { "slug": "morpho", "pol": {...}, "fetched_at": "2026-06-07T12:00:00", ... },
+    "fluid": { "slug": "instadapp", "pol": {...}, ... }
+  },
+  "vaults": [ ... ]
+}
+```
+
+Core3 risk intelligence records are attached at the top level keyed by protocol
+slug (not duplicated per-vault). The `core3_protocols` dict is built directly
+from the Core3 DuckDB at export time and only includes protocols present in the
+exported vaults.
+
+#### Brotli-compressed R2 upload
+
+When the top-vaults JSON is uploaded to R2 (via the post-processing pipeline or
+`scan-vaults-all-chains.py`), both the raw `.json` and a brotli-compressed
+`.json.br` variant are uploaded to each configured bucket. The `.json.br` object
+uses `Content-Encoding: br` and `Content-Type: application/json` so that
+browsers transparently decompress it.
+
+Brotli compression uses quality 11 (maximum, suitable for offline pipelines).
+If the `brotli` package is not installed, the upload fails with a logged warning
+and the function returns `False` — the raw JSON is still uploaded first.
+
+The `brotli` package is included in the `cloudflare_r2` poetry extra:
+
+```shell
+poetry install -E cloudflare_r2
+```
+
 In production, run with `OUTPUT_JSON` pointing to the upload path:
 
 ```shell
@@ -638,6 +674,7 @@ OUTPUT_JSON=~/.tradingstrategy/top_vaults_by_chain.json poetry run python script
 | Variable | Description |
 |----------|-------------|
 | `OUTPUT_JSON` | Optional. Output file path. Default: `~/.tradingstrategy/vaults/stablecoin-vault-metrics.json`. |
+| `CORE3_DATABASE_PATH` | Optional. Core3 DuckDB path. Default: `~/.tradingstrategy/vaults/core3/core3.duckdb`. |
 
 After generating, upload to R2 with rclone:
 

--- a/scripts/erc-4626/vault-analysis-json.py
+++ b/scripts/erc-4626/vault-analysis-json.py
@@ -35,12 +35,14 @@ from pathlib import Path
 
 from eth_defi.core3.constants import CORE3_DATABASE_PATH
 from eth_defi.core3.database import Core3Database
+from eth_defi.core3.vault_protocol import build_core3_protocols_for_export
 from eth_defi.token import is_stablecoin_like
 
 # Import core TradingStrategy / eth_defi modules
 from eth_defi.vault.base import VaultSpec  # noqa: F401
 from eth_defi.vault.vaultdb import VaultDatabase, get_pipeline_data_dir
 from eth_defi.research.vault_metrics import (
+    VaultMetricsExport,
     calculate_lifetime_metrics,
     export_lifetime_row,
     cross_check_data,
@@ -214,26 +216,7 @@ def main(
 
     raw_returns_df = returns_df = calculate_hourly_returns_for_all_vaults(prices_df)
 
-    # Open Core3 risk intelligence database if locally available.
-    # Resolved from explicit argument, CORE3_DATABASE_PATH env var, or the default constant.
-    # Only opened if the file exists — constructing Core3Database on a non-existent
-    # path would create an empty database rather than being truly optional.
-    core3_db = None
-    if core3_db_path is None:
-        db_path_env = os.getenv("CORE3_DATABASE_PATH")
-        if db_path_env:
-            core3_db_path = Path(db_path_env).expanduser()
-        else:
-            core3_db_path = CORE3_DATABASE_PATH
-    if core3_db_path.exists():
-        core3_db = Core3Database(core3_db_path)
-        print(f"Opened Core3 risk database at {core3_db_path} with {core3_db.get_project_count()} projects")
-
-    try:
-        lifetime_data_df = calculate_lifetime_metrics(returns_df, vault_db, core3_db=core3_db)
-    finally:
-        if core3_db is not None:
-            core3_db.close()
+    lifetime_data_df = calculate_lifetime_metrics(returns_df, vault_db)
 
     print(f"Calculated lifetime metrics for {len(lifetime_data_df):,} vaults with {len(lifetime_data_df.columns):,} columns")
 
@@ -244,9 +227,30 @@ def main(
     # 5️⃣ Convert DataFrame → list of dicts
     vaults = [export_lifetime_row(r) for _, r in filtered_lifetime_data_df.iterrows()]
 
-    # 6️⃣ Add metadata and deep sanitize
-    output_data = {
+    # 6️⃣ Build Core3 protocol-level risk data directly for the export.
+    # Core3 data is per-protocol (not per-vault), so it lives at the top level
+    # of the JSON export keyed by our internal protocol slugs.
+    core3_protocols = {}
+    if core3_db_path is None:
+        db_path_env = os.getenv("CORE3_DATABASE_PATH")
+        if db_path_env:
+            core3_db_path = Path(db_path_env).expanduser()
+        else:
+            core3_db_path = CORE3_DATABASE_PATH
+    if core3_db_path.exists():
+        core3_db = Core3Database(core3_db_path)
+        try:
+            print(f"Opened Core3 risk database at {core3_db_path} with {core3_db.get_project_count()} projects")
+            unique_slugs = {v.get("protocol_slug") for v in vaults if v.get("protocol_slug")}
+            unique_slugs.discard(None)
+            core3_protocols = build_core3_protocols_for_export(core3_db, unique_slugs)
+        finally:
+            core3_db.close()
+
+    # 7️⃣ Add metadata and deep sanitize
+    output_data: VaultMetricsExport = {
         "generated_at": datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "core3_protocols": core3_protocols,
         "vaults": vaults,
     }
 

--- a/tests/core3/test_vault_protocol_export.py
+++ b/tests/core3/test_vault_protocol_export.py
@@ -1,0 +1,87 @@
+"""Test Core3 export helper for vault metrics JSON export."""
+
+import datetime
+from pathlib import Path
+
+import pytest
+
+from eth_defi.core3.database import Core3Database
+from eth_defi.core3.vault_protocol import build_core3_protocols_for_export
+
+
+def _make_core3_project_json(slug: str, name: str, rank: int, pol_score: float) -> dict:
+    """Build a Core3 project JSON matching the full API payload shape."""
+    return {
+        "slug": slug,
+        "name": name,
+        "description": f"{name} is a DeFi protocol.",
+        "rank": rank,
+        "pol": {"score": pol_score, "rating": "BB", "confidence": "High"},
+        "ticker": slug.upper(),
+        "coingecko_id": slug,
+        "logo": f"https://example.com/{slug}.png",
+        "link": f"https://core3.io{slug}",
+        "launched_at": None,
+        "category": {"name": "Decentralized Finance"},
+        "data_coverage": {"percentage": 76.7},
+        "market_cap": {"in_usd": "1000000", "change_24h_percentage": -0.5, "change_24h_in_usd": "-5000"},
+        "chains": [{"name": "Ethereum"}, {"name": "Base"}],
+        "links": {
+            "website": f"https://{slug}.org/",
+            "legal": None,
+            "whitepaper": None,
+            "socials": [{"name": "Twitter", "link": f"https://twitter.com/{slug}"}],
+        },
+        "tags": [],
+        "top_risks": [{"content": "Example risk finding.", "date": "2026-01-01T00:00:00.000Z"}],
+        "recent_changes": [],
+        "seals": {
+            "security_measures": {"value": False, "logo": None},
+            "independent_certificates": {"value": False, "logo": None},
+            "self_regulation": {"value": False, "logo": None},
+        },
+    }
+
+
+def test_build_core3_protocols_for_export(tmp_path: Path):
+    """Core3 export helper builds a protocol-slug-keyed dict from the DB.
+
+    1. Create a temp Core3 DuckDB with morpho and instadapp (fluid alias) snapshots
+    2. Call build_core3_protocols_for_export with morpho, fluid, euler, some-random
+    3. Assert morpho is returned with correct PoL score
+    4. Assert fluid is keyed as "fluid" with Core3 slug "instadapp"
+    5. Assert euler (no DB data) and some-random (no mapping) are absent
+    6. Assert fetched_at is an ISO 8601 string, not a datetime
+    """
+    # 1. Create temp Core3 DB with morpho and instadapp snapshots
+    db = Core3Database(tmp_path / "test-core3.duckdb")
+    t_fetch = datetime.datetime(2026, 7, 1, 12, 0, 0)
+
+    db.insert_project_snapshot("morpho", t_fetch, _make_core3_project_json("morpho", "Morpho", rank=96, pol_score=32.15))
+    db.insert_project_snapshot("instadapp", t_fetch, _make_core3_project_json("instadapp", "Fluid (Instadapp)", rank=150, pol_score=45.0))
+
+    try:
+        # 2. Build export for a mix of valid, aliased, missing, and unmapped slugs
+        result = build_core3_protocols_for_export(db, ["morpho", "fluid", "euler", "some-random"])
+    finally:
+        db.close()
+
+    # 3. Morpho is returned with correct data
+    assert "morpho" in result
+    assert result["morpho"]["slug"] == "morpho"
+    assert result["morpho"]["pol"]["score"] == pytest.approx(32.15)
+    assert result["morpho"]["rank"] == 96
+
+    # 4. Fluid is keyed as "fluid" but the Core3 record has slug "instadapp"
+    assert "fluid" in result
+    assert result["fluid"]["slug"] == "instadapp"
+    assert result["fluid"]["pol"]["score"] == pytest.approx(45.0)
+
+    # 5. Euler (no DB data) and some-random (no mapping) are absent
+    assert "euler" not in result
+    assert "some-random" not in result
+
+    # 6. fetched_at is an ISO 8601 string
+    assert result["morpho"]["fetched_at"] == "2026-07-01T12:00:00"
+    assert isinstance(result["morpho"]["fetched_at"], str)
+    assert result["fluid"]["fetched_at"] == "2026-07-01T12:00:00"

--- a/tests/erc_4626/test_post_processing.py
+++ b/tests/erc_4626/test_post_processing.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import brotli
 import pytest
+
+brotli = pytest.importorskip("brotli", reason="brotli not installed (cloudflare_r2 extra)")
 
 from eth_defi.vault import post_processing
 

--- a/tests/erc_4626/test_post_processing.py
+++ b/tests/erc_4626/test_post_processing.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import brotli
 import pytest
 
 from eth_defi.vault import post_processing
@@ -39,3 +40,114 @@ def test_upload_top_vaults_json_to_configured_buckets_continues_after_primary_fa
 
     assert success is False
     assert upload_attempts == ["public-bucket", "private-bucket"]
+
+
+def test_brotli_upload_params(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Brotli upload sends correct content_encoding, content_type, and object key.
+
+    1. Write a small JSON file
+    2. Stub upload_file_to_r2 (raw) and upload_bytes_to_r2 (brotli)
+    3. Call _upload_top_vaults_json_to_bucket
+    4. Assert brotli upload was called with correct params
+    5. Assert the uploaded payload is valid brotli-compressed data
+    """
+    # 1. Write test JSON
+    output_path = tmp_path / "top_vaults_by_chain.json"
+    json_content = '{"vaults": []}'
+    output_path.write_text(json_content, encoding="utf-8")
+
+    # 2. Stub upload functions
+    raw_calls: list[dict] = []
+    brotli_calls: list[dict] = []
+
+    def fake_upload_file_to_r2(**kwargs) -> bool:
+        raw_calls.append(kwargs)
+        return True
+
+    def fake_upload_bytes_to_r2(**kwargs) -> bool:
+        brotli_calls.append(kwargs)
+        return True
+
+    def fake_calculate_bytes_digest(payload: bytes):
+        return "fake-digest"
+
+    monkeypatch.setattr(post_processing, "upload_file_to_r2", fake_upload_file_to_r2)
+    monkeypatch.setattr(post_processing, "upload_bytes_to_r2", fake_upload_bytes_to_r2)
+    monkeypatch.setattr(post_processing, "calculate_bytes_digest", fake_calculate_bytes_digest)
+
+    # 3. Call the single-bucket upload
+    result = post_processing._upload_top_vaults_json_to_bucket(
+        s3_client=object(),
+        output_path=output_path,
+        bucket_name="test-bucket",
+        endpoint_url="https://example.r2.cloudflarestorage.com",
+        object_key="top_vaults_by_chain.json",
+        access_key_id="test-key-12345678",
+        bucket_label="primary",
+    )
+
+    assert result is True
+
+    # 4. Assert brotli upload params
+    assert len(brotli_calls) == 1
+    br_call = brotli_calls[0]
+    assert br_call["object_name"] == "top_vaults_by_chain.json.br"
+    assert br_call["content_type"] == "application/json"
+    assert br_call["content_encoding"] == "br"
+    assert br_call["skip_if_current"] is True
+    assert br_call["source_digest"] == "fake-digest"
+
+    # 5. Assert the payload is valid brotli-compressed data
+    decompressed = brotli.decompress(br_call["payload"])
+    assert decompressed == json_content.encode("utf-8")
+
+
+def test_brotli_failure_returns_false(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When brotli upload fails, raw JSON is already uploaded and function returns False.
+
+    1. Write a small JSON file
+    2. Stub upload_file_to_r2 to succeed, upload_bytes_to_r2 to raise
+    3. Call _upload_top_vaults_json_to_bucket
+    4. Assert raw upload succeeded but function returns False
+    """
+    # 1. Write test JSON
+    output_path = tmp_path / "top_vaults_by_chain.json"
+    output_path.write_text('{"vaults": []}', encoding="utf-8")
+
+    # 2. Stub upload functions
+    raw_calls: list[dict] = []
+
+    def fake_upload_file_to_r2(**kwargs) -> bool:
+        raw_calls.append(kwargs)
+        return True
+
+    def fake_upload_bytes_to_r2(**kwargs) -> bool:
+        raise RuntimeError("Simulated brotli upload failure")
+
+    def fake_calculate_bytes_digest(payload: bytes):
+        return "fake-digest"
+
+    monkeypatch.setattr(post_processing, "upload_file_to_r2", fake_upload_file_to_r2)
+    monkeypatch.setattr(post_processing, "upload_bytes_to_r2", fake_upload_bytes_to_r2)
+    monkeypatch.setattr(post_processing, "calculate_bytes_digest", fake_calculate_bytes_digest)
+
+    # 3. Call single-bucket upload
+    result = post_processing._upload_top_vaults_json_to_bucket(
+        s3_client=object(),
+        output_path=output_path,
+        bucket_name="test-bucket",
+        endpoint_url="https://example.r2.cloudflarestorage.com",
+        object_key="top_vaults_by_chain.json",
+        access_key_id="test-key-12345678",
+        bucket_label="primary",
+    )
+
+    # 4. Raw upload succeeded but brotli failed → returns False
+    assert len(raw_calls) == 1
+    assert result is False

--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -1,6 +1,5 @@
 """Test vault metrics calculations and charts."""
 
-import datetime
 import json
 import os.path
 import pickle
@@ -11,7 +10,6 @@ import pytest
 import zstandard as zstd
 from plotly.graph_objects import Figure
 
-from eth_defi.core3.database import Core3Database
 from eth_defi.research.sparkline import export_sparkline_as_png, export_sparkline_as_svg, extract_vault_price_data, render_sparkline_simple
 from eth_defi.research.vault_benchmark import visualise_vault_return_benchmark
 from eth_defi.research.vault_metrics import PeriodMetrics, apply_abnormal_value_checks, apply_morpho_not_in_api_check, calculate_lifetime_metrics, calculate_period_metrics, display_vault_chart_and_tearsheet, export_lifetime_row, format_lifetime_table
@@ -535,123 +533,3 @@ def test_export_lifetime_row_nat_serialization():
     # Verify other fields are still properly serialized
     assert parsed["name"] == "Test Vault"
     assert parsed["current_nav"] == 1000.0
-
-
-def _make_core3_project_json(slug: str, name: str, rank: int, pol_score: float) -> dict:
-    """Build a Core3 project JSON matching the full API payload shape.
-
-    Local helper — not imported from ``tests/core3/`` to avoid
-    cross-test-tree imports.
-    """
-    return {
-        "slug": slug,
-        "name": name,
-        "description": f"{name} is a DeFi protocol.",
-        "rank": rank,
-        "pol": {"score": pol_score, "rating": "BB", "confidence": "High"},
-        "ticker": slug.upper(),
-        "coingecko_id": slug,
-        "logo": f"https://example.com/{slug}.png",
-        "link": f"https://core3.io{slug}",
-        "launched_at": None,
-        "category": {"name": "Decentralized Finance"},
-        "data_coverage": {"percentage": 76.7},
-        "market_cap": {"in_usd": "1000000", "change_24h_percentage": -0.5, "change_24h_in_usd": "-5000"},
-        "chains": [{"name": "Ethereum"}, {"name": "Base"}],
-        "links": {
-            "website": f"https://{slug}.org/",
-            "legal": None,
-            "whitepaper": None,
-            "socials": [{"name": "Twitter", "link": f"https://twitter.com/{slug}"}],
-        },
-        "tags": [],
-        "top_risks": [{"content": "Example risk finding.", "date": "2026-01-01T00:00:00.000Z"}],
-        "recent_changes": [],
-        "seals": {
-            "security_measures": {"value": False, "logo": None},
-            "independent_certificates": {"value": False, "logo": None},
-            "self_regulation": {"value": False, "logo": None},
-        },
-    }
-
-
-def test_core3_integration_in_lifetime_metrics(
-    vault_db: VaultDatabase,
-    price_df: pd.DataFrame,
-    tmp_path: Path,
-):
-    """Core3 risk data flows through calculate_lifetime_metrics into JSON export.
-
-    The Hemi test fixture contains Morpho vaults (protocol_slug == "morpho").
-    We insert a synthetic Core3 snapshot for "morpho" and verify:
-
-    1. Create a temp Core3 DuckDB and insert a "morpho" project snapshot
-    2. Call calculate_lifetime_metrics with core3_db
-    3. Verify Morpho vaults have other_data["core3"] populated with PoL score
-    4. Verify non-Morpho vaults have other_data["core3"] as None
-    5. Run export_lifetime_row + json.dumps to verify full serialisation path
-    6. Assert fetched_at becomes an ISO 8601 string, not a raw datetime
-    """
-    # 1. Create temp Core3 DuckDB with a morpho snapshot
-    core3_db = Core3Database(tmp_path / "test-core3.duckdb")
-    t_fetch = datetime.datetime(2025, 7, 1, 12, 0, 0)
-    raw = _make_core3_project_json("morpho", "Morpho", rank=96, pol_score=32.15)
-    core3_db.insert_project_snapshot("morpho", t_fetch, raw)
-
-    try:
-        # 2. Calculate lifetime metrics with Core3 DB
-        metrics = calculate_lifetime_metrics(
-            price_df,
-            vault_db,
-            core3_db=core3_db,
-        )
-    finally:
-        core3_db.close()
-
-    assert len(metrics) == 3
-
-    # 3. Morpho vault should have Core3 data populated
-    morpho_row = metrics.set_index("id").loc["43111-0x05c2e246156d37b39a825a25dd08d5589e3fd883"]
-    assert morpho_row["protocol_slug"] == "morpho"
-    core3_data = morpho_row["other_data"]["core3"]
-    assert core3_data is not None
-    assert core3_data["slug"] == "morpho"
-    assert core3_data["pol"]["score"] == pytest.approx(32.15)
-    assert core3_data["rank"] == 96
-    assert len(core3_data["top_risks"]) == 1
-    assert isinstance(core3_data["fetched_at"], datetime.datetime)
-
-    # 4. Non-Morpho vaults should have core3 as None
-    non_morpho_rows = metrics[metrics["protocol_slug"] != "morpho"]
-    for _, row in non_morpho_rows.iterrows():
-        assert row["other_data"]["core3"] is None
-
-    # 5. Full serialisation path: export_lifetime_row + json.dumps
-    exported = export_lifetime_row(morpho_row)
-    json_str = json.dumps(exported)
-    parsed = json.loads(json_str)
-
-    # 6. fetched_at must be an ISO 8601 string after serialisation
-    assert parsed["other_data"]["core3"]["fetched_at"] == "2025-07-01T12:00:00"
-    assert parsed["other_data"]["core3"]["pol"]["score"] == pytest.approx(32.15)
-    assert parsed["other_data"]["core3"]["rank"] == 96
-
-
-def test_core3_none_when_db_not_provided(
-    vault_db: VaultDatabase,
-    price_df: pd.DataFrame,
-):
-    """Without Core3 DB, all vaults have other_data["core3"] as None.
-
-    1. Call calculate_lifetime_metrics without core3_db
-    2. Verify all rows have other_data["core3"] as None
-    """
-    # 1. No core3_db argument
-    metrics = calculate_lifetime_metrics(
-        price_df,
-        vault_db,
-    )
-
-    # 2. All rows should have core3 as None
-    for _, row in metrics.iterrows():
-        assert row["other_data"]["core3"] is None

--- a/tests/vault/test_sample_export.py
+++ b/tests/vault/test_sample_export.py
@@ -1,0 +1,52 @@
+"""Test sample export core3_protocols filtering."""
+
+import json
+from pathlib import Path
+
+from eth_defi.vault.sample_export import generate_sample_json
+
+
+def test_sample_json_filters_core3_protocols(tmp_path: Path):
+    """Sample JSON export filters core3_protocols to only Ethereum protocol slugs.
+
+    1. Create a source JSON with Ethereum and non-Ethereum vaults plus core3_protocols
+    2. Generate sample JSON (Ethereum-only filter)
+    3. Assert only protocol slugs present in Ethereum vaults are kept in core3_protocols
+    """
+    # 1. Create source JSON with mixed chains and core3_protocols
+    source_data = {
+        "generated_at": "2026-06-08T00:00:00Z",
+        "core3_protocols": {
+            "morpho": {"slug": "morpho", "name": "Morpho", "pol": {"score": 32.0}},
+            "fluid": {"slug": "instadapp", "name": "Fluid", "pol": {"score": 45.0}},
+            "gains-network": {"slug": "gains-network", "name": "Gains", "pol": {"score": 60.0}},
+        },
+        "vaults": [
+            {"chain_id": 1, "protocol_slug": "morpho", "name": "Morpho Vault A"},
+            {"chain_id": 1, "protocol_slug": "morpho", "name": "Morpho Vault B"},
+            {"chain_id": 1, "protocol_slug": "fluid", "name": "Fluid Vault"},
+            {"chain_id": 42161, "protocol_slug": "gains-network", "name": "Gains Vault on Arbitrum"},
+        ],
+    }
+
+    source_path = tmp_path / "source.json"
+    source_path.write_text(json.dumps(source_data), encoding="utf-8")
+
+    output_path = tmp_path / "sample.json"
+
+    # 2. Generate sample (filters to chain_id=1 only)
+    count = generate_sample_json(source_path, output_path)
+
+    # 3. Read and verify
+    result = json.loads(output_path.read_text(encoding="utf-8"))
+
+    assert count == 3
+    assert len(result["vaults"]) == 3
+
+    # core3_protocols should only have morpho and fluid (Ethereum vaults)
+    assert "morpho" in result["core3_protocols"]
+    assert "fluid" in result["core3_protocols"]
+    # gains-network is Arbitrum only — should be excluded
+    assert "gains-network" not in result["core3_protocols"]
+
+    assert result["generated_at"] == "2026-06-08T00:00:00Z"


### PR DESCRIPTION
## Why

The vault JSON export (`top_vaults_by_chain.json`) duplicated Core3 risk intelligence records across every vault of the same protocol — ~15 MB of redundant data (214 KB unique) across ~1,454 vaults and 21 mapped protocols. The JSON was also uploaded uncompressed. There was no TypedDict describing the export shape.

## Summary

**Core3 normalisation:**
- Removed Core3 from `calculate_lifetime_metrics()` pipeline entirely — no more `core3_db` parameter or per-vault `other_data["core3"]`
- Added `build_core3_protocols_for_export()` helper that builds a top-level `core3_protocols` dict directly from the Core3 DB at JSON export time, keyed by our internal protocol slugs
- Sample export filters `core3_protocols` to only Ethereum protocol slugs

**TypedDict schema:**
- Added `VaultMetricsExport` and `VaultMetricsRecord` TypedDicts for the JSON export shape
- Added `Core3ExportRecord` TypedDict for the serialised Core3 record (fetched_at as str)

**Brotli compression:**
- Both raw `.json` and brotli-compressed `.json.br` are uploaded to each R2 bucket
- `.json.br` uses `Content-Encoding: br` for transparent browser decompression
- `brotli` added as optional dependency in the `cloudflare_r2` extra
- Missing brotli or upload failure returns `False`; raw JSON is uploaded first

**Tests:**
- New `test_vault_protocol_export.py` — mapped, aliased, missing, unmapped slug lookups
- New `test_sample_export.py` — core3_protocols filtering for Ethereum-only sample
- Extended `test_post_processing.py` — brotli upload params and failure handling
- Removed obsolete Core3 integration tests from `test_vault_metrics.py`

## Lessons learnt

- Shallow-copy records before mutating TypedDict fields to avoid type lies
- Materialise iterables before logging `len()` to avoid zero denominators from generators
- Missing optional dependencies should return failure, not silent success

## Related issues and PRs

Continues the Core3 integration from the previous PR that added `other_data["core3"]`.