### PR TITLE
Update pytz dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -7340,14 +7340,14 @@ unidecode = ["Unidecode (>=1.1.1)"]
 
 [[package]]
 name = "pytz"
-version = "2024.2"
+version = "2026.2"
 description = "World timezone definitions, modern and historical"
 optional = false
 python-versions = "*"
 groups = ["main"]
 files = [
-    {file = "pytz-2024.2-py2.py3-none-any.whl", hash = "sha256:31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725"},
-    {file = "pytz-2024.2.tar.gz", hash = "sha256:2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a"},
+    {file = "pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126"},
+    {file = "pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a"},
 ]
 
 [[package]]
@@ -10181,4 +10181,4 @@ test = ["pytest-xdist"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "23da9d75b205a2aaf8fb96f673296695720a5309c81dff40f2a10b239b7e407e"
+content-hash = "7ad7490b8535878b085297ad1d9dc6bbd1aa4b7a20d0888a3fdccd7f2f570bf0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ tenacity = {version = "*", optional = true}# Needed for Plotly
 #eth-pydantic-types = {version = "^0.2.0"}
 
 # web3-google-hsm = {git = "https://github.com/Ankvik-Tech-Labs/web3-google-hsm"}
-pytz = "^2024.2"
+pytz = ">=2026.1.0"
 web3-google-hsm = "^0.1.0"
 
 # Docs


### PR DESCRIPTION
## Why

Update the project pytz dependency constraint so installs can use pytz 2026 releases.

## Lessons learnt

Poetry 2.3.4 rewrites unrelated lock-file metadata compared to the existing Poetry 2.1.4 generated lock, so the lock diff was kept focused manually after resolving the package.

## Summary

- Changed the project pytz dependency lower bound to `>=2026.1.0`.
- Updated the lock entry to resolve pytz `2026.2`.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.