### PR TITLE
fix: stop vault scanner subprocess workers re-verifying RPC chain ID (429 storm)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- fix: Stop the vault scanner's subprocess workers from re-running RPC chain ID verification — `create_multi_provider_web3()` and `MultiProviderWeb3Factory` gain a `skip_verification` flag (with `expected_chain_id` seeding to keep runtime switchover chain-id safety), used by the vault and price scan fan-out so 24 workers no longer storm the primary provider with `eth_chainId` probes and trip QuickNode's HTTP 429 rate limit (2026-06-23)
+
 - feat: Add direct offchain manager-name curator mapping for Euler, Morpho and Lagoon vaults, with protocol-specific curator YAML metadata fields and the new 722 Capital Lagoon curator record so vault scans can attribute these vaults without relying on vault-name fuzzy matching (2026-06-22)
 
 - feat: Add pending asynchronous vault flow event discovery — `VaultDepositManager.fetch_vault_flow_events()` now lets Lagoon ERC-7540 and Ostium V1.5 managers reconstruct missing pending deposit and redemption requests from Hypersync event scans, with protocol-neutral `PendingVaultFlow` records and live fixed-range integration tests for Base Lagoon and Arbitrum Ostium vaults (2026-06-19)

--- a/eth_defi/erc_4626/lead_scan_core.py
+++ b/eth_defi/erc_4626/lead_scan_core.py
@@ -131,9 +131,15 @@ def scan_leads(
     assert isinstance(vault_db_file, Path)
 
     web3 = create_multi_provider_web3(json_rpc_urls)
-    web3factory = MultiProviderWeb3Factory(json_rpc_urls, retries=5)
-
     chain_id = web3.eth.chain_id
+
+    # The parent process verified provider chain IDs above. Subprocess workers
+    # rebuild Web3 from this factory; skip per-worker re-verification so we do not
+    # storm the primary provider with eth_chainId probes and trip HTTP 429. Seed
+    # the verified chain ID so worker-side provider switchover still rejects an
+    # endpoint that mis-routes to the wrong chain.
+    web3factory = MultiProviderWeb3Factory(json_rpc_urls, retries=5, skip_verification=True, expected_chain_id=chain_id)
+
     name = get_chain_name(chain_id)
     rpcs = get_provider_name(web3.provider)
 

--- a/eth_defi/provider/multi_provider.py
+++ b/eth_defi/provider/multi_provider.py
@@ -134,6 +134,8 @@ def create_multi_provider_web3(
     hint: Optional[str] = "",
     unit_test=False,
     add_signing_middleware: LocalAccount | None = None,
+    skip_verification: bool = False,
+    expected_chain_id: int | None = None,
 ) -> MultiProviderWeb3:
     """Create a Web3 instance with multi-provider support.
 
@@ -218,6 +220,29 @@ def create_multi_provider_web3(
         Pass an :py:class:`eth_account.signers.local.LocalAccount` instance,
         e.g. from ``Account.from_key(private_key)``.
 
+    :param skip_verification:
+        Skip the startup ``eth_chainId`` cross-check of all providers
+        (:py:meth:`FallbackProvider.verify_providers`).
+
+        That cross-check probes every configured provider with ``eth_chainId``.
+        When fanning out to multiprocessing worker pools (e.g.
+        :py:class:`~eth_defi.event_reader.multicall_batcher.MultiprocessMulticallReader`),
+        each worker rebuilds its own Web3 via :py:class:`MultiProviderWeb3Factory`,
+        so this probe runs once per worker and multiplies ``eth_chainId`` load on
+        the *primary* provider — which can itself trip rate limits (HTTP 429).
+        The parent process has already verified the chain ID before fan-out, so
+        pass ``True`` for subprocess factories together with ``expected_chain_id``.
+
+    :param expected_chain_id:
+        Pre-seed :py:attr:`FallbackProvider.expected_chain_id` without probing.
+
+        **Required** when ``skip_verification`` is set (asserted). The parent
+        process passes the chain ID it already verified so that runtime provider
+        switchover in the worker still rejects an endpoint that mis-routes to the
+        wrong chain. Without it, a verification-skipped worker would have no
+        chain-id baseline and could silently accept a wrong-chain provider on
+        failover, so the combination is rejected rather than silently downgraded.
+
     :return:
         Configured Web3 instance with multiple providers
     """
@@ -299,8 +324,17 @@ def create_multi_provider_web3(
         retries=retries,
     )
 
-    # Verify all call providers report the same chain ID before proceeding
-    fallback_provider.verify_providers()
+    # Verify all call providers report the same chain ID before proceeding.
+    # Skipped for subprocess factories: the parent has already verified, and
+    # re-probing eth_chainId in every worker can trip provider rate limits.
+    # When skipping, the caller must seed the parent-verified chain ID so runtime
+    # switchover still rejects an endpoint that mis-routes to the wrong chain;
+    # skipping without a baseline would silently disable that safety guard.
+    if not skip_verification:
+        fallback_provider.verify_providers()
+    else:
+        assert expected_chain_id is not None, f"skip_verification=True requires expected_chain_id to preserve runtime switchover chain-id safety. Hint is {hint}."
+        fallback_provider.expected_chain_id = expected_chain_id
 
     transact_provider = None
     if len(transact_endpoints) > 0:
@@ -379,10 +413,23 @@ class MultiProviderWeb3Factory:
     - Allows creating web3 connections from a config line in multiprocessing worker pools
     """
 
-    def __init__(self, rpc_url: str, retries=6, hint: str | None = ""):
+    def __init__(self, rpc_url: str, retries=6, hint: str | None = "", skip_verification: bool = False, expected_chain_id: int | None = None):
         self.rpc_url = rpc_url
         self.retries = retries
         self.hint = hint
+        #: Skip the per-worker ``eth_chainId`` provider cross-check.
+        #:
+        #: Defaults to ``False`` so a stand-alone factory behaves like
+        #: :py:func:`create_multi_provider_web3`. Set to ``True`` when this
+        #: factory is handed to a multiprocessing worker pool: the parent
+        #: process has already verified the chain ID, and re-verifying in every
+        #: worker multiplies ``eth_chainId`` load on the primary provider and
+        #: can itself trigger HTTP 429 rate limiting.
+        self.skip_verification = skip_verification
+        #: Parent-verified chain ID to seed into each worker when
+        #: :py:attr:`skip_verification` is set, preserving the runtime
+        #: switchover chain-id safety check.
+        self.expected_chain_id = expected_chain_id
 
     def __call__(self, context: Optional[Any] = None) -> Web3:
         """CAlled by the subprocess.
@@ -390,4 +437,10 @@ class MultiProviderWeb3Factory:
         :param context:
             Legacy argument, not used.
         """
-        return create_multi_provider_web3(self.rpc_url, retries=self.retries, hint=self.hint)
+        return create_multi_provider_web3(
+            self.rpc_url,
+            retries=self.retries,
+            hint=self.hint,
+            skip_verification=self.skip_verification,
+            expected_chain_id=self.expected_chain_id,
+        )

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -455,9 +455,13 @@ def scan_prices_for_chain(
     try:
         # Setup Web3 connection
         web3 = create_multi_provider_web3(rpc_url)
-        web3factory = MultiProviderWeb3Factory(rpc_url, retries=5)
         token_cache = TokenDiskCache()
         chain_id = web3.eth.chain_id
+        # Subprocess price-reading workers rebuild Web3 from this factory; the
+        # parent already verified the chain ID, so skip per-worker re-verification
+        # to avoid storming the primary provider with eth_chainId probes (HTTP 429).
+        # Seed the verified chain ID so worker switchover still rejects wrong-chain endpoints.
+        web3factory = MultiProviderWeb3Factory(rpc_url, retries=5, skip_verification=True, expected_chain_id=chain_id)
 
         # Load vault database
         if not vault_db_path.exists():

--- a/tests/rpc/test_provider_skip_verification.py
+++ b/tests/rpc/test_provider_skip_verification.py
@@ -1,0 +1,133 @@
+"""Test skipping startup chain ID verification for subprocess web3 factories.
+
+The vault scanner fans out multicalls to many worker processes. Each worker
+rebuilds its own Web3 via :py:class:`MultiProviderWeb3Factory`. If every worker
+re-ran :py:meth:`FallbackProvider.verify_providers`, the ``eth_chainId`` probe
+load on the primary provider would multiply and could itself trigger HTTP 429
+rate limiting (the production "429 death loop"). ``skip_verification`` lets the
+parent verify once and the workers skip re-verification while still inheriting
+the verified chain ID for runtime switchover safety.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from eth_defi.provider import multi_provider as mp
+from eth_defi.provider.fallback import FallbackProvider
+from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
+
+ARBITRUM_CHAIN_ID = 42161
+
+#: Two distinct, never-contacted endpoints. With verification skipped and the
+#: network touch-points patched out, no request is ever made to them.
+FAKE_RPC_CONFIG = "https://fake-a.example/rpc https://fake-b.example/rpc"
+
+
+@pytest.fixture
+def no_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Neutralise the two network touch-points in create_multi_provider_web3.
+
+    ``is_anvil()`` calls ``web3.client_version`` and
+    ``install_chain_middleware()`` calls ``web3.eth.chain_id``; both would hit
+    the network. We stub them so the test exercises only the verification
+    branch without any real RPC traffic.
+    """
+    monkeypatch.setattr(mp, "is_anvil", lambda web3: False)
+    monkeypatch.setattr(mp, "install_chain_middleware", lambda web3, hint=None: None)
+
+
+def test_skip_verification_seeds_expected_chain_id(no_network, monkeypatch: pytest.MonkeyPatch):
+    """skip_verification avoids the probe but still seeds expected_chain_id.
+
+    1. Spy on FallbackProvider.verify_providers
+    2. Build a Web3 with skip_verification=True and expected_chain_id set
+    3. Assert verify_providers() was never called (no eth_chainId storm)
+    4. Assert expected_chain_id was seeded so runtime switchover stays safe
+    """
+    # 1. Spy on the verification method
+    verify_spy = MagicMock()
+    monkeypatch.setattr(FallbackProvider, "verify_providers", verify_spy)
+
+    # 2. Build with verification skipped, chain ID pre-seeded by the parent
+    web3 = create_multi_provider_web3(
+        FAKE_RPC_CONFIG,
+        skip_verification=True,
+        expected_chain_id=ARBITRUM_CHAIN_ID,
+    )
+
+    # 3. No startup verification probe was issued
+    verify_spy.assert_not_called()
+
+    # 4. Runtime switchover still has a chain-id baseline to reject wrong chains
+    assert web3.get_fallback_provider().expected_chain_id == ARBITRUM_CHAIN_ID
+
+
+def test_skip_verification_without_seed_is_rejected(no_network, monkeypatch: pytest.MonkeyPatch):
+    """skip_verification without expected_chain_id must fail loudly.
+
+    Skipping verification but leaving expected_chain_id unset would silently
+    disable the runtime switchover chain-id safety guard, so the API rejects it.
+
+    1. Spy on FallbackProvider.verify_providers (must not even be reached)
+    2. Build a Web3 with skip_verification=True but no expected_chain_id
+    3. Assert an AssertionError is raised
+    4. Assert verification was not silently run as a fallback
+    """
+    # 1. Spy to prove we did not fall back to verifying
+    verify_spy = MagicMock()
+    monkeypatch.setattr(FallbackProvider, "verify_providers", verify_spy)
+
+    # 2-3. Missing seed is a programming error, not a silent downgrade
+    with pytest.raises(AssertionError, match="expected_chain_id"):
+        create_multi_provider_web3(FAKE_RPC_CONFIG, skip_verification=True)
+
+    # 4. We failed closed rather than verifying anyway
+    verify_spy.assert_not_called()
+
+
+def test_default_runs_verification(no_network, monkeypatch: pytest.MonkeyPatch):
+    """Without skip_verification, verify_providers() is called as before.
+
+    1. Spy on FallbackProvider.verify_providers
+    2. Build a Web3 with default arguments
+    3. Assert verify_providers() was called exactly once
+    """
+    # 1. Spy on the verification method
+    verify_spy = MagicMock()
+    monkeypatch.setattr(FallbackProvider, "verify_providers", verify_spy)
+
+    # 2. Default construction
+    create_multi_provider_web3(FAKE_RPC_CONFIG)
+
+    # 3. Verification still happens on the normal (parent) path
+    verify_spy.assert_called_once()
+
+
+def test_factory_passes_skip_verification_through(no_network, monkeypatch: pytest.MonkeyPatch):
+    """MultiProviderWeb3Factory forwards skip_verification and expected_chain_id.
+
+    1. Spy on FallbackProvider.verify_providers
+    2. Build a factory with skip_verification=True and expected_chain_id
+    3. Invoke the factory as a subprocess worker would
+    4. Assert no verification probe ran and the chain ID was seeded
+    """
+    # 1. Spy on the verification method
+    verify_spy = MagicMock()
+    monkeypatch.setattr(FallbackProvider, "verify_providers", verify_spy)
+
+    # 2. Factory configured for subprocess fan-out
+    factory = MultiProviderWeb3Factory(
+        FAKE_RPC_CONFIG,
+        skip_verification=True,
+        expected_chain_id=ARBITRUM_CHAIN_ID,
+    )
+    assert factory.skip_verification is True
+    assert factory.expected_chain_id == ARBITRUM_CHAIN_ID
+
+    # 3. A worker process calls the factory to build its own Web3
+    web3 = factory()
+
+    # 4. Same guarantees as the direct call
+    verify_spy.assert_not_called()
+    assert web3.get_fallback_provider().expected_chain_id == ARBITRUM_CHAIN_ID


### PR DESCRIPTION
## Why

The production vault scanner (`vault-scanner-looped`) died in a **429 death loop** on Arbitrum.

The multicall stage fans out to ~24 loky worker processes. Each worker rebuilt its own Web3 via `MultiProviderWeb3Factory` → `create_multi_provider_web3()`, which re-ran `FallbackProvider.verify_providers()` and probed `eth_chainId` on **every** configured provider. Those 24× redundant probes — on top of ~298k multicalls — pushed the primary provider (QuickNode) over its `125/second` cap, returning HTTP 429:

```
429 Client Error: Too Many Requests ... "125/second request limit reached"
```

The parent process already verifies the chain ID **once** before fan-out, so the per-worker re-verification is pure redundant load that helped cause the rate limit in the first place.

This builds on #(9b4209c6) *"fix: tolerate unavailable fallback RPC at startup"*, which made `verify_providers()` non-fatal when a provider is temporarily unavailable. That fix stops a 429 from being *fatal*; this PR stops the storm that *triggers* the 429.

## Lessons learnt

Verification that is cheap in a single process becomes a **self-inflicted rate limit** when fanned out across a worker pool. The fix is to skip redundant startup probes in subprocesses — but the safety property they provided must be preserved another way. Here we seed the parent-verified `expected_chain_id` into each worker so runtime provider switchover still rejects an endpoint that mis-routes to the wrong chain, and we `assert` the seed is supplied when skipping so the guard can never be silently disabled.

## Summary

- Add `skip_verification` flag to `create_multi_provider_web3()` and `MultiProviderWeb3Factory`; subprocess workers no longer re-probe `eth_chainId`.
- Add `expected_chain_id` seeding so verification-skipped workers keep the runtime switchover chain-id safety guard. `skip_verification=True` without `expected_chain_id` is rejected (fail closed, not a silent downgrade).
- Use `skip_verification` + `expected_chain_id` in **both** scanner fan-out paths: `lead_scan_core.scan_leads()` (vault discovery) and `scan_all_chains.scan_prices_for_chain()` (price reading).
- Add `tests/rpc/test_provider_skip_verification.py`: skip path seeds chain ID without probing, default path still verifies, factory plumbing forwards both args, and missing-seed raises.

## Related issues and PRs

- Builds on `9b4209c6` *"fix: tolerate unavailable fallback RPC at startup"* (same production incident, Arbitrum vault scanner, 2026-06-23).

## Unrelated CI and test fixes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
