### PR TITLE
fix: Correct Lagoon vault app links

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/lagoon/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/vault.py
@@ -876,7 +876,7 @@ class LagoonVault(ERC7540Vault, AutomatedSafe):
         return False
 
     def get_link(self, referral: str | None = None) -> str:
-        return f"https://app.lagoon.finance/{self.chain_id}/{self.vault_address}"
+        return f"https://app.lagoon.finance/vault/{self.chain_id}/{self.vault_address}"
 
 
 class LagoonFlowManager(VaultFlowManager):

--- a/tests/lagoon/test_lagoon_erc_7540.py
+++ b/tests/lagoon/test_lagoon_erc_7540.py
@@ -72,7 +72,9 @@ def erc_vault_7540(web3) -> LagoonVault:
         address="0xb09f761cb13baca8ec087ac476647361b6314f98",
         features={ERC4626Feature.lagoon_like, ERC4626Feature.erc_7540_like},
     )
-    return cast(LagoonVault, vault)
+    lagoon_vault = cast(LagoonVault, vault)
+    assert lagoon_vault.get_link() == "https://app.lagoon.finance/vault/8453/0xB09F761Cb13baCa8eC087Ac476647361b6314F98"
+    return lagoon_vault
 
 
 def test_lagoon_erc_7540(


### PR DESCRIPTION
## Why

Lagoon Finance expects vault pages under the Next.js route `/vault/[chainId]/[address]`. The old generated route `https://app.lagoon.finance/{chain_id}/{vault_address}` returns 404 for Lagoon vaults, including DAMM Stablecoin Fund 5 on Arbitrum.

## Lessons learnt

Lagoon native app links should be treated as app routes, not as a simple chain/address root path. When a protocol frontend route changes, refresh persisted vault metadata before regenerating the public top-vaults JSON.

## Summary

- Updated `LagoonVault.get_link()` to generate `https://app.lagoon.finance/vault/{chain_id}/{vault_address}`.
- Extended the existing Lagoon ERC-7540 vault test to assert the native Lagoon app link uses the `/vault/[chainId]/[address]` route.
- Locally verified the regenerated `top_vaults_by_chain.json` had 0 links matching `^https://app\.lagoon\.finance/\d+/0x` and 88 Lagoon links matching `^https://app\.lagoon\.finance/vault/\d+/0x`.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.