### PR TITLE
feat: Add get_deposit_delay_over() to estimate async deposit settlement time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- feat: Add `VaultDepositManager.get_deposit_delay_over()` to estimate when a pending async deposit will settle, with an Ostium V1.5 implementation (mirrors `get_redemption_delay_over()` using `targetSettlementId(true)`); operator-driven ERC-7540 vaults return `None` (2026-06-09)
+
 - fix: Restore Sphinx docs build on Python 3.13/3.14 by adding the `standard-imghdr` backport, since stdlib `imghdr` (imported by Sphinx 4.x) was removed in Python 3.13 (2026-06-09)
 
 - feat: Add curator short and long descriptions to feeder metadata, curator exports, and all current curator YAML files (2026-06-09)

--- a/eth_defi/erc_4626/vault_protocol/gains/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/gains/deposit_redeem.py
@@ -551,6 +551,20 @@ class OstiumV15DepositManager(ERC4626DepositManager):
         settlements_to_wait = max(target_id - last_id, 1)
         return from_unix_timestamp(last_ts + settlements_to_wait * interval)
 
+    def get_deposit_delay_over(self, address: HexAddress | str) -> datetime.datetime | None:
+        """Estimate when the next deposit settlement will occur.
+
+        Mirror of :py:meth:`get_redemption_delay_over` but for the deposit
+        target settlement (``targetSettlementId(True)``).
+        """
+        vault = self.vault
+        target_id = vault.vault_contract.functions.targetSettlementId(True).call()
+        last_id = vault.vault_contract.functions.lastSettlementId().call()
+        last_ts = vault.vault_contract.functions.lastSettlementTs().call()
+        interval = vault.vault_contract.functions.maxSettlementInterval().call()
+        settlements_to_wait = max(target_id - last_id, 1)
+        return from_unix_timestamp(last_ts + settlements_to_wait * interval)
+
     def analyse_deposit(
         self,
         claim_tx_hash: HexBytes | str,

--- a/eth_defi/vault/deposit_redeem.py
+++ b/eth_defi/vault/deposit_redeem.py
@@ -564,6 +564,28 @@ class VaultDepositManager(ABC):
         """
         raise NotImplementedError(f"Class {self.__class__.__name__} does not implement get_redemption_delay_over()")
 
+    def get_deposit_delay_over(self, address: HexAddress | str) -> datetime.datetime | None:
+        """Estimate when a pending async deposit request will settle.
+
+        - Mirror of :py:meth:`get_redemption_delay_over` for the deposit side.
+
+        - Used to show an estimated settlement time for unsettled deposits
+          (e.g. in the trade-executor ``trade-ui`` table).
+
+        - Default returns ``None``: the protocol has no deterministic on-chain
+          settlement schedule (e.g. operator-driven ERC-7540 vaults like Lagoon).
+          Subclasses with a predictable settlement cadence (e.g. Ostium V1.5)
+          override this to return an estimated UTC timestamp.
+
+        :param address:
+            Owner of the pending deposit request.
+
+        :return:
+            Naive UTC timestamp when the deposit is expected to settle, or
+            ``None`` when no on-chain estimate is available.
+        """
+        return None
+
     @abstractmethod
     def analyse_deposit(
         self,


### PR DESCRIPTION
## Why

trade-executor's `trade-ui` wants to show an estimated settlement time for async vault deposits (Ostium V1.5, ERC-7540 Lagoon) that have been requested on-chain but not yet settled. The deposit side had no equivalent of the existing `get_redemption_delay_over()`, so there was no generic way to ask "when will this deposit settle?".

## Summary

- Add a non-abstract `VaultDepositManager.get_deposit_delay_over(address) -> datetime | None`. Default returns `None`, meaning the protocol has no deterministic on-chain settlement schedule (e.g. operator-driven ERC-7540 vaults such as Lagoon).
- Implement the override on `OstiumV15DepositManager`, mirroring `get_redemption_delay_over()` but using `targetSettlementId(true)` to target the deposit settlement: `lastSettlementTs + max(targetSettlementId(true) - lastSettlementId, 1) * maxSettlementInterval`.
- Add a `# Current` CHANGELOG entry.

## Lessons learnt

- Deposit and withdrawal settlements in Ostium V1.5 share the same `maxSettlementInterval` / `lastSettlementTs` clock; only the target settlement id differs (`true` for deposits, `false` for withdrawals), so the deposit estimate is a one-argument change away from the existing redemption estimate.
- Keeping the estimate behind the generic `VaultDepositManager` interface lets callers stay protocol-agnostic — non-deterministic vaults simply return `None` rather than the caller special-casing each protocol.
