### PR TITLE
Export generic vault display flags

### DIFF
--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -331,6 +331,34 @@ class VaultMetricsExport(TypedDict):
     vaults: list[VaultMetricsRecord]
 
 
+def make_vault_display_flags(
+    red_flags: list[str],
+    yellow_flags: list[str],
+    source: str,
+) -> list[dict[str, str]]:
+    """Build generic vault warning display entries for JSON export.
+
+    :param red_flags:
+        Warning type strings with red severity.
+    :param yellow_flags:
+        Warning type strings with yellow severity.
+    :param source:
+        Protocol or data-source slug that produced the warnings.
+
+    :return:
+        JSON-safe warning entries suitable for user interfaces.
+    """
+    return [
+        {
+            "severity": severity,
+            "type": flag_type,
+            "source": source,
+        }
+        for severity, flags in (("red", red_flags), ("yellow", yellow_flags))
+        for flag_type in flags
+    ]
+
+
 def fmt_one_decimal_or_int(x: float | None) -> str:
     """Display fees to .1 accuracy if there are .1 fractions, otherwise as int."""
 
@@ -1546,11 +1574,21 @@ def calculate_vault_record(
             if not notes:
                 notes = morpho_analytics.note
 
+    vault_display_flags = make_vault_display_flags(
+        red_flags=morpho_red_flags,
+        yellow_flags=morpho_yellow_flags,
+        source="morpho",
+    )
+
     # ``other_data`` is a protocol-specific extension dict included in the metrics Series.
     # Currently populated for Morpho warnings; Core3 risk intelligence is attached
     # at JSON export time as a top-level ``core3_protocols`` dict (not per-vault).
     # Future protocols should add their own keys here rather than adding top-level Series fields.
     other_data: dict = {
+        # Generic warning display hints for user interfaces. Protocol adapters
+        # should append entries with ``severity`` and ``type`` instead of making
+        # UI code understand protocol-specific warning keys.
+        "vault_display_flags": vault_display_flags,
         # Vault-level governance warning types from the Morpho Blue API.
         # Sourced from MorphoVaultData["vault_warnings"] (via _morpho_offchain_data in VaultRow).
         # Example: ["not_whitelisted", "short_timelock"]

--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -22,6 +22,7 @@ from eth_defi.research.vault_metrics import (
     display_vault_chart_and_tearsheet,
     export_lifetime_row,
     format_lifetime_table,
+    make_vault_display_flags,
 )
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.fee import FeeData, VaultFeeMode
@@ -66,6 +67,32 @@ def test_apply_morpho_not_in_api_check_preserves_existing_note():
     assert risk == VaultTechnicalRisk.blacklisted
     assert notes == "Existing manual note"
     assert flags == {VaultFlag.not_in_morpho_api}
+
+
+def test_make_vault_display_flags_builds_generic_warning_contract() -> None:
+    """Generic vault display flags use a compact JSON-safe warning contract.
+
+    1. Build display flags from red and yellow warning type strings.
+    2. Assert the output preserves severity, type and source in order.
+    3. Assert empty inputs produce an empty list for clean vaults.
+    """
+
+    # 1. Build display flags from red and yellow warning type strings.
+    display_flags = make_vault_display_flags(
+        red_flags=["bad_debt_unrealized", "short_timelock"],
+        yellow_flags=["not_whitelisted"],
+        source="morpho",
+    )
+
+    # 2. The output preserves severity, type and source in order.
+    assert display_flags == [
+        {"severity": "red", "type": "bad_debt_unrealized", "source": "morpho"},
+        {"severity": "red", "type": "short_timelock", "source": "morpho"},
+        {"severity": "yellow", "type": "not_whitelisted", "source": "morpho"},
+    ]
+
+    # 3. Clean vaults do not emit display flags.
+    assert make_vault_display_flags(red_flags=[], yellow_flags=[], source="morpho") == []
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Why

Morpho red/yellow warnings are useful operator-facing information, but downstream UIs should not need to understand Morpho-specific warning arrays. A generic display contract lets other vault protocols add similar warning hints later.

## Lessons learnt

The existing Morpho red/yellow analytics already provide the right severity split, so the export can stay small and additive by deriving a JSON-safe `vault_display_flags` list from those arrays.

## Summary

- Add `make_vault_display_flags()` for generic warning display entries.
- Include `other_data["vault_display_flags"]` in vault metric records.
- Add a focused unit test for the exported warning contract.