### PR TITLE
Fix Hypersync timestamp head range failures

### DIFF
--- a/eth_defi/hypersync/hypersync_timestamp.py
+++ b/eth_defi/hypersync/hypersync_timestamp.py
@@ -26,19 +26,17 @@ Example:
 """
 
 import asyncio
-from typing import AsyncIterable
 import logging
-
-import pandas as pd
-from eth_typing import BlockNumber
+from typing import AsyncIterable
 
 import hypersync
+import pandas as pd
+from eth_typing import BlockNumber
 from hypersync import BlockField
-
 from tqdm_loggable.auto import tqdm
 
 from eth_defi.event_reader.block_header import BlockHeader
-from eth_defi.event_reader.timestamp_cache import load_timestamp_cache, BlockTimestampDatabase, DEFAULT_TIMESTAMP_CACHE_FOLDER, BlockTimestampSlicer
+from eth_defi.event_reader.timestamp_cache import DEFAULT_TIMESTAMP_CACHE_FOLDER, BlockTimestampDatabase, BlockTimestampSlicer, load_timestamp_cache
 from eth_defi.hypersync.session import is_hypersync_client, open_hypersync_stream
 from eth_defi.utils import from_unix_timestamp
 
@@ -56,6 +54,20 @@ def _is_hypersync_rate_limit_error(e: Exception) -> bool:
     after exhausting its internal retries.
     """
     return isinstance(e, RuntimeError) and "429" in str(e)
+
+
+def _is_hypersync_next_block_range_error(e: Exception) -> bool:
+    """Check if a Hypersync stream failed on an internal pagination boundary.
+
+    Some Hypersync backends can fail near the indexed chain head with an
+    ``inner receiver`` error where ``next_block`` is at the lower boundary of
+    the server-side subrange. Treat this as a flaky stream error so the caller
+    can retry or wait for the backend to index more blocks.
+    """
+    if not isinstance(e, RuntimeError):
+        return False
+    message = str(e)
+    return "inner receiver" in message and "server returned next_block" in message and "outside the requested range" in message
 
 
 async def _validate_hypersync_chain_id_async(
@@ -77,6 +89,20 @@ async def _validate_hypersync_chain_id_async(
             raise HypersyncFlaky(f"Hypersync rate limited during chain_id validation{reason_suffix}: {e}") from e
         raise
     assert connected == expected_chain_id, f"Hypersync client connected to chain {connected}, but expected {expected_chain_id}"
+
+
+async def _fetch_hypersync_block_height_async(
+    client: hypersync.HypersyncClient,
+    reason: str | None = None,
+) -> int:
+    """Fetch the latest indexed Hypersync block height."""
+    reason_suffix = f" [{reason}]" if reason else ""
+    try:
+        return await client.get_height()
+    except RuntimeError as e:
+        if _is_hypersync_rate_limit_error(e):
+            raise HypersyncFlaky(f"Hypersync rate limited during block height check{reason_suffix}: {e}") from e
+        raise
 
 
 async def get_block_timestamps_using_hypersync_async(
@@ -179,6 +205,8 @@ async def get_block_timestamps_using_hypersync_async(
         except RuntimeError as e:
             if _is_hypersync_rate_limit_error(e):
                 raise HypersyncFlaky(f"Hypersync rate limited during streaming{reason_suffix}: {e}") from e
+            if _is_hypersync_next_block_range_error(e):
+                raise HypersyncFlaky(f"Hypersync stream pagination failed{reason_suffix}: {e}") from e
             raise
 
         # exit if the stream finished
@@ -309,28 +337,33 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
         f"{end_block:,}",
     )
 
-    # Build (start, end) pairs for blocks we need to fetch.
-    # Head and tail are computed separately so a partial backfill
-    # followed by a 429 doesn't leave permanent holes on retry.
-    fetch_ranges: list[tuple[int, int]] = []
+    def _build_fetch_ranges(range_end_block: int) -> list[tuple[int, int]]:
+        """Build (start, end) pairs for blocks we need to fetch."""
+        fetch_ranges: list[tuple[int, int]] = []
 
-    if last_read_block:
-        if start_block < first_read_block:
-            fetch_ranges.append((start_block, first_read_block - 1))
-        if end_block > last_read_block:
-            fetch_ranges.append((last_read_block + 1, end_block))
+        if last_read_block:
+            if start_block < first_read_block:
+                head_end_block = min(first_read_block - 1, range_end_block)
+                if start_block <= head_end_block:
+                    fetch_ranges.append((start_block, head_end_block))
+            if range_end_block > last_read_block:
+                fetch_ranges.append((last_read_block + 1, range_end_block))
 
-        # Detect interior gaps (e.g. from a partial backfill that saved
-        # blocks 1-99 then got a 429, leaving a hole at 100-999).
-        # Clip each gap to the requested range since we only care about
-        # the intersection.
-        for gap_start, gap_end, _count in timestamp_db.find_gaps():
-            clip_start = max(start_block, gap_start + 1)
-            clip_end = min(end_block, gap_end - 1)
-            if clip_start <= clip_end:
-                fetch_ranges.append((clip_start, clip_end))
-    else:
-        fetch_ranges.append((start_block, end_block))
+            # Detect interior gaps (e.g. from a partial backfill that saved
+            # blocks 1-99 then got a 429, leaving a hole at 100-999).
+            # Clip each gap to the requested range since we only care about
+            # the intersection.
+            for gap_start, gap_end, _count in timestamp_db.find_gaps():
+                clip_start = max(start_block, gap_start + 1)
+                clip_end = min(range_end_block, gap_end - 1)
+                if clip_start <= clip_end:
+                    fetch_ranges.append((clip_start, clip_end))
+        else:
+            fetch_ranges.append((start_block, range_end_block))
+
+        return fetch_ranges
+
+    fetch_ranges = _build_fetch_ranges(end_block)
 
     total_to_fetch = sum(e - s + 1 for s, e in fetch_ranges)
 
@@ -338,9 +371,33 @@ async def fetch_block_timestamps_using_hypersync_cached_async(
         logger.info("Chain %d: cache fully covers requested range, nothing to fetch", chain_id)
         return timestamp_db.get_slicer()
 
-    # Validate chain_id once before streaming
+    # Validate chain_id once before streaming, and avoid querying beyond
+    # Hypersync's current indexed height. Near-head overreads can surface as
+    # Rust receiver pagination errors instead of clean empty responses.
     if is_hypersync_client(client):
         await _validate_hypersync_chain_id_async(client, chain_id, reason="timestamp-cache-validate")
+        hypersync_height = await _fetch_hypersync_block_height_async(client, reason="timestamp-cache-height")
+        if end_block > hypersync_height:
+            logger.warning(
+                "Chain %d: clipping timestamp request end block from %s to Hypersync indexed height %s",
+                chain_id,
+                f"{end_block:,}",
+                f"{hypersync_height:,}",
+            )
+            end_block = hypersync_height
+            if end_block < start_block:
+                logger.warning(
+                    "Chain %d: Hypersync indexed height %s is before requested start block %s, nothing to fetch",
+                    chain_id,
+                    f"{hypersync_height:,}",
+                    f"{start_block:,}",
+                )
+                return timestamp_db.get_slicer()
+            fetch_ranges = _build_fetch_ranges(end_block)
+            total_to_fetch = sum(e - s + 1 for s, e in fetch_ranges)
+            if not fetch_ranges:
+                logger.info("Chain %d: cache fully covers clipped requested range, nothing to fetch", chain_id)
+                return timestamp_db.get_slicer()
 
     # Split ranges into chunks — each opens a separate stream() call
     # so the Python-side throttle can pace requests, and progress is

--- a/tests/hypersync/test_hypersync_gap_healing.py
+++ b/tests/hypersync/test_hypersync_gap_healing.py
@@ -12,12 +12,15 @@ No live HyperSync connection needed — uses mocked async generators.
 
 import asyncio
 import datetime
-from unittest.mock import patch, MagicMock
-
-import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from eth_defi.event_reader.block_header import BlockHeader
-from eth_defi.hypersync.hypersync_timestamp import fetch_block_timestamps_using_hypersync_cached_async
+from eth_defi.hypersync.hypersync_timestamp import (
+    HypersyncFlaky,
+    _is_hypersync_next_block_range_error,
+    fetch_block_timestamps_using_hypersync_cached,
+    fetch_block_timestamps_using_hypersync_cached_async,
+)
 
 
 def _make_block_header(block_number: int) -> BlockHeader:
@@ -137,6 +140,225 @@ def test_hypersync_gap_healing_no_gaps(tmp_path):
     slicer.close()
 
 
+def test_hypersync_next_block_range_error_is_flaky():
+    """Verify that Hypersync near-head pagination failures are retryable."""
+    err = RuntimeError("inner receiver\n\nCaused by:\n    server returned next_block 24535975 outside the requested range [24535975..24535985)")
+
+    assert _is_hypersync_next_block_range_error(err)
+
+
+def test_hypersync_cached_sync_retries_next_block_range_error(tmp_path):
+    """Verify that the sync cached wrapper retries a flaky stream failure."""
+
+    chain_id = 1
+    start_block = 1000
+    end_block = 1009
+    call_count = 0
+
+    async def mock_get_timestamps(client, chain_id, start_block, end_block, timeout=120.0, display_progress=True, progress_throttle=10_000, validate_chain_id=True, reason=None):
+        nonlocal call_count
+        call_count += 1
+
+        if call_count == 1:
+            raise HypersyncFlaky("Hypersync stream pagination failed: inner receiver")
+
+        for block_num in range(start_block, end_block + 1):
+            yield _make_block_header(block_num)
+
+    with (
+        patch(
+            "eth_defi.hypersync.hypersync_timestamp.get_block_timestamps_using_hypersync_async",
+            side_effect=mock_get_timestamps,
+        ),
+        patch(
+            "eth_defi.hypersync.hypersync_timestamp.asyncio.sleep",
+            new_callable=AsyncMock,
+        ),
+    ):
+        slicer = fetch_block_timestamps_using_hypersync_cached(
+            client=MagicMock(),
+            chain_id=chain_id,
+            start_block=start_block,
+            end_block=end_block,
+            cache_path=tmp_path,
+            display_progress=False,
+            attempts=2,
+        )
+
+    assert call_count == 2
+    assert len(slicer) == 10
+    assert slicer[start_block] == datetime.datetime(2023, 11, 14, 22, 30)
+    assert slicer[end_block] == datetime.datetime(2023, 11, 14, 22, 30, 9)
+
+    slicer.close()
+
+
+def test_hypersync_timestamp_fetch_clips_to_indexed_height(tmp_path):
+    """Verify that timestamp fetch does not stream past Hypersync indexed height."""
+
+    chain_id = 1
+    fetch_calls = []
+
+    async def mock_get_timestamps(client, chain_id, start_block, end_block, timeout=120.0, display_progress=True, progress_throttle=10_000, validate_chain_id=True, reason=None):
+        fetch_calls.append((start_block, end_block))
+        for block_num in range(start_block, end_block + 1):
+            yield _make_block_header(block_num)
+
+    async def _run():
+        with (
+            patch(
+                "eth_defi.hypersync.hypersync_timestamp.is_hypersync_client",
+                return_value=True,
+            ),
+            patch(
+                "eth_defi.hypersync.hypersync_timestamp._validate_hypersync_chain_id_async",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "eth_defi.hypersync.hypersync_timestamp._fetch_hypersync_block_height_async",
+                new_callable=AsyncMock,
+                return_value=1050,
+            ),
+            patch(
+                "eth_defi.hypersync.hypersync_timestamp.get_block_timestamps_using_hypersync_async",
+                side_effect=mock_get_timestamps,
+            ),
+        ):
+            slicer = await fetch_block_timestamps_using_hypersync_cached_async(
+                client=MagicMock(),
+                chain_id=chain_id,
+                start_block=1000,
+                end_block=1099,
+                cache_path=tmp_path,
+                display_progress=False,
+            )
+
+        return slicer
+
+    slicer = asyncio.run(_run())
+
+    assert fetch_calls == [(1000, 1050)]
+    assert len(slicer) == 51
+    assert slicer.get_last_block() == 1050
+
+    slicer.close()
+
+
+def test_hypersync_timestamp_fetch_uses_warm_cache_without_height_check(tmp_path):
+    """Verify that a fully cached range does not call Hypersync."""
+
+    chain_id = 1
+
+    import pandas as pd
+
+    from eth_defi.event_reader.timestamp_cache import BlockTimestampDatabase
+
+    db = BlockTimestampDatabase.create(chain_id, tmp_path)
+    existing_index = list(range(1000, 1100))
+    existing_values = [1_700_000_000 + b for b in existing_index]
+    db.import_chain_data(chain_id, pd.Series(data=existing_values, index=existing_index))
+    db.close()
+
+    async def _run():
+        height_check = AsyncMock(return_value=1099)
+        validate_chain = AsyncMock()
+
+        with (
+            patch(
+                "eth_defi.hypersync.hypersync_timestamp.is_hypersync_client",
+                return_value=True,
+            ),
+            patch(
+                "eth_defi.hypersync.hypersync_timestamp._validate_hypersync_chain_id_async",
+                validate_chain,
+            ),
+            patch(
+                "eth_defi.hypersync.hypersync_timestamp._fetch_hypersync_block_height_async",
+                height_check,
+            ),
+        ):
+            slicer = await fetch_block_timestamps_using_hypersync_cached_async(
+                client=MagicMock(),
+                chain_id=chain_id,
+                start_block=1000,
+                end_block=1099,
+                cache_path=tmp_path,
+                display_progress=False,
+            )
+
+        return slicer, validate_chain, height_check
+
+    slicer, validate_chain, height_check = asyncio.run(_run())
+
+    assert len(slicer) == 100
+    validate_chain.assert_not_awaited()
+    height_check.assert_not_awaited()
+
+    slicer.close()
+
+
+def test_hypersync_head_backfill_respects_clipped_indexed_height(tmp_path):
+    """Verify that head backfills do not fetch past clipped Hypersync height."""
+
+    chain_id = 1
+
+    import pandas as pd
+
+    from eth_defi.event_reader.timestamp_cache import BlockTimestampDatabase
+
+    db = BlockTimestampDatabase.create(chain_id, tmp_path)
+    existing_index = list(range(1000, 1100))
+    existing_values = [1_700_000_000 + b for b in existing_index]
+    db.import_chain_data(chain_id, pd.Series(data=existing_values, index=existing_index))
+    db.close()
+
+    fetch_calls = []
+
+    async def mock_get_timestamps(client, chain_id, start_block, end_block, timeout=120.0, display_progress=True, progress_throttle=10_000, validate_chain_id=True, reason=None):
+        fetch_calls.append((start_block, end_block))
+        for block_num in range(start_block, end_block + 1):
+            yield _make_block_header(block_num)
+
+    async def _run():
+        with (
+            patch(
+                "eth_defi.hypersync.hypersync_timestamp.is_hypersync_client",
+                return_value=True,
+            ),
+            patch(
+                "eth_defi.hypersync.hypersync_timestamp._validate_hypersync_chain_id_async",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "eth_defi.hypersync.hypersync_timestamp._fetch_hypersync_block_height_async",
+                new_callable=AsyncMock,
+                return_value=500,
+            ),
+            patch(
+                "eth_defi.hypersync.hypersync_timestamp.get_block_timestamps_using_hypersync_async",
+                side_effect=mock_get_timestamps,
+            ),
+        ):
+            slicer = await fetch_block_timestamps_using_hypersync_cached_async(
+                client=MagicMock(),
+                chain_id=chain_id,
+                start_block=1,
+                end_block=1200,
+                cache_path=tmp_path,
+                display_progress=False,
+            )
+
+        return slicer
+
+    slicer = asyncio.run(_run())
+
+    assert fetch_calls == [(1, 500)]
+    assert len(slicer) == 600
+    assert slicer.get_last_block() == 1099
+
+    slicer.close()
+
+
 def test_hypersync_gap_healing_persistent_gap(tmp_path):
     """Verify behaviour when a gap persists across all healing attempts.
 
@@ -209,9 +431,9 @@ def test_hypersync_head_backfill_no_holes(tmp_path):
     chain_id = 1
 
     # Pre-populate cache with blocks 1000-2000
-    from eth_defi.event_reader.timestamp_cache import BlockTimestampDatabase
-
     import pandas as pd
+
+    from eth_defi.event_reader.timestamp_cache import BlockTimestampDatabase
 
     db = BlockTimestampDatabase.create(chain_id, tmp_path)
     existing_index = list(range(1000, 2001))
@@ -280,9 +502,9 @@ def test_hypersync_interior_gap_detected_on_retry(tmp_path):
 
     chain_id = 1
 
-    from eth_defi.event_reader.timestamp_cache import BlockTimestampDatabase
-
     import pandas as pd
+
+    from eth_defi.event_reader.timestamp_cache import BlockTimestampDatabase
 
     # Pre-populate cache simulating partial backfill state:
     # blocks 1-99 (saved before 429) + blocks 1000-2000 (original cache)


### PR DESCRIPTION
## Why

Production Soneium vault scanning failed while reading block timestamps through Hypersync near the indexed chain head. The Rust receiver raised `inner receiver` with `server returned next_block ... outside the requested range`, which escaped our `HypersyncFlaky` retry path and aborted the price scan.

## Lessons learnt

Hypersync can surface near-head pagination/indexing boundary issues as generic receiver `RuntimeError`s instead of rate limit or timeout failures. Timestamp cache reads should also preserve the warm-cache fast path and only ask Hypersync for height when missing blocks need to be fetched.

## Summary

- Treat Hypersync `next_block outside the requested range` receiver failures as flaky stream errors so the cached wrapper can retry.
- Clip timestamp fetch ranges to the current Hypersync indexed height before opening streams.
- Keep fully cached timestamp ranges independent from live Hypersync validation or height checks.
- Add mocked regressions for retrying the production error, height clipping, warm-cache behaviour, and clipped head backfills.

## Related issues and PRs

Production vault scanner failure on Soneium, reported from logs on 2026-06-23.

## Unrelated CI and test fixes

None.
