### PR TITLE
fix: document Webshare proxy reset guidance

### DIFF
--- a/eth_defi/event_reader/README-webshares-proxy.md
+++ b/eth_defi/event_reader/README-webshares-proxy.md
@@ -1,0 +1,100 @@
+# Webshare proxy
+
+## What is Webshare
+
+[Webshare](https://www.webshare.io/) is a proxy service used by this repository
+through the helper module `eth_defi.event_reader.webshare`.
+
+The helper loads proxy credentials from the Webshare API, converts them to
+formats used by `requests` and Playwright, and rotates through the proxy pool
+when remote services rate limit or block requests.
+
+Proxy support is optional. If `WEBSHARE_API_KEY` is not set, the helper returns
+`None` or an empty list and callers continue without proxies.
+
+## Why do we use it
+
+Some upstream services used by data collection scripts rate limit, throttle, or
+block repeated requests from a single IP address. Webshare gives us a managed
+proxy pool so long-running scanners can distribute requests across different
+exit IPs.
+
+The proxy layer also tracks failed proxies locally. When a proxy fails, it is
+placed in a grace period and skipped by later runs. This avoids retrying known
+bad proxies on every scan cycle.
+
+## Where do we use it
+
+The shared implementation lives in:
+
+```text
+eth_defi/event_reader/webshare.py
+```
+
+Known callers include:
+
+- `eth_defi/feed/collector.py` for proxy-backed feed fetches.
+- `eth_defi/vault/scan_all_chains.py` for vault scanning.
+- `eth_defi/hyperliquid/session.py` for Hyperliquid HTTP sessions.
+- `scripts/hyperliquid/sync-trade-history.py` for trade history syncing.
+- `scripts/hyperliquid/high-freq-vault-metrics.py` for high-frequency vault metric fetching.
+- `scripts/erc-4626/scan-vault-posts.py` for vault post scanning.
+
+Enable proxies with:
+
+```shell
+export WEBSHARE_API_KEY=your_webshare_api_key_here
+```
+
+The proxy mode defaults to `backbone`. Override it with:
+
+```shell
+export WEBSHARE_PROXY_MODE=backbone
+```
+
+Supported modes are `backbone` and `direct`.
+
+## Limitations
+
+Webshare does not guarantee that every proxy in the pool is usable for every
+target service. Individual proxies may be blocked, rate limited, slow, or fail
+TLS/HTTP negotiation.
+
+The local failure state is conservative. A proxy that fails is skipped for the
+configured grace period, currently 14 days. If every proxy gets marked failed,
+callers fall back to direct connections or return no proxy URLs.
+
+The current Webshare API request reads the first page of up to 100 proxies. If
+the account has more proxies than that, the helper does not currently paginate
+through the full account pool.
+
+The proxy state file is local to the machine running the scanner. Clearing it on
+one host does not clear status on another host.
+
+## Diagnostics and how to reset
+
+The proxy state file is:
+
+```shell
+~/.tradingstrategy/webshare-proxy-state.json
+```
+
+When all proxies are blocked, the log includes a warning with reset
+instructions. To inspect the blocked proxies and reset them interactively, run:
+
+```shell
+poetry run python scripts/erc-4626/reset-proxy-state.py
+```
+
+The script prints the blocked proxy IDs, failure timestamps, failure reasons,
+and failure counts. Confirm with `y` when prompted to clear all blocked proxy
+state.
+
+For a non-interactive reset, delete the state file:
+
+```shell
+rm ~/.tradingstrategy/webshare-proxy-state.json
+```
+
+After reset, the next run fetches the Webshare proxy list again and treats all
+returned valid proxies as available until new failures are recorded.

--- a/eth_defi/event_reader/webshare.py
+++ b/eth_defi/event_reader/webshare.py
@@ -47,6 +47,19 @@ DEFAULT_PROXY_STATE_PATH = Path("~/.tradingstrategy/webshare-proxy-state.json").
 GRACE_PERIOD_DAYS = 14
 
 
+def get_proxy_status_reset_instructions() -> str:
+    """Return operator instructions for clearing Webshare proxy status.
+
+    Webshare proxy failures are cached on disk so that bad proxies are skipped
+    during the grace period. When every proxy is blocked, the operator can
+    clear this local status file to retry the whole proxy pool.
+
+    :return:
+        Human-readable instructions for log messages.
+    """
+    return f"Reset Webshare proxy status with: poetry run python scripts/erc-4626/reset-proxy-state.py (or delete {DEFAULT_PROXY_STATE_PATH})"
+
+
 @dataclass(slots=True)
 class FailedProxyEntry:
     """Tracks a failed proxy with timestamp and reason."""
@@ -518,8 +531,9 @@ def load_proxy_rotator() -> ProxyRotator | None:
 
     if not proxies:
         logger.warning(
-            "All %d proxies are blocked — falling back to direct connection",
+            "All %d Webshare proxies are blocked; falling back to direct connection. %s",
             total_count,
+            get_proxy_status_reset_instructions(),
         )
         return None
 
@@ -588,7 +602,11 @@ def load_proxy_urls(api_key: str | None = None) -> list[str]:
         )
 
     if not proxies:
-        logger.warning("All %d proxies are blocked — returning empty list", total_count)
+        logger.warning(
+            "All %d Webshare proxies are blocked; returning empty list. %s",
+            total_count,
+            get_proxy_status_reset_instructions(),
+        )
         return []
 
     random.shuffle(proxies)

--- a/tests/event_reader/test_webshare_proxy_state.py
+++ b/tests/event_reader/test_webshare_proxy_state.py
@@ -1,0 +1,113 @@
+"""Unit tests for Webshare proxy failure state."""
+
+import logging
+from collections.abc import Callable
+from pathlib import Path
+
+from _pytest.logging import LogCaptureFixture
+from _pytest.monkeypatch import MonkeyPatch
+
+from eth_defi.event_reader import webshare
+from eth_defi.event_reader.webshare import ProxyStateManager, WebshareProxy, load_proxy_rotator, load_proxy_urls
+
+
+def _make_proxy(username: str) -> WebshareProxy:
+    """Create a synthetic Webshare proxy for status tests.
+
+    The proxy is never contacted over network. It only needs enough identity
+    fields for :class:`~eth_defi.event_reader.webshare.ProxyStateManager`.
+
+    :param username:
+        Proxy username used as the backbone proxy identifier.
+    :return:
+        Synthetic proxy entry.
+    """
+    return WebshareProxy(
+        proxy_address=None,
+        port=80,
+        username=username,
+        password="password",
+        country_code="FI",
+        city_name="Helsinki",
+    )
+
+
+def _make_fetch_proxy_list(proxies: list[WebshareProxy]) -> Callable[[str, str], list[WebshareProxy]]:
+    """Create a Webshare proxy list mock.
+
+    The mock validates the expected test API key and proxy mode so that the
+    tests cover the production call signature.
+
+    :param proxies:
+        Synthetic proxies to return.
+    :return:
+        Mock function for :func:`eth_defi.event_reader.webshare.fetch_proxy_list`.
+    """
+
+    def _fetch_proxy_list(api_key: str, mode: str = "backbone") -> list[WebshareProxy]:
+        assert api_key == "test-key"
+        assert mode == "backbone"
+        return proxies
+
+    return _fetch_proxy_list
+
+
+def test_load_proxy_rotator_warns_how_to_reset_exhausted_proxy_status(monkeypatch: MonkeyPatch, tmp_path: Path, caplog: LogCaptureFixture) -> None:
+    """All blocked proxies emit reset instructions as a warning.
+
+    Operators need actionable instructions when cached Webshare proxy failure
+    status has blocked the whole pool.
+
+    :param monkeypatch:
+        Pytest monkeypatch fixture.
+    :param tmp_path:
+        Temporary path fixture.
+    :param caplog:
+        Pytest log capture fixture.
+    """
+    state_path = tmp_path / "webshare-proxy-state.json"
+    proxies = [_make_proxy("proxy-1"), _make_proxy("proxy-2")]
+    state_manager = ProxyStateManager(state_path=state_path)
+    for proxy in proxies:
+        state_manager.record_failure(proxy, "test_failure")
+
+    monkeypatch.setenv("WEBSHARE_API_KEY", "test-key")
+    monkeypatch.setattr(webshare, "DEFAULT_PROXY_STATE_PATH", state_path)
+    monkeypatch.setattr(webshare, "fetch_proxy_list", _make_fetch_proxy_list(proxies))
+
+    caplog.set_level(logging.WARNING, logger=webshare.__name__)
+
+    rotator = load_proxy_rotator()
+
+    assert rotator is None
+    assert any(record.levelno == logging.WARNING and "reset-proxy-state.py" in record.message for record in caplog.records)
+    assert str(state_path) in caplog.text
+
+
+def test_load_proxy_urls_warns_how_to_reset_exhausted_proxy_status(monkeypatch: MonkeyPatch, tmp_path: Path, caplog: LogCaptureFixture) -> None:
+    """Proxy URL loading logs reset instructions when all proxies are blocked.
+
+    :param monkeypatch:
+        Pytest monkeypatch fixture.
+    :param tmp_path:
+        Temporary path fixture.
+    :param caplog:
+        Pytest log capture fixture.
+    """
+    state_path = tmp_path / "webshare-proxy-state.json"
+    proxies = [_make_proxy("proxy-1"), _make_proxy("proxy-2")]
+    state_manager = ProxyStateManager(state_path=state_path)
+    for proxy in proxies:
+        state_manager.record_failure(proxy, "test_failure")
+
+    monkeypatch.setenv("WEBSHARE_API_KEY", "test-key")
+    monkeypatch.setattr(webshare, "DEFAULT_PROXY_STATE_PATH", state_path)
+    monkeypatch.setattr(webshare, "fetch_proxy_list", _make_fetch_proxy_list(proxies))
+
+    caplog.set_level(logging.WARNING, logger=webshare.__name__)
+
+    urls = load_proxy_urls()
+
+    assert urls == []
+    assert any(record.levelno == logging.WARNING and "reset-proxy-state.py" in record.message for record in caplog.records)
+    assert str(state_path) in caplog.text


### PR DESCRIPTION
## Why

When all Webshare proxies are marked failed, the scanner can fall back to direct connections or stop returning proxy URLs without telling the operator how to recover. The warning now includes the reset command and state file path.

## Lessons learnt

Webshare proxy failures are cached locally for a 14 day grace period. Operator-facing warnings need to mention the local reset workflow because the failure state is not visible from the Webshare account itself.

## Summary

- Added shared reset guidance for exhausted Webshare proxy pools.
- Included the guidance in both proxy rotator and proxy URL loading warnings.
- Added unit coverage for the exhausted proxy state path.
- Added `eth_defi/event_reader/README-webshares-proxy.md` with Webshare usage, limitations, diagnostics and reset instructions.
- Verified with `ruff check` and the focused Webshare proxy state tests in the clean PR worktree.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.