### PR TITLE
fix: Increase default HTTP timeout and add flaky markers for CI stability

### DIFF
--- a/eth_defi/provider/multi_provider.py
+++ b/eth_defi/provider/multi_provider.py
@@ -129,7 +129,7 @@ def create_multi_provider_web3(
     request_kwargs: Optional[Any] = None,
     session: Optional[Any] = None,
     switchover_noisiness=logging.WARNING,
-    default_http_timeout=(3.0, 30.0),
+    default_http_timeout=(3.0, 60.0),
     retries: int = 6,
     hint: Optional[str] = "",
     unit_test=False,

--- a/tests/erc_4626/test_4626_deposit_redeem.py
+++ b/tests/erc_4626/test_4626_deposit_redeem.py
@@ -59,6 +59,7 @@ def web3(anvil_base_fork) -> Web3:
         web3 = create_multi_provider_web3(
             anvil_base_fork.json_rpc_url,
             retries=0,
+            default_http_timeout=(3, 250.0),
         )
     assert web3.eth.chain_id == 8453
     return web3

--- a/tests/lagoon/test_deploy_base.py
+++ b/tests/lagoon/test_deploy_base.py
@@ -804,6 +804,7 @@ def test_lagoon_legacy_deploy_base_guarded_any_token(
     assert usdc.fetch_balance_of(depositor) > 994
 
 
+@flaky.flaky
 def test_lagoon_settle_v_0_1_0(
     web3: Web3,
     uniswap_v2,

--- a/tests/lagoon/test_erc_7540_deposit_redeem.py
+++ b/tests/lagoon/test_erc_7540_deposit_redeem.py
@@ -74,6 +74,7 @@ def web3(anvil_base_fork) -> Web3:
         web3 = create_multi_provider_web3(
             anvil_base_fork.json_rpc_url,
             retries=1,
+            default_http_timeout=(3, 250.0),
         )
     assert web3.eth.chain_id == 8453
     return web3

--- a/tests/lagoon/test_lagoon_flow_analysis.py
+++ b/tests/lagoon/test_lagoon_flow_analysis.py
@@ -2,6 +2,7 @@
 
 from decimal import Decimal
 
+import flaky
 import pytest
 from eth_typing import HexAddress
 from web3 import Web3
@@ -14,6 +15,7 @@ from eth_defi.uniswap_v2.deployment import UniswapV2Deployment
 from eth_defi.uniswap_v2.swap import swap_with_slippage_protection
 
 
+@flaky.flaky
 def test_lagoon_deposit_redeem(
     web3: Web3,
     automated_lagoon_vault: LagoonAutomatedDeployment,
@@ -181,6 +183,7 @@ def test_lagoon_deposit_redeem(
     assert isinstance(data, dict)
 
 
+@flaky.flaky
 def test_lagoon_redeem_too_much(
     web3: Web3,
     automated_lagoon_vault: LagoonAutomatedDeployment,

--- a/tests/uniswap_v3/test_uniswap_v3_tvl.py
+++ b/tests/uniswap_v3/test_uniswap_v3_tvl.py
@@ -47,6 +47,7 @@ def matic_usdc_pool(web3) -> PoolDetails:
     return pool
 
 
+@flaky.flaky
 def test_fetch_current_tvl(
     matic_usdc_pool: PoolDetails,
     usdc: TokenDetails,
@@ -57,8 +58,7 @@ def test_fetch_current_tvl(
     assert usdc_tvl > 10_000, f"Hoped we have at least $10,000 USDC locked up at 5 BPS pool"
 
 
-# FAILED tests/uniswap_v3/test_uniswap_v3_tvl.py::test_fetch_historic_tvl - ValueError: ***'message': "state histories haven't been fully indexed yet", 'code': -32000***
-@flaky.flaky
+@flaky.flaky(max_runs=3)
 def test_fetch_historic_tvl(
     matic_usdc_pool: PoolDetails,
     usdc: TokenDetails,


### PR DESCRIPTION
## Why

CI tests are failing intermittently due to two categories of flakiness:

1. **Anvil ReadTimeout (30s)** — `create_multi_provider_web3()` defaults to a 30-second read timeout, which is too short for CI runners under parallel Anvil fork load. Tests like `test_erc_4626_deposit` and `test_erc_7540_deposit_722_capital` fail during fixture setup.

2. **RPC transient errors** — `BlockOutOfRangeError` from upstream RPC nodes and `"historical state is not available"` from Polygon archive nodes cause sporadic failures in Lagoon deploy and Uniswap TVL tests.

## Summary

- Increased `create_multi_provider_web3()` default read timeout from 30s → 60s to reduce flakiness across all tests
- Added `default_http_timeout=(3, 250.0)` to `test_4626_deposit_redeem` and `test_erc_7540_deposit_redeem` web3 fixtures (matching existing Lagoon conftest pattern)
- Added `@flaky.flaky` to `test_lagoon_settle_v_0_1_0`, `test_lagoon_deposit_redeem`, `test_lagoon_redeem_too_much` for `BlockOutOfRangeError` recovery
- Added `@flaky.flaky` to `test_fetch_current_tvl` and increased `max_runs=3` on `test_fetch_historic_tvl` for archive state availability issues

## Lessons learnt

- Many test fixtures used the 30s default from `create_multi_provider_web3()` while the Lagoon conftest already discovered the fix (`default_http_timeout=(3, 250.0)`) — the pattern wasn't propagated to other tests
- `BlockOutOfRangeError` is a transient RPC issue unrelated to test logic; `@flaky.flaky` is the correct mitigation