### PR TITLE
fix: Default wait_for_transaction_receipt_robust() to 2 confirmations on live chains

### DIFF
--- a/eth_defi/provider/receipt.py
+++ b/eth_defi/provider/receipt.py
@@ -39,6 +39,17 @@ PROVIDER_READ_EXCEPTIONS = (
 """Exceptions raised by unavailable or read-restricted JSON-RPC providers."""
 
 
+#: Default number of confirmations each read provider must see before
+#: :py:func:`wait_for_transaction_receipt_robust` returns on a live (non-Anvil) chain.
+#:
+#: Set to 2 so that a state read (``eth_call``) issued immediately after the wait is
+#: very likely served by a backend whose state trie already reflects the transaction,
+#: not just one that has the receipt visible. Avoids read-after-write races on
+#: MultiProvider setups where writes go to a sequencer / transaction provider and reads
+#: go to lagging public RPCs. Anvil ignores this (single coherent state view).
+DEFAULT_CONFIRMATION_BLOCK_COUNT = 2
+
+
 class ReceiptVisibilityTimedOut(TimeoutError):
     """Timed out before all read providers could see a transaction receipt."""
 
@@ -204,7 +215,7 @@ def wait_for_transaction_receipt_robust(
     timeout: float = 120.0,
     poll_delay: float = 1.0,
     max_poll_delay: float = 5.0,
-    confirmation_block_count: int = 0,
+    confirmation_block_count: int | None = None,
     extra_sleep: float = 0.0,
 ) -> TxReceipt:
     """Wait until a transaction receipt is visible through all read RPC providers.
@@ -229,6 +240,20 @@ def wait_for_transaction_receipt_robust(
     :param confirmation_block_count:
         How many confirmations each read provider should see. This is best-effort
         because provider block numbers are fetched sequentially.
+
+        Defaults to ``None``, which resolves to
+        :py:data:`DEFAULT_CONFIRMATION_BLOCK_COUNT` (2) on live chains and is ignored
+        on Anvil (Anvil has a single coherent state view).
+
+        Why 2 by default: requiring confirmations makes it very likely a state-read
+        ``eth_call`` issued immediately after this wait hits a backend whose state trie
+        already reflects the transaction, rather than merely a backend that has the
+        receipt visible. This prevents read-after-write races on MultiProvider setups —
+        for example reading an ``allowance()`` of 0 right after a confirmed ``approve()``
+        when the read provider trails the sequencer.
+
+        Pass ``confirmation_block_count=0`` explicitly to opt back into pure
+        receipt-visibility behaviour without waiting for confirmations.
     :param extra_sleep:
         Extra seconds to sleep once after all read providers have seen the
         matching receipt and enough confirmations.
@@ -238,7 +263,7 @@ def wait_for_transaction_receipt_robust(
     assert timeout > 0, f"timeout must be positive, got {timeout}"
     assert poll_delay > 0, f"poll_delay must be positive, got {poll_delay}"
     assert max_poll_delay >= poll_delay, f"max_poll_delay must be >= poll_delay, got {max_poll_delay} < {poll_delay}"
-    assert confirmation_block_count >= 0, f"confirmation_block_count must be non-negative, got {confirmation_block_count}"
+    assert confirmation_block_count is None or confirmation_block_count >= 0, f"confirmation_block_count must be non-negative, got {confirmation_block_count}"
     assert extra_sleep >= 0, f"extra_sleep must be non-negative, got {extra_sleep}"
 
     tx_hash_bytes = HexBytes(tx_hash)
@@ -274,6 +299,11 @@ def wait_for_transaction_receipt_robust(
             receipt.get("blockNumber"),
         )
         return receipt
+
+    # Resolve the Anvil-aware sentinel: live chains wait for confirmations by default,
+    # Anvil already returned above and never reaches here.
+    if confirmation_block_count is None:
+        confirmation_block_count = DEFAULT_CONFIRMATION_BLOCK_COUNT
 
     providers = get_read_providers(web3)
     provider_entries = list(enumerate(providers))

--- a/tests/rpc/test_receipt.py
+++ b/tests/rpc/test_receipt.py
@@ -220,7 +220,7 @@ def test_wait_for_transaction_receipt_robust_immediate(monkeypatch: pytest.Monke
     monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
 
     # 2. Wait for robust receipt visibility.
-    receipt = wait_for_transaction_receipt_robust(web3, TX_HASH, timeout=1, poll_delay=0.001, max_poll_delay=0.002)
+    receipt = wait_for_transaction_receipt_robust(web3, TX_HASH, timeout=1, poll_delay=0.001, max_poll_delay=0.002, confirmation_block_count=0)
 
     # 3. Check the original Web3 receipt is returned.
     assert receipt == {"status": 1, "source": "original-web3"}
@@ -241,7 +241,7 @@ def test_wait_for_transaction_receipt_robust_lagging_provider(monkeypatch: pytes
     monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
 
     # 2. Wait for robust receipt visibility.
-    wait_for_transaction_receipt_robust(web3, TX_HASH, timeout=1, poll_delay=0.001, max_poll_delay=0.002)
+    wait_for_transaction_receipt_robust(web3, TX_HASH, timeout=1, poll_delay=0.001, max_poll_delay=0.002, confirmation_block_count=0)
 
     # 3. Check the lagging provider was polled more than once.
     assert provider_2.calls.count("eth_getTransactionReceipt") == 2
@@ -271,6 +271,7 @@ def test_wait_for_transaction_receipt_robust_extra_sleep_after_visibility(monkey
         poll_delay=0.001,
         max_poll_delay=0.002,
         extra_sleep=0.123,
+        confirmation_block_count=0,
     )
 
     # 3. Check the extra sleep happens after the lagging provider is retried.
@@ -344,7 +345,7 @@ def test_wait_for_transaction_receipt_robust_transient_mismatch(monkeypatch: pyt
     monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
 
     # 2. Wait for robust receipt visibility.
-    receipt = wait_for_transaction_receipt_robust(web3, TX_HASH, timeout=1, poll_delay=0.001, max_poll_delay=0.002)
+    receipt = wait_for_transaction_receipt_robust(web3, TX_HASH, timeout=1, poll_delay=0.001, max_poll_delay=0.002, confirmation_block_count=0)
 
     # 3. Check the original Web3 receipt is returned after retrying.
     assert receipt == {"status": 1, "source": "original-web3"}
@@ -376,6 +377,29 @@ def test_wait_for_transaction_receipt_robust_confirmation_success(monkeypatch: p
     )
 
     # 3. Check block numbers were polled until confirmations were high enough.
+    assert provider_1.calls.count("eth_blockNumber") == 2
+
+
+def test_wait_for_transaction_receipt_robust_default_confirmations(monkeypatch: pytest.MonkeyPatch):
+    """Wait for the default two confirmations on a live chain when none is given.
+
+    1. Create a provider that climbs from one to two confirmations over the receipt block.
+    2. Wait without passing confirmation_block_count, so the default resolves to 2.
+    3. Check block numbers were polled until two confirmations were reached.
+    """
+
+    # 1. Create a provider that climbs from one to two confirmations over the receipt block.
+    #    Receipt block is 0x1, so 0x2 is one confirmation (insufficient) and 0x3 is two (enough).
+    provider_1 = FakeProvider("read-1", block_number=["0x2", "0x3"])
+    provider_2 = FakeProvider("read-2", block_number="0x3")
+    web3 = FakeWeb3(FallbackProvider([provider_1, provider_2]))
+    monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
+
+    # 2. Wait without passing confirmation_block_count, so the default resolves to 2.
+    wait_for_transaction_receipt_robust(web3, TX_HASH, timeout=1, poll_delay=0.001, max_poll_delay=0.002)
+
+    # 3. Check block numbers were polled until two confirmations were reached.
+    assert receipt_module.DEFAULT_CONFIRMATION_BLOCK_COUNT == 2
     assert provider_1.calls.count("eth_blockNumber") == 2
 
 
@@ -460,7 +484,7 @@ def test_wait_for_transaction_receipt_robust_final_typed_receipt_retry(monkeypat
     monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
 
     # 2. Make the original Web3 receipt fetch fail once.
-    receipt = wait_for_transaction_receipt_robust(web3, TX_HASH, timeout=1, poll_delay=0.001, max_poll_delay=0.002)
+    receipt = wait_for_transaction_receipt_robust(web3, TX_HASH, timeout=1, poll_delay=0.001, max_poll_delay=0.002, confirmation_block_count=0)
 
     # 3. Check the typed receipt is retried and returned.
     assert receipt == {"status": 1, "source": "typed-retry"}
@@ -512,5 +536,5 @@ def test_wait_for_transaction_receipt_robust_real_fallback_provider(anvil: Anvil
 
     # 3. Force the live robust path and check receipt visibility succeeds.
     monkeypatch.setattr(receipt_module, "_is_anvil", lambda web3: False)
-    receipt = wait_for_transaction_receipt_robust(web3, tx_hash, timeout=10, poll_delay=0.01, max_poll_delay=0.05)
+    receipt = wait_for_transaction_receipt_robust(web3, tx_hash, timeout=10, poll_delay=0.01, max_poll_delay=0.05, confirmation_block_count=0)
     assert receipt["status"] == 1


### PR DESCRIPTION
## Why

`lagoon-first-deposit` crashed on Arbitrum with:

```
AssertionError: Cannot deposit USDC by 0x... Allowance: 0, asked to deposit: 10000000
```

The approve transaction was broadcast to the sequencer (transact provider) and confirmed (`status=1`), but the immediately following `allowance()` `eth_call` was served by a lagging call provider (goldsky / drpc) whose state trie had not yet caught up — so it returned `0`. The robust wait at the call site used the previous default `confirmation_block_count=0`, which only proves the *receipt object* is visible on read providers, not that their *state* reflects the transaction.

## Lessons learnt

On MultiProvider setups, **receipt visibility is not the same as state-read freshness**. Writes go to a sequencer; reads go to public RPCs that trail by a block or two. Waiting for the receipt to appear does not guarantee the next `eth_call` hits a backend with fresh state. Requiring a small number of confirmations makes the subsequent state read very likely to be served by an up-to-date backend.

## Summary

- Add module constant `DEFAULT_CONFIRMATION_BLOCK_COUNT = 2`.
- Change `wait_for_transaction_receipt_robust()` `confirmation_block_count` default from `0` to an Anvil-aware sentinel `None`, resolved **after** the Anvil early-return so live chains wait for 2 confirmations by default while Anvil (single coherent state view) is unaffected.
- Callers can pass `confirmation_block_count=0` explicitly to opt back into pure receipt-visibility behaviour.
- Document the new default and rationale in the function docstring.
- Tests: the visibility/retry/mismatch tests that rely on the default now pass `confirmation_block_count=0` to preserve their original intent; add `test_wait_for_transaction_receipt_robust_default_confirmations` asserting the default resolves to 2 on live chains.

## Related issues and PRs

Fixes the read-after-write race behind the Lagoon first-deposit and check-wallet/redeem flows (#1492, #1493, #1494). All trade-executor production callers already pass `confirmation_block_count=2`; this makes that the safe default for the two library callers in `lagoon/testing.py` that relied on it.
