### PR TITLE
notes: flag Altura vault as controversial

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -38,6 +38,9 @@ class VaultFlag(str, enum.Enum):
     #: The contract will steal your money
     malicious = "malicious"
 
+    #: Vault has unresolved controversy based on community reports
+    controversial = "controversial"
+
     #: Abnormal TVL
     abnormal_tvl = "abnormal_tvl"
 
@@ -87,6 +90,7 @@ BAD_FLAGS = {
     VaultFlag.illiquid,
     VaultFlag.broken,
     VaultFlag.malicious,
+    VaultFlag.controversial,
     VaultFlag.abnormal_tvl,
     VaultFlag.unofficial,
     VaultFlag.abnormal_price_on_low_tvl,
@@ -151,6 +155,8 @@ HIDDEN_VAULT = "Vault not actively listed on any known website. Likely unmaintai
 BROKEN_VAULT = "Onchain metrics coming out of this vault do not make sense and it's likely the smart contract is broken."
 
 MALICIOUS_VAULT = "This vault is reported as malicious, and may have some sort of mechanism to steal funds."
+
+CONTROVERSIAL_VAULT = "Based on community reports, this vault is controversial. Do not deposit, unless the issue is resolved and full transparency becomes available."
 
 MAINST_VAULT = "Main Street Market related products were wiped out in Oct 10th event https://x.com/Main_St_Finance/status/1976972055951147194"
 
@@ -510,6 +516,8 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0xf0795c47fa58d00f5f77f4d5c01f31ee891e21b4": (VaultFlag.illiquid, RESOLV_USDC_ILLIQUID),
     # Mainstreet USDC (msUSDC, Morpho on Ethereum)
     "0xe3ba8f17fe581dd473e6699cfad04502998a57c7": (VaultFlag.malicious, MALICIOUS_VAULT),
+    # Altura Vault Tokens (AVLT) on Hyperliquid
+    "0xd0ee0cf300dfb598270cd7f4d0c6e0d8f6e13f29": (VaultFlag.controversial, CONTROVERSIAL_VAULT),
 }
 
 for addr in VAULT_FLAGS_AND_NOTES.keys():

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -11,6 +11,11 @@ def test_not_in_morpho_api_is_bad_flag():
     assert VaultFlag.not_in_morpho_api in BAD_FLAGS
 
 
+def test_controversial_is_bad_flag():
+    """Controversial vaults are blacklisted."""
+    assert VaultFlag.controversial in BAD_FLAGS
+
+
 @pytest.mark.parametrize(
     ("address", "protocol", "expected_flag", "expected_note"),
     [
@@ -22,6 +27,7 @@ def test_not_in_morpho_api_is_bad_flag():
         ("0x3094b241aade60f91f1c82b0628a10d9501462f9", "Morpho", VaultFlag.illiquid, "illiquid"),
         ("0xfa17f7aadbfac2c5d3c8125555404c1ae17df853", "Morpho", VaultFlag.illiquid, "illiquid"),
         ("0xed9278c5188f37670b33ef3b00729e38260cd5d5", "Euler", VaultFlag.illiquid, "illiquid"),
+        ("0xd0ee0cf300dfb598270cd7f4d0c6e0d8f6e13f29", "Altura", VaultFlag.controversial, "controversial"),
     ],
 )
 def test_abnormal_main_listing_vaults_are_hidden(


### PR DESCRIPTION
## Why

Altura vaults need a manual blacklist-style warning while the controversy around community reports remains unresolved.

## Lessons learnt

The current top-vault export lists one Altura vault row: Altura Vault Tokens on Hyperliquid at `0xd0ee0cf300dfb598270cd7f4d0c6e0d8f6e13f29`.

## Summary

- Added `VaultFlag.controversial` and included it in `BAD_FLAGS`.
- Added the requested controversial vault warning message.
- Flagged Altura Vault Tokens as controversial.
- Added focused tests for the new flag and Altura vault note.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.