### PR TITLE
feat: add pending vault flow event discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- feat: Add pending asynchronous vault flow event discovery — `VaultDepositManager.fetch_vault_flow_events()` now lets Lagoon ERC-7540 and Ostium V1.5 managers reconstruct missing pending deposit and redemption requests from Hypersync event scans, with protocol-neutral `PendingVaultFlow` records and live fixed-range integration tests for Base Lagoon and Arbitrum Ostium vaults (2026-06-19)
+
 - feat: Fix Read the Docs builds timing out — RTD no longer runs Sphinx itself. GitHub Actions (`docs.yml`) builds the full HTML on our own runners, uploads it as a rolling `docs-latest` GitHub Release asset and triggers a Read the Docs rebuild via the RTD API; RTD's `build.commands` just download and publish that pre-built zip, so the full API/tutorials/vaults docs are served again instead of the previous redirect stub (2026-06-12)
 
 - feat: Add Aera vault protocol support with hardcoded address classification, ABI-backed management/performance fee extraction, protocol metadata, official logo assets, Sphinx docs and focused tests for the currently discovered Ethereum and Polygon Aera strategy/wrapper vaults (2026-06-12)

--- a/docs/source/api/vault/index.rst
+++ b/docs/source/api/vault/index.rst
@@ -16,6 +16,7 @@ A generic high-level Python framework to integrate different vault providers.
    :recursive:
 
    eth_defi.vault.base
+   eth_defi.vault.flow_events
    eth_defi.vault.risk
    eth_defi.vault.fee
    eth_defi.vault.deposit_redeem

--- a/eth_defi/erc_4626/vault_protocol/gains/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/gains/deposit_redeem.py
@@ -5,26 +5,40 @@ Supports both Gains V1 (epoch-based) and Ostium V1.5 (settlement-based) flows.
 
 import datetime
 import logging
+from collections.abc import Iterator
 from dataclasses import dataclass
 from decimal import Decimal
 
+from eth_typing import HexAddress
+from hexbytes import HexBytes
+from web3 import Web3
+from web3._utils.events import EventLogErrorFlags
+from web3.contract.contract import ContractFunction
+
+from eth_defi.abi import get_topic_signature_from_event
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
 from eth_defi.timestamp import get_block_timestamp
 from eth_defi.utils import from_unix_timestamp
+from eth_defi.vault.flow_events import (
+    PendingVaultFlow,
+    VaultFlowDirection,
+    create_pending_vault_flow,
+    decode_indexed_event_address,
+    decode_indexed_event_uint,
+    decode_single_uint256_event_data,
+    fetch_vault_flow_logs_hypersync,
+    normalise_event_topic,
+)
 from eth_defi.vault.deposit_redeem import (
+    AsyncVaultRequestStatus,
+    CannotParseRedemptionTransaction,
     DepositRedeemEventAnalysis,
     DepositRedeemEventFailure,
     DepositRequest,
     DepositTicket,
-    RedemptionTicket,
     RedemptionRequest,
-    CannotParseRedemptionTransaction,
+    RedemptionTicket,
 )
-from hexbytes import HexBytes
-from web3._utils.events import EventLogErrorFlags
-from eth_typing import HexAddress
-
-from web3.contract.contract import ContractFunction
 
 logger = logging.getLogger(__name__)
 
@@ -359,6 +373,109 @@ class OstiumV15DepositManager(ERC4626DepositManager):
         assert isinstance(vault, OstiumVault), f"Got {type(vault)}"
         assert vault.version == OstiumVersion.v1_5, f"OstiumV15DepositManager requires V1.5 vault, got {vault.version}"
         self.vault = vault
+
+    def fetch_vault_flow_events(
+        self,
+        hypersync_client,
+        start_block: int,
+        end_block: int,
+    ) -> Iterator[PendingVaultFlow]:
+        """Fetch Ostium V1.5 request events using Hypersync.
+
+        Ostium V1.5 emits concrete settlement ids in ``DepositRequestedV2`` and
+        ``WithdrawRequestedV2`` events. These ids are stable enough to
+        reconstruct the same tickets that live transaction parsing produces.
+
+        :param hypersync_client:
+            Configured Hypersync client for Arbitrum.
+
+        :param start_block:
+            Inclusive start block.
+
+        :param end_block:
+            Inclusive end block.
+
+        :return:
+            Iterator of indexed pending vault flow events in chain order.
+        """
+        vault = self.vault
+        deposit_topic = get_topic_signature_from_event(vault.vault_contract.events.DepositRequestedV2).lower()
+        withdraw_topic = get_topic_signature_from_event(vault.vault_contract.events.WithdrawRequestedV2).lower()
+        topic_map = {
+            deposit_topic: VaultFlowDirection.deposit,
+            withdraw_topic: VaultFlowDirection.redeem,
+        }
+
+        logs = fetch_vault_flow_logs_hypersync(
+            hypersync_client=hypersync_client,
+            vault_address=vault.address,
+            topic0_list=list(topic_map.keys()),
+            start_block=start_block,
+            end_block=end_block,
+        )
+        chain_id = self.web3.eth.chain_id
+        vault_address = Web3.to_checksum_address(vault.address)
+
+        for log in logs:
+            topic0 = normalise_event_topic(log.topics[0])
+            direction = topic_map.get(topic0)
+            if direction == VaultFlowDirection.deposit:
+                # event DepositRequestedV2(address indexed owner, uint32 indexed settlementId, uint256 assets)
+                owner = Web3.to_checksum_address(decode_indexed_event_address(log.topics[1]))
+                settlement_id = decode_indexed_event_uint(log.topics[2])
+                raw_assets = decode_single_uint256_event_data(log.data)
+                ticket = OstiumDepositTicket(
+                    vault_address=vault.address,
+                    owner=owner,
+                    to=owner,
+                    raw_amount=raw_assets,
+                    tx_hash=HexBytes(log.transaction_hash),
+                    gas_used=0,
+                    block_number=log.block_number,
+                    block_timestamp=log.block_timestamp,
+                    settlement_id=settlement_id,
+                )
+                yield create_pending_vault_flow(
+                    chain_id=chain_id,
+                    vault_address=vault_address,
+                    owner=owner,
+                    controller=owner,
+                    direction=VaultFlowDirection.deposit,
+                    status=AsyncVaultRequestStatus.pending,
+                    request_id=None,
+                    settlement_id=settlement_id,
+                    raw_assets=raw_assets,
+                    raw_shares=None,
+                    log=log,
+                    ticket_data=self.serialize_deposit_ticket(ticket),
+                )
+            elif direction == VaultFlowDirection.redeem:
+                # event WithdrawRequestedV2(address indexed owner, uint32 indexed settlementId, uint256 shares)
+                owner = Web3.to_checksum_address(decode_indexed_event_address(log.topics[1]))
+                settlement_id = decode_indexed_event_uint(log.topics[2])
+                raw_shares = decode_single_uint256_event_data(log.data)
+                ticket = OstiumRedemptionTicket(
+                    vault_address=vault.address,
+                    owner=owner,
+                    to=owner,
+                    raw_shares=raw_shares,
+                    tx_hash=HexBytes(log.transaction_hash),
+                    settlement_id=settlement_id,
+                )
+                yield create_pending_vault_flow(
+                    chain_id=chain_id,
+                    vault_address=vault_address,
+                    owner=owner,
+                    controller=owner,
+                    direction=VaultFlowDirection.redeem,
+                    status=AsyncVaultRequestStatus.pending,
+                    request_id=None,
+                    settlement_id=settlement_id,
+                    raw_assets=None,
+                    raw_shares=raw_shares,
+                    log=log,
+                    ticket_data=self.serialize_redemption_ticket(ticket),
+                )
 
     def has_synchronous_deposit(self) -> bool:
         return False

--- a/eth_defi/erc_4626/vault_protocol/lagoon/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/deposit_redeem.py
@@ -1,24 +1,44 @@
 """Deposit/redemption flow for ERC-7540 vaults."""
 
+import datetime
+from collections.abc import Iterator
 from dataclasses import dataclass
+from decimal import Decimal
 from pprint import pformat
 from typing import cast
 
-from eth_defi.abi import get_topic_signature_from_event, ZERO_ADDRESS_STR
-from eth_defi.event_reader.conversion import convert_bytes32_to_uint, convert_bytes32_to_address
-from eth_defi.timestamp import get_block_timestamp
-from eth_typing import HexAddress, HexStr
-
-from eth_defi.vault.deposit_redeem import DepositTicket, CannotParseRedemptionTransaction, VaultDepositManager, DepositRedeemEventAnalysis, DepositRedeemEventFailure, AsyncVaultRequestStatus
-from eth_defi.vault.deposit_redeem import DepositRequest, RedemptionRequest, RedemptionTicket
-
-import datetime
-from decimal import Decimal
-
-from web3.contract.contract import ContractFunction
-from eth_typing import HexAddress, BlockIdentifier
+import eth_abi
+from eth_typing import BlockIdentifier, HexAddress, HexStr
 from hexbytes import HexBytes
+from web3 import Web3
 from web3._utils.events import EventLogErrorFlags
+from web3.contract.contract import ContractFunction
+
+from eth_defi.abi import ZERO_ADDRESS_STR, get_topic_signature_from_event
+from eth_defi.event_reader.conversion import convert_bytes32_to_address, convert_bytes32_to_uint
+from eth_defi.timestamp import get_block_timestamp
+from eth_defi.vault.flow_events import (
+    PendingVaultFlow,
+    VaultFlowDirection,
+    create_pending_vault_flow,
+    decode_indexed_event_address,
+    decode_indexed_event_uint,
+    decode_single_uint256_event_data,
+    event_data_to_bytes,
+    fetch_vault_flow_logs_hypersync,
+    normalise_event_topic,
+)
+from eth_defi.vault.deposit_redeem import (
+    AsyncVaultRequestStatus,
+    CannotParseRedemptionTransaction,
+    DepositRedeemEventAnalysis,
+    DepositRedeemEventFailure,
+    DepositRequest,
+    DepositTicket,
+    RedemptionRequest,
+    RedemptionTicket,
+    VaultDepositManager,
+)
 
 
 @dataclass(slots=True)
@@ -46,8 +66,7 @@ class ERC7540DepositRequest(DepositRequest):
             If we did not know how to parse the transaction
         """
 
-        from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
-        from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVersion
+        from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault, LagoonVersion
 
         tx_hash = tx_hashes[-1]
 
@@ -114,8 +133,7 @@ class ERC7540RedemptionRequest(RedemptionRequest):
     """Synchronous deposit request for ERC-7540 vaults."""
 
     def parse_redeem_transaction(self, tx_hashes: list[HexBytes]) -> RedemptionTicket:
-        from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
-        from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVersion
+        from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault, LagoonVersion
 
         tx_hash = tx_hashes[-1]
 
@@ -159,6 +177,135 @@ class ERC7540DepositManager(VaultDepositManager):
 
         assert isinstance(vault, LagoonVault), f"Got {type(vault)}"
         self.vault = vault
+
+    def fetch_vault_flow_events(
+        self,
+        hypersync_client,
+        start_block: int,
+        end_block: int,
+    ) -> Iterator[PendingVaultFlow]:
+        """Fetch Lagoon ERC-7540 request events using Hypersync.
+
+        Lagoon vaults emit ``DepositRequest`` for deposit requests and
+        ``RedeemRequest`` for redemption requests. Some deployments also emit
+        ``Referral`` with the same request id and asset amount. ``Referral`` is
+        treated as a fallback only, because modern referred deposits can emit
+        both events in the same transaction.
+
+        :param hypersync_client:
+            Configured Hypersync client for the vault chain.
+
+        :param start_block:
+            Inclusive start block.
+
+        :param end_block:
+            Inclusive end block.
+
+        :return:
+            Iterator of indexed pending vault flow events in chain order.
+        """
+        vault = self.vault
+        deposit_topic = get_topic_signature_from_event(vault.vault_contract.events.DepositRequest).lower()
+        redeem_topic = get_topic_signature_from_event(vault.vault_contract.events.RedeemRequest).lower()
+        topic_map = {
+            deposit_topic: VaultFlowDirection.deposit,
+            redeem_topic: VaultFlowDirection.redeem,
+        }
+        if hasattr(vault.vault_contract.events, "Referral"):
+            referral_topic = get_topic_signature_from_event(vault.vault_contract.events.Referral).lower()
+            topic_map[referral_topic] = VaultFlowDirection.deposit
+
+        logs = fetch_vault_flow_logs_hypersync(
+            hypersync_client=hypersync_client,
+            vault_address=vault.address,
+            topic0_list=list(topic_map.keys()),
+            start_block=start_block,
+            end_block=end_block,
+        )
+        chain_id = self.web3.eth.chain_id
+        vault_address = Web3.to_checksum_address(vault.address)
+        deposit_request_ids = {decode_indexed_event_uint(log.topics[3]) for log in logs if normalise_event_topic(log.topics[0]) == deposit_topic}
+
+        for log in logs:
+            topic0 = normalise_event_topic(log.topics[0])
+            direction = topic_map.get(topic0)
+            if direction == VaultFlowDirection.deposit:
+                # event DepositRequest(address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 assets)
+                # Legacy event Referral(address indexed referral, address indexed owner, uint256 indexed requestId, uint256 assets) has no separate controller.
+                request_id = decode_indexed_event_uint(log.topics[3])
+                if topic0 == deposit_topic:
+                    controller = Web3.to_checksum_address(decode_indexed_event_address(log.topics[1]))
+                    owner = Web3.to_checksum_address(decode_indexed_event_address(log.topics[2]))
+                    _sender, raw_assets = eth_abi.decode(["address", "uint256"], event_data_to_bytes(log.data))
+                    raw_assets = int(raw_assets)
+                else:
+                    if request_id in deposit_request_ids:
+                        continue
+                    # Confirmed from the live legacy Lagoon vault ABI/event shape:
+                    # Referral only indexes referral, owner and requestId, and the
+                    # non-indexed data only carries assets. It does not emit a
+                    # controller/sender, so only self-controller legacy requests can
+                    # be reconstructed from events alone.
+                    owner = Web3.to_checksum_address(decode_indexed_event_address(log.topics[2]))
+                    controller = owner
+                    raw_assets = decode_single_uint256_event_data(log.data)
+                # Recovered tickets use the controller for owner/to because ERC-7540
+                # claim/status calls are controller-scoped. The economic owner is
+                # still exposed separately as PendingVaultFlow.owner.
+                ticket = ERC7540DepositTicket(
+                    vault_address=vault.address,
+                    owner=controller,
+                    to=controller,
+                    raw_amount=raw_assets,
+                    tx_hash=HexBytes(log.transaction_hash),
+                    gas_used=0,
+                    block_number=log.block_number,
+                    block_timestamp=log.block_timestamp,
+                    request_id=request_id,
+                )
+                yield create_pending_vault_flow(
+                    chain_id=chain_id,
+                    vault_address=vault_address,
+                    owner=owner,
+                    controller=controller,
+                    direction=VaultFlowDirection.deposit,
+                    status=AsyncVaultRequestStatus.pending,
+                    request_id=request_id,
+                    settlement_id=None,
+                    raw_assets=raw_assets,
+                    raw_shares=None,
+                    log=log,
+                    ticket_data=self.serialize_deposit_ticket(ticket),
+                )
+            elif direction == VaultFlowDirection.redeem:
+                # event RedeemRequest(address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 shares)
+                controller = Web3.to_checksum_address(decode_indexed_event_address(log.topics[1]))
+                owner = Web3.to_checksum_address(decode_indexed_event_address(log.topics[2]))
+                request_id = decode_indexed_event_uint(log.topics[3])
+                _sender, raw_shares = eth_abi.decode(["address", "uint256"], event_data_to_bytes(log.data))
+                raw_shares = int(raw_shares)
+                ticket = ERC7540RedemptionTicket(
+                    vault_address=vault.address,
+                    owner=controller,
+                    to=controller,
+                    raw_shares=raw_shares,
+                    tx_hash=HexBytes(log.transaction_hash),
+                    request_id=request_id,
+                )
+                yield create_pending_vault_flow(
+                    chain_id=chain_id,
+                    vault_address=vault_address,
+                    owner=owner,
+                    controller=controller,
+                    direction=VaultFlowDirection.redeem,
+                    status=AsyncVaultRequestStatus.pending,
+                    request_id=request_id,
+                    settlement_id=None,
+                    raw_assets=None,
+                    raw_shares=raw_shares,
+                    log=log,
+                    ticket_data=self.serialize_redemption_ticket(ticket),
+                )
 
     def create_deposit_request(
         self,

--- a/eth_defi/vault/deposit_redeem.py
+++ b/eth_defi/vault/deposit_redeem.py
@@ -2,21 +2,21 @@
 
 import datetime
 import enum
+import logging
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
 from dataclasses import dataclass
 from decimal import Decimal
-import logging
 from pprint import pformat
 
+from eth_typing import BlockIdentifier, BlockNumber, HexAddress
+from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract.contract import ContractFunction
 
-from hexbytes import HexBytes
-from eth_typing import HexAddress, BlockIdentifier, BlockNumber
-
 from eth_defi.timestamp import get_block_timestamp
 from eth_defi.trace import assert_transaction_success_with_explanation
-
+from eth_defi.vault.flow_events import PendingVaultFlow, VaultFlowDirection
 
 logger = logging.getLogger(__name__)
 
@@ -465,6 +465,31 @@ class VaultDepositManager(ABC):
         Vault can be full?
         """
         raise NotImplementedError(f"Class {self.__class__.__name__} does not implement can_create_deposit_request()")
+
+    def fetch_vault_flow_events(
+        self,
+        hypersync_client,
+        start_block: int,
+        end_block: int,
+    ) -> Iterator[PendingVaultFlow]:
+        """Fetch asynchronous vault request events from an indexed backend.
+
+        The base implementation returns no events for vault managers that do
+        not have a two-phase deposit or redemption flow.
+
+        :param hypersync_client:
+            Configured Hypersync client for this vault's chain.
+
+        :param start_block:
+            Inclusive start block.
+
+        :param end_block:
+            Inclusive end block.
+
+        :return:
+            Iterator of protocol-neutral pending vault flow events.
+        """
+        return iter(())
 
     def get_max_deposit(self, owner: HexAddress) -> Decimal | None:
         """How much we can deposit"""

--- a/eth_defi/vault/flow_events.py
+++ b/eth_defi/vault/flow_events.py
@@ -1,0 +1,394 @@
+"""Asynchronous vault request event discovery helpers."""
+
+import asyncio
+import datetime
+import enum
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+
+import eth_abi
+from eth_typing import HexAddress
+from web3 import Web3
+
+from eth_defi.utils import from_unix_timestamp
+
+try:
+    import hypersync
+    from hypersync import BlockField, LogField
+
+    from eth_defi.hypersync.session import open_hypersync_stream
+except ImportError:
+    hypersync = None
+
+
+class VaultFlowDirection(enum.Enum):
+    """Direction of an asynchronous vault flow."""
+
+    #: The flow moves denomination tokens into a vault and later claims shares.
+    deposit = "deposit"
+
+    #: The flow moves vault shares into escrow and later claims denomination tokens.
+    redeem = "redeem"
+
+
+@dataclass(slots=True, frozen=True)
+class PendingVaultFlow:
+    """An indexed asynchronous vault request event.
+
+    This object is the protocol-neutral bridge between event discovery and
+    higher-level accounting recovery. It intentionally carries both the raw
+    request facts and a serialised ticket payload that can be fed back to the
+    protocol-specific vault ticket reconstruction path.
+
+    :param chain_id:
+        EVM chain id where the event was emitted.
+
+    :param vault_address:
+        Vault contract that emitted the request event.
+
+    :param owner:
+        Economic owner of the request.
+
+    :param controller:
+        ERC-7540 controller address where applicable. Protocols without a
+        separate controller use the owner address.
+
+    :param direction:
+        Deposit or redemption request.
+
+    :param status:
+        Status implied by the event. Request events are emitted before
+        settlement, so this is normally ``pending``; callers can query the
+        current status with the reconstructed ticket.
+
+    :param request_id:
+        Protocol request id, if any.
+
+    :param settlement_id:
+        Protocol settlement id, if any.
+
+    :param raw_assets:
+        Raw denomination token amount for deposits, when known.
+
+    :param raw_shares:
+        Raw vault share amount for redemptions, when known.
+
+    :param request_tx_hash:
+        Transaction hash that emitted the request event.
+
+    :param request_block_number:
+        Block number that emitted the request event.
+
+    :param request_block_timestamp:
+        Naive UTC timestamp for the request block, when provided by the event
+        backend.
+
+    :param log_index:
+        Log index for stable event identity.
+
+    :param ticket_data:
+        Serialised protocol ticket data compatible with the manager's
+        ``reconstruct_*_ticket()`` methods.
+    """
+
+    chain_id: int
+    vault_address: HexAddress
+    owner: HexAddress
+    controller: HexAddress | None
+    direction: VaultFlowDirection
+    status: enum.Enum
+    request_id: int | None
+    settlement_id: int | None
+    raw_assets: int | None
+    raw_shares: int | None
+    request_tx_hash: str
+    request_block_number: int
+    request_block_timestamp: datetime.datetime | None
+    log_index: int
+    ticket_data: dict
+
+
+def create_pending_vault_flow(
+    *,
+    chain_id: int,
+    vault_address: HexAddress,
+    owner: HexAddress,
+    controller: HexAddress | None,
+    direction: VaultFlowDirection,
+    status: enum.Enum,
+    log: "IndexedVaultFlowLog",
+    ticket_data: dict,
+    request_id: int | None = None,
+    settlement_id: int | None = None,
+    raw_assets: int | None = None,
+    raw_shares: int | None = None,
+) -> PendingVaultFlow:
+    """Create a pending vault flow from common indexed log metadata."""
+    return PendingVaultFlow(
+        chain_id=chain_id,
+        vault_address=vault_address,
+        owner=owner,
+        controller=controller,
+        direction=direction,
+        status=status,
+        request_id=request_id,
+        settlement_id=settlement_id,
+        raw_assets=raw_assets,
+        raw_shares=raw_shares,
+        request_tx_hash=log.transaction_hash,
+        request_block_number=log.block_number,
+        request_block_timestamp=log.block_timestamp,
+        log_index=log.log_index,
+        ticket_data=ticket_data,
+    )
+
+
+@dataclass(slots=True, frozen=True)
+class IndexedVaultFlowLog:
+    """Raw indexed log data returned by Hypersync for vault flow discovery."""
+
+    #: Contract address that emitted the log.
+    address: HexAddress
+
+    #: Log topics as hex strings.
+    topics: list[str | None]
+
+    #: ABI-encoded non-indexed event data.
+    data: str
+
+    #: Emitting block number.
+    block_number: int
+
+    #: Optional block timestamp as naive UTC.
+    block_timestamp: datetime.datetime | None
+
+    #: Transaction hash as a hex string.
+    transaction_hash: str
+
+    #: Log index inside the transaction.
+    log_index: int
+
+
+async def _fetch_vault_flow_logs_hypersync_async(
+    *,
+    hypersync_client,
+    vault_address: HexAddress,
+    topic0_list: list[str],
+    start_block: int,
+    end_block: int,
+    recv_timeout: float = 90.0,
+) -> list[IndexedVaultFlowLog]:
+    """Fetch raw vault request logs with Hypersync.
+
+    :param hypersync_client:
+        Configured Hypersync client for the vault chain.
+
+    :param vault_address:
+        Vault contract address to scan.
+
+    :param topic0_list:
+        Event signature topics to include.
+
+    :param start_block:
+        Inclusive start block.
+
+    :param end_block:
+        Inclusive end block.
+
+    :param recv_timeout:
+        Timeout for each stream receive.
+
+    :return:
+        Raw logs sorted by ``(block_number, log_index)``.
+    """
+    assert hypersync is not None, "hypersync package is required"
+    assert start_block <= end_block, f"Bad block range: {start_block} - {end_block}"
+
+    query = hypersync.Query(
+        from_block=start_block,
+        # Hypersync uses an exclusive to_block.
+        to_block=end_block + 1,
+        logs=[
+            hypersync.LogSelection(
+                address=[vault_address.lower()],
+                topics=[topic0_list],
+            )
+        ],
+        field_selection=hypersync.FieldSelection(
+            block=[BlockField.NUMBER, BlockField.TIMESTAMP],
+            log=[
+                LogField.BLOCK_NUMBER,
+                LogField.LOG_INDEX,
+                LogField.ADDRESS,
+                LogField.TRANSACTION_HASH,
+                LogField.TOPIC0,
+                LogField.TOPIC1,
+                LogField.TOPIC2,
+                LogField.TOPIC3,
+                LogField.DATA,
+            ],
+        ),
+    )
+
+    receiver = await open_hypersync_stream(hypersync_client, query)
+    events: list[IndexedVaultFlowLog] = []
+    while True:
+        res = await asyncio.wait_for(receiver.recv(), timeout=recv_timeout)
+        if res is None:
+            break
+
+        block_timestamps = {int(block.number): from_unix_timestamp(decode_hypersync_int(block.timestamp)) for block in res.data.blocks or [] if block.number is not None and block.timestamp is not None}
+
+        for log in res.data.logs or []:
+            block_number = decode_hypersync_int(log.block_number)
+            events.append(
+                IndexedVaultFlowLog(
+                    address=Web3.to_checksum_address(log.address),
+                    topics=log.topics,
+                    data=log.data or "0x",
+                    block_number=block_number,
+                    block_timestamp=block_timestamps.get(block_number),
+                    transaction_hash=log.transaction_hash,
+                    log_index=decode_hypersync_int(log.log_index),
+                )
+            )
+
+    events.sort(key=lambda e: (e.block_number, e.log_index))
+    return events
+
+
+def decode_hypersync_int(value: int | str) -> int:
+    """Decode a hex integer field returned by Hypersync."""
+    if isinstance(value, int):
+        return value
+    if value.startswith("0x"):
+        value = value[2:]
+    return int(value, 16)
+
+
+def normalise_event_topic(topic: str | bytes) -> str:
+    """Normalise an event topic to a lower-case ``0x``-prefixed hex string.
+
+    :param topic:
+        Topic value from Web3.py or Hypersync.
+
+    :return:
+        Lower-case ``0x``-prefixed topic.
+    """
+    if isinstance(topic, bytes):
+        topic = topic.hex()
+    if not topic.startswith("0x"):
+        topic = "0x" + topic
+    return topic.lower()
+
+
+def event_data_to_bytes(data: str | bytes) -> bytes:
+    """Convert ABI event data to bytes.
+
+    :param data:
+        Hex string or bytes returned by the event backend.
+
+    :return:
+        Raw ABI payload bytes.
+    """
+    if isinstance(data, bytes):
+        return data
+    if data.startswith("0x"):
+        data = data[2:]
+    return bytes.fromhex(data)
+
+
+def decode_indexed_event_address(topic: str | bytes) -> HexAddress:
+    """Decode an indexed address topic.
+
+    :param topic:
+        ABI event topic containing a right-aligned address.
+
+    :return:
+        Checksummed address.
+    """
+    normalised = normalise_event_topic(topic)
+    return Web3.to_checksum_address("0x" + normalised[-40:])
+
+
+def decode_indexed_event_uint(topic: str | bytes) -> int:
+    """Decode an indexed unsigned integer topic.
+
+    :param topic:
+        ABI event topic.
+
+    :return:
+        Decoded integer.
+    """
+    normalised = normalise_event_topic(topic)
+    return int(normalised, 16)
+
+
+def decode_single_uint256_event_data(data: str | bytes) -> int:
+    """Decode a single non-indexed ``uint256`` event argument.
+
+    :param data:
+        ABI event data payload.
+
+    :return:
+        Decoded integer.
+    """
+    return int(eth_abi.decode(["uint256"], event_data_to_bytes(data))[0])
+
+
+def fetch_vault_flow_logs_hypersync(
+    *,
+    hypersync_client,
+    vault_address: HexAddress,
+    topic0_list: list[str],
+    start_block: int,
+    end_block: int,
+) -> list[IndexedVaultFlowLog]:
+    """Fetch raw vault request logs with Hypersync.
+
+    This synchronous wrapper keeps vault manager APIs threaded and blocking,
+    matching the rest of the vault manager interface.
+
+    :param hypersync_client:
+        Configured Hypersync client for the vault chain.
+
+    :param vault_address:
+        Vault contract address to scan.
+
+    :param topic0_list:
+        Event signature topics to include.
+
+    :param start_block:
+        Inclusive start block.
+
+    :param end_block:
+        Inclusive end block.
+
+    :return:
+        Raw logs sorted by ``(block_number, log_index)``.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(
+            _fetch_vault_flow_logs_hypersync_async(
+                hypersync_client=hypersync_client,
+                vault_address=vault_address,
+                topic0_list=topic0_list,
+                start_block=start_block,
+                end_block=end_block,
+            )
+        )
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(
+            asyncio.run,
+            _fetch_vault_flow_logs_hypersync_async(
+                hypersync_client=hypersync_client,
+                vault_address=vault_address,
+                topic0_list=topic0_list,
+                start_block=start_block,
+                end_block=end_block,
+            ),
+        )
+        return future.result()

--- a/tests/vault/test_flow_events.py
+++ b/tests/vault/test_flow_events.py
@@ -1,0 +1,56 @@
+"""Unit tests for vault flow event decoding helpers."""
+
+import eth_abi
+
+from eth_defi.vault.flow_events import (
+    decode_hypersync_int,
+    decode_indexed_event_address,
+    decode_indexed_event_uint,
+    decode_single_uint256_event_data,
+    event_data_to_bytes,
+    normalise_event_topic,
+)
+
+EXPECTED_TOPIC_UINT = 42
+EXPECTED_RAW_ASSETS = 300_000_000
+EXPECTED_NATIVE_INT = 26
+EXPECTED_BARE_HEX_INT = 16
+
+
+def test_event_topic_and_data_decoders() -> None:
+    """Decode EVM log topics and event data without network access.
+
+    1. Normalise topic and data encodings from bytes and hex strings.
+    2. Decode indexed address and integer topics.
+    3. Decode a single uint256 ABI data payload.
+    """
+    # 1. Normalise topic and data encodings from bytes and hex strings.
+    assert normalise_event_topic(bytes.fromhex("ab" * 32)) == "0x" + "ab" * 32
+    assert normalise_event_topic("cd" * 32) == "0x" + "cd" * 32
+    assert event_data_to_bytes("0x1234") == bytes.fromhex("1234")
+    assert event_data_to_bytes(bytes.fromhex("5678")) == bytes.fromhex("5678")
+
+    # 2. Decode indexed address and integer topics.
+    topic_address = "0x" + "00" * 12 + "81ae3f0d805d1ebab21d3b16175ee3dfa5a18656"
+    assert decode_indexed_event_address(topic_address) == "0x81AE3f0D805D1EBAb21D3B16175eE3Dfa5a18656"
+    assert decode_indexed_event_uint("0x" + "00" * 31 + "2a") == EXPECTED_TOPIC_UINT
+
+    # 3. Decode a single uint256 ABI data payload.
+    assert decode_single_uint256_event_data(eth_abi.encode(["uint256"], [EXPECTED_RAW_ASSETS])) == EXPECTED_RAW_ASSETS
+
+
+def test_decode_hypersync_int_uses_hex_strings() -> None:
+    """Decode Hypersync integer fields using the hex-string convention.
+
+    1. Preserve native integer values.
+    2. Decode prefixed hex strings.
+    3. Decode bare hex strings as base 16, not base 10.
+    """
+    # 1. Preserve native integer values.
+    assert decode_hypersync_int(EXPECTED_NATIVE_INT) == EXPECTED_NATIVE_INT
+
+    # 2. Decode prefixed hex strings.
+    assert decode_hypersync_int("0x1a") == EXPECTED_NATIVE_INT
+
+    # 3. Decode bare hex strings as base 16, not base 10.
+    assert decode_hypersync_int("10") == EXPECTED_BARE_HEX_INT

--- a/tests/vault/test_pending_vault_flow_events.py
+++ b/tests/vault/test_pending_vault_flow_events.py
@@ -1,0 +1,141 @@
+"""Integration tests for async vault flow event discovery."""
+
+import os
+
+import hypersync
+import pytest
+
+from eth_defi.erc_4626.classification import create_vault_instance_autodetect
+from eth_defi.erc_4626.vault_protocol.gains.deposit_redeem import OstiumDepositTicket, OstiumRedemptionTicket, OstiumV15DepositManager
+from eth_defi.erc_4626.vault_protocol.lagoon.deposit_redeem import ERC7540DepositManager, ERC7540DepositTicket, ERC7540RedemptionTicket
+from eth_defi.hypersync.server import get_hypersync_server
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.vault.flow_events import VaultFlowDirection
+
+JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
+JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
+HYPERSYNC_API_KEY = os.environ.get("HYPERSYNC_API_KEY")
+
+LAGOON_EXPECTED_FLOW_COUNT = 4
+LAGOON_FIRST_REDEEM_REQUEST_ID = 2
+LAGOON_FIRST_REDEEM_RAW_SHARES = 1_000_000_000_000_000_000
+LAGOON_FIRST_DEPOSIT_REQUEST_ID = 21
+LAGOON_FIRST_DEPOSIT_RAW_ASSETS = 30_000_000_000
+
+OSTIUM_EXPECTED_FLOW_COUNT = 8
+OSTIUM_FIRST_REDEEM_SETTLEMENT_ID = 78
+OSTIUM_FIRST_REDEEM_RAW_SHARES = 8_530_000_000
+OSTIUM_LAST_DEPOSIT_SETTLEMENT_ID = 77
+OSTIUM_LAST_DEPOSIT_RAW_ASSETS = 300_000_000
+
+pytestmark = pytest.mark.skipif(
+    not HYPERSYNC_API_KEY,
+    reason="HYPERSYNC_API_KEY needed",
+)
+
+
+def _create_hypersync_client(chain_id: int) -> hypersync.HypersyncClient:
+    """Create a Hypersync client for a chain."""
+    return hypersync.HypersyncClient(
+        hypersync.ClientConfig(
+            url=get_hypersync_server(chain_id),
+            bearer_token=HYPERSYNC_API_KEY,
+        )
+    )
+
+
+@pytest.mark.skipif(not JSON_RPC_BASE, reason="JSON_RPC_BASE needed")
+def test_lagoon_fetch_vault_flow_events_from_hypersync() -> None:
+    """Fetch Lagoon ERC-7540 deposit and redemption request events.
+
+    1. Open the live Base 722 Capital Lagoon vault and its deposit manager.
+    2. Fetch a small historical block range with known request events.
+    3. Assert deposit and redemption flows decode to ticket-compatible data.
+    """
+    # 1. Open the live Base 722 Capital Lagoon vault and its deposit manager.
+    web3 = create_multi_provider_web3(JSON_RPC_BASE)
+    vault = create_vault_instance_autodetect(web3, "0xb09f761cb13baca8ec087ac476647361b6314f98")
+    manager = vault.get_deposit_manager()
+    assert isinstance(manager, ERC7540DepositManager)
+
+    # 2. Fetch a small historical block range with known request events.
+    flows = list(
+        manager.fetch_vault_flow_events(
+            hypersync_client=_create_hypersync_client(8453),
+            start_block=30_623_046,
+            end_block=30_786_520,
+        )
+    )
+
+    # 3. Assert deposit and redemption flows decode to ticket-compatible data.
+    assert len(flows) == LAGOON_EXPECTED_FLOW_COUNT
+    assert [flow.direction for flow in flows] == [
+        VaultFlowDirection.redeem,
+        VaultFlowDirection.deposit,
+        VaultFlowDirection.deposit,
+        VaultFlowDirection.redeem,
+    ]
+
+    first_redeem = flows[0]
+    assert first_redeem.request_id == LAGOON_FIRST_REDEEM_REQUEST_ID
+    assert first_redeem.raw_shares == LAGOON_FIRST_REDEEM_RAW_SHARES
+    assert first_redeem.raw_assets is None
+    assert first_redeem.owner == "0x81AE3f0D805D1EBAb21D3B16175eE3Dfa5a18656"
+    redeem_ticket = manager.reconstruct_redemption_ticket(first_redeem.ticket_data)
+    assert isinstance(redeem_ticket, ERC7540RedemptionTicket)
+    assert redeem_ticket.request_id == first_redeem.request_id
+    assert redeem_ticket.raw_shares == first_redeem.raw_shares
+
+    first_deposit = flows[1]
+    assert first_deposit.request_id == LAGOON_FIRST_DEPOSIT_REQUEST_ID
+    assert first_deposit.raw_assets == LAGOON_FIRST_DEPOSIT_RAW_ASSETS
+    assert first_deposit.raw_shares is None
+    assert first_deposit.owner == "0x81AE3f0D805D1EBAb21D3B16175eE3Dfa5a18656"
+    deposit_ticket = manager.reconstruct_deposit_ticket(first_deposit.ticket_data)
+    assert isinstance(deposit_ticket, ERC7540DepositTicket)
+    assert deposit_ticket.request_id == first_deposit.request_id
+    assert deposit_ticket.raw_amount == first_deposit.raw_assets
+
+
+@pytest.mark.skipif(not JSON_RPC_ARBITRUM, reason="JSON_RPC_ARBITRUM needed")
+def test_ostium_fetch_vault_flow_events_from_hypersync() -> None:
+    """Fetch Ostium V1.5 deposit and redemption request events.
+
+    1. Open the live Arbitrum Ostium V1.5 vault and its deposit manager.
+    2. Fetch a small historical block range with known request events.
+    3. Assert settlement ids and raw amounts decode to ticket-compatible data.
+    """
+    # 1. Open the live Arbitrum Ostium V1.5 vault and its deposit manager.
+    web3 = create_multi_provider_web3(JSON_RPC_ARBITRUM)
+    vault = create_vault_instance_autodetect(web3, "0x20d419a8e12c45f88fda7c5760bb6923cee27f98")
+    manager = vault.get_deposit_manager()
+    assert isinstance(manager, OstiumV15DepositManager)
+
+    # 2. Fetch a small historical block range with known request events.
+    flows = list(
+        manager.fetch_vault_flow_events(
+            hypersync_client=_create_hypersync_client(42161),
+            start_block=457_241_109,
+            end_block=457_408_441,
+        )
+    )
+
+    # 3. Assert settlement ids and raw amounts decode to ticket-compatible data.
+    assert len(flows) == OSTIUM_EXPECTED_FLOW_COUNT
+    assert flows[0].direction == VaultFlowDirection.redeem
+    assert flows[0].settlement_id == OSTIUM_FIRST_REDEEM_SETTLEMENT_ID
+    assert flows[0].raw_shares == OSTIUM_FIRST_REDEEM_RAW_SHARES
+    assert flows[0].owner == "0x2EF23e69262297a6e8892603271702Ec0C3F3Aba"
+    redeem_ticket = manager.reconstruct_redemption_ticket(flows[0].ticket_data)
+    assert isinstance(redeem_ticket, OstiumRedemptionTicket)
+    assert redeem_ticket.settlement_id == flows[0].settlement_id
+    assert redeem_ticket.raw_shares == flows[0].raw_shares
+
+    assert flows[-1].direction == VaultFlowDirection.deposit
+    assert flows[-1].settlement_id == OSTIUM_LAST_DEPOSIT_SETTLEMENT_ID
+    assert flows[-1].raw_assets == OSTIUM_LAST_DEPOSIT_RAW_ASSETS
+    assert flows[-1].owner == "0xa150B6bBAaD01bB77fAADCc9CAD6F5619b10366A"
+    deposit_ticket = manager.reconstruct_deposit_ticket(flows[-1].ticket_data)
+    assert isinstance(deposit_ticket, OstiumDepositTicket)
+    assert deposit_ticket.settlement_id == flows[-1].settlement_id
+    assert deposit_ticket.raw_amount == flows[-1].raw_assets


### PR DESCRIPTION
## Why

Trade-executor account correction needs to recover pending two-phase vault deposits and redemptions that were missed by local state. JSON-RPC `eth_getLogs` is too slow for this job on broad historical ranges, so eth-defi needs a reusable Hypersync-backed event discovery path that can reconstruct protocol-specific pending request tickets.

## Lessons learnt

Lagoon/Ostium pending request recovery can be handled with a small number of indexed event scans and protocol-specific ticket reconstruction. Lagoon legacy `Referral` events do not emit a controller address, so event-only reconstruction is explicitly limited to self-controller legacy requests. Synchronous wrapper APIs also need to tolerate callers that already run an event loop, such as notebooks and async test runners.

## Summary

- Add `eth_defi.vault.flow_events` with protocol-neutral `PendingVaultFlow` records, Hypersync log fetching, event topic/data decoding helpers and an event-loop-safe synchronous wrapper.
- Add `VaultDepositManager.fetch_vault_flow_events()` as the generic discovery hook for asynchronous vault managers.
- Implement pending flow discovery for Lagoon ERC-7540 request/redeem events and Ostium V1.5 deposit/withdraw request events.
- Add live fixed-range Hypersync integration tests covering Base Lagoon and Arbitrum Ostium pending deposit/redemption event reconstruction.
- Register the new vault flow event module in API docs and add a changelog entry.

## Related issues and PRs

- Continues the trade-executor account correction work for missing pending two-phase vault deposits and redemptions.

## Unrelated CI and test fixes

None.
