### PR TITLE
fix: blacklist multi-entry depegged stablecoin denominations (USDX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- fix: Blacklist multi-entry depegged stablecoin denominations such as USDX. The depeg lookup only matched single-entry stablecoin YAML files, so USDX-denominated vaults (~$269M nominal TVL) were never blacklisted in production. Pin the dead Stables Labs USDX token by contract address, keep symbol matching off for ambiguous multi-entry tickers (so unrelated same-ticker tokens like Axis USD are not blacklisted), warn when a depeg cannot be enforced for lack of a contract address, and add `scripts/erc-4626/list-depegged-vaults.py` to report the blacklisted depeg TVL impact (2026-06-28)
+
 - refactor: Move the reusable `LoggingRetry` HTTP retry adapter out of the Velvet submodule to its own top-level `eth_defi.logging_retry` module, since it is shared across the Velvet, Derive, Core3, Hibachi, GRVT, Lighter, Hyperliquid and token-analysis integrations (2026-06-28)
 
 - feat: Add a CoinGecko-backed stablecoin denomination rate feed and depeg monitor for vault metrics, with daily post-scan refresh, sticky YAML `depegged_at` flags, failure stamps for missing prices, `denomination_token_rate` export fields, and automatic vault blacklisting when a denomination stablecoin is marked depegged (2026-06-26)

--- a/eth_defi/data/stablecoins/usdx.yaml
+++ b/eth_defi/data/stablecoins/usdx.yaml
@@ -15,6 +15,15 @@ entries:
     coingecko: https://www.coingecko.com/en/coins/usdx-money-usdx
     defillama: https://defillama.com/stablecoin/usdx-money
     twitter: https://x.com/usdx_money
+  contract_addresses:
+    - chain: ethereum
+      address: '0xf3527ef8dE265eAa3716FB312c12847bFBA66Cef'
+    - chain: arbitrum
+      address: '0xf3527ef8dE265eAa3716FB312c12847bFBA66Cef'
+    - chain: binance
+      address: '0xf3527ef8dE265eAa3716FB312c12847bFBA66Cef'
+    - chain: base
+      address: '0xf3527ef8dE265eAa3716FB312c12847bFBA66Cef'
   coingecko_id: usdx-money-usdx
   coingecko_link: https://www.coingecko.com/en/coins/usdx-money-usdx
   coingecko_id_source: manual

--- a/eth_defi/feed/stablecoin_rate.py
+++ b/eth_defi/feed/stablecoin_rate.py
@@ -217,6 +217,20 @@ class StablecoinRateFeeder:
 
         return DenominationTokenRate(coingecko_id=None, usd_rate=None, usd_rate_fetched_at=None, usd_rate_source=None)
 
+    @property
+    def depegged_contracts(self) -> set[tuple[int, str]]:
+        """Set of ``(chain_id, lowercased_address)`` keys for depegged tokens (built lazily, cached)."""
+        if self._depegged_contracts is None or self._depegged_symbols is None:
+            self._depegged_contracts, self._depegged_symbols = build_depegged_stablecoin_lookups(self.data_dir)
+        return self._depegged_contracts
+
+    @property
+    def depegged_symbols(self) -> set[str]:
+        """Set of unambiguously depegged normalised symbols (built lazily, cached)."""
+        if self._depegged_contracts is None or self._depegged_symbols is None:
+            self._depegged_contracts, self._depegged_symbols = build_depegged_stablecoin_lookups(self.data_dir)
+        return self._depegged_symbols
+
     def is_depegged_stablecoin_token(
         self,
         chain_id: int | None,
@@ -224,15 +238,12 @@ class StablecoinRateFeeder:
         symbol: str | None,
     ) -> bool:
         """Return ``True`` when a denomination token is marked depegged."""
-        if self._depegged_contracts is None or self._depegged_symbols is None:
-            self._depegged_contracts, self._depegged_symbols = build_depegged_stablecoin_lookups(self.data_dir)
-
         key = _normalise_contract_key(chain_id, address)
-        if key and key in self._depegged_contracts:
+        if key and key in self.depegged_contracts:
             return True
 
         normalised_symbol = normalise_token_symbol(symbol)
-        return bool(normalised_symbol and normalised_symbol in self._depegged_symbols)
+        return bool(normalised_symbol and normalised_symbol in self.depegged_symbols)
 
 
 def extract_coingecko_id(url: str | None) -> str | None:
@@ -424,10 +435,40 @@ def refresh_stablecoin_rates(
 
 
 def build_depegged_stablecoin_lookups(data_dir: Path = STABLECOINS_DATA_DIR) -> tuple[set[tuple[int, str]], set[str]]:
-    """Build contract and unambiguous symbol lookups for depegged stablecoins."""
+    """Build contract and unambiguous symbol lookups for depegged stablecoins.
+
+    Determine which denomination tokens should be treated as depegged for vault
+    blacklisting. Two independent lookups are returned:
+
+    - A set of ``(chain_id, lowercased_address)`` contract keys for **every**
+      entry that carries a ``depegged_at`` marker, regardless of whether the
+      entry lives in a single- or multi-entry YAML file. This is the precise
+      path: it pins the dead token by address and never blacklists an unrelated
+      token that merely reuses the same ticker.
+    - A set of normalised symbols that are *unambiguously* depegged. A symbol is
+      only eligible here when a single flat (single-entry) YAML file owns it and
+      that file is marked ``depegged_at``.
+
+    Symbol matching is deliberately **not** used for multi-entry tokens. Tickers
+    such as ``USDX`` are reused by several unrelated tokens in the wild — e.g.
+    the dead Stables Labs USDX (``0xf3527ef8…``) versus the live Axis USD
+    (``USDx``) on Plasma — so matching by ticker would blacklist healthy vaults.
+    Multi-entry depegged tokens must therefore be pinned by ``contract_addresses``
+    in their YAML entry. A warning is logged for any depegged entry that has no
+    contract address and is not covered by an unambiguous symbol, because such a
+    depeg silently fails to blacklist anything (this is the gap that previously
+    let USDX-denominated vaults stay listed).
+
+    :param data_dir:
+        Directory of stablecoin metadata YAML files.
+
+    :return:
+        Tuple of ``(depegged_contract_keys, depegged_symbols)``.
+    """
     depegged_contracts: set[tuple[int, str]] = set()
     symbol_owner_counts: dict[str, int] = {}
     depegged_symbol_candidates: set[str] = set()
+    depegged_without_contract: list[StablecoinRateTarget] = []
 
     for target in iter_stablecoin_rate_targets(data_dir):
         normalised_symbol = normalise_token_symbol(target.symbol)
@@ -439,8 +480,25 @@ def build_depegged_stablecoin_lookups(data_dir: Path = STABLECOINS_DATA_DIR) -> 
         depegged_contracts.update(target.contract_addresses)
         if normalised_symbol and target.entry_index is None:
             depegged_symbol_candidates.add(normalised_symbol)
+        if not target.contract_addresses:
+            depegged_without_contract.append(target)
 
     depegged_symbols = {symbol for symbol in depegged_symbol_candidates if symbol_owner_counts.get(symbol) == 1}
+
+    # Warn about depegged entries we cannot enforce: no contract address and the
+    # symbol is not an unambiguous single-owner symbol (typically multi-entry
+    # tokens such as USDX). These need contract_addresses added to their YAML.
+    for target in depegged_without_contract:
+        normalised_symbol = normalise_token_symbol(target.symbol)
+        if normalised_symbol and normalised_symbol in depegged_symbols:
+            continue
+        logger.warning(
+            "Depegged stablecoin %s (%s) in %s has no contract address and an ambiguous symbol; vaults denominated in it cannot be blacklisted. Add contract_addresses to the YAML entry.",
+            target.symbol,
+            target.name,
+            target.yaml_path.name,
+        )
+
     return depegged_contracts, depegged_symbols
 
 

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -789,6 +789,37 @@ Test rendering a sparkline for a single vault and open the result in a browser.
 poetry run python scripts/erc-4626/render-sparkline.py
 ```
 
+### list-depegged-vaults.py
+
+Report which vaults are blacklisted because their denomination stablecoin has
+depegged, and the total TVL impact. Cross-references the vault metadata database
+against the stablecoin depeg markers (`depegged_at` in
+`eth_defi/data/stablecoins/*.yaml`) using the same lookup the export pipeline
+uses (`build_depegged_stablecoin_lookups`), so the figures match what gets
+blacklisted in production. Prints a per-stablecoin summary (vault count, nominal
+TVL, and estimated real USD value at the current depegged rate), a grand total,
+and an optional per-vault detail table. It also logs a warning for any depegged
+stablecoin that cannot be enforced because it has no `contract_addresses` and an
+ambiguous ticker (e.g. multi-entry tokens such as USDX before their address is
+pinned).
+
+```shell
+# Use the locally cached vault database
+poetry run python scripts/erc-4626/list-depegged-vaults.py
+
+# Point at an explicitly downloaded database and hide the per-vault detail
+VAULT_DB_PATH=/tmp/vault-metadata-db.pickle SHOW_DETAIL=false \
+    poetry run python scripts/erc-4626/list-depegged-vaults.py
+```
+
+| Variable | Description |
+|----------|-------------|
+| `VAULT_DB_PATH` | Optional. Path to the vault metadata database pickle. Default: `~/.tradingstrategy/vaults/vault-metadata-db.pickle`. |
+| `STABLECOINS_DIR` | Optional. Stablecoin metadata YAML directory. Default: packaged `eth_defi/data/stablecoins`. |
+| `MIN_TVL` | Optional. Ignore vaults whose NAV is below this nominal value. Default: 0. |
+| `SHOW_DETAIL` | Optional. Print the per-vault detail table. Default: true. |
+| `LOG_LEVEL` | Optional. Default: warning. |
+
 ## Data extraction
 
 Scripts for extracting subsets of data for testing or analysis.

--- a/scripts/erc-4626/list-depegged-vaults.py
+++ b/scripts/erc-4626/list-depegged-vaults.py
@@ -1,0 +1,177 @@
+"""Report vaults blacklisted because their denomination stablecoin has depegged.
+
+Cross-references the vault metadata database against the stablecoin depeg
+markers (``depegged_at`` in ``eth_defi/data/stablecoins/*.yaml``) and prints:
+
+- A per-stablecoin summary of how many vaults are blacklisted and their TVL.
+- The total nominal TVL we blacklist due to denomination-token depegs, plus an
+  estimate of the real USD value at the current (depegged) exchange rate.
+- An optional per-vault detail table.
+
+The depeg detection reuses the exact production lookup
+(:class:`eth_defi.feed.stablecoin_rate.StablecoinRateFeeder`), so the numbers
+here match what :func:`eth_defi.research.vault_metrics.calculate_vault_record`
+blacklists in the export pipeline.
+
+Usage:
+
+.. code-block:: shell
+
+    # Use the locally cached vault database (~/.tradingstrategy/vaults/vault-metadata-db.pickle)
+    poetry run python scripts/erc-4626/list-depegged-vaults.py
+
+    # Point at an explicitly downloaded database and hide the per-vault detail
+    VAULT_DB_PATH=/tmp/vault-metadata-db.pickle SHOW_DETAIL=false \
+        poetry run python scripts/erc-4626/list-depegged-vaults.py
+
+Environment variables:
+
+- ``VAULT_DB_PATH``: Optional. Path to the vault metadata database pickle.
+  Default: ``~/.tradingstrategy/vaults/vault-metadata-db.pickle``.
+- ``STABLECOINS_DIR``: Optional. Path to the stablecoin metadata YAML directory.
+  Default: the packaged ``eth_defi/data/stablecoins`` directory.
+- ``MIN_TVL``: Optional. Ignore vaults whose NAV is below this nominal value.
+  Default: 0 (include everything).
+- ``SHOW_DETAIL``: Optional. Print the per-vault detail table. Default: true.
+- ``LOG_LEVEL``: Optional. Default: warning.
+"""
+
+import logging
+import os
+from collections import defaultdict
+from decimal import Decimal
+from pathlib import Path
+
+from tabulate import tabulate
+
+from eth_defi.chain import get_chain_name
+from eth_defi.feed.stablecoin_rate import STABLECOINS_DATA_DIR, StablecoinRateFeeder
+from eth_defi.token import normalise_token_symbol
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.vaultdb import DEFAULT_VAULT_DATABASE, VaultDatabase
+
+logger = logging.getLogger(__name__)
+
+
+def _to_float(value: Decimal | float | int | None) -> float:
+    """Coerce an optional NAV/Decimal value to a plain float."""
+    if value is None:
+        return 0.0
+    return float(value)
+
+
+def _format_usd(value: float | None) -> str:
+    """Format a USD amount for tabular output."""
+    if value is None:
+        return "-"
+    return f"${value:,.0f}"
+
+
+def _format_rate(value: float | None) -> str:
+    """Format a USD exchange rate for tabular output."""
+    if value is None:
+        return "-"
+    return f"{value:.4f}"
+
+
+def main() -> None:
+    """Build and print the depegged-denomination vault blacklist report."""
+    setup_console_logging(default_log_level=os.environ.get("LOG_LEVEL", "warning"))
+
+    db_path = Path(os.environ.get("VAULT_DB_PATH", str(DEFAULT_VAULT_DATABASE))).expanduser()
+    stablecoins_dir = Path(os.environ.get("STABLECOINS_DIR", str(STABLECOINS_DATA_DIR))).expanduser()
+    min_tvl = float(os.environ.get("MIN_TVL", "0"))
+    show_detail = os.environ.get("SHOW_DETAIL", "true").lower() in ("1", "true", "yes")
+
+    assert db_path.exists(), f"Vault database not found: {db_path}. Download vault-metadata-db.pickle or set VAULT_DB_PATH."
+
+    logger.info("Reading vault database %s", db_path)
+    vault_db = VaultDatabase.read(db_path)
+
+    # The feeder is the single source of truth for depeg + rate lookups, matching production.
+    feeder = StablecoinRateFeeder(data_dir=stablecoins_dir)
+
+    # Per-stablecoin aggregation keyed by the normalised denomination symbol.
+    stats: dict[str, dict] = defaultdict(lambda: {"count": 0, "nominal": 0.0, "real": 0.0, "rate": None})
+    detail_rows: list[list] = []
+
+    for spec, row in vault_db.rows.items():
+        denomination_token = row.get("_denomination_token") or {}
+        chain_id = spec.chain_id
+        token_address = denomination_token.get("address")
+        token_symbol = denomination_token.get("symbol") or row.get("Denomination")
+
+        if not feeder.is_depegged_stablecoin_token(chain_id=chain_id, address=token_address, symbol=token_symbol):
+            continue
+
+        nav = _to_float(row.get("NAV"))
+        if nav < min_tvl:
+            continue
+
+        symbol = normalise_token_symbol(token_symbol) or (token_symbol or "?").upper()
+        usd_rate = feeder.get_denomination_token_rate_section(chain_id=chain_id, address=token_address, symbol=token_symbol).usd_rate
+        real_usd = nav * usd_rate if usd_rate is not None else None
+
+        entry = stats[symbol]
+        entry["count"] += 1
+        entry["nominal"] += nav
+        entry["real"] += real_usd or 0.0
+        entry["rate"] = usd_rate
+
+        detail_rows.append(
+            [
+                symbol,
+                get_chain_name(chain_id),
+                row.get("Name") or "?",
+                row.get("Protocol") or "?",
+                _format_usd(nav),
+                _format_usd(real_usd),
+                spec.vault_address,
+            ]
+        )
+
+    # Summary table sorted by nominal TVL impact.
+    summary_rows = []
+    total_count = 0
+    total_nominal = 0.0
+    total_real = 0.0
+    for symbol, entry in sorted(stats.items(), key=lambda kv: kv[1]["nominal"], reverse=True):
+        total_count += entry["count"]
+        total_nominal += entry["nominal"]
+        total_real += entry["real"]
+        summary_rows.append([symbol, _format_rate(entry["rate"]), entry["count"], _format_usd(entry["nominal"]), _format_usd(entry["real"])])
+
+    summary_rows.append(["TOTAL", "", total_count, _format_usd(total_nominal), _format_usd(total_real)])
+
+    print()
+    print(f"Vault database: {db_path}")
+    print(f"Vaults scanned: {len(vault_db.rows):,}")
+    print(f"Depegged stablecoin symbols: {', '.join(sorted(feeder.depegged_symbols)) or '(none)'}")
+    print(f"Depegged stablecoin contracts: {len(feeder.depegged_contracts)}")
+    print()
+    print("Blacklisted vaults by depegged denomination stablecoin")
+    print(
+        tabulate(
+            summary_rows,
+            headers=["Stablecoin", "USD rate", "Vaults", "Nominal TVL", "Est. real USD"],
+            tablefmt="fancy_grid",
+            colalign=("left", "right", "right", "right", "right"),
+        )
+    )
+
+    if show_detail and detail_rows:
+        detail_rows.sort(key=lambda r: (r[0], r[1]))
+        print()
+        print("Per-vault detail")
+        print(
+            tabulate(
+                detail_rows,
+                headers=["Stablecoin", "Chain", "Vault", "Protocol", "Nominal TVL", "Est. real USD", "Address"],
+                tablefmt="fancy_grid",
+                colalign=("left", "left", "left", "left", "right", "right", "left"),
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/feed/test_stablecoin_rate.py
+++ b/tests/feed/test_stablecoin_rate.py
@@ -584,6 +584,84 @@ checks:
     assert StablecoinRateFeeder(tmp_path).is_depegged_stablecoin_token(1, None, "USDX") is False
 
 
+def test_depegged_multi_entry_blacklists_by_contract_not_symbol(tmp_path: Path) -> None:
+    """Multi-entry depegged tokens (e.g. USDX) blacklist by contract address, never by ticker.
+
+    Reproduces the production gap where USDX-denominated vaults stayed listed: a
+    multi-entry stablecoin YAML must blacklist the dead token by its pinned
+    contract address while leaving an unrelated token that merely reuses the
+    same ``USDX``/``USDx`` ticker (e.g. Axis USD) untouched.
+
+    1. Write a multi-entry USDX YAML where both entries are depegged and the
+       first carries ``contract_addresses``.
+    2. Build the depeg lookups and assert the contract is indexed but the
+       ambiguous ``USDX`` symbol is not.
+    3. Assert the dead token matches by contract while a same-ticker token at a
+       different address does not.
+    """
+    # 1. Multi-entry USDX YAML: both entries dead, first one pinned by address.
+    dead_address = "0xf3527ef8de265eaa3716fb312c12847bfba66cef"
+    (tmp_path / "usdx.yaml").write_text(
+        """symbol: USDX
+category: stablecoin
+entries:
+- name: Stables Labs USDX
+  short_description: ''
+  long_description: ''
+  contract_addresses:
+    - chain: ethereum
+      address: '0xf3527ef8dE265eAa3716FB312c12847bFBA66Cef'
+    - chain: binance
+      address: '0xf3527ef8dE265eAa3716FB312c12847bFBA66Cef'
+  coingecko_id: usdx-money-usdx
+  usd_rate: 0.0076
+  usd_rate_fetched_at: '2026-06-26T12:00:00'
+  depegged_at: '2026-06-26T12:00:00'
+  links:
+    homepage: ''
+    coingecko: ''
+    defillama: ''
+    twitter: ''
+  checks:
+    twitter_last_post_at: ''
+    domain_up_at: ''
+    marked_dead_at: ''
+    information_found_missing_at: ''
+- name: Kava USDX
+  short_description: ''
+  long_description: ''
+  coingecko_id: kava-lend
+  usd_rate: 0.63
+  usd_rate_fetched_at: '2026-06-26T12:00:00'
+  depegged_at: '2026-06-26T12:00:00'
+  links:
+    homepage: ''
+    coingecko: ''
+    defillama: ''
+    twitter: ''
+  checks:
+    twitter_last_post_at: ''
+    domain_up_at: ''
+    marked_dead_at: ''
+    information_found_missing_at: ''
+slug: usdx
+"""
+    )
+
+    # 2. The pinned address is indexed; the ambiguous USDX ticker is not.
+    depegged_contracts, depegged_symbols = build_depegged_stablecoin_lookups(tmp_path)
+    assert (1, dead_address) in depegged_contracts
+    assert (56, dead_address) in depegged_contracts
+    assert "USDX" not in depegged_symbols
+
+    # 3. Dead token matches by contract; a same-ticker token elsewhere does not.
+    feeder = StablecoinRateFeeder(tmp_path)
+    assert feeder.is_depegged_stablecoin_token(1, dead_address, "USDX") is True
+    other_address = "0xa1fa77779e6866fa3ef48fc0720657e042158387"  # Axis USD reuses the USDx ticker
+    assert feeder.is_depegged_stablecoin_token(8453, other_address, "USDX") is False
+    assert feeder.is_depegged_stablecoin_token(8453, None, "USDX") is False
+
+
 def test_stablecoin_yaml_atomic_write_preserves_existing_file_mode(tmp_path: Path) -> None:
     """Atomic YAML updates keep existing package file permissions."""
     yaml_path = _write_usdc_yaml(tmp_path)


### PR DESCRIPTION
## Why

We added denomination-stablecoin depeg blacklisting recently, but after running it in production for a day the USDX-denominated vaults were still listed. Investigation against the live `vault-metadata-db.pickle` showed the depeg lookup only matched **single-entry** stablecoin YAML files. Multi-entry tokens such as USDX (Stables Labs USDX + Kava USDX) were silently skipped, so ~$269M of nominal TVL across 8 USDX-denominated vaults (real value only ~$2M at $0.0076) was never blacklisted.

## Lessons learnt

- Symbol-based blacklisting is unsafe for tickers reused by unrelated tokens. The `USDX`/`USDx` ticker is shared by the dead Stables Labs USDX (`0xf3527ef8…`) and the live Plasma "Axis USD" ($41M) — matching by ticker would have falsely blacklisted Axis USD. Depegged multi-entry tokens must be pinned by `contract_addresses`.
- A depeg that cannot be enforced (no contract address, ambiguous ticker) used to fail silently. It now emits a warning, which is what would have surfaced this bug immediately.
- `StablecoinRateFeeder` is now the single source of truth for depeg/rate lookups (it exposes the cached depeg sets), so consumers no longer re-implement the contract-then-symbol matching.

## Summary

- `eth_defi/feed/stablecoin_rate.py`: keep contract-based matching for every depegged entry (single- or multi-entry), keep symbol matching off for ambiguous multi-entry tickers, and warn when a depeg cannot be enforced. Add cached `depegged_contracts` / `depegged_symbols` properties to `StablecoinRateFeeder` and reuse them in `is_depegged_stablecoin_token()`.
- `eth_defi/data/stablecoins/usdx.yaml`: pin the dead Stables Labs USDX token contract (`0xf3527ef8dE265eAa3716FB312c12847bFBA66Cef`) on Ethereum, Arbitrum, BNB and Base so USDX-denominated vaults are blacklisted precisely.
- `scripts/erc-4626/list-depegged-vaults.py`: new diagnostic that tabulates depegged stablecoins, vault counts and blacklisted TVL (nominal + estimated real USD) using the production lookup. Documented in `README-vault-scripts.md`.
- `tests/feed/test_stablecoin_rate.py`: regression test that a multi-entry depegged token is blacklisted by contract address while a same-ticker token at a different address is not.
- `CHANGELOG.md`: entry.

Current impact (against today's production vault database): 16 vaults / $278.6M nominal TVL blacklisted, dominated by USDX ($269M).

## Related issues and PRs

Follow-up to the stablecoin depeg monitor feature.

## Unrelated CI and test fixes

None.
