### PR TITLE
feat: Export curator metadata and recent feed entries in vault JSON bundle

### DIFF
--- a/docs/source/api/vault/index.rst
+++ b/docs/source/api/vault/index.rst
@@ -27,4 +27,5 @@ A generic high-level Python framework to integrate different vault providers.
    eth_defi.vault.flag
    eth_defi.vault.protocol_metadata
    eth_defi.vault.curator
+   eth_defi.vault.curator_export
    eth_defi.vault.data_file_export

--- a/eth_defi/feed/database.py
+++ b/eth_defi/feed/database.py
@@ -413,3 +413,71 @@ class VaultPostDatabase:
         """Return stored posts for diagnostics."""
 
         return self.con.execute("SELECT * FROM posts ORDER BY source_id, COALESCE(published_at, fetched_at)").df()
+
+    def fetch_recent_posts_by_feeder(
+        self,
+        feeder_ids: Iterable[str],
+        max_per_feeder: int = 10,
+    ) -> dict[str, list[dict]]:
+        """Fetch the most recent posts for each feeder across all source types.
+
+        Joins ``tracked_sources`` and ``posts`` on ``source_id``, ranks
+        posts per feeder by ``COALESCE(published_at, fetched_at) DESC``,
+        and returns the *max_per_feeder* newest posts per feeder.
+
+        :param feeder_ids:
+            Iterable of feeder-id slugs to look up.
+
+        :param max_per_feeder:
+            Maximum number of posts to return per feeder.
+
+        :return:
+            Dict mapping ``feeder_id`` to a list of post dicts with keys
+            ``title``, ``short_description``, ``post_url``, ``source_type``,
+            ``published_at`` (always set via COALESCE fallback to
+            ``fetched_at``).  Lists are ordered newest-first.
+        """
+        ids = list(feeder_ids)
+        if not ids:
+            return {}
+
+        placeholders = ", ".join("?" * len(ids))
+        rows = self.con.execute(
+            f"""
+            WITH ranked AS (
+                SELECT
+                    ts.feeder_id,
+                    p.title,
+                    p.short_description,
+                    p.post_url,
+                    ts.source_type,
+                    COALESCE(p.published_at, p.fetched_at) AS published_at,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY ts.feeder_id
+                        ORDER BY COALESCE(p.published_at, p.fetched_at) DESC
+                    ) AS rn
+                FROM tracked_sources ts
+                JOIN posts p ON ts.source_id = p.source_id
+                WHERE ts.feeder_id IN ({placeholders})
+            )
+            SELECT feeder_id, title, short_description, post_url, source_type, published_at
+            FROM ranked
+            WHERE rn <= ?
+            ORDER BY feeder_id, published_at DESC
+            """,
+            ids + [max_per_feeder],
+        ).fetchall()
+
+        result: dict[str, list[dict]] = {}
+        for row in rows:
+            feeder_id, title, short_description, post_url, source_type, published_at = row
+            result.setdefault(feeder_id, []).append(
+                {
+                    "title": title,
+                    "short_description": short_description,
+                    "post_url": post_url,
+                    "source_type": source_type,
+                    "published_at": published_at,
+                }
+            )
+        return result

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -10,7 +10,7 @@ import math
 import warnings
 from dataclasses import asdict, dataclass, is_dataclass
 from enum import Enum
-from typing import Literal, Optional, TypeAlias, TypedDict
+from typing import TYPE_CHECKING, Literal, Optional, TypeAlias, TypedDict
 
 import numpy as np
 import pandas as pd
@@ -45,6 +45,9 @@ from eth_defi.vault.flag import (
 )
 from eth_defi.vault.risk import VaultTechnicalRisk, get_vault_risk
 from eth_defi.vault.vaultdb import VaultDatabase, VaultRow
+
+if TYPE_CHECKING:
+    from eth_defi.vault.curator_export import CuratorExportRecord
 
 logger = logging.getLogger(__name__)
 
@@ -268,6 +271,10 @@ class VaultMetricsExport(TypedDict):
     #: Core3 risk intelligence keyed by protocol slug.
     #: Only protocols present in the exported vaults are included.
     core3_protocols: dict[str, Core3ExportRecord]
+
+    #: Curator metadata and recent feed entries keyed by curator slug.
+    #: Only curators present in the exported vaults are included.
+    curators: dict[str, "CuratorExportRecord"]
 
     #: List of per-vault metric records
     vaults: list[VaultMetricsRecord]

--- a/eth_defi/vault/curator_export.py
+++ b/eth_defi/vault/curator_export.py
@@ -1,0 +1,282 @@
+"""Build curator metadata and recent feed entries for the vault JSON export.
+
+Resolves curator slugs from vault records to structured metadata
+(name, website, social URLs, logos) and recent feed entries from the
+post database.  The result is a dict keyed by curator slug, stored
+at the top level of the vault metrics JSON bundle alongside
+``core3_protocols``.
+
+Example::
+
+    from eth_defi.feed.database import VaultPostDatabase
+    from eth_defi.vault.curator_export import build_curators_for_export
+
+    feed_db = VaultPostDatabase(Path("vault-post-database.duckdb"))
+    curators = build_curators_for_export(
+        ["gauntlet", "re7-labs", "hyperliquid"],
+        feed_db=feed_db,
+    )
+    feed_db.close()
+
+    # curators["gauntlet"]["recent_posts"] → list of recent feed entries
+"""
+
+import datetime
+import logging
+from collections.abc import Iterable
+from typing import TypedDict
+
+from eth_defi.feed.database import VaultPostDatabase
+from eth_defi.feed.sources import FEEDS_DATA_DIR, load_feeder_metadata
+from eth_defi.vault.curator import (
+    ALL_PROTOCOL_CURATOR_SLUGS,
+    CURATORS_DATA_DIR,
+    PROTOCOL_CURATOR_NAMES,
+    CuratorLogos,
+    _build_curator_logo_urls,
+    build_curator_metadata_json,
+    load_curator_map,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CuratorFeedEntry(TypedDict):
+    """A single recent feed entry from a curator's tracked sources.
+
+    Used inside :py:class:`CuratorExportRecord` to surface recent
+    social media and blog activity in the vault JSON bundle.
+    """
+
+    #: Post title, or ``None`` for untitled posts (e.g. tweets).
+    title: str | None
+
+    #: Short preview text (first ~280 chars).
+    snippet: str
+
+    #: Canonical URL to the original post, or ``None``.
+    link: str | None
+
+    #: Source transport type: ``"twitter"``, ``"linkedin"``, or ``"rss"``.
+    source_type: str
+
+    #: ISO 8601 UTC timestamp when the post was published.
+    #: Always set — falls back to fetch time when the source
+    #: does not provide a publication timestamp.
+    published_at: str
+
+
+class CuratorExportRecord(TypedDict):
+    """Serialised curator record for the vault metrics JSON export.
+
+    Contains curator identity metadata and recent feed entries.
+    Keyed by curator slug in the top-level ``curators`` dict of
+    :py:class:`~eth_defi.research.vault_metrics.VaultMetricsExport`.
+    """
+
+    #: Curator slug (e.g. ``"gauntlet"``, ``"re7-labs"``).
+    slug: str
+
+    #: Human-readable display name.
+    name: str
+
+    #: Company website URL, or ``None``.
+    website: str | None
+
+    #: Full Twitter/X profile URL (e.g. ``"https://x.com/gauntlet_xyz"``),
+    #: or ``None``.
+    twitter: str | None
+
+    #: Full LinkedIn company URL, or ``None``.
+    linkedin: str | None
+
+    #: RSS or Atom feed URL, or ``None``.
+    rss: str | None
+
+    #: Whether this is a protocol-native curator (the protocol itself
+    #: acts as curator) rather than a third-party risk manager.
+    protocol_curator: bool
+
+    #: When this curator is an alias, the slug of the canonical feeder
+    #: whose posts should be used.  ``None`` for non-alias curators.
+    canonical_feeder_id: str | None
+
+    #: Logo URLs for available 256x256 PNG variants.
+    logos: CuratorLogos
+
+    #: Most recent feed entries, ordered newest first.
+    recent_posts: list[CuratorFeedEntry]
+
+
+def _build_protocol_curator_from_yaml(
+    slug: str,
+    public_url: str = "",
+) -> CuratorExportRecord:
+    """Build a curator export record for a protocol curator using its protocol YAML.
+
+    Protocol curators like Hyperliquid, Ostium, Lighter have protocol
+    YAML files at ``eth_defi/data/feeds/protocols/{slug}.yaml`` but
+    no curator YAML.  This function loads the protocol YAML metadata
+    to populate website, twitter, linkedin, and rss fields.
+
+    :param slug:
+        Protocol curator slug (e.g. ``"hyperliquid"``).
+
+    :param public_url:
+        Public base URL for constructing logo URLs.
+
+    :return:
+        Curator export record with metadata from the protocol YAML.
+    """
+    protocol_yaml = FEEDS_DATA_DIR / "protocols" / f"{slug}.yaml"
+    name = PROTOCOL_CURATOR_NAMES.get(slug, slug)
+
+    website = None
+    twitter_url = None
+    linkedin_url = None
+    rss = None
+
+    if protocol_yaml.exists():
+        meta = load_feeder_metadata(protocol_yaml)
+        name = meta.get("name", name)
+        website = meta.get("website")
+        twitter_handle = meta.get("twitter")
+        linkedin_id = meta.get("linkedin")
+        rss = meta.get("rss")
+
+        if twitter_handle:
+            twitter_url = f"https://x.com/{twitter_handle}"
+        if linkedin_id:
+            linkedin_url = f"https://www.linkedin.com/company/{linkedin_id}"
+
+    return CuratorExportRecord(
+        slug=slug,
+        name=name,
+        website=website,
+        twitter=twitter_url,
+        linkedin=linkedin_url,
+        rss=rss,
+        protocol_curator=True,
+        canonical_feeder_id=None,
+        logos=_build_curator_logo_urls(slug, public_url=public_url),
+        recent_posts=[],
+    )
+
+
+def build_curators_for_export(
+    curator_slugs: Iterable[str],
+    feed_db: VaultPostDatabase | None = None,
+    max_posts_per_curator: int = 10,
+    public_url: str = "",
+) -> dict[str, CuratorExportRecord]:
+    """Build a curator-slug-keyed dict for the vault metrics JSON export.
+
+    For each curator slug present in the exported vaults:
+
+    1. Load metadata from curator YAML via
+       :py:func:`~eth_defi.vault.curator.build_curator_metadata_json`,
+       or from the protocol YAML for protocol curators without a
+       curator YAML file.
+    2. Resolve ``canonical_feeder_id`` for alias curators so that
+       feed posts are looked up under the correct feeder.
+    3. Batch-query recent posts from the feed database.
+    4. Convert timestamps to ISO 8601 strings and assemble the
+       final :py:class:`CuratorExportRecord` dicts.
+
+    When *feed_db* is ``None`` (e.g. the database file does not
+    exist), all ``recent_posts`` lists will be empty.
+
+    :param curator_slugs:
+        Iterable of curator slugs to include (typically extracted
+        from ``curator_slug`` fields in the vault records).
+
+    :param feed_db:
+        Open vault post database for querying recent posts.
+        Pass ``None`` to skip feed enrichment.
+
+    :param max_posts_per_curator:
+        Maximum number of recent posts per curator.
+
+    :param public_url:
+        Public base URL for constructing logo URLs.
+
+    :return:
+        Dict mapping curator slug to :py:class:`CuratorExportRecord`.
+    """
+    slugs = list(set(curator_slugs))
+    if not slugs:
+        return {}
+
+    curator_map = load_curator_map()
+
+    # 1. Build metadata for each slug
+    records: dict[str, CuratorExportRecord] = {}
+    # Maps resolved feeder_id → list of curator slugs that use it
+    feeder_to_curators: dict[str, list[str]] = {}
+
+    for slug in slugs:
+        if slug in curator_map:
+            # Curator has a YAML file — use the existing builder
+            yaml_path = CURATORS_DATA_DIR / f"{slug}.yaml"
+            meta = build_curator_metadata_json(yaml_path, public_url=public_url)
+            canonical = curator_map[slug].get("canonical_feeder_id")
+            records[slug] = CuratorExportRecord(
+                slug=meta["slug"],
+                name=meta["name"],
+                website=meta["website"],
+                twitter=meta["twitter"],
+                linkedin=meta["linkedin"],
+                rss=meta["rss"],
+                protocol_curator=meta["protocol_curator"],
+                canonical_feeder_id=canonical,
+                logos=meta["logos"],
+                recent_posts=[],
+            )
+            # Resolve which feeder_id to use for post lookup
+            feeder_id = canonical if canonical else slug
+            feeder_to_curators.setdefault(feeder_id, []).append(slug)
+
+        elif slug in ALL_PROTOCOL_CURATOR_SLUGS:
+            # Protocol curator without curator YAML — load from protocol YAML
+            records[slug] = _build_protocol_curator_from_yaml(slug, public_url=public_url)
+            feeder_to_curators.setdefault(slug, []).append(slug)
+
+        else:
+            logger.warning("Curator slug %r not found in curator YAML map or protocol curators; skipping", slug)
+            continue
+
+    # 2. Batch-query recent posts from the feed database
+    if feed_db is not None:
+        all_feeder_ids = list(feeder_to_curators.keys())
+        posts_by_feeder = feed_db.fetch_recent_posts_by_feeder(
+            all_feeder_ids,
+            max_per_feeder=max_posts_per_curator,
+        )
+
+        # Map posts back to curator slugs
+        for feeder_id, posts in posts_by_feeder.items():
+            feed_entries = []
+            for post in posts:
+                published_at = post["published_at"]
+                if isinstance(published_at, datetime.datetime):
+                    published_at = published_at.isoformat()
+                elif published_at is not None:
+                    published_at = str(published_at)
+
+                feed_entries.append(
+                    CuratorFeedEntry(
+                        title=post["title"],
+                        snippet=post["short_description"],
+                        link=post["post_url"],
+                        source_type=post["source_type"],
+                        published_at=published_at,
+                    )
+                )
+
+            # Multiple curator slugs may share the same canonical feeder
+            for curator_slug in feeder_to_curators.get(feeder_id, []):
+                if curator_slug in records:
+                    records[curator_slug]["recent_posts"] = feed_entries
+
+    logger.info("Built curator export for %d curators", len(records))
+    return records

--- a/eth_defi/vault/sample_export.py
+++ b/eth_defi/vault/sample_export.py
@@ -97,9 +97,14 @@ def generate_sample_json(json_path: Path, output_path: Path) -> int:
     sample_slugs = {v["protocol_slug"] for v in filtered_vaults if v.get("protocol_slug")}
     core3 = {k: v for k, v in data.get("core3_protocols", {}).items() if k in sample_slugs}
 
+    # Filter curators to only curator slugs present in the sample vaults
+    sample_curator_slugs = {v["curator_slug"] for v in filtered_vaults if v.get("curator_slug")}
+    curators = {k: v for k, v in data.get("curators", {}).items() if k in sample_curator_slugs}
+
     sample_data = {
         "generated_at": data["generated_at"],
         "core3_protocols": core3,
+        "curators": curators,
         "vaults": filtered_vaults,
     }
 

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -642,6 +642,10 @@ Generates `top_vaults_by_chain.json` with the following top-level structure:
     "morpho": { "slug": "morpho", "pol": {...}, "fetched_at": "2026-06-07T12:00:00", ... },
     "fluid": { "slug": "instadapp", "pol": {...}, ... }
   },
+  "curators": {
+    "gauntlet": { "slug": "gauntlet", "name": "Gauntlet", "twitter": "https://x.com/gauntlet_xyz", "recent_posts": [...], ... },
+    "hyperliquid": { "slug": "hyperliquid", "name": "Hyperliquid", "protocol_curator": true, ... }
+  },
   "vaults": [ ... ]
 }
 ```
@@ -650,6 +654,12 @@ Core3 risk intelligence records are attached at the top level keyed by protocol
 slug (not duplicated per-vault). The `core3_protocols` dict is built directly
 from the Core3 DuckDB at export time and only includes protocols present in the
 exported vaults.
+
+Curator metadata and recent feed entries are attached at the top level keyed by
+curator slug. The `curators` dict is built from curator/protocol YAML files and
+the vault post feed database at export time, and only includes curators present
+in the exported vaults. Each curator record includes up to 10 recent posts from
+Twitter, LinkedIn, and RSS feeds.
 
 #### Brotli-compressed R2 upload
 
@@ -679,6 +689,8 @@ OUTPUT_JSON=~/.tradingstrategy/top_vaults_by_chain.json poetry run python script
 |----------|-------------|
 | `OUTPUT_JSON` | Optional. Output file path. Default: `~/.tradingstrategy/vaults/stablecoin-vault-metrics.json`. |
 | `CORE3_DATABASE_PATH` | Optional. Core3 DuckDB path. Default: `~/.tradingstrategy/vaults/core3/core3.duckdb`. |
+| `FEED_DB_PATH` | Optional. Vault post feed DuckDB path. Falls back to `DB_PATH` (used by the feed collector). Default: `~/.tradingstrategy/vaults/vault-post-database.duckdb`. |
+| `R2_VAULT_METADATA_PUBLIC_URL` | Optional. Public base URL for curator logo URLs in the export. |
 
 After generating, upload to R2 with rclone:
 

--- a/scripts/erc-4626/vault-analysis-json.py
+++ b/scripts/erc-4626/vault-analysis-json.py
@@ -36,7 +36,9 @@ from pathlib import Path
 from eth_defi.core3.constants import CORE3_DATABASE_PATH
 from eth_defi.core3.database import Core3Database
 from eth_defi.core3.vault_protocol import build_core3_protocols_for_export
+from eth_defi.feed.database import DEFAULT_VAULT_POST_DATABASE, VaultPostDatabase
 from eth_defi.token import is_stablecoin_like
+from eth_defi.vault.curator_export import build_curators_for_export
 
 # Import core TradingStrategy / eth_defi modules
 from eth_defi.vault.base import VaultSpec  # noqa: F401
@@ -136,6 +138,7 @@ def main(
     parquet_path: Path | None = None,
     output_path: Path | None = None,
     core3_db_path: Path | None = None,
+    feed_db_path: Path | None = None,
 ):
     """Main execution function for vault analysis and JSON export.
 
@@ -173,6 +176,13 @@ def main(
         When ``None``, resolved from ``CORE3_DATABASE_PATH`` env var,
         then the default constant. The database is only opened if the
         resolved file exists on disk.
+
+    :param feed_db_path:
+        Path to the vault post feed DuckDB database.
+        When ``None``, resolved from ``FEED_DB_PATH`` env var,
+        falling back to ``DB_PATH`` (used by the feed collector),
+        then :py:data:`~eth_defi.feed.database.DEFAULT_VAULT_POST_DATABASE`.
+        The database is only opened if the resolved file exists on disk.
     """
     defaults = _resolve_defaults_from_env()
     if data_dir is None:
@@ -247,10 +257,45 @@ def main(
         finally:
             core3_db.close()
 
+    # 6b. Build curator metadata and recent feed entries for the export.
+    # Curator data is per-curator (not per-vault), keyed by curator slug.
+    curators_export = {}
+    unique_curator_slugs = {v.get("curator_slug") for v in vaults if v.get("curator_slug")}
+    unique_curator_slugs.discard(None)
+    public_url = os.getenv("R2_VAULT_METADATA_PUBLIC_URL", "")
+
+    if feed_db_path is None:
+        feed_db_path_env = os.getenv("FEED_DB_PATH") or os.getenv("DB_PATH")
+        if feed_db_path_env:
+            feed_db_path = Path(feed_db_path_env).expanduser()
+        else:
+            feed_db_path = DEFAULT_VAULT_POST_DATABASE
+
+    if feed_db_path.exists():
+        feed_db = VaultPostDatabase(feed_db_path)
+        try:
+            print(f"Opened feed database at {feed_db_path}")
+            curators_export = build_curators_for_export(
+                unique_curator_slugs,
+                feed_db=feed_db,
+                public_url=public_url,
+            )
+        finally:
+            feed_db.close()
+    else:
+        curators_export = build_curators_for_export(
+            unique_curator_slugs,
+            feed_db=None,
+            public_url=public_url,
+        )
+
+    print(f"Built curator export for {len(curators_export)} curators")
+
     # 7️⃣ Add metadata and deep sanitize
     output_data: VaultMetricsExport = {
         "generated_at": datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "core3_protocols": core3_protocols,
+        "curators": curators_export,
         "vaults": vaults,
     }
 

--- a/tests/feed/test_fetch_recent_posts.py
+++ b/tests/feed/test_fetch_recent_posts.py
@@ -1,0 +1,115 @@
+"""Test VaultPostDatabase.fetch_recent_posts_by_feeder() query method."""
+
+import datetime
+from pathlib import Path
+
+from eth_defi.feed.database import CollectedPost, VaultPostDatabase
+from eth_defi.feed.sources import TrackedPostSource
+
+
+def test_fetch_recent_posts_by_feeder(tmp_path: Path):
+    """Recent posts query returns at most max_per_feeder posts per feeder, newest first.
+
+    1. Create a temp feed DuckDB
+    2. Insert tracked sources for two feeders via upsert_tracked_source()
+    3. Insert 12 posts for feeder A and 5 posts for feeder B via insert_posts()
+    4. Call fetch_recent_posts_by_feeder(max_per_feeder=3)
+    5. Assert feeder A returns exactly 3 posts (capped), feeder B returns 5
+    6. Assert posts are ordered newest-first
+    7. Assert posts without published_at use fetched_at via COALESCE
+    8. Assert source_type is included from tracked_sources
+    9. Assert empty feeder_ids returns {}
+    """
+    db = VaultPostDatabase(tmp_path / "test-feed.duckdb")
+    try:
+        # 2. Insert tracked sources for two feeders
+        source_a = TrackedPostSource(
+            feeder_id="feeder-a",
+            name="Feeder A",
+            role="curator",
+            website="https://a.example.com",
+            source_type="twitter",
+            source_key="feeder_a",
+            canonical_url="https://x.com/feeder_a",
+            mapping_file=Path("fake-a.yaml"),
+        )
+        source_b = TrackedPostSource(
+            feeder_id="feeder-b",
+            name="Feeder B",
+            role="curator",
+            website="https://b.example.com",
+            source_type="rss",
+            source_key="https://b.example.com/feed",
+            canonical_url="https://b.example.com/feed",
+            mapping_file=Path("fake-b.yaml"),
+        )
+        sid_a = db.upsert_tracked_source(source_a)
+        sid_b = db.upsert_tracked_source(source_b)
+
+        # 3. Insert 12 posts for feeder A (2 without published_at)
+        base_time = datetime.datetime(2026, 6, 1, 12, 0, 0)
+        posts_a = []
+        for i in range(12):
+            published = base_time + datetime.timedelta(hours=i) if i >= 2 else None
+            posts_a.append(
+                CollectedPost(
+                    external_post_id=f"a-post-{i}",
+                    title=f"Post A {i}",
+                    post_url=f"https://x.com/feeder_a/status/{i}",
+                    published_at=published,
+                    fetched_at=base_time + datetime.timedelta(hours=i, minutes=30),
+                    short_description=f"Description of post A {i}",
+                    full_text=f"Full text of post A {i}",
+                )
+            )
+        db.insert_posts(sid_a, posts_a)
+
+        # Insert 5 posts for feeder B
+        posts_b = []
+        for i in range(5):
+            posts_b.append(
+                CollectedPost(
+                    external_post_id=f"b-post-{i}",
+                    title=f"Post B {i}",
+                    post_url=f"https://b.example.com/post/{i}",
+                    published_at=base_time + datetime.timedelta(hours=i),
+                    fetched_at=base_time + datetime.timedelta(hours=i, minutes=15),
+                    short_description=f"Description of post B {i}",
+                    full_text=f"Full text of post B {i}",
+                )
+            )
+        db.insert_posts(sid_b, posts_b)
+
+        # 4. Call with max_per_feeder=3
+        result = db.fetch_recent_posts_by_feeder(["feeder-a", "feeder-b"], max_per_feeder=3)
+
+        # 5. Feeder A capped at 3, feeder B returns all 5 (within limit)
+        assert len(result["feeder-a"]) == 3
+        # Feeder B has 5 posts but max_per_feeder=3 caps it
+        assert len(result["feeder-b"]) == 3
+
+        # 6. Posts are ordered newest-first
+        timestamps_a = [p["published_at"] for p in result["feeder-a"]]
+        assert timestamps_a == sorted(timestamps_a, reverse=True)
+
+        # 7. Posts without published_at use fetched_at
+        # The 2 posts without published_at (i=0, i=1) have fetched_at earlier
+        # than posts with published_at, so they won't be in the top 3.
+        # Let's verify with a larger limit to see the COALESCE behaviour.
+        result_all = db.fetch_recent_posts_by_feeder(["feeder-a"], max_per_feeder=20)
+        assert len(result_all["feeder-a"]) == 12
+        # All posts should have published_at set (COALESCE fills in fetched_at)
+        for post in result_all["feeder-a"]:
+            assert post["published_at"] is not None
+
+        # 8. Source type is included
+        for post in result["feeder-a"]:
+            assert post["source_type"] == "twitter"
+        for post in result["feeder-b"]:
+            assert post["source_type"] == "rss"
+
+        # 9. Empty feeder_ids returns {}
+        assert db.fetch_recent_posts_by_feeder([]) == {}
+
+    finally:
+        db.close()

--- a/tests/vault/test_curator_export.py
+++ b/tests/vault/test_curator_export.py
@@ -1,0 +1,174 @@
+"""Test curator export builder for vault metrics JSON export."""
+
+import datetime
+from pathlib import Path
+
+from eth_defi.feed.database import CollectedPost, VaultPostDatabase
+from eth_defi.feed.sources import TrackedPostSource
+from eth_defi.vault.curator_export import build_curators_for_export
+
+
+def test_build_curators_for_export_with_feed(tmp_path: Path):
+    """Curator export builder returns metadata and recent posts from the feed DB.
+
+    1. Create temp feed DuckDB with a tracked source for 'gauntlet'
+    2. Insert sample posts under the gauntlet source
+    3. Call build_curators_for_export with ['gauntlet']
+    4. Assert gauntlet has metadata (name, website, twitter URL)
+    5. Assert recent_posts has correct shape and published_at is ISO 8601 string
+    """
+    # 1. Create temp feed DuckDB
+    db = VaultPostDatabase(tmp_path / "test-feed.duckdb")
+    try:
+        # 2. Insert tracked source for gauntlet
+        source = TrackedPostSource(
+            feeder_id="gauntlet",
+            name="Gauntlet",
+            role="curator",
+            website="https://www.gauntlet.xyz",
+            source_type="twitter",
+            source_key="gauntlet_xyz",
+            canonical_url="https://x.com/gauntlet_xyz",
+            mapping_file=Path("curators/gauntlet.yaml"),
+        )
+        sid = db.upsert_tracked_source(source)
+
+        base_time = datetime.datetime(2026, 6, 1, 12, 0, 0)
+        posts = []
+        for i in range(5):
+            posts.append(
+                CollectedPost(
+                    external_post_id=f"gauntlet-post-{i}",
+                    title=f"Gauntlet update {i}",
+                    post_url=f"https://x.com/gauntlet_xyz/status/{1000 + i}",
+                    published_at=base_time + datetime.timedelta(hours=i),
+                    fetched_at=base_time + datetime.timedelta(hours=i, minutes=10),
+                    short_description=f"Risk analysis update {i}",
+                    full_text=f"Full risk analysis {i}",
+                )
+            )
+        db.insert_posts(sid, posts)
+
+        # 3. Call builder
+        result = build_curators_for_export(["gauntlet"], feed_db=db)
+    finally:
+        db.close()
+
+    # 4. Assert gauntlet has correct metadata
+    assert "gauntlet" in result
+    rec = result["gauntlet"]
+    assert rec["slug"] == "gauntlet"
+    assert rec["name"] == "Gauntlet"
+    assert rec["website"] == "https://www.gauntlet.xyz"
+    assert rec["twitter"] == "https://x.com/gauntlet_xyz"
+    assert rec["protocol_curator"] is False
+    assert rec["canonical_feeder_id"] is None
+
+    # 5. Assert recent_posts
+    assert len(rec["recent_posts"]) == 5
+    post = rec["recent_posts"][0]
+    assert post["source_type"] == "twitter"
+    assert post["link"].startswith("https://x.com/gauntlet_xyz/status/")
+    assert post["snippet"].startswith("Risk analysis")
+    # published_at is ISO 8601 string
+    assert isinstance(post["published_at"], str)
+    assert "T" in post["published_at"]
+
+
+def test_build_curators_for_export_without_feed():
+    """Curator export builder works without a feed database.
+
+    1. Call build_curators_for_export with feed_db=None for a known curator
+    2. Assert metadata is present
+    3. Assert recent_posts is an empty list
+    """
+    # 1. Call with feed_db=None
+    result = build_curators_for_export(["gauntlet"], feed_db=None)
+
+    # 2. Assert metadata present
+    assert "gauntlet" in result
+    rec = result["gauntlet"]
+    assert rec["name"] == "Gauntlet"
+    assert rec["protocol_curator"] is False
+
+    # 3. Assert recent_posts is empty
+    assert rec["recent_posts"] == []
+
+
+def test_build_curators_for_export_protocol_curator_with_protocol_yaml():
+    """Protocol curators load metadata from protocol YAML when no curator YAML exists.
+
+    1. Call build_curators_for_export with 'hyperliquid'
+    2. Assert protocol_curator is True
+    3. Assert name, website, twitter come from protocol YAML
+    """
+    # 1. Call builder with hyperliquid (has protocol YAML but no curator YAML)
+    result = build_curators_for_export(["hyperliquid"], feed_db=None)
+
+    # 2. Assert protocol_curator
+    assert "hyperliquid" in result
+    rec = result["hyperliquid"]
+    assert rec["protocol_curator"] is True
+
+    # 3. Assert metadata from protocol YAML
+    assert rec["name"] == "Hyperliquid"
+    assert rec["website"] == "https://hyperliquid.xyz"
+    assert rec["twitter"] == "https://x.com/HyperliquidX"
+    assert rec["linkedin"] == "https://www.linkedin.com/company/hyperliquid"
+
+
+def test_build_curators_for_export_canonical_feeder(tmp_path: Path):
+    """Alias curators fetch posts from the canonical feeder.
+
+    1. Create temp feed DuckDB with posts stored under feeder_id 'usde'
+    2. Call build_curators_for_export with ['ethena']
+    3. Assert canonical_feeder_id == 'usde'
+    4. Assert recent_posts contains the posts from the 'usde' feeder
+
+    We use 'ethena' which is an alias curator pointing to canonical
+    feeder 'usde' (a stablecoin feeder).
+    """
+    # 1. Create temp feed DuckDB with posts under 'usde'
+    db = VaultPostDatabase(tmp_path / "test-feed.duckdb")
+    try:
+        source = TrackedPostSource(
+            feeder_id="usde",
+            name="Ethena USDe",
+            role="stablecoin",
+            website="https://ethena.fi/",
+            source_type="twitter",
+            source_key="ethena",
+            canonical_url="https://x.com/ethena",
+            mapping_file=Path("stablecoins/usde.yaml"),
+        )
+        sid = db.upsert_tracked_source(source)
+
+        base_time = datetime.datetime(2026, 6, 1, 12, 0, 0)
+        posts = []
+        for i in range(3):
+            posts.append(
+                CollectedPost(
+                    external_post_id=f"usde-post-{i}",
+                    title=f"Ethena update {i}",
+                    post_url=f"https://x.com/ethena/status/{2000 + i}",
+                    published_at=base_time + datetime.timedelta(hours=i),
+                    fetched_at=base_time + datetime.timedelta(hours=i, minutes=5),
+                    short_description=f"USDe news {i}",
+                    full_text=f"Full USDe text {i}",
+                )
+            )
+        db.insert_posts(sid, posts)
+
+        # 2. Call builder with ethena (alias → usde)
+        result = build_curators_for_export(["ethena"], feed_db=db)
+    finally:
+        db.close()
+
+    # 3. Assert canonical_feeder_id
+    assert "ethena" in result
+    rec = result["ethena"]
+    assert rec["canonical_feeder_id"] == "usde"
+
+    # 4. Assert recent_posts come from usde feeder
+    assert len(rec["recent_posts"]) == 3
+    assert rec["recent_posts"][0]["snippet"].startswith("USDe news")

--- a/tests/vault/test_sample_export.py
+++ b/tests/vault/test_sample_export.py
@@ -1,4 +1,4 @@
-"""Test sample export core3_protocols filtering."""
+"""Test sample export core3_protocols and curators filtering."""
 
 import json
 from pathlib import Path
@@ -6,14 +6,15 @@ from pathlib import Path
 from eth_defi.vault.sample_export import generate_sample_json
 
 
-def test_sample_json_filters_core3_protocols(tmp_path: Path):
-    """Sample JSON export filters core3_protocols to only Ethereum protocol slugs.
+def test_sample_json_filters_core3_protocols_and_curators(tmp_path: Path):
+    """Sample JSON export filters core3_protocols and curators to Ethereum-only slugs.
 
-    1. Create a source JSON with Ethereum and non-Ethereum vaults plus core3_protocols
+    1. Create a source JSON with Ethereum and non-Ethereum vaults plus core3_protocols and curators
     2. Generate sample JSON (Ethereum-only filter)
     3. Assert only protocol slugs present in Ethereum vaults are kept in core3_protocols
+    4. Assert only curator slugs present in Ethereum vaults are kept in curators
     """
-    # 1. Create source JSON with mixed chains and core3_protocols
+    # 1. Create source JSON with mixed chains, core3_protocols, and curators
     source_data = {
         "generated_at": "2026-06-08T00:00:00Z",
         "core3_protocols": {
@@ -21,11 +22,16 @@ def test_sample_json_filters_core3_protocols(tmp_path: Path):
             "fluid": {"slug": "instadapp", "name": "Fluid", "pol": {"score": 45.0}},
             "gains-network": {"slug": "gains-network", "name": "Gains", "pol": {"score": 60.0}},
         },
+        "curators": {
+            "gauntlet": {"slug": "gauntlet", "name": "Gauntlet", "recent_posts": []},
+            "re7-labs": {"slug": "re7-labs", "name": "RE7 Labs", "recent_posts": []},
+            "gains-network": {"slug": "gains-network", "name": "Gains Network", "recent_posts": []},
+        },
         "vaults": [
-            {"chain_id": 1, "protocol_slug": "morpho", "name": "Morpho Vault A"},
-            {"chain_id": 1, "protocol_slug": "morpho", "name": "Morpho Vault B"},
-            {"chain_id": 1, "protocol_slug": "fluid", "name": "Fluid Vault"},
-            {"chain_id": 42161, "protocol_slug": "gains-network", "name": "Gains Vault on Arbitrum"},
+            {"chain_id": 1, "protocol_slug": "morpho", "curator_slug": "gauntlet", "name": "Morpho Vault A"},
+            {"chain_id": 1, "protocol_slug": "morpho", "curator_slug": "gauntlet", "name": "Morpho Vault B"},
+            {"chain_id": 1, "protocol_slug": "fluid", "curator_slug": "re7-labs", "name": "Fluid Vault"},
+            {"chain_id": 42161, "protocol_slug": "gains-network", "curator_slug": "gains-network", "name": "Gains Vault on Arbitrum"},
         ],
     }
 
@@ -48,5 +54,11 @@ def test_sample_json_filters_core3_protocols(tmp_path: Path):
     assert "fluid" in result["core3_protocols"]
     # gains-network is Arbitrum only — should be excluded
     assert "gains-network" not in result["core3_protocols"]
+
+    # 4. curators should only have gauntlet and re7-labs (Ethereum vaults)
+    assert "gauntlet" in result["curators"]
+    assert "re7-labs" in result["curators"]
+    # gains-network curator is Arbitrum only — should be excluded
+    assert "gains-network" not in result["curators"]
 
     assert result["generated_at"] == "2026-06-08T00:00:00Z"


### PR DESCRIPTION
## Why

The vault metrics JSON bundle (`top_vaults_by_chain.json`) already includes Core3 risk intelligence at the top level. Frontend curator pages and vault listing enrichment need the same treatment for curators: metadata (name, website, social URLs, logos) and recent feed entries from Twitter, LinkedIn, and RSS.

## Lessons learnt

- Protocol curators (Hyperliquid, Ostium, Lighter) have protocol YAML but no curator YAML — the builder must fall back to protocol YAML for metadata.
- `TYPE_CHECKING` guard needed when a TypedDict import chain pulls in optional dependencies (DuckDB via feed database).
- Feed DB env var must align between collector (`DB_PATH`) and exporter (`FEED_DB_PATH` with `DB_PATH` fallback) to avoid silent empty exports.

## Summary

- Add `fetch_recent_posts_by_feeder()` to `VaultPostDatabase` with `ROW_NUMBER` window function and `COALESCE(published_at, fetched_at)` ordering
- New `eth_defi/vault/curator_export.py` with `CuratorFeedEntry`, `CuratorExportRecord` TypedDicts and `build_curators_for_export()` builder
- Add `curators` field to `VaultMetricsExport` (`TYPE_CHECKING` import)
- Wire curator export into `vault-analysis-json.py` after Core3 block
- Filter curators in `sample_export.py` for Ethereum-only samples
- Add Sphinx API docs entry for `curator_export` module
- Update `README-vault-scripts.md` with curators JSON structure and env vars
- Tests: `fetch_recent_posts_by_feeder`, `build_curators_for_export` (with feed, without feed, protocol curator, canonical feeder alias), sample filtering