### PR TITLE
feat: log the reason for each proxy rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - feat: Add Rich-powered coloured console logging for Docker Compose vault scanner logs, with Docker log autodetection, coloured levels/context, plain file logging, and a smoke script for comparing terminal, forced-colour and Docker output modes (2026-06-28)
 
+- feat: Proxy rotation log lines now explain *why* a rotation happened. `ProxyRotator.rotate()` gains a `reason` parameter for proactive (non-failure) rotations, and the log message reads `Rotated from proxy <prev> to <new> (CC/city) [gen N] — reason: <reason>`. Feed collection now tags its proactive per-source rotation with the source URL, and the Hyperliquid throttle path folds its separate "Rotated on HTTP …" line into the centralised reason logging, so operators can distinguish routine load-distribution rotations from failure-driven ones (2026-06-28)
+
 - fix: Blacklist multi-entry depegged stablecoin denominations such as USDX. The depeg lookup only matched single-entry stablecoin YAML files, so USDX-denominated vaults (~$269M nominal TVL) were never blacklisted in production. Pin the dead Stables Labs USDX token by contract address, keep symbol matching off for ambiguous multi-entry tickers (so unrelated same-ticker tokens like Axis USD are not blacklisted), warn when a depeg cannot be enforced for lack of a contract address, and add `scripts/erc-4626/list-depegged-vaults.py` to report the blacklisted depeg TVL impact (2026-06-28)
 
 - refactor: Move the reusable `LoggingRetry` HTTP retry adapter out of the Velvet submodule to its own top-level `eth_defi.logging_retry` module, since it is shared across the Velvet, Derive, Core3, Hibachi, GRVT, Lighter, Hyperliquid and token-analysis integrations (2026-06-28)

--- a/eth_defi/event_reader/webshare.py
+++ b/eth_defi/event_reader/webshare.py
@@ -319,7 +319,12 @@ class ProxyRotator:
         if self.state_manager is not None:
             self.state_manager.record_failure(self.current(), reason)
 
-    def rotate(self, expected_generation: int | None = None, failure_reason: str | None = None) -> WebshareProxy:
+    def rotate(
+        self,
+        expected_generation: int | None = None,
+        failure_reason: str | None = None,
+        reason: str | None = None,
+    ) -> WebshareProxy:
         """Advance to the next proxy in the pool.
 
         If *expected_generation* is given and differs from the current
@@ -327,7 +332,14 @@ class ProxyRotator:
         without rotating again.
 
         If *failure_reason* is provided, records the current proxy as failed
-        before rotating.
+        before rotating; it also doubles as the logged rotation reason.
+
+        :param reason:
+            Human-readable explanation of *why* we rotate, used only for
+            logging. Use this for proactive rotations that do not mark the
+            current proxy as failed (e.g. load distribution, throttling).
+            When *failure_reason* is set it takes precedence as the logged
+            reason, so pass only one of the two.
         """
         with self._lock:
             if expected_generation is not None and expected_generation != self._generation:
@@ -341,17 +353,33 @@ class ProxyRotator:
             if failure_reason is not None:
                 self.record_failure(failure_reason)
 
+            # ``failure_reason`` describes a failure of the *previous* proxy and
+            # always wins as the logged reason; ``reason`` covers proactive
+            # rotations. Use explicit None checks (mirroring the record_failure
+            # guard above) so an empty string is not silently swallowed, and
+            # fall back to a sentinel so the cause is never silent.
+            if failure_reason is not None:
+                log_reason = failure_reason
+            elif reason is not None:
+                log_reason = reason
+            else:
+                log_reason = "no reason given"
+
+            previous = self.current()
             self._current_index = (self._current_index + 1) % len(self.proxies)
             self._generation += 1
             proxy = self.current()
             logger.log(
                 self.log_level,
-                "Rotated to proxy %s:%d (%s/%s) [gen %d]",
+                "Rotated from proxy %s:%d to %s:%d (%s/%s) [gen %d] — reason: %s",
+                previous.proxy_address,
+                previous.port,
                 proxy.proxy_address,
                 proxy.port,
                 proxy.country_code,
                 proxy.city_name,
                 self._generation,
+                log_reason,
             )
             return proxy
 

--- a/eth_defi/feed/collector.py
+++ b/eth_defi/feed/collector.py
@@ -549,7 +549,9 @@ def _collect_posts_for_source_worker(
     # different IPs.  Cloning per-source resets the index and causes proxy reuse.
     checked_rotator = proxy_rotator
     if checked_rotator is not None:
-        checked_rotator.rotate(failure_reason=None)
+        # Proactive pre-request rotation so consecutive requests to the same
+        # domain come from different IPs — not a proxy failure.
+        checked_rotator.rotate(reason=f"new source request: {source.canonical_url}")
 
     if request_delay_seconds > 0:
         time.sleep(request_delay_seconds)

--- a/eth_defi/hyperliquid/session.py
+++ b/eth_defi/hyperliquid/session.py
@@ -302,12 +302,10 @@ class HyperliquidSession(Session):
                     self._rotation_count += 1
                     # Rotate without failure_reason — the ProxyStateManager
                     # must NOT mark this proxy as dead. It is only throttled
-                    # and will recover within minutes.
-                    self._rotator.rotate(failure_reason=None)
-                    logger.log(
-                        self._rotator.log_level,
-                        "Rotated on HTTP %d (throttled, proxy not marked dead)",
-                        response.status_code,
+                    # and will recover within minutes. The reason is logged by
+                    # rotate() itself.
+                    self._rotator.rotate(
+                        reason=f"HTTP {response.status_code} throttled (proxy not marked dead)",
                     )
                     continue
                 return response

--- a/tests/event_reader/test_proxy_rotation_logging.py
+++ b/tests/event_reader/test_proxy_rotation_logging.py
@@ -1,0 +1,97 @@
+"""Unit tests for proxy rotation reason logging.
+
+These tests do not need network access or a Webshare API key — they build a
+:class:`ProxyRotator` from synthetic proxies and assert on captured log output.
+"""
+
+import logging
+
+import pytest
+
+from eth_defi.event_reader.webshare import ProxyRotator, ProxyStateManager, WebshareProxy
+
+
+def _make_proxy(port: int, country: str) -> WebshareProxy:
+    """Build a synthetic backbone proxy entry for testing."""
+    return WebshareProxy(
+        proxy_address=None,
+        port=port,
+        username=f"user-{country}-{port}",
+        password="secret",
+        country_code=country,
+        city_name=None,
+    )
+
+
+@pytest.fixture()
+def state_manager(tmp_path) -> ProxyStateManager:
+    """A state manager backed by a temp file so failure recording is observable."""
+    return ProxyStateManager(state_path=tmp_path / "proxy-state.json")
+
+
+@pytest.fixture()
+def rotator(state_manager: ProxyStateManager) -> ProxyRotator:
+    """A two-proxy rotator logging at INFO so caplog can capture reasons."""
+    return ProxyRotator(
+        proxies=[_make_proxy(10000, "FI"), _make_proxy(10001, "US")],
+        state_manager=state_manager,
+        log_level=logging.INFO,
+    )
+
+
+def test_rotation_logs_proactive_reason(
+    rotator: ProxyRotator,
+    state_manager: ProxyStateManager,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Proactive rotations log the reason without marking the proxy as failed.
+
+    1. Rotate with an explicit ``reason`` (no failure recorded).
+    2. Assert the rotation log line contains that reason verbatim.
+    3. Assert no proxy was recorded as blocked by the state manager.
+    """
+    # 1. Rotate with an explicit reason (load-distribution style rotation)
+    with caplog.at_level(logging.INFO, logger="eth_defi.event_reader.webshare"):
+        rotator.rotate(reason="new source request: https://example.com/rss/")
+
+    # 2. The reason must appear in the emitted log line
+    assert "reason: new source request: https://example.com/rss/" in caplog.text
+
+    # 3. A proactive rotation must NOT mark the previous proxy as dead
+    assert state_manager.get_blocked_count() == 0
+
+
+def test_rotation_logs_failure_reason(
+    rotator: ProxyRotator,
+    state_manager: ProxyStateManager,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Failure-triggered rotations log the failure and mark the proxy as failed.
+
+    1. Rotate with a ``failure_reason`` and no separate ``reason``.
+    2. Assert the failure string is logged as the rotation reason.
+    3. Assert the previous proxy was recorded as blocked.
+    """
+    # 1. Rotate due to a failure of the previous proxy
+    with caplog.at_level(logging.INFO, logger="eth_defi.event_reader.webshare"):
+        rotator.rotate(failure_reason="HTTP 503")
+
+    # 2. failure_reason doubles as the logged rotation reason
+    assert "reason: HTTP 503" in caplog.text
+
+    # 3. A failure rotation records the previous proxy in the state manager
+    assert state_manager.get_blocked_count() == 1
+
+
+def test_rotation_logs_sentinel_when_no_reason(rotator: ProxyRotator, caplog: pytest.LogCaptureFixture):
+    """When neither reason is given, a sentinel keeps the cause non-silent.
+
+    1. Rotate with no reason at all.
+    2. Assert the fallback sentinel reason is logged rather than nothing.
+    """
+    # 1. Rotate with no reason supplied at all
+    with caplog.at_level(logging.INFO, logger="eth_defi.event_reader.webshare"):
+        rotator.rotate()
+
+    # 2. A sentinel reason is logged so the cause is never silently blank
+    assert "reason: no reason given" in caplog.text

--- a/tests/event_reader/test_proxy_rotation_logging.py
+++ b/tests/event_reader/test_proxy_rotation_logging.py
@@ -5,6 +5,7 @@ These tests do not need network access or a Webshare API key — they build a
 """
 
 import logging
+from pathlib import Path
 
 import pytest
 
@@ -24,7 +25,7 @@ def _make_proxy(port: int, country: str) -> WebshareProxy:
 
 
 @pytest.fixture()
-def state_manager(tmp_path) -> ProxyStateManager:
+def state_manager(tmp_path: Path) -> ProxyStateManager:
     """A state manager backed by a temp file so failure recording is observable."""
     return ProxyStateManager(state_path=tmp_path / "proxy-state.json")
 


### PR DESCRIPTION
## Why

Proxy rotation log lines told us *which* proxy we rotated to, but never *why*:

```
Rotated to proxy None:10088 (CL/None) [gen 1]
Rotated to proxy None:10081 (BR/None) [gen 2]
...
```

The bulk of these come from a **proactive per-source rotation** in feed
collection (`rotate(failure_reason=None)`), which exists purely to give
consecutive requests to the same domain a different egress IP — not a failure.
Because the log line carried no reason, an operator staring at hundreds of these
lines could not tell a routine load-distribution rotation from a failure-driven
one (HTTP 429/503, connection error, health-check failure).

## Lessons learnt

- A single rotation log message serves several callers with very different
  intents (proactive load-spreading vs. proxy failure vs. upstream throttling).
  Centralising the *reason* in `rotate()` keeps every caller's intent visible at
  the one place the line is emitted, instead of scattering ad-hoc extra log
  lines at call sites (the Hyperliquid path had its own duplicate line).
- `failure_reason` already encodes a reason, but it is overloaded: it both
  records the proxy as dead in `ProxyStateManager` *and* describes the cause.
  Keeping it as the failure path and adding a separate `reason` for proactive
  rotations preserves the "don't mark throttled proxies dead" contract while
  still logging a cause. Explicit `is not None` checks (not truthiness) keep an
  empty string from being silently swallowed.

## Summary

- `ProxyRotator.rotate()` gains a `reason` parameter for proactive rotations.
  `failure_reason` still records a proxy failure and doubles as the logged
  reason; `reason` covers non-failure rotations. The log line now reads:
  `Rotated from proxy <prev> to <new> (CC/city) [gen N] — reason: <reason>`
  and also reports the previous proxy for traceability.
- `eth_defi/feed/collector.py`: the proactive per-source rotation now passes
  `reason="new source request: <url>"`.
- `eth_defi/hyperliquid/session.py`: throttle rotations pass a descriptive
  `reason` and drop the now-redundant separate "Rotated on HTTP …" log line.
- New offline unit tests in `tests/event_reader/test_proxy_rotation_logging.py`
  cover the proactive reason, the failure reason, and the sentinel fallback,
  and assert that proactive rotations do **not** mark a proxy as failed while
  failure rotations do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
