### PR TITLE
fix: use canonical vault report links

### DIFF
--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -400,7 +400,7 @@ def _get_chain_slug(chain_name: str) -> str:
 def _get_trading_strategy_chain_link(chain_name: str) -> str:
     """Get the tradingstrategy.ai vault listing URL for a chain."""
     chain_slug = _get_chain_slug(chain_name)
-    return f"https://tradingstrategy.ai/trading-view/{chain_slug}/vaults"
+    return f"https://tradingstrategy.ai/trading-view/vaults/chains/{chain_slug}"
 
 
 def _get_trading_strategy_protocol_link(protocol_slug: str) -> str:
@@ -409,14 +409,15 @@ def _get_trading_strategy_protocol_link(protocol_slug: str) -> str:
 
 
 def _get_trading_strategy_vault_link(
-    chain_id: int,
-    chain_name: str,
-    protocol_slug: str,
     vault_slug: str,
     vault_address: str,
-):
-    chain_slug = _get_chain_slug(chain_name)
-    return f"https://tradingstrategy.ai/trading-view/{chain_slug}/vaults/{vault_slug}?a={vault_address}"
+) -> str:
+    """Get the tradingstrategy.ai vault URL.
+
+    The vault address is kept in the URL fragment so the canonical page route
+    avoids the legacy redirect and the address does not affect routing.
+    """
+    return f"https://tradingstrategy.ai/trading-view/vaults/{vault_slug}#{vault_address}"
 
 
 def create_fee_label(
@@ -1437,9 +1438,6 @@ def calculate_vault_record(
     curator_name = get_curator_name(curator_slug) if curator_slug else None
 
     trading_strategy_link = _get_trading_strategy_vault_link(
-        chain_id=chain_id,
-        chain_name=get_chain_name(chain_id),
-        protocol_slug=protocol_slug,
         vault_slug=vault_slug,
         vault_address=vault_address,
     )

--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -10,14 +10,36 @@ import pytest
 import zstandard as zstd
 from plotly.graph_objects import Figure
 
+from eth_defi.research import vault_metrics
 from eth_defi.research.sparkline import export_sparkline_as_png, export_sparkline_as_svg, extract_vault_price_data, render_sparkline_simple
 from eth_defi.research.vault_benchmark import visualise_vault_return_benchmark
-from eth_defi.research.vault_metrics import PeriodMetrics, apply_abnormal_value_checks, apply_morpho_not_in_api_check, calculate_lifetime_metrics, calculate_period_metrics, display_vault_chart_and_tearsheet, export_lifetime_row, format_lifetime_table
+from eth_defi.research.vault_metrics import (
+    PeriodMetrics,
+    apply_abnormal_value_checks,
+    apply_morpho_not_in_api_check,
+    calculate_lifetime_metrics,
+    calculate_period_metrics,
+    display_vault_chart_and_tearsheet,
+    export_lifetime_row,
+    format_lifetime_table,
+)
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.fee import FeeData, VaultFeeMode
 from eth_defi.vault.flag import NOT_IN_MORPHO_API, VaultFlag
 from eth_defi.vault.risk import VaultTechnicalRisk
 from eth_defi.vault.vaultdb import VaultDatabase
+
+
+def test_get_trading_strategy_links_use_canonical_vault_routes():
+    """Generated Trading Strategy links use canonical flat vault routes."""
+    vault_link = vault_metrics._get_trading_strategy_vault_link(
+        vault_slug="steakhouse-usdc",
+        vault_address="0x6043828A0cE0FccC6D27eC4848673Ff7F54Ebd0C",
+    )
+
+    assert vault_link == "https://tradingstrategy.ai/trading-view/vaults/steakhouse-usdc#0x6043828A0cE0FccC6D27eC4848673Ff7F54Ebd0C"
+    assert vault_metrics._get_trading_strategy_chain_link("Ethereum") == "https://tradingstrategy.ai/trading-view/vaults/chains/ethereum"
+    assert vault_metrics._get_trading_strategy_chain_link("Hypercore") == "https://tradingstrategy.ai/trading-view/vaults/chains/hyperliquid"
 
 
 def test_apply_morpho_not_in_api_check_blacklists_vault():


### PR DESCRIPTION
## Why

Vault metric reports and exported datasets still generated Trading Strategy links using retired chain-prefixed vault routes. The old vault URLs also carried the contract address as a query parameter that the frontend redirect dropped.

## Lessons learnt

The vault metrics pipeline owns these report URLs, so canonical route changes need to be reflected in `eth_defi.research.vault_metrics` instead of the frontend.

## Summary

- Point chain listing links at `/trading-view/vaults/chains/{chain}`.
- Point vault links at `/trading-view/vaults/{vault_slug}#{vault_address}` so the contract address remains behind a page anchor.
- Add focused regression coverage for canonical vault and chain links.
- Formatted the touched files and ran the targeted regression test.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.