### PR TITLE
feat: add currency rates to all-chain vault scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- feat: Run the `eth_defi.currency_api` exchange-rate fetcher as a default-on `scan-vaults-all-chains` scheduled item, with a built-in 24h cycle, pipeline-local DuckDB path, backup coverage, configurable `CURRENCY_API_*` environment overrides and best-effort failure handling so currency API outages do not stop vault scans (2026-06-30)
+
 - feat: Add `eth_defi.currency_api` — incremental historical exchange rate ingestion into DuckDB from the free, no-API-key fawazahmed0 Exchange API. Scans a configurable set of named currencies (default EUR, GBP, JPY, AUD, BTC, ETH against USD) with completeness-driven resume, a quote-level gap table, jsDelivr→pages.dev host fallback, a per-date transient-failure budget, and a `source` column for future multi-source support. Includes a `scan-currencies` Poetry console entry point, a separate `filter_known_bad_rates()` cleaning step for documented upstream source glitches, and black-box integration tests (2026-06-29)
 
 - feat: Add Tokenised GBP (tGBP) — BCP Technologies' FCA-registered, GBP-pegged stablecoin — to stablecoin classification, rich metadata YAML, news feed and logo, so tGBP-denominated vaults are recognised by `is_stablecoin_like()` and survive `filter_vaults_by_stablecoin()` across Ethereum, Base, Polygon, BNB Chain and Avalanche (2026-06-29)

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -35,30 +35,29 @@ from filelock import Timeout as FileLockTimeout
 
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.core3.constants import resolve_core3_database_path
-from eth_defi.feed.database import resolve_feed_database_path
-from eth_defi.version_info import VersionInfo
 from eth_defi.core3.scanner import scan_projects as core3_scan_projects
 from eth_defi.core3.session import create_core3_session
+from eth_defi.currency_api.constants import (
+    CURRENCY_API_DATABASE,
+    DEFAULT_BASE_CURRENCY,
+    DEFAULT_QUOTE_CURRENCIES,
+    SOURCE_NAME,
+)
+from eth_defi.currency_api.scanner import run_incremental_scan as currency_run_incremental_scan
 from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS, create_vault_instance
 from eth_defi.erc_4626.lead_scan_core import scan_leads
-from eth_defi.grvt.constants import GRVT_CHAIN_ID
-from eth_defi.grvt.daily_metrics import GRVTDailyMetricsDatabase
+from eth_defi.feed.database import resolve_feed_database_path
 from eth_defi.grvt.daily_metrics import run_daily_scan as grvt_run_daily_scan
 from eth_defi.grvt.vault_data_export import merge_into_vault_database as grvt_merge_vault_db
-from eth_defi.hyperliquid.constants import HYPERCORE_CHAIN_ID
-from eth_defi.hyperliquid.daily_metrics import HyperliquidDailyMetricsDatabase
-from eth_defi.hyperliquid.daily_metrics import run_daily_scan as hyperliquid_run_daily_scan
-from eth_defi.hyperliquid.session import create_hyperliquid_session
-from eth_defi.hyperliquid.vault_data_export import merge_into_vault_database as hyperliquid_merge_vault_db
-from eth_defi.hypersync.utils import configure_hypersync_from_env
-from eth_defi.lighter.constants import LIGHTER_CHAIN_ID
-from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase
-from eth_defi.lighter.daily_metrics import run_daily_scan as lighter_run_daily_scan
-from eth_defi.lighter.session import create_lighter_session
-from eth_defi.lighter.vault_data_export import merge_into_vault_database as lighter_merge_vault_db
 from eth_defi.hibachi.constants import HIBACHI_DAILY_METRICS_DATABASE
 from eth_defi.hibachi.daily_metrics import run_daily_scan as hibachi_run_daily_scan
 from eth_defi.hibachi.vault_data_export import merge_into_vault_database as hibachi_merge_vault_db
+from eth_defi.hyperliquid.daily_metrics import run_daily_scan as hyperliquid_run_daily_scan
+from eth_defi.hyperliquid.session import create_hyperliquid_session
+from eth_defi.hypersync.utils import configure_hypersync_from_env
+from eth_defi.lighter.daily_metrics import run_daily_scan as lighter_run_daily_scan
+from eth_defi.lighter.session import create_lighter_session
+from eth_defi.lighter.vault_data_export import merge_into_vault_database as lighter_merge_vault_db
 from eth_defi.provider.broken_provider import verify_archive_node
 from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
 from eth_defi.token import TokenDiskCache
@@ -66,11 +65,14 @@ from eth_defi.utils import setup_console_logging, wait_other_writers
 from eth_defi.vault.historical import scan_historical_prices_to_parquet
 from eth_defi.vault.post_processing import run_post_processing, validate_top_vaults_config
 from eth_defi.vault.vaultdb import DEFAULT_READER_STATE_DATABASE, DEFAULT_UNCLEANED_PRICE_DATABASE, DEFAULT_VAULT_DATABASE, get_pipeline_data_dir
+from eth_defi.version_info import VersionInfo
 
 #: How many days of backups to keep
 BACKUP_RETENTION_DAYS = int(os.environ.get("BACKUP_RETENTION_DAYS", "7"))
 
 CORE3_PROTOCOL_NAME = "Core3"
+CURRENCY_RATES_PROTOCOL_NAME = "CurrencyRates"
+CURRENCY_RATES_DEFAULT_CYCLE = datetime.timedelta(hours=24)
 
 logger = logging.getLogger(__name__)
 
@@ -121,6 +123,24 @@ def parse_scan_cycles(cycles_str: str) -> dict[str, datetime.timedelta]:
     return result
 
 
+def ensure_default_scan_cycles(cycle_overrides: dict[str, datetime.timedelta]) -> dict[str, datetime.timedelta]:
+    """Apply built-in per-item scan cycle defaults.
+
+    Currency rates are a daily reference data feed. Keep them on a 24h
+    cycle even if the operator sets a shorter ``DEFAULT_CYCLE`` for vault
+    sources, unless ``SCAN_CYCLES`` explicitly overrides
+    ``CurrencyRates``.
+
+    :param cycle_overrides:
+        Parsed operator cycle overrides.
+    :return:
+        Copy of the overrides with built-in defaults applied.
+    """
+    result = dict(cycle_overrides)
+    result.setdefault(CURRENCY_RATES_PROTOCOL_NAME, CURRENCY_RATES_DEFAULT_CYCLE)
+    return result
+
+
 def format_duration(td: datetime.timedelta) -> str:
     """Format a timedelta as a human-friendly duration string.
 
@@ -162,12 +182,31 @@ def should_scan_core3(skip_core3: bool, core3_api_key: str | None) -> bool:
     return True
 
 
+def should_scan_currency_rates(skip_currency_rates: bool) -> bool:
+    """Determine whether currency rate scanning should run.
+
+    Currency rates use a public, no-auth data source, so they are
+    default-on in the all-chain vault pipeline. Operators can disable
+    the fetcher with ``SKIP_CURRENCY_RATES=true``.
+
+    :param skip_currency_rates:
+        Whether the operator explicitly disabled currency rate scans.
+    :return:
+        ``True`` if currency rates should be added to the scheduled item list.
+    """
+    if skip_currency_rates:
+        logger.info("SKIP_CURRENCY_RATES=true - currency rate scan disabled")
+        return False
+    return True
+
+
 def build_active_protocols(
     scan_hypercore: bool,
     scan_grvt: bool,
     scan_lighter: bool,
     scan_hibachi: bool,
     scan_core3: bool,
+    scan_currency_rates: bool,
 ) -> list[str]:
     """Build scheduled non-EVM scan item names.
 
@@ -185,6 +224,8 @@ def build_active_protocols(
         Include Hibachi native vaults.
     :param scan_core3:
         Include Core3 enrichment data.
+    :param scan_currency_rates:
+        Include daily currency exchange rates.
     :return:
         Scheduled non-EVM scan item names.
     """
@@ -199,6 +240,8 @@ def build_active_protocols(
         all_protocols.append("Hibachi")
     if scan_core3:
         all_protocols.append(CORE3_PROTOCOL_NAME)
+    if scan_currency_rates:
+        all_protocols.append(CURRENCY_RATES_PROTOCOL_NAME)
     return all_protocols
 
 
@@ -1151,6 +1194,152 @@ def scan_core3_fn(
     return result
 
 
+def _parse_optional_date_env(name: str) -> datetime.date | None:
+    """Parse an optional ``YYYY-MM-DD`` environment variable.
+
+    :param name:
+        Environment variable name.
+    :return:
+        Parsed date, or ``None`` when the variable is unset or empty.
+    """
+    value = os.environ.get(name, "").strip()
+    if not value:
+        return None
+    return datetime.date.fromisoformat(value)
+
+
+def _read_currency_quote_currencies() -> tuple[str, ...]:
+    """Read currency rate quote configuration from environment variables.
+
+    The all-chain scanner accepts prefixed ``CURRENCY_API_*`` variables so
+    operators can configure this embedded fetcher without colliding with
+    other pipeline scripts. It also falls back to the standalone
+    ``scan-currencies`` ``QUOTE_CURRENCIES`` variable for compatibility.
+
+    :return:
+        Lower-cased quote currency tuple.
+    """
+    quotes_str = os.environ.get("CURRENCY_API_QUOTE_CURRENCIES") or os.environ.get("QUOTE_CURRENCIES", "")
+    quotes_str = quotes_str.strip()
+    if not quotes_str:
+        return DEFAULT_QUOTE_CURRENCIES
+    return tuple(q.strip().lower() for q in quotes_str.split(",") if q.strip())
+
+
+def resolve_currency_api_database_path(data_dir: Path | None = None) -> Path:
+    """Resolve the embedded currency-rate DuckDB database path.
+
+    The all-chain scanner uses a prefixed path variable to avoid
+    collisions with other scripts that already consume ``DB_PATH``.
+    Without an override the database is colocated with the vault pipeline
+    files, making backups and deployment volumes predictable.
+
+    :param data_dir:
+        Pipeline data directory. ``None`` falls back to the standalone
+        currency API default path.
+    :return:
+        Path from ``CURRENCY_API_DB_PATH`` or ``CURRENCY_API_DATABASE_PATH``,
+        then ``data_dir / "exchange-rates.duckdb"``, then the standalone
+        default.
+    """
+    path = os.environ.get("CURRENCY_API_DB_PATH") or os.environ.get("CURRENCY_API_DATABASE_PATH")
+    if path:
+        return Path(path).expanduser()
+    if data_dir is not None:
+        return data_dir / "exchange-rates.duckdb"
+    return CURRENCY_API_DATABASE
+
+
+def scan_currency_rates_fn(
+    db_path: Path,
+    max_workers: int = 8,
+) -> ChainResult:
+    """Scan daily currency exchange rates.
+
+    This is a best-effort auxiliary data fetch for the vault pipeline.
+    Failures are logged and intentionally downgraded to a successful
+    :class:`ChainResult` so an exchange-rate source outage does not stop
+    vault discovery, price scanning, or post-processing.
+
+    Environment variables mirror
+    :py:mod:`eth_defi.currency_api.cli`, with ``CURRENCY_API_*`` aliases
+    preferred by this embedded scanner:
+
+    - ``CURRENCY_API_BASE_CURRENCY`` / ``BASE_CURRENCY``
+    - ``CURRENCY_API_QUOTE_CURRENCIES`` / ``QUOTE_CURRENCIES``
+    - ``CURRENCY_API_START_DATE`` / ``START_DATE``
+    - ``CURRENCY_API_END_DATE`` / ``END_DATE``
+    - ``CURRENCY_API_REFETCH_TAIL_DAYS`` / ``REFETCH_TAIL_DAYS``
+    - ``CURRENCY_API_UNAVAILABLE_GRACE_DAYS`` / ``UNAVAILABLE_GRACE_DAYS``
+    - ``CURRENCY_API_MAX_TRANSIENT_ATTEMPTS`` / ``MAX_TRANSIENT_ATTEMPTS``
+    - ``CURRENCY_API_SOURCE`` / ``SOURCE``
+
+    :param db_path:
+        DuckDB path for exchange rates.
+    :param max_workers:
+        Number of threaded date fetchers.
+    :return:
+        Successful result even when the underlying fetcher fails.
+    """
+    result = ChainResult(name=CURRENCY_RATES_PROTOCOL_NAME, status="running")
+    start_time = time.time()
+
+    def _get_env(name: str, fallback_name: str, default: str) -> str:
+        return os.environ.get(name) or os.environ.get(fallback_name, default)
+
+    db = None
+
+    try:
+        scan_result = currency_run_incremental_scan(
+            db_path=db_path,
+            base_currency=_get_env("CURRENCY_API_BASE_CURRENCY", "BASE_CURRENCY", DEFAULT_BASE_CURRENCY).strip().lower(),
+            quote_currencies=_read_currency_quote_currencies(),
+            start_date=_parse_optional_date_env("CURRENCY_API_START_DATE") or _parse_optional_date_env("START_DATE"),
+            end_date=_parse_optional_date_env("CURRENCY_API_END_DATE") or _parse_optional_date_env("END_DATE"),
+            source=_get_env("CURRENCY_API_SOURCE", "SOURCE", SOURCE_NAME).strip(),
+            max_workers=max_workers,
+            refetch_tail_days=int(_get_env("CURRENCY_API_REFETCH_TAIL_DAYS", "REFETCH_TAIL_DAYS", "3")),
+            unavailable_grace_days=int(_get_env("CURRENCY_API_UNAVAILABLE_GRACE_DAYS", "UNAVAILABLE_GRACE_DAYS", "2")),
+            max_transient_attempts=int(_get_env("CURRENCY_API_MAX_TRANSIENT_ATTEMPTS", "MAX_TRANSIENT_ATTEMPTS", "5")),
+        )
+        db = scan_result.db
+        result.vault_scan_ok = True
+        result.price_scan_ok = None
+        result.price_rows = scan_result.rows_upserted
+
+        logger.info(
+            "CurrencyRates: fetched %d dates, upserted %d rows, unavailable dates=%d, transient failures=%d",
+            scan_result.dates_requested,
+            scan_result.rows_upserted,
+            scan_result.dates_unavailable,
+            scan_result.transient_failures,
+        )
+        if scan_result.transient_failures:
+            logger.warning(
+                "CurrencyRates: %d dates failed transiently; ignoring in the vault pipeline and retrying on the next 24h cycle",
+                scan_result.transient_failures,
+            )
+            result.error = f"{scan_result.transient_failures} transient currency rate failures ignored"
+        result.status = "success"
+    except Exception as e:
+        logger.warning(
+            "CurrencyRates: scan failed and will be ignored by the vault pipeline: %s",
+            e,
+            exc_info=True,
+        )
+        result.status = "success"
+        result.vault_scan_ok = True
+        result.price_scan_ok = None
+        result.error = f"ignored failure: {e}"
+        result.traceback_str = traceback.format_exc()
+    finally:
+        if db is not None:
+            db.close()
+
+    result.duration = time.time() - start_time
+    return result
+
+
 def _load_last_timestamps(uncleaned_price_path: Path | None = None) -> dict[str, str]:
     """Load the last data timestamp per chain from the uncleaned parquet.
 
@@ -1348,8 +1537,10 @@ def run_scan_tick(
     scan_lighter: bool,
     scan_hibachi: bool,
     scan_core3: bool,
+    scan_currency_rates: bool,
     max_workers: int,
     core3_max_workers: int,
+    currency_api_max_workers: int,
     frequency: str,
     retry_count: int,
     skip_post_processing: bool,
@@ -1379,6 +1570,7 @@ def run_scan_tick(
     core3_fetch_sections: bool = True,
     hypersync_concurrency: int | None = None,
     feed_db_path: Path | None = None,
+    currency_api_db_path: Path | None = None,
 ) -> dict[str, ChainResult]:
     """Execute one scan tick: EVM chains + native protocols + post-processing.
 
@@ -1403,6 +1595,9 @@ def run_scan_tick(
         Path to the vault post feed DuckDB used to enrich the top-vaults
         JSON with curator metadata and recent feed entries. Forwarded to
         :py:func:`~eth_defi.vault.post_processing.run_post_processing`.
+
+    :param currency_api_db_path:
+        Path to the currency API exchange-rate DuckDB.
     """
     # Back up critical pipeline files before any scanning
     backup_pipeline_files(backup_files=bkp_files, backup_dir=bkp_dir)
@@ -1565,6 +1760,33 @@ def run_scan_tick(
             logger.error("Core3: FAILED - %s", r.error)
         print_dashboard(results, display_order, uncleaned_price_path=uncleaned_price_path)
 
+    if scan_currency_rates and CURRENCY_RATES_PROTOCOL_NAME in active_protocols:
+        logger.info("Scanning CurrencyRates (daily exchange rates)")
+        try:
+            results[CURRENCY_RATES_PROTOCOL_NAME] = scan_currency_rates_fn(
+                db_path=currency_api_db_path or resolve_currency_api_database_path(),
+                max_workers=currency_api_max_workers,
+            )
+        except Exception as e:
+            logger.warning(
+                "CurrencyRates scan crashed with unhandled exception and will be ignored: %s",
+                e,
+                exc_info=True,
+            )
+            results[CURRENCY_RATES_PROTOCOL_NAME] = ChainResult(
+                name=CURRENCY_RATES_PROTOCOL_NAME,
+                status="success",
+                vault_scan_ok=True,
+                price_scan_ok=None,
+                error=f"ignored failure: {e}",
+                traceback_str=traceback.format_exc(),
+            )
+        r = results[CURRENCY_RATES_PROTOCOL_NAME]
+        logger.info("CurrencyRates: SUCCESS - %d rows", r.price_rows or 0)
+        if on_item_success:
+            on_item_success(CURRENCY_RATES_PROTOCOL_NAME)
+        print_dashboard(results, display_order, uncleaned_price_path=uncleaned_price_path)
+
     # Retry passes - retry failed EVM chains (native protocols are not retried)
     evm_chain_names = {c.name for c in chains}
     for attempt in range(1, retry_count + 1):
@@ -1707,6 +1929,8 @@ def main():
     scan_hibachi = os.environ.get("SCAN_HIBACHI", "false").lower() == "true"
     skip_core3 = os.environ.get("SKIP_CORE3", "false").lower() == "true"
     scan_core3 = should_scan_core3(skip_core3=skip_core3, core3_api_key=os.environ.get("CORE3_API_KEY"))
+    skip_currency_rates = os.environ.get("SKIP_CURRENCY_RATES", "false").lower() == "true"
+    scan_currency_rates = should_scan_currency_rates(skip_currency_rates=skip_currency_rates)
     force_rescan = os.environ.get("FORCE_RESCAN", "false").lower() == "true"
     max_workers = int(os.environ.get("MAX_WORKERS", "50"))
     # Pipeline default is 1 (sequential) to avoid API pressure when scanning
@@ -1716,6 +1940,7 @@ def main():
     hypersync_concurrency = int(os.environ.get("HYPERSYNC_CONCURRENCY", "1"))
     core3_max_workers = int(os.environ.get("CORE3_MAX_WORKERS", "8"))
     core3_fetch_sections = os.environ.get("CORE3_FETCH_SECTIONS", "true").lower() == "true"
+    currency_api_max_workers = int(os.environ.get("CURRENCY_API_MAX_WORKERS", "8"))
     frequency = os.environ.get("FREQUENCY", "1h")
     skip_post_processing = os.environ.get("SKIP_POST_PROCESSING", "false").lower() == "true"
     skip_cleaning = os.environ.get("SKIP_CLEANING", "false").lower() == "true"
@@ -1739,7 +1964,7 @@ def main():
     looped_mode = loop_interval > 0
 
     if looped_mode:
-        cycle_overrides = parse_scan_cycles(os.environ.get("SCAN_CYCLES", ""))
+        cycle_overrides = ensure_default_scan_cycles(parse_scan_cycles(os.environ.get("SCAN_CYCLES", "")))
         default_cycle = parse_duration(os.environ.get("DEFAULT_CYCLE", "24h"))
         logger.info("Looped mode: tick every %ds, cycles=%s, default=%s", loop_interval, cycle_overrides, default_cycle)
         if max_cycles > 0:
@@ -1761,6 +1986,7 @@ def main():
     hyperliquid_db_path = data_dir / "hyperliquid-vaults.duckdb"
     hyperliquid_hf_db_path = data_dir / "hyperliquid-vaults-hf.duckdb"
     grvt_db_path = data_dir / "grvt-vaults.duckdb"
+    currency_api_db_path = resolve_currency_api_database_path(data_dir=data_dir)
 
     # Core3 risk intelligence database path — resolved from env var or default constant.
     core3_db_path = resolve_core3_database_path()
@@ -1770,7 +1996,18 @@ def main():
     # export reads the same database the feed collector writes.
     feed_db_path = resolve_feed_database_path()
 
-    bkp_files = [uncleaned_price_path, reader_state_path, vault_db_path, hyperliquid_db_path, hyperliquid_hf_db_path, grvt_db_path, lighter_db_path, hibachi_db_path, core3_db_path]
+    bkp_files = [
+        uncleaned_price_path,
+        reader_state_path,
+        vault_db_path,
+        hyperliquid_db_path,
+        hyperliquid_hf_db_path,
+        grvt_db_path,
+        lighter_db_path,
+        hibachi_db_path,
+        core3_db_path,
+        currency_api_db_path,
+    ]
 
     # Test mode - filter chains if TEST_CHAINS is set
     disable_chains_str = os.environ.get("DISABLE_CHAINS")
@@ -1786,7 +2023,7 @@ def main():
     version_info = VersionInfo.read_docker_version()
     logger.info("Docker image version: tag=%s, commit=%s", version_info.tag, version_info.commit_hash)
     logger.info(
-        "SCAN_PRICES: %s, SCAN_HYPERCORE: %s, SCAN_GRVT: %s, SCAN_LIGHTER: %s, SCAN_HIBACHI: %s, SKIP_CORE3: %s, CORE3: %s, RETRY_COUNT: %d, MAX_WORKERS: %d, CORE3_MAX_WORKERS: %d, FREQUENCY: %s",
+        "SCAN_PRICES: %s, SCAN_HYPERCORE: %s, SCAN_GRVT: %s, SCAN_LIGHTER: %s, SCAN_HIBACHI: %s, SKIP_CORE3: %s, CORE3: %s, SKIP_CURRENCY_RATES: %s, CURRENCY_RATES: %s, RETRY_COUNT: %d, MAX_WORKERS: %d, CORE3_MAX_WORKERS: %d, CURRENCY_API_MAX_WORKERS: %d, FREQUENCY: %s",
         scan_prices,
         scan_hypercore,
         scan_grvt,
@@ -1794,13 +2031,17 @@ def main():
         scan_hibachi,
         skip_core3,
         scan_core3,
+        skip_currency_rates,
+        scan_currency_rates,
         retry_count,
         max_workers,
         core3_max_workers,
+        currency_api_max_workers,
         frequency,
     )
     logger.info("PIPELINE_DATA_DIR: %s", data_dir)
     logger.info("Feed post database: %s (exists=%s)", feed_db_path, feed_db_path.exists())
+    logger.info("Currency rate database: %s (exists=%s)", currency_api_db_path, currency_api_db_path.exists())
     if skip_post_processing:
         logger.info("SKIP_POST_PROCESSING: true")
     if test_chain_names:
@@ -1869,6 +2110,7 @@ def main():
         scan_lighter=scan_lighter,
         scan_hibachi=scan_hibachi,
         scan_core3=scan_core3,
+        scan_currency_rates=scan_currency_rates,
     )
 
     # Pre-compute human-readable cycle intervals for all items
@@ -1892,9 +2134,11 @@ def main():
         scan_lighter=scan_lighter,
         scan_hibachi=scan_hibachi,
         scan_core3=scan_core3,
+        scan_currency_rates=scan_currency_rates,
         max_workers=max_workers,
         hypersync_concurrency=hypersync_concurrency,
         core3_max_workers=core3_max_workers,
+        currency_api_max_workers=currency_api_max_workers,
         frequency=frequency,
         retry_count=retry_count,
         skip_post_processing=skip_post_processing,
@@ -1920,6 +2164,7 @@ def main():
         core3_db_path=core3_db_path,
         core3_fetch_sections=core3_fetch_sections,
         feed_db_path=feed_db_path,
+        currency_api_db_path=currency_api_db_path,
     )
 
     # Clear cycle state on disc so the first tick rescans everything.

--- a/tests/vault/test_scan_all_chains_core3.py
+++ b/tests/vault/test_scan_all_chains_core3.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+from eth_defi.currency_api.constants import CURRENCY_API_DATABASE, DEFAULT_QUOTE_CURRENCIES
+from eth_defi.currency_api.scanner import ScanResult
 from eth_defi.vault import scan_all_chains
 from eth_defi.vault.scan_all_chains import ChainResult
 
@@ -23,9 +25,97 @@ def test_core3_is_scheduled_by_default_with_api_key():
         scan_lighter=False,
         scan_hibachi=False,
         scan_core3=scan_core3,
+        scan_currency_rates=False,
     )
 
     assert protocols == ["Core3"]
+
+
+def test_currency_rates_are_scheduled_by_default():
+    """Currency rates are default-on because the data source needs no API key."""
+    assert scan_all_chains.should_scan_currency_rates(skip_currency_rates=False) is True
+
+    protocols = scan_all_chains.build_active_protocols(
+        scan_hypercore=False,
+        scan_grvt=False,
+        scan_lighter=False,
+        scan_hibachi=False,
+        scan_core3=False,
+        scan_currency_rates=True,
+    )
+
+    assert protocols == [scan_all_chains.CURRENCY_RATES_PROTOCOL_NAME]
+
+
+def test_skip_currency_rates_disables_currency_rates(caplog: pytest.LogCaptureFixture):
+    """``SKIP_CURRENCY_RATES=true`` disables currency-rate scans."""
+    caplog.set_level(logging.INFO)
+
+    assert scan_all_chains.should_scan_currency_rates(skip_currency_rates=True) is False
+    assert "SKIP_CURRENCY_RATES=true" in caplog.text
+
+
+def test_currency_rate_helpers_read_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Currency-rate helper functions honour prefixed environment variables.
+
+    Steps:
+
+    1. Assert defaults are used when no environment variables are configured.
+    2. Assert prefixed variables override standalone ``scan-currencies`` names.
+    3. Assert dates are parsed as ``datetime.date``.
+    """
+    for name in (
+        "CURRENCY_API_DB_PATH",
+        "CURRENCY_API_DATABASE_PATH",
+        "CURRENCY_API_QUOTE_CURRENCIES",
+        "QUOTE_CURRENCIES",
+        "CURRENCY_API_START_DATE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    assert scan_all_chains.resolve_currency_api_database_path() == CURRENCY_API_DATABASE
+    assert scan_all_chains.resolve_currency_api_database_path(tmp_path) == tmp_path / "exchange-rates.duckdb"
+    assert scan_all_chains._read_currency_quote_currencies() == DEFAULT_QUOTE_CURRENCIES
+    assert scan_all_chains._parse_optional_date_env("CURRENCY_API_START_DATE") is None
+
+    monkeypatch.setenv("QUOTE_CURRENCIES", "eur, gbp")
+    monkeypatch.setenv("CURRENCY_API_QUOTE_CURRENCIES", "JPY, aud, btc")
+    monkeypatch.setenv("CURRENCY_API_DATABASE_PATH", str(tmp_path / "fallback.duckdb"))
+    monkeypatch.setenv("CURRENCY_API_DB_PATH", str(tmp_path / "rates.duckdb"))
+    monkeypatch.setenv("CURRENCY_API_START_DATE", "2026-06-30")
+
+    assert scan_all_chains._read_currency_quote_currencies() == ("jpy", "aud", "btc")
+    assert scan_all_chains.resolve_currency_api_database_path(tmp_path) == tmp_path / "rates.duckdb"
+    assert scan_all_chains._parse_optional_date_env("CURRENCY_API_START_DATE") == datetime.date(2026, 6, 30)
+
+
+def test_currency_rates_have_24h_default_cycle():
+    """Currency rates keep a daily cycle even if other items use a shorter default."""
+    cycle_overrides = scan_all_chains.ensure_default_scan_cycles({})
+
+    _, due_protocols = scan_all_chains.get_due_items(
+        chain_configs=[],
+        native_protocols=[scan_all_chains.CURRENCY_RATES_PROTOCOL_NAME],
+        cycle_overrides=cycle_overrides,
+        default_cycle=datetime.timedelta(hours=1),
+        state={
+            scan_all_chains.CURRENCY_RATES_PROTOCOL_NAME: (scan_all_chains.native_datetime_utc_now() - datetime.timedelta(hours=23)).isoformat(),
+        },
+    )
+
+    assert due_protocols == []
+
+    _, due_protocols = scan_all_chains.get_due_items(
+        chain_configs=[],
+        native_protocols=[scan_all_chains.CURRENCY_RATES_PROTOCOL_NAME],
+        cycle_overrides=cycle_overrides,
+        default_cycle=datetime.timedelta(hours=1),
+        state={
+            scan_all_chains.CURRENCY_RATES_PROTOCOL_NAME: (scan_all_chains.native_datetime_utc_now() - datetime.timedelta(hours=25)).isoformat(),
+        },
+    )
+
+    assert due_protocols == [scan_all_chains.CURRENCY_RATES_PROTOCOL_NAME]
 
 
 def test_skip_core3_disables_core3():
@@ -140,8 +230,10 @@ def test_run_scan_tick_updates_core3_cycle_state(tmp_path: Path, monkeypatch: py
         scan_lighter=False,
         scan_hibachi=False,
         scan_core3=True,
+        scan_currency_rates=False,
         max_workers=1,
         core3_max_workers=1,
+        currency_api_max_workers=1,
         frequency="1h",
         retry_count=0,
         skip_post_processing=True,
@@ -202,8 +294,10 @@ def test_run_scan_tick_fetches_core3_sections_by_default(tmp_path: Path, monkeyp
         scan_lighter=False,
         scan_hibachi=False,
         scan_core3=True,
+        scan_currency_rates=False,
         max_workers=1,
         core3_max_workers=1,
+        currency_api_max_workers=1,
         frequency="1h",
         retry_count=0,
         skip_post_processing=True,
@@ -227,3 +321,125 @@ def test_run_scan_tick_fetches_core3_sections_by_default(tmp_path: Path, monkeyp
     )
 
     assert captured_kwargs["fetch_sections"] is True
+
+
+def test_scan_currency_rates_fn_success_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """The currency-rate wrapper maps scanner metrics to a best-effort result.
+
+    Steps:
+
+    1. Mock the currency API incremental scanner to return a closeable DB.
+    2. Run the wrapper.
+    3. Assert the row count is exposed and the DB handle is closed.
+    """
+
+    class FakeDb:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    fake_db = FakeDb()
+
+    def fake_currency_run_incremental_scan(**_: object) -> ScanResult:
+        return ScanResult(
+            db=fake_db,
+            dates_requested=2,
+            rows_upserted=12,
+            dates_unavailable=1,
+            transient_failures=1,
+        )
+
+    monkeypatch.setattr(scan_all_chains, "currency_run_incremental_scan", fake_currency_run_incremental_scan)
+
+    result = scan_all_chains.scan_currency_rates_fn(
+        db_path=tmp_path / "exchange-rates.duckdb",
+        max_workers=2,
+    )
+
+    assert result.status == "success"
+    assert result.vault_scan_ok is True
+    assert result.price_scan_ok is None
+    assert result.price_rows == 12
+    assert result.error == "1 transient currency rate failures ignored"
+    assert fake_db.closed is True
+
+
+def test_scan_currency_rates_fn_ignores_scanner_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Underlying currency API failures are downgraded inside the wrapper."""
+
+    def fake_currency_run_incremental_scan(**_: object) -> ScanResult:
+        raise RuntimeError("currency source down")
+
+    monkeypatch.setattr(scan_all_chains, "currency_run_incremental_scan", fake_currency_run_incremental_scan)
+
+    result = scan_all_chains.scan_currency_rates_fn(
+        db_path=tmp_path / "exchange-rates.duckdb",
+        max_workers=2,
+    )
+
+    assert result.status == "success"
+    assert result.vault_scan_ok is True
+    assert result.price_scan_ok is None
+    assert "ignored failure: currency source down" in result.error
+    assert "RuntimeError: currency source down" in result.traceback_str
+
+
+def test_run_scan_tick_ignores_currency_rate_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Currency rate failures do not block the all-chain scan cycle.
+
+    Steps:
+
+    1. Mock the currency-rate wrapper to raise an unexpected error.
+    2. Run a scan tick with only currency rates active.
+    3. Assert the item is treated as successful and its cycle state is advanced.
+    """
+    saved_items: list[str] = []
+
+    def fake_scan_currency_rates_fn(**_: object) -> ChainResult:
+        raise RuntimeError("currency source down")
+
+    monkeypatch.setattr(scan_all_chains, "scan_currency_rates_fn", fake_scan_currency_rates_fn)
+    monkeypatch.setattr(scan_all_chains, "print_dashboard", lambda *_, **__: None)
+
+    results = scan_all_chains.run_scan_tick(
+        chains=[],
+        active_protocols=[scan_all_chains.CURRENCY_RATES_PROTOCOL_NAME],
+        scan_prices=False,
+        scan_hypercore=False,
+        scan_grvt=False,
+        scan_lighter=False,
+        scan_hibachi=False,
+        scan_core3=False,
+        scan_currency_rates=True,
+        max_workers=1,
+        core3_max_workers=1,
+        currency_api_max_workers=1,
+        frequency="1h",
+        retry_count=0,
+        skip_post_processing=True,
+        skip_cleaning=True,
+        skip_top_vaults=True,
+        skip_sparklines=True,
+        skip_metadata=True,
+        skip_data=True,
+        skip_samples=True,
+        vault_db_path=tmp_path / "vault-metadata-db.pickle",
+        uncleaned_price_path=tmp_path / "vault-prices-1h.parquet",
+        reader_state_path=tmp_path / "vault-reader-state-1h.pickle",
+        hyperliquid_db_path=tmp_path / "hyperliquid-vaults.duckdb",
+        hyperliquid_hf_db_path=tmp_path / "hyperliquid-vaults-hf.duckdb",
+        grvt_db_path=tmp_path / "grvt-vaults.duckdb",
+        lighter_db_path=tmp_path / "lighter-pools.duckdb",
+        hibachi_db_path=tmp_path / "hibachi-vaults.duckdb",
+        bkp_files=[],
+        bkp_dir=tmp_path / "backups",
+        core3_db_path=tmp_path / "core3.duckdb",
+        currency_api_db_path=tmp_path / "exchange-rates.duckdb",
+        on_item_success=saved_items.append,
+    )
+
+    result = results[scan_all_chains.CURRENCY_RATES_PROTOCOL_NAME]
+    assert result.status == "success"
+    assert "ignored failure" in result.error
+    assert saved_items == [scan_all_chains.CURRENCY_RATES_PROTOCOL_NAME]


### PR DESCRIPTION
## Why
We need the daily historical exchange-rate ingestion from `eth_defi.currency_api` to run as part of the existing all-chain vault scanning process, not as a separate operator step. The fetcher is best-effort reference data, so outages must not block vault discovery, price scanning, or post-processing.

## Lessons learnt
Claude CLI review found no blocking issues, but highlighted that the realistic failure path and helper environment precedence were cheap to test. The follow-up tests now cover the wrapper success/failure paths, prefixed env override precedence, the skip branch and the 24h cycle behaviour. CurrencyRates intentionally advances cycle state even after ignored failures so a source outage does not retry-loop.

## Summary
- Add `CurrencyRates` as a default-on scheduled item in `scan-vaults-all-chains`, disabled with `SKIP_CURRENCY_RATES=true`.
- Run the currency API incremental scanner on a built-in 24h cycle, with `SCAN_CYCLES=CurrencyRates=...` override support.
- Store the integrated DuckDB at `PIPELINE_DATA_DIR/exchange-rates.duckdb` by default, with `CURRENCY_API_DB_PATH` / `CURRENCY_API_DATABASE_PATH` overrides and backup coverage.
- Add `CURRENCY_API_*` configuration aliases and best-effort failure handling so currency API errors are logged but do not stop the vault pipeline.
- Extend scan-loop tests for scheduling, env resolution, wrapper success/failure and ignored hard failures.

## Related issues and PRs
Continues #1158.

## Unrelated CI and test fixes
None.