### PR TITLE
fix: Disable verbose Rich tracebacks

### DIFF
--- a/eth_defi/coloured_logging.py
+++ b/eth_defi/coloured_logging.py
@@ -15,7 +15,6 @@ from rich.theme import Theme
 # Rich only honours fixed redirected-console width when both dimensions are set.
 RICH_LOG_WIDTH = 1000
 RICH_LOG_HEIGHT = 25
-RICH_TRACEBACK_WIDTH = 160
 DISABLED_FORCE_COLOUR_VALUES: set[str | None] = {None, "", "0"}
 RICH_LOG_THEME = Theme(
     {
@@ -138,14 +137,15 @@ def is_running_inside_docker() -> bool:
     return any(marker in cgroup for marker in ("docker", "containerd", "kubepods"))
 
 
-def should_do_colour_logging(stream: TextIO, *, autodetect_docker_log: bool = False) -> bool:
+def should_do_colour_logging(stream: TextIO, *, autodetect_docker_log: bool = True) -> bool:
     """Determine whether console logging should use ANSI colours.
 
     :param stream:
         Console stream that receives log output.
     :param autodetect_docker_log:
         Enable colours when the process is inside Docker even if the stream is
-        not a TTY.
+        not a TTY. Enabled by default because Docker Compose preserves ANSI
+        escape sequences in ``logs -f``.
     :return:
         ``True`` if ANSI colour output should be enabled.
     """
@@ -203,8 +203,7 @@ def create_rich_log_handler(
         show_path=False,
         omit_repeated_times=False,
         markup=False,
-        rich_tracebacks=True,
-        tracebacks_width=RICH_TRACEBACK_WIDTH,
+        rich_tracebacks=False,
         highlighter=ReprHighlighter(),
         show_context=not simplified_logging,
         colour_threads=coloured_threads,
@@ -258,7 +257,7 @@ def setup_console_logging(
     only_log_file: bool = False,
     clear_log_file: bool = True,
     coloured_threads: bool = False,
-    autodetect_docker_log: bool = False,
+    autodetect_docker_log: bool = True,
     stream: TextIO | None = None,
 ) -> logging.Logger:
     """Set up coloured log output.
@@ -283,7 +282,8 @@ def setup_console_logging(
         colour so interleaved parallel logs are easy to follow visually.
     :param autodetect_docker_log:
         Enable coloured Rich output inside Docker even when stderr is not a
-        TTY. Docker Compose preserves ANSI escape sequences in ``logs -f``.
+        TTY. Enabled by default because Docker Compose preserves ANSI escape
+        sequences in ``logs -f``.
     :param stream:
         Console stream that receives log output. Defaults to ``sys.stderr``.
     :return:

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -1680,7 +1680,6 @@ def main():
     log_dir.mkdir(parents=True, exist_ok=True)
     setup_console_logging(
         default_log_level=os.environ.get("LOG_LEVEL", "warning"),
-        autodetect_docker_log=True,
     )
 
     log_file = log_dir / "scan-all-chains.log"

--- a/scripts/gmx/cancel_gmx_orders.py
+++ b/scripts/gmx/cancel_gmx_orders.py
@@ -55,7 +55,7 @@ console = Console()
 logging.basicConfig(
     level=logging.INFO,
     format="%(message)s",
-    handlers=[RichHandler(console=console, show_path=False, rich_tracebacks=True)],
+    handlers=[RichHandler(console=console, show_path=False, rich_tracebacks=False)],
 )
 logger = logging.getLogger(__name__)
 
@@ -279,7 +279,7 @@ def main() -> None:
         )
     )
 
-    confirm = Prompt.ask("[bold yellow]Proceed?[/bold yellow] [dim]\[y/N][/dim]", default="n").strip().lower()
+    confirm = Prompt.ask("[bold yellow]Proceed?[/bold yellow] [dim]\\[y/N][/dim]", default="n").strip().lower()
     if confirm not in ("y", "yes"):
         console.print("[dim]Aborted.[/dim]")
         return

--- a/scripts/smoke_console_logging.py
+++ b/scripts/smoke_console_logging.py
@@ -55,7 +55,7 @@ def emit_sample_logs() -> None:
         message = "Intentional smoke-test exception"
         raise ValueError(message)
     except ValueError:
-        logger.exception("EXCEPTION line with rich traceback")
+        logger.exception("EXCEPTION line with compact traceback")
 
 
 def emit_threaded_logs() -> None:
@@ -165,14 +165,6 @@ def configure_file_logging() -> None:
     logger.info("Plain file log target: %s", log_file)
 
 
-def configure_docker_autodetect() -> None:
-    """Configure logging with Docker autodetection enabled."""
-
-    configure_logging(
-        autodetect_docker_log=True,
-    )
-
-
 def main() -> None:
     """Run all console logging smoke scenarios."""
 
@@ -182,7 +174,6 @@ def main() -> None:
     run_scenario("Scenario 4: simplified Rich output", configure_simplified)
     run_scenario("Scenario 5: Rich output with coloured threads", configure_thread_colours, include_threads=True)
     run_scenario("Scenario 6: Rich console plus plain file log", configure_file_logging)
-    run_scenario("Scenario 7: Docker autodetect", configure_docker_autodetect)
 
 
 if __name__ == "__main__":

--- a/tests/test_utils_logging.py
+++ b/tests/test_utils_logging.py
@@ -237,8 +237,9 @@ def test_rich_logging_uses_compact_standard_tracebacks(monkeypatch: pytest.Monke
     setup_console_logging(default_log_level="info", stream=stream)
 
     logger = logging.getLogger("eth_defi.tests.traceback")
+    error_message = "inner receiver"
     try:
-        raise RuntimeError("inner receiver")
+        raise RuntimeError(error_message)
     except RuntimeError:
         logger.exception("Failure with compact traceback")
 

--- a/tests/test_utils_logging.py
+++ b/tests/test_utils_logging.py
@@ -57,7 +57,7 @@ def test_should_do_colour_logging_respects_no_color(monkeypatch: pytest.MonkeyPa
     monkeypatch.setenv("NO_COLOR", "1")
     monkeypatch.setenv("FORCE_COLOR", "1")
 
-    assert should_do_colour_logging(DummyStream(is_tty=True), autodetect_docker_log=True) is False
+    assert should_do_colour_logging(DummyStream(is_tty=True)) is False
 
 
 def test_should_do_colour_logging_detects_docker(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -68,7 +68,32 @@ def test_should_do_colour_logging_detects_docker(monkeypatch: pytest.MonkeyPatch
     monkeypatch.delenv("CLICOLOR_FORCE", raising=False)
     monkeypatch.setattr(coloured_logging, "is_running_inside_docker", lambda: True)
 
-    assert should_do_colour_logging(DummyStream(is_tty=False), autodetect_docker_log=True) is True
+    assert should_do_colour_logging(DummyStream(is_tty=False)) is True
+
+
+def test_should_do_colour_logging_can_disable_docker_autodetection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Docker log autodetection can be explicitly disabled."""
+
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.delenv("CLICOLOR_FORCE", raising=False)
+    monkeypatch.setattr(coloured_logging, "is_running_inside_docker", lambda: True)
+
+    assert should_do_colour_logging(DummyStream(is_tty=False), autodetect_docker_log=False) is False
+
+
+def test_setup_console_logging_detects_docker_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Docker log autodetection is enabled unless explicitly disabled."""
+
+    stream = DummyStream(is_tty=False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.delenv("CLICOLOR_FORCE", raising=False)
+    monkeypatch.setattr(coloured_logging, "is_running_inside_docker", lambda: True)
+
+    root = setup_console_logging(default_log_level="info", stream=stream)
+
+    assert root.handlers[0].__class__.__name__ == "EthDefiRichHandler"
 
 
 def test_is_running_inside_docker_detects_marker_file(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -97,7 +122,7 @@ def test_setup_console_logging_installs_rich_handler(monkeypatch: pytest.MonkeyP
     assert handler.__class__.__name__ == "EthDefiRichHandler"
     assert handler.level == logging.INFO
     assert handler.console.width == coloured_logging.RICH_LOG_WIDTH
-    assert handler.tracebacks_width == coloured_logging.RICH_TRACEBACK_WIDTH
+    assert handler.rich_tracebacks is False
     assert handler._log_render.show_path is False
     assert handler._log_render.omit_repeated_times is False
 
@@ -200,6 +225,31 @@ def test_rich_logging_does_not_pad_lines(monkeypatch: pytest.MonkeyPatch) -> Non
     plain_line = ANSI_RE.sub("", stream.getvalue()).splitlines()[0]
     assert plain_line == plain_line.rstrip(" \t")
     assert len(plain_line) < MAX_SHORT_RICH_LINE_LENGTH
+
+
+def test_rich_logging_uses_compact_standard_tracebacks(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Rich logging must not emit verbose boxed tracebacks."""
+
+    stream = DummyStream(is_tty=False)
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    monkeypatch.delenv("NO_COLOR", raising=False)
+
+    setup_console_logging(default_log_level="info", stream=stream)
+
+    logger = logging.getLogger("eth_defi.tests.traceback")
+    try:
+        raise RuntimeError("inner receiver")
+    except RuntimeError:
+        logger.exception("Failure with compact traceback")
+
+    output = stream.getvalue()
+    plain_output = ANSI_RE.sub("", output)
+    assert "Failure with compact traceback" in plain_output
+    assert "Traceback (most recent call last)" in plain_output
+    assert "RuntimeError: inner receiver" in plain_output
+    assert "\u256d" not in output
+    assert "\u2502" not in output
+    assert "\u2570" not in output
 
 
 def test_rich_thread_colours_are_stable(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Why

Rich boxed tracebacks are too verbose for long Docker and file-oriented log review. They add wide panels and line wrapping around exceptions, making scanner failures harder to read in collected logs.

Docker colour autodetection should also be the default for the shared console logging helper so Docker-based entrypoints do not need repeated opt-in parameters.

## Lessons learnt

Rich can still provide coloured log levels, highlighted values and module/thread context while delegating exception formatting back to the standard logging traceback formatter. File handlers remain plain because they use a separate standard formatter.

## Summary

- Disable Rich boxed traceback rendering in the shared coloured logging handler.
- Make Docker log colour autodetection default-on, with `NO_COLOR` and `autodetect_docker_log=False` still available as opt-outs.
- Remove redundant Docker autodetection call-site and smoke-test scenario.
- Disable an explicit Rich traceback formatter in the GMX cancel-orders script.
- Add focused logging tests for Docker autodetection defaults, opt-out behaviour and compact traceback output.
- Fix an existing Python 3.14 invalid escape warning in the GMX prompt string.

## Related issues and PRs

Continues PR #1150.

## Unrelated CI and test fixes

None.
