### PR TITLE
notes: Mark Borrowable USDC Deposit SiloId 178 as illiquid

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -490,6 +490,8 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0x322e1d5384aa4ed66aeca770b95686271de61dc3": (VaultFlag.illiquid, XUSD_MESSAGE),
     # Etherealm USDC (Morpho on Ethereum)
     "0xb7305d968ecd8a23a13ec01927e3f9588c7653b5": (VaultFlag.illiquid, ETHEREALM_USDC_ILLIQUID),
+    # Borrowable USDC Deposit, SiloId: 178 (Ethereum)
+    "0x93c8201c35666f9af8b3b943bad67b42ad0159a1": (VaultFlag.illiquid, XUSD_MESSAGE),
 }
 
 for addr in VAULT_FLAGS_AND_NOTES.keys():


### PR DESCRIPTION
## Why

The vault [Borrowable USDC Deposit, SiloId: 178](https://tradingstrategy.ai/trading-view/vaults/borrowable-usdc-deposit-siloid-178) on Ethereum is illiquid. Like the other Silo "Borrowable USDC Deposit" markets already flagged, it carries Stream xUSD exposure, so deposits are at risk.

## Lessons learnt

Silo "Borrowable USDC Deposit" markets keep surfacing with the same xUSD illiquidity issue — these follow an established pattern in `VAULT_FLAGS_AND_NOTES` (`VaultFlag.illiquid` + `XUSD_MESSAGE`).

## Summary

- Added `0x93c8201c35666f9af8b3b943bad67b42ad0159a1` (Borrowable USDC Deposit, SiloId: 178, Ethereum) to `VAULT_FLAGS_AND_NOTES` in `eth_defi/vault/flag.py` with `VaultFlag.illiquid` and `XUSD_MESSAGE`.
