### PR TITLE
fix: set default R2 cache control to 1 hour

### DIFF
--- a/eth_defi/cloudflare_r2.py
+++ b/eth_defi/cloudflare_r2.py
@@ -24,6 +24,9 @@ R2_SOURCE_SHA256_METADATA_KEY = "source_sha256"
 #: Custom S3 metadata key for the source payload byte length.
 R2_SOURCE_SIZE_METADATA_KEY = "source_size"
 
+#: Default browser/CDN cache time for public R2 uploads.
+R2_DEFAULT_CACHE_CONTROL = "public, max-age=3600"
+
 
 @dataclass(slots=True)
 class R2SourceDigest:
@@ -407,6 +410,7 @@ def _is_remote_object_current(  # noqa: PLR0917
     expected_length: int,
     content_type: str | None = None,
     content_encoding: str | None = None,
+    cache_control: str | None = R2_DEFAULT_CACHE_CONTROL,
     payload_md5: str | None = None,
 ) -> bool:
     """Check whether a remote object already matches a local source.
@@ -430,6 +434,9 @@ def _is_remote_object_current(  # noqa: PLR0917
     :param content_encoding:
         Expected content encoding, if relevant for this upload.
 
+    :param cache_control:
+        Expected Cache-Control header, if relevant for this upload.
+
     :param payload_md5:
         Optional MD5 digest of the exact uploaded body for ETag fallback.
 
@@ -443,6 +450,9 @@ def _is_remote_object_current(  # noqa: PLR0917
         return False
 
     if content_encoding is not None and remote_head.get("ContentEncoding") != content_encoding:
+        return False
+
+    if cache_control is not None and remote_head.get("CacheControl") != cache_control:
         return False
 
     metadata = {key.lower(): value for key, value in (remote_head.get("Metadata") or {}).items()}
@@ -465,6 +475,7 @@ def upload_bytes_to_r2(
     *,
     content_type: str | None = None,
     content_encoding: str | None = None,
+    cache_control: str | None = R2_DEFAULT_CACHE_CONTROL,
     skip_if_current: bool = False,
     source_digest: R2SourceDigest | None = None,
 ) -> bool:
@@ -491,6 +502,9 @@ def upload_bytes_to_r2(
 
     :param content_encoding:
         Optional content encoding for the upload.
+
+    :param cache_control:
+        Optional Cache-Control header for the upload.
 
     :param skip_if_current:
         Skip the upload if the existing object already matches the local
@@ -525,6 +539,7 @@ def upload_bytes_to_r2(
                 expected_length=len(payload),
                 content_type=content_type,
                 content_encoding=content_encoding,
+                cache_control=cache_control,
                 payload_md5=_calculate_md5_hex(payload),
             ):
                 return False
@@ -539,6 +554,8 @@ def upload_bytes_to_r2(
         put_kwargs["ContentType"] = content_type
     if content_encoding is not None:
         put_kwargs["ContentEncoding"] = content_encoding
+    if cache_control is not None:
+        put_kwargs["CacheControl"] = cache_control
 
     try:
         s3_client.put_object(**put_kwargs)
@@ -556,6 +573,7 @@ def upload_file_to_r2(
     *,
     skip_if_current: bool = False,
     content_type: str | None = None,
+    cache_control: str | None = R2_DEFAULT_CACHE_CONTROL,
     callback: Callable[[int], None] | None = None,
 ) -> bool:
     """Upload a file from disk to R2.
@@ -581,6 +599,9 @@ def upload_file_to_r2(
 
     :param content_type:
         Optional MIME type for the upload.
+
+    :param cache_control:
+        Optional Cache-Control header for the upload.
 
     :param callback:
         Optional boto3 progress callback.
@@ -609,6 +630,7 @@ def upload_file_to_r2(
                 source_digest=source_digest,
                 expected_length=source_digest.size,
                 content_type=content_type,
+                cache_control=cache_control,
             ):
                 return False
 
@@ -617,6 +639,8 @@ def upload_file_to_r2(
     }
     if content_type is not None:
         extra_args["ContentType"] = content_type
+    if cache_control is not None:
+        extra_args["CacheControl"] = cache_control
 
     with file_path.open("rb") as handle:
         try:

--- a/tests/test_cloudflare_r2.py
+++ b/tests/test_cloudflare_r2.py
@@ -12,6 +12,7 @@ import pytest
 
 from eth_defi.cloudflare_r2 import (
     R2AccessDeniedError,
+    R2_DEFAULT_CACHE_CONTROL,
     calculate_bytes_digest,
     calculate_file_digest,
     copy_r2_object_daily_backup,
@@ -65,6 +66,7 @@ class FakeS3Client:
             "ContentLength": len(kwargs["Body"]),
             "ContentType": kwargs.get("ContentType"),
             "ContentEncoding": kwargs.get("ContentEncoding"),
+            "CacheControl": kwargs.get("CacheControl"),
             "Metadata": kwargs.get("Metadata", {}),
             "ETag": f'"{_md5_hex(kwargs["Body"])}"',
         }
@@ -102,6 +104,7 @@ class FakeS3Client:
         self.head_responses[bucket_name, object_name] = {
             "ContentLength": len(payload),
             "ContentType": extra_args.get("ContentType"),
+            "CacheControl": extra_args.get("CacheControl"),
             "Metadata": extra_args.get("Metadata", {}),
         }
 
@@ -122,6 +125,7 @@ def test_upload_bytes_to_r2_skips_when_remote_checksum_matches() -> None:
         "ContentLength": len(compressed_payload),
         "ContentType": "application/json",
         "ContentEncoding": "gzip",
+        "CacheControl": R2_DEFAULT_CACHE_CONTROL,
         "Metadata": source_digest.as_metadata(),
     }
 
@@ -150,6 +154,7 @@ def test_upload_bytes_to_r2_skips_with_matching_legacy_etag() -> None:
         "ContentLength": len(compressed_payload),
         "ContentType": "application/json",
         "ContentEncoding": "gzip",
+        "CacheControl": R2_DEFAULT_CACHE_CONTROL,
         "Metadata": {},
         "ETag": f'"{_md5_hex(compressed_payload)}"',
     }
@@ -186,6 +191,34 @@ def test_upload_bytes_to_r2_uploads_and_sets_checksum_metadata() -> None:
     assert uploaded is True
     assert len(s3_client.put_calls) == 1
     assert s3_client.put_calls[0]["Metadata"] == calculate_bytes_digest(payload).as_metadata()
+    assert s3_client.put_calls[0]["CacheControl"] == R2_DEFAULT_CACHE_CONTROL
+
+
+def test_upload_bytes_to_r2_refreshes_when_cache_control_is_missing() -> None:
+    """Objects missing the default cache header should be refreshed."""
+    s3_client = FakeS3Client()
+    payload = b"vault metadata"
+    source_digest = calculate_bytes_digest(payload)
+
+    s3_client.head_responses["bucket", "metadata.json"] = {
+        "ContentLength": len(payload),
+        "ContentType": "application/json",
+        "Metadata": source_digest.as_metadata(),
+    }
+
+    uploaded = upload_bytes_to_r2(
+        s3_client=s3_client,
+        payload=payload,
+        bucket_name="bucket",
+        object_name="metadata.json",
+        content_type="application/json",
+        skip_if_current=True,
+        source_digest=source_digest,
+    )
+
+    assert uploaded is True
+    assert len(s3_client.put_calls) == 1
+    assert s3_client.put_calls[0]["CacheControl"] == R2_DEFAULT_CACHE_CONTROL
 
 
 def test_upload_file_to_r2_skips_when_remote_checksum_matches(tmp_path: Path) -> None:
@@ -197,6 +230,7 @@ def test_upload_file_to_r2_skips_when_remote_checksum_matches(tmp_path: Path) ->
 
     s3_client.head_responses["bucket", file_path.name] = {
         "ContentLength": file_path.stat().st_size,
+        "CacheControl": R2_DEFAULT_CACHE_CONTROL,
         "Metadata": source_digest.as_metadata(),
     }
 
@@ -234,6 +268,7 @@ def test_upload_file_to_r2_uploads_when_remote_checksum_differs(tmp_path: Path) 
     assert uploaded is True
     assert len(s3_client.upload_calls) == 1
     assert s3_client.upload_calls[0]["ExtraArgs"]["Metadata"] == calculate_file_digest(file_path).as_metadata()
+    assert s3_client.upload_calls[0]["ExtraArgs"]["CacheControl"] == R2_DEFAULT_CACHE_CONTROL
 
 
 def test_fetch_r2_object_head_raises_enriched_access_denied_error() -> None:


### PR DESCRIPTION
## Why

Vault R2 uploads did not set a Cache-Control header, leaving cache behaviour to bucket or Cloudflare defaults. We want a consistent one-hour cache period for public vault upload artefacts.

## Lessons learnt

The shared R2 upload helpers already cover the vault metadata, compressed JSON and file upload paths, so the cache policy belongs there rather than in individual scripts. The skip-if-current comparison also needs to include the header so existing objects are refreshed with the new cache policy.

## Summary

- Added `R2_DEFAULT_CACHE_CONTROL = "public, max-age=3600"`.
- Applied the default Cache-Control header to byte and file R2 uploads.
- Included Cache-Control in unchanged-object checks, causing old uploads without the header to refresh.
- Extended R2 helper tests for the default header and missing-header refresh path.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.