### PR TITLE
fix: tolerate unavailable fallback RPC at startup

### DIFF
--- a/eth_defi/provider/fallback.py
+++ b/eth_defi/provider/fallback.py
@@ -10,13 +10,13 @@ import time
 from collections import Counter, defaultdict
 from pprint import pformat
 from typing import Any, cast
-from requests.exceptions import HTTPError
 
+from requests.exceptions import HTTPError
 from web3 import Web3
 from web3.types import RPCEndpoint, RPCResponse
 
 from eth_defi.event_reader.fast_json_rpc import get_last_headers
-from eth_defi.middleware import DEFAULT_RETRYABLE_EXCEPTIONS, DEFAULT_RETRYABLE_HTTP_STATUS_CODES, DEFAULT_RETRYABLE_RPC_ERROR_CODES, ProbablyNodeHasNoBlock, is_retryable_http_exception, SomeCrappyRPCProviderException
+from eth_defi.middleware import DEFAULT_RETRYABLE_EXCEPTIONS, DEFAULT_RETRYABLE_HTTP_STATUS_CODES, DEFAULT_RETRYABLE_RPC_ERROR_CODES, ProbablyNodeHasNoBlock, SomeCrappyRPCProviderException, is_retryable_http_exception
 from eth_defi.provider.named import BaseNamedProvider, NamedProvider, get_provider_name
 from eth_defi.utils import get_url_domain
 
@@ -72,6 +72,16 @@ class ChainIdMismatch(Exception):
 
     This typically happens when an RPC endpoint is misconfigured or its
     backend temporarily routes requests to the wrong chain after an outage.
+    """
+
+
+class ProviderNotAvailable(ChainIdMismatch):
+    """Raised when a provider cannot answer chain ID verification.
+
+    This is a recoverable switchover condition when other fallback providers
+    are available. It subclasses :py:class:`ChainIdMismatch` for backwards
+    compatibility with callers that treat failed chain ID verification as a
+    rejected provider selection.
     """
 
 
@@ -189,27 +199,41 @@ class FallbackProvider(BaseNamedProvider):
     def verify_providers(self):
         """Check that all providers return the same chain ID.
 
-        Call this at startup to detect misconfigured RPC endpoints
-        before any trading logic runs.
+        Call this at startup to detect misconfigured RPC endpoints before any
+        trading logic runs. Providers that do not answer during startup are
+        left in the fallback rotation, because their availability can be
+        transient and runtime switching verifies chain ID before selecting
+        them.
 
         :raises ChainIdMismatch:
-            If any provider returns a different chain ID, or if a
-            provider cannot be reached at all.
+            If responding providers return different chain IDs, or if no
+            provider can be reached at all.
         """
         if len(self.providers) < 2:
             return
 
         results: dict[str, int] = {}
+        unavailable: dict[str, Exception] = {}
         for provider in self.providers:
             name = get_provider_name(provider)
-            if name in results:
+            if name in results or name in unavailable:
                 # Same endpoint appears multiple times, skip duplicate
                 continue
             try:
                 chain_id = self._fetch_chain_id_from_provider(provider)
             except Exception as e:
-                raise ChainIdMismatch(f"Provider {name} did not respond to eth_chainId during startup verification: {e}") from e
+                unavailable[name] = e
+                logger.warning(
+                    "Provider %s did not respond to eth_chainId during startup verification, keeping it in fallback rotation: %s",
+                    name,
+                    e,
+                )
+                continue
             results[name] = chain_id
+
+        if not results:
+            detail = ", ".join(f"{name}: {exc}" for name, exc in unavailable.items())
+            raise ChainIdMismatch(f"No RPC providers responded to eth_chainId during startup verification: {detail}")
 
         chain_ids = set(results.values())
         if len(chain_ids) > 1:
@@ -219,7 +243,12 @@ class FallbackProvider(BaseNamedProvider):
         # Pre-populate expected_chain_id for runtime switch checks
         if chain_ids:
             self.expected_chain_id = chain_ids.pop()
-            logger.info("All %d RPC providers verified on chain ID %d", len(results), self.expected_chain_id)
+            logger.info(
+                "Verified %d/%d RPC providers on chain ID %d",
+                len(results),
+                len(results) + len(unavailable),
+                self.expected_chain_id,
+            )
 
     @property
     def endpoint_uri(self):
@@ -269,9 +298,9 @@ class FallbackProvider(BaseNamedProvider):
         """Switch to next available provider.
 
         After switching, verifies that the new provider returns the same
-        ``eth_chainId`` as the previously observed value.  If the chain ID
-        does not match or cannot be fetched, the provider index is rolled
-        back to the previous value and the exception is raised.
+        ``eth_chainId`` as the previously observed value. Providers that cannot
+        answer the verification call are skipped when other alternatives are
+        available. Providers that answer with a different chain ID are rejected.
 
         :param log_level:
             Logging level to be verbose about the switch over
@@ -279,12 +308,34 @@ class FallbackProvider(BaseNamedProvider):
         :param randomise:
             If set switch to a random provider instead of cycling.
         """
-        if randomise:
-            new_index = random.randint(0, len(self.providers) - 1)
-        else:
-            new_index = (self.currently_active_provider + 1) % len(self.providers)
+        provider_count = len(self.providers)
+        if provider_count <= 1:
+            self.switch_to_provider_index(self.currently_active_provider, log_level=log_level, cause=cause)
+            return
 
-        self.switch_to_provider_index(new_index, log_level=log_level, cause=cause)
+        old_index = self.currently_active_provider
+        if randomise:
+            candidate_indexes = [idx for idx in range(provider_count) if idx != old_index]
+            random.shuffle(candidate_indexes)
+        else:
+            candidate_indexes = [(old_index + offset) % provider_count for offset in range(1, provider_count)]
+
+        last_unavailable: ProviderNotAvailable | None = None
+        for new_index in candidate_indexes:
+            try:
+                self.switch_to_provider_index(new_index, log_level=log_level, cause=cause)
+                return
+            except ProviderNotAvailable as e:
+                last_unavailable = e
+                continue
+
+        if last_unavailable is not None:
+            provider = self.get_active_provider()
+            logger.warning(
+                "No alternative RPC provider could be verified during switchover from %s; keeping current provider. Last verification failure: %s",
+                get_provider_name(provider),
+                last_unavailable,
+            )
 
     def switch_to_provider_index(self, new_index: int, log_level: int = None, cause: str = "<not specified>"):
         """Switch to a specific provider by index, with the same verification as :py:meth:`switch_provider`.
@@ -293,7 +344,7 @@ class FallbackProvider(BaseNamedProvider):
         fail a chain over to a known-good single node) rather than cycling or
         randomising. Like :py:meth:`switch_provider`, after switching it verifies
         the new provider returns the expected ``eth_chainId`` and rolls back to the
-        previous provider (raising :py:class:`ChainIdMismatch`) if it does not — so
+        previous provider (raising :py:class:`ChainIdMismatch`) if it does not, so
         a misconfigured or mis-routing endpoint cannot be silently selected.
 
         :param new_index:
@@ -306,9 +357,10 @@ class FallbackProvider(BaseNamedProvider):
             Human-readable reason for the switch, logged for diagnostics.
 
         :raises ChainIdMismatch:
-            If the new provider reports a different chain ID than expected, or its
-            ``eth_chainId`` cannot be fetched. The active provider is rolled back
-            to the previous one before raising.
+            If the new provider reports a different chain ID than expected.
+
+        :raises ProviderNotAvailable:
+            If the new provider cannot answer ``eth_chainId`` verification.
         """
         assert 0 <= new_index < len(self.providers), f"Provider index {new_index} out of range for {len(self.providers)} providers"
 
@@ -332,21 +384,21 @@ class FallbackProvider(BaseNamedProvider):
             log_level = self.switchover_noisiness
 
         if old_provider_name != new_provider_name:
-            logger.log(log_level, "Switched RPC providers %s -> %s, cause: %s\n", old_provider_name, new_provider_name, cause)
-
             # Verify the new provider is on the same chain
             if self.expected_chain_id is not None:
                 try:
                     new_chain_id = self._fetch_chain_id_from_provider(new_provider)
                 except Exception as e:
                     self.currently_active_provider = old_index
-                    logger.warning("Rolling back to provider %s: new provider %s failed eth_chainId: %s", old_provider_name, new_provider_name, e)
-                    raise ChainIdMismatch(f"Provider {new_provider_name} could not be verified (eth_chainId failed: {e}). Rolled back to {old_provider_name}.") from e
+                    logger.warning("Keeping provider %s: new provider %s failed eth_chainId: %s", old_provider_name, new_provider_name, e)
+                    raise ProviderNotAvailable(f"Provider {new_provider_name} could not be verified (eth_chainId failed: {e}). Kept {old_provider_name}.") from e
                 if new_chain_id != self.expected_chain_id:
                     self.currently_active_provider = old_index
                     raise ChainIdMismatch(f"Provider {new_provider_name} returned chain ID {new_chain_id}, but expected {self.expected_chain_id} (from {old_provider_name}). The RPC endpoint may be misconfigured or routing to the wrong chain.")
+
+            logger.log(log_level, "Switched RPC providers %s -> %s, cause: %s\n", old_provider_name, new_provider_name, cause)
         else:
-            logger.log(log_level, "Only 1 RPC provider configured: %s, cannot switch, sleeping and hoping the issue resolves itself", old_provider_name)
+            logger.log(log_level, "No alternative RPC provider configured: %s, cannot switch, sleeping and hoping the issue resolves itself", old_provider_name)
 
     def get_active_provider(self) -> NamedProvider:
         """Get currently active provider.

--- a/tests/rpc/test_provider_chain_id_verification.py
+++ b/tests/rpc/test_provider_chain_id_verification.py
@@ -5,11 +5,16 @@ endpoint mixed into an Arbitrum provider list) are caught at startup
 rather than at runtime when a provider switch occurs.
 """
 
+import re
 from unittest.mock import MagicMock
 
 import pytest
 
-from eth_defi.provider.fallback import ChainIdMismatch, FallbackProvider
+from eth_defi.provider.fallback import ChainIdMismatch, FallbackProvider, ProviderNotAvailable
+
+ARBITRUM_CHAIN_ID = 42161
+ETHEREUM_CHAIN_ID = 1
+PROVIDER_C_INDEX = 2
 
 
 def _make_mock_provider(name: str, chain_id: int) -> MagicMock:
@@ -29,34 +34,34 @@ def _make_mock_provider(name: str, chain_id: int) -> MagicMock:
 def test_verify_providers_same_chain():
     """All providers on the same chain should pass verification.
 
-    1. Create two mock providers both returning chain ID 42161 (Arbitrum)
+    1. Create two mock providers both returning Arbitrum chain ID
     2. Call verify_providers()
     3. Assert no exception is raised and expected_chain_id is set
     """
     # 1. Create mock providers on the same chain
-    p1 = _make_mock_provider("provider-a.com", 42161)
-    p2 = _make_mock_provider("provider-b.com", 42161)
+    p1 = _make_mock_provider("provider-a.com", ARBITRUM_CHAIN_ID)
+    p2 = _make_mock_provider("provider-b.com", ARBITRUM_CHAIN_ID)
 
     fallback = FallbackProvider([p1, p2], sleep=0, backoff=1)
 
-    # 2. Verify — should not raise
+    # 2. Verify - should not raise
     fallback.verify_providers()
 
     # 3. expected_chain_id should be populated
-    assert fallback.expected_chain_id == 42161
+    assert fallback.expected_chain_id == ARBITRUM_CHAIN_ID
 
 
 def test_verify_providers_chain_mismatch():
     """A provider returning a different chain ID should fail verification.
 
-    1. Create one provider returning chain ID 42161 (Arbitrum)
-    2. Create another returning chain ID 1 (Ethereum mainnet)
+    1. Create one provider returning Arbitrum chain ID
+    2. Create another returning Ethereum mainnet chain ID
     3. Call verify_providers()
     4. Assert ChainIdMismatch is raised with both chain IDs in the message
     """
     # 1-2. Create providers on different chains
-    p1 = _make_mock_provider("arbitrum-rpc.com", 42161)
-    p2 = _make_mock_provider("mainnet-rpc.com", 1)
+    p1 = _make_mock_provider("arbitrum-rpc.com", ARBITRUM_CHAIN_ID)
+    p2 = _make_mock_provider("mainnet-rpc.com", ETHEREUM_CHAIN_ID)
 
     fallback = FallbackProvider([p1, p2], sleep=0, backoff=1)
 
@@ -66,14 +71,14 @@ def test_verify_providers_chain_mismatch():
 
 
 def test_verify_providers_unreachable():
-    """A provider that fails to respond should raise at startup.
+    """A provider that fails to respond should not fail startup if others work.
 
     1. Create one working provider and one that raises on eth_chainId
     2. Call verify_providers()
-    3. Assert ChainIdMismatch is raised mentioning the failing provider
+    3. Assert the working provider populates expected_chain_id
     """
     # 1. Create one working and one broken provider
-    p1 = _make_mock_provider("good-rpc.com", 42161)
+    p1 = _make_mock_provider("good-rpc.com", ARBITRUM_CHAIN_ID)
     p2 = MagicMock()
     p2.endpoint_uri = "https://broken-rpc.com/rpc"
     p2.middlewares = ()
@@ -82,9 +87,91 @@ def test_verify_providers_unreachable():
 
     fallback = FallbackProvider([p1, p2], sleep=0, backoff=1)
 
-    # 2-3. Should raise mentioning the broken provider
-    with pytest.raises(ChainIdMismatch, match="broken-rpc.com"):
+    # 2. Should not raise, because at least one provider proves the chain id
+    fallback.verify_providers()
+
+    # 3. Runtime switchover verifies the broken provider before selecting it
+    assert fallback.expected_chain_id == ARBITRUM_CHAIN_ID
+
+
+def test_verify_providers_all_unreachable():
+    """Startup verification fails if no provider can prove the chain ID.
+
+    1. Create two providers that fail on eth_chainId
+    2. Call verify_providers()
+    3. Assert ChainIdMismatch is raised because no expected chain ID can be set
+    """
+    # 1. All providers are broken
+    p1 = MagicMock()
+    p1.endpoint_uri = "https://broken-rpc-1.com/rpc"
+    p1.middlewares = ()
+    p1.exception_retry_configuration = None
+    p1.make_request.side_effect = ConnectionError("Connection refused")
+
+    p2 = MagicMock()
+    p2.endpoint_uri = "https://broken-rpc-2.com/rpc"
+    p2.middlewares = ()
+    p2.exception_retry_configuration = None
+    p2.make_request.side_effect = ConnectionError("Connection refused")
+
+    fallback = FallbackProvider([p1, p2], sleep=0, backoff=1)
+
+    # 2-3. There is no safe chain ID baseline
+    with pytest.raises(ChainIdMismatch, match="No RPC providers responded"):
         fallback.verify_providers()
+
+
+def test_switch_provider_skips_unavailable_provider():
+    """Runtime switchover skips providers that cannot answer eth_chainId.
+
+    1. Create active provider A, unavailable provider B, and working provider C
+    2. Seed expected_chain_id as startup verification would do
+    3. Switch provider
+    4. Assert provider C is selected and provider B was not made active
+    """
+    # 1. Provider B is between the active provider and the next usable provider
+    p1 = _make_mock_provider("provider-a.com", ARBITRUM_CHAIN_ID)
+    p2 = MagicMock()
+    p2.endpoint_uri = "https://broken-rpc.com/rpc"
+    p2.middlewares = ()
+    p2.exception_retry_configuration = None
+    p2.make_request.side_effect = ConnectionError("Connection refused")
+    p3 = _make_mock_provider("provider-c.com", ARBITRUM_CHAIN_ID)
+
+    fallback = FallbackProvider([p1, p2, p3], sleep=0, backoff=1)
+    fallback.expected_chain_id = ARBITRUM_CHAIN_ID
+
+    # 2-3. Switchover tries B, skips it, and selects C
+    fallback.switch_provider()
+
+    # 4. Broken provider was probed but not selected
+    assert fallback.currently_active_provider == PROVIDER_C_INDEX
+    p2.make_request.assert_called_once_with("eth_chainId", [])
+
+
+def test_switch_to_provider_index_unavailable_rolls_back():
+    """Direct provider pinning rejects an unavailable provider.
+
+    1. Create an active provider and a broken provider
+    2. Try to pin directly to the broken provider
+    3. Assert ProviderNotAvailable is raised and the active provider is unchanged
+    """
+    # 1. Broken provider cannot be chain-id verified
+    p1 = _make_mock_provider("provider-a.com", ARBITRUM_CHAIN_ID)
+    p2 = MagicMock()
+    p2.endpoint_uri = "https://broken-rpc.com/rpc"
+    p2.middlewares = ()
+    p2.exception_retry_configuration = None
+    p2.make_request.side_effect = ConnectionError("Connection refused")
+
+    fallback = FallbackProvider([p1, p2], sleep=0, backoff=1)
+    fallback.expected_chain_id = ARBITRUM_CHAIN_ID
+
+    # 2-3. Direct pinning should fail closed
+    with pytest.raises(ProviderNotAvailable, match=re.escape("broken-rpc.com")):
+        fallback.switch_to_provider_index(1)
+
+    assert fallback.currently_active_provider == 0
 
 
 def test_verify_providers_single_provider():
@@ -95,7 +182,7 @@ def test_verify_providers_single_provider():
     3. Assert no exception and no RPC call is made
     """
     # 1. Single provider
-    p1 = _make_mock_provider("solo-rpc.com", 42161)
+    p1 = _make_mock_provider("solo-rpc.com", ARBITRUM_CHAIN_ID)
 
     fallback = FallbackProvider([p1], sleep=0, backoff=1)
 


### PR DESCRIPTION
## Why

The production vault scanner failed on Arbitrum during `create_multi_provider_web3()` startup verification. The configured RPC list had multiple healthy fallback endpoints, but Goldsky returned HTTP 403 for the initial `eth_chainId` call:

```text
eth_defi.provider.fallback.ChainIdMismatch: Provider edge.goldsky.com did not respond to eth_chainId during startup verification: 403 Client Error: Forbidden for url: https://edge.goldsky.com/standard/evm/42161?...
```

The startup verifier was introduced to catch a dangerous class of issues where fallback RPCs point to different chains. However, it treated an unavailable provider the same as a provider that responded with the wrong chain ID. That made the multi-provider setup brittle: one temporarily forbidden, rate-limited, or otherwise unavailable fallback endpoint could abort the whole scan before QuickNode, dRPC, or Alchemy could be used.

This PR keeps the chain safety check, but narrows the fatal condition to cases where chain safety cannot be established. Responding providers must still agree on `eth_chainId`. If a provider does not answer, we log it and keep it in the rotation so it can recover later. If no provider answers, startup still fails because there is no safe chain ID baseline.

## Lessons learnt

Fallback provider startup checks need to distinguish between two different risks:

- wrong-chain responses are safety failures and must be rejected
- unavailable providers are availability failures and should be skipped when another provider can prove the chain ID

Runtime switching also needs the same distinction. A dead provider should not stop fallback cycling, but a provider that answers with the wrong chain ID still must not be selected.

## Summary

- Added `ProviderNotAvailable` for recoverable provider verification failures.
- Changed startup verification to accept partial provider availability when all responding providers agree on chain ID.
- Kept startup failure when all providers are unavailable or responding providers disagree on chain ID.
- Changed runtime provider switching to skip unavailable providers and continue to the next fallback.
- Kept direct provider pinning fail-closed when the selected provider cannot be verified.
- Added focused tests for partial startup outage, all-provider startup outage, skipped runtime providers, and direct pin rollback.

## Related issues and PRs

Production vault scanner failure on Arbitrum, observed 2026-06-23.

## Unrelated CI and test fixes

None.
