### PR TITLE
feat: add Lighter account valuation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- feat: Add Lighter account valuation helper for fetching total equity / NAV from live account state, with downstream trade-executor integration coverage and the Lagoon + Lighter manual tutorial now using this helper for withdrawal sizing (2026-06-26)
+
 - feat: Expand the Lagoon + Lighter manual test into a full mainnet lifecycle script with automatic Lagoon deployment JSON saving/loading, existing-vault resume support, live Lighter minimum sizing, Safe-owned API-key registration, ETH long open/close, Lighter withdrawal, Lagoon redemption back to the hot wallet, and reusable `eth_defi.lighter.api` / `eth_defi.lighter.lagoon` helpers (2026-06-26)
 
 - feat: Add Lighter API-key registration (`changePubKey`) tooling for a Safe-controlled (Lagoon vault) account — `eth_defi.lighter.pubkey` (validate / encode / build / execute) and a CLI `scripts/lighter/lagoon-lighter-change-pubkey.py` that prints the transaction (To / value / Data + ABI) for the Safe{Wallet} Transaction Builder so the owners co-sign. This is a privileged Safe-owner action, deliberately outside the asset-manager guard whitelist. Includes Anvil-fork integration tests (registration is bound to `msg.sender`) (2026-06-25)

--- a/docs/source/api/lighter/index.rst
+++ b/docs/source/api/lighter/index.rst
@@ -24,6 +24,7 @@ The guarded Lagoon/Safe surface supports the manual mainnet custody lifecycle:
 - Safe-owned ``changePubKey`` API-key registration
 - Lagoon-vault helpers for USDC deposits, secure Lighter withdrawals and
   pending-balance claims
+- Account valuation via public Lighter account NAV fields
 - Small manual ETH perpetual round trips through the optional Lighter SDK
 
 Tutorials
@@ -40,6 +41,7 @@ fee model documentation, see
    :recursive:
 
    eth_defi.lighter.vault
+   eth_defi.lighter.valuation
    eth_defi.lighter.daily_metrics
    eth_defi.lighter.vault_data_export
    eth_defi.lighter.session

--- a/eth_defi/lighter/README-lighter-guard.md
+++ b/eth_defi/lighter/README-lighter-guard.md
@@ -145,6 +145,24 @@ USDC and credits the Safe's Lighter account.
 
 Funds are released on-chain directly to the Safe address.
 
+## Account valuation (off-chain)
+
+Lighter account NAV is read off-chain from the public account API, not through
+the guard. Use `eth_defi.lighter.valuation.fetch_lighter_total_equity()` with
+the Safe's Lighter account index to fetch `LighterEquity`.
+
+`LighterEquity.get_total()` returns Lighter's canonical `total_asset_value`
+field in USDC. The helper also exposes collateral, unrealised PnL, available
+balance and margin requirements so downstream systems, such as trade-executor,
+can report account state and size withdrawals without duplicating Lighter API
+parsing.
+
+The Lagoon + Lighter manual tutorial
+`scripts/lagoon/lagoon-lighter-example.py` uses this module after the ETH
+round-trip and before requesting the secure Lighter withdrawal. The guard still
+only authorises the L1 custody calls described above; valuation and trading are
+off-chain reads/signatures.
+
 ## Account creation (deposit-driven — not a guard call)
 
 Lighter's

--- a/eth_defi/lighter/__init__.py
+++ b/eth_defi/lighter/__init__.py
@@ -6,6 +6,7 @@ decentralised perpetuals exchange, including pool data extraction and daily metr
 Lighter is a ZK-rollup perp DEX on Ethereum with public pools (vaults)
 including the LLP (Lighter Liquidity Pool) and user-created leveraged pools.
 
-See :py:mod:`eth_defi.lighter.vault` for pool-related functionality and
-:py:mod:`eth_defi.lighter.daily_metrics` for the daily metrics pipeline.
+See :py:mod:`eth_defi.lighter.vault` for pool-related functionality,
+:py:mod:`eth_defi.lighter.daily_metrics` for the daily metrics pipeline and
+:py:mod:`eth_defi.lighter.valuation` for account NAV helpers.
 """

--- a/eth_defi/lighter/valuation.py
+++ b/eth_defi/lighter/valuation.py
@@ -1,0 +1,258 @@
+"""Lighter account valuation.
+
+Calculate the net asset value of a Lighter trading account using the public
+``/api/v1/account`` endpoint.
+
+Lighter returns account equity directly as ``total_asset_value``. For cross
+margin accounts this value matches ``collateral + sum(position.unrealized_pnl)``
+within API rounding. This module preserves both values so downstream callers can
+use the canonical API NAV while still logging a useful breakdown.
+
+.. code-block:: python
+
+    from eth_defi.lighter.session import create_lighter_session
+    from eth_defi.lighter.valuation import fetch_lighter_total_equity
+
+    session = create_lighter_session()
+    result = fetch_lighter_total_equity(session, account_index=123456)
+
+    nav = result.get_total()
+"""
+
+import logging
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from eth_defi.lighter.session import LighterSession
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class LighterEquity:
+    """Equity breakdown for a Lighter trading account.
+
+    See :py:func:`fetch_lighter_total_equity`.
+    """
+
+    #: Lighter account index.
+    account_index: int
+
+    #: Account collateral in USDC, before unrealised position PnL.
+    collateral: Decimal
+
+    #: Sum of ``positions[].unrealized_pnl`` in USDC.
+    unrealised_pnl: Decimal
+
+    #: Canonical account NAV reported by Lighter as ``total_asset_value``.
+    total_asset_value: Decimal
+
+    #: Free USDC balance available for new orders or withdrawals.
+    available_balance: Decimal
+
+    #: Cross-margin initial margin requirement in USDC.
+    initial_margin_requirement: Decimal
+
+    #: Cross-margin maintenance margin requirement in USDC.
+    maintenance_margin_requirement: Decimal
+
+    #: Number of open position records returned by the Lighter API.
+    position_count: int
+
+    def get_total(self) -> Decimal:
+        """Return canonical Lighter account NAV.
+
+        Lighter exposes ``total_asset_value`` directly, so this method returns
+        the API value instead of recomputing it locally. Use
+        :py:meth:`calculate_total_from_parts` for a collateral plus PnL sanity
+        check.
+
+        :return:
+            Account net asset value in USDC.
+        """
+        return self.total_asset_value
+
+    def calculate_total_from_parts(self) -> Decimal:
+        """Calculate account NAV from collateral and unrealised PnL.
+
+        :return:
+            ``collateral + unrealised_pnl`` in USDC.
+        """
+        return self.collateral + self.unrealised_pnl
+
+
+def fetch_lighter_total_equity(
+    session: LighterSession,
+    account_index: int,
+    timeout: float = 30.0,
+) -> LighterEquity:
+    """Calculate the total equity of a Lighter trading account.
+
+    Uses Lighter's public ``/api/v1/account?by=index&value={account_index}``
+    endpoint. No API key is required. The returned
+    :py:meth:`LighterEquity.get_total` value is the canonical
+    ``total_asset_value`` reported by Lighter, denominated in USDC.
+
+    Authoritative endpoint documentation:
+    https://apidocs.lighter.xyz/reference/account
+
+    :param session:
+        Lighter HTTP session.
+    :param account_index:
+        Lighter account index.
+    :param timeout:
+        HTTP request timeout.
+    :return:
+        :class:`LighterEquity` with NAV, collateral, unrealised PnL,
+        available balance, margin requirements and position count.
+    :raises ValueError:
+        If the API returns no account or malformed decimal fields.
+    """
+    account = fetch_lighter_account_by_index(
+        session=session,
+        account_index=account_index,
+        timeout=timeout,
+    )
+    equity = parse_lighter_account_equity(account)
+    logger.info(
+        "Total equity for Lighter account %d: collateral=%s, unrealised_pnl=%s, total=%s, available=%s",
+        equity.account_index,
+        equity.collateral,
+        equity.unrealised_pnl,
+        equity.total_asset_value,
+        equity.available_balance,
+    )
+    return equity
+
+
+def fetch_lighter_account_by_index(
+    session: LighterSession,
+    account_index: int,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    """Fetch a raw Lighter account dict by account index.
+
+    :param session:
+        Lighter HTTP session.
+    :param account_index:
+        Lighter account index.
+    :param timeout:
+        HTTP request timeout.
+    :return:
+        Raw account dict from the first ``accounts`` response item.
+    :raises ValueError:
+        If the response contains no accounts.
+    """
+    url = f"{session.api_url}/api/v1/account"
+    params = {"by": "index", "value": str(account_index)}
+    resp = session.get(url, params=params, timeout=timeout)
+    resp.raise_for_status()
+    data = resp.json()
+
+    accounts = data.get("accounts", [])
+    if not accounts:
+        raise ValueError(f"No Lighter account data returned for index {account_index}")
+
+    account = accounts[0]
+    returned_index_value = account.get("account_index", account.get("index"))
+    if returned_index_value is None:
+        msg = "Lighter API account response did not include account_index or index"
+        raise ValueError(msg)
+    returned_index = int(returned_index_value)
+    if returned_index != account_index:
+        raise ValueError(f"Lighter API returned account index {returned_index}, expected {account_index}")
+    return account
+
+
+def parse_lighter_account_equity(account: dict[str, Any]) -> LighterEquity:
+    """Parse a raw Lighter account dict into :class:`LighterEquity`.
+
+    The Lighter API uses strings for decimal values. This parser converts them
+    to :class:`~decimal.Decimal` and treats missing optional balances as zero.
+
+    :param account:
+        Raw account dict from ``/api/v1/account``.
+    :return:
+        Parsed equity breakdown.
+    :raises ValueError:
+        If required account fields are missing or malformed.
+    """
+    account_index_value = account.get("account_index", account.get("index"))
+    if account_index_value is None:
+        msg = "Lighter account field account_index is missing"
+        raise ValueError(msg)
+    account_index = int(account_index_value)
+    collateral = _parse_decimal(account.get("collateral"), "collateral", default=Decimal(0))
+    available_balance = _parse_decimal(account.get("available_balance"), "available_balance", default=Decimal(0))
+    initial_margin_requirement = _parse_decimal(account.get("cross_initial_margin_requirement"), "cross_initial_margin_requirement", default=Decimal(0))
+    maintenance_margin_requirement = _parse_decimal(account.get("cross_maintenance_margin_requirement"), "cross_maintenance_margin_requirement", default=Decimal(0))
+
+    positions = account.get("positions") or []
+    unrealised_pnl = sum(
+        (_parse_position_unrealised_pnl(position) for position in positions),
+        Decimal(0),
+    )
+
+    total_asset_value = _parse_decimal(
+        account.get("total_asset_value", account.get("cross_asset_value")),
+        "total_asset_value",
+        default=collateral + unrealised_pnl,
+    )
+
+    return LighterEquity(
+        account_index=account_index,
+        collateral=collateral,
+        unrealised_pnl=unrealised_pnl,
+        total_asset_value=total_asset_value,
+        available_balance=available_balance,
+        initial_margin_requirement=initial_margin_requirement,
+        maintenance_margin_requirement=maintenance_margin_requirement,
+        position_count=len(positions),
+    )
+
+
+def _parse_position_unrealised_pnl(position: dict[str, Any]) -> Decimal:
+    """Parse unrealised PnL from a Lighter position record.
+
+    The public account endpoint currently returns ``unrealized_pnl``. Support
+    ``unrealizedPnl`` as a defensive fallback because other exchange APIs in the
+    repository use camelCase for the same concept.
+
+    :param position:
+        Raw position dict from ``account["positions"]``.
+    :return:
+        Position unrealised PnL in USDC.
+    """
+    value = position.get("unrealized_pnl", position.get("unrealizedPnl"))
+    return _parse_decimal(value, "positions[].unrealized_pnl", default=Decimal(0))
+
+
+def _parse_decimal(value: Any, field_name: str, default: Decimal | None = None) -> Decimal:
+    """Parse a decimal value returned by Lighter.
+
+    :param value:
+        Raw value from the Lighter API.
+    :param field_name:
+        Field name used in error messages.
+    :param default:
+        Value to use when ``value`` is ``None`` or an empty string.
+    :return:
+        Parsed decimal value.
+    :raises ValueError:
+        If no value/default is available or parsing fails.
+    """
+    if value is None or value == "":
+        if default is not None:
+            return default
+        raise ValueError(f"Lighter account field {field_name} is missing")
+
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError) as e:
+        raise ValueError(f"Lighter account field {field_name} is not a decimal: {value!r}") from e
+
+    if not parsed.is_finite():
+        raise ValueError(f"Lighter account field {field_name} is not a finite decimal: {value!r}")
+
+    return parsed

--- a/scripts/lagoon/lagoon-lighter-example.py
+++ b/scripts/lagoon/lagoon-lighter-example.py
@@ -171,9 +171,6 @@ from eth_defi.hotwallet import HotWallet
 from eth_defi.lighter.api import (
     LIGHTER_MIN_MAINNET_USDC,
     LighterTradeAmounts,
-    fetch_lighter_account,
-    get_lighter_available_balance,
-    get_lighter_collateral,
     import_lighter,
     register_lighter_api_key,
     resolve_eth_trade_amounts,
@@ -186,6 +183,8 @@ from eth_defi.lighter.constants import LIGHTER_USDC_ETHEREUM
 from eth_defi.lighter.deployment import LighterDeployment
 from eth_defi.lighter.lagoon import broadcast_tx, claim_lighter_pending_balance, deposit_usdc_from_lagoon_safe_into_lighter, sweep_safe_usdc_to_hot_wallet
 from eth_defi.lighter.pubkey import MIN_API_KEY_INDEX
+from eth_defi.lighter.session import create_lighter_session
+from eth_defi.lighter.valuation import fetch_lighter_total_equity
 from eth_defi.provider.anvil import fork_network_anvil, fund_erc20_on_anvil, set_balance
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.token import fetch_erc20_details
@@ -630,14 +629,19 @@ async def run_mainnet() -> None:  # noqa: PLR0914
     api_private_key = await register_lighter_api_key(lighter, web3, vault.safe, hot_wallet, account_index, api_key_index)
     await trade_eth_roundtrip(lighter, account_index, api_private_key, api_key_index, amounts)
 
-    account = await fetch_lighter_account(lighter, account_index)
-    available_usdc = get_lighter_available_balance(account)
-    collateral_usdc = get_lighter_collateral(account)
-    withdraw_usdc = available_usdc.quantize(Decimal("0.000001"))
-    print("\nLighter balances after ETH round-trip:")
-    print(f"  Collateral: {collateral_usdc} USDC")
-    print(f"  Available:  {available_usdc} USDC")
-    print(f"  Withdrawal: {withdraw_usdc} USDC")
+    lighter_session = create_lighter_session()
+    try:
+        equity = fetch_lighter_total_equity(lighter_session, account_index)
+    finally:
+        lighter_session.close()
+
+    withdraw_usdc = equity.available_balance.quantize(Decimal("0.000001"))
+    print("\nLighter valuation after ETH round-trip:")
+    print(f"  NAV:            {equity.get_total()} USDC")
+    print(f"  Collateral:     {equity.collateral} USDC")
+    print(f"  Unrealised PnL: {equity.unrealised_pnl} USDC")
+    print(f"  Available:      {equity.available_balance} USDC")
+    print(f"  Withdrawal:     {withdraw_usdc} USDC")
     if withdraw_usdc < LIGHTER_MIN_MAINNET_USDC:
         raise RuntimeError(f"Lighter available balance {withdraw_usdc} USDC is below the secure withdrawal minimum {LIGHTER_MIN_MAINNET_USDC} USDC")
     await withdraw_from_lighter(lighter, account_index, api_private_key, api_key_index, withdraw_usdc)

--- a/tests/lighter/test_valuation.py
+++ b/tests/lighter/test_valuation.py
@@ -1,0 +1,229 @@
+"""Integration tests for Lighter account valuation."""
+
+import os
+import site
+import sys
+from decimal import Decimal
+from importlib import machinery, util
+from types import ModuleType
+
+import pytest
+
+from eth_defi.lighter.constants import LIGHTER_API_URL
+from eth_defi.lighter.session import create_lighter_session
+from eth_defi.lighter.valuation import fetch_lighter_account_by_index, fetch_lighter_total_equity, parse_lighter_account_equity
+
+pytestmark = pytest.mark.timeout(60)
+
+ACCOUNT_INDEX = 731323
+API_KEY_INDEX = 4
+POSITION_COUNT = 2
+ROUNDING_TOLERANCE = Decimal("0.01")
+
+
+class FakeResponse:
+    """Minimal response object for valuation unit tests."""
+
+    def __init__(self, data: dict):
+        self.data = data
+
+    def raise_for_status(self) -> None:
+        """Simulate a successful HTTP response."""
+
+    def json(self) -> dict:
+        """Return fake JSON payload."""
+        return self.data
+
+
+class FakeSession:
+    """Minimal Lighter session stand-in."""
+
+    api_url = "https://lighter.example"
+
+    def __init__(self, data: dict):
+        self.data = data
+        self.calls: list[tuple[str, dict, float]] = []
+
+    def get(self, url: str, params: dict, timeout: float) -> FakeResponse:
+        """Record the call and return fake account data."""
+        self.calls.append((url, params, timeout))
+        return FakeResponse(self.data)
+
+
+def make_account() -> dict:
+    """Create a realistic Lighter account response item."""
+    return {
+        "account_index": ACCOUNT_INDEX,
+        "collateral": "1000.50",
+        "available_balance": "800.25",
+        "cross_initial_margin_requirement": "120.00",
+        "cross_maintenance_margin_requirement": "60.00",
+        "total_asset_value": "1012.75",
+        "positions": [
+            {"unrealized_pnl": "10.00"},
+            {"unrealizedPnl": "2.25"},
+        ],
+    }
+
+
+def _require_env(name: str) -> str:
+    """Read an environment variable or skip the integration test."""
+    value = os.environ.get(name)
+    if not value:
+        pytest.skip(f"Set {name} to run Lighter valuation integration tests")
+    return value
+
+
+def _import_lighter_sdk() -> ModuleType:
+    """Import the installed Lighter SDK, avoiding ``tests/lighter`` shadowing."""
+    existing = sys.modules.get("lighter")
+    if existing is not None and hasattr(existing, "SignerClient"):
+        return existing
+
+    for package_path in site.getsitepackages():
+        spec = machinery.PathFinder.find_spec("lighter", [package_path])
+        if spec is None or spec.loader is None:
+            continue
+        if not spec.origin or "site-packages" not in spec.origin:
+            continue
+
+        module = util.module_from_spec(spec)
+        sys.modules["lighter"] = module
+        spec.loader.exec_module(module)
+        if hasattr(module, "SignerClient"):
+            return module
+
+    pytest.skip("Install the Lighter SDK to run Lighter valuation integration tests")
+
+
+def test_parse_lighter_account_equity() -> None:
+    """Lighter account parser returns Decimal NAV components."""
+    equity = parse_lighter_account_equity(make_account())
+
+    assert equity.account_index == ACCOUNT_INDEX
+    assert equity.collateral == Decimal("1000.50")
+    assert equity.unrealised_pnl == Decimal("12.25")
+    assert equity.total_asset_value == Decimal("1012.75")
+    assert equity.available_balance == Decimal("800.25")
+    assert equity.initial_margin_requirement == Decimal("120.00")
+    assert equity.maintenance_margin_requirement == Decimal("60.00")
+    assert equity.position_count == POSITION_COUNT
+    assert equity.get_total() == Decimal("1012.75")
+    assert equity.calculate_total_from_parts() == Decimal("1012.75")
+
+
+def test_parse_lighter_account_equity_falls_back_to_index_and_cross_asset_value() -> None:
+    """Parser accepts alternative account and NAV fields from Lighter responses."""
+    account = make_account()
+    account["index"] = account.pop("account_index")
+    account["cross_asset_value"] = account.pop("total_asset_value")
+
+    equity = parse_lighter_account_equity(account)
+
+    assert equity.account_index == ACCOUNT_INDEX
+    assert equity.get_total() == Decimal("1012.75")
+
+
+def test_parse_lighter_account_equity_falls_back_to_calculated_total() -> None:
+    """Missing total asset value falls back to collateral plus unrealised PnL."""
+    account = make_account()
+    del account["total_asset_value"]
+
+    equity = parse_lighter_account_equity(account)
+
+    assert equity.get_total() == Decimal("1012.75")
+
+
+def test_fetch_lighter_account_by_index() -> None:
+    """Fetcher calls the Lighter account endpoint by index."""
+    session = FakeSession({"accounts": [make_account()]})
+
+    account = fetch_lighter_account_by_index(session, account_index=ACCOUNT_INDEX, timeout=5.0)  # type: ignore[arg-type]
+
+    assert account["account_index"] == ACCOUNT_INDEX
+    assert session.calls == [
+        (
+            "https://lighter.example/api/v1/account",
+            {"by": "index", "value": str(ACCOUNT_INDEX)},
+            5.0,
+        )
+    ]
+
+
+def test_fetch_lighter_account_by_index_rejects_empty_response() -> None:
+    """Fetcher raises if the Lighter API returns no accounts."""
+    session = FakeSession({"accounts": []})
+
+    with pytest.raises(ValueError, match="No Lighter account data returned"):
+        fetch_lighter_account_by_index(session, account_index=ACCOUNT_INDEX)  # type: ignore[arg-type]
+
+
+def test_fetch_lighter_account_by_index_rejects_mismatched_response() -> None:
+    """Fetcher raises if the Lighter API returns a different account."""
+    account = make_account()
+    account["account_index"] = ACCOUNT_INDEX + 1
+    session = FakeSession({"accounts": [account]})
+
+    with pytest.raises(ValueError, match="returned account index"):
+        fetch_lighter_account_by_index(session, account_index=ACCOUNT_INDEX)  # type: ignore[arg-type]
+
+
+def test_fetch_lighter_account_by_index_rejects_missing_response_index() -> None:
+    """Fetcher raises if the account object has no account index field."""
+    account = make_account()
+    del account["account_index"]
+    session = FakeSession({"accounts": [account]})
+
+    with pytest.raises(ValueError, match="account_index or index"):
+        fetch_lighter_account_by_index(session, account_index=ACCOUNT_INDEX)  # type: ignore[arg-type]
+
+
+def test_parse_lighter_account_equity_rejects_bad_decimal() -> None:
+    """Malformed decimal fields raise a clear error."""
+    account = make_account()
+    account["collateral"] = "not-a-number"
+
+    with pytest.raises(ValueError, match="collateral"):
+        parse_lighter_account_equity(account)
+
+
+def test_parse_lighter_account_equity_rejects_non_finite_decimal() -> None:
+    """Non-finite decimal fields raise a clear error."""
+    account = make_account()
+    account["total_asset_value"] = "NaN"
+
+    with pytest.raises(ValueError, match="finite decimal"):
+        parse_lighter_account_equity(account)
+
+
+@pytest.mark.asyncio
+async def test_fetch_lighter_total_equity_with_registered_api_key() -> None:
+    """Fetch NAV for a real Lighter account with a registered API key."""
+    lighter = _import_lighter_sdk()
+
+    account_index = int(_require_env("LIGHTER_TEST_ACCOUNT_INDEX"))
+    api_private_key = _require_env("LIGHTER_TEST_ACCOUNT_API_KEY")
+    api_key_index = int(os.environ.get("LIGHTER_TEST_ACCOUNT_API_KEY_INDEX", str(API_KEY_INDEX)))
+
+    client = lighter.SignerClient(
+        url=LIGHTER_API_URL,
+        account_index=account_index,
+        api_private_keys={api_key_index: api_private_key},
+    )
+    try:
+        err = client.check_client()
+        assert err is None
+    finally:
+        await client.close()
+
+    session = create_lighter_session()
+    try:
+        equity = fetch_lighter_total_equity(session, account_index)
+    finally:
+        session.close()
+
+    assert equity.account_index == account_index
+    assert equity.get_total() >= Decimal("1")
+    assert equity.collateral >= Decimal("1")
+    assert equity.available_balance >= Decimal(0)
+    assert equity.calculate_total_from_parts() == pytest.approx(equity.get_total(), abs=ROUNDING_TOLERANCE)


### PR DESCRIPTION
## Why

Trade-executor needs a Lighter account NAV helper comparable to the existing GMX total-equity helper, so downstream code can read canonical account value after deposits and trades.

## Lessons learnt

Lighter exposes canonical NAV as `total_asset_value` on the public account endpoint. The component calculation from collateral plus unrealised PnL is useful as a sanity check, but the API field should remain the source of truth because rounding can differ.

## Summary

- Add `eth_defi.lighter.valuation` with `fetch_lighter_total_equity()`, raw account fetching and Decimal parsing.
- Update the Lagoon + Lighter manual tutorial to fetch valuation through the helper before withdrawal sizing.
- Add Lighter valuation API docs and changelog entry.
- Convert valuation coverage to include a live integration test using `LIGHTER_TEST_ACCOUNT_API_KEY`.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.