### PR TITLE
fix: Stablecoin metadata/feed data consistency pass + audit script

### DIFF
--- a/eth_defi/data/feeds/stablecoins/eure.yaml
+++ b/eth_defi/data/feeds/stablecoins/eure.yaml
@@ -1,5 +1,5 @@
 feeder-id: eure
-name: Monerium EUR
+name: Monerium EUR emoney
 role: stablecoin
 website: https://monerium.com/
 twitter: monerium

--- a/eth_defi/data/feeds/stablecoins/gmdusdc.yaml
+++ b/eth_defi/data/feeds/stablecoins/gmdusdc.yaml
@@ -1,5 +1,5 @@
 feeder-id: gmdusdc
-name: GMD Protocol USDC
+name: GMD Protocol USDC Vault
 role: stablecoin
 website: https://gmdprotocol.com/
 twitter: GMDprotocol

--- a/eth_defi/data/feeds/stablecoins/jchf.yaml
+++ b/eth_defi/data/feeds/stablecoins/jchf.yaml
@@ -1,5 +1,5 @@
 feeder-id: jchf
-name: Jarvis Synthetic CHF
+name: Jarvis Synthetic Swiss Franc
 role: stablecoin
 website: https://www.jarvis.network/
 twitter: Jarvis_Network

--- a/eth_defi/data/feeds/stablecoins/msusd.yaml
+++ b/eth_defi/data/feeds/stablecoins/msusd.yaml
@@ -1,6 +1,5 @@
 feeder-id: msusd
-name: Mainstreet USD
+name: Main Street USD
 role: stablecoin
 website: https://mainstreet.finance/
-twitter: MainSt_Finance
-twitter-dead-at: 2026-04-06
+twitter: Main_St_Finance

--- a/eth_defi/data/feeds/stablecoins/sausd.yaml
+++ b/eth_defi/data/feeds/stablecoins/sausd.yaml
@@ -1,5 +1,5 @@
 feeder-id: sausd
-name: Agora AUSD
+name: Agora Savings AUSD
 role: stablecoin
 website: https://www.agora.finance/
 twitter: withAUSD

--- a/eth_defi/data/feeds/stablecoins/ysusdc.yaml
+++ b/eth_defi/data/feeds/stablecoins/ysusdc.yaml
@@ -1,5 +1,5 @@
 feeder-id: ysusdc
-name: Yearn V3 USDC Vault
+name: Yearn V3 USDC Vault Token
 role: stablecoin
 website: https://yearn.fi/
 twitter: yearnfi

--- a/eth_defi/data/stablecoins/TODO_STABLECOIN_DATA_FIXES_NEEDED.md
+++ b/eth_defi/data/stablecoins/TODO_STABLECOIN_DATA_FIXES_NEEDED.md
@@ -1,0 +1,156 @@
+# Stablecoin data fixes needed
+
+Audit of `eth_defi/data/stablecoins/*.yaml` (metadata, 198 files),
+`eth_defi/data/feeds/stablecoins/*.yaml` (feeds, 184 files) and
+`eth_defi/stablecoin_metadata.py`, performed 2026-06-10.
+
+This file lists issues that **could not be resolved automatically** and need a
+human decision or research with on-chain verification. Items already fixed in
+the same pass are listed first so reviewers know what changed.
+
+## Already fixed in this pass (no action needed)
+
+- **EIP-55 checksums** — 137 lowercase/mixed EVM addresses across 85 metadata
+  files were rewritten to checksummed form via `eth_utils.to_checksum_address`.
+  Addresses embedded in `long_description` prose and Etherscan URLs were
+  normalised too (identical bytes, harmless). Non-EVM addresses were left alone
+  (see below).
+- **Name mismatches (metadata ↔ feed)** — 6 feed `name:` fields were aligned to
+  the metadata `name:` (metadata is the single source of truth for display):
+  `eure`, `gmdusdc`, `jchf`, `msusd`, `sausd`, `ysusdc`.
+
+After these fixes all 198 metadata files load cleanly through
+`build_stablecoin_metadata_json()` and all 9 Royco denominations still resolve
+through `is_stablecoin_like()`.
+
+## 1. Missing formatted logos (13)
+
+No `formatted_logos/<slug>/light.png`. Use the `extract-project-logo` +
+`post-process-logo` skills with the homepage in each metadata file as the source.
+
+Obtainable (active projects, homepage known):
+
+| slug | symbol | logo source (homepage) |
+|------|--------|------------------------|
+| aa-falconxusdc | AA_FalconXUSDC | Idle Finance / Falcon |
+| apyusd | apyUSD | (see metadata homepage) |
+| autousd | autoUSD | Auto Finance |
+| bbqusdc | bbqUSDC | Steakhouse Financial |
+| eearn | eEARN | Ember |
+| savusd | savUSD | Avant / avUSD |
+| snusd | sNUSD | Neutrl |
+| stcusd | stcUSD | Cap |
+| syrupusdc | syrupUSDC | Maple / Syrup |
+| audt | AUDT | Anchored Coins |
+| vusd | VUSD | (multi-issuer, confirm which) |
+
+Not obtainable (unidentified placeholder tokens — leave without logo):
+`mtusd`, `usxau`.
+
+## 2. Missing contract addresses (genuinely active, ~40)
+
+These metadata files have **no `contract_addresses`** but are active projects
+that should have at least the canonical mainnet address. Needs lookup +
+on-chain `symbol()` verification before adding (do **not** add unverified
+addresses — hallucination risk):
+
+`bvusd`, `djed`, `doladusd`, `eosdt`, `feusd`, `ftusd`, `ghst`, `iusd-indigo`,
+`kdai`, `kusd`, `mtusdc`, `mtusdt`, `plusd`, `silk`, `susg`, `usc`, `usd-plus`,
+`usd-t`, `usd-t0`, `usdai`, `usdc-e`, `usdh`, `usdm`, `usds-sperax`, `usdt-e`,
+`usdt0`, `usdtb`, `usdxl`, `usg`, `ush`, `usk`, `ust`, `ustc`, `usx`, `uusd`,
+`vbusdc`, `vbusdt`, `vusd-virtue`, `vusd-vow`, `ysusdc`, `zsd`.
+
+**Correctly empty — do not "fix":**
+
+- Native gas token, no ERC-20 contract: `xdai` (Gnosis Chain native).
+- Defunct projects (address optional, low priority): `fei`, `flexusd`, `iron`,
+  `plusd-polyquity`, `tor`, `usdv`.
+- Unidentified / placeholder (cannot add): `dusd`, `mtusd`, `rusd`, `satusd`,
+  `sosusdt`, `usdf`, `usdn`, `usdx`, `meusdt`, `usxau`, `usd8`, `usdh-hubble`.
+
+## 3. Twitter & website drift (metadata ↔ feed) — RESOLVED
+
+All 30 twitter handle drifts and 6 website drifts were researched (each issuer's
+official site checked for the X handle / domain it links to) and the metadata
+side was corrected to the verified canonical value. In every case the **feed
+side was canonical** (the feed is actively curated) **except `msusd`**, where the
+metadata `@Main_St_Finance` was the real handle and the feed `@MainSt_Finance`
+was wrong — the feed was corrected and its stale `twitter-dead-at` marker (which
+referred to the wrong handle) was removed.
+
+Notable confirmations:
+
+- **Rings → Trevee** rebrand confirmed (renamed "Trevee Earn", 2025-10-20).
+  `scusd`/`plusd` metadata homepage → `trevee.xyz`, twitter → `@Trevee_xyz`,
+  in-prose `app.rings.money`/`trevee.com` links updated too.
+- Migrations to shorter handles (site-verified): Tether `@tether_to`→`@tether`,
+  Synthetix `@synthetix_io`→`@synthetix`, Ethena `@ethena_labs`→`@ethena`,
+  Paxos `@PaxosGlobal`→`@Paxos`, Mento `@MentoProtocol`→`@MentoLabs`,
+  TrueUSD `@TrueUSD`→`@tusdio` + `trueusd.com`→`tusd.io` (301 redirect),
+  Native Markets `@native_markets`→`@nativemarkets` + `.xyz`→`.com`,
+  OpenEden `@OpenEdenLabs`→`@OpenEden_X`, Mountain `@MountainPrtcl`→`@MountainUSDM`,
+  Elixir `@ElixirProtocol`→`@elixir`, EUROe `@membrane_fi`→`@EUROemoney`,
+  Fathom `@FathomProtocol`→`@Fathom_fi`, Indigo `@IndigoProtocol1`→`@Indigo_protocol`,
+  Level `@leveldotmoney`→`@levelusd`, Mimo `@mimodefi`→`@mimo_labs`,
+  VNX `@VNX_fi`→`@VNX_Platform`, TrueFi `@TrueFi_DAO`→`@TrueFiDAO`,
+  YieldNest homepage `app.yieldnest.finance`→`yieldnest.finance`.
+
+**Still open (1) — needs decision:**
+
+- `usdm-megaeth`: metadata `@megaborealeth` vs feed `@megaeth`. Research could
+  not corroborate `@megaborealeth` as the issuer's account, and `@megaeth` is the
+  MegaETH **chain** account, not a distinct USDm issuer (USDm is MegaETH's native
+  stablecoin on Ethena USDtb whitelabel rails). No clearly-correct dedicated
+  issuer handle exists — left unchanged pending a human call. Canonical site is
+  `megaeth.com`.
+
+**Minor follow-up:** `scusd` metadata `name:` is still `Rings scUSD` while its
+homepage/twitter/descriptions now reflect Trevee; consider renaming to
+`Trevee scUSD` (and matching the feed name) for consistency with `plUSD`
+(`Trevee Plasma USD`). Left as-is to avoid introducing a new name mismatch.
+
+## 4. (merged into section 3)
+
+## 5. Missing external listing links (content gap)
+
+Lower priority — fill where the listing genuinely exists.
+
+- Missing `coingecko` (42): `aa-falconxusdc, audt, autousd, bbqusdc, bvusd,
+  cnht, csusd, eearn, ftusd, gmdusdc, gmusd, kdai, meusdt, msusd, mtusd, mtusdc,
+  mtusdt, nusd, plusd-polyquity, rusd, satusd, sausd, sosusdt, susdc, susg,
+  tfusdc, usc, usd-t0, usd8, usdcv, usdf, usdh, usdh-hubble, usdm-megaeth,
+  usdt-e, usg, usxau, vbusdc, vbusdt, vusd-vesper, xusd, ysusdc`.
+- Missing `defillama` (98): see audit script output — most older entries. Many
+  yield-bearing/wrapped derivatives live under `defillama.com/rwa/asset/...` or
+  have no DeFiLlama page at all; only add real URLs.
+
+## 6. Non-EVM addresses (intentional — documented, no fix)
+
+These look "malformed" to an EVM checksum validator but are correct native
+formats. The structural audit script should be taught to skip non-EVM chains:
+
+- `fxd` → chain `xdc`, address `xdc49d3f7543335cf38Fa10889CCFF10207e22110B5`
+  (XDC Network uses the `xdc` address prefix).
+- `tcnh` → chain `tron`, address `TBqsNXUtqaLptVK8AYvdPPctpqd8oBYWUC`
+  (TRON Base58 address).
+
+## 7. Intentionally feedless (NOT bugs)
+
+14 metadata files have no matching feed YAML. All are explainable and should
+**not** get a feed:
+
+- Multi-project tickers (9, one slug = several distinct issuers, no single news
+  source): `ausd`, `dusd`, `rusd`, `satusd`, `usdn`, `usdx`, `usdf`, `yusd`,
+  `xusd`.
+- Dead / unidentified single tokens with no scannable source (5): `meusdt`,
+  `mtusd`, `onc`, `sosusdt`, `usxau`.
+
+## Reproducing the audit
+
+```shell
+poetry run python scripts/stablecoins/audit-stablecoin-data.py
+```
+
+Exits non-zero on ERROR-level findings. After this pass it reports 0 errors,
+13 warnings (all missing logos, section 1) and 50 info items (intentionally
+feedless tokens in section 7 plus the twitter/website drift in sections 3–4).

--- a/eth_defi/data/stablecoins/adai.yaml
+++ b/eth_defi/data/stablecoins/adai.yaml
@@ -22,7 +22,7 @@ long_description: |
   ## Sources
 
   - [Aave V2 documentation](https://docs.aave.com/developers/v/2.0/)
-  - [Etherscan: aDAI on Ethereum](https://etherscan.io/token/0x028171bca77440897b824ca71d1c56cac55b68a3)
+  - [Etherscan: aDAI on Ethereum](https://etherscan.io/token/0x028171bCA77440897B824Ca71D1c56caC55b68A3)
 category: yield_bearing
 links:
   homepage: https://aave.com/
@@ -32,7 +32,7 @@ links:
 slug: adai
 contract_addresses:
   - chain: ethereum
-    address: '0x028171bca77440897b824ca71d1c56cac55b68a3'
+    address: '0x028171bCA77440897B824Ca71D1c56caC55b68A3'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/ageur.yaml
+++ b/eth_defi/data/stablecoins/ageur.yaml
@@ -21,7 +21,7 @@ long_description: |
   ## Sources
 
   - [Angle Protocol documentation](https://docs.angle.money/)
-  - [Etherscan: EURA/agEUR on Ethereum](https://etherscan.io/token/0x1a7e4e63778b4f12a199c062f3efdd288afcbce8)
+  - [Etherscan: EURA/agEUR on Ethereum](https://etherscan.io/token/0x1a7e4e63778B4f12a199C062f3eFdD288afCBce8)
   - [DeFiLlama: agEUR stablecoin page](https://defillama.com/stablecoin/ageur)
 category: stablecoin
 links:
@@ -32,7 +32,7 @@ links:
 slug: ageur
 contract_addresses:
   - chain: ethereum
-    address: '0x1a7e4e63778b4f12a199c062f3efdd288afcbce8'
+    address: '0x1a7e4e63778B4f12a199C062f3eFdD288afCBce8'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/alusd.yaml
+++ b/eth_defi/data/stablecoins/alusd.yaml
@@ -18,7 +18,7 @@ long_description: |
   ## Sources
 
   - [Alchemix documentation](https://alchemix-finance.gitbook.io/user-docs/)
-  - [Etherscan: alUSD on Ethereum](https://etherscan.io/token/0xbc6da0fe9ad5f3b0d58160288917aa56653660e9)
+  - [Etherscan: alUSD on Ethereum](https://etherscan.io/token/0xBC6DA0FE9aD5f3b0d58160288917AA56653660E9)
   - [DeFiLlama: Alchemix USD](https://defillama.com/stablecoin/alchemix-usd)
 category: stablecoin
 links:
@@ -32,11 +32,11 @@ token_symbols:
 - alUSD
 contract_addresses:
   - chain: ethereum
-    address: '0xbc6da0fe9ad5f3b0d58160288917aa56653660e9'
+    address: '0xBC6DA0FE9aD5f3b0d58160288917AA56653660E9'
   - chain: arbitrum
-    address: '0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a'
+    address: '0xCB8FA9a76b8e203D8C3797bF438d8FB81Ea3326A'
   - chain: optimism
-    address: '0xcb8fa9a76b8e203d8c3797bf438d8fb81ea3326a'
+    address: '0xCB8FA9a76b8e203D8C3797bF438d8FB81Ea3326A'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/audt.yaml
+++ b/eth_defi/data/stablecoins/audt.yaml
@@ -22,7 +22,7 @@ long_description: |
   ## Sources
 
   - [Chrono.tech — AUDT](https://chrono.tech/)
-  - [Etherscan: AUDT on Ethereum](https://etherscan.io/token/0xd7e0f80fb28233bdde0006c50568606a8feb964c)
+  - [Etherscan: AUDT on Ethereum](https://etherscan.io/token/0xD7e0F80FB28233bdde0006c50568606A8feb964C)
   - [CoinMarketCap: Australian Dollar Token](https://coinmarketcap.com/currencies/australian-dollar-token/)
 category: stablecoin
 links:
@@ -33,7 +33,7 @@ links:
 slug: audt
 contract_addresses:
   - chain: ethereum
-    address: '0xd7e0f80fb28233bdde0006c50568606a8feb964c'
+    address: '0xD7e0F80FB28233bdde0006c50568606A8feb964C'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/ausd.yaml
+++ b/eth_defi/data/stablecoins/ausd.yaml
@@ -37,11 +37,11 @@ entries:
     twitter: https://x.com/AgoraCurrency
   contract_addresses:
     - chain: ethereum
-      address: '0x00000000efe302beaa2b3e6e1b18d08d69a9012a'
+      address: '0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a'
     - chain: base
-      address: '0x00000000efe302beaa2b3e6e1b18d08d69a9012a'
+      address: '0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a'
     - chain: arbitrum
-      address: '0x00000000efe302beaa2b3e6e1b18d08d69a9012a'
+      address: '0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a'
   checks:
     twitter_last_post_at: ''
     domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/avusd.yaml
+++ b/eth_defi/data/stablecoins/avusd.yaml
@@ -27,7 +27,7 @@ links:
 slug: avusd
 contract_addresses:
   - chain: avalanche
-    address: '0x24de8771bc5ddb3362db529fc3358f2df3a0e346'
+    address: '0x24dE8771bC5DdB3362Db529Fc3358F2df3A0E346'
   - chain: ethereum
     address: '0xf4c13D631450De6B12a19829E37c8e2826891dC4'
 checks:

--- a/eth_defi/data/stablecoins/bac.yaml
+++ b/eth_defi/data/stablecoins/bac.yaml
@@ -21,7 +21,7 @@ long_description: |
 
   ## Sources
 
-  - [Etherscan: BAC on Ethereum](https://etherscan.io/token/0x3449fc1cd036255ba1eb19d65ff4ba2b8903a69a)
+  - [Etherscan: BAC on Ethereum](https://etherscan.io/token/0x3449FC1Cd036255BA1EB19d65fF4BA2b8903A69a)
   - [CoinGecko: Basis Cash](https://www.coingecko.com/en/coins/basis-cash)
 category: stablecoin
 links:
@@ -32,7 +32,7 @@ links:
 slug: bac
 contract_addresses:
   - chain: ethereum
-    address: '0x3449fc1cd036255ba1eb19d65ff4ba2b8903a69a'
+    address: '0x3449FC1Cd036255BA1EB19d65fF4BA2b8903A69a'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/bdo.yaml
+++ b/eth_defi/data/stablecoins/bdo.yaml
@@ -31,7 +31,7 @@ links:
 slug: bdo
 contract_addresses:
   - chain: bnb
-    address: '0x190b589cf9fb8ddeabbfeae36a813ffb2a702454'
+    address: '0x190b589cf9Fb8DDEabBFeae36a813FFb2A702454'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/bean.yaml
+++ b/eth_defi/data/stablecoins/bean.yaml
@@ -23,7 +23,7 @@ long_description: |
   ## Sources
 
   - [Beanstalk documentation](https://docs.bean.money/)
-  - [Arbiscan: Bean on Arbitrum](https://arbiscan.io/token/0xbea0005b8599265d41256905a9b3073d397812e4)
+  - [Arbiscan: Bean on Arbitrum](https://arbiscan.io/token/0xBEA0005B8599265D41256905A9B3073D397812E4)
   - [DeFiLlama: Bean stablecoin](https://defillama.com/stablecoin/bean)
 category: stablecoin
 links:
@@ -34,7 +34,7 @@ links:
 slug: bean
 contract_addresses:
   - chain: arbitrum
-    address: '0xbea0005b8599265d41256905a9b3073d397812e4'
+    address: '0xBEA0005B8599265D41256905A9B3073D397812E4'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/blusd.yaml
+++ b/eth_defi/data/stablecoins/blusd.yaml
@@ -23,7 +23,7 @@ long_description: |
   ## Sources
 
   - [Chicken Bonds documentation](https://docs.chickenbonds.org/)
-  - [Etherscan: bLUSD on Ethereum](https://etherscan.io/token/0xb9d7dddca9a4ac480991865efef82e01273f79c3)
+  - [Etherscan: bLUSD on Ethereum](https://etherscan.io/token/0xB9D7DdDca9a4AC480991865EfEf82E01273F79C3)
 category: yield_bearing
 links:
   homepage: https://www.chickenbonds.org/
@@ -33,7 +33,7 @@ links:
 slug: blusd
 contract_addresses:
   - chain: ethereum
-    address: '0xb9d7dddca9a4ac480991865efef82e01273f79c3'
+    address: '0xB9D7DdDca9a4AC480991865EfEf82E01273F79C3'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/bob.yaml
+++ b/eth_defi/data/stablecoins/bob.yaml
@@ -23,7 +23,7 @@ long_description: |
   ## Sources
 
   - [zkBob documentation](https://docs.zkbob.com/)
-  - [Etherscan: BOB on Ethereum](https://etherscan.io/token/0xb0b195aefa3650a6908f15cdac7d92f8a5791b0b)
+  - [Etherscan: BOB on Ethereum](https://etherscan.io/token/0xB0B195aEFA3650A6908f15CdaC7D92F8a5791B0B)
   - [DeFiLlama: BOB](https://defillama.com/stablecoin/bob)
 category: stablecoin
 links:
@@ -34,9 +34,9 @@ links:
 slug: bob
 contract_addresses:
   - chain: ethereum
-    address: '0xb0b195aefa3650a6908f15cdac7d92f8a5791b0b'
+    address: '0xB0B195aEFA3650A6908f15CdaC7D92F8a5791B0B'
   - chain: polygon
-    address: '0xb0b195aefa3650a6908f15cdac7d92f8a5791b0b'
+    address: '0xB0B195aEFA3650A6908f15CdaC7D92F8a5791B0B'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/bold.yaml
+++ b/eth_defi/data/stablecoins/bold.yaml
@@ -19,7 +19,7 @@ long_description: |
   ## Sources
 
   - [Liquity V2 documentation](https://docs.liquity.org/)
-  - [Etherscan: BOLD on Ethereum](https://etherscan.io/token/0x6440f144b7e50d6a8439336510312d2f54beb01d)
+  - [Etherscan: BOLD on Ethereum](https://etherscan.io/token/0x6440f144b7e50D6a8439336510312d2F54beB01D)
   - [DeFiLlama: Liquity BOLD](https://defillama.com/stablecoin/liquity-bold)
 category: stablecoin
 links:
@@ -30,7 +30,7 @@ links:
 slug: bold
 contract_addresses:
   - chain: ethereum
-    address: '0x6440f144b7e50d6a8439336510312d2f54beb01d'
+    address: '0x6440f144b7e50D6a8439336510312d2F54beB01D'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/busd.yaml
+++ b/eth_defi/data/stablecoins/busd.yaml
@@ -16,7 +16,7 @@ long_description: |
 
   ## Sources
 
-  - [Etherscan: BUSD on Ethereum](https://etherscan.io/token/0x4fabb145d64652a948d72533023f6e7a623c7c53)
+  - [Etherscan: BUSD on Ethereum](https://etherscan.io/token/0x4Fabb145d64652a948d72533023f6E7A623C7C53)
   - [DeFiLlama: Binance USD](https://defillama.com/stablecoin/binance-usd)
 category: stablecoin
 links:
@@ -27,7 +27,7 @@ links:
 slug: busd
 contract_addresses:
   - chain: ethereum
-    address: '0x4fabb145d64652a948d72533023f6e7a623c7c53'
+    address: '0x4Fabb145d64652a948d72533023f6E7A623C7C53'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/byusd.yaml
+++ b/eth_defi/data/stablecoins/byusd.yaml
@@ -39,7 +39,7 @@ links:
 slug: byusd
 contract_addresses:
   - chain: berachain
-    address: '0x688e72142674041f8f6af4c808a4045ca1d6ac82'
+    address: '0x688e72142674041f8f6Af4c808a4045cA1D6aC82'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/cadc.yaml
+++ b/eth_defi/data/stablecoins/cadc.yaml
@@ -15,7 +15,7 @@ long_description: |
 
   ## Sources
 
-  - [Etherscan: CADC on Ethereum](https://etherscan.io/token/0xcadc0acd4b445166f12d2c07eac6e2544fbe2eef)
+  - [Etherscan: CADC on Ethereum](https://etherscan.io/token/0xcaDC0acd4B445166f12d2C07EAc6E2544FbE2Eef)
   - [CoinGecko: CAD Coin](https://www.coingecko.com/en/coins/cad-coin)
 category: stablecoin
 links:
@@ -26,13 +26,13 @@ links:
 slug: cadc
 contract_addresses:
   - chain: ethereum
-    address: '0xcadc0acd4b445166f12d2c07eac6e2544fbe2eef'
+    address: '0xcaDC0acd4B445166f12d2C07EAc6E2544FbE2Eef'
   - chain: base
-    address: '0x043eb4b75d0805c43d7c834902e335621983cf03'
+    address: '0x043eB4B75d0805c43D7C834902E335621983Cf03'
   - chain: arbitrum
-    address: '0x2b28e826b55e399f4d4699b85f68666ac51e6f70'
+    address: '0x2b28E826b55e399F4d4699b85f68666AC51e6f70'
   - chain: polygon
-    address: '0x9de41aff9f55219d5bf4359f167d1d0c772a396d'
+    address: '0x9de41aFF9f55219D5bf4359F167d1D0c772A396D'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/cdai.yaml
+++ b/eth_defi/data/stablecoins/cdai.yaml
@@ -22,7 +22,7 @@ long_description: |
   ## Sources
 
   - [Compound V2 documentation](https://docs.compound.finance/v2/)
-  - [Etherscan: cDAI on Ethereum](https://etherscan.io/token/0x5d3a536e4d6dbd6114cc1ead35777bab948e3643)
+  - [Etherscan: cDAI on Ethereum](https://etherscan.io/token/0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643)
 category: yield_bearing
 links:
   homepage: https://compound.finance/
@@ -32,7 +32,7 @@ links:
 slug: cdai
 contract_addresses:
   - chain: ethereum
-    address: '0x5d3a536e4d6dbd6114cc1ead35777bab948e3643'
+    address: '0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/ceur.yaml
+++ b/eth_defi/data/stablecoins/ceur.yaml
@@ -23,11 +23,11 @@ links:
   homepage: https://mento.org/
   coingecko: https://www.coingecko.com/en/coins/celo-euro
   defillama: https://defillama.com/stablecoin/celo-euro
-  twitter: https://x.com/MentoProtocol
+  twitter: https://x.com/MentoLabs
 slug: ceur
 contract_addresses:
   - chain: celo
-    address: '0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73'
+    address: '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/cjpy.yaml
+++ b/eth_defi/data/stablecoins/cjpy.yaml
@@ -16,7 +16,7 @@ long_description: |
 
   ## Sources
 
-  - [Etherscan: CJPY on Ethereum](https://etherscan.io/token/0x1cfa5641c01406ab8ac350ded7d735ec41298372)
+  - [Etherscan: CJPY on Ethereum](https://etherscan.io/token/0x1cfa5641c01406aB8AC350dEd7d735ec41298372)
   - [CoinGecko: Convertible JPY Token](https://www.coingecko.com/en/coins/convertible-jpy-token)
 category: stablecoin
 links:
@@ -27,7 +27,7 @@ links:
 slug: cjpy
 contract_addresses:
   - chain: ethereum
-    address: '0x1cfa5641c01406ab8ac350ded7d735ec41298372'
+    address: '0x1cfa5641c01406aB8AC350dEd7d735ec41298372'
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/cnht.yaml
+++ b/eth_defi/data/stablecoins/cnht.yaml
@@ -19,17 +19,17 @@ long_description: |
 
   ## Sources
 
-  - [Etherscan: CNHT on Ethereum](https://etherscan.io/token/0x6e109e9dd7fa1a58bc3eff667e8e41fc3cc07aef)
+  - [Etherscan: CNHT on Ethereum](https://etherscan.io/token/0x6E109E9dD7Fa1a58BC3eff667e8e41fC3cc07AEF)
 category: stablecoin
 links:
   homepage: https://tether.to/
   coingecko: ''
   defillama: ''
-  twitter: https://x.com/Tether_to
+  twitter: https://x.com/tether
 slug: cnht
 contract_addresses:
   - chain: ethereum
-    address: '0x6e109e9dd7fa1a58bc3eff667e8e41fc3cc07aef'
+    address: '0x6E109E9dD7Fa1a58BC3eff667e8e41fC3cc07AEF'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/crvusd.yaml
+++ b/eth_defi/data/stablecoins/crvusd.yaml
@@ -19,7 +19,7 @@ long_description: |
   ## Sources
 
   - [Curve crvUSD documentation](https://resources.curve.fi/crvusd/understanding-crvusd/)
-  - [Etherscan: crvUSD on Ethereum](https://etherscan.io/token/0xf939e0a03fb07f59a73314e73794be0e57ac1b4e)
+  - [Etherscan: crvUSD on Ethereum](https://etherscan.io/token/0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E)
   - [DeFiLlama: crvUSD](https://defillama.com/stablecoin/crvusd)
 category: stablecoin
 links:
@@ -33,7 +33,7 @@ token_symbols:
 - crvUSD
 contract_addresses:
   - chain: ethereum
-    address: '0xf939e0a03fb07f59a73314e73794be0e57ac1b4e'
+    address: '0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/csusd.yaml
+++ b/eth_defi/data/stablecoins/csusd.yaml
@@ -34,7 +34,7 @@ links:
   twitter: https://x.com/csigmafinance
 contract_addresses:
   - chain: ethereum
-    address: '0xd5d097f278a735d0a3c609deee71234cac14b47e'
+    address: '0xD5D097F278a735d0a3c609DEEE71234CAc14B47e'
 slug: csusd
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/cusd.yaml
+++ b/eth_defi/data/stablecoins/cusd.yaml
@@ -24,11 +24,11 @@ links:
   homepage: https://mento.org/
   coingecko: https://www.coingecko.com/en/coins/celo-dollar
   defillama: https://defillama.com/stablecoin/celo-dollar
-  twitter: https://x.com/MentoProtocol
+  twitter: https://x.com/MentoLabs
 slug: cusd
 contract_addresses:
   - chain: celo
-    address: '0x765de816845861e75a25fca122bb6898b8b1282a'
+    address: '0x765DE816845861e75A25fCA122bb6898B8B1282a'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/cusdc.yaml
+++ b/eth_defi/data/stablecoins/cusdc.yaml
@@ -22,7 +22,7 @@ long_description: |
   ## Sources
 
   - [Compound V2 documentation](https://docs.compound.finance/v2/)
-  - [Etherscan: cUSDC on Ethereum](https://etherscan.io/token/0x39aa39c021dfbae8fac545936693ac917d5e7563)
+  - [Etherscan: cUSDC on Ethereum](https://etherscan.io/token/0x39AA39c021dfbaE8faC545936693aC917d5E7563)
 category: yield_bearing
 links:
   homepage: https://compound.finance/
@@ -32,7 +32,7 @@ links:
 slug: cusdc
 contract_addresses:
   - chain: ethereum
-    address: '0x39aa39c021dfbae8fac545936693ac917d5e7563'
+    address: '0x39AA39c021dfbaE8faC545936693aC917d5E7563'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/cusdt.yaml
+++ b/eth_defi/data/stablecoins/cusdt.yaml
@@ -18,7 +18,7 @@ links:
   twitter: https://x.com/compoundfinance
 contract_addresses:
   - chain: ethereum
-    address: '0xf650c3d88d12db855b8bf7d11be6c55a4e07dcc9'
+    address: '0xf650C3d88D12dB855b8bf7D11Be6C55A4e07dCC9'
 slug: cusdt
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/dai.yaml
+++ b/eth_defi/data/stablecoins/dai.yaml
@@ -20,7 +20,7 @@ links:
   twitter: https://x.com/MakerDAO
 contract_addresses:
   - chain: ethereum
-    address: '0x6b175474e89094c44da98b954eedeac495271d0f'
+    address: '0x6B175474E89094C44Da98b954EedeAC495271d0F'
 slug: dai
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/deusd.yaml
+++ b/eth_defi/data/stablecoins/deusd.yaml
@@ -13,10 +13,10 @@ links:
   homepage: https://www.elixir.xyz/
   coingecko: https://www.coingecko.com/en/coins/elixir-deusd
   defillama: https://defillama.com/stablecoin/elixir-deusd
-  twitter: https://x.com/ElixirProtocol
+  twitter: https://x.com/elixir
 contract_addresses:
   - chain: ethereum
-    address: '0x15700b564ca08d9439c58ca5053166e8317aa138'
+    address: '0x15700B564Ca08D9439C58cA5053166E8317aa138'
 slug: deusd
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/dola.yaml
+++ b/eth_defi/data/stablecoins/dola.yaml
@@ -20,7 +20,7 @@ links:
   twitter: https://x.com/InverseFinance
 contract_addresses:
   - chain: ethereum
-    address: '0x865377367054516e17014ccded1e7d814edc9ce4'
+    address: '0x865377367054516e17014CcdED1e7d814EDC9ce4'
 slug: dola
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/dusd.yaml
+++ b/eth_defi/data/stablecoins/dusd.yaml
@@ -34,7 +34,7 @@ entries:
     - [The Block: DefiDollar raises $1.2M](https://www.theblock.co/post/82682/defidollar-stablecoin-usd-funding-round)
     - [Medium: A Curvy DefiDollar](https://medium.com/defidollar/a-curvy-defidollar-c249438c154a)
     - [CoinGecko: DefiDollar](https://www.coingecko.com/en/coins/defidollar)
-    - [Etherscan: DFD governance token](https://etherscan.io/token/0x20c36f062a31865bed8a5b1e512d9a1a20aa333a)
+    - [Etherscan: DFD governance token](https://etherscan.io/token/0x20c36f062a31865bED8a5B1e512D9a1A20AA333A)
   links:
     homepage: https://dusd.finance/
     coingecko: https://www.coingecko.com/en/coins/defidollar

--- a/eth_defi/data/stablecoins/eura.yaml
+++ b/eth_defi/data/stablecoins/eura.yaml
@@ -18,7 +18,7 @@ links:
   twitter: https://x.com/AngleProtocol
 contract_addresses:
   - chain: ethereum
-    address: '0x1a7e4e63778b4f12a199c062f3efdd288afcbce8'
+    address: '0x1a7e4e63778B4f12a199C062f3eFdD288afCBce8'
 slug: eura
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/eurcv.yaml
+++ b/eth_defi/data/stablecoins/eurcv.yaml
@@ -18,7 +18,7 @@ links:
   twitter: https://x.com/SG_FORGE
 contract_addresses:
   - chain: ethereum
-    address: '0x5f7827fdeb7c20b443265fc2f40845b715385ff2'
+    address: '0x5F7827FDeb7c20b443265Fc2F40845B715385Ff2'
 slug: eurcv
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/eure.yaml
+++ b/eth_defi/data/stablecoins/eure.yaml
@@ -18,7 +18,7 @@ links:
   twitter: https://x.com/monerium
 contract_addresses:
   - chain: ethereum
-    address: '0x39b8b6385416f4ca36a20319f70d28621895279d'
+    address: '0x39b8B6385416f4cA36a20319F70D28621895279D'
 slug: eure
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/euroc.yaml
+++ b/eth_defi/data/stablecoins/euroc.yaml
@@ -18,7 +18,7 @@ links:
   twitter: https://x.com/circle
 contract_addresses:
   - chain: ethereum
-    address: '0x1abaea1f7c830bd89acc67ec4af516284b1bc33c'
+    address: '0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c'
 slug: euroc
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/euroe.yaml
+++ b/eth_defi/data/stablecoins/euroe.yaml
@@ -23,10 +23,10 @@ links:
   homepage: https://www.euroe.com/
   coingecko: https://www.coingecko.com/en/coins/euroe-stablecoin
   defillama: https://defillama.com/stablecoin/euroe-stablecoin
-  twitter: https://x.com/membrane_fi
+  twitter: https://x.com/EUROemoney
 contract_addresses:
   - chain: ethereum
-    address: '0x820802fa8a99901f52e39acd21177b0be6ee2974'
+    address: '0x820802Fa8a99901F52e39acD21177b0BE6EE2974'
 slug: euroe
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/eurs.yaml
+++ b/eth_defi/data/stablecoins/eurs.yaml
@@ -18,7 +18,7 @@ links:
   twitter: https://x.com/stasisnet
 contract_addresses:
   - chain: ethereum
-    address: '0xdb25f211ab05b1c97d595516f45794528a807ad8'
+    address: '0xdB25f211AB05b1c97D595516F45794528a807ad8'
 slug: eurs
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/eurt.yaml
+++ b/eth_defi/data/stablecoins/eurt.yaml
@@ -15,10 +15,10 @@ links:
   homepage: https://tether.to/
   coingecko: https://www.coingecko.com/en/coins/tether-eurt
   defillama: https://defillama.com/stablecoin/tether-eurt
-  twitter: https://x.com/Tether_to
+  twitter: https://x.com/tether
 contract_addresses:
   - chain: ethereum
-    address: '0xc581b735a1688071a1746c968e0798d642ede491'
+    address: '0xC581b735A1688071A1746c968e0798D642EDE491'
 slug: eurt
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/eusd-reserve.yaml
+++ b/eth_defi/data/stablecoins/eusd-reserve.yaml
@@ -2,7 +2,7 @@ symbol: EUSD
 name: Reserve Protocol eUSD
 short_description: Electronic USD (eUSD) is a decentralised, asset-backed stablecoin built on Reserve Protocol. It is backed by a diversified basket of yield-bearing stablecoins and is fully collateralised. eUSD is available on Ethereum.
 long_description: |
-  [Electronic USD](https://app.reserve.org/ethereum/token/0xa0d69e286b938e21cbf7e51d71f6a4c8918f482f/overview) is an RToken issued on the [Reserve Protocol](https://reserve.org/), a permissionless framework for creating asset-backed stablecoins.
+  [Electronic USD](https://app.reserve.org/ethereum/token/0xA0d69E286B938e21CBf7E51D71F6A4c8918f482F/overview) is an RToken issued on the [Reserve Protocol](https://reserve.org/), a permissionless framework for creating asset-backed stablecoins.
   It is backed 1:1 by a basket of yield-bearing stablecoin derivatives including aUSDC (Aave USDC), cUSDC (Compound USDC), aUSDT, and cUSDT.
   An over-collateralisation buffer of RSR (Reserve Rights) tokens provides additional protection.
 
@@ -13,13 +13,13 @@ long_description: |
   **Note:** The symbol EUSD is also used by [Lybra Finance's eUSD](https://lybra.finance/) — see `eusd.yaml`.
 category: stablecoin
 links:
-  homepage: https://app.reserve.org/ethereum/token/0xa0d69e286b938e21cbf7e51d71f6a4c8918f482f/overview
+  homepage: https://app.reserve.org/ethereum/token/0xA0d69E286B938e21CBf7E51D71F6A4c8918f482F/overview
   coingecko: https://www.coingecko.com/en/coins/electronic-usd
   defillama: https://defillama.com/stablecoin/electronic-usd
   twitter: https://x.com/reserveprotocol
 contract_addresses:
   - chain: ethereum
-    address: '0xa0d69e286b938e21cbf7e51d71f6a4c8918f482f'
+    address: '0xA0d69E286B938e21CBf7E51D71F6A4c8918f482F'
 slug: eusd-reserve
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/eusd.yaml
+++ b/eth_defi/data/stablecoins/eusd.yaml
@@ -22,7 +22,7 @@ links:
   twitter: https://x.com/LybraFinance
 contract_addresses:
   - chain: ethereum
-    address: '0x97de57ec338ab5d51557da3434828c5dbfada371'
+    address: '0x97de57eC338AB5d51557DA3434828C5DbFaDA371'
 slug: eusd
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/fdusd.yaml
+++ b/eth_defi/data/stablecoins/fdusd.yaml
@@ -16,9 +16,9 @@ links:
   twitter: https://x.com/FDLabsHQ
 contract_addresses:
   - chain: ethereum
-    address: '0xc5f0f7b66764f6ec8c8dff7ba683102295e16409'
+    address: '0xc5f0f7b66764F6ec8C8Dff7BA683102295E16409'
   - chain: binance
-    address: '0xc5f0f7b66764f6ec8c8dff7ba683102295e16409'
+    address: '0xc5f0f7b66764F6ec8C8Dff7BA683102295E16409'
 slug: fdusd
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/frax.yaml
+++ b/eth_defi/data/stablecoins/frax.yaml
@@ -22,7 +22,7 @@ links:
   twitter: https://x.com/fraxfinance
 contract_addresses:
   - chain: ethereum
-    address: '0x853d955acef822db058eb8505911ed77f175b99e'
+    address: '0x853d955aCEf822Db058eb8505911ED77F175b99e'
 slug: frax
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/frxusd.yaml
+++ b/eth_defi/data/stablecoins/frxusd.yaml
@@ -18,7 +18,7 @@ links:
   twitter: https://x.com/fraxfinance
 contract_addresses:
   - chain: ethereum
-    address: '0xcacd6fd266af91b8aed52accc382b4e165586e29'
+    address: '0xCAcd6fd266aF91b8AeD52aCCc382b4e165586E29'
 slug: frxusd
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/fusd.yaml
+++ b/eth_defi/data/stablecoins/fusd.yaml
@@ -7,7 +7,7 @@ long_description: |
   minted by depositing FTM as collateral into the Fantom DeFi suite. It was pegged to the US dollar through an
   overcollateralisation mechanism. The project is now defunct following the broader wind-down of the original
   Fantom DeFi ecosystem. The Fantom blockchain itself later rebranded and upgraded to [Sonic](https://soniclabs.com/).
-  The token contract on Fantom at address `0xAD84341756Bf337f5a0164515b1f6F993D194E1f` is no longer actively
+  The token contract on Fantom at address `0xAd84341756Bf337f5a0164515b1f6F993D194E1f` is no longer actively
   supported.
 category: stablecoin
 links:
@@ -17,7 +17,7 @@ links:
   twitter: https://x.com/FantomFDN
 contract_addresses:
   - chain: fantom
-    address: '0xAD84341756Bf337f5a0164515b1f6F993D194E1f'
+    address: '0xAd84341756Bf337f5a0164515b1f6F993D194E1f'
 slug: fusd
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/fxd.yaml
+++ b/eth_defi/data/stablecoins/fxd.yaml
@@ -13,7 +13,7 @@ links:
   homepage: https://fathom.fi/
   coingecko: https://www.coingecko.com/en/coins/fathom-dollar
   defillama: https://defillama.com/stablecoin/fathom-dollar
-  twitter: https://x.com/FathomProtocol
+  twitter: https://x.com/Fathom_fi
 contract_addresses:
   - chain: xdc
     address: 'xdc49d3f7543335cf38Fa10889CCFF10207e22110B5'

--- a/eth_defi/data/stablecoins/gdai.yaml
+++ b/eth_defi/data/stablecoins/gdai.yaml
@@ -33,7 +33,7 @@ long_description: |
 
   - [Gains Network gToken vaults docs](https://docs.gains.trade/liquidity-farming-pools/gtoken-vaults)
   - [Medium — Introducing gToken Vaults](https://medium.com/gains-network/introducing-gtoken-vaults-ea98f10a49d5)
-  - [Arbiscan — gDAI token](https://arbiscan.io/token/0xd85e038593d7a098614721eae955ec2022b9b91b)
+  - [Arbiscan — gDAI token](https://arbiscan.io/token/0xd85E038593d7A098614721EaE955EC2022B9B91B)
 category: wrapped
 links:
   homepage: https://gains.trade/

--- a/eth_defi/data/stablecoins/gmdusdc.yaml
+++ b/eth_defi/data/stablecoins/gmdusdc.yaml
@@ -42,7 +42,7 @@ links:
   twitter: https://x.com/GMDprotocol
 contract_addresses:
   - chain: arbitrum
-    address: '0x3DB4B7DA67dd5aF61Cb9b3C70501B1BdB24B2C22'
+    address: '0x3DB4B7DA67dd5aF61Cb9b3C70501B1BdB24b2C22'
 slug: gmdusdc
 checks:
   twitter_last_post_at: '2024-01-24'

--- a/eth_defi/data/stablecoins/gmusd.yaml
+++ b/eth_defi/data/stablecoins/gmusd.yaml
@@ -23,7 +23,7 @@ links:
   twitter: https://x.com/GNDProtocol
 contract_addresses:
   - chain: arbitrum
-    address: '0xeC13336BBD50790a00CDc0FEDdF11287eAf92529'
+    address: '0xEC13336bbd50790a00CDc0fEddF11287eaF92529'
 slug: gmusd
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/gusd.yaml
+++ b/eth_defi/data/stablecoins/gusd.yaml
@@ -22,7 +22,7 @@ long_description: |
   - [Gemini Dollar overview](https://www.gemini.com/dollar)
   - [Gemini cryptopedia: GUSD](https://www.gemini.com/cryptopedia/gusd-stablecoin-gemini-dollar)
   - [CoinGecko: Gemini Dollar](https://www.coingecko.com/en/coins/gemini-dollar)
-  - [Etherscan: GUSD token](https://etherscan.io/token/0x056Fd409E1d7A124Bd7017459dFEa2F387b6d5Cd)
+  - [Etherscan: GUSD token](https://etherscan.io/token/0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd)
 category: stablecoin
 links:
   homepage: https://gemini.com/dollar
@@ -31,7 +31,7 @@ links:
   twitter: https://x.com/Gemini
 contract_addresses:
   - chain: ethereum
-    address: '0x056Fd409E1d7A124Bd7017459dFEa2F387b6d5Cd'
+    address: '0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd'
 slug: gusd
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/gyd.yaml
+++ b/eth_defi/data/stablecoins/gyd.yaml
@@ -38,7 +38,7 @@ long_description: |
   - [CoinDesk — GYD goes live on Ethereum mainnet](https://www.coindesk.com/markets/2023/12/07/galaxy-backed-gyroscopes-all-weather-decentralized-stablecoin-goes-live-on-ethereum-mainnet/)
   - [Consensys — Gyroscope overview](https://consensys.io/blog/gyroscope-a-self-stabilizing-all-weather-reserve-backed-stablecoin)
   - [Gyroscope docs — GYFI tokenomics](https://docs.gyro.finance/governance/gyfi-tokenomics)
-  - [Etherscan — GYD token](https://etherscan.io/token/0xe07F9D810A48ab5c3C914BA3cA53AF14E4491e8A)
+  - [Etherscan — GYD token](https://etherscan.io/token/0xe07F9D810a48ab5c3c914BA3cA53AF14E4491e8A)
 category: stablecoin
 links:
   homepage: https://www.gyro.finance/
@@ -47,9 +47,9 @@ links:
   twitter: https://x.com/GyroscopeFi
 contract_addresses:
   - chain: ethereum
-    address: '0xe07F9D810A48ab5c3C914BA3cA53AF14E4491e8A'
+    address: '0xe07F9D810a48ab5c3c914BA3cA53AF14E4491e8A'
   - chain: arbitrum
-    address: '0xCA5d8F8A8d49439357d3CF46Ca2e720702F132b8'
+    address: '0xCA5d8F8a8d49439357d3CF46Ca2e720702F132b8'
 slug: gyd
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/gyen.yaml
+++ b/eth_defi/data/stablecoins/gyen.yaml
@@ -27,7 +27,7 @@ long_description: |
 
   - [GYEN official site](https://stablecoin.z.com/gyen/)
   - [CoinGecko — GYEN](https://www.coingecko.com/en/coins/gyen)
-  - [Etherscan — GYEN](https://etherscan.io/token/0xC08512927D12348F6620a698105e1BaAc6EcD911)
+  - [Etherscan — GYEN](https://etherscan.io/token/0xC08512927D12348F6620a698105e1BAac6EcD911)
 category: stablecoin
 links:
   homepage: https://stablecoin.z.com/gyen
@@ -36,7 +36,7 @@ links:
   twitter: https://x.com/GMOTrust
 contract_addresses:
   - chain: ethereum
-    address: '0xC08512927D12348F6620a698105e1BaAc6EcD911'
+    address: '0xC08512927D12348F6620a698105e1BAac6EcD911'
 slug: gyen
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/husd.yaml
+++ b/eth_defi/data/stablecoins/husd.yaml
@@ -15,7 +15,7 @@ links:
   twitter: https://x.com/Stablecoin_HUSD
 contract_addresses:
   - chain: ethereum
-    address: '0xdF574c24545E5FfEcb9a659C229253D4111d87e1'
+    address: '0xdF574c24545E5FfEcb9a659c229253D4111d87e1'
 slug: husd
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/iusd-indigo.yaml
+++ b/eth_defi/data/stablecoins/iusd-indigo.yaml
@@ -42,7 +42,7 @@ links:
   homepage: https://indigoprotocol.io/
   coingecko: https://www.coingecko.com/en/coins/indigo-protocol-iusd
   defillama: ''
-  twitter: https://x.com/IndigoProtocol1
+  twitter: https://x.com/Indigo_protocol
 slug: iusd-indigo
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/iusd.yaml
+++ b/eth_defi/data/stablecoins/iusd.yaml
@@ -24,7 +24,7 @@ links:
   twitter: https://x.com/infinifilabs
 contract_addresses:
   - chain: ethereum
-    address: '0x48f9e38f3070ad8945dfeae3fa70987722e3d89c'
+    address: '0x48f9e38f3070AD8945DFEae3FA70987722E3D89c'
 slug: iusd
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/jchf.yaml
+++ b/eth_defi/data/stablecoins/jchf.yaml
@@ -22,7 +22,7 @@ long_description: |
   - [Jarvis Network](https://www.jarvis.network/)
   - [Jarvis Network: jFIAT minting overview](https://learn.jarvis.network/protocol-overview/minting)
   - [CoinGecko: Jarvis Synthetic Swiss Franc](https://www.coingecko.com/en/coins/jarvis-synthetic-swiss-franc)
-  - [Etherscan: jCHF token](https://etherscan.io/token/0x53dFEa0a8CC2A2a2e425E1C174Bc162999723ea0)
+  - [Etherscan: jCHF token](https://etherscan.io/token/0x53dfEa0A8CC2A2A2e425E1C174Bc162999723ea0)
 category: stablecoin
 links:
   homepage: https://www.jarvis.network/
@@ -31,7 +31,7 @@ links:
   twitter: https://x.com/Jarvis_Network
 contract_addresses:
   - chain: ethereum
-    address: '0x53dFEa0a8CC2A2a2e425E1C174Bc162999723ea0'
+    address: '0x53dfEa0A8CC2A2A2e425E1C174Bc162999723ea0'
 slug: jchf
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/jeur.yaml
+++ b/eth_defi/data/stablecoins/jeur.yaml
@@ -31,7 +31,7 @@ long_description: |
   ## Sources
 
   - [Jarvis Network — Synthereum docs](https://learn.jarvis.network/)
-  - [Etherscan — jEUR token](https://etherscan.io/token/0x0f17BC9a994b87b5225cFb6a2CD4D667ADB4F20B)
+  - [Etherscan — jEUR token](https://etherscan.io/token/0x0f17BC9a994b87b5225cFb6a2Cd4D667ADb4F20B)
   - [CoinTelegraph — Jarvis jFIAT stablecoins](https://cointelegraph.com/press-releases/jarvis-network-launches-liquid-cad-sgd-and-php-stablecoins-on-polygon)
 category: stablecoin
 links:
@@ -41,7 +41,7 @@ links:
   twitter: https://x.com/Jarvis_Network
 contract_addresses:
   - chain: ethereum
-    address: '0x0f17BC9a994b87b5225cFb6a2CD4D667ADB4F20B'
+    address: '0x0f17BC9a994b87b5225cFb6a2Cd4D667ADb4F20B'
 slug: jeur
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/jpyc.yaml
+++ b/eth_defi/data/stablecoins/jpyc.yaml
@@ -27,7 +27,7 @@ long_description: |
 
   - [JPYC official site](https://jpyc.jp/)
   - [CoinGecko — JPYC](https://www.coingecko.com/en/coins/jpyc)
-  - [Etherscan — JPYC](https://etherscan.io/token/0x431D5dfF03120AFA4bDF332c61A6e1766eF37BDB)
+  - [Etherscan — JPYC](https://etherscan.io/token/0x431D5dfF03120AFA4bDf332c61A6e1766eF37BDB)
 category: stablecoin
 links:
   homepage: https://jpyc.jp/
@@ -36,7 +36,7 @@ links:
   twitter: https://x.com/jpy_coin
 contract_addresses:
   - chain: ethereum
-    address: '0x431D5dfF03120AFA4bDF332c61A6e1766eF37BDB'
+    address: '0x431D5dfF03120AFA4bDf332c61A6e1766eF37BDB'
 slug: jpyc
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/lvlusd.yaml
+++ b/eth_defi/data/stablecoins/lvlusd.yaml
@@ -28,7 +28,7 @@ links:
   homepage: https://www.level.money/
   coingecko: https://www.coingecko.com/en/coins/level-usd
   defillama: ''
-  twitter: https://x.com/leveldotmoney
+  twitter: https://x.com/levelusd
 contract_addresses:
   - chain: ethereum
     address: '0x7C1156E515aA1A2E851674120074968C905aAF37'

--- a/eth_defi/data/stablecoins/meusdt.yaml
+++ b/eth_defi/data/stablecoins/meusdt.yaml
@@ -14,7 +14,7 @@ long_description: |
 
   ## Sources
 
-  - [Etherscan — Curve ROMEUSDT Pool](https://etherscan.io/token/0xf0909ea2428bbba587797d6874a3f611b31d907c)
+  - [Etherscan — Curve ROMEUSDT Pool](https://etherscan.io/token/0xF0909Ea2428bBBA587797D6874a3F611B31d907c)
 category: stablecoin
 links:
   homepage: ''

--- a/eth_defi/data/stablecoins/msusd.yaml
+++ b/eth_defi/data/stablecoins/msusd.yaml
@@ -19,7 +19,7 @@ long_description: |
   ## Sources
 
   - [Main Street Finance](https://mainstreet.finance/)
-  - [Etherscan — msUSD](https://etherscan.io/token/0x4ba01f22827018b4772cd326c7627fb4956a7c00)
+  - [Etherscan — msUSD](https://etherscan.io/token/0x4ba01f22827018b4772CD326C7627FB4956A7C00)
 category: stablecoin
 links:
   homepage: https://mainstreet.finance/
@@ -28,7 +28,7 @@ links:
   twitter: https://x.com/Main_St_Finance
 contract_addresses:
   - chain: ethereum
-    address: '0x4ba01f22827018b4772cd326c7627fb4956a7c00'
+    address: '0x4ba01f22827018b4772CD326C7627FB4956A7C00'
 slug: msusd
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/nusd.yaml
+++ b/eth_defi/data/stablecoins/nusd.yaml
@@ -15,13 +15,13 @@ long_description: |
 
   ## Key contracts (Ethereum)
 
-  - NUSD: `0xE556ABa6fe6036275ec1f87eda296be72c811bce`
-  - sNUSD: `0x08EFCC2F3e61185d0ea7f8830b3fec9bfa2ee313`
+  - NUSD: `0xE556ABa6fe6036275Ec1f87eda296BE72C811BCE`
+  - sNUSD: `0x08EFCC2F3e61185D0EA7F8830B3FEc9Bfa2EE313`
 
   ## Note on NUSD duplicates
 
   There is also a separate legacy token, **Neutral Dollar (NUSD)** by Neutral Project
-  (`0x0C6144c16af288948c8fdb37fd8fec94bff3d1d9`), a stablecoin basket project from 2018–2019
+  (`0x0C6144c16af288948C8fdB37fD8fEc94bfF3d1d9`), a stablecoin basket project from 2018–2019
   that is now defunct (22,096 tokens, 97 holders, no activity).
 
   ## Status
@@ -33,7 +33,7 @@ long_description: |
 
   - [Neutrl](https://neutrl.fi/)
   - [Neutrl docs — contract addresses](https://docs.neutrl.fi/resources-and-ecosystem/addresses)
-  - [Etherscan — NUSD](https://etherscan.io/token/0xE556ABa6fe6036275ec1f87eda296be72c811bce)
+  - [Etherscan — NUSD](https://etherscan.io/token/0xE556ABa6fe6036275Ec1f87eda296BE72C811BCE)
 category: stablecoin
 links:
   homepage: https://neutrl.fi/
@@ -42,7 +42,7 @@ links:
   twitter: https://x.com/Neutrl
 contract_addresses:
   - chain: ethereum
-    address: '0xE556ABa6fe6036275ec1f87eda296be72c811bce'
+    address: '0xE556ABa6fe6036275Ec1f87eda296BE72C811BCE'
 slug: nusd
 checks:
   twitter_last_post_at: '2026-02-08'

--- a/eth_defi/data/stablecoins/ousd.yaml
+++ b/eth_defi/data/stablecoins/ousd.yaml
@@ -22,13 +22,13 @@ long_description: |
   ## Status
 
   Active on Ethereum with approximately $5.8 million TVL and a 5.49% 30-day APY (as of early 2025).
-  The current contract at `0x2A8e1E676Ec238d8A992307B495b45B3feAA5e86` is the post-exploit version.
+  The current contract at `0x2A8e1E676Ec238d8A992307B495b45B3fEAa5e86` is the post-exploit version.
 
   ## Sources
 
   - [Origin Protocol — OUSD](https://www.originprotocol.com/ousd)
   - [DeFiLlama — Origin Dollar](https://defillama.com/stablecoin/origin-dollar)
-  - [Etherscan — OUSD](https://etherscan.io/token/0x2A8e1E676Ec238d8A992307B495b45B3feAA5e86)
+  - [Etherscan — OUSD](https://etherscan.io/token/0x2A8e1E676Ec238d8A992307B495b45B3fEAa5e86)
 category: yield_bearing
 links:
   homepage: https://www.originprotocol.com/ousd
@@ -37,7 +37,7 @@ links:
   twitter: https://x.com/OriginProtocol
 contract_addresses:
   - chain: ethereum
-    address: '0x2A8e1E676Ec238d8A992307B495b45B3feAA5e86'
+    address: '0x2A8e1E676Ec238d8A992307B495b45B3fEAa5e86'
 slug: ousd
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/par.yaml
+++ b/eth_defi/data/stablecoins/par.yaml
@@ -28,7 +28,7 @@ links:
   homepage: https://par.mimo.capital/
   coingecko: https://www.coingecko.com/en/coins/par-stablecoin
   defillama: ''
-  twitter: https://x.com/mimodefi
+  twitter: https://x.com/mimo_labs
 contract_addresses:
   - chain: ethereum
     address: '0x68037790A0229e9Ce6EaA8A99ea92964106C4703'

--- a/eth_defi/data/stablecoins/paxg.yaml
+++ b/eth_defi/data/stablecoins/paxg.yaml
@@ -31,7 +31,7 @@ links:
   homepage: https://paxos.com/paxgold/
   coingecko: https://www.coingecko.com/en/coins/pax-gold
   defillama: ''
-  twitter: https://x.com/PaxosGlobal
+  twitter: https://x.com/Paxos
 contract_addresses:
   - chain: ethereum
     address: '0x45804880De22913dAFE09f4980848ECE6EcbAf78'

--- a/eth_defi/data/stablecoins/plusd.yaml
+++ b/eth_defi/data/stablecoins/plusd.yaml
@@ -2,7 +2,7 @@ symbol: plUSD
 name: Trevee Plasma USD
 short_description: Trevee Plasma USD (plUSD) is a meta-stablecoin backed 1:1 by USDT on the Plasma L1 chain. Deposits are deployed into Aave and Fluid for yield. Previously known as Rings Protocol.
 long_description: |
-  plUSD is issued by [Trevee](https://trevee.com/) (previously known as Rings Protocol)
+  plUSD is issued by [Trevee](https://trevee.xyz/) (previously known as Rings Protocol)
   on the [Plasma](https://plasma.network/) L1 blockchain, a chain purpose-built for stablecoins.
 
   ## Mechanism
@@ -25,7 +25,7 @@ long_description: |
   - [DeFiLlama — Trevee Earn](https://defillama.com/protocol/trevee-earn)
 category: stablecoin
 links:
-  homepage: https://trevee.com/
+  homepage: https://trevee.xyz/
   coingecko: https://www.coingecko.com/en/coins/trevee-plasma-usd
   defillama: https://defillama.com/protocol/trevee-earn
   twitter: https://x.com/Trevee_xyz

--- a/eth_defi/data/stablecoins/reusd.yaml
+++ b/eth_defi/data/stablecoins/reusd.yaml
@@ -22,7 +22,7 @@ long_description: |
   ## Sources
 
   - [Resupply](https://resupply.fi/)
-  - [Etherscan — reUSD](https://etherscan.io/token/0x57ab1e0003f623289cd798b1824be09a793e4bec)
+  - [Etherscan — reUSD](https://etherscan.io/token/0x57aB1E0003F623289CD798B1824Be09a793e4Bec)
 category: stablecoin
 links:
   homepage: https://resupply.fi/
@@ -31,7 +31,7 @@ links:
   twitter: https://x.com/ResupplyFi
 contract_addresses:
   - chain: ethereum
-    address: '0x57ab1e0003f623289cd798b1824be09a793e4bec'
+    address: '0x57aB1E0003F623289CD798B1824Be09a793e4Bec'
 slug: reusd
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/rusd-ipor.yaml
+++ b/eth_defi/data/stablecoins/rusd-ipor.yaml
@@ -15,7 +15,7 @@ links:
   twitter: https://x.com/__reservoir
 contract_addresses:
   - chain: ethereum
-    address: '0x09d4214c03d01f49544c0448dbe3a27f768f2b34'
+    address: '0x09D4214C03D01F49544C0448DBE3A27f768F2b34'
 slug: rusd-ipor
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/rusd.yaml
+++ b/eth_defi/data/stablecoins/rusd.yaml
@@ -29,7 +29,7 @@ entries:
     collateral (wstETH, WBTC) into a stable token (rUSD/fxUSD) and a leveraged perpetual
     (xPOSITION). The protocol has completed 16 security audits including OpenZeppelin.
 
-    Contract address on Ethereum: `0x65d72aa8da931f047169112fcf34f52dbaae7d18`
+    Contract address on Ethereum: `0x65D72AA8DA931F047169112fcf34f52DbaAE7D18`
     (103,956 rUSD, 142 holders as of early 2025)
   links:
     homepage: https://fx.aladdin.club/
@@ -47,7 +47,7 @@ entries:
     [Realio Network](https://realio.fund/) issues rUSD as "a Realio multichain stablecoin asset"
     providing users of the Realio Platform a fiat on/off ramp for trading.
 
-    Contract address on Ethereum: `0xF9A2D7E60a3297e513317ad1d7ce101cc4c6c8f6`
+    Contract address on Ethereum: `0xF9A2D7E60a3297E513317AD1d7Ce101CC4C6C8F6`
     (100M max supply, 89 holders, minimal activity as of early 2025)
   links:
     homepage: https://realio.fund/

--- a/eth_defi/data/stablecoins/sbold.yaml
+++ b/eth_defi/data/stablecoins/sbold.yaml
@@ -15,7 +15,7 @@ links:
   twitter: https://x.com/k3_capital
 contract_addresses:
   - chain: ethereum
-    address: '0x50bd66d59911f5e086ec87ae43c811e0d059dd11'
+    address: '0x50Bd66D59911F5e086Ec87aE43C811e0D059DD11'
 slug: sbold
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/scusd.yaml
+++ b/eth_defi/data/stablecoins/scusd.yaml
@@ -2,7 +2,7 @@ symbol: scUSD
 name: Rings scUSD
 short_description: scUSD is a yield-bearing stablecoin from Rings Protocol (rebranded as Trevee Earn) on the Sonic network. It is backed by Ethereum mainnet stablecoins bridged to Sonic and earns yield via Veda BoringVaults. scUSD reached over $111M TVL in early 2025.
 long_description: |
-  [Rings Protocol](https://app.rings.money/) is the meta-stable protocol of the [Sonic](https://www.soniclabs.com/) chain, built on Veda BoringVault infrastructure and drawing inspiration from Blast's native yield concept. It bridges Ethereum mainnet stablecoin holders to Sonic to earn yield.
+  [Rings Protocol](https://trevee.xyz/) (now Trevee Earn) is the meta-stable protocol of the [Sonic](https://www.soniclabs.com/) chain, built on Veda BoringVault infrastructure and drawing inspiration from Blast's native yield concept. It bridges Ethereum mainnet stablecoin holders to Sonic to earn yield.
 
   scUSD is minted on Sonic when users deposit supported stablecoins. The protocol integrates with Solidly's ve(3,3) model for liquidity incentives. Rings has since rebranded to Trevee Earn.
 
@@ -13,10 +13,10 @@ long_description: |
   In 2025–2026, Trevee (formerly Rings Protocol) suffered losses from two separate incidents: exposure to the Credix Finance exploit ($4.5M hack, team vanished) and alleged fraudulent conduct by Stream Finance. As a result, Trevee accrued bad debt of approximately $700k and suspended stkscUSD staking and unstaking until legal proceedings are resolved. scUSD itself remains redeemable but the broader Trevee Earn ecosystem is operating under restrictions.
 category: stablecoin
 links:
-  homepage: https://app.rings.money/
+  homepage: https://trevee.xyz/
   coingecko: https://www.coingecko.com/en/coins/rings-scusd
   defillama: https://defillama.com/stablecoin/rings-scusd
-  twitter: https://x.com/RingsProtocol
+  twitter: https://x.com/Trevee_xyz
 contract_addresses:
   - chain: sonic
     address: '0xd3DCe716f3eF535C5Ff8d041c1A41C3bd89b97aE'

--- a/eth_defi/data/stablecoins/seur.yaml
+++ b/eth_defi/data/stablecoins/seur.yaml
@@ -12,7 +12,7 @@ links:
   homepage: https://synthetix.io/
   coingecko: https://www.coingecko.com/en/coins/seur
   defillama: ''
-  twitter: https://x.com/synthetix_io
+  twitter: https://x.com/synthetix
 contract_addresses:
   - chain: ethereum
     address: '0xD71eCFF9342A5Ced620049e616c5035F1dB98620'

--- a/eth_defi/data/stablecoins/sfrax.yaml
+++ b/eth_defi/data/stablecoins/sfrax.yaml
@@ -15,7 +15,7 @@ links:
   twitter: https://x.com/fraxfinance
 contract_addresses:
   - chain: ethereum
-    address: '0xa663b02cF0a4b149d2ad41910CB81e23e1c41c32'
+    address: '0xA663B02CF0a4b149d2aD41910CB81e23e1c41c32'
 slug: sfrax
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/sfrxusd.yaml
+++ b/eth_defi/data/stablecoins/sfrxusd.yaml
@@ -15,7 +15,7 @@ links:
   twitter: https://x.com/fraxfinance
 contract_addresses:
   - chain: ethereum
-    address: '0xcf62f905562626cfcdd2261162a51fd02fc9c5b6'
+    address: '0xcf62F905562626CfcDD2261162a51fd02Fc9c5b6'
 slug: sfrxusd
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/snusd.yaml
+++ b/eth_defi/data/stablecoins/snusd.yaml
@@ -15,7 +15,7 @@ long_description: |
 
   ## Key contracts (Ethereum)
 
-  - NUSD: `0xE556ABa6fe6036275ec1f87eda296be72c811bce`
+  - NUSD: `0xE556ABa6fe6036275Ec1f87eda296BE72C811BCE`
   - sNUSD: `0x08EFCC2F3e61185D0EA7F8830B3FEc9Bfa2EE313`
 
   ## Cross-chain

--- a/eth_defi/data/stablecoins/stusd.yaml
+++ b/eth_defi/data/stablecoins/stusd.yaml
@@ -19,7 +19,7 @@ links:
   twitter: https://x.com/AngleProtocol
 contract_addresses:
   - chain: ethereum
-    address: '0x0022228a2cc5e7ef0274a7baa600d44da5ab5776'
+    address: '0x0022228a2cc5E7eF0274A7Baa600d44da5aB5776'
 slug: stusd
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/susd.yaml
+++ b/eth_defi/data/stablecoins/susd.yaml
@@ -12,7 +12,7 @@ links:
   homepage: https://synthetix.io/
   coingecko: https://www.coingecko.com/en/coins/susd
   defillama: https://defillama.com/stablecoin/susd
-  twitter: https://x.com/synthetix_io
+  twitter: https://x.com/synthetix
 contract_addresses:
   - chain: ethereum
     address: '0x57Ab1ec28D129707052df4dF418D58a2D46d5f51'

--- a/eth_defi/data/stablecoins/susdai.yaml
+++ b/eth_defi/data/stablecoins/susdai.yaml
@@ -15,7 +15,7 @@ links:
   twitter: https://x.com/usd_ai
 contract_addresses:
   - chain: arbitrum
-    address: '0x0b2b2b2076d95dda7817e785989fe353fe955ef9'
+    address: '0x0B2b2B2076d95dda7817e785989fE353fe955ef9'
 slug: susdai
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/susdc.yaml
+++ b/eth_defi/data/stablecoins/susdc.yaml
@@ -17,7 +17,7 @@ contract_addresses:
   - chain: ethereum
     address: '0xBc65ad17c5C0a2A4D159fa5a503f4992c7B545FE'
   - chain: arbitrum
-    address: '0x940098b108fb7d0a7e374f6eded7760787464609'
+    address: '0x940098b108fB7D0a7E374f6eDED7760787464609'
 slug: susdc
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/susde.yaml
+++ b/eth_defi/data/stablecoins/susde.yaml
@@ -12,7 +12,7 @@ links:
   homepage: https://ethena.fi/
   coingecko: https://www.coingecko.com/en/coins/ethena-staked-usde
   defillama: https://defillama.com/stablecoin/ethena-usde
-  twitter: https://x.com/ethena_labs
+  twitter: https://x.com/ethena
 contract_addresses:
   - chain: ethereum
     address: '0x9D39A5DE30e57443BfF2A8307A4256c8797A3497'

--- a/eth_defi/data/stablecoins/tcnh.yaml
+++ b/eth_defi/data/stablecoins/tcnh.yaml
@@ -9,10 +9,10 @@ long_description: |
   Note: Tether issued a separate offshore CNY stablecoin (CNH₮) on Ethereum and other networks. TCNH and CNH₮ are distinct products from different issuers.
 category: stablecoin
 links:
-  homepage: https://trueusd.com/
+  homepage: https://tusd.io/
   coingecko: https://www.coingecko.com/en/coins/truecnh
   defillama: ''
-  twitter: https://x.com/TrueUSD
+  twitter: https://x.com/tusdio
 contract_addresses:
   - chain: tron
     address: 'TBqsNXUtqaLptVK8AYvdPPctpqd8oBYWUC'

--- a/eth_defi/data/stablecoins/tfusdc.yaml
+++ b/eth_defi/data/stablecoins/tfusdc.yaml
@@ -14,10 +14,10 @@ links:
   homepage: https://truefi.io/
   coingecko: ''
   defillama: ''
-  twitter: https://x.com/TrueFi_DAO
+  twitter: https://x.com/TrueFiDAO
 contract_addresses:
   - chain: ethereum
-    address: '0xa991356d261fbaF194463aF6DF8f0464F8f1c742'
+    address: '0xA991356d261fbaF194463aF6DF8f0464F8f1c742'
 slug: tfusdc
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/tryb.yaml
+++ b/eth_defi/data/stablecoins/tryb.yaml
@@ -15,7 +15,7 @@ links:
   twitter: https://x.com/BiLira_Official
 contract_addresses:
   - chain: ethereum
-    address: '0x2c537E5624e4af88A7ae4060C022609376C8D0EB'
+    address: '0x2C537E5624e4af88A7ae4060C022609376C8D0EB'
 slug: tryb
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/tusd.yaml
+++ b/eth_defi/data/stablecoins/tusd.yaml
@@ -9,10 +9,10 @@ long_description: |
   TUSD is available on Ethereum, BNB Chain, Avalanche, and other networks. It is listed on [CoinGecko](https://www.coingecko.com/en/coins/true-usd) and [DefiLlama](https://defillama.com/stablecoin/trueusd).
 category: stablecoin
 links:
-  homepage: https://trueusd.com/
+  homepage: https://tusd.io/
   coingecko: https://www.coingecko.com/en/coins/true-usd
   defillama: https://defillama.com/stablecoin/trueusd
-  twitter: https://x.com/TrueUSD
+  twitter: https://x.com/tusdio
 contract_addresses:
   - chain: ethereum
     address: '0x0000000000085d4780B73119b644AE5ecd22b376'

--- a/eth_defi/data/stablecoins/usd-t.yaml
+++ b/eth_defi/data/stablecoins/usd-t.yaml
@@ -33,7 +33,7 @@ links:
   homepage: https://tether.to/
   coingecko: https://www.coingecko.com/en/coins/tether
   defillama: https://defillama.com/stablecoin/tether
-  twitter: https://x.com/Tether_to
+  twitter: https://x.com/tether
 slug: usd-t
 checks:
   twitter_last_post_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usd-t0.yaml
+++ b/eth_defi/data/stablecoins/usd-t0.yaml
@@ -28,7 +28,7 @@ links:
   homepage: https://usdt0.to/
   coingecko: ''
   defillama: ''
-  twitter: https://x.com/Tether_to
+  twitter: https://x.com/tether
 slug: usd-t0
 checks:
   twitter_last_post_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usda-avalon.yaml
+++ b/eth_defi/data/stablecoins/usda-avalon.yaml
@@ -32,11 +32,11 @@ links:
 slug: usda-avalon
 contract_addresses:
   - chain: ethereum
-    address: '0x8a60e489004ca22d775c5f2c657598278d17d9c2'
+    address: '0x8A60E489004Ca22d775C5F2c657598278d17D9c2'
   - chain: mantle
-    address: '0x075df695b8e7f4361fa7f8c1426c63f11b06e326'
+    address: '0x075df695b8E7f4361FA7F8c1426C63f11B06e326'
   - chain: binance
-    address: '0x9356086146be5158e98ad827e21b5cf944699894'
+    address: '0x9356086146be5158E98aD827E21b5cF944699894'
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdbc.yaml
+++ b/eth_defi/data/stablecoins/usdbc.yaml
@@ -41,7 +41,7 @@ links:
 slug: usdbc
 contract_addresses:
   - chain: base
-    address: '0xd9aAEc86b65D86f6A7B5B1b0c42FFA531710b6CA'
+    address: '0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA'
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdd.yaml
+++ b/eth_defi/data/stablecoins/usdd.yaml
@@ -48,11 +48,11 @@ links:
 slug: usdd
 contract_addresses:
   - chain: ethereum
-    address: '0x4f8e5de400de08b164e7421b3ee387f461becd1a'
+    address: '0x4f8e5DE400DE08B164E7421B3EE387f461beCD1A'
   - chain: binance
-    address: '0x392004bee213f1ff580c867359c246924f21e6ad'
+    address: '0x392004BEe213F1FF580C867359C246924f21E6Ad'
   - chain: arbitrum
-    address: '0x680447595e8b7b3aa1b43beb9f6098c79ac2ab3f'
+    address: '0x680447595e8b7b3Aa1B43beB9f6098C79ac2Ab3f'
 checks:
   twitter_last_post_at: '2026-02-06'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usde.yaml
+++ b/eth_defi/data/stablecoins/usde.yaml
@@ -41,7 +41,7 @@ links:
   homepage: https://ethena.fi/
   coingecko: https://www.coingecko.com/en/coins/ethena-usde
   defillama: https://defillama.com/stablecoin/ethena-usde
-  twitter: https://x.com/ethena_labs
+  twitter: https://x.com/ethena
 slug: usde
 token_symbols:
 - USDE

--- a/eth_defi/data/stablecoins/usdh.yaml
+++ b/eth_defi/data/stablecoins/usdh.yaml
@@ -44,10 +44,10 @@ long_description: |
   - [Brave New Coin — USDH launch](https://bravenewcoin.com/insights/hyperliquid-launches-usdh-stablecoin-after-native-markets-wins-competitive-bid)
 category: stablecoin
 links:
-  homepage: https://nativemarkets.xyz/
+  homepage: https://nativemarkets.com/
   coingecko: ''
   defillama: ''
-  twitter: https://x.com/native_markets
+  twitter: https://x.com/nativemarkets
 slug: usdh
 checks:
   twitter_last_post_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdm.yaml
+++ b/eth_defi/data/stablecoins/usdm.yaml
@@ -15,7 +15,7 @@ links:
   homepage: https://mountainprotocol.com/
   coingecko: https://www.coingecko.com/en/coins/mountain-protocol-usdm
   defillama: https://defillama.com/stablecoin/mountain-protocol-usdm
-  twitter: https://x.com/MountainPrtcl
+  twitter: https://x.com/MountainUSDM
 slug: usdm
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/usdo.yaml
+++ b/eth_defi/data/stablecoins/usdo.yaml
@@ -26,7 +26,7 @@ links:
   homepage: https://openeden.com/
   coingecko: https://www.coingecko.com/en/coins/openeden-open-dollar
   defillama: https://defillama.com/protocol/openeden-usdo
-  twitter: https://x.com/OpenEdenLabs
+  twitter: https://x.com/OpenEden_X
 contract_addresses:
   - chain: ethereum
     address: '0x8238884Ec9668Ef77B90C6dfF4D1a9F4F4823BFe'

--- a/eth_defi/data/stablecoins/usdt.yaml
+++ b/eth_defi/data/stablecoins/usdt.yaml
@@ -23,7 +23,7 @@ links:
   homepage: https://tether.to/
   coingecko: https://www.coingecko.com/en/coins/tether
   defillama: https://defillama.com/stablecoin/tether
-  twitter: https://x.com/Tether_to
+  twitter: https://x.com/tether
 contract_addresses:
   - chain: ethereum
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7'

--- a/eth_defi/data/stablecoins/usdtb.yaml
+++ b/eth_defi/data/stablecoins/usdtb.yaml
@@ -23,7 +23,7 @@ links:
   homepage: https://usdtb.money/
   coingecko: https://www.coingecko.com/en/coins/usdtb
   defillama: https://defillama.com/stablecoin/usdtb
-  twitter: https://x.com/ethena_labs
+  twitter: https://x.com/ethena
 slug: usdtb
 checks:
   twitter_last_post_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usr.yaml
+++ b/eth_defi/data/stablecoins/usr.yaml
@@ -19,7 +19,7 @@ long_description: |
 
   ## Contract address
 
-  - Ethereum: `0x66a1E37c9b0Eaddca17d3662D6c05F4DECf3e110`
+  - Ethereum: `0x66a1E37c9b0eAddca17d3662D6c05F4DECf3e110`
 
   ## Sources
 
@@ -34,7 +34,7 @@ links:
   twitter: https://x.com/ResolvLabs
 contract_addresses:
   - chain: ethereum
-    address: '0x66a1E37c9b0Eaddca17d3662D6c05F4DECf3e110'
+    address: '0x66a1E37c9b0eAddca17d3662D6c05F4DECf3e110'
 slug: usr
 checks:
   twitter_last_post_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/uty.yaml
+++ b/eth_defi/data/stablecoins/uty.yaml
@@ -29,7 +29,7 @@ links:
   twitter: https://x.com/xsy_fi
 contract_addresses:
   - chain: avalanche
-    address: '0xdbc5192a6b6ffee7451301bb4ec312f844f02b4a'
+    address: '0xDBc5192A6B6FfEe7451301bb4ec312f844F02B4A'
 slug: uty
 checks:
   twitter_last_post_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/veur.yaml
+++ b/eth_defi/data/stablecoins/veur.yaml
@@ -21,12 +21,12 @@ links:
   homepage: https://vnx.li/
   coingecko: https://www.coingecko.com/en/coins/vnx-euro
   defillama: https://defillama.com/stablecoin/vnx-euro
-  twitter: https://x.com/VNX_fi
+  twitter: https://x.com/VNX_Platform
 contract_addresses:
   - chain: ethereum
     address: '0x6bA75D640bEbfe5dA1197bb5A2aff3327789b5d3'
   - chain: arbitrum
-    address: '0x4883c8f0529f37e40ebea870f3c13cdfad5d01f8'
+    address: '0x4883C8f0529F37e40eBeA870F3C13cDfAD5d01f8'
 slug: veur
 checks:
   twitter_last_post_at: '2026-03-01'

--- a/eth_defi/data/stablecoins/vst.yaml
+++ b/eth_defi/data/stablecoins/vst.yaml
@@ -25,7 +25,7 @@ links:
   twitter: https://x.com/vestafinance
 contract_addresses:
   - chain: arbitrum
-    address: '0x64343594ab9b56e99087bfa6f2335db24c2d1f17'
+    address: '0x64343594Ab9b56e99087BfA6F2335Db24c2d1F17'
 slug: vst
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/vusd-hemi.yaml
+++ b/eth_defi/data/stablecoins/vusd-hemi.yaml
@@ -21,7 +21,7 @@ links:
   twitter: https://x.com/hemi_xyz
 contract_addresses:
   - chain: hemi
-    address: '0x7a06c4aef988e7925575c50261297a946ad204a8'
+    address: '0x7A06C4AeF988e7925575C50261297a946aD204A8'
 slug: vusd-hemi
 checks:
   twitter_last_post_at: ''

--- a/eth_defi/data/stablecoins/vusd-vesper.yaml
+++ b/eth_defi/data/stablecoins/vusd-vesper.yaml
@@ -14,7 +14,7 @@ long_description: |
   ## Sources
 
   - [Vesper Finance](https://vesper.finance/)
-  - [Etherscan — VUSD](https://etherscan.io/token/0x677ddbd918637e5f2c79e164d402454de7da8619)
+  - [Etherscan — VUSD](https://etherscan.io/token/0x677ddbd918637E5F2c79e164D402454dE7dA8619)
 category: stablecoin
 links:
   homepage: https://vesper.finance/
@@ -23,7 +23,7 @@ links:
   twitter: https://x.com/VesperFi
 contract_addresses:
   - chain: ethereum
-    address: '0x677ddbd918637e5f2c79e164d402454de7da8619'
+    address: '0x677ddbd918637E5F2c79e164D402454dE7dA8619'
 slug: vusd-vesper
 checks:
   twitter_last_post_at: '2025-08-01'

--- a/eth_defi/data/stablecoins/wm.yaml
+++ b/eth_defi/data/stablecoins/wm.yaml
@@ -29,7 +29,7 @@ links:
   twitter: https://x.com/m0foundation
 contract_addresses:
   - chain: ethereum
-    address: '0x437cc33344a0b27a429f795ff6b469c72698b291'
+    address: '0x437cc33344a0B27A429f795ff6B469C72698B291'
 slug: wm
 checks:
   twitter_last_post_at: '2025-05-01'

--- a/eth_defi/data/stablecoins/xaut.yaml
+++ b/eth_defi/data/stablecoins/xaut.yaml
@@ -46,10 +46,10 @@ links:
   homepage: https://gold.tether.to/
   coingecko: https://www.coingecko.com/en/coins/tether-gold
   defillama: ''
-  twitter: https://x.com/Tether_to
+  twitter: https://x.com/tether
 contract_addresses:
   - chain: ethereum
-    address: '0x68749665ff8d2d112fa859aa293f07a622782f38'
+    address: '0x68749665FF8D2d112Fa859AA293F07A622782F38'
 slug: xaut
 checks:
   twitter_last_post_at: '2026-03-01'

--- a/eth_defi/data/stablecoins/xsgd.yaml
+++ b/eth_defi/data/stablecoins/xsgd.yaml
@@ -38,7 +38,7 @@ long_description: |
   - [StraitsX — XSGD](https://www.straitsx.com/xsgd)
   - [StraitsX — MAS IPA announcement](https://www.straitsx.com/blog-post/straitsx-receives-in-principle-approval-from-mas-to-issue-scs)
   - [CoinGecko — XSGD](https://www.coingecko.com/en/coins/xsgd)
-  - [Etherscan — XSGD token](https://etherscan.io/token/0x70e8de73ce538da2beed35d14187f6959a8eca96)
+  - [Etherscan — XSGD token](https://etherscan.io/token/0x70e8dE73cE538DA2bEEd35d14187F6959a8ecA96)
 category: stablecoin
 links:
   homepage: https://www.straitsx.com/xsgd
@@ -47,7 +47,7 @@ links:
   twitter: https://x.com/StraitsX
 contract_addresses:
   - chain: ethereum
-    address: '0x70e8de73ce538da2beed35d14187f6959a8eca96'
+    address: '0x70e8dE73cE538DA2bEEd35d14187F6959a8ecA96'
   - chain: polygon
     address: '0xDC3326e71D45186F113a2F448984CA0e8D201995'
 slug: xsgd

--- a/eth_defi/data/stablecoins/xstusd.yaml
+++ b/eth_defi/data/stablecoins/xstusd.yaml
@@ -30,7 +30,7 @@ links:
   twitter: https://x.com/sora_xor
 contract_addresses:
   - chain: ethereum
-    address: '0xc7d9c108d4e1dd1484d3e2568d7f74bfd763d356'
+    address: '0xc7D9c108D4E1dD1484D3e2568d7f74bfD763d356'
 slug: xstusd
 checks:
   twitter_last_post_at: '2025-01-14'

--- a/eth_defi/data/stablecoins/xusd.yaml
+++ b/eth_defi/data/stablecoins/xusd.yaml
@@ -22,7 +22,7 @@ entries:
     - chain: ethereum
       address: '0xC08e7E23C235073C6807C2EFE7021304cb7c2815'
     - chain: bsc
-      address: '0xF81aC2E1A0373ddE1BCE01E2Fe694a9b7E3bfcB9'
+      address: '0xF81aC2E1A0373ddE1BcE01E2Fe694a9b7E3bfcB9'
   checks:
     twitter_last_post_at: '2025-12-16'
     domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/ynusdx.yaml
+++ b/eth_defi/data/stablecoins/ynusdx.yaml
@@ -21,13 +21,13 @@ long_description: |
   - [DefiLlama — YieldNest](https://defillama.com/protocol/yieldnest)
 category: yield_bearing
 links:
-  homepage: https://app.yieldnest.finance/token/ynUSDx
+  homepage: https://yieldnest.finance/
   coingecko: https://www.coingecko.com/en/coins/ynusd-max
   defillama: https://defillama.com/protocol/yieldnest
   twitter: https://x.com/YieldNestFi
 contract_addresses:
   - chain: ethereum
-    address: '0x3db228fe836d99ccb25ec4dfdc80ed6d2cddcb4b'
+    address: '0x3DB228FE836D99Ccb25Ec4dfdC80ED6d2CDdCB4b'
 slug: ynusdx
 checks:
   twitter_last_post_at: '2026-01-22'

--- a/eth_defi/data/stablecoins/yusd.yaml
+++ b/eth_defi/data/stablecoins/yusd.yaml
@@ -35,9 +35,9 @@ entries:
     twitter: https://x.com/GetYieldFi
   contract_addresses:
     - chain: arbitrum
-      address: '0x4772d2e014f9fc3a820c444e3313968e9a5c8121'
+      address: '0x4772D2e014F9fC3a820C444e3313968e9a5C8121'
     - chain: base
-      address: '0x895e15020c3f52ddd4d8e9514eb83c39f53b1579'
+      address: '0x895e15020C3f52ddD4D8e9514eB83C39F53B1579'
   checks:
     twitter_last_post_at: '2025-10-28'
     domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/zchf.yaml
+++ b/eth_defi/data/stablecoins/zchf.yaml
@@ -29,7 +29,7 @@ links:
   twitter: https://x.com/frankencoinzchf
 contract_addresses:
   - chain: ethereum
-    address: '0xb58e61c3098d85632df34eecfb899a1ed80921cb'
+    address: '0xB58E61C3098d85632Df34EecfB899A1Ed80921cB'
 slug: zchf
 checks:
   twitter_last_post_at: '2026-03-01'

--- a/scripts/stablecoins/audit-stablecoin-data.py
+++ b/scripts/stablecoins/audit-stablecoin-data.py
@@ -1,0 +1,169 @@
+"""Audit stablecoin metadata and feed YAML data for inconsistencies.
+
+Deterministic structural + cross-link checks over
+
+- ``eth_defi/data/stablecoins/*.yaml`` (metadata)
+- ``eth_defi/data/feeds/stablecoins/*.yaml`` (news feeds)
+
+It reports, grouped by severity:
+
+- ERROR — malformed/blocking (bad address format, slug/feeder-id mismatch,
+  dangling ``canonical-feeder-id``)
+- WARN — likely wrong (non-checksummed EVM address, name drift, missing logo)
+- INFO — content gaps (missing links / long_description)
+
+and the metadata↔feed drift (twitter handle, website) that needs a human
+decision. See ``eth_defi/data/stablecoins/TODO_STABLECOIN_DATA_FIXES_NEEDED.md``
+for the triaged backlog.
+
+No network access; safe to run any time::
+
+    poetry run python scripts/stablecoins/audit-stablecoin-data.py
+"""
+
+import logging
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+import yaml
+from eth_utils import to_checksum_address
+
+logger = logging.getLogger(__name__)
+
+ROOT = Path(__file__).resolve().parents[2] / "eth_defi" / "data"
+META_DIR = ROOT / "stablecoins"
+FEED_DIR = ROOT / "feeds" / "stablecoins"
+LOGO_DIR = META_DIR / "formatted_logos"
+FEED_ROLES = {
+    "stablecoins": ROOT / "feeds" / "stablecoins",
+    "curators": ROOT / "feeds" / "curators",
+    "protocols": ROOT / "feeds" / "protocols",
+}
+
+VALID_CATEGORIES = {"stablecoin", "yield_bearing", "wrapped"}
+LINK_FIELDS = ["homepage", "coingecko", "defillama", "twitter"]
+CHECK_FIELDS = ["twitter_last_post_at", "domain_up_at", "marked_dead_at", "information_found_missing_at"]
+EVM_ADDR_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
+#: Chains whose addresses are not EVM hex and must skip the checksum/format check
+NON_EVM_CHAINS = {"tron", "xdc", "solana", "near", "starknet"}
+
+
+def load_yaml(p: Path) -> dict:
+    return yaml.safe_load(p.read_text())
+
+
+def tw_handle(value: str | None) -> str | None:
+    if not value:
+        return None
+    value = value.strip().rstrip("/")
+    m = re.search(r"(?:x\.com|twitter\.com)/([^/?#]+)", value)
+    handle = m.group(1) if m else value
+    return handle.lower().lstrip("@")
+
+
+def domain(value: str | None) -> str | None:
+    if not value:
+        return None
+    value = value.strip().rstrip("/")
+    m = re.search(r"https?://(?:www\.)?([^/]+)", value)
+    return (m.group(1) if m else value).lower()
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stdout)
+
+    all_feeders: dict[str, list] = {}
+    for role, d in FEED_ROLES.items():
+        for p in sorted(d.glob("*.yaml")):
+            fid = load_yaml(p).get("feeder-id")
+            if fid:
+                all_feeders.setdefault(fid, []).append(role)
+
+    meta_files = {p.stem: p for p in META_DIR.glob("*.yaml")}
+    feed_files = {p.stem: p for p in FEED_DIR.glob("*.yaml")}
+    meta_data = {s: load_yaml(p) for s, p in meta_files.items()}
+    feed_data = {s: load_yaml(p) for s, p in feed_files.items()}
+
+    issues: list[tuple[str, str, str]] = []
+
+    def add(slug: str, sev: str, msg: str) -> None:
+        issues.append((slug, sev, msg))
+
+    # Metadata without feed and vice versa
+    for slug in sorted(set(meta_files) - set(feed_files)):
+        multi = "entries" in meta_data[slug]
+        add(slug, "INFO", "metadata has no feed (multi-project)" if multi else "metadata has no feed")
+    for slug in sorted(set(feed_files) - set(meta_files)):
+        add(slug, "WARN", "feed has no matching metadata")
+
+    # Per-metadata checks
+    for slug, d in sorted(meta_data.items()):
+        multi = "entries" in d
+        if d.get("slug") and d["slug"] != slug:
+            add(slug, "ERROR", f"slug '{d['slug']}' != filename")
+        if not d.get("symbol"):
+            add(slug, "ERROR", "missing symbol")
+        cat = d.get("category")
+        if not multi and cat is not None and cat not in VALID_CATEGORIES:
+            add(slug, "ERROR", f"invalid category '{cat}'")
+
+        for ei, entry in enumerate([*d["entries"]] if multi else [d]):
+            tag = f"entry[{ei}] " if multi else ""
+            if not entry.get("short_description"):
+                add(slug, "WARN", f"{tag}missing short_description")
+            for ca in entry.get("contract_addresses") or []:
+                chain, addr = ca.get("chain"), ca.get("address")
+                if not chain:
+                    add(slug, "ERROR", f"{tag}contract_address missing chain")
+                if addr and chain not in NON_EVM_CHAINS:
+                    if not EVM_ADDR_RE.match(addr):
+                        add(slug, "ERROR", f"{tag}malformed EVM address {addr} ({chain})")
+                    elif to_checksum_address(addr) != addr:
+                        add(slug, "WARN", f"{tag}address not checksummed {addr} ({chain})")
+            checks = entry.get("checks")
+            if checks is not None:
+                for cf in CHECK_FIELDS:
+                    if cf not in checks:
+                        add(slug, "WARN", f"{tag}checks missing key {cf}")
+
+        if not (LOGO_DIR / slug / "light.png").exists():
+            add(slug, "WARN", "missing formatted logo")
+
+    # Per-feed checks
+    for slug, d in sorted(feed_data.items()):
+        if d.get("feeder-id") != slug:
+            add(slug, "ERROR", f"feeder-id '{d.get('feeder-id')}' != filename")
+        if d.get("role") != "stablecoin":
+            add(slug, "WARN", f"role '{d.get('role')}' (expected stablecoin)")
+        canon = d.get("canonical-feeder-id")
+        if canon and canon not in all_feeders:
+            add(slug, "ERROR", f"canonical-feeder-id '{canon}' does not resolve")
+
+    # Name + cross-link drift
+    for slug in sorted(set(meta_files) & set(feed_files)):
+        md, fd = meta_data[slug], feed_data[slug]
+        if "entries" in md or fd.get("canonical-feeder-id"):
+            continue
+        if md.get("name") and fd.get("name") and md["name"] != fd["name"]:
+            add(slug, "WARN", f"name drift meta='{md['name']}' feed='{fd['name']}'")
+        m_tw, f_tw = tw_handle((md.get("links") or {}).get("twitter")), tw_handle(fd.get("twitter"))
+        if m_tw and f_tw and m_tw != f_tw:
+            add(slug, "INFO", f"twitter drift meta=@{m_tw} feed=@{f_tw}")
+        m_hp, f_ws = domain((md.get("links") or {}).get("homepage")), domain(fd.get("website"))
+        if m_hp and f_ws and m_hp != f_ws:
+            add(slug, "INFO", f"website drift meta={m_hp} feed={f_ws}")
+
+    sev_order = {"ERROR": 0, "WARN": 1, "INFO": 2}
+    issues.sort(key=lambda x: (sev_order[x[1]], x[0]))
+    counts = Counter(s for _, s, _ in issues)
+    logger.info("%d metadata, %d feed files", len(meta_files), len(feed_files))
+    logger.info("issues: %s", dict(counts))
+    for slug, sev, msg in issues:
+        logger.info("[%s] %s: %s", sev, slug, msg)
+    return 1 if counts.get("ERROR") else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# Why

The stablecoin metadata (`eth_defi/data/stablecoins/*.yaml`), the matching news
feed files (`eth_defi/data/feeds/stablecoins/*.yaml`) and
`eth_defi/stablecoin_metadata.py` had accumulated drift across ~200 hand-curated
files. An audit surfaced four classes of inconsistency:

- EVM addresses stored in inconsistent case (mostly lowercase), against the
  repo convention of EIP-55 checksummed addresses.
- `name:` divergence between a token's metadata file and its feed file.
- `links.twitter` / `links.homepage` in metadata pointing at stale accounts and
  domains that no longer match the actively-curated feed side (many caused by
  project rebrands and handle migrations).
- Structural gaps with no automated guard to catch regressions.

# Lessons learnt

- **Metadata is the single source of truth for display; the feed side is the
  better source of truth for live socials.** The feed files carry `*-dead-at`
  curation markers, so when a twitter/website drift existed the feed value was
  canonical in every case **except `msUSD`**, where the metadata handle
  `@Main_St_Finance` was correct and the feed `@MainSt_Finance` was a typo (its
  stale `twitter-dead-at` marker referred to the wrong handle and was removed).
- **Verify socials against the project's own website**, not memory — handles
  migrate (Tether `@tether_to`→`@tether`, Synthetix `@synthetix_io`→`@synthetix`,
  Ethena `@ethena_labs`→`@ethena`, Paxos `@PaxosGlobal`→`@Paxos`, etc.) and
  projects rebrand (**Rings → Trevee Earn**, confirmed 2025-10-20).
- **Checksum normalisation is safe to apply in bulk** — it only changes case,
  so addresses embedded in prose / Etherscan URLs can be normalised too.
- **Not every "missing" thing is a bug.** Multi-project tickers (one slug, many
  issuers) and dead/unidentified tokens are intentionally feedless; native gas
  tokens (e.g. Gnosis `xDAI`) have no ERC-20 address. These are documented as
  *not* fixes so a future pass does not "correct" them.
- **One genuinely undecidable case was left alone:** `usdm-megaeth`
  (`@megaborealeth` is unverifiable; `@megaeth` is the chain, not a distinct USDm
  issuer). Documented rather than guessed.

# Summary

Data fixes (113 files):

- **Checksums** — 137 lowercase/mixed EVM addresses across 85 metadata files
  rewritten to EIP-55 via `eth_utils.to_checksum_address`. Non-EVM addresses
  (XDC `xdc…`, TRON Base58) left untouched.
- **Name alignment** — 6 feed `name:` fields aligned to their metadata name
  (`eure`, `gmdusdc`, `jchf`, `msusd`, `sausd`, `ysusdc`).
- **Twitter/website drift** — 35 of 36 drifts corrected to the verified
  canonical value (each issuer's official site checked for the handle/domain it
  links to). Includes the Rings→Trevee rebrand for `scUSD`/`plUSD` (homepage,
  twitter and in-prose links). The 1 remaining (`usdm-megaeth`) is documented.

Tooling and docs:

- `scripts/stablecoins/audit-stablecoin-data.py` — a no-network validator that
  re-runs all of the above checks and exits non-zero on ERROR-level findings, so
  it can gate future edits. After this pass it reports 0 errors.
- `eth_defi/data/stablecoins/TODO_STABLECOIN_DATA_FIXES_NEEDED.md` — triaged
  backlog of the research-gated gaps that still need help: 13 missing logos,
  ~40 active tokens missing contract addresses (need on-chain verification), and
  missing CoinGecko/DeFiLlama listing links.

All 198 metadata files still load through `build_stablecoin_metadata_json()` and
all 9 Royco tranche denominations still resolve through `is_stablecoin_like()`.

# Related issues and PRs

Follows #1091 (Royco tranche stablecoin denominations) — the missing-logo and
missing-address items for the nine Royco denominations added there are tracked
in the new TODO file.
