### PR TITLE
fix: Stamp vault scanner image via build script

### DIFF
--- a/Dockerfile.vault-scanner
+++ b/Dockerfile.vault-scanner
@@ -65,7 +65,13 @@ RUN poetry cache clear pypi --all --no-interaction
 RUN python -m compileall -q /usr/local/lib/python3.14
 RUN python -m compileall -q eth_defi
 
-# Passed from the image build command, e.g. Github Actions or docker compose build.
+# Passed from scripts/build-container.sh.
+#
+# Always build production images with that script. It extracts git metadata
+# from the checkout, passes these ARGs to Docker Compose, and verifies the
+# resulting image stamp. A direct `docker compose build` will use the
+# ``unspecified`` defaults below and produce null JSON metadata fields.
+#
 # Declared and written at the end so commit metadata changes do not invalidate
 # the expensive dependency install layers above.
 ARG GIT_VERSION_TAG=unspecified
@@ -74,9 +80,9 @@ ARG GIT_VERSION_HASH=unspecified
 
 # Read by eth_defi.version_info.VersionInfo at runtime so the scanner can
 # report which git revision it is running, e.g. in the top-vaults JSON export.
-RUN echo $GIT_VERSION_TAG > GIT_VERSION_TAG.txt
-RUN echo $GIT_COMMIT_MESSAGE > GIT_COMMIT_MESSAGE.txt
-RUN echo $GIT_VERSION_HASH > GIT_VERSION_HASH.txt
+RUN printf '%s\n' "$GIT_VERSION_TAG" > GIT_VERSION_TAG.txt
+RUN printf '%s\n' "$GIT_COMMIT_MESSAGE" > GIT_COMMIT_MESSAGE.txt
+RUN printf '%s\n' "$GIT_VERSION_HASH" > GIT_VERSION_HASH.txt
 
 ENV SCAN_PRICES=true
 CMD ["python", "scripts/erc-4626/scan-vaults-all-chains.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,15 @@ services:
       context: .
       dockerfile: Dockerfile.vault-scanner
       # Stamp the image with its git revision, read at runtime by
-      # eth_defi.version_info.VersionInfo. Build with:
+      # eth_defi.version_info.VersionInfo.
       #
-      #   GIT_VERSION_HASH=$(git rev-parse HEAD) \
-      #   GIT_VERSION_TAG=$(git describe --tags --exact-match 2>/dev/null || true) \
-      #   GIT_COMMIT_MESSAGE=$(git log -1 --pretty=%s) \
-      #   docker compose build vault-scanner
+      # Always build the image with:
+      #
+      #   scripts/build-container.sh
+      #
+      # Do not call `docker compose build` directly for production images:
+      # the wrapper extracts the current git hash, exact tag and commit
+      # message, passes them as build args, and verifies the image stamp.
       #
       # GIT_VERSION_TAG must be an exact tag or empty — never a fallback
       # describe string or abbreviated hash. Untagged builds leave it empty,

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Build the vault scanner Docker image with a git version stamp.
+#
+# Always use this script instead of calling ``docker compose build`` directly.
+# It extracts the current git revision and passes it to Docker Compose as
+# build arguments consumed by Dockerfile.vault-scanner.
+#
+# Environment overrides:
+#
+# - BUILD_SERVICE: Compose service to build. Defaults to vault-scanner-oneshot.
+# - BUILD_PROFILE: Compose profile needed for the build service. Defaults to oneshot.
+# - IMAGE_NAME: Docker image to verify after build. Defaults to vault-scanner:local.
+# - SKIP_VERIFY: Set to true to skip post-build image stamp verification.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+build_service="${BUILD_SERVICE:-vault-scanner-oneshot}"
+build_profile="${BUILD_PROFILE:-oneshot}"
+image_name="${IMAGE_NAME:-vault-scanner:local}"
+
+git_version_hash="$(git rev-parse HEAD)"
+git_version_tag="$(git describe --tags --exact-match 2>/dev/null || true)"
+git_commit_message="$(git log -1 --pretty=%s)"
+
+export GIT_VERSION_HASH="$git_version_hash"
+export GIT_VERSION_TAG="$git_version_tag"
+export GIT_COMMIT_MESSAGE="$git_commit_message"
+
+printf 'Building %s as %s\n' "$build_service" "$image_name"
+printf 'Git commit: %s\n' "$GIT_VERSION_HASH"
+if [[ -n "$GIT_VERSION_TAG" ]]; then
+    printf 'Git tag: %s\n' "$GIT_VERSION_TAG"
+else
+    printf 'Git tag: <none>\n'
+fi
+printf 'Git commit message: %s\n' "$GIT_COMMIT_MESSAGE"
+
+docker compose --profile "$build_profile" build "$build_service"
+
+if [[ "${SKIP_VERIFY:-false}" == "true" ]]; then
+    printf 'Skipping image stamp verification because SKIP_VERIFY=true\n'
+    exit 0
+fi
+
+docker run \
+    --rm \
+    --entrypoint python \
+    -e EXPECTED_GIT_VERSION_HASH="$GIT_VERSION_HASH" \
+    -e EXPECTED_GIT_VERSION_TAG="$GIT_VERSION_TAG" \
+    -e EXPECTED_GIT_COMMIT_MESSAGE="$GIT_COMMIT_MESSAGE" \
+    "$image_name" \
+    -c '
+import os
+
+from eth_defi.version_info import VersionInfo
+
+version = VersionInfo.read_docker_version()
+print(f"Stamped commit: {version.commit_hash}")
+print(f"Stamped tag: {version.tag}")
+print(f"Stamped commit message: {version.commit_message}")
+assert version.commit_hash == os.environ["EXPECTED_GIT_VERSION_HASH"], (version.commit_hash, os.environ["EXPECTED_GIT_VERSION_HASH"])
+assert version.commit_message == os.environ["EXPECTED_GIT_COMMIT_MESSAGE"], (version.commit_message, os.environ["EXPECTED_GIT_COMMIT_MESSAGE"])
+expected_tag = os.environ["EXPECTED_GIT_VERSION_TAG"] or None
+assert version.tag == expected_tag, (version.tag, expected_tag)
+'
+
+printf 'Image stamp verified for %s\n' "$image_name"


### PR DESCRIPTION
## Why

The production vault metadata JSON had `metadata.version` fields set to `null` because the Docker image could be built without passing the `GIT_VERSION_*` build args. The Dockerfile already supported image stamping, but the production build path made it easy to bypass that wiring.

## Lessons learnt

Relying on operators to remember inline Git metadata variables is fragile. The build entry point should extract and verify the version stamp itself, and direct `docker compose build` usage should be clearly discouraged for production images.

## Summary

- Added `scripts/build-container.sh` to extract the current git hash, exact tag and commit message, pass them to Docker Compose, and verify the built image stamp.
- Updated Dockerfile comments to make the build script the required production build path.
- Quoted Dockerfile stamp writes with `printf` so commit subjects are preserved correctly.
- Updated Docker Compose comments to point at the build script instead of manual build arg commands.

## Related issues and PRs

Continues the Docker image version stamping work that added `metadata.version` to the top-vaults JSON export.

## Unrelated CI and test fixes

None.