### PR TITLE
fix: Export denomination_decimals and share_token_decimals in vault metrics JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- fix: Export `denomination_decimals` and `share_token_decimals` in the vault metrics JSON (`top_vaults_by_chain.json`). The on-chain token decimals were captured during the scan but dropped when building the per-vault export record, so consumers had no decimals to read and defaulted them (e.g. USDC to 18), scaling raw amounts by 10**12 (2026-06-09)
+
 - feat: Add `VaultDepositManager.get_deposit_delay_over()` to estimate when a pending async deposit will settle, with an Ostium V1.5 implementation (mirrors `get_redemption_delay_over()` using `targetSettlementId(true)`); operator-driven ERC-7540 vaults return `None` (2026-06-09)
 
 - fix: Restore Sphinx docs build on Python 3.13/3.14 by adding the `standard-imghdr` backport, since stdlib `imghdr` (imported by Sphinx 4.x) was removed in Python 3.13 (2026-06-09)

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -252,6 +252,14 @@ class VaultMetricsRecord(TypedDict, total=False):
     #: Performance fee percentage
     performance_fee: float | None
 
+    #: Denomination (reserve) token ERC-20 decimals, e.g. ``6`` for USDC.
+    #: Consumers use this to convert human amounts to raw uint256; a missing
+    #: value must NOT be defaulted to 18 (see ``denomination_token_address``).
+    denomination_decimals: int | None
+
+    #: Share token ERC-20 decimals (the vault's own ERC-4626 token).
+    share_token_decimals: int | None
+
     #: Protocol-specific extension data (Morpho flags, etc.)
     other_data: dict
 
@@ -1519,19 +1527,32 @@ def calculate_vault_record(
     detection: ERC4262VaultDetection = vault_metadata["_detection_data"]
     features = sorted([f.name for f in detection.features])
 
-    # Token addresses
+    # Token addresses and decimals.
+    #
+    # The decimals come from on-chain ERC-20 metadata captured during the
+    # scan (TokenDetails.export()). They MUST be carried through to the JSON
+    # export: downstream consumers convert human amounts to raw uint256 with
+    # these decimals, and a missing/wrong value (e.g. defaulting USDC to 18)
+    # scales transfers by 10**12 and reverts on-chain.
     share_token_data = vault_metadata.get("_share_token")
     if isinstance(share_token_data, dict):
         share_token_address = share_token_data.get("address")
+        share_token_decimals = share_token_data.get("decimals")
     else:
         share_token_address = None
+        share_token_decimals = None
 
     # Most ERC-4626 vaults are also the share token (ERC-20) contract.
     if not share_token_address:
         share_token_address = vault_metadata.get("Address") or detection.address
 
     denomination_token_data = vault_metadata.get("_denomination_token")
-    denomination_token_address = denomination_token_data.get("address") if isinstance(denomination_token_data, dict) else None
+    if isinstance(denomination_token_data, dict):
+        denomination_token_address = denomination_token_data.get("address")
+        denomination_token_decimals = denomination_token_data.get("decimals")
+    else:
+        denomination_token_address = None
+        denomination_token_decimals = None
 
     # Do we know fees for this vault
     known_fee = mgmt_fee is not None and perf_fee is not None
@@ -1650,7 +1671,9 @@ def calculate_vault_record(
             "curator_name": curator_name,
             "protocol_curator": is_protocol_curator(curator_slug) if curator_slug else None,
             "share_token_address": share_token_address,
+            "share_token_decimals": share_token_decimals,
             "denomination_token_address": denomination_token_address,
+            "denomination_decimals": denomination_token_decimals,
             "lifetime_return": lifetime_return,
             "lifetime_return_net": lifetime_return_net,
             "cagr": cagr,
@@ -2239,6 +2262,11 @@ def format_lifetime_table(
     # Addresses
     _del("share_token_address")
     _del("denomination_token_address")
+
+    # Token decimals are exported via JSON API (used for raw-amount math), not
+    # for the human-readable table.
+    _del("share_token_decimals")
+    _del("denomination_decimals")
 
     _del("link")
 

--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -110,6 +110,14 @@ def test_calculate_lifetime_metrics(
     assert sample_row["current_nav"] == pytest.approx(2345373.103418)
     assert sample_row["fee_label"] == "0% / 15% (int.)"
 
+    # Token decimals must be carried into the export from the on-chain
+    # metadata. Regression: previously dropped entirely, which made downstream
+    # consumers default a missing value to 18 and break raw-amount math (a
+    # 6-decimal USDC burn scaled by 10**18 reverts on-chain). The denomination
+    # token (USDC.e) is 6 decimals, distinct from the share token (CSUSDCE) at 18.
+    assert sample_row["denomination_decimals"] == 6
+    assert sample_row["share_token_decimals"] == 18
+
     assert sample_row["lifetime_return"] == pytest.approx(0.002758)
     assert sample_row["cagr"] == pytest.approx(0.02483940718068034)
     assert sample_row["cagr_net"] == pytest.approx(0.02483940718068034)


### PR DESCRIPTION
## Why

`calculate_vault_record()` builds each per-vault record for the `top_vaults_by_chain.json` export, but it pulled only `.get("address")` out of the on-chain `_denomination_token` / `_share_token` metadata and **dropped the decimals**. The exported JSON therefore carried no decimal fields at all.

Downstream, `tradingstrategy.load_vault_database_with_metadata()` reads `vault_entry.get("denomination_decimals", 18)` — with the key absent it silently defaults to **18**. For 6-decimal tokens like USDC this scales raw amounts by `10**12`. It surfaced in production as a CCTP bridge `depositForBurn` burning `5000000000000000000` (5×10¹⁸) for 5 USDC and reverting with `ERC20: transfer amount exceeds balance`.

The decimals are already captured on-chain during the scan and present in the exported `TokenDetails` dicts — they were just being discarded at the export step.

## Lessons learnt

- On-chain token decimals are authoritative and must be carried all the way to the JSON export; consumers cannot recover them and will fabricate wrong defaults.
- Defaulting a missing decimals value to 18 is dangerous for stablecoins (6) and other non-18 tokens — fail loud or carry the real value.

## Summary

- **`vault_metrics.py`**: extract `decimals` alongside `address` from `_denomination_token` / `_share_token`, and emit `denomination_decimals` and `share_token_decimals` in the per-vault record. Stripped from the human-readable table (like the address columns), kept in the JSON API export. Documented both fields in the `VaultMetricsRecord` TypedDict.
- **Tests**: `test_calculate_lifetime_metrics` now asserts the Clearstar USDC.e sample exports `denomination_decimals=6` (USDC.e) and `share_token_decimals=18` (CSUSDCE), proving the denomination decimals survive distinct from the share token.
- **CHANGELOG.md**: entry added.

## Note

This is the producer half of a cross-repo fix. The consumer (`trading-strategy`) is being hardened separately to stop defaulting missing decimals to 18. `trade-executor` has a defensive layer that pins native USDC to 6 and converts bridge amounts from on-chain decimals regardless. The dataset must be regenerated for consumers to pick up the new fields.
