### PR TITLE
fix: Use 3-arg ERC-7540 deposit(assets, receiver, controller) to claim async deposits

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/lagoon/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/vault.py
@@ -797,12 +797,15 @@ class LagoonVault(ERC7540Vault, AutomatedSafe):
         """Move shares we received to the user wallet.
 
         - Phase 2 of deposit after settlement
+        - Uses the 3-argument ERC-7540 ``deposit(assets, receiver, controller)``
+          to claim async deposits, where the depositor is both receiver and
+          controller
         """
 
         if raw_amount is None:
             raw_amount = self.vault_contract.functions.maxDeposit(depositor).call()
 
-        return self.vault_contract.functions.deposit(raw_amount, depositor)
+        return self.vault_contract.functions.deposit(raw_amount, depositor, depositor)
 
     def request_redeem(self, depositor: HexAddress, raw_amount: int) -> ContractFunction:
         """Build a redeem transction.

--- a/eth_defi/erc_7540/vault.py
+++ b/eth_defi/erc_7540/vault.py
@@ -56,12 +56,15 @@ class ERC7540Vault(ERC4626Vault):
         """Move shares we received to the user wallet.
 
         - Phase 2 of deposit after settlement
+        - Uses the 3-argument ERC-7540 ``deposit(assets, receiver, controller)``
+          to claim async deposits, where the depositor is both receiver and
+          controller
         """
 
         if raw_amount is None:
             raw_amount = self.vault_contract.functions.maxDeposit(depositor).call()
 
-        return self.vault_contract.functions.deposit(raw_amount, depositor)
+        return self.vault_contract.functions.deposit(raw_amount, depositor, depositor)
 
     def request_redeem(self, depositor: HexAddress, raw_amount: int) -> ContractFunction:
         """Build a redeem transction.


### PR DESCRIPTION
## Why

ERC-7540 async vaults (Lagoon) mint shares to the vault contract on settlement; the depositor must then call `deposit()` to claim them into their own wallet. The 2-argument `deposit(assets, receiver)` form does not express the controller that owns the claimable request, so the claim could target the wrong path. The 3-argument ERC-7540 `deposit(assets, receiver, controller)` form claims the depositor's own settled request explicitly.

## Lessons learnt

For ERC-7540 async deposit claims, always use the 3-argument `deposit(assets, receiver, controller)` where the depositor is both receiver and controller. The 2-argument ERC-4626 form is insufficient for the async claim flow.

## Summary

- `ERC7540Vault.finalise_deposit()` and `LagoonVault.finalise_deposit()` now build `deposit(raw_amount, depositor, depositor)` (3-argument ERC-7540) instead of `deposit(raw_amount, depositor)`.
- Update docstrings to document the receiver/controller semantics.

## Related issues and PRs

Submodule side of the 3-arg ERC-7540 deposit claim fix tracked in trade-executor #1493.
