### PR TITLE
Fix Hypersync lead discovery head failures

### DIFF
--- a/eth_defi/erc_4626/hypersync_discovery.py
+++ b/eth_defi/erc_4626/hypersync_discovery.py
@@ -20,6 +20,7 @@ from eth_defi.chain import get_chain_name
 from eth_defi.compat import native_datetime_utc_fromtimestamp
 from eth_defi.erc_4626.discovery_base import LeadScanReport, PotentialVaultMatch, VaultDiscoveryBase, get_vault_discovery_events, get_vault_event_topic_map, is_deposit_event
 from eth_defi.event_reader.web3factory import Web3Factory
+from eth_defi.hypersync.hypersync_timestamp import HypersyncFlaky, _is_hypersync_next_block_range_error, get_hypersync_block_height
 
 try:
     import hypersync
@@ -29,8 +30,10 @@ except ImportError as e:
 
 from eth_defi.hypersync.session import open_hypersync_stream
 
-
 logger = logging.getLogger(__name__)
+
+VAULT_LEAD_HEIGHT_CHECK_ATTEMPTS = 3
+VAULT_LEAD_HEIGHT_CHECK_RETRY_SLEEP = 30
 
 
 class HypersyncCrappedOut(Exception):
@@ -120,6 +123,79 @@ class HypersyncVaultDiscover(VaultDiscoveryBase):
         )
         return query
 
+    def clip_end_block_to_available_height(self, start_block: int, end_block: int) -> int:
+        """Clip scan end block to heights available from RPC and Hypersync.
+
+        Hypersync may lag the chain head by a few blocks. Asking it to stream
+        over that head gap can fail with an ``inner receiver`` pagination error.
+        We also cap by RPC height so follow-up vault probing does not request a
+        future block from the JSON-RPC provider.
+
+        :param start_block:
+            Inclusive scan start block.
+
+        :param end_block:
+            Requested inclusive scan end block.
+
+        :return:
+            End block that both Hypersync and RPC should be able to serve.
+        """
+        try:
+            rpc_height = self.web3.eth.block_number
+            hypersync_height = get_hypersync_block_height(self.client)
+        except HypersyncFlaky as e:
+            raise HypersyncCrappedOut(f"Hypersync failed during vault lead height check: {e}") from e
+
+        clipped_end_block = min(end_block, rpc_height, hypersync_height)
+        if clipped_end_block < end_block:
+            logger.warning(
+                "Clipping vault lead discovery end block from %s to %s (RPC height %s, Hypersync height %s)",
+                f"{end_block:,}",
+                f"{clipped_end_block:,}",
+                f"{rpc_height:,}",
+                f"{hypersync_height:,}",
+            )
+
+        return clipped_end_block
+
+    def scan_vaults(
+        self,
+        start_block: int,
+        end_block: int,
+        display_progress=True,
+    ) -> LeadScanReport:
+        """Scan vaults using a Hypersync-safe head block."""
+        last_exception = None
+        for attempt in range(VAULT_LEAD_HEIGHT_CHECK_ATTEMPTS):
+            try:
+                end_block = self.clip_end_block_to_available_height(start_block, end_block)
+                break
+            except HypersyncCrappedOut as e:
+                last_exception = e
+                logger.error("Hypersync vault lead height check attempt %d/%d failed: %s", attempt + 1, VAULT_LEAD_HEIGHT_CHECK_ATTEMPTS, e)
+                if attempt + 1 >= VAULT_LEAD_HEIGHT_CHECK_ATTEMPTS:
+                    raise
+                logger.info("Retrying Hypersync vault lead height check after %d seconds backoff", VAULT_LEAD_HEIGHT_CHECK_RETRY_SLEEP)
+                time.sleep(VAULT_LEAD_HEIGHT_CHECK_RETRY_SLEEP)
+        else:
+            raise last_exception or RuntimeError("Hypersync vault lead height check failed with no exception recorded")
+
+        if end_block <= start_block:
+            logger.info(
+                "No new Hypersync vault lead blocks to scan: start block %s, available end block %s",
+                f"{start_block:,}",
+                f"{end_block:,}",
+            )
+            return LeadScanReport(
+                backend=self,
+                leads=self.existing_leads.copy(),
+                old_leads=len(self.existing_leads),
+                start_block=start_block,
+                end_block=end_block,
+            )
+
+        return super().scan_vaults(start_block, end_block, display_progress=display_progress)
+
     def fetch_leads(self, start_block: int, end_block: int, display_progress=True, attempts=3, retry_sleep=30) -> LeadScanReport:
         """
         Synchronous wrapper around async lead scanning.
@@ -151,7 +227,7 @@ class HypersyncVaultDiscover(VaultDiscoveryBase):
                         raise
                     else:
                         logger.info(f"Retrying HyperSync scan after {retry_sleep} seconds backoff")
-                        time.sleep(retry_sleep)
+                        await asyncio.sleep(retry_sleep)
 
             # Should never reach here, but raise if we somehow do
             raise last_exception or RuntimeError("HyperSync scan failed with no exception recorded")
@@ -193,6 +269,8 @@ class HypersyncVaultDiscover(VaultDiscoveryBase):
         except RuntimeError as e:
             if "429" in str(e):
                 raise HypersyncCrappedOut(f"Hypersync rate limited [vault-lead-discovery]: {e}") from e
+            if _is_hypersync_next_block_range_error(e):
+                raise HypersyncCrappedOut(f"Hypersync stream pagination failed [vault-lead-discovery]: {e}") from e
             raise
 
         if display_progress:
@@ -207,7 +285,7 @@ class HypersyncVaultDiscover(VaultDiscoveryBase):
         last_block = start_block
         timestamp = None
 
-        logger.info(f"Streaming HyperSync")
+        logger.info("Streaming HyperSync")
 
         last_synced = None
 
@@ -227,6 +305,8 @@ class HypersyncVaultDiscover(VaultDiscoveryBase):
             except RuntimeError as e:
                 if "429" in str(e):
                     raise HypersyncCrappedOut(f"Hypersync rate limited [vault-lead-discovery]: {e}") from e
+                if _is_hypersync_next_block_range_error(e):
+                    raise HypersyncCrappedOut(f"Hypersync stream pagination failed [vault-lead-discovery]: {e}") from e
                 raise
 
             # exit if the stream finished

--- a/eth_defi/erc_4626/lead_scan_core.py
+++ b/eth_defi/erc_4626/lead_scan_core.py
@@ -196,6 +196,7 @@ def scan_leads(
     # Perform vault discovery and categorisation,
     # so we get information which address contains which kind of a vault
     report = vault_discover.scan_vaults(start_block, end_block)
+    end_block = report.end_block
     vault_detections = list(report.detections.values())
 
     # Prepare data export by reading further per-vault data using multiprocessing

--- a/tests/erc_4626/test_hypersync_discovery_flaky.py
+++ b/tests/erc_4626/test_hypersync_discovery_flaky.py
@@ -1,0 +1,204 @@
+"""Test Hypersync vault lead discovery flaky head handling."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from eth_defi.erc_4626.discovery_base import LeadScanReport, VaultDiscoveryBase
+from eth_defi.erc_4626.hypersync_discovery import HypersyncCrappedOut, HypersyncVaultDiscover
+from eth_defi.hypersync.hypersync_timestamp import HypersyncFlaky
+
+
+def _create_discover(rpc_height: int = 200) -> HypersyncVaultDiscover:
+    """Create a vault discover instance with mocked dependencies."""
+    web3 = MagicMock()
+    web3.eth.chain_id = 1868
+    web3.eth.block_number = rpc_height
+    return HypersyncVaultDiscover(
+        web3=web3,
+        web3factory=MagicMock(),
+        client=MagicMock(),
+    )
+
+
+def test_hypersync_vault_discovery_clips_end_block_to_available_height():
+    """Verify lead discovery does not ask Hypersync for unavailable head blocks."""
+    discover = _create_discover(rpc_height=24537799)
+
+    with patch(
+        "eth_defi.erc_4626.hypersync_discovery.get_hypersync_block_height",
+        return_value=24537791,
+    ):
+        clipped_end_block = discover.clip_end_block_to_available_height(
+            start_block=24483147,
+            end_block=24537799,
+        )
+
+    assert clipped_end_block == 24537791
+
+
+def test_hypersync_vault_discovery_scan_uses_clipped_end_block():
+    """Verify the base discovery workflow sees the clipped end block."""
+    discover = _create_discover(rpc_height=200)
+
+    with (
+        patch(
+            "eth_defi.erc_4626.hypersync_discovery.get_hypersync_block_height",
+            return_value=150,
+        ),
+        patch.object(
+            VaultDiscoveryBase,
+            "scan_vaults",
+            return_value=LeadScanReport(end_block=150),
+        ) as base_scan,
+    ):
+        report = discover.scan_vaults(
+            start_block=100,
+            end_block=200,
+            display_progress=False,
+        )
+
+    assert report.end_block == 150
+    base_scan.assert_called_once_with(100, 150, display_progress=False)
+
+
+def test_hypersync_vault_discovery_scan_noops_when_no_blocks_available():
+    """Verify an up-to-date scanner does not fail when Hypersync has no new blocks."""
+    discover = _create_discover(rpc_height=100)
+
+    with (
+        patch(
+            "eth_defi.erc_4626.hypersync_discovery.get_hypersync_block_height",
+            return_value=100,
+        ),
+        patch.object(
+            VaultDiscoveryBase,
+            "scan_vaults",
+        ) as base_scan,
+    ):
+        report = discover.scan_vaults(
+            start_block=100,
+            end_block=120,
+            display_progress=False,
+        )
+
+    assert report.end_block == 100
+    assert report.old_leads == 0
+    base_scan.assert_not_called()
+
+
+def test_hypersync_vault_discovery_height_check_retries_flaky_error():
+    """Verify transient Hypersync height failures are retried before scanning."""
+    discover = _create_discover(rpc_height=200)
+
+    with (
+        patch(
+            "eth_defi.erc_4626.hypersync_discovery.get_hypersync_block_height",
+            side_effect=[
+                HypersyncFlaky("rate limited"),
+                150,
+            ],
+        ),
+        patch(
+            "eth_defi.erc_4626.hypersync_discovery.time.sleep",
+        ) as sleep_mock,
+        patch.object(
+            VaultDiscoveryBase,
+            "scan_vaults",
+            return_value=LeadScanReport(end_block=150),
+        ) as base_scan,
+    ):
+        report = discover.scan_vaults(
+            start_block=100,
+            end_block=200,
+            display_progress=False,
+        )
+
+    assert report.end_block == 150
+    sleep_mock.assert_called_once()
+    base_scan.assert_called_once_with(100, 150, display_progress=False)
+
+
+def test_hypersync_vault_discovery_next_block_range_error_is_retryable():
+    """Verify the production receiver pagination error becomes retryable."""
+    discover = _create_discover()
+    receiver = MagicMock()
+    receiver.recv = AsyncMock(side_effect=RuntimeError("inner receiver\n\nCaused by:\n    server returned next_block 24537791 outside the requested range [24537791..24537799)"))
+
+    async def _run():
+        with (
+            patch.object(discover, "build_query", return_value=MagicMock()),
+            patch(
+                "eth_defi.erc_4626.hypersync_discovery.get_vault_event_topic_map",
+                return_value={},
+            ),
+            patch(
+                "eth_defi.erc_4626.hypersync_discovery.open_hypersync_stream",
+                new_callable=AsyncMock,
+                return_value=receiver,
+            ),
+        ):
+            with pytest.raises(HypersyncCrappedOut, match="stream pagination failed"):
+                await discover.scan_potential_vaults(
+                    start_block=24483147,
+                    end_block=24537791,
+                    display_progress=False,
+                )
+
+    asyncio.run(_run())
+
+
+def test_hypersync_vault_discovery_stream_setup_next_block_range_error_is_retryable():
+    """Verify stream setup pagination errors are retryable."""
+    discover = _create_discover()
+
+    async def _run():
+        with (
+            patch.object(discover, "build_query", return_value=MagicMock()),
+            patch(
+                "eth_defi.erc_4626.hypersync_discovery.get_vault_event_topic_map",
+                return_value={},
+            ),
+            patch(
+                "eth_defi.erc_4626.hypersync_discovery.open_hypersync_stream",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("inner receiver\n\nCaused by:\n    server returned next_block 24537791 outside the requested range [24537791..24537799)"),
+            ),
+        ):
+            with pytest.raises(HypersyncCrappedOut, match="stream pagination failed"):
+                await discover.scan_potential_vaults(
+                    start_block=24483147,
+                    end_block=24537791,
+                    display_progress=False,
+                )
+
+    asyncio.run(_run())
+
+
+def test_hypersync_vault_discovery_fetch_leads_retries_flaky_error():
+    """Verify the sync wrapper retries retryable discovery failures."""
+    discover = _create_discover()
+    report = LeadScanReport()
+    discover.scan_potential_vaults = AsyncMock(
+        side_effect=[
+            HypersyncCrappedOut("temporary Hypersync failure"),
+            report,
+        ]
+    )
+
+    with patch(
+        "eth_defi.erc_4626.hypersync_discovery.asyncio.sleep",
+        new_callable=AsyncMock,
+    ) as sleep_mock:
+        result = discover.fetch_leads(
+            start_block=1,
+            end_block=2,
+            display_progress=False,
+            attempts=2,
+            retry_sleep=1,
+        )
+
+    assert result is report
+    assert discover.scan_potential_vaults.await_count == 2
+    sleep_mock.assert_awaited_once_with(1)


### PR DESCRIPTION
## Why

Production Soneium vault scanning still failed after the timestamp-cache fix because the same Hypersync near-head pagination error also occurs in ERC-4626 vault lead discovery. The scanner requested blocks beyond the currently available RPC/Hypersync head and the Rust receiver raised `inner receiver` with `server returned next_block ... outside the requested range`.

## Lessons learnt

The Hypersync head-lag issue affects every stream consumer, not only timestamp prefetching. Lead discovery must clip its scan end before the base discovery workflow so vault probing and database progress use the actually scanned block range.

## Summary

- Clip Hypersync vault lead discovery end blocks to the minimum of requested end, RPC height, and Hypersync indexed height.
- Convert the Hypersync `next_block outside the requested range` receiver failure to `HypersyncCrappedOut` so discovery retries can handle it.
- Persist and probe against the clipped `report.end_block` in `scan_leads()`.
- Replace blocking retry sleep inside the async discovery wrapper with `await asyncio.sleep()`.
- Add mocked regressions for head clipping, retry conversion, and retry behaviour.

## Related issues and PRs

Follow-up to PR #1126. Production Soneium vault lead discovery failure from logs on 2026-06-23.

## Unrelated CI and test fixes

None.
