### PR TITLE
Simplify Hypersync head handling

### DIFF
--- a/eth_defi/erc_4626/hypersync_discovery.py
+++ b/eth_defi/erc_4626/hypersync_discovery.py
@@ -9,7 +9,6 @@
 
 import asyncio
 import logging
-import time
 
 from eth_typing import HexAddress, HexStr
 from tqdm_loggable.auto import tqdm
@@ -20,7 +19,7 @@ from eth_defi.chain import get_chain_name
 from eth_defi.compat import native_datetime_utc_fromtimestamp
 from eth_defi.erc_4626.discovery_base import LeadScanReport, PotentialVaultMatch, VaultDiscoveryBase, get_vault_discovery_events, get_vault_event_topic_map, is_deposit_event
 from eth_defi.event_reader.web3factory import Web3Factory
-from eth_defi.hypersync.hypersync_timestamp import HypersyncFlaky, _is_hypersync_next_block_range_error, get_hypersync_block_height
+from eth_defi.hypersync.hypersync_timestamp import HypersyncFlaky, get_hypersync_block_height_with_retries, is_hypersync_next_block_range_error, is_hypersync_rate_limit_error, is_hypersync_retryable_runtime_error
 
 try:
     import hypersync
@@ -38,6 +37,16 @@ VAULT_LEAD_HEIGHT_CHECK_RETRY_SLEEP = 30
 
 class HypersyncCrappedOut(Exception):
     pass
+
+
+def _raise_recoverable_hypersync_error(e: RuntimeError, reason: str) -> None:
+    """Convert known recoverable Hypersync runtime errors to discovery errors."""
+    if not is_hypersync_retryable_runtime_error(e):
+        return
+    if is_hypersync_rate_limit_error(e):
+        raise HypersyncCrappedOut(f"Hypersync rate limited [{reason}]: {e}") from e
+    if is_hypersync_next_block_range_error(e):
+        raise HypersyncCrappedOut(f"Hypersync stream pagination failed [{reason}]: {e}") from e
 
 
 class HypersyncVaultDiscover(VaultDiscoveryBase):
@@ -142,7 +151,12 @@ class HypersyncVaultDiscover(VaultDiscoveryBase):
         """
         try:
             rpc_height = self.web3.eth.block_number
-            hypersync_height = get_hypersync_block_height(self.client)
+            hypersync_height = get_hypersync_block_height_with_retries(
+                self.client,
+                attempts=VAULT_LEAD_HEIGHT_CHECK_ATTEMPTS,
+                retry_sleep=VAULT_LEAD_HEIGHT_CHECK_RETRY_SLEEP,
+                reason="vault-lead-discovery",
+            )
         except HypersyncFlaky as e:
             raise HypersyncCrappedOut(f"Hypersync failed during vault lead height check: {e}") from e
 
@@ -165,20 +179,7 @@ class HypersyncVaultDiscover(VaultDiscoveryBase):
         display_progress=True,
     ) -> LeadScanReport:
         """Scan vaults using a Hypersync-safe head block."""
-        last_exception = None
-        for attempt in range(VAULT_LEAD_HEIGHT_CHECK_ATTEMPTS):
-            try:
-                end_block = self.clip_end_block_to_available_height(start_block, end_block)
-                break
-            except HypersyncCrappedOut as e:
-                last_exception = e
-                logger.error("Hypersync vault lead height check attempt %d/%d failed: %s", attempt + 1, VAULT_LEAD_HEIGHT_CHECK_ATTEMPTS, e)
-                if attempt + 1 >= VAULT_LEAD_HEIGHT_CHECK_ATTEMPTS:
-                    raise
-                logger.info("Retrying Hypersync vault lead height check after %d seconds backoff", VAULT_LEAD_HEIGHT_CHECK_RETRY_SLEEP)
-                time.sleep(VAULT_LEAD_HEIGHT_CHECK_RETRY_SLEEP)
-        else:
-            raise last_exception or RuntimeError("Hypersync vault lead height check failed with no exception recorded")
+        end_block = self.clip_end_block_to_available_height(start_block, end_block)
 
         if end_block <= start_block:
             logger.info(
@@ -267,10 +268,7 @@ class HypersyncVaultDiscover(VaultDiscoveryBase):
         try:
             receiver = await open_hypersync_stream(self.client, query)
         except RuntimeError as e:
-            if "429" in str(e):
-                raise HypersyncCrappedOut(f"Hypersync rate limited [vault-lead-discovery]: {e}") from e
-            if _is_hypersync_next_block_range_error(e):
-                raise HypersyncCrappedOut(f"Hypersync stream pagination failed [vault-lead-discovery]: {e}") from e
+            _raise_recoverable_hypersync_error(e, "vault-lead-discovery")
             raise
 
         if display_progress:
@@ -303,10 +301,7 @@ class HypersyncVaultDiscover(VaultDiscoveryBase):
                 logger.error("HyperSync receiver timed out [vault-lead-discovery]")
                 raise HypersyncCrappedOut(f"Cannot recover from HyperSync stream timeout after {self.recv_timeout} seconds [vault-lead-discovery]") from e
             except RuntimeError as e:
-                if "429" in str(e):
-                    raise HypersyncCrappedOut(f"Hypersync rate limited [vault-lead-discovery]: {e}") from e
-                if _is_hypersync_next_block_range_error(e):
-                    raise HypersyncCrappedOut(f"Hypersync stream pagination failed [vault-lead-discovery]: {e}") from e
+                _raise_recoverable_hypersync_error(e, "vault-lead-discovery")
                 raise
 
             # exit if the stream finished

--- a/eth_defi/hypersync/hypersync_timestamp.py
+++ b/eth_defi/hypersync/hypersync_timestamp.py
@@ -27,6 +27,7 @@ Example:
 
 import asyncio
 import logging
+import time
 from typing import AsyncIterable
 
 import hypersync
@@ -47,7 +48,7 @@ class HypersyncFlaky(Exception):
     """Hypersync stream flaky error, e.g. timeout or rate limit."""
 
 
-def _is_hypersync_rate_limit_error(e: Exception) -> bool:
+def is_hypersync_rate_limit_error(e: Exception) -> bool:
     """Check if a Hypersync RuntimeError is a 429 rate limit error.
 
     The Rust client raises ``RuntimeError`` with the HTTP status in the message
@@ -56,7 +57,7 @@ def _is_hypersync_rate_limit_error(e: Exception) -> bool:
     return isinstance(e, RuntimeError) and "429" in str(e)
 
 
-def _is_hypersync_next_block_range_error(e: Exception) -> bool:
+def is_hypersync_next_block_range_error(e: Exception) -> bool:
     """Check if a Hypersync stream failed on an internal pagination boundary.
 
     Some Hypersync backends can fail near the indexed chain head with an
@@ -68,6 +69,16 @@ def _is_hypersync_next_block_range_error(e: Exception) -> bool:
         return False
     message = str(e)
     return "inner receiver" in message and "server returned next_block" in message and "outside the requested range" in message
+
+
+def is_hypersync_retryable_runtime_error(e: Exception) -> bool:
+    """Check if a Hypersync ``RuntimeError`` should be handled by retry logic."""
+    return is_hypersync_rate_limit_error(e) or is_hypersync_next_block_range_error(e)
+
+
+# Backwards-compatible aliases for older tests and integrations.
+_is_hypersync_rate_limit_error = is_hypersync_rate_limit_error
+_is_hypersync_next_block_range_error = is_hypersync_next_block_range_error
 
 
 async def _validate_hypersync_chain_id_async(
@@ -292,6 +303,51 @@ def get_hypersync_block_height(
             raise
 
     return asyncio.run(_hypersync_asyncio_wrapper())
+
+
+def get_hypersync_block_height_with_retries(
+    client: hypersync.HypersyncClient,
+    attempts: int = 3,
+    retry_sleep: int = 30,
+    reason: str = "block-height-check",
+) -> int:
+    """Get latest Hypersync block height with retry/backoff.
+
+    Hypersync height checks are one-shot API calls and can hit the same 429
+    rate limits as streams. Use this helper when a caller needs a height check
+    before opening a stream.
+
+    :param client:
+        Hypersync client.
+
+    :param attempts:
+        Maximum number of attempts before raising the last
+        :py:class:`HypersyncFlaky`.
+
+    :param retry_sleep:
+        Sleep time between attempts, in seconds.
+
+    :param reason:
+        Human-readable operation label for logs.
+
+    :return:
+        Latest block number known to Hypersync.
+    """
+    assert attempts > 0, "attempts must be at least 1"
+
+    last_exception = None
+    for attempt in range(attempts):
+        try:
+            return get_hypersync_block_height(client)
+        except HypersyncFlaky as e:
+            last_exception = e
+            logger.error("Hypersync height check %s attempt %d/%d failed: %s", reason, attempt + 1, attempts, e)
+            if attempt + 1 >= attempts:
+                raise
+            logger.info("Retrying Hypersync height check %s after %d seconds backoff", reason, retry_sleep)
+            time.sleep(retry_sleep)
+
+    raise last_exception or RuntimeError("Hypersync height check failed with no exception recorded")
 
 
 async def fetch_block_timestamps_using_hypersync_cached_async(

--- a/tests/erc_4626/test_hypersync_discovery_flaky.py
+++ b/tests/erc_4626/test_hypersync_discovery_flaky.py
@@ -27,7 +27,7 @@ def test_hypersync_vault_discovery_clips_end_block_to_available_height():
     discover = _create_discover(rpc_height=24537799)
 
     with patch(
-        "eth_defi.erc_4626.hypersync_discovery.get_hypersync_block_height",
+        "eth_defi.erc_4626.hypersync_discovery.get_hypersync_block_height_with_retries",
         return_value=24537791,
     ):
         clipped_end_block = discover.clip_end_block_to_available_height(
@@ -44,7 +44,7 @@ def test_hypersync_vault_discovery_scan_uses_clipped_end_block():
 
     with (
         patch(
-            "eth_defi.erc_4626.hypersync_discovery.get_hypersync_block_height",
+            "eth_defi.erc_4626.hypersync_discovery.get_hypersync_block_height_with_retries",
             return_value=150,
         ),
         patch.object(
@@ -69,7 +69,7 @@ def test_hypersync_vault_discovery_scan_noops_when_no_blocks_available():
 
     with (
         patch(
-            "eth_defi.erc_4626.hypersync_discovery.get_hypersync_block_height",
+            "eth_defi.erc_4626.hypersync_discovery.get_hypersync_block_height_with_retries",
             return_value=100,
         ),
         patch.object(
@@ -88,36 +88,40 @@ def test_hypersync_vault_discovery_scan_noops_when_no_blocks_available():
     base_scan.assert_not_called()
 
 
-def test_hypersync_vault_discovery_height_check_retries_flaky_error():
-    """Verify transient Hypersync height failures are retried before scanning."""
+def test_hypersync_vault_discovery_height_check_failure_is_wrapped():
+    """Verify Hypersync height failures are converted to discovery errors."""
     discover = _create_discover(rpc_height=200)
 
-    with (
-        patch(
-            "eth_defi.erc_4626.hypersync_discovery.get_hypersync_block_height",
-            side_effect=[
-                HypersyncFlaky("rate limited"),
-                150,
-            ],
-        ),
-        patch(
-            "eth_defi.erc_4626.hypersync_discovery.time.sleep",
-        ) as sleep_mock,
-        patch.object(
-            VaultDiscoveryBase,
-            "scan_vaults",
-            return_value=LeadScanReport(end_block=150),
-        ) as base_scan,
+    with patch(
+        "eth_defi.erc_4626.hypersync_discovery.get_hypersync_block_height_with_retries",
+        side_effect=HypersyncFlaky("rate limited"),
     ):
-        report = discover.scan_vaults(
+        with pytest.raises(HypersyncCrappedOut, match="rate limited"):
+            discover.scan_vaults(
+                start_block=100,
+                end_block=200,
+                display_progress=False,
+            )
+
+
+def test_hypersync_vault_discovery_scan_uses_shared_height_retry():
+    """Verify discovery asks the shared helper to retry height checks."""
+    discover = _create_discover(rpc_height=200)
+
+    with patch(
+        "eth_defi.erc_4626.hypersync_discovery.get_hypersync_block_height_with_retries",
+        return_value=150,
+    ) as height_check:
+        discover.clip_end_block_to_available_height(
             start_block=100,
             end_block=200,
-            display_progress=False,
         )
 
-    assert report.end_block == 150
-    sleep_mock.assert_called_once()
-    base_scan.assert_called_once_with(100, 150, display_progress=False)
+    height_check.assert_called_once()
+    kwargs = height_check.call_args.kwargs
+    assert kwargs["attempts"] == 3
+    assert kwargs["retry_sleep"] == 30
+    assert kwargs["reason"] == "vault-lead-discovery"
 
 
 def test_hypersync_vault_discovery_next_block_range_error_is_retryable():

--- a/tests/hypersync/test_hypersync_gap_healing.py
+++ b/tests/hypersync/test_hypersync_gap_healing.py
@@ -17,9 +17,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from eth_defi.event_reader.block_header import BlockHeader
 from eth_defi.hypersync.hypersync_timestamp import (
     HypersyncFlaky,
-    _is_hypersync_next_block_range_error,
     fetch_block_timestamps_using_hypersync_cached,
     fetch_block_timestamps_using_hypersync_cached_async,
+    get_hypersync_block_height_with_retries,
+    is_hypersync_next_block_range_error,
 )
 
 
@@ -144,7 +145,35 @@ def test_hypersync_next_block_range_error_is_flaky():
     """Verify that Hypersync near-head pagination failures are retryable."""
     err = RuntimeError("inner receiver\n\nCaused by:\n    server returned next_block 24535975 outside the requested range [24535975..24535985)")
 
-    assert _is_hypersync_next_block_range_error(err)
+    assert is_hypersync_next_block_range_error(err)
+
+
+def test_hypersync_block_height_retry_helper_retries_flaky_error():
+    """Verify that transient Hypersync height failures are retried."""
+    mock_client = MagicMock()
+
+    with (
+        patch(
+            "eth_defi.hypersync.hypersync_timestamp.get_hypersync_block_height",
+            side_effect=[
+                HypersyncFlaky("rate limited"),
+                1234,
+            ],
+        ) as height_check,
+        patch(
+            "eth_defi.hypersync.hypersync_timestamp.time.sleep",
+        ) as sleep_mock,
+    ):
+        height = get_hypersync_block_height_with_retries(
+            mock_client,
+            attempts=2,
+            retry_sleep=1,
+            reason="test-height",
+        )
+
+    assert height == 1234
+    assert height_check.call_count == 2
+    sleep_mock.assert_called_once_with(1)
 
 
 def test_hypersync_cached_sync_retries_next_block_range_error(tmp_path):


### PR DESCRIPTION
## Why

PRs #1126 and #1129 fixed production Hypersync near-head failures, but left duplicated retry/error-classification logic between timestamp loading and ERC-4626 lead discovery. Simplifying this keeps the production behaviour while making future Hypersync stream consumers easier to harden consistently.

## Lessons learnt

The same Hypersync receiver and rate-limit failures can appear in multiple stream consumers. Shared predicates and height retry helpers make it less likely that one path handles a production failure while another path misses it.

## Summary

- Expose public Hypersync retryable-error predicates for rate limits and `next_block outside the requested range` receiver failures.
- Add a shared `get_hypersync_block_height_with_retries()` helper.
- Replace the local vault lead height retry loop with the shared helper.
- Collapse duplicate lead-discovery stream setup/receive error conversion into one helper.
- Update mocked tests to cover the shared height retry helper and the simplified discovery path.

## Related issues and PRs

Simplifies follow-up fixes from PR #1126 and PR #1129.

## Unrelated CI and test fixes

None.
