### PR TITLE
feat: add curator descriptions metadata

### DIFF
--- a/.claude/skills/add-curator/SKILL.md
+++ b/.claude/skills/add-curator/SKILL.md
@@ -16,6 +16,7 @@ Gather or infer these before editing:
 - Curator slug, using the existing feeder slug style
 - Evidence from vault data: vault names, protocols, chains, and why this is a curator
 - Curator type: third-party curator, alias to an existing feeder, protocol-managed curator, or name-pattern update
+- Short curator description and long curator description
 - Optional website, Twitter/X, LinkedIn, blog/RSS, supporting links, and logo source
 
 If the candidate was produced by `find-new-curators`, open its result
@@ -50,6 +51,18 @@ Use official sources when possible:
 - RSS or Atom feed for an official blog, only if it works
 - Documentation, forum post, or vault UI proving the organisation acts as curator
 
+Add descriptions from primary sources:
+
+- `short_description`: one concise sentence.  Prefer the Twitter/X or
+  LinkedIn bio when available; otherwise use the official homepage
+  tagline.  Describe the organisation, not a single vault or token.
+- `long_description`: two to four Markdown-safe sentences summarising
+  the official homepage, docs, or product overview.  Avoid hype,
+  rankings, unverifiable performance claims, and investment advice.
+- For alias curators, describe the curator organisation represented by
+  the alias.  Do not blindly inherit a product-only description from
+  the canonical feeder when it would misrepresent the alias.
+
 Avoid adding aggregator pages, unofficial social accounts, or broken
 RSS feeds.  If a social account is inferred from search results, note
 that it was inferred in the final answer.
@@ -63,6 +76,10 @@ feeder-id: {curator-slug}
 name: {Curator name}
 role: curator
 website: https://example.org
+short_description: {One-sentence curator description.}
+long_description: |
+  {Two to four sentence curator description based on official homepage,
+  docs, Twitter/X bio, or LinkedIn bio.}
 twitter: example
 linkedin: example-company
 rss: https://example.org/feed.xml
@@ -89,11 +106,15 @@ eth_defi/data/feeds/curators/{curator-slug}.yaml
 ```
 
 Omit unknown optional fields instead of leaving empty keys.
+Always add `short_description` and `long_description` for new curator
+YAML files.  If primary-source evidence is too weak to write them, stop
+and ask instead of inventing descriptions.
 Use `other-links` for evidence pages such as protocol forum
 announcements, documentation pages, or vault launch posts that prove
 the organisation acts as curator.
 
-For an alias to an existing feeder, create only identity metadata:
+For an alias to an existing feeder, create identity and description
+metadata:
 
 ```yaml
 # {Curator name} curator - feeds provided by {role}/{canonical-slug}.yaml
@@ -101,6 +122,9 @@ feeder-id: {curator-slug}
 name: {Curator name}
 role: curator
 canonical-feeder-id: {canonical-slug}
+short_description: {One-sentence curator description.}
+long_description: |
+  {Two to four sentence curator description based on official sources.}
 ```
 
 Do not duplicate feed sources on alias files.
@@ -190,12 +214,30 @@ poetry run ruff check eth_defi/vault/curator.py
 
 If YAML feed files were edited and no specific feed tests exist, at
 least run a script or small import path that loads feeder metadata.
+For curator YAML edits, also verify descriptions are present and load
+through the shared schema:
+
+```shell
+poetry run python - <<'PY'
+from pathlib import Path
+
+from eth_defi.feed.sources import load_feeder_metadata
+
+for path in sorted(Path("eth_defi/data/feeds/curators").glob("*.yaml")):
+    data = load_feeder_metadata(path)
+    assert data.get("short_description"), path
+    assert data.get("long_description"), path
+
+print("ok")
+PY
+```
 
 ## Step 7: Report
 
 Summarise:
 
 - Feed files created or aliased
+- Short and long descriptions added, with source pages used
 - Detection logic changed
 - Logo files added or reused
 - Verification commands run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- feat: Add curator short and long descriptions to feeder metadata, curator exports, and all current curator YAML files (2026-06-09)
+
 - feat: Default Hypersync stream concurrency to 1 in the vault scanner pipeline, configurable via `HYPERSYNC_CONCURRENCY` env var and docker-compose (2026-06-09)
 
 - feat: Add Hypersync 1.1 stream tuning parameters — concurrency, batch_size, response byte limits configurable on ThrottledHypersyncClient and via HYPERSYNC_CONCURRENCY env var (2026-06-08)

--- a/eth_defi/data/feeds/curators/9summits.yaml
+++ b/eth_defi/data/feeds/curators/9summits.yaml
@@ -2,5 +2,8 @@ feeder-id: 9summits
 name: 9Summits
 role: curator
 website: https://vaults.9summits.io
+short_description: '9Summits curates DeFi vaults to help clients access yield opportunities with confidence and precision.'
+long_description: |
+  9Summits presents itself as an asset management project focused on curated DeFi vaults. Its homepage says it helps clients access decentralised finance opportunities by selecting top-performing vaults, while the vault app frames the product around earning and portfolio access.
 twitter: nine_summits
 # linkedin: not found

--- a/eth_defi/data/feeds/curators/agora-finance.yaml
+++ b/eth_defi/data/feeds/curators/agora-finance.yaml
@@ -2,4 +2,7 @@ feeder-id: agora-finance
 name: Agora Finance
 role: curator
 website: https://www.agora.finance/
+short_description: 'Agora Finance builds AUSD and stablecoin infrastructure for internet-native money movement.'
+long_description: |
+  Agora describes itself as powering the assets and infrastructure of digital finance. Its homepage centres on AUSD, an institutional-grade digital dollar minted 1:1 with USD fiat, plus white-labelled stablecoins, instant liquidity, cross-chain bridging, and enterprise stablecoin utility.
 twitter: withAUSD

--- a/eth_defi/data/feeds/curators/alleged-alpha.yaml
+++ b/eth_defi/data/feeds/curators/alleged-alpha.yaml
@@ -1,5 +1,8 @@
 feeder-id: alleged-alpha
 name: Alleged Alpha
 role: curator
+short_description: 'Alleged Alpha runs a systematic, fully automated multi-strategy long/short trading vault.'
+long_description: |
+  No standalone homepage was found for Alleged Alpha. Public vault metadata describes it as executing a systematic, fully automated long/short approach that combines cross-sectional, momentum, and reversal strategies on Lighter.
 twitter: allegedalpha
 # linkedin: not found

--- a/eth_defi/data/feeds/curators/alphagrowth.yaml
+++ b/eth_defi/data/feeds/curators/alphagrowth.yaml
@@ -2,6 +2,9 @@ feeder-id: alphagrowth
 name: AlphaGrowth
 role: curator
 website: https://alphagrowth.io/
+short_description: 'AlphaGrowth is a DeFi growth and execution firm supporting ecosystems, DAOs, investors, and protocols.'
+long_description: |
+  AlphaGrowth describes itself as a gateway to DeFi alpha, combining partners, systems, and institutional-grade execution. Its site highlights growth work for DeFi ecosystems and protocols, research content, deal flow, and solutions such as DeFi in a box, token-as-a-product, private lending, and onchain insurance.
 twitter: alphagrowth1
 
 # Evidence and background references.

--- a/eth_defi/data/feeds/curators/alphaping.yaml
+++ b/eth_defi/data/feeds/curators/alphaping.yaml
@@ -2,6 +2,9 @@ feeder-id: alphaping
 name: AlphaPing
 role: curator
 website: https://alphaping.ch
+short_description: 'AlphaPing operates mandate-driven, non-custodial on-chain credit vaults for institutional use cases.'
+long_description: |
+  AlphaPing describes its product as operator-grade on-chain credit vaults governed by explicit, mechanically enforced risk constraints. The homepage focuses on institutional allocators and asset managers, with over-collateralised credit, isolated mandates, deterministic exits, and verifiable on-chain accounting.
 twitter: 0xAlphaping
 linkedin: alphaping-gmbh
 

--- a/eth_defi/data/feeds/curators/alterscope.yaml
+++ b/eth_defi/data/feeds/curators/alterscope.yaml
@@ -2,5 +2,8 @@ feeder-id: alterscope
 name: Alterscope
 role: curator
 website: https://www.alterscope.org
+short_description: 'Alterscope provides risk data for on-chain markets across Ethereum, Stellar, and DeFi yield opportunities.'
+long_description: |
+  Alterscope describes itself as a data-first risk platform for on-chain markets. Its homepage says it helps users understand market backing, liquidity, failure conditions, oracle health, dependencies, and governance changes, with data delivered through an app, API, SDKs, webhooks, and agent-focused endpoints.
 twitter: Alterscope
 linkedin: alterscope

--- a/eth_defi/data/feeds/curators/altura.yaml
+++ b/eth_defi/data/feeds/curators/altura.yaml
@@ -10,4 +10,7 @@
 feeder-id: altura
 name: Altura
 role: curator
+short_description: 'Altura is a HyperEVM multi-strategy yield protocol for passive USDT0 yield.'
+long_description: |
+  Altura describes itself as a yield engine that turns USDT0 into diversified, sustainable yield through a single multi-strategy vault on HyperEVM. Its homepage says the vault automatically allocates across funding and basis arbitrage, market making, liquidity provision, and RWA strategies while reflecting yield through on-chain price-per-share growth.
 canonical-feeder-id: altura

--- a/eth_defi/data/feeds/curators/anthias-labs.yaml
+++ b/eth_defi/data/feeds/curators/anthias-labs.yaml
@@ -2,6 +2,9 @@ feeder-id: anthias-labs
 name: Anthias Labs
 role: curator
 website: https://anthias.xyz
+short_description: 'Anthias Labs is a boutique on-chain advisory firm focused on DeFi risk management and system design.'
+long_description: |
+  Anthias Labs describes itself as a mission-critical risk partner for protocols. Its homepage says it provides DeFi risk advisory, monitoring systems, technical research, and open-source tooling, with experience around depeggings, liquidation cascades, flash crashes, and protocol health monitoring.
 twitter: anthiasxyz
 linkedin: anthias-xyz
 

--- a/eth_defi/data/feeds/curators/api3.yaml
+++ b/eth_defi/data/feeds/curators/api3.yaml
@@ -2,6 +2,9 @@ feeder-id: api3
 name: API3
 role: curator
 website: https://api3.org
+short_description: 'API3 provides oracle infrastructure and OEV rewards for DeFi protocols across multiple chains.'
+long_description: |
+  API3 presents its oracle network as infrastructure that lets DeFi projects receive OEV rewards wherever they build. Its homepage highlights OEV rewards paid, lending protocol adopters, and more than 100 data feeds across supported chains.
 twitter: API3DAO
 linkedin: api3
 rss: https://blog.api3.org/rss/

--- a/eth_defi/data/feeds/curators/apostro.yaml
+++ b/eth_defi/data/feeds/curators/apostro.yaml
@@ -2,6 +2,9 @@ feeder-id: apostro
 name: Apostro
 role: curator
 website: https://apostro.xyz
+short_description: 'Apostro kickstarts and curates on-chain money markets using proprietary DeFi risk intelligence.'
+long_description: |
+  Apostro says it kickstarts and curates on-chain money markets with specific trading strategies in mind. Its homepage states that its markets hold more than $50M in TVL and that every product uses a proprietary risk intelligence engine analysing more than $45B in DeFi money markets.
 twitter: apostroxyz
 linkedin: apostro
 linkedin-rss-hub-disabled-at: 2026-04-04

--- a/eth_defi/data/feeds/curators/august-digital.yaml
+++ b/eth_defi/data/feeds/curators/august-digital.yaml
@@ -2,6 +2,9 @@ feeder-id: august-digital
 name: August Digital
 role: curator
 website: https://www.augustdigital.io
+short_description: 'August Digital builds institutional on-chain prime brokerage infrastructure for digital assets.'
+long_description: |
+  August describes itself as an institutional-grade crypto platform for managing and settling digital assets. Its homepage highlights on-chain prime brokerage infrastructure, smart contract accounts, pricing and risk engines, execution capabilities, automated loan lifecycle tools, and reporting for institutional clients.
 twitter: august_digital
 linkedin: augustdigital
 linkedin-rss-hub-disabled-at: 2026-04-04

--- a/eth_defi/data/feeds/curators/avantgarde-finance.yaml
+++ b/eth_defi/data/feeds/curators/avantgarde-finance.yaml
@@ -2,6 +2,9 @@ feeder-id: avantgarde-finance
 name: Avantgarde Finance
 role: curator
 website: https://avantgarde.finance
+short_description: 'Avantgarde Finance curates on-chain asset management strategies and Morpho vaults.'
+long_description: |
+  Avantgarde Finance describes itself as pioneering on-chain asset management through curated vault strategies. Its homepage says it serves crypto-native organisations with DeFi vaults, Morpho curation, separately managed accounts, RWA-backed looping strategies, and non-custodial infrastructure designed around pre-approved investor controls.
 twitter: avantgardefi
 linkedin: avantgarde-finance
 rss: https://medium.com/feed/@avantgardefi

--- a/eth_defi/data/feeds/curators/b-cube-ai.yaml
+++ b/eth_defi/data/feeds/curators/b-cube-ai.yaml
@@ -2,6 +2,9 @@ feeder-id: b-cube-ai
 name: B-CUBE.AI
 role: curator
 website: https://b-cube.ai
+short_description: 'B-CUBE.AI is an AI and quantamental crypto trading platform for funds, strategies, and trading tools.'
+long_description: |
+  B-CUBE.AI describes itself as a regulated quantamental trading platform combining AI, quantitative models, and fundamentals for institutional clients. Public company information also describes an AI-driven platform for building, optimising, renting, and copying crypto trading strategies, with execution, sentiment analysis, and portfolio tools.
 twitter: bcubeai
 linkedin: b-cube-ai
 linkedin-rss-hub-disabled-at: 2026-04-04

--- a/eth_defi/data/feeds/curators/b-protocol.yaml
+++ b/eth_defi/data/feeds/curators/b-protocol.yaml
@@ -2,6 +2,9 @@ feeder-id: b-protocol
 name: B.Protocol
 role: curator
 website: https://www.bprotocol.org
+short_description: 'B.Protocol develops DeFi backstop liquidity, liquidation, and risk-management infrastructure.'
+long_description: |
+  B.Protocol describes itself as a community of risk-aware DeFi participants building open protocols for risk mitigation and assessment. Its public materials focus on the Backstop AMM for liquidation liquidity, Pythia as an on-chain risk oracle, and RiskDAO for economic risk assessments, audits, dashboards, and monitoring.
 twitter: bprotocoleth
 
 # Evidence and background references.

--- a/eth_defi/data/feeds/curators/blackalgo.yaml
+++ b/eth_defi/data/feeds/curators/blackalgo.yaml
@@ -2,6 +2,9 @@ feeder-id: blackalgo
 name: Blackalgo
 role: curator
 website: https://blackalgo.com
+short_description: 'Blackalgo offers AI-powered trading automation focused on BTC and ETH strategies.'
+long_description: |
+  Blackalgo describes itself as AI for trading BTC and ETH, combining market analysis, automated execution, and risk management. Its homepage highlights self-learning algorithms, real-time optimisation, conservative to dynamic risk profiles, verified performance history, account controls, and institutional-grade protection.
 twitter: blackalgo
 linkedin: blackalgo
 linkedin-rss-hub-disabled-at: 2026-04-04

--- a/eth_defi/data/feeds/curators/block-analitica.yaml
+++ b/eth_defi/data/feeds/curators/block-analitica.yaml
@@ -2,6 +2,9 @@ feeder-id: block-analitica
 name: Block Analitica
 role: curator
 website: https://blockanalitica.com
+short_description: 'Block Analitica provides DeFi lending risk intelligence, dashboards, modelling, and advisory.'
+long_description: |
+  Block Analitica describes itself as a risk intelligence provider for DeFi lending protocols. Its homepage says it builds custom dashboards, tooling, monitoring, advisory, stress tests, and simulations, and notes support for the Sky ecosystem and other DeFi protocols since 2019.
 twitter: BlockAnalitica
 linkedin: block-analitica
 rss: https://medium.com/feed/block-analitica

--- a/eth_defi/data/feeds/curators/cap.yaml
+++ b/eth_defi/data/feeds/curators/cap.yaml
@@ -9,4 +9,7 @@
 feeder-id: cap
 name: CAP
 role: curator
+short_description: 'Cap is a verifiable money platform for USD yield, private credit, and financial guarantees.'
+long_description: |
+  Cap describes itself as a three-sided platform connecting USD yield, private credit, and financial guarantees. Its homepage presents a protocol where depositors earn yield, borrowers take unsecured USD loans, and underwriters provide guarantees through a marketplace structure.
 canonical-feeder-id: cap

--- a/eth_defi/data/feeds/curators/clearstar-labs.yaml
+++ b/eth_defi/data/feeds/curators/clearstar-labs.yaml
@@ -2,6 +2,9 @@ feeder-id: clearstar-labs
 name: Clearstar Labs
 role: curator
 website: https://www.clearstar.xyz
+short_description: 'Clearstar Labs curates on-chain strategies with qualitative vetting, monitoring, and distribution infrastructure.'
+long_description: |
+  Clearstar Labs describes itself as building safer DeFi with a qualitative-first approach. Its homepage positions the company as an onchain strategy curator providing enterprise-grade infrastructure, risk and vetting, technical monitoring, execution, capital routing, and distribution across institutional blockchain networks.
 twitter: ClearstarLabs
 linkedin: clearstar-labs-ag
 linkedin-rss-hub-disabled-at: 2026-04-04

--- a/eth_defi/data/feeds/curators/compound-dao.yaml
+++ b/eth_defi/data/feeds/curators/compound-dao.yaml
@@ -2,6 +2,9 @@ feeder-id: compound-dao
 name: Compound DAO
 role: curator
 website: https://compound.finance/
+short_description: 'Compound is a DeFi lending protocol and credit infrastructure project governed by the COMP ecosystem.'
+long_description: |
+  Compound is one of DeFi's established lending and borrowing protocols. Its public materials describe an infrastructure layer for credit, with markets and partner-facing lending rails intended for exchanges, fintechs and institutions. The protocol has historically focused on permissionless money markets and governance-controlled upgrades.
 twitter: compoundfinance
 linkedin: compound-labs
 # Compound Medium is stale; use the active governance/forum RSS.

--- a/eth_defi/data/feeds/curators/curvance.yaml
+++ b/eth_defi/data/feeds/curators/curvance.yaml
@@ -9,4 +9,7 @@
 feeder-id: curvance
 name: Curvance
 role: curator
+short_description: 'Curvance is a DeFi app for depositing, borrowing, leveraging, swapping and earning yield from one dashboard.'
+long_description: |
+  Curvance presents itself as a unified DeFi dashboard where users can deposit crypto, borrow against it and keep assets earning yield. The homepage emphasises isolated markets, user-controlled exposure and portfolio-wide yield opportunities across blue chips, stablecoins and other assets. Its vaults are described as routing deposits across approved markets and rebalancing as rates change.
 canonical-feeder-id: curvance

--- a/eth_defi/data/feeds/curators/damm-capital.yaml
+++ b/eth_defi/data/feeds/curators/damm-capital.yaml
@@ -2,5 +2,8 @@ feeder-id: damm-capital
 name: DAMM Capital
 role: curator
 website: https://dammcap.finance
+short_description: 'DAMM Capital is a DeFi asset management firm building quantitative on-chain strategies and tokenised funds.'
+long_description: |
+  DAMM Capital describes itself as an on-chain asset management firm focused on quantitative strategies that execute through smart contracts. Its homepage highlights tokenised funds, capital-preserving stablecoin strategies, ETH yield products and DeFi-as-a-service work for protocols and institutions. The firm stresses non-custodial infrastructure, transparency and risk management.
 twitter: DAMM_Capital
 linkedin: damm-capital

--- a/eth_defi/data/feeds/curators/edge-and-hedge.yaml
+++ b/eth_defi/data/feeds/curators/edge-and-hedge.yaml
@@ -1,5 +1,8 @@
 feeder-id: edge-and-hedge
 name: Edge & Hedge
 role: curator
+short_description: 'Edge & Hedge is a Hyperliquid vault running a quantitative delta-neutral long-short strategy.'
+long_description: |
+  Public vault listings describe Edge & Hedge as a Hyperliquid strategy using quantitative long and short positioning with roughly 3x leverage. The available description points to a delta-neutral approach and directs users to the operator's X account for updates. Because no official homepage or company profile was listed, the description is based on vault metadata and should be treated cautiously.
 twitter: blothecap
 # linkedin: not found

--- a/eth_defi/data/feeds/curators/ethena.yaml
+++ b/eth_defi/data/feeds/curators/ethena.yaml
@@ -2,4 +2,7 @@
 feeder-id: ethena
 name: Ethena
 role: curator
+short_description: 'Ethena is a synthetic dollar protocol behind USDe and dollar-denominated crypto-native savings products.'
+long_description: |
+  Ethena describes USDe as a crypto-native synthetic dollar designed for use across DeFi, exchanges and institutional venues. Its public materials present staking and rewards products around USDe, with transparency metrics for backing, minting and redemption availability. LinkedIn describes Ethena as a synthetic dollar protocol built on Ethereum and associated with the Internet Bond concept.
 canonical-feeder-id: usde

--- a/eth_defi/data/feeds/curators/felix.yaml
+++ b/eth_defi/data/feeds/curators/felix.yaml
@@ -2,6 +2,9 @@ feeder-id: felix
 name: Felix
 role: curator
 website: https://www.usefelix.xyz/
+short_description: 'Felix is a Hyperliquid-native CDP protocol for borrowing and earning with the feUSD stablecoin.'
+long_description: |
+  Felix is described in ecosystem profiles as a Hyperliquid-native collateralised debt position protocol. It centres on feUSD, a stablecoin that users can borrow against crypto collateral such as BTC, ETH and HYPE. Public descriptions say Felix is based on a licensed Liquity V2 design and is aimed at saving, borrowing and yield use cases on Hyperliquid.
 twitter: felixprotocol
 
 # Evidence and background references.

--- a/eth_defi/data/feeds/curators/fija.yaml
+++ b/eth_defi/data/feeds/curators/fija.yaml
@@ -2,5 +2,8 @@ feeder-id: fija
 name: Fija
 role: curator
 website: https://fija.finance
+short_description: 'fija Finance offers compliant, curated DeFi yield strategies with automated risk scoring and on-chain transparency.'
+long_description: |
+  fija's homepage describes a platform for earning real yields on crypto through curated DeFi strategies. It presents the product as compliant, easy and transparent, with strategy safety scores, automated risk management and fully on-chain fund visibility. The site says users can select risk-assessed strategies and let automated tools optimise yield execution.
 twitter: fija_finance
 linkedin: fija-finance-gmbh

--- a/eth_defi/data/feeds/curators/fisher8-capital.yaml
+++ b/eth_defi/data/feeds/curators/fisher8-capital.yaml
@@ -2,5 +2,8 @@ feeder-id: fisher8-capital
 name: Fisher8 Capital
 role: curator
 website: https://fisher8.capital
+short_description: 'Fisher8 Capital is a trading desk and venture studio investing and building across global markets.'
+long_description: |
+  Fisher8 Capital says it began as a family office in 2020 and now operates as a trading desk and venture studio. Its LinkedIn profile describes automated and discretionary strategies across global markets alongside support for early-stage companies. The public homepage is sparse, so the richer description comes mainly from its LinkedIn profile.
 twitter: fisher8cap
 linkedin: fisher8-capital

--- a/eth_defi/data/feeds/curators/flowdesk.yaml
+++ b/eth_defi/data/feeds/curators/flowdesk.yaml
@@ -2,6 +2,9 @@ feeder-id: flowdesk
 name: Flowdesk
 role: curator
 website: https://www.flowdesk.co
+short_description: 'Flowdesk is a full-service digital asset trading and technology firm for liquidity and OTC execution.'
+long_description: |
+  Flowdesk describes itself as a trading and technology firm delivering liquidity solutions, OTC trading and venture support for digital asset markets. Its homepage highlights institutional-grade compliance, proprietary execution algorithms, global 24/7 service and integrations across more than 150 venues. LinkedIn adds that Flowdesk serves institutions, exchanges and token issuers globally.
 twitter: flowdesk_co
 linkedin: flowdesk-france
 other-links:

--- a/eth_defi/data/feeds/curators/frax-finance.yaml
+++ b/eth_defi/data/feeds/curators/frax-finance.yaml
@@ -3,3 +3,8 @@ feeder-id: frax-finance
 name: Frax Finance
 role: curator
 canonical-feeder-id: frax
+short_description: Frax builds stablecoin and Fraxtal infrastructure for open, on-chain digital money.
+long_description: |
+  Frax is a DeFi protocol and financial technology organisation behind frxUSD, FPI, frxETH and the Fraxtal blockchain.
+  Its documentation describes frxUSD as a fiat-redeemable, fully collateralised stablecoin backed by cash-equivalent reserves and governed by the Frax DAO.
+  FraxNet provides cross-chain minting and redemption infrastructure for frxUSD across supported networks and institutions.

--- a/eth_defi/data/feeds/curators/gains-network.yaml
+++ b/eth_defi/data/feeds/curators/gains-network.yaml
@@ -10,3 +10,8 @@ feeder-id: gains-network
 name: Gains Network
 role: curator
 canonical-feeder-id: gains-network
+short_description: Gains Network develops gTrade, a decentralised leveraged trading platform for crypto and traditional market synthetics.
+long_description: |
+  Gains Network develops gTrade, a liquidity-efficient decentralised leveraged trading platform.
+  The platform supports markets including crypto, forex, stocks, indices and commodities, with trades settled on-chain against gToken liquidity vaults instead of per-pair order books.
+  Its documentation describes synthetic leverage, Chainlink oracle pricing and fee flows to governance, liquidity providers, staking, referrals and oracle execution.

--- a/eth_defi/data/feeds/curators/galaxy.yaml
+++ b/eth_defi/data/feeds/curators/galaxy.yaml
@@ -2,6 +2,11 @@ feeder-id: galaxy
 name: Galaxy
 role: curator
 website: https://www.galaxy.com
+short_description: Galaxy provides institutional digital asset, blockchain, asset management and data centre infrastructure services.
+long_description: |
+  Galaxy is a digital asset and blockchain firm serving institutions, startups and qualified individuals.
+  Its homepage presents global markets, asset management and infrastructure, blockchain infrastructure, GalaxyOne and data centres as the main business areas.
+  The firm provides digital asset trading, lending, derivatives, investment solutions, staking, tokenisation, self-custody technology and AI/HPC data centre infrastructure.
 twitter: GalaxyHQ
 linkedin: galaxyhq
 

--- a/eth_defi/data/feeds/curators/gami.yaml
+++ b/eth_defi/data/feeds/curators/gami.yaml
@@ -2,5 +2,10 @@ feeder-id: gami
 name: Gami
 role: curator
 website: https://gamilabs.io
+short_description: Gami provides institutional-grade DeFi vaults with on-chain curation and dynamic risk management.
+long_description: |
+  Gami Labs offers DeFi vaults designed to give users access to professionally curated on-chain yield strategies.
+  Its site describes a restricted set of vetted protocols across lending markets, liquidity engines and structured yield markets, with vaults that are dynamically rebalanced.
+  Gami also emphasises institutional infrastructure, multisig and HSM security, active risk management and governance-driven strategy support.
 twitter: GamiLabs
 # linkedin: not found

--- a/eth_defi/data/feeds/curators/gamma-strategies.yaml
+++ b/eth_defi/data/feeds/curators/gamma-strategies.yaml
@@ -4,6 +4,11 @@ feeder-id: gamma-strategies
 name: Gamma Strategies
 role: curator
 website: https://www.gamma.xyz
+short_description: Gamma is a protocol for active liquidity management and trading on decentralised exchanges.
+long_description: |
+  Gamma is a protocol for active liquidity management and trading on decentralised exchanges.
+  Its documentation lists a Uniswap v4 limit order hook, non-custodial automated LP vaults and perpetual trading vaults as its core products.
+  The LP vaults rebalance liquidity on concentrated liquidity AMMs, while the perpetual vaults run Hyperliquid strategies based on financial signals, momentum and sentiment analysis.
 twitter: GammaStrategies
 rss: https://medium.com/feed/@gammastrategies
 rss-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/curators/gauntlet.yaml
+++ b/eth_defi/data/feeds/curators/gauntlet.yaml
@@ -2,6 +2,11 @@ feeder-id: gauntlet
 name: Gauntlet
 role: curator
 website: https://www.gauntlet.xyz
+short_description: Gauntlet provides quantitative risk management, optimisation and vault strategies for DeFi protocols.
+long_description: |
+  Gauntlet applies quantitative optimisation, simulation and research to risk management and growth problems in DeFi.
+  Its site describes work across lending, restaking, real-world asset yield, applied research and self-custodial vault strategies.
+  The company builds tooling and recommendations for protocols, DAOs, builders and capital allocators while monitoring on-chain markets.
 twitter: gauntlet_xyz
 linkedin: gauntlet-xyz
 rss: https://medium.com/feed/gauntlet-networks

--- a/eth_defi/data/feeds/curators/growi-finance.yaml
+++ b/eth_defi/data/feeds/curators/growi-finance.yaml
@@ -2,5 +2,10 @@ feeder-id: growi-finance
 name: Growi Finance
 role: curator
 website: https://growi.fi
+short_description: Growi.fi develops quantitative DeFi investment products designed to be accessible to a broad user base.
+long_description: |
+  Growi.fi builds decentralised finance products that aim to make quantitative investment strategies easier to access.
+  Its Growi.HF documentation describes an expert-driven protocol for bringing hedge fund-style quant strategies to DeFi through automated, transparent vault operations.
+  The product uses Hyperliquid infrastructure and quantitative models to trade futures contracts while showing allocations and activity on-chain.
 twitter: GrowiFinance
 linkedin: growi-fi

--- a/eth_defi/data/feeds/curators/grvt.yaml
+++ b/eth_defi/data/feeds/curators/grvt.yaml
@@ -10,3 +10,8 @@ feeder-id: grvt
 name: GRVT
 role: curator
 canonical-feeder-id: grvt
+short_description: GRVT is a regulated self-custodial decentralised exchange for crypto trading and investment strategies.
+long_description: |
+  GRVT is a self-custodial decentralised exchange for trading crypto perpetuals and accessing managed investment strategies.
+  Its site describes trading, investing and earning tools, including curated and verified managers for strategy vaults.
+  GRVT documentation says the platform is built on ZKsync infrastructure for scalability, low latency, high throughput, gasless trading and trading privacy.

--- a/eth_defi/data/feeds/curators/hakutora.yaml
+++ b/eth_defi/data/feeds/curators/hakutora.yaml
@@ -1,6 +1,11 @@
 feeder-id: hakutora
 name: Hakutora
 role: curator
+short_description: Hakutora provides on-chain asset management and risk control solutions for DeFi strategies.
+long_description: |
+  Hakutora focuses on uncovering on-chain opportunities and managing risk.
+  Its homepage describes decentralised investment and risk-management strategies built on on-chain protocols, with a platform for on-chain asset management.
+  Hakutora also describes protocol analysis, function-level risk control and automatic withdrawal services in extreme situations when authorised.
 
 # Evidence and background references.
 #

--- a/eth_defi/data/feeds/curators/harvest.yaml
+++ b/eth_defi/data/feeds/curators/harvest.yaml
@@ -3,3 +3,8 @@ feeder-id: harvest
 name: Harvest Finance
 role: curator
 canonical-feeder-id: harvest-finance
+short_description: Harvest Finance is an automated DeFi yield farming platform for discovering and managing yield strategies.
+long_description: |
+  Harvest is a smart contract platform that optimises yield farming through automated strategies.
+  Its documentation describes aggregating yield opportunities from lending, staking and liquidity provision across DeFi so users do not need to move funds manually.
+  Harvest also provides strategy discovery and performance metrics for assets across multiple blockchain networks.

--- a/eth_defi/data/feeds/curators/hyperithm.yaml
+++ b/eth_defi/data/feeds/curators/hyperithm.yaml
@@ -2,6 +2,11 @@ feeder-id: hyperithm
 name: Hyperithm
 role: curator
 website: https://www.hyperithm.com
+short_description: Hyperithm is a digital asset gateway for institutions focused on asset management, quant trading and venture investments.
+long_description: |
+  Hyperithm is a digital asset manager based in Tokyo and Seoul, serving institutions and high-net-worth individuals.
+  Its homepage describes quant trading, algorithmic and HFT market-neutral strategies, diversified arbitrage and risk management as part of its asset management work.
+  Hyperithm also makes venture investments in Web3 teams and operates with regulatory registrations in Japan and Korea.
 twitter: hyperithm
 linkedin: hyperithm
 rss: https://hyperithm.substack.com/feed

--- a/eth_defi/data/feeds/curators/ignight-capital.yaml
+++ b/eth_defi/data/feeds/curators/ignight-capital.yaml
@@ -2,6 +2,11 @@ feeder-id: ignight-capital
 name: Ignight Capital
 role: curator
 website: https://ignight.capital
+short_description: Ignight Capital is a crypto investment and liquidity bootstrapping firm for DeFi projects.
+long_description: |
+  Ignight Capital focuses on crypto investment opportunities and liquidity bootstrapping for emerging protocols.
+  Its site describes support for early-stage projects through strategic investments and guidance.
+  The firm also provides capital intended to help DeFi protocols grow total value locked and gain market visibility.
 twitter: IgnightCapital
 linkedin: ignightcapital
 rss: https://medium.com/feed/@ignightcapital

--- a/eth_defi/data/feeds/curators/infinifi.yaml
+++ b/eth_defi/data/feeds/curators/infinifi.yaml
@@ -3,3 +3,8 @@ feeder-id: infinifi
 name: infiniFi
 role: curator
 canonical-feeder-id: infinifi
+short_description: infiniFi is a DeFi protocol that uses transparent capital efficiency to generate stablecoin yield without leverage.
+long_description: |
+  infiniFi is a DeFi protocol designed to amplify returns on existing platforms such as Pendle, Ethena and Aave.
+  Its documentation describes an on-chain fractional reserve system that aims to maximise yields while maintaining liquidity.
+  Users deposit USDC to receive iUSD, then can stake or lock positions through siUSD and liUSD tokens for different liquid and locked return profiles.

--- a/eth_defi/data/feeds/curators/insertive-capital.yaml
+++ b/eth_defi/data/feeds/curators/insertive-capital.yaml
@@ -1,5 +1,10 @@
 feeder-id: insertive-capital
 name: Insertive Capital
 role: curator
+short_description: Insertive Capital is a discretionary on-chain trading vault associated with the onchainquant profile.
+long_description: |
+  Insertive Capital appears as an on-chain discretionary trading vault under the onchainquant profile.
+  The published vault profile describes a high-risk, high-return strategy that seeks asymmetric opportunities across volatile markets.
+  The vault runs on Lighter and is denominated in USDC, with performance-fee-based operation shown in the vault metadata.
 twitter: onchainquant
 # linkedin: not found

--- a/eth_defi/data/feeds/curators/ipor.yaml
+++ b/eth_defi/data/feeds/curators/ipor.yaml
@@ -2,4 +2,7 @@
 feeder-id: ipor
 name: IPOR
 role: curator
+short_description: 'IPOR builds Fusion, onchain vault infrastructure for institutional-grade yield strategies.'
+long_description: |
+  IPOR's homepage focuses on Fusion, a product for creating and managing onchain vaults inside a risk framework. The site presents Fusion as infrastructure for asset managers, institutions, and builders to create, white-label, and explore yield strategies.
 canonical-feeder-id: ipor-fusion

--- a/eth_defi/data/feeds/curators/janus-henderson-anemoy.yaml
+++ b/eth_defi/data/feeds/curators/janus-henderson-anemoy.yaml
@@ -2,6 +2,9 @@ feeder-id: janus-henderson-anemoy
 name: Janus Henderson Anemoy
 role: curator
 website: https://www.anemoy.io/funds/jtrsy
+short_description: 'Janus Henderson Anemoy is a regulated onchain treasury fund providing access to short-duration US Treasury yield.'
+long_description: |
+  The Janus Henderson Anemoy Treasury Fund is described as a regulated, fully onchain actively managed fund for direct access to US Treasury yield with maturities under six months. The fund page emphasises daily redemptions, onchain transparency, investor protection, and tokenised fund shares.
 twitter: anemoycapital
 linkedin: anemoy
 

--- a/eth_defi/data/feeds/curators/k3-capital.yaml
+++ b/eth_defi/data/feeds/curators/k3-capital.yaml
@@ -12,4 +12,7 @@
 feeder-id: k3-capital
 name: K3 Capital
 role: curator
+short_description: 'K3 Capital is a crypto-native asset and risk manager focused on non-directional DeFi yield strategies.'
+long_description: |
+  K3 Capital says it has deployed liquidity onchain since 2021 and manages non-directional DeFi strategies. Its homepage highlights interest-rate arbitrage, liquidity provision, early-stage protocol participation, and risk-managed funds for crypto-native institutions and high-net-worth investors.
 canonical-feeder-id: sbold

--- a/eth_defi/data/feeds/curators/kappa-lab.yaml
+++ b/eth_defi/data/feeds/curators/kappa-lab.yaml
@@ -2,6 +2,9 @@ feeder-id: kappa-lab
 name: Kappa Lab
 role: curator
 website: https://kappalab.io
+short_description: 'Kappa Lab is a digital asset market maker providing liquidity solutions across centralised and decentralised venues.'
+long_description: |
+  Kappa Lab describes itself as a cryptocurrency market maker delivering around-the-clock liquidity and improving market efficiency. Its homepage highlights proprietary trading technology, algorithms, risk controls, onchain infrastructure, and liquidity solutions for exchanges, token issuers, and ecosystems.
 twitter: KappaLab_io
 linkedin: kappalab
 

--- a/eth_defi/data/feeds/curators/keyrock.yaml
+++ b/eth_defi/data/feeds/curators/keyrock.yaml
@@ -2,6 +2,9 @@ feeder-id: keyrock
 name: Keyrock
 role: curator
 website: https://keyrock.com
+short_description: 'Keyrock is a digital asset market maker and investment firm building financial services for tokenised markets.'
+long_description: |
+  Keyrock says it builds digital asset financial services across markets, asset management, and ecosystem solutions. Its homepage describes market making, OTC trading, options, onchain liquidity, validator services, and quant-led investment strategies across centralised and decentralised venues.
 twitter: keyrock
 linkedin: keyrock
 

--- a/eth_defi/data/feeds/curators/kpk.yaml
+++ b/eth_defi/data/feeds/curators/kpk.yaml
@@ -2,6 +2,9 @@ feeder-id: kpk
 name: kpk
 role: curator
 website: https://kpk.io
+short_description: 'KPK provides scalable onchain asset management through funds, vaults, and treasury mandates.'
+long_description: |
+  KPK describes its work as scalable onchain asset management built around risk frameworks, automation, and policy-enforced execution. Its homepage presents tokenised funds, automated vault strategies, and bespoke treasury mandates for structured capital allocation across DeFi markets.
 twitter: kpk_io
 linkedin: kpk-io
 rss: https://newsletter.kpk.io/feed

--- a/eth_defi/data/feeds/curators/llama-risk.yaml
+++ b/eth_defi/data/feeds/curators/llama-risk.yaml
@@ -2,6 +2,9 @@ feeder-id: llama-risk
 name: LlamaRisk
 role: curator
 website: https://llamarisk.com
+short_description: 'LlamaRisk provides DeFi risk intelligence, advisory, and automated risk infrastructure for protocols.'
+long_description: |
+  LlamaRisk presents itself as a DeFi risk organisation scaling financial infrastructure with actionable risk intelligence. Its homepage describes advisory work, liquidity and oracle risk analysis, stress simulations, legal and regulatory analysis, and the LlamaGuard infrastructure suite.
 twitter: LlamaRisk
 linkedin: llamarisk
 rss: https://llamarisk.substack.com/feed

--- a/eth_defi/data/feeds/curators/mev-capital.yaml
+++ b/eth_defi/data/feeds/curators/mev-capital.yaml
@@ -2,5 +2,8 @@ feeder-id: mev-capital
 name: MEV Capital
 role: curator
 website: https://www.mevcapital.com
+short_description: 'MEV Capital is a DeFi investment and risk management firm focused on onchain liquidity and vault curation.'
+long_description: |
+  MEV Capital says it manages liquidity in DeFi through bespoke yield strategies, economic-security curation, and risk-parameter management in permissionless vaults. Its homepage describes digital asset funds, vault curation services, segregated managed accounts, and market-neutral yield strategies.
 twitter: MEVCapital
 linkedin: mev-capital

--- a/eth_defi/data/feeds/curators/moonwell.yaml
+++ b/eth_defi/data/feeds/curators/moonwell.yaml
@@ -2,6 +2,9 @@ feeder-id: moonwell
 name: Moonwell
 role: curator
 website: https://moonwell.fi
+short_description: 'Moonwell builds simple onchain lending and borrowing tools, primarily known for DeFi markets on Base and related networks.'
+long_description: |
+  Moonwell is publicly described as a decentralised lending and borrowing protocol with a focus on simple financial tools. Search-visible profile text and app pages position it around lending, borrowing, earning, and making treasuries productive onchain.
 twitter: MoonwellDeFi
 
 # Evidence and background references.

--- a/eth_defi/data/feeds/curators/pangolins.yaml
+++ b/eth_defi/data/feeds/curators/pangolins.yaml
@@ -2,6 +2,9 @@ feeder-id: pangolins
 name: Pangolins
 role: curator
 website: https://pangolins.io
+short_description: 'Pangolins is a DeFi risk-management project researching protocols, strategies, and automated risk controls.'
+long_description: |
+  Pangolins describes its focus as DeFi risk management for safer participation in decentralised finance. Its public Morpho forum profile says it researches protocols, designs strategies, and implements automated risk controls without taking custody of user funds.
 twitter: PangolinsVault
 
 # Evidence and background references.

--- a/eth_defi/data/feeds/curators/pareto-technologies.yaml
+++ b/eth_defi/data/feeds/curators/pareto-technologies.yaml
@@ -2,5 +2,8 @@ feeder-id: pareto-technologies
 name: Pareto Technologies
 role: curator
 website: https://paretotechnologies.com
+short_description: 'Pareto Technologies is a digital asset investment, research, and technology firm using systematic crypto strategies.'
+long_description: |
+  Pareto Technologies describes itself as an investment, research, and technology firm operating in global digital asset markets. Its homepage says it uses multi-strategy systematic approaches, analytics, and risk management to seek alpha from fragmented and inefficient crypto markets.
 linkedin: pareto-technologies-llc
 # rss: https://paretotechnologies.beehiiv.com/feed.xml  # Beehiiv archive is active, but /feed and /feed.xml return HTML 404 pages as of 2026-05.

--- a/eth_defi/data/feeds/curators/pistachio.yaml
+++ b/eth_defi/data/feeds/curators/pistachio.yaml
@@ -2,3 +2,6 @@ feeder-id: pistachio
 name: Pistachio
 role: curator
 website: https://www.pistachio.fi
+short_description: 'Pistachio Fi is a mobile self-custodial DeFi app for earning yield from curated vaults and tokenised bond products.'
+long_description: |
+  Pistachio Fi presents itself as a mobile app for passive income through curated low-risk vaults and multinational sovereign bonds. Its homepage highlights self-custody, device-level key security, recovery, gasless use, Apple Pay and Google Pay ramping, and simplified access to DeFi yield.

--- a/eth_defi/data/feeds/curators/re7-labs.yaml
+++ b/eth_defi/data/feeds/curators/re7-labs.yaml
@@ -2,6 +2,9 @@ feeder-id: re7-labs
 name: RE7 Labs
 role: curator
 website: https://re7.capital
+short_description: 'Re7 Labs is the innovation arm of Re7 Capital, supporting DeFi investment strategies and ecosystem development.'
+long_description: |
+  Re7 Capital describes itself as a research-driven digital asset investment firm specialising in DeFi yield and liquid alpha strategies. Its homepage and LinkedIn presence frame Re7 as investors and operators across decentralised digital asset ecosystems, with Re7 Labs referenced as the innovation arm behind its strategy stack.
 twitter: Re7Capital
 linkedin: re7capital
 rss: https://re7research.substack.com/feed

--- a/eth_defi/data/feeds/curators/reservoir.yaml
+++ b/eth_defi/data/feeds/curators/reservoir.yaml
@@ -2,4 +2,7 @@ feeder-id: reservoir
 name: Reservoir
 role: curator
 website: https://reservoir.xyz
+short_description: 'Reservoir is a permissionless stablecoin protocol offering rUSD, yield-bearing srUSD/wsrUSD, term products, and lending markets.'
+long_description: |
+  Reservoir presents itself as a next-generation stablecoin protocol with higher yield, multi-collateral backing, and instant liquidity. Its documentation describes rUSD as a stablecoin backed by digital and real-world assets, with srUSD, wsrUSD, trUSD, and lending markets designed to distribute protocol yield and support DeFi integrations.
 twitter: reservoir_xyz

--- a/eth_defi/data/feeds/curators/resolv.yaml
+++ b/eth_defi/data/feeds/curators/resolv.yaml
@@ -2,4 +2,7 @@
 feeder-id: resolv
 name: Resolv
 role: curator
+short_description: 'Resolv is a DeFi protocol for stable returns through USR, RLP, and professionally operated yield vaults.'
+long_description: |
+  Resolv describes itself as the financial layer for stable returns, built around transparent dollar products backed by diversified crypto yield sources. Its product stack includes USR as a stable prime asset, RLP as a risk-bearing liquidity pool, and vaults that allocate collateral into strategies such as staking, futures, lending, and tokenised real-world assets.
 canonical-feeder-id: usr

--- a/eth_defi/data/feeds/curators/rockawayx.yaml
+++ b/eth_defi/data/feeds/curators/rockawayx.yaml
@@ -2,5 +2,8 @@ feeder-id: rockawayx
 name: RockawayX
 role: curator
 website: https://www.rockawayx.com
+short_description: 'RockawayX is a digital asset investment and engineering firm spanning venture, liquidity, and blockchain infrastructure.'
+long_description: |
+  RockawayX says it runs blockchains and provides liquidity to fuel protocols. Its homepage describes early-stage investing, validator and bare-metal infrastructure, and on-chain liquidity services for blockchain ecosystems, with a focus on building alongside portfolio projects rather than only providing capital.
 twitter: Rockaway_X
 linkedin: rockawayx

--- a/eth_defi/data/feeds/curators/rogue-traders.yaml
+++ b/eth_defi/data/feeds/curators/rogue-traders.yaml
@@ -1,6 +1,9 @@
 feeder-id: rogue-traders
 name: Rogue Traders
 role: curator
+short_description: 'Rogue Traders is a low-information public profile tied to the @Rogue_Traders handle.'
+long_description: |
+  No official homepage was provided, and the X profile could not be inspected through accessible public text. Public search results for the name are ambiguous and mostly point to unrelated music, television, or gaming references, so the DeFi curator identity could not be verified from reliable public sources.
 twitter: Rogue_Traders
 # linkedin: not found
 twitter-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/curators/sbold.yaml
+++ b/eth_defi/data/feeds/curators/sbold.yaml
@@ -17,4 +17,7 @@
 feeder-id: sbold
 name: sBOLD
 role: curator
+short_description: 'sBOLD is a K3 Capital ERC-4626 vault tokenising deposits into Liquity v2 Stability Pools.'
+long_description: |
+  K3 Capital sBOLD documentation describes the product as a yield-bearing tokenised representation of deposits into Liquity v2 Stability Pools. Depositors supply BOLD and receive an ERC-4626 token while the vault routes funds across selected stability pools, compounds interest, and automates liquidation-collateral conversion back into BOLD.
 canonical-feeder-id: sbold

--- a/eth_defi/data/feeds/curators/sentora.yaml
+++ b/eth_defi/data/feeds/curators/sentora.yaml
@@ -2,6 +2,9 @@ feeder-id: sentora
 name: Sentora
 role: curator
 website: https://sentora.com
+short_description: 'Sentora is an institutional DeFi platform for capital deployment, risk management, strategy design, and cover.'
+long_description: |
+  Sentora describes its platform as institutional-grade intelligence for deploying on-chain capital across DeFi. The homepage highlights strategy design, risk management, integrated cover, stablecoin adoption, risk curation, and tokenised equity yield as solutions for protocols and institutions.
 twitter: SentoraHQ
 linkedin: sentorahq
 rss: https://medium.com/feed/sentora

--- a/eth_defi/data/feeds/curators/silentist.yaml
+++ b/eth_defi/data/feeds/curators/silentist.yaml
@@ -2,5 +2,8 @@ feeder-id: silentist
 name: Silentist
 role: curator
 website: https://www.silentist.xyz
+short_description: 'Silentist is a crypto trading algorithm developer and provider offering client-account algorithmic strategies.'
+long_description: |
+  Silentist describes itself as a professional crypto trading algorithm developer and provider. Its homepage presents algorithmic long-short and spot strategies that operate on clients' own accounts, with live records and integrations through venues such as Binance Copy Trading, Lighter, and GRVT.
 twitter: silentist_inc
 linkedin: silentist-inc

--- a/eth_defi/data/feeds/curators/singularity.yaml
+++ b/eth_defi/data/feeds/curators/singularity.yaml
@@ -2,4 +2,7 @@ feeder-id: singularity
 name: Singularity Finance
 role: curator
 website: https://singularityfinance.ai
+short_description: 'Singularity Finance is AI-economy on-chain infrastructure for AI-driven finance, trading agents, and tokenised assets.'
+long_description: |
+  Singularity Finance presents itself as on-chain infrastructure powering the AI economy. Its homepage describes an AI-centric DeFi platform with agent discovery, autonomous non-custodial trading agents, AI portfolio tools, yield vaults, and real-world asset frameworks connected to the ASI Chain ecosystem.
 twitter: Singularity_fi

--- a/eth_defi/data/feeds/curators/singularv.yaml
+++ b/eth_defi/data/feeds/curators/singularv.yaml
@@ -2,6 +2,9 @@ feeder-id: singularv
 name: SingularV
 role: curator
 website: https://www.singularv.xyz
+short_description: 'SingularV is a DeFi asset management firm using AI-driven yield optimisation and risk curation.'
+long_description: |
+  SingularV describes itself as a DeFi asset management firm powered by proprietary AI technology. Its site highlights market-neutral strategies, liquidity optimisation, svUSDC yield vaults, and risk curation services across lending protocols such as Morpho and Euler for DeFi and institutional partners.
 twitter: singularv_xyz
 
 # SingularV is an onchain market-making firm focusing on optimisation and

--- a/eth_defi/data/feeds/curators/sky.yaml
+++ b/eth_defi/data/feeds/curators/sky.yaml
@@ -2,4 +2,7 @@
 feeder-id: sky
 name: Sky
 role: curator
+short_description: 'Sky.money is a non-custodial interface to Sky Protocol for USDS, sUSDS, vaults, rewards, and SKY participation.'
+long_description: |
+  Sky.money presents itself as a stablecoin-yield interface where users can put stablecoins to work through Sky Protocol savings tools. The site covers USDS conversion, sUSDS via the Sky Savings Rate, third-party Morpho vault strategies, fixed yield via Pendle, ecosystem rewards, and SKY staking or governance participation.
 canonical-feeder-id: usds

--- a/eth_defi/data/feeds/curators/smardex.yaml
+++ b/eth_defi/data/feeds/curators/smardex.yaml
@@ -3,6 +3,9 @@ feeder-id: smardex
 name: SmarDex
 role: curator
 website: https://smardex.io
+short_description: 'SmarDex is a decentralised exchange and AMM protocol focused on smart liquidity and low-slippage swaps.'
+long_description: |
+  SmarDex describes itself as a decentralised exchange designed for efficient, low-slippage cryptocurrency swaps through smart liquidity mechanisms. Its documentation explains that it operates as an AMM using pricing algorithms, while its LinkedIn profile frames SmarDex.io as a DeFi access point for users of the SmarDex protocol.
 twitter: SmarDex
 linkedin: realsmardex
 linkedin-rss-hub-disabled-at: 2026-04-04

--- a/eth_defi/data/feeds/curators/spark.yaml
+++ b/eth_defi/data/feeds/curators/spark.yaml
@@ -2,4 +2,7 @@
 feeder-id: spark
 name: Spark
 role: curator
+short_description: 'Spark is an on-chain asset allocator and DeFi yield engine powered by Sky, SparkLend, savings, and liquidity deployments.'
+long_description: |
+  Spark describes itself as an on-chain asset allocator deploying capital across DeFi, CeFi, and real-world assets. Its homepage highlights institutional-grade savings, SparkLend borrowing markets, the Spark Liquidity Layer, transparent on-chain deployments, governance through SPK, and integrations that help grow other protocols.
 canonical-feeder-id: spark

--- a/eth_defi/data/feeds/curators/stake-dao.yaml
+++ b/eth_defi/data/feeds/curators/stake-dao.yaml
@@ -2,6 +2,9 @@ feeder-id: stake-dao
 name: Stake DAO
 role: curator
 website: https://stakedao.org
+short_description: 'Stake DAO is a non-custodial DeFi protocol for liquid lockers, yield strategies, lending, and vote markets.'
+long_description: |
+  Stake DAO describes itself as the Liquid Lockers Protocol, focused on governance tokens. Its documentation says the platform helps users maximise governance-token value through liquid lockers, boosted yield strategies, lending against staked positions, and Votemarket, an on-chain marketplace for vote incentives.
 twitter: StakeDAOHQ
 linkedin: stake-dao
 rss: https://medium.com/@stakedaohq/feed

--- a/eth_defi/data/feeds/curators/steakhouse-financial.yaml
+++ b/eth_defi/data/feeds/curators/steakhouse-financial.yaml
@@ -2,5 +2,8 @@ feeder-id: steakhouse-financial
 name: Steakhouse Financial
 role: curator
 website: https://steakhouse.financial
+short_description: 'Steakhouse Financial builds institutional-grade DeFi products, vaults, risk infrastructure, and stablecoin advisory services.'
+long_description: |
+  Steakhouse Financial describes its work as products for the stablecoin economy. The homepage presents services for launching stablecoin and yield products, earning through risk-curated DeFi vaults, advisory on crypto and tokenised asset strategy, and raising capital through on-chain credit and liquidity infrastructure.
 twitter: SteakhouseFi
 linkedin: steakhouse-financial

--- a/eth_defi/data/feeds/curators/strata.yaml
+++ b/eth_defi/data/feeds/curators/strata.yaml
@@ -2,3 +2,6 @@ feeder-id: strata
 name: Strata
 role: curator
 website: https://strata.markets
+short_description: 'Strata is a structured-yield protocol that splits on-chain yield strategies into senior and junior risk tranches.'
+long_description: |
+  Strata documentation describes it as a generalised risk-tranching protocol for structured yield products. It tokenises yield strategies into senior and junior tranches so users can choose different risk-reward profiles, with the junior tranche absorbing more risk in exchange for higher potential yield and the senior tranche targeting more protected exposure.

--- a/eth_defi/data/feeds/curators/summer-fi.yaml
+++ b/eth_defi/data/feeds/curators/summer-fi.yaml
@@ -9,4 +9,7 @@
 feeder-id: summer-fi
 name: Summer.fi
 role: curator
+short_description: 'Summer.fi is a DeFi frontend for passive yield optimisation and advanced lending, borrowing, and earning strategies.'
+long_description: |
+  Summer.fi describes itself as the home of the Lazy Summer Protocol and a way to integrate high-quality DeFi yield. Its documentation explains that Summer.fi combines Lazy Summer vaults for passive, auto-rebalanced yield with Summer.fi Pro tools for experienced users who want lending, borrowing, multiply vaults, looping strategies, and protocol aggregation.
 canonical-feeder-id: summer-fi

--- a/eth_defi/data/feeds/curators/swissborg.yaml
+++ b/eth_defi/data/feeds/curators/swissborg.yaml
@@ -2,6 +2,9 @@ feeder-id: swissborg
 name: SwissBorg
 role: curator
 website: https://swissborg.com
+short_description: 'SwissBorg is a Swiss crypto wealth app for buying, selling, earning, spending, and automating digital asset investing.'
+long_description: |
+  SwissBorg presents itself as a Switzerland-engineered crypto app for buying and selling crypto safely at low fees. Its homepage and LinkedIn profile describe a regulated wealth app with exchange aggregation, fiat gateways, Auto-Invest, trigger orders, crypto card spending, yield products, and the BORG loyalty token.
 twitter: swissborg
 linkedin: swissborg
 

--- a/eth_defi/data/feeds/curators/syntropia.yaml
+++ b/eth_defi/data/feeds/curators/syntropia.yaml
@@ -2,5 +2,8 @@ feeder-id: syntropia
 name: Syntropia
 role: curator
 website: https://syntropia.ai
+short_description: 'Syntropia is a decentralised fund of risk-curated DeFi strategies with tranche-based yield products and circuit breakers.'
+long_description: |
+  Syntropia describes itself as automated yield from DeFi market making with institutional-grade security and protection through circuit breakers. Its documentation frames the product as a decentralised fund of risk-curated DeFi strategies, offering senior, mezzanine, and junior tranche assets alongside real-time monitoring of liquidity, borrow rates, market events, and sentiment.
 twitter: syntropia_ai
 linkedin: syntropiaai

--- a/eth_defi/data/feeds/curators/systemic-strategies.yaml
+++ b/eth_defi/data/feeds/curators/systemic-strategies.yaml
@@ -1,5 +1,8 @@
 feeder-id: systemic-strategies
 name: Systemic Strategies
 role: curator
+short_description: 'Systemic Strategies builds and operates Hyperliquid trading vaults.'
+long_description: |
+  Systemic Strategies appears to be a Hyperliquid-native vault operator focused on trading strategies. Public profile and vault pages reference HyperGrowth and L/S Grids vault activity, including volume, profits and depositor capacity updates. Because no standalone website was found, the description is based on social profile data and third-party vault pages.
 twitter: SystemicStratHL
 # linkedin: not found

--- a/eth_defi/data/feeds/curators/tangent-finance.yaml
+++ b/eth_defi/data/feeds/curators/tangent-finance.yaml
@@ -2,4 +2,7 @@ feeder-id: tangent-finance
 name: Tangent Finance
 role: curator
 website: https://www.tangent.finance/
+short_description: 'Tangent Finance builds USG, an over-collateralised DeFi stablecoin backed by productive collateral.'
+long_description: |
+  Tangent Finance presents USG as a decentralised, over-collateralised stablecoin designed around DeFi composability and capital efficiency. Its homepage describes markets where users can borrow against productive collateral, including LP and yield-bearing assets. It also offers sUSG as a yield-bearing version of USG and positions TAN holders as protocol governors who share in earnings.
 twitter: Tangent_fi

--- a/eth_defi/data/feeds/curators/tanken.yaml
+++ b/eth_defi/data/feeds/curators/tanken.yaml
@@ -1,3 +1,6 @@
 feeder-id: tanken
 name: Tanken
 role: curator
+short_description: 'Tanken Capital is a DeFi research, risk management and investment team involved in vault curation.'
+long_description: |
+  Tanken Capital is described by Napier Finance as a professional team specialising in DeFi research, risk management and investment. DefiLlama lists Tanken Capital under risk curators, with on-chain vaults that allocate assets across multiple DeFi protocols using data and allocation frameworks. Because no official homepage was found, this description relies on protocol and data aggregator sources.

--- a/eth_defi/data/feeds/curators/tau.yaml
+++ b/eth_defi/data/feeds/curators/tau.yaml
@@ -2,5 +2,8 @@ feeder-id: tau
 name: TAU
 role: curator
 website: https://www.628labs.xyz
+short_description: 'TAU Labs is a crypto-native vault curation and mechanism design firm.'
+long_description: |
+  TAU Labs, operating via 628 Labs, describes its work as crypto-native vault curation, mechanism design, incentive optimisation, token design and risk management. Its homepage says it runs strategies for stablecoins, BTC, ETH and other assets across chains. The site also highlights economic modelling for interest rates, liquidations, auctions, stress testing and tokenomics.
 twitter: 628Labs
 linkedin: tau-labs

--- a/eth_defi/data/feeds/curators/telosc.yaml
+++ b/eth_defi/data/feeds/curators/telosc.yaml
@@ -2,6 +2,9 @@ feeder-id: telosc
 name: Telos Consilium
 role: curator
 website: https://telosc.com
+short_description: 'Telos Consilium advises Web3 projects on strategy, tokenomics, integrations and growth.'
+long_description: |
+  Telos Consilium presents itself as an accelerator and consulting firm for Web3 projects. Its homepage describes services including go-to-market strategy, non-custodial asset management, business development, technical services, curation, data verification and research. LinkedIn describes the firm as helping Web3 projects through strategy, tokenomics and ecosystem integrations.
 twitter: TelosConsilium
 linkedin: telosc
 

--- a/eth_defi/data/feeds/curators/tesseract.yaml
+++ b/eth_defi/data/feeds/curators/tesseract.yaml
@@ -2,5 +2,8 @@ feeder-id: tesseract
 name: Tesseract
 role: curator
 website: https://tesseract.fi
+short_description: 'Tesseract is a Finnish institutional digital asset yield firm offering regulated vaults and lending.'
+long_description: |
+  Tesseract presents itself as an institutional digital asset yield provider with products for discretionary on-chain portfolio management and institutional counterparty lending. Its homepage says Tesseract Investment Oy is MiCA-authorised as a crypto-asset service provider and supervised by the Finnish Financial Supervisory Authority. LinkedIn describes its vaults as dedicated client vaults operated within its MiCA CASP authorisation and its lending product as CeFi lending to institutional counterparties.
 twitter: tesseractcrypto
 linkedin: tesseractinvestment

--- a/eth_defi/data/feeds/curators/tid-capital.yaml
+++ b/eth_defi/data/feeds/curators/tid-capital.yaml
@@ -1,3 +1,6 @@
 feeder-id: tid-capital
 name: TiD Capital
 role: curator
+short_description: 'TID Capital is the research-driven farming and trading arm associated with Today in DeFi.'
+long_description: |
+  TID Capital is publicly described as the research-driven farming and trading arm of Today in DeFi. Its social profile says it publishes trade theses, position disclosures and information related to curated vaults. Today in DeFi describes itself as a DeFi alpha research team founded by Danger, a professional DeFi trader and farmer at TID Capital.

--- a/eth_defi/data/feeds/curators/tulipa-capital.yaml
+++ b/eth_defi/data/feeds/curators/tulipa-capital.yaml
@@ -2,6 +2,9 @@ feeder-id: tulipa-capital
 name: Tulipa Capital
 role: curator
 website: https://tulipa.capital
+short_description: 'Tulipa Capital is a DeFi prop fund and risk curator focused on asset management and capital protection.'
+long_description: |
+  Tulipa Capital describes itself as a DeFi risk curator for the long term. Its homepage says the team has been active in DeFi since 2019, began as a prop fund running delta-neutral strategies, and later built a public curation arm for lending markets and vaults. Its stated approach prioritises risk assessment, transparent feedback, accountability and capital protection over chasing yield.
 twitter: tulipacapital
 linkedin: tulipa-capital
 linkedin-rss-hub-disabled-at: 2026-04-04

--- a/eth_defi/data/feeds/curators/turtle.yaml
+++ b/eth_defi/data/feeds/curators/turtle.yaml
@@ -2,5 +2,8 @@ feeder-id: turtle
 name: Turtle
 role: curator
 website: https://www.turtle.xyz
+short_description: 'Turtle is a liquidity distribution protocol for Web3 deals, yield opportunities and incentive programmes.'
+long_description: |
+  Turtle describes itself as a liquidity distribution protocol that helps users unlock boosted rewards across Web3. Its homepage focuses on institutional liquidity, dealflow and diligence, connecting partner protocols, liquidity providers and distribution partners. Turtle says protocols can submit opportunities and track TVL, while liquidity providers can deposit into partner protocols to earn native yield and rewards.
 twitter: turtledotxyz
 linkedin: turtlexyz

--- a/eth_defi/data/feeds/curators/ultrayield.yaml
+++ b/eth_defi/data/feeds/curators/ultrayield.yaml
@@ -2,6 +2,9 @@ feeder-id: ultrayield
 name: UltraYield
 role: curator
 website: https://ultrayield.app
+short_description: 'UltraYield is a vault curator and infrastructure provider for CeFi and DeFi yield strategies.'
+long_description: |
+  UltraYield presents itself as a vault curator and infrastructure provider offering yield-generating strategies across CeFi and DeFi. Its homepage describes institutional-grade opportunities, market-neutral strategies and smart contract infrastructure for vaults. It lists curated vaults for USD, BTC and ETH exposure, as well as partner vaults across several yield products.
 twitter: ultrayieldapp
 
 # UltraYield is the vault curation product of Edge Capital Group, a crypto

--- a/eth_defi/data/feeds/curators/unified-labs.yaml
+++ b/eth_defi/data/feeds/curators/unified-labs.yaml
@@ -2,6 +2,9 @@ feeder-id: unified-labs
 name: Unified Labs
 role: curator
 website: https://unifiedlabs.io
+short_description: 'Unified Labs builds institutional risk strategies and liquidity infrastructure for on-chain finance.'
+long_description: |
+  Unified Labs describes its purpose as building infrastructure for institutional DeFi adoption. Its homepage says it delivers institutional risk strategies and liquidity infrastructure for optimal on-chain allocation. The site highlights stablecoin and yield product design, risk-vetted DeFi vault allocation, and advisory work around RWAs, stablecoins and tokenised assets.
 twitter: unifiedlabs_
 rss: https://unifiedlabs.substack.com/feed
 

--- a/eth_defi/data/feeds/curators/upshift.yaml
+++ b/eth_defi/data/feeds/curators/upshift.yaml
@@ -9,4 +9,7 @@
 feeder-id: upshift
 name: Upshift
 role: curator
+short_description: 'Upshift is a DeFi platform making institutional yield products accessible through non-custodial vault infrastructure.'
+long_description: |
+  Upshift describes itself as a platform for democratising institutional yield. Its homepage says it bridges CeFi and DeFi with institutional-grade yield and gives users access to strategies used by institutions for assets such as USDC and HYPE. LinkedIn also describes Upshift as supporting non-custodial vaults, tokenised asset management and yield strategies across on-chain lending, RWAs, market-making and basis trades.
 canonical-feeder-id: upshift

--- a/eth_defi/data/feeds/curators/usdai.yaml
+++ b/eth_defi/data/feeds/curators/usdai.yaml
@@ -2,4 +2,7 @@
 feeder-id: usdai
 name: USD.AI
 role: curator
+short_description: 'USD.AI issues USDai, a synthetic dollar backed by AI compute infrastructure and machine-backed credit.'
+long_description: |
+  USD.AI presents USDai as a fully backed synthetic dollar and sUSDai as its yield-bearing staked version. Its homepage says the protocol links yield to machine-backed credit and collateralises USDai with high-performance GPUs and compute infrastructure. The site also highlights verified reserves, decentralised underwriting and mechanisms intended to support exits from real-world loans.
 canonical-feeder-id: usdai

--- a/eth_defi/data/feeds/curators/varlamore-capital.yaml
+++ b/eth_defi/data/feeds/curators/varlamore-capital.yaml
@@ -2,5 +2,8 @@ feeder-id: varlamore-capital
 name: Varlamore Capital
 role: curator
 website: https://varlamore.capital
+short_description: 'Varlamore Capital is a DeFi liquidity allocator focused on risk-curated vault strategies.'
+long_description: |
+  Varlamore Capital describes itself as a DeFi liquidity allocator that provides optimised yield matched to user risk profiles. Its homepage frames its work around curation, risk stratification and dynamic liquidity allocation. It says it operates as a vault manager for DeFi lending protocols and currently offers vaults on Silo Finance.
 twitter: VarlamoreCap
 # linkedin: not found

--- a/eth_defi/data/feeds/curators/woo.yaml
+++ b/eth_defi/data/feeds/curators/woo.yaml
@@ -2,5 +2,8 @@ feeder-id: woo
 name: Woo
 role: curator
 website: https://woo.org
+short_description: 'WOO builds crypto trading, automation and on-chain execution infrastructure for traders and agents.'
+long_description: |
+  WOO describes itself as AI-powered infrastructure for trading, automation and on-chain execution across markets. Its homepage points users to WOOFi for cross-chain swaps and earn vaults, WOOFi Pro for a gasless orderbook perpetual DEX, and WOO Stake for on-chain WOO token staking. The site positions the ecosystem as infrastructure used by traders and agents across centralised and decentralised markets.
 twitter: WOO_ecosystem
 twitter-dead-at: 2026-04-06

--- a/eth_defi/data/feeds/curators/xerberus.yaml
+++ b/eth_defi/data/feeds/curators/xerberus.yaml
@@ -2,4 +2,7 @@ feeder-id: xerberus
 name: Xerberus
 role: curator
 website: https://xerberus.io
+short_description: 'Xerberus is a decentralised crypto risk ratings protocol using on-chain data and open-source models.'
+long_description: |
+  Xerberus describes itself as a risk ratings protocol designed to provide automated, objective and real-time risk insights from on-chain data. Its homepage says the Xerberus Oracle network supplies reporting for dApps and DeFi protocols, including data for collateral, leverage pricing and risk management. Its about page describes a DAO-led project focused on crypto-native risk ratings and risk-weighted vaults.
 twitter: Xerberus

--- a/eth_defi/data/feeds/curators/yearn.yaml
+++ b/eth_defi/data/feeds/curators/yearn.yaml
@@ -2,4 +2,7 @@
 feeder-id: yearn
 name: Yearn
 role: curator
+short_description: 'Yearn is a DeFi protocol that automates yield generation through vaults and related products.'
+long_description: |
+  Yearn documentation describes yVaults as capital pools that automatically generate yield from market opportunities. The docs say vaults socialise gas costs, automate yield generation and rebalancing, and move capital as opportunities arise. Yearn also offers yLockers, which are vault products built around vote-escrow governance tokens.
 canonical-feeder-id: yearn

--- a/eth_defi/data/feeds/curators/yieldnest.yaml
+++ b/eth_defi/data/feeds/curators/yieldnest.yaml
@@ -9,4 +9,7 @@
 feeder-id: yieldnest
 name: YieldNest
 role: curator
+short_description: 'YieldNest creates liquid DeFi yield products and MAX Vaults for unified, risk-adjusted strategy exposure.'
+long_description: |
+  YieldNest says it merges DeFi strategies into single, unified assets. Its homepage describes products for USD, ETH and RWA exposure, including MAX Vaults that rebalance across strategies to select risk-adjusted opportunities. The site also highlights audits, an in-house risk team and external risk support from LlamaRisk.
 canonical-feeder-id: yieldnest

--- a/eth_defi/data/feeds/curators/yo.yaml
+++ b/eth_defi/data/feeds/curators/yo.yaml
@@ -2,4 +2,7 @@
 feeder-id: yo
 name: Yo
 role: curator
+short_description: 'YO is a multi-chain DeFi yield engine for wallets, exchanges, apps and end users.'
+long_description: |
+  YO Protocol describes itself as a yield engine for the crypto economy that can be embedded into apps in minutes. Its homepage lists yield products such as yoUSD, yoETH, yoBTC, yoEUR, yoSOL and yoGOLD across multiple chains. The site says YO tracks yield across DeFi protocols and chains while using Exponential.fi risk ratings to balance risk and reward.
 canonical-feeder-id: yo

--- a/eth_defi/feed/README-feed.md
+++ b/eth_defi/feed/README-feed.md
@@ -82,6 +82,8 @@ feeder-id: { curator slug, protocol slug, or vault slug }
 name: { human-readable name }
 role: { curator | protocol | stablecoin | vault }
 website: { optional company website URL }
+short_description: { optional one-line company or project summary }
+long_description: { optional multi-paragraph Markdown company or project description }
 twitter: { optional Twitter/X username }
 linkedin: { optional LinkedIn company id }
 rss: { optional RSS or Atom feed URL }
@@ -95,6 +97,8 @@ Notes:
 - `feeder-id` is the canonical slug and acts as the feeder identity
 - `role` must be one of `curator`, `protocol`, `stablecoin`, or `vault`
 - `website` is optional company metadata and is stored alongside tracked sources
+- `short_description` is optional feeder metadata for list and card views
+- `long_description` is optional Markdown feeder metadata for detail views
 - `twitter` is a username such as `gauntlet_xyz`, not a full profile URL
 - `linkedin` is collected through operator-supplied LinkedIn bridge templates
 - `linkedin` is a company id such as `gauntlet-xyz`, not a full LinkedIn URL
@@ -120,10 +124,10 @@ role: stablecoin
 canonical-feeder-id: usdt
 ```
 
-Alias files must contain only `feeder-id`, `name`, `role`, and
-`canonical-feeder-id` — no feed source fields (`twitter`, `linkedin`,
-`rss`).  They produce no tracked sources and no posts are collected for
-them.
+Alias files contain `feeder-id`, `name`, `role`, and `canonical-feeder-id`,
+and may carry non-source metadata like descriptions. They must not contain
+feed source fields (`twitter`, `linkedin`, `rss`). They produce no tracked
+sources and no posts are collected for them.
 
 `canonical-feeder-id` can cross roles.  When the same entity is a
 stablecoin, a protocol, and a curator, the priority order is:
@@ -161,6 +165,10 @@ feeder-id: gauntlet
 name: Gauntlet
 role: curator
 website: https://www.gauntlet.xyz/
+short_description: Gauntlet is a DeFi risk manager.
+long_description: |
+  Gauntlet builds risk management systems for lending markets, vaults and
+  other on-chain financial applications.
 twitter: gauntlet_xyz
 linkedin: gauntlet-xyz
 rss: https://medium.com/feed/gauntlet-networks

--- a/eth_defi/feed/sources.py
+++ b/eth_defi/feed/sources.py
@@ -45,6 +45,8 @@ _MAPPING_SCHEMA = Map(
         "role": Str(),
         Optional("canonical-feeder-id"): Str(),
         Optional("website"): Str(),
+        Optional("short_description"): Str(),
+        Optional("long_description"): Str(),
         Optional("twitter"): Str(),
         Optional("linkedin"): Str(),
         Optional("linkedin-rss-hub-disabled-at"): Str(),
@@ -229,6 +231,13 @@ def _normalise_mapping_metadata(parsed: dict, mapping_file: Path) -> None:
     other_links = _normalise_other_links(parsed.get("other-links"), mapping_file)
     if other_links is not None:
         parsed["other-links"] = other_links
+
+    for key in ("short_description", "long_description"):
+        value = parsed.get(key)
+        if value is not None:
+            if not isinstance(value, str):
+                raise ValueError(f"{key} must be a string in {mapping_file}")
+            parsed[key] = value.strip() or None
 
 
 def _normalise_twitter_source(handle: str, mapping_file: Path) -> tuple[str, str]:
@@ -686,7 +695,7 @@ def load_feeder_metadata(yaml_path: Path) -> dict:
     filename stem to catch slug/filename mismatches.
 
     This function provides a public API for modules that need feeder
-    metadata (slug, name, website, twitter, linkedin, rss) without
+    metadata (slug, name, descriptions, website, twitter, linkedin, rss) without
     pulling in the full feed-collection machinery of
     :py:func:`load_post_sources`.
 
@@ -695,7 +704,8 @@ def load_feeder_metadata(yaml_path: Path) -> dict:
 
     :return:
         Dict with keys: ``feeder-id``, ``name``, ``role``, ``website``,
-        ``twitter``, ``linkedin``, ``rss``, etc.
+        ``short_description``, ``long_description``, ``twitter``,
+        ``linkedin``, ``rss``, etc.
     """
     parsed = load(yaml_path.read_text(), _MAPPING_SCHEMA).data
     feeder_id = _validate_slug(parsed.get("feeder-id"), "feeder-id", yaml_path)

--- a/eth_defi/vault/curator.py
+++ b/eth_defi/vault/curator.py
@@ -35,14 +35,18 @@ Curator YAML files use the shared feeder schema defined in
     twitter: gauntlet_xyz
     linkedin: gauntlet-xyz
     rss: https://medium.com/feed/gauntlet-networks
+    short_description: Gauntlet is a DeFi risk manager.
+    long_description: |
+      Gauntlet builds risk management systems for lending markets,
+      vaults and other on-chain financial applications.
 
 Canonical feeder aliases
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 When the same organisation appears as both a curator and a stablecoin
 issuer or vault protocol, duplicate feed fetching is avoided by using
-``canonical-feeder-id``.  An alias YAML file contains only identity
-metadata — no feed source fields (twitter, linkedin, rss)::
+``canonical-feeder-id``.  An alias YAML file contains identity and
+description metadata, but no feed source fields (twitter, linkedin, rss)::
 
     feeder-id: ethena
     name: Ethena
@@ -257,6 +261,12 @@ class CuratorInfo(TypedDict):
     #: Company website URL, or ``None`` if not configured in YAML.
     website: str | None
 
+    #: One-line description of the curator.
+    short_description: str | None
+
+    #: Multi-paragraph Markdown description of the curator.
+    long_description: str | None
+
     #: Twitter/X handle without ``@`` prefix (e.g. ``"gauntlet_xyz"``),
     #: or ``None`` if not configured.
     twitter: str | None
@@ -318,6 +328,12 @@ class CuratorMetadata(TypedDict):
     #: Company website URL, or ``None``.
     website: str | None
 
+    #: One-line description of the curator.
+    short_description: str | None
+
+    #: Multi-paragraph Markdown description of the curator.
+    long_description: str | None
+
     #: Full Twitter/X profile URL (e.g. ``"https://x.com/gauntlet_xyz"``),
     #: or ``None``.
     twitter: str | None
@@ -366,6 +382,8 @@ def _load_curator_yaml(yaml_path: Path) -> CuratorInfo:
         slug=parsed["feeder-id"],
         name=parsed["name"],
         website=parsed.get("website"),
+        short_description=parsed.get("short_description"),
+        long_description=parsed.get("long_description"),
         twitter=parsed.get("twitter"),
         linkedin=parsed.get("linkedin"),
         rss=parsed.get("rss"),
@@ -632,6 +650,8 @@ def build_curator_metadata_json(yaml_path: Path, public_url: str = "") -> Curato
         slug=slug,
         name=info["name"],
         website=website,
+        short_description=info["short_description"],
+        long_description=info["long_description"],
         twitter=twitter_url,
         linkedin=linkedin_url,
         rss=rss,
@@ -665,6 +685,8 @@ def _build_protocol_curator_entries(public_url: str = "") -> list[CuratorMetadat
                     slug=slug,
                     name=name,
                     website=None,
+                    short_description=None,
+                    long_description=None,
                     twitter=None,
                     linkedin=None,
                     rss=None,

--- a/eth_defi/vault/curator_export.py
+++ b/eth_defi/vault/curator_export.py
@@ -83,6 +83,12 @@ class CuratorExportRecord(TypedDict):
     #: Company website URL, or ``None``.
     website: str | None
 
+    #: One-line description of the curator.
+    short_description: str | None
+
+    #: Multi-paragraph Markdown description of the curator.
+    long_description: str | None
+
     #: Full Twitter/X profile URL (e.g. ``"https://x.com/gauntlet_xyz"``),
     #: or ``None``.
     twitter: str | None
@@ -132,6 +138,8 @@ def _build_protocol_curator_from_yaml(
     name = PROTOCOL_CURATOR_NAMES.get(slug, slug)
 
     website = None
+    short_description = None
+    long_description = None
     twitter_url = None
     linkedin_url = None
     rss = None
@@ -140,6 +148,8 @@ def _build_protocol_curator_from_yaml(
         meta = load_feeder_metadata(protocol_yaml)
         name = meta.get("name", name)
         website = meta.get("website")
+        short_description = meta.get("short_description")
+        long_description = meta.get("long_description")
         twitter_handle = meta.get("twitter")
         linkedin_id = meta.get("linkedin")
         rss = meta.get("rss")
@@ -153,6 +163,8 @@ def _build_protocol_curator_from_yaml(
         slug=slug,
         name=name,
         website=website,
+        short_description=short_description,
+        long_description=long_description,
         twitter=twitter_url,
         linkedin=linkedin_url,
         rss=rss,
@@ -224,6 +236,8 @@ def build_curators_for_export(
                 slug=meta["slug"],
                 name=meta["name"],
                 website=meta["website"],
+                short_description=meta["short_description"],
+                long_description=meta["long_description"],
                 twitter=meta["twitter"],
                 linkedin=meta["linkedin"],
                 rss=meta["rss"],

--- a/tests/feed/test_canonical_feeder.py
+++ b/tests/feed/test_canonical_feeder.py
@@ -156,21 +156,24 @@ def test_real_yaml_files_load_without_errors():
 
 
 def test_other_links_metadata_loads(tmp_path: Path):
-    """Supporting feeder links are accepted and normalised.
+    """Supporting feeder metadata is accepted and normalised.
 
     1. Create a curator YAML with ``other-links`` evidence.
     2. Load the metadata through the shared feeder loader.
-    3. Assert the link title is preserved and the URL is normalised.
+    3. Assert descriptions are preserved.
+    4. Assert the link title is preserved and the URL is normalised.
     """
 
     yaml_path = tmp_path / "curators" / "flowdesk.yaml"
     _write_yaml(
         yaml_path,
-        "feeder-id: flowdesk\nname: Flowdesk\nrole: curator\ntwitter: flowdesk_co\nother-links:\n  - title: Morpho forum evidence\n    url: https://forum.morpho.org/t/announcing-flowdesk-ausd-rwa-strategy/2213\n",
+        "feeder-id: flowdesk\nname: Flowdesk\nrole: curator\nshort_description: Flowdesk is an institutional market maker.\nlong_description: |\n  Flowdesk provides market making and liquidity services.\ntwitter: flowdesk_co\nother-links:\n  - title: Morpho forum evidence\n    url: https://forum.morpho.org/t/announcing-flowdesk-ausd-rwa-strategy/2213\n",
     )
 
     metadata = load_feeder_metadata(yaml_path)
 
+    assert metadata["short_description"] == "Flowdesk is an institutional market maker."
+    assert metadata["long_description"] == "Flowdesk provides market making and liquidity services."
     assert metadata["other-links"] == [
         {
             "title": "Morpho forum evidence",
@@ -180,29 +183,32 @@ def test_other_links_metadata_loads(tmp_path: Path):
 
 
 def test_metadata_inheritance_in_curator_export(tmp_path: Path):
-    """Curator metadata export inherits fields from canonical stablecoin feeder.
+    """Curator metadata export inherits source fields from canonical stablecoin feeder.
 
     1. Create stablecoins/usde.yaml with website, twitter, linkedin.
-    2. Create curators/ethena.yaml as alias pointing to usde.
+    2. Create curators/ethena.yaml as alias pointing to usde, with curator descriptions.
     3. Call build_curator_metadata_json().
     4. Assert website, twitter, linkedin are inherited (not None).
-    5. Create a second alias whose canonical has no linkedin — assert linkedin is None.
+    5. Assert descriptions come from the curator alias YAML.
+    6. Create a second alias whose canonical has no linkedin — assert linkedin is None.
     """
 
     # Full metadata canonical
     _write_yaml(
         tmp_path / "stablecoins" / "usde.yaml",
-        "feeder-id: usde\nname: Ethena USDe\nrole: stablecoin\nwebsite: https://ethena.fi/\ntwitter: ethena\nlinkedin: ethena-labs\n",
+        "feeder-id: usde\nname: Ethena USDe\nrole: stablecoin\nwebsite: https://ethena.fi/\nshort_description: USDe is a synthetic dollar.\nlong_description: |\n  USDe is a stablecoin product.\ntwitter: ethena\nlinkedin: ethena-labs\n",
     )
     _write_yaml(
         tmp_path / "curators" / "ethena.yaml",
-        "feeder-id: ethena\nname: Ethena\nrole: curator\ncanonical-feeder-id: usde\n",
+        "feeder-id: ethena\nname: Ethena\nrole: curator\ncanonical-feeder-id: usde\nshort_description: Ethena is a synthetic dollar protocol team.\nlong_description: |\n  Ethena operates the protocol behind USDe and related products.\n",
     )
 
     metadata = curator_module.build_curator_metadata_json(tmp_path / "curators" / "ethena.yaml")
     assert metadata["slug"] == "ethena"
     assert metadata["name"] == "Ethena"
     assert metadata["website"] == "https://ethena.fi/"
+    assert metadata["short_description"] == "Ethena is a synthetic dollar protocol team."
+    assert metadata["long_description"] == "Ethena operates the protocol behind USDe and related products."
     assert metadata["twitter"] == "https://x.com/ethena"
     assert metadata["linkedin"] == "https://www.linkedin.com/company/ethena-labs"
     assert metadata["logos"] == {"generic": None, "dark": None, "light": None}
@@ -234,7 +240,7 @@ def test_curator_metadata_export_includes_logo_urls(tmp_path: Path, monkeypatch:
 
     _write_yaml(
         tmp_path / "curators" / "gauntlet.yaml",
-        "feeder-id: gauntlet\nname: Gauntlet\nrole: curator\ntwitter: gauntlet_xyz\n",
+        "feeder-id: gauntlet\nname: Gauntlet\nrole: curator\nshort_description: Gauntlet is a DeFi risk manager.\nlong_description: |\n  Gauntlet builds risk management systems.\ntwitter: gauntlet_xyz\n",
     )
     logo_dir = tmp_path / "logos" / "gauntlet"
     logo_dir.mkdir(parents=True)
@@ -252,6 +258,8 @@ def test_curator_metadata_export_includes_logo_urls(tmp_path: Path, monkeypatch:
         "dark": "https://pub.example/curator-metadata/gauntlet/dark.png",
         "light": None,
     }
+    assert metadata["short_description"] == "Gauntlet is a DeFi risk manager."
+    assert metadata["long_description"] == "Gauntlet builds risk management systems."
 
 
 def test_curator_metadata_uploads_logo_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/tests/vault/test_curator_export.py
+++ b/tests/vault/test_curator_export.py
@@ -33,9 +33,10 @@ def test_build_curators_for_export_with_feed(tmp_path: Path):
         )
         sid = db.upsert_tracked_source(source)
 
-        base_time = datetime.datetime(2026, 6, 1, 12, 0, 0)
+        base_time = datetime.datetime(2026, 6, 1, 12, 0, 0)  # noqa: DTZ001
+        post_count = 5
         posts = []
-        for i in range(5):
+        for i in range(post_count):
             posts.append(
                 CollectedPost(
                     external_post_id=f"gauntlet-post-{i}",
@@ -60,12 +61,14 @@ def test_build_curators_for_export_with_feed(tmp_path: Path):
     assert rec["slug"] == "gauntlet"
     assert rec["name"] == "Gauntlet"
     assert rec["website"] == "https://www.gauntlet.xyz"
+    assert rec["short_description"].startswith("Gauntlet provides")
+    assert "risk management" in rec["long_description"]
     assert rec["twitter"] == "https://x.com/gauntlet_xyz"
     assert rec["protocol_curator"] is False
     assert rec["canonical_feeder_id"] is None
 
     # 5. Assert recent_posts
-    assert len(rec["recent_posts"]) == 5
+    assert len(rec["recent_posts"]) == post_count
     post = rec["recent_posts"][0]
     assert post["source_type"] == "twitter"
     assert post["link"].startswith("https://x.com/gauntlet_xyz/status/")
@@ -113,6 +116,8 @@ def test_build_curators_for_export_protocol_curator_with_protocol_yaml():
     # 3. Assert metadata from protocol YAML
     assert rec["name"] == "Hyperliquid"
     assert rec["website"] == "https://hyperliquid.xyz"
+    assert rec["short_description"] is None
+    assert rec["long_description"] is None
     assert rec["twitter"] == "https://x.com/HyperliquidX"
     assert rec["linkedin"] == "https://www.linkedin.com/company/hyperliquid"
 
@@ -143,9 +148,10 @@ def test_build_curators_for_export_canonical_feeder(tmp_path: Path):
         )
         sid = db.upsert_tracked_source(source)
 
-        base_time = datetime.datetime(2026, 6, 1, 12, 0, 0)
+        base_time = datetime.datetime(2026, 6, 1, 12, 0, 0)  # noqa: DTZ001
+        post_count = 3
         posts = []
-        for i in range(3):
+        for i in range(post_count):
             posts.append(
                 CollectedPost(
                     external_post_id=f"usde-post-{i}",
@@ -170,5 +176,5 @@ def test_build_curators_for_export_canonical_feeder(tmp_path: Path):
     assert rec["canonical_feeder_id"] == "usde"
 
     # 4. Assert recent_posts come from usde feeder
-    assert len(rec["recent_posts"]) == 3
+    assert len(rec["recent_posts"]) == post_count
     assert rec["recent_posts"][0]["snippet"].startswith("USDe news")

--- a/tests/vault/test_sample_export.py
+++ b/tests/vault/test_sample_export.py
@@ -23,9 +23,27 @@ def test_sample_json_filters_core3_protocols_and_curators(tmp_path: Path):
             "gains-network": {"slug": "gains-network", "name": "Gains", "pol": {"score": 60.0}},
         },
         "curators": {
-            "gauntlet": {"slug": "gauntlet", "name": "Gauntlet", "recent_posts": []},
-            "re7-labs": {"slug": "re7-labs", "name": "RE7 Labs", "recent_posts": []},
-            "gains-network": {"slug": "gains-network", "name": "Gains Network", "recent_posts": []},
+            "gauntlet": {
+                "slug": "gauntlet",
+                "name": "Gauntlet",
+                "short_description": "Gauntlet short description.",
+                "long_description": "Gauntlet long description.",
+                "recent_posts": [],
+            },
+            "re7-labs": {
+                "slug": "re7-labs",
+                "name": "RE7 Labs",
+                "short_description": "RE7 Labs short description.",
+                "long_description": "RE7 Labs long description.",
+                "recent_posts": [],
+            },
+            "gains-network": {
+                "slug": "gains-network",
+                "name": "Gains Network",
+                "short_description": "Gains Network short description.",
+                "long_description": "Gains Network long description.",
+                "recent_posts": [],
+            },
         },
         "vaults": [
             {"chain_id": 1, "protocol_slug": "morpho", "curator_slug": "gauntlet", "name": "Morpho Vault A"},
@@ -46,8 +64,9 @@ def test_sample_json_filters_core3_protocols_and_curators(tmp_path: Path):
     # 3. Read and verify
     result = json.loads(output_path.read_text(encoding="utf-8"))
 
-    assert count == 3
-    assert len(result["vaults"]) == 3
+    expected_ethereum_vault_count = 3
+    assert count == expected_ethereum_vault_count
+    assert len(result["vaults"]) == expected_ethereum_vault_count
 
     # core3_protocols should only have morpho and fluid (Ethereum vaults)
     assert "morpho" in result["core3_protocols"]
@@ -58,6 +77,10 @@ def test_sample_json_filters_core3_protocols_and_curators(tmp_path: Path):
     # 4. curators should only have gauntlet and re7-labs (Ethereum vaults)
     assert "gauntlet" in result["curators"]
     assert "re7-labs" in result["curators"]
+    assert result["curators"]["gauntlet"]["short_description"] == "Gauntlet short description."
+    assert result["curators"]["gauntlet"]["long_description"] == "Gauntlet long description."
+    assert result["curators"]["re7-labs"]["short_description"] == "RE7 Labs short description."
+    assert result["curators"]["re7-labs"]["long_description"] == "RE7 Labs long description."
     # gains-network curator is Arbitrum only — should be excluded
     assert "gains-network" not in result["curators"]
 


### PR DESCRIPTION
## Why

Curator metadata currently exposes names, websites, social links, logos and recent posts, but not a stable description that frontends can use in curator lists or detail views.

Adding short and long descriptions makes curator records more useful without requiring consumers to infer company context from recent posts or external pages.

## Lessons learnt

Curator aliases should keep their own organisation descriptions instead of inheriting product-specific descriptions from canonical stablecoin or protocol feeders.

The feed YAML schema is shared across curators, protocols, stablecoins and vaults, so description support belongs in the common feeder loader and can be reused by other feeder roles later.

## Summary

- Add optional `short_description` and `long_description` fields to the shared feeder YAML schema.
- Export curator descriptions through curator metadata and vault metrics curator records.
- Backfill descriptions for all current curator YAML files using official homepages, docs and social bios.
- Update feed documentation and focused tests for description loading, alias behaviour and curator export output.
- Update the `add-curator` skill so future curator additions include sourced descriptions, and guard that descriptions survive in the exported JSON blob.
- Add a changelog entry for the new curator description metadata.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.