### PR TITLE
fix: autoretry HyperSync vault scans on textual server rate-limit errors

### DIFF
--- a/.claude/docs/agent-tricks-and-troubleshooting.md
+++ b/.claude/docs/agent-tricks-and-troubleshooting.md
@@ -54,6 +54,88 @@ Use `codex exec` for CI-like or scripted work. It streams progress to stderr and
 
 Use interactive `codex` when the task needs back-and-forth decisions, screenshots, manual inspection, or careful approval of edits.
 
+### Required method for non-interactive Codex reviews
+
+Plain `codex exec "..."` run in the foreground is **not** a safe way to get a
+review from an agent. In practice it buffers all output until the end, so the
+call looks hung, and an agent's wall-clock timeout fires (observed: a 7m30s
+foreground run terminated with **zero output**). It can also silently review
+the wrong git tree. Always follow the steps below for an automated review.
+
+**1. Run Codex from the exact tree you want reviewed, and prove it sees the diff
+first.** Codex reviews the git working tree of its current working directory.
+When the changes live in a git worktree, you must launch Codex from that
+worktree path, otherwise it inspects a clean tree and reports "no changes". A
+clean-tree review is the single most common false negative — verify before
+trusting any "no findings" result:
+
+```shell
+cd /path/to/the/worktree-or-repo-with-changes
+git status --short          # must list your changed files
+git diff --name-only        # must be non-empty
+```
+
+If these are empty, Codex will find nothing no matter how good the prompt is.
+Fix the working directory (or move the changes into the right tree) before
+running the review.
+
+**2. Always use `--json` so output streams as JSONL events.** This is what
+prevents the silent-buffering hang. Never rely on plain-text `codex exec` for a
+long review.
+
+**3. Run it in the background, redirect to a log file, then poll the PID.** Do
+not block a foreground call on a multi-minute review:
+
+```shell
+rm -f /tmp/codex-review.log
+nohup codex exec --json --sandbox read-only --skip-git-repo-check \
+  "Review the uncommitted worktree diff for correctness bugs only. Do not run
+   tests. Run 'git diff --name-only' first, then inspect hunks with
+   'git diff -- <path>'. Give file:line findings; if none, say so with residual
+   risks." \
+  > /tmp/codex-review.log 2>&1 &
+CODEX_PID=$!
+
+# Poll until done (use a generous agent/bash timeout, e.g. 9 minutes).
+until ! kill -0 "$CODEX_PID" 2>/dev/null; do sleep 15; done
+echo "codex review finished"
+```
+
+**4. Parse the JSONL for the actual review text.** The human-readable review is
+in `item.completed` events whose `item.type == "agent_message"`:
+
+```shell
+python3 -c "
+import json
+for line in open('/tmp/codex-review.log'):
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        o = json.loads(line)
+    except ValueError:
+        continue
+    if o.get('type') == 'item.completed' and o.get('item', {}).get('type') == 'agent_message':
+        print(o['item']['text']); print('---')
+"
+```
+
+Flag conventions for review runs:
+
+- `--sandbox read-only` — review must never edit files.
+- `--skip-git-repo-check` — needed when launching from a worktree path that
+  Codex does not recognise as a top-level repo.
+- `--json` — mandatory for non-interactive runs to avoid buffered/silent output.
+
+Checklist before you trust a Codex review verdict:
+
+1. `git diff --name-only` in the review cwd was non-empty.
+2. The run used `--json` and you read `agent_message` items, not just the tail.
+3. The run actually completed (PID exited) rather than being killed by a
+   timeout.
+4. A "no changes"/"clean tree" message means a wrong-directory run, not a clean
+   review — re-run from the correct tree.
+
 ## Claude CLI
 
 Claude CLI is useful for independent second opinions, code reviews, background agents, and checking whether another agent's change makes sense.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- fix: Autoretry HyperSync vault scans on server-side rate limiting. The Envio/HyperSync Rust client reports an exhausted request budget as a textual `rate limited by server` error with no HTTP `429`, which slipped past the rate-limit classifier and crashed the whole chain scan instead of being retried. Broaden `is_hypersync_rate_limit_error()` to match the textual form, consolidate four duplicated recoverable-error handlers into a shared `raise_if_recoverable_hypersync_flaky()` helper, and document the required `codex exec --json` background review method (2026-06-28)
+
 - fix: Track and blacklist more depegged stablecoin denominations — apxUSD (~$177.5M nominal vault TVL), StablR EURR/USDR and the Synthetix sUSD rate source. Add an `ambiguous_symbol` flag so shared tickers (`sUSD`, `USDR`) match by contract address only, protecting healthy same-ticker tokens (e.g. YieldFi sUSD, Tangible vs StablR USDR) from being false-blacklisted, and manually flag the unrelated Rezerve.money USD vault that previously rode the USDR symbol match (2026-06-28)
 
 - feat: Add Rich-powered coloured console logging for Docker Compose vault scanner logs, with Docker log autodetection, coloured levels/context, plain file logging, and a smoke script for comparing terminal, forced-colour and Docker output modes (2026-06-28)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,13 @@ touches the relevant area:
 - `.claude/docs/agent-tricks-and-troubleshooting.md` — Codex CLI and
   Claude CLI usage patterns, including cross-agent review commands,
   streaming Claude review output, and common failure modes.
+  **When invoking Codex CLI for a non-interactive review you MUST follow
+  the "Required method for non-interactive Codex reviews" section of that
+  doc** (run from the tree containing the changes and verify the diff is
+  non-empty first, use `codex exec --json` in the background, poll the PID,
+  and parse `agent_message` events). Do not run plain foreground
+  `codex exec "..."` — it buffers output, looks hung, and can silently
+  review the wrong git tree.
 
 ## Skills
 

--- a/eth_defi/hypersync/hypersync_timestamp.py
+++ b/eth_defi/hypersync/hypersync_timestamp.py
@@ -49,12 +49,32 @@ class HypersyncFlaky(Exception):
 
 
 def is_hypersync_rate_limit_error(e: Exception) -> bool:
-    """Check if a Hypersync RuntimeError is a 429 rate limit error.
+    """Check if a Hypersync RuntimeError is a rate limit error.
 
-    The Rust client raises ``RuntimeError`` with the HTTP status in the message
-    after exhausting its internal retries.
+    The Rust client raises ``RuntimeError`` after exhausting its internal
+    retries. The rate limit can surface in two different textual forms
+    depending on where in the client it is detected:
+
+    - As an HTTP status, e.g. ``... 429 Too Many Requests ...``.
+
+    - As a server-side budget message wrapped inside a stream ``inner
+      receiver`` error, e.g.::
+
+          inner receiver
+          Caused by:
+            0: get initial data
+            1: rate limited by server (remaining=0/100 reqs, resets_in=15s).
+               To increase your rate limits, upgrade your plan at https://envio.dev/app/api-tokens
+
+      This second form contains no ``429`` token, so we also match the
+      ``rate limited by server`` wording. See the ``resets_in`` note in the
+      retry callers: we deliberately do not parse it and instead rely on the
+      caller's fixed backoff (typically longer than the reset window).
     """
-    return isinstance(e, RuntimeError) and "429" in str(e)
+    if not isinstance(e, RuntimeError):
+        return False
+    message = str(e).lower()
+    return "429" in message or "rate limited" in message or "too many requests" in message
 
 
 def is_hypersync_next_block_range_error(e: Exception) -> bool:
@@ -76,9 +96,23 @@ def is_hypersync_retryable_runtime_error(e: Exception) -> bool:
     return is_hypersync_rate_limit_error(e) or is_hypersync_next_block_range_error(e)
 
 
-# Backwards-compatible aliases for older tests and integrations.
-_is_hypersync_rate_limit_error = is_hypersync_rate_limit_error
-_is_hypersync_next_block_range_error = is_hypersync_next_block_range_error
+def raise_if_recoverable_hypersync_flaky(e: RuntimeError, context: str) -> None:
+    """Re-raise a recoverable Hypersync ``RuntimeError`` as :py:class:`HypersyncFlaky`.
+
+    The Rust Hypersync client raises a bare ``RuntimeError`` for both server-side
+    rate limiting and near-head pagination glitches. Wrapping them as
+    :py:class:`HypersyncFlaky` lets the caller's retry/backoff loop recover
+    instead of crashing the whole scan. Non-recoverable errors are left
+    untouched so the caller can re-raise them with a bare ``raise``.
+
+    :param context:
+        Where the error happened, included in the wrapped message,
+        e.g. ``"stream setup [vault-prices]"``.
+    """
+    if is_hypersync_rate_limit_error(e):
+        raise HypersyncFlaky(f"Hypersync rate limited during {context}: {e}") from e
+    if is_hypersync_next_block_range_error(e):
+        raise HypersyncFlaky(f"Hypersync stream pagination failed during {context}: {e}") from e
 
 
 async def _validate_hypersync_chain_id_async(
@@ -96,8 +130,7 @@ async def _validate_hypersync_chain_id_async(
     try:
         connected = await client.get_chain_id()
     except RuntimeError as e:
-        if _is_hypersync_rate_limit_error(e):
-            raise HypersyncFlaky(f"Hypersync rate limited during chain_id validation{reason_suffix}: {e}") from e
+        raise_if_recoverable_hypersync_flaky(e, f"chain_id validation{reason_suffix}")
         raise
     assert connected == expected_chain_id, f"Hypersync client connected to chain {connected}, but expected {expected_chain_id}"
 
@@ -111,8 +144,7 @@ async def _fetch_hypersync_block_height_async(
     try:
         return await client.get_height()
     except RuntimeError as e:
-        if _is_hypersync_rate_limit_error(e):
-            raise HypersyncFlaky(f"Hypersync rate limited during block height check{reason_suffix}: {e}") from e
+        raise_if_recoverable_hypersync_flaky(e, f"block height check{reason_suffix}")
         raise
 
 
@@ -203,8 +235,7 @@ async def get_block_timestamps_using_hypersync_async(
     try:
         receiver = await open_hypersync_stream(client, query)
     except RuntimeError as e:
-        if _is_hypersync_rate_limit_error(e):
-            raise HypersyncFlaky(f"Hypersync rate limited during stream setup{reason_suffix}: {e}") from e
+        raise_if_recoverable_hypersync_flaky(e, f"stream setup{reason_suffix}")
         raise
 
     while True:
@@ -214,10 +245,7 @@ async def get_block_timestamps_using_hypersync_async(
             logger.error("HyperSync receiver timed out%s, cannot recover", reason_suffix)
             raise HypersyncFlaky(f"Cannot recover from HyperSync stream timeout after {timeout} seconds{reason_suffix}") from e
         except RuntimeError as e:
-            if _is_hypersync_rate_limit_error(e):
-                raise HypersyncFlaky(f"Hypersync rate limited during streaming{reason_suffix}: {e}") from e
-            if _is_hypersync_next_block_range_error(e):
-                raise HypersyncFlaky(f"Hypersync stream pagination failed{reason_suffix}: {e}") from e
+            raise_if_recoverable_hypersync_flaky(e, f"streaming{reason_suffix}")
             raise
 
         # exit if the stream finished
@@ -298,8 +326,7 @@ def get_hypersync_block_height(
         try:
             return await client.get_height()
         except RuntimeError as e:
-            if _is_hypersync_rate_limit_error(e):
-                raise HypersyncFlaky(f"Hypersync rate limited [block-height-check]: {e}") from e
+            raise_if_recoverable_hypersync_flaky(e, "block-height-check")
             raise
 
     return asyncio.run(_hypersync_asyncio_wrapper())

--- a/tests/erc_4626/test_hypersync_discovery_flaky.py
+++ b/tests/erc_4626/test_hypersync_discovery_flaky.py
@@ -153,6 +153,51 @@ def test_hypersync_vault_discovery_next_block_range_error_is_retryable():
     asyncio.run(_run())
 
 
+def test_hypersync_vault_discovery_server_rate_limit_error_is_retryable():
+    """Verify the production server-side rate limit error becomes retryable.
+
+    The Envio/HyperSync Rust client surfaces an exhausted request budget as a
+    ``RuntimeError`` whose message contains ``rate limited by server`` rather
+    than a literal ``429`` HTTP status. This previously slipped past the
+    classifier, propagated as a bare ``RuntimeError``, and crashed the whole
+    chain scan instead of being retried.
+
+    1. Build a receiver that raises the exact production rate limit message.
+    2. Run the lead discovery stream over it.
+    3. Assert it is converted to a retryable ``HypersyncCrappedOut``.
+    """
+
+    # 1. Build a receiver that raises the exact production rate limit message.
+    discover = _create_discover()
+    receiver = MagicMock()
+    rate_limit_message = "inner receiver\n\nCaused by:\n    0: get initial data\n    1: rate limited by server (remaining=0/100 reqs, resets_in=15s). To increase your rate limits, upgrade your plan at https://envio.dev/app/api-tokens\n    2: "
+    receiver.recv = AsyncMock(side_effect=RuntimeError(rate_limit_message))
+
+    async def _run():
+        with (
+            patch.object(discover, "build_query", return_value=MagicMock()),
+            patch(
+                "eth_defi.erc_4626.hypersync_discovery.get_vault_event_topic_map",
+                return_value={},
+            ),
+            patch(
+                "eth_defi.erc_4626.hypersync_discovery.open_hypersync_stream",
+                new_callable=AsyncMock,
+                return_value=receiver,
+            ),
+        ):
+            # 2. Run the lead discovery stream over it.
+            # 3. Assert it is converted to a retryable HypersyncCrappedOut.
+            with pytest.raises(HypersyncCrappedOut, match="rate limited"):
+                await discover.scan_potential_vaults(
+                    start_block=24483147,
+                    end_block=24537791,
+                    display_progress=False,
+                )
+
+    asyncio.run(_run())
+
+
 def test_hypersync_vault_discovery_stream_setup_next_block_range_error_is_retryable():
     """Verify stream setup pagination errors are retryable."""
     discover = _create_discover()

--- a/tests/hypersync/test_hypersync_gap_healing.py
+++ b/tests/hypersync/test_hypersync_gap_healing.py
@@ -21,7 +21,70 @@ from eth_defi.hypersync.hypersync_timestamp import (
     fetch_block_timestamps_using_hypersync_cached_async,
     get_hypersync_block_height_with_retries,
     is_hypersync_next_block_range_error,
+    is_hypersync_rate_limit_error,
+    raise_if_recoverable_hypersync_flaky,
 )
+
+
+def test_is_hypersync_rate_limit_error_matches_textual_form():
+    """Verify the rate limit classifier matches both HTTP and textual server forms.
+
+    The Envio/HyperSync Rust client surfaces an exhausted request budget in two
+    shapes: as an HTTP ``429`` status, or as a textual ``rate limited by server``
+    message wrapped inside an ``inner receiver`` error. The textual form
+    contains no ``429`` and previously slipped past the classifier, so the whole
+    chain scan crashed instead of being retried.
+
+    1. Match the exact production textual rate limit message.
+    2. Match the legacy HTTP 429 form.
+    3. Reject unrelated runtime errors and non-RuntimeError exceptions.
+    """
+
+    # 1. Match the exact production textual rate limit message.
+    production_message = "inner receiver\n\nCaused by:\n    0: get initial data\n    1: rate limited by server (remaining=0/100 reqs, resets_in=15s). To increase your rate limits, upgrade your plan at https://envio.dev/app/api-tokens\n    2: "
+    assert is_hypersync_rate_limit_error(RuntimeError(production_message)) is True
+
+    # 2. Match the legacy HTTP 429 form and a "Too Many Requests" phrasing.
+    assert is_hypersync_rate_limit_error(RuntimeError("HTTP 429 Too Many Requests")) is True
+
+    # 3. Reject unrelated runtime errors and non-RuntimeError exceptions.
+    assert is_hypersync_rate_limit_error(RuntimeError("connection reset")) is False
+    assert is_hypersync_rate_limit_error(ValueError("rate limited")) is False
+
+
+def test_raise_if_recoverable_hypersync_flaky_wraps_and_passes_through():
+    """Verify the shared wrapper converts recoverable errors and ignores others.
+
+    The consolidated helper replaces four near-identical ``except RuntimeError``
+    blocks. It must wrap rate-limit and pagination errors as
+    :py:class:`HypersyncFlaky` so retry loops recover, while leaving unrelated
+    errors untouched for the caller's bare ``raise``.
+
+    1. A textual rate limit error becomes a HypersyncFlaky mentioning "rate limited".
+    2. A next_block_range pagination error becomes a HypersyncFlaky mentioning "stream pagination failed".
+    3. An unrelated RuntimeError is left untouched (helper returns None).
+    """
+
+    # 1. A textual rate limit error becomes a HypersyncFlaky mentioning "rate limited".
+    try:
+        raise_if_recoverable_hypersync_flaky(RuntimeError("rate limited by server"), "stream setup [unit-test]")
+    except HypersyncFlaky as e:
+        assert "rate limited" in str(e)
+        assert "stream setup [unit-test]" in str(e)
+    else:
+        assert False, "Expected HypersyncFlaky for rate limit error"
+
+    # 2. A next_block_range pagination error becomes a HypersyncFlaky mentioning "stream pagination failed".
+    pagination_message = "inner receiver\n\nCaused by:\n    server returned next_block 100 outside the requested range [100..200)"
+    try:
+        raise_if_recoverable_hypersync_flaky(RuntimeError(pagination_message), "streaming [unit-test]")
+    except HypersyncFlaky as e:
+        assert "stream pagination failed" in str(e)
+    else:
+        assert False, "Expected HypersyncFlaky for pagination error"
+
+    # 3. An unrelated RuntimeError is left untouched (helper returns None).
+    assert raise_if_recoverable_hypersync_flaky(RuntimeError("connection reset"), "streaming [unit-test]") is None
 
 
 def _make_block_header(block_number: int) -> BlockHeader:


### PR DESCRIPTION
## Why

A production vault lead scan crashed on Berachain with an unrecovered
`RuntimeError: inner receiver / rate limited by server (remaining=0/100 reqs,
resets_in=15s)`. We already have a 3×/30 s retry loop around HyperSync scans,
but it only catches `HypersyncCrappedOut` / `HypersyncFlaky`, and the
conversion from a raw `RuntimeError` to those types was gated on
`is_hypersync_rate_limit_error()`, which only matched the literal string
`"429"`. The Envio/HyperSync Rust client surfaces an exhausted request budget
as a *textual* `rate limited by server` message with no `429` token, so it was
classified as non-recoverable, re-raised bare, and took down the whole chain
scan instead of being retried.

## Lessons learnt

- HyperSync's Rust client reports rate limiting in two shapes: an HTTP `429`
  status, and a textual `rate limited by server (...)` budget message wrapped
  inside an `inner receiver` error. Detection must cover both.
- `resets_in` is deliberately not honoured — the existing fixed 30 s backoff
  already exceeds the reported ~15 s reset window, so parsing it adds nothing.
- The single `is_hypersync_rate_limit_error()` classifier is the choke point
  for every HyperSync retry path (chain-id validation, block-height checks,
  stream setup, streaming, lead discovery), so widening it fixes all of them at
  once.
- Non-interactive Codex CLI reviews must run from the tree that actually holds
  the diff and must use `codex exec --json` in the background; plain foreground
  `codex exec` buffers output, looks hung, times out with no result, and can
  silently review the wrong git tree (it reported a clean tree when the changes
  were sitting in a different worktree).

## Summary

- Broaden `is_hypersync_rate_limit_error()` to match `429`, `rate limited` and
  `too many requests` (case-insensitive), so the textual server budget error is
  now retryable everywhere.
- Consolidate four near-identical `except RuntimeError` blocks in
  `hypersync_timestamp.py` into a shared
  `raise_if_recoverable_hypersync_flaky(e, context)` helper, and remove the
  now-unused private `_is_hypersync_*` aliases.
- Add tests: a direct unit test of the classifier with the exact production
  message (+ 429 and negative cases), a unit test of the new helper, and an
  integration test driving the production rate-limit message through
  `scan_potential_vaults`.
- Document the required `codex exec --json` background review method in
  `.claude/docs/agent-tricks-and-troubleshooting.md` and make `CLAUDE.md`
  require it for non-interactive Codex reviews.

## Related issues and PRs

None.
