### PR TITLE
fix: Stop Morpho API spam for unsupported chains (e.g. BNB Smart Chain)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- fix: Stop the vault scanner spamming the Morpho GraphQL API for chains it does not index (e.g. BNB Smart Chain / chain 56) — add a `MORPHO_API_SUPPORTED_CHAINS` allowlist that short-circuits Morpho lookups before any HTTP call, and reclassify the API's `BAD_USER_INPUT` / `unsupported chainId` GraphQL error as a definitive `NOT_FOUND` instead of a retried transient error, eliminating the per-vault-per-cycle warning log spam and wasted round-trips (2026-06-23)
+
 - fix: Stop the vault scanner's subprocess workers from re-running RPC chain ID verification — `create_multi_provider_web3()` and `MultiProviderWeb3Factory` gain a `skip_verification` flag (with `expected_chain_id` seeding to keep runtime switchover chain-id safety), used by the vault and price scan fan-out so 24 workers no longer storm the primary provider with `eth_chainId` probes and trip QuickNode's HTTP 429 rate limit (2026-06-23)
 
 - feat: Add direct offchain manager-name curator mapping for Euler, Morpho and Lagoon vaults, with protocol-specific curator YAML metadata fields and the new 722 Capital Lagoon curator record so vault scans can attribute these vaults without relying on vault-name fuzzy matching (2026-06-22)

--- a/eth_defi/erc_4626/vault_protocol/morpho/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/offchain_metadata.py
@@ -56,6 +56,43 @@ DEFAULT_CACHE_PATH = DEFAULT_CACHE_ROOT / "morpho"
 #: Morpho public GraphQL API endpoint
 MORPHO_BLUE_GRAPHQL_URL = "https://api.morpho.org/graphql"
 
+#: Chain IDs the Morpho GraphQL API (``api.morpho.org``) indexes.
+#:
+#: The API rejects any other chain with a ``BAD_USER_INPUT`` /
+#: ``unsupported chainId`` GraphQL error. The vault scanner detects Morpho-like
+#: vaults on chains Morpho does not support (e.g. BNB Smart Chain, chain 56),
+#: and without this guard it would query the API once per such vault on every
+#: scan cycle — calls that can never succeed, producing log spam and wasted
+#: round-trips.
+#:
+#: This set is a performance/noise optimisation only: it is safe for it to be
+#: incomplete, because :py:func:`_query_morpho_api` also treats an
+#: ``unsupported chainId`` / ``BAD_USER_INPUT`` error as a definitive
+#: ``NOT_FOUND``. If Morpho adds a new chain, add it here so we resume fetching
+#: warning metadata for that chain.
+#:
+#: Source: Morpho deployment list at https://docs.morpho.org/
+MORPHO_API_SUPPORTED_CHAINS = frozenset(
+    {
+        1,  # Ethereum
+        10,  # Optimism
+        130,  # Unichain
+        137,  # Polygon
+        146,  # Sonic
+        252,  # Fraxtal
+        480,  # World Chain
+        999,  # HyperEVM / Hyperliquid
+        1868,  # Soneium
+        8453,  # Base
+        34443,  # Mode
+        42161,  # Arbitrum One
+        43111,  # Hemi
+        57073,  # Ink
+        98866,  # Plume
+        747474,  # Katana
+    }
+)
+
 logger = logging.getLogger(__name__)
 
 #: GraphQL query to fetch vault-level and market-level warnings for a single vault
@@ -400,8 +437,23 @@ def fetch_morpho_vault_api_result(  # noqa: PLR0917
         Three-way Morpho API lookup result.
     """
     chain_id = web3.eth.chain_id
-    address_lower = vault_address.lower()
     checksum_address = Web3.to_checksum_address(vault_address)
+
+    # Short-circuit chains the Morpho API does not index (e.g. BNB Smart Chain,
+    # chain 56). Without this the scanner would query the API once per Morpho-like
+    # vault on every cycle, each call failing with "unsupported chainId". Logged at
+    # debug level to avoid spamming production logs once per vault. Returning here
+    # also skips the cache-key/address bookkeeping below, which is wasted for
+    # unsupported chains.
+    if chain_id not in MORPHO_API_SUPPORTED_CHAINS:
+        logger.debug(
+            "Morpho API does not index chain %d, skipping lookup for %s",
+            chain_id,
+            checksum_address,
+        )
+        return MorphoVaultAPIResult(MorphoVaultAPIStatus.not_found)
+
+    address_lower = vault_address.lower()
     cache_key = _get_cache_key(cache_path, chain_id, address_lower, api_version)
 
     logger.info("Resolving Morpho GraphQL data for vault %s on chain %d", checksum_address, chain_id)
@@ -506,6 +558,30 @@ def fetch_morpho_vault_data(  # noqa: PLR0917
     return result.data if result.status == MorphoVaultAPIStatus.found else None
 
 
+def _is_definitive_morpho_error(error: dict) -> bool:
+    """Is a Morpho GraphQL error a permanent miss rather than a transient failure.
+
+    A definitive error means the same request will never succeed, so it should be
+    reported as ``NOT_FOUND`` (and not retried on the next scan cycle):
+
+    - ``NOT_FOUND`` status — the vault is not indexed by Morpho.
+    - ``BAD_USER_INPUT`` status with an ``unsupported chainId`` message — the chain
+      is not indexed. We match the message rather than the bare status so a
+      genuinely malformed query (a different ``BAD_USER_INPUT``) stays a visible
+      transient warning instead of being silently swallowed.
+
+    :param error:
+        A single entry from the GraphQL ``errors`` array.
+
+    :return:
+        ``True`` if the error is permanent, ``False`` if it should be retried.
+    """
+    status = str(error.get("status", "")).upper()
+    if status == "NOT_FOUND":
+        return True
+    return status == "BAD_USER_INPUT" and "unsupported chainid" in str(error.get("message", "")).lower()
+
+
 def _query_morpho_api(chain_id: int, address: str, api_version: MorphoVaultAPIVersion = "v1") -> MorphoVaultAPIResult:
     """Execute the GraphQL query against the Morpho API.
 
@@ -542,11 +618,12 @@ def _query_morpho_api(chain_id: int, address: str, api_version: MorphoVaultAPIVe
         logger.warning("Morpho API returned invalid JSON for %s on chain %d: %s", address, chain_id, e)
         return MorphoVaultAPIResult(MorphoVaultAPIStatus.transient_error)
 
-    # Check for GraphQL-level errors
+    # Check for GraphQL-level errors. Definitive errors (see
+    # _is_definitive_morpho_error) are reported as not_found; everything else is
+    # transient and retried on the next scan cycle.
     errors = body.get("errors")
     if errors:
-        # Only treat NOT_FOUND as definitively absent; everything else is a transient error
-        if any(str(err.get("status", "")).upper() == "NOT_FOUND" for err in errors):
+        if any(_is_definitive_morpho_error(err) for err in errors):
             return MorphoVaultAPIResult(MorphoVaultAPIStatus.not_found)
         logger.warning(
             "Morpho API returned unexpected GraphQL errors for %s on chain %d: %s",

--- a/eth_defi/erc_4626/vault_protocol/morpho/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/offchain_metadata.py
@@ -445,6 +445,11 @@ def fetch_morpho_vault_api_result(  # noqa: PLR0917
     # debug level to avoid spamming production logs once per vault. Returning here
     # also skips the cache-key/address bookkeeping below, which is wasted for
     # unsupported chains.
+    #
+    # Note: returning not_found here intentionally makes callers flag these vaults
+    # with VaultFlag.not_in_morpho_api (a BAD flag). We treat a Morpho-like vault we
+    # cannot verify against the Morpho risk API as untouchable, regardless of whether
+    # it is unofficial or simply on a chain Morpho does not index.
     if chain_id not in MORPHO_API_SUPPORTED_CHAINS:
         logger.debug(
             "Morpho API does not index chain %d, skipping lookup for %s",

--- a/tests/morpho/test_morpho_offchain_metadata.py
+++ b/tests/morpho/test_morpho_offchain_metadata.py
@@ -98,13 +98,19 @@ NOT_FOUND_TEST_VAULT = "0x000000000000000000000000000000000000dead"
 class _FakeEth:
     """Minimal fake Web3.eth object for Morpho API tests."""
 
-    chain_id = 1
+    def __init__(self, chain_id: int = 1):
+        self.chain_id = chain_id
 
 
 class _FakeWeb3:
-    """Minimal fake Web3 object for Morpho API tests."""
+    """Minimal fake Web3 object for Morpho API tests.
 
-    eth = _FakeEth()
+    :param chain_id:
+        Chain ID reported by ``web3.eth.chain_id``. Defaults to Ethereum mainnet (1).
+    """
+
+    def __init__(self, chain_id: int = 1):
+        self.eth = _FakeEth(chain_id)
 
 
 class _FakeResponse:
@@ -232,6 +238,70 @@ def test_morpho_not_found_is_not_cached(monkeypatch: pytest.MonkeyPatch, tmp_pat
     assert not cache_file.exists()
     expected_call_count = 2
     assert len(calls) == expected_call_count
+
+
+def test_morpho_unsupported_chain_short_circuits(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """Vaults on chains Morpho does not index resolve to NOT_FOUND without any HTTP call.
+
+    The vault scanner detects Morpho-like vaults on chains the Morpho API does not
+    support (e.g. BNB Smart Chain, chain 56). Such lookups must be short-circuited so
+    the scanner does not query the API once per vault on every cycle.
+
+    1. Build a fake Web3 reporting chain 56 (BNB Smart Chain).
+    2. Patch the HTTP layer to fail loudly if it is ever called.
+    3. Assert the lookup returns NOT_FOUND with zero HTTP calls and no cache file.
+    """
+
+    # 1. Fake Web3 on chain 56 (BNB Smart Chain), which the Morpho API does not index.
+    web3 = _FakeWeb3(chain_id=56)
+
+    # 2. Any HTTP call would mean the short-circuit failed.
+    def fail_post(*_args, **_kwargs):
+        raise AssertionError("Morpho API must not be called for unsupported chains")
+
+    monkeypatch.setattr("eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata.requests.post", fail_post)
+
+    # 3. Lookup is NOT_FOUND, no HTTP call, no cache written.
+    result = fetch_morpho_vault_api_result(web3, NOT_FOUND_TEST_VAULT, cache_path=tmp_path)
+    assert result.is_not_found
+    cache_file = tmp_path / f"morpho_56_{NOT_FOUND_TEST_VAULT.lower()}.json"
+    assert not cache_file.exists()
+
+
+def test_morpho_unsupported_chainid_graphql_error_is_not_found(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    """A ``BAD_USER_INPUT`` / ``unsupported chainId`` GraphQL error is treated as NOT_FOUND.
+
+    This is the defensive layer: even if a chain slips past the supported-chain
+    allowlist, the API's ``BAD_USER_INPUT`` response must be classified as a
+    definitive miss (NOT_FOUND) rather than a transient error, so it is not
+    retried on every scan cycle.
+
+    1. Patch the API to return the real ``unsupported chainId`` GraphQL error.
+    2. Assert the result is NOT_FOUND (not transient) and nothing is cached.
+    """
+
+    # 1. Reproduce the exact production error payload for chain 56.
+    _patch_morpho_api(
+        monkeypatch,
+        [
+            {
+                "errors": [
+                    {
+                        "message": 'unsupported chainId "56"',
+                        "status": "BAD_USER_INPUT",
+                        "extensions": {},
+                    }
+                ],
+                "data": None,
+            }
+        ],
+    )
+
+    # 2. Classified as a definitive miss, nothing cached.
+    result = fetch_morpho_vault_api_result(_FakeWeb3(), NOT_FOUND_TEST_VAULT, cache_path=tmp_path)
+    assert result.status == MorphoVaultAPIStatus.not_found
+    cache_file = tmp_path / f"morpho_1_{NOT_FOUND_TEST_VAULT.lower()}.json"
+    assert not cache_file.exists()
 
 
 def test_morpho_transient_error_does_not_add_not_found_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):


### PR DESCRIPTION
## Why

In production the `vault-scanner-looped` service logged a flood of warnings like:

```
Morpho API returned unexpected GraphQL errors for 0x... on chain 56:
[{'message': 'unsupported chainId "56"', 'status': 'BAD_USER_INPUT', 'extensions': {}}]
```

Chain 56 is BNB Smart Chain, which the Morpho GraphQL API (`api.morpho.org`) does not index. The scanner detects BSC contracts that pattern-match as Morpho V1 vaults (they expose a `MORPHO()` method) and then queries the Morpho API for each one.

Two compounding problems made this noisy and wasteful:

1. **No chain guard** — we queried Morpho's API for chains it does not support at all.
2. **Misclassification** — the `unsupported chainId` / `BAD_USER_INPUT` error was not `NOT_FOUND`, so it was treated as a *transient* error. Transient errors are deliberately never cached, so every BSC Morpho-like vault was re-queried on **every** scan cycle, forever — one HTTP round-trip and one `WARNING` log line each.

## Lessons learnt

- **"API indexes this chain" is not the same as "the protocol is deployed on this chain."** The fix lives in the offchain-metadata layer (`MORPHO_API_SUPPORTED_CHAINS`), *not* in the contract detection/classification layer. Gating detection would stop classifying genuine Morpho vaults on BSC as Morpho; we only want to skip the offchain API enrichment.
- **Caching policy interacts with error classification.** Because `transient_error` is intentionally never cached (to allow retries), misclassifying a permanent condition as transient turns it into an infinite per-cycle retry loop. Permanent conditions must resolve to `NOT_FOUND`.
- **Match the error message, not the bare status.** `BAD_USER_INPUT` is broad; reclassifying *any* `BAD_USER_INPUT` as `NOT_FOUND` would silently swallow genuinely malformed queries during development. We match the `unsupported chainId` message so other input errors stay visible as transient warnings.
- **Intended flag behaviour (confirmed in review).** Returning `NOT_FOUND` from the short-circuit makes callers add `VaultFlag.not_in_morpho_api`, which is a BAD ("don't touch") flag. This is intentional: a Morpho-like vault we cannot verify against the Morpho risk API is treated as untouchable, whether it is unofficial or simply on a chain Morpho does not index.

## Summary

In `eth_defi/erc_4626/vault_protocol/morpho/offchain_metadata.py`:

- Added `MORPHO_API_SUPPORTED_CHAINS` (frozenset of chain IDs the Morpho API indexes). `fetch_morpho_vault_api_result()` now short-circuits to `NOT_FOUND` for any other chain **before** any HTTP call or cache-key bookkeeping, logging at `debug` (not `warning`) level.
- Added `_is_definitive_morpho_error()` helper and reclassified the `unsupported chainId` (`BAD_USER_INPUT`) GraphQL error as a definitive `NOT_FOUND` rather than a retried transient error. Matched on the message so other `BAD_USER_INPUT` errors remain transient/visible.

The allowlist is a performance/noise optimisation that is safe to be incomplete, because the error reclassification self-heals any chain it misses. New Morpho chains just need adding to the set to resume metadata fetching.

Tests (`tests/morpho/test_morpho_offchain_metadata.py`):

- Parameterised the shared `_FakeWeb3`/`_FakeEth` fakes with an optional `chain_id` (default 1).
- `test_morpho_unsupported_chain_short_circuits` — chain 56 resolves to `NOT_FOUND` with zero HTTP calls and no cache file.
- `test_morpho_unsupported_chainid_graphql_error_is_not_found` — the exact production `BAD_USER_INPUT` payload is classified as `NOT_FOUND`, not transient.

## Review

Reviewed locally with the Codex CLI (`codex review --base master`): no regressions found. The reviewer traced the `is_not_found` → `not_in_morpho_api` (BAD flag) path; that flagging is intended behaviour, now documented in code and in Lessons learnt above.
