### PR TITLE
fix: Detect renamed Hibachi FLP - Closed vault as Kappa Lab curator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- fix: Add an `FLP` short pattern to the Kappa Lab curator so the closed Hibachi vault renamed from `Fire Liquidity Provider` to `FLP - Closed` is still detected by `identify_curator()`; the rename had dropped the only string the previous pattern matched, leaving the vault uncurated (2026-06-11)
+
 - feat: Add Domination Finance as a protocol-managed vault curator so its dfUSDC counterparty liquidity vault on Base is recognised by `identify_curator()` and exported with market-making-vault-specific short and long descriptions in the curator JSON, matching the existing Hyperliquid, GRVT, Ostium and Gains Network (gTrade) perp-DEX curator entries (2026-06-11)
 
 - feat: Add `eth_defi.cctp.events` — engine-agnostic scanning of CCTP V2 `DepositForBurn` events, wrapped into the slotted `CCTPDepositForBurn` dataclass so the underlying event reading engine can change without touching callers; `fetch_deposit_for_burn_events()` prefers HyperSync (server-side filtered streaming, scales to full-history scans) and falls back to chunked `eth_getLogs` with adaptive chunk shrinking when HyperSync is unavailable (e.g. Anvil forks). The correct V2 event topic is pinned in `DEPOSIT_FOR_BURN_EVENT_TOPIC0` because the bundled `TokenMessengerV2.json` ABI carries the stale V1 event signature whose topic hash matches nothing emitted on-chain (2026-06-10)

--- a/eth_defi/vault/curator.py
+++ b/eth_defi/vault/curator.py
@@ -244,7 +244,9 @@ CURATOR_NAME_PATTERNS: dict[str, list[str]] = {
     "fija": ["Fija"],
     "woo": ["Woo"],
     "telosc": ["TelosC"],
-    "kappa-lab": ["Fire Liquidity Provider"],
+    # "FLP" matches the closed Hibachi vault renamed to "FLP - Closed", which no
+    # longer contains the full "Fire Liquidity Provider" name (2026-06-11).
+    "kappa-lab": ["Fire Liquidity Provider", "FLP"],
     # New curators from Morpho verified list (2026-05-05)
     "b-protocol": ["B.Protocol"],
     "felix": ["Felix"],

--- a/tests/vault/test_curator.py
+++ b/tests/vault/test_curator.py
@@ -66,12 +66,29 @@ def test_identify_telosc_short_name() -> None:
 
 
 def test_identify_kappa_lab_fire_liquidity_provider() -> None:
-    """Fire Liquidity Provider vault names resolve to Kappa Lab."""
+    """Fire Liquidity Provider and renamed FLP vault names resolve to Kappa Lab.
 
+    1. The full "Fire Liquidity Provider" name resolves to Kappa Lab.
+    2. The closed Hibachi vault renamed to "FLP - Closed" still resolves via
+       the short "FLP" pattern.
+    """
+
+    # 1. Full name resolves to Kappa Lab
     slug = identify_curator(
         chain_id=9999,
         vault_token_symbol="FLP",
         vault_name="Fire Liquidity Provider",
+        vault_address="hibachi:vault:4",
+        protocol_slug="hibachi",
+    )
+
+    assert slug == "kappa-lab"
+
+    # 2. Renamed "FLP - Closed" vault still resolves via the short pattern
+    slug = identify_curator(
+        chain_id=9999,
+        vault_token_symbol="FLP",
+        vault_name="FLP - Closed",
         vault_address="hibachi:vault:3",
         protocol_slug="hibachi",
     )


### PR DESCRIPTION
## Why

A Hibachi curator-lead check surfaced a detection regression. `identify_curator()` keys off the vault display name, and the Kappa Lab curator was matched only by the literal pattern `Fire Liquidity Provider`. Hibachi has since renamed the closed vault's `shortDescription` to `FLP - Closed`, which no longer contains that string — so the vault (`hibachi-vault-3`) fell through to no curator. The live `FLP2` vault still carries the full name and was unaffected.

## Lessons learnt

Curator detection that matches on the marketing display name is fragile: a third party renaming their vault silently breaks the mapping. The reliable operator signal for Hibachi actually lives in the vault `description` field (`"operated by Kappa Lab"`), which detection does not currently consult. A short symbol-derived pattern is a low-risk patch here, but description/manager-name based matching would be more robust long term.

## Summary

- Add `FLP` to the `kappa-lab` entry in `CURATOR_NAME_PATTERNS` in `eth_defi/vault/curator.py`. Verified `\bFLP\b` matches only `hibachi-vault-3` across the full local vault dataset, so there is no collision risk.
- Extend `test_identify_kappa_lab_fire_liquidity_provider` to also assert the renamed `FLP - Closed` name resolves to `kappa-lab`.
- Add a CHANGELOG entry.
