### PR TITLE
fix: track and blacklist more depegged stablecoins (apxUSD, sUSD, StablR EURR/USDR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- fix: Track and blacklist more depegged stablecoin denominations — apxUSD (~$177.5M nominal vault TVL), StablR EURR/USDR and the Synthetix sUSD rate source. Add an `ambiguous_symbol` flag so shared tickers (`sUSD`, `USDR`) match by contract address only, protecting healthy same-ticker tokens (e.g. YieldFi sUSD, Tangible vs StablR USDR) from being false-blacklisted, and manually flag the unrelated Rezerve.money USD vault that previously rode the USDR symbol match (2026-06-28)
+
 - fix: Blacklist multi-entry depegged stablecoin denominations such as USDX. The depeg lookup only matched single-entry stablecoin YAML files, so USDX-denominated vaults (~$269M nominal TVL) were never blacklisted in production. Pin the dead Stables Labs USDX token by contract address, keep symbol matching off for ambiguous multi-entry tickers (so unrelated same-ticker tokens like Axis USD are not blacklisted), warn when a depeg cannot be enforced for lack of a contract address, and add `scripts/erc-4626/list-depegged-vaults.py` to report the blacklisted depeg TVL impact (2026-06-28)
 
 - refactor: Move the reusable `LoggingRetry` HTTP retry adapter out of the Velvet submodule to its own top-level `eth_defi.logging_retry` module, since it is shared across the Velvet, Derive, Core3, Hibachi, GRVT, Lighter, Hyperliquid and token-analysis integrations (2026-06-28)

--- a/eth_defi/data/stablecoins/apxusd.yaml
+++ b/eth_defi/data/stablecoins/apxusd.yaml
@@ -1,0 +1,47 @@
+symbol: apxUSD
+name: apxUSD
+short_description: apxUSD is an overcollateralised USD stablecoin. It lost its peg in June 2026 after collateral volatility, trading well below $1.
+long_description: |
+  apxUSD is an overcollateralised USD-pegged stablecoin.
+
+  ## Depeg
+
+  apxUSD first slipped below peg in early June 2026 as a fall in BTC increased the
+  volatility of its underlying collateral. The protocol initially described the
+  deviation as expected behaviour for an overcollateralised system, but the
+  discount deepened through June 2026, with apxUSD trading well below $1.
+
+  ## Sources
+
+  - [CoinGecko — apxUSD](https://www.coingecko.com/en/coins/apxusd)
+category: stablecoin
+links:
+  homepage: ''
+  coingecko: https://www.coingecko.com/en/coins/apxusd
+  defillama: ''
+  twitter: ''
+contract_addresses:
+  - chain: ethereum
+    address: '0x98a878b1cd98131b271883b390f68d2c90674665'
+  - chain: base
+    address: '0xd993935e13851dd7517af10687ec7e5022127228'
+  - chain: binance
+    address: '0x6b3788fd6604bbf03c5378d24e57bb334baad4af'
+slug: apxusd
+coingecko_id: apxusd
+coingecko_link: https://www.coingecko.com/en/coins/apxusd
+coingecko_id_source: manual
+coingecko_id_verified_at: '2026-06-28T00:00:00'
+usd_rate: 0.747085
+usd_rate_fetched_at: '2026-06-28T00:00:00'
+usd_rate_updated_at: '2026-06-28T00:00:00'
+peg_rate: 0.747085
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: '2026-06-28T00:00:00'
+checks:
+  twitter_last_post_at: ''
+  domain_up_at: ''
+  marked_dead_at: ''
+  information_found_missing_at: ''

--- a/eth_defi/data/stablecoins/eurr.yaml
+++ b/eth_defi/data/stablecoins/eurr.yaml
@@ -1,0 +1,42 @@
+symbol: EURR
+name: StablR Euro
+short_description: EURR is a euro-pegged stablecoin issued by StablR. It depegged in May 2026 after a minting multisig exploit minted unbacked tokens.
+long_description: |
+  EURR is a euro-pegged stablecoin issued by [StablR](https://stablr.com/).
+
+  ## Depeg
+
+  On 23–24 May 2026, StablR suffered an exploit of its minting multisig: a
+  compromised key allowed an attacker to mint unbacked EURR (and USDR) and dump
+  them, collapsing the peg by more than 20% at first and far further afterwards.
+
+  ## Sources
+
+  - [CoinGecko — StablR Euro](https://www.coingecko.com/en/coins/stablr-euro)
+category: stablecoin
+links:
+  homepage: https://stablr.com/
+  coingecko: https://www.coingecko.com/en/coins/stablr-euro
+  defillama: ''
+  twitter: ''
+contract_addresses:
+  - chain: ethereum
+    address: '0x50753cfaf86c094925bf976f218d043f8791e408'
+slug: eurr
+coingecko_id: stablr-euro
+coingecko_link: https://www.coingecko.com/en/coins/stablr-euro
+coingecko_id_source: manual
+coingecko_id_verified_at: '2026-06-28T00:00:00'
+usd_rate: 0.135679
+usd_rate_fetched_at: '2026-06-28T00:00:00'
+usd_rate_updated_at: '2026-06-28T00:00:00'
+peg_rate: 0.119126
+peg_rate_currency: eur
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: '2026-06-28T00:00:00'
+checks:
+  twitter_last_post_at: ''
+  domain_up_at: ''
+  marked_dead_at: ''
+  information_found_missing_at: ''

--- a/eth_defi/data/stablecoins/susd.yaml
+++ b/eth_defi/data/stablecoins/susd.yaml
@@ -19,11 +19,19 @@ contract_addresses:
   - chain: optimism
     address: '0x8c6f28f2F1A3C87F0f938b96d27520d9751ec8d9'
 slug: susd
-coingecko_id: susd
-coingecko_link: https://www.coingecko.com/en/coins/susd
-coingecko_id_source: url
-rate_fetch_failed_at: '2026-06-26T12:16:16'
-rate_fetch_failed_reason: coingecko_price_missing
+coingecko_id: nusd
+coingecko_link: https://www.coingecko.com/en/coins/nusd
+coingecko_id_source: manual
+coingecko_id_verified_at: '2026-06-28T00:00:00'
+usd_rate: 0.231948
+usd_rate_fetched_at: '2026-06-28T00:00:00'
+usd_rate_updated_at: '2026-06-28T00:00:00'
+peg_rate: 0.231948
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: '2026-06-28T00:00:00'
+ambiguous_symbol: true
 checks:
   twitter_last_post_at: ''
   domain_up_at: '2026-03-17'

--- a/eth_defi/data/stablecoins/usdr-stablr.yaml
+++ b/eth_defi/data/stablecoins/usdr-stablr.yaml
@@ -1,0 +1,45 @@
+symbol: USDR
+name: StablR USD
+short_description: StablR USD (USDR) is a USD-pegged stablecoin by StablR. It depegged in May 2026 after a minting multisig exploit and is effectively defunct.
+long_description: |
+  StablR USD (USDR) is a USD-pegged stablecoin issued by [StablR](https://stablr.com/).
+  It shares the ``USDR`` ticker with the unrelated, also-defunct Tangible Real USD,
+  so it is matched only by contract address.
+
+  ## Depeg
+
+  On 23–24 May 2026, StablR suffered an exploit of its minting multisig: a
+  compromised key allowed an attacker to mint unbacked USDR (and EURR) and dump
+  them. USDR collapsed and now trades near zero.
+
+  ## Sources
+
+  - [CoinGecko — StablR USD](https://www.coingecko.com/en/coins/stablr-usd)
+category: stablecoin
+links:
+  homepage: https://stablr.com/
+  coingecko: https://www.coingecko.com/en/coins/stablr-usd
+  defillama: ''
+  twitter: ''
+contract_addresses:
+  - chain: ethereum
+    address: '0x7b43e3875440b44613dc3bc08e7763e6da63c8f8'
+ambiguous_symbol: true
+slug: usdr-stablr
+coingecko_id: stablr-usd
+coingecko_link: https://www.coingecko.com/en/coins/stablr-usd
+coingecko_id_source: manual
+coingecko_id_verified_at: '2026-06-28T00:00:00'
+usd_rate: 0.0161127
+usd_rate_fetched_at: '2026-06-28T00:00:00'
+usd_rate_updated_at: '2026-06-28T00:00:00'
+peg_rate: 0.0161127
+peg_rate_currency: usd
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: '2026-06-28T00:00:00'
+checks:
+  twitter_last_post_at: ''
+  domain_up_at: ''
+  marked_dead_at: ''
+  information_found_missing_at: ''

--- a/eth_defi/data/stablecoins/usdr.yaml
+++ b/eth_defi/data/stablecoins/usdr.yaml
@@ -29,6 +29,9 @@ links:
 contract_addresses:
   - chain: polygon
     address: '0x40379a439D4F6795B6fc9aa5687dB461677A2dBa'
+  - chain: polygon
+    address: '0xb5DFABd7fF7F83BAB83995E72A52B97ABb7bcf63'
+ambiguous_symbol: true
 slug: usdr
 coingecko_id: real-usd
 coingecko_link: https://www.coingecko.com/en/coins/real-usd

--- a/eth_defi/feed/stablecoin_rate.py
+++ b/eth_defi/feed/stablecoin_rate.py
@@ -157,6 +157,12 @@ class StablecoinRateTarget:
     depegged_at: datetime.datetime | None
     contract_addresses: list[tuple[int, str]]
 
+    #: The ticker is reused by unrelated tokens, so never match this entry by
+    #: symbol — only by contract address. Set ``ambiguous_symbol: true`` in the
+    #: YAML for tickers such as ``sUSD`` or ``USDR`` that several distinct tokens
+    #: share, otherwise marking one depegged would blacklist the healthy ones.
+    ambiguous_symbol: bool = False
+
 
 @dataclass(slots=True)
 class StablecoinRateRefreshSummary:
@@ -472,13 +478,14 @@ def build_depegged_stablecoin_lookups(data_dir: Path = STABLECOINS_DATA_DIR) -> 
 
     for target in iter_stablecoin_rate_targets(data_dir):
         normalised_symbol = normalise_token_symbol(target.symbol)
-        if normalised_symbol and target.entry_index is None:
+        symbol_matchable = bool(normalised_symbol) and target.entry_index is None and not target.ambiguous_symbol
+        if symbol_matchable:
             symbol_owner_counts[normalised_symbol] = symbol_owner_counts.get(normalised_symbol, 0) + 1
 
         if target.depegged_at is None:
             continue
         depegged_contracts.update(target.contract_addresses)
-        if normalised_symbol and target.entry_index is None:
+        if symbol_matchable:
             depegged_symbol_candidates.add(normalised_symbol)
         if not target.contract_addresses:
             depegged_without_contract.append(target)
@@ -513,7 +520,7 @@ def build_stablecoin_rate_lookups(data_dir: Path = STABLECOINS_DATA_DIR) -> tupl
             contract_rates[contract_key] = rate
 
         normalised_symbol = normalise_token_symbol(target.symbol)
-        if normalised_symbol and target.entry_index is None:
+        if normalised_symbol and target.entry_index is None and not target.ambiguous_symbol:
             symbol_candidates.setdefault(normalised_symbol, []).append((target, rate))
 
     symbol_rates = {symbol: matches[0][1] for symbol, matches in symbol_candidates.items() if len(matches) == 1}
@@ -592,6 +599,7 @@ def _build_target(yaml_path: Path, entry_index: int | None, slug: str, symbol: s
         rate_fetch_failed_reason=_clean_string(entry.get("rate_fetch_failed_reason")),
         depegged_at=_parse_datetime(entry.get("depegged_at")),
         contract_addresses=_parse_contract_addresses(entry),
+        ambiguous_symbol=bool(entry.get("ambiguous_symbol", False)),
     )
 
 

--- a/eth_defi/stablecoin_metadata.py
+++ b/eth_defi/stablecoin_metadata.py
@@ -203,6 +203,7 @@ STABLECOIN_LINK_FIELDS = ["homepage", "coingecko", "defillama", "twitter"]
 STABLECOIN_LIKE = set(
     [
         "ALUSD",
+        "apxUSD",
         "AUDT",
         "AUSD",
         "BAC",
@@ -228,6 +229,7 @@ STABLECOIN_LIKE = set(
         "EURCV",
         "EUROC",
         "EUROe",
+        "EURR",
         "EURS",
         "EURT",
         "EURe",

--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -390,6 +390,11 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0xa446938b0204aa4055cdfed68ddf0e0d1bab3e9e": (VaultFlag.unofficial, MISSING_IN_PROTOCOL_FRONTEND),
     # Rezerve USDC
     "0xc42d337861878baa4dc820d9e6b6c667c2b57e8a": (VaultFlag.unofficial, MISSING_IN_PROTOCOL_FRONTEND),
+    # Rezerve.money USD "USDR 2029 Bond" on Ethereum - unverified Rezerve product.
+    # Its denomination token reuses the USDR ticker (shared with the defunct Tangible
+    # and StablR USDR), so it is no longer caught by the USDR depeg blacklist now that
+    # USDR is matched by contract only. Keep it suppressed via a manual flag.
+    "0x3839a0dd920463eb5d8231efe4d8c5edc44145ec": (VaultFlag.unofficial, MISSING_IN_PROTOCOL_FRONTEND),
     # YieldNest ynRWAx vault on Ethereum - fixed maturity date 15 Oct 2026
     "0x01ba69727e2860b37bc1a2bd56999c1afb4c15d8": (None, YIELDNEST_YNRWAX),
     # Supply USDC on ZeroLend RWA Market

--- a/tests/feed/test_stablecoin_rate.py
+++ b/tests/feed/test_stablecoin_rate.py
@@ -725,3 +725,29 @@ checks:
     yieldfi_susd = "0x4f8e1426a9d10bddc11d26042ad270f16ccb95f2"  # YieldFi Stable Token reuses the sUSD ticker
     assert feeder.is_depegged_stablecoin_token(1, yieldfi_susd, "sUSD") is False
     assert feeder.is_depegged_stablecoin_token(1, None, "sUSD") is False
+
+
+def test_packaged_duplicate_symbol_stablecoins_match_by_contract_only() -> None:
+    """Guard the real packaged data: shared-ticker depegged stablecoins match by contract, never by symbol.
+
+    ``USDX``, ``sUSD`` and ``USDR`` are each reused by several distinct tokens
+    (some healthy, e.g. Axis USD, YieldFi sUSD). This regression test locks in the
+    contract-only handling so a future edit to the packaged YAML cannot re-enable
+    ticker matching and blacklist the healthy same-ticker tokens.
+
+    1. Build the depeg lookups from the packaged ``eth_defi/data/stablecoins`` directory.
+    2. Assert each shared ticker is absent from the symbol set (so it is never symbol-matched).
+    3. Assert each known dead token is pinned by contract address instead.
+    """
+    # 1. Use the real shipped stablecoin metadata.
+    depegged_contracts, depegged_symbols = build_depegged_stablecoin_lookups()
+
+    # 2. The ambiguous shared tickers must not be symbol-matched.
+    for ticker in ("USDX", "SUSD", "USDR"):
+        assert ticker not in depegged_symbols, f"{ticker} is a shared ticker and must match by contract only"
+
+    # 3. The dead tokens behind those tickers must be pinned by contract.
+    assert (1, "0xf3527ef8de265eaa3716fb312c12847bfba66cef") in depegged_contracts  # Stables Labs USDX
+    assert (1, "0x57ab1ec28d129707052df4df418d58a2d46d5f51") in depegged_contracts  # Synthetix sUSD
+    assert (137, "0x40379a439d4f6795b6fc9aa5687db461677a2dba") in depegged_contracts  # Tangible Real USD
+    assert (1, "0x7b43e3875440b44613dc3bc08e7763e6da63c8f8") in depegged_contracts  # StablR USD

--- a/tests/feed/test_stablecoin_rate.py
+++ b/tests/feed/test_stablecoin_rate.py
@@ -672,3 +672,56 @@ def test_stablecoin_yaml_atomic_write_preserves_existing_file_mode(tmp_path: Pat
     assert yaml_path.stat().st_mode & 0o777 == 0o644
     target = next(iter_stablecoin_rate_targets(tmp_path))
     assert target.usd_rate == pytest.approx(1.0)
+
+
+def test_ambiguous_symbol_matches_by_contract_only(tmp_path: Path) -> None:
+    """``ambiguous_symbol`` entries blacklist by contract address only, never by the shared ticker.
+
+    Tickers such as ``sUSD`` are reused by several unrelated tokens (Synthetix sUSD,
+    YieldFi Stable Token, Solaris USD). Marking the Synthetix one depegged must not
+    blacklist the healthy ticker-mates, so a flagged entry is matched by contract only.
+
+    1. Write a single depegged ``sUSD`` entry flagged ``ambiguous_symbol`` with a pinned contract.
+    2. Build the lookups and assert the contract is indexed but the ``SUSD`` symbol is not.
+    3. Assert the pinned Synthetix contract matches while a same-ticker token at another address does not.
+    """
+    # 1. A flat, single-owner depegged sUSD entry that is flagged ambiguous.
+    (tmp_path / "susd.yaml").write_text(
+        """symbol: SUSD
+name: Synthetix sUSD
+short_description: ''
+long_description: ''
+category: stablecoin
+contract_addresses:
+  - chain: ethereum
+    address: '0x57Ab1ec28D129707052df4dF418D58a2D46d5f51'
+ambiguous_symbol: true
+slug: susd
+coingecko_id: nusd
+usd_rate: 0.23
+usd_rate_fetched_at: '2026-06-28T00:00:00'
+depegged_at: '2026-06-28T00:00:00'
+links:
+  homepage: ''
+  coingecko: ''
+  defillama: ''
+  twitter: ''
+checks:
+  twitter_last_post_at: ''
+  domain_up_at: ''
+  marked_dead_at: ''
+  information_found_missing_at: ''
+"""
+    )
+
+    # 2. Contract indexed, but the ambiguous SUSD ticker is deliberately excluded.
+    depegged_contracts, depegged_symbols = build_depegged_stablecoin_lookups(tmp_path)
+    assert (1, "0x57ab1ec28d129707052df4df418d58a2d46d5f51") in depegged_contracts
+    assert "SUSD" not in depegged_symbols
+
+    # 3. Pinned Synthetix contract matches; a same-ticker token elsewhere stays safe.
+    feeder = StablecoinRateFeeder(tmp_path)
+    assert feeder.is_depegged_stablecoin_token(1, "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51", "sUSD") is True
+    yieldfi_susd = "0x4f8e1426a9d10bddc11d26042ad270f16ccb95f2"  # YieldFi Stable Token reuses the sUSD ticker
+    assert feeder.is_depegged_stablecoin_token(1, yieldfi_susd, "sUSD") is False
+    assert feeder.is_depegged_stablecoin_token(1, None, "sUSD") is False


### PR DESCRIPTION
## Why

Follow-up to #1149. After fixing USDX I cross-checked the live vault database against the notable 2026 stablecoin depegs (sUSD, MIM, apxUSD, StablR EURR/USDR) and found more gaps:

- **apxUSD** (~**$177.5M** nominal vault TVL across 17 vaults, trading ~$0.74) was **completely untracked** — the single biggest unblacklisted depeg exposure.
- **Synthetix sUSD** used a broken CoinGecko id (`susd` → `coingecko_price_missing`), so it never received a rate and was never marked depegged. The correct id is `nusd` ($0.23).
- **StablR EURR and USDR** were untracked. StablR's USDR shares the `USDR` ticker with the defunct Tangible Real USD *and* an unrelated Rezerve.money USD bond vault.

## Lessons learnt

- **Ticker reuse is pervasive and dangerous.** The `sUSD` ticker maps to 5 different tokens in our universe (Synthetix sUSD, YieldFi Stable Token $12.9M, Solaris USD, Sensand USD, …) and `USDR` to 4 (Tangible ×2, StablR, Rezerve). A symbol-based depeg match would have wrongly blacklisted ~$14.7M of healthy sUSD-ticker tokens. Depegged stablecoins with shared tickers must be matched by **contract address only**.
- A depeg marker is useless if the CoinGecko id is wrong; `coingecko_price_missing` on a known-dead token is a signal the id needs fixing, not that the token is fine.
- apxUSD's "minor, expected" early-June deviation deepened to a real ~26% discount — overcollateralised ≠ safe.

## Summary

- `eth_defi/feed/stablecoin_rate.py`: add an `ambiguous_symbol` flag to `StablecoinRateTarget`; when set, the entry is matched by contract address only (never by ticker) in both the depeg and rate lookups.
- New metadata YAMLs: `apxusd.yaml` (eth/base/bsc contracts), `eurr.yaml` (StablR Euro, EUR-pegged), `usdr-stablr.yaml` (StablR USD, `ambiguous_symbol`).
- `susd.yaml`: fix CoinGecko id `susd`→`nusd`, mark depegged, set `ambiguous_symbol` (Synthetix contracts only).
- `usdr.yaml`: set `ambiguous_symbol` and pin both Tangible Real USD contracts.
- `eth_defi/stablecoin_metadata.py`: add `apxUSD` and `EURR` to `STABLECOIN_LIKE`.
- `eth_defi/vault/flag.py`: manually flag the Rezerve.money USD "USDR 2029 Bond" vault (unverified Rezerve product, previously only suppressed via the USDR symbol match).
- Regression test for `ambiguous_symbol` contract-only matching.

Net result against today's production vault database: depeg-blacklisted TVL rises from ~$278.6M to **~$455.9M nominal (~$139M real)** — apxUSD adds 17 vaults / $177.5M, while $14.7M of healthy sUSD-ticker tokens are correctly left untouched.

## Related issues and PRs

Follow-up to #1149 (USDX depeg blacklisting) and the stablecoin depeg monitor feature.

## Unrelated CI and test fixes

None.
