### PR TITLE
fix: Make feed post scanner resilient to transient X API 503 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - feat: Add `VaultDepositManager.get_deposit_delay_over()` to estimate when a pending async deposit will settle, with an Ostium V1.5 implementation (mirrors `get_redemption_delay_over()` using `targetSettlementId(true)`); operator-driven ERC-7540 vaults return `None` (2026-06-09)
 
+- fix: Make the feed post scanner resilient to transient X API failures — retry `503 Service Unavailable` and other 5xx errors with exponential backoff when reading X list members, and catch per-cycle errors in the scan loop so a transient upstream outage no longer crashes the process into a Docker restart hot-loop (2026-06-09)
+
 - fix: Restore Sphinx docs build on Python 3.13/3.14 by adding the `standard-imghdr` backport, since stdlib `imghdr` (imported by Sphinx 4.x) was removed in Python 3.13 (2026-06-09)
 
 - feat: Add curator short and long descriptions to feeder metadata, curator exports, and all current curator YAML files (2026-06-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - feat: Add `VaultDepositManager.get_deposit_delay_over()` to estimate when a pending async deposit will settle, with an Ostium V1.5 implementation (mirrors `get_redemption_delay_over()` using `targetSettlementId(true)`); operator-driven ERC-7540 vaults return `None` (2026-06-09)
 
-- fix: Make the feed post scanner resilient to X API list-member `503 Service Unavailable` errors — the `GET /2/lists/{id}/members` endpoint returns persistent endpoint-wide 503s while the list timeline keeps working, so list membership sync now degrades gracefully and lets post collection continue, the read loop retries transient 5xx with exponential backoff, and the scan loop isolates per-cycle errors so the process no longer crashes into a Docker restart hot-loop (2026-06-09)
+- fix: Make the feed post scanner resilient to X API list-member `503 Service Unavailable` errors — the `GET /2/lists/{id}/members` endpoint returns persistent endpoint-wide 503s while the list timeline keeps working, so list membership sync no longer reads back members from that broken endpoint but tracks added member IDs in a local `feed_sync_state` cache, every X read path retries transient 5xx with shared exponential-backoff handling, membership sync degrades gracefully if it still fails, and the scan loop isolates per-cycle errors so the process no longer crashes into a Docker restart hot-loop (2026-06-09)
 
 - fix: Restore Sphinx docs build on Python 3.13/3.14 by adding the `standard-imghdr` backport, since stdlib `imghdr` (imported by Sphinx 4.x) was removed in Python 3.13 (2026-06-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - feat: Add `VaultDepositManager.get_deposit_delay_over()` to estimate when a pending async deposit will settle, with an Ostium V1.5 implementation (mirrors `get_redemption_delay_over()` using `targetSettlementId(true)`); operator-driven ERC-7540 vaults return `None` (2026-06-09)
 
-- fix: Make the feed post scanner resilient to transient X API failures — retry `503 Service Unavailable` and other 5xx errors with exponential backoff when reading X list members, and catch per-cycle errors in the scan loop so a transient upstream outage no longer crashes the process into a Docker restart hot-loop (2026-06-09)
+- fix: Make the feed post scanner resilient to X API list-member `503 Service Unavailable` errors — the `GET /2/lists/{id}/members` endpoint returns persistent endpoint-wide 503s while the list timeline keeps working, so list membership sync now degrades gracefully and lets post collection continue, the read loop retries transient 5xx with exponential backoff, and the scan loop isolates per-cycle errors so the process no longer crashes into a Docker restart hot-loop (2026-06-09)
 
 - fix: Restore Sphinx docs build on Python 3.13/3.14 by adding the `standard-imghdr` backport, since stdlib `imghdr` (imported by Sphinx 4.x) was removed in Python 3.13 (2026-06-09)
 

--- a/eth_defi/feed/README-feed.md
+++ b/eth_defi/feed/README-feed.md
@@ -398,9 +398,19 @@ want to update the configured X list membership without running RSS, LinkedIn,
 or post collection.
 
 The script reads Twitter/X handles from the feeder YAML files, resolves them
-through the X API, updates the configured X list, and writes
-`twitter_handles_hash` to the `feed_sync_state` table.  Running it again with
-the same handle set is idempotent and will skip the external list update.
+through the X API, updates the configured X list, and writes a per-list handle
+hash (`twitter_handles_hash:<list_id>`) and member cache
+(`x_list_member_ids:<list_id>`) to the `feed_sync_state` table.  Both keys are
+scoped by list ID so one database can sync multiple X lists without their state
+colliding.  Running it again with the same handle set is idempotent and will
+skip the external list update.
+
+Because the X API `GET /2/lists/{id}/members` endpoint returns persistent
+`503 Service Unavailable` errors, the script does not read current membership
+back from X.  Instead it records the member IDs it has successfully added in the
+per-list `x_list_member_ids:<list_id>` cache and only writes the delta on later
+runs.  Re-adding an existing member is a no-op on X's side, so a cold cache
+self-heals on the first run.
 
 By default the script resolves the list named `Best builders in DeFi` from the
 authenticated X user's owned lists.  Set `X_LIST_ID` only when you want to

--- a/eth_defi/feed/scanner.py
+++ b/eth_defi/feed/scanner.py
@@ -190,6 +190,20 @@ def run_post_scan_cycle(config: PostScanConfig) -> CollectorRunSummary:
                 rate_limit_sleep_max_seconds=config.x_list_rate_limit_sleep_max_seconds,
             )
             db_for_sync.save()
+        except XApiError as e:
+            # List membership sync is non-essential maintenance that runs before
+            # post collection.  The X ``GET /2/lists/{id}/members`` endpoint is
+            # known to return persistent ``503 Service Unavailable`` for extended
+            # periods (endpoint-wide, not list-specific), while the list timeline
+            # read used for actual post collection keeps working.  Degrade
+            # gracefully and continue the cycle instead of aborting it — the sync
+            # state hash is left unchanged, so the next cycle retries.  This
+            # mirrors the timeline-collection fallback below.
+            logger.warning(
+                "X list membership sync failed for list %s, continuing post collection without it: %s",
+                resolved_x_list_id,
+                e,
+            )
         finally:
             db_for_sync.close()
 

--- a/eth_defi/feed/twitter_api.py
+++ b/eth_defi/feed/twitter_api.py
@@ -41,6 +41,7 @@ import re
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, Callable
 
 import tweepy
 
@@ -78,6 +79,15 @@ X_SERVER_ERROR_MAX_RETRIES = 5
 
 #: Base delay in seconds for exponential backoff on transient 5xx errors.
 X_SERVER_ERROR_BACKOFF_BASE_SECONDS = 5.0
+
+#: ``feed_sync_state`` key under which the X list member IDs we have added are
+#: stored as a JSON array.
+#:
+#: We maintain our own record of confirmed list members instead of reading them
+#: back from the X API, because ``GET /2/lists/{id}/members`` returns persistent
+#: endpoint-wide ``503 Service Unavailable`` errors.  See ``README`` notes and
+#: :func:`sync_x_list_members`.
+X_LIST_MEMBER_IDS_STATE_KEY = "x_list_member_ids"
 
 
 @dataclass(slots=True)
@@ -198,10 +208,10 @@ def resolve_twitter_handles(
     # Batch-resolve in groups of 100 (API limit)
     for i in range(0, len(stale), 100):
         batch = stale[i : i + 100]
-        try:
-            response = client.get_users(usernames=batch, user_fields=["id", "name", "username"])
-        except tweepy.TweepyException as e:
-            raise XApiError(f"Failed to resolve handles {batch[:3]}...: {e}") from e
+        response = _x_api_read_with_retry(
+            lambda: client.get_users(usernames=batch, user_fields=["id", "name", "username"]),
+            description=f"resolving handles {batch[:3]}...",
+        )
 
         if response.data:
             for user in response.data:
@@ -271,11 +281,10 @@ def resolve_x_list_id_by_name(
         access_token_secret=access_token_secret,
     )
 
-    try:
-        me_response = client.get_me(user_auth=True)
-    except tweepy.TweepyException as e:
-        message = f"Failed to resolve authenticated X user: {e}"
-        raise XApiError(message) from e
+    me_response = _x_api_read_with_retry(
+        lambda: client.get_me(user_auth=True),
+        description="resolving authenticated X user",
+    )
 
     if me_response.data is None:
         message = "Failed to resolve authenticated X user: response did not include user data"
@@ -293,14 +302,10 @@ def resolve_x_list_id_by_name(
         if pagination_token:
             request_params["pagination_token"] = pagination_token
 
-        try:
-            response = client.get_owned_lists(
-                owner_id,
-                **request_params,
-            )
-        except tweepy.TweepyException as e:
-            message = f"Failed to fetch owned X lists for user {owner_id}: {e}"
-            raise XApiError(message) from e
+        response = _x_api_read_with_retry(
+            lambda: client.get_owned_lists(owner_id, **request_params),
+            description=f"fetching owned X lists for user {owner_id}",
+        )
 
         if response.data:
             for item in response.data:
@@ -421,18 +426,18 @@ def fetch_tweets_from_x_list(
     user_fields = ["id", "username", "name"]
 
     while total_fetched < max_tweets:
-        try:
-            page_size = min(100, max_tweets - total_fetched)
-            response = client.get_list_tweets(
+        page_size = min(100, max_tweets - total_fetched)
+        response = _x_api_read_with_retry(
+            lambda: client.get_list_tweets(
                 list_id,
                 max_results=page_size,
                 tweet_fields=tweet_fields,
                 expansions=expansions,
                 user_fields=user_fields,
                 pagination_token=pagination_token,
-            )
-        except tweepy.TweepyException as e:
-            raise XApiError(f"Failed to fetch list timeline for list {list_id}: {e}") from e
+            ),
+            description=f"fetching list timeline for list {list_id}",
+        )
 
         if not response.data:
             break
@@ -499,15 +504,15 @@ def fetch_user_tweets(
         # X API requires RFC 3339 format with Z suffix
         kwargs["start_time"] = since.strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    try:
-        response = client.get_users_tweets(
+    response = _x_api_read_with_retry(
+        lambda: client.get_users_tweets(
             user_id,
             max_results=min(max_tweets, 100),
             tweet_fields=tweet_fields,
             **kwargs,
-        )
-    except tweepy.TweepyException as e:
-        raise XApiError(f"Failed to fetch tweets for user {user_id} (@{author_handle}): {e}") from e
+        ),
+        description=f"fetching tweets for user {user_id} (@{author_handle})",
+    )
 
     if not response.data:
         return []
@@ -577,6 +582,110 @@ def _get_rate_limit_sleep_seconds(exc: tweepy.TooManyRequests) -> int | None:
     return max(1, int((reset_at - native_datetime_utc_now()).total_seconds()) + 1)
 
 
+def _x_api_read_with_retry(
+    fn: Callable[[], Any],
+    *,
+    description: str,
+    rate_limit_sleep_max_seconds: float = 1200.0,
+) -> Any:
+    """Call an X API read operation, retrying transient failures.
+
+    Wraps a single X API read call (one page) with uniform handling for the two
+    transient failure modes the X API exhibits, so every read path in this
+    module is resilient rather than each duplicating the logic:
+
+    - ``TwitterServerError`` (HTTP 5xx, e.g. ``503 Service Unavailable``) is
+      retried with exponential backoff up to :data:`X_SERVER_ERROR_MAX_RETRIES`
+      attempts before being surfaced as :class:`XApiError`.
+    - ``TooManyRequests`` (HTTP 429) is retried after sleeping until the
+      rate-limit reset window, as long as that wait is within
+      ``rate_limit_sleep_max_seconds``; otherwise :class:`XRateLimitError`.
+
+    Any other :class:`tweepy.TweepyException` is treated as a genuine
+    client-side error (bad id, auth failure, malformed request) and raised
+    immediately as :class:`XApiError` without retry.
+
+    :param fn:
+        Zero-argument callable performing exactly one X API read request.
+    :param description:
+        Present-participle description of the operation used in log and error
+        messages, e.g. ``"fetching list timeline for list 123"``.
+    :param rate_limit_sleep_max_seconds:
+        Maximum automatic sleep honoured for a rate-limit reset window.
+    :return:
+        Whatever ``fn`` returns on its first successful call.
+    :raise XApiError:
+        On non-transient errors, or once 5xx retries are exhausted.
+    :raise XRateLimitError:
+        When a rate-limit wait exceeds ``rate_limit_sleep_max_seconds``.
+    """
+
+    server_error_retries = 0
+
+    while True:
+        try:
+            return fn()
+        except tweepy.TooManyRequests as e:
+            wait_seconds = _get_rate_limit_sleep_seconds(e)
+            if wait_seconds is None or wait_seconds > rate_limit_sleep_max_seconds:
+                raise XRateLimitError(f"X API rate limit hit while {description}.{_format_rate_limit_reset(e)} Rerun later to resume.") from e
+            logger.warning("X API rate limit hit while %s; sleeping %.0f seconds before retrying", description, wait_seconds)
+            time.sleep(wait_seconds)
+        except tweepy.TwitterServerError as e:
+            # Transient X-side 5xx.  Back off and retry rather than failing the
+            # whole scan cycle; an uncaught error here can crash the process and,
+            # under a Docker ``restart`` policy, produce a hot restart loop that
+            # hammers X while it is already failing.
+            server_error_retries += 1
+            if server_error_retries > X_SERVER_ERROR_MAX_RETRIES:
+                raise XApiError(f"X API still failing after {X_SERVER_ERROR_MAX_RETRIES} retries while {description}: {e}") from e
+            backoff = X_SERVER_ERROR_BACKOFF_BASE_SECONDS * 2 ** (server_error_retries - 1)
+            logger.warning(
+                "Transient X API server error (%s) while %s; retry %d/%d after %.0f seconds",
+                e,
+                description,
+                server_error_retries,
+                X_SERVER_ERROR_MAX_RETRIES,
+                backoff,
+            )
+            time.sleep(backoff)
+        except tweepy.TweepyException as e:
+            raise XApiError(f"Failed while {description}: {e}") from e
+
+
+def _load_known_member_ids(db: VaultPostDatabase) -> set[str]:
+    """Load the set of X list member IDs we have previously added.
+
+    :param db:
+        Vault post database holding the ``feed_sync_state`` table.
+    :return:
+        Set of numeric user IDs, empty when no record exists yet.
+    """
+
+    raw = db.get_sync_state(X_LIST_MEMBER_IDS_STATE_KEY)
+    if not raw:
+        return set()
+    try:
+        return {str(member_id) for member_id in json.loads(raw)}
+    except (json.JSONDecodeError, TypeError):
+        # A corrupt record must not crash the sync — start from empty and let
+        # the add loop repopulate it (re-adding existing members is a no-op).
+        logger.warning("Corrupt X list member ID cache in feed_sync_state; rebuilding from empty")
+        return set()
+
+
+def _save_known_member_ids(db: VaultPostDatabase, member_ids: set[str]) -> None:
+    """Persist the set of X list member IDs we have added.
+
+    :param db:
+        Vault post database holding the ``feed_sync_state`` table.
+    :param member_ids:
+        Numeric user IDs confirmed present in the list.
+    """
+
+    db.set_sync_state(X_LIST_MEMBER_IDS_STATE_KEY, json.dumps(sorted(member_ids)))
+
+
 def sync_x_list_members(
     list_id: str,
     twitter_handles: list[str],
@@ -610,71 +719,24 @@ def sync_x_list_members(
     # Resolve handles → user IDs
     handle_to_id = resolve_twitter_handles(twitter_handles, bearer_token, user_cache)
 
-    # Get current list members
-    client_read = tweepy.Client(bearer_token=bearer_token)
-    current_member_ids: set[str] = set()
-    pagination_token = None
-
-    server_error_retries = 0
-
-    while True:
-        try:
-            response = client_read.get_list_members(
-                list_id,
-                max_results=100,
-                pagination_token=pagination_token,
-            )
-        except tweepy.TooManyRequests as e:
-            # Read endpoint is rate-limited; honour the reset window and retry
-            # within the operator-configured ceiling, like the write loop below.
-            wait_seconds = _get_rate_limit_sleep_seconds(e)
-            if wait_seconds is None or wait_seconds > rate_limit_sleep_max_seconds:
-                raise XRateLimitError(f"X API rate limit hit while reading members of list {list_id}.{_format_rate_limit_reset(e)} Rerun later to resume.") from e
-            logger.warning(
-                "X API rate limit hit while reading members of list %s; sleeping %.0f seconds before retrying",
-                list_id,
-                wait_seconds,
-            )
-            time.sleep(wait_seconds)
-            continue
-        except tweepy.TwitterServerError as e:
-            # Transient X-side 5xx (e.g. 503 Service Unavailable).  Back off and
-            # retry rather than crashing the scan cycle: an uncaught error here
-            # exits the process and, under a Docker ``restart`` policy, produces
-            # a hot restart loop that hammers X while it is already failing.
-            server_error_retries += 1
-            if server_error_retries > X_SERVER_ERROR_MAX_RETRIES:
-                raise XApiError(f"X API still failing after {X_SERVER_ERROR_MAX_RETRIES} retries while fetching members of list {list_id}: {e}") from e
-            backoff = X_SERVER_ERROR_BACKOFF_BASE_SECONDS * 2 ** (server_error_retries - 1)
-            logger.warning(
-                "Transient X API server error (%s) while reading members of list %s; retry %d/%d after %.0f seconds",
-                e,
-                list_id,
-                server_error_retries,
-                X_SERVER_ERROR_MAX_RETRIES,
-                backoff,
-            )
-            time.sleep(backoff)
-            continue
-        except tweepy.TweepyException as e:
-            raise XApiError(f"Failed to fetch list members for list {list_id}: {e}") from e
-
-        # Reset the transient-error counter after a successful page fetch.
-        server_error_retries = 0
-
-        if response.data:
-            for member in response.data:
-                current_member_ids.add(str(member.id))
-
-        pagination_token = (response.meta or {}).get("next_token")
-        if not pagination_token:
-            break
-
-    # Add missing members using OAuth 1.0a user context
-    to_add = set(handle_to_id.values()) - current_member_ids
+    # Determine which resolved members still need adding.
+    #
+    # The X API ``GET /2/lists/{id}/members`` endpoint returns persistent,
+    # endpoint-wide ``503 Service Unavailable`` errors (it fails for unrelated
+    # lists too, with a healthy rate-limit budget) and cannot be relied on to
+    # read back current membership.  Instead we keep our own record of the
+    # member IDs we have successfully added in ``feed_sync_state`` and diff
+    # against that.  Re-adding an existing member is a harmless no-op on X's
+    # side (the v2 add endpoint returns ``is_member`` without error), so a cold
+    # cache simply re-adds current members once before settling into delta-only
+    # syncs.  The list *timeline* endpoint used for actual post collection is
+    # unaffected by the members-endpoint outage.
+    known_member_ids = _load_known_member_ids(db)
+    resolved_ids = set(handle_to_id.values())
+    to_add = resolved_ids - known_member_ids
 
     if not to_add:
-        logger.info("All %d handles already in X list %s", len(twitter_handles), list_id)
+        logger.info("All %d resolved handles already in X list %s (per local member cache)", len(resolved_ids), list_id)
         db.set_sync_state("twitter_handles_hash", current_hash)
         return 0
 
@@ -694,6 +756,9 @@ def sync_x_list_members(
             try:
                 client_write.add_list_member(list_id, user_id)
                 added += 1
+                # Record confirmed membership so we never re-add this member,
+                # even if a later add in this batch fails (see persistence below).
+                known_member_ids.add(user_id)
                 logger.info(
                     "Added @%s (%s) to X list %s (%d/%d missing members)",
                     id_to_handle.get(user_id, "unknown"),
@@ -739,6 +804,10 @@ def sync_x_list_members(
                     time.sleep(add_delay_seconds)
                 break
 
+    # Persist confirmed membership even on partial failure so successfully
+    # added members are never re-added next cycle.
+    _save_known_member_ids(db, known_member_ids)
+
     # Only persist the hash when every add succeeded.  When some fail due to
     # transient API errors the next cycle will detect the mismatch and retry.
     if failed == 0:
@@ -752,10 +821,10 @@ def sync_x_list_members(
 
     user_cache.save()
     logger.info(
-        "Added %d members to X list %s (%d already present, %d failed)",
+        "Added %d members to X list %s (%d known members, %d failed)",
         added,
         list_id,
-        len(current_member_ids),
+        len(known_member_ids),
         failed,
     )
     return added

--- a/eth_defi/feed/twitter_api.py
+++ b/eth_defi/feed/twitter_api.py
@@ -69,6 +69,17 @@ class XRateLimitError(XApiError):
     """Raised when the X API rate-limits a list sync operation."""
 
 
+#: Maximum retries for transient X API server errors (HTTP 5xx).
+#:
+#: The X API intermittently returns ``503 Service Unavailable`` and other 5xx
+#: responses during partial outages.  These are transient and succeed on retry,
+#: so we back off and try again rather than treating them as fatal.
+X_SERVER_ERROR_MAX_RETRIES = 5
+
+#: Base delay in seconds for exponential backoff on transient 5xx errors.
+X_SERVER_ERROR_BACKOFF_BASE_SECONDS = 5.0
+
+
 @dataclass(slots=True)
 class CachedTwitterUser:
     """Cached user metadata from a handle-to-ID lookup."""
@@ -604,6 +615,8 @@ def sync_x_list_members(
     current_member_ids: set[str] = set()
     pagination_token = None
 
+    server_error_retries = 0
+
     while True:
         try:
             response = client_read.get_list_members(
@@ -611,8 +624,43 @@ def sync_x_list_members(
                 max_results=100,
                 pagination_token=pagination_token,
             )
+        except tweepy.TooManyRequests as e:
+            # Read endpoint is rate-limited; honour the reset window and retry
+            # within the operator-configured ceiling, like the write loop below.
+            wait_seconds = _get_rate_limit_sleep_seconds(e)
+            if wait_seconds is None or wait_seconds > rate_limit_sleep_max_seconds:
+                raise XRateLimitError(f"X API rate limit hit while reading members of list {list_id}.{_format_rate_limit_reset(e)} Rerun later to resume.") from e
+            logger.warning(
+                "X API rate limit hit while reading members of list %s; sleeping %.0f seconds before retrying",
+                list_id,
+                wait_seconds,
+            )
+            time.sleep(wait_seconds)
+            continue
+        except tweepy.TwitterServerError as e:
+            # Transient X-side 5xx (e.g. 503 Service Unavailable).  Back off and
+            # retry rather than crashing the scan cycle: an uncaught error here
+            # exits the process and, under a Docker ``restart`` policy, produces
+            # a hot restart loop that hammers X while it is already failing.
+            server_error_retries += 1
+            if server_error_retries > X_SERVER_ERROR_MAX_RETRIES:
+                raise XApiError(f"X API still failing after {X_SERVER_ERROR_MAX_RETRIES} retries while fetching members of list {list_id}: {e}") from e
+            backoff = X_SERVER_ERROR_BACKOFF_BASE_SECONDS * 2 ** (server_error_retries - 1)
+            logger.warning(
+                "Transient X API server error (%s) while reading members of list %s; retry %d/%d after %.0f seconds",
+                e,
+                list_id,
+                server_error_retries,
+                X_SERVER_ERROR_MAX_RETRIES,
+                backoff,
+            )
+            time.sleep(backoff)
+            continue
         except tweepy.TweepyException as e:
             raise XApiError(f"Failed to fetch list members for list {list_id}: {e}") from e
+
+        # Reset the transient-error counter after a successful page fetch.
+        server_error_retries = 0
 
         if response.data:
             for member in response.data:

--- a/eth_defi/feed/twitter_api.py
+++ b/eth_defi/feed/twitter_api.py
@@ -80,14 +80,37 @@ X_SERVER_ERROR_MAX_RETRIES = 5
 #: Base delay in seconds for exponential backoff on transient 5xx errors.
 X_SERVER_ERROR_BACKOFF_BASE_SECONDS = 5.0
 
-#: ``feed_sync_state`` key under which the X list member IDs we have added are
-#: stored as a JSON array.
+#: ``feed_sync_state`` key prefix under which the X list member IDs we have
+#: added are stored as a JSON array.
 #:
 #: We maintain our own record of confirmed list members instead of reading them
 #: back from the X API, because ``GET /2/lists/{id}/members`` returns persistent
 #: endpoint-wide ``503 Service Unavailable`` errors.  See ``README`` notes and
 #: :func:`sync_x_list_members`.
-X_LIST_MEMBER_IDS_STATE_KEY = "x_list_member_ids"
+#:
+#: The actual key is suffixed with the list ID (see :func:`_member_ids_state_key`)
+#: so a single database can sync multiple X lists without their member caches
+#: colliding.
+X_LIST_MEMBER_IDS_STATE_KEY_PREFIX = "x_list_member_ids"
+
+#: ``feed_sync_state`` key prefix under which the hash of synced Twitter handles
+#: is stored, used to skip list sync when the handle set is unchanged.
+#:
+#: Suffixed with the list ID (see :func:`_handles_hash_state_key`) so the
+#: change-detection hash is scoped to each X list.
+X_HANDLES_HASH_STATE_KEY_PREFIX = "twitter_handles_hash"
+
+
+def _member_ids_state_key(list_id: str) -> str:
+    """Return the per-list ``feed_sync_state`` key for the member ID cache."""
+
+    return f"{X_LIST_MEMBER_IDS_STATE_KEY_PREFIX}:{list_id}"
+
+
+def _handles_hash_state_key(list_id: str) -> str:
+    """Return the per-list ``feed_sync_state`` key for the handle hash."""
+
+    return f"{X_HANDLES_HASH_STATE_KEY_PREFIX}:{list_id}"
 
 
 @dataclass(slots=True)
@@ -653,16 +676,18 @@ def _x_api_read_with_retry(
             raise XApiError(f"Failed while {description}: {e}") from e
 
 
-def _load_known_member_ids(db: VaultPostDatabase) -> set[str]:
-    """Load the set of X list member IDs we have previously added.
+def _load_known_member_ids(db: VaultPostDatabase, list_id: str) -> set[str]:
+    """Load the set of member IDs we have previously added to an X list.
 
     :param db:
         Vault post database holding the ``feed_sync_state`` table.
+    :param list_id:
+        X list ID, used to scope the cache so multiple lists do not collide.
     :return:
         Set of numeric user IDs, empty when no record exists yet.
     """
 
-    raw = db.get_sync_state(X_LIST_MEMBER_IDS_STATE_KEY)
+    raw = db.get_sync_state(_member_ids_state_key(list_id))
     if not raw:
         return set()
     try:
@@ -670,20 +695,22 @@ def _load_known_member_ids(db: VaultPostDatabase) -> set[str]:
     except (json.JSONDecodeError, TypeError):
         # A corrupt record must not crash the sync — start from empty and let
         # the add loop repopulate it (re-adding existing members is a no-op).
-        logger.warning("Corrupt X list member ID cache in feed_sync_state; rebuilding from empty")
+        logger.warning("Corrupt X list member ID cache in feed_sync_state for list %s; rebuilding from empty", list_id)
         return set()
 
 
-def _save_known_member_ids(db: VaultPostDatabase, member_ids: set[str]) -> None:
-    """Persist the set of X list member IDs we have added.
+def _save_known_member_ids(db: VaultPostDatabase, list_id: str, member_ids: set[str]) -> None:
+    """Persist the set of member IDs we have added to an X list.
 
     :param db:
         Vault post database holding the ``feed_sync_state`` table.
+    :param list_id:
+        X list ID, used to scope the cache so multiple lists do not collide.
     :param member_ids:
         Numeric user IDs confirmed present in the list.
     """
 
-    db.set_sync_state(X_LIST_MEMBER_IDS_STATE_KEY, json.dumps(sorted(member_ids)))
+    db.set_sync_state(_member_ids_state_key(list_id), json.dumps(sorted(member_ids)))
 
 
 def sync_x_list_members(
@@ -709,7 +736,7 @@ def sync_x_list_members(
     """
 
     current_hash = compute_handles_hash(twitter_handles)
-    stored_hash = db.get_sync_state("twitter_handles_hash")
+    stored_hash = db.get_sync_state(_handles_hash_state_key(list_id))
     if stored_hash == current_hash:
         logger.info("Twitter handles unchanged (hash=%s), skipping list sync", current_hash[:12])
         return 0
@@ -731,13 +758,13 @@ def sync_x_list_members(
     # cache simply re-adds current members once before settling into delta-only
     # syncs.  The list *timeline* endpoint used for actual post collection is
     # unaffected by the members-endpoint outage.
-    known_member_ids = _load_known_member_ids(db)
+    known_member_ids = _load_known_member_ids(db, list_id)
     resolved_ids = set(handle_to_id.values())
     to_add = resolved_ids - known_member_ids
 
     if not to_add:
         logger.info("All %d resolved handles already in X list %s (per local member cache)", len(resolved_ids), list_id)
-        db.set_sync_state("twitter_handles_hash", current_hash)
+        db.set_sync_state(_handles_hash_state_key(list_id), current_hash)
         return 0
 
     client_write = tweepy.Client(
@@ -806,12 +833,12 @@ def sync_x_list_members(
 
     # Persist confirmed membership even on partial failure so successfully
     # added members are never re-added next cycle.
-    _save_known_member_ids(db, known_member_ids)
+    _save_known_member_ids(db, list_id, known_member_ids)
 
     # Only persist the hash when every add succeeded.  When some fail due to
     # transient API errors the next cycle will detect the mismatch and retry.
     if failed == 0:
-        db.set_sync_state("twitter_handles_hash", current_hash)
+        db.set_sync_state(_handles_hash_state_key(list_id), current_hash)
     else:
         logger.warning(
             "Skipping hash update — %d/%d list member adds failed, will retry next cycle",

--- a/scripts/erc-4626/scan-vault-posts.py
+++ b/scripts/erc-4626/scan-vault-posts.py
@@ -48,6 +48,7 @@ Environment variables:
 - ``DEATH_DETECTION_PERIOD``: Optional. Default: 180 days.
 """
 
+import logging
 import os
 import time
 from pathlib import Path
@@ -59,6 +60,8 @@ from eth_defi.feed.database import DEFAULT_VAULT_POST_DATABASE
 from eth_defi.feed.scanner import PostScanConfig, run_post_scan_cycle
 from eth_defi.feed.sources import FEEDS_DATA_DIR
 from eth_defi.utils import setup_console_logging
+
+logger = logging.getLogger(__name__)
 
 
 def _parse_csv(raw_value: str | None) -> list[str]:
@@ -225,8 +228,20 @@ def main() -> None:
         cycle += 1
         print(f"\n=== Post scan cycle {cycle} ===")
 
-        summary = run_post_scan_cycle(config)
-        _print_dashboard(summary)
+        try:
+            summary = run_post_scan_cycle(config)
+            _print_dashboard(summary)
+        except Exception as e:
+            # A single cycle must never crash the long-running daemon.  Transient
+            # upstream failures (e.g. X API 503, RSS bridge outages) used to
+            # propagate out of main(), exit the process and — under a Docker
+            # ``restart`` policy — trigger an immediate restart loop with no
+            # backoff that hammered the failing service.  Log and wait for the
+            # next scheduled cycle instead.  When running as a single shot
+            # (loop_interval <= 0) we re-raise so the failure is still visible.
+            logger.exception("Post scan cycle %d failed: %s", cycle, e)
+            if loop_interval <= 0:
+                raise
 
         if loop_interval <= 0:
             break

--- a/tests/feed/test_twitter_api.py
+++ b/tests/feed/test_twitter_api.py
@@ -163,7 +163,7 @@ def test_sync_x_list_members_waits_on_rate_limit(monkeypatch: pytest.MonkeyPatch
         assert added == 2
         assert add_calls == ["1", "1", "2"]
         assert sleep_calls == [2]
-        assert db.get_sync_state("twitter_handles_hash") == compute_handles_hash(["alice", "bob"])
+        assert db.get_sync_state(twitter_api._handles_hash_state_key(LIST_ID)) == compute_handles_hash(["alice", "bob"])
     finally:
         db.close()
 
@@ -291,6 +291,65 @@ def test_sync_x_list_members_uses_local_member_cache(monkeypatch: pytest.MonkeyP
         assert added_first == 2
         assert added_second == 1
         assert add_calls == ["3"]
-        assert db.get_sync_state(twitter_api.X_LIST_MEMBER_IDS_STATE_KEY) is not None
+        assert db.get_sync_state(twitter_api._member_ids_state_key(LIST_ID)) is not None
+    finally:
+        db.close()
+
+
+def test_sync_x_list_members_caches_are_scoped_per_list(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Keep member caches isolated per X list within one database.
+
+    Two different X lists synced against the same database must not share a
+    member cache: members of one list must never be treated as already present
+    in another, or handles would silently be left missing from the second list.
+
+    1. Stub a client that records (list_id, user_id) writes.
+    2. Sync ``alice,bob`` into one list, then ``alice,bob,carol`` into another.
+    3. Assert the second list receives all three members, not just the delta.
+    """
+
+    # 1. Stub resolution and a client recording which list each add targets
+    handle_map = {"alice": "1", "bob": "2", "carol": "3"}
+    monkeypatch.setattr(
+        twitter_api,
+        "resolve_twitter_handles",
+        lambda handles, _bearer_token, _user_cache: {h: handle_map[h] for h in handles},
+    )
+
+    add_calls: list[tuple[str, str]] = []
+
+    class FakeClient:
+        """Fake Tweepy client recording the list each member is added to."""
+
+        def __init__(self, **_kwargs: object):
+            pass
+
+        @staticmethod
+        def add_list_member(list_id: str, user_id: str) -> None:
+            """Record the (list, member) pair."""
+
+            add_calls.append((list_id, user_id))
+
+    monkeypatch.setattr(twitter_api.tweepy, "Client", FakeClient)
+    monkeypatch.setattr(twitter_api.time, "sleep", lambda _seconds: None)
+
+    common_args = (
+        "consumer-key",
+        "consumer-secret",
+        "access-token",
+        "access-token-secret",
+        TwitterUserCache(tmp_path / "twitter-users.json"),
+        "bearer-token",
+    )
+
+    db = VaultPostDatabase(tmp_path / "posts.duckdb")
+    try:
+        # 2. Sync alice,bob into list A, then alice,bob,carol into list B
+        sync_x_list_members("list-A", ["alice", "bob"], *common_args, db, add_delay_seconds=0)
+        sync_x_list_members("list-B", ["alice", "bob", "carol"], *common_args, db, add_delay_seconds=0)
+
+        # 3. List B must get all three members despite list A caching alice,bob
+        list_b_added = sorted(user_id for list_id, user_id in add_calls if list_id == "list-B")
+        assert list_b_added == ["1", "2", "3"]
     finally:
         db.close()

--- a/tests/feed/test_twitter_api.py
+++ b/tests/feed/test_twitter_api.py
@@ -89,6 +89,21 @@ class _RateLimitedResponse:
         return {"title": "Too Many Requests"}
 
 
+class _ServerErrorResponse:
+    """Minimal response object for Tweepy 503 server errors."""
+
+    headers: ClassVar[dict[str, str]] = {}
+    reason = "Service Unavailable"
+    status_code = 503
+    text = "Service Unavailable"
+
+    @staticmethod
+    def json() -> dict[str, str]:
+        """Return a minimal X API error payload."""
+
+        return {"title": "Service Unavailable"}
+
+
 def test_sync_x_list_members_waits_on_rate_limit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Wait for X rate-limit reset and retry the same list member.
 
@@ -154,5 +169,76 @@ def test_sync_x_list_members_waits_on_rate_limit(monkeypatch: pytest.MonkeyPatch
         assert add_calls == ["1", "1", "2"]
         assert sleep_calls == [2]
         assert db.get_sync_state("twitter_handles_hash") == compute_handles_hash(["alice", "bob"])
+    finally:
+        db.close()
+
+
+def test_sync_x_list_members_retries_on_server_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Retry transient X API 503 server errors when reading list members.
+
+    A transient ``503 Service Unavailable`` from X used to propagate out of the
+    scan cycle and crash the long-running process, producing a Docker restart
+    hot-loop.  The read loop must back off and retry instead.
+
+    1. Stub a client whose ``get_list_members`` raises 503 twice, then succeeds.
+    2. Run the sync and capture the backoff sleeps.
+    3. Assert the read retried and the sync completed without raising.
+    """
+
+    # 1. Stub a client whose get_list_members raises 503 twice, then succeeds
+    monkeypatch.setattr(
+        twitter_api,
+        "resolve_twitter_handles",
+        lambda _handles, _bearer_token, _user_cache: {"alice": "1"},
+    )
+
+    read_calls: list[int] = []
+    sleep_calls: list[float] = []
+
+    class FakeClient:
+        """Fake Tweepy client that fails reads transiently before succeeding."""
+
+        def __init__(self, **_kwargs: object):
+            pass
+
+        @staticmethod
+        def get_list_members(list_id: str, max_results: int, pagination_token: str | None):
+            """Raise 503 for the first two calls, then return the member."""
+
+            read_calls.append(1)
+            if len(read_calls) <= 2:
+                raise tweepy.TwitterServerError(_ServerErrorResponse())
+            return SimpleNamespace(data=[SimpleNamespace(id="1")], meta={})
+
+        @staticmethod
+        def add_list_member(list_id: str, user_id: str) -> None:
+            """Member already present, so no writes should occur."""
+
+            raise AssertionError("add_list_member should not be called")
+
+    monkeypatch.setattr(twitter_api.tweepy, "Client", FakeClient)
+    monkeypatch.setattr(twitter_api.time, "sleep", lambda seconds: sleep_calls.append(seconds))
+
+    db = VaultPostDatabase(tmp_path / "posts.duckdb")
+    try:
+        # 2. Run the sync and capture the backoff sleeps
+        added = sync_x_list_members(
+            LIST_ID,
+            ["alice"],
+            "consumer-key",
+            "consumer-secret",
+            "access-token",
+            "access-token-secret",
+            TwitterUserCache(tmp_path / "twitter-users.json"),
+            "bearer-token",
+            db,
+            add_delay_seconds=0,
+        )
+
+        # 3. The read retried twice and the sync completed without raising
+        assert added == 0
+        assert len(read_calls) == 3
+        assert sleep_calls == [5.0, 10.0]
+        assert db.get_sync_state("twitter_handles_hash") == compute_handles_hash(["alice"])
     finally:
         db.close()

--- a/tests/feed/test_twitter_api.py
+++ b/tests/feed/test_twitter_api.py
@@ -124,19 +124,14 @@ def test_sync_x_list_members_waits_on_rate_limit(monkeypatch: pytest.MonkeyPatch
     sleep_calls: list[float] = []
 
     class FakeClient:
-        """Fake Tweepy client for list member reads and writes."""
+        """Fake Tweepy client for list member writes.
+
+        The local member cache starts empty, so both resolved handles need
+        adding and the broken ``get_list_members`` endpoint is never touched.
+        """
 
         def __init__(self, **_kwargs: object):
             pass
-
-        @staticmethod
-        def get_list_members(list_id: str, max_results: int, pagination_token: str | None):
-            """Return an empty list so every resolved user needs adding."""
-
-            assert list_id == LIST_ID
-            assert max_results == LIST_MEMBER_PAGE_SIZE
-            assert pagination_token is None
-            return SimpleNamespace(data=[], meta={})
 
         @staticmethod
         def add_list_member(list_id: str, user_id: str) -> None:
@@ -173,72 +168,129 @@ def test_sync_x_list_members_waits_on_rate_limit(monkeypatch: pytest.MonkeyPatch
         db.close()
 
 
-def test_sync_x_list_members_retries_on_server_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Retry transient X API 503 server errors when reading list members.
+def test_x_api_read_with_retry_retries_server_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retry transient X API 5xx errors with exponential backoff, then succeed.
 
-    A transient ``503 Service Unavailable`` from X used to propagate out of the
-    scan cycle and crash the long-running process, producing a Docker restart
-    hot-loop.  The read loop must back off and retry instead.
+    The shared read wrapper protects every X read path (handle resolution, list
+    timeline, user timeline) from transient ``503 Service Unavailable`` blips
+    that would otherwise abort a scan cycle.
 
-    1. Stub a client whose ``get_list_members`` raises 503 twice, then succeeds.
-    2. Run the sync and capture the backoff sleeps.
-    3. Assert the read retried and the sync completed without raising.
+    1. Build a callable that raises 503 twice, then returns a value.
+    2. Call the retry wrapper, capturing the backoff sleeps.
+    3. Assert it returned the value after exactly two backoff sleeps.
     """
 
-    # 1. Stub a client whose get_list_members raises 503 twice, then succeeds
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(twitter_api.time, "sleep", lambda seconds: sleep_calls.append(seconds))
+
+    # 1. Build a callable that raises 503 twice, then returns a value
+    calls: list[int] = []
+
+    def flaky() -> str:
+        calls.append(1)
+        if len(calls) <= 2:
+            raise tweepy.TwitterServerError(_ServerErrorResponse())
+        return "ok"
+
+    # 2. Call the retry wrapper, capturing the backoff sleeps
+    result = twitter_api._x_api_read_with_retry(flaky, description="testing the retry wrapper")
+
+    # 3. It returned after exactly two backoff sleeps
+    assert result == "ok"
+    assert len(calls) == 3
+    assert sleep_calls == [5.0, 10.0]
+
+
+def test_x_api_read_with_retry_raises_after_exhausting_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Surface an XApiError once 5xx retries are exhausted.
+
+    A persistently failing endpoint (like ``GET /2/lists/{id}/members``) must
+    eventually raise rather than retry forever.
+
+    1. Build a callable that always raises 503.
+    2. Call the retry wrapper.
+    3. Assert it raises XApiError after the configured maximum retries.
+    """
+
+    monkeypatch.setattr(twitter_api.time, "sleep", lambda _seconds: None)
+
+    # 1. Build a callable that always raises 503
+    def always_503() -> str:
+        raise tweepy.TwitterServerError(_ServerErrorResponse())
+
+    # 2. + 3. The wrapper gives up with XApiError after the retry budget
+    with pytest.raises(twitter_api.XApiError):
+        twitter_api._x_api_read_with_retry(always_503, description="hitting a dead endpoint")
+
+
+def test_sync_x_list_members_uses_local_member_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Sync membership from a local cache instead of the broken members endpoint.
+
+    Because ``GET /2/lists/{id}/members`` returns persistent 503s, the sync must
+    never call it; it tracks added member IDs locally and only writes the delta
+    when handles change.
+
+    1. Stub resolution and a client that fails if the members endpoint is read.
+    2. Run sync, then add a third handle and run sync again.
+    3. Assert the first run adds all members and the second adds only the delta.
+    """
+
+    # 1. Stub resolution (mutable so the second run resolves a new handle) and a
+    #    client whose read endpoint must never be called.
+    handle_map = {"alice": "1", "bob": "2"}
     monkeypatch.setattr(
         twitter_api,
         "resolve_twitter_handles",
-        lambda _handles, _bearer_token, _user_cache: {"alice": "1"},
+        lambda handles, _bearer_token, _user_cache: {h: handle_map[h] for h in handles},
     )
 
-    read_calls: list[int] = []
-    sleep_calls: list[float] = []
+    add_calls: list[str] = []
 
     class FakeClient:
-        """Fake Tweepy client that fails reads transiently before succeeding."""
+        """Fake Tweepy client that records writes and forbids member reads."""
 
         def __init__(self, **_kwargs: object):
             pass
 
         @staticmethod
-        def get_list_members(list_id: str, max_results: int, pagination_token: str | None):
-            """Raise 503 for the first two calls, then return the member."""
+        def get_list_members(*_args: object, **_kwargs: object):
+            """The members endpoint is broken and must never be called."""
 
-            read_calls.append(1)
-            if len(read_calls) <= 2:
-                raise tweepy.TwitterServerError(_ServerErrorResponse())
-            return SimpleNamespace(data=[SimpleNamespace(id="1")], meta={})
+            raise AssertionError("get_list_members must not be called")
 
         @staticmethod
         def add_list_member(list_id: str, user_id: str) -> None:
-            """Member already present, so no writes should occur."""
+            """Record each successful add."""
 
-            raise AssertionError("add_list_member should not be called")
+            assert list_id == LIST_ID
+            add_calls.append(user_id)
 
     monkeypatch.setattr(twitter_api.tweepy, "Client", FakeClient)
-    monkeypatch.setattr(twitter_api.time, "sleep", lambda seconds: sleep_calls.append(seconds))
+    monkeypatch.setattr(twitter_api.time, "sleep", lambda _seconds: None)
+
+    common_args = (
+        "consumer-key",
+        "consumer-secret",
+        "access-token",
+        "access-token-secret",
+        TwitterUserCache(tmp_path / "twitter-users.json"),
+        "bearer-token",
+    )
 
     db = VaultPostDatabase(tmp_path / "posts.duckdb")
     try:
-        # 2. Run the sync and capture the backoff sleeps
-        added = sync_x_list_members(
-            LIST_ID,
-            ["alice"],
-            "consumer-key",
-            "consumer-secret",
-            "access-token",
-            "access-token-secret",
-            TwitterUserCache(tmp_path / "twitter-users.json"),
-            "bearer-token",
-            db,
-            add_delay_seconds=0,
-        )
+        # 2. First run adds both members from an empty cache
+        added_first = sync_x_list_members(LIST_ID, ["alice", "bob"], *common_args, db, add_delay_seconds=0)
 
-        # 3. The read retried twice and the sync completed without raising
-        assert added == 0
-        assert len(read_calls) == 3
-        assert sleep_calls == [5.0, 10.0]
-        assert db.get_sync_state("twitter_handles_hash") == compute_handles_hash(["alice"])
+        # 2. Second run after a new handle is introduced
+        handle_map["carol"] = "3"
+        add_calls.clear()
+        added_second = sync_x_list_members(LIST_ID, ["alice", "bob", "carol"], *common_args, db, add_delay_seconds=0)
+
+        # 3. First run added all, second run added only the delta
+        assert added_first == 2
+        assert added_second == 1
+        assert add_calls == ["3"]
+        assert db.get_sync_state(twitter_api.X_LIST_MEMBER_IDS_STATE_KEY) is not None
     finally:
         db.close()


### PR DESCRIPTION
## Why

The `post-scanner` container was stuck in an endless crash loop. The logs showed `=== Post scan cycle 1 ===` repeating forever, each time with the same traceback ending in:

```
tweepy.errors.TwitterServerError: 503 Service Unavailable
  ...
eth_defi.feed.twitter_api.XApiError: Failed to fetch list members for list 2051667540674236789: 503 Service Unavailable
```

### Root cause — confirmed by local reproduction

I reproduced the failing call locally with the production bearer token against list `2051667540674236789`. The 503 is **deterministic and endpoint-specific**, not a transient outage:

| Call | Result |
|------|--------|
| `get_user(@jack)` | OK — bearer token is valid |
| `get_list(2051667540674236789)` metadata | OK — list exists ("Best builders in DeFi") |
| `get_list_tweets(...)` — the timeline the scanner actually collects posts from | OK — returns tweets |
| **`get_list_members(...)`** | **503 on every attempt** |
| `get_list_members("84839422")` — an unrelated public list | **503 too** |

- Rate limit was healthy (`x-rate-limit-remaining: 888/900`), so it is not throttling.
- Response body: `{"title":"Service Unavailable","detail":"Service Unavailable","status":503}`.
- It fails for an **unrelated list too**, so the problem is not our list — the X API `GET /2/lists/{id}/members` endpoint itself is degraded server-side. This is a known, long-running X API condition for that specific endpoint.

### Why it became a crash loop

1. **The membership sync was the only X call without graceful error handling.** `sync_x_list_members()` runs at the top of the scan cycle, *before* post collection. The tweet-collection path already caught `XApiError` and fell back; the membership-sync call did not — so a 503 there aborted the whole cycle, even though the timeline endpoint used for actual collection works fine.
2. **The crash escaped `main()` and Docker hot-restarted it.** `XApiError` propagated out of `run_post_scan_cycle()` -> `main()` uncaught, so the process exited before reaching its `time.sleep(loop_interval)`. With `restart: unless-stopped` on the `post-scanner` service, Docker relaunched it instantly, resetting the in-process cycle counter to 1 — hence "cycle 1" forever, a zero-backoff retry loop hammering X while it was already failing.

## Lessons learnt

- **Reproduce before assuming "transient".** The first instinct was 503 = transient blip curable by retry. Local reproduction proved it is persistent and endpoint-wide, so retry alone does not recover it — the real fix is to stop depending on the broken endpoint and to degrade gracefully.
- **A non-essential maintenance step must never abort the essential work.** List membership sync only adds new handles; its failure should not stop post collection, which uses a different, working endpoint.
- **Error handling should be symmetric across an integration.** The same `XApiError` was already handled for tweet collection but not for membership sync, and only one of several X read paths retried transient 5xx — both gaps are now closed with one shared helper.
- **A supervised daemon must isolate per-cycle failures**, or a `restart` policy turns into a tight retry loop against a failing upstream.

## Summary

Fixes are layered from "stops the bleeding" to "removes the dependency on the broken endpoint":

- **Stop reading membership from the broken endpoint** (`eth_defi/feed/twitter_api.py`): `sync_x_list_members()` no longer calls `get_list_members`. It tracks the member IDs it has successfully added in a local `feed_sync_state` cache (`x_list_member_ids`) and diffs new handles against that. Re-adding an existing member is a no-op on X's side (the v2 add endpoint returns `is_member` without error), so a cold cache self-heals on the first run and subsequent runs only write the delta. **This makes the sync work again despite the outage**, rather than merely tolerating it.
- **Shared retry/backoff for every X read** (`eth_defi/feed/twitter_api.py`): extracted `_x_api_read_with_retry()` and applied it to all read paths — handle resolution (`get_users`), authenticated-user + owned-list lookup (`get_me`, `get_owned_lists`), list-timeline collection (`get_list_tweets`), and user-timeline reads (`get_users_tweets`). Each now retries `TwitterServerError` (5xx) with exponential backoff (`X_SERVER_ERROR_MAX_RETRIES`, `X_SERVER_ERROR_BACKOFF_BASE_SECONDS`) and honours `TooManyRequests` windows; genuine client errors still fail fast.
- **Graceful degradation of membership sync** (`eth_defi/feed/scanner.py`): the `sync_x_list_members()` call is wrapped in `except XApiError`, logging a warning and continuing post collection if it still fails (e.g. retries exhausted). Mirrors the existing list-timeline fallback.
- **Per-cycle error isolation** (`scripts/erc-4626/scan-vault-posts.py`): `main()` wraps `run_post_scan_cycle()` in try/except so any failed cycle is logged and the daemon waits for the next interval instead of crashing into the Docker restart loop. Single-shot runs (`LOOP_INTERVAL_SECONDS <= 0`) still re-raise.
- **Tests** (`tests/feed/test_twitter_api.py`): retry helper succeeds after backoff and raises `XApiError` once retries are exhausted; membership sync uses the local cache, never calls `get_list_members`, and writes only the delta when a handle is added. The live `test_scanner_integration.py` still passes against the real X API.
- **Changelog** entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
