### PR TITLE
fix: Prioritise Frax USD curator detection

### DIFF
--- a/eth_defi/vault/curator.py
+++ b/eth_defi/vault/curator.py
@@ -228,7 +228,7 @@ CURATOR_NAME_PATTERNS: dict[str, list[str]] = {
     "llama-risk": ["LlamaRisk"],
     "9summits": ["9 Summits"],
     "sentora": ["IntoTheBlock"],
-    "frax-finance": ["Frax", "FRAX"],
+    "frax-finance": ["Frax USD", "frxUSD", "Frax", "FRAX"],
     "usdai": ["USD.AI", "USDai"],
     "agora-finance": ["Agora"],
     "tangent-finance": ["Tangent"],
@@ -270,6 +270,16 @@ CURATOR_NAME_PATTERNS: dict[str, list[str]] = {
 SPONSOR_CURATOR_SLUGS: set[str] = {
     "trust-wallet",
     "cool-wallet",
+}
+
+#: Curators whose asset issuer match should win over co-branded vault names.
+#:
+#: Frax USD vaults on Morpho can include a third-party UI curator brand
+#: while the actual product family is Frax-managed.
+#: Stake DAO frxUSD V2, Alpha Frax USD Enhanced V2 and Steakhouse Prime
+#: frxUSD are Frax-based vaults based on the conversation with Frax (2026-06).
+PRIORITY_CURATOR_SLUGS: set[str] = {
+    "frax-finance",
 }
 
 
@@ -472,10 +482,9 @@ def _build_matching_patterns() -> list[tuple[re.Pattern, str]]:
         for extra in CURATOR_NAME_PATTERNS.get(slug, []):
             raw_pairs.append((extra, slug))
 
-    # Sort so that sponsor/distributor patterns are matched last (so the real
-    # risk curator wins on co-branded vaults), and within each priority group
-    # the longest (most specific) pattern matches first.
-    raw_pairs.sort(key=lambda pair: (pair[1] in SPONSOR_CURATOR_SLUGS, -len(pair[0])))
+    # Sort so that priority curators win over co-branded vault names, sponsor
+    # patterns are matched last, and the longest pattern wins within each group.
+    raw_pairs.sort(key=lambda pair: (pair[1] not in PRIORITY_CURATOR_SLUGS, pair[1] in SPONSOR_CURATOR_SLUGS, -len(pair[0])))
 
     patterns = []
     for pattern_text, slug in raw_pairs:

--- a/tests/vault/test_curator.py
+++ b/tests/vault/test_curator.py
@@ -141,6 +141,28 @@ def test_identify_pangolins_vault() -> None:
     assert get_curator_name("pangolins") == "Pangolins"
 
 
+def test_identify_frax_usd_vaults() -> None:
+    """Frax USD and frxUSD vault names resolve to Frax Finance."""
+
+    cases = (
+        ("euler", "Euler Yield frxUSD"),
+        ("frax-finance", "Stable Frax USD Pre-Deposit"),
+        ("morpho", "Stake DAO frxUSD V2"),
+        ("morpho", "Alpha Frax USD Enhanced V2"),
+        ("morpho", "Steakhouse Prime frxUSD"),
+    )
+    for protocol_slug, vault_name in cases:
+        slug = identify_curator(
+            chain_id=1,
+            vault_token_symbol="",
+            vault_name=vault_name,
+            vault_address="0x0000000000000000000000000000000000000005",
+            protocol_slug=protocol_slug,
+        )
+
+        assert slug == "frax-finance", f"{vault_name!r} -> {slug!r}"
+
+
 def test_identify_gains_network_protocol_curator() -> None:
     """Gains Network protocol vaults resolve to the exported protocol slug."""
 
@@ -315,7 +337,7 @@ def test_identify_vault_name_sweep_curators() -> None:
         ("euler", "Keyring zkVerified Cluster"): "keyring-network",
         ("kiln-metavault", "Trust Wallet AAVE v3 USDT"): "trust-wallet",
         ("kiln-metavault", "Cool Wallet AAVEv3 USDC"): "cool-wallet",
-        ("lagoon-finance", "Mt Pelerin – USD strategy pool"): "mt-pelerin",
+        ("lagoon-finance", "Mt Pelerin - USD strategy pool"): "mt-pelerin",
         ("euler", "HypurrFi Earn USDC"): "hypurrfi",
         ("lagoon-finance", "DAMM Stablecoin Fund"): "damm-capital",
         ("morpho", "August USDC"): "august-digital",


### PR DESCRIPTION
## Why

Frax USD vaults can appear with co-branded vault names, such as Stake DAO frxUSD V2 and Steakhouse Prime frxUSD, while still being Frax-based vaults. Curator detection should classify these frxUSD / Frax USD vaults under Frax Finance instead of letting the co-branded third-party name win.

## Lessons learnt

A simple extra `frxUSD` pattern is not enough when another curator name appears earlier in the same vault title. Frax needs explicit priority for these Frax USD vault names so asset issuer matching wins over UI curator branding.

## Summary

- Added explicit Frax Finance matching for `Frax USD` and `frxUSD` vault names.
- Added priority curator ordering so Frax-based vaults win over co-branded curator names.
- Added regression coverage for Euler Yield frxUSD, Stable Frax USD Pre-Deposit, Stake DAO frxUSD V2, Alpha Frax USD Enhanced V2 and Steakhouse Prime frxUSD.

## Related issues and PRs

None.

## Unrelated CI and test fixes

- Replaced an existing en dash in the touched curator test data with an ASCII hyphen so ruff passes on the edited file.
