### PR TITLE
feat: Save full X/Twitter note tweets in feed collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - feat: Add curator short and long descriptions to feeder metadata, curator exports, and all current curator YAML files (2026-06-09)
 
+- feat: Save full X/Twitter note tweets — request the `note_tweet` API field so tweets longer than 280 characters are stored and exported in full instead of truncated, and surface `full_text` alongside the 200-char `snippet` in the vault JSON bundle (2026-06-09)
+
 - feat: Default Hypersync stream concurrency to 1 in the vault scanner pipeline, configurable via `HYPERSYNC_CONCURRENCY` env var and docker-compose (2026-06-09)
 
 - feat: Add Hypersync 1.1 stream tuning parameters — concurrency, batch_size, response byte limits configurable on ThrottledHypersyncClient and via HYPERSYNC_CONCURRENCY env var (2026-06-08)

--- a/docs/source/api/feed/index.rst
+++ b/docs/source/api/feed/index.rst
@@ -10,3 +10,4 @@ Off-chain feed collection helpers for vault-related content.
    eth_defi.feed.sources
    eth_defi.feed.database
    eth_defi.feed.collector
+   eth_defi.feed.twitter_api

--- a/eth_defi/feed/database.py
+++ b/eth_defi/feed/database.py
@@ -35,8 +35,16 @@ class CollectedPost:
     #: Timestamp when the collector fetched this post in naive UTC.
     fetched_at: datetime.datetime
     #: Short preview text stored alongside the post.
+    #:
+    #: Capped at 200 characters for compact listings; this is **not** the
+    #: complete post body.  See :py:attr:`full_text` for the full content.
     short_description: str
     #: Best available full text extracted from the feed entry.
+    #:
+    #: For X/Twitter this is the complete *note tweet* body for tweets longer
+    #: than 280 characters, populated via
+    #: :py:func:`eth_defi.feed.twitter_api._extract_full_tweet_text`.  See
+    #: :py:attr:`short_description` for the truncated preview.
     full_text: str
     #: Optional future AI-generated summary, null in the current version.
     ai_summary: str | None = None
@@ -433,9 +441,9 @@ class VaultPostDatabase:
 
         :return:
             Dict mapping ``feeder_id`` to a list of post dicts with keys
-            ``title``, ``short_description``, ``post_url``, ``source_type``,
-            ``published_at`` (always set via COALESCE fallback to
-            ``fetched_at``).  Lists are ordered newest-first.
+            ``title``, ``short_description``, ``full_text``, ``post_url``,
+            ``source_type``, ``published_at`` (always set via COALESCE
+            fallback to ``fetched_at``).  Lists are ordered newest-first.
         """
         ids = list(feeder_ids)
         if not ids:
@@ -449,6 +457,7 @@ class VaultPostDatabase:
                     ts.feeder_id,
                     p.title,
                     p.short_description,
+                    p.full_text,
                     p.post_url,
                     ts.source_type,
                     COALESCE(p.published_at, p.fetched_at) AS published_at,
@@ -460,7 +469,7 @@ class VaultPostDatabase:
                 JOIN posts p ON ts.source_id = p.source_id
                 WHERE ts.feeder_id IN ({placeholders})
             )
-            SELECT feeder_id, title, short_description, post_url, source_type, published_at
+            SELECT feeder_id, title, short_description, full_text, post_url, source_type, published_at
             FROM ranked
             WHERE rn <= ?
             ORDER BY feeder_id, published_at DESC
@@ -470,11 +479,12 @@ class VaultPostDatabase:
 
         result: dict[str, list[dict]] = {}
         for row in rows:
-            feeder_id, title, short_description, post_url, source_type, published_at = row
+            feeder_id, title, short_description, full_text, post_url, source_type, published_at = row
             result.setdefault(feeder_id, []).append(
                 {
                     "title": title,
                     "short_description": short_description,
+                    "full_text": full_text,
                     "post_url": post_url,
                     "source_type": source_type,
                     "published_at": published_at,

--- a/eth_defi/feed/twitter_api.py
+++ b/eth_defi/feed/twitter_api.py
@@ -5,6 +5,31 @@ Provides a user metadata cache to avoid repeated handle-to-ID lookups.
 
 Reading requires only a bearer token (``TWITTER_BEARER_TOKEN``).
 List membership writes require full OAuth 1.0a credentials.
+
+Note tweets and full text
+-------------------------
+
+The X API v2 caps the ``text`` field of every tweet at **280 characters**.
+Tweets longer than this — so called *note tweets*, available to premium and
+verified accounts — are returned with a truncated ``text`` value (ending in an
+ellipsis) and the complete body, up to ~25,000 characters, in a separate
+``note_tweet`` object.
+
+The ``note_tweet`` object is only present when the ``note_tweet`` field is
+explicitly requested via the ``tweet_fields`` request parameter.  Both
+:py:func:`fetch_tweets_from_x_list` and :py:func:`fetch_user_tweets` request it,
+and :py:func:`_extract_full_tweet_text` prefers ``note_tweet.text`` over the
+truncated ``text`` so the full body is preserved.
+
+The full body lands in :py:attr:`~eth_defi.feed.database.CollectedPost.full_text`,
+while :py:attr:`~eth_defi.feed.database.CollectedPost.short_description` keeps a
+200-character preview for compact listings.  Both are carried through to the
+vault JSON bundle as
+:py:attr:`~eth_defi.vault.curator_export.CuratorFeedEntry.full_text` and
+:py:attr:`~eth_defi.vault.curator_export.CuratorFeedEntry.snippet` respectively.
+
+See the X API v2 note tweet documentation:
+https://docs.x.com/x-api/fundamentals/note-tweets
 """
 
 import datetime
@@ -287,11 +312,55 @@ def resolve_x_list_id_by_name(
     return matches[0]
 
 
+def _extract_full_tweet_text(tweet_data: dict) -> str:
+    """Return the full, untruncated text of a tweet.
+
+    The X API v2 caps the ``text`` field at 280 characters.  Tweets longer
+    than this (so called *note tweets*, posted by premium accounts) are
+    truncated in ``text`` with a trailing ellipsis, and the complete body is
+    only returned in the ``note_tweet`` object when the ``note_tweet`` tweet
+    field is requested.  Prefer that full body when present, falling back to
+    the legacy ``text`` field.
+
+    The returned value is stored, after whitespace normalisation, in
+    :py:attr:`~eth_defi.feed.database.CollectedPost.full_text`.  The companion
+    :py:attr:`~eth_defi.feed.database.CollectedPost.short_description` keeps a
+    200-character preview of the same body.  See :py:func:`_tweet_to_collected_post`
+    for the mapping and the module docstring for the note tweet API overview.
+
+    :param tweet_data:
+        Raw tweet dict from the X API v2 (``tweepy`` ``Tweet.data``).
+        Carries ``note_tweet`` only when the ``note_tweet`` field was requested
+        in ``tweet_fields`` — see :py:func:`fetch_tweets_from_x_list`.
+
+    :return:
+        The longest available tweet body, raw (not whitespace-normalised).
+
+    See the X API v2 note tweet documentation:
+    https://docs.x.com/x-api/fundamentals/note-tweets
+    """
+
+    note_tweet = tweet_data.get("note_tweet")
+    if note_tweet:
+        note_text = note_tweet.get("text")
+        if note_text:
+            return note_text
+    return tweet_data.get("text", "")
+
+
 def _tweet_to_collected_post(tweet_data: dict, author_handle: str) -> CollectedPost:
-    """Map a raw tweet dict from the X API to a :class:`CollectedPost`."""
+    """Map a raw tweet dict from the X API to a :class:`CollectedPost`.
+
+    The full tweet body — including the complete *note tweet* for long tweets,
+    see :py:func:`_extract_full_tweet_text` — is stored in
+    :py:attr:`~eth_defi.feed.database.CollectedPost.full_text`, while
+    :py:attr:`~eth_defi.feed.database.CollectedPost.short_description` keeps the
+    first 200 characters as a preview.
+    """
 
     tweet_id = str(tweet_data["id"])
-    text = tweet_data.get("text", "")
+    # Prefer the full note_tweet body over the 280-char truncated text field
+    text = _extract_full_tweet_text(tweet_data)
     normalised_text = _normalise_whitespace(text)
     created_at_str = tweet_data.get("created_at")
     published_at = None
@@ -334,7 +403,9 @@ def fetch_tweets_from_x_list(
     total_fetched = 0
     pagination_token = None
 
-    tweet_fields = ["id", "text", "created_at", "author_id", "public_metrics", "entities", "referenced_tweets"]
+    # ``note_tweet`` is required to receive the full body of tweets longer than
+    # 280 chars — without it the X API returns only a truncated ``text`` field.
+    tweet_fields = ["id", "text", "note_tweet", "created_at", "author_id", "public_metrics", "entities", "referenced_tweets"]
     expansions = ["author_id"]
     user_fields = ["id", "username", "name"]
 
@@ -408,7 +479,9 @@ def fetch_user_tweets(
     """
 
     client = tweepy.Client(bearer_token=bearer_token)
-    tweet_fields = ["id", "text", "created_at", "author_id", "public_metrics", "entities", "referenced_tweets"]
+    # ``note_tweet`` is required to receive the full body of tweets longer than
+    # 280 chars — without it the X API returns only a truncated ``text`` field.
+    tweet_fields = ["id", "text", "note_tweet", "created_at", "author_id", "public_metrics", "entities", "referenced_tweets"]
 
     kwargs = {}
     if since is not None:

--- a/eth_defi/vault/curator_export.py
+++ b/eth_defi/vault/curator_export.py
@@ -51,8 +51,20 @@ class CuratorFeedEntry(TypedDict):
     #: Post title, or ``None`` for untitled posts (e.g. tweets).
     title: str | None
 
-    #: Short preview text (first ~280 chars).
+    #: Short preview text (first 200 chars), suitable for compact listings.
+    #:
+    #: Derived from :py:attr:`~eth_defi.feed.database.CollectedPost.short_description`.
+    #: For the complete post body see :py:attr:`full_text`.
     snippet: str
+
+    #: Full untruncated post body.
+    #:
+    #: For X/Twitter this includes the complete *note tweet* text for tweets
+    #: longer than 280 characters, not just the preview — see
+    #: :py:func:`eth_defi.feed.twitter_api._extract_full_tweet_text`.  Derived
+    #: from :py:attr:`~eth_defi.feed.database.CollectedPost.full_text`.  For the
+    #: 200-character preview see :py:attr:`snippet`.
+    full_text: str
 
     #: Canonical URL to the original post, or ``None``.
     link: str | None
@@ -281,6 +293,7 @@ def build_curators_for_export(
                     CuratorFeedEntry(
                         title=post["title"],
                         snippet=post["short_description"],
+                        full_text=post["full_text"],
                         link=post["post_url"],
                         source_type=post["source_type"],
                         published_at=published_at,

--- a/tests/feed/test_fetch_recent_posts.py
+++ b/tests/feed/test_fetch_recent_posts.py
@@ -102,11 +102,13 @@ def test_fetch_recent_posts_by_feeder(tmp_path: Path):
         for post in result_all["feeder-a"]:
             assert post["published_at"] is not None
 
-        # 8. Source type is included
+        # 8. Source type and full_text are included
         for post in result["feeder-a"]:
             assert post["source_type"] == "twitter"
+            assert post["full_text"].startswith("Full text of post A ")
         for post in result["feeder-b"]:
             assert post["source_type"] == "rss"
+            assert post["full_text"].startswith("Full text of post B ")
 
         # 9. Empty feeder_ids returns {}
         assert db.fetch_recent_posts_by_feeder([]) == {}

--- a/tests/feed/test_twitter_api.py
+++ b/tests/feed/test_twitter_api.py
@@ -7,10 +7,71 @@ import tweepy
 
 from eth_defi.feed import twitter_api
 from eth_defi.feed.database import VaultPostDatabase
-from eth_defi.feed.twitter_api import TwitterUserCache, compute_handles_hash, sync_x_list_members
+from eth_defi.feed.twitter_api import (
+    TwitterUserCache,
+    _tweet_to_collected_post,
+    compute_handles_hash,
+    sync_x_list_members,
+)
 
 LIST_ID = "123"
 LIST_MEMBER_PAGE_SIZE = 100
+
+
+def test_tweet_to_collected_post_keeps_full_note_tweet() -> None:
+    """Store the full note tweet body, not the 280-char truncated preview.
+
+    The X API v2 caps the ``text`` field at 280 characters for long tweets and
+    returns the complete body in ``note_tweet`` only when that field is
+    requested.  We must keep the full text so downstream exports are not cut.
+
+    1. Build a tweet whose ``text`` is the truncated 280-char preview and whose
+       ``note_tweet.text`` carries the full long body.
+    2. Map it to a :class:`CollectedPost`.
+    3. Assert ``full_text`` holds the complete note tweet text.
+    4. Assert ``short_description`` is the 200-char preview.
+    """
+
+    # 1. Build a tweet with both the truncated text and the full note_tweet body
+    full_body = "A " + "long " * 200 + "tail."
+    tweet_data = {
+        "id": "999",
+        "text": full_body[:277] + "…",
+        "note_tweet": {"text": full_body},
+        "created_at": "2026-06-09T12:00:00.000Z",
+    }
+
+    # 2. Map it to a CollectedPost
+    post = _tweet_to_collected_post(tweet_data, "hyperliquidx")
+
+    # 3. full_text holds the complete note tweet text (whitespace-normalised)
+    assert post.full_text == twitter_api._normalise_whitespace(full_body)
+    assert len(post.full_text) > 280
+
+    # 4. short_description is the 200-char preview
+    assert len(post.short_description) == 200
+    assert post.full_text.startswith(post.short_description)
+
+
+def test_tweet_to_collected_post_falls_back_to_text() -> None:
+    """Use the legacy ``text`` field for short tweets without a note tweet.
+
+    Most tweets are under 280 characters and carry no ``note_tweet`` object, so
+    the mapper must fall back to ``text`` without error.
+
+    1. Build a short tweet with only a ``text`` field.
+    2. Map it to a :class:`CollectedPost`.
+    3. Assert ``full_text`` equals the normalised ``text``.
+    """
+
+    # 1. Build a short tweet with only a text field
+    tweet_data = {"id": "1", "text": "gm", "created_at": "2026-06-09T12:00:00.000Z"}
+
+    # 2. Map it to a CollectedPost
+    post = _tweet_to_collected_post(tweet_data, "someone")
+
+    # 3. full_text equals the normalised text
+    assert post.full_text == "gm"
 
 
 class _RateLimitedResponse:

--- a/tests/vault/test_curator_export.py
+++ b/tests/vault/test_curator_export.py
@@ -73,6 +73,7 @@ def test_build_curators_for_export_with_feed(tmp_path: Path):
     assert post["source_type"] == "twitter"
     assert post["link"].startswith("https://x.com/gauntlet_xyz/status/")
     assert post["snippet"].startswith("Risk analysis")
+    assert post["full_text"].startswith("Full risk analysis")
     # published_at is ISO 8601 string
     assert isinstance(post["published_at"], str)
     assert "T" in post["published_at"]


### PR DESCRIPTION
## Why

Our X/Twitter feed reader was silently truncating long tweets. The X API v2 caps the `text` field at 280 characters; tweets longer than that (*note tweets*, posted by premium/verified accounts) return the full body — up to ~25,000 characters — only in a separate `note_tweet` object, and only when the `note_tweet` field is explicitly requested.

We were not requesting it, so even the `full_text` column stored only the first ~280 characters, and the vault JSON bundle exported a 200-char `snippet` on top of that. A reported example, the [@HyperliquidX USDH/AQAv2 announcement](https://x.com/HyperliquidX/status/2054895699498619143), was stored as 278 of its 1,587 characters.

## Lessons learnt

- **The X API v2 `text` field is capped at 280 chars.** Long tweets need `note_tweet` in `tweet_fields`; the full body lives in `note_tweet.text`. Verified live against the configured bearer token: the example tweet returned `text` len 278 vs `note_tweet.text` len 1587.
- **No database migration is needed.** `full_text` is an existing `VARCHAR NOT NULL` column in the DuckDB `posts` table — the fix only changes what is *written* into it going forward, plus reads it in the export query. Schema setup is `CREATE TABLE IF NOT EXISTS` + idempotent `ADD COLUMN IF NOT EXISTS`, so existing `posts.duckdb` files open unchanged.
- **Historical rows are not auto-repaired.** Tweets collected before this change stored the truncated `text`, and DuckDB cannot recover text that was never written. New scans store full text, so tracked feeds self-heal on the next cycle; a one-off re-scan/backfill (re-`insert_posts` by primary key overwrites) is only worth it if full text on already-collected long tweets is specifically needed.

## Summary

- `eth_defi/feed/twitter_api.py`
  - Added `note_tweet` to `tweet_fields` in `fetch_tweets_from_x_list` and `fetch_user_tweets`.
  - New `_extract_full_tweet_text()` helper prefers `note_tweet.text`, falling back to the legacy `text` field; `_tweet_to_collected_post` now uses it.
  - Documented the note tweet API in detail in the module docstring with cross-references to the relevant fields.
- `eth_defi/feed/database.py`
  - `fetch_recent_posts_by_feeder` now also selects and returns `full_text`.
  - Cross-referenced `CollectedPost.short_description` ↔ `full_text`.
- `eth_defi/vault/curator_export.py`
  - `CuratorFeedEntry` gained a `full_text` field carrying the complete body alongside the 200-char `snippet`; `build_curators_for_export` populates it.
  - Fixed a misleading `snippet` docstring (claimed "~280 chars", actually 200) and cross-referenced `snippet` ↔ `full_text`.
- `docs/source/api/feed/index.rst`
  - Added the previously missing `eth_defi.feed.twitter_api` autosummary stub.
- Tests: two new cases for the note-tweet mapper (full body kept; fallback to `text`), plus `full_text` assertions extended into the `fetch_recent_posts` and `curator_export` tests. 8/8 pass.

## Unrelated CI and test fixes

None. Note that `make build-docs` currently fails in this environment on a pre-existing, unrelated issue — Sphinx 4.5 imports the `imghdr` stdlib module, which was removed in Python 3.13+ (repo runs 3.14). The RST/docstring changes here are syntactically valid but could not be verified with a full docs build.
