### PR TITLE
feat: Add protocol manager name curator mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- feat: Add direct offchain manager-name curator mapping for Euler, Morpho and Lagoon vaults, with protocol-specific curator YAML metadata fields and the new 722 Capital Lagoon curator record so vault scans can attribute these vaults without relying on vault-name fuzzy matching (2026-06-22)
+
 - feat: Add pending asynchronous vault flow event discovery — `VaultDepositManager.fetch_vault_flow_events()` now lets Lagoon ERC-7540 and Ostium V1.5 managers reconstruct missing pending deposit and redemption requests from Hypersync event scans, with protocol-neutral `PendingVaultFlow` records and live fixed-range integration tests for Base Lagoon and Arbitrum Ostium vaults (2026-06-19)
 
 - feat: Add Aave (v4) as a recognised ERC-4626 vault protocol — detect Aave v4 Tokenization Spokes (the `wa{Hub}{Asset}` ERC-4626 vaults, e.g. `waCoreUSDC`) via the spoke-specific `SPOKE_REVISION()` probe as the new `AaveVault`/`aave_like` protocol, with protocol metadata, official ghost-mark logos, news feed entry, Sphinx docs and a focused mainnet-fork test against the live `CORE_USDC` spoke (2026-06-20)

--- a/eth_defi/data/curators.md
+++ b/eth_defi/data/curators.md
@@ -6,6 +6,36 @@ Curators are responsible for setting risk parameters, allocating assets, and man
 
 Sources: On-disk vault metadata database (~11,000 stablecoin vaults across Morpho, Euler, IPOR Fusion, Lagoon Finance, and other protocols), Lagoon Finance API cache, Hyperliquid/GRVT/Lighter native DuckDB databases (vault descriptions parsed for manager identity), web search verification.
 
+## Curator YAML manager metadata
+
+Canonical curator records live in `eth_defi/data/feeds/curators/`. Besides
+feed source fields such as `twitter`, `linkedin` and `rss`, curator YAML files
+can declare protocol-specific manager names used for exact vault attribution:
+
+| YAML field | Protocol | Source value |
+|------------|----------|--------------|
+| `ipor-atomist` | IPOR Fusion | Atomist display name |
+| `euler-entity` | Euler | Offchain API `entity` string |
+| `morpho-curator` | Morpho | Offchain API curator display name |
+| `lagoon-curator` | Lagoon Finance | Lagoon API curator display name |
+
+Use the exact string exposed by the protocol API or app. If the same
+organisation appears with different spellings across protocols, keep one
+canonical YAML file and add the protocol-specific fields there instead of
+creating duplicate curator records. The curator detector compares these values
+case-insensitively after trimming whitespace and requires each value to be
+unique within a protocol.
+
+Example:
+
+```yaml
+feeder-id: mev-capital
+name: MEV Capital
+role: curator
+ipor-atomist: MEV Capital
+euler-entity: mev-capital
+```
+
 ## Cross-platform curators
 
 Active across multiple vault protocols (Morpho, Euler, Lagoon, IPOR Fusion, etc.).

--- a/eth_defi/data/feeds/README.md
+++ b/eth_defi/data/feeds/README.md
@@ -14,10 +14,26 @@ The feed loader scans all YAML files recursively under this folder, so we can
 add more subfolders later without changing the loader contract.
 
 Some YAML files are **aliases** — they set `canonical-feeder-id` to delegate
-feed collection to another feeder file.  Alias files contain only identity
-metadata (feeder-id, name, role) and produce no tracked sources.  See the
-"Canonical feeder aliases" section in
-[`eth_defi/feed/README-feed.md`](../../feed/README-feed.md) for details.
+feed collection to another feeder file. Alias files contain identity metadata
+and other non-source metadata, such as descriptions or protocol manager
+metadata, but produce no tracked sources. See the "Canonical feeder aliases"
+section in [`eth_defi/feed/README-feed.md`](../../feed/README-feed.md) for
+details.
+
+Curator YAML files can also carry protocol-specific manager metadata used by
+vault curator detection:
+
+- `ipor-atomist`: IPOR Fusion atomist display name.
+- `euler-entity`: Euler offchain API `entity` value.
+- `morpho-curator`: Morpho offchain API curator display name.
+- `lagoon-curator`: Lagoon API curator display name.
+
+These fields are not feed sources. They map protocol-native manager names to
+the repository's canonical curator records so vault scans can resolve curators
+from `VaultBase.manager_name` without relying on vault-name fuzzy matching.
+Use the exact value exposed by the protocol API or app, and keep spelling
+variants on the canonical curator YAML instead of creating duplicate curator
+records.
 
 For the schema, collection behaviour, and configuration details, see
 [`eth_defi/feed/README-feed.md`](../../feed/README-feed.md).

--- a/eth_defi/data/feeds/curators/722-capital.yaml
+++ b/eth_defi/data/feeds/curators/722-capital.yaml
@@ -1,0 +1,19 @@
+feeder-id: 722-capital
+name: 722 Capital
+role: curator
+lagoon-curator: 722 Capital
+website: https://722.capital
+short_description: '722 Capital builds institutional-grade DeFi yield strategies for sophisticated investors, DAOs, protocols, and institutions.'
+long_description: |
+  722 Capital describes itself as a DeFi strategy firm founded by DeFi veterans. Its homepage says it builds institutional-grade yield strategies that use opportunities across decentralised finance, and serves sophisticated investors, DAOs, protocols, and institutions entering DeFi. Lagoon's vault API lists 722 Capital as the curator for the 722Capital-USDC vault on Base.
+
+# Evidence and background references.
+#
+# Lagoon's own vault API identifies 722 Capital as the curator for the
+# 722Capital-USDC vault on Base. The official 722 Capital website describes
+# the firm as building institutional-grade DeFi yield strategies.
+other-links:
+  - title: Lagoon Finance vault - 722Capital-USDC lists 722 Capital as curator
+    url: https://app.lagoon.finance/vault/8453/0xb09f761cb13baca8ec087ac476647361b6314f98
+  - title: 722 Capital vault app - 722 USDC vault
+    url: https://app.722.capital/v/722-usdc

--- a/eth_defi/data/feeds/curators/alphagrowth.yaml
+++ b/eth_defi/data/feeds/curators/alphagrowth.yaml
@@ -1,6 +1,7 @@
 feeder-id: alphagrowth
 name: AlphaGrowth
 role: curator
+euler-entity: alphagrowth
 website: https://alphagrowth.io/
 short_description: 'AlphaGrowth is a DeFi growth and execution firm supporting ecosystems, DAOs, investors, and protocols.'
 long_description: |

--- a/eth_defi/data/feeds/curators/alterscope.yaml
+++ b/eth_defi/data/feeds/curators/alterscope.yaml
@@ -1,6 +1,7 @@
 feeder-id: alterscope
 name: Alterscope
 role: curator
+euler-entity: alterscope
 website: https://www.alterscope.org
 short_description: 'Alterscope provides risk data for on-chain markets across Ethereum, Stellar, and DeFi yield opportunities.'
 long_description: |

--- a/eth_defi/data/feeds/curators/apostro.yaml
+++ b/eth_defi/data/feeds/curators/apostro.yaml
@@ -1,6 +1,7 @@
 feeder-id: apostro
 name: Apostro
 role: curator
+euler-entity: apostro
 website: https://apostro.xyz
 short_description: 'Apostro kickstarts and curates on-chain money markets using proprietary DeFi risk intelligence.'
 long_description: |

--- a/eth_defi/data/feeds/curators/clearstar-labs.yaml
+++ b/eth_defi/data/feeds/curators/clearstar-labs.yaml
@@ -2,6 +2,7 @@ feeder-id: clearstar-labs
 name: Clearstar Labs
 role: curator
 ipor-atomist: Clearstar
+euler-entity: clearstar
 website: https://www.clearstar.xyz
 short_description: 'Clearstar Labs curates on-chain strategies with qualitative vetting, monitoring, and distribution infrastructure.'
 long_description: |

--- a/eth_defi/data/feeds/curators/damm-capital.yaml
+++ b/eth_defi/data/feeds/curators/damm-capital.yaml
@@ -1,6 +1,7 @@
 feeder-id: damm-capital
 name: DAMM Capital
 role: curator
+lagoon-curator: DAMM Capital
 website: https://dammcap.finance
 short_description: 'DAMM Capital is a DeFi asset management firm building quantitative on-chain strategies and tokenised funds.'
 long_description: |

--- a/eth_defi/data/feeds/curators/der.yaml
+++ b/eth_defi/data/feeds/curators/der.yaml
@@ -1,6 +1,7 @@
 feeder-id: der
 name: DER
 role: curator
+lagoon-curator: Der
 short_description: Anonymous curator on Lagoon
 long_description: |
   DER is an anonymous curator operating a family of vaults on the Lagoon Finance

--- a/eth_defi/data/feeds/curators/gauntlet.yaml
+++ b/eth_defi/data/feeds/curators/gauntlet.yaml
@@ -1,6 +1,7 @@
 feeder-id: gauntlet
 name: Gauntlet
 role: curator
+morpho-curator: Gauntlet
 website: https://www.gauntlet.xyz
 short_description: Gauntlet provides quantitative risk management, optimisation and vault strategies for DeFi protocols.
 long_description: |

--- a/eth_defi/data/feeds/curators/k3-capital.yaml
+++ b/eth_defi/data/feeds/curators/k3-capital.yaml
@@ -13,6 +13,7 @@ feeder-id: k3-capital
 name: K3 Capital
 role: curator
 ipor-atomist: K3 Capital
+euler-entity: k3
 short_description: 'K3 Capital is a crypto-native asset and risk manager focused on non-directional DeFi yield strategies.'
 long_description: |
   K3 Capital says it has deployed liquidity onchain since 2021 and manages non-directional DeFi strategies. Its homepage highlights interest-rate arbitrage, liquidity provision, early-stage protocol participation, and risk-managed funds for crypto-native institutions and high-net-worth investors.

--- a/eth_defi/data/feeds/curators/mev-capital.yaml
+++ b/eth_defi/data/feeds/curators/mev-capital.yaml
@@ -2,6 +2,7 @@ feeder-id: mev-capital
 name: MEV Capital
 role: curator
 ipor-atomist: MEV Capital
+euler-entity: mev-capital
 website: https://www.mevcapital.com
 short_description: 'MEV Capital is a DeFi investment and risk management firm focused on onchain liquidity and vault curation.'
 long_description: |

--- a/eth_defi/data/feeds/curators/mt-pelerin.yaml
+++ b/eth_defi/data/feeds/curators/mt-pelerin.yaml
@@ -1,6 +1,7 @@
 feeder-id: mt-pelerin
 name: Mt Pelerin
 role: curator
+lagoon-curator: Mt Pelerin
 website: https://www.mtpelerin.com
 short_description: Mt Pelerin is a regulated Swiss fintech offering self-custodial crypto-fiat exchange, asset tokenisation, and DeFi vault curation since 2018.
 long_description: |

--- a/eth_defi/data/feeds/curators/re7-labs.yaml
+++ b/eth_defi/data/feeds/curators/re7-labs.yaml
@@ -1,6 +1,7 @@
 feeder-id: re7-labs
 name: RE7 Labs
 role: curator
+euler-entity: re7-labs
 website: https://re7.capital
 short_description: 'Re7 Labs is the innovation arm of Re7 Capital, supporting DeFi investment strategies and ecosystem development.'
 long_description: |

--- a/eth_defi/data/feeds/curators/steakhouse-financial.yaml
+++ b/eth_defi/data/feeds/curators/steakhouse-financial.yaml
@@ -1,6 +1,7 @@
 feeder-id: steakhouse-financial
 name: Steakhouse Financial
 role: curator
+morpho-curator: Steakhouse Financial
 website: https://steakhouse.financial
 short_description: 'Steakhouse Financial builds institutional-grade DeFi products, vaults, risk infrastructure, and stablecoin advisory services.'
 long_description: |

--- a/eth_defi/data/feeds/curators/tulipa-capital.yaml
+++ b/eth_defi/data/feeds/curators/tulipa-capital.yaml
@@ -1,6 +1,7 @@
 feeder-id: tulipa-capital
 name: Tulipa Capital
 role: curator
+lagoon-curator: Tulipa Capital
 website: https://tulipa.capital
 short_description: 'Tulipa Capital is a DeFi prop fund and risk curator focused on asset management and capital protection.'
 long_description: |

--- a/eth_defi/erc_4626/vault_protocol/euler/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/euler/vault.py
@@ -296,6 +296,11 @@ class EulerVault(ERC4626Vault):
             return self.euler_metadata.get("entity")
         return None
 
+    @property
+    def manager_name(self) -> str | None:
+        """Euler product entity slug from Euler offchain metadata."""
+        return self.entity
+
     def get_management_fee(self, block_identifier: BlockIdentifier) -> float:
         """Euler vault kit vaults never have management fee"""
         return 0.0

--- a/eth_defi/erc_4626/vault_protocol/ipor/README-IPOR-Curators.md
+++ b/eth_defi/erc_4626/vault_protocol/ipor/README-IPOR-Curators.md
@@ -5,11 +5,21 @@ In this repository we map IPOR atomists to the shared vault curator system, so
 IPOR vaults can be grouped under the same curator records as Morpho, Euler,
 Lagoon, GRVT and other vault protocols.
 
+IPOR uses the same protocol manager metadata mechanism as other ERC-4626
+protocols:
+
+| Protocol | Vault `manager_name` source | Curator YAML field |
+| --- | --- | --- |
+| IPOR Fusion | Atomist display name | `ipor-atomist` |
+| Euler | Offchain API `entity` value | `euler-entity` |
+| Morpho | Offchain API curator display name | `morpho-curator` |
+| Lagoon Finance | API curator display name | `lagoon-curator` |
+
 The curator mapping flow is:
 
 1. IPOR vault address -> IPOR atomist display name.
 2. IPOR atomist display name -> generic vault `manager_name`.
-3. `manager_name` -> repository curator slug.
+3. Exact `ipor-atomist` value -> repository curator slug.
 4. Curator slug -> metadata YAML in `eth_defi/data/feeds/curators/`.
 
 ## Data structures
@@ -37,8 +47,9 @@ Keys are formatted as:
 Values are IPOR atomist names as shown by the IPOR app or API. Keep the value
 as IPOR publishes it, even when the spelling differs from the curator's
 official name. The same value must appear in the resolved curator YAML
-`ipor-atomist` field. Spelling differences are handled by curator name
-patterns.
+`ipor-atomist` field. This exact field is the primary mapping; curator name
+patterns are only needed when the spelling should also be recognised by the
+legacy fuzzy `manager_name` fallback.
 
 The loader is implemented in `curators.py`:
 
@@ -53,10 +64,12 @@ ERC-4626 manager hook. During vault scanning, `eth_defi/erc_4626/scan.py`
 writes `vault.manager_name` to the internal scan row field `_manager_name`.
 
 Later, vault metric processing passes `_manager_name` to
-`eth_defi.vault.curator.identify_curator()`. Curator detection matches the
-vault name first and then the manager name. This means a branded vault name can
-still win, while IPOR vaults whose names do not contain the atomist brand can
-resolve from the atomist field.
+`eth_defi.vault.curator.identify_curator()`. Curator detection first handles
+protocol-level system vaults and priority vault-name matches. It then checks
+exact protocol manager metadata, including `ipor-atomist`, before ordinary
+vault-name fuzzy matching. This means priority branded vault names can still
+win, while IPOR vaults whose names do not contain the atomist brand can resolve
+from the atomist field.
 
 ## Curator records
 
@@ -88,8 +101,10 @@ elsewhere in the repository when it exists. Examples:
 | `Llama Risk` | `llama-risk` | IPOR includes a space; existing record is `LlamaRisk`. |
 | `Bizantine` | `bizantine` | IPOR spelling differs from official `Byzantine Finance`. |
 
-When the IPOR atomist spelling differs from the YAML `name`, add an explicit
-pattern in `eth_defi/vault/curator.py`:
+When the IPOR atomist spelling differs from the YAML `name`, `ipor-atomist`
+is enough for exact IPOR mapping. Add an explicit pattern in
+`eth_defi/vault/curator.py` only when the spelling should also work through
+legacy fuzzy manager-name matching:
 
 ```python
 CURATOR_NAME_PATTERNS = {
@@ -100,6 +115,21 @@ CURATOR_NAME_PATTERNS = {
 
 Do not create duplicate curator YAML files for spelling variants. Prefer one
 canonical curator record and one or more explicit name patterns.
+
+The same curator YAML file can carry multiple protocol manager fields when the
+same organisation appears in several protocol APIs:
+
+```yaml
+feeder-id: mev-capital
+name: MEV Capital
+role: curator
+ipor-atomist: MEV Capital
+euler-entity: mev-capital
+```
+
+Protocol manager field values are stripped and compared case-insensitively.
+They must be unique within the same protocol. Duplicate values fail loudly when
+the curator map is loaded.
 
 ## Updating atomist mappings
 
@@ -141,8 +171,8 @@ for atomist in atomists:
 PY
 ```
 
-This intentionally uses a neutral vault name so the result comes from
-`manager_name`, not from accidental vault-name matching.
+This intentionally uses a neutral vault name so the result comes from the exact
+`ipor-atomist` manager metadata, not from accidental vault-name matching.
 
 ## Adding a new IPOR curator
 
@@ -166,8 +196,9 @@ For a new third-party curator:
    no second hardcoded atomist list is needed.
 
 If the IPOR atomist is only a spelling variant of an existing curator, do not
-add a new YAML file. Add the spelling to `CURATOR_NAME_PATTERNS` and cover it
-with the IPOR manager-name test.
+add a new YAML file. Add `ipor-atomist` to the canonical curator YAML file.
+Add the spelling to `CURATOR_NAME_PATTERNS` only if the fallback fuzzy manager
+matcher also needs to recognise it.
 
 If the atomist is the protocol itself, map it to the protocol curator slug
 already used by the repository, such as `ipor` for `IPOR DAO`.

--- a/eth_defi/erc_4626/vault_protocol/lagoon/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/offchain_metadata.py
@@ -103,7 +103,7 @@ def _parse_curator(raw: dict) -> LagoonCuratorMetadata:
     """Parse a curator object from the Lagoon API response."""
     return LagoonCuratorMetadata(
         id=raw.get("id", ""),
-        name=raw.get("name", ""),
+        name=raw.get("name") or "",
         url=raw.get("url"),
         logo_url=raw.get("logoUrl"),
         about_description=raw.get("aboutDescription"),

--- a/eth_defi/erc_4626/vault_protocol/lagoon/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/vault.py
@@ -500,6 +500,15 @@ class LagoonVault(ERC7540Vault, AutomatedSafe):
             return self.lagoon_metadata.get("short_description")
         return None
 
+    @property
+    def manager_name(self) -> str | None:
+        """Lagoon curator names from Lagoon's offchain vault API."""
+        if not self.lagoon_metadata:
+            return None
+
+        names = (name for curator in self.lagoon_metadata.get("curators", []) if (name := (curator.get("name") or "").strip()))
+        return ", ".join(names) or None
+
     def get_flags(self) -> set[VaultFlag]:
         """Get vault flags, auto-flagging vaults missing from Lagoon's frontend.
 

--- a/eth_defi/erc_4626/vault_protocol/morpho/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/offchain_metadata.py
@@ -68,6 +68,9 @@ query MorphoVaultWarnings($address: String!, $chainId: Int!) {
       level
     }
     state {
+      curators {
+        name
+      }
       allocation {
         market {
           marketId
@@ -108,6 +111,11 @@ query MorphoVaultV2Warnings($address: String!, $chainId: Int!) {
     warnings {
       type
       level
+    }
+    curators {
+      items {
+        name
+      }
     }
   }
 }
@@ -207,6 +215,12 @@ class MorphoVaultData(TypedDict):
     #: Example: ``[{"type": "bad_debt_unrealized", "level": "RED", "market_id": "0x...", ...}]``
     market_warnings: list[MorphoMarketWarning]
 
+    #: Human-readable curator name from the Morpho offchain API, if listed.
+    #:
+    #: Morpho exposes this as ``vaultByAddress.state.curators[].name`` for V1
+    #: vaults and ``vaultV2ByAddress.curators.items[].name`` for V2 vaults.
+    manager_name: str | None
+
 
 #: In-process cache of fetched vault data.
 #:
@@ -275,6 +289,26 @@ def _parse_market_warning(warning: dict, market_id: str) -> MorphoMarketWarning:
     )
 
 
+def _parse_manager_name(raw_vault: dict) -> str | None:
+    """Parse curator display names from a Morpho vault GraphQL response.
+
+    :param raw_vault:
+        The ``vaultByAddress`` or ``vaultV2ByAddress`` dict from the GraphQL
+        ``data`` field.
+
+    :return:
+        Comma-separated curator display names, or ``None`` if Morpho does not
+        list named curators for the vault.
+    """
+    state = raw_vault.get("state") or {}
+    raw_curators = state.get("curators")
+    if raw_curators is None:
+        raw_curators = (raw_vault.get("curators") or {}).get("items") or []
+
+    names = (name for curator in raw_curators if isinstance(curator, dict) and (name := (curator.get("name") or "").strip()))
+    return ", ".join(names) or None
+
+
 def _build_vault_data_from_api_response(raw_vault: dict) -> MorphoVaultData:
     """Build a :py:class:`MorphoVaultData` from the ``vaultByAddress`` GraphQL response.
 
@@ -297,6 +331,7 @@ def _build_vault_data_from_api_response(raw_vault: dict) -> MorphoVaultData:
     return MorphoVaultData(
         vault_warnings=vault_warnings,
         market_warnings=market_warnings,
+        manager_name=_parse_manager_name(raw_vault),
     )
 
 
@@ -419,6 +454,7 @@ def fetch_morpho_vault_api_result(  # noqa: PLR0917
         serialisable = {
             "vault_warnings": result.data["vault_warnings"],
             "market_warnings": [dict(w) for w in result.data["market_warnings"]],
+            "manager_name": result.data.get("manager_name"),
         }
         with file.open("wt") as f:
             json.dump(serialisable, f, indent=2)

--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v1.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v1.py
@@ -191,6 +191,11 @@ class MorphoV1Vault(ERC4626Vault):
         """
         return self.morpho_api_result.data if self.morpho_api_result.status == MorphoVaultAPIStatus.found else None
 
+    @property
+    def manager_name(self) -> str | None:
+        """Morpho curator name from the offchain GraphQL API."""
+        return (self.morpho_offchain_data or {}).get("manager_name")
+
     def get_morpho_vault_flags(self) -> set[str]:
         """Return warning type strings from vault-level Morpho API warnings.
 

--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
@@ -237,6 +237,11 @@ class MorphoV2Vault(ERC4626Vault):
         """
         return self.morpho_api_result.data if self.morpho_api_result.status == MorphoVaultAPIStatus.found else None
 
+    @property
+    def manager_name(self) -> str | None:
+        """Morpho curator name from the offchain GraphQL API."""
+        return (self.morpho_offchain_data or {}).get("manager_name")
+
     def get_morpho_vault_flags(self) -> set[str]:
         """Return warning type strings from vault-level Morpho API warnings.
 

--- a/eth_defi/feed/README-feed.md
+++ b/eth_defi/feed/README-feed.md
@@ -84,6 +84,10 @@ role: { curator | protocol | stablecoin | vault }
 website: { optional company website URL }
 short_description: { optional one-line company or project summary }
 long_description: { optional multi-paragraph Markdown company or project description }
+ipor-atomist: { optional IPOR Fusion atomist display name, normally curator role }
+euler-entity: { optional Euler offchain API entity value, normally curator role }
+morpho-curator: { optional Morpho offchain API curator display name, normally curator role }
+lagoon-curator: { optional Lagoon API curator display name, normally curator role }
 twitter: { optional Twitter/X username }
 linkedin: { optional LinkedIn company id }
 rss: { optional RSS or Atom feed URL }
@@ -99,6 +103,9 @@ Notes:
 - `website` is optional company metadata and is stored alongside tracked sources
 - `short_description` is optional feeder metadata for list and card views
 - `long_description` is optional Markdown feeder metadata for detail views
+- `ipor-atomist`, `euler-entity`, `morpho-curator`, and `lagoon-curator` are
+  optional curator metadata fields. They are not collected as feeds; they map
+  protocol-native manager names to the canonical curator record
 - `twitter` is a username such as `gauntlet_xyz`, not a full profile URL
 - `linkedin` is collected through operator-supplied LinkedIn bridge templates
 - `linkedin` is a company id such as `gauntlet-xyz`, not a full LinkedIn URL
@@ -110,6 +117,56 @@ Notes:
   - one Twitter source
   - one LinkedIn source
   - one RSS source
+
+## Protocol manager metadata
+
+Some vault protocols expose the manager or curator identity through an offchain
+API field instead of, or in addition to, the vault display name. Curator YAML
+files can store these protocol-native names so vault scans can map
+`VaultBase.manager_name` directly to a curator slug:
+
+| YAML field | Protocol slug | API/app source | Example |
+| --- | --- | --- | --- |
+| `ipor-atomist` | `ipor-fusion` | IPOR Fusion atomist name | `TAU Labs` |
+| `euler-entity` | `euler` | Euler offchain `entity` string | `mev-capital` |
+| `morpho-curator` | `morpho` | Morpho curator display name | `Gauntlet` |
+| `lagoon-curator` | `lagoon-finance` | Lagoon curator display name | `Tulipa Capital` |
+
+These values are compared case-insensitively after stripping whitespace. They
+must be unique within a protocol. If two curator YAML files declare the same
+normalised value for the same protocol, `load_curator_map()` raises a
+`ValueError` so the data issue is fixed before vault scans continue.
+
+Use the exact value published by the protocol API or app. If the protocol
+spelling differs from the organisation's canonical `name`, keep one curator
+record and set the protocol-specific field there:
+
+```yaml
+feeder-id: tau
+name: TAU
+role: curator
+ipor-atomist: TAU Labs
+website: https://www.628labs.ai/
+```
+
+```yaml
+feeder-id: mev-capital
+name: MEV Capital
+role: curator
+ipor-atomist: MEV Capital
+euler-entity: mev-capital
+website: https://www.mevcapital.com
+```
+
+The curator detector checks protocol manager metadata after priority
+vault-name matches, currently used for Frax-branded vaults, and before ordinary
+vault-name fuzzy matching. This preserves existing priority curator behaviour
+while letting exact protocol metadata win over accidental ordinary vault-name
+matches.
+
+Protocol manager metadata can appear on alias curator YAML files too. The alias
+still delegates feed collection through `canonical-feeder-id`, but its manager
+metadata remains available for curator detection.
 
 ## Canonical feeder aliases
 

--- a/eth_defi/feed/sources.py
+++ b/eth_defi/feed/sources.py
@@ -37,6 +37,7 @@ KNOWN_FEEDER_ROLES = {
 
 _SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 _VALID_SOURCE_TYPES = {"rss", "twitter", "linkedin"}
+_MANAGER_METADATA_KEYS = ("ipor-atomist", "euler-entity", "morpho-curator", "lagoon-curator")
 
 _MAPPING_SCHEMA = Map(
     {
@@ -45,6 +46,9 @@ _MAPPING_SCHEMA = Map(
         "role": Str(),
         Optional("canonical-feeder-id"): Str(),
         Optional("ipor-atomist"): Str(),
+        Optional("euler-entity"): Str(),
+        Optional("morpho-curator"): Str(),
+        Optional("lagoon-curator"): Str(),
         Optional("website"): Str(),
         Optional("short_description"): Str(),
         Optional("long_description"): Str(),
@@ -240,12 +244,13 @@ def _normalise_mapping_metadata(parsed: dict, mapping_file: Path) -> None:
                 raise ValueError(f"{key} must be a string in {mapping_file}")
             parsed[key] = value.strip() or None
 
-    ipor_atomist = parsed.get("ipor-atomist")
-    if ipor_atomist is not None:
-        ipor_atomist = ipor_atomist.strip()
-        if not ipor_atomist:
-            raise ValueError(f"ipor-atomist must be a non-empty string in {mapping_file}")
-        parsed["ipor-atomist"] = ipor_atomist
+    for key in _MANAGER_METADATA_KEYS:
+        value = parsed.get(key)
+        if value is not None:
+            value = value.strip()
+            if not value:
+                raise ValueError(f"{key} must be a non-empty string in {mapping_file}")
+            parsed[key] = value
 
 
 def _normalise_twitter_source(handle: str, mapping_file: Path) -> tuple[str, str]:

--- a/eth_defi/vault/curator.py
+++ b/eth_defi/vault/curator.py
@@ -283,6 +283,14 @@ PRIORITY_CURATOR_SLUGS: set[str] = {
     "frax-finance",
 }
 
+#: Protocol-specific curator metadata fields in curator YAML files.
+PROTOCOL_MANAGER_YAML_FIELDS: dict[str, str] = {
+    "ipor-fusion": "ipor-atomist",
+    "euler": "euler-entity",
+    "morpho": "morpho-curator",
+    "lagoon-finance": "lagoon-curator",
+}
+
 
 class CuratorInfo(TypedDict):
     """Metadata for a single curator loaded from YAML.
@@ -332,6 +340,12 @@ class CuratorInfo(TypedDict):
     #: curator should be looked up under the canonical feeder's sources.
     #: ``None`` for curators that have their own feed sources.
     canonical_feeder_id: str | None
+
+    #: Exact protocol manager names keyed by protocol slug.
+    #:
+    #: These values are sourced from protocol-specific YAML fields such as
+    #: ``euler-entity`` and ``lagoon-curator``.
+    protocol_manager_names: dict[str, str]
 
 
 class CuratorLogos(TypedDict):
@@ -418,6 +432,8 @@ def _load_curator_yaml(yaml_path: Path) -> CuratorInfo:
         Path to a curator YAML file.
     """
     parsed = load_feeder_metadata(yaml_path)
+    protocol_manager_names = {protocol_slug: parsed[yaml_key] for protocol_slug, yaml_key in PROTOCOL_MANAGER_YAML_FIELDS.items() if parsed.get(yaml_key)}
+
     return CuratorInfo(
         slug=parsed["feeder-id"],
         name=parsed["name"],
@@ -429,6 +445,7 @@ def _load_curator_yaml(yaml_path: Path) -> CuratorInfo:
         rss=parsed.get("rss"),
         protocol_curator=parsed["feeder-id"] in ALL_PROTOCOL_CURATOR_SLUGS,
         canonical_feeder_id=parsed.get("canonical-feeder-id"),
+        protocol_manager_names=protocol_manager_names,
     )
 
 
@@ -448,8 +465,14 @@ def load_curator_map() -> dict[str, CuratorInfo]:
         return _cached_curator_map
 
     result: dict[str, CuratorInfo] = {}
+    protocol_manager_values: dict[tuple[str, str], str] = {}
     for yaml_path in sorted(CURATORS_DATA_DIR.glob("*.yaml")):
         info = _load_curator_yaml(yaml_path)
+        for protocol_slug, manager_name in info["protocol_manager_names"].items():
+            key = (protocol_slug, manager_name.strip().casefold())
+            if existing_slug := protocol_manager_values.get(key):
+                raise ValueError(f"Duplicate {protocol_slug} manager metadata {manager_name!r} in curator YAML files: {existing_slug} and {info['slug']}")
+            protocol_manager_values[key] = info["slug"]
         result[info["slug"]] = info
 
     _cached_curator_map = result
@@ -496,13 +519,75 @@ def _build_matching_patterns() -> list[tuple[re.Pattern, str]]:
     return patterns
 
 
+def _identify_curator_by_protocol_manager_name(protocol_slug: str, manager_name: str | None) -> str | None:
+    """Identify curator from an exact protocol-specific manager metadata field.
+
+    :param protocol_slug:
+        Normalised protocol slug.
+
+    :param manager_name:
+        Raw manager or curator name exposed by the protocol offchain API.
+
+    :return:
+        Curator slug, or ``None`` if no protocol-specific field matches.
+    """
+    if protocol_slug not in PROTOCOL_MANAGER_YAML_FIELDS:
+        return None
+
+    manager_name = (manager_name or "").strip()
+    if not manager_name:
+        return None
+
+    manager_name_lower = manager_name.casefold()
+    for slug, info in load_curator_map().items():
+        value = info["protocol_manager_names"].get(protocol_slug)
+        if value is not None and value.strip().casefold() == manager_name_lower:
+            return slug
+    return None
+
+
+def _identify_curator_by_patterns(
+    haystack: str | None,
+    patterns: list[tuple[re.Pattern, str]],
+    *,
+    include_slugs: set[str] | None = None,
+    exclude_slugs: set[str] | None = None,
+) -> str | None:
+    """Identify a curator by regex patterns, with optional slug filtering.
+
+    :param haystack:
+        Text to match, or ``None``/empty string to skip.
+    :param patterns:
+        Compiled curator regex patterns from :py:func:`_build_matching_patterns`.
+    :param include_slugs:
+        When given, only these curator slugs are considered.
+    :param exclude_slugs:
+        When given, these curator slugs are ignored.
+    :return:
+        Matching curator slug, or ``None`` if no pattern matched.
+    """
+
+    if not haystack:
+        return None
+
+    for regex, slug in patterns:
+        if include_slugs is not None and slug not in include_slugs:
+            continue
+        if exclude_slugs is not None and slug in exclude_slugs:
+            continue
+        if regex.search(haystack):
+            return slug
+
+    return None
+
+
 def identify_curator(  # noqa: PLR0917
     chain_id: int,
     vault_token_symbol: str,
     vault_name: str,
     vault_address: str,
     protocol_slug: str = "",
-    manager_name: str = "",
+    manager_name: str | None = "",
 ) -> str | None:
     """Identify the curator managing a vault.
 
@@ -515,8 +600,9 @@ def identify_curator(  # noqa: PLR0917
     name — the vault name there is the strategy name (e.g.
     ``"Ethereum Moving Average Long/Short"``) while the curator identity
     (e.g. ``"Gerhard - Bitcoin Strategy"``) is the manager.  Pass
-    ``manager_name`` so these curators are detected.  The vault name is
-    matched first and takes precedence over the manager name.
+    ``manager_name`` so these curators are detected.  Priority vault-name
+    matches run first, then exact protocol manager metadata, then ordinary
+    vault-name and manager-name fuzzy matching.
 
     :param chain_id:
         Chain ID where the vault is deployed.
@@ -540,7 +626,7 @@ def identify_curator(  # noqa: PLR0917
         Optional name of the vault manager/operator, used by native
         marketplace protocols (e.g. GRVT) where the curator brand lives
         in the manager field rather than the vault name.  Empty string
-        when unknown.
+        or ``None`` when unknown.
 
     :return:
         Curator slug (e.g. ``"gauntlet"``, ``"ostium"``, ``"hyperliquid"``),
@@ -573,16 +659,23 @@ def identify_curator(  # noqa: PLR0917
         if vault_address.lower() in GRVT_SYSTEM_VAULT_ADDRESSES:
             return "grvt"
 
-    # 5. Word-boundary regex matching against vault name, then manager name.
-    #    Vault name is matched first so it takes precedence over the
-    #    manager name when both carry a recognisable brand.
+    # 5. Priority vault-name matches, e.g. Frax-branded Morpho vaults with a
+    #    third-party UI curator.
     patterns = _build_matching_patterns()
-    for haystack in (vault_name, manager_name):
-        if not haystack:
-            continue
-        for regex, slug in patterns:
-            if regex.search(haystack):
-                return slug
+    if priority_slug := _identify_curator_by_patterns(vault_name, patterns, include_slugs=PRIORITY_CURATOR_SLUGS):
+        return priority_slug
+
+    # 6. Exact protocol-specific manager name mapping from offchain APIs.
+    if manager_slug := _identify_curator_by_protocol_manager_name(protocol_slug, manager_name):
+        return manager_slug
+
+    # 7. Ordinary vault-name fuzzy matching.
+    if vault_slug := _identify_curator_by_patterns(vault_name, patterns, exclude_slugs=PRIORITY_CURATOR_SLUGS):
+        return vault_slug
+
+    # 8. Legacy fuzzy matching against manager name for native marketplaces like GRVT.
+    if manager_slug := _identify_curator_by_patterns(manager_name, patterns):
+        return manager_slug
 
     return None
 

--- a/tests/erc_4626/test_euler_metadata.py
+++ b/tests/erc_4626/test_euler_metadata.py
@@ -65,6 +65,7 @@ def test_euler_metadata(
     assert "EVK Vault" in euler_prime_susds.name or "Euler Prime" in euler_prime_susds.name
     assert euler_prime_susds.description is None
     assert euler_prime_susds.entity is None
+    assert euler_prime_susds.manager_name is None
     assert euler_prime_susds.denomination_token.symbol == "sUSDS"
 
     # 4. Lending protocol identification

--- a/tests/erc_4626/vault_protocol/test_euler_links.py
+++ b/tests/erc_4626/vault_protocol/test_euler_links.py
@@ -43,6 +43,7 @@ def test_euler_alphagrowth_ausd_vault_uses_light_metadata() -> None:
     assert vault.name == "AlphaGrowth AUSD Borrow Vault"
     assert vault.description == "Borrow AUSD against Balancer BPT collateral."
     assert vault.entity == "alphagrowth"
+    assert vault.manager_name == "alphagrowth"
 
 
 def test_euler_alphagrowth_wmon_vault_uses_light_frontend() -> None:

--- a/tests/lagoon/test_lagoon_metadata.py
+++ b/tests/lagoon/test_lagoon_metadata.py
@@ -18,10 +18,7 @@ from web3 import Web3
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect, detect_vault_features
 from eth_defi.erc_4626.core import ERC4262VaultDetection
 from eth_defi.erc_4626.scan import create_vault_scan_record
-from eth_defi.erc_4626.vault_protocol.lagoon.offchain_metadata import (
-    LagoonVaultMetadata,
-    fetch_lagoon_vaults_for_chain,
-)
+from eth_defi.erc_4626.vault_protocol.lagoon.offchain_metadata import fetch_lagoon_vaults_for_chain
 from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.token import TokenDiskCache
@@ -31,6 +28,7 @@ CI = os.environ.get("CI") == "true"
 
 #: RockSolid rETH Vault on Ethereum - known to have descriptions in Lagoon's API
 ROCKSOLID_VAULT_ADDRESS = "0x936facdf10c8c36294e7b9d28345255539d81bc7"
+MIN_DESCRIPTION_LENGTH = 10
 
 pytestmark = [
     pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests"),
@@ -58,6 +56,7 @@ def test_lagoon_metadata(web3: Web3):
     assert vault.description is not None
     assert "rETH" in vault.description
     assert vault.short_description is not None
+    assert vault.manager_name == "Tulipa Capital"
 
 
 @flaky.flaky
@@ -83,7 +82,7 @@ def test_lagoon_metadata_cache(tmp_path: Path):
 
 
 @flaky.flaky
-def test_lagoon_scan_record_has_descriptions(web3: Web3, tmp_path: Path):
+def test_lagoon_scan_record_has_descriptions(web3: Web3):
     """Verify that descriptions flow through create_vault_scan_record() for Lagoon vaults."""
 
     vault_address = Web3.to_checksum_address(ROCKSOLID_VAULT_ADDRESS)
@@ -93,9 +92,9 @@ def test_lagoon_scan_record_has_descriptions(web3: Web3, tmp_path: Path):
         chain=1,
         address=vault_address,
         first_seen_at_block=0,
-        first_seen_at=datetime.datetime(2024, 1, 1),
+        first_seen_at=datetime.datetime(2024, 1, 1),  # noqa: DTZ001
         features=features,
-        updated_at=datetime.datetime(2024, 1, 1),
+        updated_at=datetime.datetime(2024, 1, 1),  # noqa: DTZ001
         deposit_count=0,
         redeem_count=0,
     )
@@ -112,5 +111,6 @@ def test_lagoon_scan_record_has_descriptions(web3: Web3, tmp_path: Path):
 
     assert record["Protocol"] == "Lagoon Finance"
     assert record["_description"] is not None, f"Expected _description to be set, got record keys: {list(record.keys())}"
-    assert len(record["_description"]) > 10, f"Expected non-trivial description, got: {record['_description']}"
-    assert record["_short_description"] is not None, f"Expected _short_description to be set"
+    assert len(record["_description"]) > MIN_DESCRIPTION_LENGTH, f"Expected non-trivial description, got: {record['_description']}"
+    assert record["_short_description"] is not None, "Expected _short_description to be set"
+    assert record["_manager_name"] is not None, "Expected _manager_name to be set from Lagoon curators"

--- a/tests/morpho/test_morpho_offchain_metadata.py
+++ b/tests/morpho/test_morpho_offchain_metadata.py
@@ -273,7 +273,13 @@ def test_morpho_found_data_uses_disk_cache(monkeypatch: pytest.MonkeyPatch, tmp_
                     "vaultByAddress": {
                         "address": Web3.to_checksum_address(DUNE_USDC_ETHEREUM),
                         "warnings": [{"type": "short_timelock", "level": "RED"}],
-                        "state": {"allocation": []},
+                        "state": {
+                            "curators": [
+                                {"name": None},
+                                {"name": "Gauntlet"},
+                            ],
+                            "allocation": [],
+                        },
                     }
                 }
             }
@@ -284,6 +290,7 @@ def test_morpho_found_data_uses_disk_cache(monkeypatch: pytest.MonkeyPatch, tmp_
     result_1 = fetch_morpho_vault_data(web3, DUNE_USDC_ETHEREUM, cache_path=tmp_path)
     assert result_1 is not None
     assert result_1["vault_warnings"] == [{"type": "short_timelock", "level": "RED"}]
+    assert result_1["manager_name"] == "Gauntlet"
 
     cache_key = f"{tmp_path}:1:{DUNE_USDC_ETHEREUM.lower()}"
     _cached_vault_data.pop(cache_key, None)
@@ -292,6 +299,49 @@ def test_morpho_found_data_uses_disk_cache(monkeypatch: pytest.MonkeyPatch, tmp_
 
     assert result_2 == result_1
     assert len(calls) == 1
+
+    def fake_fetch_morpho_vault_api_result(*_args, **_kwargs) -> MorphoVaultAPIResult:
+        return MorphoVaultAPIResult(
+            MorphoVaultAPIStatus.found,
+            {
+                "vault_warnings": [],
+                "market_warnings": [],
+                "manager_name": "Gauntlet",
+            },
+        )
+
+    monkeypatch.setattr(
+        "eth_defi.erc_4626.vault_protocol.morpho.vault_v1.fetch_morpho_vault_api_result",
+        fake_fetch_morpho_vault_api_result,
+    )
+
+    vault = _make_morpho_v1_vault(GAUNTLET_USDC_PRIME_ETHEREUM)
+
+    assert vault.manager_name == "Gauntlet"
+
+    v2_calls = _patch_morpho_api(
+        monkeypatch,
+        [
+            {
+                "data": {
+                    "vaultV2ByAddress": {
+                        "address": Web3.to_checksum_address(GAUNTLET_USDC_PRIME_ETHEREUM),
+                        "warnings": [],
+                        "curators": {
+                            "items": [{"name": "Steakhouse Financial"}],
+                        },
+                    }
+                }
+            }
+        ],
+    )
+
+    result_3 = fetch_morpho_vault_api_result(web3, GAUNTLET_USDC_PRIME_ETHEREUM, cache_path=tmp_path, api_version="v2")
+
+    assert result_3.status == MorphoVaultAPIStatus.found
+    assert result_3.data is not None
+    assert result_3.data["manager_name"] == "Steakhouse Financial"
+    assert len(v2_calls) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/vault/test_curator.py
+++ b/tests/vault/test_curator.py
@@ -37,6 +37,107 @@ def test_identify_alphagrowth_vault() -> None:
     assert get_curator_name("alphagrowth") == "AlphaGrowth"
 
 
+def test_identify_euler_curator_by_entity_metadata() -> None:
+    """Euler manager names resolve by exact ``euler-entity`` YAML metadata."""
+
+    slug = identify_curator(
+        chain_id=146,
+        vault_token_symbol="",
+        vault_name="Sonic USDC Market",
+        vault_address="0x0000000000000000000000000000000000000006",
+        protocol_slug="euler",
+        manager_name="mev-capital",
+    )
+
+    assert slug == "mev-capital"
+
+
+def test_identify_ipor_curator_by_atomist_metadata() -> None:
+    """IPOR manager names resolve by exact ``ipor-atomist`` YAML metadata."""
+
+    slug = identify_curator(
+        chain_id=1,
+        vault_token_symbol="",
+        vault_name="Prime HELOC Loop",
+        vault_address="0x0000000000000000000000000000000000000009",
+        protocol_slug="ipor-fusion",
+        manager_name="TAU Labs",
+    )
+
+    assert slug == "tau"
+
+
+def test_protocol_manager_metadata_precedes_ordinary_vault_name_match() -> None:
+    """Exact protocol manager metadata wins over non-priority vault-name matches."""
+
+    slug = identify_curator(
+        chain_id=146,
+        vault_token_symbol="",
+        vault_name="Gauntlet Sonic USDC Market",
+        vault_address="0x0000000000000000000000000000000000000010",
+        protocol_slug="euler",
+        manager_name="mev-capital",
+    )
+
+    assert slug == "mev-capital"
+
+
+def test_identify_curator_tolerates_none_manager_name() -> None:
+    """Unknown manager names can be passed as ``None``."""
+
+    slug = identify_curator(
+        chain_id=1,
+        vault_token_symbol="",
+        vault_name="Unbranded USDC Market",
+        vault_address="0x0000000000000000000000000000000000000011",
+        protocol_slug="morpho",
+        manager_name=None,
+    )
+
+    assert slug is None
+
+
+def test_identify_morpho_curator_by_curator_metadata() -> None:
+    """Morpho manager names resolve by exact ``morpho-curator`` YAML metadata."""
+
+    slug = identify_curator(
+        chain_id=1,
+        vault_token_symbol="",
+        vault_name="USDC Prime",
+        vault_address="0x0000000000000000000000000000000000000007",
+        protocol_slug="morpho",
+        manager_name="Gauntlet",
+    )
+
+    assert slug == "gauntlet"
+
+
+def test_identify_lagoon_curator_by_curator_metadata() -> None:
+    """Lagoon manager names resolve by exact ``lagoon-curator`` YAML metadata."""
+
+    slug = identify_curator(
+        chain_id=1,
+        vault_token_symbol="",
+        vault_name="Stablecoin Fund",
+        vault_address="0x0000000000000000000000000000000000000008",
+        protocol_slug="lagoon-finance",
+        manager_name="DAMM Capital",
+    )
+
+    assert slug == "damm-capital"
+
+    slug = identify_curator(
+        chain_id=8453,
+        vault_token_symbol="",
+        vault_name="722Capital-USDC",
+        vault_address="0xb09f761cb13baca8ec087ac476647361b6314f98",
+        protocol_slug="lagoon-finance",
+        manager_name="722 Capital",
+    )
+
+    assert slug == "722-capital"
+
+
 def test_identify_smokehouse_as_steakhouse_financial() -> None:
     """Smokehouse vault names resolve to Steakhouse Financial."""
 
@@ -161,6 +262,21 @@ def test_identify_frax_usd_vaults() -> None:
         )
 
         assert slug == "frax-finance", f"{vault_name!r} -> {slug!r}"
+
+
+def test_identify_frax_usd_vault_name_precedes_manager_name() -> None:
+    """Frax-branded vault names win over third-party protocol manager names."""
+
+    slug = identify_curator(
+        chain_id=1,
+        vault_token_symbol="",
+        vault_name="Steakhouse Prime frxUSD",
+        vault_address="0x0000000000000000000000000000000000000005",
+        protocol_slug="morpho",
+        manager_name="Steakhouse Financial",
+    )
+
+    assert slug == "frax-finance"
 
 
 def test_identify_gains_network_protocol_curator() -> None:


### PR DESCRIPTION
## Why

Vault scans were still relying on vault-name fuzzy matching for non-IPOR protocols even when the protocol offchain APIs expose the underlying manager, entity or curator name directly. This caused curator attribution to miss vaults whose names do not contain our curator keywords.

## Lessons learnt

Euler exposes product entity slugs, Morpho exposes curator names through its GraphQL vault payloads, and Lagoon exposes curator names in its vault API. Keeping those source-specific names in curator YAML avoids lossy hyphen/name normalisation and lets us match exact protocol metadata instead.

## Summary

- Add direct `manager_name` support for Euler, Morpho and Lagoon vault implementations.
- Add protocol-specific curator YAML metadata fields for Euler entities, Morpho curators and Lagoon curators.
- Match protocol manager names through a shared `protocol_manager_names` curator map.
- Add 722 Capital as a Lagoon curator and annotate existing curator YAML records with protocol manager metadata.
- Extend curator, Lagoon, Euler and Morpho tests for the manager-name mapping chain.
- Add a changelog entry for the feature.

## Related issues and PRs

Continues the IPOR curator atomist mapping work by adding the same direct-manager attribution pattern for Euler, Morpho and Lagoon.

## Unrelated CI and test fixes

None.