### PR TITLE
notes: mark Borrowable USDC Deposit SiloId 178 as illiquid

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -494,6 +494,8 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0x322e1d5384aa4ed66aeca770b95686271de61dc3": (VaultFlag.illiquid, XUSD_MESSAGE),
     # Etherealm USDC (Morpho on Ethereum)
     "0xb7305d968ecd8a23a13ec01927e3f9588c7653b5": (VaultFlag.illiquid, ETHEREALM_USDC_ILLIQUID),
+    # Borrowable USDC Deposit, SiloId: 178 (Ethereum)
+    "0x93c8201c35666f9af8b3b943bad67b42ad0159a1": (VaultFlag.illiquid, XUSD_MESSAGE),
 }
 
 for addr in VAULT_FLAGS_AND_NOTES.keys():


### PR DESCRIPTION
## Why

The vault [Borrowable USDC Deposit, SiloId: 178](https://tradingstrategy.ai/trading-view/vaults/borrowable-usdc-deposit-siloid-178) on Ethereum needs to be marked as illiquid so users are warned before depositing. It follows the same Stream xUSD exposure pattern as the other Silo "Borrowable USDC Deposit" vaults already flagged in `flag.py`.

## Lessons learnt

Silo "Borrowable USDC Deposit" vaults consistently share the same illiquidity cause (Stream xUSD exposure) and reuse `XUSD_MESSAGE`, so new ones should be added with the same flag and note for consistency.

## Summary

- Added `0x93c8201c35666f9af8b3b943bad67b42ad0159a1` (Borrowable USDC Deposit, SiloId: 178, Ethereum) to `VAULT_FLAGS_AND_NOTES` with `VaultFlag.illiquid` and `XUSD_MESSAGE`.
