### PR TITLE
Add 3Jane USD3 and sUSD3 stablecoins

### DIFF
--- a/eth_defi/data/feeds/stablecoins/susd3.yaml
+++ b/eth_defi/data/feeds/stablecoins/susd3.yaml
@@ -1,0 +1,5 @@
+# sUSD3 - junior tranche, same issuer as USD3 (3Jane)
+feeder-id: susd3
+name: 3Jane sUSD3
+role: stablecoin
+canonical-feeder-id: usd3

--- a/eth_defi/data/feeds/stablecoins/usd3.yaml
+++ b/eth_defi/data/feeds/stablecoins/usd3.yaml
@@ -1,0 +1,5 @@
+feeder-id: usd3
+name: 3Jane USD3
+role: stablecoin
+website: https://www.3jane.xyz/
+twitter: 3janexyz

--- a/eth_defi/data/stablecoins/susd3.yaml
+++ b/eth_defi/data/stablecoins/susd3.yaml
@@ -1,0 +1,47 @@
+symbol: sUSD3
+name: 3Jane sUSD3
+slug: susd3
+category: yield_bearing
+short_description: |
+  sUSD3 is the junior-tranche token of the 3Jane credit protocol, minted by staking
+  USD3. It is an ERC-4626 token whose underlying asset is USD3, appreciating as it
+  captures a higher share of pool yield in exchange for absorbing losses before USD3
+  in the waterfall. Junior deposits carry a one-month lock.
+long_description: |
+  sUSD3 is the **junior tranche** of the [3Jane](https://www.3jane.xyz/) credit
+  protocol, obtained by staking USD3 (the senior tranche). It is an ERC-4626 token whose
+  underlying asset is USD3 rather than USDC directly, so its value is denominated through
+  USD3's USDC peg.
+
+  ## Mechanism
+
+  Junior depositors stake USD3 to mint sUSD3 and, in return for accepting first-loss risk,
+  receive a higher proportion of the lending pool's yield. sUSD3 absorbs losses before USD3
+  is impaired in the loss waterfall, and junior positions are subject to a one-month lock.
+  Like USD3, sUSD3 appreciates against its underlying as interest accrues — yield is
+  reflected in the exchange rate rather than rebasing distributions, and additional $JANE
+  emissions can layer on top.
+
+  ## Relationship to USD3
+
+  sUSD3 is a staked derivative of USD3; it does not have a separate issuer or news source.
+  See the USD3 metadata for the full description of 3Jane's credit-backed money market.
+
+  ## Sources
+
+  - [3Jane documentation — FAQ](https://docs.3jane.xyz/resources/faq)
+  - [3Jane homepage](https://www.3jane.xyz/)
+  - [sUSD3 on Etherscan](https://etherscan.io/address/0xf689555121e529Ff0463e191F9Bd9d1E496164a7)
+links:
+  homepage: https://www.3jane.xyz/
+  coingecko: ''
+  defillama: https://defillama.com/protocol/3jane
+  twitter: https://x.com/3janexyz
+contract_addresses:
+  - chain: ethereum
+    address: '0xf689555121e529Ff0463e191F9Bd9d1E496164a7'
+checks:
+  twitter_last_post_at: ''
+  domain_up_at: ''
+  marked_dead_at: ''
+  information_found_missing_at: ''

--- a/eth_defi/data/stablecoins/usd3.yaml
+++ b/eth_defi/data/stablecoins/usd3.yaml
@@ -1,0 +1,56 @@
+symbol: USD3
+name: 3Jane USD3
+slug: usd3
+category: wrapped
+short_description: |
+  USD3 is the yield-bearing ERC-4626 senior-tranche token of the 3Jane credit
+  protocol. Users deposit USDC to mint USD3, whose value appreciates against USDC
+  as the protocol earns interest from uncollateralised crypto credit lines and
+  fintech credit conduits. As the senior tranche it is credit-enhanced and the
+  last to be impaired in the loss waterfall.
+long_description: |
+  USD3 is a yield-bearing ERC-4626 token issued by [3Jane](https://www.3jane.xyz/),
+  a decentralised credit-based money market on Ethereum (with a Base deployment) that
+  facilitates uncollateralised stablecoin loans. When a user deposits USDC they receive
+  USD3 shares at the current exchange rate, which starts at 1:1 with USDC and rises
+  continuously as the lending pool accrues interest — holders do not claim rebasing
+  rewards; instead each USD3 redeems for progressively more USDC over time.
+
+  ## Mechanism
+
+  Deposited USDC is allocated across two credit sleeves:
+
+  - **Crypto Credit Lines** — uncollateralised USDC lines to crypto-native borrowers.
+  - **Fintech Credit Conduits** — funding to U.S. fintech lenders backed by eligible
+    receivables and verified on-chain, CEX and bank assets.
+
+  Idle USDC is parked in [Aave](https://aave.com/) while awaiting deployment. Borrowers
+  pay interest, and that interest flows back to depositors as USD3 appreciation.
+
+  ## Tranche structure
+
+  3Jane runs a two-tier deposit structure. USD3 is the **senior tranche**: it earns a
+  variable share of pool yield, is credit-enhanced, and is the last to be impaired in
+  the waterfall. The **junior tranche** (sUSD3) absorbs losses before USD3 and carries
+  a one-month lock in exchange for higher yield. Both tranches take a fixed proportion
+  of whatever the backing generates, and additional $JANE token emissions can layer on
+  top of the native yield.
+
+  ## Sources
+
+  - [3Jane documentation — FAQ](https://docs.3jane.xyz/resources/faq)
+  - [3Jane homepage](https://www.3jane.xyz/)
+  - [USD3 on Etherscan](https://etherscan.io/address/0x056B269Eb1f75477a8666ae8C7fE01b64dD55eCc)
+links:
+  homepage: https://www.3jane.xyz/
+  coingecko: ''
+  defillama: https://defillama.com/protocol/3jane
+  twitter: https://x.com/3janexyz
+contract_addresses:
+  - chain: ethereum
+    address: '0x056B269Eb1f75477a8666ae8C7fE01b64dD55eCc'
+checks:
+  twitter_last_post_at: ''
+  domain_up_at: ''
+  marked_dead_at: ''
+  information_found_missing_at: ''

--- a/eth_defi/stablecoin_metadata.py
+++ b/eth_defi/stablecoin_metadata.py
@@ -377,11 +377,11 @@ STABLECOIN_LIKE = set(
 
 #: Stablecoins which can be used as collateral, but which also have built-in yield bearing function
 #: with rebasing.
-YIELD_BEARING_STABLES = {"sfrxUSD", "sUSDe", "sUSDai", "sBOLD", "sAUSD", "sUSG", "ynUSDx", "sNUSD", "savUSD", "syrupUSDC", "stcUSD", "apyUSD"}
+YIELD_BEARING_STABLES = {"sfrxUSD", "sUSDe", "sUSDai", "sBOLD", "sAUSD", "sUSG", "ynUSDx", "sNUSD", "savUSD", "syrupUSDC", "stcUSD", "apyUSD", "sUSD3"}
 
 #: Stablecoins plus their interest wrapped counterparts on Compound and Aave.
 #: Also contains other derivates.
-WRAPPED_STABLECOIN_LIKE = {"cUSDC", "cUSDT", "sUSD", "aDAI", "cDAI", "tfUSDC", "alUSD", "agEUR", "gmdUSDC", "gDAI", "blUSD", "eEARN", "autoUSD", "bbqUSDC", "AA_FalconXUSDC"}
+WRAPPED_STABLECOIN_LIKE = {"cUSDC", "cUSDT", "sUSD", "aDAI", "cDAI", "tfUSDC", "alUSD", "agEUR", "gmdUSDC", "gDAI", "blUSD", "eEARN", "autoUSD", "bbqUSDC", "AA_FalconXUSDC", "USD3"}
 
 #: All stablecoin likes - both interested bearing and non interest bearing.
 ALL_STABLECOIN_LIKE = STABLECOIN_LIKE | WRAPPED_STABLECOIN_LIKE | YIELD_BEARING_STABLES


### PR DESCRIPTION
## Why

A vault denominated in 3Jane's **USD3** (or its staked junior tranche **sUSD3**)
is dropped by `filter_vaults_by_stablecoin()` because `is_stablecoin_like()` did
not recognise either symbol, so it never reaches `top_vaults_by_chain.json`.
USD3 is a credit-backed yieldcoin from [3Jane](https://www.3jane.xyz/), a
decentralised uncollateralised-credit money market. This PR wires it (and sUSD3)
into the stablecoin classification, metadata, feed and logo layers; registers
3Jane as a protocol-managed curator; and adds 3Jane as a first-class ERC-4626
vault protocol so its vaults are detected and attributed.

## Lessons learnt

- **Two live deployments share the USD3/sUSD3 symbols.** The canonical pair is
  USD3 `0x056B269E…` (6 decimals, ~$27M `totalAssets`, ERC-4626 `asset()` = Circle
  USDC) with sUSD3 `0xf6895551…` (6 decimals, `asset()` = that USD3). A second,
  smaller pair (USD3 `0xCcE9…`, 18 decimals, `asset()` = aEthUSDC; sUSD3 `0x32a7…`)
  also returns `symbol() == "USD3"`/`"sUSD3"`. On-chain `symbol()` + `asset()` +
  `totalAssets()` checks were needed to pick the right addresses.
- **USD3 → `wrapped`, sUSD3 → `yield_bearing`.** USD3 is an ERC-4626 receipt whose
  underlying is plain USDC (wrapped); sUSD3's `asset()` is USD3 — a staked form of
  a base we now carry (yield_bearing). For the filter the set choice is immaterial.
- **The protocol slug starts with a digit.** `slugify_protocol("3Jane") == "3jane"`,
  but Python packages/enum members can't start with a digit — so the module is
  `eth_defi.erc_4626.vault_protocol.threejane`, the class is `ThreeJaneVault`, and
  the feature is `threejane_like`, while every user-facing slug/name stays `3jane`/
  `3Jane`. Keeping `get_vault_protocol_name()` → `"3Jane"` is what makes the vault
  protocol, the protocol-managed curator, and the metadata slug all line up.
- **Hardcoded-address detection, not a probe.** 3Jane issues only its two own
  vaults, so they're registered in `HARDCODED_PROTOCOLS` rather than via a
  bespoke on-chain probe call — simpler and conflict-free.
- **Single-source feed graph.** `protocols/3jane.yaml` carries the only copy of
  `@3janexyz`; the `usd3`/`susd3` stablecoin feeders and the `3jane` curator all
  alias it via `canonical-feeder-id` (which may cross roles), so the account is
  scanned once.

## Summary

- **Stablecoin classification**: `USD3` → `WRAPPED_STABLECOIN_LIKE`, `sUSD3` →
  `YIELD_BEARING_STABLES` in `eth_defi/stablecoin_metadata.py`.
- **Stablecoin metadata/logos**: `data/stablecoins/{usd3,susd3}.yaml` + 256×256
  `formatted_logos/{usd3,susd3}/light.png` (official 3Jane brand mark).
- **Vault protocol**: new `ThreeJaneVault` + `ERC4626Feature.threejane_like`;
  `get_vault_protocol_name()` → `"3Jane"`; both vault addresses added to
  `HARDCODED_PROTOCOLS`; `create_vault_instance()` case; `risk.py`/`fee.py` stubs
  (`None`, pending human assessment); protocol metadata `data/vaults/metadata/3jane.yaml`
  + logo; docs page `docs/source/vaults/threejane/`; tests `test_threejane.py`.
- **Curator**: `"3jane"` in `PROTOCOL_CURATED_SLUGS` / `PROTOCOL_CURATOR_NAMES`;
  `data/feeds/curators/3jane.yaml`; `test_identify_3jane_protocol_curator`.
- **Feed graph**: `data/feeds/protocols/3jane.yaml` is the single source; the
  stablecoin + curator feeders alias it.
- **Verification**: `is_stablecoin_like("USD3")`/`("sUSD3")` True; USD3/sUSD3
  autodetect as `ThreeJaneVault` on an Ethereum fork; `identify_curator(protocol_slug="3jane")`
  → `"3jane"` with `is_protocol_curator` True; all real feed/curator YAMLs load;
  `test_threejane`, `test_curator`, `test_canonical_feeder`, `test_curator_export`,
  plus `test_cap`/`test_ethena` regression checks pass (33 tests).
