### PR TITLE
feat: Add eth_defi.currency_api historical exchange rate ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- feat: Add `eth_defi.currency_api` — incremental historical exchange rate ingestion into DuckDB from the free, no-API-key fawazahmed0 Exchange API. Scans a configurable set of named currencies (default EUR, GBP, JPY, AUD, BTC, ETH against USD) with completeness-driven resume, a quote-level gap table, jsDelivr→pages.dev host fallback, a per-date transient-failure budget, and a `source` column for future multi-source support. Includes `scripts/currency_api/scan-currencies.py` and black-box integration tests (2026-06-29)
+
 - feat: Add Tokenised GBP (tGBP) — BCP Technologies' FCA-registered, GBP-pegged stablecoin — to stablecoin classification, rich metadata YAML, news feed and logo, so tGBP-denominated vaults are recognised by `is_stablecoin_like()` and survive `filter_vaults_by_stablecoin()` across Ethereum, Base, Polygon, BNB Chain and Avalanche (2026-06-29)
 
 - fix: Autoretry HyperSync vault scans on server-side rate limiting. The Envio/HyperSync Rust client reports an exhausted request budget as a textual `rate limited by server` error with no HTTP `429`, which slipped past the rate-limit classifier and crashed the whole chain scan instead of being retried. Broaden `is_hypersync_rate_limit_error()` to match the textual form, consolidate four duplicated recoverable-error handlers into a shared `raise_if_recoverable_hypersync_flaky()` helper, and document the required `codex exec --json` background review method (2026-06-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Current
 
-- feat: Add `eth_defi.currency_api` — incremental historical exchange rate ingestion into DuckDB from the free, no-API-key fawazahmed0 Exchange API. Scans a configurable set of named currencies (default EUR, GBP, JPY, AUD, BTC, ETH against USD) with completeness-driven resume, a quote-level gap table, jsDelivr→pages.dev host fallback, a per-date transient-failure budget, and a `source` column for future multi-source support. Includes a `scan-currencies` Poetry console entry point and black-box integration tests (2026-06-29)
+- feat: Add `eth_defi.currency_api` — incremental historical exchange rate ingestion into DuckDB from the free, no-API-key fawazahmed0 Exchange API. Scans a configurable set of named currencies (default EUR, GBP, JPY, AUD, BTC, ETH against USD) with completeness-driven resume, a quote-level gap table, jsDelivr→pages.dev host fallback, a per-date transient-failure budget, and a `source` column for future multi-source support. Includes a `scan-currencies` Poetry console entry point, a separate `filter_known_bad_rates()` cleaning step for documented upstream source glitches, and black-box integration tests (2026-06-29)
 
 - feat: Add Tokenised GBP (tGBP) — BCP Technologies' FCA-registered, GBP-pegged stablecoin — to stablecoin classification, rich metadata YAML, news feed and logo, so tGBP-denominated vaults are recognised by `is_stablecoin_like()` and survive `filter_vaults_by_stablecoin()` across Ethereum, Base, Polygon, BNB Chain and Avalanche (2026-06-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Current
 
-- feat: Add `eth_defi.currency_api` — incremental historical exchange rate ingestion into DuckDB from the free, no-API-key fawazahmed0 Exchange API. Scans a configurable set of named currencies (default EUR, GBP, JPY, AUD, BTC, ETH against USD) with completeness-driven resume, a quote-level gap table, jsDelivr→pages.dev host fallback, a per-date transient-failure budget, and a `source` column for future multi-source support. Includes `scripts/currency_api/scan-currencies.py` and black-box integration tests (2026-06-29)
+- feat: Add `eth_defi.currency_api` — incremental historical exchange rate ingestion into DuckDB from the free, no-API-key fawazahmed0 Exchange API. Scans a configurable set of named currencies (default EUR, GBP, JPY, AUD, BTC, ETH against USD) with completeness-driven resume, a quote-level gap table, jsDelivr→pages.dev host fallback, a per-date transient-failure budget, and a `source` column for future multi-source support. Includes a `scan-currencies` Poetry console entry point and black-box integration tests (2026-06-29)
 
 - feat: Add Tokenised GBP (tGBP) — BCP Technologies' FCA-registered, GBP-pegged stablecoin — to stablecoin classification, rich metadata YAML, news feed and logo, so tGBP-denominated vaults are recognised by `is_stablecoin_like()` and survive `filter_vaults_by_stablecoin()` across Ethereum, Base, Polygon, BNB Chain and Avalanche (2026-06-29)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,6 +321,7 @@ Consult these for domain-specific context. Logo READMEs under `eth_defi/data/vau
 | `scripts/base/README.md` | Base chain related manual test scripts |
 | `scripts/debian-bullseye-compatibility/README.md` | Running on Debian Bullseye |
 | `scripts/erc-4626/README-vault-scripts.md` | ERC-4626 vault scripts |
+| `scripts/currency_api/README-currency-api.md` | Historical exchange rate ingestion (fawazahmed0 Exchange API) into DuckDB |
 | `scripts/grvt/README-grvt-vaults.md` | GRVT native vault metrics pipeline |
 | `scripts/hyperliquid/README-hyperliquid-copy-trading.md` | Hyperliquid copy trading platforms and HFT account identification |
 | `scripts/hyperliquid/README-hyperliquid-vaults.md` | Hyperliquid native vault metrics pipeline |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,6 +309,7 @@ Consult these for domain-specific context. Logo READMEs under `eth_defi/data/vau
 | `eth_defi/abi/uniswap-swap-contracts/README.md` | SwapRouter02 deployment on Base |
 | `eth_defi/cctp/README-cctp.md` | Circle CCTP V2 integration |
 | `eth_defi/core3/README-core3.md` | Core3 risk intelligence integration — modules, database schema, scripts, API reference |
+| `eth_defi/currency_api/README-currency-api.md` | Historical exchange rate ingestion (fawazahmed0 Exchange API) into DuckDB |
 | `eth_defi/data/vaults/README.md` | Vault protocol metadata and logo system |
 | `eth_defi/erc_4626/vault_protocol/README-reader-states.md` | Vault reader states and warmup system |
 | `eth_defi/erc_4626/vault_protocol/README-utilisation.md` | Utilisation and available liquidity metrics for lending vaults |
@@ -321,7 +322,6 @@ Consult these for domain-specific context. Logo READMEs under `eth_defi/data/vau
 | `scripts/base/README.md` | Base chain related manual test scripts |
 | `scripts/debian-bullseye-compatibility/README.md` | Running on Debian Bullseye |
 | `scripts/erc-4626/README-vault-scripts.md` | ERC-4626 vault scripts |
-| `scripts/currency_api/README-currency-api.md` | Historical exchange rate ingestion (fawazahmed0 Exchange API) into DuckDB |
 | `scripts/grvt/README-grvt-vaults.md` | GRVT native vault metrics pipeline |
 | `scripts/hyperliquid/README-hyperliquid-copy-trading.md` | Hyperliquid copy trading platforms and HFT account identification |
 | `scripts/hyperliquid/README-hyperliquid-vaults.md` | Hyperliquid native vault metrics pipeline |

--- a/docs/source/api/currency_api/index.rst
+++ b/docs/source/api/currency_api/index.rst
@@ -29,6 +29,7 @@ incremental scanning model, see
    eth_defi.currency_api.scanner
    eth_defi.currency_api.client
    eth_defi.currency_api.database
+   eth_defi.currency_api.cleaning
    eth_defi.currency_api.session
    eth_defi.currency_api.constants
    eth_defi.currency_api.cli

--- a/docs/source/api/currency_api/index.rst
+++ b/docs/source/api/currency_api/index.rst
@@ -20,7 +20,7 @@ No authentication is required -- all data comes from a public endpoint.
 
 For architecture details, the DuckDB schema, environment variables and the
 incremental scanning model, see
-`README-currency-api.md <https://github.com/tradingstrategy-ai/web3-ethereum-defi/blob/master/scripts/currency_api/README-currency-api.md>`__.
+`README-currency-api.md <https://github.com/tradingstrategy-ai/web3-ethereum-defi/blob/master/eth_defi/currency_api/README-currency-api.md>`__.
 
 .. autosummary::
    :toctree: _autosummary_currency_api
@@ -31,3 +31,4 @@ incremental scanning model, see
    eth_defi.currency_api.database
    eth_defi.currency_api.session
    eth_defi.currency_api.constants
+   eth_defi.currency_api.cli

--- a/docs/source/api/currency_api/index.rst
+++ b/docs/source/api/currency_api/index.rst
@@ -1,0 +1,33 @@
+Currency API
+------------
+
+Historical exchange rate ingestion from the free, no-API-key
+`fawazahmed0 Exchange API <https://github.com/fawazahmed0/exchange-api>`__
+(``@fawazahmed0/currency-api``).
+
+This module incrementally scans daily historical exchange rates for a
+configurable set of named currencies (default: EUR, GBP, JPY, AUD, BTC, ETH against
+USD) and stores them in DuckDB:
+
+- One HTTP request per date returns the base currency against ~200 fiat and
+  crypto currencies, with a jsDelivr → Cloudflare Pages host fallback
+- Completeness-driven incremental resume (backfills holes and newly added
+  currencies; tracks permanently missing cells)
+- A ``source`` column so additional rate sources can be added later behind the
+  same schema
+
+No authentication is required -- all data comes from a public endpoint.
+
+For architecture details, the DuckDB schema, environment variables and the
+incremental scanning model, see
+`README-currency-api.md <https://github.com/tradingstrategy-ai/web3-ethereum-defi/blob/master/scripts/currency_api/README-currency-api.md>`__.
+
+.. autosummary::
+   :toctree: _autosummary_currency_api
+   :recursive:
+
+   eth_defi.currency_api.scanner
+   eth_defi.currency_api.client
+   eth_defi.currency_api.database
+   eth_defi.currency_api.session
+   eth_defi.currency_api.constants

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -55,6 +55,7 @@ See :ref:`tutorials <tutorials>` for guides and examples on how to use the libra
    token_analysis/index
    event_reader/index
    price_oracle/index
+   currency_api/index
    research/index
 
 

--- a/eth_defi/currency_api/README-currency-api.md
+++ b/eth_defi/currency_api/README-currency-api.md
@@ -54,7 +54,7 @@ run_incremental_scan()  --upsert-->      exchange_rates
 | Fallback URL | `https://{date}.currency-api.pages.dev/v1/currencies/{base}.min.json` |
 | `{date}` | `latest` or `YYYY-MM-DD` |
 | Frequency | Daily |
-| Earliest data | ~`2024-03-02` (constant `EARLIEST_AVAILABLE_DATE`) |
+| Earliest data | `2024-03-02` (verified — no history before this; all of 2020–2023 returns 404). Constant `EARLIEST_AVAILABLE_DATE`; earlier `START_DATE` clamps to it |
 
 ### Response shape
 

--- a/eth_defi/currency_api/README-currency-api.md
+++ b/eth_defi/currency_api/README-currency-api.md
@@ -12,7 +12,7 @@ ECB/Frankfurter, CoinGecko, on-chain oracles) can be added later without
 disturbing existing rows.
 
 **No authentication is required** — all data comes from a free, public,
-no-API-key endpoint with no rate limits.
+no-API-key endpoint with no documented rate limit.
 
 ## Architecture
 

--- a/eth_defi/currency_api/README-currency-api.md
+++ b/eth_defi/currency_api/README-currency-api.md
@@ -143,6 +143,26 @@ These are accepted for now (configurable via the env vars above):
 - **`MAX_TRANSIENT_ATTEMPTS=1` gives up on the first transient failure.** There
   is no lower-bound guard; keep the default (5) unless you intend this.
 
+## Data cleaning
+
+Ingestion stores **raw** source values verbatim — it never fabricates or corrects
+data, so the DuckDB file stays a faithful, auditable mirror of the source.
+Cleaning is a **separate, explicit step**: `filter_known_bad_rates()` in
+`eth_defi/currency_api/cleaning.py` drops a small, documented allowlist of
+known-bad datapoints (upstream source glitches found by manual review) from a
+rates DataFrame, without touching the stored data.
+
+```python
+from eth_defi.currency_api.cleaning import filter_known_bad_rates
+
+clean_df = filter_known_bad_rates(db.get_rates_dataframe())
+```
+
+Currently the allowlist contains one entry: **2025-12-06 BTC and ETH**, where the
+source returned garbage values (`usd.btc ≈ 38.9`, `usd.eth ≈ 49,644` — ~6-7 orders
+of magnitude off, confirmed at the source; fiat for the same day was fine). Each
+entry in `KNOWN_BAD_RATES` is documented with the observed value and evidence.
+
 ## Quick start
 
 The scanner is installed as the `scan-currencies` Poetry console script:
@@ -192,6 +212,7 @@ poetry run python -m eth_defi.currency_api.cli
 | `eth_defi/currency_api/client.py` | `fetch_rates_for_date()` — fetch, jsDelivr→pages.dev host fallback, parse, outcome classification |
 | `eth_defi/currency_api/database.py` | `CurrencyRateDatabase` — DuckDB storage, upserts, gap tracking |
 | `eth_defi/currency_api/scanner.py` | `run_incremental_scan()` — completeness-driven incremental orchestration |
+| `eth_defi/currency_api/cleaning.py` | `filter_known_bad_rates()` — separate cleaning step dropping known source glitches |
 | `eth_defi/currency_api/cli.py` | `main()` — env-driven `scan-currencies` Poetry console entry point |
 
 ## Running tests

--- a/eth_defi/currency_api/README-currency-api.md
+++ b/eth_defi/currency_api/README-currency-api.md
@@ -127,21 +127,26 @@ The scanner resume is **completeness-driven**, not `MAX(date)`-driven:
 
 ## Quick start
 
+The scanner is installed as the `scan-currencies` Poetry console script:
+
 ```shell
 # Full incremental scan (resume from existing DB, default currencies)
-LOG_LEVEL=info poetry run python scripts/currency_api/scan-currencies.py
+LOG_LEVEL=info poetry run scan-currencies
 
 # Small test batch — a few days only (fast, deterministic)
 LOG_LEVEL=info START_DATE=2026-06-01 END_DATE=2026-06-05 \
-  poetry run python scripts/currency_api/scan-currencies.py
+  poetry run scan-currencies
 
 # Add more currencies (no schema change; history backfills automatically)
 QUOTE_CURRENCIES=eur,gbp,jpy,chf,btc,eth,sol \
-  poetry run python scripts/currency_api/scan-currencies.py
+  poetry run scan-currencies
 
 # Use a non-USD base
 BASE_CURRENCY=eur QUOTE_CURRENCIES=usd,gbp,jpy \
-  poetry run python scripts/currency_api/scan-currencies.py
+  poetry run scan-currencies
+
+# Equivalent module form (no install needed)
+poetry run python -m eth_defi.currency_api.cli
 ```
 
 ## Environment variables
@@ -169,6 +174,7 @@ BASE_CURRENCY=eur QUOTE_CURRENCIES=usd,gbp,jpy \
 | `eth_defi/currency_api/client.py` | `fetch_rates_for_date()` — fetch, jsDelivr→pages.dev host fallback, parse, outcome classification |
 | `eth_defi/currency_api/database.py` | `CurrencyRateDatabase` — DuckDB storage, upserts, gap tracking |
 | `eth_defi/currency_api/scanner.py` | `run_incremental_scan()` — completeness-driven incremental orchestration |
+| `eth_defi/currency_api/cli.py` | `main()` — env-driven `scan-currencies` Poetry console entry point |
 
 ## Running tests
 
@@ -193,8 +199,9 @@ DB state:
   overwrites, clears, and escalates to a `persistent_error` gap.
 - **Present/unavailable disjoint** — upserting data for a cell removes any prior
   gap record so the two tables stay mutually exclusive.
-- **Script entry point** — invokes `scan-currencies.py` as a subprocess
-  with env vars set, asserting exit code 0 and expected DB rows.
+- **Script entry point** — invokes the `scan-currencies` entry point
+  (`python -m eth_defi.currency_api.cli`) as a subprocess with env vars set,
+  asserting exit code 0 and expected DB rows.
 
 Exact rates are never asserted (the source may revise history); only presence,
 bounds, idempotency, and gap-filling.

--- a/eth_defi/currency_api/README-currency-api.md
+++ b/eth_defi/currency_api/README-currency-api.md
@@ -125,6 +125,24 @@ The scanner resume is **completeness-driven**, not `MAX(date)`-driven:
    given up on — recorded as a permanent gap (`reason='persistent_error'`) and no longer
    fetched. The counter resets as soon as the date succeeds or returns a definitive 404.
 
+### Known trade-offs
+
+These are accepted for now (configurable via the env vars above):
+
+- **`UNAVAILABLE_GRACE_DAYS` (2) is below `REFETCH_TAIL_DAYS` (3).** A date that
+  404s once it is `UNAVAILABLE_GRACE_DAYS` old is recorded as a permanent
+  `date_404` gap and is not retried (it has no stored data, so the tail-refresh
+  rule does not resurrect it). If the source ever publishes a date *later* than
+  the grace window, that date stays missing. To force a retry, delete its rows
+  from `unavailable_rates`. Set `UNAVAILABLE_GRACE_DAYS >= REFETCH_TAIL_DAYS` if
+  your source is prone to late publication.
+- **Upsert and gap-deletion are two statements, not one transaction.** A crash
+  between them could briefly leave a cell in both `exchange_rates` and
+  `unavailable_rates`; the next run's upsert re-deletes the stale gap, so it
+  self-heals.
+- **`MAX_TRANSIENT_ATTEMPTS=1` gives up on the first transient failure.** There
+  is no lower-bound guard; keep the default (5) unless you intend this.
+
 ## Quick start
 
 The scanner is installed as the `scan-currencies` Poetry console script:

--- a/eth_defi/currency_api/__init__.py
+++ b/eth_defi/currency_api/__init__.py
@@ -15,6 +15,6 @@ ECB/Frankfurter, CoinGecko, on-chain oracles) can be added later without
 disturbing existing rows.
 
 See :py:func:`eth_defi.currency_api.scanner.run_incremental_scan` for the main
-entry point and ``scripts/currency_api/README-currency-api.md`` for operator
+entry point and ``eth_defi/currency_api/README-currency-api.md`` for operator
 documentation.
 """

--- a/eth_defi/currency_api/__init__.py
+++ b/eth_defi/currency_api/__init__.py
@@ -1,0 +1,20 @@
+"""Historical exchange rate ingestion from the fawazahmed0 Exchange API.
+
+This package incrementally scans daily historical exchange rates for a
+configurable set of named currencies (default: EUR, GBP, JPY, AUD, BTC, ETH against
+USD) and stores them in a DuckDB database.
+
+The data is sourced from the free, no-API-key
+`fawazahmed0 Exchange API <https://github.com/fawazahmed0/exchange-api>`__
+(``@fawazahmed0/currency-api``). A single HTTP request per date returns the base
+currency against ~200 fiat and crypto currencies, so all named quote currencies
+come from one endpoint.
+
+The DuckDB schema carries a ``source`` column so additional rate sources (e.g.
+ECB/Frankfurter, CoinGecko, on-chain oracles) can be added later without
+disturbing existing rows.
+
+See :py:func:`eth_defi.currency_api.scanner.run_incremental_scan` for the main
+entry point and ``scripts/currency_api/README-currency-api.md`` for operator
+documentation.
+"""

--- a/eth_defi/currency_api/cleaning.py
+++ b/eth_defi/currency_api/cleaning.py
@@ -33,7 +33,9 @@ KNOWN_BAD_RATES: tuple[tuple[datetime.date, str, str, str], ...] = (
     # upstream glitch, not a local parsing/scaling bug. Fiat rates (eur/gbp/jpy/aud)
     # for the same day were normal, and the neighbouring days (12-05, 12-07) are
     # normal, so the bad point is isolated to btc/eth on 2025-12-06.
-    # Found during the 1-year data-quality review on PR #1158.
+    # A full-history audit (the entire available range 2024-03-02 .. 2026-06-29,
+    # rolling-median ratio test) found this to be the ONLY anomaly across all
+    # currencies. Found during the data-quality review on PR #1158.
     (datetime.date(2025, 12, 6), "usd", "btc", "fawazahmed0"),
     (datetime.date(2025, 12, 6), "usd", "eth", "fawazahmed0"),
 )

--- a/eth_defi/currency_api/cleaning.py
+++ b/eth_defi/currency_api/cleaning.py
@@ -1,0 +1,75 @@
+"""Cleaning step for currency_api exchange rate data.
+
+Ingestion (:py:mod:`eth_defi.currency_api.scanner`) stores raw source values
+verbatim and never fabricates or "corrects" data. This module is the separate,
+explicit cleaning pass: it drops a hardcoded allowlist of known-bad datapoints —
+upstream source glitches found by manual data review — *without* mutating the
+stored raw data. Apply it on read/export when you want a sanitised view.
+
+Keeping cleaning separate means the DuckDB file remains a faithful mirror of the
+source (auditable, re-cleanable), while consumers that want trustworthy series
+call :py:func:`filter_known_bad_rates`.
+"""
+
+import datetime
+import logging
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+#: Hardcoded allowlist of known-bad ``(date, base_currency, quote_currency, source)``
+#: cells from the fawazahmed0 Exchange API, identified by manual data review.
+#:
+#: Each entry documents the observed bad value and why it is dropped. Keep this
+#: list small and evidence-based — only add a cell after confirming the bad value
+#: is present at the source (i.e. the raw API returns it), not a local bug.
+KNOWN_BAD_RATES: tuple[tuple[datetime.date, str, str, str], ...] = (
+    # 2025-12-06 — the source returned garbage crypto rates for this single day:
+    #   usd.btc = 38.87461377   (should be ~1.5e-5; implies 1 USD ≈ 38.9 BTC)
+    #   usd.eth = 49644.07797781 (should be ~5e-4; implies 1 USD ≈ 49,644 ETH)
+    # i.e. ~6-7 orders of magnitude wrong. Confirmed at the source — fetching the
+    # raw `usd.min.json` for this date returns the same values — so this is an
+    # upstream glitch, not a local parsing/scaling bug. Fiat rates (eur/gbp/jpy/aud)
+    # for the same day were normal, and the neighbouring days (12-05, 12-07) are
+    # normal, so the bad point is isolated to btc/eth on 2025-12-06.
+    # Found during the 1-year data-quality review on PR #1158.
+    (datetime.date(2025, 12, 6), "usd", "btc", "fawazahmed0"),
+    (datetime.date(2025, 12, 6), "usd", "eth", "fawazahmed0"),
+)
+
+
+def filter_known_bad_rates(df: pd.DataFrame) -> pd.DataFrame:
+    """Drop known-bad exchange rate rows from a rates DataFrame.
+
+    Removes the rows whose ``(date, base_currency, quote_currency, source)`` match
+    an entry in :py:data:`KNOWN_BAD_RATES`. The input is not mutated; a filtered
+    copy is returned. This is a separate cleaning step — the stored DuckDB data is
+    left untouched (raw).
+
+    :param df:
+        Rates DataFrame as returned by
+        :py:meth:`eth_defi.currency_api.database.CurrencyRateDatabase.get_rates_dataframe`,
+        i.e. with columns ``date`` (``datetime.date`` or pandas ``Timestamp``),
+        ``base_currency``, ``quote_currency``, ``rate``, ``source`` and
+        ``written_at``.
+    :return:
+        A new DataFrame with the known-bad rows removed and the index reset. If
+        the input is empty it is returned unchanged (a copy).
+    """
+    if df.empty:
+        return df.copy()
+
+    bad = set(KNOWN_BAD_RATES)
+
+    # Normalise the date column (DuckDB `.df()` yields pandas Timestamp; direct
+    # construction may yield datetime.date) so the tuple keys compare correctly.
+    dates = pd.to_datetime(df["date"]).dt.date
+    keys = zip(dates, df["base_currency"], df["quote_currency"], df["source"])
+    mask = [key not in bad for key in keys]
+
+    removed = len(df) - sum(mask)
+    if removed:
+        logger.info("filter_known_bad_rates: removed %d known-bad row(s)", removed)
+
+    return df.loc[mask].reset_index(drop=True)

--- a/eth_defi/currency_api/cli.py
+++ b/eth_defi/currency_api/cli.py
@@ -1,4 +1,4 @@
-"""Incrementally scan historical exchange rates into DuckDB.
+"""Command-line entry point for the currency_api exchange rate scanner.
 
 Fetches daily exchange rates for a configurable set of named currencies
 (default: EUR, GBP, JPY, AUD, BTC, ETH against USD) from the free, no-API-key
@@ -7,20 +7,19 @@ completeness-driven, so re-running only fetches missing dates/currencies.
 
 No authentication is required — all data comes from a public endpoint.
 
-Usage:
-
-.. code-block:: shell
+Installed as the ``scan-currencies`` Poetry console script
+(``[tool.poetry.scripts]``). Run it with::
 
     # Full incremental scan (resume from existing DB, default currencies)
-    LOG_LEVEL=info poetry run python scripts/currency_api/scan-currencies.py
+    LOG_LEVEL=info poetry run scan-currencies
 
     # Small test batch — a few days only
-    LOG_LEVEL=info START_DATE=2026-06-01 END_DATE=2026-06-05 \
-      poetry run python scripts/currency_api/scan-currencies.py
+    LOG_LEVEL=info START_DATE=2026-06-01 END_DATE=2026-06-05 poetry run scan-currencies
 
     # Add more currencies (history backfills automatically)
-    QUOTE_CURRENCIES=eur,gbp,jpy,chf,btc,eth,sol \
-      poetry run python scripts/currency_api/scan-currencies.py
+    QUOTE_CURRENCIES=eur,gbp,jpy,chf,btc,eth,sol poetry run scan-currencies
+
+It can also be run as a module: ``poetry run python -m eth_defi.currency_api.cli``.
 
 Environment variables:
 
@@ -64,6 +63,12 @@ def _parse_date(name: str) -> datetime.date | None:
 
 
 def main() -> None:
+    """Run an incremental exchange rate scan from environment configuration.
+
+    Reads the configuration from environment variables (see the module
+    docstring), runs :py:func:`~eth_defi.currency_api.scanner.run_incremental_scan`,
+    and exits non-zero if any date failed transiently so cron alerting fires.
+    """
     default_log_level = os.environ.get("LOG_LEVEL", "warning")
     setup_console_logging(
         default_log_level=default_log_level,

--- a/eth_defi/currency_api/client.py
+++ b/eth_defi/currency_api/client.py
@@ -1,0 +1,234 @@
+"""HTTP client for the fawazahmed0 Exchange API.
+
+Fetches the daily exchange rate document for a single date and base currency,
+with jsDelivr → pages.dev host fallback, and classifies the outcome so the
+scanner can distinguish "permanently missing" from "retry later".
+
+Rate direction: the API returns ``base[quote]`` = units of ``quote`` per **1
+unit of base** (e.g. for base ``usd``, ``usd["eur"] = 0.878`` means 1 USD =
+0.878 EUR). We keep this raw value; USD-per-unit is the inverse ``1 / rate``.
+
+Canonical API documentation: https://github.com/fawazahmed0/exchange-api
+"""
+
+import datetime
+import logging
+from dataclasses import dataclass, field
+from typing import Literal
+
+import requests
+from requests import Session
+
+from eth_defi.currency_api.constants import JSDELIVR_URL_TEMPLATE, PAGES_DEV_URL_TEMPLATE
+
+logger = logging.getLogger(__name__)
+
+#: Outcome of a single date fetch.
+#:
+#: - ``ok``: the date document was retrieved (some requested quotes may still be
+#:   absent — see :py:attr:`FetchResult.missing_quotes`).
+#: - ``unavailable``: HTTP 404 on **both** hosts — the whole date has no data.
+#: - ``transient_error``: network error / 5xx / malformed body — must be retried.
+FetchStatus = Literal["ok", "unavailable", "transient_error"]
+
+#: Default per-request timeout in seconds.
+DEFAULT_TIMEOUT = 30.0
+
+
+@dataclass(slots=True)
+class DateRates:
+    """Parsed exchange rates for one date and base currency.
+
+    :ivar date:
+        UTC calendar date of the quotes.
+    :ivar base_currency:
+        Lower-cased base currency code (e.g. ``usd``).
+    :ivar source:
+        Provider identifier written to the ``source`` column.
+    :ivar rows:
+        List of ``(quote_currency, rate)`` tuples where ``rate`` is units of the
+        quote currency per 1 unit of the base currency (raw API value).
+    """
+
+    #: UTC calendar date of the quotes.
+    date: datetime.date
+    #: Lower-cased base currency code.
+    base_currency: str
+    #: Provider identifier.
+    source: str
+    #: ``(quote_currency, rate)`` tuples, raw API values.
+    rows: list[tuple[str, float]]
+
+
+@dataclass(slots=True)
+class FetchResult:
+    """Classified result of fetching one date.
+
+    :ivar date:
+        The date that was requested.
+    :ivar status:
+        See :py:data:`FetchStatus`.
+    :ivar rates:
+        Parsed rates for the present quotes, or ``None`` when not ``ok``.
+    :ivar missing_quotes:
+        Requested quote currencies that were absent from an otherwise-200 body.
+        Never fabricated — handed back so the scanner can grace/record them.
+    """
+
+    #: The date that was requested.
+    date: datetime.date
+    #: Outcome classification.
+    status: FetchStatus
+    #: Parsed rates for present quotes, or ``None``.
+    rates: DateRates | None = None
+    #: Requested quotes absent from a 200 body.
+    missing_quotes: tuple[str, ...] = field(default_factory=tuple)
+
+
+def _attempt(session: Session, url: str, timeout: float) -> tuple[str, dict | None]:
+    """Make a single GET attempt and classify the HTTP outcome.
+
+    :param session:
+        Shared requests session (carries retry policy).
+    :param url:
+        Fully-formed URL to fetch.
+    :param timeout:
+        Per-request timeout in seconds.
+    :return:
+        ``("ok", json_dict)`` on 200, ``("404", None)`` on a definitive 404,
+        or ``("transient", None)`` on a network error / non-200 / non-404 /
+        unparseable body.
+    """
+    try:
+        resp = session.get(url, timeout=timeout)
+    except requests.RequestException as e:
+        # Connection reset, DNS failure, timeout, etc. — retry later.
+        logger.debug("Request to %s failed transiently: %s", url, e)
+        return "transient", None
+
+    if resp.status_code == 200:
+        try:
+            return "ok", resp.json()
+        except ValueError as e:
+            # 200 but body is not JSON — treat as transient, do not advance.
+            logger.warning("Malformed JSON from %s: %s", url, e)
+            return "transient", None
+
+    if resp.status_code == 404:
+        return "404", None
+
+    # 5xx is already retried by the adapter; anything else here is transient.
+    logger.debug("Unexpected status %d from %s", resp.status_code, url)
+    return "transient", None
+
+
+def fetch_rates_for_date(
+    session: Session,
+    date: datetime.date,
+    base_currency: str,
+    quote_currencies: tuple[str, ...],
+    source: str,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> FetchResult:
+    """Fetch and classify the exchange rate document for a single date.
+
+    Tries the jsDelivr host first, falling back to the pages.dev host on a 404
+    or transient failure. A date is only declared :py:data:`unavailable` when
+    **both** hosts return a definitive 404.
+
+    :param session:
+        Shared requests session from
+        :py:func:`~eth_defi.currency_api.session.create_currency_api_session`.
+    :param date:
+        UTC calendar date to fetch.
+    :param base_currency:
+        Lower-cased base currency code; interpolated into the URL (never
+        hardcoded ``usd``).
+    :param quote_currencies:
+        Quote currency codes to extract from the document.
+    :param source:
+        Provider identifier stored on the returned :py:class:`DateRates`.
+    :param timeout:
+        Per-request timeout in seconds.
+    :return:
+        A :py:class:`FetchResult` classifying the outcome.
+    """
+    iso = date.isoformat()
+    base = base_currency.lower()
+
+    primary_url = JSDELIVR_URL_TEMPLATE.format(date=iso, base=base)
+    primary_status, data = _attempt(session, primary_url, timeout)
+
+    if primary_status != "ok":
+        # Try the Cloudflare Pages fallback on either a 404 or a transient error.
+        fallback_url = PAGES_DEV_URL_TEMPLATE.format(date=iso, base=base)
+        fallback_status, fallback_data = _attempt(session, fallback_url, timeout)
+
+        if fallback_status == "ok":
+            data = fallback_data
+        elif primary_status == "404" and fallback_status == "404":
+            # Both hosts agree the date does not exist.
+            return FetchResult(date=date, status="unavailable")
+        else:
+            # Mixed / transient — cannot confirm absence, retry next run.
+            return FetchResult(date=date, status="transient_error")
+
+    return _parse_document(date, base, quote_currencies, source, data)
+
+
+def _parse_document(
+    date: datetime.date,
+    base_currency: str,
+    quote_currencies: tuple[str, ...],
+    source: str,
+    data: dict | None,
+) -> FetchResult:
+    """Extract the requested quotes from a 200 response body.
+
+    :param date:
+        Date being parsed.
+    :param base_currency:
+        Lower-cased base currency code; the document nests rates under this key.
+    :param quote_currencies:
+        Quote codes to extract.
+    :param source:
+        Provider identifier.
+    :param data:
+        Decoded JSON body, expected shape ``{"date": ..., "<base>": {...}}``.
+    :return:
+        ``ok`` result with the present quotes (and any ``missing_quotes``) when the
+        document is well-formed — even if no requested quote is present, since a
+        valid document means the date IS published and absent quotes are permanent
+        per-quote gaps, not a transient failure. Returns ``transient_error`` only
+        when the body is structurally malformed (missing the base key).
+    """
+    base_map = data.get(base_currency) if isinstance(data, dict) else None
+    if not isinstance(base_map, dict):
+        # Document missing the base key entirely — malformed, retry later.
+        logger.warning("Document for %s missing base key %r", date, base_currency)
+        return FetchResult(date=date, status="transient_error")
+
+    rows: list[tuple[str, float]] = []
+    missing: list[str] = []
+    for quote in quote_currencies:
+        value = base_map.get(quote)
+        if value is None:
+            # Quote not present — never fabricate; hand back for grace/record.
+            missing.append(quote)
+            continue
+        try:
+            rows.append((quote, float(value)))
+        except (TypeError, ValueError):
+            # Malformed numeric for this quote — treat the cell as missing rather
+            # than raising out of the worker and aborting the whole parallel batch.
+            logger.warning("Malformed rate %r for %s/%s on %s", value, base_currency, quote, date)
+            missing.append(quote)
+
+    # A well-formed document with zero present quotes is still ``ok``: the date
+    # exists, so the absent quotes are recorded as permanent gaps after grace
+    # (not retried forever as a transient failure).
+    if not rows:
+        logger.warning("No requested quotes present for %s (missing %s)", date, missing)
+
+    rates = DateRates(date=date, base_currency=base_currency, source=source, rows=rows)
+    return FetchResult(date=date, status="ok", rates=rates, missing_quotes=tuple(missing))

--- a/eth_defi/currency_api/client.py
+++ b/eth_defi/currency_api/client.py
@@ -198,9 +198,11 @@ def _parse_document(
     :return:
         ``ok`` result with the present quotes (and any ``missing_quotes``) when the
         document is well-formed — even if no requested quote is present, since a
-        valid document means the date IS published and absent quotes are permanent
-        per-quote gaps, not a transient failure. Returns ``transient_error`` only
-        when the body is structurally malformed (missing the base key).
+        valid document means the date IS published and *absent* quotes are permanent
+        per-quote gaps, not a transient failure. Returns ``transient_error`` when the
+        body is structurally malformed (missing the base key) **or** a requested
+        quote is present but its value is unparseable: corrupt data must be retried,
+        not stored partially or recorded as a permanent ``quote_missing`` gap.
     """
     base_map = data.get(base_currency) if isinstance(data, dict) else None
     if not isinstance(base_map, dict):
@@ -210,19 +212,24 @@ def _parse_document(
 
     rows: list[tuple[str, float]] = []
     missing: list[str] = []
+    malformed: list[str] = []
     for quote in quote_currencies:
         value = base_map.get(quote)
         if value is None:
-            # Quote not present — never fabricate; hand back for grace/record.
+            # Quote genuinely absent — never fabricate; a permanent per-quote gap.
             missing.append(quote)
             continue
         try:
             rows.append((quote, float(value)))
         except (TypeError, ValueError):
-            # Malformed numeric for this quote — treat the cell as missing rather
-            # than raising out of the worker and aborting the whole parallel batch.
+            # Present but unparseable — corrupt source data, distinct from "absent".
             logger.warning("Malformed rate %r for %s/%s on %s", value, base_currency, quote, date)
-            missing.append(quote)
+            malformed.append(quote)
+
+    if malformed:
+        # A corrupt value means the document is suspect: retry the whole date rather
+        # than storing partial data or permanently recording the cell as missing.
+        return FetchResult(date=date, status="transient_error", missing_quotes=tuple(missing))
 
     # A well-formed document with zero present quotes is still ``ok``: the date
     # exists, so the absent quotes are recorded as permanent gaps after grace

--- a/eth_defi/currency_api/constants.py
+++ b/eth_defi/currency_api/constants.py
@@ -30,11 +30,14 @@ DEFAULT_BASE_CURRENCY = "usd"
 #: Default set of named quote currencies to scan.
 DEFAULT_QUOTE_CURRENCIES = ("eur", "gbp", "jpy", "aud", "btc", "eth")
 
-#: Earliest date for which the source publishes data.
+#: Earliest date for which the source publishes data: 2024-03-02.
 #:
-#: Verified via jsDelivr/npm version probing: the earliest dated package
-#: version is ``2024.3.2``; dates before this return HTTP 404. Adjust here if the
-#: provider backfills older history.
+#: Confirmed empirically by binary-searching the date-pinned endpoint —
+#: ``2024-03-02`` returns HTTP 200 while ``2024-03-01`` and every earlier date
+#: (all of 2020–2023, and 2019) return HTTP 404. There is **no pre-2020 history**,
+#: indeed nothing before 2024-03-02; the legacy GitHub-hosted endpoint serves
+#: nothing either. A scan requested from an earlier date is clamped to this floor.
+#: Adjust here if the provider ever backfills older history.
 EARLIEST_AVAILABLE_DATE = datetime.date(2024, 3, 2)
 
 #: Default DuckDB database path.

--- a/eth_defi/currency_api/constants.py
+++ b/eth_defi/currency_api/constants.py
@@ -1,0 +1,41 @@
+"""Constants for the fawazahmed0 Exchange API integration.
+
+Canonical API documentation: https://github.com/fawazahmed0/exchange-api
+"""
+
+import datetime
+from pathlib import Path
+
+#: Primary host (jsDelivr CDN) URL template.
+#:
+#: ``{date}`` is ``latest`` or an ISO ``YYYY-MM-DD`` date; ``{base}`` is the
+#: lower-cased base currency (e.g. ``usd``). One request returns the base
+#: currency against ~200 fiat and crypto currencies.
+JSDELIVR_URL_TEMPLATE = "https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@{date}/v1/currencies/{base}.min.json"
+
+#: Fallback host (Cloudflare Pages) URL template.
+#:
+#: Used when jsDelivr returns 404 or a transient error. The upstream docs
+#: recommend always having this fallback configured.
+PAGES_DEV_URL_TEMPLATE = "https://{date}.currency-api.pages.dev/v1/currencies/{base}.min.json"
+
+#: Value written to the ``source`` column for rows fetched from this provider.
+#:
+#: Future rate sources get their own string (e.g. ``frankfurter``, ``coingecko``).
+SOURCE_NAME = "fawazahmed0"
+
+#: Default base currency. All rates are stored as "units of quote per 1 base".
+DEFAULT_BASE_CURRENCY = "usd"
+
+#: Default set of named quote currencies to scan.
+DEFAULT_QUOTE_CURRENCIES = ("eur", "gbp", "jpy", "aud", "btc", "eth")
+
+#: Earliest date for which the source publishes data.
+#:
+#: Verified via jsDelivr/npm version probing: the earliest dated package
+#: version is ``2024.3.2``; dates before this return HTTP 404. Adjust here if the
+#: provider backfills older history.
+EARLIEST_AVAILABLE_DATE = datetime.date(2024, 3, 2)
+
+#: Default DuckDB database path.
+CURRENCY_API_DATABASE = Path("~/.tradingstrategy/currency-api/exchange-rates.duckdb").expanduser()

--- a/eth_defi/currency_api/database.py
+++ b/eth_defi/currency_api/database.py
@@ -5,7 +5,7 @@ quote-level gap table (``unavailable_rates``) so the scanner can resume on
 completeness rather than on ``MAX(date)`` and never re-fetch genuinely missing
 cells forever.
 
-See ``scripts/currency_api/README-currency-api.md`` for the schema overview.
+See ``eth_defi/currency_api/README-currency-api.md`` for the schema overview.
 """
 
 import datetime

--- a/eth_defi/currency_api/database.py
+++ b/eth_defi/currency_api/database.py
@@ -61,7 +61,7 @@ class CurrencyRateDatabase:
         self.con = duckdb.connect(str(path))
         self._init_schema()
 
-    def __del__(self):
+    def __del__(self) -> None:
         if hasattr(self, "con") and self.con is not None:
             self.con.close()
             self.con = None
@@ -188,8 +188,9 @@ class CurrencyRateDatabase:
         :param source:
             Provider identifier.
         :param reason:
-            ``date_404`` (whole date 404 on both hosts) or ``quote_missing``
-            (quote absent from an otherwise-200 body).
+            ``date_404`` (whole date 404 on both hosts), ``quote_missing``
+            (quote absent from an otherwise-200 body), or ``persistent_error``
+            (given up after exceeding the transient-failure budget).
         :param http_status:
             HTTP status that confirmed the gap, if applicable.
         """

--- a/eth_defi/currency_api/database.py
+++ b/eth_defi/currency_api/database.py
@@ -24,14 +24,17 @@ logger = logging.getLogger(__name__)
 class CurrencyRateDatabase:
     """DuckDB database for storing historical exchange rates.
 
-    Two tables:
+    Three tables:
 
     - ``exchange_rates`` — the data, keyed by
       ``(date, base_currency, quote_currency, source)``. ``rate`` is the raw API
       value (units of quote per 1 unit of base).
     - ``unavailable_rates`` — quote-level gap tracking for cells confirmed to
-      have no data (whole-date 404s and individually missing quotes), so they are
-      not re-fetched on every run.
+      have no data (whole-date 404s, individually missing quotes and given-up
+      persistent errors), so they are not re-fetched on every run.
+    - ``fetch_attempts`` — internal bookkeeping of the consecutive
+      transient-failure count per ``(date, base_currency, source)``, used to give
+      up on a stuck date after a bounded number of attempts.
 
     Example::
 

--- a/eth_defi/currency_api/database.py
+++ b/eth_defi/currency_api/database.py
@@ -193,19 +193,42 @@ class CurrencyRateDatabase:
             (given up after exceeding the transient-failure budget).
         :param http_status:
             HTTP status that confirmed the gap, if applicable.
+
+        No-op for a cell that already has data in ``exchange_rates`` — the two
+        tables are kept mutually exclusive. This mirrors :py:meth:`upsert_rates`,
+        which deletes the gap row when data arrives; together they ensure a cell is
+        never recorded as both present and unavailable (e.g. when a date that
+        already has stored data later 404s on a tail refetch, or hits give-up).
         """
         self.con.execute(
             """
             INSERT INTO unavailable_rates (
                 date, base_currency, quote_currency, source, reason, http_status, checked_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            )
+            SELECT ?, ?, ?, ?, ?, ?, ?
+            WHERE NOT EXISTS (
+                SELECT 1 FROM exchange_rates
+                WHERE date = ? AND base_currency = ? AND quote_currency = ? AND source = ?
+            )
             ON CONFLICT (date, base_currency, quote_currency, source)
             DO UPDATE SET
                 reason = EXCLUDED.reason,
                 http_status = EXCLUDED.http_status,
                 checked_at = EXCLUDED.checked_at
             """,
-            [date, base_currency, quote_currency, source, reason, http_status, native_datetime_utc_now()],
+            [
+                date,
+                base_currency,
+                quote_currency,
+                source,
+                reason,
+                http_status,
+                native_datetime_utc_now(),
+                date,
+                base_currency,
+                quote_currency,
+                source,
+            ],
         )
 
     def get_transient_attempts(self, base_currency: str, source: str) -> dict[datetime.date, int]:

--- a/eth_defi/currency_api/database.py
+++ b/eth_defi/currency_api/database.py
@@ -1,0 +1,348 @@
+"""DuckDB persistence for historical exchange rates.
+
+Stores one row per ``(date, base_currency, quote_currency, source)`` plus a
+quote-level gap table (``unavailable_rates``) so the scanner can resume on
+completeness rather than on ``MAX(date)`` and never re-fetch genuinely missing
+cells forever.
+
+See ``scripts/currency_api/README-currency-api.md`` for the schema overview.
+"""
+
+import datetime
+import logging
+from pathlib import Path
+
+import duckdb
+import pandas as pd
+
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.currency_api.client import DateRates
+
+logger = logging.getLogger(__name__)
+
+
+class CurrencyRateDatabase:
+    """DuckDB database for storing historical exchange rates.
+
+    Two tables:
+
+    - ``exchange_rates`` — the data, keyed by
+      ``(date, base_currency, quote_currency, source)``. ``rate`` is the raw API
+      value (units of quote per 1 unit of base).
+    - ``unavailable_rates`` — quote-level gap tracking for cells confirmed to
+      have no data (whole-date 404s and individually missing quotes), so they are
+      not re-fetched on every run.
+
+    Example::
+
+        from pathlib import Path
+        from eth_defi.currency_api.database import CurrencyRateDatabase
+
+        db = CurrencyRateDatabase(Path("/tmp/rates.duckdb"))
+        print(db.get_rates_dataframe())
+        db.close()
+    """
+
+    def __init__(self, path: Path) -> None:
+        """Open (or create) the database and ensure the schema exists.
+
+        :param path:
+            Path to the DuckDB file. Parent directories are created if needed.
+        """
+        assert isinstance(path, Path), f"Expected Path for path, got {type(path)}"
+        assert not path.is_dir(), f"Expected file path, got directory: {path}"
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        self.path = path
+        self.con = duckdb.connect(str(path))
+        self._init_schema()
+
+    def __del__(self):
+        if hasattr(self, "con") and self.con is not None:
+            self.con.close()
+            self.con = None
+
+    def _init_schema(self) -> None:
+        """Create tables if they do not exist."""
+        self.con.execute("""
+            CREATE TABLE IF NOT EXISTS exchange_rates (
+                date DATE NOT NULL,
+                base_currency VARCHAR NOT NULL,
+                quote_currency VARCHAR NOT NULL,
+                rate DOUBLE NOT NULL,
+                source VARCHAR NOT NULL,
+                written_at TIMESTAMP,
+                PRIMARY KEY (date, base_currency, quote_currency, source)
+            )
+        """)
+
+        self.con.execute("""
+            CREATE TABLE IF NOT EXISTS unavailable_rates (
+                date DATE NOT NULL,
+                base_currency VARCHAR NOT NULL,
+                quote_currency VARCHAR NOT NULL,
+                source VARCHAR NOT NULL,
+                reason VARCHAR,
+                http_status INTEGER,
+                checked_at TIMESTAMP,
+                PRIMARY KEY (date, base_currency, quote_currency, source)
+            )
+        """)
+
+        # Consecutive transient-failure counter per date, so a date that keeps
+        # failing with a non-404 error (403/5xx/network) across runs can be given
+        # up on after a bounded number of attempts instead of retrying forever.
+        # Reset (deleted) as soon as a date succeeds or is confirmed unavailable.
+        self.con.execute("""
+            CREATE TABLE IF NOT EXISTS fetch_attempts (
+                date DATE NOT NULL,
+                base_currency VARCHAR NOT NULL,
+                source VARCHAR NOT NULL,
+                transient_attempts INTEGER NOT NULL,
+                last_attempt_at TIMESTAMP,
+                PRIMARY KEY (date, base_currency, source)
+            )
+        """)
+
+    def save(self) -> None:
+        """Force a checkpoint so data is flushed to disk."""
+        self.con.commit()
+
+    def close(self) -> None:
+        """Close the database connection."""
+        if self.con is not None:
+            logger.info("Closing currency rate database at %s", self.path)
+            self.con.close()
+            self.con = None
+
+    def upsert_rates(self, date_rates: DateRates) -> None:
+        """Idempotently upsert the rates for one date.
+
+        Re-running with the same key overwrites the value and ``written_at``
+        (``ON CONFLICT DO UPDATE``), so a repeated scan produces no duplicates.
+
+        :param date_rates:
+            Parsed rates to store.
+        """
+        if not date_rates.rows:
+            return
+
+        written_at = native_datetime_utc_now()
+        params = [
+            (
+                date_rates.date,
+                date_rates.base_currency,
+                quote,
+                rate,
+                date_rates.source,
+                written_at,
+            )
+            for quote, rate in date_rates.rows
+        ]
+
+        self.con.executemany(
+            """
+            INSERT INTO exchange_rates (
+                date, base_currency, quote_currency, rate, source, written_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT (date, base_currency, quote_currency, source)
+            DO UPDATE SET
+                rate = EXCLUDED.rate,
+                written_at = EXCLUDED.written_at
+            """,
+            params,
+        )
+
+        # A cell that now has data is no longer a gap: keep exchange_rates and
+        # unavailable_rates mutually exclusive so a previously-recorded gap
+        # (quote_missing / date_404 / persistent_error) cannot linger as a stale row.
+        self.con.executemany(
+            """
+            DELETE FROM unavailable_rates
+            WHERE date = ? AND base_currency = ? AND quote_currency = ? AND source = ?
+            """,
+            [(date_rates.date, date_rates.base_currency, quote, date_rates.source) for quote, _ in date_rates.rows],
+        )
+
+    def record_unavailable(
+        self,
+        date: datetime.date,
+        base_currency: str,
+        quote_currency: str,
+        source: str,
+        reason: str,
+        http_status: int | None = None,
+    ) -> None:
+        """Record a single rate cell as permanently unavailable.
+
+        :param date:
+            Date of the missing cell.
+        :param base_currency:
+            Base currency code.
+        :param quote_currency:
+            Quote currency code that has no data.
+        :param source:
+            Provider identifier.
+        :param reason:
+            ``date_404`` (whole date 404 on both hosts) or ``quote_missing``
+            (quote absent from an otherwise-200 body).
+        :param http_status:
+            HTTP status that confirmed the gap, if applicable.
+        """
+        self.con.execute(
+            """
+            INSERT INTO unavailable_rates (
+                date, base_currency, quote_currency, source, reason, http_status, checked_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (date, base_currency, quote_currency, source)
+            DO UPDATE SET
+                reason = EXCLUDED.reason,
+                http_status = EXCLUDED.http_status,
+                checked_at = EXCLUDED.checked_at
+            """,
+            [date, base_currency, quote_currency, source, reason, http_status, native_datetime_utc_now()],
+        )
+
+    def get_transient_attempts(self, base_currency: str, source: str) -> dict[datetime.date, int]:
+        """Return the consecutive transient-failure count per date.
+
+        :param base_currency:
+            Base currency to filter on.
+        :param source:
+            Provider identifier to filter on.
+        :return:
+            Mapping of ``date`` to the number of consecutive transient failures
+            recorded so far. Dates with no failures are absent.
+        """
+        rows = self.con.execute(
+            """
+            SELECT date, transient_attempts FROM fetch_attempts
+            WHERE base_currency = ? AND source = ?
+            """,
+            [base_currency, source],
+        ).fetchall()
+        return dict(rows)
+
+    def set_transient_attempts(
+        self,
+        date: datetime.date,
+        base_currency: str,
+        source: str,
+        attempts: int,
+    ) -> None:
+        """Persist the consecutive transient-failure count for a date.
+
+        :param date:
+            Date that failed.
+        :param base_currency:
+            Base currency code.
+        :param source:
+            Provider identifier.
+        :param attempts:
+            New cumulative count of consecutive transient failures.
+        """
+        self.con.execute(
+            """
+            INSERT INTO fetch_attempts (
+                date, base_currency, source, transient_attempts, last_attempt_at
+            ) VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT (date, base_currency, source)
+            DO UPDATE SET
+                transient_attempts = EXCLUDED.transient_attempts,
+                last_attempt_at = EXCLUDED.last_attempt_at
+            """,
+            [date, base_currency, source, attempts, native_datetime_utc_now()],
+        )
+
+    def clear_transient_attempts(self, date: datetime.date, base_currency: str, source: str) -> None:
+        """Reset the transient-failure counter for a date once it resolves.
+
+        :param date:
+            Date that succeeded or was confirmed unavailable.
+        :param base_currency:
+            Base currency code.
+        :param source:
+            Provider identifier.
+        """
+        self.con.execute(
+            """
+            DELETE FROM fetch_attempts
+            WHERE date = ? AND base_currency = ? AND source = ?
+            """,
+            [date, base_currency, source],
+        )
+
+    def _distinct_pairs(self, table: str, base_currency: str, source: str) -> set[tuple[datetime.date, str]]:
+        """Return the distinct ``(date, quote_currency)`` pairs in a table.
+
+        :param table:
+            Table name (``exchange_rates`` or ``unavailable_rates``); an internal
+            constant, never user input.
+        :param base_currency:
+            Base currency to filter on.
+        :param source:
+            Provider identifier to filter on.
+        :return:
+            Set of ``(date, quote_currency)`` tuples.
+        """
+        rows = self.con.execute(
+            f"SELECT date, quote_currency FROM {table} WHERE base_currency = ? AND source = ?",
+            [base_currency, source],
+        ).fetchall()
+        return set(rows)
+
+    def get_present_pairs(self, base_currency: str, source: str) -> set[tuple[datetime.date, str]]:
+        """Return ``(date, quote_currency)`` pairs already stored in ``exchange_rates``."""
+        return self._distinct_pairs("exchange_rates", base_currency, source)
+
+    def get_unavailable_pairs(self, base_currency: str, source: str) -> set[tuple[datetime.date, str]]:
+        """Return ``(date, quote_currency)`` pairs recorded in ``unavailable_rates``."""
+        return self._distinct_pairs("unavailable_rates", base_currency, source)
+
+    def row_count(self) -> int:
+        """Return the total number of stored exchange rate rows."""
+        return self.con.execute("SELECT COUNT(*) FROM exchange_rates").fetchone()[0]
+
+    def get_min_date(self, base_currency: str, source: str) -> datetime.date | None:
+        """Return the earliest stored date for a base/source, or ``None`` if empty."""
+        return self.con.execute(
+            "SELECT MIN(date) FROM exchange_rates WHERE base_currency = ? AND source = ?",
+            [base_currency, source],
+        ).fetchone()[0]
+
+    def get_max_date(self, base_currency: str, source: str) -> datetime.date | None:
+        """Return the latest stored date for a base/source, or ``None`` if empty."""
+        return self.con.execute(
+            "SELECT MAX(date) FROM exchange_rates WHERE base_currency = ? AND source = ?",
+            [base_currency, source],
+        ).fetchone()[0]
+
+    def get_rates_dataframe(
+        self,
+        base_currency: str | None = None,
+        source: str | None = None,
+    ) -> pd.DataFrame:
+        """Return stored rates as a DataFrame ordered by date then quote.
+
+        :param base_currency:
+            Optional base currency filter.
+        :param source:
+            Optional source filter.
+        :return:
+            DataFrame with columns
+            ``date, base_currency, quote_currency, rate, source, written_at``.
+        """
+        clauses = []
+        params: list = []
+        if base_currency is not None:
+            clauses.append("base_currency = ?")
+            params.append(base_currency)
+        if source is not None:
+            clauses.append("source = ?")
+            params.append(source)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        return self.con.execute(
+            f"SELECT * FROM exchange_rates {where} ORDER BY date, quote_currency",
+            params,
+        ).df()

--- a/eth_defi/currency_api/scanner.py
+++ b/eth_defi/currency_api/scanner.py
@@ -1,0 +1,269 @@
+"""Incremental, gap-aware exchange rate scanner.
+
+Drives :py:func:`~eth_defi.currency_api.client.fetch_rates_for_date` over a date
+window, fetching dates in parallel (threaded) and writing to a single shared
+DuckDB connection. Resume is **completeness-driven**: it computes the missing
+``(date, quote)`` cells from the stored data and the gap table, so transient
+holes and newly added quote currencies are always backfilled.
+
+Example::
+
+    from eth_defi.currency_api.scanner import run_incremental_scan
+    from eth_defi.currency_api.constants import CURRENCY_API_DATABASE
+
+    result = run_incremental_scan(db_path=CURRENCY_API_DATABASE)
+    print(result.db.row_count())
+    result.db.close()
+"""
+
+import datetime
+import logging
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+from joblib import Parallel, delayed
+from requests import Session
+from tqdm_loggable.auto import tqdm
+
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.currency_api.client import FetchResult, fetch_rates_for_date
+from eth_defi.currency_api.constants import (
+    DEFAULT_BASE_CURRENCY,
+    DEFAULT_QUOTE_CURRENCIES,
+    EARLIEST_AVAILABLE_DATE,
+    SOURCE_NAME,
+)
+from eth_defi.currency_api.database import CurrencyRateDatabase
+from eth_defi.currency_api.session import create_currency_api_session
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class ScanResult:
+    """Outcome of an incremental scan.
+
+    :ivar db:
+        The (still open) database. The caller is responsible for closing it.
+    :ivar dates_requested:
+        Number of distinct dates fetched over HTTP this run.
+    :ivar rows_upserted:
+        Number of ``(date, quote)`` rate rows written.
+    :ivar quotes_recorded:
+        Individually missing quotes recorded as permanently unavailable.
+    :ivar quotes_pending:
+        Individually missing quotes left pending (within grace, retried later).
+    :ivar dates_unavailable:
+        Whole dates recorded as permanently unavailable (404 on both hosts).
+    :ivar dates_pending:
+        Whole dates that 404'd but are within grace (retried later).
+    :ivar transient_failures:
+        Dates that failed transiently this run and will be retried; the run
+        should exit non-zero.
+    :ivar dates_given_up:
+        Dates that exceeded ``max_transient_attempts`` consecutive transient
+        failures and were recorded as permanent ``persistent_error`` gaps.
+    """
+
+    #: The still-open database.
+    db: CurrencyRateDatabase
+    #: Distinct dates fetched over HTTP.
+    dates_requested: int = 0
+    #: Rate rows written.
+    rows_upserted: int = 0
+    #: Missing quotes recorded as permanently unavailable.
+    quotes_recorded: int = 0
+    #: Missing quotes left pending within grace.
+    quotes_pending: int = 0
+    #: Whole dates recorded as unavailable.
+    dates_unavailable: int = 0
+    #: Whole dates pending within grace.
+    dates_pending: int = 0
+    #: Transient failures requiring retry / non-zero exit.
+    transient_failures: int = 0
+    #: Dates given up on after exceeding the transient-attempt budget.
+    dates_given_up: int = 0
+
+
+def _iter_dates(start: datetime.date, end: datetime.date) -> Iterator[datetime.date]:
+    """Yield every calendar date in ``[start, end]`` inclusive."""
+    current = start
+    while current <= end:
+        yield current
+        current += datetime.timedelta(days=1)
+
+
+def run_incremental_scan(
+    db_path: Path,
+    base_currency: str = DEFAULT_BASE_CURRENCY,
+    quote_currencies: tuple[str, ...] = DEFAULT_QUOTE_CURRENCIES,
+    start_date: datetime.date | None = None,
+    end_date: datetime.date | None = None,
+    source: str = SOURCE_NAME,
+    max_workers: int = 8,
+    refetch_tail_days: int = 3,
+    unavailable_grace_days: int = 2,
+    max_transient_attempts: int = 5,
+    session: Session | None = None,
+) -> ScanResult:
+    """Incrementally populate exchange rates into DuckDB.
+
+    Computes the missing ``(date, quote)`` work set from the stored data and the
+    gap table, fetches the needed dates in parallel, and upserts the results.
+    Permanent gaps are recorded; transient failures are left for retry and
+    surfaced in the returned :py:class:`ScanResult`.
+
+    :param db_path:
+        DuckDB file path. Created if it does not exist.
+    :param base_currency:
+        Lower-cased base currency (e.g. ``usd``).
+    :param quote_currencies:
+        Quote currencies to populate. Adding a currency later backfills its full
+        history automatically (no schema change needed).
+    :param start_date:
+        Lower bound (inclusive). Defaults to ``EARLIEST_AVAILABLE_DATE``;
+        clamped so it can never go below it.
+    :param end_date:
+        Upper bound (inclusive). Defaults to today (UTC).
+    :param source:
+        Provider identifier written to the ``source`` column.
+    :param max_workers:
+        Number of threaded date fetchers.
+    :param refetch_tail_days:
+        Always re-fetch the most recent N days to pick up source corrections.
+    :param unavailable_grace_days:
+        A 404/missing-quote younger than this many days is treated as
+        "not published yet" and retried, not recorded as permanent.
+    :param max_transient_attempts:
+        Maximum number of consecutive transient failures (non-404 errors such as
+        403/5xx/network) tolerated for a single date across runs. Once a date
+        reaches this many failures it is given up on — recorded as a permanent
+        ``persistent_error`` gap and no longer retried. The counter resets as
+        soon as the date succeeds or is confirmed unavailable.
+    :param session:
+        Optional pre-built session; one is created if omitted.
+    :return:
+        A :py:class:`ScanResult` carrying the open db and per-run counts.
+    """
+    base_currency = base_currency.lower()
+    quote_currencies = tuple(q.lower() for q in quote_currencies)
+
+    today = native_datetime_utc_now().date()
+
+    floor = start_date or EARLIEST_AVAILABLE_DATE
+    if floor < EARLIEST_AVAILABLE_DATE:
+        floor = EARLIEST_AVAILABLE_DATE
+    end = end_date or today
+
+    db = CurrencyRateDatabase(db_path)
+    result = ScanResult(db=db)
+
+    if end < floor:
+        logger.warning("Empty scan window: end %s < floor %s", end, floor)
+        return result
+
+    # Determine the missing work set at (date, quote) granularity.
+    present = db.get_present_pairs(base_currency, source)
+    unavailable = db.get_unavailable_pairs(base_currency, source)
+    tail_threshold = end - datetime.timedelta(days=refetch_tail_days)
+
+    def date_needs_fetch(d: datetime.date) -> bool:
+        # Fetch if any quote is neither present nor a known gap (real missing work).
+        if any((d, q) not in present and (d, q) not in unavailable for q in quote_currencies):
+            return True
+        # All quotes resolved. In the recent tail, re-fetch only dates that actually
+        # have data, to capture source corrections — never resurrect a date whose
+        # quotes are all recorded gaps (e.g. given-up persistent_error dates).
+        if d > tail_threshold:
+            return any((d, q) in present for q in quote_currencies)
+        return False
+
+    dates_to_fetch = [d for d in _iter_dates(floor, end) if date_needs_fetch(d)]
+    result.dates_requested = len(dates_to_fetch)
+
+    if not dates_to_fetch:
+        logger.info("Nothing to fetch: %s..%s already complete for %s/%s", floor, end, base_currency, source)
+        return result
+
+    logger.info(
+        "Fetching %d dates (%s..%s) for base=%s quotes=%s source=%s",
+        len(dates_to_fetch),
+        dates_to_fetch[0],
+        dates_to_fetch[-1],
+        base_currency,
+        ",".join(quote_currencies),
+        source,
+    )
+
+    if session is None:
+        session = create_currency_api_session(pool_maxsize=max(max_workers, 16))
+
+    # Parallel fetch — workers only do HTTP, no DB writes (thread-safe).
+    results: list[FetchResult] = Parallel(n_jobs=max_workers, backend="threading")(delayed(fetch_rates_for_date)(session, d, base_currency, quote_currencies, source) for d in tqdm(dates_to_fetch, desc="Fetching exchange rates"))
+
+    # Single-threaded write phase on the shared connection.
+    prior_attempts = db.get_transient_attempts(base_currency, source)
+
+    for res in results:
+        # A gap is recorded as permanent once the date is at least
+        # ``unavailable_grace_days`` old; younger gaps are "not published yet".
+        is_old = (today - res.date).days >= unavailable_grace_days
+
+        if res.status == "ok":
+            if res.rates and res.rates.rows:
+                db.upsert_rates(res.rates)
+                result.rows_upserted += len(res.rates.rows)
+            for quote in res.missing_quotes:
+                if is_old:
+                    db.record_unavailable(res.date, base_currency, quote, source, reason="quote_missing")
+                    result.quotes_recorded += 1
+                else:
+                    result.quotes_pending += 1
+            # The date resolved — reset any transient-failure streak.
+            db.clear_transient_attempts(res.date, base_currency, source)
+
+        elif res.status == "unavailable":
+            if is_old:
+                for quote in quote_currencies:
+                    db.record_unavailable(res.date, base_currency, quote, source, reason="date_404", http_status=404)
+                result.dates_unavailable += 1
+            else:
+                result.dates_pending += 1
+            # Definitive answer (even if pending on grace) — reset the streak.
+            db.clear_transient_attempts(res.date, base_currency, source)
+
+        else:  # transient_error
+            attempts = prior_attempts.get(res.date, 0) + 1
+            if attempts >= max_transient_attempts:
+                # Budget exhausted: give up and record a permanent gap so this
+                # date is no longer retried (and no longer alerts).
+                logger.warning(
+                    "Giving up on %s after %d consecutive transient failures; recording persistent_error",
+                    res.date,
+                    attempts,
+                )
+                for quote in quote_currencies:
+                    db.record_unavailable(res.date, base_currency, quote, source, reason="persistent_error")
+                db.clear_transient_attempts(res.date, base_currency, source)
+                result.dates_given_up += 1
+            else:
+                # Still within budget: persist the streak and retry next run.
+                db.set_transient_attempts(res.date, base_currency, source, attempts)
+                result.transient_failures += 1
+
+    db.save()
+
+    logger.info(
+        "Scan complete: requested=%d rows_upserted=%d quotes_recorded=%d quotes_pending=%d dates_unavailable=%d dates_pending=%d transient_failures=%d dates_given_up=%d",
+        result.dates_requested,
+        result.rows_upserted,
+        result.quotes_recorded,
+        result.quotes_pending,
+        result.dates_unavailable,
+        result.dates_pending,
+        result.transient_failures,
+        result.dates_given_up,
+    )
+
+    return result

--- a/eth_defi/currency_api/scanner.py
+++ b/eth_defi/currency_api/scanner.py
@@ -210,30 +210,7 @@ def run_incremental_scan(
         # ``unavailable_grace_days`` old; younger gaps are "not published yet".
         is_old = (today - res.date).days >= unavailable_grace_days
 
-        if res.status == "ok":
-            if res.rates and res.rates.rows:
-                db.upsert_rates(res.rates)
-                result.rows_upserted += len(res.rates.rows)
-            for quote in res.missing_quotes:
-                if is_old:
-                    db.record_unavailable(res.date, base_currency, quote, source, reason="quote_missing")
-                    result.quotes_recorded += 1
-                else:
-                    result.quotes_pending += 1
-            # The date resolved — reset any transient-failure streak.
-            db.clear_transient_attempts(res.date, base_currency, source)
-
-        elif res.status == "unavailable":
-            if is_old:
-                for quote in quote_currencies:
-                    db.record_unavailable(res.date, base_currency, quote, source, reason="date_404", http_status=404)
-                result.dates_unavailable += 1
-            else:
-                result.dates_pending += 1
-            # Definitive answer (even if pending on grace) — reset the streak.
-            db.clear_transient_attempts(res.date, base_currency, source)
-
-        else:  # transient_error
+        if res.status == "transient_error":
             attempts = prior_attempts.get(res.date, 0) + 1
             if attempts >= max_transient_attempts:
                 # Budget exhausted: give up and record a permanent gap so this
@@ -251,6 +228,28 @@ def run_incremental_scan(
                 # Still within budget: persist the streak and retry next run.
                 db.set_transient_attempts(res.date, base_currency, source, attempts)
                 result.transient_failures += 1
+            continue
+
+        if res.status == "ok":
+            if res.rates and res.rates.rows:
+                db.upsert_rates(res.rates)
+                result.rows_upserted += len(res.rates.rows)
+            for quote in res.missing_quotes:
+                if is_old:
+                    db.record_unavailable(res.date, base_currency, quote, source, reason="quote_missing")
+                    result.quotes_recorded += 1
+                else:
+                    result.quotes_pending += 1
+        else:  # unavailable — whole-date 404 on both hosts
+            if is_old:
+                for quote in quote_currencies:
+                    db.record_unavailable(res.date, base_currency, quote, source, reason="date_404", http_status=404)
+                result.dates_unavailable += 1
+            else:
+                result.dates_pending += 1
+
+        # ok / unavailable are definitive answers for the date — reset any streak.
+        db.clear_transient_attempts(res.date, base_currency, source)
 
     db.save()
 

--- a/eth_defi/currency_api/session.py
+++ b/eth_defi/currency_api/session.py
@@ -1,0 +1,69 @@
+"""HTTP session factory for the fawazahmed0 Exchange API.
+
+The endpoints are static JSON files served from a CDN (jsDelivr) with a
+Cloudflare Pages fallback, and the provider documents no rate limit. We
+therefore only need retry/backoff on the transport, not the SQLite rate-limiter
+used by the GRVT/Hyperliquid sessions.
+
+Canonical API documentation: https://github.com/fawazahmed0/exchange-api
+"""
+
+import logging
+
+from requests import Session
+from requests.adapters import HTTPAdapter
+
+from eth_defi.logging_retry import LoggingRetry
+
+logger = logging.getLogger(__name__)
+
+#: Default number of transport-level retries.
+DEFAULT_RETRIES = 5
+
+#: Default exponential backoff factor between retries.
+DEFAULT_BACKOFF_FACTOR = 0.5
+
+#: Default connection pool size.
+DEFAULT_POOL_MAXSIZE = 16
+
+
+def create_currency_api_session(
+    retries: int = DEFAULT_RETRIES,
+    backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
+    pool_maxsize: int = DEFAULT_POOL_MAXSIZE,
+) -> Session:
+    """Create a :py:class:`requests.Session` configured for the Exchange API.
+
+    Installs an :py:class:`~eth_defi.logging_retry.LoggingRetry` policy with
+    exponential backoff that retries on ``429`` and ``5xx`` responses, and a
+    connection pool sized for the threaded scanner. Host fallback
+    (jsDelivr → pages.dev) is handled by the client, not here.
+
+    :param retries:
+        Maximum number of transport-level retries per request.
+    :param backoff_factor:
+        Exponential backoff factor passed to the retry policy.
+    :param pool_maxsize:
+        Connection pool size; should be >= the scanner ``max_workers``.
+    :return:
+        A configured session. Safe to share across threads.
+    """
+    session = Session()
+
+    retry_policy = LoggingRetry(
+        total=retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=[429, 500, 502, 503, 504],
+        respect_retry_after_header=True,
+        logger=logger,
+    )
+
+    adapter = HTTPAdapter(
+        max_retries=retry_policy,
+        pool_connections=pool_maxsize,
+        pool_maxsize=pool_maxsize,
+    )
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+
+    return session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -337,3 +337,5 @@ skip-magic-trailing-comma = false # Respect trailing commas to force multi-line
 
 [tool.poetry.scripts]
 install-aave-for-testing = 'eth_defi.aave_v3.deployer:install_aave_for_testing'
+# Incremental historical exchange rate scanner (eth_defi.currency_api)
+scan-currencies = 'eth_defi.currency_api.cli:main'

--- a/scripts/currency_api/README-currency-api.md
+++ b/scripts/currency_api/README-currency-api.md
@@ -1,0 +1,197 @@
+# Currency API historical exchange rate pipeline
+
+## Overview
+
+Incrementally scans daily historical exchange rates for a configurable set of
+named currencies (default: EUR, GBP, JPY, AUD, BTC, ETH against USD) and stores them
+in a DuckDB database. The data is sourced from the **fawazahmed0 Exchange API**
+(`@fawazahmed0/currency-api`).
+
+The schema carries a `source` column so additional rate sources (e.g.
+ECB/Frankfurter, CoinGecko, on-chain oracles) can be added later without
+disturbing existing rows.
+
+**No authentication is required** — all data comes from a free, public,
+no-API-key endpoint with no rate limits.
+
+> This README documents the design in
+> `.claude/plans/currency-api-exchange-rates.md`, against which the module is
+> implemented.
+
+## Architecture
+
+```
+fawazahmed0 Exchange API                 Local storage
+========================                 =============
+jsDelivr CDN (primary)
+  cdn.jsdelivr.net/npm/@fawazahmed0/
+    currency-api@{date}/v1/
+      currencies/usd.min.json
+      |
+      |  (HTTP 404 / 5xx → fallback host)
+      v
+pages.dev (Cloudflare fallback)
+  {date}.currency-api.pages.dev/v1/
+    currencies/usd.min.json
+      |
+      v
+fetch_rates_for_date()                   exchange-rates.duckdb
+  one request per date                     exchange_rates table
+  returns base vs ~200 currencies          unavailable_rates table
+  extract named quote currencies
+      |
+      v
+run_incremental_scan()  --upsert-->      exchange_rates
+  completeness-driven (date,quote) set     (date, base, quote, source) PK
+  joblib threaded fetch
+  records permanent gaps ----------->      unavailable_rates
+  (whole-date 404s + missing quotes)       (date, base, quote, source) PK
+```
+
+## Data source
+
+| Property | Value |
+|----------|-------|
+| Provider | fawazahmed0 Exchange API (`@fawazahmed0/currency-api`) |
+| Cost | Free, no API key, no documented rate limit |
+| Primary URL | `https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@{date}/v1/currencies/{base}.min.json` |
+| Fallback URL | `https://{date}.currency-api.pages.dev/v1/currencies/{base}.min.json` |
+| `{date}` | `latest` or `YYYY-MM-DD` |
+| Frequency | Daily |
+| Earliest data | ~`2024-03-02` (constant `EARLIEST_AVAILABLE_DATE`) |
+
+### Response shape
+
+A single request for a `base` currency returns that base against ~200 fiat and
+crypto currencies:
+
+```json
+{
+  "date": "2026-06-28",
+  "usd": { "eur": 0.87803784, "gbp": 0.75771599, "jpy": 161.75, "btc": 0.000016638, "eth": 0.00063644, ... }
+}
+```
+
+One HTTP request therefore covers every named currency for that date, so the
+scanner parallelises **across dates**, not currencies.
+
+### Rate direction
+
+`usd[quote]` is the number of units of `quote` per **1 unit of base** (e.g.
+1 USD = 0.878 EUR). We store this **raw** value. USD-per-unit is the inverse
+(`1 / rate`); invert on read. Because both `base_currency` and `quote_currency`
+are stored, the direction is always unambiguous.
+
+## DuckDB schema
+
+```
+exchange_rates                              unavailable_rates
+==============                              =================
+date           DATE     \                   date           DATE     \
+base_currency  VARCHAR   \                  base_currency  VARCHAR    \
+quote_currency VARCHAR    > composite PK    quote_currency VARCHAR     > composite PK
+source         VARCHAR   /                  source         VARCHAR    /
+rate           DOUBLE                        reason         VARCHAR
+written_at     TIMESTAMP                     http_status    INTEGER
+                                            checked_at     TIMESTAMP
+```
+
+- `rate` — raw API value, `quote` units per 1 `base`.
+- `source` — part of the primary key so multiple sources coexist.
+- `unavailable_rates` — rate cells confirmed to have no data (older than the grace
+  window), tracked at `(date, base, quote, source)` granularity. `reason` is
+  `date_404` (whole date 404 on both hosts), `quote_missing` (a single quote
+  absent from an otherwise-200 body), or `persistent_error` (gave up after too
+  many transient failures). Lets the scanner stop re-fetching genuinely missing
+  cells while still retrying transient failures.
+- `fetch_attempts` — internal bookkeeping: consecutive transient-failure count
+  per `(date, base, source)`, used to give up on a stuck date after
+  `MAX_TRANSIENT_ATTEMPTS`. Reset when the date succeeds or returns a 404.
+
+## Incremental, gap-aware scanning
+
+The scanner resume is **completeness-driven**, not `MAX(date)`-driven:
+
+1. Window: `floor = START_DATE or EARLIEST_AVAILABLE_DATE`, `end = END_DATE or today (UTC)`.
+2. Missing work = every `(date, quote)` in the window that is not already present in
+   `exchange_rates` and not recorded in `unavailable_rates`, plus the last
+   `REFETCH_TAIL_DAYS` to refresh recent corrections.
+3. This automatically backfills mid-history holes **and the full history of any newly
+   added quote currency**.
+4. Permanent gaps older than `UNAVAILABLE_GRACE_DAYS` are recorded in `unavailable_rates`:
+   whole-date 404s (`reason='date_404'`) and individual quotes absent from a 200 body
+   (`reason='quote_missing'`). Recent gaps are treated as "not published yet" and retried.
+5. Transient network/5xx failures are never recorded as unavailable; they are retried on
+   the next run and cause the script to exit non-zero so cron alerting fires.
+6. To stop a genuinely stuck date (a persistent non-404 denial such as 403/410 or a
+   permanent 5xx) from retrying and alerting forever, a per-date counter tracks
+   consecutive transient failures. After `MAX_TRANSIENT_ATTEMPTS` (default 5) the date is
+   given up on — recorded as a permanent gap (`reason='persistent_error'`) and no longer
+   fetched. The counter resets as soon as the date succeeds or returns a definitive 404.
+
+## Quick start
+
+```shell
+# Full incremental scan (resume from existing DB, default currencies)
+LOG_LEVEL=info poetry run python scripts/currency_api/scan-currencies.py
+
+# Small test batch — a few days only (fast, deterministic)
+LOG_LEVEL=info START_DATE=2026-06-01 END_DATE=2026-06-05 \
+  poetry run python scripts/currency_api/scan-currencies.py
+
+# Add more currencies (no schema change; history backfills automatically)
+QUOTE_CURRENCIES=eur,gbp,jpy,chf,btc,eth,sol \
+  poetry run python scripts/currency_api/scan-currencies.py
+
+# Use a non-USD base
+BASE_CURRENCY=eur QUOTE_CURRENCIES=usd,gbp,jpy \
+  poetry run python scripts/currency_api/scan-currencies.py
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LOG_LEVEL` | `warning` | Logging level |
+| `DB_PATH` | `~/.tradingstrategy/currency-api/exchange-rates.duckdb` | DuckDB database path |
+| `BASE_CURRENCY` | `usd` | Base currency |
+| `QUOTE_CURRENCIES` | `eur,gbp,jpy,aud,btc,eth` | Comma-separated quote currencies |
+| `START_DATE` | *(resume / earliest)* | `YYYY-MM-DD` lower bound (small-batch testing) |
+| `END_DATE` | *(today, UTC)* | `YYYY-MM-DD` upper bound (small-batch testing) |
+| `MAX_WORKERS` | `8` | Parallel date fetchers (threaded) |
+| `REFETCH_TAIL_DAYS` | `3` | Recent days to always re-fetch for corrections |
+| `UNAVAILABLE_GRACE_DAYS` | `2` | Age before a 404 is recorded as permanent |
+| `MAX_TRANSIENT_ATTEMPTS` | `5` | Consecutive transient failures per date before giving up |
+| `SOURCE` | `fawazahmed0` | Value written to the `source` column |
+
+## Key modules
+
+| Module | Role |
+|--------|------|
+| `eth_defi/currency_api/constants.py` | API URL templates, source name, default/earliest-date constants, default currency tuple |
+| `eth_defi/currency_api/session.py` | `requests.Session` factory — retries/backoff transport |
+| `eth_defi/currency_api/client.py` | `fetch_rates_for_date()` — fetch, jsDelivr→pages.dev host fallback, parse, outcome classification |
+| `eth_defi/currency_api/database.py` | `CurrencyRateDatabase` — DuckDB storage, upserts, gap tracking |
+| `eth_defi/currency_api/scanner.py` | `run_incremental_scan()` — completeness-driven incremental orchestration |
+
+## Running tests
+
+```shell
+source .local-test.env && poetry run pytest tests/currency_api/ -x --timeout=300
+```
+
+Testing is **black-box, real-network, no mocks**. Each test runs the real
+`run_incremental_scan` against the live API over a small bounded date window
+(via `START_DATE`/`END_DATE`) into a temporary DuckDB, then asserts on the real
+DB state:
+
+- **Limited end-to-end scan** — a 3-day window × the default currencies; asserts
+  rows present, `source = 'fawazahmed0'`, sane value bounds, and idempotent re-runs.
+- **Incremental gap-fill + reconfiguration** — a partial window then an extended
+  window with an extra currency; asserts new dates and the new currency's history
+  backfill while existing rows are not duplicated.
+- **Script entry point** (optional) — invokes `scan-currencies.py` as a subprocess
+  with env vars set, asserting exit code 0 and expected DB rows.
+
+Exact rates are never asserted (the source may revise history); only presence,
+bounds, idempotency, and gap-filling.

--- a/scripts/currency_api/README-currency-api.md
+++ b/scripts/currency_api/README-currency-api.md
@@ -14,10 +14,6 @@ disturbing existing rows.
 **No authentication is required** — all data comes from a free, public,
 no-API-key endpoint with no rate limits.
 
-> This README documents the design in
-> `.claude/plans/currency-api-exchange-rates.md`, against which the module is
-> implemented.
-
 ## Architecture
 
 ```
@@ -190,7 +186,14 @@ DB state:
 - **Incremental gap-fill + reconfiguration** — a partial window then an extended
   window with an extra currency; asserts new dates and the new currency's history
   backfill while existing rows are not duplicated.
-- **Script entry point** (optional) — invokes `scan-currencies.py` as a subprocess
+- **Missing quote recorded, not retried** — a nonexistent currency code is
+  recorded in `unavailable_rates` as a permanent `quote_missing` gap, not a
+  transient failure.
+- **Transient-attempt counter** — the per-date give-up bookkeeping persists,
+  overwrites, clears, and escalates to a `persistent_error` gap.
+- **Present/unavailable disjoint** — upserting data for a cell removes any prior
+  gap record so the two tables stay mutually exclusive.
+- **Script entry point** — invokes `scan-currencies.py` as a subprocess
   with env vars set, asserting exit code 0 and expected DB rows.
 
 Exact rates are never asserted (the source may revise history); only presence,

--- a/scripts/currency_api/scan-currencies.py
+++ b/scripts/currency_api/scan-currencies.py
@@ -1,0 +1,129 @@
+"""Incrementally scan historical exchange rates into DuckDB.
+
+Fetches daily exchange rates for a configurable set of named currencies
+(default: EUR, GBP, JPY, AUD, BTC, ETH against USD) from the free, no-API-key
+fawazahmed0 Exchange API and stores them in a DuckDB database. Resume is
+completeness-driven, so re-running only fetches missing dates/currencies.
+
+No authentication is required — all data comes from a public endpoint.
+
+Usage:
+
+.. code-block:: shell
+
+    # Full incremental scan (resume from existing DB, default currencies)
+    LOG_LEVEL=info poetry run python scripts/currency_api/scan-currencies.py
+
+    # Small test batch — a few days only
+    LOG_LEVEL=info START_DATE=2026-06-01 END_DATE=2026-06-05 \
+      poetry run python scripts/currency_api/scan-currencies.py
+
+    # Add more currencies (history backfills automatically)
+    QUOTE_CURRENCIES=eur,gbp,jpy,chf,btc,eth,sol \
+      poetry run python scripts/currency_api/scan-currencies.py
+
+Environment variables:
+
+- ``LOG_LEVEL``: Logging level (debug, info, warning, error). Default: warning
+- ``DB_PATH``: DuckDB database file. Default: ~/.tradingstrategy/currency-api/exchange-rates.duckdb
+- ``BASE_CURRENCY``: Base currency. Default: usd
+- ``QUOTE_CURRENCIES``: Comma-separated quote currencies. Default: eur,gbp,jpy,aud,btc,eth
+- ``START_DATE``: ``YYYY-MM-DD`` lower bound. Default: resume / earliest available
+- ``END_DATE``: ``YYYY-MM-DD`` upper bound. Default: today (UTC)
+- ``MAX_WORKERS``: Parallel date fetchers. Default: 8
+- ``REFETCH_TAIL_DAYS``: Recent days to always re-fetch. Default: 3
+- ``UNAVAILABLE_GRACE_DAYS``: Age before a 404 is recorded as permanent. Default: 2
+- ``MAX_TRANSIENT_ATTEMPTS``: Consecutive transient failures per date before giving up. Default: 5
+- ``SOURCE``: Value written to the ``source`` column. Default: fawazahmed0
+"""
+
+import datetime
+import logging
+import os
+import sys
+from pathlib import Path
+
+from eth_defi.currency_api.constants import (
+    CURRENCY_API_DATABASE,
+    DEFAULT_BASE_CURRENCY,
+    DEFAULT_QUOTE_CURRENCIES,
+    SOURCE_NAME,
+)
+from eth_defi.currency_api.scanner import run_incremental_scan
+from eth_defi.utils import setup_console_logging
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_date(name: str) -> datetime.date | None:
+    """Parse an optional ``YYYY-MM-DD`` environment variable into a date."""
+    value = os.environ.get(name, "").strip()
+    if not value:
+        return None
+    return datetime.date.fromisoformat(value)
+
+
+def main() -> None:
+    default_log_level = os.environ.get("LOG_LEVEL", "warning")
+    setup_console_logging(
+        default_log_level=default_log_level,
+        log_file=Path("logs/currency-api-scan.log"),
+    )
+
+    db_path_str = os.environ.get("DB_PATH")
+    db_path = Path(db_path_str).expanduser() if db_path_str else CURRENCY_API_DATABASE
+
+    base_currency = os.environ.get("BASE_CURRENCY", DEFAULT_BASE_CURRENCY).strip().lower()
+
+    quotes_str = os.environ.get("QUOTE_CURRENCIES", "").strip()
+    if quotes_str:
+        quote_currencies = tuple(q.strip().lower() for q in quotes_str.split(",") if q.strip())
+    else:
+        quote_currencies = DEFAULT_QUOTE_CURRENCIES
+
+    start_date = _parse_date("START_DATE")
+    end_date = _parse_date("END_DATE")
+    max_workers = int(os.environ.get("MAX_WORKERS", "8"))
+    refetch_tail_days = int(os.environ.get("REFETCH_TAIL_DAYS", "3"))
+    unavailable_grace_days = int(os.environ.get("UNAVAILABLE_GRACE_DAYS", "2"))
+    max_transient_attempts = int(os.environ.get("MAX_TRANSIENT_ATTEMPTS", "5"))
+    source = os.environ.get("SOURCE", SOURCE_NAME).strip()
+
+    logger.info("Using log level: %s", default_log_level)
+    logger.info("Database path: %s", db_path)
+    logger.info("Base currency: %s, quotes: %s", base_currency, ",".join(quote_currencies))
+
+    result = run_incremental_scan(
+        db_path=db_path,
+        base_currency=base_currency,
+        quote_currencies=quote_currencies,
+        start_date=start_date,
+        end_date=end_date,
+        source=source,
+        max_workers=max_workers,
+        refetch_tail_days=refetch_tail_days,
+        unavailable_grace_days=unavailable_grace_days,
+        max_transient_attempts=max_transient_attempts,
+    )
+
+    db = result.db
+    try:
+        logger.info(
+            "Total rows: %d, date range: %s..%s",
+            db.row_count(),
+            db.get_min_date(base_currency, source),
+            db.get_max_date(base_currency, source),
+        )
+    finally:
+        db.close()
+
+    if result.transient_failures:
+        logger.error(
+            "%d dates failed transiently; they will be retried on the next run",
+            result.transient_failures,
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/currency_api/test_currency_api.py
+++ b/tests/currency_api/test_currency_api.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from eth_defi.currency_api.cleaning import filter_known_bad_rates
 from eth_defi.currency_api.client import DateRates
 from eth_defi.currency_api.database import CurrencyRateDatabase
 from eth_defi.currency_api.scanner import run_incremental_scan
@@ -245,6 +246,48 @@ def test_present_and_unavailable_disjoint(db_path: Path):
         assert (date, "eur") not in db.get_unavailable_pairs("usd", "fawazahmed0")
     finally:
         db.close()
+
+
+def test_filter_known_bad_rates_removes_source_outlier(db_path: Path):
+    """The cleaning step removes the known 2025-12-06 BTC/ETH source outlier.
+
+    Real-network, no mocks: scans the window around the known upstream glitch and
+    applies the separate cleaning step.
+
+    1. Scan 2025-12-05..07 for the default currencies (the source returns garbage
+       btc/eth on 2025-12-06).
+    2. Assert the raw data still contains the bad 2025-12-06 btc/eth cells
+       (ingestion stores raw, unfiltered).
+    3. Apply `filter_known_bad_rates` and assert exactly those two cells are gone,
+       the row count drops by 2, and good rows (e.g. 2025-12-06 EUR) remain.
+    """
+
+    bad_date = datetime.date(2025, 12, 6)
+
+    # 1. Scan the window around the known source glitch.
+    result = run_incremental_scan(
+        db_path=db_path,
+        start_date=datetime.date(2025, 12, 5),
+        end_date=datetime.date(2025, 12, 7),
+    )
+    try:
+        raw = result.db.get_rates_dataframe()
+        raw["date"] = pd.to_datetime(raw["date"]).dt.date
+
+        # 2. Raw ingestion keeps the bad cells verbatim.
+        raw_pairs = {(row.date, row.quote_currency) for row in raw.itertuples()}
+        assert (bad_date, "btc") in raw_pairs
+        assert (bad_date, "eth") in raw_pairs
+
+        # 3. Cleaning removes exactly the two known-bad cells, keeps the rest.
+        cleaned = filter_known_bad_rates(raw)
+        cleaned_pairs = {(row.date, row.quote_currency) for row in cleaned.itertuples()}
+        assert (bad_date, "btc") not in cleaned_pairs
+        assert (bad_date, "eth") not in cleaned_pairs
+        assert (bad_date, "eur") in cleaned_pairs  # good rows untouched
+        assert len(cleaned) == len(raw) - 2
+    finally:
+        result.db.close()
 
 
 def test_scan_script_entry_point(db_path: Path, tmp_path: Path):

--- a/tests/currency_api/test_currency_api.py
+++ b/tests/currency_api/test_currency_api.py
@@ -21,7 +21,7 @@ import pandas as pd
 import pytest
 
 from eth_defi.currency_api.cleaning import filter_known_bad_rates
-from eth_defi.currency_api.client import DateRates
+from eth_defi.currency_api.client import DateRates, _parse_document
 from eth_defi.currency_api.database import CurrencyRateDatabase
 from eth_defi.currency_api.scanner import run_incremental_scan
 
@@ -226,8 +226,8 @@ def test_present_and_unavailable_disjoint(db_path: Path):
     Runs against a real DuckDB (no mocks).
 
     1. Record a (date, quote) as an unavailable gap.
-    2. Upsert real data for the same cell.
-    3. Assert the cell is now present and no longer recorded as unavailable.
+    2. Upsert real data for the same cell — the stale gap row is deleted.
+    3. Recording the same cell as unavailable again is a no-op while it has data.
     """
 
     db = CurrencyRateDatabase(db_path)
@@ -238,14 +238,49 @@ def test_present_and_unavailable_disjoint(db_path: Path):
         db.record_unavailable(date, "usd", "eur", "fawazahmed0", reason="quote_missing")
         assert (date, "eur") in db.get_unavailable_pairs("usd", "fawazahmed0")
 
-        # 2. Upsert real data for the same cell.
+        # 2. Upsert real data for the same cell — gap removed, cell now present.
         db.upsert_rates(DateRates(date=date, base_currency="usd", source="fawazahmed0", rows=[("eur", 0.9)]))
+        assert (date, "eur") in db.get_present_pairs("usd", "fawazahmed0")
+        assert (date, "eur") not in db.get_unavailable_pairs("usd", "fawazahmed0")
 
-        # 3. The cell is present and the stale gap row is gone.
+        # 3. Reverse direction: recording a gap for an already-present cell is a
+        #    no-op (e.g. a present date that later 404s on a tail refetch / give-up).
+        db.record_unavailable(date, "usd", "eur", "fawazahmed0", reason="date_404", http_status=404)
         assert (date, "eur") in db.get_present_pairs("usd", "fawazahmed0")
         assert (date, "eur") not in db.get_unavailable_pairs("usd", "fawazahmed0")
     finally:
         db.close()
+
+
+def test_parse_document_classifies_present_absent_and_malformed():
+    """_parse_document distinguishes present, absent, and malformed quotes.
+
+    Pure-function test on literal JSON bodies (no network, no mocks).
+
+    1. A well-formed body returns `ok` with every requested quote parsed.
+    2. A quote absent from the body is reported in `missing_quotes` (still `ok`).
+    3. A present-but-unparseable value makes the whole date `transient_error`
+       (corrupt data is retried, not stored or recorded as a permanent gap).
+    """
+
+    date = datetime.date(2026, 6, 1)
+    quotes = ("eur", "gbp")
+
+    # 1. Well-formed body → ok with both quotes.
+    ok = _parse_document(date, "usd", quotes, "fawazahmed0", {"usd": {"eur": 0.9, "gbp": 0.8}})
+    assert ok.status == "ok"
+    assert dict(ok.rates.rows) == {"eur": 0.9, "gbp": 0.8}
+    assert ok.missing_quotes == ()
+
+    # 2. Absent quote → ok, reported as missing (a permanent per-quote gap).
+    absent = _parse_document(date, "usd", quotes, "fawazahmed0", {"usd": {"eur": 0.9}})
+    assert absent.status == "ok"
+    assert absent.missing_quotes == ("gbp",)
+    assert dict(absent.rates.rows) == {"eur": 0.9}
+
+    # 3. Present but unparseable value → transient_error (retry, do not record).
+    malformed = _parse_document(date, "usd", quotes, "fawazahmed0", {"usd": {"eur": 0.9, "gbp": "oops"}})
+    assert malformed.status == "transient_error"
 
 
 def test_filter_known_bad_rates_removes_source_outlier(db_path: Path):

--- a/tests/currency_api/test_currency_api.py
+++ b/tests/currency_api/test_currency_api.py
@@ -1,0 +1,286 @@
+"""Black-box integration tests for the currency_api exchange rate scanner.
+
+These are real-network, no-mock tests: each one drives the real
+:py:func:`eth_defi.currency_api.scanner.run_incremental_scan` against the live
+fawazahmed0 Exchange API over a small bounded date window (via
+``start_date``/``end_date``) into a temporary DuckDB, then asserts on the real
+database state. Exact rates are never asserted (the source may revise history) —
+only presence, sane bounds, idempotency, and gap-filling behaviour.
+
+A fixed historical window (June 2026) is used so the dates are inside the
+available range and older than the scanner grace window.
+"""
+
+import datetime
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from eth_defi.currency_api.client import DateRates
+from eth_defi.currency_api.database import CurrencyRateDatabase
+from eth_defi.currency_api.scanner import run_incremental_scan
+
+
+def _rates_with_python_dates(db: CurrencyRateDatabase) -> pd.DataFrame:
+    """Return the rates DataFrame with the DuckDB DATE column as ``datetime.date``.
+
+    DuckDB materialises a ``DATE`` column as pandas ``Timestamp`` via ``.df()``;
+    normalise it so set comparisons against ``datetime.date`` literals work.
+    """
+    df = db.get_rates_dataframe()
+    df["date"] = pd.to_datetime(df["date"]).dt.date
+    return df
+
+
+#: Fixed historical scan window, comfortably inside the available range and
+#: older than the default ``unavailable_grace_days``.
+WINDOW_START = datetime.date(2026, 6, 1)
+WINDOW_END = datetime.date(2026, 6, 3)
+
+#: Loose sanity bounds per currency (USD base). The source may revise history,
+#: so we only check the rate is in a plausible range, not an exact value.
+RATE_BOUNDS = {
+    "eur": (0.5, 1.5),
+    "gbp": (0.5, 1.5),
+    "jpy": (50.0, 500.0),
+    "aud": (1.0, 2.5),
+    "btc": (0.0, 1.0),
+    "eth": (0.0, 1.0),
+}
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    """Return a temporary DuckDB path inside the pytest tmp directory."""
+    return tmp_path / "exchange-rates.duckdb"
+
+
+def test_limited_end_to_end_scan(db_path: Path):
+    """Limited real-network end-to-end scan stores and is idempotent.
+
+    1. Run a 3-day scan (2026-06-01..03) for the default currencies into a temp DB.
+    2. Assert every (date, quote) cell is present (3 dates x 6 quotes = 18 rows),
+       the source column is populated, rates are within loose sanity bounds, and
+       there were no transient failures.
+    3. Re-run the identical scan and assert the row count is unchanged (idempotent
+       upsert, no duplicates).
+    """
+
+    # 1. Run a 3-day scan for the default currencies.
+    result = run_incremental_scan(db_path=db_path, start_date=WINDOW_START, end_date=WINDOW_END)
+    try:
+        # 2. Assert completeness, source, bounds and no transient failures.
+        assert result.transient_failures == 0
+        df = _rates_with_python_dates(result.db)
+        assert len(df) == 18  # 3 dates x 6 default quotes
+
+        expected_dates = {WINDOW_START, WINDOW_START + datetime.timedelta(days=1), WINDOW_END}
+        present_pairs = {(row.date, row.quote_currency) for row in df.itertuples()}
+        for date in expected_dates:
+            for quote in RATE_BOUNDS:
+                assert (date, quote) in present_pairs, f"missing {date} {quote}"
+
+        assert set(df["source"].unique()) == {"fawazahmed0"}
+
+        for row in df.itertuples():
+            low, high = RATE_BOUNDS[row.quote_currency]
+            assert low < row.rate < high, f"{row.quote_currency} rate {row.rate} outside {low}..{high}"
+
+        # 3. Re-run the identical scan: idempotent, no duplicate rows.
+        rerun = run_incremental_scan(db_path=db_path, start_date=WINDOW_START, end_date=WINDOW_END)
+        try:
+            assert rerun.db.row_count() == 18
+        finally:
+            rerun.db.close()
+    finally:
+        result.db.close()
+
+
+def test_incremental_gap_fill_and_reconfiguration(db_path: Path):
+    """Completeness-driven resume backfills new dates and newly added currencies.
+
+    1. Scan a partial window (2026-06-01..02) with only EUR and GBP; assert 4 rows.
+    2. Re-run with an extended window (..06-04) and an added currency (JPY); assert
+       the new dates are filled, the new JPY history is backfilled across all four
+       dates, and the original EUR/GBP rows are not duplicated.
+    """
+
+    # 1. Scan a partial window with a reduced currency set.
+    first = run_incremental_scan(
+        db_path=db_path,
+        quote_currencies=("eur", "gbp"),
+        start_date=WINDOW_START,
+        end_date=WINDOW_START + datetime.timedelta(days=1),
+    )
+    try:
+        assert first.db.row_count() == 4  # 2 dates x 2 quotes
+    finally:
+        first.db.close()
+
+    # 2. Re-run with an extended window and an added currency.
+    extended_end = WINDOW_START + datetime.timedelta(days=3)  # 2026-06-04
+    second = run_incremental_scan(
+        db_path=db_path,
+        quote_currencies=("eur", "gbp", "jpy"),
+        start_date=WINDOW_START,
+        end_date=extended_end,
+    )
+    try:
+        df = _rates_with_python_dates(second.db)
+        all_dates = {WINDOW_START + datetime.timedelta(days=i) for i in range(4)}
+
+        # JPY (newly added) is backfilled across all four dates.
+        jpy_dates = {row.date for row in df.itertuples() if row.quote_currency == "jpy"}
+        assert jpy_dates == all_dates
+
+        # EUR/GBP exist for all four dates with no duplication.
+        for quote in ("eur", "gbp"):
+            quote_dates = [row.date for row in df.itertuples() if row.quote_currency == quote]
+            assert sorted(quote_dates) == sorted(all_dates)
+            assert len(quote_dates) == len(set(quote_dates))  # no duplicates
+
+        # Total = 4 dates x 3 quotes.
+        assert second.db.row_count() == 12
+    finally:
+        second.db.close()
+
+
+def test_missing_quote_recorded_not_transient(db_path: Path):
+    """A nonexistent currency is recorded as a permanent gap, not retried forever.
+
+    Uses a real request for a currency code that does not exist in the source
+    (``zzz``) alongside a real one (``eur``), over an old window so the grace
+    window has elapsed.
+
+    1. Scan 2026-06-01..05 for ("eur", "zzz") into a temp DB.
+    2. Assert the run had no transient failures and stored only the real EUR rows.
+    3. Assert each (date, "zzz") cell was recorded in unavailable_rates as a
+       permanent quote gap (so it will not be re-fetched forever).
+    """
+
+    # 1. Scan an old window mixing a real and a nonexistent currency.
+    result = run_incremental_scan(
+        db_path=db_path,
+        quote_currencies=("eur", "zzz"),
+        start_date=WINDOW_START,
+        end_date=WINDOW_START + datetime.timedelta(days=4),  # 2026-06-05
+    )
+    try:
+        # 2. A well-formed document with a missing quote is not a transient failure.
+        assert result.transient_failures == 0
+        assert result.db.row_count() == 5  # 5 dates x 1 present quote (eur)
+
+        # 3. The nonexistent quote is recorded as a permanent gap for every date.
+        unavailable = result.db.get_unavailable_pairs("usd", "fawazahmed0")
+        zzz_dates = {date for date, quote in unavailable if quote == "zzz"}
+        assert len(zzz_dates) == 5
+    finally:
+        result.db.close()
+
+
+def test_transient_attempt_counter(db_path: Path):
+    """The per-date transient-attempt counter persists, resets, and escalates.
+
+    Exercises the bookkeeping the scanner's give-up budget relies on, against a
+    real DuckDB (no mocks). A persistent non-404 failure cannot be forced against
+    the live CDN, so this validates the mechanism directly.
+
+    1. Set and read back a transient-failure count for a date.
+    2. Overwrite it (simulating another failed run) and read the new value.
+    3. Clear it (simulating the date resolving) and assert it is gone.
+    4. Record a give-up as a persistent_error gap and assert it is tracked as
+       unavailable so the scanner would no longer re-fetch it.
+    """
+
+    db = CurrencyRateDatabase(db_path)
+    try:
+        date = datetime.date(2026, 6, 1)
+
+        # 1. Set and read back a count.
+        db.set_transient_attempts(date, "usd", "fawazahmed0", 3)
+        assert db.get_transient_attempts("usd", "fawazahmed0") == {date: 3}
+
+        # 2. Overwrite with a higher count (next failed run).
+        db.set_transient_attempts(date, "usd", "fawazahmed0", 4)
+        assert db.get_transient_attempts("usd", "fawazahmed0") == {date: 4}
+
+        # 3. Clear it once the date resolves.
+        db.clear_transient_attempts(date, "usd", "fawazahmed0")
+        assert db.get_transient_attempts("usd", "fawazahmed0") == {}
+
+        # 4. Give-up recording marks the cell unavailable.
+        db.record_unavailable(date, "usd", "eur", "fawazahmed0", reason="persistent_error")
+        assert (date, "eur") in db.get_unavailable_pairs("usd", "fawazahmed0")
+    finally:
+        db.close()
+
+
+def test_present_and_unavailable_disjoint(db_path: Path):
+    """Storing data for a cell removes any prior gap record (tables stay disjoint).
+
+    Runs against a real DuckDB (no mocks).
+
+    1. Record a (date, quote) as an unavailable gap.
+    2. Upsert real data for the same cell.
+    3. Assert the cell is now present and no longer recorded as unavailable.
+    """
+
+    db = CurrencyRateDatabase(db_path)
+    try:
+        date = datetime.date(2026, 6, 1)
+
+        # 1. Record the cell as a gap.
+        db.record_unavailable(date, "usd", "eur", "fawazahmed0", reason="quote_missing")
+        assert (date, "eur") in db.get_unavailable_pairs("usd", "fawazahmed0")
+
+        # 2. Upsert real data for the same cell.
+        db.upsert_rates(DateRates(date=date, base_currency="usd", source="fawazahmed0", rows=[("eur", 0.9)]))
+
+        # 3. The cell is present and the stale gap row is gone.
+        assert (date, "eur") in db.get_present_pairs("usd", "fawazahmed0")
+        assert (date, "eur") not in db.get_unavailable_pairs("usd", "fawazahmed0")
+    finally:
+        db.close()
+
+
+def test_scan_script_entry_point(db_path: Path, tmp_path: Path):
+    """The scan-currencies.py entry point runs end-to-end as an operator would.
+
+    1. Invoke scripts/currency_api/scan-currencies.py as a subprocess with the
+       date window, currency set and DB path passed via environment variables.
+    2. Assert the process exits 0 and the DuckDB contains the expected rows.
+    """
+
+    # 1. Invoke the script as a subprocess with env-var configuration.
+    repo_root = Path(__file__).resolve().parents[2]
+    script = repo_root / "scripts" / "currency_api" / "scan-currencies.py"
+    assert script.exists(), f"script not found: {script}"
+
+    env = {
+        **os.environ,
+        "DB_PATH": str(db_path),
+        "START_DATE": WINDOW_START.isoformat(),
+        "END_DATE": WINDOW_START.isoformat(),  # single day, keep it tiny
+        "QUOTE_CURRENCIES": "eur,gbp",
+        "LOG_LEVEL": "info",
+    }
+    completed = subprocess.run(
+        [sys.executable, str(script)],
+        env=env,
+        cwd=tmp_path,  # keep logs/ out of the repo tree
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    # 2. Assert clean exit and expected rows on disk.
+    assert completed.returncode == 0, f"script failed: {completed.stderr}"
+    db = CurrencyRateDatabase(db_path)
+    try:
+        assert db.row_count() == 2  # 1 date x 2 quotes
+    finally:
+        db.close()

--- a/tests/currency_api/test_currency_api.py
+++ b/tests/currency_api/test_currency_api.py
@@ -248,18 +248,15 @@ def test_present_and_unavailable_disjoint(db_path: Path):
 
 
 def test_scan_script_entry_point(db_path: Path, tmp_path: Path):
-    """The scan-currencies.py entry point runs end-to-end as an operator would.
+    """The scan-currencies entry point runs end-to-end as an operator would.
 
-    1. Invoke scripts/currency_api/scan-currencies.py as a subprocess with the
-       date window, currency set and DB path passed via environment variables.
+    1. Invoke the ``scan-currencies`` entry point module
+       (``python -m eth_defi.currency_api.cli``) as a subprocess with the date
+       window, currency set and DB path passed via environment variables.
     2. Assert the process exits 0 and the DuckDB contains the expected rows.
     """
 
-    # 1. Invoke the script as a subprocess with env-var configuration.
-    repo_root = Path(__file__).resolve().parents[2]
-    script = repo_root / "scripts" / "currency_api" / "scan-currencies.py"
-    assert script.exists(), f"script not found: {script}"
-
+    # 1. Invoke the entry-point module as a subprocess with env-var configuration.
     env = {
         **os.environ,
         "DB_PATH": str(db_path),
@@ -269,7 +266,7 @@ def test_scan_script_entry_point(db_path: Path, tmp_path: Path):
         "LOG_LEVEL": "info",
     }
     completed = subprocess.run(
-        [sys.executable, str(script)],
+        [sys.executable, "-m", "eth_defi.currency_api.cli"],
         env=env,
         cwd=tmp_path,  # keep logs/ out of the repo tree
         capture_output=True,


### PR DESCRIPTION
## Why

We need free, API-based, daily historical USD exchange rates for a set of named
currencies (EUR, GBP, JPY, AUD, BTC, ETH) for research and backtesting, with no
API key. This adds a reusable `eth_defi.currency_api` module that ingests them
into DuckDB, built so additional rate sources (ECB/Frankfurter, CoinGecko,
on-chain oracles) can be added later behind the same schema via a `source`
column.

Source: the free, no-API-key [fawazahmed0 Exchange API](https://github.com/fawazahmed0/exchange-api).
One request per date returns the base currency against ~200 fiat and crypto
currencies, so all named quotes come from a single endpoint, with a
jsDelivr → Cloudflare Pages host fallback.

## Lessons learnt

- **Resume must be completeness-driven, not `MAX(date)`-driven.** A naive
  high-water-mark resume permanently skips mid-history holes and never backfills
  newly added currencies. The scanner instead computes the missing
  `(date, quote)` set from the stored data and a quote-level gap table.
- **Distinguish "permanently missing" from "retry later".** Only a 404 on both
  hosts (or a missing quote in a well-formed body, after a grace window) is
  recorded as a permanent gap; transient errors are retried and surfaced as a
  non-zero exit. A per-date transient-failure budget (`MAX_TRANSIENT_ATTEMPTS`,
  default 5) stops a genuinely stuck date from retrying/alerting forever, after
  which it is recorded with reason `persistent_error`.
- **Keep `exchange_rates` and the gap table mutually exclusive.** Upserting data
  for a cell deletes any stale gap row, so a cell is never both present and
  unavailable.
- **DuckDB `DATE` materialises as pandas `Timestamp` via `.df()`** but as
  `datetime.date` via `.fetchall()` — normalise in tests when comparing.
- Worktrees use the parent repo's editable install, so run with
  `PYTHONPATH="$(pwd):$PYTHONPATH"` and the parent venv.

## Summary

- New `eth_defi/currency_api/` module: `constants`, `session` (retry/backoff),
  `client` (`fetch_rates_for_date` with host fallback and outcome
  classification), `database` (`CurrencyRateDatabase` over DuckDB:
  `exchange_rates`, quote-level `unavailable_rates`, `fetch_attempts`),
  `scanner` (`run_incremental_scan` — completeness-driven, threaded fetch,
  single-writer phase), and `cli` (`main`).
- `scan-currencies` Poetry console entry point (`[tool.poetry.scripts]` →
  `eth_defi.currency_api.cli:main`), env-driven (`DB_PATH`, `BASE_CURRENCY`,
  `QUOTE_CURRENCIES`, `START_DATE`/`END_DATE`, `MAX_WORKERS`,
  `REFETCH_TAIL_DAYS`, `UNAVAILABLE_GRACE_DAYS`, `MAX_TRANSIENT_ATTEMPTS`,
  `SOURCE`); exits non-zero on transient failures. Also runnable as
  `python -m eth_defi.currency_api.cli`.
- DuckDB schema carries a `source` column in the primary key for future
  multi-source support. Default currencies: EUR, GBP, JPY, AUD, BTC, ETH vs USD;
  fully reconfigurable, with new currencies backfilled automatically.
- Docs: `docs/source/api/currency_api/index.rst` (+ api index cross-ref),
  `eth_defi/currency_api/README-currency-api.md` (lives inside the submodule
  alongside the other module READMEs, registered in `CLAUDE.md`), and a
  CHANGELOG entry.
- Tests: `tests/currency_api/` — black-box, real-network, no-mock integration
  tests (limited end-to-end scan, incremental gap-fill + currency
  reconfiguration, missing-quote recording, table-disjointness, transient
  attempt counter, and the entry point via `python -m eth_defi.currency_api.cli`).

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
