### PR TITLE
feat: add stablecoin depeg monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- feat: Add a CoinGecko-backed stablecoin denomination rate feed and depeg monitor for vault metrics, with daily post-scan refresh, sticky YAML `depegged_at` flags, failure stamps for missing prices, `denomination_token_rate` export fields, and automatic vault blacklisting when a denomination stablecoin is marked depegged (2026-06-26)
+
 - feat: Add Lighter account valuation helper for fetching total equity / NAV from live account state, with downstream trade-executor integration coverage and the Lagoon + Lighter manual tutorial now using this helper for withdrawal sizing (2026-06-26)
 
 - feat: Expand the Lagoon + Lighter manual test into a full mainnet lifecycle script with automatic Lagoon deployment JSON saving/loading, existing-vault resume support, live Lighter minimum sizing, Safe-owned API-key registration, ETH long open/close, Lighter withdrawal, Lagoon redemption back to the hot wallet, and reusable `eth_defi.lighter.api` / `eth_defi.lighter.lagoon` helpers (2026-06-26)

--- a/docs/claude-plans/depeg-monitor.md
+++ b/docs/claude-plans/depeg-monitor.md
@@ -1,0 +1,1031 @@
+# Stablecoin depeg monitor implementation plan
+
+Date: 2026-06-26
+
+## Goal
+
+Filter out stablecoins, and vaults denominated in those stablecoins, when the
+denomination token has materially depegged.
+
+The system will refresh stablecoin exchange rates from the CoinGecko free API,
+persist the latest USD rate in `eth_defi/data/stablecoins/*.yaml`, stamp a
+manual-clearable `depegged_at` flag when the token trades below 90% of its
+nominal peg, and mark all affected vaults as
+`VaultTechnicalRisk.blacklisted`.
+
+The daily refresh runs as part of the existing vault post scan process in
+`scripts/erc-4626/scan-vault-posts.py`.
+
+## Starting context
+
+- Feed collection is documented in `eth_defi/feed/README-feed.md`.
+- Stablecoin metadata is stored in `eth_defi/data/stablecoins/*.yaml` and
+  loaded/exported by `eth_defi/stablecoin_metadata.py`.
+- Stablecoin YAML files already store `links.coingecko`, but this URL is not
+  authoritative enough for rate fetching. The Kava USDX metadata currently
+  points to CoinGecko's `kava-lend` page, while the actual Kava USDX price is
+  served from CoinGecko id `usdx`.
+- Store both `coingecko_id` and `coingecko_link` directly on the stablecoin
+  metadata entry so the fetch key and the human-auditable CoinGecko page are
+  explicit and do not depend on the generic `links` block.
+- Vault blacklisting already uses `VaultTechnicalRisk.blacklisted` in
+  `eth_defi/vault/risk.py` and dynamic export checks in
+  `eth_defi/research/vault_metrics.py`.
+- The post scan process already mutates YAML source files for operational state
+  such as dead Twitter and RSS source markers.
+- CoinGecko documents the keyless public base URL as
+  `https://api.coingecko.com/api/v3/`, and the `/simple/price` endpoint can
+  query multiple coin ids with `vs_currencies` and
+  `include_last_updated_at=true`.
+
+## YAML schema
+
+Add these fields to every stablecoin metadata entry:
+
+```yaml
+coingecko_id: usd-coin
+coingecko_link: https://www.coingecko.com/en/coins/usd-coin
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T00:00:00'
+usd_rate: 0.9998
+usd_rate_fetched_at: '2026-06-26T00:00:00'
+usd_rate_updated_at: '2026-06-26T00:00:00'
+peg_rate: 0.9998
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
+```
+
+Rules:
+
+- For standard files, fields live at the top level, near `checks`.
+- For `entries:` files, fields live inside each entry.
+- Stablecoin YAML is currently loaded schemaless with `strictyaml.load()`.
+  Treat all YAML scalar values as strings on read. The new module must coerce
+  floats and datetimes explicitly when building `StablecoinRateTarget`, and the
+  JSON exporter must coerce numeric rate fields to JSON numbers rather than
+  passing through YAML strings.
+- `coingecko_id` is the canonical CoinGecko API coin id used for
+  `/simple/price` calls. Prefer this explicit field over parsing
+  `coingecko_link` or `links.coingecko`.
+- `coingecko_link` is the canonical human-readable CoinGecko page URL for the
+  same asset. It should normally be
+  `https://www.coingecko.com/en/coins/{coingecko_id}`. Persist it even when the
+  legacy `links.coingecko` field is also present.
+- `coingecko_id_source` records how the id was selected. Suggested values:
+  `manual`, `url`, and `search`. Use `manual` for ambiguous symbols such as
+  USDX, where several CoinGecko assets share the same ticker.
+- `coingecko_id_verified_at` is a naive UTC ISO timestamp with seconds
+  precision recording when the id last returned a valid CoinGecko price, or an
+  empty string when never verified.
+- `usd_rate` is a float, or empty string when never fetched.
+- `usd_rate_fetched_at` is a naive UTC ISO timestamp with seconds precision
+  recording when our updater fetched and wrote the rate, or empty string when
+  never fetched. This is the daily gating timestamp and must always be based on
+  our `now_`, not CoinGecko's upstream update timestamp.
+- `usd_rate_updated_at` is a naive UTC ISO timestamp with seconds precision
+  recording CoinGecko's upstream `last_updated_at` for the USD rate when
+  present, or empty string when CoinGecko did not provide it.
+- `peg_rate` is the price in the denomination's peg currency that was used for
+  the depeg decision, or empty string when the peg currency is unknown.
+- `peg_rate_currency` is the CoinGecko `vs_currencies` key used for `peg_rate`
+  (`usd`, `eur`, `chf`, `xau`, etc.), or empty string when unknown.
+- `rate_fetch_failed_at` is a naive UTC ISO timestamp with seconds precision
+  recording when the latest rate refresh failed for this entry, or empty string
+  when the latest refresh succeeded or has never been attempted.
+- `rate_fetch_failed_reason` is a short machine-readable reason for the latest
+  failed refresh, or empty string when there is no active failure. Suggested
+  values: `missing_coingecko_id`, `invalid_coingecko_id`,
+  `coingecko_price_missing`, `coingecko_http_error`, `coingecko_response_error`.
+- `depegged_at` is a naive UTC ISO timestamp with seconds precision, or empty
+  string when not flagged.
+- The updater sets `depegged_at` only when the current rate is below the
+  threshold.
+- The updater never clears `depegged_at`; operators clear the flag manually by
+  editing the YAML file.
+- If an operator clears `depegged_at` while the token is still below threshold,
+  the next daily refresh stamps it again.
+- The updater clears `rate_fetch_failed_at` and `rate_fetch_failed_reason` on a
+  successful rate refresh for that entry.
+- If no CoinGecko price is available for an entry, the updater stamps
+  `rate_fetch_failed_at` and `rate_fetch_failed_reason` but does not stamp
+  `depegged_at` and does not blacklist vaults.
+- If `coingecko_id`, `coingecko_link`, and `links.coingecko` disagree, use
+  `coingecko_id` for the fetch and log a warning. The URLs can be corrected by
+  a later metadata cleanup, but an incorrect URL must not cause the rate updater
+  to fetch the wrong asset.
+- When a parsed URL id or manually selected id successfully returns a price,
+  update `coingecko_id_verified_at` to the fetch timestamp. For newly parsed URL
+  ids, also persist `coingecko_id`, `coingecko_link`, and
+  `coingecko_id_source: url`.
+- Do not persist volatile CoinGecko market-cap or 24-hour-volume fields from
+  the probe response. They are useful for manual validation but are not needed
+  for the daily fetch, depeg decision, or vault blacklisting.
+- Daily gating applies to both successful and failed attempts. Skip an entry
+  when either `usd_rate_fetched_at` or `rate_fetch_failed_at` is already the
+  current UTC date, unless `force=True`. This prevents missing CoinGecko ids,
+  delisted assets, and transient HTTP failures from being retried on every
+  8-hour post scan loop.
+- Daily gating reads raw YAML strings and parses the stored ISO date prefix.
+  It must not depend on metadata JSON export normalisation, where empty strings
+  become `None`.
+- Preserve existing YAML ordering and formatting as much as practical. Use a
+  concrete round-trip mutation mechanism, not trailing append helpers. Prefer
+  `ruamel.yaml` round-trip editing with preserved order/comments, or implement
+  an entry-index-keyed block editor that can update and clear fields inside the
+  correct `entries:` item. If `ruamel.yaml` is added, add it as an explicit
+  `pyproject.toml` dependency with a comment explaining that stablecoin rate
+  YAML mutation needs round-trip formatting preservation.
+
+## Depeg threshold
+
+Use `DEPEG_THRESHOLD = 0.90`.
+
+Use `MIN_PLAUSIBLE_STABLECOIN_RATE = 0.01` as a wrong-asset guard before the
+depeg comparison for URL-derived or unverified CoinGecko ids. For those ids, a
+positive `peg_rate` below this floor is treated as a data-quality failure with
+`rate_fetch_failed_reason: coingecko_price_missing`, not as a depeg. Explicitly
+manual and verified `coingecko_id` values may still stamp a sub-cent
+catastrophic depeg. This keeps stale metadata such as the Kava USDX
+`kava-lend` link (`0.00049975`) from silently blacklisting vaults, while still
+allowing a real manually verified depeg to stamp `depegged_at`.
+
+The persisted `usd_rate` is always the token price in USD. The depeg comparison
+should use the nominal peg currency when it is known:
+
+- USD-pegged tokens: compare CoinGecko `usd` price against `0.90`.
+- EUR/CHF/SGD/TRY and other recognised fiat-pegged tokens: request both `usd`
+  and the peg currency from CoinGecko, persist `usd_rate`, and compare the peg
+  currency price against `0.90`.
+- XAU/gold-pegged tokens: compare against `xau` when a conservative mapping is
+  available. This assumes troy-ounce pegs such as PAXG; do not map gram-pegged
+  gold tokens without a separate peg-unit rule.
+- Unknown or ambiguous peg targets: refresh and persist `usd_rate`, but do not
+  stamp `depegged_at`. Log a warning so the stablecoin can be annotated later.
+
+Add a conservative symbol/name based peg-currency map in the new module. Avoid
+guessing when a wrong guess would blacklist vaults incorrectly.
+
+Persist `peg_rate` and `peg_rate_currency` alongside `usd_rate` so an operator
+can audit why a non-USD stablecoin was or was not flagged. Do not use
+`usd_rate_updated_at` or any other upstream timestamp for daily refresh gating;
+CoinGecko timestamps can lag and would otherwise cause repeated fetches in every
+post scan cycle.
+
+## Kava USDX CoinGecko probe
+
+The Trading Strategy Kava USDX page
+(`https://tradingstrategy.ai/trading-view/vaults/stablecoins/usdx`) resolves to
+the second entry in `eth_defi/data/stablecoins/usdx.yaml`.
+
+Probe findings on 2026-06-26:
+
+- The current local Kava USDX entry has
+  `links.coingecko: https://www.coingecko.com/en/coins/kava-lend`.
+- CoinGecko `/simple/price` for `kava-lend` returned a HARD/Kava Lend price:
+  `usd: 0.00049975`, `last_updated_at: 1782199898`
+  (`2026-06-23T07:31:38` after UTC conversion).
+- CoinGecko `/simple/price` for `usdx` returned the Kava USDX price:
+  `usd: 0.646809`, `usd_market_cap: 72165490.51902083`,
+  `usd_24h_vol: 11420.442904345602`,
+  `last_updated_at: 1782464168`
+  (`2026-06-26T08:56:08` after UTC conversion).
+- CoinGecko search for `USDX` returned both `usdx` for Kava USDX and
+  `usdx-money-usdx` for Stables Labs USDX, proving symbol-based automatic
+  resolution is ambiguous.
+
+Plan impact:
+
+- Add `coingecko_id: usdx`,
+  `coingecko_link: https://www.coingecko.com/en/coins/usdx`,
+  `coingecko_id_source: manual`, and a verified timestamp to the Kava USDX
+  entry when implementing the YAML migration.
+- Add `contract_addresses` to the Kava USDX entry during the migration before
+  relying on vault blacklisting. The current `usdx.yaml` has no
+  `contract_addresses`, and symbol fallback is intentionally disabled for
+  multi-entry files, so a depegged USDX entry without addresses can be stamped
+  but cannot blacklist any vault.
+- Correct the legacy Kava USDX `links.coingecko` URL to
+  `https://www.coingecko.com/en/coins/usdx` during metadata cleanup, or stop
+  exporting the legacy field if `coingecko_link` supersedes it.
+- Use `coingecko_id: usdx-money-usdx` for the Stables Labs USDX entry if it is
+  kept fetchable, with
+  `coingecko_link: https://www.coingecko.com/en/coins/usdx-money-usdx`. The
+  current URL slug `stables-labs-usdx` did not return a `/simple/price` result
+  in the probe and would otherwise produce
+  `rate_fetch_failed_reason: coingecko_price_missing`.
+- Never auto-select a CoinGecko id from search results when multiple plausible
+  matches share the same symbol; require a stored `coingecko_id` instead.
+
+## New module
+
+Create `eth_defi/feed/stablecoin_rate.py`.
+
+Proposed API:
+
+```python
+@dataclass(slots=True)
+class StablecoinRateTarget:
+    yaml_path: Path
+    entry_index: int | None
+    slug: str
+    symbol: str
+    name: str
+    coingecko_id: str | None
+    coingecko_link: str | None
+    coingecko_id_source: str | None
+    coingecko_id_verified_at: datetime.datetime | None
+    peg_currency: str | None
+    usd_rate: float | None
+    usd_rate_fetched_at: datetime.datetime | None
+    usd_rate_updated_at: datetime.datetime | None
+    peg_rate: float | None
+    peg_rate_currency: str | None
+    rate_fetch_failed_at: datetime.datetime | None
+    rate_fetch_failed_reason: str | None
+    depegged_at: datetime.datetime | None
+
+
+@dataclass(slots=True)
+class StablecoinRateRefreshSummary:
+    files_scanned: int
+    entries_seen: int
+    rates_fetched: int
+    files_updated: int
+    depegged_count: int
+    unactionable_depegged_count: int
+    skipped_missing_coingecko: int
+    skipped_unknown_peg: int
+    failed_count: int
+```
+
+Add a small section dataclass for vault metric rows:
+
+```python
+@dataclass(slots=True)
+class DenominationTokenRate:
+    coingecko_id: str | None
+    usd_rate: float | None
+    usd_rate_fetched_at: datetime.datetime | None
+    usd_rate_source: str | None
+
+
+@dataclass(slots=True)
+class StablecoinRateFeeder:
+    data_dir: Path = STABLECOINS_DATA_DIR
+    _depegged_contracts: set[tuple[int, str]] | None = field(default=None, init=False, repr=False)
+    _depegged_symbols: set[str] | None = field(default=None, init=False, repr=False)
+    _rate_contracts: dict[tuple[int, str], DenominationTokenRate] | None = field(default=None, init=False, repr=False)
+    _rate_symbols: dict[str, DenominationTokenRate] | None = field(default=None, init=False, repr=False)
+
+    def get_denomination_token_rate_section(
+        self,
+        chain_id: int | None,
+        address: HexAddress | None,
+        symbol: str | None,
+    ) -> DenominationTokenRate:
+        ...
+
+    def is_depegged_stablecoin_token(
+        self,
+        chain_id: int | None,
+        address: HexAddress | None,
+        symbol: str | None,
+    ) -> bool:
+        ...
+```
+
+Functions:
+
+- `extract_coingecko_id(url: str) -> str | None`
+- `resolve_coingecko_metadata(entry: StablecoinMetadataEntry) -> tuple[str | None, str | None, str | None]`
+- `iter_stablecoin_rate_targets(data_dir: Path) -> Iterator[StablecoinRateTarget]`
+- `fetch_stablecoin_rates(targets: Sequence[StablecoinRateTarget], timeout: float) -> dict[str, dict[str, float | int]]`
+- `refresh_stablecoin_rates(data_dir: Path = STABLECOINS_DATA_DIR, now_: datetime.datetime | None = None, force: bool = False, timeout: float = 20.0) -> StablecoinRateRefreshSummary`
+- `apply_coingecko_mapping_file(data_dir: Path, mapping_path: Path) -> int`
+
+`vault_metrics.py` should use `StablecoinRateFeeder` as its dependency
+boundary. Production and hot-path code must share one feeder instance across a
+batch so YAML paths, cache invalidation, chain alias handling, and future
+data-source changes stay out of the vault metrics calculation code.
+
+`DenominationTokenRate` and `StablecoinRateFeeder` live in
+`eth_defi/feed/stablecoin_rate.py`. `eth_defi/research/vault_metrics.py`
+imports the dataclass and feeder from that module, and separately extends its
+own `VaultMetricsRecord` `TypedDict` with the `denomination_token_rate` field.
+Keep the dataclass fields and the `TypedDict` field type in sync.
+
+Implementation notes:
+
+- Use a normal browser-like `User-Agent`. Keep the HTTP client surface
+  monkeypatchable as `stablecoin_rate.requests.get`, but avoid adding a new
+  dependency if the standard-library fallback is enough for keyless GETs.
+- Use the keyless endpoint by default:
+  `https://api.coingecko.com/api/v3/simple/price`.
+- Support optional `COINGECKO_DEMO_API_KEY`; when present, send
+  `x-cg-demo-api-key`. Because neither `refresh_stablecoin_rates()` nor
+  `PostScanConfig` carries this key, `eth_defi.feed.stablecoin_rate` should
+  read `os.environ["COINGECKO_DEMO_API_KEY"]` directly.
+- Request prices in batches. The documented `/simple/price` ids limit is high
+  enough for the current stablecoin set, but keep batching to avoid future
+  surprises.
+- Request `include_last_updated_at=true`. CoinGecko returns
+  `last_updated_at` as a Unix epoch integer; convert it with
+  `native_datetime_utc_fromtimestamp()` and persist the resulting naive UTC ISO
+  timestamp as `usd_rate_updated_at`. Fall back to an empty string for this
+  upstream timestamp; `usd_rate_fetched_at` remains our fetch time.
+- Always request `usd` plus the peg currency for non-USD pegs. If CoinGecko
+  does not support the peg currency key, persist `usd_rate`, leave
+  `depegged_at` empty, increment `skipped_unknown_peg`, and log a warning
+  instead of crashing.
+- Prefer the stored `coingecko_id` field. Fall back to parsing
+  `coingecko_link`, then legacy `links.coingecko`, only when the explicit id is
+  empty. Persist successful URL fallback resolution as `coingecko_id`,
+  `coingecko_link`, and `coingecko_id_source: url`.
+- Do not use CoinGecko search for automatic production resolution. Search is
+  acceptable for manual probes and metadata cleanup, but ambiguous symbols such
+  as USDX must be resolved by explicitly storing `coingecko_id`.
+- Treat HTTP errors, missing ids, missing CoinGecko prices, and malformed
+  responses as refresh failures for those entries only. Stamp
+  `rate_fetch_failed_at` and `rate_fetch_failed_reason`; do not abort the entire
+  post scan cycle.
+- `StablecoinRateTarget.coingecko_id` is optional so entries with missing
+  CoinGecko metadata can still be counted, stamped with
+  `rate_fetch_failed_reason: missing_coingecko_id`, and included in summaries.
+- Treat missing, `null`, zero, negative, NaN, or non-finite prices as
+  `coingecko_price_missing` failures. Do not stamp `depegged_at` from invalid
+  or non-positive price values.
+- Apply the `MIN_PLAUSIBLE_STABLECOIN_RATE` wrong-asset guard before the
+  depeg threshold comparison only for URL-derived or unverified CoinGecko ids.
+  Implausibly tiny positive rates from those ids are `coingecko_price_missing`
+  data-quality failures, not depegs. Manual and verified ids may still stamp a
+  sub-cent catastrophic depeg.
+- Daily gating is file-content based: skip an entry when either
+  `usd_rate_fetched_at` or `rate_fetch_failed_at` is already the current UTC
+  date, unless `force=True`.
+- `refresh_stablecoin_rates()` first builds all targets, then filters out
+  targets gated by today's `usd_rate_fetched_at` or `rate_fetch_failed_at`.
+  Only the remaining due targets are passed to the batched CoinGecko request.
+  Batch network fetches are keyed by unique `coingecko_id`, while the gate,
+  result stamping, and YAML writes remain per target entry.
+- If CoinGecko returns no price for the selected id, stamp
+  `rate_fetch_failed_at` with
+  `rate_fetch_failed_reason: coingecko_price_missing` instead of silently
+  treating the asset as healthy.
+- Use naive UTC datetimes and `native_datetime_utc_now()`.
+- Treat `StablecoinRateFeeder` instances as batch-scoped caches. Code that
+  refreshes YAML and then needs fresh lookups should construct a new feeder.
+- Use module-level `logger = logging.getLogger(__name__)`.
+
+## Stablecoin metadata export
+
+Update `eth_defi/stablecoin_metadata.py`:
+
+- Add `coingecko_id`, `coingecko_link`, `coingecko_id_source`,
+  `coingecko_id_verified_at`, `usd_rate`, `usd_rate_fetched_at`,
+  `usd_rate_updated_at`, `peg_rate`, `peg_rate_currency`,
+  `rate_fetch_failed_at`, `rate_fetch_failed_reason`, and `depegged_at` to the
+  documented YAML format.
+- Extend the relevant `TypedDict` exports so R2 metadata JSON includes the new
+  fields.
+- Parse empty strings as `None` in JSON export, following the existing optional
+  field convention.
+- Coerce `usd_rate` and `peg_rate` from YAML strings to JSON numbers during
+  export. Do not let schemaless `strictyaml` parsing leak numeric fields as
+  JSON strings.
+- Avoid data-directory split-brain. Any code path that exports all stablecoin
+  metadata or calls `load_all_stablecoin_metadata()` must be able to read from
+  the same directory used by `refresh_stablecoin_rates()` and
+  `StablecoinRateFeeder`. Add a shared optional `data_dir:
+  Path = STABLECOINS_DATA_DIR` parameter or equivalent helper for the
+  all-files loader/export paths, and use it in tests that override
+  `stablecoin_data_dir`.
+- Put the new fields on `StablecoinMetadata` as top-level fields, not under
+  `StablecoinChecks`. They live near `checks` in YAML for readability, but they
+  must use the existing `normalise()` empty-string-to-`None` export behaviour;
+  `checks` intentionally preserves empty strings.
+- Keep backwards compatibility with files that do not yet have the fields.
+
+## Vault blacklisting
+
+Add a dynamic depeg-denomination check in vault metric calculation.
+
+Recommended hook:
+
+- Extend `eth_defi/research/vault_metrics.py::VaultMetricsRecord` with a new
+  `denomination_token_rate` section field modelled by the
+  `DenominationTokenRate` dataclass.
+- `DenominationTokenRate` includes:
+  - `coingecko_id`: CoinGecko coin id used for the rate fetch, or `None`
+  - `usd_rate`: latest denomination stablecoin USD rate, or `None`
+  - `usd_rate_fetched_at`: naive UTC timestamp for when our updater fetched
+    the rate, or `None`
+  - `usd_rate_source`: string source identifier, initially `coingecko`, or
+    `None` when no rate is available
+- `calculate_lifetime_metrics()` builds each vault row through
+  `calculate_vault_record()`. Add the section in `calculate_vault_record()` so
+  every vault row produced by `calculate_lifetime_metrics()` includes the rate
+  section.
+- Add `stablecoin_rate_feeder: StablecoinRateFeeder | None = None` to both
+  `calculate_lifetime_metrics()` and `calculate_vault_record()`, and thread the
+  same feeder through the internal `_apply_vault_record()` call.
+  `calculate_lifetime_metrics()` should construct one default
+  `StablecoinRateFeeder()` when the argument is omitted, then reuse that
+  instance for all vault rows in the call.
+- Do not pass `stablecoin_data_dir` directly through the vault metrics API.
+  Full-stack tests that need temporary USDC/USDX YAML fixtures should construct
+  `StablecoinRateFeeder(data_dir=tmp_path)` and pass the feeder to
+  `calculate_lifetime_metrics()` or `calculate_vault_record()`.
+- In `eth_defi/research/vault_metrics.py`, call the new stablecoin-rate helper
+  through `stablecoin_rate_feeder` in `calculate_vault_record()` after `risk`
+  and `risk_numeric` have been initialised. Do not insert at the line where
+  `normalised_denomination` is first computed, because `risk` does not exist
+  yet there.
+- Place the final depeg override after the existing abnormal-value,
+  Morpho-not-in-API, Morpho red-flag checks, and the later abnormal-volatility
+  check so the blacklist state is not clobbered later in the function. Recompute
+  `risk_numeric` from the final `risk` unconditionally immediately before the
+  returned `pd.Series` is built. Do not only set `risk_numeric` in the depeg
+  override; this also fixes the existing abnormal-volatility path where `risk`
+  can change after `risk_numeric` was first calculated.
+- If `normalised_denomination` resolves to a stablecoin with non-empty
+  `depegged_at`, set:
+  - `risk = VaultTechnicalRisk.blacklisted`
+  - `risk_numeric = VaultTechnicalRisk.blacklisted.value`
+  - a clear note such as
+    `Denomination stablecoin {symbol} is marked as depegged`
+  - a display flag if there is a suitable existing enum; otherwise add a
+    focused `VaultFlag.depegged_denomination_token`.
+- If `VaultFlag.depegged_denomination_token` is added, also add it to
+  `eth_defi/vault/flag.py::BAD_FLAGS` so downstream "do not touch" checks see
+  it as a blocking condition.
+- Current `vault_display_flags` are built before the planned final depeg
+  override. Rebuild or append the display flag after the depeg override so
+  `other_data["vault_display_flags"]` includes the depegged denomination flag.
+  Use the existing display flag shape:
+  `{"severity": "red", "type": "depegged_denomination_token", "source": "stablecoin"}`.
+  This can be produced by merging the current Morpho list with
+  `make_vault_display_flags(red_flags=["depegged_denomination_token"], yellow_flags=[], source="stablecoin")`.
+- Include `denomination_token_rate` in the returned `pd.Series` next to
+  `core3` and `other_data`, because it is another compact per-vault enrichment
+  section.
+
+Design constraints:
+
+- Do not blacklist a vault merely because CoinGecko is unavailable.
+- Still include `denomination_token_rate` for vaults with a known stablecoin
+  rate even when the rate is healthy, e.g. USDC. The section value is modelled
+  as `DenominationTokenRate`.
+- For vaults with no matched stablecoin rate, include
+  `DenominationTokenRate(coingecko_id=None, usd_rate=None, usd_rate_fetched_at=None, usd_rate_source=None)`.
+  Do not use `None` for the whole section; every row must expose the same
+  `denomination_token_rate` dataclass shape.
+- Do not blacklist a vault merely because the stablecoin lacks `coingecko_id`,
+  `coingecko_link`, or `links.coingecko`.
+- Do not blacklist a vault merely because the stablecoin has
+  `rate_fetch_failed_at`; missing market data is an operational data-quality
+  issue, not proof of a depeg.
+- Prefer contract-aware matching: use the vault row's denomination chain and
+  `_denomination_token.get("address")` against stablecoin YAML
+  `contract_addresses`. In current `vault_metrics.py` the `_denomination_token`
+  value is a plain dict, not an object with an `.address` attribute.
+  `StablecoinRateFeeder` must read both top-level `contract_addresses` and
+  per-entry `contract_addresses` inside `entries:` files.
+  Fall back to normalised symbol matching only when the symbol maps to exactly
+  one non-entry stablecoin record. Do not symbol-blacklist multi-entry files
+  such as `ausd.yaml`, where one `symbol` can represent multiple unrelated
+  assets.
+- A depegged entry with no contract addresses and an ambiguous or multi-entry
+  symbol is unactionable for vault blacklisting. Log a warning and surface a
+  summary counter for these entries, because they are rate/depeg metadata but
+  cannot safely affect vaults.
+- Canonicalise both sides before contract-aware matching by converting YAML
+  chain slugs to chain ids with an explicit alias table, then matching
+  `(chain_id, lower-case address)`. Do not convert vault `chain_id` to a single
+  YAML slug: the current data contains aliases such as `binance`, `bnb`, and
+  `bsc` for BNB chain. Do not compare title-case display chain names from
+  `get_chain_name()` to YAML chain slugs.
+- When using symbol fallback, normalise YAML symbols with the same
+  `eth_defi.token.normalise_token_symbol()` helper that `vault_metrics.py` uses
+  for the vault denomination.
+- Symbol fallback inside `StablecoinRateFeeder` must expose only the
+  unambiguous fallback set. It must exclude all `entries:` files and any symbol
+  that appears in more than one stablecoin YAML record, including case variants.
+- Cache depegged stablecoin contract identifiers and unambiguous normalised
+  symbols inside `StablecoinRateFeeder` so metrics calculation does not parse
+  all YAML files for every vault.
+- Build separate rate-section lookup caches for healthy and depegged rates,
+  keyed by `(chain_id, address)` and by unambiguous normalised symbol, inside
+  `StablecoinRateFeeder`. These use the same contract-aware and ambiguity rules
+  as blacklisting, but they include healthy entries such as USDC so
+  `denomination_token_rate` is populated even when no depeg exists.
+- Treat `StablecoinRateFeeder` as a batch-scoped cache. Tests that mutate
+  temporary YAML data should construct a fresh feeder for the temporary
+  directory.
+- Avoid introducing an import cycle between `eth_defi.research.vault_metrics`
+  and `eth_defi.feed.stablecoin_rate`. If a top-level import creates a cycle,
+  use a narrow lazy import to construct the default `StablecoinRateFeeder`.
+
+## Post scan integration
+
+Run the stablecoin population/refresh side job from the post scan process, but
+gate it so the stablecoin YAML corpus is scanned and potentially rewritten at
+most once every 24 hours unless explicitly forced. The post scanner may run
+more often, e.g. every 8 hours, so this must be a durable scanner-level gate in
+addition to the per-entry daily gates in stablecoin YAML.
+
+Update `eth_defi/feed/scanner.py`:
+
+- Add `refresh_stablecoin_rates: bool = True` to `PostScanConfig`.
+- Add `force_stablecoin_rate_refresh: bool = False` to `PostScanConfig`.
+- Add `stablecoin_data_dir: Path = STABLECOINS_DATA_DIR`.
+- Add `stablecoin_rate_timeout: float = 20.0`.
+- Add `stablecoin_rate_gate_path: Path | None = None` to `PostScanConfig`.
+  When omitted, derive a sidecar state path next to the post-scan database,
+  e.g. `config.db_path.with_suffix(".stablecoin-rate-state.json")`.
+- Persist the scanner-level gate as JSON containing
+  `last_started_at`, `last_succeeded_at`, and `last_failed_at` naive UTC ISO
+  timestamps. `last_succeeded_at` controls the 24-hour skip decision and
+  survives process restarts.
+- Update existing scanner integration tests that instantiate `PostScanConfig`
+  so they either set `refresh_stablecoin_rates=False` or point
+  `stablecoin_data_dir` at a temporary test directory. The default-on side job
+  must not mutate real repository stablecoin YAML during feed scanner tests.
+- At the start of `run_post_scan_cycle()`, call `refresh_stablecoin_rates()`
+  only when enabled and either `force_stablecoin_rate_refresh=True` or the
+  durable gate says the last successful run was at least 24 hours ago.
+- Update `last_started_at` before the refresh. Update `last_succeeded_at` only
+  after `refresh_stablecoin_rates()` returns successfully. Update
+  `last_failed_at` when an unexpected refresh exception is caught.
+- Add explicit stablecoin rate slots fields to
+  `eth_defi/feed/collector.py::CollectorRunSummary`; do not attach arbitrary
+  attributes at runtime because `CollectorRunSummary` is a `slots=True`
+  dataclass. Use `TYPE_CHECKING`, a forward reference, or `Any` for the summary
+  type annotation if importing `StablecoinRateRefreshSummary` would create an
+  import cycle.
+- Add explicit summary status fields so dashboards can distinguish disabled,
+  skipped, successful, and failed side-job states:
+  - `stablecoin_rate_status: str | None` with values `disabled`,
+    `skipped_recent`, `succeeded`, or `failed`
+  - `stablecoin_rate_summary: StablecoinRateRefreshSummary | None`, populated
+    only when a refresh actually runs successfully
+  - `stablecoin_rate_error: str | None`, populated only for unexpected refresh
+    exceptions
+- Fail soft: log stablecoin-rate refresh errors and continue post collection.
+
+Update `scripts/erc-4626/scan-vault-posts.py`:
+
+- Add environment variables:
+  - `REFRESH_STABLECOIN_RATES`: default `true`
+  - `FORCE_STABLECOIN_RATE_REFRESH`: default `false`, bypasses the scanner-level
+    24-hour gate and passes `force=True` to `refresh_stablecoin_rates()`
+  - `STABLECOIN_RATE_TIMEOUT`: default `20`
+  - `STABLECOIN_DATA_DIR`: optional path override for tests, worktrees, and
+    production deployments that pass the same directory to stablecoin metadata
+    export/load paths. Do not point the refresh at a different directory than
+    metadata export, because refreshed depeg flags would otherwise not appear in
+    exported R2 metadata.
+  - `STABLECOIN_RATE_GATE_PATH`: optional durable 24-hour gate JSON path
+  - `COINGECKO_DEMO_API_KEY`: optional, passed through by environment
+- Include a compact dashboard row for rates fetched, files updated and
+  depegged stablecoins.
+
+## Initial YAML population helper
+
+Add a standalone helper script for the one-off or manually triggered
+population of stablecoin YAML rate metadata before the post scanner owns the
+full workflow.
+
+Create `scripts/erc-4626/populate-stablecoin-rates.py`:
+
+- Use environment variables only, following the style of the existing ERC-4626
+  scripts.
+- Read `STABLECOIN_DATA_DIR`, defaulting to `STABLECOINS_DATA_DIR`.
+- Read `FORCE`, defaulting to `false`; when true, pass `force=True` to
+  `refresh_stablecoin_rates()`.
+- Read `STABLECOIN_RATE_TIMEOUT`, defaulting to `20`.
+- Read optional `COINGECKO_ID_MAPPING_FILE`. When provided, apply explicit
+  operator-curated mappings before refresh. The mapping file should key entries
+  by stablecoin slug plus entry name or index, and provide `coingecko_id`,
+  `coingecko_link`, and `coingecko_id_source: manual`.
+- Read `COINGECKO_DEMO_API_KEY` from the environment indirectly through
+  `eth_defi.feed.stablecoin_rate`.
+- Set up logging like `scripts/erc-4626/scan-vaults.py` /
+  `scripts/erc-4626/scan-vault-posts.py`.
+- Call `refresh_stablecoin_rates(data_dir=..., force=..., timeout=...)`.
+- Print one compact `tabulate` summary row with files scanned, entries seen,
+  rates fetched, files updated, depegged count, failed count, skipped missing
+  CoinGecko ids, skipped unknown pegs, and unactionable depegged entries.
+- Exit non-zero only on unexpected implementation/configuration errors. Normal
+  per-entry CoinGecko failures should be reflected in summary counters and YAML
+  `rate_fetch_failed_*` fields.
+
+This helper is the initial population mechanism for adding rate metadata to the
+existing stablecoin YAML corpus. It may populate `coingecko_id` and
+`coingecko_link` from an unambiguous existing URL or from the explicit
+`COINGECKO_ID_MAPPING_FILE`, then populate `usd_rate`, `usd_rate_fetched_at`,
+and related fields from CoinGecko. It must not auto-select from ambiguous
+CoinGecko search results; entries without a reliable id should be stamped with
+`rate_fetch_failed_reason: missing_coingecko_id` or left for manual mapping. It
+should also be safe to re-run idempotently.
+
+Future integration: after the helper has proven reliable, the same population
+logic should become part of the post scanner loop and run at most once every 24
+hours. The 24-hour gate should be explicit and separate from each individual
+stablecoin's daily rate gate, so the post scanner can run more frequently
+without repeatedly scanning and rewriting the stablecoin YAML corpus.
+
+## Documentation
+
+Update:
+
+- `eth_defi/feed/README-feed.md` with a short section explaining the stablecoin
+  rate refresh side job, the initial population helper, and the CoinGecko
+  dependency.
+- `eth_defi/stablecoin_metadata.py` module documentation with the new YAML
+  fields.
+- `docs/source/api/feed/index.rst` by adding `eth_defi.feed.stablecoin_rate`
+  to the existing `autosummary` module list. Do not add a standalone
+  `stablecoin_rate.rst`; this API section uses generated autosummary pages.
+
+## Tests
+
+Add focused tests, avoiding the full test suite.
+
+Suggested files:
+
+- `tests/feed/test_stablecoin_rate.py`
+- `tests/research/test_vault_metrics_depeg.py` or the closest existing vault
+  metrics test file
+- `tests/stablecoin/test_stablecoin_metadata_export.py` if a stablecoin
+  metadata test package already exists; otherwise add a focused test under
+  `tests/feed`
+
+Test cases:
+
+- Happy-path full-stack integration uses USDC:
+  - temporary `usdc.yaml` with `coingecko_id: usd-coin`,
+    `coingecko_link: https://www.coingecko.com/en/coins/usd-coin`, and
+    Ethereum/Base contract addresses
+  - mocked CoinGecko `/simple/price` returns `usd: 1.0`
+  - `refresh_stablecoin_rates()` writes `usd_rate`, timestamps, and clears
+    failure/depeg fields
+  - `calculate_lifetime_metrics(stablecoin_rate_feeder=StablecoinRateFeeder(data_dir=tmp_path))`
+    uses the temporary YAML fixture, not repository stablecoin data
+  - vault metrics for a USDC-denominated vault remain non-blacklisted
+  - `calculate_lifetime_metrics()` output includes
+    `denomination_token_rate.coingecko_id == "usd-coin"`,
+    `denomination_token_rate.usd_rate == 1.0`,
+    non-empty `denomination_token_rate.usd_rate_fetched_at`, and
+    `denomination_token_rate.usd_rate_source == "coingecko"`
+- Bad-path full-stack integration uses Kava USDX:
+  - temporary multi-entry `usdx.yaml` fixture with Kava USDX entry,
+    `coingecko_id: usdx`, `coingecko_link:
+    https://www.coingecko.com/en/coins/usdx`, and per-entry
+    `contract_addresses`
+  - mocked CoinGecko `/simple/price` returns `usd: 0.646809`
+  - `refresh_stablecoin_rates()` stamps `depegged_at`
+  - `calculate_lifetime_metrics(stablecoin_rate_feeder=StablecoinRateFeeder(data_dir=tmp_path))`
+    uses the temporary YAML fixture, not repository stablecoin data
+  - depegged contract lookup sees the USDX entry by `(chain_id, address)`
+  - vault metrics for a vault whose `_denomination_token` dict has an
+    `"address"` matching that USDX contract set `risk` to
+    `VaultTechnicalRisk.blacklisted`,
+    `risk_numeric` to `VaultTechnicalRisk.blacklisted.value`, and add the
+    depegged denomination note/flag
+  - `VaultFlag.depegged_denomination_token` is present in `BAD_FLAGS` if the
+    enum is added
+  - `other_data["vault_display_flags"]` contains the depegged denomination
+    display flag after the final risk override
+  - `calculate_lifetime_metrics()` output includes
+    `denomination_token_rate.coingecko_id == "usdx"`,
+    `denomination_token_rate.usd_rate == 0.646809`,
+    non-empty `denomination_token_rate.usd_rate_fetched_at`, and
+    `denomination_token_rate.usd_rate_source == "coingecko"`
+- Parse CoinGecko ids from normal URLs such as
+  `https://www.coingecko.com/en/coins/usd-coin`.
+- Prefer a stored `coingecko_id` over `coingecko_link` and `links.coingecko`
+  when they disagree.
+- Persist a successfully parsed URL id as `coingecko_id`,
+  `coingecko_link`, `coingecko_id_source: url`, and
+  `coingecko_id_verified_at`.
+- YAML mutation writes never-verified optional timestamps such as
+  `coingecko_id_verified_at` as empty strings, not the literal `None`.
+- Do not auto-resolve ambiguous symbols from CoinGecko search results; require
+  an explicit `coingecko_id`.
+- Cover the USDX case: `coingecko_id: usdx` should be treated as depegged,
+  while the stale `kava-lend` URL must not override the stored id.
+- Ignore empty or malformed CoinGecko ids and URLs.
+- Fetch multiple ids from a mocked `/simple/price` response and persist
+  `usd_rate`, `usd_rate_fetched_at`.
+- Clear `rate_fetch_failed_at` and `rate_fetch_failed_reason` after a later
+  successful rate refresh.
+- Stamp `rate_fetch_failed_at` and `rate_fetch_failed_reason` when the
+  CoinGecko response does not contain a price for a parsed id.
+- Stamp `rate_fetch_failed_at` and `rate_fetch_failed_reason` for missing or
+  invalid CoinGecko ids.
+- Entries with missing `coingecko_id` still produce a target, are counted, and
+  are stamped with `rate_fetch_failed_reason: missing_coingecko_id`.
+- Persist CoinGecko's `last_updated_at` as `usd_rate_updated_at`, but use our
+  `now_` value for `usd_rate_fetched_at` and daily gating.
+- Convert CoinGecko `last_updated_at` epoch integers to naive UTC ISO strings
+  with `native_datetime_utc_fromtimestamp()`.
+- Coerce YAML string values such as `usd_rate: 0.9998` and
+  `peg_rate: 0.9998` to Python floats when reading targets and to JSON numbers
+  when exporting metadata.
+- Parse daily-gating timestamps from raw YAML strings and cover the
+  `23:59` to `00:01` UTC date-boundary case.
+- Treat `0`, negative, `null`, NaN, and non-finite prices as
+  `coingecko_price_missing` failures, not as depegs.
+- Cover the wrong-asset boundary: a URL-derived or unverified id with a price
+  below `MIN_PLAUSIBLE_STABLECOIN_RATE`, such as `kava-lend` at `0.00049975`,
+  is a fetch/data-quality failure, while Kava USDX at `0.646809` is a real
+  depeg. Also cover that a manual and verified id can still stamp a sub-cent
+  catastrophic depeg.
+- Stamp `depegged_at` when USD-pegged token price is below `0.90`.
+- Do not stamp `depegged_at` when price is `0.90` or above.
+- Compare non-USD fiat-pegged tokens using their peg currency rate, persist the
+  USD rate separately, and persist `peg_rate`/`peg_rate_currency`.
+- Always request `usd` plus the peg currency for non-USD pegs.
+- If CoinGecko does not return the requested peg currency, persist `usd_rate`,
+  leave `depegged_at` empty, increment `skipped_unknown_peg`, and log a
+  warning.
+- Compare XAU/gold-pegged tokens using the `xau` rate where mapped.
+- For unknown or ambiguous peg targets, persist `usd_rate`, leave
+  `depegged_at` empty, increment `skipped_unknown_peg`, and log a warning.
+- Preserve an existing `depegged_at` value when the price recovers.
+- Re-stamp `depegged_at` if the operator cleared it and the token remains
+  below threshold.
+- Skip daily refresh when `usd_rate_fetched_at` is already today.
+- Skip daily retry when `rate_fetch_failed_at` is already today.
+- `force=True` refreshes even when the entry was already updated today.
+- `force=True` refreshes even when the entry already failed today.
+- Multi-entry YAML files update only the relevant entries.
+- Multi-entry YAML mutation is idempotent when re-run on a file whose fields
+  already exist, updating values instead of appending duplicates.
+- Two entries or files sharing the same `coingecko_id` are fetched once but
+  stamped independently.
+- Two entries sharing the same `coingecko_id` but with different daily-gate
+  states only fetch for due targets; gated entries are not stamped again, and
+  due entries are still updated from the shared fetched price.
+- Metadata JSON export includes the new rate/depeg fields and converts empty
+  strings to `None`.
+- Metadata JSON export emits `usd_rate` and `peg_rate` as numbers, not strings.
+- Metadata export/load tests prove that a temporary stablecoin data directory
+  used by `refresh_stablecoin_rates()` is also the directory used for all-files
+  metadata export, preventing package-dir/override split-brain.
+- Temporary-data tests construct fresh `StablecoinRateFeeder` instances for the
+  fixture directory.
+- Healthy stablecoin rate lookup caches populate `denomination_token_rate` for
+  USDC by `(chain_id, address)` and by unambiguous normalised symbol.
+- `denomination_token_rate` is always a `DenominationTokenRate` object. For an
+  unmatched denomination token, all fields are `None`; the whole section
+  is never `None`.
+- Vault metrics blacklists a vault whose normalised denomination symbol is
+  marked depegged.
+- Vault metrics first matches depegged denomination by `(chain_id, address)` and
+  does not blacklist unrelated entries sharing the same `symbol` in an
+  `entries:` YAML file.
+- Vault metrics converts YAML chain slug aliases to numeric chain ids and
+  normalises both vault and YAML addresses before matching.
+- Vault metrics covers YAML chain alias collisions such as `binance`, `bnb`,
+  and `bsc` mapping to the same BNB chain id.
+- A depegged multi-entry stablecoin without `contract_addresses`, such as the
+  current USDX file before migration, logs an unactionable warning and does not
+  silently blacklist by ambiguous symbol.
+- USDX blacklisting test data includes per-entry `contract_addresses`, proving
+  the Kava USDX use case works through contract-aware matching.
+- Full-stack integration tests must not stop at the feed module. They must
+  exercise the stack from mocked CoinGecko response through YAML mutation,
+  `StablecoinRateFeeder` lookup, and `calculate_vault_record()` risk output.
+- Vault metrics tests inject `StablecoinRateFeeder(data_dir=tmp_path)` instead
+  of passing a raw stablecoin data directory into metrics functions.
+- `calculate_lifetime_metrics()` includes a `denomination_token_rate` section
+  for each vault row with `coingecko_id`, `usd_rate`,
+  `usd_rate_fetched_at`, and `usd_rate_source`.
+- Vaults with no matched stablecoin rate still get a stable
+  `denomination_token_rate` shape modelled by `DenominationTokenRate`, with
+  all fields set to `None`. Do not use `None` for the whole section.
+- YAML symbols and vault denominations are normalised with the same
+  `eth_defi.token.normalise_token_symbol()` path before any symbol fallback
+  comparison.
+- Symbol fallback ignores ambiguous symbols, multi-entry symbols, and case
+  variants that resolve to more than one stablecoin record.
+- Vault metrics does not blacklist a vault when the stablecoin has no rate, no
+  CoinGecko id, `rate_fetch_failed_at`, or no `depegged_at`.
+- Post scan cycle continues if CoinGecko returns an HTTP error.
+- Existing feed scanner tests disable the side job or use a temporary
+  `stablecoin_data_dir`, proving the default-on integration does not mutate real
+  stablecoin YAML in unrelated tests.
+- Summary counters are asserted for missing CoinGecko ids, unknown peg targets,
+  unactionable depegged entries, failed CoinGecko responses, rates fetched, and
+  files updated.
+
+Use the existing repository HTTP mocking style: define a small response object
+with `raise_for_status()` and patch `eth_defi.feed.stablecoin_rate.requests.get`
+using `monkeypatch.setattr()`. Do not introduce `responses` or
+`requests_mock` just for these tests.
+
+Run targeted tests with the repository pytest wrapper:
+
+```shell
+source .local-test.env && poetry run pytest tests/feed/test_stablecoin_rate.py --log-cli-level=info
+```
+
+Use the 3 minute timeout convention for pytest commands.
+
+## Implementation chunks
+
+### Chunk 1: Rate module foundation
+
+- [ ] Create `eth_defi/feed/stablecoin_rate.py`.
+- [ ] Add dataclasses and CoinGecko id extraction.
+- [ ] Keep the CoinGecko HTTP client monkeypatchable without adding an
+      unnecessary direct dependency.
+- [ ] Add explicit `coingecko_id` resolution, source tracking, and verification
+      timestamp handling.
+- [ ] Add scalar coercion helpers for YAML string values:
+      floats, optional datetimes, and daily-gating date strings.
+- [ ] Convert CoinGecko epoch `last_updated_at` values to naive UTC datetimes
+      with `native_datetime_utc_fromtimestamp()`.
+- [ ] Validate prices and treat missing, non-positive, NaN, and non-finite
+      values as fetch failures.
+- [ ] Add `MIN_PLAUSIBLE_STABLECOIN_RATE = 0.01` and apply it before the depeg
+      threshold comparison for URL-derived or unverified ids so implausibly
+      tiny positive prices become data-quality failures, not depegs. Manual
+      and verified ids may still stamp sub-cent catastrophic depegs.
+- [ ] Filter daily-gated targets before constructing the unique
+      `coingecko_id` batch, while keeping result stamping per target entry.
+- [ ] Store `coingecko_link` alongside `coingecko_id` for both standard and
+      `entries:` stablecoin YAML records.
+- [ ] Add stablecoin YAML target iterator for standard and `entries:` files.
+- [ ] Add `StablecoinRateFeeder` as the public vault metrics access layer for
+      rate lookups and depeg checks.
+- [ ] Ensure vault metrics uses one shared `StablecoinRateFeeder` instance and
+      does not reload stablecoin YAML inside the per-vault loop.
+- [ ] Add healthy rate-section lookup caches by `(chain_id, address)` and
+      unambiguous normalised symbol, separate from depegged-only caches.
+- [ ] Add mocked CoinGecko fetcher tests.
+- [ ] Add daily success-skip, daily failure-skip, and `force=True` tests.
+
+### Chunk 2: YAML mutation
+
+- [ ] Implement focused YAML mutation with a concrete round-trip strategy
+      (`ruamel.yaml` or an entry-index-keyed block editor). It must update
+      existing values, clear failure fields, and write inside the correct
+      `entries:` item without duplicate fields.
+- [ ] Add `usd_rate`, `usd_rate_fetched_at`, and `depegged_at` to updated
+      stablecoin entries.
+- [ ] Add `usd_rate_updated_at`, `peg_rate`, and `peg_rate_currency` to updated
+      stablecoin entries.
+- [ ] Add `rate_fetch_failed_at` and `rate_fetch_failed_reason` to failed
+      stablecoin refresh entries, and clear them on successful refresh.
+- [ ] Persist `coingecko_id`, `coingecko_link`, `coingecko_id_source`, and
+      `coingecko_id_verified_at` when needed for reliable CoinGecko fetches.
+- [ ] Ensure YAML mutation writes optional empty datetime fields as `''`, not
+      the literal `None`.
+- [ ] During metadata migration, add per-entry `contract_addresses` for
+      depegged multi-entry assets that must affect vault blacklisting, starting
+      with Kava USDX.
+- [ ] Preserve existing `depegged_at` unless manually cleared.
+- [ ] Add idempotent update tests for standard and multi-entry files.
+
+### Chunk 3: Metadata export
+
+- [ ] Extend `eth_defi/stablecoin_metadata.py` documentation and TypedDicts.
+- [ ] Export new fields in `build_stablecoin_metadata_json()`, coercing
+      numeric YAML strings to JSON numbers.
+- [ ] Add an optional `data_dir: Path = STABLECOINS_DATA_DIR` path through
+      all-files metadata load/export helpers so tests and configured refresh
+      overrides do not write one directory and export another.
+- [ ] Add backwards-compatible tests for old YAML files without rate fields.
+
+### Chunk 4: Vault blacklist integration
+
+- [ ] Add depegged stablecoin lookup helper with in-process cache.
+- [ ] Add `DenominationTokenRate` section typing to
+      `eth_defi/research/vault_metrics.py` with `coingecko_id`, `usd_rate`,
+      `usd_rate_fetched_at`, and `usd_rate_source`.
+- [ ] Include the denomination token rate section in every row produced by
+      `calculate_lifetime_metrics()` via `calculate_vault_record()`.
+- [ ] Add `stablecoin_rate_feeder: StablecoinRateFeeder | None = None`
+      parameters to `calculate_lifetime_metrics()` and
+      `calculate_vault_record()`, and pass the same feeder through
+      `_apply_vault_record()`.
+- [ ] Construct one default `StablecoinRateFeeder()` per
+      `calculate_lifetime_metrics()` call when no feeder is supplied, and reuse
+      it for all vault rows.
+- [ ] Keep `stablecoin_data_dir` out of the vault metrics function signatures;
+      tests inject temporary YAML through `StablecoinRateFeeder(data_dir=tmp_path)`.
+- [ ] Ensure unmatched denomination tokens still return
+      `DenominationTokenRate(coingecko_id=None, usd_rate=None,
+      usd_rate_fetched_at=None, usd_rate_source=None)`.
+- [ ] Add vault metric risk override for depegged denomination tokens after
+      all existing dynamic blacklist checks, including abnormal volatility.
+- [ ] Recompute `risk_numeric` unconditionally from final `risk` immediately
+      before building the returned `pd.Series`.
+- [ ] Match denomination tokens by `(chain_id, address)` first, reading
+      top-level and per-entry `contract_addresses`, with normalised symbol
+      fallback only for unambiguous records.
+- [ ] Add YAML chain slug alias to numeric chain id mapping, covering aliases
+      such as `binance`, `bnb`, and `bsc`.
+- [ ] Add chain-alias and address normalisation tests.
+- [ ] Warn and count depegged entries that are unactionable for vault
+      blacklisting because they lack addresses and have ambiguous symbols.
+- [ ] Add a user-facing note and display flag; rebuild or append
+      `other_data["vault_display_flags"]` after the final depeg override using
+      severity `red`, type `depegged_denomination_token`, and source
+      `stablecoin`.
+- [ ] If adding `VaultFlag.depegged_denomination_token`, include it in
+      `BAD_FLAGS`.
+- [ ] Add focused vault metrics tests.
+- [ ] Add full-stack integration tests:
+      USDC happy path remains non-blacklisted, and USDX bad path is refreshed,
+      marked depegged, resolved by denomination token contract, and blacklisted
+      in `calculate_lifetime_metrics()`/`calculate_vault_record()`, with
+      `denomination_token_rate.coingecko_id`,
+      `denomination_token_rate.usd_rate`,
+      `denomination_token_rate.usd_rate_fetched_at`, and
+      `denomination_token_rate.usd_rate_source` asserted.
+
+### Chunk 5: Post scan side job
+
+- [ ] Extend `PostScanConfig`.
+- [ ] Call the refresh at the start of `run_post_scan_cycle()` only when the
+      side job is enabled and the durable 24-hour gate allows it.
+- [ ] Add an explicit post-scan-level 24-hour gate for the stablecoin
+      population/refresh job, separate from per-entry daily rate gates. The
+      scanner can run more often, but the stablecoin YAML corpus should be
+      scanned and rewritten at most once per 24 hours unless forced.
+- [ ] Persist the 24-hour gate in a JSON sidecar file with `last_started_at`,
+      `last_succeeded_at`, and `last_failed_at` so the gate survives process
+      restarts.
+- [ ] Add `force_stablecoin_rate_refresh` to `PostScanConfig` and
+      `FORCE_STABLECOIN_RATE_REFRESH` to `scan-vault-posts.py`.
+- [ ] Add environment variable wiring in `scan-vault-posts.py`, including
+      `STABLECOIN_DATA_DIR` and `STABLECOIN_RATE_GATE_PATH`.
+- [ ] Add dashboard/log output.
+- [ ] Extend `eth_defi/feed/collector.py::CollectorRunSummary` with an
+      explicit stablecoin rate status, summary, and error fields for dashboard
+      output, avoiding an import cycle with a forward reference,
+      `TYPE_CHECKING`, or `Any`.
+- [ ] Update existing scanner tests to disable the side job or use temporary
+      stablecoin YAML data.
+- [ ] Use fresh `StablecoinRateFeeder(data_dir=tmp_path)` instances in tests
+      that use temporary data.
+- [ ] Add tests proving post scan continues when the refresh fails.
+- [ ] Add a scanner test proving `CollectorRunSummary.stablecoin_rate_summary`
+      is populated on a successful refresh.
+- [ ] Add scanner tests for disabled, skipped-recent, forced, failed, 8-hour
+      loop, and process-restart 24-hour gate behaviour, asserting
+      `stablecoin_rate_status`, `stablecoin_rate_summary`, and
+      `stablecoin_rate_error` semantics in each case.
+- [ ] Add a scanner/export integration test proving `STABLECOIN_DATA_DIR` and
+      metadata export/load paths use the same stablecoin YAML directory when an
+      override is configured.
+
+### Chunk 6: Initial population helper script
+
+- [ ] Add `scripts/erc-4626/populate-stablecoin-rates.py`.
+- [ ] Wire `STABLECOIN_DATA_DIR`, `FORCE`, `STABLECOIN_RATE_TIMEOUT`,
+      `COINGECKO_ID_MAPPING_FILE`, and `COINGECKO_DEMO_API_KEY` via
+      environment variables.
+- [ ] Support explicit operator-curated CoinGecko id mappings from
+      `COINGECKO_ID_MAPPING_FILE` and do not auto-select ambiguous CoinGecko
+      search results.
+- [ ] Use the same logging conventions as the existing ERC-4626 scripts.
+- [ ] Call `refresh_stablecoin_rates()` and render the
+      `StablecoinRateRefreshSummary` as one compact `tabulate` row.
+- [ ] Ensure normal per-entry CoinGecko failures do not make the helper exit
+      non-zero; unexpected implementation/configuration errors should still
+      fail hard.
+- [ ] Add a smoke/unit test for the helper entry point that monkeypatches
+      `refresh_stablecoin_rates()` and verifies env var parsing plus summary
+      rendering.
+- [ ] Add a helper test proving `COINGECKO_ID_MAPPING_FILE` mappings are
+      applied before refresh and ambiguous search results are not auto-selected.
+- [ ] Add helper tests proving `failed_count > 0` exits successfully, while an
+      unexpected exception exits non-zero.
+
+### Chunk 7: Documentation and verification
+
+- [ ] Update `eth_defi/feed/README-feed.md`.
+- [ ] Add `eth_defi.feed.stablecoin_rate` to
+      `docs/source/api/feed/index.rst`.
+- [ ] Run formatting with `poetry run ruff format`.
+- [ ] Run targeted tests.
+- [ ] Inspect `git diff` to confirm no unrelated stablecoin YAML churn.
+
+## Operational notes
+
+- This job mutates repository YAML files during post scanning. In production,
+  make sure the scanner runs in a checkout where this state is expected to be
+  persisted or committed by an operator.
+- CoinGecko free/keyless access is rate-limited. The once-per-day gate and
+  batched request design are important for keeping the process quiet.
+- A depeg flag is intentionally sticky. Human operators decide when a stablecoin
+  is safe again by clearing `depegged_at`.
+- The implementation should report missing CoinGecko ids separately from true
+  depegs; missing rate coverage is an operational data-quality issue, not a
+  blacklist reason.

--- a/docs/source/api/feed/index.rst
+++ b/docs/source/api/feed/index.rst
@@ -10,4 +10,5 @@ Off-chain feed collection helpers for vault-related content.
    eth_defi.feed.sources
    eth_defi.feed.database
    eth_defi.feed.collector
+   eth_defi.feed.stablecoin_rate
    eth_defi.feed.twitter_api

--- a/eth_defi/data/stablecoins/aa-falconxusdc.yaml
+++ b/eth_defi/data/stablecoins/aa-falconxusdc.yaml
@@ -58,6 +58,8 @@ links:
 contract_addresses:
   - chain: ethereum
     address: '0xC26A6Fa2C37b38E549a4a1807543801Db684f99C'
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/adai.yaml
+++ b/eth_defi/data/stablecoins/adai.yaml
@@ -33,6 +33,18 @@ slug: adai
 contract_addresses:
   - chain: ethereum
     address: '0x028171bCA77440897B824Ca71D1c56caC55b68A3'
+coingecko_id: aave-dai
+coingecko_link: https://www.coingecko.com/en/coins/aave-dai
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.998755
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:00:11'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/ageur.yaml
+++ b/eth_defi/data/stablecoins/ageur.yaml
@@ -33,6 +33,18 @@ slug: ageur
 contract_addresses:
   - chain: ethereum
     address: '0x1a7e4e63778B4f12a199C062f3eFdD288afCBce8'
+coingecko_id: ageur
+coingecko_link: https://www.coingecko.com/en/coins/ageur
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.14
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:11'
+peg_rate: 0.996731
+peg_rate_currency: eur
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/alusd.yaml
+++ b/eth_defi/data/stablecoins/alusd.yaml
@@ -37,6 +37,18 @@ contract_addresses:
     address: '0xCB8FA9a76b8e203D8C3797bF438d8FB81Ea3326A'
   - chain: optimism
     address: '0xCB8FA9a76b8e203D8C3797bF438d8FB81Ea3326A'
+coingecko_id: alchemix-usd
+coingecko_link: https://www.coingecko.com/en/coins/alchemix-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.959967
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:25'
+peg_rate: 0.959967
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/apyusd.yaml
+++ b/eth_defi/data/stablecoins/apyusd.yaml
@@ -25,6 +25,18 @@ contract_addresses:
     address: '0x38EEb52F0771140d10c4E9A9a72349A329Fe8a6A'
   - chain: base
     address: '0x2c271ddF484aC0386d216eB7eB9Ff02D4Dc0F6AA'
+coingecko_id: apyusd
+coingecko_link: https://www.coingecko.com/en/coins/apyusd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.962211
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:24'
+peg_rate: 0.962211
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/audt.yaml
+++ b/eth_defi/data/stablecoins/audt.yaml
@@ -34,6 +34,8 @@ slug: audt
 contract_addresses:
   - chain: ethereum
     address: '0xD7e0F80FB28233bdde0006c50568606A8feb964C'
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/ausd.yaml
+++ b/eth_defi/data/stablecoins/ausd.yaml
@@ -42,6 +42,18 @@ entries:
       address: '0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a'
     - chain: arbitrum
       address: '0x00000000eFE302BEAA2b3e6e1b18d08D69a9012a'
+  coingecko_id: agora-dollar
+  coingecko_link: https://www.coingecko.com/en/coins/agora-dollar
+  coingecko_id_source: url
+  coingecko_id_verified_at: '2026-06-26T12:16:16'
+  usd_rate: 0.999529
+  usd_rate_fetched_at: '2026-06-26T12:16:16'
+  usd_rate_updated_at: '2026-06-26T12:15:13'
+  peg_rate: 0.999529
+  peg_rate_currency: usd
+  rate_fetch_failed_at: ''
+  rate_fetch_failed_reason: ''
+  depegged_at: ''
   checks:
     twitter_last_post_at: ''
     domain_up_at: '2026-03-17'
@@ -79,6 +91,18 @@ entries:
     coingecko: https://www.coingecko.com/en/coins/acala-dollar
     defillama: https://defillama.com/stablecoin/acala-dollar
     twitter: https://x.com/AcalaNetwork
+  coingecko_id: acala-dollar
+  coingecko_link: https://www.coingecko.com/en/coins/acala-dollar
+  coingecko_id_source: url
+  coingecko_id_verified_at: '2026-06-26T12:16:16'
+  usd_rate: 0.51763
+  usd_rate_fetched_at: '2026-06-26T12:16:16'
+  usd_rate_updated_at: '2023-07-20T12:00:03'
+  peg_rate: 0.51763
+  peg_rate_currency: usd
+  rate_fetch_failed_at: ''
+  rate_fetch_failed_reason: ''
+  depegged_at: '2026-06-26T12:13:31'
   checks:
     twitter_last_post_at: ''
     domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/autousd.yaml
+++ b/eth_defi/data/stablecoins/autousd.yaml
@@ -30,6 +30,8 @@ links:
 contract_addresses:
   - chain: ethereum
     address: "0xa7569A44f348d3D70d8ad5889e50F78E33d80D35"
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ""
   domain_up_at: ""

--- a/eth_defi/data/stablecoins/avusd.yaml
+++ b/eth_defi/data/stablecoins/avusd.yaml
@@ -30,6 +30,18 @@ contract_addresses:
     address: '0x24dE8771bC5DdB3362Db529Fc3358F2df3A0E346'
   - chain: ethereum
     address: '0xf4c13D631450De6B12a19829E37c8e2826891dC4'
+coingecko_id: avant-usd
+coingecko_link: https://www.coingecko.com/en/coins/avant-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.998158
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:10'
+peg_rate: 0.998158
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-02-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/bac.yaml
+++ b/eth_defi/data/stablecoins/bac.yaml
@@ -33,6 +33,11 @@ slug: bac
 contract_addresses:
   - chain: ethereum
     address: '0x3449FC1Cd036255BA1EB19d65fF4BA2b8903A69a'
+coingecko_id: basis-cash
+coingecko_link: https://www.coingecko.com/en/coins/basis-cash
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/bbqusdc.yaml
+++ b/eth_defi/data/stablecoins/bbqusdc.yaml
@@ -33,6 +33,8 @@ links:
 contract_addresses:
   - chain: ethereum
     address: '0xBEeFFF209270748ddd194831b3fa287a5386f5bC'
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/bdo.yaml
+++ b/eth_defi/data/stablecoins/bdo.yaml
@@ -32,6 +32,18 @@ slug: bdo
 contract_addresses:
   - chain: bnb
     address: '0x190b589cf9Fb8DDEabBFeae36a813FFb2A702454'
+coingecko_id: bdollar
+coingecko_link: https://www.coingecko.com/en/coins/bdollar
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.00104384
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:27'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/bean.yaml
+++ b/eth_defi/data/stablecoins/bean.yaml
@@ -35,6 +35,18 @@ slug: bean
 contract_addresses:
   - chain: arbitrum
     address: '0xBEA0005B8599265D41256905A9B3073D397812E4'
+coingecko_id: bean
+coingecko_link: https://www.coingecko.com/en/coins/bean
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.252806
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-04-16T12:30:44'
+peg_rate: 0.252806
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: '2026-06-26T12:13:31'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/blusd.yaml
+++ b/eth_defi/data/stablecoins/blusd.yaml
@@ -34,6 +34,18 @@ slug: blusd
 contract_addresses:
   - chain: ethereum
     address: '0xB9D7DdDca9a4AC480991865EfEf82E01273F79C3'
+coingecko_id: boosted-lusd
+coingecko_link: https://www.coingecko.com/en/coins/boosted-lusd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.23
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2025-04-18T16:44:01'
+peg_rate: 1.23
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/bob.yaml
+++ b/eth_defi/data/stablecoins/bob.yaml
@@ -37,6 +37,18 @@ contract_addresses:
     address: '0xB0B195aEFA3650A6908f15CdaC7D92F8a5791B0B'
   - chain: polygon
     address: '0xB0B195aEFA3650A6908f15CdaC7D92F8a5791B0B'
+coingecko_id: bob
+coingecko_link: https://www.coingecko.com/en/coins/bob
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999415
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:19'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/bold.yaml
+++ b/eth_defi/data/stablecoins/bold.yaml
@@ -31,6 +31,18 @@ slug: bold
 contract_addresses:
   - chain: ethereum
     address: '0x6440f144b7e50D6a8439336510312d2F54beB01D'
+coingecko_id: liquity-bold
+coingecko_link: https://www.coingecko.com/en/coins/liquity-bold
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999886
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-25T08:14:59'
+peg_rate: 0.999886
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/busd.yaml
+++ b/eth_defi/data/stablecoins/busd.yaml
@@ -28,6 +28,18 @@ slug: busd
 contract_addresses:
   - chain: ethereum
     address: '0x4Fabb145d64652a948d72533023f6E7A623C7C53'
+coingecko_id: binance-usd
+coingecko_link: https://www.coingecko.com/en/coins/binance-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.997674
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:15'
+peg_rate: 0.997674
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/bvusd.yaml
+++ b/eth_defi/data/stablecoins/bvusd.yaml
@@ -35,6 +35,8 @@ links:
   defillama: ''
   twitter: https://x.com/BitVaultFinance
 slug: bvusd
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: '2026-02-17'
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/byusd.yaml
+++ b/eth_defi/data/stablecoins/byusd.yaml
@@ -40,6 +40,18 @@ slug: byusd
 contract_addresses:
   - chain: berachain
     address: '0x688e72142674041f8f6Af4c808a4045cA1D6aC82'
+coingecko_id: byusd
+coingecko_link: https://www.coingecko.com/en/coins/byusd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.996983
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:14:45'
+peg_rate: 0.996983
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/cadc.yaml
+++ b/eth_defi/data/stablecoins/cadc.yaml
@@ -33,6 +33,18 @@ contract_addresses:
     address: '0x2b28E826b55e399F4d4699b85f68666AC51e6f70'
   - chain: polygon
     address: '0x9de41aFF9f55219D5bf4359F167d1D0c772A396D'
+coingecko_id: cad-coin
+coingecko_link: https://www.coingecko.com/en/coins/cad-coin
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.702083
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:14:50'
+peg_rate: 0.995744
+peg_rate_currency: cad
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/cdai.yaml
+++ b/eth_defi/data/stablecoins/cdai.yaml
@@ -33,6 +33,18 @@ slug: cdai
 contract_addresses:
   - chain: ethereum
     address: '0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643'
+coingecko_id: cdai
+coingecko_link: https://www.coingecko.com/en/coins/cdai
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.02506299
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:21'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/ceur.yaml
+++ b/eth_defi/data/stablecoins/ceur.yaml
@@ -28,6 +28,18 @@ slug: ceur
 contract_addresses:
   - chain: celo
     address: '0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73'
+coingecko_id: celo-euro
+coingecko_link: https://www.coingecko.com/en/coins/celo-euro
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.14
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:19'
+peg_rate: 0.998119
+peg_rate_currency: eur
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/cjpy.yaml
+++ b/eth_defi/data/stablecoins/cjpy.yaml
@@ -28,6 +28,18 @@ slug: cjpy
 contract_addresses:
   - chain: ethereum
     address: '0x1cfa5641c01406aB8AC350dEd7d735ec41298372'
+coingecko_id: convertible-jpy-token
+coingecko_link: https://www.coingecko.com/en/coins/convertible-jpy-token
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.00396901
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:14:37'
+peg_rate: 0.641587
+peg_rate_currency: jpy
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: '2026-06-26T12:13:31'
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/cnht.yaml
+++ b/eth_defi/data/stablecoins/cnht.yaml
@@ -30,6 +30,8 @@ slug: cnht
 contract_addresses:
   - chain: ethereum
     address: '0x6E109E9dD7Fa1a58BC3eff667e8e41fC3cc07AEF'
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/crvusd.yaml
+++ b/eth_defi/data/stablecoins/crvusd.yaml
@@ -34,6 +34,18 @@ token_symbols:
 contract_addresses:
   - chain: ethereum
     address: '0xf939E0A03FB07F59A73314E73794Be0E57ac1b4E'
+coingecko_id: crvusd
+coingecko_link: https://www.coingecko.com/en/coins/crvusd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.998762
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:06'
+peg_rate: 0.998762
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/csusd.yaml
+++ b/eth_defi/data/stablecoins/csusd.yaml
@@ -36,6 +36,8 @@ contract_addresses:
   - chain: ethereum
     address: '0xD5D097F278a735d0a3c609DEEE71234CAc14B47e'
 slug: csusd
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/cusd.yaml
+++ b/eth_defi/data/stablecoins/cusd.yaml
@@ -29,6 +29,18 @@ slug: cusd
 contract_addresses:
   - chain: celo
     address: '0x765DE816845861e75A25fCA122bb6898B8B1282a'
+coingecko_id: celo-dollar
+coingecko_link: https://www.coingecko.com/en/coins/celo-dollar
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999848
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:25'
+peg_rate: 0.999848
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/cusdc.yaml
+++ b/eth_defi/data/stablecoins/cusdc.yaml
@@ -33,6 +33,18 @@ slug: cusdc
 contract_addresses:
   - chain: ethereum
     address: '0x39AA39c021dfbaE8faC545936693aC917d5E7563'
+coingecko_id: compound-usd-coin
+coingecko_link: https://www.coingecko.com/en/coins/compound-usd-coin
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.02531505
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:21'
+peg_rate: 0.02531505
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/cusdt.yaml
+++ b/eth_defi/data/stablecoins/cusdt.yaml
@@ -20,6 +20,11 @@ contract_addresses:
   - chain: ethereum
     address: '0xf650C3d88D12dB855b8bf7D11Be6C55A4e07dCC9'
 slug: cusdt
+coingecko_id: compound-usdt
+coingecko_link: https://www.coingecko.com/en/coins/compound-usdt
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/dai.yaml
+++ b/eth_defi/data/stablecoins/dai.yaml
@@ -22,6 +22,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x6B175474E89094C44Da98b954EedeAC495271d0F'
 slug: dai
+coingecko_id: dai
+coingecko_link: https://www.coingecko.com/en/coins/dai
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999703
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:15'
+peg_rate: 0.999703
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/deusd.yaml
+++ b/eth_defi/data/stablecoins/deusd.yaml
@@ -18,6 +18,11 @@ contract_addresses:
   - chain: ethereum
     address: '0x15700B564Ca08D9439C58cA5053166E8317aa138'
 slug: deusd
+coingecko_id: elixir-deusd
+coingecko_link: https://www.coingecko.com/en/coins/elixir-deusd
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/djed.yaml
+++ b/eth_defi/data/stablecoins/djed.yaml
@@ -18,6 +18,18 @@ links:
   defillama: https://defillama.com/stablecoin/djed-stablecoin
   twitter: https://x.com/DjedStablecoin
 slug: djed
+coingecko_id: djed
+coingecko_link: https://www.coingecko.com/en/coins/djed
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.977593
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:12'
+peg_rate: 0.977593
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2025-08-08'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/dola.yaml
+++ b/eth_defi/data/stablecoins/dola.yaml
@@ -22,6 +22,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x865377367054516e17014CcdED1e7d814EDC9ce4'
 slug: dola
+coingecko_id: dola-usd
+coingecko_link: https://www.coingecko.com/en/coins/dola-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.995206
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:25'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/doladusd.yaml
+++ b/eth_defi/data/stablecoins/doladusd.yaml
@@ -14,6 +14,18 @@ links:
   defillama: https://defillama.com/stablecoin/dola
   twitter: https://x.com/InverseFinance
 slug: doladusd
+coingecko_id: dola-usd
+coingecko_link: https://www.coingecko.com/en/coins/dola-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.995206
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:25'
+peg_rate: 0.995206
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/dusd.yaml
+++ b/eth_defi/data/stablecoins/dusd.yaml
@@ -13,6 +13,18 @@ entries:
     coingecko: https://www.coingecko.com/en/coins/standx-dusd
     defillama: https://defillama.com/stablecoin/standx-dusd
     twitter: 'https://x.com/StandX_Official'
+  coingecko_id: standx-dusd
+  coingecko_link: https://www.coingecko.com/en/coins/standx-dusd
+  coingecko_id_source: url
+  coingecko_id_verified_at: '2026-06-26T12:16:16'
+  usd_rate: 0.997268
+  usd_rate_fetched_at: '2026-06-26T12:16:16'
+  usd_rate_updated_at: '2026-06-26T12:15:11'
+  peg_rate: 0.997268
+  peg_rate_currency: usd
+  rate_fetch_failed_at: ''
+  rate_fetch_failed_reason: ''
+  depegged_at: ''
   checks:
     twitter_last_post_at: '2025-12-02'
     domain_up_at: '2026-03-17'
@@ -40,6 +52,18 @@ entries:
     coingecko: https://www.coingecko.com/en/coins/defidollar
     defillama: ''
     twitter: https://x.com/defidollar
+  coingecko_id: defidollar
+  coingecko_link: https://www.coingecko.com/en/coins/defidollar
+  coingecko_id_source: url
+  coingecko_id_verified_at: '2026-06-26T12:16:16'
+  usd_rate: 0.124085
+  usd_rate_fetched_at: '2026-06-26T12:16:16'
+  usd_rate_updated_at: '2026-06-26T12:15:05'
+  peg_rate: 0.124085
+  peg_rate_currency: usd
+  rate_fetch_failed_at: ''
+  rate_fetch_failed_reason: ''
+  depegged_at: '2026-06-26T12:13:31'
   checks:
     twitter_last_post_at: ''
     domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/eearn.yaml
+++ b/eth_defi/data/stablecoins/eearn.yaml
@@ -45,6 +45,8 @@ links:
 contract_addresses:
   - chain: ethereum
     address: '0x9be9294722f8AAd37b11a9792Be2C782182caFA2'
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/eosdt.yaml
+++ b/eth_defi/data/stablecoins/eosdt.yaml
@@ -15,6 +15,11 @@ links:
   defillama: ''
   twitter: https://x.com/EquilibriumDeFi
 slug: eosdt
+coingecko_id: eosdt
+coingecko_link: https://www.coingecko.com/en/coins/eosdt
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/eura.yaml
+++ b/eth_defi/data/stablecoins/eura.yaml
@@ -20,6 +20,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x1a7e4e63778B4f12a199C062f3eFdD288afCBce8'
 slug: eura
+coingecko_id: ageur
+coingecko_link: https://www.coingecko.com/en/coins/ageur
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.14
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:11'
+peg_rate: 0.996731
+peg_rate_currency: eur
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/eurcv.yaml
+++ b/eth_defi/data/stablecoins/eurcv.yaml
@@ -20,6 +20,11 @@ contract_addresses:
   - chain: ethereum
     address: '0x5F7827FDeb7c20b443265Fc2F40845B715385Ff2'
 slug: eurcv
+coingecko_id: coinvertible
+coingecko_link: https://www.coingecko.com/en/coins/coinvertible
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/eure.yaml
+++ b/eth_defi/data/stablecoins/eure.yaml
@@ -20,6 +20,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x39b8B6385416f4cA36a20319F70D28621895279D'
 slug: eure
+coingecko_id: monerium-eur-money
+coingecko_link: https://www.coingecko.com/en/coins/monerium-eur-money
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.14
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:27'
+peg_rate: 0.999365
+peg_rate_currency: eur
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/euroc.yaml
+++ b/eth_defi/data/stablecoins/euroc.yaml
@@ -20,6 +20,11 @@ contract_addresses:
   - chain: ethereum
     address: '0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c'
 slug: euroc
+coingecko_id: eurc
+coingecko_link: https://www.coingecko.com/en/coins/eurc
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/euroe.yaml
+++ b/eth_defi/data/stablecoins/euroe.yaml
@@ -28,6 +28,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x820802Fa8a99901F52e39acD21177b0BE6EE2974'
 slug: euroe
+coingecko_id: euroe-stablecoin
+coingecko_link: https://www.coingecko.com/en/coins/euroe-stablecoin
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.16
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2025-10-27T21:12:55'
+peg_rate: 0.999289
+peg_rate_currency: eur
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/eurs.yaml
+++ b/eth_defi/data/stablecoins/eurs.yaml
@@ -20,6 +20,18 @@ contract_addresses:
   - chain: ethereum
     address: '0xdB25f211AB05b1c97D595516F45794528a807ad8'
 slug: eurs
+coingecko_id: stasis-eurs
+coingecko_link: https://www.coingecko.com/en/coins/stasis-eurs
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.21
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:10'
+peg_rate: 1.063
+peg_rate_currency: eur
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/eurt.yaml
+++ b/eth_defi/data/stablecoins/eurt.yaml
@@ -20,6 +20,18 @@ contract_addresses:
   - chain: ethereum
     address: '0xC581b735A1688071A1746c968e0798D642EDE491'
 slug: eurt
+coingecko_id: tether-eurt
+coingecko_link: https://www.coingecko.com/en/coins/tether-eurt
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.054311
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:07'
+peg_rate: 0.04763623
+peg_rate_currency: eur
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: '2026-06-26T12:13:31'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/eusd-reserve.yaml
+++ b/eth_defi/data/stablecoins/eusd-reserve.yaml
@@ -21,6 +21,18 @@ contract_addresses:
   - chain: ethereum
     address: '0xA0d69E286B938e21CBf7E51D71F6A4c8918f482F'
 slug: eusd-reserve
+coingecko_id: electronic-usd
+coingecko_link: https://www.coingecko.com/en/coins/electronic-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999112
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:10'
+peg_rate: 0.999112
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/eusd.yaml
+++ b/eth_defi/data/stablecoins/eusd.yaml
@@ -24,6 +24,11 @@ contract_addresses:
   - chain: ethereum
     address: '0x97de57eC338AB5d51557DA3434828C5DbFaDA371'
 slug: eusd
+coingecko_id: lybra-finance-eusd
+coingecko_link: https://www.coingecko.com/en/coins/lybra-finance-eusd
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/fdusd.yaml
+++ b/eth_defi/data/stablecoins/fdusd.yaml
@@ -20,6 +20,18 @@ contract_addresses:
   - chain: binance
     address: '0xc5f0f7b66764F6ec8C8Dff7BA683102295E16409'
 slug: fdusd
+coingecko_id: first-digital-usd
+coingecko_link: https://www.coingecko.com/en/coins/first-digital-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.996691
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:16'
+peg_rate: 7.82
+peg_rate_currency: hkd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/fei.yaml
+++ b/eth_defi/data/stablecoins/fei.yaml
@@ -20,6 +20,18 @@ links:
   defillama: https://defillama.com/stablecoin/fei-usd
   twitter: https://x.com/feiprotocol
 slug: fei
+coingecko_id: fei-usd
+coingecko_link: https://www.coingecko.com/en/coins/fei-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.993942
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:08'
+peg_rate: 0.993942
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/feusd.yaml
+++ b/eth_defi/data/stablecoins/feusd.yaml
@@ -16,6 +16,18 @@ links:
   defillama: ''
   twitter: https://x.com/felixprotocol
 slug: feusd
+coingecko_id: felix-feusd
+coingecko_link: https://www.coingecko.com/en/coins/felix-feusd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.998944
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:11'
+peg_rate: 0.998944
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/fidd.yaml
+++ b/eth_defi/data/stablecoins/fidd.yaml
@@ -22,6 +22,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x7C135549504245B5eAe64fc0E99Fa5ebabb8e35D'
 slug: fidd
+coingecko_id: fidelity-digital-dollar
+coingecko_link: https://www.coingecko.com/en/coins/fidelity-digital-dollar
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999861
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:24'
+peg_rate: 0.999861
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/flexusd.yaml
+++ b/eth_defi/data/stablecoins/flexusd.yaml
@@ -16,6 +16,18 @@ links:
   defillama: ''
   twitter: https://x.com/CoinFLEX_COM
 slug: flexusd
+coingecko_id: flex-usd
+coingecko_link: https://www.coingecko.com/en/coins/flex-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.04068416
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-08T18:41:57'
+peg_rate: 0.04068416
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: '2026-06-26T12:13:31'
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/frax.yaml
+++ b/eth_defi/data/stablecoins/frax.yaml
@@ -24,6 +24,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x853d955aCEf822Db058eb8505911ED77F175b99e'
 slug: frax
+coingecko_id: frax
+coingecko_link: https://www.coingecko.com/en/coins/frax
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.982337
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:25'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/frxusd.yaml
+++ b/eth_defi/data/stablecoins/frxusd.yaml
@@ -20,6 +20,18 @@ contract_addresses:
   - chain: ethereum
     address: '0xCAcd6fd266aF91b8AeD52aCCc382b4e165586E29'
 slug: frxusd
+coingecko_id: frax-usd
+coingecko_link: https://www.coingecko.com/en/coins/frax-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999328
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:26'
+peg_rate: 0.999328
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/ftusd.yaml
+++ b/eth_defi/data/stablecoins/ftusd.yaml
@@ -16,6 +16,8 @@ links:
   defillama: ''
   twitter: https://x.com/flyingtulip_
 slug: ftusd
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: '2026-02-01'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/fusd.yaml
+++ b/eth_defi/data/stablecoins/fusd.yaml
@@ -19,6 +19,18 @@ contract_addresses:
   - chain: fantom
     address: '0xAd84341756Bf337f5a0164515b1f6F993D194E1f'
 slug: fusd
+coingecko_id: fantom-usd
+coingecko_link: https://www.coingecko.com/en/coins/fantom-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.050878
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2025-09-30T17:59:16'
+peg_rate: 0.050878
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: '2026-06-26T12:13:31'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/fxd.yaml
+++ b/eth_defi/data/stablecoins/fxd.yaml
@@ -18,6 +18,18 @@ contract_addresses:
   - chain: xdc
     address: 'xdc49d3f7543335cf38Fa10889CCFF10207e22110B5'
 slug: fxd
+coingecko_id: fathom-dollar
+coingecko_link: https://www.coingecko.com/en/coins/fathom-dollar
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.917367
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:14:35'
+peg_rate: 0.917367
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/fxusd.yaml
+++ b/eth_defi/data/stablecoins/fxusd.yaml
@@ -40,6 +40,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x085780639CC2cACd35E474e71f4d000e2405d8f6'
 slug: fxusd
+coingecko_id: f-x-protocol-fxusd
+coingecko_link: https://www.coingecko.com/en/coins/f-x-protocol-fxusd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.995719
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:07'
+peg_rate: 0.995719
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-01-02'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/gbpt.yaml
+++ b/eth_defi/data/stablecoins/gbpt.yaml
@@ -18,6 +18,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x86B4dBE5D203e634a12364C0e428fa242A3FbA98'
 slug: gbpt
+coingecko_id: poundtoken
+coingecko_link: https://www.coingecko.com/en/coins/poundtoken
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.32
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2024-06-12T16:08:51'
+peg_rate: 1.026
+peg_rate_currency: gbp
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/gdai.yaml
+++ b/eth_defi/data/stablecoins/gdai.yaml
@@ -44,6 +44,11 @@ contract_addresses:
   - chain: arbitrum
     address: '0xd85E038593d7A098614721EaE955EC2022B9B91B'
 slug: gdai
+coingecko_id: gains-network-dai
+coingecko_link: https://www.coingecko.com/en/coins/gains-network-dai
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/gho.yaml
+++ b/eth_defi/data/stablecoins/gho.yaml
@@ -23,6 +23,18 @@ contract_addresses:
   - chain: base
     address: '0x6Bb7a212910682DCFdbd5BCBb3e28FB4E8da10Ee'
 slug: gho
+coingecko_id: gho
+coingecko_link: https://www.coingecko.com/en/coins/gho
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.998206
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:26'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/ghst.yaml
+++ b/eth_defi/data/stablecoins/ghst.yaml
@@ -39,6 +39,18 @@ links:
   defillama: ''
   twitter: https://x.com/aavegotchi
 slug: ghst
+coingecko_id: aavegotchi
+coingecko_link: https://www.coingecko.com/en/coins/aavegotchi
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.058124
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:20'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/gmdusdc.yaml
+++ b/eth_defi/data/stablecoins/gmdusdc.yaml
@@ -44,6 +44,8 @@ contract_addresses:
   - chain: arbitrum
     address: '0x3DB4B7DA67dd5aF61Cb9b3C70501B1BdB24b2C22'
 slug: gmdusdc
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: '2024-01-24'
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/gmusd.yaml
+++ b/eth_defi/data/stablecoins/gmusd.yaml
@@ -25,6 +25,8 @@ contract_addresses:
   - chain: arbitrum
     address: '0xEC13336bbd50790a00CDc0fEddF11287eaF92529'
 slug: gmusd
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/grai.yaml
+++ b/eth_defi/data/stablecoins/grai.yaml
@@ -21,6 +21,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x15f74458aE0bFdAA1a96CA1aa779D715Cc1Eefe4'
 slug: grai
+coingecko_id: grai
+coingecko_link: https://www.coingecko.com/en/coins/grai
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.704285
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:12'
+peg_rate: 0.704285
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: '2026-06-26T12:13:31'
 checks:
   twitter_last_post_at: '2024-10-29'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/gusd.yaml
+++ b/eth_defi/data/stablecoins/gusd.yaml
@@ -33,6 +33,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd'
 slug: gusd
+coingecko_id: gemini-dollar
+coingecko_link: https://www.coingecko.com/en/coins/gemini-dollar
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999162
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:13'
+peg_rate: 0.999162
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/gyd.yaml
+++ b/eth_defi/data/stablecoins/gyd.yaml
@@ -51,6 +51,18 @@ contract_addresses:
   - chain: arbitrum
     address: '0xCA5d8F8a8d49439357d3CF46Ca2e720702F132b8'
 slug: gyd
+coingecko_id: gyroscope-gyd
+coingecko_link: https://www.coingecko.com/en/coins/gyroscope-gyd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.992463
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-02-01T07:23:58'
+peg_rate: 0.992463
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/gyen.yaml
+++ b/eth_defi/data/stablecoins/gyen.yaml
@@ -38,6 +38,18 @@ contract_addresses:
   - chain: ethereum
     address: '0xC08512927D12348F6620a698105e1BAac6EcD911'
 slug: gyen
+coingecko_id: gyen
+coingecko_link: https://www.coingecko.com/en/coins/gyen
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.00219065
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:14:39'
+peg_rate: 0.354117
+peg_rate_currency: jpy
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: '2026-06-26T12:13:31'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/hai.yaml
+++ b/eth_defi/data/stablecoins/hai.yaml
@@ -41,6 +41,11 @@ contract_addresses:
   - chain: optimism
     address: '0x10398AbC267496E49106B07dd6BE13364D10dC71'
 slug: hai
+coingecko_id: hai
+coingecko_link: https://www.coingecko.com/en/coins/hai
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/husd.yaml
+++ b/eth_defi/data/stablecoins/husd.yaml
@@ -17,6 +17,18 @@ contract_addresses:
   - chain: ethereum
     address: '0xdF574c24545E5FfEcb9a659c229253D4111d87e1'
 slug: husd
+coingecko_id: husd
+coingecko_link: https://www.coingecko.com/en/coins/husd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.03780304
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T01:44:18'
+peg_rate: 0.03780304
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: '2026-06-26T12:13:31'
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/iron.yaml
+++ b/eth_defi/data/stablecoins/iron.yaml
@@ -39,6 +39,18 @@ links:
   defillama: ''
   twitter: https://x.com/ironfinance
 slug: iron
+coingecko_id: iron-finance
+coingecko_link: https://www.coingecko.com/en/coins/iron-finance
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 2.12e-06
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:14:59'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/iusd-indigo.yaml
+++ b/eth_defi/data/stablecoins/iusd-indigo.yaml
@@ -44,6 +44,11 @@ links:
   defillama: ''
   twitter: https://x.com/Indigo_protocol
 slug: iusd-indigo
+coingecko_id: indigo-protocol-iusd
+coingecko_link: https://www.coingecko.com/en/coins/indigo-protocol-iusd
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/iusd.yaml
+++ b/eth_defi/data/stablecoins/iusd.yaml
@@ -26,6 +26,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x48f9e38f3070AD8945DFEae3FA70987722E3D89c'
 slug: iusd
+coingecko_id: infinifi-usd
+coingecko_link: https://www.coingecko.com/en/coins/infinifi-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999462
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:12'
+peg_rate: 0.999462
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/jchf.yaml
+++ b/eth_defi/data/stablecoins/jchf.yaml
@@ -33,6 +33,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x53dfEa0A8CC2A2A2e425E1C174Bc162999723ea0'
 slug: jchf
+coingecko_id: jarvis-synthetic-swiss-franc
+coingecko_link: https://www.coingecko.com/en/coins/jarvis-synthetic-swiss-franc
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.307638
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:04'
+peg_rate: 0.248732
+peg_rate_currency: chf
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: '2026-06-26T12:13:31'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/jeur.yaml
+++ b/eth_defi/data/stablecoins/jeur.yaml
@@ -43,6 +43,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x0f17BC9a994b87b5225cFb6a2Cd4D667ADb4F20B'
 slug: jeur
+coingecko_id: jarvis-synthetic-euro
+coingecko_link: https://www.coingecko.com/en/coins/jarvis-synthetic-euro
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.533557
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:12'
+peg_rate: 0.467979
+peg_rate_currency: eur
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: '2026-06-26T12:13:31'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/jpyc.yaml
+++ b/eth_defi/data/stablecoins/jpyc.yaml
@@ -38,6 +38,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x431D5dfF03120AFA4bDf332c61A6e1766eF37BDB'
 slug: jpyc
+coingecko_id: jpyc
+coingecko_link: https://www.coingecko.com/en/coins/jpyc
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.00767749
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:26'
+peg_rate: 1.24
+peg_rate_currency: jpy
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/kdai.yaml
+++ b/eth_defi/data/stablecoins/kdai.yaml
@@ -37,6 +37,8 @@ links:
   defillama: ''
   twitter: https://x.com/kaiachain
 slug: kdai
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/kusd.yaml
+++ b/eth_defi/data/stablecoins/kusd.yaml
@@ -38,6 +38,18 @@ links:
   defillama: ''
   twitter: https://x.com/KolibriDAO
 slug: kusd
+coingecko_id: kolibri-usd
+coingecko_link: https://www.coingecko.com/en/coins/kolibri-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.014
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:14:50'
+peg_rate: 1.014
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/lisusd.yaml
+++ b/eth_defi/data/stablecoins/lisusd.yaml
@@ -18,6 +18,11 @@ contract_addresses:
   - chain: binance
     address: '0x0782b6d8c4551B9760e74c0545a9bCD90bdc41E5'
 slug: lisusd
+coingecko_id: lista-usd
+coingecko_link: https://www.coingecko.com/en/coins/lista-usd
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/lusd.yaml
+++ b/eth_defi/data/stablecoins/lusd.yaml
@@ -34,6 +34,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x5f98805A4E8be255a32880FDeC7F6728C6568bA0'
 slug: lusd
+coingecko_id: liquity-usd
+coingecko_link: https://www.coingecko.com/en/coins/liquity-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.006
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:26'
+peg_rate: 1.006
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-02-19'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/lvlusd.yaml
+++ b/eth_defi/data/stablecoins/lvlusd.yaml
@@ -33,6 +33,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x7C1156E515aA1A2E851674120074968C905aAF37'
 slug: lvlusd
+coingecko_id: level-usd
+coingecko_link: https://www.coingecko.com/en/coins/level-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999713
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T11:22:02'
+peg_rate: 0.999713
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/meusdt.yaml
+++ b/eth_defi/data/stablecoins/meusdt.yaml
@@ -22,6 +22,8 @@ links:
   defillama: ''
   twitter: ''
 slug: meusdt
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/mim.yaml
+++ b/eth_defi/data/stablecoins/mim.yaml
@@ -38,6 +38,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x99D8a9C45b2ecA8864373A26D1459e3Dff1e17F3'
 slug: mim
+coingecko_id: magic-internet-money
+coingecko_link: https://www.coingecko.com/en/coins/magic-internet-money
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.444172
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:26'
+peg_rate: 0.444172
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: '2026-06-26T12:13:31'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/mimatic.yaml
+++ b/eth_defi/data/stablecoins/mimatic.yaml
@@ -37,6 +37,18 @@ contract_addresses:
   - chain: polygon
     address: '0xa3Fa99A148fA48D14Ed51d610c367C61876997F1'
 slug: mimatic
+coingecko_id: mai
+coingecko_link: https://www.coingecko.com/en/coins/mai
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 3.19e-06
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-04-02T12:32:28'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-02-24'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/mkusd.yaml
+++ b/eth_defi/data/stablecoins/mkusd.yaml
@@ -32,6 +32,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x4591DBfF62656E7859Afe5e45f6f47D3669fBB28'
 slug: mkusd
+coingecko_id: prisma-mkusd
+coingecko_link: https://www.coingecko.com/en/coins/prisma-mkusd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.985483
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:25'
+peg_rate: 0.985483
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2024-04-06'
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/msusd.yaml
+++ b/eth_defi/data/stablecoins/msusd.yaml
@@ -30,6 +30,8 @@ contract_addresses:
   - chain: ethereum
     address: '0x4ba01f22827018b4772CD326C7627FB4956A7C00'
 slug: msusd
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/mtusd.yaml
+++ b/eth_defi/data/stablecoins/mtusd.yaml
@@ -12,6 +12,8 @@ links:
   defillama: ''
   twitter: ''
 slug: mtusd
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/mtusdc.yaml
+++ b/eth_defi/data/stablecoins/mtusdc.yaml
@@ -29,6 +29,8 @@ links:
   defillama: ''
   twitter: https://x.com/MutuumFinance
 slug: mtusdc
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: '2026-02-10'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/mtusdt.yaml
+++ b/eth_defi/data/stablecoins/mtusdt.yaml
@@ -40,6 +40,8 @@ links:
   defillama: ''
   twitter: https://x.com/MutuumFinance
 slug: mtusdt
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: '2026-02-10'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/musd.yaml
+++ b/eth_defi/data/stablecoins/musd.yaml
@@ -39,6 +39,18 @@ slug: musd
 token_symbols:
 - MUSD
 - mUSD
+coingecko_id: musd
+coingecko_link: https://www.coingecko.com/en/coins/musd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.992263
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:22'
+peg_rate: 0.992263
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2024-10-24'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/nusd.yaml
+++ b/eth_defi/data/stablecoins/nusd.yaml
@@ -44,6 +44,8 @@ contract_addresses:
   - chain: ethereum
     address: '0xE556ABa6fe6036275Ec1f87eda296BE72C811BCE'
 slug: nusd
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: '2026-02-08'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/onc.yaml
+++ b/eth_defi/data/stablecoins/onc.yaml
@@ -33,6 +33,11 @@ contract_addresses:
   - chain: ethereum
     address: '0xD90E69f67203EBE02c917B5128629E77B4cd92dc'
 slug: onc
+coingecko_id: one-cash
+coingecko_link: https://www.coingecko.com/en/coins/one-cash
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/ousd.yaml
+++ b/eth_defi/data/stablecoins/ousd.yaml
@@ -39,6 +39,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x2A8e1E676Ec238d8A992307B495b45B3fEAa5e86'
 slug: ousd
+coingecko_id: origin-dollar
+coingecko_link: https://www.coingecko.com/en/coins/origin-dollar
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999245
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:25'
+peg_rate: 0.999245
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/par.yaml
+++ b/eth_defi/data/stablecoins/par.yaml
@@ -33,6 +33,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x68037790A0229e9Ce6EaA8A99ea92964106C4703'
 slug: par
+coingecko_id: par-stablecoin
+coingecko_link: https://www.coingecko.com/en/coins/par-stablecoin
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.18
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:12'
+peg_rate: 1.037
+peg_rate_currency: eur
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/paxg.yaml
+++ b/eth_defi/data/stablecoins/paxg.yaml
@@ -36,6 +36,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x45804880De22913dAFE09f4980848ECE6EcbAf78'
 slug: paxg
+coingecko_id: pax-gold
+coingecko_link: https://www.coingecko.com/en/coins/pax-gold
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 4038.6
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:25'
+peg_rate: 0.997695
+peg_rate_currency: xau
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/plusd-polyquity.yaml
+++ b/eth_defi/data/stablecoins/plusd-polyquity.yaml
@@ -26,6 +26,8 @@ links:
   defillama: https://defillama.com/protocol/polyquity
   twitter: https://x.com/polyquity_org
 slug: plusd-polyquity
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/plusd.yaml
+++ b/eth_defi/data/stablecoins/plusd.yaml
@@ -30,6 +30,18 @@ links:
   defillama: https://defillama.com/protocol/trevee-earn
   twitter: https://x.com/Trevee_xyz
 slug: plusd
+coingecko_id: trevee-plasma-usd
+coingecko_link: https://www.coingecko.com/en/coins/trevee-plasma-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.996522
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-01-11T12:56:52'
+peg_rate: 0.996522
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/pyusd.yaml
+++ b/eth_defi/data/stablecoins/pyusd.yaml
@@ -33,6 +33,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x6c3ea9036406852006290770BEdFcAbA0e23A0e8'
 slug: pyusd
+coingecko_id: paypal-usd
+coingecko_link: https://www.coingecko.com/en/coins/paypal-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999959
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:21'
+peg_rate: 0.999959
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/rai.yaml
+++ b/eth_defi/data/stablecoins/rai.yaml
@@ -38,6 +38,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x03ab458634910AaD20eF5f1C8ee96F1D6ac54919'
 slug: rai
+coingecko_id: rai
+coingecko_link: https://www.coingecko.com/en/coins/rai
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.76
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:13'
+peg_rate: 1.76
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2025-06-13'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/reusd.yaml
+++ b/eth_defi/data/stablecoins/reusd.yaml
@@ -33,6 +33,11 @@ contract_addresses:
   - chain: ethereum
     address: '0x57aB1E0003F623289CD798B1824Be09a793e4Bec'
 slug: reusd
+coingecko_id: resupply-reusd
+coingecko_link: https://www.coingecko.com/en/coins/resupply-reusd
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/rlusd.yaml
+++ b/eth_defi/data/stablecoins/rlusd.yaml
@@ -35,6 +35,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x8292Bb45bf1Ee4d140127049757C2E0fF06317eD'
 slug: rlusd
+coingecko_id: ripple-usd
+coingecko_link: https://www.coingecko.com/en/coins/ripple-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999799
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:13'
+peg_rate: 0.999799
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/rusd-ipor.yaml
+++ b/eth_defi/data/stablecoins/rusd-ipor.yaml
@@ -17,6 +17,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x09D4214C03D01F49544C0448DBE3A27f768F2b34'
 slug: rusd-ipor
+coingecko_id: reservoir-rusd
+coingecko_link: https://www.coingecko.com/en/coins/reservoir-rusd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.003
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:16'
+peg_rate: 1.003
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/rusd.yaml
+++ b/eth_defi/data/stablecoins/rusd.yaml
@@ -16,6 +16,8 @@ entries:
     coingecko: ''
     defillama: ''
     twitter: https://x.com/reservoir_xyz
+  rate_fetch_failed_at: '2026-06-26T12:16:16'
+  rate_fetch_failed_reason: missing_coingecko_id
   checks:
     twitter_last_post_at: ''
     domain_up_at: '2026-03-17'
@@ -36,6 +38,8 @@ entries:
     coingecko: ''
     defillama: ''
     twitter: https://x.com/protocol_fx
+  rate_fetch_failed_at: '2026-06-26T12:16:16'
+  rate_fetch_failed_reason: missing_coingecko_id
   checks:
     twitter_last_post_at: ''
     domain_up_at: '2026-03-17'
@@ -54,6 +58,8 @@ entries:
     coingecko: ''
     defillama: ''
     twitter: https://x.com/realio_network
+  rate_fetch_failed_at: '2026-06-26T12:16:16'
+  rate_fetch_failed_reason: missing_coingecko_id
   checks:
     twitter_last_post_at: ''
     domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/sai.yaml
+++ b/eth_defi/data/stablecoins/sai.yaml
@@ -17,6 +17,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359'
 slug: sai
+coingecko_id: sai
+coingecko_link: https://www.coingecko.com/en/coins/sai
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 8.13
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:26'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/satusd.yaml
+++ b/eth_defi/data/stablecoins/satusd.yaml
@@ -40,6 +40,18 @@ entries:
     coingecko: https://www.coingecko.com/en/coins/satoshi-stablecoin
     defillama: ''
     twitter: https://x.com/Satoshi_BTCFi
+  coingecko_id: satoshi-stablecoin
+  coingecko_link: https://www.coingecko.com/en/coins/satoshi-stablecoin
+  coingecko_id_source: url
+  coingecko_id_verified_at: '2026-06-26T12:16:16'
+  usd_rate: 0.99317
+  usd_rate_fetched_at: '2026-06-26T12:16:16'
+  usd_rate_updated_at: '2026-06-26T12:15:14'
+  peg_rate: 0.99317
+  peg_rate_currency: usd
+  rate_fetch_failed_at: ''
+  rate_fetch_failed_reason: ''
+  depegged_at: ''
   checks:
     twitter_last_post_at: ''
     domain_up_at: '2026-03-17'
@@ -81,6 +93,8 @@ entries:
     coingecko: ''
     defillama: ''
     twitter: https://x.com/RiverdotInc
+  rate_fetch_failed_at: '2026-06-26T12:16:16'
+  rate_fetch_failed_reason: missing_coingecko_id
   checks:
     twitter_last_post_at: ''
     domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/sausd.yaml
+++ b/eth_defi/data/stablecoins/sausd.yaml
@@ -17,6 +17,8 @@ contract_addresses:
   - chain: monad
     address: '0xD793c04B87386A6bb84ee61D98e0065FdE7fdA5E'
 slug: sausd
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/savusd.yaml
+++ b/eth_defi/data/stablecoins/savusd.yaml
@@ -43,6 +43,18 @@ contract_addresses:
     address: '0xA322e23a357cB7C596A7a834102B9d6d5b15da3e'
   - chain: linea
     address: '0x5C247948fD58Bb02B6c4678d9940F5e6B9af1127'
+coingecko_id: avant-staked-usd
+coingecko_link: https://www.coingecko.com/en/coins/avant-staked-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.16
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:10'
+peg_rate: 1.16
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/sbold.yaml
+++ b/eth_defi/data/stablecoins/sbold.yaml
@@ -17,6 +17,11 @@ contract_addresses:
   - chain: ethereum
     address: '0x50Bd66D59911F5e086Ec87aE43C811e0D059DD11'
 slug: sbold
+coingecko_id: sbold-by-k3-capital
+coingecko_link: https://www.coingecko.com/en/coins/sbold-by-k3-capital
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/scusd.yaml
+++ b/eth_defi/data/stablecoins/scusd.yaml
@@ -21,6 +21,18 @@ contract_addresses:
   - chain: sonic
     address: '0xd3DCe716f3eF535C5Ff8d041c1A41C3bd89b97aE'
 slug: scusd
+coingecko_id: rings-scusd
+coingecko_link: https://www.coingecko.com/en/coins/rings-scusd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999351
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:14'
+peg_rate: 0.999351
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/sdai.yaml
+++ b/eth_defi/data/stablecoins/sdai.yaml
@@ -17,6 +17,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x83F20F44975D03b1b09e64809B757c47f942BEeA'
 slug: sdai
+coingecko_id: savings-dai
+coingecko_link: https://www.coingecko.com/en/coins/savings-dai
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.18
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:06'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/seur.yaml
+++ b/eth_defi/data/stablecoins/seur.yaml
@@ -17,6 +17,18 @@ contract_addresses:
   - chain: ethereum
     address: '0xD71eCFF9342A5Ced620049e616c5035F1dB98620'
 slug: seur
+coingecko_id: seur
+coingecko_link: https://www.coingecko.com/en/coins/seur
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.01831119
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:14:38'
+peg_rate: 0.01606062
+peg_rate_currency: eur
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: '2026-06-26T12:13:31'
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/sfrax.yaml
+++ b/eth_defi/data/stablecoins/sfrax.yaml
@@ -17,6 +17,18 @@ contract_addresses:
   - chain: ethereum
     address: '0xA663B02CF0a4b149d2aD41910CB81e23e1c41c32'
 slug: sfrax
+coingecko_id: staked-frax
+coingecko_link: https://www.coingecko.com/en/coins/staked-frax
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.09
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2025-10-02T17:12:08'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/sfrxusd.yaml
+++ b/eth_defi/data/stablecoins/sfrxusd.yaml
@@ -17,6 +17,18 @@ contract_addresses:
   - chain: ethereum
     address: '0xcf62F905562626CfcDD2261162a51fd02Fc9c5b6'
 slug: sfrxusd
+coingecko_id: staked-frax-usd
+coingecko_link: https://www.coingecko.com/en/coins/staked-frax-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.2
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:10'
+peg_rate: 1.2
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/silk.yaml
+++ b/eth_defi/data/stablecoins/silk.yaml
@@ -14,6 +14,18 @@ links:
   defillama: ''
   twitter: https://x.com/Shade_Protocol
 slug: silk
+coingecko_id: silk
+coingecko_link: https://www.coingecko.com/en/coins/silk
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.0099997
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2025-09-10T02:06:33'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/snusd.yaml
+++ b/eth_defi/data/stablecoins/snusd.yaml
@@ -36,6 +36,18 @@ links:
 contract_addresses:
   - chain: ethereum
     address: "0x08EFCC2F3e61185D0EA7F8830B3FEc9Bfa2EE313"
+coingecko_id: snusd
+coingecko_link: https://www.coingecko.com/en/coins/snusd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.049
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:06'
+peg_rate: 1.049
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ""
   domain_up_at: ""

--- a/eth_defi/data/stablecoins/sosusdt.yaml
+++ b/eth_defi/data/stablecoins/sosusdt.yaml
@@ -19,6 +19,8 @@ links:
   defillama: ''
   twitter: ''
 slug: sosusdt
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/stcusd.yaml
+++ b/eth_defi/data/stablecoins/stcusd.yaml
@@ -18,6 +18,18 @@ links:
 contract_addresses:
   - chain: ethereum
     address: '0x88887bE419578051FF9F4eb6C858A951921D8888'
+coingecko_id: staked-cap-usd
+coingecko_link: https://www.coingecko.com/en/coins/staked-cap-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.069
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:10:09'
+peg_rate: 1.069
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/stusd.yaml
+++ b/eth_defi/data/stablecoins/stusd.yaml
@@ -21,6 +21,11 @@ contract_addresses:
   - chain: ethereum
     address: '0x0022228a2cc5E7eF0274A7Baa600d44da5aB5776'
 slug: stusd
+coingecko_id: angle-staked-usda
+coingecko_link: https://www.coingecko.com/en/coins/angle-staked-usda
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/susd.yaml
+++ b/eth_defi/data/stablecoins/susd.yaml
@@ -19,6 +19,11 @@ contract_addresses:
   - chain: optimism
     address: '0x8c6f28f2F1A3C87F0f938b96d27520d9751ec8d9'
 slug: susd
+coingecko_id: susd
+coingecko_link: https://www.coingecko.com/en/coins/susd
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/susd3.yaml
+++ b/eth_defi/data/stablecoins/susd3.yaml
@@ -40,6 +40,8 @@ links:
 contract_addresses:
   - chain: ethereum
     address: '0xf689555121e529Ff0463e191F9Bd9d1E496164a7'
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/susdai.yaml
+++ b/eth_defi/data/stablecoins/susdai.yaml
@@ -17,6 +17,11 @@ contract_addresses:
   - chain: arbitrum
     address: '0x0B2b2B2076d95dda7817e785989fE353fe955ef9'
 slug: susdai
+coingecko_id: staked-usdai
+coingecko_link: https://www.coingecko.com/en/coins/staked-usdai
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/susdc.yaml
+++ b/eth_defi/data/stablecoins/susdc.yaml
@@ -19,6 +19,8 @@ contract_addresses:
   - chain: arbitrum
     address: '0x940098b108fB7D0a7E374f6eDED7760787464609'
 slug: susdc
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/susde.yaml
+++ b/eth_defi/data/stablecoins/susde.yaml
@@ -17,6 +17,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x9D39A5DE30e57443BfF2A8307A4256c8797A3497'
 slug: susde
+coingecko_id: ethena-staked-usde
+coingecko_link: https://www.coingecko.com/en/coins/ethena-staked-usde
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.23
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:07'
+peg_rate: 1.23
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/susg.yaml
+++ b/eth_defi/data/stablecoins/susg.yaml
@@ -14,6 +14,8 @@ links:
   defillama: ''
   twitter: https://x.com/Tangent_fi
 slug: susg
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/syrupusdc.yaml
+++ b/eth_defi/data/stablecoins/syrupusdc.yaml
@@ -24,6 +24,11 @@ contract_addresses:
     address: "0x660975730059246A68521a3e2FBD4740173100f5"
   - chain: arbitrum
     address: "0x41CA7586cC1311807B4605fBB748a3B8862b42b5"
+coingecko_id: syrup-usdc
+coingecko_link: https://www.coingecko.com/en/coins/syrup-usdc
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: ""
   domain_up_at: ""

--- a/eth_defi/data/stablecoins/tcnh.yaml
+++ b/eth_defi/data/stablecoins/tcnh.yaml
@@ -17,6 +17,18 @@ contract_addresses:
   - chain: tron
     address: 'TBqsNXUtqaLptVK8AYvdPPctpqd8oBYWUC'
 slug: tcnh
+coingecko_id: truecnh
+coingecko_link: https://www.coingecko.com/en/coins/truecnh
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.194503
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2025-03-06T05:06:09'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/tfusdc.yaml
+++ b/eth_defi/data/stablecoins/tfusdc.yaml
@@ -19,6 +19,8 @@ contract_addresses:
   - chain: ethereum
     address: '0xA991356d261fbaF194463aF6DF8f0464F8f1c742'
 slug: tfusdc
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/tor.yaml
+++ b/eth_defi/data/stablecoins/tor.yaml
@@ -14,6 +14,18 @@ links:
   defillama: ''
   twitter: https://x.com/Hector_Network
 slug: tor
+coingecko_id: tor
+coingecko_link: https://www.coingecko.com/en/coins/tor
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.01549515
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-25T20:34:40'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/tryb.yaml
+++ b/eth_defi/data/stablecoins/tryb.yaml
@@ -17,6 +17,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x2C537E5624e4af88A7ae4060C022609376C8D0EB'
 slug: tryb
+coingecko_id: bilira
+coingecko_link: https://www.coingecko.com/en/coins/bilira
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.02085399
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:24'
+peg_rate: 0.97164
+peg_rate_currency: try
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/tusd.yaml
+++ b/eth_defi/data/stablecoins/tusd.yaml
@@ -17,6 +17,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x0000000000085d4780B73119b644AE5ecd22b376'
 slug: tusd
+coingecko_id: true-usd
+coingecko_link: https://www.coingecko.com/en/coins/true-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.998917
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:26'
+peg_rate: 0.998917
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usc.yaml
+++ b/eth_defi/data/stablecoins/usc.yaml
@@ -34,6 +34,8 @@ links:
   defillama: ''
   twitter: https://x.com/OrbyNetwork
 slug: usc
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usd-plus.yaml
+++ b/eth_defi/data/stablecoins/usd-plus.yaml
@@ -41,6 +41,18 @@ links:
   defillama: https://defillama.com/stablecoin/usd+
   twitter: https://x.com/overnight_fi
 slug: usd-plus
+coingecko_id: usd
+coingecko_link: https://www.coingecko.com/en/coins/usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.993561
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-03-18T03:37:53'
+peg_rate: 0.993561
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-02-25'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usd-t.yaml
+++ b/eth_defi/data/stablecoins/usd-t.yaml
@@ -35,6 +35,18 @@ links:
   defillama: https://defillama.com/stablecoin/tether
   twitter: https://x.com/tether
 slug: usd-t
+coingecko_id: tether
+coingecko_link: https://www.coingecko.com/en/coins/tether
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.998536
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:25'
+peg_rate: 0.998536
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usd-t0.yaml
+++ b/eth_defi/data/stablecoins/usd-t0.yaml
@@ -30,6 +30,8 @@ links:
   defillama: ''
   twitter: https://x.com/tether
 slug: usd-t0
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usd0.yaml
+++ b/eth_defi/data/stablecoins/usd0.yaml
@@ -46,6 +46,18 @@ slug: usd0
 contract_addresses:
   - chain: ethereum
     address: '0x73A15FeD60Bf67631dC6cd7Bc5B6e8da8190aCF5'
+coingecko_id: usual-usd
+coingecko_link: https://www.coingecko.com/en/coins/usual-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.998721
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:08'
+peg_rate: 0.998721
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usd1.yaml
+++ b/eth_defi/data/stablecoins/usd1.yaml
@@ -43,6 +43,18 @@ contract_addresses:
     address: '0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d'
   - chain: binance
     address: '0x8d0D000Ee44948FC98c9B98A4FA4921476f08B0d'
+coingecko_id: usd1-wlfi
+coingecko_link: https://www.coingecko.com/en/coins/usd1-wlfi
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999145
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:11'
+peg_rate: 0.999145
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usd3.yaml
+++ b/eth_defi/data/stablecoins/usd3.yaml
@@ -49,6 +49,8 @@ links:
 contract_addresses:
   - chain: ethereum
     address: '0x056B269Eb1f75477a8666ae8C7fE01b64dD55eCc'
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/usd8.yaml
+++ b/eth_defi/data/stablecoins/usd8.yaml
@@ -33,6 +33,8 @@ links:
   defillama: ''
   twitter: https://x.com/usd8_fi
 slug: usd8
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usda-avalon.yaml
+++ b/eth_defi/data/stablecoins/usda-avalon.yaml
@@ -37,6 +37,18 @@ contract_addresses:
     address: '0x075df695b8E7f4361FA7F8c1426C63f11B06e326'
   - chain: binance
     address: '0x9356086146be5158E98aD827E21b5cF944699894'
+coingecko_id: usda-2
+coingecko_link: https://www.coingecko.com/en/coins/usda-2
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.98282
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-24T20:29:08'
+peg_rate: 0.98282
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usda.yaml
+++ b/eth_defi/data/stablecoins/usda.yaml
@@ -46,6 +46,18 @@ contract_addresses:
     address: '0x0000206329b97DB379d5E1Bf586BbDB969C63274'
   - chain: optimism
     address: '0x0000206329b97DB379d5E1Bf586BbDB969C63274'
+coingecko_id: angle-usd
+coingecko_link: https://www.coingecko.com/en/coins/angle-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.1
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-10T03:22:56'
+peg_rate: 1.1
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-04'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdai.yaml
+++ b/eth_defi/data/stablecoins/usdai.yaml
@@ -33,6 +33,18 @@ links:
   defillama: https://defillama.com/stablecoin/usdai
   twitter: https://x.com/USDai_Official
 slug: usdai
+coingecko_id: usdai
+coingecko_link: https://www.coingecko.com/en/coins/usdai
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999023
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:11'
+peg_rate: 0.999023
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdb.yaml
+++ b/eth_defi/data/stablecoins/usdb.yaml
@@ -43,6 +43,18 @@ slug: usdb
 contract_addresses:
   - chain: blast
     address: '0x4300000000000000000000000000000000000003'
+coingecko_id: usdb
+coingecko_link: https://www.coingecko.com/en/coins/usdb
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.989529
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:07'
+peg_rate: 0.989529
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdbc.yaml
+++ b/eth_defi/data/stablecoins/usdbc.yaml
@@ -42,6 +42,18 @@ slug: usdbc
 contract_addresses:
   - chain: base
     address: '0xd9aAEc86B65D86f6A7B5B1b0c42FFA531710b6CA'
+coingecko_id: bridged-usd-coin-base
+coingecko_link: https://www.coingecko.com/en/coins/bridged-usd-coin-base
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999232
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:11'
+peg_rate: 0.999232
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdc-e.yaml
+++ b/eth_defi/data/stablecoins/usdc-e.yaml
@@ -33,6 +33,18 @@ links:
   defillama: ''
   twitter: https://x.com/circle
 slug: usdc-e
+coingecko_id: bridged-usdc
+coingecko_link: https://www.coingecko.com/en/coins/bridged-usdc
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999844
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:02'
+peg_rate: 0.999844
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdc.yaml
+++ b/eth_defi/data/stablecoins/usdc.yaml
@@ -57,6 +57,18 @@ slug: usdc
 contract_addresses:
   - chain: ethereum
     address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'
+coingecko_id: usd-coin
+coingecko_link: https://www.coingecko.com/en/coins/usd-coin
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999667
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:26'
+peg_rate: 0.999667
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdcv.yaml
+++ b/eth_defi/data/stablecoins/usdcv.yaml
@@ -43,6 +43,8 @@ slug: usdcv
 contract_addresses:
   - chain: ethereum
     address: '0x5422374B27757da72d5265cC745ea906E0446634'
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdd.yaml
+++ b/eth_defi/data/stablecoins/usdd.yaml
@@ -53,6 +53,18 @@ contract_addresses:
     address: '0x392004BEe213F1FF580C867359C246924f21E6Ad'
   - chain: arbitrum
     address: '0x680447595e8b7b3Aa1B43beB9f6098C79ac2Ab3f'
+coingecko_id: usdd
+coingecko_link: https://www.coingecko.com/en/coins/usdd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.996668
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:27'
+peg_rate: 0.996668
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-02-06'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usde.yaml
+++ b/eth_defi/data/stablecoins/usde.yaml
@@ -53,6 +53,18 @@ contract_addresses:
     address: '0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34'
   - chain: base
     address: '0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34'
+coingecko_id: ethena-usde
+coingecko_link: https://www.coingecko.com/en/coins/ethena-usde
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.997966
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:24'
+peg_rate: 0.997966
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdf-falcon.yaml
+++ b/eth_defi/data/stablecoins/usdf-falcon.yaml
@@ -46,6 +46,18 @@ slug: usdf-falcon
 contract_addresses:
   - chain: ethereum
     address: '0xFa2B947eEc368f42195f24F36d2aF29f7c24CeC2'
+coingecko_id: falcon-finance
+coingecko_link: https://www.coingecko.com/en/coins/falcon-finance
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.993101
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:10'
+peg_rate: 0.993101
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdf.yaml
+++ b/eth_defi/data/stablecoins/usdf.yaml
@@ -44,6 +44,18 @@ entries:
     coingecko: https://www.coingecko.com/en/coins/falcon-finance
     defillama: https://defillama.com/stablecoin/falcon-finance
     twitter: https://x.com/FalconStable
+  coingecko_id: falcon-finance
+  coingecko_link: https://www.coingecko.com/en/coins/falcon-finance
+  coingecko_id_source: url
+  coingecko_id_verified_at: '2026-06-26T12:16:16'
+  usd_rate: 0.993101
+  usd_rate_fetched_at: '2026-06-26T12:16:16'
+  usd_rate_updated_at: '2026-06-26T12:15:10'
+  peg_rate: 0.993101
+  peg_rate_currency: usd
+  rate_fetch_failed_at: ''
+  rate_fetch_failed_reason: ''
+  depegged_at: ''
   checks:
     twitter_last_post_at: '2026-03-17'
     domain_up_at: '2026-03-17'
@@ -94,6 +106,8 @@ entries:
     coingecko: ''
     defillama: ''
     twitter: https://x.com/USDFConsortium
+  rate_fetch_failed_at: '2026-06-26T12:16:16'
+  rate_fetch_failed_reason: missing_coingecko_id
   checks:
     twitter_last_post_at: ''
     domain_up_at: ''

--- a/eth_defi/data/stablecoins/usdg.yaml
+++ b/eth_defi/data/stablecoins/usdg.yaml
@@ -52,6 +52,18 @@ slug: usdg
 contract_addresses:
   - chain: ethereum
     address: '0xe343167631d89B6Ffc58B88d6b7fB0228795491D'
+coingecko_id: global-dollar
+coingecko_link: https://www.coingecko.com/en/coins/global-dollar
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999797
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:18'
+peg_rate: 1.29
+peg_rate_currency: sgd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-02-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdh-hubble.yaml
+++ b/eth_defi/data/stablecoins/usdh-hubble.yaml
@@ -27,6 +27,8 @@ links:
   defillama: ''
   twitter: https://x.com/HubbleProtocol
 slug: usdh-hubble
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdh.yaml
+++ b/eth_defi/data/stablecoins/usdh.yaml
@@ -49,6 +49,8 @@ links:
   defillama: ''
   twitter: https://x.com/nativemarkets
 slug: usdh
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdm-megaeth.yaml
+++ b/eth_defi/data/stablecoins/usdm-megaeth.yaml
@@ -19,6 +19,8 @@ slug: usdm-megaeth
 contract_addresses:
   - chain: megaeth
     address: '0xFAfDdbb3FC7688494971a79cc65DCa3EF82079E7'
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/usdm.yaml
+++ b/eth_defi/data/stablecoins/usdm.yaml
@@ -17,6 +17,18 @@ links:
   defillama: https://defillama.com/stablecoin/mountain-protocol-usdm
   twitter: https://x.com/MountainUSDM
 slug: usdm
+coingecko_id: mountain-protocol-usdm
+coingecko_link: https://www.coingecko.com/en/coins/mountain-protocol-usdm
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.003
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:19'
+peg_rate: 1.003
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdn.yaml
+++ b/eth_defi/data/stablecoins/usdn.yaml
@@ -38,6 +38,11 @@ entries:
     coingecko: https://www.coingecko.com/en/coins/noble-dollar
     defillama: https://defillama.com/stablecoin/noble-dollar
     twitter: https://x.com/noble_xyz
+  coingecko_id: noble-dollar
+  coingecko_link: https://www.coingecko.com/en/coins/noble-dollar
+  coingecko_id_source: url
+  rate_fetch_failed_at: '2026-06-26T12:16:16'
+  rate_fetch_failed_reason: coingecko_price_missing
   checks:
     twitter_last_post_at: '2026-03-17'
     domain_up_at: '2026-03-17'
@@ -79,6 +84,18 @@ entries:
     coingecko: https://www.coingecko.com/en/coins/neutrino
     defillama: https://defillama.com/stablecoin/neutrino
     twitter: https://x.com/neutrino_proto
+  coingecko_id: neutrino
+  coingecko_link: https://www.coingecko.com/en/coins/neutrino
+  coingecko_id_source: url
+  coingecko_id_verified_at: '2026-06-26T12:16:16'
+  usd_rate: 0.04658615
+  usd_rate_fetched_at: '2026-06-26T12:16:16'
+  usd_rate_updated_at: '2026-06-26T12:14:34'
+  peg_rate: 0.04658615
+  peg_rate_currency: usd
+  rate_fetch_failed_at: ''
+  rate_fetch_failed_reason: ''
+  depegged_at: '2026-06-26T12:13:31'
   checks:
     twitter_last_post_at: ''
     domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdo.yaml
+++ b/eth_defi/data/stablecoins/usdo.yaml
@@ -31,6 +31,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x8238884Ec9668Ef77B90C6dfF4D1a9F4F4823BFe'
 slug: usdo
+coingecko_id: openeden-open-dollar
+coingecko_link: https://www.coingecko.com/en/coins/openeden-open-dollar
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999288
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:10'
+peg_rate: 0.999288
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdp.yaml
+++ b/eth_defi/data/stablecoins/usdp.yaml
@@ -25,6 +25,11 @@ contract_addresses:
   - chain: ethereum
     address: '0x8E870D67F660D95d5be530380D0eC0bd388289E1'
 slug: usdp
+coingecko_id: pax-dollar
+coingecko_link: https://www.coingecko.com/en/coins/pax-dollar
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdr.yaml
+++ b/eth_defi/data/stablecoins/usdr.yaml
@@ -30,6 +30,18 @@ contract_addresses:
   - chain: polygon
     address: '0x40379a439D4F6795B6fc9aa5687dB461677A2dBa'
 slug: usdr
+coingecko_id: real-usd
+coingecko_link: https://www.coingecko.com/en/coins/real-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.464988
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:20'
+peg_rate: 0.464988
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: '2026-06-26T12:13:31'
 checks:
   twitter_last_post_at: '2024-10-31'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usds-sperax.yaml
+++ b/eth_defi/data/stablecoins/usds-sperax.yaml
@@ -25,6 +25,18 @@ links:
   defillama: https://defillama.com/stablecoin/sperax-usd
   twitter: https://x.com/SperaxUSD
 slug: usds-sperax
+coingecko_id: sperax-usd
+coingecko_link: https://www.coingecko.com/en/coins/sperax-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.997833
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:17'
+peg_rate: 0.997833
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2025-01-29'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usds.yaml
+++ b/eth_defi/data/stablecoins/usds.yaml
@@ -33,6 +33,18 @@ contract_addresses:
   - chain: ethereum
     address: '0xdC035D45d973E3EC169d2276DDab16f1e407384F'
 slug: usds
+coingecko_id: usds
+coingecko_link: https://www.coingecko.com/en/coins/usds
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999541
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:09'
+peg_rate: 0.999541
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdt-e.yaml
+++ b/eth_defi/data/stablecoins/usdt-e.yaml
@@ -43,6 +43,8 @@ links:
   defillama: ''
   twitter: https://x.com/Tether_to
 slug: usdt-e
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdt.yaml
+++ b/eth_defi/data/stablecoins/usdt.yaml
@@ -31,6 +31,18 @@ slug: usdt
 token_symbols:
 - USDT
 - USDt
+coingecko_id: tether
+coingecko_link: https://www.coingecko.com/en/coins/tether
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.998536
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:25'
+peg_rate: 0.998536
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdt0.yaml
+++ b/eth_defi/data/stablecoins/usdt0.yaml
@@ -30,6 +30,18 @@ links:
   defillama: https://defillama.com/protocol/usdt0
   twitter: https://x.com/usdt0_to
 slug: usdt0
+coingecko_id: usdt0
+coingecko_link: https://www.coingecko.com/en/coins/usdt0
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.998458
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:16'
+peg_rate: 0.998458
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdtb.yaml
+++ b/eth_defi/data/stablecoins/usdtb.yaml
@@ -25,6 +25,18 @@ links:
   defillama: https://defillama.com/stablecoin/usdtb
   twitter: https://x.com/ethena
 slug: usdtb
+coingecko_id: usdtb
+coingecko_link: https://www.coingecko.com/en/coins/usdtb
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:10'
+peg_rate: 1
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdv.yaml
+++ b/eth_defi/data/stablecoins/usdv.yaml
@@ -31,6 +31,11 @@ links:
   defillama: https://defillama.com/stablecoin/verified-usd
   twitter: https://x.com/USDV_Money
 slug: usdv
+coingecko_id: verified-usd
+coingecko_link: https://www.coingecko.com/en/coins/verified-usd
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: '2024-11-14'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdx.yaml
+++ b/eth_defi/data/stablecoins/usdx.yaml
@@ -12,9 +12,21 @@ entries:
     on March 13, 2026. The homepage (usdx.money) was unreachable as of March 2026. USDX is considered defunct.
   links:
     homepage: https://usdx.money/
-    coingecko: https://www.coingecko.com/en/coins/stables-labs-usdx
+    coingecko: https://www.coingecko.com/en/coins/usdx-money-usdx
     defillama: https://defillama.com/stablecoin/usdx-money
     twitter: https://x.com/usdx_money
+  coingecko_id: usdx-money-usdx
+  coingecko_link: https://www.coingecko.com/en/coins/usdx-money-usdx
+  coingecko_id_source: manual
+  coingecko_id_verified_at: '2026-06-26T12:16:16'
+  usd_rate: 0.0076278
+  usd_rate_fetched_at: '2026-06-26T12:16:16'
+  usd_rate_updated_at: '2026-06-26T01:17:30'
+  peg_rate: 0.0076278
+  peg_rate_currency: usd
+  rate_fetch_failed_at: ''
+  rate_fetch_failed_reason: ''
+  depegged_at: '2026-06-26T12:16:16'
   checks:
     twitter_last_post_at: '2025-01-14'
     domain_up_at: ''
@@ -51,12 +63,24 @@ entries:
     ## Sources
 
     - [Kava documentation — basics](https://docs.kava.io/docs/faq/basics/)
-    - [CoinGecko — Kava Lend](https://www.coingecko.com/en/coins/kava-lend)
+    - [CoinGecko — USDX](https://www.coingecko.com/en/coins/usdx)
   links:
     homepage: https://www.kava.io/
-    coingecko: https://www.coingecko.com/en/coins/kava-lend
+    coingecko: https://www.coingecko.com/en/coins/usdx
     defillama: ''
     twitter: https://x.com/KAVA_CHAIN
+  coingecko_id: usdx
+  coingecko_link: https://www.coingecko.com/en/coins/usdx
+  coingecko_id_source: manual
+  coingecko_id_verified_at: '2026-06-26T12:16:16'
+  usd_rate: 0.633962
+  usd_rate_fetched_at: '2026-06-26T12:16:16'
+  usd_rate_updated_at: '2026-06-26T12:15:25'
+  peg_rate: 0.633962
+  peg_rate_currency: usd
+  rate_fetch_failed_at: ''
+  rate_fetch_failed_reason: ''
+  depegged_at: '2026-06-26T12:15:26'
   checks:
     twitter_last_post_at: '2026-03-17'
     domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdxl.yaml
+++ b/eth_defi/data/stablecoins/usdxl.yaml
@@ -29,6 +29,18 @@ links:
   defillama: https://defillama.com/protocol/hypurrfi
   twitter: https://x.com/HypurrFi
 slug: usdxl
+coingecko_id: last-usd
+coingecko_link: https://www.coingecko.com/en/coins/last-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.988521
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:14:52'
+peg_rate: 0.988521
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-02-13'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usg.yaml
+++ b/eth_defi/data/stablecoins/usg.yaml
@@ -25,6 +25,8 @@ links:
   defillama: ''
   twitter: https://x.com/Tangent_fi
 slug: usg
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/ush.yaml
+++ b/eth_defi/data/stablecoins/ush.yaml
@@ -27,6 +27,11 @@ links:
   defillama: https://defillama.com/protocol/unsheth
   twitter: https://x.com/unshETH_xyz
 slug: ush
+coingecko_id: unshething-token
+coingecko_link: https://www.coingecko.com/en/coins/unshething-token
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usk.yaml
+++ b/eth_defi/data/stablecoins/usk.yaml
@@ -27,6 +27,18 @@ links:
   defillama: https://defillama.com/stablecoin/usk
   twitter: https://x.com/TeamKujira
 slug: usk
+coingecko_id: usk
+coingecko_link: https://www.coingecko.com/en/coins/usk
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.314985
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2025-10-11T05:03:12'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usr.yaml
+++ b/eth_defi/data/stablecoins/usr.yaml
@@ -36,6 +36,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x66a1E37c9b0eAddca17d3662D6c05F4DECf3e110'
 slug: usr
+coingecko_id: resolv-usr
+coingecko_link: https://www.coingecko.com/en/coins/resolv-usr
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.15642
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:14:40'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/ust.yaml
+++ b/eth_defi/data/stablecoins/ust.yaml
@@ -37,6 +37,11 @@ links:
   defillama: https://defillama.com/stablecoin/terrausd
   twitter: https://x.com/terra_money
 slug: ust
+coingecko_id: terrausd
+coingecko_link: https://www.coingecko.com/en/coins/terrausd
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/ustc.yaml
+++ b/eth_defi/data/stablecoins/ustc.yaml
@@ -28,6 +28,11 @@ links:
   defillama: https://defillama.com/stablecoin/terraclassicusd
   twitter: https://x.com/terra_money
 slug: ustc
+coingecko_id: terraclassicusd
+coingecko_link: https://www.coingecko.com/en/coins/terraclassicusd
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usx.yaml
+++ b/eth_defi/data/stablecoins/usx.yaml
@@ -18,6 +18,11 @@ links:
   defillama: https://defillama.com/stablecoin/dforce-usd
   twitter: https://x.com/dForcenet
 slug: usx
+coingecko_id: dforce-usd
+coingecko_link: https://www.coingecko.com/en/coins/dforce-usd
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usxau.yaml
+++ b/eth_defi/data/stablecoins/usxau.yaml
@@ -18,6 +18,8 @@ links:
   defillama: ''
   twitter: ''
 slug: usxau
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/uty.yaml
+++ b/eth_defi/data/stablecoins/uty.yaml
@@ -31,6 +31,18 @@ contract_addresses:
   - chain: avalanche
     address: '0xDBc5192A6B6FfEe7451301bb4ec312f844F02B4A'
 slug: uty
+coingecko_id: unity-2
+coingecko_link: https://www.coingecko.com/en/coins/unity-2
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999222
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:11'
+peg_rate: 0.999222
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/uusd.yaml
+++ b/eth_defi/data/stablecoins/uusd.yaml
@@ -20,6 +20,18 @@ links:
   defillama: ''
   twitter: https://x.com/UtopiaP2P
 slug: uusd
+coingecko_id: utopia-usd
+coingecko_link: https://www.coingecko.com/en/coins/utopia-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.949609
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-04-28T12:04:24'
+peg_rate: 0.949609
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/vai.yaml
+++ b/eth_defi/data/stablecoins/vai.yaml
@@ -24,6 +24,18 @@ contract_addresses:
   - chain: bsc
     address: '0x4BD17003473389A42DAF6a0a729f6Fdb328BbBd7'
 slug: vai
+coingecko_id: vai
+coingecko_link: https://www.coingecko.com/en/coins/vai
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.999084
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:14:39'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/vbusdc.yaml
+++ b/eth_defi/data/stablecoins/vbusdc.yaml
@@ -17,6 +17,8 @@ links:
   defillama: ''
   twitter: https://x.com/katana
 slug: vbusdc
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/vbusdt.yaml
+++ b/eth_defi/data/stablecoins/vbusdt.yaml
@@ -17,6 +17,8 @@ links:
   defillama: ''
   twitter: https://x.com/katana
 slug: vbusdt
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: '2026-03-17'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/veur.yaml
+++ b/eth_defi/data/stablecoins/veur.yaml
@@ -28,6 +28,18 @@ contract_addresses:
   - chain: arbitrum
     address: '0x4883C8f0529F37e40eBeA870F3C13cDfAD5d01f8'
 slug: veur
+coingecko_id: vnx-euro
+coingecko_link: https://www.coingecko.com/en/coins/vnx-euro
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.299938
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-21T12:27:09'
+peg_rate: 0.261441
+peg_rate_currency: eur
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: '2026-06-26T12:13:31'
 checks:
   twitter_last_post_at: '2026-03-01'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/vst.yaml
+++ b/eth_defi/data/stablecoins/vst.yaml
@@ -27,6 +27,18 @@ contract_addresses:
   - chain: arbitrum
     address: '0x64343594Ab9b56e99087BfA6F2335Db24c2d1F17'
 slug: vst
+coingecko_id: vesta-stable
+coingecko_link: https://www.coingecko.com/en/coins/vesta-stable
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2025-07-11T03:31:59'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/vusd-hemi.yaml
+++ b/eth_defi/data/stablecoins/vusd-hemi.yaml
@@ -23,6 +23,11 @@ contract_addresses:
   - chain: hemi
     address: '0x7A06C4AeF988e7925575C50261297a946aD204A8'
 slug: vusd-hemi
+coingecko_id: vusd-hemi
+coingecko_link: https://www.coingecko.com/en/coins/vusd-hemi
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/vusd-vesper.yaml
+++ b/eth_defi/data/stablecoins/vusd-vesper.yaml
@@ -25,6 +25,8 @@ contract_addresses:
   - chain: ethereum
     address: '0x677ddbd918637E5F2c79e164D402454dE7dA8619'
 slug: vusd-vesper
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: '2025-08-01'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/vusd-virtue.yaml
+++ b/eth_defi/data/stablecoins/vusd-virtue.yaml
@@ -28,6 +28,18 @@ links:
   defillama: ''
   twitter: https://x.com/Virtue_Money
 slug: vusd-virtue
+coingecko_id: virtue-usd
+coingecko_link: https://www.coingecko.com/en/coins/virtue-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.003
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:14:20'
+peg_rate: 1.003
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2025-07-10'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/vusd-vow.yaml
+++ b/eth_defi/data/stablecoins/vusd-vow.yaml
@@ -20,6 +20,11 @@ links:
   defillama: ''
   twitter: https://x.com/Vowcurrency
 slug: vusd-vow
+coingecko_id: vow-usd
+coingecko_link: https://www.coingecko.com/en/coins/vow-usd
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: '2025-11-30'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/vusd.yaml
+++ b/eth_defi/data/stablecoins/vusd.yaml
@@ -24,6 +24,18 @@ contract_addresses:
   - chain: cronos-zkevm
     address: '0x5b91e29Ae5A71d9052620Acb813d5aC25eC7a4A2'
 slug: vusd
+coingecko_id: veno-usd
+coingecko_link: https://www.coingecko.com/en/coins/veno-usd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.994315
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:14:44'
+peg_rate: 0.994315
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2025-08-22'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/wm.yaml
+++ b/eth_defi/data/stablecoins/wm.yaml
@@ -31,6 +31,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x437cc33344a0B27A429f795ff6B469C72698B291'
 slug: wm
+coingecko_id: wrapped-m
+coingecko_link: https://www.coingecko.com/en/coins/wrapped-m
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.87062
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:01'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2025-05-01'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/wxdai.yaml
+++ b/eth_defi/data/stablecoins/wxdai.yaml
@@ -41,6 +41,18 @@ contract_addresses:
   - chain: gnosis
     address: '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d'
 slug: wxdai
+coingecko_id: wrapped-xdai
+coingecko_link: https://www.coingecko.com/en/coins/wrapped-xdai
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.003
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2024-03-18T13:19:02'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-02-26'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/xaut.yaml
+++ b/eth_defi/data/stablecoins/xaut.yaml
@@ -51,6 +51,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x68749665FF8D2d112Fa859AA293F07A622782F38'
 slug: xaut
+coingecko_id: tether-gold
+coingecko_link: https://www.coingecko.com/en/coins/tether-gold
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 4034.67
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:25'
+peg_rate: 0.996726
+peg_rate_currency: xau
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-01'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/xdai.yaml
+++ b/eth_defi/data/stablecoins/xdai.yaml
@@ -23,6 +23,18 @@ links:
   defillama: ''
   twitter: https://x.com/gnosischain
 slug: xdai
+coingecko_id: xdai
+coingecko_link: https://www.coingecko.com/en/coins/xdai
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.9997
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:25'
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-02-26'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/xidr.yaml
+++ b/eth_defi/data/stablecoins/xidr.yaml
@@ -34,6 +34,11 @@ contract_addresses:
   - chain: ethereum
     address: '0xebF2096E01455108bAdCbAF86cE30b6e5A72aa52'
 slug: xidr
+coingecko_id: straitsx-indonesia-rupiah
+coingecko_link: https://www.coingecko.com/en/coins/straitsx-indonesia-rupiah
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: '2025-12-16'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/xsgd.yaml
+++ b/eth_defi/data/stablecoins/xsgd.yaml
@@ -51,6 +51,18 @@ contract_addresses:
   - chain: polygon
     address: '0xDC3326e71D45186F113a2F448984CA0e8D201995'
 slug: xsgd
+coingecko_id: xsgd
+coingecko_link: https://www.coingecko.com/en/coins/xsgd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.771327
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:25'
+peg_rate: 0.998224
+peg_rate_currency: sgd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2025-12-16'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/xstusd.yaml
+++ b/eth_defi/data/stablecoins/xstusd.yaml
@@ -32,6 +32,11 @@ contract_addresses:
   - chain: ethereum
     address: '0xc7D9c108D4E1dD1484D3e2568d7f74bfD763d356'
 slug: xstusd
+coingecko_id: sora-synthetic-usd
+coingecko_link: https://www.coingecko.com/en/coins/sora-synthetic-usd
+coingecko_id_source: url
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: coingecko_price_missing
 checks:
   twitter_last_post_at: '2025-01-14'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/xusd.yaml
+++ b/eth_defi/data/stablecoins/xusd.yaml
@@ -23,6 +23,8 @@ entries:
       address: '0xC08e7E23C235073C6807C2EFE7021304cb7c2815'
     - chain: bsc
       address: '0xF81aC2E1A0373ddE1BcE01E2Fe694a9b7E3bfcB9'
+  rate_fetch_failed_at: '2026-06-26T12:16:16'
+  rate_fetch_failed_reason: missing_coingecko_id
   checks:
     twitter_last_post_at: '2025-12-16'
     domain_up_at: '2026-03-17'
@@ -57,6 +59,8 @@ entries:
     coingecko: ''
     defillama: ''
     twitter: https://x.com/xdollarfi
+  rate_fetch_failed_at: '2026-06-26T12:16:16'
+  rate_fetch_failed_reason: missing_coingecko_id
   checks:
     twitter_last_post_at: ''
     domain_up_at: ''

--- a/eth_defi/data/stablecoins/ynusdx.yaml
+++ b/eth_defi/data/stablecoins/ynusdx.yaml
@@ -29,6 +29,18 @@ contract_addresses:
   - chain: ethereum
     address: '0x3DB228FE836D99Ccb25Ec4dfdC80ED6d2CDdCB4b'
 slug: ynusdx
+coingecko_id: ynusd-max
+coingecko_link: https://www.coingecko.com/en/coins/ynusd-max
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.982652
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:14:38'
+peg_rate: 0.982652
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-01-22'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/ysusdc.yaml
+++ b/eth_defi/data/stablecoins/ysusdc.yaml
@@ -25,6 +25,8 @@ links:
   defillama: ''
   twitter: https://x.com/yearnfi
 slug: ysusdc
+rate_fetch_failed_at: '2026-06-26T12:16:16'
+rate_fetch_failed_reason: missing_coingecko_id
 checks:
   twitter_last_post_at: '2026-02-20'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/yusd.yaml
+++ b/eth_defi/data/stablecoins/yusd.yaml
@@ -13,6 +13,18 @@ entries:
     coingecko: https://www.coingecko.com/en/coins/yusd-stablecoin
     defillama: https://defillama.com/protocol/yeti-finance
     twitter: https://x.com/yetifinance
+  coingecko_id: yusd-stablecoin
+  coingecko_link: https://www.coingecko.com/en/coins/yusd-stablecoin
+  coingecko_id_source: url
+  coingecko_id_verified_at: '2026-06-26T12:16:16'
+  usd_rate: 0.99583
+  usd_rate_fetched_at: '2026-06-26T12:16:16'
+  usd_rate_updated_at: '2026-06-26T12:15:27'
+  peg_rate: 0.99583
+  peg_rate_currency: usd
+  rate_fetch_failed_at: ''
+  rate_fetch_failed_reason: ''
+  depegged_at: ''
   checks:
     twitter_last_post_at: ''
     domain_up_at: ''
@@ -38,6 +50,18 @@ entries:
       address: '0x4772D2e014F9fC3a820C444e3313968e9a5C8121'
     - chain: base
       address: '0x895e15020C3f52ddD4D8e9514eB83C39F53B1579'
+  coingecko_id: yieldfi-ytoken
+  coingecko_link: https://www.coingecko.com/en/coins/yieldfi-ytoken
+  coingecko_id_source: url
+  coingecko_id_verified_at: '2026-06-26T12:16:16'
+  usd_rate: 0.998454
+  usd_rate_fetched_at: '2026-06-26T12:16:16'
+  usd_rate_updated_at: '2026-06-26T12:10:09'
+  peg_rate: 0.998454
+  peg_rate_currency: usd
+  rate_fetch_failed_at: ''
+  rate_fetch_failed_reason: ''
+  depegged_at: ''
   checks:
     twitter_last_post_at: '2025-10-28'
     domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/zchf.yaml
+++ b/eth_defi/data/stablecoins/zchf.yaml
@@ -31,6 +31,18 @@ contract_addresses:
   - chain: ethereum
     address: '0xB58E61C3098d85632Df34EecfB899A1Ed80921cB'
 slug: zchf
+coingecko_id: frankencoin
+coingecko_link: https://www.coingecko.com/en/coins/frankencoin
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 1.24
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:15:08'
+peg_rate: 0.998705
+peg_rate_currency: chf
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-01'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/zsd.yaml
+++ b/eth_defi/data/stablecoins/zsd.yaml
@@ -45,6 +45,18 @@ links:
   defillama: ''
   twitter: https://x.com/zephyr_org
 slug: zsd
+coingecko_id: zephyr-protocol-stable-dollar
+coingecko_link: https://www.coingecko.com/en/coins/zephyr-protocol-stable-dollar
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.989348
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-26T12:12:40'
+peg_rate: 0.989348
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2025-08-06'
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/zusd.yaml
+++ b/eth_defi/data/stablecoins/zusd.yaml
@@ -40,6 +40,18 @@ contract_addresses:
   - chain: ethereum
     address: '0xc56c2b7e71B54d38Aab6d52E94a04Cbfa8F604fA'
 slug: zusd
+coingecko_id: zusd
+coingecko_link: https://www.coingecko.com/en/coins/zusd
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-06-26T12:16:16'
+usd_rate: 0.9983
+usd_rate_fetched_at: '2026-06-26T12:16:16'
+usd_rate_updated_at: '2026-06-08T03:32:39'
+peg_rate: 0.9983
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
 checks:
   twitter_last_post_at: '2025-08-28'
   domain_up_at: '2026-03-17'

--- a/eth_defi/feed/README-feed.md
+++ b/eth_defi/feed/README-feed.md
@@ -372,6 +372,52 @@ The main runner is
 
 It uses environment variables instead of a command line parser.
 
+## Stablecoin rate refresh
+
+The post scanner also runs the stablecoin rate refresh side job implemented in
+[`stablecoin_rate.py`](./stablecoin_rate.py). The side job reads
+`eth_defi/data/stablecoins/*.yaml`, fetches USD prices from the CoinGecko
+`/simple/price` endpoint, and writes the current rate metadata back to the YAML
+entry:
+
+- `coingecko_id` and `coingecko_link`
+- `usd_rate`, `usd_rate_fetched_at`, and `usd_rate_updated_at`
+- `peg_rate` and `peg_rate_currency`
+- `rate_fetch_failed_at` and `rate_fetch_failed_reason`
+- sticky `depegged_at`
+
+The scanner has a durable 24-hour gate, so the refresh is attempted at most
+once per day during normal post scanning. Per-entry daily gates also prevent a
+missing or failed CoinGecko asset from being retried on every scanner cycle.
+Set `FORCE_STABLECOIN_RATE_REFRESH=true` to bypass the scanner-level gate.
+
+If a stablecoin trades below 90% of its nominal peg, the updater stamps
+`depegged_at`. The updater does not clear this flag; operators clear it
+manually in the YAML file after reviewing the asset. Vault metrics use
+`StablecoinRateFeeder` to read the YAML data, export a
+`denomination_token_rate` section per vault, and blacklist vaults whose
+denomination token has a non-empty `depegged_at` field. This blacklist is
+intentionally sticky: a recovered or false-positive asset remains excluded
+until an operator clears `depegged_at` in the YAML file.
+
+For initial YAML population or manual refreshes, use:
+
+```shell
+poetry run python scripts/erc-4626/populate-stablecoin-rates.py
+```
+
+Useful environment variables:
+
+- `STABLECOIN_DATA_DIR`: override stablecoin YAML directory
+- `COINGECKO_ID_MAPPING_FILE`: JSON mapping for explicit ambiguous ids
+- `FORCE=true`: bypass per-entry daily gates
+- `COINGECKO_DEMO_API_KEY`: optional CoinGecko demo API key
+- `STABLECOIN_RATE_TIMEOUT`: CoinGecko timeout in seconds
+
+Ambiguous symbols must store an explicit `coingecko_id`. For example, Kava
+USDX uses `coingecko_id: usdx` even though older metadata linked to the
+CoinGecko Kava Lend page.
+
 ### Default run (RSS + Twitter/X + LinkedIn)
 
 Collects all sources.  Twitter/X and LinkedIn bridge URLs are built in as

--- a/eth_defi/feed/collector.py
+++ b/eth_defi/feed/collector.py
@@ -9,7 +9,7 @@ import re
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Iterator, Sequence
+from typing import Any, Iterator, Sequence
 
 import feedparser
 import joblib
@@ -119,6 +119,12 @@ class CollectorRunSummary:
     twitter_duration_seconds: float | None = None
     #: Total scan duration in seconds.
     total_duration_seconds: float | None = None
+    #: Stablecoin rate side-job status: disabled, skipped_recent, succeeded, or failed.
+    stablecoin_rate_status: str | None = None
+    #: Stablecoin rate side-job summary when a refresh ran successfully.
+    stablecoin_rate_summary: Any | None = None
+    #: Stablecoin rate side-job error when an unexpected refresh exception was caught.
+    stablecoin_rate_error: str | None = None
 
 
 @dataclass(slots=True)

--- a/eth_defi/feed/scanner.py
+++ b/eth_defi/feed/scanner.py
@@ -6,11 +6,17 @@ without going through the script entry point.
 """
 
 import datetime
+import json
 import logging
+import os
 import re
+import stat
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+
+from strictyaml import YAMLError
 
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.feed.collector import CollectorRunSummary, collect_posts, collect_twitter_list_posts, fetch_feed_proxy_rotator
@@ -25,9 +31,22 @@ from eth_defi.feed.sources import (
     mark_twitter_handle_unknown,
     mark_twitter_source_dead,
 )
+from eth_defi.feed.stablecoin_rate import StablecoinRateRefreshSummary, refresh_stablecoin_rates
 from eth_defi.feed.twitter_api import TwitterUserCache, XApiError, resolve_twitter_handles, resolve_x_list_id_by_name, sync_x_list_members
+from eth_defi.stablecoin_metadata import STABLECOINS_DATA_DIR
 
 logger = logging.getLogger(__name__)
+
+_STABLECOIN_RATE_SIDE_JOB_ERROR_TYPES = (
+    YAMLError,
+    OSError,
+    RuntimeError,
+    ValueError,
+    TypeError,
+    KeyError,
+    AttributeError,
+    IndexError,
+)
 
 
 @dataclass(slots=True)
@@ -80,6 +99,16 @@ class PostScanConfig:
     death_detection_days: int = 180
     #: Comma-separated RSS bridge base URLs.
     twitter_rss_base_urls: list[str] = field(default_factory=list)
+    #: Refresh stablecoin rates as a post-scan side job.
+    refresh_stablecoin_rates: bool = True
+    #: Force stablecoin refresh even if the scanner-level 24h gate would skip it.
+    force_stablecoin_rate_refresh: bool = False
+    #: Stablecoin YAML data directory.
+    stablecoin_data_dir: Path = field(default_factory=lambda: STABLECOINS_DATA_DIR)
+    #: Stablecoin rate HTTP timeout.
+    stablecoin_rate_timeout: float = 20.0
+    #: Durable state file for scanner-level 24h stablecoin refresh gate.
+    stablecoin_rate_gate_path: Path | None = None
 
 
 def run_post_scan_cycle(config: PostScanConfig) -> CollectorRunSummary:
@@ -212,6 +241,8 @@ def run_post_scan_cycle(config: PostScanConfig) -> CollectorRunSummary:
     combined_summary = CollectorRunSummary(source_results=[], feeders_skipped=feeders_skipped)
     twitter_collection_used_list_timeline = False
     total_start = time.monotonic()
+
+    _run_stablecoin_rate_side_job(config, combined_summary)
 
     try:
         # Phase 1: RSS sources
@@ -459,3 +490,126 @@ def _merge_summary(target: CollectorRunSummary, source: CollectorRunSummary) -> 
         if target.source_results is None:
             target.source_results = []
         target.source_results.extend(source.source_results)
+
+
+def _stablecoin_gate_path(config: PostScanConfig) -> Path:
+    """Return the durable stablecoin refresh gate path for this scan config."""
+    if config.stablecoin_rate_gate_path is not None:
+        return config.stablecoin_rate_gate_path
+    return config.db_path.with_suffix(".stablecoin-rate-state.json")
+
+
+def _read_stablecoin_gate(path: Path) -> dict:
+    """Read the stablecoin refresh gate JSON state."""
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Could not read stablecoin rate gate state %s: %s", path, e)
+        return {}
+
+
+def _write_stablecoin_gate(path: Path, state: dict) -> None:
+    """Write the stablecoin refresh gate JSON state."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _write_text_atomic(path, json.dumps(state, indent=2, sort_keys=True))
+
+
+def _write_text_atomic(path: Path, text: str) -> None:
+    """Write text to a file using a same-directory atomic replacement."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        existing_mode = stat.S_IMODE(path.stat().st_mode)
+    except FileNotFoundError:
+        existing_mode = None
+
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.", suffix=".tmp", delete=False) as tmp_file:
+        tmp_file.write(text)
+        tmp_path = Path(tmp_file.name)
+
+    try:
+        if existing_mode is not None:
+            os.chmod(tmp_path, existing_mode)
+        os.replace(tmp_path, path)
+    except OSError:
+        if tmp_path.exists():
+            tmp_path.unlink()
+        raise
+
+
+def _stablecoin_refresh_due(state: dict, now_: datetime.datetime) -> bool:
+    """Return ``True`` if scanner-level 24h stablecoin refresh gate is open."""
+    last_succeeded_at = state.get("last_succeeded_at")
+    if not last_succeeded_at:
+        return True
+    try:
+        last_succeeded = datetime.datetime.fromisoformat(last_succeeded_at)
+    except ValueError:
+        return True
+    return now_ - last_succeeded >= datetime.timedelta(hours=24)
+
+
+def _run_stablecoin_rate_side_job(config: PostScanConfig, summary: CollectorRunSummary) -> None:
+    """Run the stablecoin rate refresh side job when the durable gate allows it."""
+    if not config.refresh_stablecoin_rates:
+        summary.stablecoin_rate_status = "disabled"
+        return
+
+    now_ = native_datetime_utc_now()
+    gate_path = _stablecoin_gate_path(config)
+    gate_state = _read_stablecoin_gate(gate_path)
+
+    if not config.force_stablecoin_rate_refresh and not _stablecoin_refresh_due(gate_state, now_):
+        summary.stablecoin_rate_status = "skipped_recent"
+        return
+
+    try:
+        stablecoin_summary: StablecoinRateRefreshSummary = refresh_stablecoin_rates(
+            data_dir=config.stablecoin_data_dir,
+            now_=now_,
+            force=config.force_stablecoin_rate_refresh,
+            timeout=config.stablecoin_rate_timeout,
+        )
+        if _stablecoin_rate_summary_failed(stablecoin_summary):
+            _record_stablecoin_rate_side_job_failure(
+                gate_path,
+                gate_state,
+                summary,
+                f"stablecoin rate refresh failed for all due entries: failed_count={stablecoin_summary.failed_count}, rates_fetched={stablecoin_summary.rates_fetched}",
+            )
+            summary.stablecoin_rate_summary = stablecoin_summary
+            return
+
+        gate_state["last_succeeded_at"] = native_datetime_utc_now().replace(microsecond=0).isoformat()
+        _write_stablecoin_gate(gate_path, gate_state)
+    except _STABLECOIN_RATE_SIDE_JOB_ERROR_TYPES as e:
+        _record_stablecoin_rate_side_job_failure(gate_path, gate_state, summary, e)
+        return
+
+    summary.stablecoin_rate_status = "succeeded"
+    summary.stablecoin_rate_summary = stablecoin_summary
+
+
+def _stablecoin_rate_summary_failed(summary: StablecoinRateRefreshSummary) -> bool:
+    """Return ``True`` if a refresh ran but all due entries failed."""
+    all_attempts_failed = summary.failed_count > 0 and summary.rates_fetched == 0
+    only_failed_attempts_were_skipped = summary.due_count == 0 and summary.rates_fetched == 0 and summary.skipped_failed_today_count > 0 and summary.skipped_succeeded_today_count == 0
+    return all_attempts_failed or only_failed_attempts_were_skipped
+
+
+def _record_stablecoin_rate_side_job_failure(
+    gate_path: Path,
+    gate_state: dict,
+    summary: CollectorRunSummary,
+    error: BaseException | str,
+) -> None:
+    """Record a stablecoin refresh failure without aborting post collection."""
+    logger.warning("Stablecoin rate refresh failed, continuing post scan: %s", error)
+    gate_state["last_failed_at"] = native_datetime_utc_now().replace(microsecond=0).isoformat()
+    try:
+        _write_stablecoin_gate(gate_path, gate_state)
+    except _STABLECOIN_RATE_SIDE_JOB_ERROR_TYPES as gate_error:
+        logger.warning("Could not write stablecoin rate gate failure state %s: %s", gate_path, gate_error)
+    summary.stablecoin_rate_status = "failed"
+    summary.stablecoin_rate_error = str(error)

--- a/eth_defi/feed/stablecoin_rate.py
+++ b/eth_defi/feed/stablecoin_rate.py
@@ -1,0 +1,867 @@
+"""Stablecoin rate refresh and depeg lookups.
+
+This module maintains mutable rate metadata in
+``eth_defi/data/stablecoins/*.yaml``. It fetches stablecoin prices from the
+CoinGecko simple price API, stores the latest USD rate and fetch timestamp, and
+marks a sticky ``depegged_at`` timestamp when a token trades below the
+configured threshold in its inferred peg currency.
+
+Vault metric calculation should use :class:`StablecoinRateFeeder` instead of
+reading YAML files directly. The feeder owns the in-process lookup caches used
+to resolve a vault denomination token to stablecoin rate metadata.
+
+See `CoinGecko simple price documentation <https://docs.coingecko.com/reference/simple-price>`__.
+"""
+
+import datetime
+import json
+import logging
+import math
+import os
+import re
+import stat
+import tempfile
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterator, Sequence, TypeVar
+
+from eth_typing import HexAddress
+from strictyaml import YAMLError
+from tqdm_loggable.auto import tqdm
+
+from eth_defi.compat import native_datetime_utc_fromtimestamp, native_datetime_utc_now
+from eth_defi.stablecoin_metadata import STABLECOINS_DATA_DIR, normalise_token_symbol, read_stablecoin_metadata
+
+try:
+    import requests  # type: ignore[import-not-found]
+except ModuleNotFoundError:
+
+    class _UrllibResponse:
+        """Small ``requests.Response`` compatible wrapper for keyless GETs."""
+
+        def __init__(self, status_code: int, body: bytes):
+            self.status_code = status_code
+            self._body = body
+            self.text = body.decode("utf-8", errors="replace")
+
+        def raise_for_status(self) -> None:
+            """Raise an HTTP-style error for non-2xx responses."""
+            if self.status_code >= 400:
+                raise RuntimeError(f"HTTP {self.status_code}: {self.text[:200]}")
+
+        def json(self) -> Any:
+            """Decode the response body as JSON."""
+            return json.loads(self.text)
+
+    class _RequestsFallback:
+        """Tiny subset of :mod:`requests` used by this module.
+
+        The repository currently receives ``requests`` transitively in some
+        extras, but the base Poetry environment may not install it. Keeping this
+        shim avoids import-time failures while preserving a monkeypatchable
+        ``requests.get`` surface for tests.
+        """
+
+        @staticmethod
+        def get(url: str, params: dict[str, str] | None = None, headers: dict[str, str] | None = None, timeout: float = 20.0) -> _UrllibResponse:
+            """Perform a blocking HTTP GET with urllib."""
+            encoded_params = urllib.parse.urlencode(params or {})
+            request_url = f"{url}?{encoded_params}" if encoded_params else url
+            request = urllib.request.Request(request_url, headers=headers or {})
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                return _UrllibResponse(response.status, response.read())
+
+    requests = _RequestsFallback()  # type: ignore[assignment]
+
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+COINGECKO_SIMPLE_PRICE_URL = "https://api.coingecko.com/api/v3/simple/price"
+COINGECKO_LINK_PREFIX = "https://www.coingecko.com/en/coins/"
+DEPEG_THRESHOLD = 0.90
+MIN_PLAUSIBLE_STABLECOIN_RATE = 0.01
+STABLECOIN_RATE_SOURCE_COINGECKO = "coingecko"
+
+_RATE_FIELDS = (
+    "coingecko_id",
+    "coingecko_link",
+    "coingecko_id_source",
+    "coingecko_id_verified_at",
+    "usd_rate",
+    "usd_rate_fetched_at",
+    "usd_rate_updated_at",
+    "peg_rate",
+    "peg_rate_currency",
+    "rate_fetch_failed_at",
+    "rate_fetch_failed_reason",
+    "depegged_at",
+)
+
+_CHAIN_ALIASES_TO_ID: dict[str, int] = {
+    "ethereum": 1,
+    "eth": 1,
+    "mainnet": 1,
+    "base": 8453,
+    "arbitrum": 42161,
+    "arbitrum_one": 42161,
+    "arbitrum-one": 42161,
+    "polygon": 137,
+    "matic": 137,
+    "optimism": 10,
+    "op": 10,
+    "binance": 56,
+    "bnb": 56,
+    "bsc": 56,
+    "avalanche": 43114,
+    "avax": 43114,
+    "fantom": 250,
+    "gnosis": 100,
+    "xdai": 100,
+    "mantle": 5000,
+    "linea": 59144,
+    "scroll": 534352,
+    "celo": 42220,
+    "kava": 2222,
+    "berachain": 80094,
+    "hyperevm": 999,
+    "hyperliquid": 999,
+}
+
+
+@dataclass(slots=True)
+class StablecoinRateTarget:
+    """One stablecoin YAML entry that may be refreshed from CoinGecko."""
+
+    yaml_path: Path
+    entry_index: int | None
+    slug: str
+    symbol: str
+    category: str
+    name: str
+    coingecko_id: str | None
+    coingecko_link: str | None
+    coingecko_id_source: str | None
+    coingecko_id_verified_at: datetime.datetime | None
+    peg_currency: str | None
+    usd_rate: float | None
+    usd_rate_fetched_at: datetime.datetime | None
+    usd_rate_updated_at: datetime.datetime | None
+    peg_rate: float | None
+    peg_rate_currency: str | None
+    rate_fetch_failed_at: datetime.datetime | None
+    rate_fetch_failed_reason: str | None
+    depegged_at: datetime.datetime | None
+    contract_addresses: list[tuple[int, str]]
+
+
+@dataclass(slots=True)
+class StablecoinRateRefreshSummary:
+    """Counters for one stablecoin rate refresh run."""
+
+    files_scanned: int = 0
+    entries_seen: int = 0
+    due_count: int = 0
+    skipped_attempted_today_count: int = 0
+    skipped_failed_today_count: int = 0
+    skipped_succeeded_today_count: int = 0
+    rates_fetched: int = 0
+    files_updated: int = 0
+    depegged_count: int = 0
+    unactionable_depegged_count: int = 0
+    skipped_missing_coingecko: int = 0
+    skipped_unknown_peg: int = 0
+    failed_count: int = 0
+
+
+@dataclass(slots=True)
+class DenominationTokenRate:
+    """Rate data section exported for a vault denomination token."""
+
+    coingecko_id: str | None
+    usd_rate: float | None
+    usd_rate_fetched_at: datetime.datetime | None
+    usd_rate_source: str | None
+
+
+@dataclass(slots=True)
+class StablecoinRateFeeder:
+    """Cached stablecoin rate/depeg lookup helper for vault metrics."""
+
+    data_dir: Path = STABLECOINS_DATA_DIR
+    _depegged_contracts: set[tuple[int, str]] | None = field(default=None, init=False, repr=False)
+    _depegged_symbols: set[str] | None = field(default=None, init=False, repr=False)
+    _rate_contracts: dict[tuple[int, str], DenominationTokenRate] | None = field(default=None, init=False, repr=False)
+    _rate_symbols: dict[str, DenominationTokenRate] | None = field(default=None, init=False, repr=False)
+
+    def get_denomination_token_rate_section(
+        self,
+        chain_id: int | None,
+        address: HexAddress | str | None,
+        symbol: str | None,
+    ) -> DenominationTokenRate:
+        """Resolve a vault denomination token to exported rate metadata."""
+        if self._rate_contracts is None or self._rate_symbols is None:
+            self._rate_contracts, self._rate_symbols = build_stablecoin_rate_lookups(self.data_dir)
+
+        key = _normalise_contract_key(chain_id, address)
+        if key and key in self._rate_contracts:
+            return self._rate_contracts[key]
+
+        normalised_symbol = normalise_token_symbol(symbol)
+        if normalised_symbol and normalised_symbol in self._rate_symbols:
+            return self._rate_symbols[normalised_symbol]
+
+        return DenominationTokenRate(coingecko_id=None, usd_rate=None, usd_rate_fetched_at=None, usd_rate_source=None)
+
+    def is_depegged_stablecoin_token(
+        self,
+        chain_id: int | None,
+        address: HexAddress | str | None,
+        symbol: str | None,
+    ) -> bool:
+        """Return ``True`` when a denomination token is marked depegged."""
+        if self._depegged_contracts is None or self._depegged_symbols is None:
+            self._depegged_contracts, self._depegged_symbols = build_depegged_stablecoin_lookups(self.data_dir)
+
+        key = _normalise_contract_key(chain_id, address)
+        if key and key in self._depegged_contracts:
+            return True
+
+        normalised_symbol = normalise_token_symbol(symbol)
+        return bool(normalised_symbol and normalised_symbol in self._depegged_symbols)
+
+
+def extract_coingecko_id(url: str | None) -> str | None:
+    """Extract a CoinGecko coin id from a human-readable CoinGecko URL."""
+    if not url:
+        return None
+
+    parsed = urllib.parse.urlparse(url.strip())
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) >= 3 and parts[0] == "en" and parts[1] == "coins":
+        return parts[2]
+    return None
+
+
+def resolve_coingecko_metadata(entry: dict[str, Any]) -> tuple[str | None, str | None, str | None]:
+    """Resolve the CoinGecko id, page link, and id source for one YAML entry."""
+    explicit_id = _clean_string(entry.get("coingecko_id"))
+    explicit_link = _clean_string(entry.get("coingecko_link"))
+    source = _clean_string(entry.get("coingecko_id_source"))
+
+    if explicit_id:
+        return explicit_id, explicit_link or f"{COINGECKO_LINK_PREFIX}{explicit_id}", source or "manual"
+
+    for link in (explicit_link, _clean_string((entry.get("links") or {}).get("coingecko"))):
+        parsed_id = extract_coingecko_id(link)
+        if parsed_id:
+            return parsed_id, f"{COINGECKO_LINK_PREFIX}{parsed_id}", "url"
+
+    return None, explicit_link, source
+
+
+def iter_stablecoin_rate_targets(data_dir: Path = STABLECOINS_DATA_DIR) -> Iterator[StablecoinRateTarget]:
+    """Iterate stablecoin YAML entries that can participate in rate refreshes."""
+    for yaml_path in sorted(data_dir.glob("*.yaml")):
+        try:
+            data = read_stablecoin_metadata(yaml_path)
+        except YAMLError as e:
+            raise ValueError(f"Could not read stablecoin metadata {yaml_path}: {e}") from e
+        symbol = data["symbol"]
+        slug = data.get("slug") or yaml_path.stem
+
+        if "entries" in data:
+            for entry_index, entry in enumerate(data["entries"]):
+                yield _build_target(yaml_path, entry_index, slug, symbol, data.get("category", ""), entry)
+        else:
+            yield _build_target(yaml_path, None, slug, symbol, data.get("category", ""), data)
+
+
+def fetch_stablecoin_rates(targets: Sequence[StablecoinRateTarget], timeout: float = 20.0, progress_bar: bool = False) -> dict[str, dict[str, Any]]:
+    """Fetch CoinGecko prices for due stablecoin targets.
+
+    :param targets:
+        Due targets with resolved CoinGecko ids.
+
+    :param timeout:
+        HTTP request timeout in seconds.
+
+    :param progress_bar:
+        Show a tqdm progress bar for CoinGecko request batches.
+
+    :return:
+        CoinGecko response keyed by coin id.
+    """
+    ids = sorted({target.coingecko_id for target in targets if target.coingecko_id})
+    if not ids:
+        return {}
+
+    vs_currencies = sorted({"usd"} | {target.peg_currency for target in targets if target.peg_currency})
+    headers = {"User-Agent": "web3-ethereum-defi stablecoin rate refresh"}
+    api_key = os.environ.get("COINGECKO_DEMO_API_KEY")
+    if api_key:
+        headers["x-cg-demo-api-key"] = api_key
+
+    result: dict[str, dict[str, Any]] = {}
+    batch_size = 200
+    batch_starts = list(range(0, len(ids), batch_size))
+    for start in _progress(batch_starts, progress_bar, "Fetching CoinGecko batches", "batch"):
+        batch = ids[start : start + batch_size]
+        response = requests.get(
+            COINGECKO_SIMPLE_PRICE_URL,
+            params={
+                "ids": ",".join(batch),
+                "vs_currencies": ",".join(vs_currencies),
+                "include_last_updated_at": "true",
+            },
+            headers=headers,
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise ValueError("CoinGecko simple price response was not a JSON object")
+        result.update(payload)
+    return result
+
+
+def refresh_stablecoin_rates(
+    data_dir: Path = STABLECOINS_DATA_DIR,
+    now_: datetime.datetime | None = None,
+    force: bool = False,
+    timeout: float = 20.0,
+    progress_bar: bool = False,
+) -> StablecoinRateRefreshSummary:
+    """Refresh stablecoin rates and persist YAML metadata updates.
+
+    This function is intentionally entry tolerant: missing CoinGecko ids and
+    missing prices are written to per-entry failure fields instead of aborting
+    the whole run. HTTP-level failures are recorded for all due targets in the
+    batch, then returned in the summary. Depeg decisions are made only when the
+    token's peg currency can be inferred and CoinGecko returns that currency.
+    """
+    now_ = now_ or native_datetime_utc_now()
+    targets = list(_progress(iter_stablecoin_rate_targets(data_dir), progress_bar, "Reading stablecoin YAML", "entry"))
+    summary = StablecoinRateRefreshSummary(
+        files_scanned=len({target.yaml_path for target in targets}),
+        entries_seen=len(targets),
+    )
+
+    due_targets: list[StablecoinRateTarget] = []
+    skipped_targets: list[StablecoinRateTarget] = []
+    for target in targets:
+        if force or not _target_was_attempted_today(target, now_):
+            due_targets.append(target)
+        else:
+            skipped_targets.append(target)
+    summary.due_count = len(due_targets)
+    summary.skipped_attempted_today_count = len(skipped_targets)
+    summary.skipped_failed_today_count = sum(1 for target in skipped_targets if _target_failed_today(target, now_))
+    summary.skipped_succeeded_today_count = sum(1 for target in skipped_targets if _target_succeeded_today(target, now_))
+    due_with_ids = [target for target in due_targets if target.coingecko_id]
+    updates: dict[tuple[Path, int | None], dict[str, Any]] = {}
+
+    for target in _progress(due_targets, progress_bar, "Checking stablecoin entries", "entry"):
+        if not target.coingecko_id:
+            summary.skipped_missing_coingecko += 1
+            summary.failed_count += 1
+            updates[(target.yaml_path, target.entry_index)] = _failure_update(now_, "missing_coingecko_id", target)
+
+    prices: dict[str, dict[str, Any]] = {}
+    if due_with_ids:
+        try:
+            prices = fetch_stablecoin_rates(due_with_ids, timeout=timeout, progress_bar=progress_bar)
+        except _coingecko_fetch_error_types() as e:
+            logger.warning("CoinGecko stablecoin rate batch failed: %s", e)
+            for target in due_with_ids:
+                summary.failed_count += 1
+                updates[(target.yaml_path, target.entry_index)] = _failure_update(now_, "coingecko_http_error", target)
+            return _apply_refresh_updates(updates, summary, progress_bar=progress_bar)
+
+    fetched_ids: set[str] = set()
+    for target in _progress(due_with_ids, progress_bar, "Applying CoinGecko prices", "entry"):
+        price_data = prices.get(target.coingecko_id or "")
+        if not isinstance(price_data, dict):
+            summary.failed_count += 1
+            updates[(target.yaml_path, target.entry_index)] = _failure_update(now_, "coingecko_price_missing", target)
+            continue
+
+        usd_rate = _parse_price(price_data.get("usd"))
+        if usd_rate is None:
+            summary.failed_count += 1
+            updates[(target.yaml_path, target.entry_index)] = _failure_update(now_, "coingecko_price_missing", target)
+            continue
+
+        peg_currency = target.peg_currency
+        peg_rate = _parse_price(price_data.get(peg_currency)) if peg_currency else None
+        if peg_currency is None or peg_rate is None:
+            summary.skipped_unknown_peg += 1
+
+        upstream_updated_at = _parse_upstream_timestamp(price_data.get("last_updated_at"))
+        update = _success_update(target, usd_rate, peg_rate, peg_currency if peg_rate is not None else None, upstream_updated_at, now_)
+
+        should_check_depeg = peg_rate is not None and target.category == "stablecoin"
+        if should_check_depeg and _is_wrong_asset_guard_failure(target, peg_rate):
+            summary.failed_count += 1
+            updates[(target.yaml_path, target.entry_index)] = _failure_update(now_, "coingecko_price_missing", target)
+            continue
+        elif should_check_depeg and peg_rate < DEPEG_THRESHOLD:
+            update["depegged_at"] = target.depegged_at or now_
+            summary.depegged_count += 1
+            if not _target_is_actionable(target):
+                summary.unactionable_depegged_count += 1
+                logger.warning("Depegged stablecoin entry %s/%s is not actionable for vault blacklisting", target.slug, target.name)
+
+        updates[(target.yaml_path, target.entry_index)] = update
+        fetched_ids.add(target.coingecko_id or "")
+
+    summary.rates_fetched = len(fetched_ids)
+    return _apply_refresh_updates(updates, summary, progress_bar=progress_bar)
+
+
+def build_depegged_stablecoin_lookups(data_dir: Path = STABLECOINS_DATA_DIR) -> tuple[set[tuple[int, str]], set[str]]:
+    """Build contract and unambiguous symbol lookups for depegged stablecoins."""
+    depegged_contracts: set[tuple[int, str]] = set()
+    symbol_owner_counts: dict[str, int] = {}
+    depegged_symbol_candidates: set[str] = set()
+
+    for target in iter_stablecoin_rate_targets(data_dir):
+        normalised_symbol = normalise_token_symbol(target.symbol)
+        if normalised_symbol and target.entry_index is None:
+            symbol_owner_counts[normalised_symbol] = symbol_owner_counts.get(normalised_symbol, 0) + 1
+
+        if target.depegged_at is None:
+            continue
+        depegged_contracts.update(target.contract_addresses)
+        if normalised_symbol and target.entry_index is None:
+            depegged_symbol_candidates.add(normalised_symbol)
+
+    depegged_symbols = {symbol for symbol in depegged_symbol_candidates if symbol_owner_counts.get(symbol) == 1}
+    return depegged_contracts, depegged_symbols
+
+
+def build_stablecoin_rate_lookups(data_dir: Path = STABLECOINS_DATA_DIR) -> tuple[dict[tuple[int, str], DenominationTokenRate], dict[str, DenominationTokenRate]]:
+    """Build contract and unambiguous symbol lookups for all known rate data."""
+    contract_rates: dict[tuple[int, str], DenominationTokenRate] = {}
+    symbol_candidates: dict[str, list[tuple[StablecoinRateTarget, DenominationTokenRate]]] = {}
+
+    for target in iter_stablecoin_rate_targets(data_dir):
+        rate = _target_to_denomination_rate(target)
+        for contract_key in target.contract_addresses:
+            contract_rates[contract_key] = rate
+
+        normalised_symbol = normalise_token_symbol(target.symbol)
+        if normalised_symbol and target.entry_index is None:
+            symbol_candidates.setdefault(normalised_symbol, []).append((target, rate))
+
+    symbol_rates = {symbol: matches[0][1] for symbol, matches in symbol_candidates.items() if len(matches) == 1}
+    return contract_rates, symbol_rates
+
+
+def apply_coingecko_mapping_file(data_dir: Path, mapping_path: Path, progress_bar: bool = False) -> int:
+    """Apply explicit CoinGecko id mappings to stablecoin YAML files.
+
+    The mapping JSON shape is intentionally simple:
+
+    .. code-block:: json
+
+        {
+          "usdx": {
+            "Kava USDX": {
+              "coingecko_id": "usdx",
+              "coingecko_link": "https://www.coingecko.com/en/coins/usdx"
+            }
+          }
+        }
+
+    Top-level keys are stablecoin slugs. For multi-entry files, the nested key
+    can be the entry name or a numeric entry index encoded as a string. Standard
+    files may use ``"default"``.
+    """
+    if not mapping_path.exists():
+        raise FileNotFoundError(f"CoinGecko mapping file does not exist: {mapping_path}")
+
+    raw = json.loads(mapping_path.read_text())
+    if not isinstance(raw, dict):
+        raise ValueError("CoinGecko mapping file must contain a JSON object")
+
+    changed = 0
+    for slug, slug_mapping in _progress(list(raw.items()), progress_bar, "Applying CoinGecko mappings", "file"):
+        yaml_path = data_dir / f"{slug}.yaml"
+        if not yaml_path.exists() or not isinstance(slug_mapping, dict):
+            continue
+        data = read_stablecoin_metadata(yaml_path)
+        if "entries" in data:
+            for entry_index, entry in enumerate(data["entries"]):
+                mapping = slug_mapping.get(entry.get("name")) or slug_mapping.get(str(entry_index))
+                if isinstance(mapping, dict):
+                    _update_yaml_entry_fields(yaml_path, entry_index, _mapping_update(mapping))
+                    changed += 1
+        else:
+            mapping = slug_mapping.get("default") or slug_mapping.get(data.get("name")) or slug_mapping
+            if isinstance(mapping, dict) and mapping.get("coingecko_id"):
+                _update_yaml_entry_fields(yaml_path, None, _mapping_update(mapping))
+                changed += 1
+
+    return changed
+
+
+def _build_target(yaml_path: Path, entry_index: int | None, slug: str, symbol: str, category: str, entry: dict[str, Any]) -> StablecoinRateTarget:
+    coingecko_id, coingecko_link, coingecko_id_source = resolve_coingecko_metadata(entry)
+    peg_currency = _guess_peg_currency(symbol, f"{entry.get('name', '')} {entry.get('short_description', '')}")
+    return StablecoinRateTarget(
+        yaml_path=yaml_path,
+        entry_index=entry_index,
+        slug=slug,
+        symbol=symbol,
+        category=category,
+        name=entry.get("name", ""),
+        coingecko_id=coingecko_id,
+        coingecko_link=coingecko_link,
+        coingecko_id_source=coingecko_id_source,
+        coingecko_id_verified_at=_parse_datetime(entry.get("coingecko_id_verified_at")),
+        peg_currency=peg_currency,
+        usd_rate=_parse_float(entry.get("usd_rate")),
+        usd_rate_fetched_at=_parse_datetime(entry.get("usd_rate_fetched_at")),
+        usd_rate_updated_at=_parse_datetime(entry.get("usd_rate_updated_at")),
+        peg_rate=_parse_float(entry.get("peg_rate")),
+        peg_rate_currency=_clean_string(entry.get("peg_rate_currency")),
+        rate_fetch_failed_at=_parse_datetime(entry.get("rate_fetch_failed_at")),
+        rate_fetch_failed_reason=_clean_string(entry.get("rate_fetch_failed_reason")),
+        depegged_at=_parse_datetime(entry.get("depegged_at")),
+        contract_addresses=_parse_contract_addresses(entry),
+    )
+
+
+def _parse_contract_addresses(entry: dict[str, Any]) -> list[tuple[int, str]]:
+    raw = entry.get("contract_addresses") or []
+    result = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        chain_id = _chain_slug_to_id(item.get("chain"))
+        address = _clean_string(item.get("address"))
+        if chain_id is not None and address:
+            result.append((chain_id, address.lower()))
+    return result
+
+
+def _coingecko_fetch_error_types() -> tuple[type[BaseException], ...]:
+    """Return exception types expected from CoinGecko HTTP/JSON fetches."""
+    request_exception = getattr(getattr(requests, "exceptions", None), "RequestException", None)
+    base_types: tuple[type[BaseException], ...] = (OSError, RuntimeError, TimeoutError, ValueError)
+    if isinstance(request_exception, type):
+        return (request_exception, *base_types)
+    return base_types
+
+
+def _chain_slug_to_id(chain: Any) -> int | None:
+    if chain is None:
+        return None
+    if isinstance(chain, int):
+        return chain
+    slug = str(chain).strip().lower().replace(" ", "_")
+    return _CHAIN_ALIASES_TO_ID.get(slug)
+
+
+def _normalise_contract_key(chain_id: int | None, address: HexAddress | str | None) -> tuple[int, str] | None:
+    if chain_id is None or not address:
+        return None
+    return int(chain_id), str(address).lower()
+
+
+def _clean_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    value = str(value).strip()
+    return value or None
+
+
+def _parse_datetime(value: Any) -> datetime.datetime | None:
+    text = _clean_string(value)
+    if not text:
+        return None
+    try:
+        return datetime.datetime.fromisoformat(text.replace("Z", ""))
+    except ValueError:
+        return None
+
+
+def _format_datetime(value: datetime.datetime | None) -> str:
+    if value is None:
+        return ""
+    return value.replace(microsecond=0).isoformat()
+
+
+def _parse_float(value: Any) -> float | None:
+    text = _clean_string(value)
+    if not text:
+        return None
+    try:
+        parsed = float(text)
+    except ValueError:
+        return None
+    if not math.isfinite(parsed):
+        return None
+    return parsed
+
+
+def _parse_price(value: Any) -> float | None:
+    parsed = _parse_float(value)
+    if parsed is None or parsed <= 0:
+        return None
+    return parsed
+
+
+def _parse_upstream_timestamp(value: Any) -> datetime.datetime | None:
+    if value in (None, ""):
+        return None
+    try:
+        return native_datetime_utc_fromtimestamp(float(value))
+    except (TypeError, ValueError, OSError, OverflowError):
+        return None
+
+
+def _guess_peg_currency(symbol: str, name: str) -> str | None:
+    symbol_lower = symbol.lower()
+    name_words = set(re.findall(r"[a-z0-9]+", name.lower()))
+
+    def symbol_has(code: str) -> bool:
+        return code in symbol_lower
+
+    def name_has(*terms: str) -> bool:
+        return any(term in name_words for term in terms)
+
+    if symbol_has("cad") or name_has("cad", "canadian"):
+        return "cad"
+    if symbol_has("jpy") or name_has("jpy", "yen", "japanese"):
+        return "jpy"
+    if symbol_has("gbp") or name_has("gbp", "pound", "sterling"):
+        return "gbp"
+    if symbol_has("aud") or name_has("aud", "australian"):
+        return "aud"
+    if symbol_has("hkd") or ("hong" in name_words and "kong" in name_words):
+        return "hkd"
+    if symbol_has("nzd") or ("new" in name_words and "zealand" in name_words):
+        return "nzd"
+    if symbol_has("eur") or name_has("eur", "euro"):
+        return "eur"
+    if symbol_has("chf") or name_has("chf", "franc"):
+        return "chf"
+    if symbol_has("sgd") or name_has("sgd", "singapore"):
+        return "sgd"
+    if symbol_has("try") or name_has("try", "turkish"):
+        return "try"
+    if symbol_has("xau") or symbol_lower == "paxg" or ("tether" in name_words and "gold" in name_words):
+        return "xau"
+    if symbol_has("usd") or name_has("usd", "dollar"):
+        return "usd"
+    return None
+
+
+def _target_was_attempted_today(target: StablecoinRateTarget, now_: datetime.datetime) -> bool:
+    today = now_.date()
+    for value in (target.usd_rate_fetched_at, target.rate_fetch_failed_at):
+        if value and value.date() == today:
+            return True
+    return False
+
+
+def _target_failed_today(target: StablecoinRateTarget, now_: datetime.datetime) -> bool:
+    """Return ``True`` if a target already recorded a failed refresh today."""
+    return bool(target.rate_fetch_failed_at and target.rate_fetch_failed_at.date() == now_.date())
+
+
+def _target_succeeded_today(target: StablecoinRateTarget, now_: datetime.datetime) -> bool:
+    """Return ``True`` if a target already recorded a successful refresh today."""
+    return bool(target.usd_rate_fetched_at and target.usd_rate_fetched_at.date() == now_.date())
+
+
+def _success_update(
+    target: StablecoinRateTarget,
+    usd_rate: float,
+    peg_rate: float | None,
+    peg_currency: str | None,
+    upstream_updated_at: datetime.datetime | None,
+    now_: datetime.datetime,
+) -> dict[str, Any]:
+    update: dict[str, Any] = {
+        "coingecko_id": target.coingecko_id or "",
+        "coingecko_link": target.coingecko_link or (f"{COINGECKO_LINK_PREFIX}{target.coingecko_id}" if target.coingecko_id else ""),
+        "coingecko_id_source": target.coingecko_id_source or "",
+        "coingecko_id_verified_at": now_,
+        "usd_rate": usd_rate,
+        "usd_rate_fetched_at": now_,
+        "usd_rate_updated_at": upstream_updated_at,
+        "peg_rate": peg_rate,
+        "peg_rate_currency": peg_currency or "",
+        "rate_fetch_failed_at": "",
+        "rate_fetch_failed_reason": "",
+        "depegged_at": target.depegged_at,
+    }
+    return update
+
+
+def _failure_update(now_: datetime.datetime, reason: str, target: StablecoinRateTarget) -> dict[str, Any]:
+    update: dict[str, Any] = {
+        "rate_fetch_failed_at": now_,
+        "rate_fetch_failed_reason": reason,
+    }
+    if target.coingecko_id:
+        update.update(
+            {
+                "coingecko_id": target.coingecko_id,
+                "coingecko_link": target.coingecko_link or f"{COINGECKO_LINK_PREFIX}{target.coingecko_id}",
+                "coingecko_id_source": target.coingecko_id_source or "",
+            }
+        )
+    return update
+
+
+def _is_wrong_asset_guard_failure(target: StablecoinRateTarget, peg_rate: float) -> bool:
+    source = target.coingecko_id_source or ""
+    verified = target.coingecko_id_verified_at is not None
+    return peg_rate < MIN_PLAUSIBLE_STABLECOIN_RATE and source != "manual" and not verified
+
+
+def _target_is_actionable(target: StablecoinRateTarget) -> bool:
+    if target.contract_addresses:
+        return True
+    return target.entry_index is None and bool(normalise_token_symbol(target.symbol))
+
+
+def _target_to_denomination_rate(target: StablecoinRateTarget) -> DenominationTokenRate:
+    return DenominationTokenRate(
+        coingecko_id=target.coingecko_id,
+        usd_rate=target.usd_rate,
+        usd_rate_fetched_at=target.usd_rate_fetched_at,
+        usd_rate_source=STABLECOIN_RATE_SOURCE_COINGECKO if target.usd_rate is not None else None,
+    )
+
+
+def _progress(items: Sequence[T] | Iterator[T], enabled: bool, desc: str, unit: str) -> Iterator[T]:
+    """Wrap an iterable in tqdm when requested."""
+    if enabled:
+        total = len(items) if isinstance(items, Sequence) else None
+        yield from tqdm(items, total=total, desc=desc, unit=unit)
+    else:
+        yield from items
+
+
+def _apply_refresh_updates(updates: dict[tuple[Path, int | None], dict[str, Any]], summary: StablecoinRateRefreshSummary, progress_bar: bool = False) -> StablecoinRateRefreshSummary:
+    updated_paths: set[Path] = set()
+    for (yaml_path, entry_index), fields in _progress(list(updates.items()), progress_bar, "Writing stablecoin YAML", "entry"):
+        if fields:
+            _update_yaml_entry_fields(yaml_path, entry_index, fields)
+            updated_paths.add(yaml_path)
+    summary.files_updated = len(updated_paths)
+    return summary
+
+
+def _mapping_update(mapping: dict[str, Any]) -> dict[str, Any]:
+    coingecko_id = _clean_string(mapping.get("coingecko_id"))
+    return {
+        "coingecko_id": coingecko_id or "",
+        "coingecko_link": _clean_string(mapping.get("coingecko_link")) or (f"{COINGECKO_LINK_PREFIX}{coingecko_id}" if coingecko_id else ""),
+        "coingecko_id_source": _clean_string(mapping.get("coingecko_id_source")) or "manual",
+    }
+
+
+def _format_yaml_value(value: Any) -> str:
+    if value is None or value == "":
+        return "''"
+    if isinstance(value, datetime.datetime):
+        return f"'{_format_datetime(value)}'"
+    if isinstance(value, float):
+        return f"{value:.12g}"
+    if isinstance(value, int):
+        return str(value)
+    text = str(value)
+    if not text:
+        return "''"
+    if re.fullmatch(r"[A-Za-z0-9_.:/?#=&%+-]+", text):
+        return text
+    return json.dumps(text)
+
+
+def _update_yaml_entry_fields(yaml_path: Path, entry_index: int | None, fields: dict[str, Any]) -> None:
+    lines = yaml_path.read_text().splitlines(keepends=True)
+    start, end, indent = _find_yaml_entry_block(lines, entry_index)
+    existing = _find_existing_field_lines(lines, start, end, indent)
+
+    rendered = [f"{indent}{key}: {_format_yaml_value(fields.get(key))}\n" for key in _RATE_FIELDS if key in fields]
+    for key, line_index in sorted(existing.items(), key=lambda item: item[1], reverse=True):
+        if key in fields:
+            del lines[line_index]
+            end -= 1
+
+    insert_at = _find_insert_position(lines, start, end, indent)
+    for offset, line in enumerate(rendered):
+        lines.insert(insert_at + offset, line)
+
+    _write_text_atomic(yaml_path, "".join(lines))
+
+
+def _write_text_atomic(path: Path, text: str) -> None:
+    """Write text to a file using a same-directory atomic replacement."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        existing_mode = stat.S_IMODE(path.stat().st_mode)
+    except FileNotFoundError:
+        existing_mode = None
+
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.", suffix=".tmp", delete=False) as tmp_file:
+        tmp_file.write(text)
+        tmp_path = Path(tmp_file.name)
+
+    try:
+        if existing_mode is not None:
+            os.chmod(tmp_path, existing_mode)
+        os.replace(tmp_path, path)
+    except OSError:
+        if tmp_path.exists():
+            tmp_path.unlink()
+        raise
+
+
+def _find_yaml_entry_block(lines: list[str], entry_index: int | None) -> tuple[int, int, str]:
+    if entry_index is None:
+        return 0, len(lines), ""
+
+    entries_line = next((i for i, line in enumerate(lines) if line.startswith("entries:")), None)
+    if entries_line is None:
+        raise ValueError("Cannot update entry metadata from YAML without entries block")
+
+    item_starts = [i for i in range(entries_line + 1, len(lines)) if re.match(r"^-\s+[A-Za-z_][A-Za-z0-9_]*\s*:", lines[i])]
+    if entry_index >= len(item_starts):
+        raise IndexError(f"Entry index {entry_index} out of range for {len(item_starts)} entries")
+
+    start = item_starts[entry_index]
+    end = item_starts[entry_index + 1] if entry_index + 1 < len(item_starts) else len(lines)
+    for i in range(start + 1, len(lines)):
+        if i >= end:
+            break
+        if re.match(r"^[A-Za-z_][A-Za-z0-9_]*:\s*", lines[i]):
+            end = i
+            break
+    return start, end, "  "
+
+
+def _find_existing_field_lines(lines: list[str], start: int, end: int, indent: str) -> dict[str, int]:
+    existing = {}
+    for i in range(start, end):
+        for key in _RATE_FIELDS:
+            if lines[i].startswith(f"{indent}{key}:"):
+                existing[key] = i
+    return existing
+
+
+def _find_insert_position(lines: list[str], start: int, end: int, indent: str) -> int:
+    for i in range(start, end):
+        if lines[i].startswith(f"{indent}checks:"):
+            return i
+    return end

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -29,6 +29,7 @@ from eth_defi.core3.vault_protocol import Core3ExportRecord, Core3VaultSection, 
 from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS
 from eth_defi.erc_4626.core import ERC4262VaultDetection
 from eth_defi.erc_4626.vault_protocol.morpho.flag_analytics import MorphoFlagAnalytics, analyze_morpho_flags
+from eth_defi.feed.stablecoin_rate import DenominationTokenRate, StablecoinRateFeeder
 from eth_defi.research.value_table import format_grouped_series_as_multi_column_grid, format_series_as_multi_column_grid
 from eth_defi.research.wrangle_vault_prices import forward_fill_vault
 from eth_defi.token import is_stablecoin_like, normalise_token_symbol
@@ -267,6 +268,9 @@ class VaultMetricsRecord(TypedDict, total=False):
     #: when no Core3 data is available. See
     #: :py:class:`~eth_defi.core3.vault_protocol.Core3VaultSection`.
     core3: "Core3VaultSection | None"
+
+    #: Stablecoin rate data for the vault denomination token.
+    denomination_token_rate: DenominationTokenRate
 
     #: Per-period tearsheet results
     period_results: list[dict]
@@ -1340,6 +1344,7 @@ def calculate_vault_record(
     three_months_ago: pd.Timestamp,
     vault_id: str | None = None,
     core3_protocols: dict[str, Core3ExportRecord] | None = None,
+    stablecoin_rate_feeder: StablecoinRateFeeder | None = None,
 ) -> pd.Series:
     """Process a single vault metadata + prices to calculate its full data.
 
@@ -1369,6 +1374,13 @@ def calculate_vault_record(
         (:py:class:`~eth_defi.core3.vault_protocol.Core3VaultSection`) is
         attached to the record for the vault's protocol, or ``None`` if
         the protocol has no Core3 data.
+
+    :param stablecoin_rate_feeder:
+        Stablecoin rate/depeg lookup helper. If omitted, a default feeder using
+        package stablecoin metadata is constructed for this vault. Batch callers
+        should pass one shared
+        :py:class:`~eth_defi.feed.stablecoin_rate.StablecoinRateFeeder` so the
+        stablecoin YAML lookups are cached consistently across the batch.
 
     :return:
         Series with calculated metrics
@@ -1650,6 +1662,15 @@ def calculate_vault_record(
         denomination_token_address = None
         denomination_token_decimals = None
 
+    if stablecoin_rate_feeder is None:
+        stablecoin_rate_feeder = StablecoinRateFeeder()
+
+    denomination_token_rate = stablecoin_rate_feeder.get_denomination_token_rate_section(
+        chain_id=chain_id,
+        address=denomination_token_address,
+        symbol=normalised_denomination,
+    )
+
     # Do we know fees for this vault
     known_fee = mgmt_fee is not None and perf_fee is not None
 
@@ -1732,6 +1753,22 @@ def calculate_vault_record(
         three_months_volatility=three_months_volatility,
     )
 
+    if stablecoin_rate_feeder.is_depegged_stablecoin_token(
+        chain_id=chain_id,
+        address=denomination_token_address,
+        symbol=normalised_denomination,
+    ):
+        flags = set(flags)
+        flags.add(VaultFlag.depegged_denomination_token)
+        risk = VaultTechnicalRisk.blacklisted
+        depeg_note = f"Denomination stablecoin {normalised_denomination or denomination} is marked as depegged"
+        notes = f"{notes}; {depeg_note}" if notes else depeg_note
+        other_data["vault_display_flags"] = list(other_data.get("vault_display_flags") or []) + make_vault_display_flags(
+            red_flags=[VaultFlag.depegged_denomination_token.value],
+            yellow_flags=[],
+            source="stablecoin",
+        )
+
     # Legacy: One month metrics
     if one_month_pm and one_month_pm.error_reason is None:
         one_month_returns = one_month_pm.returns_gross
@@ -1757,6 +1794,7 @@ def calculate_vault_record(
     last_share_price = prices_df.iloc[-1]["share_price"]
     first_updated_at = prices_df.index.min()
     first_updated_block = prices_df.iloc[0]["block_number"]
+    risk_numeric = risk.value if isinstance(risk, VaultTechnicalRisk) else None
 
     return pd.Series(
         {
@@ -1859,6 +1897,7 @@ def calculate_vault_record(
             # Compact per-vault Core3 risk summary (risk_score, market_cap, rating, etc.).
             # None when no Core3 data is available for the vault's protocol.
             "core3": core3_section,
+            "denomination_token_rate": denomination_token_rate,
             # Protocol-specific extension data; see other_data definition above for structure
             "other_data": other_data,
         }
@@ -1870,6 +1909,7 @@ def calculate_lifetime_metrics(
     vault_db: VaultDatabase | dict[VaultSpec, VaultRow],
     returns_column: str = "returns_1h",
     core3_protocols: dict[str, Core3ExportRecord] | None = None,
+    stablecoin_rate_feeder: StablecoinRateFeeder | None = None,
 ) -> pd.DataFrame:
     """Calculate lifetime metrics for each vault in the provided DataFrame.
 
@@ -1895,6 +1935,10 @@ def calculate_lifetime_metrics(
         Threaded through to :py:func:`calculate_vault_record` to attach a
         per-vault ``core3`` summary. ``None`` to skip Core3 enrichment.
 
+    :param stablecoin_rate_feeder:
+        Stablecoin rate/depeg lookup helper shared across all vault rows in
+        this calculation. If omitted, one default feeder is constructed.
+
     :return:
         DataFrame, one row per vault.
     """
@@ -1918,11 +1962,22 @@ def calculate_lifetime_metrics(
         vaults=vaults_by_id,
     )
 
+    if stablecoin_rate_feeder is None:
+        stablecoin_rate_feeder = StablecoinRateFeeder()
+
     # Use progress_apply instead of the for loop
     # Sort is needed for slug stability
     # We pass include_groups=False to avoid FutureWarning, and pass id via group.name
     def _apply_vault_record(group):
-        return calculate_vault_record(group, vaults_by_id, month_ago, three_months_ago, vault_id=group.name, core3_protocols=core3_protocols)
+        return calculate_vault_record(
+            group,
+            vaults_by_id,
+            month_ago,
+            three_months_ago,
+            vault_id=group.name,
+            core3_protocols=core3_protocols,
+            stablecoin_rate_feeder=stablecoin_rate_feeder,
+        )
 
     results_df = df.groupby("id", group_keys=False, sort=True).progress_apply(
         _apply_vault_record,
@@ -2397,6 +2452,7 @@ def format_lifetime_table(
     _del("short_description")
     _del("other_data")
     _del("core3")
+    _del("denomination_token_rate")
 
     # Metadata timestamp, not relevant for human-readable table
     _del("generated_at")

--- a/eth_defi/stablecoin_metadata.py
+++ b/eth_defi/stablecoin_metadata.py
@@ -176,9 +176,11 @@ Workflow to add a logo for a new stablecoin:
 import json
 import logging
 from pathlib import Path
-from typing import TypedDict
+from typing import Any, TypedDict
 
 from strictyaml import load
+
+from eth_defi.types import ISODateString, ISODateTimeString
 
 logger = logging.getLogger(__name__)
 
@@ -454,16 +456,16 @@ class StablecoinChecks(TypedDict):
     """Automated liveness checks for a stablecoin project."""
 
     #: Date (YYYY-MM-DD) of the most recent Twitter/X post, or empty string if unknown/missing
-    twitter_last_post_at: str
+    twitter_last_post_at: ISODateString
 
     #: Date (YYYY-MM-DD) when the homepage was last confirmed reachable, or empty string
-    domain_up_at: str
+    domain_up_at: ISODateString
 
     #: Date (YYYY-MM-DD) when the project was confirmed dead, or empty string if alive/unknown
-    marked_dead_at: str
+    marked_dead_at: ISODateString
 
     #: Date (YYYY-MM-DD) when liveness could not be determined (no links found), or empty string
-    information_found_missing_at: str
+    information_found_missing_at: ISODateString
 
 
 class StablecoinMetadata(TypedDict):
@@ -502,6 +504,42 @@ class StablecoinMetadata(TypedDict):
     #: Automated liveness checks (``None`` if checks have not been run yet)
     checks: StablecoinChecks | None
 
+    #: CoinGecko API coin id used for price refreshes.
+    coingecko_id: str | None
+
+    #: Human-readable CoinGecko page URL for this asset.
+    coingecko_link: str | None
+
+    #: How the CoinGecko id was selected: ``manual``, ``url``, or ``search``.
+    coingecko_id_source: str | None
+
+    #: Last time the CoinGecko id returned a valid price.
+    coingecko_id_verified_at: ISODateTimeString | None
+
+    #: Latest USD rate from the stablecoin rate feed.
+    usd_rate: float | None
+
+    #: Time when the USD rate was fetched by our updater.
+    usd_rate_fetched_at: ISODateTimeString | None
+
+    #: CoinGecko upstream update timestamp for the USD rate.
+    usd_rate_updated_at: ISODateTimeString | None
+
+    #: Price in the denomination's peg currency used for depeg checks.
+    peg_rate: float | None
+
+    #: CoinGecko currency key used for ``peg_rate``.
+    peg_rate_currency: str | None
+
+    #: Last failed rate refresh timestamp.
+    rate_fetch_failed_at: ISODateTimeString | None
+
+    #: Machine-readable reason for the latest rate refresh failure.
+    rate_fetch_failed_reason: str | None
+
+    #: Sticky depeg marker. Operators clear this manually.
+    depegged_at: ISODateTimeString | None
+
 
 def read_stablecoin_metadata(yaml_path: Path) -> dict:
     """Read and parse a stablecoin metadata YAML file.
@@ -521,11 +559,11 @@ def read_stablecoin_metadata(yaml_path: Path) -> dict:
 _cached_metadata: dict[str, list[StablecoinInfo]] | None = None
 
 
-def load_all_stablecoin_metadata() -> dict[str, list[StablecoinInfo]]:
+def load_all_stablecoin_metadata(data_dir: Path = STABLECOINS_DATA_DIR) -> dict[str, list[StablecoinInfo]]:
     """Load all stablecoin metadata from YAML files.
 
     Returns a dict mapping symbol to list of StablecoinInfo entries.
-    Cached in-process after first call.
+    Cached in-process after first call for the default package data directory.
 
     Files with a ``token_symbols`` list register the same metadata
     under each variant symbol (e.g. ``USDT`` and ``USDt``).
@@ -535,12 +573,13 @@ def load_all_stablecoin_metadata() -> dict[str, list[StablecoinInfo]]:
     """
     global _cached_metadata
 
-    if _cached_metadata is not None:
+    use_cache = data_dir == STABLECOINS_DATA_DIR
+    if use_cache and _cached_metadata is not None:
         return _cached_metadata
 
     result: dict[str, list[StablecoinInfo]] = {}
 
-    for yaml_path in sorted(STABLECOINS_DATA_DIR.glob("*.yaml")):
+    for yaml_path in sorted(data_dir.glob("*.yaml")):
         data = read_stablecoin_metadata(yaml_path)
         symbol = data["symbol"]
 
@@ -581,7 +620,8 @@ def load_all_stablecoin_metadata() -> dict[str, list[StablecoinInfo]]:
             if variant != symbol:
                 result[variant] = info_list
 
-    _cached_metadata = result
+    if use_cache:
+        _cached_metadata = result
     return result
 
 
@@ -692,6 +732,31 @@ def build_stablecoin_metadata_json(yaml_path: Path, public_url: str = "") -> lis
             return stripped if stripped else None
         return value
 
+    def normalise_float(value: Any) -> float | None:
+        normalised = normalise(value)
+        if normalised is None:
+            return None
+        try:
+            return float(normalised)
+        except (TypeError, ValueError):
+            return None
+
+    def parse_rate_fields(source: dict) -> dict[str, str | float | None]:
+        return {
+            "coingecko_id": normalise(source.get("coingecko_id")),
+            "coingecko_link": normalise(source.get("coingecko_link")),
+            "coingecko_id_source": normalise(source.get("coingecko_id_source")),
+            "coingecko_id_verified_at": normalise(source.get("coingecko_id_verified_at")),
+            "usd_rate": normalise_float(source.get("usd_rate")),
+            "usd_rate_fetched_at": normalise(source.get("usd_rate_fetched_at")),
+            "usd_rate_updated_at": normalise(source.get("usd_rate_updated_at")),
+            "peg_rate": normalise_float(source.get("peg_rate")),
+            "peg_rate_currency": normalise(source.get("peg_rate_currency")),
+            "rate_fetch_failed_at": normalise(source.get("rate_fetch_failed_at")),
+            "rate_fetch_failed_reason": normalise(source.get("rate_fetch_failed_reason")),
+            "depegged_at": normalise(source.get("depegged_at")),
+        }
+
     # Build logo URLs based on availability
     available = get_stablecoin_available_logos(slug)
     public_url = public_url.rstrip("/") if public_url else ""
@@ -740,6 +805,7 @@ def build_stablecoin_metadata_json(yaml_path: Path, public_url: str = "") -> lis
                     logos=logos,
                     contract_addresses=parse_contract_addresses(entry),
                     checks=parse_checks(entry),
+                    **parse_rate_fields(entry),
                 )
             )
         return result
@@ -761,6 +827,7 @@ def build_stablecoin_metadata_json(yaml_path: Path, public_url: str = "") -> lis
                 logos=logos,
                 contract_addresses=parse_contract_addresses(data),
                 checks=parse_checks(data),
+                **parse_rate_fields(data),
             )
         ]
 
@@ -842,7 +909,7 @@ def process_and_upload_stablecoin_metadata(
     return metadata
 
 
-def build_stablecoin_index(public_url: str = "") -> list[StablecoinMetadata]:
+def build_stablecoin_index(public_url: str = "", data_dir: Path = STABLECOINS_DATA_DIR) -> list[StablecoinMetadata]:
     """Build a single index of all stablecoin metadata.
 
     Loads every YAML file and returns a flat list of :py:class:`StablecoinMetadata`
@@ -851,11 +918,14 @@ def build_stablecoin_index(public_url: str = "") -> list[StablecoinMetadata]:
     :param public_url:
         Public base URL for constructing logo URLs
 
+    :param data_dir:
+        Stablecoin YAML data directory to export.
+
     :return:
         List of all stablecoin metadata entries
     """
     index: list[StablecoinMetadata] = []
-    for yaml_path in sorted(STABLECOINS_DATA_DIR.glob("*.yaml")):
+    for yaml_path in sorted(data_dir.glob("*.yaml")):
         entries = build_stablecoin_metadata_json(yaml_path, public_url=public_url)
         index.extend(entries)
     return index
@@ -868,6 +938,7 @@ def upload_stablecoin_index(
     secret_access_key: str,
     public_url: str = "",
     key_prefix: str = "",
+    data_dir: Path = STABLECOINS_DATA_DIR,
 ) -> list[StablecoinMetadata]:
     """Build and upload the aggregate stablecoin index to R2.
 
@@ -878,7 +949,7 @@ def upload_stablecoin_index(
     """
     from eth_defi.research.sparkline import upload_to_r2_compressed
 
-    index = build_stablecoin_index(public_url=public_url)
+    index = build_stablecoin_index(public_url=public_url, data_dir=data_dir)
 
     json_bytes = json.dumps(index, indent=2).encode()
     index_uploaded = upload_to_r2_compressed(

--- a/eth_defi/types.py
+++ b/eth_defi/types.py
@@ -4,3 +4,9 @@ from typing import TypeAlias
 
 #: Percent number as 0...1
 Percent: TypeAlias = float
+
+#: ISO 8601 calendar date string, e.g. ``2026-06-26``.
+ISODateString: TypeAlias = str
+
+#: ISO 8601 datetime string in naive UTC, e.g. ``2026-06-26T12:00:00``.
+ISODateTimeString: TypeAlias = str

--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -78,6 +78,9 @@ class VaultFlag(str, enum.Enum):
     #: Morpho API does not return this vault by address.
     not_in_morpho_api = "not_in_morpho_api"
 
+    #: Vault denomination stablecoin is marked as depegged.
+    depegged_denomination_token = "depegged_denomination_token"
+
 
 #: Don't touch vaults with these flags
 BAD_FLAGS = {
@@ -92,6 +95,7 @@ BAD_FLAGS = {
     VaultFlag.subvault,
     VaultFlag.irregular_reporting,
     VaultFlag.not_in_morpho_api,
+    VaultFlag.depegged_denomination_token,
 }
 
 

--- a/scripts/erc-4626/populate-stablecoin-rates.py
+++ b/scripts/erc-4626/populate-stablecoin-rates.py
@@ -1,0 +1,122 @@
+"""Populate stablecoin YAML rate metadata from CoinGecko.
+
+This helper is intended for initial one-off population and manual re-runs. The
+post scanner later calls the same library refresh path through its own durable
+24-hour gate.
+
+Environment variables:
+
+- ``STABLECOIN_DATA_DIR``: Optional. Stablecoin YAML directory.
+- ``FORCE``: Optional. Set to ``true`` to bypass per-entry daily gates.
+- ``STABLECOIN_RATE_TIMEOUT``: Optional. CoinGecko timeout in seconds. Default: 20.
+- ``COINGECKO_ID_MAPPING_FILE``: Optional. JSON file with explicit id mappings.
+- ``COINGECKO_DEMO_API_KEY``: Optional. CoinGecko demo API key read by the rate module.
+- ``PROGRESS``: Optional. Set to ``false`` to hide tqdm progress bars. Default: true.
+- ``LOG_LEVEL``: Optional. Default: info.
+"""
+
+import logging
+import os
+from collections import Counter
+from pathlib import Path
+
+from tabulate import tabulate
+
+from eth_defi.feed.stablecoin_rate import apply_coingecko_mapping_file, iter_stablecoin_rate_targets, refresh_stablecoin_rates
+from eth_defi.stablecoin_metadata import STABLECOINS_DATA_DIR
+from eth_defi.utils import setup_console_logging
+
+logger = logging.getLogger(__name__)
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    """Parse a boolean environment variable."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.lower() in {"1", "true", "yes", "y"}
+
+
+def main() -> int:
+    """Run the stablecoin rate population helper."""
+    setup_console_logging(
+        default_log_level=os.environ.get("LOG_LEVEL", "info"),
+        log_file=Path("logs/populate-stablecoin-rates.log"),
+    )
+
+    data_dir_raw = os.environ.get("STABLECOIN_DATA_DIR")
+    data_dir = Path(data_dir_raw).expanduser() if data_dir_raw else STABLECOINS_DATA_DIR
+    force = _env_bool("FORCE")
+    progress_bar = _env_bool("PROGRESS", default=True)
+    timeout = float(os.environ.get("STABLECOIN_RATE_TIMEOUT", "20"))
+
+    logger.info("Starting stablecoin rate population")
+    logger.info("Stablecoin data directory: %s", data_dir)
+    logger.info("Force refresh: %s", force)
+    logger.info("CoinGecko timeout: %.1f seconds", timeout)
+    logger.info("Progress bars: %s", progress_bar)
+
+    mapping_path_raw = os.environ.get("COINGECKO_ID_MAPPING_FILE")
+    mappings_applied = 0
+    if mapping_path_raw:
+        mapping_path = Path(mapping_path_raw).expanduser()
+        logger.info("Applying CoinGecko id mapping file: %s", mapping_path)
+        mappings_applied = apply_coingecko_mapping_file(data_dir, mapping_path, progress_bar=progress_bar)
+        logger.info("Applied %d CoinGecko id mapping entries", mappings_applied)
+
+    logger.info("Refreshing stablecoin rates from CoinGecko")
+    summary = refresh_stablecoin_rates(
+        data_dir=data_dir,
+        force=force,
+        timeout=timeout,
+        progress_bar=progress_bar,
+    )
+    logger.info(
+        "Stablecoin rate population finished: files_scanned=%d entries_seen=%d rates_fetched=%d files_updated=%d failures=%d depegged=%d",
+        summary.files_scanned,
+        summary.entries_seen,
+        summary.rates_fetched,
+        summary.files_updated,
+        summary.failed_count,
+        summary.depegged_count,
+    )
+    _log_population_details(data_dir)
+
+    rows = [
+        ["Mappings applied", mappings_applied],
+        ["Files scanned", summary.files_scanned],
+        ["Entries seen", summary.entries_seen],
+        ["Rates fetched", summary.rates_fetched],
+        ["Files updated", summary.files_updated],
+        ["Depegged", summary.depegged_count],
+        ["Unactionable depegged", summary.unactionable_depegged_count],
+        ["Missing CoinGecko ids", summary.skipped_missing_coingecko],
+        ["Unknown pegs", summary.skipped_unknown_peg],
+        ["Failures", summary.failed_count],
+    ]
+    print(tabulate(rows, headers=["Metric", "Value"], tablefmt="fancy_grid"))
+    return 0
+
+
+def _log_population_details(data_dir: Path) -> None:
+    """Log depeg and failure details after a population run."""
+    targets = list(iter_stablecoin_rate_targets(data_dir))
+    failure_reasons = Counter(target.rate_fetch_failed_reason for target in targets if target.rate_fetch_failed_reason)
+    if failure_reasons:
+        logger.warning("Stablecoin rate failure reasons: %s", dict(failure_reasons))
+
+    for target in targets:
+        if target.depegged_at:
+            logger.warning(
+                "Depegged stablecoin: slug=%s symbol=%s name=%s usd_rate=%s peg_rate=%s peg_currency=%s",
+                target.slug,
+                target.symbol,
+                target.name,
+                target.usd_rate,
+                target.peg_rate,
+                target.peg_rate_currency,
+            )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/erc-4626/scan-vault-posts.py
+++ b/scripts/erc-4626/scan-vault-posts.py
@@ -46,6 +46,12 @@ Environment variables:
 - ``LOOP_INTERVAL_SECONDS``: Optional. Default: 28800 (8 hours). Set to 0 for single run.
 - ``LIMIT``: Optional. Limit sources per type for test runs.
 - ``DEATH_DETECTION_PERIOD``: Optional. Default: 180 days.
+- ``REFRESH_STABLECOIN_RATES``: Optional. Refresh stablecoin rates. Default: true.
+- ``FORCE_STABLECOIN_RATE_REFRESH``: Optional. Bypass the 24h stablecoin gate. Default: false.
+- ``STABLECOIN_RATE_TIMEOUT``: Optional. CoinGecko timeout. Default: 20.
+- ``STABLECOIN_DATA_DIR``: Optional. Stablecoin YAML directory.
+- ``STABLECOIN_RATE_GATE_PATH``: Optional. Durable stablecoin refresh gate JSON path.
+- ``COINGECKO_DEMO_API_KEY``: Optional. CoinGecko demo API key used by the rate module.
 """
 
 import logging
@@ -59,6 +65,7 @@ from eth_defi.feed.constants import DEFAULT_X_LIST_NAME
 from eth_defi.feed.database import DEFAULT_VAULT_POST_DATABASE
 from eth_defi.feed.scanner import PostScanConfig, run_post_scan_cycle
 from eth_defi.feed.sources import FEEDS_DATA_DIR
+from eth_defi.stablecoin_metadata import STABLECOINS_DATA_DIR
 from eth_defi.utils import setup_console_logging
 
 logger = logging.getLogger(__name__)
@@ -109,6 +116,20 @@ def _print_dashboard(summary) -> None:
         ["Posts fetched", summary.posts_fetched],
         ["Posts inserted", summary.posts_inserted],
     ]
+    if summary.stablecoin_rate_status:
+        stablecoin_summary = summary.stablecoin_rate_summary
+        rows.append(["Stablecoin rate status", summary.stablecoin_rate_status])
+        if stablecoin_summary:
+            rows.extend(
+                [
+                    ["Stablecoin rates fetched", stablecoin_summary.rates_fetched],
+                    ["Stablecoin files updated", stablecoin_summary.files_updated],
+                    ["Stablecoins depegged", stablecoin_summary.depegged_count],
+                    ["Stablecoin rate failures", stablecoin_summary.failed_count],
+                ]
+            )
+        if summary.stablecoin_rate_error:
+            rows.append(["Stablecoin rate error", summary.stablecoin_rate_error[:80]])
     for medium in sorted(fetched_by_medium):
         rows.append([f"Posts fetched: {medium}", fetched_by_medium[medium]])
         rows.append([f"Posts inserted: {medium}", inserted_by_medium.get(medium, 0)])
@@ -183,6 +204,8 @@ def _build_config() -> PostScanConfig:
 
     db_path_str = os.environ.get("DB_PATH")
     mappings_dir_str = os.environ.get("MAPPINGS_DIR")
+    stablecoin_data_dir_str = os.environ.get("STABLECOIN_DATA_DIR")
+    stablecoin_rate_gate_path_str = os.environ.get("STABLECOIN_RATE_GATE_PATH")
     limit_str = os.environ.get("LIMIT")
 
     return PostScanConfig(
@@ -208,6 +231,11 @@ def _build_config() -> PostScanConfig:
         limit=int(limit_str) if limit_str else None,
         death_detection_days=int(os.environ.get("DEATH_DETECTION_PERIOD", "180")),
         twitter_rss_base_urls=_parse_csv(os.environ.get("TWITTER_RSS_BASE_URLS")),
+        refresh_stablecoin_rates=os.environ.get("REFRESH_STABLECOIN_RATES", "true").lower() == "true",
+        force_stablecoin_rate_refresh=os.environ.get("FORCE_STABLECOIN_RATE_REFRESH", "false").lower() == "true",
+        stablecoin_data_dir=Path(stablecoin_data_dir_str).expanduser() if stablecoin_data_dir_str else STABLECOINS_DATA_DIR,
+        stablecoin_rate_timeout=float(os.environ.get("STABLECOIN_RATE_TIMEOUT", "20")),
+        stablecoin_rate_gate_path=Path(stablecoin_rate_gate_path_str).expanduser() if stablecoin_rate_gate_path_str else None,
     )
 
 

--- a/tests/feed/test_scanner_integration.py
+++ b/tests/feed/test_scanner_integration.py
@@ -13,7 +13,6 @@ import pytest
 
 from eth_defi.feed.scanner import PostScanConfig, run_post_scan_cycle
 
-
 pytestmark = pytest.mark.skipif(
     not os.environ.get("TWITTER_BEARER_TOKEN"),
     reason="TWITTER_BEARER_TOKEN not set — skipping live X API tests",
@@ -43,10 +42,11 @@ def test_scan_single_twitter_account(tmp_path: Path) -> None:
         max_posts_per_source=10,
         request_delay_seconds=0,
         twitter_rss_base_urls=[],
+        refresh_stablecoin_rates=False,
     )
 
     # 2. Call run_post_scan_cycle()
-    summary = run_post_scan_cycle(config)
+    run_post_scan_cycle(config)
 
     # 3. Assert posts are stored in DuckDB with raw_payload
     from eth_defi.feed.database import VaultPostDatabase

--- a/tests/feed/test_stablecoin_rate.py
+++ b/tests/feed/test_stablecoin_rate.py
@@ -1,0 +1,596 @@
+"""Tests for stablecoin CoinGecko rate refresh and depeg lookups."""
+
+import datetime
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from eth_defi.feed import stablecoin_rate
+from eth_defi.feed.stablecoin_rate import StablecoinRateFeeder, build_depegged_stablecoin_lookups, iter_stablecoin_rate_targets, refresh_stablecoin_rates
+from eth_defi.stablecoin_metadata import build_stablecoin_metadata_json
+
+USDC_ADDRESS = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+USDX_ADDRESS = "0x1111111111111111111111111111111111111111"
+
+
+@dataclass(slots=True)
+class DummyCoinGeckoResponse:
+    """Small response object for mocked CoinGecko tests."""
+
+    payload: dict[str, Any]
+
+    def raise_for_status(self) -> None:
+        """Mock successful HTTP response."""
+
+    def json(self) -> dict[str, Any]:
+        """Return the mocked JSON body."""
+        return self.payload
+
+
+def _write_usdc_yaml(data_dir: Path) -> Path:
+    """Create a minimal standard USDC stablecoin YAML file."""
+    yaml_path = data_dir / "usdc.yaml"
+    yaml_path.write_text(
+        f"""symbol: USDC
+name: Circle USDC
+short_description: USD Coin
+long_description: ''
+category: stablecoin
+links:
+  homepage: https://www.circle.com/usdc
+  coingecko: https://www.coingecko.com/en/coins/usd-coin
+  defillama: https://defillama.com/stablecoin/usd-coin
+  twitter: https://x.com/circle
+slug: usdc
+contract_addresses:
+  - chain: ethereum
+    address: '{USDC_ADDRESS}'
+checks:
+  twitter_last_post_at: ''
+  domain_up_at: ''
+  marked_dead_at: ''
+  information_found_missing_at: ''
+"""
+    )
+    return yaml_path
+
+
+def _write_usdx_yaml(data_dir: Path) -> Path:
+    """Create a minimal multi-entry USDX YAML file with Kava USDX metadata."""
+    yaml_path = data_dir / "usdx.yaml"
+    yaml_path.write_text(
+        f"""symbol: USDX
+category: stablecoin
+entries:
+- name: Stables Labs USDX
+  short_description: Stables Labs USDX
+  long_description: ''
+  coingecko_id: usdx-money-usdx
+  coingecko_link: https://www.coingecko.com/en/coins/usdx-money-usdx
+  coingecko_id_source: manual
+  links:
+    homepage: https://usdx.money/
+    coingecko: https://www.coingecko.com/en/coins/stables-labs-usdx
+    defillama: ''
+    twitter: https://x.com/usdx_money
+  checks:
+    twitter_last_post_at: ''
+    domain_up_at: ''
+    marked_dead_at: ''
+    information_found_missing_at: ''
+- name: Kava USDX
+  short_description: Kava USDX
+  long_description: ''
+  coingecko_id: usdx
+  coingecko_link: https://www.coingecko.com/en/coins/usdx
+  coingecko_id_source: manual
+  links:
+    homepage: https://www.kava.io/
+    coingecko: https://www.coingecko.com/en/coins/kava-lend
+    defillama: ''
+    twitter: https://x.com/KAVA_CHAIN
+  contract_addresses:
+    - chain: kava
+      address: '{USDX_ADDRESS}'
+  checks:
+    twitter_last_post_at: ''
+    domain_up_at: ''
+    marked_dead_at: ''
+    information_found_missing_at: ''
+slug: usdx
+"""
+    )
+    return yaml_path
+
+
+def _write_fiat_stablecoin_yaml(data_dir: Path, symbol: str, name: str, coingecko_id: str) -> Path:
+    """Create a minimal non-USD fiat stablecoin YAML file."""
+    yaml_path = data_dir / f"{symbol.lower()}.yaml"
+    yaml_path.write_text(
+        f"""symbol: {symbol}
+name: {name}
+short_description: {name}
+long_description: ''
+category: stablecoin
+coingecko_id: {coingecko_id}
+coingecko_link: https://www.coingecko.com/en/coins/{coingecko_id}
+coingecko_id_source: manual
+links:
+  homepage: ''
+  coingecko: https://www.coingecko.com/en/coins/{coingecko_id}
+  defillama: ''
+  twitter: ''
+slug: {symbol.lower()}
+checks:
+  twitter_last_post_at: ''
+  domain_up_at: ''
+  marked_dead_at: ''
+  information_found_missing_at: ''
+"""
+    )
+    return yaml_path
+
+
+def test_refresh_stablecoin_rates_updates_usdc_happy_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """USDC refresh stores CoinGecko rate fields and feeder lookup data."""
+    _write_usdc_yaml(tmp_path)
+
+    def fake_get(url: str, params: dict[str, str], headers: dict[str, str], timeout: float) -> DummyCoinGeckoResponse:
+        assert url == stablecoin_rate.COINGECKO_SIMPLE_PRICE_URL
+        assert params["ids"] == "usd-coin"
+        assert "usd" in params["vs_currencies"].split(",")
+        assert "User-Agent" in headers
+        assert timeout == 20.0
+        return DummyCoinGeckoResponse(
+            {
+                "usd-coin": {
+                    "usd": 0.9998,
+                    "last_updated_at": 1782464168,
+                }
+            }
+        )
+
+    monkeypatch.setattr(stablecoin_rate.requests, "get", fake_get)
+    now_ = datetime.datetime(2026, 6, 26, 12, 0, 0)
+
+    summary = refresh_stablecoin_rates(data_dir=tmp_path, now_=now_, force=True)
+
+    assert summary.files_scanned == 1
+    assert summary.entries_seen == 1
+    assert summary.rates_fetched == 1
+    assert summary.failed_count == 0
+    assert summary.depegged_count == 0
+
+    target = next(iter_stablecoin_rate_targets(tmp_path))
+    assert target.coingecko_id == "usd-coin"
+    assert target.coingecko_link == "https://www.coingecko.com/en/coins/usd-coin"
+    assert target.coingecko_id_source == "url"
+    assert target.usd_rate == pytest.approx(0.9998)
+    assert target.usd_rate_fetched_at == now_
+    assert target.rate_fetch_failed_reason is None
+    assert target.depegged_at is None
+
+    metadata = build_stablecoin_metadata_json(tmp_path / "usdc.yaml")[0]
+    assert metadata["coingecko_id"] == "usd-coin"
+    assert metadata["usd_rate"] == pytest.approx(0.9998)
+    assert metadata["usd_rate_fetched_at"] == "2026-06-26T12:00:00"
+
+    feeder = StablecoinRateFeeder(data_dir=tmp_path)
+    rate = feeder.get_denomination_token_rate_section(1, USDC_ADDRESS, "USDC")
+    assert rate.coingecko_id == "usd-coin"
+    assert rate.usd_rate == pytest.approx(0.9998)
+    assert rate.usd_rate_fetched_at == now_
+    assert rate.usd_rate_source == "coingecko"
+    assert feeder.is_depegged_stablecoin_token(1, USDC_ADDRESS, "USDC") is False
+
+
+def test_refresh_stablecoin_rates_marks_usdx_depegged(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """USDX depeg refresh stamps ``depegged_at`` and blacklisting lookups."""
+    _write_usdx_yaml(tmp_path)
+
+    def fake_get(url: str, params: dict[str, str], headers: dict[str, str], timeout: float) -> DummyCoinGeckoResponse:
+        assert url == stablecoin_rate.COINGECKO_SIMPLE_PRICE_URL
+        assert set(params["ids"].split(",")) == {"usdx", "usdx-money-usdx"}
+        assert "User-Agent" in headers
+        assert timeout > 0
+        return DummyCoinGeckoResponse(
+            {
+                "usdx-money-usdx": {"usd": 1.0, "last_updated_at": 1782464168},
+                "usdx": {"usd": 0.646809, "last_updated_at": 1782464168},
+            }
+        )
+
+    monkeypatch.setattr(stablecoin_rate.requests, "get", fake_get)
+    now_ = datetime.datetime(2026, 6, 26, 12, 0, 0)
+
+    summary = refresh_stablecoin_rates(data_dir=tmp_path, now_=now_, force=True)
+
+    assert summary.entries_seen == 2
+    assert summary.rates_fetched == 2
+    assert summary.depegged_count == 1
+    assert summary.failed_count == 0
+
+    kava_target = next(target for target in iter_stablecoin_rate_targets(tmp_path) if target.name == "Kava USDX")
+    assert kava_target.usd_rate == pytest.approx(0.646809)
+    assert kava_target.depegged_at == now_
+
+    feeder = StablecoinRateFeeder(data_dir=tmp_path)
+    assert feeder.is_depegged_stablecoin_token(2222, USDX_ADDRESS, "USDX") is True
+    assert feeder.is_depegged_stablecoin_token(2222, None, "USDX") is False
+
+    rate = feeder.get_denomination_token_rate_section(2222, USDX_ADDRESS, "USDX")
+    assert rate.coingecko_id == "usdx"
+    assert rate.usd_rate == pytest.approx(0.646809)
+    assert rate.usd_rate_source == "coingecko"
+
+
+def test_refresh_stablecoin_rates_preserves_sticky_depegged_at(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Existing depeg timestamps survive repeat depeg checks and later recovery."""
+    _write_usdx_yaml(tmp_path)
+    previous_depegged_at = datetime.datetime(2026, 6, 25, 12, 0, 0)
+    now_ = datetime.datetime(2026, 6, 26, 12, 0, 0)
+
+    stablecoin_rate._update_yaml_entry_fields(
+        tmp_path / "usdx.yaml",
+        1,
+        {
+            "usd_rate": 0.646809,
+            "usd_rate_fetched_at": previous_depegged_at,
+            "peg_rate": 0.646809,
+            "peg_rate_currency": "usd",
+            "depegged_at": previous_depegged_at,
+        },
+    )
+
+    prices = [
+        {"usdx-money-usdx": {"usd": 1.0, "last_updated_at": 1782464168}, "usdx": {"usd": 0.5, "last_updated_at": 1782464168}},
+        {"usdx-money-usdx": {"usd": 1.0, "last_updated_at": 1782464168}, "usdx": {"usd": 1.0, "last_updated_at": 1782464168}},
+    ]
+
+    def fake_get(url: str, params: dict[str, str], headers: dict[str, str], timeout: float) -> DummyCoinGeckoResponse:
+        assert url == stablecoin_rate.COINGECKO_SIMPLE_PRICE_URL
+        assert set(params["ids"].split(",")) == {"usdx", "usdx-money-usdx"}
+        assert isinstance(headers, dict)
+        assert timeout > 0
+        return DummyCoinGeckoResponse(prices.pop(0))
+
+    monkeypatch.setattr(stablecoin_rate.requests, "get", fake_get)
+
+    still_depegged_summary = refresh_stablecoin_rates(data_dir=tmp_path, now_=now_, force=True)
+    assert still_depegged_summary.depegged_count == 1
+    target = next(target for target in iter_stablecoin_rate_targets(tmp_path) if target.name == "Kava USDX")
+    assert target.depegged_at == previous_depegged_at
+
+    recovered_summary = refresh_stablecoin_rates(data_dir=tmp_path, now_=now_ + datetime.timedelta(days=1), force=True)
+    assert recovered_summary.depegged_count == 0
+    target = next(target for target in iter_stablecoin_rate_targets(tmp_path) if target.name == "Kava USDX")
+    assert target.usd_rate == pytest.approx(1.0)
+    assert target.depegged_at == previous_depegged_at
+
+
+def test_refresh_stablecoin_rates_entry_gate_skips_same_day_and_refetches_next_day(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Entry-level daily gate avoids repeat CoinGecko calls after an attempt."""
+    _write_usdc_yaml(tmp_path)
+    calls: list[dict[str, str]] = []
+
+    def fake_get(url: str, params: dict[str, str], headers: dict[str, str], timeout: float) -> DummyCoinGeckoResponse:
+        assert url == stablecoin_rate.COINGECKO_SIMPLE_PRICE_URL
+        assert isinstance(headers, dict)
+        assert timeout > 0
+        calls.append(params)
+        return DummyCoinGeckoResponse({"usd-coin": {"usd": 0.9998, "last_updated_at": 1782464168}})
+
+    monkeypatch.setattr(stablecoin_rate.requests, "get", fake_get)
+
+    first_summary = refresh_stablecoin_rates(data_dir=tmp_path, now_=datetime.datetime(2026, 6, 26, 12, 0, 0))
+    second_summary = refresh_stablecoin_rates(data_dir=tmp_path, now_=datetime.datetime(2026, 6, 26, 13, 0, 0))
+    third_summary = refresh_stablecoin_rates(data_dir=tmp_path, now_=datetime.datetime(2026, 6, 27, 12, 0, 0))
+
+    assert first_summary.rates_fetched == 1
+    assert second_summary.rates_fetched == 0
+    assert second_summary.files_updated == 0
+    assert third_summary.rates_fetched == 1
+    assert len(calls) == 2
+
+
+def test_refresh_stablecoin_rates_records_missing_price_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing CoinGecko price stamps failure fields without depeg flag."""
+    _write_usdc_yaml(tmp_path)
+
+    def fake_get(url: str, params: dict[str, str], headers: dict[str, str], timeout: float) -> DummyCoinGeckoResponse:
+        assert url == stablecoin_rate.COINGECKO_SIMPLE_PRICE_URL
+        assert params["ids"] == "usd-coin"
+        assert "User-Agent" in headers
+        assert timeout > 0
+        return DummyCoinGeckoResponse({})
+
+    monkeypatch.setattr(stablecoin_rate.requests, "get", fake_get)
+    now_ = datetime.datetime(2026, 6, 26, 12, 0, 0)
+
+    summary = refresh_stablecoin_rates(data_dir=tmp_path, now_=now_, force=True)
+
+    assert summary.failed_count == 1
+    target = next(iter_stablecoin_rate_targets(tmp_path))
+    assert target.rate_fetch_failed_at == now_
+    assert target.rate_fetch_failed_reason == "coingecko_price_missing"
+    assert target.depegged_at is None
+
+
+@pytest.mark.parametrize(
+    ("symbol", "name", "coingecko_id", "peg_currency", "usd_rate"),
+    [
+        ("CADC", "PayTrie CADC Canadian Dollar stablecoin", "cad-coin", "cad", 0.73),
+        ("CJPY", "Yamato CJPY Japanese Yen stablecoin", "convertible-jpy-token", "jpy", 0.0064),
+    ],
+)
+def test_non_usd_fiat_stablecoins_compare_against_their_peg_currency(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    symbol: str,
+    name: str,
+    coingecko_id: str,
+    peg_currency: str,
+    usd_rate: float,
+) -> None:
+    """Non-USD fiat stablecoins do not depeg merely because their USD price is below one."""
+    _write_fiat_stablecoin_yaml(tmp_path, symbol, name, coingecko_id)
+
+    def fake_get(url: str, params: dict[str, str], headers: dict[str, str], timeout: float) -> DummyCoinGeckoResponse:
+        assert url == stablecoin_rate.COINGECKO_SIMPLE_PRICE_URL
+        assert params["ids"] == coingecko_id
+        assert set(params["vs_currencies"].split(",")) == {"usd", peg_currency}
+        assert "User-Agent" in headers
+        assert timeout > 0
+        return DummyCoinGeckoResponse({coingecko_id: {"usd": usd_rate, peg_currency: 1.0, "last_updated_at": 1782464168}})
+
+    monkeypatch.setattr(stablecoin_rate.requests, "get", fake_get)
+    now_ = datetime.datetime(2026, 6, 26, 12, 0, 0)
+
+    summary = refresh_stablecoin_rates(data_dir=tmp_path, now_=now_, force=True)
+
+    assert summary.failed_count == 0
+    assert summary.depegged_count == 0
+    target = next(iter_stablecoin_rate_targets(tmp_path))
+    assert target.usd_rate == pytest.approx(usd_rate)
+    assert target.peg_rate == pytest.approx(1.0)
+    assert target.peg_rate_currency == peg_currency
+    assert target.depegged_at is None
+
+
+def test_url_derived_sub_cent_price_is_failure_not_depeg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Wrong-asset guard rejects URL-derived sub-cent CoinGecko prices."""
+    _write_usdc_yaml(tmp_path)
+
+    def fake_get(url: str, params: dict[str, str], headers: dict[str, str], timeout: float) -> DummyCoinGeckoResponse:
+        assert url == stablecoin_rate.COINGECKO_SIMPLE_PRICE_URL
+        assert params["ids"] == "usd-coin"
+        assert "User-Agent" in headers
+        assert timeout > 0
+        return DummyCoinGeckoResponse(
+            {
+                "usd-coin": {
+                    "usd": 0.00049975,
+                    "last_updated_at": 1782199898,
+                }
+            }
+        )
+
+    monkeypatch.setattr(stablecoin_rate.requests, "get", fake_get)
+    now_ = datetime.datetime(2026, 6, 26, 12, 0, 0)
+
+    summary = refresh_stablecoin_rates(data_dir=tmp_path, now_=now_, force=True)
+
+    assert summary.failed_count == 1
+    assert summary.depegged_count == 0
+    target = next(iter_stablecoin_rate_targets(tmp_path))
+    assert target.usd_rate is None
+    assert target.rate_fetch_failed_reason == "coingecko_price_missing"
+    assert target.depegged_at is None
+
+
+def test_manual_sub_cent_price_is_trusted_as_depeg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Manual CoinGecko ids are trusted even when a failed stablecoin trades below one cent."""
+    (tmp_path / "usdx.yaml").write_text(
+        """symbol: USDX
+name: Stables Labs USDX
+short_description: USDX is a USD stablecoin.
+long_description: ''
+category: stablecoin
+coingecko_id: usdx-money-usdx
+coingecko_link: https://www.coingecko.com/en/coins/usdx-money-usdx
+coingecko_id_source: manual
+links:
+  homepage: https://usdx.money/
+  coingecko: https://www.coingecko.com/en/coins/usdx-money-usdx
+  defillama: ''
+  twitter: ''
+slug: usdx
+checks:
+  twitter_last_post_at: ''
+  domain_up_at: ''
+  marked_dead_at: ''
+  information_found_missing_at: ''
+"""
+    )
+
+    def fake_get(url: str, params: dict[str, str], headers: dict[str, str], timeout: float) -> DummyCoinGeckoResponse:
+        assert url == stablecoin_rate.COINGECKO_SIMPLE_PRICE_URL
+        assert params["ids"] == "usdx-money-usdx"
+        assert "User-Agent" in headers
+        assert timeout > 0
+        return DummyCoinGeckoResponse({"usdx-money-usdx": {"usd": 0.0076, "last_updated_at": 1782464168}})
+
+    monkeypatch.setattr(stablecoin_rate.requests, "get", fake_get)
+    now_ = datetime.datetime(2026, 6, 26, 12, 0, 0)
+
+    summary = refresh_stablecoin_rates(data_dir=tmp_path, now_=now_, force=True)
+
+    assert summary.failed_count == 0
+    assert summary.depegged_count == 1
+    target = next(iter_stablecoin_rate_targets(tmp_path))
+    assert target.usd_rate == pytest.approx(0.0076)
+    assert target.depegged_at == now_
+
+
+def test_peg_detection_avoids_substring_false_matches(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Peg inference does not read currency names from inside unrelated words."""
+    (tmp_path / "mim.yaml").write_text(
+        """symbol: MIM
+name: Abracadabra MIM
+short_description: Magic Internet Money is a USD-pegged stablecoin.
+long_description: ''
+category: stablecoin
+coingecko_id: magic-internet-money
+coingecko_link: https://www.coingecko.com/en/coins/magic-internet-money
+coingecko_id_source: manual
+links:
+  homepage: https://abracadabra.money/
+  coingecko: https://www.coingecko.com/en/coins/magic-internet-money
+  defillama: ''
+  twitter: ''
+slug: mim
+checks:
+  twitter_last_post_at: ''
+  domain_up_at: ''
+  marked_dead_at: ''
+  information_found_missing_at: ''
+"""
+    )
+
+    def fake_get(url: str, params: dict[str, str], headers: dict[str, str], timeout: float) -> DummyCoinGeckoResponse:
+        assert url == stablecoin_rate.COINGECKO_SIMPLE_PRICE_URL
+        assert params["ids"] == "magic-internet-money"
+        assert set(params["vs_currencies"].split(",")) == {"usd"}
+        assert "User-Agent" in headers
+        assert timeout > 0
+        return DummyCoinGeckoResponse({"magic-internet-money": {"usd": 0.444314, "last_updated_at": 1782464168}})
+
+    monkeypatch.setattr(stablecoin_rate.requests, "get", fake_get)
+    now_ = datetime.datetime(2026, 6, 26, 12, 0, 0)
+
+    summary = refresh_stablecoin_rates(data_dir=tmp_path, now_=now_, force=True)
+
+    assert summary.failed_count == 0
+    assert summary.depegged_count == 1
+    target = next(iter_stablecoin_rate_targets(tmp_path))
+    assert target.peg_rate_currency == "usd"
+    assert target.peg_rate == pytest.approx(0.444314)
+
+
+def test_yield_bearing_share_token_is_not_depegged_by_low_share_price(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-nominal yield-bearing share token prices are exported but not depegged."""
+    (tmp_path / "cusdc.yaml").write_text(
+        """symbol: cUSDC
+name: Compound USDC
+short_description: Compound USDC
+long_description: ''
+category: yield_bearing
+coingecko_id: compound-usd-coin
+coingecko_link: https://www.coingecko.com/en/coins/compound-usd-coin
+coingecko_id_source: manual
+links:
+  homepage: https://compound.finance/
+  coingecko: https://www.coingecko.com/en/coins/compound-usd-coin
+  defillama: ''
+  twitter: ''
+slug: cusdc
+checks:
+  twitter_last_post_at: ''
+  domain_up_at: ''
+  marked_dead_at: ''
+  information_found_missing_at: ''
+"""
+    )
+
+    def fake_get(url: str, params: dict[str, str], headers: dict[str, str], timeout: float) -> DummyCoinGeckoResponse:
+        assert url == stablecoin_rate.COINGECKO_SIMPLE_PRICE_URL
+        assert params["ids"] == "compound-usd-coin"
+        assert set(params["vs_currencies"].split(",")) == {"usd"}
+        assert "User-Agent" in headers
+        assert timeout > 0
+        return DummyCoinGeckoResponse({"compound-usd-coin": {"usd": 0.02531505, "last_updated_at": 1782464168}})
+
+    monkeypatch.setattr(stablecoin_rate.requests, "get", fake_get)
+    now_ = datetime.datetime(2026, 6, 26, 12, 0, 0)
+
+    summary = refresh_stablecoin_rates(data_dir=tmp_path, now_=now_, force=True)
+
+    assert summary.failed_count == 0
+    assert summary.depegged_count == 0
+    target = next(iter_stablecoin_rate_targets(tmp_path))
+    assert target.usd_rate == pytest.approx(0.02531505)
+    assert target.peg_rate_currency == "usd"
+    assert target.depegged_at is None
+
+
+def test_depegged_symbol_blacklist_ignores_ambiguous_symbols(tmp_path: Path) -> None:
+    """Symbol-only blacklisting is used only when a depegged symbol is unique."""
+    (tmp_path / "usdx-a.yaml").write_text(
+        """symbol: USDX
+name: USDX A
+short_description: USDX A
+long_description: ''
+category: stablecoin
+coingecko_id: usdx-a
+coingecko_link: https://www.coingecko.com/en/coins/usdx-a
+coingecko_id_source: manual
+usd_rate: 0.5
+usd_rate_fetched_at: '2026-06-26T12:00:00'
+depegged_at: '2026-06-26T12:00:00'
+links:
+  homepage: ''
+  coingecko: ''
+  defillama: ''
+  twitter: ''
+slug: usdx-a
+checks:
+  twitter_last_post_at: ''
+  domain_up_at: ''
+  marked_dead_at: ''
+  information_found_missing_at: ''
+"""
+    )
+    (tmp_path / "usdx-b.yaml").write_text(
+        """symbol: USDX
+name: USDX B
+short_description: USDX B
+long_description: ''
+category: stablecoin
+coingecko_id: usdx-b
+coingecko_link: https://www.coingecko.com/en/coins/usdx-b
+coingecko_id_source: manual
+usd_rate: 1.0
+usd_rate_fetched_at: '2026-06-26T12:00:00'
+links:
+  homepage: ''
+  coingecko: ''
+  defillama: ''
+  twitter: ''
+slug: usdx-b
+checks:
+  twitter_last_post_at: ''
+  domain_up_at: ''
+  marked_dead_at: ''
+  information_found_missing_at: ''
+"""
+    )
+
+    depegged_contracts, depegged_symbols = build_depegged_stablecoin_lookups(tmp_path)
+
+    assert depegged_contracts == set()
+    assert depegged_symbols == set()
+    assert StablecoinRateFeeder(tmp_path).is_depegged_stablecoin_token(1, None, "USDX") is False
+
+
+def test_stablecoin_yaml_atomic_write_preserves_existing_file_mode(tmp_path: Path) -> None:
+    """Atomic YAML updates keep existing package file permissions."""
+    yaml_path = _write_usdc_yaml(tmp_path)
+    yaml_path.chmod(0o644)
+
+    stablecoin_rate._update_yaml_entry_fields(yaml_path, None, {"usd_rate": 1.0})
+
+    assert yaml_path.stat().st_mode & 0o777 == 0o644
+    target = next(iter_stablecoin_rate_targets(tmp_path))
+    assert target.usd_rate == pytest.approx(1.0)

--- a/tests/feed/test_stablecoin_rate_scanner.py
+++ b/tests/feed/test_stablecoin_rate_scanner.py
@@ -1,0 +1,317 @@
+"""Tests for the post scanner stablecoin rate side job."""
+
+import datetime
+import json
+from pathlib import Path
+
+import pytest
+
+from eth_defi.feed import scanner, stablecoin_rate
+from eth_defi.feed.collector import CollectorRunSummary
+from eth_defi.feed.scanner import PostScanConfig, run_post_scan_cycle
+from eth_defi.feed.stablecoin_rate import StablecoinRateRefreshSummary
+
+
+def _write_usdc_yaml(data_dir: Path) -> None:
+    """Create a minimal USDC YAML file for scanner side-job tests."""
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "usdc.yaml").write_text(
+        """symbol: USDC
+name: Circle USDC
+short_description: USD Coin
+long_description: ''
+category: stablecoin
+links:
+  homepage: https://www.circle.com/usdc
+  coingecko: https://www.coingecko.com/en/coins/usd-coin
+  defillama: ''
+  twitter: ''
+slug: usdc
+checks:
+  twitter_last_post_at: ''
+  domain_up_at: ''
+  marked_dead_at: ''
+  information_found_missing_at: ''
+"""
+    )
+
+
+def test_stablecoin_rate_side_job_uses_24h_gate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The scanner side job refreshes once, skips recent runs, then honours force."""
+    calls = []
+
+    def fake_refresh_stablecoin_rates(**kwargs) -> StablecoinRateRefreshSummary:
+        calls.append(kwargs)
+        return StablecoinRateRefreshSummary(files_scanned=1, entries_seen=1, rates_fetched=1)
+
+    monkeypatch.setattr(scanner, "refresh_stablecoin_rates", fake_refresh_stablecoin_rates)
+
+    gate_path = tmp_path / "stablecoin-rate-state.json"
+    config = PostScanConfig(
+        db_path=tmp_path / "posts.duckdb",
+        mappings_dir=tmp_path / "feeds",
+        stablecoin_data_dir=tmp_path / "stablecoins",
+        stablecoin_rate_gate_path=gate_path,
+        stablecoin_rate_timeout=7.5,
+    )
+
+    first_summary = CollectorRunSummary()
+    scanner._run_stablecoin_rate_side_job(config, first_summary)
+
+    assert first_summary.stablecoin_rate_status == "succeeded"
+    assert first_summary.stablecoin_rate_summary.rates_fetched == 1
+    assert calls[0]["data_dir"] == tmp_path / "stablecoins"
+    assert calls[0]["force"] is False
+    assert calls[0]["timeout"] == 7.5
+    assert json.loads(gate_path.read_text())["last_succeeded_at"]
+
+    second_summary = CollectorRunSummary()
+    scanner._run_stablecoin_rate_side_job(config, second_summary)
+
+    assert second_summary.stablecoin_rate_status == "skipped_recent"
+    assert len(calls) == 1
+
+    forced_summary = CollectorRunSummary()
+    forced_config = PostScanConfig(
+        db_path=tmp_path / "posts.duckdb",
+        mappings_dir=tmp_path / "feeds",
+        stablecoin_data_dir=tmp_path / "stablecoins",
+        stablecoin_rate_gate_path=gate_path,
+        force_stablecoin_rate_refresh=True,
+    )
+    scanner._run_stablecoin_rate_side_job(forced_config, forced_summary)
+
+    assert forced_summary.stablecoin_rate_status == "succeeded"
+    assert calls[-1]["force"] is True
+    assert len(calls) == 2
+
+
+def test_stablecoin_rate_side_job_can_be_disabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disabled scanner config does not call the stablecoin refresh function."""
+    called = False
+
+    def fake_refresh_stablecoin_rates(**kwargs) -> StablecoinRateRefreshSummary:
+        nonlocal called
+        assert isinstance(kwargs, dict)
+        called = True
+        return StablecoinRateRefreshSummary()
+
+    monkeypatch.setattr(scanner, "refresh_stablecoin_rates", fake_refresh_stablecoin_rates)
+
+    summary = CollectorRunSummary()
+    config = PostScanConfig(
+        db_path=tmp_path / "posts.duckdb",
+        mappings_dir=tmp_path / "feeds",
+        stablecoin_data_dir=tmp_path / "stablecoins",
+        stablecoin_rate_gate_path=tmp_path / "gate.json",
+        refresh_stablecoin_rates=False,
+    )
+
+    scanner._run_stablecoin_rate_side_job(config, summary)
+
+    assert summary.stablecoin_rate_status == "disabled"
+    assert called is False
+
+
+def test_post_scan_cycle_runs_stablecoin_rate_side_job(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The full post scan cycle invokes the stablecoin rate side job."""
+    feeds_dir = tmp_path / "feeds"
+    feeds_dir.mkdir()
+    stablecoins_dir = tmp_path / "stablecoins"
+    stablecoins_dir.mkdir()
+
+    def fake_refresh_stablecoin_rates(**kwargs) -> StablecoinRateRefreshSummary:
+        assert kwargs["data_dir"] == stablecoins_dir
+        return StablecoinRateRefreshSummary(files_scanned=1, entries_seen=1, rates_fetched=1)
+
+    monkeypatch.setattr(scanner, "refresh_stablecoin_rates", fake_refresh_stablecoin_rates)
+
+    summary = run_post_scan_cycle(
+        PostScanConfig(
+            db_path=tmp_path / "posts.duckdb",
+            mappings_dir=feeds_dir,
+            stablecoin_data_dir=stablecoins_dir,
+            stablecoin_rate_gate_path=tmp_path / "stablecoin-rate-state.json",
+            request_delay_seconds=0,
+            twitter_rss_base_urls=[],
+        )
+    )
+
+    assert summary.stablecoin_rate_status == "succeeded"
+    assert summary.stablecoin_rate_summary.rates_fetched == 1
+    assert summary.sources_loaded == 0
+
+
+def test_post_scan_cycle_continues_after_unexpected_stablecoin_rate_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unexpected stablecoin side-job errors do not abort the post scan."""
+    feeds_dir = tmp_path / "feeds"
+    feeds_dir.mkdir()
+    stablecoins_dir = tmp_path / "stablecoins"
+    stablecoins_dir.mkdir()
+
+    def fake_refresh_stablecoin_rates(**kwargs) -> StablecoinRateRefreshSummary:
+        assert kwargs["data_dir"] == stablecoins_dir
+        raise TypeError("unexpected stablecoin YAML shape")
+
+    monkeypatch.setattr(scanner, "refresh_stablecoin_rates", fake_refresh_stablecoin_rates)
+
+    summary = run_post_scan_cycle(
+        PostScanConfig(
+            db_path=tmp_path / "posts.duckdb",
+            mappings_dir=feeds_dir,
+            stablecoin_data_dir=stablecoins_dir,
+            stablecoin_rate_gate_path=tmp_path / "stablecoin-rate-state.json",
+            request_delay_seconds=0,
+            twitter_rss_base_urls=[],
+        )
+    )
+
+    assert summary.stablecoin_rate_status == "failed"
+    assert summary.stablecoin_rate_error == "unexpected stablecoin YAML shape"
+    assert summary.sources_loaded == 0
+
+
+def test_post_scan_cycle_continues_after_malformed_stablecoin_yaml(tmp_path: Path) -> None:
+    """Malformed stablecoin YAML is reported as a side-job failure only."""
+    feeds_dir = tmp_path / "feeds"
+    feeds_dir.mkdir()
+    stablecoins_dir = tmp_path / "stablecoins"
+    stablecoins_dir.mkdir()
+    (stablecoins_dir / "broken.yaml").write_text("symbol: [broken\n")
+
+    summary = run_post_scan_cycle(
+        PostScanConfig(
+            db_path=tmp_path / "posts.duckdb",
+            mappings_dir=feeds_dir,
+            stablecoin_data_dir=stablecoins_dir,
+            stablecoin_rate_gate_path=tmp_path / "stablecoin-rate-state.json",
+            request_delay_seconds=0,
+            twitter_rss_base_urls=[],
+        )
+    )
+
+    assert summary.stablecoin_rate_status == "failed"
+    assert "broken.yaml" in summary.stablecoin_rate_error
+    assert summary.sources_loaded == 0
+
+
+def test_stablecoin_rate_side_job_gate_write_failure_is_non_fatal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Gate write failures are reported without escaping the side job."""
+    called = False
+
+    def fake_refresh_stablecoin_rates(**kwargs) -> StablecoinRateRefreshSummary:
+        nonlocal called
+        assert isinstance(kwargs, dict)
+        called = True
+        return StablecoinRateRefreshSummary(files_scanned=1)
+
+    def fake_write_stablecoin_gate(path: Path, state: dict) -> None:
+        assert isinstance(state, dict)
+        raise PermissionError(f"cannot write {path}")
+
+    monkeypatch.setattr(scanner, "refresh_stablecoin_rates", fake_refresh_stablecoin_rates)
+    monkeypatch.setattr(scanner, "_write_stablecoin_gate", fake_write_stablecoin_gate)
+
+    summary = CollectorRunSummary()
+    scanner._run_stablecoin_rate_side_job(
+        PostScanConfig(
+            db_path=tmp_path / "posts.duckdb",
+            mappings_dir=tmp_path / "feeds",
+            stablecoin_data_dir=tmp_path / "stablecoins",
+            stablecoin_rate_gate_path=tmp_path / "gate.json",
+        ),
+        summary,
+    )
+
+    assert summary.stablecoin_rate_status == "failed"
+    assert "cannot write" in summary.stablecoin_rate_error
+    assert called is True
+
+
+def test_stablecoin_rate_side_job_all_failed_summary_keeps_success_gate_open(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A refresh with no fetched rates is recorded as failed for scanner gating."""
+
+    def fake_refresh_stablecoin_rates(**kwargs) -> StablecoinRateRefreshSummary:
+        assert isinstance(kwargs, dict)
+        return StablecoinRateRefreshSummary(files_scanned=1, entries_seen=2, failed_count=2, rates_fetched=0)
+
+    monkeypatch.setattr(scanner, "refresh_stablecoin_rates", fake_refresh_stablecoin_rates)
+
+    gate_path = tmp_path / "gate.json"
+    summary = CollectorRunSummary()
+    scanner._run_stablecoin_rate_side_job(
+        PostScanConfig(
+            db_path=tmp_path / "posts.duckdb",
+            mappings_dir=tmp_path / "feeds",
+            stablecoin_data_dir=tmp_path / "stablecoins",
+            stablecoin_rate_gate_path=gate_path,
+        ),
+        summary,
+    )
+
+    gate_state = json.loads(gate_path.read_text())
+    assert summary.stablecoin_rate_status == "failed"
+    assert "failed for all due entries" in summary.stablecoin_rate_error
+    assert "last_failed_at" in gate_state
+    assert "last_succeeded_at" not in gate_state
+
+
+def test_stablecoin_rate_side_job_same_day_failed_attempts_do_not_become_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Entries skipped after same-day failures do not close the scanner success gate."""
+    stablecoins_dir = tmp_path / "stablecoins"
+    _write_usdc_yaml(stablecoins_dir)
+
+    class MissingPriceResponse:
+        """Small successful HTTP response with no CoinGecko price payload."""
+
+        def raise_for_status(self) -> None:
+            """Mock a successful HTTP status."""
+
+        def json(self) -> dict[str, object]:
+            """Return an empty CoinGecko payload."""
+            return {}
+
+    def fake_missing_price_get(url: str, params: dict[str, str], headers: dict[str, str], timeout: float) -> MissingPriceResponse:
+        assert url == stablecoin_rate.COINGECKO_SIMPLE_PRICE_URL
+        assert params["ids"] == "usd-coin"
+        assert isinstance(headers, dict)
+        assert timeout > 0
+        return MissingPriceResponse()
+
+    monkeypatch.setattr(stablecoin_rate.requests, "get", fake_missing_price_get)
+    monkeypatch.setattr(scanner, "native_datetime_utc_now", lambda: datetime.datetime(2026, 6, 26, 12, 0, 0))
+
+    gate_path = tmp_path / "gate.json"
+    config = PostScanConfig(
+        db_path=tmp_path / "posts.duckdb",
+        mappings_dir=tmp_path / "feeds",
+        stablecoin_data_dir=stablecoins_dir,
+        stablecoin_rate_gate_path=gate_path,
+    )
+
+    first_summary = CollectorRunSummary()
+    scanner._run_stablecoin_rate_side_job(config, first_summary)
+    assert first_summary.stablecoin_rate_status == "failed"
+    assert first_summary.stablecoin_rate_summary.failed_count == 1
+
+    second_summary = CollectorRunSummary()
+    scanner._run_stablecoin_rate_side_job(config, second_summary)
+    gate_state = json.loads(gate_path.read_text())
+
+    assert second_summary.stablecoin_rate_status == "failed"
+    assert second_summary.stablecoin_rate_summary.due_count == 0
+    assert second_summary.stablecoin_rate_summary.skipped_failed_today_count == 1
+    assert "last_failed_at" in gate_state
+    assert "last_succeeded_at" not in gate_state
+
+
+def test_stablecoin_gate_atomic_write_preserves_existing_file_mode(tmp_path: Path) -> None:
+    """Atomic gate writes keep the operator-selected file permissions."""
+    gate_path = tmp_path / "gate.json"
+    gate_path.write_text("{}")
+    gate_path.chmod(0o644)
+
+    scanner._write_stablecoin_gate(gate_path, {"last_succeeded_at": "2026-06-26T12:00:00"})
+
+    assert gate_path.stat().st_mode & 0o777 == 0o644
+    assert json.loads(gate_path.read_text())["last_succeeded_at"] == "2026-06-26T12:00:00"

--- a/tests/research/test_vault_metrics_stablecoin_rate.py
+++ b/tests/research/test_vault_metrics_stablecoin_rate.py
@@ -1,0 +1,263 @@
+"""Vault metrics integration tests for stablecoin depeg data."""
+
+import datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from eth_defi.erc_4626.core import ERC4262VaultDetection
+from eth_defi.feed.stablecoin_rate import StablecoinRateFeeder, iter_stablecoin_rate_targets, refresh_stablecoin_rates
+from eth_defi.research.vault_metrics import calculate_lifetime_metrics, export_lifetime_row
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.fee import FeeData, VaultFeeMode
+from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.risk import VaultTechnicalRisk
+
+VAULT_ADDRESS = "0x2222222222222222222222222222222222222222"
+USDC_ADDRESS = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+USDX_ADDRESS = "0x1111111111111111111111111111111111111111"
+
+
+def _write_depegged_usdx_yaml(data_dir: Path) -> None:
+    """Create a USDX stablecoin fixture already marked as depegged."""
+    (data_dir / "usdx.yaml").write_text(
+        f"""symbol: USDX
+name: Kava USDX
+short_description: Kava USDX
+long_description: ''
+category: stablecoin
+coingecko_id: usdx
+coingecko_link: https://www.coingecko.com/en/coins/usdx
+coingecko_id_source: manual
+coingecko_id_verified_at: '2026-06-26T12:00:00'
+usd_rate: 0.646809
+usd_rate_fetched_at: '2026-06-26T12:00:00'
+usd_rate_updated_at: '2026-06-26T08:56:08'
+peg_rate: 0.646809
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: '2026-06-26T12:00:00'
+links:
+  homepage: https://www.kava.io/
+  coingecko: https://www.coingecko.com/en/coins/usdx
+  defillama: ''
+  twitter: https://x.com/KAVA_CHAIN
+slug: usdx
+contract_addresses:
+  - chain: ethereum
+    address: '{USDX_ADDRESS}'
+checks:
+  twitter_last_post_at: ''
+  domain_up_at: ''
+  marked_dead_at: ''
+  information_found_missing_at: ''
+"""
+    )
+
+
+def _write_live_usdc_yaml(data_dir: Path) -> None:
+    """Create a USDC fixture whose rate is fetched from live CoinGecko."""
+    (data_dir / "usdc.yaml").write_text(
+        f"""symbol: USDC
+name: Circle USDC
+short_description: USD Coin
+long_description: ''
+category: stablecoin
+coingecko_id: usd-coin
+coingecko_link: https://www.coingecko.com/en/coins/usd-coin
+coingecko_id_source: manual
+links:
+  homepage: https://www.circle.com/usdc
+  coingecko: https://www.coingecko.com/en/coins/usd-coin
+  defillama: https://defillama.com/stablecoin/usd-coin
+  twitter: https://x.com/circle
+slug: usdc
+contract_addresses:
+  - chain: ethereum
+    address: '{USDC_ADDRESS}'
+checks:
+  twitter_last_post_at: ''
+  domain_up_at: ''
+  marked_dead_at: ''
+  information_found_missing_at: ''
+"""
+    )
+
+
+def _write_live_usdx_yaml(data_dir: Path) -> None:
+    """Create a Kava USDX fixture whose rate is fetched from live CoinGecko."""
+    (data_dir / "usdx.yaml").write_text(
+        f"""symbol: USDX
+name: Kava USDX
+short_description: Kava USDX
+long_description: ''
+category: stablecoin
+coingecko_id: usdx
+coingecko_link: https://www.coingecko.com/en/coins/usdx
+coingecko_id_source: manual
+links:
+  homepage: https://www.kava.io/
+  coingecko: https://www.coingecko.com/en/coins/usdx
+  defillama: ''
+  twitter: https://x.com/KAVA_CHAIN
+slug: usdx
+contract_addresses:
+  - chain: ethereum
+    address: '{USDX_ADDRESS}'
+checks:
+  twitter_last_post_at: ''
+  domain_up_at: ''
+  marked_dead_at: ''
+  information_found_missing_at: ''
+"""
+    )
+
+
+def _calculate_bad_usdx_vault_metrics(data_dir: Path) -> pd.DataFrame:
+    """Calculate lifetime metrics for a vault that uses USDX as denomination."""
+    chain_id = 1
+    vault_id = f"{chain_id}-{VAULT_ADDRESS}"
+    spec = VaultSpec(chain_id=chain_id, vault_address=VAULT_ADDRESS)
+    detection = ERC4262VaultDetection(
+        chain=chain_id,
+        address=VAULT_ADDRESS,
+        first_seen_at_block=1,
+        first_seen_at=datetime.datetime(2026, 1, 1),
+        features=set(),
+        updated_at=datetime.datetime(2026, 1, 1),
+        deposit_count=10,
+        redeem_count=10,
+    )
+    fee_data = FeeData(
+        fee_mode=VaultFeeMode.externalised,
+        management=0.0,
+        performance=0.1,
+        deposit=0.0,
+        withdraw=0.0,
+    )
+    vault_row = {
+        "Symbol": "BADUSDX",
+        "Name": "Bad USDX Vault",
+        "Address": VAULT_ADDRESS,
+        "Denomination": "USDX",
+        "Share token": "BADUSDX",
+        "NAV": Decimal("1000"),
+        "Shares": Decimal("1000"),
+        "Protocol": "Example protocol",
+        "Link": "https://example.com/vault",
+        "First seen": datetime.datetime(2026, 1, 1),
+        "Mgmt fee": 0.0,
+        "Perf fee": 0.1,
+        "Deposit fee": 0.0,
+        "Withdraw fee": 0.0,
+        "Features": "",
+        "_detection_data": detection,
+        "_denomination_token": {"address": USDX_ADDRESS, "symbol": "USDX", "decimals": 6},
+        "_share_token": {"address": VAULT_ADDRESS, "symbol": "BADUSDX", "decimals": 18},
+        "_fees": fee_data,
+        "_flags": set(),
+        "_lockup": None,
+        "_description": None,
+        "_short_description": None,
+        "_available_liquidity": None,
+        "_utilisation": None,
+        "_deposit_closed_reason": None,
+        "_deposit_next_open": None,
+        "_redemption_closed_reason": None,
+        "_redemption_next_open": None,
+        "_risk": VaultTechnicalRisk.negligible,
+        "_manual_review_status": None,
+    }
+
+    index = pd.date_range("2026-01-01", periods=24 * 31, freq="1h")
+    prices_df = pd.DataFrame(
+        {
+            "id": vault_id,
+            "total_assets": 1_000.0,
+            "share_price": 1.0,
+            "event_count": 20,
+            "chain": chain_id,
+            "block_number": range(len(index)),
+        },
+        index=index,
+    )
+
+    metrics = calculate_lifetime_metrics(
+        prices_df,
+        {spec: vault_row},
+        stablecoin_rate_feeder=StablecoinRateFeeder(data_dir=data_dir),
+    )
+    return metrics
+
+
+def _assert_bad_usdx_vault_blacklisted(metrics: pd.DataFrame, expected_usd_rate: float, expected_fetched_at: datetime.datetime) -> None:
+    """Assert depegged USDX makes the vault blacklisted and exports rate data."""
+    assert len(metrics) == 1
+    row = metrics.iloc[0]
+    assert row["risk"] == VaultTechnicalRisk.blacklisted
+    assert row["risk_numeric"] == VaultTechnicalRisk.blacklisted.value
+    assert VaultFlag.depegged_denomination_token in row["flags"]
+    assert "Denomination stablecoin USDX is marked as depegged" in row["notes"]
+
+    denomination_token_rate = row["denomination_token_rate"]
+    assert denomination_token_rate.coingecko_id == "usdx"
+    assert denomination_token_rate.usd_rate == pytest.approx(expected_usd_rate)
+    assert denomination_token_rate.usd_rate_fetched_at == expected_fetched_at
+    assert denomination_token_rate.usd_rate_source == "coingecko"
+
+    exported = export_lifetime_row(row)
+    assert exported["risk"] == "Blacklisted"
+    assert exported["denomination_token_rate"] == {
+        "coingecko_id": "usdx",
+        "usd_rate": expected_usd_rate,
+        "usd_rate_fetched_at": expected_fetched_at.isoformat(),
+        "usd_rate_source": "coingecko",
+    }
+    assert "depegged_denomination_token" in exported["flags"]
+
+
+def test_calculate_lifetime_metrics_blacklists_depegged_usdx_denomination(tmp_path: Path) -> None:
+    """A vault denominated in depegged USDX is blacklisted in lifetime metrics."""
+    _write_depegged_usdx_yaml(tmp_path)
+
+    metrics = _calculate_bad_usdx_vault_metrics(tmp_path)
+
+    _assert_bad_usdx_vault_blacklisted(metrics, expected_usd_rate=0.646809, expected_fetched_at=datetime.datetime(2026, 6, 26, 12, 0, 0))
+
+
+@pytest.mark.live
+def test_live_coingecko_refresh_blacklists_usdx_denomination_and_keeps_usdc_healthy(tmp_path: Path) -> None:
+    """Fetch real CoinGecko rates and blacklist a USDX-denominated vault."""
+    _write_live_usdc_yaml(tmp_path)
+    _write_live_usdx_yaml(tmp_path)
+    now_ = datetime.datetime(2026, 6, 26, 12, 0, 0)
+
+    summary = refresh_stablecoin_rates(data_dir=tmp_path, now_=now_, force=True, timeout=20.0)
+    targets = {target.symbol: target for target in iter_stablecoin_rate_targets(tmp_path)}
+    failure_reasons = {target.rate_fetch_failed_reason for target in targets.values() if target.rate_fetch_failed_reason}
+    if summary.rates_fetched == 0 and failure_reasons == {"coingecko_http_error"}:
+        pytest.skip("CoinGecko live API returned an HTTP error during this run")
+
+    assert summary.entries_seen == 2
+    assert summary.rates_fetched == 2
+    assert summary.failed_count == 0
+    assert summary.depegged_count == 1
+
+    usdc_target = targets["USDC"]
+    usdx_target = targets["USDX"]
+    assert usdc_target.usd_rate == pytest.approx(1.0, abs=0.02)
+    assert usdc_target.depegged_at is None
+    assert usdx_target.usd_rate is not None
+    assert usdx_target.usd_rate < 0.90
+    assert usdx_target.depegged_at == now_
+
+    feeder = StablecoinRateFeeder(data_dir=tmp_path)
+    assert feeder.is_depegged_stablecoin_token(1, USDC_ADDRESS, "USDC") is False
+    assert feeder.is_depegged_stablecoin_token(1, USDX_ADDRESS, "USDX") is True
+
+    metrics = _calculate_bad_usdx_vault_metrics(tmp_path)
+
+    _assert_bad_usdx_vault_blacklisted(metrics, expected_usd_rate=usdx_target.usd_rate, expected_fetched_at=now_)


### PR DESCRIPTION
## Why

Stablecoin-denominated vaults should not remain eligible when their denomination token has materially depegged. The post-scan pipeline also needs current denomination rate metadata so exports can explain the rate source used for vault metrics.

## Lessons learnt

CoinGecko ticker symbols and URLs are ambiguous for assets like USDX, so the YAML metadata needs explicit `coingecko_id` and `coingecko_link` fields. Non-USD fiat stablecoins such as CADC and CJPY must compare against their peg currency, not their USD price. The stablecoin refresh also needs to be a best-effort side job so feed post collection keeps running when CoinGecko or YAML rate refresh fails.

## Summary

- Add `eth_defi.feed.stablecoin_rate` for CoinGecko simple-price refreshes, YAML rate/failure stamps, sticky `depegged_at` handling, and `StablecoinRateFeeder` lookups.
- Run the rate refresh from the post scanner behind a durable 24-hour gate and expose side-job status in collector summaries and the scanner dashboard.
- Add `DenominationTokenRate` data to vault lifetime metrics and blacklist vaults whose denomination token has a non-empty depeg marker.
- Add a manual population script plus feed API docs, README notes, implementation plan notes, changelog entry, and focused integration tests.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.