### PR TITLE
fix: use correct ERC-7540 DepositRequest event name in Lagoon deposit parsing

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/lagoon/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/deposit_redeem.py
@@ -73,9 +73,12 @@ class ERC7540DepositRequest(DepositRequest):
             request_id = convert_bytes32_to_uint(topics[-1])
 
         else:
-            logs = vault.vault_contract.events.DepositRequested().process_receipt(receipt, errors=EventLogErrorFlags.Discard)
+            # ERC-7540 standard event is named DepositRequest (not DepositRequested).
+            # Lagoon v0.5+ vaults emit this; the legacy branch above parses the
+            # Referral event instead.
+            logs = vault.vault_contract.events.DepositRequest().process_receipt(receipt, errors=EventLogErrorFlags.Discard)
             if len(logs) != 1:
-                raise CannotParseRedemptionTransaction(f"Expected exactly one DepositRequested event, got logs: {logs} at {tx_hash.hex()}")
+                raise CannotParseRedemptionTransaction(f"Expected exactly one DepositRequest event, got logs: {logs} at {tx_hash.hex()}")
 
             log = logs[0]
             request_id = log["args"]["requestId"]
@@ -124,7 +127,7 @@ class ERC7540RedemptionRequest(RedemptionRequest):
         logs = vault.vault_contract.events.RedeemRequest().process_receipt(receipt, errors=EventLogErrorFlags.Discard)
 
         if len(logs) != 1:
-            raise CannotParseRedemptionTransaction(f"Expected exactly one DepositRequested event, got logs: {logs} at {tx_hash.hex()}")
+            raise CannotParseRedemptionTransaction(f"Expected exactly one RedeemRequest event, got logs: {logs} at {tx_hash.hex()}")
 
         log = logs[0]
         request_id = log["args"]["requestId"]

--- a/tests/lagoon/test_lagoon_erc_7540.py
+++ b/tests/lagoon/test_lagoon_erc_7540.py
@@ -15,7 +15,7 @@ from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.hotwallet import HotWallet
 from eth_defi.erc_4626.vault_protocol.lagoon.deployment import LagoonAutomatedDeployment, LagoonDeploymentParameters, deploy_automated_lagoon_vault
 from eth_defi.erc_4626.vault_protocol.lagoon.testing import force_lagoon_settle
-from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
+from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault, LagoonVersion
 from eth_defi.provider.anvil import mine, fork_network_anvil, AnvilLaunch
 from eth_defi.token import TokenDetails, USDC_NATIVE_TOKEN
 from eth_defi.trace import assert_transaction_success_with_explanation, TransactionAssertionError
@@ -147,6 +147,22 @@ def test_lagoon_erc_7540(
     deposit_func = vault.request_deposit(depositor, usdc_amount)
     tx_hash = deposit_func.transact({"from": depositor})
     assert_transaction_success_with_explanation(web3, tx_hash)
+
+    # Regression for ABIEventNotFound: parse the requestDeposit receipt on the
+    # freshly deployed non-legacy (v0.5.0) Lagoon vault. parse_deposit_transaction()
+    # has two branches: the legacy branch parses the raw Referral topic, while the
+    # non-legacy branch reads the ERC-7540 DepositRequest event. A typo
+    # (DepositRequested) silently broke the non-legacy branch for every modern
+    # Lagoon vault, yet no test caught it because all ERC-7540 fixtures point at the
+    # legacy 722 Capital vault. This exercises the non-legacy branch and asserts it
+    # resolves the event and returns a usable request_id.
+    assert vault.version != LagoonVersion.legacy
+    fresh_deposit_request = vault.get_deposit_manager().create_deposit_request(
+        depositor,
+        raw_amount=usdc_amount,
+    )
+    fresh_ticket = fresh_deposit_request.parse_deposit_transaction([tx_hash])
+    assert fresh_ticket.request_id >= 0
 
     # We need to do the initial valuation at value 0
     valuation = Decimal(0)
@@ -312,6 +328,22 @@ def test_lagoon_erc_7540_malicious_redemption(
     deposit_func = vault.request_deposit(depositor, usdc_amount)
     tx_hash = deposit_func.transact({"from": depositor})
     assert_transaction_success_with_explanation(web3, tx_hash)
+
+    # Regression for ABIEventNotFound: parse the requestDeposit receipt on the
+    # freshly deployed non-legacy (v0.5.0) Lagoon vault. parse_deposit_transaction()
+    # has two branches: the legacy branch parses the raw Referral topic, while the
+    # non-legacy branch reads the ERC-7540 DepositRequest event. A typo
+    # (DepositRequested) silently broke the non-legacy branch for every modern
+    # Lagoon vault, yet no test caught it because all ERC-7540 fixtures point at the
+    # legacy 722 Capital vault. This exercises the non-legacy branch and asserts it
+    # resolves the event and returns a usable request_id.
+    assert vault.version != LagoonVersion.legacy
+    fresh_deposit_request = vault.get_deposit_manager().create_deposit_request(
+        depositor,
+        raw_amount=usdc_amount,
+    )
+    fresh_ticket = fresh_deposit_request.parse_deposit_transaction([tx_hash])
+    assert fresh_ticket.request_id >= 0
 
     # We need to do the initial valuation at value 0
     valuation = Decimal(0)


### PR DESCRIPTION
## Why

Live trading (`trade-executor` `trade-ui`) crashed with `web3.exceptions.ABIEventNotFound` when settling an async ERC-7540 deposit into a non-legacy (Lagoon v0.5+) vault such as DeTrade Core USDC:

```
web3.exceptions.ABIEventNotFound: The event 'DepositRequested' was not found in this
contract's abi. Did you mean: 'DepositRequest'?
```

`ERC7540DepositRequest.parse_deposit_transaction()` referenced a misspelled `DepositRequested` event. The ERC-7540 standard — and the Lagoon v0.5 ABI — names the event `DepositRequest`. The method has two branches: the legacy branch parses the raw `Referral` topic, while the non-legacy branch reads the named event. Only the non-legacy branch carried the typo, so every modern Lagoon vault deposit settlement crashed.

## Lessons learnt

- The bug had existed since the code was first written, yet no test caught it: **every** Lagoon ERC-7540 test fixture points at the legacy 722 Capital vault, which takes the `Referral`-topic branch. The non-legacy (v0.5+) branch was never executed by any test, even though it is the path real production vaults use.
- `test_lagoon_erc_7540` deployed a fresh non-legacy vault but built the deposit manually via `deposit_ticket.funcs[0]`, bypassing `parse_deposit_transaction()` entirely — so deploying a modern vault was not enough; the parsing code path itself was never reached.
- When a method branches on contract version, each branch needs a fixture that actually drives it.

## Summary

- Fix `ERC7540DepositRequest.parse_deposit_transaction()` to use `events.DepositRequest()` instead of the non-existent `events.DepositRequested()`.
- Correct the misleading `DepositRequested` text in the deposit and redeem `CannotParseRedemptionTransaction` error messages.
- Extend `test_lagoon_erc_7540` to parse a `requestDeposit` receipt on the freshly deployed non-legacy (v0.5.0) vault, exercising the fixed branch as a regression. Verified passing on a Base fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
