### PR TITLE
Add Core3 per-category scores and per-vault risk summary to JSON export

### DIFF
--- a/eth_defi/core3/README-core3.md
+++ b/eth_defi/core3/README-core3.md
@@ -20,6 +20,7 @@ and centralised exchanges, scoring risk on a 0-100 scale where 0 = Exceptional a
 | `eth_defi.core3.database` | `Core3Database` — DuckDB persistence with thread-safe inserts, deduplication, sync state watermarks, and query methods |
 | `eth_defi.core3.scanner` | `scan_projects()` orchestrator — parallel fetching with `joblib.Parallel`, incremental sync, error handling |
 | `eth_defi.core3.mappings` | `CORE3_MAPPINGS` — canonical mapping from our vault protocol slugs to Core3 project slugs |
+| `eth_defi.core3.vault_protocol` | `build_core3_protocols_for_export()` / `get_core3_protocol_record()` — resolve vault protocol slugs to Core3 records for the vault metrics JSON export (`core3_protocols` key), including the latest per-category PoL sub-scores (`pol_categories`) |
 
 ## Database files
 

--- a/eth_defi/core3/database.py
+++ b/eth_defi/core3/database.py
@@ -520,6 +520,46 @@ class Core3Database:
                 [slug],
             ).df()
 
+    def get_latest_pol_category(self, slug: str) -> dict | None:
+        """Get the latest per-category PoL breakdown for a project.
+
+        Returns the most recent row from ``pol_category_daily``, which
+        holds the API-native sub-scores for the five Core3 risk
+        categories (security, financial, operational, reputational,
+        regulatory). Used to embed the category breakdown in the vault
+        metrics JSON export.
+
+        :param slug:
+            Core3 project slug.
+
+        :return:
+            Dict with ``ts`` (naive UTC :class:`~datetime.datetime`) and
+            ``security``, ``financial``, ``operational``,
+            ``reputational``, ``regulatory`` float sub-scores (each may
+            be ``None``), or ``None`` if the slug has no category rows.
+        """
+        with self._db_lock:
+            row = self.con.execute(
+                """
+                SELECT ts, security_score, financial_score, operational_score, reputational_score, regulatory_score
+                FROM pol_category_daily
+                WHERE slug = ?
+                ORDER BY ts DESC
+                LIMIT 1
+                """,
+                [slug],
+            ).fetchone()
+        if row is None:
+            return None
+        return {
+            "ts": row[0],
+            "security": row[1],
+            "financial": row[2],
+            "operational": row[3],
+            "reputational": row[4],
+            "regulatory": row[5],
+        }
+
     def get_project_count(self) -> int:
         """Get number of unique projects in the database.
 

--- a/eth_defi/core3/vault_protocol.py
+++ b/eth_defi/core3/vault_protocol.py
@@ -80,6 +80,37 @@ class Core3PolScore(TypedDict):
     confidence: str | None
 
 
+class Core3PolCategories(TypedDict):
+    """Latest per-category Probability of Loss (PoL) sub-scores.
+
+    Core3 assesses PoL across five risk categories, each with its own
+    sub-score on the same 0 (Exceptional) to 100 (Critical) scale as the
+    overall PoL. Sourced from the API-native category breakdown
+    (``/v1/{slug}/pol/by_category``), stored daily in
+    ``pol_category_daily``. Any sub-score may be ``None`` for
+    less-covered projects.
+    """
+
+    #: ISO 8601 timestamp of the category snapshot these scores come from.
+    #: ``None`` if not available.
+    ts: str | None
+
+    #: Security sub-score: audits, bug bounty, contract verification, monitoring.
+    security: float | None
+
+    #: Financial sub-score: revenue sources, treasury quality, token inflation.
+    financial: float | None
+
+    #: Operational sub-score: GitHub activity, team track record, liquidity.
+    operational: float | None
+
+    #: Reputational sub-score: auditor ratings, incidents, social metrics, insurance.
+    reputational: float | None
+
+    #: Regulatory sub-score: KYC/KYT, jurisdiction, legal documentation, transparency.
+    regulatory: float | None
+
+
 class Core3MarketCap(TypedDict):
     """Market capitalisation data from Core3.
 
@@ -210,6 +241,11 @@ class Core3Record(TypedDict):
     #: Probability of Loss score, rating, and confidence level.
     pol: Core3PolScore
 
+    #: Latest per-category PoL sub-scores (security, financial, etc.).
+    #: ``None`` if the project has no category breakdown in the database.
+    #: Added by the database layer, not present in the original API response.
+    pol_categories: NotRequired[Core3PolCategories | None]
+
     #: Token ticker symbol, e.g. ``"MORPHO"``, ``"EUL"``.
     #: Some projects omit this key entirely from the API response.
     ticker: NotRequired[str | None]
@@ -298,6 +334,11 @@ def get_core3_protocol_record(
     payload = json.loads(payload_str)
     payload["fetched_at"] = fetched_at
 
+    # Attach the latest per-category PoL breakdown (security, financial,
+    # operational, reputational, regulatory). Stored separately from the
+    # project snapshot payload in the pol_category_daily table.
+    payload["pol_categories"] = db.get_latest_pol_category(core3_slug)
+
     return payload
 
 
@@ -324,6 +365,10 @@ class Core3ExportRecord(TypedDict):
 
     #: Probability of Loss score, rating, and confidence level.
     pol: Core3PolScore
+
+    #: Latest per-category PoL sub-scores (security, financial, etc.).
+    #: ``None`` if the project has no category breakdown in the database.
+    pol_categories: NotRequired[Core3PolCategories | None]
 
     #: Token ticker symbol, e.g. ``"MORPHO"``, ``"EUL"``.
     ticker: NotRequired[str | None]
@@ -371,6 +416,75 @@ class Core3ExportRecord(TypedDict):
     fetched_at: str
 
 
+class Core3VaultSection(TypedDict):
+    """Compact per-vault Core3 risk summary.
+
+    A flattened subset of :class:`Core3ExportRecord` embedded under the
+    ``core3`` key of each vault record produced by
+    :py:func:`eth_defi.research.vault_metrics.calculate_vault_record`.
+    Individual values are ``None`` when the underlying Core3 field is
+    missing; the whole section is ``None`` when the vault's protocol has
+    no Core3 data (see :py:func:`build_core3_vault_section`).
+    """
+
+    #: Overall Probability of Loss score, 0 (Exceptional) – 100 (Critical).
+    risk_score: float | None
+
+    #: Total cross-chain market capitalisation in USD.
+    market_cap: float | None
+
+    #: Core3 global rank (1 = lowest risk).
+    core3_ranking: int | None
+
+    #: Data coverage percentage, 0–100.
+    data_coverage: float | None
+
+    #: PoL confidence label, e.g. ``"High"``, ``"Medium"``, ``"Low"``.
+    confidence: str | None
+
+    #: Credit-style PoL rating label, e.g. ``"BB"``, ``"AAA"``.
+    risk_rating_label: str | None
+
+
+def build_core3_vault_section(record: Core3ExportRecord | None) -> Core3VaultSection | None:
+    """Flatten a Core3 export record into a compact per-vault risk summary.
+
+    Picks the handful of headline risk fields the frontend shows on each
+    vault row, flattening the nested :class:`Core3ExportRecord` structure
+    (``pol.score``, ``market_cap.in_usd``, ``data_coverage.percentage``)
+    into a single flat dict.
+
+    :param record:
+        The Core3 export record for the vault's protocol, as returned by
+        :py:func:`build_core3_protocols_for_export`, or ``None`` if the
+        protocol has no Core3 data.
+
+    :return:
+        A :class:`Core3VaultSection` dict, or ``None`` if ``record`` is
+        ``None``. Individual keys are ``None`` when the corresponding
+        Core3 field is absent.
+    """
+    if record is None:
+        return None
+
+    pol = record.get("pol") or {}
+    market_cap = record.get("market_cap") or {}
+    data_coverage = record.get("data_coverage") or {}
+
+    # market_cap.in_usd is a numeric string from the Core3 API, e.g. "1246877334".
+    in_usd = market_cap.get("in_usd")
+    market_cap_usd = float(in_usd) if in_usd is not None else None
+
+    return {
+        "risk_score": pol.get("score"),
+        "market_cap": market_cap_usd,
+        "core3_ranking": record.get("rank"),
+        "data_coverage": data_coverage.get("percentage"),
+        "confidence": pol.get("confidence"),
+        "risk_rating_label": pol.get("rating"),
+    }
+
+
 def build_core3_protocols_for_export(
     db: Core3Database,
     protocol_slugs: Iterable[str],
@@ -408,6 +522,17 @@ def build_core3_protocols_for_export(
         fetched_at = export_record["fetched_at"]
         if isinstance(fetched_at, datetime.datetime):
             export_record["fetched_at"] = fetched_at.isoformat()
+
+        # Serialise the nested per-category snapshot timestamp, which the
+        # database layer returns as a datetime rather than an ISO string.
+        pol_categories = export_record.get("pol_categories")
+        if pol_categories is not None:
+            # Shallow copy to avoid mutating the cached Core3Record dict
+            pol_categories = {**pol_categories}
+            ts = pol_categories.get("ts")
+            if isinstance(ts, datetime.datetime):
+                pol_categories["ts"] = ts.isoformat()
+            export_record["pol_categories"] = pol_categories
 
         result[slug] = export_record
 

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -25,7 +25,7 @@ from tqdm_loggable.auto import tqdm
 
 from eth_defi.chain import get_chain_name
 from eth_defi.compat import native_datetime_utc_now
-from eth_defi.core3.vault_protocol import Core3ExportRecord
+from eth_defi.core3.vault_protocol import Core3ExportRecord, Core3VaultSection, build_core3_vault_section
 from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS
 from eth_defi.erc_4626.core import ERC4262VaultDetection
 from eth_defi.erc_4626.vault_protocol.morpho.flag_analytics import MorphoFlagAnalytics, analyze_morpho_flags
@@ -262,6 +262,11 @@ class VaultMetricsRecord(TypedDict, total=False):
 
     #: Protocol-specific extension data (Morpho flags, etc.)
     other_data: dict
+
+    #: Compact Core3 risk summary for the vault's protocol, or ``None``
+    #: when no Core3 data is available. See
+    #: :py:class:`~eth_defi.core3.vault_protocol.Core3VaultSection`.
+    core3: "Core3VaultSection | None"
 
     #: Per-period tearsheet results
     period_results: list[dict]
@@ -1305,6 +1310,7 @@ def calculate_vault_record(
     month_ago: pd.Timestamp,
     three_months_ago: pd.Timestamp,
     vault_id: str | None = None,
+    core3_protocols: dict[str, Core3ExportRecord] | None = None,
 ) -> pd.Series:
     """Process a single vault metadata + prices to calculate its full data.
 
@@ -1325,6 +1331,15 @@ def calculate_vault_record(
 
     :param vault_id:
         Vault ID string. If not provided, extracted from prices_df["id"].
+
+    :param core3_protocols:
+        Optional Core3 risk records keyed by our protocol slug, as
+        returned by
+        :py:func:`eth_defi.core3.vault_protocol.build_core3_protocols_for_export`.
+        When given, a compact per-vault ``core3`` summary
+        (:py:class:`~eth_defi.core3.vault_protocol.Core3VaultSection`) is
+        attached to the record for the vault's protocol, or ``None`` if
+        the protocol has no Core3 data.
 
     :return:
         Series with calculated metrics
@@ -1404,6 +1419,12 @@ def calculate_vault_record(
     vault_slug = vault_metadata["vault_slug"]
     protocol_slug = vault_metadata["protocol_slug"]
     risk_numeric = risk.value if isinstance(risk, VaultTechnicalRisk) else None
+
+    # Compact per-vault Core3 risk summary for the vault's protocol.
+    # Core3 data is per-protocol, so all vaults of the same protocol share
+    # the same summary. None when no Core3 records were supplied or the
+    # protocol has no Core3 data.
+    core3_section = build_core3_vault_section((core3_protocols or {}).get(protocol_slug))
 
     curator_slug = identify_curator(
         chain_id=chain_id,
@@ -1799,6 +1820,9 @@ def calculate_vault_record(
             "short_description": short_description,
             # Manual review decision from the Hyperliquid review Google Sheet
             "manual_review_status": manual_review_status,
+            # Compact per-vault Core3 risk summary (risk_score, market_cap, rating, etc.).
+            # None when no Core3 data is available for the vault's protocol.
+            "core3": core3_section,
             # Protocol-specific extension data; see other_data definition above for structure
             "other_data": other_data,
         }
@@ -1809,6 +1833,7 @@ def calculate_lifetime_metrics(
     df: pd.DataFrame,
     vault_db: VaultDatabase | dict[VaultSpec, VaultRow],
     returns_column: str = "returns_1h",
+    core3_protocols: dict[str, Core3ExportRecord] | None = None,
 ) -> pd.DataFrame:
     """Calculate lifetime metrics for each vault in the provided DataFrame.
 
@@ -1826,6 +1851,13 @@ def calculate_lifetime_metrics(
 
     :param vault_db:
         Pass all vaults or subset of vaults as VaultRows, or full VaultDatabase
+
+    :param core3_protocols:
+        Optional Core3 risk records keyed by our protocol slug, as
+        returned by
+        :py:func:`eth_defi.core3.vault_protocol.build_core3_protocols_for_export`.
+        Threaded through to :py:func:`calculate_vault_record` to attach a
+        per-vault ``core3`` summary. ``None`` to skip Core3 enrichment.
 
     :return:
         DataFrame, one row per vault.
@@ -1854,7 +1886,7 @@ def calculate_lifetime_metrics(
     # Sort is needed for slug stability
     # We pass include_groups=False to avoid FutureWarning, and pass id via group.name
     def _apply_vault_record(group):
-        return calculate_vault_record(group, vaults_by_id, month_ago, three_months_ago, vault_id=group.name)
+        return calculate_vault_record(group, vaults_by_id, month_ago, three_months_ago, vault_id=group.name, core3_protocols=core3_protocols)
 
     results_df = df.groupby("id", group_keys=False, sort=True).progress_apply(
         _apply_vault_record,
@@ -2328,6 +2360,7 @@ def format_lifetime_table(
     _del("description")
     _del("short_description")
     _del("other_data")
+    _del("core3")
 
     # Metadata timestamp, not relevant for human-readable table
     _del("generated_at")

--- a/scripts/erc-4626/vault-analysis-json.py
+++ b/scripts/erc-4626/vault-analysis-json.py
@@ -50,6 +50,7 @@ from eth_defi.research.vault_metrics import (
     export_lifetime_row,
     cross_check_data,
     calculate_hourly_returns_for_all_vaults,
+    slugify_protocol,
 )
 
 # --------------------------------------------------------------------
@@ -227,20 +228,10 @@ def main(
 
     raw_returns_df = returns_df = calculate_hourly_returns_for_all_vaults(prices_df)
 
-    lifetime_data_df = calculate_lifetime_metrics(returns_df, vault_db)
-
-    print(f"Calculated lifetime metrics for {len(lifetime_data_df):,} vaults with {len(lifetime_data_df.columns):,} columns")
-
-    # Don't export all crappy vaults to keep the data more compact
-    # Use peak TVL so we will export old vaults too which were popular in the past
-    filtered_lifetime_data_df = lifetime_data_df[lifetime_data_df["peak_nav"] >= THRESHOLD_TVL]
-
-    # 5️⃣ Convert DataFrame → list of dicts
-    vaults = [export_lifetime_row(r) for _, r in filtered_lifetime_data_df.iterrows()]
-
-    # 6️⃣ Build Core3 protocol-level risk data directly for the export.
-    # Core3 data is per-protocol (not per-vault), so it lives at the top level
-    # of the JSON export keyed by our internal protocol slugs.
+    # Build Core3 protocol-level risk data up front, so it can be attached
+    # both per-vault (compact ``core3`` summary inside each vault record) and
+    # at the top level of the export (full ``core3_protocols`` dict).
+    # Core3 records are keyed by our internal protocol slug.
     core3_protocols = {}
     if core3_db_path is None:
         db_path_env = os.getenv("CORE3_DATABASE_PATH")
@@ -252,11 +243,31 @@ def main(
         core3_db = Core3Database(core3_db_path)
         try:
             print(f"Opened Core3 risk database at {core3_db_path} with {core3_db.get_project_count()} projects")
-            unique_slugs = {v.get("protocol_slug") for v in vaults if v.get("protocol_slug")}
-            unique_slugs.discard(None)
-            core3_protocols = build_core3_protocols_for_export(core3_db, unique_slugs)
+            # Derive protocol slugs directly from vault metadata (slugify_vaults
+            # has not run yet at this point, so compute the slug from "Protocol").
+            all_protocol_slugs = {slugify_protocol(v["Protocol"]) for v in vault_db.values()}
+            core3_protocols = build_core3_protocols_for_export(core3_db, all_protocol_slugs)
         finally:
             core3_db.close()
+
+    lifetime_data_df = calculate_lifetime_metrics(returns_df, vault_db, core3_protocols=core3_protocols)
+
+    print(f"Calculated lifetime metrics for {len(lifetime_data_df):,} vaults with {len(lifetime_data_df.columns):,} columns")
+
+    # Don't export all crappy vaults to keep the data more compact
+    # Use peak TVL so we will export old vaults too which were popular in the past
+    filtered_lifetime_data_df = lifetime_data_df[lifetime_data_df["peak_nav"] >= THRESHOLD_TVL]
+
+    # 5️⃣ Convert DataFrame → list of dicts
+    vaults = [export_lifetime_row(r) for _, r in filtered_lifetime_data_df.iterrows()]
+
+    # 6️⃣ Restrict the top-level Core3 protocol risk data to protocols that
+    # actually survived the export filter. Core3 data is per-protocol (not
+    # per-vault), so it lives at the top level keyed by our protocol slugs;
+    # the full dict was built up front (above) and also fed per-vault.
+    exported_slugs = {v.get("protocol_slug") for v in vaults if v.get("protocol_slug")}
+    exported_slugs.discard(None)
+    core3_protocols = {slug: record for slug, record in core3_protocols.items() if slug in exported_slugs}
 
     # 6b. Build curator metadata and recent feed entries for the export.
     # Curator data is per-curator (not per-vault), keyed by curator slug.

--- a/tests/core3/test_vault_protocol_export.py
+++ b/tests/core3/test_vault_protocol_export.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from eth_defi.core3.database import Core3Database
-from eth_defi.core3.vault_protocol import build_core3_protocols_for_export
+from eth_defi.core3.vault_protocol import build_core3_protocols_for_export, build_core3_vault_section
 
 
 def _make_core3_project_json(slug: str, name: str, rank: int, pol_score: float) -> dict:
@@ -47,11 +47,14 @@ def test_build_core3_protocols_for_export(tmp_path: Path):
     """Core3 export helper builds a protocol-slug-keyed dict from the DB.
 
     1. Create a temp Core3 DuckDB with morpho and instadapp (fluid alias) snapshots
-    2. Call build_core3_protocols_for_export with morpho, fluid, euler, some-random
-    3. Assert morpho is returned with correct PoL score
-    4. Assert fluid is keyed as "fluid" with Core3 slug "instadapp"
-    5. Assert euler (no DB data) and some-random (no mapping) are absent
-    6. Assert fetched_at is an ISO 8601 string, not a datetime
+    2. Insert two days of per-category PoL points for morpho (so latest wins)
+    3. Call build_core3_protocols_for_export with morpho, fluid, euler, some-random
+    4. Assert morpho is returned with correct PoL score
+    5. Assert fluid is keyed as "fluid" with Core3 slug "instadapp"
+    6. Assert euler (no DB data) and some-random (no mapping) are absent
+    7. Assert fetched_at is an ISO 8601 string, not a datetime
+    8. Assert morpho carries the latest per-category sub-scores with an ISO ts
+    9. Assert fluid (no category data) has pol_categories set to None
     """
     # 1. Create temp Core3 DB with morpho and instadapp snapshots
     db = Core3Database(tmp_path / "test-core3.duckdb")
@@ -60,28 +63,106 @@ def test_build_core3_protocols_for_export(tmp_path: Path):
     db.insert_project_snapshot("morpho", t_fetch, _make_core3_project_json("morpho", "Morpho", rank=96, pol_score=32.15))
     db.insert_project_snapshot("instadapp", t_fetch, _make_core3_project_json("instadapp", "Fluid (Instadapp)", rank=150, pol_score=45.0))
 
+    # 2. Insert two daily category points; the later one must win in the export.
+    # Unix timestamps: 2026-06-30 and 2026-07-01 (UTC midnight).
+    db.insert_pol_category_daily_points(
+        "morpho",
+        [
+            {
+                "timestamp": 1782777600,  # 2026-06-30T00:00:00Z (stale)
+                "security": {"score": 10.0},
+                "financial": {"score": 20.0},
+                "operational": {"score": 30.0},
+                "reputational": {"score": 40.0},
+                "regulatory": {"score": 50.0},
+            },
+            {
+                "timestamp": 1782864000,  # 2026-07-01T00:00:00Z (latest)
+                "security": {"score": 11.1},
+                "financial": {"score": 22.2},
+                "operational": {"score": 33.3},
+                "reputational": {"score": 44.4},
+                "regulatory": {"score": None},
+            },
+        ],
+        t_fetch,
+    )
+
     try:
-        # 2. Build export for a mix of valid, aliased, missing, and unmapped slugs
+        # 3. Build export for a mix of valid, aliased, missing, and unmapped slugs
         result = build_core3_protocols_for_export(db, ["morpho", "fluid", "euler", "some-random"])
     finally:
         db.close()
 
-    # 3. Morpho is returned with correct data
+    # 4. Morpho is returned with correct data
     assert "morpho" in result
     assert result["morpho"]["slug"] == "morpho"
     assert result["morpho"]["pol"]["score"] == pytest.approx(32.15)
     assert result["morpho"]["rank"] == 96
 
-    # 4. Fluid is keyed as "fluid" but the Core3 record has slug "instadapp"
+    # 5. Fluid is keyed as "fluid" but the Core3 record has slug "instadapp"
     assert "fluid" in result
     assert result["fluid"]["slug"] == "instadapp"
     assert result["fluid"]["pol"]["score"] == pytest.approx(45.0)
 
-    # 5. Euler (no DB data) and some-random (no mapping) are absent
+    # 6. Euler (no DB data) and some-random (no mapping) are absent
     assert "euler" not in result
     assert "some-random" not in result
 
-    # 6. fetched_at is an ISO 8601 string
+    # 7. fetched_at is an ISO 8601 string
     assert result["morpho"]["fetched_at"] == "2026-07-01T12:00:00"
     assert isinstance(result["morpho"]["fetched_at"], str)
     assert result["fluid"]["fetched_at"] == "2026-07-01T12:00:00"
+
+    # 8. Morpho carries the latest per-category sub-scores with an ISO ts string
+    categories = result["morpho"]["pol_categories"]
+    assert categories["ts"] == "2026-07-01T00:00:00"
+    assert isinstance(categories["ts"], str)
+    assert categories["security"] == pytest.approx(11.1)
+    assert categories["financial"] == pytest.approx(22.2)
+    assert categories["operational"] == pytest.approx(33.3)
+    assert categories["reputational"] == pytest.approx(44.4)
+    assert categories["regulatory"] is None
+
+    # 9. Fluid has no category rows, so pol_categories is None
+    assert result["fluid"]["pol_categories"] is None
+
+
+def test_build_core3_vault_section():
+    """Per-vault Core3 summary flattens the headline risk fields, None when absent.
+
+    1. Build a section from a full Core3 export record and assert each key maps correctly
+    2. Assert market_cap is converted from the API string to a float
+    3. Assert a None input yields a None section (protocol has no Core3 data)
+    4. Assert missing nested fields degrade each key to None rather than raising
+    """
+    # 1. Full record maps every headline field into the flat section
+    record = {
+        "slug": "morpho",
+        "rank": 96,
+        "pol": {"score": 32.15, "rating": "BB", "confidence": "High"},
+        "market_cap": {"in_usd": "1246877334", "change_24h_percentage": -0.7, "change_24h_in_usd": "-8000"},
+        "data_coverage": {"percentage": 76.7},
+    }
+    section = build_core3_vault_section(record)
+    assert section["risk_score"] == pytest.approx(32.15)
+    assert section["core3_ranking"] == 96
+    assert section["data_coverage"] == pytest.approx(76.7)
+    assert section["confidence"] == "High"
+    assert section["risk_rating_label"] == "BB"
+
+    # 2. market_cap string is parsed to a numeric USD float
+    assert section["market_cap"] == pytest.approx(1246877334.0)
+    assert isinstance(section["market_cap"], float)
+
+    # 3. None record (no Core3 data for the protocol) yields a None section
+    assert build_core3_vault_section(None) is None
+
+    # 4. Missing nested fields degrade gracefully to None, no KeyError
+    sparse = build_core3_vault_section({"slug": "x"})
+    assert sparse["risk_score"] is None
+    assert sparse["market_cap"] is None
+    assert sparse["core3_ranking"] is None
+    assert sparse["data_coverage"] is None
+    assert sparse["confidence"] is None
+    assert sparse["risk_rating_label"] is None


### PR DESCRIPTION
## Why

Surface Core3 risk intelligence at the granularity the frontend needs. Previously the JSON export carried only the overall PoL score per protocol, attached at the top level (`core3_protocols`). The frontend wants two more things:

1. The **per-category** PoL sub-scores (security, financial, operational, reputational, regulatory) for the latest snapshot.
2. A **compact per-vault** risk summary so each vault row can show its protocol's headline risk fields without joining against the top-level dict.

## Lessons learnt

- The per-category scores were already collected daily into the `pol_category_daily` DuckDB table but never surfaced — they live in a separate API endpoint (`/pol/by_category`) from the project detail payload, so they were absent from the snapshot JSON that drives the export.
- `protocol_slug` is only assigned by `slugify_vaults()` *inside* `calculate_lifetime_metrics()`, so to build the Core3 dict before that call the script computes the slug directly from the `"Protocol"` field via `slugify_protocol()`.
- Core3 data is per-protocol, so building the dict once up front and feeding it both per-vault and to the top level avoids opening the DuckDB database twice.

## Summary

**Per-category scores (top-level `core3_protocols`)**
- `Core3Database.get_latest_pol_category()` returns the most recent `pol_category_daily` row.
- `get_core3_protocol_record()` attaches it as `pol_categories`; `build_core3_protocols_for_export()` serialises the nested timestamp to ISO 8601.
- New `Core3PolCategories` TypedDict + field on `Core3Record`/`Core3ExportRecord`.

**Per-vault `core3` summary**
- New `Core3VaultSection` TypedDict and `build_core3_vault_section()` flattening the headline fields: `risk_score`, `market_cap` (parsed to float), `core3_ranking`, `data_coverage`, `confidence`, `risk_rating_label`. Returns `None` when the protocol has no Core3 data.
- `calculate_lifetime_metrics()` / `calculate_vault_record()` gained an optional `core3_protocols` param; each vault record gets a `core3` section. Added to `VaultMetricsRecord` and excluded from the human-readable table.
- `vault-analysis-json.py` builds the Core3 dict once from `vault_db`, feeds it per-vault, and filters the top-level dict to exported protocols (preserving previous top-level output).

**Tests**
- `test_build_core3_protocols_for_export` extended for the latest-wins per-category breakdown and ISO timestamp.
- New `test_build_core3_vault_section` covering field mapping, market-cap string→float, `None` input, and graceful degradation of missing fields.
- Existing `test_calculate_lifetime_metrics` / `test_export_lifetime_metrics` confirm the new `core3` column serialises cleanly.

**Docs**
- `README-core3.md` documents the `vault_protocol` module and the new export fields.
