### PR TITLE
fix: Fail HyperEVM multicall over to Alchemy on goldsky eRPC consensus disagreement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- fix: Stop HyperEVM (chain 999) vault scans aborting on goldsky eRPC `not enough agreement among responses` consensus failures — when the failing provider mix contains both goldsky and Alchemy, multicall retries are now pinned to the Alchemy single node instead of randomly cycling back onto goldsky's consensus endpoint (which cannot serve these calls); the disagreement is intermittent and upstream-pool driven, documented with on-chain evidence in `docs/README-hyperevm-goldsky-failure.md` (2026-06-10)
+
 - feat: Add eight vault curators discovered from a full vault-name sweep — Coinshift, Hyperbeat, Lista DAO, Keyring Network, Trust Wallet, CoolWallet, Mt Pelerin and HypurrFi (Morpho/Euler/Lagoon/Kiln Metavault) — plus name-pattern fixes so existing August Digital and DAMM Capital vaults are detected; distributor curators (Trust Wallet, CoolWallet) are matched at lowest priority so the underlying risk curator (Steakhouse, Gauntlet, ...) wins on co-branded vaults (2026-06-09)
 
 - feat: Add the anonymous "DER" curator for the Lagoon "Der" vault family (Der USDC, Der base USDC, Der EURC, Der ETH, Der BTC) (2026-06-09)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,7 @@ Consult these for domain-specific context. Logo READMEs under `eth_defi/data/vau
 | `contracts/in-house/README.md` | Web3-Eth-Defi integration contracts |
 | `contracts/safe-integration/README.md` | Trading Strategy Zodiac-module for Safe multisig wallets |
 | `docs/README-Hypercore-guard.md` | Hypercore native vault guard integration |
+| `docs/README-hyperevm-goldsky-failure.md` | HyperEVM goldsky eRPC "not enough agreement" consensus failure and Alchemy failover |
 | `docs/README-contract-size.md` | Contract sizes and compiler optimisation |
 | `docs/derive-onboarding/README-derive-trader.md` | Derive session key for vault traders |
 | `docs/protocol-research/README.md` | AI-assisted vault protocol discovery notes |

--- a/docs/README-hyperevm-goldsky-failure.md
+++ b/docs/README-hyperevm-goldsky-failure.md
@@ -129,6 +129,21 @@ If all three hold, `pin_fallback_provider_by_host(fallback_provider, "alchemy")`
 deterministically selects the Alchemy provider for the retries. Otherwise the normal
 random switch is used, so the change is inert on every other chain and provider mix.
 
+Two safeguards keep the pin robust:
+
+- **Chain-id verified pin.** Pinning goes through
+  `FallbackProvider.switch_to_provider_index()`, which performs the same
+  `eth_chainId` verification and rollback as `switch_provider()`. If the Alchemy
+  endpoint is misconfigured or starts routing to the wrong chain at runtime, the
+  switch rolls back and `pin_fallback_provider_by_host()` returns `False`, so we
+  never silently read from a bad endpoint — the caller resumes normal switching.
+- **Recomputed every retry.** The failover is re-evaluated on each retry against the
+  *latest* failure. We only stay pinned to Alchemy while the error is still the
+  consensus disagreement. If a later retry fails for a different reason (Alchemy
+  429 / timeout / outage), the detection returns `None` and we resume normal
+  provider switching, so retries are not all burned on one endpoint while dRPC or
+  another single node is still available.
+
 ### Providers / nodes involved
 
 | Role | Endpoint | Notes |

--- a/docs/README-hyperevm-goldsky-failure.md
+++ b/docs/README-hyperevm-goldsky-failure.md
@@ -1,0 +1,168 @@
+# HyperEVM goldsky eRPC consensus failure
+
+This document explains why HyperEVM (Hyperliquid, chain id 999) vault scans fail
+with the eRPC error `not enough agreement among responses`, why retrying does not
+help, and the failover special case we added to work around it.
+
+It backs the line comments in
+[`eth_defi/event_reader/multicall_batcher.py`](../eth_defi/event_reader/multicall_batcher.py)
+(`resolve_hyperevm_consensus_failover`, `pin_fallback_provider_by_host`,
+`ERPC_CONSENSUS_DISAGREEMENT_CLUE`, `HYPEREVM_CHAIN_ID`).
+
+## Symptom
+
+The vault discovery / price scan aborts the whole HyperEVM chain with:
+
+```
+eth_defi.vault.scan_all_chains  ERROR  Hyperliquid: Out of multicall retries, even
+after dropping multicall batch size to 1 and switching providers, bailing out.
+...
+chain 999, block 37,395,809, batch size: 1.
+Exception: MulticallRetryable: Multicall failed for chain 999
+{'code': -32603, 'message': 'not enough agreement among responses'}
+```
+
+All five retries (including batch-size-1 and provider switches) fail with the same
+`-32603 not enough agreement among responses`, then the scan bails out.
+
+## Root cause
+
+The scan's primary HyperEVM provider is **goldsky's eRPC endpoint
+(`edge.goldsky.com`) running in consensus mode** (`x-erpc-consensus-slots: 5`). It
+fans each `eth_call` out to ~5 upstream nodes and only returns a result when enough
+of them return **byte-identical** responses. The upstreams seen in the response
+headers:
+
+```
+x-erpc-upstreams: systx-quicknode-hyperevm; standard-quicknode-hyperevm;
+                  systx-chainstack-hyperevm; standard-chainstack-hyperevm;
+                  systx-nirvana-hyperevm-us-chi-1
+```
+
+For some vaults these upstreams **genuinely disagree**, so eRPC returns
+`not enough agreement among responses`. There are two independent reasons the
+upstreams return different bytes for the same call, both verified on-chain by
+comparing a single node (Alchemy, `hyperliquid-mainnet.g.alchemy.com`) against the
+goldsky consensus endpoint:
+
+### Cause A — node-dependent return values (HyperCore-oracle vaults)
+
+`totalAssets()` / `convertToAssets()` on oracle-priced vaults read **live HyperCore
+state** (mark/oracle price) via precompiles. Each upstream reads its own momentary
+HyperCore view, so the returned value differs between nodes and consensus fails —
+**at every block, including `latest`**, while constant reads pass:
+
+```
+block=latest (goldsky consensus)
+  decimals()    : OK
+  totalSupply() : OK
+  totalAssets() : FAIL  not enough agreement among responses
+```
+
+### Cause B — divergent revert serialisation past the execution window
+
+Probe calls that revert get serialised inconsistently across upstreams. For the
+identical call at a historical block one node returns `code 3 execution reverted`
+while another returns
+`-32603 InvalidTransaction(Revert(RevertError { output: None }))`. This kicks in
+**past a sharp ~tip-126 boundary** — these RPC nodes only keep full execution state
+for ~128 recent blocks; beyond that the revert path diverges:
+
+```
+selector 0x2d06b331, vault 0x9b3a8f7c, single node (Alchemy), by block age:
+  tip-100  : code 3 execution reverted
+  tip-200  : -32603 InvalidTransaction(Revert(...))      <- divergence starts
+  tip-1232 : -32603 InvalidTransaction(Revert(...))
+  @ latest both nodes agree on code 3
+```
+
+The failing scan read block 37,395,809, which was **1,232 blocks behind the live
+tip** — well past the ~128-block window — because the discovery scan captures
+`end_block = web3.eth.block_number` at scan start
+([`eth_defi/erc_4626/lead_scan_core.py`](../eth_defi/erc_4626/lead_scan_core.py),
+`scan_leads`) but executes the reads ~20–40 min later, by which time the tip has
+moved far ahead.
+
+`tryBlockAndAggregate` concatenates all sub-call results into one blob, so a single
+divergent sub-call (Cause A or Cause B) poisons the whole batch.
+
+## Why retrying does not help
+
+The disagreement is **intermittent and upstream-pool driven, not a transient
+per-request glitch**. Verified across two windows hours apart:
+
+- In one window, `totalAssets()` on `0x26672d3e`, `0x8a5b15ea`, `0x9c59a93`,
+  `0x9b3a8f7c` and several full captured batches returned `NO-AGREEMENT`
+  reproducibly at every block.
+- Hours later the **same** read-only calls and batches all passed — nothing on
+  chain had changed; the condition flipped on its own as the upstream pool
+  re-synced.
+
+So the failure clusters on the same handful of vaults (those whose reads expose
+per-node variance) but is **not** a permanent property of any address. It is also
+not a "block too fresh" problem — `get_almost_latest_block_number()` (tip-4) would
+not avoid it, since Cause A fails at `latest` too. Retrying or randomly cycling
+back onto goldsky's consensus endpoint within the ~5-retry budget cannot outrun a
+multi-minute pool divergence.
+
+Because no single address is persistently broken, these vaults are **not** added to
+`_BROKEN_VAULT_CONTRACTS` (that list is for genuinely dead/cooked contracts). They
+are legitimate, working vaults — blacklisting them would permanently drop real data
+for a transient RPC condition.
+
+## The fix — pin HyperEVM consensus failures to Alchemy
+
+When a HyperEVM multicall fails with `not enough agreement among responses`, instead
+of randomly switching providers (which keeps landing back on goldsky), we **pin all
+retries to the Alchemy single node**, which returns a usable answer without
+cross-node consensus.
+
+Detection is deliberately narrow (`resolve_hyperevm_consensus_failover`):
+
+1. **Chain id is 999** (`HYPEREVM_CHAIN_ID`).
+2. The error contains `not enough agreement among responses`
+   (`ERPC_CONSENSUS_DISAGREEMENT_CLUE`).
+3. The `FallbackProvider` mix contains **both** a goldsky and an Alchemy endpoint
+   (matched on `get_provider_name()` host substrings `goldsky` / `alchemy`).
+
+If all three hold, `pin_fallback_provider_by_host(fallback_provider, "alchemy")`
+deterministically selects the Alchemy provider for the retries. Otherwise the normal
+random switch is used, so the change is inert on every other chain and provider mix.
+
+### Providers / nodes involved
+
+| Role | Endpoint | Notes |
+|------|----------|-------|
+| Consensus endpoint that fails | `edge.goldsky.com` | eRPC consensus mode over 5 upstreams (quicknode×2, chainstack×2, nirvana) |
+| Single node we fail over to | `hyperliquid-mainnet.g.alchemy.com` | No consensus; returns one node's answer directly |
+| Other single node in mix | `lb.drpc.live` / `lb.drpc.org` | Also single-node, but we pin to Alchemy per design |
+
+### Vault addresses observed in the failure (chain 999)
+
+Recorded for reference only — these are **working vaults**, not blacklisted:
+
+```
+0x08af2526bb162a99719754d81b7b4b21665064a0
+0x0d13f5149b2e736f807f9c4b0ecdf8644e842af9
+0x26672d3ef84b53ddbcd3732e9bc96c3712ad758d
+0x54112417c5838470ad867c3df6ad8bbae1fd58a7
+0x5baceb306193c2315ed29bb3d9d33dd335739eec
+0x60c13af3b33db0348cdb8f62d4c2d62aa49f0efd
+0x6714cd43536e7e242923ace3d301a3311dbca6bb
+0x8a5b15ea614fbdecb19f23213625d26a3460e101
+0x9b3a8f7cec208e247d97dee13313690977e24459
+0x9c59a9389d8f72de2cdaf1126f36ea4790e2275e
+0xc4b2aaf0d3f0ab607a5978bdd01886dd0191e339
+0xc55fab3ddcab42b6dd2358fbdc59950f832f67fc
+0xf44f49e6577b3934f981c6f0629d15154d2606e6
+0xffeaca6f5af9a30bb22d962c105877727e331b8e
+0x4107dd3e907a26ee6297bad486e887c51e6a918a   (the batch-size-1 fatal bail-out target)
+```
+
+## Related
+
+- [`eth_defi/event_reader/multicall_batcher.py`](../eth_defi/event_reader/multicall_batcher.py)
+  — retry loop and the failover helpers.
+- `WTF_RETRY_EXCEPTIONS_MESSAGE_CLUES` in the same file still classifies
+  `not enough agreement among responses` as retryable; the HyperEVM pin makes those
+  retries actually productive instead of cycling back onto goldsky.

--- a/eth_defi/event_reader/multicall_batcher.py
+++ b/eth_defi/event_reader/multicall_batcher.py
@@ -874,8 +874,14 @@ WTF_RETRY_EXCEPTIONS_MESSAGE_CLUES = {
         "API key is not allowed to access blockchain",
         # eRPC consensus mode requires multiple upstream RPC providers to return
         # identical responses. When providers disagree (e.g. Hyperliquid nodes with
-        # inconsistent state), eRPC returns this error. It is transient and should
-        # be retried, as a subsequent attempt may hit providers that agree.
+        # inconsistent HyperCore-oracle state or divergent revert serialisation),
+        # eRPC returns this error. Classified retryable, but on HyperEVM the
+        # disagreement is intermittent and pool-driven, so simply retrying the same
+        # consensus endpoint may never converge — see the goldsky->Alchemy failover
+        # in resolve_hyperevm_consensus_failover() and the full analysis in
+        # docs/README-hyperevm-goldsky-failure.md. Keep this literal in sync with
+        # ERPC_CONSENSUS_DISAGREEMENT_CLUE (defined below; cannot reference it here
+        # as this set is built before it).
         "not enough agreement among responses",
     )
 }
@@ -1315,6 +1321,20 @@ class MultiprocessMulticallReader:
 
             last_exception = e
 
+            # HyperEVM (chain 999) goldsky eRPC consensus special case.
+            #
+            # When the failure is goldsky's "not enough agreement among responses"
+            # and the provider mix also has an Alchemy single node, randomly cycling
+            # providers keeps landing back on goldsky's consensus endpoint, which
+            # cannot serve these calls — the scan then burns all retries and aborts
+            # the whole chain. Instead we pin every retry to the Alchemy single node,
+            # which returns a usable answer without cross-node consensus.
+            #
+            # Detected by chain id (999) AND by the RPC mix containing both goldsky
+            # and Alchemy. Full failure analysis, nodes involved and on-chain
+            # evidence: docs/README-hyperevm-goldsky-failure.md.
+            consensus_failover_host = resolve_hyperevm_consensus_failover(chain_id, fallback_provider, e)
+
             if fallback_attempts > 0:
                 logger.warning("Attempting retry %d times with fallbacks", fallback_attempts)
                 for i in range(fallback_attempts):
@@ -1325,11 +1345,21 @@ class MultiprocessMulticallReader:
                     else:
                         logger.warning("Received no-throttle status %s: %s, cause: %s, multicall target addresses: %s...", status_code, pformat(headers), cause, multicall_addresses[0:12])
 
-                    fallback_provider.switch_provider(
-                        log_level=logging.WARNING,
-                        randomise=True,
-                        cause=f"Last exception: {str(last_exception)}",
-                    )
+                    if consensus_failover_host and pin_fallback_provider_by_host(fallback_provider, consensus_failover_host):
+                        # HyperEVM goldsky consensus failover — bypass consensus
+                        # endpoint and pin to the single node. See
+                        # docs/README-hyperevm-goldsky-failure.md.
+                        logger.warning(
+                            "HyperEVM (chain %d) eRPC consensus disagreement: pinning multicall retry to %r single-node provider, bypassing goldsky consensus. See docs/README-hyperevm-goldsky-failure.md",
+                            chain_id,
+                            consensus_failover_host,
+                        )
+                    else:
+                        fallback_provider.switch_provider(
+                            log_level=logging.WARNING,
+                            randomise=True,
+                            cause=f"Last exception: {str(last_exception)}",
+                        )
 
                     active_provider = fallback_provider.get_active_provider()
                     active_provider_name = get_provider_name(active_provider)

--- a/eth_defi/event_reader/multicall_batcher.py
+++ b/eth_defi/event_reader/multicall_batcher.py
@@ -49,7 +49,7 @@ from eth_defi.event_reader.multicall_timestamp import fetch_block_timestamps_mul
 from eth_defi.event_reader.timestamp_cache import DEFAULT_TIMESTAMP_CACHE_FOLDER
 from eth_defi.event_reader.web3factory import Web3Factory
 from eth_defi.middleware import ProbablyNodeHasNoBlock, is_retryable_http_exception
-from eth_defi.provider.fallback import FallbackProvider
+from eth_defi.provider.fallback import ChainIdMismatch, FallbackProvider
 from eth_defi.provider.named import get_provider_name
 from eth_defi.timestamp import get_block_timestamp
 from eth_defi.vault.risk import BROKEN_VAULT_CONTRACTS
@@ -970,6 +970,10 @@ def pin_fallback_provider_by_host(fallback_provider: FallbackProvider, host_subs
     multicall retries onto the Alchemy single node, bypassing goldsky's eRPC
     consensus endpoint. See ``docs/README-hyperevm-goldsky-failure.md``.
 
+    The switch goes through :py:meth:`FallbackProvider.switch_to_provider_index`, so
+    the pinned provider is chain-id verified and rolled back if it is misconfigured
+    or routing to the wrong chain — we never silently read from a bad endpoint.
+
     :param fallback_provider:
         The fallback provider to repoint.
 
@@ -977,12 +981,32 @@ def pin_fallback_provider_by_host(fallback_provider: FallbackProvider, host_subs
         Lower-case substring matched against :py:func:`get_provider_name` output.
 
     :return:
-        ``True`` if a matching provider was found and selected, ``False`` otherwise.
+        ``True`` if a matching provider was found and successfully selected,
+        ``False`` if no provider matched or the match failed chain-id verification
+        (in which case the caller should resume normal provider switching).
     """
     host_substring = host_substring.lower()
     for idx, candidate in enumerate(fallback_provider.providers):
         if host_substring in get_provider_name(candidate).lower():
-            fallback_provider.currently_active_provider = idx
+            if idx == fallback_provider.currently_active_provider:
+                # Already pinned to this provider; it was chain-id verified when we
+                # first switched to it, so there is nothing to do.
+                return True
+            try:
+                fallback_provider.switch_to_provider_index(
+                    idx,
+                    log_level=logging.WARNING,
+                    cause="HyperEVM goldsky eRPC consensus failover",
+                )
+            except ChainIdMismatch as e:
+                # The pinned provider failed chain-id verification and was already
+                # rolled back; let the caller fall back to normal switching.
+                logger.warning(
+                    "HyperEVM consensus failover to %r failed chain-id verification: %s; resuming normal provider switching",
+                    host_substring,
+                    e,
+                )
+                return False
             return True
     return False
 
@@ -1321,20 +1345,6 @@ class MultiprocessMulticallReader:
 
             last_exception = e
 
-            # HyperEVM (chain 999) goldsky eRPC consensus special case.
-            #
-            # When the failure is goldsky's "not enough agreement among responses"
-            # and the provider mix also has an Alchemy single node, randomly cycling
-            # providers keeps landing back on goldsky's consensus endpoint, which
-            # cannot serve these calls — the scan then burns all retries and aborts
-            # the whole chain. Instead we pin every retry to the Alchemy single node,
-            # which returns a usable answer without cross-node consensus.
-            #
-            # Detected by chain id (999) AND by the RPC mix containing both goldsky
-            # and Alchemy. Full failure analysis, nodes involved and on-chain
-            # evidence: docs/README-hyperevm-goldsky-failure.md.
-            consensus_failover_host = resolve_hyperevm_consensus_failover(chain_id, fallback_provider, e)
-
             if fallback_attempts > 0:
                 logger.warning("Attempting retry %d times with fallbacks", fallback_attempts)
                 for i in range(fallback_attempts):
@@ -1345,10 +1355,29 @@ class MultiprocessMulticallReader:
                     else:
                         logger.warning("Received no-throttle status %s: %s, cause: %s, multicall target addresses: %s...", status_code, pformat(headers), cause, multicall_addresses[0:12])
 
+                    # HyperEVM (chain 999) goldsky eRPC consensus special case.
+                    #
+                    # When the failure is goldsky's "not enough agreement among
+                    # responses" and the provider mix also has an Alchemy single
+                    # node, randomly cycling providers keeps landing back on
+                    # goldsky's consensus endpoint, which cannot serve these calls —
+                    # the scan then burns all retries and aborts the whole chain.
+                    # Instead we pin the retry to the Alchemy single node, which
+                    # returns a usable answer without cross-node consensus.
+                    #
+                    # Recomputed every iteration against the *latest* failure: we
+                    # only stay pinned while the error is still the consensus
+                    # disagreement. If a later retry fails for another reason
+                    # (Alchemy 429/timeout/outage), this returns None and we resume
+                    # normal provider switching, so we don't burn every retry on one
+                    # endpoint when dRPC or another single node is also available.
+                    #
+                    # Detected by chain id (999) AND by the RPC mix containing both
+                    # goldsky and Alchemy. Full failure analysis, nodes involved and
+                    # on-chain evidence: docs/README-hyperevm-goldsky-failure.md.
+                    consensus_failover_host = resolve_hyperevm_consensus_failover(chain_id, fallback_provider, last_exception)
+
                     if consensus_failover_host and pin_fallback_provider_by_host(fallback_provider, consensus_failover_host):
-                        # HyperEVM goldsky consensus failover — bypass consensus
-                        # endpoint and pin to the single node. See
-                        # docs/README-hyperevm-goldsky-failure.md.
                         logger.warning(
                             "HyperEVM (chain %d) eRPC consensus disagreement: pinning multicall retry to %r single-node provider, bypassing goldsky consensus. See docs/README-hyperevm-goldsky-failure.md",
                             chain_id,

--- a/eth_defi/provider/fallback.py
+++ b/eth_defi/provider/fallback.py
@@ -279,6 +279,39 @@ class FallbackProvider(BaseNamedProvider):
         :param randomise:
             If set switch to a random provider instead of cycling.
         """
+        if randomise:
+            new_index = random.randint(0, len(self.providers) - 1)
+        else:
+            new_index = (self.currently_active_provider + 1) % len(self.providers)
+
+        self.switch_to_provider_index(new_index, log_level=log_level, cause=cause)
+
+    def switch_to_provider_index(self, new_index: int, log_level: int = None, cause: str = "<not specified>"):
+        """Switch to a specific provider by index, with the same verification as :py:meth:`switch_provider`.
+
+        Use this when you need to deterministically select one upstream (e.g. to
+        fail a chain over to a known-good single node) rather than cycling or
+        randomising. Like :py:meth:`switch_provider`, after switching it verifies
+        the new provider returns the expected ``eth_chainId`` and rolls back to the
+        previous provider (raising :py:class:`ChainIdMismatch`) if it does not — so
+        a misconfigured or mis-routing endpoint cannot be silently selected.
+
+        :param new_index:
+            Index into :py:attr:`providers` to switch to.
+
+        :param log_level:
+            Logging level to be verbose about the switch over.
+
+        :param cause:
+            Human-readable reason for the switch, logged for diagnostics.
+
+        :raises ChainIdMismatch:
+            If the new provider reports a different chain ID than expected, or its
+            ``eth_chainId`` cannot be fetched. The active provider is rolled back
+            to the previous one before raising.
+        """
+        assert 0 <= new_index < len(self.providers), f"Provider index {new_index} out of range for {len(self.providers)} providers"
+
         provider = self.get_active_provider()
         old_provider_name = get_provider_name(provider)
         old_index = self.currently_active_provider
@@ -290,10 +323,7 @@ class FallbackProvider(BaseNamedProvider):
             except Exception as e:
                 logger.warning("Could not capture initial chain ID from %s: %s", old_provider_name, e)
 
-        if randomise:
-            self.currently_active_provider = random.randint(0, len(self.providers) - 1)
-        else:
-            self.currently_active_provider = (self.currently_active_provider + 1) % len(self.providers)
+        self.currently_active_provider = new_index
 
         new_provider = self.get_active_provider()
         new_provider_name = get_provider_name(new_provider)

--- a/tests/event_reader/test_hyperevm_consensus_failover.py
+++ b/tests/event_reader/test_hyperevm_consensus_failover.py
@@ -5,14 +5,15 @@ consensus failure on HyperEVM (chain 999), where we pin multicall retries to the
 Alchemy single node instead of cycling back onto the consensus endpoint. See
 ``docs/README-hyperevm-goldsky-failure.md`` for the full failure analysis.
 
-The helpers are pure (no network), so the tests construct ``FallbackProvider``
-instances from fake RPC URLs and assert detection + pinning behaviour.
+The helpers are pure (no real network): the tests use mock providers whose
+``eth_chainId`` responses are stubbed, so the verified provider switch can run
+without a live RPC.
 """
 
-import pytest
-from web3 import HTTPProvider
+from unittest.mock import MagicMock
 
-from eth_defi.compat import create_http_provider
+import pytest
+
 from eth_defi.event_reader.multicall_batcher import (
     ERPC_CONSENSUS_DISAGREEMENT_CLUE,
     HYPEREVM_CHAIN_ID,
@@ -23,15 +24,29 @@ from eth_defi.provider.fallback import FallbackProvider
 from eth_defi.provider.named import get_provider_name
 
 
+def _make_mock_provider(url: str, chain_id: int) -> MagicMock:
+    """Create a mock provider returning a given chain ID for ``eth_chainId``."""
+    provider = MagicMock()
+    provider.endpoint_uri = url
+    provider.middlewares = ()
+    provider.exception_retry_configuration = None
+    provider.make_request.return_value = {"jsonrpc": "2.0", "id": 1, "result": hex(chain_id)}
+    return provider
+
+
+def _goldsky_alchemy_mix(alchemy_chain_id: int = HYPEREVM_CHAIN_ID) -> FallbackProvider:
+    """HyperEVM-style fallback mix: goldsky (index 0), Alchemy (1), dRPC (2)."""
+    providers = [
+        _make_mock_provider("https://edge.goldsky.com/standard/evm/999?secret=x", HYPEREVM_CHAIN_ID),
+        _make_mock_provider("https://hyperliquid-mainnet.g.alchemy.com/v2/key", alchemy_chain_id),
+        _make_mock_provider("https://lb.drpc.live/ogrpc?network=hyperliquid&dkey=x", HYPEREVM_CHAIN_ID),
+    ]
+    return FallbackProvider(providers, sleep=0, backoff=1)
+
+
 @pytest.fixture()
 def goldsky_alchemy_fallback() -> FallbackProvider:
-    """A HyperEVM-style fallback mix containing goldsky, Alchemy and dRPC."""
-    providers = [
-        create_http_provider("https://edge.goldsky.com/standard/evm/999?secret=x", exception_retry_configuration=None),
-        create_http_provider("https://hyperliquid-mainnet.g.alchemy.com/v2/key", exception_retry_configuration=None),
-        create_http_provider("https://lb.drpc.live/ogrpc?network=hyperliquid&dkey=x", exception_retry_configuration=None),
-    ]
-    return FallbackProvider(providers)
+    return _goldsky_alchemy_mix()
 
 
 def test_hyperevm_consensus_failover_happy_path(goldsky_alchemy_fallback: FallbackProvider):
@@ -39,7 +54,7 @@ def test_hyperevm_consensus_failover_happy_path(goldsky_alchemy_fallback: Fallba
 
     1. A consensus disagreement error on chain 999 with a goldsky+Alchemy mix is detected.
     2. The detection returns the ``"alchemy"`` host substring to pin to.
-    3. Pinning selects the Alchemy provider as the active one.
+    3. Pinning (chain-id verified) selects the Alchemy provider as the active one.
     """
     exception = Exception("{'code': -32603, 'message': '" + ERPC_CONSENSUS_DISAGREEMENT_CLUE + "'}")
 
@@ -52,11 +67,33 @@ def test_hyperevm_consensus_failover_happy_path(goldsky_alchemy_fallback: Fallba
     assert "alchemy" in get_provider_name(goldsky_alchemy_fallback.get_active_provider()).lower()
 
 
+def test_hyperevm_consensus_failover_chain_id_rollback():
+    """A mis-routing Alchemy endpoint is not silently selected; the pin rolls back.
+
+    1. Build a mix where Alchemy starts mis-routing at runtime (reports chain ID 1,
+       not 999), after the expected chain ID (999) was already captured.
+    2. Attempt to pin to Alchemy.
+    3. Pinning returns False (chain-id verification failed and rolled back).
+    4. The active provider is still goldsky, not the bad Alchemy endpoint.
+    """
+    # 1. Alchemy mock returns chain ID 1 instead of 999. The expected chain ID was
+    #    captured earlier (e.g. at startup) while Alchemy was still healthy.
+    fallback = _goldsky_alchemy_mix(alchemy_chain_id=1)
+    fallback.expected_chain_id = HYPEREVM_CHAIN_ID
+
+    # 2. + 3. Pinning detects the mismatch, rolls back, and reports failure
+    assert pin_fallback_provider_by_host(fallback, "alchemy") is False
+
+    # 4. We did not silently switch to the wrong-chain Alchemy provider
+    assert "goldsky" in get_provider_name(fallback.get_active_provider()).lower()
+
+
 def test_hyperevm_consensus_failover_negatives(goldsky_alchemy_fallback: FallbackProvider):
     """The failover stays inert outside its exact triggering conditions.
 
     1. A different chain id is not eligible (chain 1).
-    2. A non-consensus error is not eligible (a generic 429).
+    2. A non-consensus error is not eligible (a generic 429) — this is what lets a
+       later Alchemy-specific failure fall back to normal provider switching.
     3. A non-FallbackProvider is not eligible.
     4. A mix without an Alchemy endpoint is not eligible (cannot fail over).
     """
@@ -65,19 +102,21 @@ def test_hyperevm_consensus_failover_negatives(goldsky_alchemy_fallback: Fallbac
     # 1. Wrong chain id
     assert resolve_hyperevm_consensus_failover(1, goldsky_alchemy_fallback, consensus_exc) is None
 
-    # 2. Wrong error type
+    # 2. Wrong error type (e.g. Alchemy throttling) — caller resumes normal switching
     assert resolve_hyperevm_consensus_failover(HYPEREVM_CHAIN_ID, goldsky_alchemy_fallback, Exception("HTTP 429 too many requests")) is None
 
-    # 3. Not a FallbackProvider (single HTTPProvider, nothing to fail over to)
-    single = HTTPProvider("https://edge.goldsky.com/x")
+    # 3. Not a FallbackProvider (single provider, nothing to fail over to)
+    single = _make_mock_provider("https://edge.goldsky.com/x", HYPEREVM_CHAIN_ID)
     assert resolve_hyperevm_consensus_failover(HYPEREVM_CHAIN_ID, single, consensus_exc) is None
 
     # 4. Mix without Alchemy — goldsky + dRPC only
     no_alchemy = FallbackProvider(
         [
-            create_http_provider("https://edge.goldsky.com/x", exception_retry_configuration=None),
-            create_http_provider("https://lb.drpc.live/x", exception_retry_configuration=None),
-        ]
+            _make_mock_provider("https://edge.goldsky.com/x", HYPEREVM_CHAIN_ID),
+            _make_mock_provider("https://lb.drpc.live/x", HYPEREVM_CHAIN_ID),
+        ],
+        sleep=0,
+        backoff=1,
     )
     assert resolve_hyperevm_consensus_failover(HYPEREVM_CHAIN_ID, no_alchemy, consensus_exc) is None
 

--- a/tests/event_reader/test_hyperevm_consensus_failover.py
+++ b/tests/event_reader/test_hyperevm_consensus_failover.py
@@ -1,0 +1,92 @@
+"""Tests for the HyperEVM goldsky eRPC consensus failover helpers.
+
+These cover the workaround for goldsky's "not enough agreement among responses"
+consensus failure on HyperEVM (chain 999), where we pin multicall retries to the
+Alchemy single node instead of cycling back onto the consensus endpoint. See
+``docs/README-hyperevm-goldsky-failure.md`` for the full failure analysis.
+
+The helpers are pure (no network), so the tests construct ``FallbackProvider``
+instances from fake RPC URLs and assert detection + pinning behaviour.
+"""
+
+import pytest
+from web3 import HTTPProvider
+
+from eth_defi.compat import create_http_provider
+from eth_defi.event_reader.multicall_batcher import (
+    ERPC_CONSENSUS_DISAGREEMENT_CLUE,
+    HYPEREVM_CHAIN_ID,
+    pin_fallback_provider_by_host,
+    resolve_hyperevm_consensus_failover,
+)
+from eth_defi.provider.fallback import FallbackProvider
+from eth_defi.provider.named import get_provider_name
+
+
+@pytest.fixture()
+def goldsky_alchemy_fallback() -> FallbackProvider:
+    """A HyperEVM-style fallback mix containing goldsky, Alchemy and dRPC."""
+    providers = [
+        create_http_provider("https://edge.goldsky.com/standard/evm/999?secret=x", exception_retry_configuration=None),
+        create_http_provider("https://hyperliquid-mainnet.g.alchemy.com/v2/key", exception_retry_configuration=None),
+        create_http_provider("https://lb.drpc.live/ogrpc?network=hyperliquid&dkey=x", exception_retry_configuration=None),
+    ]
+    return FallbackProvider(providers)
+
+
+def test_hyperevm_consensus_failover_happy_path(goldsky_alchemy_fallback: FallbackProvider):
+    """The goldsky consensus error on HyperEVM fails over to Alchemy.
+
+    1. A consensus disagreement error on chain 999 with a goldsky+Alchemy mix is detected.
+    2. The detection returns the ``"alchemy"`` host substring to pin to.
+    3. Pinning selects the Alchemy provider as the active one.
+    """
+    exception = Exception("{'code': -32603, 'message': '" + ERPC_CONSENSUS_DISAGREEMENT_CLUE + "'}")
+
+    # 1. + 2. Detected as the HyperEVM goldsky consensus failure, returns Alchemy host
+    host = resolve_hyperevm_consensus_failover(HYPEREVM_CHAIN_ID, goldsky_alchemy_fallback, exception)
+    assert host == "alchemy"
+
+    # 3. Pinning makes Alchemy the active provider
+    assert pin_fallback_provider_by_host(goldsky_alchemy_fallback, host) is True
+    assert "alchemy" in get_provider_name(goldsky_alchemy_fallback.get_active_provider()).lower()
+
+
+def test_hyperevm_consensus_failover_negatives(goldsky_alchemy_fallback: FallbackProvider):
+    """The failover stays inert outside its exact triggering conditions.
+
+    1. A different chain id is not eligible (chain 1).
+    2. A non-consensus error is not eligible (a generic 429).
+    3. A non-FallbackProvider is not eligible.
+    4. A mix without an Alchemy endpoint is not eligible (cannot fail over).
+    """
+    consensus_exc = Exception("{'message': '" + ERPC_CONSENSUS_DISAGREEMENT_CLUE + "'}")
+
+    # 1. Wrong chain id
+    assert resolve_hyperevm_consensus_failover(1, goldsky_alchemy_fallback, consensus_exc) is None
+
+    # 2. Wrong error type
+    assert resolve_hyperevm_consensus_failover(HYPEREVM_CHAIN_ID, goldsky_alchemy_fallback, Exception("HTTP 429 too many requests")) is None
+
+    # 3. Not a FallbackProvider (single HTTPProvider, nothing to fail over to)
+    single = HTTPProvider("https://edge.goldsky.com/x")
+    assert resolve_hyperevm_consensus_failover(HYPEREVM_CHAIN_ID, single, consensus_exc) is None
+
+    # 4. Mix without Alchemy — goldsky + dRPC only
+    no_alchemy = FallbackProvider(
+        [
+            create_http_provider("https://edge.goldsky.com/x", exception_retry_configuration=None),
+            create_http_provider("https://lb.drpc.live/x", exception_retry_configuration=None),
+        ]
+    )
+    assert resolve_hyperevm_consensus_failover(HYPEREVM_CHAIN_ID, no_alchemy, consensus_exc) is None
+
+
+def test_pin_fallback_provider_no_match(goldsky_alchemy_fallback: FallbackProvider):
+    """Pinning to a host not present in the mix reports failure and changes nothing.
+
+    1. Attempt to pin to a host substring that does not exist in the mix.
+    2. The call returns False so the caller can fall back to the normal switch.
+    """
+    # 1. + 2. No provider matches "infura", so pinning fails
+    assert pin_fallback_provider_by_host(goldsky_alchemy_fallback, "infura") is False


### PR DESCRIPTION
## Why

HyperEVM (Hyperliquid, chain id 999) vault scans were aborting the whole chain with eRPC `-32603 not enough agreement among responses`. The scan's primary provider is goldsky's eRPC endpoint running in **consensus mode**: it fans each `eth_call` out to ~5 upstream nodes and only returns a result when enough agree byte-for-byte. For some vaults the upstreams genuinely disagree, so every retry (including batch-size-1 and random provider switches) fails the same way and the scan bails out.

Verified on-chain (single Alchemy node vs goldsky consensus), there are two independent reasons the upstreams differ:

- **Cause A — node-dependent values:** `totalAssets()`/`convertToAssets()` on oracle-priced vaults read live HyperCore state, so each node returns a different value → consensus fails at every block including `latest`.
- **Cause B — divergent revert serialisation:** reverting probe calls are serialised as `code 3 execution reverted` on one node and `-32603 InvalidTransaction(Revert(...))` on another, past a ~tip-126 execution-state boundary. The failing scan read a block 1,232 behind the live tip.

`tryBlockAndAggregate` concatenates all sub-calls into one blob, so a single divergent sub-call poisons the whole batch.

The disagreement is **intermittent and upstream-pool driven**, not a permanent property of any address: calls that returned `NO-AGREEMENT` in one window all passed hours later with no on-chain change. So retrying the same consensus endpoint within the retry budget cannot outrun a multi-minute pool divergence, and blacklisting the (working) vaults would be wrong.

## Lessons learnt

- `not enough agreement among responses` is goldsky eRPC **consensus mode** rejecting a request because its upstream HyperEVM nodes disagree — not a per-request glitch. Retrying/backoff on the same endpoint does not help.
- On HyperEVM, `totalAssets`/`convertToAssets` for oracle vaults are non-deterministic across nodes (live HyperCore reads); and reverts serialise differently past the ~128-block execution-state window.
- The right lever is to fail off the consensus endpoint to a single node (Alchemy), which returns a usable answer without cross-node consensus — not retrying harder, not switching to almost-latest (Cause A fails at `latest` too), and not blacklisting working vaults.

## Summary

- New helpers in `eth_defi/event_reader/multicall_batcher.py`:
  - `resolve_hyperevm_consensus_failover(chain_id, provider, exception)` — returns `"alchemy"` only when chain id is 999, the error is the consensus-disagreement clue, **and** the `FallbackProvider` mix contains both a goldsky and an Alchemy endpoint; `None` otherwise (inert on every other chain/mix).
  - `pin_fallback_provider_by_host(...)` — deterministically selects a provider by host substring.
  - Constants `HYPEREVM_CHAIN_ID`, `ERPC_CONSENSUS_DISAGREEMENT_CLUE`.
- Wired into the `MulticallRetryable` retry loop: on detection, retries are pinned to the Alchemy single node; otherwise the original random switch is unchanged.
- Updated the stale `WTF_RETRY_EXCEPTIONS_MESSAGE_CLUES` comment (previously "transient and should be retried") to reflect the intermittent reality and cross-reference the new docs.
- New `docs/README-hyperevm-goldsky-failure.md` with the full failure analysis, nodes involved, and on-chain evidence; referenced from every code comment that mentions the error and added to the README table in `CLAUDE.md`.
- New `tests/event_reader/test_hyperevm_consensus_failover.py` (network-free) covering happy path, negatives, and no-match pinning.
- `CHANGELOG.md` entry.

## Related issues and PRs

- Follows #1085-era HyperEVM eRPC work: the prior `not enough agreement among responses` retry classification is kept, but this PR makes those retries productive (pin to Alchemy) instead of cycling back onto goldsky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
