### PR TITLE
build: prune generated ABI bundles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,20 @@ aavev3_old:
 aavev3:
 	@(cd contracts/aave-v3-origin && forge clean && forge install && forge build) > /dev/null
 	@mkdir -p eth_defi/abi/aave_v3
-	@find contracts/aave-v3-origin/out -iname "*.json" -exec cp {} eth_defi/abi/aave_v3 \;
+	@find contracts/aave-v3-origin/out -iname "*.json" \
+		-not -path "*/build-info/*" \
+		-not -iname "*.dbg.json" \
+		-not -iname "*Tests*.json" \
+		-not -iname "*Test.json" \
+		-not -iname "*TestBase.json" \
+		-not -iname "Test[A-Z]*.json" \
+		-not -iname "*Test[A-Z]*.json" \
+		-not -iname "Mock*.json" \
+		-not -iname "Vm*.json" \
+		-not -iname "Std*.json" \
+		-not -iname "console*.json" \
+		-not -iname "safeconsole.json" \
+		-exec cp {} eth_defi/abi/aave_v3 \;
 
 aavev2:
 	@(cd contracts/aave-v2 && npm ci && npm run compile) > /dev/null
@@ -158,8 +171,32 @@ lagoon:
 	@mkdir -p eth_defi/abi/lagoon/v0.4.0
 	@mkdir -p eth_defi/abi/lagoon/v0.5.0
 	@mkdir -p eth_defi/abi/lagoon/protocol-v2
-	@find contracts/lagoon-v0/out/v0.5.0 -iname "*.json" -not -iname "*.dbg.json" -exec cp {} eth_defi/abi/lagoon/v0.5.0 \;
-	@find contracts/lagoon-v0/out/v0.4.0 -iname "*.json" -not -iname "*.dbg.json" -exec cp {} eth_defi/abi/lagoon/v0.4.0 \;
+	@find contracts/lagoon-v0/out/v0.5.0 -iname "*.json" \
+		-not -path "*/build-info/*" \
+		-not -iname "*.dbg.json" \
+		-not -iname "*Tests*.json" \
+		-not -iname "*Test.json" \
+		-not -iname "*TestBase.json" \
+		-not -iname "Test[A-Z]*.json" \
+		-not -iname "*Test[A-Z]*.json" \
+		-not -iname "Vm*.json" \
+		-not -iname "Std*.json" \
+		-not -iname "console*.json" \
+		-not -iname "safeconsole.json" \
+		-exec cp {} eth_defi/abi/lagoon/v0.5.0 \;
+	@find contracts/lagoon-v0/out/v0.4.0 -iname "*.json" \
+		-not -path "*/build-info/*" \
+		-not -iname "*.dbg.json" \
+		-not -iname "*Tests*.json" \
+		-not -iname "*Test.json" \
+		-not -iname "*TestBase.json" \
+		-not -iname "Test[A-Z]*.json" \
+		-not -iname "*Test[A-Z]*.json" \
+		-not -iname "Vm*.json" \
+		-not -iname "Std*.json" \
+		-not -iname "console*.json" \
+		-not -iname "safeconsole.json" \
+		-exec cp {} eth_defi/abi/lagoon/v0.4.0 \;
 	@cp contracts/lagoon-v0/out/BeaconProxyFactory.sol/BeaconProxyFactory.json eth_defi/abi/lagoon
 	@cp contracts/lagoon-v0/out/ProtocolRegistry.sol/ProtocolRegistry.json eth_defi/abi/lagoon
 #	@find contracts/lagoon-v0/out/protocol-v2 -iname "*.json" -not -iname "*.dbg.json" -exec cp {} eth_defi/abi/lagoon/protocol-v2 \;


### PR DESCRIPTION
## Why

Generated Forge and Hardhat ABI bundles currently copy test, debug and build-info artefacts into the Python package. These files are not needed by runtime consumers and make downstream Docker images much larger.

## Lessons learnt

Filtering at ABI generation time is better than only excluding files in downstream Docker contexts, because every package consumer benefits from the smaller bundle.

## Summary

- Filter Aave v3 generated ABI copies to skip build-info, debug JSON, tests, mocks and Forge stdlib/debug artefacts.
- Filter Lagoon v0.4.0 and v0.5.0 generated ABI copies with the same runtime-oriented rules.
- Keep runtime contract artefacts copied as before.