### PR TITLE
fix: repair Royco tranche purge metadata

### DIFF
--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -24,6 +24,24 @@ from eth_defi.vault.risk import BROKEN_VAULT_CONTRACTS
 logger = logging.getLogger(__name__)
 
 
+#: Royco chains that may host WrappedVault or tranche vault markets.
+#:
+#: Based on Royco ``vault/explore`` and ``market/explore`` API rows, plus
+#: locally observed Royco vault rows that may temporarily disappear from the
+#: API response.
+ROYCO_CHAIN_IDS = {
+    1,  # Ethereum
+    146,  # Sonic
+    999,  # HyperEVM
+    8453,  # Base
+    42161,  # Arbitrum
+    43114,  # Avalanche
+    80094,  # Berachain
+    98866,  # Plume
+    11155111,  # Sepolia
+    21000000,  # Corn
+}
+
 #: Chain restrictions for protocols deployed on 3 or fewer chains.
 #:
 #: Maps probe function names to the set of chain IDs where that protocol is deployed.
@@ -32,6 +50,11 @@ logger = logging.getLogger(__name__)
 #: Data source: https://top-defi-vaults.tradingstrategy.ai/top_vaults_by_chain.json
 #: Data checked: 2026-01-13
 #:
+#: When changing vault classification probes, remember that already discovered
+#: vaults keep stored feature flags in ``vault-metadata-db.pickle`` and reader
+#: progress in reader-state pickle files. Manually purge or repair the database
+#: and rescan affected vaults; see ``scripts/erc-4626/purge-royco-tranche-data.py``
+#: for an example.
 CHAIN_RESTRICTED_PROBES: dict[str, set[int]] = {
     # Disabled protocols - not found in vault data, disable everywhere
     "outputToLp0Route": set(),  # Baklava Space - not found in data
@@ -54,7 +77,7 @@ CHAIN_RESTRICTED_PROBES: dict[str, set[int]] = {
     "getPerformanceFeeData": {1, 8453, 42161},  # IPOR - Ethereum, Base, Arbitrum
     "borrowed_token": {1, 10, 42161},  # Llama Lend - Ethereum, Optimism, Arbitrum
     "previewRateAfterDeposit": {1, 42161, 80094},  # Royco - Ethereum, Arbitrum, Berachain
-    "getRawNAV": {1},  # Royco senior/junior tranche vaults - Ethereum
+    "getRawNAV": ROYCO_CHAIN_IDS,  # Royco senior/junior tranche vaults
     "repoTokenHoldings": {1, 9745, 43114},  # Term Finance - Ethereum, Plasma, Avalanche
     "depositController": {1, 56, 42161},  # TrueFi - Ethereum, BSC, Arbitrum
     "poolId": {1, 8453, 42161},  # Centrifuge - Ethereum, Base, Arbitrum

--- a/eth_defi/erc_4626/vault_protocol/royco/README-Royco.md
+++ b/eth_defi/erc_4626/vault_protocol/royco/README-Royco.md
@@ -237,6 +237,13 @@ As of the 2026-06-03 investigation:
 Run these commands after adding Royco vault support to rediscover old Royco
 events and rebuild historical prices for Royco API vaults.
 
+When vault classification changes, the change is not retroactive for already
+discovered vaults. Stored feature flags in `vault-metadata-db.pickle`, old price
+rows and reader-state progress need to be repaired or purged manually, then the
+affected vaults must be rescanned. Use
+`scripts/erc-4626/purge-royco-tranche-data.py` below as the worked example for a
+classification migration.
+
 **Note:** These steps use the Royco market API which only returns non-tranche
 WrappedVault addresses. For tranche vaults (`ROY-ST-*`, `ROY-JT-*`), see
 [Fixing corrupted Royco tranche price data](#fixing-corrupted-royco-tranche-price-data)

--- a/scripts/erc-4626/purge-royco-tranche-data.py
+++ b/scripts/erc-4626/purge-royco-tranche-data.py
@@ -8,6 +8,11 @@ This script removes **all** historical rows for affected Royco tranche vaults
 and resets their reader states so the scanner re-populates them from scratch
 with the correct reader.
 
+This is also the reference example for future vault classification migrations:
+changing classifier probes does not update stored ``vault-metadata-db.pickle``
+features or reader-state progress. Operators must explicitly repair/purge the
+database and rescan affected vaults after classification changes.
+
 Usage:
 
 .. code-block:: shell
@@ -16,6 +21,8 @@ Usage:
 
 Environment variables:
 
+- ``VAULT_DB``: Path to the vault metadata pickle. Defaults to
+  ``~/.tradingstrategy/vaults/vault-metadata-db.pickle``.
 - ``UNCLEANED_PRICE_DATABASE``: Path to the uncleaned price parquet. Same env
   var as ``scan-prices.py``. Defaults to
   ``~/.tradingstrategy/vaults/vault-prices-1h.parquet``.
@@ -29,48 +36,204 @@ import logging
 import os
 import pickle
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
 
 import pandas as pd
 
+from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name
 from eth_defi.utils import setup_console_logging
 from eth_defi.vault.base import VaultHistoricalRead, VaultSpec
-from eth_defi.vault.vaultdb import DEFAULT_READER_STATE_DATABASE, DEFAULT_UNCLEANED_PRICE_DATABASE, VaultDatabase
+from eth_defi.vault.vaultdb import DEFAULT_READER_STATE_DATABASE, DEFAULT_UNCLEANED_PRICE_DATABASE, DEFAULT_VAULT_DATABASE, VaultDatabase
 
 logger = logging.getLogger(__name__)
 
 
-#: Royco tranche vaults are identified by the royco_tranche_like feature.
-#: We find them in the vault metadata DB by their Protocol field.
-ROYCO_PROTOCOL_NAME = "Royco"
+#: Error marker produced by the generic ERC-4626 reader when it sees Royco's
+#: ``AssetClaims`` tuple return.
+NON_STANDARD_ABI_ERROR = "non-standard ABI"
+
+#: Names that indicate Royco tranche vaults in metadata rows.
+TRANCHE_NAME_MARKER = "Tranche"
 
 
-def find_royco_tranche_specs() -> set[VaultSpec]:
+@dataclass(slots=True, frozen=True)
+class MetadataRepairResult:
+    """Result of repairing Royco tranche metadata features.
+
+    :param specs:
+        All Royco tranche specs the purge script should operate on.
+
+    :param repaired_rows:
+        Number of vault metadata rows that would be or were updated.
+    """
+
+    specs: set[VaultSpec]
+    repaired_rows: int
+
+
+def collect_non_standard_abi_specs(parquet_path: Path) -> set[VaultSpec]:
+    """Collect vault specs that produced Royco tuple ABI errors.
+
+    These rows were read with the generic ERC-4626 reader, which rejects
+    Royco ``AssetClaims`` tuple payloads after the guard was added. They are
+    strong evidence that the stored metadata features are stale and should be
+    repaired to ``royco_tranche_like``.
+
+    :param parquet_path:
+        Path to the uncleaned price parquet.
+
+    :return:
+        Set of affected ``VaultSpec`` instances.
+    """
+    if not parquet_path.exists():
+        logger.warning("Cannot scan non-standard ABI rows, parquet file not found: %s", parquet_path)
+        return set()
+
+    df = pd.read_parquet(parquet_path, columns=["chain", "address", "errors"])
+    errors = df["errors"].fillna("").astype(str)
+    affected_df = df[errors.str.contains(NON_STANDARD_ABI_ERROR, na=False)]
+    specs = {VaultSpec(int(row.chain), str(row.address).lower()) for row in affected_df[["chain", "address"]].drop_duplicates().itertuples(index=False)}
+    logger.info("Found %d specs with non-standard ABI errors", len(specs))
+    return specs
+
+
+def is_royco_tranche_metadata_row(
+    spec: VaultSpec,
+    row: dict,
+    error_specs: set[VaultSpec],
+) -> bool:
+    """Check whether a vault metadata row should be treated as a Royco tranche.
+
+    The primary signal is ``royco_tranche_like`` in stored features. For stale
+    rows we also accept names like ``Royco Senior Tranche ...`` and any row
+    that produced a Royco tuple ABI error in the uncleaned parquet.
+
+    :param spec:
+        Vault spec for the metadata row.
+
+    :param row:
+        Vault metadata row from :class:`VaultDatabase`.
+
+    :param error_specs:
+        Specs collected from ``non-standard ABI`` parquet errors.
+
+    :return:
+        ``True`` if the row should use the Royco tranche reader.
+    """
+    features = set(row.get("features") or set())
+    detection = row.get("_detection_data")
+    if detection is not None:
+        features.update(detection.features)
+
+    if ERC4626Feature.royco_tranche_like in features:
+        return True
+
+    if spec in error_specs:
+        return True
+
+    name = row.get("Name") or ""
+    return "Royco" in name and TRANCHE_NAME_MARKER in name
+
+
+def repair_royco_tranche_metadata(
+    vault_db_path: Path,
+    parquet_path: Path,
+    *,
+    dry_run: bool,
+) -> MetadataRepairResult:
+    """Repair stored Royco tranche features in the vault metadata DB.
+
+    ``scan-prices.py`` creates vault instances from the stored
+    ``_detection_data.features`` set. If a tranche vault was discovered before
+    the Royco chain probes covered its chain, it is stored with an empty
+    feature set and the generic reader is selected. This function adds
+    ``royco_tranche_like`` and refreshes the row protocol so subsequent scans
+    instantiate :class:`RoycoTrancheVault`.
+
+    :param vault_db_path:
+        Path to the vault metadata pickle.
+
+    :param parquet_path:
+        Path to the uncleaned price parquet, used to discover rows that already
+        emitted ``non-standard ABI`` errors.
+
+    :param dry_run:
+        If ``True``, report only without modifying files.
+
+    :return:
+        Specs to purge/rescan and number of repaired metadata rows.
+    """
+    try:
+        db = VaultDatabase.read(vault_db_path)
+    except (FileNotFoundError, RuntimeError) as e:
+        logger.warning("Could not read vault database %s: %s", vault_db_path, e)
+        return MetadataRepairResult(specs=set(), repaired_rows=0)
+
+    error_specs = collect_non_standard_abi_specs(parquet_path)
+    specs: set[VaultSpec] = set()
+    repaired_rows = 0
+
+    for spec, row in db.rows.items():
+        if not is_royco_tranche_metadata_row(spec, row, error_specs):
+            continue
+
+        specs.add(spec)
+
+        changed = False
+        features = set(row.get("features") or set())
+        if ERC4626Feature.royco_tranche_like not in features:
+            features.add(ERC4626Feature.royco_tranche_like)
+            row["features"] = features
+            changed = True
+
+        detection = row.get("_detection_data")
+        if detection is not None and ERC4626Feature.royco_tranche_like not in detection.features:
+            detection.features.add(ERC4626Feature.royco_tranche_like)
+            changed = True
+
+        protocol_name = get_vault_protocol_name(features)
+        if row.get("Protocol") != protocol_name:
+            row["Protocol"] = protocol_name
+            changed = True
+
+        if changed:
+            repaired_rows += 1
+            logger.info("Repairing metadata for %s: Protocol=%s, features=%s", spec, row.get("Protocol"), sorted(f.value for f in features))
+
+    if repaired_rows == 0:
+        logger.info("No Royco tranche metadata feature repairs needed")
+    elif dry_run:
+        logger.info("DRY RUN: would repair %d vault metadata rows in %s", repaired_rows, vault_db_path)
+    else:
+        backup_path = vault_db_path.with_suffix(".pickle.bak-royco-purge")
+        logger.info("Creating vault DB backup at %s", backup_path)
+        shutil.copy2(vault_db_path, backup_path)
+        db.write(vault_db_path)
+        logger.info("Repaired %d vault metadata rows in %s", repaired_rows, vault_db_path)
+
+    return MetadataRepairResult(specs=specs, repaired_rows=repaired_rows)
+
+
+def find_royco_tranche_specs(
+    vault_db_path: Path = DEFAULT_VAULT_DATABASE,
+    parquet_path: Path = DEFAULT_UNCLEANED_PRICE_DATABASE,
+) -> set[VaultSpec]:
     """Find Royco tranche vault specs from the vault metadata DB.
 
-    These are vaults with Protocol='Royco' and names matching tranche patterns.
-    Returns full ``VaultSpec`` (chain_id, address) pairs to avoid cross-chain
-    address collisions.
+    This compatibility wrapper performs a dry-run metadata repair and returns
+    the specs the main purge flow would operate on.
+
+    :param vault_db_path:
+        Path to the vault metadata pickle.
+
+    :param parquet_path:
+        Path to the uncleaned price parquet.
 
     :return:
         Set of ``VaultSpec`` instances.
     """
-    try:
-        db = VaultDatabase.read()
-    except (FileNotFoundError, RuntimeError) as e:
-        logger.warning("Could not read vault database: %s", e)
-        return set()
-
-    specs = set()
-    for spec, row in db.rows.items():
-        if row.get("Protocol") != ROYCO_PROTOCOL_NAME:
-            continue
-        name = row.get("Name", "")
-        # Tranche vaults have "Senior Tranche" or "Junior Tranche" in their name
-        if "Tranche" in name:
-            specs.add(spec)
-
-    return specs
+    return repair_royco_tranche_metadata(vault_db_path, parquet_path, dry_run=True).specs
 
 
 def purge_tranche_rows(
@@ -227,6 +390,7 @@ def main():
 
     # Use the same env vars as scan-prices.py so operators with custom paths
     # purge the same files the scanner reads/writes.
+    vault_db_path = Path(os.environ.get("VAULT_DB", str(DEFAULT_VAULT_DATABASE))).expanduser()
     parquet_path = Path(os.environ.get("UNCLEANED_PRICE_DATABASE", str(DEFAULT_UNCLEANED_PRICE_DATABASE))).expanduser()
     reader_state_path = Path(os.environ.get("READER_STATE_DATABASE", str(DEFAULT_READER_STATE_DATABASE))).expanduser()
     dry_run = os.environ.get("DRY_RUN", "false").lower() == "true"
@@ -234,8 +398,9 @@ def main():
     if dry_run:
         logger.info("DRY RUN MODE — no files will be modified")
 
-    # 1. Find tranche vault specs
-    tranche_specs = find_royco_tranche_specs()
+    # 1. Repair stale metadata features and collect tranche specs
+    metadata_repair = repair_royco_tranche_metadata(vault_db_path, parquet_path, dry_run=dry_run)
+    tranche_specs = metadata_repair.specs
     if not tranche_specs:
         logger.warning("No Royco tranche vaults found in vault metadata DB")
         logger.info("You can also specify addresses manually by extending this script")
@@ -252,6 +417,7 @@ def main():
     # 4. Summary
     action = "would be " if dry_run else ""
     logger.info("Royco tranche specs found: %d", len(tranche_specs))
+    logger.info("Vault metadata rows %srepaired: %d", action, metadata_repair.repaired_rows)
     logger.info("Tranche rows %spurged: %d", action, purged)
     logger.info("Reader states %scleared: %d", action, cleared)
 

--- a/tests/erc_4626/test_classification.py
+++ b/tests/erc_4626/test_classification.py
@@ -5,6 +5,7 @@ Tests for create_probe_calls() chain filtering functionality.
 
 from eth_defi.erc_4626.classification import (
     CHAIN_RESTRICTED_PROBES,
+    ROYCO_CHAIN_IDS,
     _should_yield_probe,
     create_probe_calls,
 )
@@ -17,6 +18,7 @@ POLYGON = 137
 BSC = 56
 MONAD = 143
 MANTLE = 5000
+AVALANCHE = 43114
 
 
 def test_chain_probe_filtering():
@@ -26,7 +28,7 @@ def test_chain_probe_filtering():
     2. Verify core probes are always present regardless of chain.
     3. Verify protocol-specific probes are filtered based on deployment chains.
     4. Verify disabled protocols never yield probes.
-    5. Verify Royco tranche detection uses one Ethereum-only probe.
+    5. Verify Royco tranche detection uses one probe on Royco chains.
     """
     test_address = "0x0000000000000000000000000000000000000001"
 
@@ -81,6 +83,13 @@ def test_chain_probe_filtering():
     royco_tranche_probe_names = ["getRawNAV"]
     assert sum(1 for func_name in func_names_eth if func_name in royco_tranche_probe_names) == 1
     assert "getRawNAV" in func_names_eth
+    assert _should_yield_probe("getRawNAV", ARBITRUM) is True
+    assert _should_yield_probe("getRawNAV", AVALANCHE) is True
+
+    for chain_id in ROYCO_CHAIN_IDS:
+        probes = list(create_probe_calls([test_address], chain_id=chain_id))
+        func_names = [p.func_name for p in probes]
+        assert sum(1 for func_name in func_names if func_name in royco_tranche_probe_names) == 1
 
     # Core probes always present
     assert "name" in func_names_eth

--- a/tests/erc_4626/vault_protocol/test_royco_purge.py
+++ b/tests/erc_4626/vault_protocol/test_royco_purge.py
@@ -1,0 +1,183 @@
+"""Test Royco tranche purge helpers."""
+
+import datetime
+import importlib.util
+from pathlib import Path
+
+import pandas as pd
+
+from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.vaultdb import VaultDatabase
+
+EXPECTED_REPAIRED_ROWS = 2
+
+
+def load_purge_module():
+    """Load the Royco purge script as a test module.
+
+    The script filename contains dashes, so it cannot be imported using normal
+    Python package syntax.
+
+    :return:
+        Loaded purge script module.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    script_path = repo_root / "scripts" / "erc-4626" / "purge-royco-tranche-data.py"
+    spec = importlib.util.spec_from_file_location("purge_royco_tranche_data", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def create_detection(
+    spec: VaultSpec,
+    features: set[ERC4626Feature] | None = None,
+) -> ERC4262VaultDetection:
+    """Create a minimal vault detection object for tests.
+
+    :param spec:
+        Vault spec to use.
+
+    :param features:
+        Initial detected feature set.
+
+    :return:
+        Detection object suitable for ``VaultDatabase`` rows.
+    """
+    timestamp = datetime.datetime(2026, 6, 9, tzinfo=datetime.UTC).replace(tzinfo=None)
+    return ERC4262VaultDetection(
+        chain=spec.chain_id,
+        address=spec.vault_address,
+        first_seen_at_block=1,
+        first_seen_at=timestamp,
+        features=set(features or set()),
+        updated_at=timestamp,
+        deposit_count=1,
+        redeem_count=0,
+    )
+
+
+def create_row(
+    spec: VaultSpec,
+    name: str | None,
+    protocol: str,
+    features: set[ERC4626Feature] | None = None,
+) -> dict:
+    """Create a minimal vault metadata row.
+
+    :param spec:
+        Vault spec.
+
+    :param name:
+        Vault display name.
+
+    :param protocol:
+        Stored protocol label.
+
+    :param features:
+        Initial detected feature set.
+
+    :return:
+        Vault metadata row.
+    """
+    initial_features = set(features or set())
+    return {
+        "Name": name,
+        "Protocol": protocol,
+        "features": set(initial_features),
+        "_detection_data": create_detection(spec, initial_features),
+    }
+
+
+def test_repair_royco_tranche_metadata_repairs_stale_features(tmp_path: Path):
+    """Royco purge metadata repair updates stale feature flags.
+
+    1. Create a fake vault DB with one existing tranche row, one tranche name
+       row, one row only identified by a ``non-standard ABI`` error, and one
+       unrelated Royco-named row.
+    2. Create a tiny uncleaned price parquet containing the ABI error.
+    3. Run metadata repair.
+    4. Verify only tranche candidates get ``royco_tranche_like`` and Protocol
+       ``Royco``.
+    """
+    purge = load_purge_module()
+
+    existing_spec = VaultSpec(1, "0x0000000000000000000000000000000000000001")
+    name_spec = VaultSpec(42161, "0x0000000000000000000000000000000000000002")
+    error_spec = VaultSpec(43114, "0x0000000000000000000000000000000000000003")
+    generic_spec = VaultSpec(1, "0x0000000000000000000000000000000000000004")
+    null_name_spec = VaultSpec(1, "0x0000000000000000000000000000000000000005")
+
+    vault_db = VaultDatabase(
+        rows={
+            existing_spec: create_row(
+                existing_spec,
+                "Royco Senior Tranche eEARN",
+                "Royco",
+                {ERC4626Feature.royco_tranche_like},
+            ),
+            name_spec: create_row(
+                name_spec,
+                "Royco Senior Tranche sUSDai",
+                "<protocol not yet identified>",
+            ),
+            error_spec: create_row(
+                error_spec,
+                "Senior Royco USDC",
+                "<protocol not yet identified>",
+            ),
+            generic_spec: create_row(
+                generic_spec,
+                "Senior Royco USDC",
+                "<protocol not yet identified>",
+            ),
+            null_name_spec: create_row(
+                null_name_spec,
+                None,
+                "<protocol not yet identified>",
+            ),
+        }
+    )
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    vault_db.write(vault_db_path)
+
+    price_path = tmp_path / "vault-prices-1h.parquet"
+    pd.DataFrame(
+        [
+            {
+                "chain": error_spec.chain_id,
+                "address": error_spec.vault_address,
+                "errors": "total_assets returned 96 bytes, expected 32 (non-standard ABI)",
+            },
+            {
+                "chain": generic_spec.chain_id,
+                "address": generic_spec.vault_address,
+                "errors": "",
+            },
+        ]
+    ).to_parquet(price_path)
+
+    result = purge.repair_royco_tranche_metadata(vault_db_path, price_path, dry_run=False)
+
+    assert result.specs == {existing_spec, name_spec, error_spec}
+    assert result.repaired_rows == EXPECTED_REPAIRED_ROWS
+
+    repaired_db = VaultDatabase.read(vault_db_path)
+    for spec in {existing_spec, name_spec, error_spec}:
+        row = repaired_db.rows[spec]
+        assert row["Protocol"] == "Royco"
+        assert ERC4626Feature.royco_tranche_like in row["features"]
+        assert ERC4626Feature.royco_tranche_like in row["_detection_data"].features
+
+    generic_row = repaired_db.rows[generic_spec]
+    assert generic_row["Protocol"] == "<protocol not yet identified>"
+    assert ERC4626Feature.royco_tranche_like not in generic_row["features"]
+    assert ERC4626Feature.royco_tranche_like not in generic_row["_detection_data"].features
+
+    null_name_row = repaired_db.rows[null_name_spec]
+    assert null_name_row["Protocol"] == "<protocol not yet identified>"
+    assert ERC4626Feature.royco_tranche_like not in null_name_row["features"]
+    assert ERC4626Feature.royco_tranche_like not in null_name_row["_detection_data"].features


### PR DESCRIPTION
## Why

Royco tranche vaults discovered before the expanded classifier probes kept stale stored feature flags in `vault-metadata-db.pickle`. Price scans then selected the generic ERC-4626 reader instead of `RoycoTrancheHistoricalReader`, causing `non-standard ABI` errors or corrupted historical rows.

## Lessons learnt

Vault classification changes are not retroactive for already discovered vaults. The metadata database, reader state and existing parquet rows need an explicit repair/purge/rescan migration when classifier behaviour changes.

## Summary

- Expand the Royco `getRawNAV` probe allowlist to all currently known Royco chains.
- Teach `purge-royco-tranche-data.py` to repair stored Royco tranche feature flags and protocol labels before purging price rows and reader states.
- Detect stale Royco tranche metadata from existing features, Royco tranche names and stored `non-standard ABI` parquet errors.
- Add regression coverage for metadata repair, including null vault names.
- Document the manual purge requirement in classification comments, the Royco purge script docstring and the Royco README.

Verification run locally: `pytest tests/erc_4626/test_classification.py tests/erc_4626/vault_protocol/test_royco_purge.py -q`; Royco integration tests were also run earlier with `tests/erc_4626/vault_protocol/test_royco.py -q --log-cli-level=info`.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.