### PR TITLE
feat: add Mellow vault discovery support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - fix: Autoretry HyperSync vault scans on server-side rate limiting. The Envio/HyperSync Rust client reports an exhausted request budget as a textual `rate limited by server` error with no HTTP `429`, which slipped past the rate-limit classifier and crashed the whole chain scan instead of being retried. Broaden `is_hypersync_rate_limit_error()` to match the textual form, consolidate four duplicated recoverable-error handlers into a shared `raise_if_recoverable_hypersync_flaky()` helper, and document the required `codex exec --json` background review method (2026-06-28)
 
+- feat: Add initial Mellow Core Vault discovery and adapter support for documented Ethereum, Plasma, Arbitrum and Monad Core factories, including Hypersync factory-event scanning, `mellow_like` routing through the existing vault pipeline, a partial `MellowVault` reader, manual mapping script and focused classification tests (2026-06-30)
+
 - fix: Track and blacklist more depegged stablecoin denominations — apxUSD (~$177.5M nominal vault TVL), StablR EURR/USDR and the Synthetix sUSD rate source. Add an `ambiguous_symbol` flag so shared tickers (`sUSD`, `USDR`) match by contract address only, protecting healthy same-ticker tokens (e.g. YieldFi sUSD, Tangible vs StablR USDR) from being false-blacklisted, and manually flag the unrelated Rezerve.money USD vault that previously rode the USDR symbol match (2026-06-28)
 
 - feat: Add Rich-powered coloured console logging for Docker Compose vault scanner logs, with Docker log autodetection, coloured levels/context, plain file logging, and a smoke script for comparing terminal, forced-colour and Docker output modes (2026-06-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - fix: Autoretry HyperSync vault scans on server-side rate limiting. The Envio/HyperSync Rust client reports an exhausted request budget as a textual `rate limited by server` error with no HTTP `429`, which slipped past the rate-limit classifier and crashed the whole chain scan instead of being retried. Broaden `is_hypersync_rate_limit_error()` to match the textual form, consolidate four duplicated recoverable-error handlers into a shared `raise_if_recoverable_hypersync_flaky()` helper, and document the required `codex exec --json` background review method (2026-06-28)
 
-- feat: Add initial Mellow Core Vault discovery and adapter support for documented Ethereum, Plasma, Arbitrum and Monad Core factories, including Hypersync factory-event scanning, `mellow_like` routing through the existing vault pipeline, a partial `MellowVault` reader, manual mapping script and focused classification tests (2026-06-30)
+- feat: Add Mellow Core Vault discovery and adapter support for documented Ethereum, Plasma, Arbitrum and Monad Core factories, including Hypersync factory-event scanning, `mellow_like` routing through the existing vault pipeline, `MellowVault` metadata/share-price/FeeManager readers, historical price rows, manual mapping script and focused real-chain tests (2026-06-30)
 
 - fix: Track and blacklist more depegged stablecoin denominations — apxUSD (~$177.5M nominal vault TVL), StablR EURR/USDR and the Synthetix sUSD rate source. Add an `ambiguous_symbol` flag so shared tickers (`sUSD`, `USDR`) match by contract address only, protecting healthy same-ticker tokens (e.g. YieldFi sUSD, Tangible vs StablR USDR) from being false-blacklisted, and manually flag the unrelated Rezerve.money USD vault that previously rode the USDR symbol match (2026-06-28)
 

--- a/docs/protocol-research/mellow-vault-architecture-plan.md
+++ b/docs/protocol-research/mellow-vault-architecture-plan.md
@@ -79,7 +79,7 @@ It scans Mellow Core Vault factory `Created(address,uint256,address,bytes)` even
 - `shareManager()`
 - share token metadata
 - registered assets and queue count, where available
-- public Mellow API TVL, where available
+- public Mellow API USD TVL for diagnostics, where available
 
 The production scanner now reuses the same factory topic and decoder helpers,
 but this script remains the operator-facing mapping and diagnostics tool.
@@ -396,8 +396,10 @@ Core properties and methods:
 - `fetch_info()`: return a `MellowVaultInfo` dataclass with all component addresses
 - `fetch_share_token()`: `fetch_erc20_details()` on `shareManager`
 - `fetch_denomination_token()`: base token for valuation, not necessarily the only deposit token
-- `fetch_nav()`: return `None` until a confirmed on-chain Mellow TVL method is
-  implemented
+- `fetch_total_assets()`: return denomination-token TVL as on-chain
+  `fetch_share_price() * fetch_total_supply()`
+- `fetch_nav()`: alias the comparable on-chain `fetch_total_assets()` value and
+  never return public API USD TVL
 - `fetch_portfolio()`: balances of vault plus subvaults, if subvault enumeration is available
 - `get_historical_reader(stateful)`: return `MellowVaultHistoricalReader`
 - `get_flow_manager()`: return `MellowVaultFlowManager`
@@ -415,8 +417,8 @@ Core properties and methods:
 - registered assets
 - subvaults, if discoverable
 - factory address and factory version, if known
-- API metadata, if attached for manual diagnostics. API TVL must not be used as
-  production `fetch_nav()` output.
+- API metadata, if attached for manual diagnostics. API USD TVL must not be
+  used as production `fetch_nav()` output.
 
 ### `VaultBase` abstract surface mapping
 
@@ -438,7 +440,7 @@ names so omissions are easy to review.
 | `get_deposit_manager()` | Return an unsupported deposit manager or raise a clear `NotImplementedError` until active deposits/redeems are implemented. Reading support does not require transaction execution. |
 | `get_historical_reader(stateful)` | Return `MellowVaultHistoricalReader(self, stateful=stateful)`. |
 | `fetch_denomination_token()` | Return the configured/API base token for valuation; preserve all deposit and withdraw tokens separately in `MellowVaultInfo`. |
-| `fetch_nav()` | Return on-chain base-asset NAV only after the TVL method is confirmed. Until then return `None`; do not use public API TVL as production NAV. |
+| `fetch_nav()` | Return the same denomination-token TVL as `fetch_total_assets()`, derived from on-chain share price and total supply; do not use public API USD TVL as production NAV. |
 | `fetch_share_token()` | Return ERC-20 details for tokenised `ShareManager`. For `BasicShareManager`, raise a protocol-specific unsupported error unless the fallback path has been implemented and tested. |
 
 Non-abstract but relevant fee methods:
@@ -544,7 +546,8 @@ For initial integration:
 
 - Treat the API `base_token` or the configured base asset as the `denomination_token`.
 - Preserve all deposit and withdraw assets in `MellowVaultInfo`.
-- Do not assume `fetch_nav()` equals the raw balance of the base asset.
+- Do not assume `fetch_nav()` equals the raw balance of the base asset; it is
+  the on-chain share price multiplied by total share supply.
 - Do not calculate USD TVL from hardcoded stablecoin assumptions in the adapter.
 
 For production on-chain TVL, choose one of these after ABI/source confirmation:
@@ -601,16 +604,17 @@ The `share_price` formula is pinned by fixed-block tests:
 - The real-chain Hypersync integration test samples two later blocks and asserts
   the historical reader writes an increasing share-price series.
 
-Current-state `fetch_nav()` is intentionally unsupported and returns `None`
-until a canonical on-chain TVL method is confirmed. Tests must prove metadata
-and price export paths do not crash when current NAV is `None`; historical rows
-still derive `total_assets` on-chain as `share_price * total_supply`.
+Current-state `fetch_nav()` is intentionally the same on-chain
+denomination-token TVL as `fetch_total_assets()`. Tests must prove the adapter
+does not return public API USD TVL as NAV, and that historical rows derive
+`total_assets` on-chain with the same `share_price * total_supply` identity.
 
 Historical reader phases:
 
 1. Current-state reader:
    - Read share manager, assets, queues and total supply.
-   - Keep API TVL in the manual mapping script only for onboarding diagnostics.
+   - Keep API USD TVL in the manual mapping script only for onboarding diagnostics.
+   - Use on-chain share price and total supply for adapter `NAV`.
 2. Oracle-based historical reader:
    - Decode `ReportHandled` / oracle report events.
    - Sample latest accepted report at or before each historical block.
@@ -705,10 +709,9 @@ Initial focused tests:
   - process a fixed-block read for Lido Earn USD
   - assert absolute values at a fixed Ethereum block
   - pin `priceD18` orientation by cross-checking
-    `share_price * total_supply` against Mellow API TVL or a confirmed on-chain
-    TVL view
-  - prove unsupported/unknown NAV or `total_assets=None` is represented as a
-    `VaultHistoricalRead.errors` entry and does not crash the export path
+    `share_price * total_supply` against adapter `fetch_total_assets()`
+  - prove unavailable oracle/supply reads are represented as
+    `VaultHistoricalRead.errors` entries and do not crash the export path
 - `tests/mellow/test_mellow_flow_events.py`
   - scan pinned deposit/redeem queue event blocks
   - convert to `PendingVaultFlow`
@@ -790,10 +793,10 @@ The manual test must produce tabulated output for:
 - leads discovered from `Factory.Created`
 - metadata rows after component probing
 - price sample rows. In the initial PR these rows contain on-chain
-  `ShareManager.totalSupply()` and API TVL where the factory lead matches the
-  public Mellow API. Oracle-derived share price and denomination-token
-  `total_assets` are covered by the production historical reader and its
-  fixed-block tests.
+  `ShareManager.totalSupply()` and public API USD TVL where the factory lead
+  matches the public Mellow API. Oracle-derived share price and
+  denomination-token `total_assets` are covered by the production historical
+  reader and its fixed-block tests.
 
 Minimum manual assertions:
 
@@ -832,8 +835,9 @@ Minimum manual assertions:
 - Implement component accessors.
 - Implement share token metadata.
 - Implement asset and queue enumeration.
-- Add `fetch_nav()` as `None` until an official on-chain view is found.
-  Do not return public API TVL from the adapter.
+- Add `fetch_total_assets()` and `fetch_nav()` as on-chain
+  `share_price * total_supply`. Do not return public API USD TVL from the
+  adapter.
 - Add the address/share-token downstream audit and fix any code path that treats
   `vault.address` as the ERC-20 share token.
 

--- a/docs/protocol-research/mellow-vault-architecture-plan.md
+++ b/docs/protocol-research/mellow-vault-architecture-plan.md
@@ -5,10 +5,11 @@
 This document records the technical mapping and phased implementation plan for
 Mellow Core Vault support. The initial PR implements factory-led discovery,
 `mellow_like` routing, the `MellowVault` adapter skeleton, share-supply
-historical reads, metadata row support, the activity-filter exemption, API docs
-and the manual mapping script. Oracle-derived TVL/share price and queue flow
-accounting remain explicitly unsupported until fixed-block checks pin those
-semantics.
+historical reads, oracle-derived share price and denomination-token TVL rows,
+metadata row support, the activity-filter exemption, API docs and the manual
+mapping script. Queue flow accounting remains explicitly unsupported until a
+separate queue-address event reader is implemented and fixed-block checks pin
+those semantics.
 
 Mellow Core Vaults should be added as a sibling vault architecture alongside ERC-4626 at the adapter level, but use `ERC4626Feature.mellow_like` as a pipeline compatibility/routing flag.
 
@@ -243,10 +244,11 @@ facts are locked down with verified ABIs and fixed-block checks:
     assuming `topic1`, `topic2` and `topic3`
   - test both the documented layout and reject malformed logs with clear errors
 - Confirmed `priceD18` orientation for Lido Earn USD:
-  - whether it means `shares / assets` or `assets / shares`
-  - how to convert it to `VaultHistoricalRead.share_price`
-  - a fixed-block cross-check where `share_price * total_supply` agrees with
-    Mellow API TVL within a documented tolerance
+  - Mellow reports raw `shares / assets`.
+  - `VaultHistoricalRead.share_price` is human-readable assets per share:
+    `10 ** (share_decimals + 18 - asset_decimals) / priceD18`.
+  - the historical reader samples `Oracle.getReport(denomination_token)` and
+    writes `total_assets = share_price * total_supply`.
 - Confirmed queue event names and event argument order for:
   - deposit request
   - deposit settlement / claim
@@ -433,12 +435,13 @@ Non-abstract but relevant fee methods:
 
 - Override `get_protocol_name()` to return `Mellow`, or make sure the generic
   implementation does not route Mellow through `ERC4626Feature.broken`.
-- Override `get_management_fee()` and `get_performance_fee()` only after fee
-  manager semantics are confirmed.
-- Leave `management_fee` as `None` in historical reads if Mellow protocol fee
-  cannot be honestly mapped to an annual management-fee percentage.
-- Override `has_custom_fees()` once deposit/redeem/performance/protocol fee
-  reading is implemented.
+- Read FeeManager D6 rates with `depositFeeD6()`, `redeemFeeD6()`,
+  `performanceFeeD6()` and `protocolFeeD6()`.
+- Map `protocolFeeD6()` to the shared `management_fee` field because Mellow
+  defines it as an annual time-based protocol fee and the generic schema does
+  not have a separate protocol-fee column.
+- Map `performanceFeeD6()` to `performance_fee`, `depositFeeD6()` to deposit
+  fee and `redeemFeeD6()` to withdraw fee.
 
 ### Detection and adapter routing
 
@@ -498,9 +501,9 @@ possible:
   ERC-4626 ABI assumptions. Treat it as a shared vault-detection envelope, not
   a standards-compliance proof.
 - Metadata row creation must support `mellow_like` without ERC-4626 scan-record
-  assumptions. Add a Mellow branch in `create_vault_scan_record()` or its
-  caller so protocol name, NAV, share token, denomination token, link and
-  `_detection_data` are populated from `MellowVault`.
+  assumptions. Keep Mellow on the same `create_vault_scan_record()` path as
+  ERC-4626 vaults and make the shared logic call only `VaultBase` methods, with
+  defensive fallbacks for optional ERC-4626-only reads like `totalAssets()`.
 
 ### Address and share-token audit
 
@@ -564,29 +567,29 @@ Initial multicalls:
 - `Vault.shareManager()`, if not cached
 - `Vault.oracle()`, if not cached
 - `Vault.feeManager()`, if not cached
-- latest oracle report for the base asset, once method name is confirmed
-- fee manager state for performance/protocol fees, once method names are confirmed
+- latest oracle report for the denomination asset through `Oracle.getReport(asset)`
+- fee manager state for performance/protocol fees
 - risk manager vault balance / limit state, once method names are confirmed
 
 Initial output fields in `VaultHistoricalRead`:
 
-- `share_price`: derive from Mellow oracle report only after confirming whether `priceD18` is `shares / assets` or `assets / shares`
-- `total_assets`: base-asset-denominated TVL if available, otherwise `None` with an error marker
+- `share_price`: derive from Mellow oracle `priceD18`, converted from raw
+  shares-per-raw-asset to human-readable denomination-token assets per share
+- `total_assets`: denomination-token TVL derived as `share_price * total_supply`
 - `total_supply`: share manager total supply converted with share token decimals
-- `performance_fee`: Mellow fee manager value if available
-- `management_fee`: protocol fee if it maps to an annual management-like fee
+- `performance_fee`: Mellow `performanceFeeD6`, converted from D6 to a
+  fractional fee
+- `management_fee`: Mellow `protocolFeeD6`, converted from D6 to a fractional
+  annual management-like fee
 - `max_deposit`: vault or risk manager remaining capacity if available
 - `errors`: explicit reasons for partial reads
 
-The `share_price` formula must be pinned by a fixed-block test:
+The `share_price` formula is pinned by fixed-block tests:
 
-- choose a block where Lido Earn USD has a recent accepted oracle report and
-  non-zero supply
-- read `ShareManager.totalSupply()` at that block
-- derive `share_price` from the oracle report in both possible orientations
-- assert the chosen orientation makes `share_price * total_supply` agree with
-  public Mellow API TVL, or a known on-chain TVL view if one is found
-- document the tolerance and the source of the comparison value
+- Lido Earn USD reads `ShareManager.totalSupply()` and `Oracle.getReport(USDC)`.
+- The direct Anvil test checks the fixed-block share price.
+- The real-chain Hypersync integration test samples two later blocks and asserts
+  the historical reader writes an increasing share-price series.
 
 If current-state `fetch_nav()` is temporarily unsupported, add a test proving
 that `MellowVaultHistoricalReader.process_result()` and the export path do not
@@ -777,9 +780,10 @@ The manual test must produce tabulated output for:
 - leads discovered from `Factory.Created`
 - metadata rows after component probing
 - price sample rows. In the initial PR these rows contain on-chain
-  `ShareManager.totalSupply()`, API TVL where the factory lead matches the
-  public Mellow API, and an explicit unsupported reason for oracle-derived share
-  price.
+  `ShareManager.totalSupply()` and API TVL where the factory lead matches the
+  public Mellow API. Oracle-derived share price and denomination-token
+  `total_assets` are covered by the production historical reader and its
+  fixed-block tests.
 
 Minimum manual assertions:
 

--- a/docs/protocol-research/mellow-vault-architecture-plan.md
+++ b/docs/protocol-research/mellow-vault-architecture-plan.md
@@ -1,19 +1,19 @@
-# Mellow vault architecture integration plan
+# Mellow vault architecture integration plan and status
 
 ## Summary
 
 This document records the technical mapping and phased implementation plan for
 Mellow Core Vault support. The initial PR implements factory-led discovery,
-`mellow_like` routing, the `MellowVault` adapter skeleton, share-supply
+`mellow_like` routing, the `MellowVault` adapter, share-supply
 historical reads, oracle-derived share price and denomination-token TVL rows,
 metadata row support, the activity-filter exemption, API docs and the manual
-mapping script. Queue flow accounting remains explicitly unsupported until a
-separate queue-address event reader is implemented and fixed-block checks pin
-those semantics.
+mapping script. Queue flow accounting and active deposit/redemption transaction
+execution remain explicitly unsupported until a separate queue-address event
+reader is implemented and fixed-block checks pin those semantics.
 
 Mellow Core Vaults should be added as a sibling vault architecture alongside ERC-4626 at the adapter level, but use `ERC4626Feature.mellow_like` as a pipeline compatibility/routing flag.
 
-The adapter should subclass `eth_defi.vault.base.VaultBase` directly:
+The adapter subclasses `eth_defi.vault.base.VaultBase` directly:
 
 - `eth_defi/mellow/vault.py`: `MellowVault`
 - `eth_defi/mellow/historical.py`: `MellowVaultHistoricalReader`
@@ -228,27 +228,35 @@ Required production change:
     while the `mellow_like` exemption prevents the zero counts from silently
     dropping Mellow vaults.
 
-## Pre-implementation gates
+## Implementation gates and status
 
-Do not start the `MellowVault` historical reader or flow reader before these
-facts are locked down with verified ABIs and fixed-block checks:
+The historical reader was implemented only after the ABI, factory-event and
+oracle-price gates below were locked down with verified ABIs and fixed-block
+checks. Queue flow accounting is still gated on queue event decoding and
+fixed-block flow checks.
+
+Resolved gates:
 
 - Canonical verified ABIs for `Vault`, `Factory`, `ShareManager`,
-  `DepositQueue`, `RedeemQueue`, `Oracle`, `FeeManager`, `RiskManager` and
-  `Subvault`.
-- Confirmed `Factory.Created` ABI indexed layout before implementing Hypersync
-  field selection or demux code:
-  - whether `instance`, `version` and `owner` are indexed topics or encoded in
-    `data`
-  - decoder code must assert against the verified ABI layout instead of
-    assuming `topic1`, `topic2` and `topic3`
-  - test both the documented layout and reject malformed logs with clear errors
+  `Oracle`, and `FeeManager`.
+- Confirmed `Factory.Created` ABI layout before implementing Hypersync field
+  selection or demux code:
+  - official docs show `instance`, `version`, `owner` and `initParams` encoded
+    in `data`
+  - decoder also accepts an indexed compatibility layout for defensive parsing
+  - tests cover the documented layout and reject malformed logs with clear
+    errors
 - Confirmed `priceD18` orientation for Lido Earn USD:
   - Mellow reports raw `shares / assets`.
   - `VaultHistoricalRead.share_price` is human-readable assets per share:
     `10 ** (share_decimals + 18 - asset_decimals) / priceD18`.
   - the historical reader samples `Oracle.getReport(denomination_token)` and
     writes `total_assets = share_price * total_supply`.
+
+Remaining queue-flow gates:
+
+- Verified queue ABIs for `DepositQueue`, `RedeemQueue` and signature queue
+  variants.
 - Confirmed queue event names and event argument order for:
   - deposit request
   - deposit settlement / claim

--- a/docs/protocol-research/mellow-vault-architecture-plan.md
+++ b/docs/protocol-research/mellow-vault-architecture-plan.md
@@ -396,7 +396,8 @@ Core properties and methods:
 - `fetch_info()`: return a `MellowVaultInfo` dataclass with all component addresses
 - `fetch_share_token()`: `fetch_erc20_details()` on `shareManager`
 - `fetch_denomination_token()`: base token for valuation, not necessarily the only deposit token
-- `fetch_nav()`: Mellow-specific TVL calculation
+- `fetch_nav()`: return `None` until a confirmed on-chain Mellow TVL method is
+  implemented
 - `fetch_portfolio()`: balances of vault plus subvaults, if subvault enumeration is available
 - `get_historical_reader(stateful)`: return `MellowVaultHistoricalReader`
 - `get_flow_manager()`: return `MellowVaultFlowManager`
@@ -414,7 +415,8 @@ Core properties and methods:
 - registered assets
 - subvaults, if discoverable
 - factory address and factory version, if known
-- API metadata, if attached
+- API metadata, if attached for manual diagnostics. API TVL must not be used as
+  production `fetch_nav()` output.
 
 ### `VaultBase` abstract surface mapping
 
@@ -436,7 +438,7 @@ names so omissions are easy to review.
 | `get_deposit_manager()` | Return an unsupported deposit manager or raise a clear `NotImplementedError` until active deposits/redeems are implemented. Reading support does not require transaction execution. |
 | `get_historical_reader(stateful)` | Return `MellowVaultHistoricalReader(self, stateful=stateful)`. |
 | `fetch_denomination_token()` | Return the configured/API base token for valuation; preserve all deposit and withdraw tokens separately in `MellowVaultInfo`. |
-| `fetch_nav()` | Return on-chain base-asset NAV only after the TVL method is confirmed. Until then raise a clear unsupported exception or return `None` only if downstream non-fatal behaviour is covered by tests. |
+| `fetch_nav()` | Return on-chain base-asset NAV only after the TVL method is confirmed. Until then return `None`; do not use public API TVL as production NAV. |
 | `fetch_share_token()` | Return ERC-20 details for tokenised `ShareManager`. For `BasicShareManager`, raise a protocol-specific unsupported error unless the fallback path has been implemented and tested. |
 
 Non-abstract but relevant fee methods:
@@ -599,16 +601,16 @@ The `share_price` formula is pinned by fixed-block tests:
 - The real-chain Hypersync integration test samples two later blocks and asserts
   the historical reader writes an increasing share-price series.
 
-If current-state `fetch_nav()` is temporarily unsupported, add a test proving
-that `MellowVaultHistoricalReader.process_result()` and the export path do not
-crash when `VaultHistoricalRead.total_assets` or current NAV is `None`; they
-must surface an explicit `errors` value instead.
+Current-state `fetch_nav()` is intentionally unsupported and returns `None`
+until a canonical on-chain TVL method is confirmed. Tests must prove metadata
+and price export paths do not crash when current NAV is `None`; historical rows
+still derive `total_assets` on-chain as `share_price * total_supply`.
 
 Historical reader phases:
 
 1. Current-state reader:
-   - Read share manager, assets, queues, total supply and API TVL.
-   - Useful for onboarding and UI mapping.
+   - Read share manager, assets, queues and total supply.
+   - Keep API TVL in the manual mapping script only for onboarding diagnostics.
 2. Oracle-based historical reader:
    - Decode `ReportHandled` / oracle report events.
    - Sample latest accepted report at or before each historical block.
@@ -830,10 +832,8 @@ Minimum manual assertions:
 - Implement component accessors.
 - Implement share token metadata.
 - Implement asset and queue enumeration.
-- Add `fetch_nav()` as best-effort:
-  - use official on-chain view if found
-  - otherwise raise a clear unsupported exception, or return `None` only after
-    tests prove this is non-fatal for historical reads and exports
+- Add `fetch_nav()` as `None` until an official on-chain view is found.
+  Do not return public API TVL from the adapter.
 - Add the address/share-token downstream audit and fix any code path that treats
   `vault.address` as the ERC-20 share token.
 

--- a/docs/protocol-research/mellow-vault-architecture-plan.md
+++ b/docs/protocol-research/mellow-vault-architecture-plan.md
@@ -1,0 +1,1000 @@
+# Mellow vault architecture integration plan
+
+## Summary
+
+This document records the technical mapping and phased implementation plan for
+Mellow Core Vault support. The initial PR implements factory-led discovery,
+`mellow_like` routing, the `MellowVault` adapter skeleton, share-supply
+historical reads, metadata row support, the activity-filter exemption, API docs
+and the manual mapping script. Oracle-derived TVL/share price and queue flow
+accounting remain explicitly unsupported until fixed-block checks pin those
+semantics.
+
+Mellow Core Vaults should be added as a sibling vault architecture alongside ERC-4626 at the adapter level, but use `ERC4626Feature.mellow_like` as a pipeline compatibility/routing flag.
+
+The adapter should subclass `eth_defi.vault.base.VaultBase` directly:
+
+- `eth_defi/mellow/vault.py`: `MellowVault`
+- `eth_defi/mellow/historical.py`: `MellowVaultHistoricalReader`
+- `eth_defi/mellow/discovery.py`: factory and component discovery
+- `eth_defi/mellow/flow.py`: deposit and redeem queue event support
+
+The initial target vault for validation is Lido Earn USD:
+
+- Vault: `0x014e6DA8F283C4aF65B2AA0f201438680A004452`
+- Share manager / share token: `0x4Ce1ac8F43E0E5BD7A346A98aF777bF8fbeA1981`
+- Public token symbol: `earnUSD`
+- Chain: Ethereum
+
+## Why Mellow is not ERC-4626
+
+Mellow Core Vaults do not expose the standard ERC-4626 accounting surface on the vault contract.
+
+ERC-4626 assumes:
+
+- The vault contract is also usually the ERC-20 share token, or exposes ERC-7575-style share lookup.
+- A single `asset()` denomination token.
+- Standard `totalAssets()`, `convertToAssets()`, `convertToShares()`, `maxDeposit()` calls.
+- Standard `Deposit` and `Withdraw` events are enough for generic discovery and flow reading.
+
+Mellow Core Vaults instead use a modular architecture:
+
+- `Vault`: central coordinator and access-control surface.
+- `ShareManager`: separate share accounting contract; tokenised variants are ERC-20 share tokens.
+- `DepositQueue`: per-asset asynchronous deposit queues.
+- `RedeemQueue`: asynchronous redemption queues.
+- `Oracle`: reports prices and drives queue settlement.
+- `FeeManager`: protocol, performance, deposit, and redeem fees.
+- `RiskManager`: limits, balances, allowed assets, and pending asset accounting.
+- `Subvault`: execution and custody compartments controlled by the vault.
+- Hooks and verifiers: queue hooks and constrained curator execution.
+
+Because user deposits and redeems settle through queues and oracle reports, a generic ERC-4626 reader will miss core state and may read incorrect share price, TVL, and flow status.
+
+Despite this, the production scanner should add and use
+`ERC4626Feature.mellow_like` for compatibility with the existing vault database,
+metadata row and price scanning pipeline. This feature flag is a routing marker,
+not a claim that the contract implements ERC-4626. Any code that sees
+`mellow_like` must instantiate `MellowVault`, not `ERC4626Vault`, and must avoid
+ERC-4626 ABI calls such as `asset()`, `totalAssets()` and `convertToAssets()`.
+
+`ERC4262VaultDetection` should also support Mellow detections even though the
+underlying contract is not ERC-4626. For Mellow, the detection address is the
+Mellow `Vault` proxy address emitted by `Factory.Created`, and
+`features={ERC4626Feature.mellow_like}` is enough to route downstream code. The
+class name remains historical; do not introduce a parallel detection object
+unless the shared pipeline can no longer carry the needed fields.
+
+## Current discovery status
+
+`scripts/mellow/scan-initial-mellow.py` has been added as an initial mapping tool.
+
+It scans Mellow Core Vault factory `Created(address,uint256,address,bytes)` events with Hypersync and enriches results with:
+
+- vault address
+- factory version
+- owner
+- creation block
+- `shareManager()`
+- share token metadata
+- registered assets and queue count, where available
+- public Mellow API TVL, where available
+
+The production scanner now reuses the same factory topic and decoder helpers,
+but this script remains the operator-facing mapping and diagnostics tool.
+
+Open discovery questions:
+
+- Confirm if Base has a deployed Core Vault factory. Mellow Core deployment docs currently document Mainnet, Plasma, Arbitrum and Monad factories used by this integration; broader Mellow product lines are outside this initial scanner scope.
+- Decide whether the production scanner should include only Core Vault factory products or all Mellow API vault product lines.
+- Confirm if older Mellow vault families, e.g. MultiVault / Symbiotic vaults, should use a separate adapter instead of `MellowVault`.
+
+## Alignment with existing event-based lead discovery
+
+The current ERC-4626 scanner uses an event-based baseline to find candidate
+vault contracts before probing them.
+
+Current baseline flow:
+
+1. `eth_defi/erc_4626/discovery_base.py` defines discovery event topics.
+2. Standard baseline topics are ERC-4626 `Deposit` and `Withdraw`.
+3. The baseline has already been extended with protocol-specific deposit-like
+   and withdraw-like events for BrinkVault, Ember, TokenGateway and Royco.
+4. `PotentialVaultMatch` is keyed by the log-emitting contract address.
+5. A lead becomes a candidate only after it has at least one deposit-like event
+   and at least one withdraw-like event:
+   `deposit_count > 0 and withdrawal_count > 0`.
+6. Hypersync and JSON-RPC backends both use the same topic map:
+   - `HypersyncVaultDiscover.build_query()` scans all configured topic0 values
+     without restricting addresses.
+   - `JSONRPCVaultDiscover.build_query()` calls `read_events_concurrent()` for
+     the same event set.
+7. `VaultDiscoveryBase.scan_vaults()` then probes the candidate log-emitting
+   addresses with ERC-4626/classification calls.
+
+This is a good baseline for ERC-4626-like protocols because the log-emitting
+address is usually the vault/share-token contract we later probe.
+
+Mellow does not align with this assumption:
+
+- Mellow user flow events are expected on `DepositQueue` and `RedeemQueue`
+  contracts, not necessarily on the primary `Vault` contract.
+- The primary adapter address should be the `Vault`, while ERC-20 share state
+  lives on `ShareManager`.
+- A deposit-like event emitted by a `DepositQueue` and a redeem-like event
+  emitted by a different `RedeemQueue` would produce two separate
+  `PotentialVaultMatch` keys in the current baseline, neither of which is the
+  `MellowVault.address`.
+- Probing the queue address with ERC-4626 calls would either fail or classify
+  the wrong contract.
+- Mellow vault creation is better identified by `Factory.Created`, because that
+  event emits the actual vault instance address.
+
+Therefore Mellow Core Vault discovery should be factory-led, not
+Deposit/Withdraw-led, but it should still run inside the same per-chain
+Hypersync query pipeline as ERC-4626 discovery. The slower JSON-RPC fallback
+must also scan configured Mellow factories over the same block range so fallback
+runs do not silently omit Mellow vaults:
+
+- Use `Factory.Created(address instance,uint256 version,address owner,bytes initParams)`
+  as the canonical lead event for vault identity.
+- Add Mellow factory `Created` topic selections to the same Hypersync stream
+  used for ERC-4626 deposit/withdraw lead discovery when the scanned chain has
+  configured Mellow factories.
+- Demultiplex logs by topic/address:
+  - ERC-4626 and ERC-4626-like flow topics update `PotentialVaultMatch` keyed by
+    the log-emitting address.
+  - Mellow `Factory.Created` topics create `PotentialVaultMatch` objects keyed
+    by the emitted `instance` vault address, with the decoded factory metadata
+    attached to the lead.
+- The shared Hypersync query must include enough fields for both discovery
+  families:
+  - ERC-4626-style discovery needs the existing block/log identity fields.
+  - Mellow factory discovery needs factory log `address`, `transaction_hash`,
+    `block_number`, `log_index`, `topic0`, `topic1`, `topic2`, `topic3` and
+    `data` so `instance`, `version`, `owner` and `initParams` can be decoded
+    whether the factory event uses indexed or non-indexed parameters.
+- Mellow factory log selections must be address-restricted to the configured
+  factory addresses for the scanned chain. Do not scan every contract that emits
+  a same-signature `Created` topic.
+- After factory log decoding, run the emitted Mellow vault addresses through
+  the shared `probe_vaults()` classification path with Mellow-specific probes.
+  The output must be `ERC4262VaultDetection(features={ERC4626Feature.mellow_like})`,
+  not an unclassified lead row.
+- Use `Vault.QueueCreated(address queue,address asset,bool isDepositQueue)` and
+  `queueAt(asset,index)` to map queue contracts back to a vault.
+- Use queue deposit/redeem events for flow accounting only after the queue has
+  been associated with a known vault.
+- Do not add Mellow queue events to `get_vault_discovery_events()` unless the
+  lead model is changed to support "child contract emitted an event for parent
+  vault" relationships.
+
+Reusable pieces from the current baseline:
+
+- The `LeadScanReport` / `PotentialVaultMatch` shape should be reused for
+  Mellow as well as ERC-4626 event leads. Mellow attaches the decoded
+  `Factory.Created` metadata to the lead, while final rows are still based on
+  `ERC4262VaultDetection`, not raw leads.
+- The Hypersync streaming structure can be reused.
+- The topic-kind idea can be reused for Mellow queue flow events, but only after
+  queue-to-vault mapping is known.
+- The "event lead first, ABI probe second" pattern remains correct: Mellow
+  factory events should be followed by the narrow classification probes
+  `shareManager()` and `getAssetCount()` before accepting a vault. Optional
+  component reads such as `oracle()` and `feeManager()` belong to metadata
+  enrichment, not lead classification.
+
+Required production change:
+
+- Add Mellow-specific discovery handling under `eth_defi/mellow/discovery.py`,
+  but wire it into the existing per-chain Hypersync discovery pipeline instead
+  of launching a separate Hypersync scan.
+- The combined per-chain discovery result should contain both ERC-4626
+  detections and Mellow `ERC4262VaultDetection` objects keyed by
+  `VaultSpec(chain_id, vault_address)`.
+- The class name `ERC4262VaultDetection` is intentional in the current codebase,
+  even though it looks like a transposed ERC-4626 name. Use the existing class
+  name in implementation and tests unless the whole codebase is renamed in a
+  separate refactor.
+- Keep ERC-4626 `Deposit`/`Withdraw` baseline unchanged.
+- Add a regression test that adding Mellow discovery does not change the
+  existing ERC-4626 lead counts/classification for a known control vault.
+- Add a negative test proving that Mellow queue contracts are not accidentally
+  stored as vault addresses.
+- For initial vault discovery and price scanning, Mellow metadata rows must
+  store `deposit_count = 0` and `redeem_count = 0`.
+- Be precise about count field names:
+  - `PotentialVaultMatch` lead objects use `deposit_count` and
+    `withdrawal_count`.
+  - `ERC4262VaultDetection` objects use `deposit_count` and `redeem_count`.
+  - Mellow factory leads use `PotentialVaultMatch` for the shared discovery and
+    probe path, but after probing Mellow detections store integer `0` in
+    `ERC4262VaultDetection.deposit_count` and
+    `ERC4262VaultDetection.redeem_count`.
+- `mellow_like` detections must be centrally exempt from deposit/redeem activity
+  filters by checking `ERC4626Feature.mellow_like in detection.features`, never
+  by checking count values or count field names. Do not implement this as
+  scattered caller-by-caller special cases.
+- Add explicit code comments at the detection construction site and at the
+  activity-filter exemption explaining why counts are zero:
+  - Mellow flow events are emitted by `DepositQueue` and `RedeemQueue`
+    contracts, not by the canonical `Vault` address.
+  - The vault identity comes from `Factory.Created`.
+  - Getting true flow counts requires a second-stage queue-address scan after
+    queue discovery.
+  - Initial vault discovery and price scanning do not need those counts.
+  - Using integer zero preserves compatibility with existing numeric consumers,
+    while the `mellow_like` exemption prevents the zero counts from silently
+    dropping Mellow vaults.
+
+## Pre-implementation gates
+
+Do not start the `MellowVault` historical reader or flow reader before these
+facts are locked down with verified ABIs and fixed-block checks:
+
+- Canonical verified ABIs for `Vault`, `Factory`, `ShareManager`,
+  `DepositQueue`, `RedeemQueue`, `Oracle`, `FeeManager`, `RiskManager` and
+  `Subvault`.
+- Confirmed `Factory.Created` ABI indexed layout before implementing Hypersync
+  field selection or demux code:
+  - whether `instance`, `version` and `owner` are indexed topics or encoded in
+    `data`
+  - decoder code must assert against the verified ABI layout instead of
+    assuming `topic1`, `topic2` and `topic3`
+  - test both the documented layout and reject malformed logs with clear errors
+- Confirmed `priceD18` orientation for Lido Earn USD:
+  - whether it means `shares / assets` or `assets / shares`
+  - how to convert it to `VaultHistoricalRead.share_price`
+  - a fixed-block cross-check where `share_price * total_supply` agrees with
+    Mellow API TVL within a documented tolerance
+- Confirmed queue event names and event argument order for:
+  - deposit request
+  - deposit settlement / claim
+  - redeem request
+  - redeem settlement / claim
+- Confirmed shared Hypersync query feasibility:
+  - one stream can contain unrestricted ERC-4626 deposit/withdraw topic
+    selections and address-restricted Mellow factory `Created` selections
+    without cross-applying the address filter
+  - a regression test proves ERC-4626 lead counts are unchanged when the Mellow
+    factory selection is added
+  - a regression test proves Mellow `Created` logs are restricted to configured
+    factory addresses and same-signature `Created` events from unrelated
+    contracts are ignored
+- One pinned real deposit event block and one pinned real redeem event block for
+  flow-reader regression tests.
+- Confirmed handling for `BasicShareManager`:
+  - either prove all initial Core Vault targets use tokenised share managers
+  - or implement an explicit unsupported error and API/offchain metadata fallback
+    for non-tokenised managers.
+
+## Proposed package layout
+
+```text
+eth_defi/mellow/
+    __init__.py
+    abi.py
+    core.py
+    discovery.py
+    vault.py
+    historical.py
+    flow.py
+    deposit_redeem.py
+```
+
+`eth_defi/erc_4626/` should not own Mellow. The ERC-4626 scanner can still reference Mellow only to suppress false positives or to bridge legacy listing code during migration.
+
+## ABI requirements
+
+Store verified ABIs under:
+
+```text
+eth_defi/abi/mellow/
+    Vault.json
+    Factory.json
+    TokenizedShareManager.json
+    BurnableTokenizedShareManager.json
+    DepositQueue.json
+    RedeemQueue.json
+    Oracle.json
+    FeeManager.json
+    RiskManager.json
+    Subvault.json
+```
+
+Do not hand-edit generated ABI JSON files. Fetch verified source ABIs from explorers or canonical Mellow source releases.
+
+Minimum ABI methods needed for `MellowVault`:
+
+- `Vault.shareManager()`
+- `Vault.feeManager()`
+- `Vault.oracle()`
+- `Vault.getAssetCount()`
+- `Vault.assetAt(uint256)`
+- `Vault.getQueueCount()`
+- `Vault.queueAt(address,uint256)`
+- `Vault.isDepositQueue(address)`
+- `Vault.isPausedQueue(address)`
+- `ShareManager.name()`
+- `ShareManager.symbol()`
+- `ShareManager.decimals()`
+- `ShareManager.totalSupply()`
+- fee, risk, oracle methods after source mapping confirms exact names
+
+Minimum ABI events needed:
+
+- `Factory.Created(address instance,uint256 version,address owner,bytes initParams)`
+- `Vault.QueueCreated(address queue,address asset,bool isDepositQueue)`
+- `Vault.QueueRemoved(address queue,address asset)`
+- `Vault.ReportHandled(address asset,uint256 priceD18,uint256 depositTimestamp,uint256 redeemTimestamp,...)`
+- deposit queue request/claim events, exact names to be confirmed from ABI
+- redeem queue request/claim events, exact names to be confirmed from ABI
+- `ShareManager.Transfer(address indexed from,address indexed to,uint256 value)` for share supply cross-checks
+
+## `MellowVault`
+
+`MellowVault` should subclass `VaultBase`.
+
+`eth_defi/mellow/vault.py` must start with an extensive module-level docstring
+that documents the Mellow Core Vault architecture for future maintainers. This
+docstring should be treated as the canonical local architecture note for the
+adapter, not just a short module description.
+
+The head docstring must cover:
+
+- why Mellow Core Vaults are modelled as `VaultBase` and not `ERC4626Vault`
+- the component graph: `Vault`, `ShareManager`, `DepositQueue`, `RedeemQueue`,
+  `Oracle`, `FeeManager`, `RiskManager`, `Subvault`, hooks, and verifiers
+- which contract address is the primary vault address and which one is the
+  ERC-20 share token
+- how deposits and redemptions move through queues and oracle settlement
+- why TVL and share price cannot be read with ERC-4626 `totalAssets()` /
+  `convertToAssets()`
+- how historical reading is expected to derive total supply, share price and
+  TVL
+- known unsupported cases, especially non-tokenised `BasicShareManager`
+- links to canonical Mellow docs, deployments, source repositories and example
+  explorer pages
+
+Constructor:
+
+```python
+class MellowVault(VaultBase):
+    def __init__(
+        self,
+        web3: Web3,
+        spec: VaultSpec,
+        token_cache: TokenDiskCache | None = None,
+        default_block_identifier: BlockIdentifier | None = None,
+    ):
+        ...
+```
+
+Primary address:
+
+- `VaultBase.address` should return the Mellow `Vault` contract address, not the `ShareManager`.
+- The `VaultSpec.vault_address` should therefore be the `Vault` address discovered from the factory.
+
+Core properties and methods:
+
+- `chain_id`: from `web3.eth.chain_id`
+- `address`: vault proxy address
+- `share_manager_address`: `vault_contract.functions.shareManager().call()`
+- `share_token`: ERC-20 metadata for tokenised `ShareManager`
+- `name`: share token name when tokenised, otherwise fallback to API/offchain metadata
+- `symbol`: share token symbol when tokenised
+- `fetch_info()`: return a `MellowVaultInfo` dataclass with all component addresses
+- `fetch_share_token()`: `fetch_erc20_details()` on `shareManager`
+- `fetch_denomination_token()`: base token for valuation, not necessarily the only deposit token
+- `fetch_nav()`: Mellow-specific TVL calculation
+- `fetch_portfolio()`: balances of vault plus subvaults, if subvault enumeration is available
+- `get_historical_reader(stateful)`: return `MellowVaultHistoricalReader`
+- `get_flow_manager()`: return `MellowVaultFlowManager`
+- `get_deposit_manager()`: return unsupported stub at first unless deposit execution is explicitly implemented
+
+`MellowVaultInfo` should include:
+
+- vault address
+- share manager address
+- fee manager address
+- risk manager address
+- oracle address
+- deposit queues by asset
+- redeem queues by asset
+- registered assets
+- subvaults, if discoverable
+- factory address and factory version, if known
+- API metadata, if attached
+
+### `VaultBase` abstract surface mapping
+
+Before coding, implement or explicitly stub every `VaultBase` abstract member.
+The first `MellowVault` PR should include this mapping in code comments or test
+names so omissions are easy to review.
+
+| `VaultBase` member | Mellow implementation plan |
+| --- | --- |
+| `chain_id` | Return `web3.eth.chain_id`, cached at construction if needed. |
+| `address` | Return the Mellow `Vault` proxy address from `VaultSpec`, not the `ShareManager`. |
+| `name` | Return tokenised `ShareManager.name()`; fallback to API/offchain metadata only if the manager is non-tokenised and the fallback is tested. |
+| `symbol` | Return tokenised `ShareManager.symbol()`; fallback to API/offchain metadata only if tested. |
+| `has_block_range_event_support()` | Return `True` after queue event scanning is implemented; before that return `False` only if `get_flow_manager()` is also an explicit unsupported stub. |
+| `has_deposit_distribution_to_all_positions()` | Return `False`; Mellow deposits settle through queues and curator/subvault allocation, not automatic pro-rata distribution to all positions. |
+| `fetch_portfolio(universe, block_identifier)` | Initially read balances of registered assets on the vault address. Extend to subvault balances after subvault enumeration is confirmed. If incomplete, return a partial portfolio with explicit notes/errors rather than pretending to have full TVL. |
+| `fetch_info()` | Return `MellowVaultInfo` with component addresses, assets, queues, factory metadata and API metadata. |
+| `get_flow_manager()` | Return `MellowVaultFlowManager` once queue event support is in place; otherwise raise a clear `NotImplementedError`. |
+| `get_deposit_manager()` | Return an unsupported deposit manager or raise a clear `NotImplementedError` until active deposits/redeems are implemented. Reading support does not require transaction execution. |
+| `get_historical_reader(stateful)` | Return `MellowVaultHistoricalReader(self, stateful=stateful)`. |
+| `fetch_denomination_token()` | Return the configured/API base token for valuation; preserve all deposit and withdraw tokens separately in `MellowVaultInfo`. |
+| `fetch_nav()` | Return on-chain base-asset NAV only after the TVL method is confirmed. Until then raise a clear unsupported exception or return `None` only if downstream non-fatal behaviour is covered by tests. |
+| `fetch_share_token()` | Return ERC-20 details for tokenised `ShareManager`. For `BasicShareManager`, raise a protocol-specific unsupported error unless the fallback path has been implemented and tested. |
+
+Non-abstract but relevant fee methods:
+
+- Override `get_protocol_name()` to return `Mellow`, or make sure the generic
+  implementation does not route Mellow through `ERC4626Feature.broken`.
+- Override `get_management_fee()` and `get_performance_fee()` only after fee
+  manager semantics are confirmed.
+- Leave `management_fee` as `None` in historical reads if Mellow protocol fee
+  cannot be honestly mapped to an annual management-fee percentage.
+- Override `has_custom_fees()` once deposit/redeem/performance/protocol fee
+  reading is implemented.
+
+### Detection and adapter routing
+
+Mellow should reuse the existing detection and adapter factory path where
+possible:
+
+- `ERC4262VaultDetection` must be able to represent a Mellow Core Vault with:
+  - `address`: Mellow `Vault` proxy address, not `ShareManager` and not queue
+    address
+  - `features`: `{ERC4626Feature.mellow_like}`
+  - `first_seen_at_block`: `Factory.Created` block
+  - `deposit_count`: integer `0`
+  - `redeem_count`: integer `0`
+- Add line comments where `deposit_count = 0` and `redeem_count = 0` are set.
+  The comments must explain that real Mellow flow events live on queue
+  contracts and need a second-stage queue-address scan, while initial discovery
+  and price scanning intentionally do not depend on those counts.
+- Add a central activity-filter helper, e.g.
+  `is_activity_filter_exempt(detection)`, that returns `True` based on
+  `ERC4626Feature.mellow_like in detection.features`. The helper must not look
+  at `deposit_count`, `redeem_count` or `withdrawal_count`.
+- `create_vault_instance()` must branch on `ERC4626Feature.mellow_like` before
+  generic ERC-4626 fallback handling and return `MellowVault(web3, spec, ...)`.
+- `create_vault_instance_autodetect()` must rely on the same ERC-4626
+  classification/probe path for Mellow. Add Mellow-specific probes to that path
+  so autodetection can classify a Mellow vault as `ERC4626Feature.mellow_like`
+  and then route to `MellowVault`.
+- `probe_vaults()` should run the shared multicall probe path for Mellow factory
+  leads. Add the two Mellow-specific classification probes, `shareManager()`
+  and `getAssetCount()`, so `identify_vault_features()` can add
+  `ERC4626Feature.mellow_like` even when standard ERC-4626 probes fail.
+- `identify_vault_features()` must evaluate successful Mellow-specific probes
+  before assigning final broken/unsupported status based on failed ERC-4626
+  probes. A failed `convertToShares()` or `asset()` call must not prevent
+  `mellow_like` classification when Mellow probes succeeded.
+- Mellow factory leads should become `ERC4262VaultDetection` objects through
+  the same classification envelope as ERC-4626 leads. The difference is that
+  `mellow_like` is a routing feature, and later adapter construction must use
+  `MellowVault` instead of `ERC4626Vault`.
+- Keep Mellow factory metadata on `PotentialVaultMatch`, keyed by lower-case
+  vault address in the normal lead map. This metadata must carry
+  `factory_address`, `factory_version`, `owner`, `created_block`, `created_at`,
+  transaction hash and log index from the decoded `Factory.Created` log.
+- After `probe_vaults()` returns features for a Mellow lead, read the factory
+  metadata from the `PotentialVaultMatch` and construct `ERC4262VaultDetection`
+  with:
+  - `first_seen_at_block = created_block`
+  - `first_seen_at = created_at`
+  - `updated_at = now`
+  - `deposit_count = 0`
+  - `redeem_count = 0`
+  - `features = features | {ERC4626Feature.mellow_like}`
+- Add a fixed-block/unit test asserting the stored Mellow detection
+  `first_seen_at_block` equals the `Factory.Created` block, not the block used
+  for the probe call.
+- Any code path receiving `ERC4262VaultDetection` with `mellow_like` must avoid
+  ERC-4626 ABI assumptions. Treat it as a shared vault-detection envelope, not
+  a standards-compliance proof.
+- Metadata row creation must support `mellow_like` without ERC-4626 scan-record
+  assumptions. Add a Mellow branch in `create_vault_scan_record()` or its
+  caller so protocol name, NAV, share token, denomination token, link and
+  `_detection_data` are populated from `MellowVault`.
+
+### Address and share-token audit
+
+Mellow splits the primary vault address from the ERC-20 share token address.
+This is the main integration risk for existing vault pipeline code.
+
+Before merging `MellowVault`, audit every downstream path that might treat
+`vault.address` as an ERC-20 token:
+
+- historical price reader and `VaultHistoricalReadMulticaller`
+- token-cache warmup in `eth_defi/vault/historical.py`
+- holder/shareholder readers
+- flow event readers
+- vault database export and JSON export
+- metadata, risk and fee matrix lookup keys
+- any `balanceOf(vault.address)` or `Transfer` scanning that should instead use
+  `vault.share_token.address`
+
+The audit must confirm these paths use `vault.share_token` or
+`fetch_share_token()` whenever they need ERC-20 share state. Add regression
+tests for at least the historical reader and export path.
+
+## Denomination token and TVL semantics
+
+Mellow can accept multiple deposit assets and can custody assets across vault and subvault contracts. This does not map cleanly to `VaultBase.denomination_token`, which is a single-token abstraction.
+
+For initial integration:
+
+- Treat the API `base_token` or the configured base asset as the `denomination_token`.
+- Preserve all deposit and withdraw assets in `MellowVaultInfo`.
+- Do not assume `fetch_nav()` equals the raw balance of the base asset.
+- Do not calculate USD TVL from hardcoded stablecoin assumptions in the adapter.
+
+For production on-chain TVL, choose one of these after ABI/source confirmation:
+
+1. Prefer an official Mellow oracle/risk-manager view that returns vault total value or base-asset balance.
+2. If unavailable, reconstruct TVL from registered asset balances held by the vault and subvaults plus the latest oracle reports.
+3. Use the public Mellow API only as an enrichment or validation source, not as canonical historical data.
+
+## Historical reader
+
+Implement `MellowVaultHistoricalReader(VaultHistoricalReader)`.
+
+It cannot subclass `ERC4626HistoricalReader`, because ERC-4626 calls like `totalAssets()` and `convertToAssets()` are not the accounting source.
+
+The class must implement the exact base hooks from
+`eth_defi.vault.base.VaultHistoricalReader`:
+
+- `construct_multicalls() -> Iterable[EncodedCall]`
+- `process_result(block_number, timestamp, call_results) -> VaultHistoricalRead`
+
+Use existing ERC-4626 readers only as examples for `EncodedCall` construction
+and `VaultHistoricalRead` creation. Do not call
+`construct_core_erc_4626_multicall()` or
+`process_core_erc_4626_result()`.
+
+Initial multicalls:
+
+- `ShareManager.totalSupply()`
+- `ShareManager.decimals()`, warmed via token cache
+- `Vault.shareManager()`, if not cached
+- `Vault.oracle()`, if not cached
+- `Vault.feeManager()`, if not cached
+- latest oracle report for the base asset, once method name is confirmed
+- fee manager state for performance/protocol fees, once method names are confirmed
+- risk manager vault balance / limit state, once method names are confirmed
+
+Initial output fields in `VaultHistoricalRead`:
+
+- `share_price`: derive from Mellow oracle report only after confirming whether `priceD18` is `shares / assets` or `assets / shares`
+- `total_assets`: base-asset-denominated TVL if available, otherwise `None` with an error marker
+- `total_supply`: share manager total supply converted with share token decimals
+- `performance_fee`: Mellow fee manager value if available
+- `management_fee`: protocol fee if it maps to an annual management-like fee
+- `max_deposit`: vault or risk manager remaining capacity if available
+- `errors`: explicit reasons for partial reads
+
+The `share_price` formula must be pinned by a fixed-block test:
+
+- choose a block where Lido Earn USD has a recent accepted oracle report and
+  non-zero supply
+- read `ShareManager.totalSupply()` at that block
+- derive `share_price` from the oracle report in both possible orientations
+- assert the chosen orientation makes `share_price * total_supply` agree with
+  public Mellow API TVL, or a known on-chain TVL view if one is found
+- document the tolerance and the source of the comparison value
+
+If current-state `fetch_nav()` is temporarily unsupported, add a test proving
+that `MellowVaultHistoricalReader.process_result()` and the export path do not
+crash when `VaultHistoricalRead.total_assets` or current NAV is `None`; they
+must surface an explicit `errors` value instead.
+
+Historical reader phases:
+
+1. Current-state reader:
+   - Read share manager, assets, queues, total supply and API TVL.
+   - Useful for onboarding and UI mapping.
+2. Oracle-based historical reader:
+   - Decode `ReportHandled` / oracle report events.
+   - Sample latest accepted report at or before each historical block.
+   - Combine with total supply at the sampled block.
+3. Full on-chain TVL reader:
+   - Include subvault balances, pending deposits, pending redemptions and risk manager balance corrections.
+   - Cross-check against the public Mellow API for recent blocks.
+
+## Flow event reader
+
+Mellow deposits and redemptions are asynchronous. We need a protocol-specific `MellowVaultFlowManager`.
+
+Map to the existing neutral model:
+
+- deposit queue request event -> `PendingVaultFlow(direction=deposit)`
+- deposit queue claim/settle event -> processed deposit flow
+- redeem queue request event -> `PendingVaultFlow(direction=redeem)`
+- redeem queue claim/settle event -> processed redemption flow
+
+Hypersync should scan queue contracts, not only the vault contract, because user request events are expected to be emitted by the queue modules.
+
+Implementation steps:
+
+- Discover queue addresses from `QueueCreated` events and `queueAt(asset,index)`.
+- Build topic lists from `DepositQueue` and `RedeemQueue` ABIs.
+- Add `fetch_mellow_vault_flow_events_hypersync()`.
+- Convert queue logs into `PendingVaultFlow`.
+- Add tests modelled after `tests/vault/test_pending_vault_flow_events.py`.
+
+Flow tests must be pinned to known events:
+
+- one fixed deposit request or processed deposit event block
+- one fixed redeem request or processed redeem event block
+- absolute assertions for owner/controller, asset or share amount, queue
+  address, vault address, transaction hash and log index
+
+Do not use a broad block range with only an "at least one event" assertion.
+
+## Discovery and classification
+
+Mellow discovery should be factory-based.
+
+Production discovery:
+
+- scan configured Mellow Core Vault factories as part of the shared per-chain
+  Hypersync query
+- decode `Created` events into factory lead candidate addresses
+- run those candidate addresses through `probe_vaults()` with Mellow-specific
+  probes
+- produce `ERC4262VaultDetection(features={ERC4626Feature.mellow_like})`
+- instantiate through `create_vault_instance()` so the shared adapter factory
+  returns `MellowVault`
+- attach factory version and first-seen block
+- optionally enrich with public Mellow API metadata
+
+Add `ERC4626Feature.mellow_like` for Mellow Core Vaults as an integration
+compatibility flag. Document in `eth_defi/erc_4626/core.py` that this flag means
+"Mellow-like vault routed through the shared vault pipeline" and does not imply
+ERC-4626 compliance. For Core Vaults, discovery remains factory-led and the
+adapter remains `MellowVault(VaultBase)`.
+
+Initial integration points:
+
+- Add `scripts/mellow/scan-initial-mellow.py` as the manual mapping tool.
+- Add `eth_defi/mellow/discovery.py` for reusable library code.
+- Extend `eth_defi/vault/scan_all_chains.py` and the ERC-4626 scanner pipeline
+  so Mellow factory discoveries are merged into the normal EVM smart-contract
+  vault scan cycle.
+- Add protocol metadata under `eth_defi/data/vaults/metadata/mellow.yaml` once
+  listings can consume non-ERC-4626 adapters without implying ERC-4626
+  compliance.
+
+## Tests
+
+Initial focused tests:
+
+- `tests/mellow/test_mellow_discovery.py`
+  - decode known factory `Created` events
+  - confirm Lido Earn USD is discovered
+  - assert Base is skipped unless `MELLOW_BASE_VAULT_FACTORY` is configured
+- `tests/mellow/test_mellow_vault_info.py`
+  - instantiate `MellowVault`
+  - read component addresses
+  - read share token metadata
+  - read registered assets and queues
+  - prove `vault.address` is the Mellow `Vault` and
+    `vault.share_token.address` is the `ShareManager`
+  - test non-tokenised `BasicShareManager` handling, either as a clear
+    unsupported error or a working API/offchain metadata fallback
+- `tests/mellow/test_mellow_historical_reader.py`
+  - construct `construct_multicalls()` output
+  - process a fixed-block read for Lido Earn USD
+  - assert absolute values at a fixed Ethereum block
+  - pin `priceD18` orientation by cross-checking
+    `share_price * total_supply` against Mellow API TVL or a confirmed on-chain
+    TVL view
+  - prove unsupported/unknown NAV or `total_assets=None` is represented as a
+    `VaultHistoricalRead.errors` entry and does not crash the export path
+- `tests/mellow/test_mellow_flow_events.py`
+  - scan pinned deposit/redeem queue event blocks
+  - convert to `PendingVaultFlow`
+  - assert absolute decoded event values, transaction hash and log index
+- `tests/mellow/test_mellow_not_erc4626.py`
+  - assert Lido Earn USD is not detected as an ERC-4626 vault
+  - assert Mellow Core Vaults are surfaced through `ERC4626Feature.mellow_like`
+    only as a routing flag
+  - assert `ERC4626Feature.mellow_like` routes to `MellowVault`, not
+    `ERC4626Vault`
+  - construct an `ERC4262VaultDetection` with `features={mellow_like}` and
+    assert `create_vault_instance()` returns `MellowVault`
+  - assert `create_vault_instance_autodetect()` uses ERC-4626 classification
+    probes to classify Lido Earn USD as `mellow_like` and returns `MellowVault`
+  - assert `create_vault_instance()` does not call ERC-4626 methods such as
+    `asset()`, `totalAssets()` or `convertToAssets()` for a `mellow_like`
+    detection
+  - assert failed ERC-4626 probes do not mark a vault broken when the two
+    Mellow-specific probes, `shareManager()` and `getAssetCount()`, succeeded
+  - assert the activity-filter exemption fires because `mellow_like` is present,
+    not because any count field has a particular value
+  - assert existing ERC-4626 detection behaviour for a known control vault is
+    unchanged
+- `tests/mellow/test_mellow_export.py`
+  - assert a Mellow `ERC4262VaultDetection` can be converted into a
+    `VaultDatabase` metadata row without ERC-4626 ABI calls
+  - assert export/listing paths do not use `vault.address` as the ERC-20 share
+    token address
+  - assert `vault.share_token.address` is used for share-token fields
+
+Use fixed archive block numbers for Anvil/mainnet-fork tests and assert absolute values where possible.
+
+## Manual script test
+
+Add an Ethereum block-range based manual test path before production pipeline
+integration. The sample range must stay capped at 1,000,000 blocks so the test
+is large enough to exercise Hypersync pagination and metadata/price reads, but
+small enough for routine operator use.
+
+The manual script should support these environment variables:
+
+- `CHAINS=ethereum`
+- `START_BLOCK`
+- `END_BLOCK`
+- `BLOCK_RANGE=1000000` as a convenience when `START_BLOCK` is omitted
+- `MELLOW_TEST_LEADS=true`
+- `MELLOW_TEST_METADATA=true`
+- `MELLOW_TEST_PRICES=true`
+- `PIPELINE_DATA_DIR` for temporary test output
+- `SKIP_WRITE=true` for read-only diagnostics where useful
+
+Example command:
+
+```shell
+source .local-test.env
+END_BLOCK=$(poetry run python - <<'PY'
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+import os
+
+web3 = create_multi_provider_web3(os.environ["JSON_RPC_ETHEREUM"])
+print(web3.eth.block_number)
+PY
+)
+START_BLOCK=$((END_BLOCK - 1000000))
+
+CHAINS=ethereum \
+START_BLOCK=$START_BLOCK \
+END_BLOCK=$END_BLOCK \
+MELLOW_TEST_LEADS=true \
+MELLOW_TEST_METADATA=true \
+MELLOW_TEST_PRICES=true \
+PIPELINE_DATA_DIR=/tmp/mellow-vault-test \
+LOG_LEVEL=info \
+poetry run python scripts/mellow/scan-initial-mellow.py
+```
+
+The manual test must produce tabulated output for:
+
+- leads discovered from `Factory.Created`
+- metadata rows after component probing
+- price sample rows. In the initial PR these rows contain on-chain
+  `ShareManager.totalSupply()`, API TVL where the factory lead matches the
+  public Mellow API, and an explicit unsupported reason for oracle-derived share
+  price.
+
+Minimum manual assertions:
+
+- Lido Earn USD appears as a vault lead when its creation block is inside the
+  selected range, or the output explicitly says the selected range starts after
+  the creation block.
+- No deposit or redeem queue address is reported as a vault address.
+- Metadata includes `Vault`, `ShareManager`, assets and queues.
+- Price rows include block number, total supply, share price, total assets or an
+  explicit unsupported/error reason.
+- The script exits non-zero if leads pass but metadata or price decoding fails
+  unexpectedly.
+
+## Implementation phases
+
+### Phase 1: ABI and static mapping
+
+- Add verified Mellow ABIs.
+- Confirm `priceD18` orientation and document the formula.
+- Confirm exact queue event names and argument order.
+- Identify pinned deposit and redeem event blocks for tests.
+- Decide and document tokenised vs non-tokenised `ShareManager` support.
+- Move reusable discovery code from `scripts/mellow/scan-initial-mellow.py` into `eth_defi/mellow/discovery.py`.
+- Keep script as the operator-facing CLI.
+- Add a static known factory registry for Ethereum, Plasma, Arbitrum and Monad.
+- Leave Base configurable until a canonical Core factory is confirmed.
+
+### Phase 2: `MellowVault`
+
+- Add the extensive `eth_defi/mellow/vault.py` head docstring before adding
+  implementation logic, so the contract architecture assumptions are reviewed
+  together with the adapter code.
+- Implement or explicitly stub every `VaultBase` abstract member listed in the
+  abstract-surface mapping above.
+- Implement `MellowVaultInfo`.
+- Implement component accessors.
+- Implement share token metadata.
+- Implement asset and queue enumeration.
+- Add `fetch_nav()` as best-effort:
+  - use official on-chain view if found
+  - otherwise raise a clear unsupported exception, or return `None` only after
+    tests prove this is non-fatal for historical reads and exports
+- Add the address/share-token downstream audit and fix any code path that treats
+  `vault.address` as the ERC-20 share token.
+
+### Phase 3: historical reader
+
+- Implement `MellowVaultHistoricalReader`.
+- Start with total supply and oracle price.
+- Add TVL once exact oracle/risk-manager semantics are confirmed.
+- Add reader-state support only after the stateless reader is reliable.
+- Add fixed-block tests for `priceD18` orientation and `VaultHistoricalRead`
+  output.
+
+### Phase 4: flow reader
+
+- Implement queue discovery and Hypersync event scanning.
+- Map queue events to `PendingVaultFlow`.
+- Add pending deposit and redemption accounting.
+- Add pinned-event tests with absolute decoded values.
+
+### Phase 5: production scanner integration
+
+- Integrate Mellow into `scripts/erc-4626/scan-vaults-all-chains.py` /
+  `eth_defi/vault/scan_all_chains.py` as part of the base EVM smart-contract
+  vault scan cycle.
+- Do not add a `SCAN_MELLOW=true` opt-in flag. Mellow should be scanned
+  whenever the normal EVM vault scanner scans a chain that has Mellow factory
+  configuration.
+- Use existing EVM chain controls:
+  - `TEST_CHAINS`, `CHAIN_ORDER` and `DISABLE_CHAINS` decide whether Ethereum,
+    Plasma, Arbitrum, Monad or Base are scanned.
+  - `SCAN_CYCLES` applies through the existing chain item, e.g.
+    `Ethereum=8h`, not a separate `Mellow=8h` item.
+  - retry handling and dashboard state remain on the chain result.
+- Add a per-chain Mellow factory registry with documented Core deployments
+  enabled by default: Ethereum, Plasma, Arbitrum and Monad. Keep Base enabled
+  only when a canonical factory is confirmed or configured.
+- Extend `scan_vaults_for_chain()` or the function it calls so one EVM chain
+  scan performs both through one shared Hypersync stream:
+  - existing ERC-4626 lead discovery and metadata extraction from
+    deposit/withdraw-like event topics
+  - Mellow factory candidate discovery, `probe_vaults()` classification and
+    metadata extraction from configured factory `Created` topics
+- Avoid a second full-chain Hypersync pass for Mellow. Mellow discovery should
+  reuse the same block range, stream lifecycle, retry handling, head clipping
+  and rate limiting as ERC-4626 discovery.
+- Keep JSON-RPC fallback support functionally equivalent by scanning configured
+  Mellow factory addresses over the same block range and feeding decoded factory
+  candidates into the same `probe_vaults()` path.
+- Merge Mellow metadata rows into the same shared `VaultDatabase` update for
+  that chain.
+- Chain-level metrics should include separate ERC-4626 and Mellow counts in
+  logs, while `ChainResult.vault_count` remains the total smart-contract vault
+  count for the chain.
+- Add Mellow-specific durable state under `PIPELINE_DATA_DIR` only if needed
+  for protocol-local reader state. Do not introduce a separate top-level
+  protocol scan cycle for Mellow.
+- When global `SCAN_PRICES=true`, the same EVM chain price pass must include
+  Mellow vaults for that chain.
+- Decide how non-ERC-4626 vaults are represented in the vault database.
+- Extend scan/export paths to include `VaultBase` adapters that are not `ERC4626Vault`.
+- Ensure Mellow rows contain enough detection data for price scanning to
+  instantiate `MellowVault` through the `ERC4626Feature.mellow_like` routing
+  branch, not the generic `ERC4626Vault`.
+- Mellow detections must store integer `0` deposit/redeem counts.
+- Add a central `mellow_like` / feature-based activity-filter exemption and use
+  it from `scan_prices_for_chain()`, standalone scripts such as
+  `scripts/erc-4626/scan-prices.py`, and any post-processing/export filters that
+  inspect deposit/redeem activity.
+- Add line comments next to the exemption explaining that `deposit_count = 0`
+  and `redeem_count = 0` are compatibility placeholders for initial discovery
+  and price scanning, not evidence that the vault has no queue activity.
+- Add or update Mellow-aware metadata row creation so `create_vault_scan_record`
+  or its caller can produce a `VaultDatabase` row for `mellow_like`.
+- Update `scan_prices_for_chain()` or add a Mellow-native price scan merge so
+  Mellow historical reads are included when `SCAN_PRICES=true`.
+- Ensure Mellow price rows are written through the same parquet schema and
+  schema-migration safety rules as ERC-4626 rows.
+- Ensure post-processing, top-vaults JSON, samples and data-file export can see
+  Mellow rows and distinguish protocol name `Mellow`.
+- Add metadata, risk and fee matrix entries.
+- Add documentation under `docs/source/api/mellow/` and cross-link from `docs/source/api/index.rst`.
+- Add a minimal export/listing path for Mellow vaults before claiming export
+  support complete.
+
+## Open technical questions
+
+- What is the canonical on-chain method for current Mellow vault TVL?
+- Does `priceD18` mean `shares / assets` or `assets / shares` for every Core Vault configuration?
+- Are all Core Vault share managers ERC-20 tokenised, or do some use non-tokenised `BasicShareManager`?
+- How are subvaults enumerated from the vault contract?
+- Which queue events are canonical for pending and processed deposits/redeems?
+- Can the public Mellow API be used as a temporary metadata source in production, or only in scripts?
+- Should broader Mellow ecosystem vaults, especially Symbiotic/MultiVault vaults, be separate adapters?
+
+## Acceptance criteria by phase
+
+### Phase 1 acceptance
+
+- Verified Mellow ABIs are stored in the repo.
+- `Factory.Created` indexed/non-indexed argument layout is documented and
+  enforced by decoder tests.
+- `priceD18` orientation is documented and backed by a fixed-block comparison.
+- Queue event names and argument order are documented.
+- Pinned deposit and redeem event blocks are documented for later tests.
+- The Ethereum manual script can scan a 1,000,000-block range and tabulate
+  leads, metadata and price rows.
+
+### Phase 2 acceptance
+
+- Lido Earn USD can be instantiated as `MellowVault`.
+- `eth_defi/mellow/vault.py` has a module-level architecture docstring that
+  explains Mellow's component model, queue-based flows, share manager split and
+  historical reading assumptions.
+- Every required `VaultBase` abstract member is implemented or explicitly
+  stubbed with a clear unsupported error.
+- `MellowVault` returns stable component metadata and share token details.
+- The address/share-token audit has confirmed historical and export code uses
+  `vault.share_token` for ERC-20 share state.
+- Existing ERC-4626 discovery and historical reading behaviour is unchanged.
+
+### Phase 3 acceptance
+
+- The historical reader returns a `VaultHistoricalRead` row without ERC-4626
+  calls.
+- `share_price * total_supply` matches a confirmed TVL source within the
+  documented tolerance at a fixed block.
+- Unsupported NAV/TVL states are represented as explicit errors and do not crash
+  historical export.
+
+### Phase 4 acceptance
+
+- The flow reader can discover pinned real deposit and redeem queue events.
+- Flow tests assert absolute decoded values, transaction hash and log index.
+
+### Phase 5 acceptance
+
+- Mellow vaults can be listed separately from ERC-4626 vaults in exports.
+- Mellow metadata, risk, fee and docs entries are present.
+- Non-ERC-4626 production scanning can include Mellow without changing existing
+  ERC-4626 behaviour.
+- `ERC4626Feature.mellow_like` exists and is documented as a compatibility
+  routing flag, not an ERC-4626 compliance claim.
+- `ERC4262VaultDetection` can carry Mellow detections with
+  `features={ERC4626Feature.mellow_like}` and the Mellow `Vault` address.
+- `create_vault_instance()` or its replacement routes `mellow_like` detections
+  to `MellowVault`.
+- `create_vault_instance_autodetect()` recognises Mellow through the ERC-4626
+  classification/probe path and routes to `MellowVault`.
+- Mellow factory leads are converted to `ERC4262VaultDetection` objects before
+  metadata row creation; raw Mellow leads are not written as final rows.
+- Mellow detections preserve `first_seen_at_block` from the factory `Created`
+  log after joining factory candidate metadata with `probe_vaults()` results.
+- The shared Hypersync query selects factory log payload fields and restricts
+  Mellow `Created` logs to configured factory addresses.
+- The combined Hypersync query keeps ERC-4626 selections unrestricted and Mellow
+  factory selections restricted to configured factory addresses.
+- Mellow detection counts are stored as integer `0`, and all price scan entry
+  points skip the ERC-4626 low-activity filter for `mellow_like`.
+- Zero deposit/redeem counts and the `mellow_like` activity-filter exemption are
+  documented with line comments in the implementation.
+- The activity-filter exemption is feature-based on
+  `ERC4626Feature.mellow_like`, not count-field-name or count-value based.
+- `mellow_like` detections can be converted into `VaultDatabase` metadata rows
+  without ERC-4626 ABI calls.
+- Mellow discovery runs automatically as part of the base EVM chain scan for
+  configured Mellow chains; there is no `SCAN_MELLOW` opt-in flag.
+- ERC-4626 lead discovery and Mellow factory discovery use the same per-chain
+  Hypersync query/stream pipeline and block range.
+- The JSON-RPC discovery fallback also scans configured Mellow factory
+  `Created` logs and produces the same `PotentialVaultMatch` lead shape before
+  `probe_vaults()`.
+- `SCAN_PRICES=true` writes Mellow historical price rows through the shared
+  price pipeline or a documented Mellow-native merge path for those same EVM
+  chains.
+- Mellow price scanning is not filtered out because of missing/zero
+  deposit/redeem event counts.

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -40,6 +40,7 @@ See :ref:`tutorials <tutorials>` for guides and examples on how to use the libra
    enzyme/index
    aera/index
    lagoon/index
+   mellow/index
    ipor/index
    royco/index
    velvet/index

--- a/docs/source/api/mellow/index.rst
+++ b/docs/source/api/mellow/index.rst
@@ -15,4 +15,5 @@ by the shared EVM vault scanner.
    eth_defi.mellow.discovery
    eth_defi.mellow.flow
    eth_defi.mellow.historical
+   eth_defi.mellow.offchain_metadata
    eth_defi.mellow.vault

--- a/docs/source/api/mellow/index.rst
+++ b/docs/source/api/mellow/index.rst
@@ -1,0 +1,18 @@
+Mellow API
+----------
+
+`Mellow Core Vaults <https://docs.mellow.finance/core-vaults>`__ integration.
+
+Mellow Core Vaults are modular, queue-based vaults rather than ERC-4626 vault
+contracts. This module provides the initial discovery and adapter support used
+by the shared EVM vault scanner.
+
+.. autosummary::
+   :toctree: _autosummary_mellow
+   :recursive:
+
+   eth_defi.mellow.abi
+   eth_defi.mellow.discovery
+   eth_defi.mellow.flow
+   eth_defi.mellow.historical
+   eth_defi.mellow.vault

--- a/eth_defi/abi/mellow/ERC20.json
+++ b/eth_defi/abi/mellow/ERC20.json
@@ -1,0 +1,54 @@
+[
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/eth_defi/abi/mellow/Factory.json
+++ b/eth_defi/abi/mellow/Factory.json
@@ -1,0 +1,33 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "instance",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "version",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "initParams",
+        "type": "bytes"
+      }
+    ],
+    "name": "Created",
+    "type": "event"
+  }
+]

--- a/eth_defi/abi/mellow/FeeManager.json
+++ b/eth_defi/abi/mellow/FeeManager.json
@@ -1,0 +1,124 @@
+[
+  {
+    "inputs": [],
+    "name": "feeRecipient",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "depositFeeD6",
+    "outputs": [
+      {
+        "internalType": "uint24",
+        "name": "",
+        "type": "uint24"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "redeemFeeD6",
+    "outputs": [
+      {
+        "internalType": "uint24",
+        "name": "",
+        "type": "uint24"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "performanceFeeD6",
+    "outputs": [
+      {
+        "internalType": "uint24",
+        "name": "",
+        "type": "uint24"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "protocolFeeD6",
+    "outputs": [
+      {
+        "internalType": "uint24",
+        "name": "",
+        "type": "uint24"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "vault",
+        "type": "address"
+      }
+    ],
+    "name": "baseAsset",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "vault",
+        "type": "address"
+      }
+    ],
+    "name": "timestamps",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "vault",
+        "type": "address"
+      }
+    ],
+    "name": "minPriceD18",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/eth_defi/abi/mellow/Oracle.json
+++ b/eth_defi/abi/mellow/Oracle.json
@@ -1,0 +1,38 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      }
+    ],
+    "name": "getReport",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint224",
+            "name": "priceD18",
+            "type": "uint224"
+          },
+          {
+            "internalType": "uint32",
+            "name": "timestamp",
+            "type": "uint32"
+          },
+          {
+            "internalType": "bool",
+            "name": "isSuspicious",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct IOracle.DetailedReport",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/eth_defi/abi/mellow/README.md
+++ b/eth_defi/abi/mellow/README.md
@@ -1,0 +1,22 @@
+Mellow Core Vault ABI fragments.
+
+These are minimal read-only ABI fragments used by the initial Mellow scanner
+and adapter:
+
+- `Factory.json` exposes the Core Vault `Created` event used for discovery.
+- `Vault.json` exposes component and asset/queue accessors on the canonical
+  Core Vault contract.
+- `Oracle.json` exposes `getReport(asset)`, whose `priceD18` value is used for
+  historical share-price reads.
+- `FeeManager.json` exposes read-only fee configuration accessors. Mellow fees
+  are configured in D6 precision and paid in vault shares.
+- `ERC20.json` exposes token metadata and `totalSupply()` for tokenised
+  ShareManager contracts.
+
+Sources:
+
+- https://docs.mellow.finance/core-vaults
+- https://docs.mellow.finance/core-vaults/core-deployments
+- https://github.com/mellow-finance/flexible-vaults/blob/main/src/managers/FeeManager.sol
+- https://etherscan.io/address/0x014e6DA8F283C4aF65B2AA0f201438680A004452
+- https://etherscan.io/address/0x4Ce1ac8F43E0E5BD7A346A98aF777bF8fbeA1981

--- a/eth_defi/abi/mellow/Vault.json
+++ b/eth_defi/abi/mellow/Vault.json
@@ -1,0 +1,148 @@
+[
+  {
+    "inputs": [],
+    "name": "shareManager",
+    "outputs": [
+      {
+        "internalType": "contract IShareManager",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "feeManager",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "riskManager",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oracle",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAssetCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "assetAt",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      }
+    ],
+    "name": "getQueueCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "queueAt",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "queue",
+        "type": "address"
+      }
+    ],
+    "name": "isDepositQueue",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -42,7 +42,17 @@ ROYCO_CHAIN_IDS = {
     21000000,  # Corn
 }
 
-#: Chain restrictions for protocols deployed on 3 or fewer chains.
+#: Mellow Core chains with official Core deployments.
+#:
+#: Source: https://docs.mellow.finance/core-vaults/core-deployments
+MELLOW_CORE_CHAIN_IDS = {
+    1,  # Ethereum
+    9745,  # Plasma
+    42161,  # Arbitrum
+    143,  # Monad
+}
+
+#: Chain restrictions for protocols deployed on a known limited chain set.
 #:
 #: Maps probe function names to the set of chain IDs where that protocol is deployed.
 #: Probes for these protocols will be skipped on chains not in their set.
@@ -71,6 +81,8 @@ CHAIN_RESTRICTED_PROBES: dict[str, set[int]] = {
     "strategy": {143},  # Accountable - Monad only
     "queue": {143},  # Accountable - Monad only
     "POOL": {999},  # Sentiment - HyperEVM only
+    "shareManager": MELLOW_CORE_CHAIN_IDS,  # Mellow Core - Ethereum, Plasma, Arbitrum, Monad
+    "getAssetCount": MELLOW_CORE_CHAIN_IDS,  # Mellow Core - Ethereum, Plasma, Arbitrum, Monad
     # Two chain protocols
     "claimableKeeper": {137, 42161},  # Untangle Finance - Polygon, Arbitrum
     # Three chain protocols
@@ -179,7 +191,7 @@ def create_probe_calls(
     :param chain_id:
         If provided, filters out probe calls for protocols that are not deployed on this chain.
         This reduces unnecessary RPC calls when scanning chains where certain protocols don't exist.
-        Protocols deployed on 3 or fewer chains have their probes skipped on other chains.
+        Protocols with a known limited deployment set have their probes skipped on other chains.
         If None, all probes are generated (no filtering).
     """
 
@@ -222,6 +234,29 @@ def create_probe_calls(
             data=convert_to_shares_payload,
             extra_data=None,
         )
+
+        # Mellow Core Vaults are not ERC-4626, but use this same probe
+        # envelope so factory leads and autodetect follow the normal adapter
+        # routing path. The two-call signature is intentionally narrow:
+        # shareManager() identifies the share-accounting component and
+        # getAssetCount() identifies the Core Vault asset registry.
+        if _should_yield_probe("shareManager", chain_id):
+            yield EncodedCall.from_keccak_signature(
+                address=address,
+                signature=Web3.keccak(text="shareManager()")[0:4],
+                function="shareManager",
+                data=b"",
+                extra_data=None,
+            )
+
+        if _should_yield_probe("getAssetCount", chain_id):
+            yield EncodedCall.from_keccak_signature(
+                address=address,
+                signature=Web3.keccak(text="getAssetCount()")[0:4],
+                function="getAssetCount",
+                data=b"",
+                extra_data=None,
+            )
 
         # ====================
         # Protocol-specific probes - some filtered by chain_id
@@ -808,13 +843,18 @@ def identify_vault_features(
     # profitMaxUnlockTime True
     # MODULE_VAULT False
 
+    # If a call to an function which cannot exist succeeds, the contract is broken
+    if calls["EVM IS BROKEN SHIT"].success:
+        return {ERC4626Feature.broken}
+
+    if calls["shareManager"].success and calls["getAssetCount"].success:
+        features.add(ERC4626Feature.mellow_like)
+
     # Should return uint256 share count. Broken proxies may return 0x or similar response.
     if not calls["convertToShares"].success and len(calls["convertToShares"].result) != 32:
         # Not ERC-4626 vault
-        return {ERC4626Feature.broken}
-
-    # If a call to an function which cannot exist succeeds, the contract is broken
-    if calls["EVM IS BROKEN SHIT"].success:
+        if ERC4626Feature.mellow_like in features:
+            return features
         return {ERC4626Feature.broken}
 
     if calls["getPerformanceFeeData"].success and len(calls["getPerformanceFeeData"].result) == 64:
@@ -1305,9 +1345,18 @@ def create_vault_instance(
         assert not features, "Do not pass features when auto-detecting vault type"
 
     spec = VaultSpec(web3.eth.chain_id, address.lower())
-    kwargs = dict(token_cache=token_cache, features=features, default_block_identifier=default_block_identifier, require_denomination_token=require_denomination_token)
+    kwargs = {
+        "token_cache": token_cache,
+        "features": features,
+        "default_block_identifier": default_block_identifier,
+        "require_denomination_token": require_denomination_token,
+    }
 
-    if ERC4626Feature.broken in features:
+    if ERC4626Feature.mellow_like in features:
+        from eth_defi.mellow.vault import MellowVault
+
+        return MellowVault(web3, spec, **kwargs)
+    elif ERC4626Feature.broken in features:
         return None
     elif ERC4626Feature.ipor_like in features:
         # IPOR instance

--- a/eth_defi/erc_4626/core.py
+++ b/eth_defi/erc_4626/core.py
@@ -641,6 +641,14 @@ class ERC4626Feature(enum.Enum):
     #: https://aave.com/
     aave_like = "aave_like"
 
+    #: Mellow Core Vault.
+    #:
+    #: Routing marker for Mellow vaults discovered through Core Vault factory
+    #: events. Mellow vaults are not ERC-4626 vault contracts; the primary
+    #: vault address is separate from the ERC-20 ShareManager.
+    #: https://docs.mellow.finance/core-vaults
+    mellow_like = "mellow_like"
+
 
 #: Features that identify lending protocol vaults.
 #:
@@ -676,6 +684,26 @@ def is_lending_protocol(features: set[ERC4626Feature]) -> bool:
     return bool(features & LENDING_PROTOCOL_FEATURES)
 
 
+def is_activity_filter_exempt(detection: "ERC4262VaultDetection") -> bool:
+    """Check if a vault detection bypasses deposit/redeem count filters.
+
+    Some shared vault database entries are not discovered from canonical
+    ERC-4626 ``Deposit`` and ``Withdraw`` events emitted by the vault address.
+    Mellow Core Vaults are the first EVM example: the vault identity comes from
+    ``Factory.Created`` while user flow events live on per-asset queue
+    contracts. The scanner stores integer zero counts for compatibility and
+    uses this feature-based exemption to keep these vaults in price scans.
+
+    :param detection:
+        Shared vault detection envelope.
+
+    :return:
+        ``True`` if low activity count filters should not drop this detection.
+    """
+
+    return ERC4626Feature.mellow_like in detection.features
+
+
 def get_vault_protocol_name(features: set[ERC4626Feature]) -> str:
     """Deduct vault protocol name based on Vault smart contract features.
 
@@ -688,6 +716,8 @@ def get_vault_protocol_name(features: set[ERC4626Feature]) -> str:
     """
     if ERC4626Feature.broken in features:
         return "<not ERC-4626>"
+    elif ERC4626Feature.mellow_like in features:
+        return "Mellow"
     elif ERC4626Feature.morpho_v2_like in features:
         return "Morpho"
     elif ERC4626Feature.morpho_like in features:

--- a/eth_defi/erc_4626/discovery_base.py
+++ b/eth_defi/erc_4626/discovery_base.py
@@ -15,7 +15,7 @@ import enum
 import logging
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Type
+from typing import TYPE_CHECKING, Type
 
 from eth_typing import HexAddress
 from web3.contract.contract import ContractEvent
@@ -23,11 +23,14 @@ from web3.contract.contract import ContractEvent
 from eth_defi.abi import get_contract
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.erc_4626.classification import probe_vaults
-from eth_defi.erc_4626.core import get_erc_4626_contract, ERC4626Feature, ERC4262VaultDetection
+from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature, get_erc_4626_contract
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.risk import BROKEN_VAULT_CONTRACTS
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from eth_defi.mellow.discovery import MellowFactoryCandidate
 
 
 class VaultEventKind(enum.Enum):
@@ -42,7 +45,7 @@ class VaultEventKind(enum.Enum):
 
 @dataclasses.dataclass(slots=True, frozen=False)
 class PotentialVaultMatch:
-    """Categorise contracts that emit ERC-4626 like events."""
+    """Categorise contracts that emit vault discovery events."""
 
     chain: int
     address: HexAddress
@@ -50,9 +53,17 @@ class PotentialVaultMatch:
     first_seen_at: datetime.datetime
     deposit_count: int = 0
     withdrawal_count: int = 0
+    #: Mellow ``Factory.Created`` metadata when this lead came from a Mellow
+    #: factory event instead of vault-local deposit/withdraw events.
+    #:
+    #: Mellow Core Vault user flow events are emitted by queue contracts, not by
+    #: the canonical Vault. Keep this metadata on the normal lead object so the
+    #: discovery path can still use one lead map and one feature-probe loop.
+    mellow_factory_candidate: "MellowFactoryCandidate | None" = None
 
     def is_candidate(self) -> bool:
-        return self.deposit_count > 0 and self.withdrawal_count > 0
+        # Compatibility shim: older persisted lead objects may not have this slot; remove after reader state migration.
+        return getattr(self, "mellow_factory_candidate", None) is not None or (self.deposit_count > 0 and self.withdrawal_count > 0)
 
 
 def get_brink_vault_contract(web3):
@@ -290,6 +301,89 @@ class LeadScanReport:
     end_block: int = 0
 
 
+def _prepare_probe_leads(leads: dict[HexAddress, PotentialVaultMatch]) -> tuple[list[HexAddress], dict[str, PotentialVaultMatch], int]:
+    """Prepare lead data for the shared feature-probe pass.
+
+    :param leads:
+        Vault leads keyed by emitting contract address or canonical Mellow
+        Vault address.
+
+    :return:
+        Probe addresses, lower-case lead lookup and Mellow factory lead count.
+    """
+
+    addresses = []
+    leads_by_address = {}
+    seen_addresses = set()
+    mellow_lead_count = 0
+    for address, lead in leads.items():
+        lowered_address = address.lower()
+        leads_by_address[lowered_address] = lead
+
+        # Compatibility shim: older persisted lead objects may not have this slot; remove after reader state migration.
+        if getattr(lead, "mellow_factory_candidate", None) is not None:
+            mellow_lead_count += 1
+
+        if lowered_address in BROKEN_VAULT_CONTRACTS or lowered_address in seen_addresses:
+            continue
+        addresses.append(address)
+        seen_addresses.add(lowered_address)
+
+    return addresses, leads_by_address, mellow_lead_count
+
+
+def create_mellow_potential_vault_match(candidate: "MellowFactoryCandidate") -> PotentialVaultMatch:
+    """Create a normal lead object from a Mellow factory candidate.
+
+    :param candidate:
+        Decoded Mellow ``Factory.Created`` log.
+
+    :return:
+        Lead compatible with the shared ``probe_vaults()`` path.
+    """
+
+    return PotentialVaultMatch(
+        chain=candidate.chain,
+        address=candidate.address,
+        first_seen_at_block=candidate.created_block,
+        first_seen_at=candidate.created_at,
+        # Mellow flow events are emitted by DepositQueue contracts, not by the
+        # canonical Vault address discovered from Factory.Created. True flow
+        # counts need a second-stage queue scan; initial discovery and price
+        # scanning intentionally use feature-based activity-filter exemption.
+        deposit_count=0,
+        # Mellow redemption events are emitted by RedeemQueue contracts. Keep
+        # an integer zero for compatibility with numeric consumers;
+        # ERC4626Feature.mellow_like prevents these rows from being silently
+        # filtered out as inactive.
+        withdrawal_count=0,
+        mellow_factory_candidate=candidate,
+    )
+
+
+def add_mellow_factory_candidate_lead(
+    report: LeadScanReport,
+    leads: dict[HexAddress, PotentialVaultMatch],
+    candidate: "MellowFactoryCandidate",
+) -> None:
+    """Add a Mellow factory candidate to the shared lead map if new.
+
+    :param report:
+        Mutable scan report whose counters are updated.
+
+    :param leads:
+        Mutable lead map.
+
+    :param candidate:
+        Decoded Mellow ``Factory.Created`` candidate.
+    """
+
+    key = HexAddress(candidate.address.lower())
+    if key not in leads:
+        leads[key] = create_mellow_potential_vault_match(candidate)
+        report.new_leads += 1
+
+
 class VaultDiscoveryBase(abc.ABC):
     def __init__(
         self,
@@ -344,17 +438,14 @@ class VaultDiscoveryBase(abc.ABC):
 
         assert type(leads) == dict, f"Expected dict, got {type(leads)}"
 
-        logger.info("Found %d leads", len(leads))
-        addresses = list(leads.keys())
+        addresses, leads_by_address, mellow_lead_count = _prepare_probe_leads(leads)
+        logger.info("Found %d vault leads, of which %d are Mellow factory leads", len(leads), mellow_lead_count)
         good_vaults = broken_vaults = 0
 
         if display_progress:
             progress_bar_desc = f"Identifying vaults, using {self.max_workers} workers"
         else:
             progress_bar_desc = None
-
-        # Filter out known bad vaults
-        addresses = [a for a in addresses if a.lower() not in BROKEN_VAULT_CONTRACTS]
 
         for feature_probe in probe_vaults(
             chain,
@@ -366,8 +457,40 @@ class VaultDiscoveryBase(abc.ABC):
         ):
             if feature_probe.address.lower() in BROKEN_VAULT_CONTRACTS:
                 logger.warning(f"Skipping known broken vault {feature_probe.address}")
+                continue
 
-            lead = leads[feature_probe.address]
+            address_key = feature_probe.address.lower()
+            lead = leads_by_address[address_key]
+            # Compatibility shim: older persisted lead objects may not have this slot; remove after reader state migration.
+            candidate = getattr(lead, "mellow_factory_candidate", None)
+            if candidate is not None:
+                features = set(feature_probe.features)
+                features.discard(ERC4626Feature.broken)
+                features.add(ERC4626Feature.mellow_like)
+
+                detection = ERC4262VaultDetection(
+                    chain=chain,
+                    address=feature_probe.address,
+                    features=features,
+                    first_seen_at_block=candidate.created_block,
+                    first_seen_at=candidate.created_at,
+                    updated_at=native_datetime_utc_now(),
+                    # Mellow flow events are emitted by DepositQueue contracts,
+                    # not by the canonical Vault address discovered from
+                    # Factory.Created. True flow counts need a second-stage
+                    # queue scan; initial discovery and price scanning
+                    # intentionally use feature-based activity-filter exemption
+                    # instead.
+                    deposit_count=0,
+                    # Mellow redemption events are emitted by RedeemQueue
+                    # contracts. Keep an integer zero for compatibility with
+                    # numeric consumers; ERC4626Feature.mellow_like prevents
+                    # these rows from being silently filtered out as inactive.
+                    redeem_count=0,
+                )
+                report.detections[feature_probe.address] = detection
+                good_vaults += 1
+                continue
 
             detection = ERC4262VaultDetection(
                 chain=chain,
@@ -387,7 +510,7 @@ class VaultDiscoveryBase(abc.ABC):
                 good_vaults += 1
 
         logger.info(
-            "Found %d good ERC-4626 vaults, %d broken vaults",
+            "Found %d good ERC-4626/Mellow vaults, %d broken vaults",
             good_vaults,
             broken_vaults,
         )

--- a/eth_defi/erc_4626/hypersync_discovery.py
+++ b/eth_defi/erc_4626/hypersync_discovery.py
@@ -10,6 +10,7 @@
 import asyncio
 import logging
 
+from eth_abi.exceptions import DecodingError
 from eth_typing import HexAddress, HexStr
 from tqdm_loggable.auto import tqdm
 from web3 import Web3
@@ -17,9 +18,10 @@ from web3 import Web3
 from eth_defi.abi import get_topic_signature_from_event
 from eth_defi.chain import get_chain_name
 from eth_defi.compat import native_datetime_utc_fromtimestamp
-from eth_defi.erc_4626.discovery_base import LeadScanReport, PotentialVaultMatch, VaultDiscoveryBase, get_vault_discovery_events, get_vault_event_topic_map, is_deposit_event
+from eth_defi.erc_4626.discovery_base import LeadScanReport, PotentialVaultMatch, VaultDiscoveryBase, add_mellow_factory_candidate_lead, get_vault_discovery_events, get_vault_event_topic_map, is_deposit_event
 from eth_defi.event_reader.web3factory import Web3Factory
 from eth_defi.hypersync.hypersync_timestamp import HypersyncFlaky, get_hypersync_block_height_with_retries, is_hypersync_next_block_range_error, is_hypersync_rate_limit_error, is_hypersync_retryable_runtime_error
+from eth_defi.mellow.discovery import create_mellow_factory_candidate, fetch_mellow_created_event_topic, fetch_mellow_factories_for_chain, is_mellow_factory_log
 
 try:
     import hypersync
@@ -108,6 +110,14 @@ class HypersyncVaultDiscover(VaultDiscoveryBase):
 
         # [['0xdcbc1c05240f31ff3ad067ef1ee35ce4997762752e3a095284754544f4c709d7'], ['0xfbde797d201c681b91056529119e0b02407c7bb96a4a2c75c01fc9667232c8db']]
         log_selections = [hypersync.LogSelection(topics=[[sig]]) for sig in self.get_topic_signatures()]
+        mellow_factories = fetch_mellow_factories_for_chain(self.web3.eth.chain_id)
+        if mellow_factories:
+            log_selections.append(
+                hypersync.LogSelection(
+                    address=mellow_factories,
+                    topics=[[fetch_mellow_created_event_topic()]],
+                )
+            )
 
         # The query to run
         query = hypersync.Query(
@@ -124,9 +134,14 @@ class HypersyncVaultDiscover(VaultDiscoveryBase):
                 ],
                 log=[
                     LogField.BLOCK_NUMBER,
+                    LogField.LOG_INDEX,
                     LogField.ADDRESS,
                     LogField.TRANSACTION_HASH,
                     LogField.TOPIC0,
+                    LogField.TOPIC1,
+                    LogField.TOPIC2,
+                    LogField.TOPIC3,
+                    LogField.DATA,
                 ],
             ),
         )
@@ -171,6 +186,100 @@ class HypersyncVaultDiscover(VaultDiscoveryBase):
             )
 
         return clipped_end_block
+
+    def process_log(
+        self,
+        report: LeadScanReport,
+        leads: dict[HexAddress, PotentialVaultMatch],
+        topic_map: dict[str, object],
+        chain: int,
+        log: hypersync.Log,
+        block_timestamp,
+        seen: set[HexAddress],
+    ) -> None:
+        """Process one Hypersync log into the shared lead map.
+
+        Both ERC-4626-like event leads and Mellow factory leads are written to
+        ``leads`` as ``PotentialVaultMatch`` objects. Mellow keeps decoded
+        factory metadata on the lead for the later detection construction step.
+
+        :param report:
+            Mutable scan report.
+
+        :param leads:
+            Mutable lead map keyed by lower-case vault address.
+
+        :param topic_map:
+            ERC-4626-style event topic classification map.
+
+        :param chain:
+            EVM chain id.
+
+        :param log:
+            Hypersync log.
+
+        :param block_timestamp:
+            Naive UTC timestamp for the log block.
+
+        :param seen:
+            Addresses already counted as matched candidates.
+
+        :return:
+            None.
+        """
+
+        if is_mellow_factory_log(chain, log.address, log.topics[0]):
+            try:
+                candidate = create_mellow_factory_candidate(
+                    self.web3,
+                    chain,
+                    log,
+                    block_timestamp,
+                )
+            except (DecodingError, ValueError) as e:
+                logger.warning(
+                    "Could not decode Mellow factory Created log at %s:%s tx %s: %s",
+                    log.block_number,
+                    getattr(log, "log_index", None),
+                    log.transaction_hash,
+                    e,
+                )
+                return
+
+            add_mellow_factory_candidate_lead(report, leads, candidate)
+            return
+
+        address_key = HexAddress(log.address.lower())
+        lead = leads.get(address_key)
+        first_seen_timestamp = None
+
+        if not lead:
+            first_seen_timestamp = block_timestamp
+            lead = PotentialVaultMatch(
+                chain=chain,
+                address=address_key,
+                first_seen_at_block=log.block_number,
+                first_seen_at=first_seen_timestamp,
+            )
+            leads[address_key] = lead
+            report.new_leads += 1
+
+        event_kind = topic_map.get(log.topics[0])
+        if event_kind is not None and is_deposit_event(event_kind):
+            lead.deposit_count += 1
+            report.deposits += 1
+        else:
+            lead.withdrawal_count += 1
+            report.withdrawals += 1
+
+        if address_key not in seen and lead.is_candidate():
+            seen.add(address_key)
+
+    def fetch_log_timestamp(self, block_lookup: dict, log: hypersync.Log):
+        """Resolve a Hypersync log timestamp from the batch block lookup."""
+
+        block = block_lookup[log.block_number]
+        return native_datetime_utc_fromtimestamp(int(block.timestamp, 16) if isinstance(block.timestamp, str) else block.timestamp)
 
     def scan_vaults(
         self,
@@ -281,7 +390,6 @@ class HypersyncVaultDiscover(VaultDiscoveryBase):
             progress_bar = None
 
         last_block = start_block
-        timestamp = None
 
         logger.info("Streaming HyperSync")
 
@@ -289,9 +397,7 @@ class HypersyncVaultDiscover(VaultDiscoveryBase):
 
         report = LeadScanReport(backend=self)
         report.old_leads = len(self.existing_leads)
-
-        leads: dict[HexAddress, PotentialVaultMatch] = self.existing_leads.copy()
-        matches = 0
+        report.leads = self.existing_leads.copy()
         seen = set()
 
         while True:
@@ -314,35 +420,15 @@ class HypersyncVaultDiscover(VaultDiscoveryBase):
                 block_lookup = {b.number: b for b in res.data.blocks}
                 log: hypersync.Log
                 for log in res.data.logs:
-                    lead = leads.get(log.address)
-
-                    if not lead:
-                        # Fresh match
-                        block = block_lookup[log.block_number]
-                        timestamp = native_datetime_utc_fromtimestamp(int(block.timestamp, 16))
-                        lead = PotentialVaultMatch(
-                            chain=chain,
-                            address=log.address.lower(),
-                            first_seen_at_block=log.block_number,
-                            first_seen_at=timestamp,
-                        )
-                        leads[log.address] = lead
-                        report.new_leads += 1
-
-                    # Classify event using topic map (supports ERC-4626 and BrinkVault)
-                    event_kind = topic_map.get(log.topics[0])
-                    if event_kind is not None and is_deposit_event(event_kind):
-                        lead.deposit_count += 1
-                        report.deposits += 1
-                    else:
-                        lead.withdrawal_count += 1
-                        report.withdrawals += 1
-
-                    if log.address not in seen:
-                        if lead.is_candidate():
-                            # Return leads early, even if we still accumulate deposit and withdraw matches for them
-                            matches += 1
-                            seen.add(log.address)
+                    self.process_log(
+                        report,
+                        report.leads,
+                        topic_map,
+                        chain,
+                        log,
+                        self.fetch_log_timestamp(block_lookup, log),
+                        seen,
+                    )
 
             last_synced = res.archive_height
 
@@ -351,18 +437,15 @@ class HypersyncVaultDiscover(VaultDiscoveryBase):
                 last_block = current_block
 
                 # Add extra data to the progress bar
-                if timestamp is not None:
-                    progress_bar.set_postfix(
-                        {
-                            "At": timestamp,
-                            "Matches": f"{matches:,}",
-                        }
-                    )
+                progress_bar.set_postfix(
+                    {
+                        "Matches": f"{len(seen):,}",
+                    }
+                )
 
         logger.info(f"HyperSync sees {last_synced} as the last block")
 
         if progress_bar is not None:
             progress_bar.close()
 
-        report.leads = leads
         return report

--- a/eth_defi/erc_4626/lead_scan_core.py
+++ b/eth_defi/erc_4626/lead_scan_core.py
@@ -144,7 +144,7 @@ def scan_leads(
     rpcs = get_provider_name(web3.provider)
 
     hypersync_config = configure_hypersync_from_env(web3, hypersync_api_key=hypersync_api_key, concurrency=hypersync_concurrency)
-    printer(f"Scanning ERC-4626 vaults on chain {web3.eth.chain_id}: {name}, using rpcs: {rpcs}, using event backend {backend}, HyperSync: {hypersync_config.hypersync_url or '<not avail>'}, and {max_workers} workers")
+    printer(f"Scanning EVM vaults on chain {web3.eth.chain_id}: {name}, using rpcs: {rpcs}, using event backend {backend}, HyperSync: {hypersync_config.hypersync_url or '<not avail>'}, and {max_workers} workers")
 
     if not vault_db_file.exists():
         logger.info("Starting vault lead scan, created new database at %s", vault_db_file)

--- a/eth_defi/erc_4626/rpc_discovery.py
+++ b/eth_defi/erc_4626/rpc_discovery.py
@@ -283,6 +283,23 @@ class JSONRPCVaultDiscover(VaultDiscoveryBase):
 
         report.leads = leads
 
-        self.scan_mellow_factory_leads(report, chain, leads, self.build_mellow_factory_query(executor, start_block, end_block))
+        # ``read_events_concurrent()`` owns the executor lifecycle. Use a fresh
+        # pool for the Mellow factory pass so the preceding ERC-4626/BrinkVault
+        # event scan cannot leave us with a shut down executor.
+        if fetch_mellow_factories_for_chain(chain):
+            self.scan_mellow_factory_leads(
+                report,
+                chain,
+                leads,
+                self.build_mellow_factory_query(
+                    create_thread_pool_executor(
+                        self.web3factory,
+                        context=None,
+                        max_workers=self.max_workers,
+                    ),
+                    start_block,
+                    end_block,
+                ),
+            )
 
         return report

--- a/eth_defi/erc_4626/rpc_discovery.py
+++ b/eth_defi/erc_4626/rpc_discovery.py
@@ -5,30 +5,32 @@
 """
 
 import logging
-
 from concurrent.futures.thread import ThreadPoolExecutor
 from pprint import pformat
 
+from eth_abi.exceptions import DecodingError
 from eth_typing import HexAddress
+from tqdm_loggable.auto import tqdm
 from web3 import Web3
 
-from tqdm_loggable.auto import tqdm
-
 from eth_defi.erc_4626.discovery_base import (
+    LeadScanReport,
+    PotentialVaultMatch,
+    VaultDiscoveryBase,
+    add_mellow_factory_candidate_lead,
     get_vault_discovery_events,
     get_vault_event_topic_map,
     is_deposit_event,
-    LeadScanReport,
-    VaultDiscoveryBase,
-    PotentialVaultMatch,
 )
+from eth_defi.event_reader.filter import Filter
 from eth_defi.event_reader.reader import read_events_concurrent
 from eth_defi.event_reader.web3factory import Web3Factory
 from eth_defi.event_reader.web3worker import create_thread_pool_executor
+from eth_defi.mellow.abi import FACTORY_ABI as MELLOW_FACTORY_ABI
+from eth_defi.mellow.discovery import create_mellow_factory_candidate, fetch_mellow_factories_for_chain
 from eth_defi.provider.log_block_range import get_logs_max_block_range
 from eth_defi.timestamp import get_block_timestamp
 from eth_defi.utils import addr
-
 
 logger = logging.getLogger(__name__)
 
@@ -84,11 +86,101 @@ class JSONRPCVaultDiscover(VaultDiscoveryBase):
             "extract_timestamps": None,  # We only need timestamps for first event per vault
         }
 
+    def build_mellow_factory_query(self, executor: ThreadPoolExecutor, start_block: int, end_block: int) -> dict | None:
+        """Create a JSON-RPC event-reader query for Mellow factory leads.
+
+        Mellow Core Vault discovery is factory-led. The JSON-RPC fallback mirrors
+        the Hypersync path by scanning only configured factory addresses and
+        storing decoded candidates as normal ``PotentialVaultMatch`` leads for
+        the shared ``probe_vaults()`` pass.
+
+        :param executor:
+            Thread pool executor for ``read_events_concurrent()``.
+
+        :param start_block:
+            Inclusive start block.
+
+        :param end_block:
+            Inclusive end block.
+
+        :return:
+            Query keyword arguments, or ``None`` when the chain has no
+            configured Mellow Core factory.
+        """
+
+        mellow_factories = fetch_mellow_factories_for_chain(self.web3.eth.chain_id)
+        if not mellow_factories:
+            return None
+
+        mellow_factory = self.web3.eth.contract(abi=MELLOW_FACTORY_ABI)
+        return {
+            "executor": executor,
+            "start_block": start_block,
+            "end_block": end_block,
+            "filter": Filter.create_filter(mellow_factories, [mellow_factory.events.Created]),
+            "chunk_size": self.max_getlogs_range or get_logs_max_block_range(self.web3),
+            "extract_timestamps": None,
+        }
+
+    def scan_mellow_factory_leads(
+        self,
+        report: LeadScanReport,
+        chain: int,
+        leads: dict[HexAddress, PotentialVaultMatch],
+        mellow_query: dict | None,
+    ) -> None:
+        """Populate Mellow factory leads using the JSON-RPC fallback.
+
+        :param report:
+            Mutable scan report whose counters are updated.
+
+        :param chain:
+            EVM chain id.
+
+        :param leads:
+            Mutable shared lead map to receive Mellow factory leads.
+
+        :param mellow_query:
+            Query keyword arguments from :py:meth:`build_mellow_factory_query`,
+            or ``None`` if the chain has no configured factory.
+        """
+
+        if mellow_query is None:
+            return
+
+        logger.info("Building Mellow factory eth_getLogs JSON-RPC query using read_events_concurrent(): %s", pformat(mellow_query))
+        block_timestamps = {}
+        for event in read_events_concurrent(**mellow_query):
+            block_number = event["blockNumber"]
+            timestamp = block_timestamps.get(block_number)
+            if timestamp is None:
+                timestamp = get_block_timestamp(self.web3, block_number)
+                block_timestamps[block_number] = timestamp
+
+            try:
+                candidate = create_mellow_factory_candidate(
+                    self.web3,
+                    chain,
+                    event,
+                    timestamp,
+                )
+            except (DecodingError, ValueError) as e:
+                logger.warning(
+                    "Could not decode Mellow factory Created log at %s:%s tx %s: %s",
+                    event.get("blockNumber"),
+                    event.get("logIndex"),
+                    event.get("transactionHash"),
+                    e,
+                )
+                continue
+
+            add_mellow_factory_candidate_lead(report, leads, candidate)
+
     def fetch_leads(
         self,
         start_block: int,
         end_block: int,
-        display_progress=True,
+        display_progress=True,  # noqa: FBT002
     ) -> LeadScanReport:
         """Identify smart contracts emitting 4626 like events.
 
@@ -130,7 +222,6 @@ class JSONRPCVaultDiscover(VaultDiscoveryBase):
         last_block = start_block
         timestamp = None
 
-        matches = 0
         seen = set()
 
         report = LeadScanReport(backend=self)
@@ -169,7 +260,6 @@ class JSONRPCVaultDiscover(VaultDiscoveryBase):
             if address not in seen:
                 if lead.is_candidate():
                     # Return leads early, even if we still accumulate deposit and withdraw matches for them
-                    matches += 1
                     seen.add(address)
                     logger.debug("Found lead %s", address)
 
@@ -183,7 +273,7 @@ class JSONRPCVaultDiscover(VaultDiscoveryBase):
                         {
                             "At": timestamp,
                             "Block": f"{last_block:,}",
-                            "Matches": f"{matches:,}",
+                            "Matches": f"{len(seen):,}",
                         }
                     )
 
@@ -191,5 +281,7 @@ class JSONRPCVaultDiscover(VaultDiscoveryBase):
             progress_bar.close()
 
         report.leads = leads
+
+        self.scan_mellow_factory_leads(report, chain, leads, self.build_mellow_factory_query(executor, start_block, end_block))
 
         return report

--- a/eth_defi/erc_4626/rpc_discovery.py
+++ b/eth_defi/erc_4626/rpc_discovery.py
@@ -13,6 +13,7 @@ from eth_typing import HexAddress
 from tqdm_loggable.auto import tqdm
 from web3 import Web3
 
+from eth_defi.abi import get_contract
 from eth_defi.erc_4626.discovery_base import (
     LeadScanReport,
     PotentialVaultMatch,
@@ -26,7 +27,7 @@ from eth_defi.event_reader.filter import Filter
 from eth_defi.event_reader.reader import read_events_concurrent
 from eth_defi.event_reader.web3factory import Web3Factory
 from eth_defi.event_reader.web3worker import create_thread_pool_executor
-from eth_defi.mellow.abi import FACTORY_ABI as MELLOW_FACTORY_ABI
+from eth_defi.mellow.abi import FACTORY_ABI_FILENAME
 from eth_defi.mellow.discovery import create_mellow_factory_candidate, fetch_mellow_factories_for_chain
 from eth_defi.provider.log_block_range import get_logs_max_block_range
 from eth_defi.timestamp import get_block_timestamp
@@ -112,7 +113,7 @@ class JSONRPCVaultDiscover(VaultDiscoveryBase):
         if not mellow_factories:
             return None
 
-        mellow_factory = self.web3.eth.contract(abi=MELLOW_FACTORY_ABI)
+        mellow_factory = get_contract(self.web3, FACTORY_ABI_FILENAME)
         return {
             "executor": executor,
             "start_block": start_block,

--- a/eth_defi/erc_4626/scan.py
+++ b/eth_defi/erc_4626/scan.py
@@ -129,8 +129,9 @@ def _fetch_total_assets(vault: VaultBase, block_identifier: BlockIdentifier) -> 
 
     # For vaults without on-chain total_assets (e.g. ForgeYields cross-chain
     # aggregator) and VaultBase protocols without an ERC-4626 totalAssets()
-    # method (e.g. Mellow), fall back to fetch_nav() which may return
-    # denomination-token TVL from an external API.
+    # method, fall back to fetch_nav(). Mellow currently returns None here until
+    # a canonical on-chain portfolio/subvault NAV method is implemented; its
+    # historical reader derives TVL from on-chain share price and supply instead.
     if total_assets is None:
         total_assets = _optional_vault_read(lambda: vault.fetch_nav(block_identifier))
 

--- a/eth_defi/erc_4626/scan.py
+++ b/eth_defi/erc_4626/scan.py
@@ -127,11 +127,10 @@ def _fetch_total_assets(vault: VaultBase, block_identifier: BlockIdentifier) -> 
 
     total_assets = _optional_vault_read(lambda: vault.fetch_total_assets(block_identifier))
 
-    # For vaults without on-chain total_assets (e.g. ForgeYields cross-chain
-    # aggregator) and VaultBase protocols without an ERC-4626 totalAssets()
-    # method, fall back to fetch_nav(). Mellow currently returns None here until
-    # a canonical on-chain portfolio/subvault NAV method is implemented; its
-    # historical reader derives TVL from on-chain share price and supply instead.
+    # For vaults without an ERC-4626 totalAssets() method, fall back to
+    # fetch_nav(). Protocol adapters can still expose comparable TVL through
+    # fetch_total_assets(); Mellow does this as share_price * total_supply, while
+    # ForgeYields uses fetch_nav() because its canonical TVL is off-chain.
     if total_assets is None:
         total_assets = _optional_vault_read(lambda: vault.fetch_nav(block_identifier))
 

--- a/eth_defi/erc_4626/scan.py
+++ b/eth_defi/erc_4626/scan.py
@@ -3,25 +3,243 @@
 import datetime
 import logging
 import threading
-from typing import cast
+from collections.abc import Callable
+from decimal import Decimal
+from typing import TypeVar
 
-import pandas as pd
-from requests.exceptions import HTTPError
+from eth_abi.exceptions import DecodingError
+from requests.exceptions import HTTPError, RequestException
 from web3 import Web3
+from web3.exceptions import BadFunctionCallOutput, ContractLogicError, MismatchedABI, Web3Exception, Web3RPCError, Web3ValueError
 from web3.types import BlockIdentifier
 
 from eth_defi.erc_4626.classification import create_vault_instance
-from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name, is_lending_protocol
+from eth_defi.erc_4626.core import get_vault_protocol_name, is_lending_protocol
 from eth_defi.erc_4626.discovery_base import ERC4262VaultDetection
-from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.morpho.vault_v1 import MorphoV1Vault
 from eth_defi.erc_4626.vault_protocol.morpho.vault_v2 import MorphoV2Vault
 from eth_defi.event_reader.web3factory import Web3Factory
 from eth_defi.provider.fallback import ExtraValueError
 from eth_defi.token import TokenDiskCache
+from eth_defi.vault.base import VaultBase
 from eth_defi.vault.fee import BROKEN_FEE_DATA, FeeData
 
 logger = logging.getLogger(__name__)
+
+OptionalVaultRead = TypeVar("OptionalVaultRead")
+ACTIVITY_STATUS_MIN_NAV = Decimal("5000")
+OPTIONAL_READ_EXCEPTIONS = (AttributeError, NotImplementedError, ValueError)
+BEST_EFFORT_READ_EXCEPTIONS = (
+    *OPTIONAL_READ_EXCEPTIONS,
+    ConnectionError,
+    KeyError,
+    RuntimeError,
+    TimeoutError,
+    TypeError,
+    DecodingError,
+    BadFunctionCallOutput,
+    ContractLogicError,
+    ExtraValueError,
+    MismatchedABI,
+    RequestException,
+    Web3Exception,
+    Web3RPCError,
+    Web3ValueError,
+)
+ROW_READ_EXCEPTIONS = (
+    *BEST_EFFORT_READ_EXCEPTIONS,
+    AssertionError,
+    ArithmeticError,
+)
+
+
+def _optional_vault_read(reader: Callable[[], OptionalVaultRead]) -> OptionalVaultRead | None:
+    """Run a best-effort vault metadata read.
+
+    Scan rows include optional fields that not every :py:class:`VaultBase`
+    adapter supports. Treat only missing or explicitly unsupported adapter
+    methods as empty values; unexpected exceptions still flow to
+    :py:func:`create_vault_scan_record` and mark the vault as broken.
+
+    :param reader:
+        Zero-argument callable that reads one optional vault field.
+
+    :return:
+        Reader value, or ``None`` when the field is unavailable.
+    """
+
+    try:
+        return reader()
+    except OPTIONAL_READ_EXCEPTIONS:
+        return None
+
+
+def _best_effort_vault_read(reader: Callable[[], OptionalVaultRead]) -> OptionalVaultRead | None:
+    """Run a non-critical vault metadata read.
+
+    Activity status and lending-liquidity fields are scan-row adornments. Before
+    the Mellow unification, these reads were fully best-effort and a failed RPC
+    call only left the individual field empty. Preserve that behaviour so a
+    transient or protocol-specific failure does not mark the whole vault row
+    broken.
+
+    :param reader:
+        Zero-argument callable that reads one non-critical vault field.
+
+    :return:
+        Reader value, or ``None`` when the field cannot be read.
+    """
+
+    try:
+        return reader()
+    except BEST_EFFORT_READ_EXCEPTIONS as e:
+        # Preserve the legacy field-level isolation for optional activity and
+        # lending reads. These calls are not required to identify or price a
+        # vault, and protocol adapters have historically raised heterogeneous
+        # RPC/decode/runtime errors here.
+        logger.debug(
+            "Ignored failed non-critical vault read %s: %s",
+            getattr(reader, "__qualname__", repr(reader)),
+            e,
+            exc_info=True,
+        )
+        return None
+
+
+def _fetch_total_assets(vault: VaultBase, block_identifier: BlockIdentifier) -> Decimal | None:
+    """Fetch vault assets through the shared scan contract.
+
+    ERC-4626 vaults expose ``totalAssets()`` through
+    :py:meth:`eth_defi.erc_4626.vault.ERC4626Vault.fetch_total_assets`.
+    Other :py:class:`eth_defi.vault.base.VaultBase` adapters, like Mellow, may
+    not have that method. In those cases we fall back to ``fetch_nav()`` so all
+    smart-contract vault protocols can use the same scan-record path.
+
+    :param vault:
+        Vault adapter instance.
+
+    :param block_identifier:
+        Block number or tag for the read.
+
+    :return:
+        Human-readable denomination-token TVL, or ``None`` if unavailable.
+    """
+
+    total_assets = _optional_vault_read(lambda: vault.fetch_total_assets(block_identifier))
+
+    # For vaults without on-chain total_assets (e.g. ForgeYields cross-chain
+    # aggregator) and VaultBase protocols without an ERC-4626 totalAssets()
+    # method (e.g. Mellow), fall back to fetch_nav() which may return
+    # denomination-token TVL from an external API.
+    if total_assets is None:
+        total_assets = _optional_vault_read(lambda: vault.fetch_nav(block_identifier))
+
+    return total_assets
+
+
+def _fetch_total_supply(vault: VaultBase, block_identifier: BlockIdentifier) -> Decimal | None:
+    """Fetch vault share supply if the adapter supports it.
+
+    :param vault:
+        Vault adapter instance.
+
+    :param block_identifier:
+        Block number or tag for the read.
+
+    :return:
+        Human-readable share supply, or ``None`` if unavailable.
+    """
+
+    return _optional_vault_read(lambda: vault.fetch_total_supply(block_identifier))
+
+
+def _export_denomination_token(vault: VaultBase) -> dict | None:
+    """Export denomination token metadata for scan rows.
+
+    :param vault:
+        Vault adapter instance.
+
+    :return:
+        Token metadata dictionary, or ``None`` if the vault does not expose a
+        denomination token.
+    """
+
+    token = vault.denomination_token
+    if token is None:
+        return None
+
+    exported_token = token.export()
+    assert isinstance(exported_token, dict), f"Got {exported_token}"
+    return exported_token
+
+
+def _fetch_activity_status(vault: VaultBase, total_assets: Decimal | None) -> dict[str, object]:
+    """Fetch deposit and redemption status fields for sizeable vaults.
+
+    :param vault:
+        Vault adapter instance.
+
+    :param total_assets:
+        Human-readable denomination-token TVL.
+
+    :return:
+        Private scan-row status fields.
+    """
+
+    status = {
+        "_deposit_closed_reason": None,
+        "_redemption_closed_reason": None,
+        "_deposit_next_open": None,
+        "_redemption_next_open": None,
+    }
+
+    if total_assets is None or total_assets <= ACTIVITY_STATUS_MIN_NAV:
+        return status
+
+    status["_deposit_closed_reason"] = _best_effort_vault_read(vault.fetch_deposit_closed_reason)
+    status["_redemption_closed_reason"] = _best_effort_vault_read(vault.fetch_redemption_closed_reason)
+    status["_deposit_next_open"] = _best_effort_vault_read(vault.fetch_deposit_next_open)
+    status["_redemption_next_open"] = _best_effort_vault_read(vault.fetch_redemption_next_open)
+
+    return status
+
+
+def _fetch_lending_stats(
+    vault: VaultBase,
+    detection: ERC4262VaultDetection,
+    total_assets: Decimal | None,
+    block_identifier: BlockIdentifier,
+) -> dict[str, object]:
+    """Fetch lending-specific row fields for lending protocols.
+
+    :param vault:
+        Vault adapter instance.
+
+    :param detection:
+        Vault detection metadata with protocol feature flags.
+
+    :param total_assets:
+        Human-readable denomination-token TVL.
+
+    :param block_identifier:
+        Block number or tag for the read.
+
+    :return:
+        Private scan-row lending fields.
+    """
+
+    stats = {
+        "_available_liquidity": None,
+        "_utilisation": None,
+    }
+
+    if not is_lending_protocol(detection.features) or total_assets is None or total_assets <= ACTIVITY_STATUS_MIN_NAV:
+        return stats
+
+    stats["_available_liquidity"] = _best_effort_vault_read(lambda: vault.fetch_available_liquidity(block_identifier))
+    stats["_utilisation"] = _best_effort_vault_read(lambda: vault.fetch_utilisation_percent(block_identifier))
+
+    return stats
 
 
 def create_vault_scan_record(
@@ -71,99 +289,16 @@ def create_vault_scan_record(
         return empty_record
 
     try:
-        if ERC4626Feature.mellow_like in detection.features:
-            from eth_defi.mellow.vault import MellowVault
-
-            mellow_vault = cast(MellowVault, vault)
-
-            try:
-                total_assets = mellow_vault.fetch_nav(block_identifier)
-            except ValueError:
-                total_assets = None
-
-            try:
-                total_supply = mellow_vault.fetch_total_supply(block_identifier)
-            except ValueError:
-                total_supply = None
-
-            denomination_token = mellow_vault.denomination_token.export() if mellow_vault.denomination_token else None
-            share_token = mellow_vault.share_token.export() if mellow_vault.share_token else None
-
-            return {
-                "Symbol": mellow_vault.symbol,
-                "Name": mellow_vault.name,
-                "Address": detection.address,
-                "Denomination": mellow_vault.denomination_token.symbol if mellow_vault.denomination_token else None,
-                "Share token": mellow_vault.share_token.symbol if mellow_vault.share_token else None,
-                "NAV": total_assets or 0,
-                "Protocol": "Mellow",
-                "Mgmt fee": None,
-                "Perf fee": None,
-                "Deposit fee": None,
-                "Withdraw fee": None,
-                "Shares": total_supply,
-                "First seen": detection.first_seen_at,
-                "Features": ", ".join(sorted([f.name for f in detection.features])),
-                "Link": mellow_vault.get_link(),
-                "_detection_data": detection,
-                "_denomination_token": denomination_token,
-                "_share_token": share_token,
-                "_fees": BROKEN_FEE_DATA,
-                "_flags": {},
-                "_lockup": None,
-                "_deposit_closed_reason": None,
-                "_redemption_closed_reason": None,
-                "_deposit_next_open": None,
-                "_redemption_next_open": None,
-                "_available_liquidity": None,
-                "_utilisation": None,
-                "_description": mellow_vault.description,
-                "_short_description": mellow_vault.short_description,
-                "_manager_name": mellow_vault.manager_name,
-                "_morpho_offchain_data": None,
-                "_mellow_info": mellow_vault.fetch_info(),
-            }
-
-        # Try to figure out the correct vault subclass
-        # to pull out the data like fees
-        vault = cast(ERC4626Vault, vault)
-
         try:
             fees = vault.get_fee_data()
-        except (NotImplementedError, ValueError) as e:
+        except (NotImplementedError, ValueError):
             fees = BROKEN_FEE_DATA
 
         assert isinstance(fees, FeeData), f"Got {type(fees)}: {fees}"
 
-        management_fee = fees.management
-        performance_fee = fees.performance
-        deposit_fee = fees.deposit
-        withdraw_fee = fees.withdraw
-
-        try:
-            total_assets = vault.fetch_total_assets(block_identifier)
-        except ValueError:
-            total_assets = None
-
-        # For vaults without on-chain total_assets (e.g. ForgeYields cross-chain
-        # aggregator), fall back to fetch_nav() which may return denomination-token
-        # TVL from an external API.
-        if total_assets is None:
-            try:
-                total_assets = vault.fetch_nav(block_identifier)
-            except (AttributeError, ValueError):
-                total_assets = None
-
-        try:
-            total_supply = vault.fetch_total_supply(block_identifier)
-        except ValueError:
-            total_supply = None
-
-        if vault.denomination_token is not None:
-            denomination_token = vault.denomination_token.export()
-            assert type(denomination_token) == dict, f"Got {denomination_token}"
-        else:
-            denomination_token = None
+        total_assets = _fetch_total_assets(vault, block_identifier)
+        total_supply = _fetch_total_supply(vault, block_identifier)
+        denomination_token = _export_denomination_token(vault)
 
         try:
             lockup = vault.get_estimated_lock_up()
@@ -181,53 +316,10 @@ def create_vault_scan_record(
             logger.error(f"Failed to read flags for vault {vault} at {detection.address}: {e}", exc_info=e)
             flags = {}
 
-        # Resolve vault flags from the smart contract state
         link = vault.get_link()
-
         protocol_name = get_vault_protocol_name(detection.features)
-
-        # Only call deposit/redemption status methods for vaults with NAV > 5000
-        # to avoid extra JSON-RPC calls for small vaults
-        deposit_closed_reason = None
-        redemption_closed_reason = None
-        deposit_next_open = None
-        redemption_next_open = None
-
-        if total_assets is not None and total_assets > 5000:
-            try:
-                deposit_closed_reason = vault.fetch_deposit_closed_reason()
-            except Exception:
-                pass
-
-            try:
-                redemption_closed_reason = vault.fetch_redemption_closed_reason()
-            except Exception:
-                pass
-
-            try:
-                deposit_next_open = vault.fetch_deposit_next_open()
-            except Exception:
-                pass
-
-            try:
-                redemption_next_open = vault.fetch_redemption_next_open()
-            except Exception:
-                pass
-
-        # Collect lending statistics for lending protocol vaults
-        available_liquidity = None
-        utilisation = None
-
-        if is_lending_protocol(detection.features) and total_assets is not None and total_assets > 5000:
-            try:
-                available_liquidity = vault.fetch_available_liquidity(block_identifier)
-            except Exception:
-                pass
-
-            try:
-                utilisation = vault.fetch_utilisation_percent(block_identifier)
-            except Exception:
-                pass
+        activity_status = _fetch_activity_status(vault, total_assets)
+        lending_stats = _fetch_lending_stats(vault, detection, total_assets, block_identifier)
 
         data = {
             "Symbol": vault.symbol,
@@ -237,10 +329,10 @@ def create_vault_scan_record(
             "Share token": vault.share_token.symbol if vault.share_token else None,
             "NAV": total_assets,
             "Protocol": protocol_name,
-            "Mgmt fee": management_fee,
-            "Perf fee": performance_fee,
-            "Deposit fee": deposit_fee,
-            "Withdraw fee": withdraw_fee,
+            "Mgmt fee": fees.management,
+            "Perf fee": fees.performance,
+            "Deposit fee": fees.deposit,
+            "Withdraw fee": fees.withdraw,
             "Shares": total_supply,
             "First seen": detection.first_seen_at,
             "Features": ", ".join(sorted([f.name for f in detection.features])),
@@ -251,22 +343,21 @@ def create_vault_scan_record(
             "_fees": fees,
             "_flags": flags,
             "_lockup": lockup,
-            "_deposit_closed_reason": deposit_closed_reason,
-            "_redemption_closed_reason": redemption_closed_reason,
-            "_deposit_next_open": deposit_next_open,
-            "_redemption_next_open": redemption_next_open,
-            "_available_liquidity": available_liquidity,
-            "_utilisation": utilisation,
             "_description": vault.description,
             "_short_description": vault.short_description,
             "_manager_name": vault.manager_name,
             "_morpho_offchain_data": vault.morpho_offchain_data if isinstance(vault, (MorphoV1Vault, MorphoV2Vault)) else None,
         }
+        data.update(vault.fetch_scan_record_extra_data())
+        data.update(activity_status)
+        data.update(lending_stats)
         return data
-    except ExtraValueError as e:
+    except ExtraValueError:
         # No idea yet
         raise
-    except Exception as e:
+    except ROW_READ_EXCEPTIONS as e:
+        # Final row-level guard: record one broken vault row and continue the
+        # wider scan when an adapter or RPC provider fails in an unexpected way.
         extra_message = ""
         if isinstance(e, HTTPError):
             # dRPC brokeness trap.

--- a/eth_defi/erc_4626/scan.py
+++ b/eth_defi/erc_4626/scan.py
@@ -11,7 +11,7 @@ from web3 import Web3
 from web3.types import BlockIdentifier
 
 from eth_defi.erc_4626.classification import create_vault_instance
-from eth_defi.erc_4626.core import get_vault_protocol_name, is_lending_protocol
+from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name, is_lending_protocol
 from eth_defi.erc_4626.discovery_base import ERC4262VaultDetection
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.morpho.vault_v1 import MorphoV1Vault
@@ -71,6 +71,59 @@ def create_vault_scan_record(
         return empty_record
 
     try:
+        if ERC4626Feature.mellow_like in detection.features:
+            from eth_defi.mellow.vault import MellowVault
+
+            mellow_vault = cast(MellowVault, vault)
+
+            try:
+                total_assets = mellow_vault.fetch_nav(block_identifier)
+            except ValueError:
+                total_assets = None
+
+            try:
+                total_supply = mellow_vault.fetch_total_supply(block_identifier)
+            except ValueError:
+                total_supply = None
+
+            denomination_token = mellow_vault.denomination_token.export() if mellow_vault.denomination_token else None
+            share_token = mellow_vault.share_token.export() if mellow_vault.share_token else None
+
+            return {
+                "Symbol": mellow_vault.symbol,
+                "Name": mellow_vault.name,
+                "Address": detection.address,
+                "Denomination": mellow_vault.denomination_token.symbol if mellow_vault.denomination_token else None,
+                "Share token": mellow_vault.share_token.symbol if mellow_vault.share_token else None,
+                "NAV": total_assets or 0,
+                "Protocol": "Mellow",
+                "Mgmt fee": None,
+                "Perf fee": None,
+                "Deposit fee": None,
+                "Withdraw fee": None,
+                "Shares": total_supply,
+                "First seen": detection.first_seen_at,
+                "Features": ", ".join(sorted([f.name for f in detection.features])),
+                "Link": mellow_vault.get_link(),
+                "_detection_data": detection,
+                "_denomination_token": denomination_token,
+                "_share_token": share_token,
+                "_fees": BROKEN_FEE_DATA,
+                "_flags": {},
+                "_lockup": None,
+                "_deposit_closed_reason": None,
+                "_redemption_closed_reason": None,
+                "_deposit_next_open": None,
+                "_redemption_next_open": None,
+                "_available_liquidity": None,
+                "_utilisation": None,
+                "_description": mellow_vault.description,
+                "_short_description": mellow_vault.short_description,
+                "_manager_name": mellow_vault.manager_name,
+                "_morpho_offchain_data": None,
+                "_mellow_info": mellow_vault.fetch_info(),
+            }
+
         # Try to figure out the correct vault subclass
         # to pull out the data like fees
         vault = cast(ERC4626Vault, vault)

--- a/eth_defi/mellow/__init__.py
+++ b/eth_defi/mellow/__init__.py
@@ -1,0 +1,1 @@
+"""Mellow Core Vault support."""

--- a/eth_defi/mellow/abi.py
+++ b/eth_defi/mellow/abi.py
@@ -1,116 +1,21 @@
-"""Minimal ABI fragments for Mellow Core Vault discovery and metadata reads."""
+"""Mellow ABI filenames.
 
-FACTORY_ABI = [
-    {
-        "anonymous": False,
-        "inputs": [
-            {"indexed": False, "internalType": "address", "name": "instance", "type": "address"},
-            {"indexed": False, "internalType": "uint256", "name": "version", "type": "uint256"},
-            {"indexed": False, "internalType": "address", "name": "owner", "type": "address"},
-            {"indexed": False, "internalType": "bytes", "name": "initParams", "type": "bytes"},
-        ],
-        "name": "Created",
-        "type": "event",
-    },
-]
+The actual ABI definitions live under :mod:`eth_defi.abi` in JSON files, like
+the rest of the project protocol integrations. Keep this module as a small
+named access point for Mellow-specific ABI paths.
+"""
 
-VAULT_ABI = [
-    {
-        "inputs": [],
-        "name": "shareManager",
-        "outputs": [{"internalType": "contract IShareManager", "name": "", "type": "address"}],
-        "stateMutability": "view",
-        "type": "function",
-    },
-    {
-        "inputs": [],
-        "name": "feeManager",
-        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
-        "stateMutability": "view",
-        "type": "function",
-    },
-    {
-        "inputs": [],
-        "name": "riskManager",
-        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
-        "stateMutability": "view",
-        "type": "function",
-    },
-    {
-        "inputs": [],
-        "name": "oracle",
-        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
-        "stateMutability": "view",
-        "type": "function",
-    },
-    {
-        "inputs": [],
-        "name": "getAssetCount",
-        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
-        "stateMutability": "view",
-        "type": "function",
-    },
-    {
-        "inputs": [{"internalType": "uint256", "name": "index", "type": "uint256"}],
-        "name": "assetAt",
-        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
-        "stateMutability": "view",
-        "type": "function",
-    },
-    {
-        "inputs": [{"internalType": "address", "name": "asset", "type": "address"}],
-        "name": "getQueueCount",
-        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
-        "stateMutability": "view",
-        "type": "function",
-    },
-    {
-        "inputs": [
-            {"internalType": "address", "name": "asset", "type": "address"},
-            {"internalType": "uint256", "name": "index", "type": "uint256"},
-        ],
-        "name": "queueAt",
-        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
-        "stateMutability": "view",
-        "type": "function",
-    },
-    {
-        "inputs": [{"internalType": "address", "name": "queue", "type": "address"}],
-        "name": "isDepositQueue",
-        "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
-        "stateMutability": "view",
-        "type": "function",
-    },
-]
+FACTORY_ABI_FILENAME = "mellow/Factory.json"
+"""Mellow Core Vault factory ABI file."""
 
+VAULT_ABI_FILENAME = "mellow/Vault.json"
+"""Mellow Core Vault ABI file."""
 
-ERC20_ABI = [
-    {
-        "inputs": [],
-        "name": "name",
-        "outputs": [{"internalType": "string", "name": "", "type": "string"}],
-        "stateMutability": "view",
-        "type": "function",
-    },
-    {
-        "inputs": [],
-        "name": "symbol",
-        "outputs": [{"internalType": "string", "name": "", "type": "string"}],
-        "stateMutability": "view",
-        "type": "function",
-    },
-    {
-        "inputs": [],
-        "name": "decimals",
-        "outputs": [{"internalType": "uint8", "name": "", "type": "uint8"}],
-        "stateMutability": "view",
-        "type": "function",
-    },
-    {
-        "inputs": [],
-        "name": "totalSupply",
-        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
-        "stateMutability": "view",
-        "type": "function",
-    },
-]
+ERC20_ABI_FILENAME = "mellow/ERC20.json"
+"""Minimal ERC-20 ABI file for tokenised Mellow ShareManagers."""
+
+ORACLE_ABI_FILENAME = "mellow/Oracle.json"
+"""Mellow Core Vault oracle ABI file."""
+
+FEE_MANAGER_ABI_FILENAME = "mellow/FeeManager.json"
+"""Mellow Core Vault FeeManager ABI file."""

--- a/eth_defi/mellow/abi.py
+++ b/eth_defi/mellow/abi.py
@@ -1,0 +1,116 @@
+"""Minimal ABI fragments for Mellow Core Vault discovery and metadata reads."""
+
+FACTORY_ABI = [
+    {
+        "anonymous": False,
+        "inputs": [
+            {"indexed": False, "internalType": "address", "name": "instance", "type": "address"},
+            {"indexed": False, "internalType": "uint256", "name": "version", "type": "uint256"},
+            {"indexed": False, "internalType": "address", "name": "owner", "type": "address"},
+            {"indexed": False, "internalType": "bytes", "name": "initParams", "type": "bytes"},
+        ],
+        "name": "Created",
+        "type": "event",
+    },
+]
+
+VAULT_ABI = [
+    {
+        "inputs": [],
+        "name": "shareManager",
+        "outputs": [{"internalType": "contract IShareManager", "name": "", "type": "address"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "feeManager",
+        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "riskManager",
+        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "oracle",
+        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "getAssetCount",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "uint256", "name": "index", "type": "uint256"}],
+        "name": "assetAt",
+        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "address", "name": "asset", "type": "address"}],
+        "name": "getQueueCount",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "asset", "type": "address"},
+            {"internalType": "uint256", "name": "index", "type": "uint256"},
+        ],
+        "name": "queueAt",
+        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "address", "name": "queue", "type": "address"}],
+        "name": "isDepositQueue",
+        "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+]
+
+
+ERC20_ABI = [
+    {
+        "inputs": [],
+        "name": "name",
+        "outputs": [{"internalType": "string", "name": "", "type": "string"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "symbol",
+        "outputs": [{"internalType": "string", "name": "", "type": "string"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "decimals",
+        "outputs": [{"internalType": "uint8", "name": "", "type": "uint8"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "totalSupply",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+]

--- a/eth_defi/mellow/discovery.py
+++ b/eth_defi/mellow/discovery.py
@@ -1,0 +1,291 @@
+"""Mellow Core Vault discovery helpers."""
+
+import dataclasses
+import datetime
+import os
+from types import SimpleNamespace
+from typing import Any
+
+from eth_typing import HexAddress
+from hexbytes import HexBytes
+from web3 import Web3
+
+MELLOW_CREATED_EVENT_SIGNATURE = "Created(address,uint256,address,bytes)"
+
+INDEXED_CREATED_EVENT_TOPIC_COUNT = 4
+
+
+@dataclasses.dataclass(slots=True, frozen=True)
+class MellowFactoryCandidate:
+    """Mellow vault candidate decoded from ``Factory.Created``.
+
+    :param chain:
+        EVM chain id.
+
+    :param address:
+        Canonical Mellow ``Vault`` proxy address.
+
+    :param factory_address:
+        Factory address that emitted the creation log.
+
+    :param factory_version:
+        Factory deployment version.
+
+    :param owner:
+        Owner argument from the factory event.
+
+    :param created_block:
+        Block where the vault was created.
+
+    :param created_at:
+        Block timestamp as naive UTC datetime.
+
+    :param transaction_hash:
+        Creation transaction hash.
+
+    :param log_index:
+        Log index in the creation transaction.
+
+    :param init_params:
+        Raw ABI-encoded init parameters.
+    """
+
+    chain: int
+    address: HexAddress
+    factory_address: HexAddress
+    factory_version: int
+    owner: HexAddress
+    created_block: int
+    created_at: datetime.datetime
+    transaction_hash: str
+    log_index: int
+    init_params: bytes
+
+
+def fetch_mellow_created_event_topic() -> str:
+    """Return the Mellow factory creation topic.
+
+    :return:
+        Topic0 for ``Created(address,uint256,address,bytes)``.
+    """
+
+    return Web3.to_hex(Web3.keccak(text=MELLOW_CREATED_EVENT_SIGNATURE))
+
+
+def fetch_mellow_factories_for_chain(chain_id: int) -> list[HexAddress]:
+    """Return configured Mellow Core Vault factories for a chain.
+
+    Mainnet, Plasma and Arbitrum share the documented Core factory address.
+    Monad has a chain-specific Core factory. Base is intentionally opt-in
+    through ``MELLOW_BASE_VAULT_FACTORY`` until a canonical Core factory is
+    confirmed.
+
+    :param chain_id:
+        EVM chain id.
+
+    :return:
+        List of factory addresses.
+    """
+
+    env_by_chain = {
+        1: ("MELLOW_ETHEREUM_VAULT_FACTORY", "0x4E38F679e46B3216f0bd4B314E9C429AFfB1dEE3"),
+        9745: ("MELLOW_PLASMA_VAULT_FACTORY", "0x4E38F679e46B3216f0bd4B314E9C429AFfB1dEE3"),
+        42161: ("MELLOW_ARBITRUM_VAULT_FACTORY", "0x4E38F679e46B3216f0bd4B314E9C429AFfB1dEE3"),
+        143: ("MELLOW_MONAD_VAULT_FACTORY", "0x04c0287DEdE16e0C04A1C2A52F31400a88f1dF4c"),
+        8453: ("MELLOW_BASE_VAULT_FACTORY", ""),
+    }
+
+    env = env_by_chain.get(chain_id)
+    if env is None:
+        return []
+
+    env_var, default = env
+    raw = os.environ.get(env_var, default).strip()
+    if not raw:
+        return []
+
+    return [HexAddress(Web3.to_checksum_address(part.strip())) for part in raw.split(",") if part.strip()]
+
+
+def _decode_hypersync_int(value: int | str | None) -> int:
+    """Decode a Hypersync integer-like value.
+
+    :param value:
+        Integer or hex string.
+
+    :return:
+        Decoded integer.
+    """
+
+    if value is None:
+        return 0
+    if isinstance(value, int):
+        return value
+    if value.startswith("0x"):
+        return int(value, 16)
+    return int(value)
+
+
+def _topic_to_address(topic: str) -> HexAddress:
+    """Decode an indexed address topic.
+
+    :param topic:
+        32-byte topic.
+
+    :return:
+        Checksummed address.
+    """
+
+    return HexAddress(Web3.to_checksum_address(f"0x{topic[-40:]}"))
+
+
+def decode_mellow_created_event(web3: Web3, log: Any) -> tuple[HexAddress, int, HexAddress, bytes]:
+    """Decode a Mellow factory ``Created`` log.
+
+    The verified event layout documented in Mellow Core is non-indexed. The
+    decoder also accepts an indexed ``instance/version/owner`` layout so older
+    or locally-patched factories are rejected only after both layouts fail.
+
+    :param web3:
+        Web3 whose ABI codec is used.
+
+    :param log:
+        Hypersync log object.
+
+    :return:
+        Vault instance, factory version, owner and raw init params.
+
+    :raise DecodingError:
+        Raised if neither supported layout decodes.
+    """
+
+    topics = list(log.topics or [])
+    data = bytes.fromhex((log.data or "0x")[2:])
+
+    if len(topics) >= INDEXED_CREATED_EVENT_TOPIC_COUNT:
+        instance = _topic_to_address(topics[1])
+        version = int(topics[2], 16)
+        owner = _topic_to_address(topics[3])
+        return instance, version, owner, data
+
+    instance, version, owner, init_params = web3.codec.decode(["address", "uint256", "address", "bytes"], data)
+    return (
+        HexAddress(Web3.to_checksum_address(instance)),
+        int(version),
+        HexAddress(Web3.to_checksum_address(owner)),
+        bytes(init_params),
+    )
+
+
+def _normalise_log_value(value: Any) -> Any:
+    """Normalise Web3.py/Hypersync log values for shared decoding.
+
+    :param value:
+        Raw log field value.
+
+    :return:
+        Hex string for bytes-like values, otherwise the original value.
+    """
+
+    if isinstance(value, HexBytes | bytes):
+        return Web3.to_hex(value)
+    return value
+
+
+def normalise_mellow_created_log(log: Any) -> Any:
+    """Normalise a raw JSON-RPC or Hypersync log for Mellow decoding.
+
+    Hypersync returns attribute-like objects, while the JSON-RPC event reader
+    returns dictionaries. This helper creates the small common surface consumed
+    by :py:func:`decode_mellow_created_event` and
+    :py:func:`create_mellow_factory_candidate`.
+
+    :param log:
+        Raw log object.
+
+    :return:
+        Namespace with ``address``, ``topics``, ``data``, ``block_number``,
+        ``transaction_hash`` and ``log_index`` attributes.
+    """
+
+    if isinstance(log, dict):
+        return SimpleNamespace(
+            address=_normalise_log_value(log["address"]),
+            topics=[_normalise_log_value(topic) for topic in log.get("topics", [])],
+            data=_normalise_log_value(log.get("data", "0x")),
+            block_number=_normalise_log_value(log.get("blockNumber")),
+            transaction_hash=_normalise_log_value(log.get("transactionHash", "")),
+            log_index=_normalise_log_value(log.get("logIndex")),
+        )
+
+    return SimpleNamespace(
+        address=_normalise_log_value(log.address),
+        topics=[_normalise_log_value(topic) for topic in list(log.topics or [])],
+        data=_normalise_log_value(log.data or "0x"),
+        block_number=_normalise_log_value(log.block_number),
+        transaction_hash=_normalise_log_value(log.transaction_hash or ""),
+        log_index=_normalise_log_value(getattr(log, "log_index", None)),
+    )
+
+
+def create_mellow_factory_candidate(
+    web3: Web3,
+    chain_id: int,
+    log: Any,
+    timestamp: datetime.datetime,
+) -> MellowFactoryCandidate:
+    """Create a factory candidate from a Hypersync log.
+
+    :param web3:
+        Web3 whose ABI codec is used.
+
+    :param chain_id:
+        EVM chain id.
+
+    :param log:
+        Hypersync log object.
+
+    :param timestamp:
+        Block timestamp.
+
+    :return:
+        Decoded factory candidate.
+    """
+
+    normalised_log = normalise_mellow_created_log(log)
+    instance, version, owner, init_params = decode_mellow_created_event(web3, normalised_log)
+    return MellowFactoryCandidate(
+        chain=chain_id,
+        address=HexAddress(instance.lower()),
+        factory_address=HexAddress(normalised_log.address.lower()),
+        factory_version=version,
+        owner=HexAddress(owner.lower()),
+        created_block=_decode_hypersync_int(normalised_log.block_number),
+        created_at=timestamp,
+        transaction_hash=normalised_log.transaction_hash or "",
+        log_index=_decode_hypersync_int(normalised_log.log_index),
+        init_params=init_params,
+    )
+
+
+def is_mellow_factory_log(chain_id: int, address: HexAddress | str, topic0: str | None) -> bool:
+    """Check if a log is from a configured Mellow factory.
+
+    :param chain_id:
+        EVM chain id.
+
+    :param address:
+        Log-emitting address.
+
+    :param topic0:
+        First log topic.
+
+    :return:
+        ``True`` if this log should be decoded as Mellow ``Factory.Created``.
+    """
+
+    if topic0 != fetch_mellow_created_event_topic():
+        return False
+
+    factories = {factory.lower() for factory in fetch_mellow_factories_for_chain(chain_id)}
+    return address.lower() in factories

--- a/eth_defi/mellow/flow.py
+++ b/eth_defi/mellow/flow.py
@@ -1,0 +1,109 @@
+"""Mellow Core Vault flow manager stubs.
+
+Mellow deposits and redemptions are asynchronous and queue based. The initial
+adapter intentionally does not expose flow accounting until the queue event ABI
+and queue-to-vault mapping tests are pinned.
+"""
+
+from decimal import Decimal
+
+from eth_typing import BlockIdentifier
+
+from eth_defi.vault.base import BlockRange, VaultFlowManager, VaultSpec
+
+PENDING_REDEMPTION_UNSUPPORTED = "Mellow queue redemption scanning is not implemented yet"
+PENDING_DEPOSIT_UNSUPPORTED = "Mellow queue deposit scanning is not implemented yet"
+PENDING_DEPOSIT_EVENTS_UNSUPPORTED = "Mellow queue deposit event scanning is not implemented yet"
+PENDING_REDEMPTION_EVENTS_UNSUPPORTED = "Mellow queue redemption event scanning is not implemented yet"
+
+
+class MellowVaultFlowManager(VaultFlowManager):
+    """Unsupported Mellow flow reader placeholder."""
+
+    def fetch_pending_redemption(
+        self,
+        block_identifier: BlockIdentifier,
+    ) -> Decimal:
+        """Fetch pending redemption amount.
+
+        Mellow redemption requests are emitted by ``RedeemQueue`` contracts.
+        Queue event scanning is not part of the first adapter slice.
+
+        :param block_identifier:
+            Block number or tag.
+
+        :return:
+            Never returns until queue scanning is implemented.
+        """
+
+        raise NotImplementedError(PENDING_REDEMPTION_UNSUPPORTED)
+
+    def fetch_pending_deposit(
+        self,
+        block_identifier: BlockIdentifier,
+    ) -> Decimal:
+        """Fetch pending deposit amount.
+
+        Mellow deposit requests are emitted by ``DepositQueue`` contracts.
+        Queue event scanning is not part of the first adapter slice.
+
+        :param block_identifier:
+            Block number or tag.
+
+        :return:
+            Never returns until queue scanning is implemented.
+        """
+
+        raise NotImplementedError(PENDING_DEPOSIT_UNSUPPORTED)
+
+    def fetch_pending_deposit_events(
+        self,
+        range: BlockRange,  # noqa: A002
+    ) -> None:
+        """Read pending deposit events.
+
+        :param range:
+            Block range to read.
+        """
+
+        raise NotImplementedError(PENDING_DEPOSIT_EVENTS_UNSUPPORTED)
+
+    def fetch_pending_redemption_event(
+        self,
+        range: BlockRange,  # noqa: A002
+    ) -> None:
+        """Read pending redemption events.
+
+        :param range:
+            Block range to read.
+        """
+
+        raise NotImplementedError(PENDING_REDEMPTION_EVENTS_UNSUPPORTED)
+
+    def fetch_processed_deposit_event(
+        self,
+        range: BlockRange,  # noqa: A002
+    ) -> None:
+        """Read processed deposit events.
+
+        :param range:
+            Block range to read.
+        """
+
+        raise NotImplementedError(PENDING_DEPOSIT_EVENTS_UNSUPPORTED)
+
+    def fetch_processed_redemption_event(
+        self,
+        vault: VaultSpec,
+        range: BlockRange,  # noqa: A002
+    ) -> None:
+        """Read processed redemption events.
+
+        :param vault:
+            Vault whose queue events should be read.
+
+        :param range:
+            Block range to read.
+        """
+
+        raise NotImplementedError(PENDING_REDEMPTION_EVENTS_UNSUPPORTED)

--- a/eth_defi/mellow/historical.py
+++ b/eth_defi/mellow/historical.py
@@ -1,0 +1,105 @@
+"""Historical reader for Mellow Core Vaults."""
+
+from __future__ import annotations
+
+import datetime
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+from eth_defi.erc_4626.vault import VaultReaderState
+from eth_defi.event_reader.conversion import convert_int256_bytes_to_int
+from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
+from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
+
+if TYPE_CHECKING:
+    from eth_defi.mellow.vault import MellowVault
+
+
+class MellowVaultHistoricalReader(VaultHistoricalReader):
+    """Read the currently supported Mellow historical state.
+
+    The first implementation intentionally reads only the tokenised
+    ``ShareManager.totalSupply()``. Mellow share price and TVL depend on oracle
+    report orientation and asset/subvault accounting that must be pinned with a
+    fixed-block test before production use.
+    """
+
+    def __init__(self, vault: MellowVault, stateful: bool):  # noqa: FBT001
+        """Create a Mellow historical reader.
+
+        :param vault:
+            Mellow vault adapter.
+
+        :param stateful:
+            Whether to attach adaptive reader state used by the shared
+            historical multicaller.
+        """
+
+        super().__init__(vault)
+        if stateful:
+            self.reader_state = VaultReaderState(vault)
+        else:
+            self.reader_state = None
+
+    def construct_multicalls(self) -> Iterable[EncodedCall]:
+        """Construct Mellow historical multicalls.
+
+        :return:
+            Multicall batch reading ``ShareManager.totalSupply()``.
+        """
+
+        yield EncodedCall.from_contract_call(
+            self.vault.share_manager_contract.functions.totalSupply(),
+            extra_data={
+                "function": "share_manager_total_supply",
+                "vault": self.vault.address,
+            },
+            first_block_number=self.first_block,
+        )
+
+    def process_result(
+        self,
+        block_number: int,
+        timestamp: datetime.datetime,
+        call_results: list[EncodedCallResult],
+    ) -> VaultHistoricalRead:
+        """Convert Mellow multicall results to a vault price row.
+
+        :param block_number:
+            Historical block number.
+
+        :param timestamp:
+            Naive UTC block timestamp.
+
+        :param call_results:
+            Multicall results for calls from :py:meth:`construct_multicalls`.
+
+        :return:
+            Partial :py:class:`VaultHistoricalRead` with explicit unsupported
+            price/TVL errors.
+        """
+
+        total_supply = None
+        errors = [
+            "Mellow share price and TVL require oracle report orientation and subvault accounting confirmation",
+        ]
+
+        for result in call_results:
+            if result.call.extra_data.get("function") == "share_manager_total_supply":
+                if result.success:
+                    raw_total_supply = convert_int256_bytes_to_int(result.result)
+                    total_supply = self.vault.share_token.convert_to_decimals(raw_total_supply)
+                else:
+                    errors.append("share_manager_total_supply call failed")
+
+        return VaultHistoricalRead(
+            vault=self.vault,
+            block_number=block_number,
+            timestamp=timestamp,
+            share_price=None,
+            total_assets=None,
+            total_supply=total_supply,
+            performance_fee=None,
+            management_fee=None,
+            errors=errors,
+        )

--- a/eth_defi/mellow/historical.py
+++ b/eth_defi/mellow/historical.py
@@ -6,9 +6,12 @@ import datetime
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
+from eth_abi import decode
+
 from eth_defi.erc_4626.vault import VaultReaderState
 from eth_defi.event_reader.conversion import convert_int256_bytes_to_int
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
+from eth_defi.mellow.vault import convert_mellow_fee_d6_to_percent, convert_mellow_price_d18_to_share_price
 from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
 
 if TYPE_CHECKING:
@@ -18,10 +21,11 @@ if TYPE_CHECKING:
 class MellowVaultHistoricalReader(VaultHistoricalReader):
     """Read the currently supported Mellow historical state.
 
-    The first implementation intentionally reads only the tokenised
-    ``ShareManager.totalSupply()``. Mellow share price and TVL depend on oracle
-    report orientation and asset/subvault accounting that must be pinned with a
-    fixed-block test before production use.
+    The reader samples tokenised ``ShareManager.totalSupply()`` and the latest
+    Mellow oracle report for the denomination asset. Mellow reports raw shares
+    per raw asset as ``priceD18``; the reader converts it to the shared
+    asset-per-share historical price convention and derives denomination-token
+    TVL as ``share_price * total_supply``.
     """
 
     def __init__(self, vault: MellowVault, stateful: bool):  # noqa: FBT001
@@ -45,7 +49,8 @@ class MellowVaultHistoricalReader(VaultHistoricalReader):
         """Construct Mellow historical multicalls.
 
         :return:
-            Multicall batch reading ``ShareManager.totalSupply()``.
+            Multicall batch reading ``ShareManager.totalSupply()``,
+            ``Oracle.getReport(denomination_token)`` and FeeManager rates.
         """
 
         yield EncodedCall.from_contract_call(
@@ -53,6 +58,39 @@ class MellowVaultHistoricalReader(VaultHistoricalReader):
             extra_data={
                 "function": "share_manager_total_supply",
                 "vault": self.vault.address,
+            },
+            first_block_number=self.first_block,
+        )
+
+        yield EncodedCall.from_contract_call(
+            self.vault.fee_manager_contract.functions.performanceFeeD6(),
+            extra_data={
+                "function": "fee_manager_performance_fee_d6",
+                "vault": self.vault.address,
+            },
+            first_block_number=self.first_block,
+        )
+
+        yield EncodedCall.from_contract_call(
+            self.vault.fee_manager_contract.functions.protocolFeeD6(),
+            extra_data={
+                "function": "fee_manager_protocol_fee_d6",
+                "vault": self.vault.address,
+            },
+            first_block_number=self.first_block,
+        )
+
+        denomination_token = self.vault.denomination_token
+        if denomination_token is None:
+            return
+
+        yield EncodedCall.from_contract_call(
+            self.vault.oracle_contract.functions.getReport(denomination_token.address),
+            extra_data={
+                "function": "oracle_get_report",
+                "vault": self.vault.address,
+                "asset_decimals": denomination_token.decimals,
+                "share_token_decimals": self.vault.share_token.decimals,
             },
             first_block_number=self.first_block,
         )
@@ -75,31 +113,71 @@ class MellowVaultHistoricalReader(VaultHistoricalReader):
             Multicall results for calls from :py:meth:`construct_multicalls`.
 
         :return:
-            Partial :py:class:`VaultHistoricalRead` with explicit unsupported
-            price/TVL errors.
+            :py:class:`VaultHistoricalRead` with Mellow share price and supply.
         """
 
         total_supply = None
-        errors = [
-            "Mellow share price and TVL require oracle report orientation and subvault accounting confirmation",
-        ]
+        share_price = None
+        performance_fee = None
+        management_fee = None
+        errors = []
+        saw_oracle_report = False
 
         for result in call_results:
-            if result.call.extra_data.get("function") == "share_manager_total_supply":
+            function = result.call.extra_data.get("function")
+
+            if function == "share_manager_total_supply":
                 if result.success:
                     raw_total_supply = convert_int256_bytes_to_int(result.result)
                     total_supply = self.vault.share_token.convert_to_decimals(raw_total_supply)
                 else:
                     errors.append("share_manager_total_supply call failed")
+            elif function == "fee_manager_performance_fee_d6":
+                if result.success:
+                    performance_fee = convert_mellow_fee_d6_to_percent(convert_int256_bytes_to_int(result.result))
+                else:
+                    errors.append("fee_manager_performance_fee_d6 call failed")
+            elif function == "fee_manager_protocol_fee_d6":
+                if result.success:
+                    # Mellow's protocol fee is an annual time-based share fee.
+                    # The shared historical schema has only management and
+                    # performance columns, so store it as management-like.
+                    management_fee = convert_mellow_fee_d6_to_percent(convert_int256_bytes_to_int(result.result))
+                else:
+                    errors.append("fee_manager_protocol_fee_d6 call failed")
+            elif function == "oracle_get_report":
+                saw_oracle_report = True
+                if result.success:
+                    ((price_d18, _report_timestamp, is_suspicious),) = decode(
+                        ["(uint224,uint32,bool)"],
+                        result.result,
+                    )
+                    if is_suspicious:
+                        errors.append("Mellow oracle report is suspicious")
+                    else:
+                        share_price = convert_mellow_price_d18_to_share_price(
+                            price_d18=int(price_d18),
+                            share_token_decimals=result.call.extra_data["share_token_decimals"],
+                            asset_decimals=result.call.extra_data["asset_decimals"],
+                        )
+                        if share_price is None:
+                            errors.append("Mellow oracle report priceD18 is zero")
+                else:
+                    errors.append("oracle_get_report call failed")
+
+        if not saw_oracle_report:
+            errors.append("Mellow denomination token is missing")
+
+        total_assets = share_price * total_supply if share_price is not None and total_supply is not None else None
 
         return VaultHistoricalRead(
             vault=self.vault,
             block_number=block_number,
             timestamp=timestamp,
-            share_price=None,
-            total_assets=None,
+            share_price=share_price,
+            total_assets=total_assets,
             total_supply=total_supply,
-            performance_fee=None,
-            management_fee=None,
-            errors=errors,
+            performance_fee=performance_fee,
+            management_fee=management_fee,
+            errors=errors or None,
         )

--- a/eth_defi/mellow/offchain_metadata.py
+++ b/eth_defi/mellow/offchain_metadata.py
@@ -1,0 +1,293 @@
+"""Mellow vault offchain metadata.
+
+Mellow publishes a public vault catalogue API at
+``https://points.mellow.finance/v1/vaults``. The adapter uses this metadata
+only for enrichment values that are not part of the canonical on-chain vault
+accounting path, such as public names, symbols and base-token hints.
+
+The current TVL value returned by the API is USD-denominated and
+point-in-time. It is useful for manual mapping diagnostics, but it is not
+written as production ``NAV`` or ``total_assets``. Mellow current and
+historical denomination-token TVL is read from on-chain vault state as
+``share_price * total_supply``.
+
+API response structure
+~~~~~~~~~~~~~~~~~~~~~~
+
+``GET /v1/vaults`` returns a JSON array. Each element is expected to include:
+
+.. code-block:: json
+
+    {
+        "chain_id": 1,
+        "address": "0x014e6DA8F283C4aF65B2AA0f201438680A004452",
+        "symbol": "earnUSD",
+        "name": "Lido Earn USD",
+        "layer": "mellow",
+        "tvl_usd": "21897383.50",
+        "base_token": {
+            "symbol": "USDC",
+            "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        }
+    }
+
+The module follows the same two-level cache pattern used by other offchain
+vault metadata integrations: a disk cache for multiprocess scanner runs and an
+in-process dictionary for adapter lookups.
+"""
+
+import datetime
+import json
+import logging
+from dataclasses import dataclass, field
+from decimal import Decimal
+from json import JSONDecodeError
+from pathlib import Path
+from typing import Any
+
+import requests
+from eth_typing import HexAddress
+from web3 import Web3
+
+from eth_defi.compat import native_datetime_utc_fromtimestamp, native_datetime_utc_now
+from eth_defi.disk_cache import DEFAULT_CACHE_ROOT
+from eth_defi.utils import wait_other_writers
+
+#: Where we cache fetched Mellow API metadata files.
+DEFAULT_CACHE_PATH = DEFAULT_CACHE_ROOT / "mellow"
+
+#: Mellow public API base URL documented at https://docs.mellow.finance/resources/api
+DEFAULT_API_BASE_URL = "https://points.mellow.finance"
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class MellowApiVaultMetadata:
+    """Optional current Mellow API metadata attached to a vault.
+
+    The Mellow API is an enrichment source. Its USD TVL is intentionally kept
+    separate from on-chain denomination-token TVL so current scan records remain
+    comparable with ERC-4626 and other smart-contract vault protocols.
+    """
+
+    #: EVM chain id.
+    chain_id: int | None = None
+
+    #: Canonical Mellow Vault address.
+    address: HexAddress | None = None
+
+    #: Public vault name.
+    name: str | None = None
+
+    #: Public vault symbol.
+    symbol: str | None = None
+
+    #: Mellow API layer field, e.g. ``mellow`` or ``symbiotic``.
+    layer: str | None = None
+
+    #: Current USD TVL from the public Mellow API, for diagnostics only.
+    #:
+    #: Do not use this value as canonical production NAV. ``MellowVault`` reads
+    #: comparable denomination-token TVL from on-chain share price and
+    #: ``ShareManager.totalSupply()``.
+    tvl_usd: Decimal | None = None
+
+    #: Base token address from API/configuration, if known.
+    base_token_address: HexAddress | None = None
+
+    #: Base token symbol from API/configuration, if known.
+    base_token_symbol: str | None = None
+
+    #: Raw API fields kept for diagnostics.
+    raw: dict[str, object] = field(default_factory=dict)
+
+
+def _parse_optional_checksum_address(address: str | None) -> HexAddress | None:
+    """Parse an optional API address.
+
+    :param address:
+        Raw address string from the API.
+
+    :return:
+        Checksummed address or ``None``.
+    """
+
+    if not address:
+        return None
+    return HexAddress(Web3.to_checksum_address(address))
+
+
+def _parse_api_vault(item: dict[str, Any]) -> MellowApiVaultMetadata:
+    """Parse one vault entry from the Mellow API.
+
+    :param item:
+        Raw JSON object from ``/v1/vaults``.
+
+    :return:
+        Parsed Mellow API metadata.
+    """
+
+    base_token = item.get("base_token") or {}
+    tvl_usd_raw = item.get("tvl_usd")
+
+    return MellowApiVaultMetadata(
+        chain_id=int(item["chain_id"]) if item.get("chain_id") is not None else None,
+        address=_parse_optional_checksum_address(item.get("address")),
+        name=item.get("name"),
+        symbol=item.get("symbol"),
+        layer=item.get("layer"),
+        tvl_usd=Decimal(str(tvl_usd_raw)) if tvl_usd_raw is not None else None,
+        base_token_address=_parse_optional_checksum_address(base_token.get("address")),
+        base_token_symbol=base_token.get("symbol"),
+        raw=item,
+    )
+
+
+def _parse_api_vaults(raw_list: list[dict[str, Any]]) -> dict[tuple[int, str], MellowApiVaultMetadata]:
+    """Parse and index the Mellow API vault list.
+
+    :param raw_list:
+        Raw JSON list from the Mellow API or cache file.
+
+    :return:
+        Mapping ``(chain_id, lower-case vault address) -> metadata``.
+    """
+
+    api_vaults: dict[tuple[int, str], MellowApiVaultMetadata] = {}
+    for item in raw_list:
+        api_vault = _parse_api_vault(item)
+        if api_vault.chain_id is None or api_vault.address is None:
+            logger.debug("Skipping Mellow API vault without chain/address: %s", item)
+            continue
+        api_vaults[api_vault.chain_id, api_vault.address.lower()] = api_vault
+
+    return api_vaults
+
+
+def _load_cached_vaults(file: Path) -> dict[tuple[int, str], MellowApiVaultMetadata]:
+    """Load Mellow vault metadata from a cache file.
+
+    :param file:
+        Cache file path.
+
+    :return:
+        Parsed API metadata mapping.
+    """
+
+    try:
+        with file.open("rt") as inp:
+            raw_list = json.load(inp)
+    except JSONDecodeError as e:
+        content = file.read_text()
+        raise RuntimeError(f"Could not parse Mellow cache at {file}, length {len(content)}, content starts with {content[:100]!r}") from e
+
+    if not isinstance(raw_list, list):
+        raise RuntimeError(f"Mellow cache at {file} must contain a JSON list, got {type(raw_list)}")
+
+    return _parse_api_vaults(raw_list)
+
+
+def fetch_mellow_api_vaults(
+    cache_path: Path = DEFAULT_CACHE_PATH,
+    api_base_url: str = DEFAULT_API_BASE_URL,
+    now_: datetime.datetime | None = None,
+    max_cache_duration: datetime.timedelta = datetime.timedelta(days=2),
+) -> dict[tuple[int, str], MellowApiVaultMetadata]:
+    """Fetch and cache public Mellow API vault data.
+
+    The public API is used only as an enrichment layer. Hypersync factory
+    events remain the source of truth for newly-created Core Vault leads, and
+    on-chain share price/supply reads remain the source of truth for
+    denomination-token TVL.
+
+    :param cache_path:
+        Directory for cache files.
+
+    :param api_base_url:
+        Mellow API base URL.
+
+    :param now_:
+        Override current time for tests.
+
+    :param max_cache_duration:
+        How long before refreshing cache.
+
+    :return:
+        Mapping ``(chain_id, lower-case vault address) -> metadata``.
+    """
+
+    assert isinstance(cache_path, Path), "cache_path must be Path instance"
+
+    cache_path.mkdir(parents=True, exist_ok=True)
+    file = (cache_path / "mellow_vaults.json").resolve()
+    file_size = file.stat().st_size if file.exists() else 0
+
+    if not now_:
+        now_ = native_datetime_utc_now()
+
+    with wait_other_writers(file):
+        if file.exists() and file_size > 0 and (now_ - native_datetime_utc_fromtimestamp(file.stat().st_mtime)) <= max_cache_duration:
+            timestamp = native_datetime_utc_fromtimestamp(file.stat().st_mtime)
+            ago = now_ - timestamp
+            logger.info("Using cached Mellow vault metadata from %s, last fetched at %s, ago %s", file, timestamp.isoformat(), ago)
+            return _load_cached_vaults(file)
+
+        url = f"{api_base_url}/v1/vaults"
+        logger.info("Fetching Mellow vault metadata from %s", url)
+
+        try:
+            response = requests.get(url, headers={"Accept": "application/json"}, timeout=30)
+            response.raise_for_status()
+            raw_list = response.json()
+        except (requests.RequestException, JSONDecodeError, ValueError) as e:
+            logger.warning("Failed to fetch Mellow vault metadata from %s: %s", url, e)
+            if file.exists() and file.stat().st_size > 0:
+                logger.info("Using stale Mellow cache at %s after API failure", file)
+                return _load_cached_vaults(file)
+            return {}
+
+        if not isinstance(raw_list, list):
+            logger.warning("Mellow API returned %s instead of list, skipping cache write", type(raw_list))
+            return {}
+
+        result = _parse_api_vaults(raw_list)
+        logger.info("Fetched metadata for %d Mellow API vaults", len(result))
+
+        if not result:
+            logger.warning("Mellow API returned 0 usable vaults, skipping cache write to avoid poisoning the cache")
+            return {}
+
+        with file.open("wt") as out:
+            json.dump(raw_list, out, indent=2)
+
+        assert file.stat().st_size > 0, f"File {file} is empty after writing"
+        return result
+
+
+def fetch_mellow_api_vault_metadata(
+    chain_id: int,
+    vault_address: HexAddress,
+) -> MellowApiVaultMetadata | None:
+    """Fetch one vault metadata entry from the Mellow offchain API.
+
+    :param chain_id:
+        EVM chain id.
+
+    :param vault_address:
+        Mellow Vault address.
+
+    :return:
+        Metadata entry or ``None`` if the API has no matching vault.
+    """
+
+    global _cached_vaults  # noqa: PLW0603 - Same in-process offchain metadata cache pattern as ForgeYields.
+
+    if _cached_vaults is None:
+        _cached_vaults = fetch_mellow_api_vaults()
+
+    return _cached_vaults.get((chain_id, vault_address.lower()))
+
+
+#: In-process cache of fetched Mellow API vaults.
+_cached_vaults: dict[tuple[int, str], MellowApiVaultMetadata] | None = None

--- a/eth_defi/mellow/vault.py
+++ b/eth_defi/mellow/vault.py
@@ -237,7 +237,12 @@ class MellowApiVaultMetadata:
     #: Public vault symbol.
     symbol: str | None = None
 
-    #: Current API TVL in USD or denomination-token units if known.
+    #: Current API TVL from the public Mellow API, for diagnostics only.
+    #:
+    #: Do not use this value as canonical production NAV. Historical price rows
+    #: derive denomination-token TVL from on-chain oracle share price and
+    #: ``ShareManager.totalSupply()``; current on-chain NAV needs a confirmed
+    #: Mellow portfolio/subvault accounting method.
     tvl: Decimal | None = None
 
     #: Base token address from API/configuration, if known.
@@ -699,18 +704,22 @@ class MellowVault(VaultBase):
     def fetch_nav(self, block_identifier: BlockIdentifier = "latest") -> Decimal | None:
         """Fetch Mellow NAV.
 
-        Full on-chain NAV requires oracle and subvault accounting that is not
-        confirmed in the initial adapter.
+        Full current on-chain NAV requires confirmed Mellow portfolio/subvault
+        accounting. The public Mellow API may expose current TVL, but this
+        adapter intentionally does not return API TVL from ``fetch_nav()`` so
+        production scan rows do not mix off-chain point-in-time data with
+        on-chain historical reads.
+
+        Historical Mellow price rows derive denomination-token TVL on-chain as
+        ``share_price * total_supply`` in :class:`MellowVaultHistoricalReader`.
 
         :param block_identifier:
             Block number or tag.
 
         :return:
-            Current API TVL if attached, otherwise ``None``.
+            ``None`` until a canonical on-chain NAV method is implemented.
         """
 
-        if self.api_metadata and self.api_metadata.tvl is not None:
-            return self.api_metadata.tvl
         return None
 
     def fetch_portfolio(

--- a/eth_defi/mellow/vault.py
+++ b/eth_defi/mellow/vault.py
@@ -1,0 +1,577 @@
+"""Mellow Core Vault adapter.
+
+Mellow Core Vaults are modular asset-management vaults for curated on-chain
+yield products. They are not ERC-4626 vault contracts, even though the shared
+scanner stores them in the ERC-4626-flavoured detection envelope for pipeline
+compatibility.
+
+The current Core Vault factory registry follows Mellow's public Core
+deployments for Ethereum mainnet, Plasma, Arbitrum and Monad. Base remains
+configuration-only until a canonical Core factory is published.
+
+The canonical adapter address is the Mellow ``Vault`` proxy emitted by the Core
+Vault ``Factory.Created`` event. This address coordinates the vault, owns the
+component graph and is the address stored in ``VaultSpec`` and
+``ERC4262VaultDetection``. It is not the ERC-20 share token address.
+
+Mellow splits vault functionality across several contracts:
+
+- ``Vault``: the central entry point. It combines access control, share module
+  lifecycle methods and subvault delegation. In scanner terms it is the vault
+  identity.
+- ``ShareManager``: share accounting, allocation, whitelist, lockup and
+  transfer-control contract. Tokenised variants expose ERC-20 metadata and
+  ``totalSupply()``; this initial adapter only supports those tokenised
+  managers.
+- ``DepositQueue`` and ``SignatureDepositQueue``: per-asset deposit entry
+  points. Standard queues are time-buffered and oracle-report settled; signature
+  queues allow trusted off-chain approvals. Deposit events are expected here,
+  not on the canonical ``Vault`` address.
+- ``RedeemQueue`` and ``SignatureRedeemQueue``: per-asset redemption entry
+  points. Redemptions are asynchronous, oracle-report settled and can involve
+  curator-managed liquidity pulls from subvaults. Redeem events are expected
+  here.
+- ``Oracle``: vault-coupled price-reporting contract. Reports drive queue
+  settlement, fee updates, limits and suspicious-price checks. Mellow's fee docs
+  describe a non-ERC-4626 price orientation where reported ``priceD18`` is
+  shares per asset, so this adapter does not map it to our normal share price
+  column until fixed-block checks pin the orientation.
+- ``FeeManager``: deposit, redeem, performance and protocol fee accounting.
+  Fees are paid in vault shares, not in underlying assets.
+- ``RiskManager``: asset support, deposit limits, balances and pending asset
+  accounting across the vault and its subvaults.
+- ``Subvault`` and verifiers: controlled execution/custody compartments whose
+  external calls are constrained by verifier contracts and access roles.
+
+This differs from ERC-4626 in the important accounting places. A generic
+ERC-4626 reader expects the vault contract to expose ``asset()``,
+``totalAssets()``, ``convertToAssets()`` and usually the share-token ERC-20
+surface. Mellow instead has a separate share manager, multiple queue contracts
+and oracle-driven settlement. Calling ERC-4626 methods on the canonical vault
+would either fail or describe the wrong abstraction.
+
+Historical reading is therefore Mellow-specific. The first reader only records
+tokenised ``ShareManager.totalSupply()`` and writes explicit errors for
+``share_price`` and ``total_assets`` until the oracle report ABI, price
+orientation, registered assets, pending queue state and subvault balance logic
+are verified at fixed blocks. The pipeline stores ``deposit_count=0`` and
+``redeem_count=0`` for initial Mellow leads because the canonical vault address
+does not emit user flow events; ``ERC4626Feature.mellow_like`` is the explicit
+activity-filter exemption that keeps these vaults in downstream scans.
+
+Known unsupported cases:
+
+- Non-tokenised ``BasicShareManager`` contracts.
+- Active deposit and redemption transaction execution.
+- Queue flow accounting from ``DepositQueue`` and ``RedeemQueue`` contracts.
+- Canonical on-chain NAV and ERC-4626-style share price.
+
+Reference material:
+
+- `Mellow Core Vaults documentation <https://docs.mellow.finance/core-vaults>`__
+- `Mellow Core deployments <https://docs.mellow.finance/core-vaults/core-deployments>`__
+- `Mellow Finance application <https://app.mellow.finance/>`__
+- `Lido Earn USD vault on Etherscan <https://etherscan.io/address/0x014e6DA8F283C4aF65B2AA0f201438680A004452>`__
+- `Lido Earn USD ShareManager on Etherscan <https://etherscan.io/address/0x4Ce1ac8F43E0E5BD7A346A98aF777bF8fbeA1981>`__
+"""
+
+# Adapter classes intentionally mirror :class:`VaultBase` method signatures.
+# ruff: noqa: ARG002, FBT001, FBT002, PLC0415, PLR0904, PLR0917, PLR6301
+
+import logging
+from dataclasses import dataclass, field
+from decimal import Decimal
+from functools import cached_property
+
+from eth_typing import BlockIdentifier, HexAddress
+from web3 import Web3
+from web3.contract import Contract
+from web3.exceptions import BadFunctionCallOutput, ContractLogicError
+
+from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.mellow.abi import ERC20_ABI, VAULT_ABI
+from eth_defi.token import TokenDetails, fetch_erc20_details
+from eth_defi.vault.base import TradingUniverse, VaultBase, VaultDepositManager, VaultFlowManager, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
+from eth_defi.vault.lower_case_dict import LowercaseDict
+
+logger = logging.getLogger(__name__)
+
+
+class MellowVaultUnsupportedError(RuntimeError):
+    """Raised when a Mellow feature is not implemented by this adapter."""
+
+
+class MellowVaultInfo(VaultInfo, total=False):
+    """Mellow component graph metadata."""
+
+    #: Canonical Mellow Vault address.
+    vault: HexAddress
+
+    #: Tokenised ShareManager address.
+    share_manager: HexAddress
+
+    #: FeeManager address, if the call succeeds.
+    fee_manager: HexAddress | None
+
+    #: RiskManager address, if the call succeeds.
+    risk_manager: HexAddress | None
+
+    #: Oracle address, if the call succeeds.
+    oracle: HexAddress | None
+
+    #: Registered asset addresses.
+    assets: list[HexAddress]
+
+    #: Deposit queue addresses keyed by asset.
+    deposit_queues: dict[HexAddress, list[HexAddress]]
+
+    #: Redeem queue addresses keyed by asset.
+    redeem_queues: dict[HexAddress, list[HexAddress]]
+
+
+@dataclass(slots=True, frozen=True)
+class MellowApiVaultMetadata:
+    """Optional current Mellow API metadata attached to a vault."""
+
+    #: Public vault name.
+    name: str | None = None
+
+    #: Public vault symbol.
+    symbol: str | None = None
+
+    #: Current API TVL in USD or denomination-token units if known.
+    tvl: Decimal | None = None
+
+    #: Base token address from API/configuration, if known.
+    base_token_address: HexAddress | None = None
+
+    #: Base token symbol from API/configuration, if known.
+    base_token_symbol: str | None = None
+
+    #: Raw API fields kept for diagnostics.
+    raw: dict[str, object] = field(default_factory=dict)
+
+
+class MellowVault(VaultBase):
+    """Mellow Core Vault adapter."""
+
+    def __init__(
+        self,
+        web3: Web3,
+        spec: VaultSpec,
+        token_cache: dict | None = None,
+        features: set[ERC4626Feature] | None = None,
+        default_block_identifier: BlockIdentifier | None = None,
+        require_denomination_token: bool = False,
+        api_metadata: MellowApiVaultMetadata | None = None,
+    ):
+        """Create a Mellow vault adapter.
+
+        :param web3:
+            Web3 connection.
+
+        :param spec:
+            Chain/address vault identity. Address must be the Mellow ``Vault``.
+
+        :param token_cache:
+            Token metadata cache.
+
+        :param features:
+            Shared scanner feature set. Expected to contain ``mellow_like``.
+
+        :param default_block_identifier:
+            Block used for metadata reads.
+
+        :param require_denomination_token:
+            Whether missing denomination token should raise through the base
+            cached property.
+
+        :param api_metadata:
+            Optional offchain Mellow metadata enrichment.
+        """
+
+        super().__init__(token_cache=token_cache, require_denomination_token=require_denomination_token)
+        self.web3 = web3
+        self.spec = spec
+        self.features = features or set()
+        self.default_block_identifier = default_block_identifier
+        self.api_metadata = api_metadata
+
+    def _get_block_identifier(self) -> BlockIdentifier:
+        """Resolve default block identifier for metadata reads.
+
+        :return:
+            Configured block identifier or ``latest``.
+        """
+
+        return self.default_block_identifier or "latest"
+
+    @property
+    def chain_id(self) -> int:
+        """Chain id for this vault."""
+
+        return self.spec.chain_id
+
+    @property
+    def address(self) -> HexAddress:
+        """Canonical Mellow ``Vault`` address."""
+
+        return HexAddress(Web3.to_checksum_address(self.spec.vault_address))
+
+    @property
+    def vault_address(self) -> HexAddress:
+        """Canonical Mellow ``Vault`` address.
+
+        ERC-4626 adapters expose this convenience property and shared historical
+        scan code still uses it for blacklists and diagnostics. For Mellow this
+        is intentionally the Core ``Vault`` proxy, not the ShareManager token.
+        """
+
+        return self.address
+
+    @property
+    def name(self) -> str:
+        """Vault share token name."""
+
+        try:
+            return self.share_token.name
+        except (MellowVaultUnsupportedError, BadFunctionCallOutput, ContractLogicError, ValueError):
+            if self.api_metadata and self.api_metadata.name:
+                return self.api_metadata.name
+            raise
+
+    @property
+    def symbol(self) -> str:
+        """Vault share token symbol."""
+
+        try:
+            return self.share_token.symbol
+        except (MellowVaultUnsupportedError, BadFunctionCallOutput, ContractLogicError, ValueError):
+            if self.api_metadata and self.api_metadata.symbol:
+                return self.api_metadata.symbol
+            raise
+
+    @cached_property
+    def vault_contract(self) -> Contract:
+        """Mellow ``Vault`` contract with minimal ABI."""
+
+        return self.web3.eth.contract(address=self.address, abi=VAULT_ABI)
+
+    @cached_property
+    def share_manager_address(self) -> HexAddress:
+        """Fetch the ShareManager address from the vault."""
+
+        address = self.vault_contract.functions.shareManager().call(block_identifier=self._get_block_identifier())
+        return HexAddress(Web3.to_checksum_address(address))
+
+    @cached_property
+    def share_manager_contract(self) -> Contract:
+        """Tokenised ShareManager contract with ERC-20 ABI."""
+
+        return self.web3.eth.contract(address=self.share_manager_address, abi=ERC20_ABI)
+
+    def fetch_share_token_address(self, block_identifier: BlockIdentifier = "latest") -> HexAddress:
+        """Return the tokenised ShareManager address.
+
+        :param block_identifier:
+            Accepted for compatibility with the shared historical multicaller.
+
+        :return:
+            ShareManager address.
+        """
+
+        return self.share_manager_address
+
+    def fetch_share_token(self) -> TokenDetails:
+        """Fetch tokenised ShareManager ERC-20 metadata.
+
+        :return:
+            Share token details.
+        """
+
+        token = fetch_erc20_details(
+            self.web3,
+            self.share_manager_address,
+            chain_id=self.chain_id,
+            raise_on_error=False,
+            cache=self.token_cache,
+            cause_diagnostics_message=f"Mellow ShareManager for vault {self.address}",
+        )
+        if token is None:
+            raise MellowVaultUnsupportedError(f"Mellow vault {self.address} ShareManager {self.share_manager_address} is not tokenised or token metadata could not be read")
+        return token
+
+    def fetch_denomination_token_address(self) -> HexAddress | None:
+        """Fetch the base asset used for initial valuation.
+
+        The initial adapter uses API/configured base token if present, otherwise
+        falls back to the first registered asset. Mellow can be multi-asset, so
+        all registered assets remain available in :py:meth:`fetch_info`.
+
+        :return:
+            Base asset address, or ``None`` if unavailable.
+        """
+
+        if self.api_metadata and self.api_metadata.base_token_address:
+            return self.api_metadata.base_token_address
+
+        assets = self.fetch_assets()
+        if assets:
+            return assets[0]
+        return None
+
+    def fetch_denomination_token(self) -> TokenDetails | None:
+        """Fetch the denomination token metadata.
+
+        :return:
+            Token details for the base asset, or ``None``.
+        """
+
+        token_address = self.fetch_denomination_token_address()
+        if token_address is None:
+            return None
+        return fetch_erc20_details(
+            self.web3,
+            token_address,
+            chain_id=self.chain_id,
+            raise_on_error=False,
+            cache=self.token_cache,
+            cause_diagnostics_message=f"Mellow denomination token for vault {self.address}",
+        )
+
+    def fetch_assets(self) -> list[HexAddress]:
+        """Fetch registered asset addresses.
+
+        :return:
+            List of registered assets.
+        """
+
+        try:
+            count = self.vault_contract.functions.getAssetCount().call(block_identifier=self._get_block_identifier())
+        except (BadFunctionCallOutput, ContractLogicError, ValueError):
+            return []
+
+        assets = []
+        for index in range(count):
+            asset = self.vault_contract.functions.assetAt(index).call(block_identifier=self._get_block_identifier())
+            assets.append(HexAddress(Web3.to_checksum_address(asset)))
+        return assets
+
+    def fetch_queues(self, asset: HexAddress) -> tuple[list[HexAddress], list[HexAddress]]:
+        """Fetch queues for a registered asset.
+
+        :param asset:
+            Registered asset address.
+
+        :return:
+            Deposit queues and redeem queues.
+        """
+
+        try:
+            queue_count = self.vault_contract.functions.getQueueCount(asset).call(block_identifier=self._get_block_identifier())
+        except (BadFunctionCallOutput, ContractLogicError, ValueError):
+            return [], []
+
+        deposit_queues: list[HexAddress] = []
+        redeem_queues: list[HexAddress] = []
+        for index in range(queue_count):
+            queue = HexAddress(Web3.to_checksum_address(self.vault_contract.functions.queueAt(asset, index).call(block_identifier=self._get_block_identifier())))
+            try:
+                is_deposit_queue = self.vault_contract.functions.isDepositQueue(queue).call(block_identifier=self._get_block_identifier())
+            except (BadFunctionCallOutput, ContractLogicError, ValueError):
+                is_deposit_queue = False
+            if is_deposit_queue:
+                deposit_queues.append(queue)
+            else:
+                redeem_queues.append(queue)
+        return deposit_queues, redeem_queues
+
+    def fetch_info(self) -> MellowVaultInfo:
+        """Fetch Mellow component graph metadata.
+
+        :return:
+            Component graph metadata.
+        """
+
+        def fetch_optional_address(function_name: str) -> HexAddress | None:
+            try:
+                address = getattr(self.vault_contract.functions, function_name)().call(block_identifier=self._get_block_identifier())
+                return HexAddress(Web3.to_checksum_address(address))
+            except (BadFunctionCallOutput, ContractLogicError, ValueError, AttributeError):
+                return None
+
+        assets = self.fetch_assets()
+        deposit_queues = {}
+        redeem_queues = {}
+        for asset in assets:
+            deposit, redeem = self.fetch_queues(asset)
+            deposit_queues[asset] = deposit
+            redeem_queues[asset] = redeem
+
+        return MellowVaultInfo(
+            vault=self.address,
+            share_manager=self.share_manager_address,
+            fee_manager=fetch_optional_address("feeManager"),
+            risk_manager=fetch_optional_address("riskManager"),
+            oracle=fetch_optional_address("oracle"),
+            assets=assets,
+            deposit_queues=deposit_queues,
+            redeem_queues=redeem_queues,
+        )
+
+    def fetch_total_supply(self, block_identifier: BlockIdentifier = "latest") -> Decimal | None:
+        """Fetch tokenised ShareManager total supply.
+
+        :param block_identifier:
+            Block number or tag.
+
+        :return:
+            Human-readable share supply.
+        """
+
+        raw_total_supply = self.share_manager_contract.functions.totalSupply().call(block_identifier=block_identifier)
+        return self.share_token.convert_to_decimals(raw_total_supply)
+
+    def fetch_nav(self, block_identifier: BlockIdentifier = "latest") -> Decimal | None:
+        """Fetch Mellow NAV.
+
+        Full on-chain NAV requires oracle and subvault accounting that is not
+        confirmed in the initial adapter.
+
+        :param block_identifier:
+            Block number or tag.
+
+        :return:
+            Current API TVL if attached, otherwise ``None``.
+        """
+
+        if self.api_metadata and self.api_metadata.tvl is not None:
+            return self.api_metadata.tvl
+        return None
+
+    def fetch_portfolio(
+        self,
+        universe: TradingUniverse,
+        block_identifier: BlockIdentifier | None = None,
+    ) -> VaultPortfolio:
+        """Fetch a partial portfolio.
+
+        The initial adapter does not reconstruct subvault balances. It returns
+        an empty portfolio instead of pretending to know full Mellow holdings.
+
+        :param universe:
+            Trading universe.
+
+        :param block_identifier:
+            Block number or tag.
+
+        :return:
+            Empty portfolio placeholder.
+        """
+
+        return VaultPortfolio(spot_erc20=LowercaseDict())
+
+    def has_block_range_event_support(self) -> bool:
+        """Whether queue event scanning is implemented.
+
+        :return:
+            ``False`` until Mellow queue flow reader is implemented.
+        """
+
+        return False
+
+    def has_deposit_distribution_to_all_positions(self) -> bool:
+        """Whether deposits are automatically distributed to positions.
+
+        :return:
+            ``False`` because Mellow deposits settle through queues and
+            curator/subvault allocation.
+        """
+
+        return False
+
+    def get_flow_manager(self) -> VaultFlowManager:
+        """Get Mellow flow manager.
+
+        :return:
+            Placeholder flow manager that raises for all read methods.
+        """
+
+        from eth_defi.mellow.flow import MellowVaultFlowManager
+
+        return MellowVaultFlowManager()
+
+    def get_deposit_manager(self) -> VaultDepositManager:
+        """Get active deposit manager.
+
+        :return:
+            Never returns until active queue transaction execution is
+            implemented.
+        """
+
+        message = "Mellow active deposits and redemptions are not implemented"
+        raise MellowVaultUnsupportedError(message)
+
+    def get_historical_reader(self, stateful: bool) -> VaultHistoricalReader:
+        """Get the Mellow historical reader.
+
+        :param stateful:
+            Whether to use shared adaptive reader state.
+
+        :return:
+            Mellow historical reader.
+        """
+
+        from eth_defi.mellow.historical import MellowVaultHistoricalReader
+
+        return MellowVaultHistoricalReader(self, stateful=stateful)
+
+    def get_protocol_name(self) -> str:
+        """Return protocol name.
+
+        :return:
+            ``Mellow``.
+        """
+
+        return "Mellow"
+
+    def get_management_fee(self, block_identifier: BlockIdentifier) -> float | None:
+        """Fetch management-like fee.
+
+        Mellow fee manager semantics need ABI confirmation before mapping to
+        annual management-fee percentage.
+
+        :param block_identifier:
+            Block number or tag.
+
+        :return:
+            ``None``.
+        """
+
+        return None
+
+    def get_performance_fee(self, block_identifier: BlockIdentifier) -> float | None:
+        """Fetch performance fee.
+
+        Mellow fee manager semantics need ABI confirmation before mapping.
+
+        :param block_identifier:
+            Block number or tag.
+
+        :return:
+            ``None``.
+        """
+
+        return None
+
+    def get_link(self, referral: str | None = None) -> str:
+        """Get Mellow vault link.
+
+        :param referral:
+            Optional referral code, currently unused.
+
+        :return:
+            Mellow app link.
+        """
+
+        return f"https://app.mellow.finance/vaults/{self.chain_id}/{self.address}"

--- a/eth_defi/mellow/vault.py
+++ b/eth_defi/mellow/vault.py
@@ -32,12 +32,14 @@ Mellow splits vault functionality across several contracts:
   curator-managed liquidity pulls from subvaults. Redeem events are expected
   here.
 - ``Oracle``: vault-coupled price-reporting contract. Reports drive queue
-  settlement, fee updates, limits and suspicious-price checks. Mellow's fee docs
-  describe a non-ERC-4626 price orientation where reported ``priceD18`` is
-  shares per asset, so this adapter does not map it to our normal share price
-  column until fixed-block checks pin the orientation.
+  settlement, fee updates, limits and suspicious-price checks. Mellow reports
+  ``priceD18`` as raw shares per raw asset, so this adapter converts it to the
+  normal asset-per-share price convention used by the shared vault pipeline.
 - ``FeeManager``: deposit, redeem, performance and protocol fee accounting.
-  Fees are paid in vault shares, not in underlying assets.
+  Fees are configured as D6 rates and paid in vault shares, not in underlying
+  assets. The shared vault schema does not have a separate protocol-fee column,
+  so the adapter maps Mellow's annual time-based ``protocolFeeD6`` to the
+  management-fee field and documents it as management-like.
 - ``RiskManager``: asset support, deposit limits, balances and pending asset
   accounting across the vault and its subvaults.
 - ``Subvault`` and verifiers: controlled execution/custody compartments whose
@@ -50,11 +52,13 @@ surface. Mellow instead has a separate share manager, multiple queue contracts
 and oracle-driven settlement. Calling ERC-4626 methods on the canonical vault
 would either fail or describe the wrong abstraction.
 
-Historical reading is therefore Mellow-specific. The first reader only records
-tokenised ``ShareManager.totalSupply()`` and writes explicit errors for
-``share_price`` and ``total_assets`` until the oracle report ABI, price
-orientation, registered assets, pending queue state and subvault balance logic
-are verified at fixed blocks. The pipeline stores ``deposit_count=0`` and
+Historical reading is therefore Mellow-specific. The first reader records the
+tokenised ``ShareManager.totalSupply()`` and reads the latest oracle report for
+the denomination asset. Mellow oracle ``priceD18`` is oriented as raw
+``shares = assets * priceD18 / 1e18``; the adapter converts it to our
+asset-per-share ``VaultHistoricalRead.share_price`` by accounting for the
+share-token and denomination-token decimals. The pipeline stores
+``deposit_count=0`` and
 ``redeem_count=0`` for initial Mellow leads because the canonical vault address
 does not emit user flow events; ``ERC4626Feature.mellow_like`` is the explicit
 activity-filter exemption that keeps these vaults in downstream scans.
@@ -64,7 +68,7 @@ Known unsupported cases:
 - Non-tokenised ``BasicShareManager`` contracts.
 - Active deposit and redemption transaction execution.
 - Queue flow accounting from ``DepositQueue`` and ``RedeemQueue`` contracts.
-- Canonical on-chain NAV and ERC-4626-style share price.
+- Full portfolio composition and subvault-level NAV breakdowns.
 
 Reference material:
 
@@ -88,13 +92,64 @@ from web3 import Web3
 from web3.contract import Contract
 from web3.exceptions import BadFunctionCallOutput, ContractLogicError
 
+from eth_defi.abi import get_deployed_contract
 from eth_defi.erc_4626.core import ERC4626Feature
-from eth_defi.mellow.abi import ERC20_ABI, VAULT_ABI
+from eth_defi.mellow.abi import ERC20_ABI_FILENAME, FEE_MANAGER_ABI_FILENAME, ORACLE_ABI_FILENAME, VAULT_ABI_FILENAME
 from eth_defi.token import TokenDetails, fetch_erc20_details
 from eth_defi.vault.base import TradingUniverse, VaultBase, VaultDepositManager, VaultFlowManager, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
+from eth_defi.vault.fee import BROKEN_FEE_DATA, FeeData
 from eth_defi.vault.lower_case_dict import LowercaseDict
 
 logger = logging.getLogger(__name__)
+
+
+def convert_mellow_price_d18_to_share_price(
+    price_d18: int,
+    share_token_decimals: int,
+    asset_decimals: int,
+) -> Decimal | None:
+    """Convert Mellow ``priceD18`` to denomination-token assets per share.
+
+    Mellow Core Vault reports use raw-token accounting:
+    ``raw_shares = raw_assets * priceD18 / 1e18``. Our historical vault price
+    convention is human-readable denomination-token assets per one
+    human-readable share token.
+
+    :param price_d18:
+        Raw Mellow oracle ``priceD18`` integer.
+
+    :param share_token_decimals:
+        ERC-20 decimals of the tokenised ShareManager.
+
+    :param asset_decimals:
+        ERC-20 decimals of the denomination asset in the report.
+
+    :return:
+        Human-readable asset amount per one human-readable share, or ``None``
+        for a zero oracle price.
+    """
+
+    if price_d18 == 0:
+        return None
+
+    return Decimal(10) ** (share_token_decimals + 18 - asset_decimals) / Decimal(price_d18)
+
+
+def convert_mellow_fee_d6_to_percent(fee_d6: int) -> float:
+    """Convert Mellow D6 fee rate to fractional percent.
+
+    Mellow stores fee rates as parts-per-million integers:
+    ``10_000`` means ``1%``. The shared vault fee interface expects fractional
+    values where ``0.01`` means ``1%``.
+
+    :param fee_d6:
+        Fee rate in D6 precision.
+
+    :return:
+        Fee rate as a fractional percentage.
+    """
+
+    return fee_d6 / 1_000_000
 
 
 class MellowVaultUnsupportedError(RuntimeError):
@@ -127,6 +182,49 @@ class MellowVaultInfo(VaultInfo, total=False):
 
     #: Redeem queue addresses keyed by asset.
     redeem_queues: dict[HexAddress, list[HexAddress]]
+
+
+@dataclass(slots=True, frozen=True)
+class MellowOracleReport:
+    """Latest Mellow oracle report for an asset."""
+
+    #: Raw Mellow ``priceD18`` value.
+    price_d18: int
+
+    #: Unix timestamp stored by the oracle.
+    timestamp: int
+
+    #: Whether the report is flagged suspicious by oracle validation.
+    is_suspicious: bool
+
+
+@dataclass(slots=True, frozen=True)
+class MellowFeeConfiguration:
+    """Mellow FeeManager configuration snapshot."""
+
+    #: Address that receives fee shares.
+    fee_recipient: HexAddress
+
+    #: Deposit fee in D6 precision.
+    deposit_fee_d6: int
+
+    #: Redeem fee in D6 precision.
+    redeem_fee_d6: int
+
+    #: Performance fee in D6 precision.
+    performance_fee_d6: int
+
+    #: Annual time-based protocol fee in D6 precision.
+    protocol_fee_d6: int
+
+    #: Base asset configured for this vault.
+    base_asset: HexAddress
+
+    #: Last FeeManager update timestamp for this vault.
+    timestamp: int
+
+    #: Minimum price observed by FeeManager for performance fee accounting.
+    min_price_d18: int
 
 
 @dataclass(slots=True, frozen=True)
@@ -255,7 +353,7 @@ class MellowVault(VaultBase):
     def vault_contract(self) -> Contract:
         """Mellow ``Vault`` contract with minimal ABI."""
 
-        return self.web3.eth.contract(address=self.address, abi=VAULT_ABI)
+        return get_deployed_contract(self.web3, VAULT_ABI_FILENAME, self.address)
 
     @cached_property
     def share_manager_address(self) -> HexAddress:
@@ -268,7 +366,33 @@ class MellowVault(VaultBase):
     def share_manager_contract(self) -> Contract:
         """Tokenised ShareManager contract with ERC-20 ABI."""
 
-        return self.web3.eth.contract(address=self.share_manager_address, abi=ERC20_ABI)
+        return get_deployed_contract(self.web3, ERC20_ABI_FILENAME, self.share_manager_address)
+
+    @cached_property
+    def oracle_address(self) -> HexAddress:
+        """Fetch the Mellow oracle address from the vault."""
+
+        address = self.vault_contract.functions.oracle().call(block_identifier=self._get_block_identifier())
+        return HexAddress(Web3.to_checksum_address(address))
+
+    @cached_property
+    def oracle_contract(self) -> Contract:
+        """Mellow oracle contract with minimal ABI."""
+
+        return get_deployed_contract(self.web3, ORACLE_ABI_FILENAME, self.oracle_address)
+
+    @cached_property
+    def fee_manager_address(self) -> HexAddress:
+        """Fetch the Mellow FeeManager address from the vault."""
+
+        address = self.vault_contract.functions.feeManager().call(block_identifier=self._get_block_identifier())
+        return HexAddress(Web3.to_checksum_address(address))
+
+    @cached_property
+    def fee_manager_contract(self) -> Contract:
+        """Mellow FeeManager contract with minimal ABI."""
+
+        return get_deployed_contract(self.web3, FEE_MANAGER_ABI_FILENAME, self.fee_manager_address)
 
     def fetch_share_token_address(self, block_identifier: BlockIdentifier = "latest") -> HexAddress:
         """Return the tokenised ShareManager address.
@@ -432,6 +556,146 @@ class MellowVault(VaultBase):
         raw_total_supply = self.share_manager_contract.functions.totalSupply().call(block_identifier=block_identifier)
         return self.share_token.convert_to_decimals(raw_total_supply)
 
+    def fetch_oracle_report(
+        self,
+        asset: HexAddress | None = None,
+        block_identifier: BlockIdentifier = "latest",
+    ) -> MellowOracleReport | None:
+        """Fetch the latest Mellow oracle report for an asset.
+
+        :param asset:
+            Asset address. Defaults to :py:attr:`denomination_token`.
+
+        :param block_identifier:
+            Block number or tag.
+
+        :return:
+            Oracle report, or ``None`` if the report cannot be read.
+        """
+
+        if asset is None:
+            denomination_token = self.denomination_token
+            if denomination_token is None:
+                return None
+            asset = denomination_token.address
+
+        try:
+            price_d18, timestamp, is_suspicious = self.oracle_contract.functions.getReport(Web3.to_checksum_address(asset)).call(block_identifier=block_identifier)
+        except (BadFunctionCallOutput, ContractLogicError, ValueError):
+            return None
+
+        return MellowOracleReport(
+            price_d18=int(price_d18),
+            timestamp=int(timestamp),
+            is_suspicious=bool(is_suspicious),
+        )
+
+    def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal | None:
+        """Fetch Mellow share price from the oracle report.
+
+        Mellow reports ``priceD18`` as raw shares per raw asset:
+        ``shares = assets * priceD18 / 1e18``. This method converts it to the
+        shared vault pipeline convention, denomination-token assets per one
+        human-readable share token.
+
+        :param block_identifier:
+            Block number or tag.
+
+        :return:
+            Denomination-token assets per share, or ``None`` if unavailable.
+        """
+
+        denomination_token = self.denomination_token
+        if denomination_token is None:
+            return None
+
+        report = self.fetch_oracle_report(denomination_token.address, block_identifier)
+        if report is None or report.is_suspicious:
+            return None
+
+        return convert_mellow_price_d18_to_share_price(
+            price_d18=report.price_d18,
+            share_token_decimals=self.share_token.decimals,
+            asset_decimals=denomination_token.decimals,
+        )
+
+    def fetch_fee_configuration(self, block_identifier: BlockIdentifier = "latest") -> MellowFeeConfiguration | None:
+        """Fetch Mellow FeeManager configuration.
+
+        Mellow stores all configured rates in D6 precision. ``protocolFeeD6`` is
+        the annual time-based fee; the adapter maps it to the shared
+        management-fee field because the shared schema has no separate protocol
+        fee column.
+
+        :param block_identifier:
+            Block number or tag.
+
+        :return:
+            FeeManager configuration, or ``None`` if the FeeManager cannot be
+            read.
+        """
+
+        try:
+            fee_recipient = self.fee_manager_contract.functions.feeRecipient().call(block_identifier=block_identifier)
+            deposit_fee_d6 = self.fee_manager_contract.functions.depositFeeD6().call(block_identifier=block_identifier)
+            redeem_fee_d6 = self.fee_manager_contract.functions.redeemFeeD6().call(block_identifier=block_identifier)
+            performance_fee_d6 = self.fee_manager_contract.functions.performanceFeeD6().call(block_identifier=block_identifier)
+            protocol_fee_d6 = self.fee_manager_contract.functions.protocolFeeD6().call(block_identifier=block_identifier)
+            base_asset = self.fee_manager_contract.functions.baseAsset(Web3.to_checksum_address(self.address)).call(block_identifier=block_identifier)
+            timestamp = self.fee_manager_contract.functions.timestamps(Web3.to_checksum_address(self.address)).call(block_identifier=block_identifier)
+            min_price_d18 = self.fee_manager_contract.functions.minPriceD18(Web3.to_checksum_address(self.address)).call(block_identifier=block_identifier)
+        except (BadFunctionCallOutput, ContractLogicError, ValueError):
+            return None
+
+        return MellowFeeConfiguration(
+            fee_recipient=HexAddress(Web3.to_checksum_address(fee_recipient)),
+            deposit_fee_d6=int(deposit_fee_d6),
+            redeem_fee_d6=int(redeem_fee_d6),
+            performance_fee_d6=int(performance_fee_d6),
+            protocol_fee_d6=int(protocol_fee_d6),
+            base_asset=HexAddress(Web3.to_checksum_address(base_asset)),
+            timestamp=int(timestamp),
+            min_price_d18=int(min_price_d18),
+        )
+
+    def get_fee_data(self) -> FeeData:
+        """Return Mellow fee data.
+
+        Mellow fees are configured through ``FeeManager`` as D6 rates and paid
+        in vault shares. ``protocolFeeD6`` is an annual time-based fee, so it is
+        mapped to the shared management-fee field. ``performanceFeeD6`` maps to
+        the performance-fee field, while deposit and redeem D6 rates map to the
+        shared deposit and withdraw fee fields.
+
+        :return:
+            Fee data, or ``BROKEN_FEE_DATA`` if the FeeManager cannot be read.
+        """
+
+        fee_configuration = self.fetch_fee_configuration(self._get_block_identifier())
+        if fee_configuration is None:
+            return BROKEN_FEE_DATA
+
+        return FeeData(
+            fee_mode=self.get_fee_mode(),
+            management=convert_mellow_fee_d6_to_percent(fee_configuration.protocol_fee_d6),
+            performance=convert_mellow_fee_d6_to_percent(fee_configuration.performance_fee_d6),
+            deposit=convert_mellow_fee_d6_to_percent(fee_configuration.deposit_fee_d6),
+            withdraw=convert_mellow_fee_d6_to_percent(fee_configuration.redeem_fee_d6),
+        )
+
+    def fetch_scan_record_extra_data(self) -> dict[str, object]:
+        """Fetch Mellow-specific private scan row columns.
+
+        ``_mellow_info`` preserves the component graph that the initial
+        Mellow-only scan branch exposed before Mellow was moved to the shared
+        vault scan path.
+
+        :return:
+            Mellow component graph metadata for raw scan rows.
+        """
+
+        return {"_mellow_info": self.fetch_info()}
+
     def fetch_nav(self, block_identifier: BlockIdentifier = "latest") -> Decimal | None:
         """Fetch Mellow NAV.
 
@@ -538,31 +802,68 @@ class MellowVault(VaultBase):
     def get_management_fee(self, block_identifier: BlockIdentifier) -> float | None:
         """Fetch management-like fee.
 
-        Mellow fee manager semantics need ABI confirmation before mapping to
-        annual management-fee percentage.
+        Mellow calls this value ``protocolFeeD6``: an annual time-based fee
+        charged in vault shares. We expose it through the shared management fee
+        column because the generic vault schema has no separate protocol-fee
+        field.
 
         :param block_identifier:
             Block number or tag.
 
         :return:
-            ``None``.
+            Fractional fee, e.g. ``0.01`` for ``1%``.
         """
 
-        return None
+        fee_configuration = self.fetch_fee_configuration(block_identifier)
+        return convert_mellow_fee_d6_to_percent(fee_configuration.protocol_fee_d6) if fee_configuration else None
 
     def get_performance_fee(self, block_identifier: BlockIdentifier) -> float | None:
         """Fetch performance fee.
 
-        Mellow fee manager semantics need ABI confirmation before mapping.
+        Mellow stores performance fees in D6 precision and charges them in
+        vault shares when oracle reports update the FeeManager state.
 
         :param block_identifier:
             Block number or tag.
 
         :return:
-            ``None``.
+            Fractional fee, e.g. ``0.15`` for ``15%``.
         """
 
-        return None
+        fee_configuration = self.fetch_fee_configuration(block_identifier)
+        return convert_mellow_fee_d6_to_percent(fee_configuration.performance_fee_d6) if fee_configuration else None
+
+    def get_deposit_fee(self, block_identifier: BlockIdentifier) -> float | None:
+        """Fetch deposit fee.
+
+        Mellow stores deposit fees in D6 precision and charges them in vault
+        shares during deposit queue report handling.
+
+        :param block_identifier:
+            Block number or tag.
+
+        :return:
+            Fractional fee, e.g. ``0.005`` for ``0.5%``.
+        """
+
+        fee_configuration = self.fetch_fee_configuration(block_identifier)
+        return convert_mellow_fee_d6_to_percent(fee_configuration.deposit_fee_d6) if fee_configuration else None
+
+    def get_withdraw_fee(self, block_identifier: BlockIdentifier) -> float | None:
+        """Fetch redeem fee.
+
+        Mellow names this value ``redeemFeeD6``. The shared vault interface uses
+        the withdraw fee field for the same user-facing redemption charge.
+
+        :param block_identifier:
+            Block number or tag.
+
+        :return:
+            Fractional fee, e.g. ``0.003`` for ``0.3%``.
+        """
+
+        fee_configuration = self.fetch_fee_configuration(block_identifier)
+        return convert_mellow_fee_d6_to_percent(fee_configuration.redeem_fee_d6) if fee_configuration else None
 
     def get_link(self, referral: str | None = None) -> str:
         """Get Mellow vault link.

--- a/eth_defi/mellow/vault.py
+++ b/eth_defi/mellow/vault.py
@@ -63,6 +63,11 @@ share-token and denomination-token decimals. The pipeline stores
 does not emit user flow events; ``ERC4626Feature.mellow_like`` is the explicit
 activity-filter exemption that keeps these vaults in downstream scans.
 
+Current scan-record TVL uses the same denomination-token accounting convention
+as the historical reader: Mellow oracle share price multiplied by tokenised
+``ShareManager.totalSupply()``. Public API USD TVL is kept as off-chain
+diagnostics and is not used for ``NAV``.
+
 Known unsupported cases:
 
 - Non-tokenised ``BasicShareManager`` contracts.
@@ -83,7 +88,7 @@ Reference material:
 # ruff: noqa: ARG002, FBT001, FBT002, PLC0415, PLR0904, PLR0917, PLR6301
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from decimal import Decimal
 from functools import cached_property
 
@@ -95,6 +100,7 @@ from web3.exceptions import BadFunctionCallOutput, ContractLogicError
 from eth_defi.abi import get_deployed_contract
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.mellow.abi import ERC20_ABI_FILENAME, FEE_MANAGER_ABI_FILENAME, ORACLE_ABI_FILENAME, VAULT_ABI_FILENAME
+from eth_defi.mellow.offchain_metadata import MellowApiVaultMetadata
 from eth_defi.token import TokenDetails, fetch_erc20_details
 from eth_defi.vault.base import TradingUniverse, VaultBase, VaultDepositManager, VaultFlowManager, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
 from eth_defi.vault.fee import BROKEN_FEE_DATA, FeeData
@@ -225,34 +231,6 @@ class MellowFeeConfiguration:
 
     #: Minimum price observed by FeeManager for performance fee accounting.
     min_price_d18: int
-
-
-@dataclass(slots=True, frozen=True)
-class MellowApiVaultMetadata:
-    """Optional current Mellow API metadata attached to a vault."""
-
-    #: Public vault name.
-    name: str | None = None
-
-    #: Public vault symbol.
-    symbol: str | None = None
-
-    #: Current API TVL from the public Mellow API, for diagnostics only.
-    #:
-    #: Do not use this value as canonical production NAV. Historical price rows
-    #: derive denomination-token TVL from on-chain oracle share price and
-    #: ``ShareManager.totalSupply()``; current on-chain NAV needs a confirmed
-    #: Mellow portfolio/subvault accounting method.
-    tvl: Decimal | None = None
-
-    #: Base token address from API/configuration, if known.
-    base_token_address: HexAddress | None = None
-
-    #: Base token symbol from API/configuration, if known.
-    base_token_symbol: str | None = None
-
-    #: Raw API fields kept for diagnostics.
-    raw: dict[str, object] = field(default_factory=dict)
 
 
 class MellowVault(VaultBase):
@@ -701,26 +679,46 @@ class MellowVault(VaultBase):
 
         return {"_mellow_info": self.fetch_info()}
 
-    def fetch_nav(self, block_identifier: BlockIdentifier = "latest") -> Decimal | None:
-        """Fetch Mellow NAV.
+    def fetch_total_assets(self, block_identifier: BlockIdentifier = "latest") -> Decimal | None:
+        """Fetch Mellow denomination-token TVL from on-chain share accounting.
 
-        Full current on-chain NAV requires confirmed Mellow portfolio/subvault
-        accounting. The public Mellow API may expose current TVL, but this
-        adapter intentionally does not return API TVL from ``fetch_nav()`` so
-        production scan rows do not mix off-chain point-in-time data with
-        on-chain historical reads.
-
-        Historical Mellow price rows derive denomination-token TVL on-chain as
-        ``share_price * total_supply`` in :class:`MellowVaultHistoricalReader`.
+        Mellow does not expose ERC-4626 ``totalAssets()`` on the canonical
+        vault. For comparable scanner output we use the same on-chain
+        accounting identity as the historical reader: oracle share price in the
+        denomination token multiplied by tokenised ``ShareManager.totalSupply``.
+        The public API USD TVL is not used here.
 
         :param block_identifier:
             Block number or tag.
 
         :return:
-            ``None`` until a canonical on-chain NAV method is implemented.
+            Human-readable denomination-token TVL, or ``None`` if either price
+            or supply is unavailable.
         """
 
-        return None
+        share_price = self.fetch_share_price(block_identifier)
+        total_supply = self.fetch_total_supply(block_identifier)
+
+        if share_price is None or total_supply is None:
+            return None
+
+        return share_price * total_supply
+
+    def fetch_nav(self, block_identifier: BlockIdentifier = "latest") -> Decimal | None:
+        """Fetch Mellow NAV.
+
+        ``fetch_nav()`` is kept as the :class:`VaultBase`-compatible alias for
+        current scanner reads. It returns the same denomination-token value as
+        :py:meth:`fetch_total_assets`, not the public API USD TVL.
+
+        :param block_identifier:
+            Block number or tag.
+
+        :return:
+            Human-readable denomination-token TVL, or ``None`` if unavailable.
+        """
+
+        return self.fetch_total_assets(block_identifier)
 
     def fetch_portfolio(
         self,

--- a/eth_defi/mellow/vault.py
+++ b/eth_defi/mellow/vault.py
@@ -799,6 +799,19 @@ class MellowVault(VaultBase):
 
         return "Mellow"
 
+    def has_custom_fees(self) -> bool:
+        """Whether Mellow exposes custom deposit and redeem fee readers.
+
+        Mellow FeeManager has explicit ``depositFeeD6`` and ``redeemFeeD6``
+        rates, so callers should not assume the VaultBase default zero
+        entry/exit fee behaviour.
+
+        :return:
+            ``True``.
+        """
+
+        return True
+
     def get_management_fee(self, block_identifier: BlockIdentifier) -> float | None:
         """Fetch management-like fee.
 

--- a/eth_defi/mellow/vault.py
+++ b/eth_defi/mellow/vault.py
@@ -800,17 +800,19 @@ class MellowVault(VaultBase):
         return "Mellow"
 
     def has_custom_fees(self) -> bool:
-        """Whether Mellow exposes custom deposit and redeem fee readers.
+        """Whether Mellow has fees outside the shared fee model.
 
-        Mellow FeeManager has explicit ``depositFeeD6`` and ``redeemFeeD6``
-        rates, so callers should not assume the VaultBase default zero
-        entry/exit fee behaviour.
+        Mellow FeeManager fees are all represented by :class:`FeeData`:
+        ``protocolFeeD6`` is management-like, ``performanceFeeD6`` is
+        performance-like, and ``depositFeeD6``/``redeemFeeD6`` map to the
+        standard deposit/withdraw fields.
 
         :return:
-            ``True``.
+            ``False`` because no Mellow FeeManager fee is outside the shared
+            fee fields.
         """
 
-        return True
+        return False
 
     def get_management_fee(self, block_identifier: BlockIdentifier) -> float | None:
         """Fetch management-like fee.

--- a/eth_defi/vault/base.py
+++ b/eth_defi/vault/base.py
@@ -1266,17 +1266,19 @@ class VaultBase(ABC):
         raise NotImplementedError(f"Class {self.__class__.__name__} does not implement get_performance_fee()")
 
     def has_custom_fees(self) -> bool:
-        """Does this vault have custom fee structure reading methods.
+        """Does this vault have fees outside the shared fee model.
 
-        Causes risk in the vault comparison.
+        Custom fees cause risk in vault comparison because the shared
+        management/performance/deposit/withdraw fee fields cannot describe the
+        full fee structure.
 
-        E.g.
-
-        - Withdraw fee
-        - Deposit fee
+        Do not return ``True`` merely because a vault implements custom
+        accessors for ordinary management, performance, deposit, or withdraw
+        fees. Return ``True`` only when some vault fee cannot be reflected in
+        those standard fields as a fee-like value.
 
         :return:
-            True if custom fee reading methods are implemented
+            ``True`` if the vault has fees outside the shared fee model.
         """
         return False
 

--- a/eth_defi/vault/base.py
+++ b/eth_defi/vault/base.py
@@ -23,7 +23,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from decimal import Decimal
 from functools import cached_property
-from typing import Iterable, Tuple, TypedDict
+from typing import TYPE_CHECKING, Iterable, Tuple, TypedDict
 
 from eth_typing import BlockIdentifier, BlockNumber, HexAddress
 from web3 import Web3
@@ -40,6 +40,10 @@ from .flag import VaultFlag, get_notes, get_vault_special_flags
 from .risk import VaultTechnicalRisk, get_vault_risk
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    import pandas as pd
+    import pyarrow
 
 BlockRange = Tuple[BlockNumber, BlockNumber]
 
@@ -690,10 +694,10 @@ class VaultHistoricalRead:
         existing_names = set(existing_table.schema.names)
 
         # Add missing canonical columns as null arrays
-        for field in target_schema:
-            if field.name not in existing_names:
-                null_array = pa.nulls(len(existing_table), type=field.type)
-                existing_table = existing_table.append_column(field, null_array)
+        for target_field in target_schema:
+            if target_field.name not in existing_names:
+                null_array = pa.nulls(len(existing_table), type=target_field.type)
+                existing_table = existing_table.append_column(target_field, null_array)
 
         # Drop only known legacy columns, preserve native protocol columns
         for name in VaultHistoricalRead._LEGACY_COLUMNS:
@@ -706,14 +710,14 @@ class VaultHistoricalRead:
         existing_table = existing_table.select(target_names + extra_names)
 
         # Cast canonical columns to their correct types
-        for field in target_schema:
-            col_idx = existing_table.schema.get_field_index(field.name)
+        for target_field in target_schema:
+            col_idx = existing_table.schema.get_field_index(target_field.name)
             col = existing_table.column(col_idx)
-            if col.type != field.type:
+            if col.type != target_field.type:
                 existing_table = existing_table.set_column(
                     col_idx,
-                    field,
-                    col.cast(field.type, safe=False),
+                    target_field,
+                    col.cast(target_field.type, safe=False),
                 )
 
         # Strip pandas metadata to avoid stale schema info
@@ -723,7 +727,7 @@ class VaultHistoricalRead:
 
     @staticmethod
     def write_uncleaned_parquet(
-        df: "pandas.DataFrame",
+        df: "pd.DataFrame",
         path: "pathlib.Path",
         compression: str = "zstd",
     ):
@@ -754,9 +758,9 @@ class VaultHistoricalRead:
         canonical = VaultHistoricalRead.to_pyarrow_schema()
         canonical_by_name = {f.name: f for f in canonical}
 
-        for i, field in enumerate(table.schema):
-            target_field = canonical_by_name.get(field.name)
-            if target_field is not None and field.type != target_field.type:
+        for i, existing_field in enumerate(table.schema):
+            target_field = canonical_by_name.get(existing_field.name)
+            if target_field is not None and existing_field.type != target_field.type:
                 table = table.set_column(
                     i,
                     target_field,
@@ -1062,6 +1066,21 @@ class VaultBase(ABC):
         - Override in subclasses that support manager or operator metadata
         """
         return None
+
+    def fetch_scan_record_extra_data(self) -> dict[str, object]:  # noqa: PLR6301
+        """Fetch protocol-specific private scan row columns.
+
+        Some vault protocols expose structured metadata that is useful for the
+        raw scanner output but does not fit the shared human-readable columns.
+        Override this hook in protocol-specific subclasses instead of adding a
+        separate branch to :py:func:`eth_defi.erc_4626.scan.create_vault_scan_record`.
+
+        :return:
+            Mapping of private scan-row column names, usually prefixed with
+            ``_``. The default implementation returns no extra data.
+        """
+
+        return {}
 
     @cached_property
     def flow_manager(self) -> VaultFlowManager:

--- a/eth_defi/vault/fee.py
+++ b/eth_defi/vault/fee.py
@@ -179,6 +179,10 @@ VAULT_PROTOCOL_FEE_MATRIX = {
     # Suppliers earn the Hub interest spread; Aave protocol revenue is taken as a reserve
     # factor on borrow interest, so yield is internalised in the Hub-derived share price.
     "Aave": VaultFeeMode.internalised_skimming,
+    # Mellow Core Vaults - FeeManager charges deposit, redeem, performance and
+    # time-based protocol fees in vault shares. Performance/protocol fees are
+    # minted as shares, while deposit/redeem fees reduce user share amounts.
+    "Mellow": VaultFeeMode.internalised_minting,
 }
 
 

--- a/eth_defi/vault/risk.py
+++ b/eth_defi/vault/risk.py
@@ -166,6 +166,8 @@ VAULT_PROTOCOL_RISK_MATRIX = {
     # Aave - v4 Tokenization Spoke; blue-chip lending protocol, audited (ChainSecurity)
     # and a 6-week public security contest, open source contracts.
     "Aave": VaultTechnicalRisk.low,
+    # Mellow - audited Core Vault architecture with verified component contracts.
+    "Mellow": VaultTechnicalRisk.low,
 }
 
 #: Particular vaults that are broken, misleading or otherwise problematic.

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -45,6 +45,7 @@ from eth_defi.currency_api.constants import (
 )
 from eth_defi.currency_api.scanner import run_incremental_scan as currency_run_incremental_scan
 from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS, create_vault_instance
+from eth_defi.erc_4626.core import is_activity_filter_exempt
 from eth_defi.erc_4626.lead_scan_core import scan_leads
 from eth_defi.feed.database import resolve_feed_database_path
 from eth_defi.grvt.daily_metrics import run_daily_scan as grvt_run_daily_scan
@@ -532,8 +533,11 @@ def scan_prices_for_chain(
         for row in chain_vaults:
             detection = row["_detection_data"]
 
-            # Skip vaults with low activity (but keep hardcoded protocol vaults)
-            if detection.deposit_count < min_deposit_threshold and detection.address.lower() not in HARDCODED_PROTOCOLS:
+            # Skip vaults with low activity (but keep hardcoded protocol vaults
+            # and Mellow factory-discovered vaults). Mellow stores zero counts
+            # because the canonical Vault does not emit user flow events; those
+            # live on queue contracts and need a later second-stage scan.
+            if detection.deposit_count < min_deposit_threshold and detection.address.lower() not in HARDCODED_PROTOCOLS and not is_activity_filter_exempt(detection):
                 continue
 
             vault = create_vault_instance(web3, detection.address, detection.features, token_cache=token_cache)

--- a/scripts/erc-4626/scan-prices.py
+++ b/scripts/erc-4626/scan-prices.py
@@ -99,7 +99,7 @@ except ImportError as e:
 
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS, create_vault_instance
-from eth_defi.erc_4626.core import ERC4262VaultDetection
+from eth_defi.erc_4626.core import ERC4262VaultDetection, is_activity_filter_exempt
 from eth_defi.provider.multi_provider import create_multi_provider_web3, MultiProviderWeb3Factory
 from eth_defi.token import TokenDiskCache
 from eth_defi.utils import setup_console_logging
@@ -215,7 +215,11 @@ def main():
         detection = row["_detection_data"]
         address = detection.address
 
-        if detection.deposit_count < min_deposit_threshold and address.lower() not in HARDCODED_PROTOCOLS:
+        # Mellow Core Vault identities come from Factory.Created, while user
+        # flow events live on DepositQueue/RedeemQueue contracts. The metadata
+        # database stores zero counts for compatibility, so use the central
+        # feature-based exemption instead of looking at count field names.
+        if detection.deposit_count < min_deposit_threshold and address.lower() not in HARDCODED_PROTOCOLS and not is_activity_filter_exempt(detection):
             # print(f"Vault does not have enough deposits: {address}, has: {detection.deposit_count}, threshold {min_deposit_threshold}")
             continue
 

--- a/scripts/mellow/scan-initial-mellow.py
+++ b/scripts/mellow/scan-initial-mellow.py
@@ -1,0 +1,1082 @@
+"""Initial Mellow vault mapping scan using Hypersync.
+
+This script discovers Mellow Core Vault instances from their factory
+``Created(address,uint256,address,bytes)`` events and enriches the results
+with light on-chain metadata and the public Mellow API TVL data.
+
+Usage:
+
+.. code-block:: shell
+
+    source .local-test.env
+    LOG_LEVEL=info poetry run python scripts/mellow/scan-initial-mellow.py
+
+Optional environment variables:
+
+``CHAINS``
+    Comma-separated chain aliases to scan. Defaults to
+    ``ethereum,arbitrum,plasma,monad,base``.
+
+``MELLOW_ETHEREUM_VAULT_FACTORY`` / ``MELLOW_ARBITRUM_VAULT_FACTORY`` /
+``MELLOW_PLASMA_VAULT_FACTORY`` / ``MELLOW_MONAD_VAULT_FACTORY`` /
+``MELLOW_BASE_VAULT_FACTORY``
+    Override the vault factory address for a chain. Mellow's public Core
+    deployments page currently documents Mainnet, Plasma, Arbitrum and Monad
+    Core vault factories, but not a Base Core vault factory.
+
+``FETCH_MELLOW_API``
+    Set to ``false`` to skip the public API TVL enrichment.
+
+``START_BLOCK`` / ``END_BLOCK`` / ``BLOCK_RANGE``
+    Restrict the factory scan block range. If ``BLOCK_RANGE`` is set without
+    ``START_BLOCK``, the scanner uses ``END_BLOCK - BLOCK_RANGE``. The manual
+    integration test path uses ``BLOCK_RANGE=1000000``.
+
+``MELLOW_TEST_LEADS`` / ``MELLOW_TEST_METADATA`` / ``MELLOW_TEST_PRICES``
+    Enable explicit manual-test sections in the tabulate output.
+
+``SKIP_WRITE``
+    Accepted for parity with pipeline manual tests. This script is read-only.
+
+``HYPERSYNC_API_KEY``
+    Optional Envio Hypersync API key.
+"""
+
+import asyncio
+import datetime
+import logging
+import os
+from collections.abc import Iterator
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+import hypersync
+import requests
+from eth_abi.exceptions import DecodingError
+from eth_typing import HexAddress
+from hypersync import BlockField, LogField
+from tabulate import tabulate
+from web3 import Web3
+from web3.contract.contract import Contract, ContractFunction
+from web3.exceptions import BadFunctionCallOutput, ContractLogicError
+
+from eth_defi.compat import native_datetime_utc_fromtimestamp
+from eth_defi.hypersync.server import get_hypersync_server
+from eth_defi.hypersync.session import (
+    create_throttled_hypersync_client,
+    get_hypersync_concurrency_from_env,
+    get_hypersync_rpm_from_env,
+    open_hypersync_stream,
+)
+from eth_defi.mellow.discovery import decode_mellow_created_event, fetch_mellow_created_event_topic, fetch_mellow_factories_for_chain
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.utils import setup_console_logging
+
+logger = logging.getLogger(__name__)
+
+MELLOW_API_VAULTS_URL = "https://points.mellow.finance/v1/vaults"
+
+ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+VAULT_ABI = [
+    {
+        "inputs": [],
+        "name": "shareManager",
+        "outputs": [{"internalType": "contract IShareManager", "name": "", "type": "address"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "getAssetCount",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "uint256", "name": "index", "type": "uint256"}],
+        "name": "assetAt",
+        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "getQueueCount",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "address", "name": "asset", "type": "address"}],
+        "name": "getQueueCount",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "asset", "type": "address"},
+            {"internalType": "uint256", "name": "index", "type": "uint256"},
+        ],
+        "name": "queueAt",
+        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+]
+
+ERC20_ABI = [
+    {
+        "inputs": [],
+        "name": "name",
+        "outputs": [{"internalType": "string", "name": "", "type": "string"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "symbol",
+        "outputs": [{"internalType": "string", "name": "", "type": "string"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "decimals",
+        "outputs": [{"internalType": "uint8", "name": "", "type": "uint8"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "totalSupply",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+]
+
+
+@dataclass(slots=True, frozen=True)
+class ChainConfig:
+    """Configuration for a chain scanned by this script.
+
+    Each chain is configured through repository-standard JSON-RPC environment
+    variables. The factory address is the Mellow Core Vault factory, if known.
+
+    :param alias:
+        Environment-facing chain name used in ``CHAINS`` and factory overrides.
+
+    :param chain_id:
+        EVM chain id expected from the JSON-RPC connection.
+
+    :param rpc_env_var:
+        JSON-RPC environment variable name.
+
+    :param vault_factory:
+        Mellow Core Vault factory address to scan with Hypersync.
+    """
+
+    alias: str
+    chain_id: int
+    rpc_env_var: str
+    vault_factory: HexAddress | None
+
+
+@dataclass(slots=True)
+class ApiVault:
+    """Mellow API vault metadata used for TVL enrichment.
+
+    The public API is used only as an enrichment layer. Hypersync factory
+    events remain the source of truth for newly-created Core Vault leads.
+
+    :param chain_id:
+        EVM chain id.
+
+    :param address:
+        Vault address.
+
+    :param symbol:
+        Public vault token symbol.
+
+    :param name:
+        Public vault name.
+
+    :param layer:
+        Mellow API layer field, e.g. ``mellow`` or ``symbiotic``.
+
+    :param tvl_usd:
+        Current API-reported TVL in USD.
+
+    :param base_token_symbol:
+        Base token symbol from the API, when present.
+    """
+
+    chain_id: int
+    address: HexAddress
+    symbol: str | None
+    name: str | None
+    layer: str | None
+    tvl_usd: Decimal | None
+    base_token_symbol: str | None
+
+
+@dataclass(slots=True)
+class CoreVaultLead:
+    """A Mellow Core Vault instance discovered from a factory event.
+
+    :param chain_id:
+        EVM chain id.
+
+    :param chain:
+        Human-readable chain alias.
+
+    :param factory:
+        Factory contract that emitted the creation event.
+
+    :param vault:
+        Created vault proxy address.
+
+    :param version:
+        Factory implementation version used for deployment.
+
+    :param owner:
+        Owner address passed to the factory.
+
+    :param block_number:
+        Block number of the creation event.
+
+    :param timestamp:
+        Block timestamp of the creation event.
+
+    :param transaction_hash:
+        Transaction hash of the creation event.
+
+    :param init_params_size:
+        ABI-encoded init parameter length in bytes.
+    """
+
+    chain_id: int
+    chain: str
+    factory: HexAddress
+    vault: HexAddress
+    version: int
+    owner: HexAddress
+    block_number: int
+    timestamp: datetime.datetime | None
+    transaction_hash: str
+    init_params_size: int
+
+
+@dataclass(slots=True)
+class CoreVaultRow:
+    """A discovered Core Vault row for tabular reporting.
+
+    :param lead:
+        The Hypersync-discovered vault lead.
+
+    :param share_manager:
+        Share manager address returned by the vault.
+
+    :param share_symbol:
+        ERC-20 symbol of the share manager, if tokenised.
+
+    :param share_name:
+        ERC-20 name of the share manager, if tokenised.
+
+    :param total_supply:
+        ERC-20 total supply converted with token decimals.
+
+    :param asset_count:
+        Number of assets registered in the vault's ShareModule.
+
+    :param queue_count:
+        Total number of queues registered in the vault's ShareModule.
+
+    :param asset_symbols:
+        Registered asset token symbols.
+
+    :param api_vault:
+        Matching public Mellow API entry, when present.
+    """
+
+    lead: CoreVaultLead
+    share_manager: HexAddress | None
+    share_symbol: str | None
+    share_name: str | None
+    total_supply: Decimal | None
+    asset_count: int | None
+    queue_count: int | None
+    asset_symbols: tuple[str, ...]
+    api_vault: ApiVault | None
+
+
+def env_bool(name: str, default: bool) -> bool:  # noqa: FBT001
+    """Read a boolean environment variable.
+
+    Accepts common true/false spellings. Empty values fall back to the
+    provided default.
+
+    :param name:
+        Environment variable name.
+
+    :param default:
+        Default value when the variable is unset.
+
+    :return:
+        Parsed boolean value.
+    """
+
+    raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return default
+    return raw in {"1", "true", "yes", "y", "on"}
+
+
+def env_int(name: str) -> int | None:
+    """Read an integer environment variable.
+
+    :param name:
+        Environment variable name.
+
+    :return:
+        Parsed integer or ``None``.
+    """
+
+    value = os.environ.get(name, "").strip()
+    if not value:
+        return None
+    return int(value.replace("_", ""))
+
+
+def resolve_scan_range(chain_alias: str, default_end_block: int) -> tuple[int, int]:
+    """Resolve block range from environment.
+
+    :param chain_alias:
+        Chain alias used in diagnostics.
+
+    :param default_end_block:
+        Latest block available from RPC/Hypersync.
+
+    :return:
+        Start and end block.
+    """
+
+    end_block = env_int("END_BLOCK") or default_end_block
+    block_range = env_int("BLOCK_RANGE")
+    start_block = env_int("START_BLOCK")
+
+    if start_block is None:
+        if block_range is not None:
+            start_block = max(0, end_block - block_range)
+        else:
+            start_block = 0
+
+    if start_block >= end_block:
+        raise ValueError(f"Invalid {chain_alias} scan range: START_BLOCK={start_block:,}, END_BLOCK={end_block:,}")
+
+    return start_block, end_block
+
+
+def get_created_event_topic() -> str:
+    """Return the Mellow factory ``Created`` event topic.
+
+    The event is documented by Mellow Core Vault docs:
+    https://docs.mellow.finance/core-vaults/architecture/factory
+
+    :return:
+        Hex topic0 for ``Created(address,uint256,address,bytes)``.
+    """
+
+    return fetch_mellow_created_event_topic()
+
+
+def get_chain_configs() -> dict[str, ChainConfig]:
+    """Build supported chain configuration from environment variables.
+
+    Mainnet, Plasma, Arbitrum and Monad defaults come from Mellow's Core
+    deployments page:
+    https://docs.mellow.finance/core-vaults/core-deployments
+
+    :return:
+        Mapping of lower-case chain alias to configuration.
+    """
+
+    mainnet_factories = fetch_mellow_factories_for_chain(1)
+    plasma_factories = fetch_mellow_factories_for_chain(9745)
+    arbitrum_factories = fetch_mellow_factories_for_chain(42161)
+    monad_factories = fetch_mellow_factories_for_chain(143)
+    base_factories = fetch_mellow_factories_for_chain(8453)
+
+    return {
+        "ethereum": ChainConfig(
+            alias="ethereum",
+            chain_id=1,
+            rpc_env_var="JSON_RPC_ETHEREUM",
+            vault_factory=mainnet_factories[0] if mainnet_factories else None,
+        ),
+        "plasma": ChainConfig(
+            alias="plasma",
+            chain_id=9745,
+            rpc_env_var="JSON_RPC_PLASMA",
+            vault_factory=plasma_factories[0] if plasma_factories else None,
+        ),
+        "arbitrum": ChainConfig(
+            alias="arbitrum",
+            chain_id=42161,
+            rpc_env_var="JSON_RPC_ARBITRUM",
+            vault_factory=arbitrum_factories[0] if arbitrum_factories else None,
+        ),
+        "monad": ChainConfig(
+            alias="monad",
+            chain_id=143,
+            rpc_env_var="JSON_RPC_MONAD",
+            vault_factory=monad_factories[0] if monad_factories else None,
+        ),
+        "base": ChainConfig(
+            alias="base",
+            chain_id=8453,
+            rpc_env_var="JSON_RPC_BASE",
+            vault_factory=base_factories[0] if base_factories else None,
+        ),
+    }
+
+
+def iter_selected_chains(configs: dict[str, ChainConfig]) -> Iterator[ChainConfig]:
+    """Yield chain configurations selected by ``CHAINS``.
+
+    :param configs:
+        All supported chain configurations.
+
+    :return:
+        Iterator of selected chain configurations.
+
+    :raise ValueError:
+        Raised when ``CHAINS`` contains an unknown alias.
+    """
+
+    chain_aliases = [part.strip().lower() for part in os.environ.get("CHAINS", "ethereum,arbitrum,plasma,monad,base").split(",") if part.strip()]
+    for alias in chain_aliases:
+        if alias not in configs:
+            raise ValueError(f"Unknown chain alias in CHAINS: {alias}. Supported: {', '.join(configs)}")
+        yield configs[alias]
+
+
+def create_hypersync_client(chain_id: int) -> hypersync.HypersyncClient:
+    """Create a throttled Hypersync client for a chain.
+
+    Handles both ``bearer_token`` and ``api_token`` constructor spellings used
+    by different Hypersync Python releases.
+
+    :param chain_id:
+        EVM chain id.
+
+    :return:
+        Hypersync client.
+    """
+
+    hypersync_url = get_hypersync_server(chain_id)
+    api_key = os.environ.get("HYPERSYNC_API_KEY")
+    config_candidates: list[dict[str, Any]]
+    if api_key:
+        config_candidates = [
+            {"url": hypersync_url, "bearer_token": api_key},
+            {"url": hypersync_url, "api_token": api_key},
+        ]
+    else:
+        config_candidates = [{"url": hypersync_url}]
+
+    last_error: TypeError | None = None
+    for config_kwargs in config_candidates:
+        try:
+            config = hypersync.ClientConfig(**config_kwargs)
+            break
+        except TypeError as e:
+            last_error = e
+    else:
+        raise TypeError(f"Could not initialise Hypersync ClientConfig for chain {chain_id}: {last_error}") from last_error
+
+    return create_throttled_hypersync_client(
+        config,
+        requests_per_minute=get_hypersync_rpm_from_env(),
+        concurrency=get_hypersync_concurrency_from_env(),
+    )
+
+
+def decode_hypersync_int(value: int | str | None) -> int:
+    """Decode an integer returned by Hypersync.
+
+    Hypersync fields may be returned as Python integers or hex strings,
+    depending on the wheel version and selected field.
+
+    :param value:
+        Hypersync integer-like value.
+
+    :return:
+        Decoded integer.
+    """
+
+    if value is None:
+        return 0
+    if isinstance(value, int):
+        return value
+    if value.startswith("0x"):
+        return int(value, 16)
+    return int(value)
+
+
+def decode_created_event(web3: Web3, log: Any) -> tuple[HexAddress, int, HexAddress, bytes]:
+    """Decode a Mellow factory ``Created`` event.
+
+    Mellow documents the event arguments as non-indexed, but this decoder also
+    supports an indexed variant to make the scanner tolerant of older factory
+    implementations.
+
+    :param web3:
+        Web3 instance whose ABI codec is used for decoding.
+
+    :param log:
+        Hypersync log object.
+
+    :return:
+        Vault instance, factory version, owner, and raw ``initParams``.
+
+    :raise DecodingError:
+        Raised when log data cannot be decoded.
+    """
+
+    return decode_mellow_created_event(web3, log)
+
+
+async def fetch_hypersync_height(client: hypersync.HypersyncClient) -> int | None:
+    """Fetch the latest block height available from Hypersync.
+
+    :param client:
+        Hypersync client.
+
+    :return:
+        Latest Hypersync block height, or ``None`` if the server does not
+        expose it cleanly.
+    """
+
+    try:
+        return decode_hypersync_int(await client.get_height())
+    except RuntimeError as e:
+        logger.warning("Could not fetch Hypersync height: %s", e)
+        return None
+
+
+async def fetch_created_events(
+    web3: Web3,
+    client: hypersync.HypersyncClient,
+    chain: ChainConfig,
+    start_block: int,
+    end_block: int,
+) -> list[CoreVaultLead]:
+    """Fetch Mellow Core Vault factory creation events with Hypersync.
+
+    :param web3:
+        Web3 connection for ABI decoding.
+
+    :param client:
+        Hypersync client.
+
+    :param chain:
+        Chain configuration.
+
+    :param start_block:
+        Inclusive start block.
+
+    :param end_block:
+        Exclusive end block for Hypersync query.
+
+    :return:
+        List of Core Vault leads discovered from the factory.
+    """
+
+    assert chain.vault_factory is not None
+
+    query = hypersync.Query(
+        from_block=start_block,
+        to_block=end_block,
+        logs=[
+            hypersync.LogSelection(
+                address=[chain.vault_factory],
+                topics=[[get_created_event_topic()]],
+            )
+        ],
+        field_selection=hypersync.FieldSelection(
+            block=[BlockField.NUMBER, BlockField.TIMESTAMP],
+            log=[
+                LogField.BLOCK_NUMBER,
+                LogField.LOG_INDEX,
+                LogField.ADDRESS,
+                LogField.TRANSACTION_HASH,
+                LogField.TOPIC0,
+                LogField.TOPIC1,
+                LogField.TOPIC2,
+                LogField.TOPIC3,
+                LogField.DATA,
+            ],
+        ),
+    )
+
+    receiver = await open_hypersync_stream(client, query)
+    leads: list[CoreVaultLead] = []
+    seen_keys: set[tuple[int, str]] = set()
+
+    while True:
+        result = await asyncio.wait_for(receiver.recv(), timeout=90.0)
+        if result is None:
+            break
+
+        block_timestamps = {decode_hypersync_int(block.number): native_datetime_utc_fromtimestamp(decode_hypersync_int(block.timestamp)) for block in result.data.blocks or [] if block.number is not None and block.timestamp is not None}
+
+        for log in result.data.logs or []:
+            try:
+                vault, version, owner, init_params = decode_created_event(web3, log)
+            except (DecodingError, ValueError) as e:
+                logger.warning(
+                    "Could not decode Mellow Created event on %s tx %s: %s",
+                    chain.alias,
+                    log.transaction_hash,
+                    e,
+                )
+                continue
+
+            key = (chain.chain_id, vault.lower())
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+
+            block_number = decode_hypersync_int(log.block_number)
+            leads.append(
+                CoreVaultLead(
+                    chain_id=chain.chain_id,
+                    chain=chain.alias,
+                    factory=chain.vault_factory,
+                    vault=vault,
+                    version=version,
+                    owner=owner,
+                    block_number=block_number,
+                    timestamp=block_timestamps.get(block_number),
+                    transaction_hash=log.transaction_hash,
+                    init_params_size=len(init_params),
+                )
+            )
+
+    return sorted(leads, key=lambda lead: (lead.block_number, lead.vault.lower()))
+
+
+def fetch_mellow_api_vaults() -> dict[tuple[int, str], ApiVault]:
+    """Fetch public Mellow API vault data for TVL enrichment.
+
+    The API schema is documented at:
+    https://docs.mellow.finance/resources/api
+
+    :return:
+        Mapping ``(chain_id, lower-case address) -> ApiVault``.
+    """
+
+    response = requests.get(MELLOW_API_VAULTS_URL, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+
+    api_vaults: dict[tuple[int, str], ApiVault] = {}
+    for item in data:
+        address = Web3.to_checksum_address(item["address"])
+        base_token = item.get("base_token") or {}
+        tvl_raw = item.get("tvl_usd")
+        api_vault = ApiVault(
+            chain_id=int(item["chain_id"]),
+            address=HexAddress(address),
+            symbol=item.get("symbol"),
+            name=item.get("name"),
+            layer=item.get("layer"),
+            tvl_usd=Decimal(str(tvl_raw)) if tvl_raw is not None else None,
+            base_token_symbol=base_token.get("symbol"),
+        )
+        api_vaults[api_vault.chain_id, api_vault.address.lower()] = api_vault
+
+    return api_vaults
+
+
+def call_contract_function(function: ContractFunction) -> Any | None:
+    """Call a contract function and return ``None`` if the method is absent.
+
+    :param function:
+        Bound Web3 contract function.
+
+    :return:
+        Function return value, or ``None`` for missing/reverting view calls.
+    """
+
+    try:
+        return function.call()
+    except (BadFunctionCallOutput, ContractLogicError, ValueError) as e:
+        logger.debug("Contract call failed: %s", e)
+        return None
+
+
+def fetch_erc20_metadata(web3: Web3, token_address: HexAddress) -> tuple[str | None, str | None, int | None, int | None]:
+    """Fetch basic ERC-20 metadata.
+
+    :param web3:
+        Web3 connection.
+
+    :param token_address:
+        ERC-20 token address.
+
+    :return:
+        ``name``, ``symbol``, ``decimals`` and ``totalSupply``.
+    """
+
+    if token_address == ZERO_ADDRESS:
+        return None, None, None, None
+
+    token = web3.eth.contract(address=token_address, abi=ERC20_ABI)
+    name = call_contract_function(token.functions.name())
+    symbol = call_contract_function(token.functions.symbol())
+    decimals = call_contract_function(token.functions.decimals())
+    total_supply = call_contract_function(token.functions.totalSupply())
+
+    return (
+        str(name) if name is not None else None,
+        str(symbol) if symbol is not None else None,
+        int(decimals) if decimals is not None else None,
+        int(total_supply) if total_supply is not None else None,
+    )
+
+
+def humanise_token_amount(raw_amount: int | None, decimals: int | None) -> Decimal | None:
+    """Convert a raw token amount to decimals.
+
+    :param raw_amount:
+        Raw ERC-20 amount.
+
+    :param decimals:
+        ERC-20 decimals.
+
+    :return:
+        Decimal human amount.
+    """
+
+    if raw_amount is None or decimals is None:
+        return None
+    return Decimal(raw_amount) / Decimal(10**decimals)
+
+
+def fetch_core_vault_row(web3: Web3, lead: CoreVaultLead, api_vaults: dict[tuple[int, str], ApiVault]) -> CoreVaultRow:  # noqa: PLR0914
+    """Fetch light on-chain metadata for a discovered Mellow Core Vault.
+
+    :param web3:
+        Web3 connection.
+
+    :param lead:
+        Hypersync-discovered vault lead.
+
+    :param api_vaults:
+        API enrichment mapping.
+
+    :return:
+        Tabular row model.
+    """
+
+    vault: Contract = web3.eth.contract(address=lead.vault, abi=VAULT_ABI)
+
+    share_manager_raw = call_contract_function(vault.functions.shareManager())
+    share_manager = HexAddress(Web3.to_checksum_address(share_manager_raw)) if share_manager_raw else None
+
+    share_name: str | None = None
+    share_symbol: str | None = None
+    total_supply: Decimal | None = None
+    if share_manager:
+        share_name, share_symbol, share_decimals, raw_total_supply = fetch_erc20_metadata(web3, share_manager)
+        total_supply = humanise_token_amount(raw_total_supply, share_decimals)
+
+    asset_count_raw = call_contract_function(vault.functions.getAssetCount())
+    asset_count = int(asset_count_raw) if asset_count_raw is not None else None
+
+    queue_count_raw = call_contract_function(vault.functions.getQueueCount())
+    queue_count = int(queue_count_raw) if queue_count_raw is not None else None
+
+    asset_symbols: list[str] = []
+    if asset_count is not None:
+        for index in range(asset_count):
+            asset_raw = call_contract_function(vault.functions.assetAt(index))
+            if not asset_raw:
+                continue
+            asset = HexAddress(Web3.to_checksum_address(asset_raw))
+            _, symbol, _, _ = fetch_erc20_metadata(web3, asset)
+            asset_symbols.append(symbol or asset)
+
+    api_vault = api_vaults.get((lead.chain_id, lead.vault.lower()))
+
+    return CoreVaultRow(
+        lead=lead,
+        share_manager=share_manager,
+        share_symbol=share_symbol,
+        share_name=share_name,
+        total_supply=total_supply,
+        asset_count=asset_count,
+        queue_count=queue_count,
+        asset_symbols=tuple(asset_symbols),
+        api_vault=api_vault,
+    )
+
+
+def format_money(value: Decimal | None) -> str:
+    """Format USD money for table output.
+
+    :param value:
+        Decimal USD value.
+
+    :return:
+        Human-readable string.
+    """
+
+    if value is None:
+        return "n/a"
+    return f"${value:,.2f}"
+
+
+def format_decimal(value: Decimal | None) -> str:
+    """Format a token amount for table output.
+
+    :param value:
+        Decimal token amount.
+
+    :return:
+        Human-readable string.
+    """
+
+    if value is None:
+        return "n/a"
+    return f"{value:,.6f}".rstrip("0").rstrip(".")
+
+
+def build_api_summary(api_vaults: dict[tuple[int, str], ApiVault], selected_chain_ids: set[int]) -> list[dict[str, Any]]:
+    """Build summary rows from the public Mellow API.
+
+    :param api_vaults:
+        API vault mapping.
+
+    :param selected_chain_ids:
+        Chain ids included in this scan.
+
+    :return:
+        Summary rows for ``tabulate``.
+    """
+
+    selected_vaults = [vault for vault in api_vaults.values() if vault.chain_id in selected_chain_ids]
+    rows: list[dict[str, Any]] = []
+
+    for label, predicate in (
+        ("Mellow API catalogue", lambda _: True),
+        ("Mellow API layer=mellow", lambda vault: vault.layer == "mellow"),
+    ):
+        matching = [vault for vault in selected_vaults if predicate(vault)]
+        rows.append(
+            {
+                "Scope": label,
+                "Vaults": len(matching),
+                "TVL": format_money(sum((vault.tvl_usd or Decimal(0) for vault in matching), Decimal(0))),
+            }
+        )
+
+    return rows
+
+
+def build_core_summary(rows: list[CoreVaultRow]) -> list[dict[str, Any]]:
+    """Build summary rows from Hypersync Core Vault discovery.
+
+    :param rows:
+        Enriched Core Vault rows.
+
+    :return:
+        Summary rows for ``tabulate``.
+    """
+
+    api_matched = [row for row in rows if row.api_vault is not None]
+    api_tvl = sum((row.api_vault.tvl_usd or Decimal(0) for row in api_matched if row.api_vault), Decimal(0))
+    return [
+        {
+            "Scope": "Hypersync Core factory events",
+            "Vaults": len(rows),
+            "TVL": format_money(api_tvl) if api_matched else "n/a",
+        },
+        {
+            "Scope": "Hypersync Core events matched to API",
+            "Vaults": len(api_matched),
+            "TVL": format_money(api_tvl),
+        },
+    ]
+
+
+def render_core_rows(rows: list[CoreVaultRow]) -> str:
+    """Render discovered Core Vaults as a table.
+
+    :param rows:
+        Enriched Core Vault rows.
+
+    :return:
+        ``tabulate`` output.
+    """
+
+    table = []
+    for row in rows:
+        api_vault = row.api_vault
+        table.append(
+            {
+                "Chain": row.lead.chain,
+                "Vault": row.lead.vault,
+                "Share": row.share_symbol or (api_vault.symbol if api_vault else "n/a"),
+                "Name": row.share_name or (api_vault.name if api_vault else "n/a"),
+                "Version": row.lead.version,
+                "Assets": ", ".join(row.asset_symbols) or "n/a",
+                "Queues": row.queue_count if row.queue_count is not None else "n/a",
+                "Supply": format_decimal(row.total_supply),
+                "API layer": api_vault.layer if api_vault else "n/a",
+                "API TVL": format_money(api_vault.tvl_usd if api_vault else None),
+                "Created": row.lead.timestamp.strftime("%Y-%m-%d") if row.lead.timestamp else row.lead.block_number,
+            }
+        )
+
+    return tabulate(table, headers="keys", tablefmt="simple")
+
+
+def render_manual_price_rows(rows: list[CoreVaultRow], end_block: int) -> str:
+    """Render manual price-scan sample rows.
+
+    :param rows:
+        Enriched Core Vault rows.
+
+    :param end_block:
+        Block used for metadata calls.
+
+    :return:
+        ``tabulate`` output.
+    """
+
+    table = []
+    for row in rows:
+        table.append(
+            {
+                "Chain": row.lead.chain,
+                "Vault": row.lead.vault,
+                "Block": end_block,
+                "Supply": format_decimal(row.total_supply),
+                "Share price": "n/a",
+                "Total assets": format_money(row.api_vault.tvl_usd if row.api_vault else None),
+                "Error": "Mellow oracle price orientation is not implemented in the initial mapping script",
+            }
+        )
+
+    return tabulate(table, headers="keys", tablefmt="simple")
+
+
+def main() -> None:  # noqa: PLR0914
+    """Run the initial Mellow scan.
+
+    The scanner prints two tables: a summary table and the per-vault mapping
+    table. It uses Hypersync for discovery and repository-standard JSON-RPC
+    variables for metadata calls.
+    """
+
+    setup_console_logging(default_log_level=os.environ.get("LOG_LEVEL", "warning"))
+
+    configs = get_chain_configs()
+    chains = list(iter_selected_chains(configs))
+    selected_chain_ids = {chain.chain_id for chain in chains}
+
+    fetch_api = env_bool("FETCH_MELLOW_API", True)
+    api_vaults: dict[tuple[int, str], ApiVault] = {}
+    if fetch_api:
+        logger.info("Fetching public Mellow API vault metadata")
+        api_vaults = fetch_mellow_api_vaults()
+
+    rows: list[CoreVaultRow] = []
+    skipped_chains: list[str] = []
+    last_end_block = 0
+
+    for chain in chains:
+        json_rpc_url = os.environ.get(chain.rpc_env_var)
+        if not json_rpc_url:
+            logger.warning("Skipping %s: %s is not set", chain.alias, chain.rpc_env_var)
+            skipped_chains.append(chain.alias)
+            continue
+
+        if chain.vault_factory is None:
+            logger.warning("Skipping %s Hypersync scan: Mellow Core Vault factory is not configured", chain.alias)
+            skipped_chains.append(chain.alias)
+            continue
+
+        web3 = create_multi_provider_web3(json_rpc_url)
+        rpc_chain_id = web3.eth.chain_id
+        if rpc_chain_id != chain.chain_id:
+            raise ValueError(f"{chain.rpc_env_var} points to chain id {rpc_chain_id}, expected {chain.chain_id}")
+
+        client = create_hypersync_client(chain.chain_id)
+        rpc_end_block = web3.eth.block_number
+        hypersync_height = asyncio.run(fetch_hypersync_height(client))
+        default_end_block = min(rpc_end_block, hypersync_height) if hypersync_height else rpc_end_block
+        start_block, end_block = resolve_scan_range(chain.alias, default_end_block)
+        last_end_block = max(last_end_block, end_block)
+
+        logger.info(
+            "Scanning %s factory %s from block %s to %s",
+            chain.alias,
+            chain.vault_factory,
+            f"{start_block:,}",
+            f"{end_block:,}",
+        )
+        leads = asyncio.run(
+            fetch_created_events(
+                web3=web3,
+                client=client,
+                chain=chain,
+                start_block=start_block,
+                end_block=end_block,
+            )
+        )
+
+        logger.info("Discovered %d Mellow Core Vault leads on %s", len(leads), chain.alias)
+        for lead in leads:
+            rows.append(fetch_core_vault_row(web3, lead, api_vaults))
+
+    summary_rows: list[dict[str, Any]] = []
+    if api_vaults:
+        summary_rows.extend(build_api_summary(api_vaults, selected_chain_ids))
+    summary_rows.extend(build_core_summary(rows))
+
+    print("Mellow vault summary")
+    print(tabulate(summary_rows, headers="keys", tablefmt="simple"))
+
+    if skipped_chains:
+        print()
+        print(f"Skipped Hypersync Core factory scan for: {', '.join(skipped_chains)}")
+
+    print()
+    print("Hypersync-discovered Mellow Core Vaults")
+    print(render_core_rows(rows) if rows else "No Core Vault factory events found.")
+
+    if env_bool("MELLOW_TEST_LEADS", False):
+        print()
+        print("Manual test: leads")
+        print(render_core_rows(rows) if rows else "No leads in the selected block range.")
+
+    if env_bool("MELLOW_TEST_METADATA", False):
+        print()
+        print("Manual test: metadata")
+        print(render_core_rows(rows) if rows else "No metadata rows in the selected block range.")
+
+    if env_bool("MELLOW_TEST_PRICES", False):
+        print()
+        print("Manual test: prices")
+        print(render_manual_price_rows(rows, last_end_block) if rows else "No price rows in the selected block range.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mellow/scan-initial-mellow.py
+++ b/scripts/mellow/scan-initial-mellow.py
@@ -2,7 +2,7 @@
 
 This script discovers Mellow Core Vault instances from their factory
 ``Created(address,uint256,address,bytes)`` events and enriches the results
-with light on-chain metadata and the public Mellow API TVL data.
+with light on-chain metadata and public Mellow API USD TVL diagnostics.
 
 Usage:
 
@@ -25,7 +25,7 @@ Optional environment variables:
     Core vault factories, but not a Base Core vault factory.
 
 ``FETCH_MELLOW_API``
-    Set to ``false`` to skip the public API TVL enrichment.
+    Set to ``false`` to skip the public API USD TVL enrichment.
 
 ``START_BLOCK`` / ``END_BLOCK`` / ``BLOCK_RANGE``
     Restrict the factory scan block range. If ``BLOCK_RANGE`` is set without
@@ -52,7 +52,6 @@ from decimal import Decimal
 from typing import Any
 
 import hypersync
-import requests
 from eth_abi.exceptions import DecodingError
 from eth_typing import HexAddress
 from hypersync import BlockField, LogField
@@ -70,12 +69,11 @@ from eth_defi.hypersync.session import (
     open_hypersync_stream,
 )
 from eth_defi.mellow.discovery import decode_mellow_created_event, fetch_mellow_created_event_topic, fetch_mellow_factories_for_chain
+from eth_defi.mellow.offchain_metadata import MellowApiVaultMetadata, fetch_mellow_api_vaults
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.utils import setup_console_logging
 
 logger = logging.getLogger(__name__)
-
-MELLOW_API_VAULTS_URL = "https://points.mellow.finance/v1/vaults"
 
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
@@ -186,44 +184,6 @@ class ChainConfig:
 
 
 @dataclass(slots=True)
-class ApiVault:
-    """Mellow API vault metadata used for TVL enrichment.
-
-    The public API is used only as an enrichment layer. Hypersync factory
-    events remain the source of truth for newly-created Core Vault leads.
-
-    :param chain_id:
-        EVM chain id.
-
-    :param address:
-        Vault address.
-
-    :param symbol:
-        Public vault token symbol.
-
-    :param name:
-        Public vault name.
-
-    :param layer:
-        Mellow API layer field, e.g. ``mellow`` or ``symbiotic``.
-
-    :param tvl_usd:
-        Current API-reported TVL in USD.
-
-    :param base_token_symbol:
-        Base token symbol from the API, when present.
-    """
-
-    chain_id: int
-    address: HexAddress
-    symbol: str | None
-    name: str | None
-    layer: str | None
-    tvl_usd: Decimal | None
-    base_token_symbol: str | None
-
-
-@dataclass(slots=True)
 class CoreVaultLead:
     """A Mellow Core Vault instance discovered from a factory event.
 
@@ -310,7 +270,7 @@ class CoreVaultRow:
     asset_count: int | None
     queue_count: int | None
     asset_symbols: tuple[str, ...]
-    api_vault: ApiVault | None
+    api_vault: MellowApiVaultMetadata | None
 
 
 def env_bool(name: str, default: bool) -> bool:  # noqa: FBT001
@@ -670,39 +630,6 @@ async def fetch_created_events(
     return sorted(leads, key=lambda lead: (lead.block_number, lead.vault.lower()))
 
 
-def fetch_mellow_api_vaults() -> dict[tuple[int, str], ApiVault]:
-    """Fetch public Mellow API vault data for TVL enrichment.
-
-    The API schema is documented at:
-    https://docs.mellow.finance/resources/api
-
-    :return:
-        Mapping ``(chain_id, lower-case address) -> ApiVault``.
-    """
-
-    response = requests.get(MELLOW_API_VAULTS_URL, timeout=30)
-    response.raise_for_status()
-    data = response.json()
-
-    api_vaults: dict[tuple[int, str], ApiVault] = {}
-    for item in data:
-        address = Web3.to_checksum_address(item["address"])
-        base_token = item.get("base_token") or {}
-        tvl_raw = item.get("tvl_usd")
-        api_vault = ApiVault(
-            chain_id=int(item["chain_id"]),
-            address=HexAddress(address),
-            symbol=item.get("symbol"),
-            name=item.get("name"),
-            layer=item.get("layer"),
-            tvl_usd=Decimal(str(tvl_raw)) if tvl_raw is not None else None,
-            base_token_symbol=base_token.get("symbol"),
-        )
-        api_vaults[api_vault.chain_id, api_vault.address.lower()] = api_vault
-
-    return api_vaults
-
-
 def call_contract_function(function: ContractFunction) -> Any | None:
     """Call a contract function and return ``None`` if the method is absent.
 
@@ -768,7 +695,7 @@ def humanise_token_amount(raw_amount: int | None, decimals: int | None) -> Decim
     return Decimal(raw_amount) / Decimal(10**decimals)
 
 
-def fetch_core_vault_row(web3: Web3, lead: CoreVaultLead, api_vaults: dict[tuple[int, str], ApiVault]) -> CoreVaultRow:  # noqa: PLR0914
+def fetch_core_vault_row(web3: Web3, lead: CoreVaultLead, api_vaults: dict[tuple[int, str], MellowApiVaultMetadata]) -> CoreVaultRow:  # noqa: PLR0914
     """Fetch light on-chain metadata for a discovered Mellow Core Vault.
 
     :param web3:
@@ -857,7 +784,7 @@ def format_decimal(value: Decimal | None) -> str:
     return f"{value:,.6f}".rstrip("0").rstrip(".")
 
 
-def build_api_summary(api_vaults: dict[tuple[int, str], ApiVault], selected_chain_ids: set[int]) -> list[dict[str, Any]]:
+def build_api_summary(api_vaults: dict[tuple[int, str], MellowApiVaultMetadata], selected_chain_ids: set[int]) -> list[dict[str, Any]]:
     """Build summary rows from the public Mellow API.
 
     :param api_vaults:
@@ -882,7 +809,7 @@ def build_api_summary(api_vaults: dict[tuple[int, str], ApiVault], selected_chai
             {
                 "Scope": label,
                 "Vaults": len(matching),
-                "TVL": format_money(sum((vault.tvl_usd or Decimal(0) for vault in matching), Decimal(0))),
+                "API USD TVL": format_money(sum((vault.tvl_usd or Decimal(0) for vault in matching), Decimal(0))),
             }
         )
 
@@ -905,12 +832,12 @@ def build_core_summary(rows: list[CoreVaultRow]) -> list[dict[str, Any]]:
         {
             "Scope": "Hypersync Core factory events",
             "Vaults": len(rows),
-            "TVL": format_money(api_tvl) if api_matched else "n/a",
+            "API USD TVL": format_money(api_tvl) if api_matched else "n/a",
         },
         {
             "Scope": "Hypersync Core events matched to API",
             "Vaults": len(api_matched),
-            "TVL": format_money(api_tvl),
+            "API USD TVL": format_money(api_tvl),
         },
     ]
 
@@ -939,7 +866,7 @@ def render_core_rows(rows: list[CoreVaultRow]) -> str:
                 "Queues": row.queue_count if row.queue_count is not None else "n/a",
                 "Supply": format_decimal(row.total_supply),
                 "API layer": api_vault.layer if api_vault else "n/a",
-                "API TVL": format_money(api_vault.tvl_usd if api_vault else None),
+                "API USD TVL": format_money(api_vault.tvl_usd if api_vault else None),
                 "Created": row.lead.timestamp.strftime("%Y-%m-%d") if row.lead.timestamp else row.lead.block_number,
             }
         )
@@ -969,7 +896,8 @@ def render_manual_price_rows(rows: list[CoreVaultRow], end_block: int) -> str:
                 "Block": end_block,
                 "Supply": format_decimal(row.total_supply),
                 "Share price": "see historical reader",
-                "Total assets": format_money(row.api_vault.tvl_usd if row.api_vault else None),
+                "Total assets": "see historical reader",
+                "API USD TVL": format_money(row.api_vault.tvl_usd if row.api_vault else None),
                 "Error": "Manual mapping script does not run the historical multicall reader",
             }
         )
@@ -992,7 +920,7 @@ def main() -> None:  # noqa: PLR0914
     selected_chain_ids = {chain.chain_id for chain in chains}
 
     fetch_api = env_bool("FETCH_MELLOW_API", True)
-    api_vaults: dict[tuple[int, str], ApiVault] = {}
+    api_vaults: dict[tuple[int, str], MellowApiVaultMetadata] = {}
     if fetch_api:
         logger.info("Fetching public Mellow API vault metadata")
         api_vaults = fetch_mellow_api_vaults()

--- a/scripts/mellow/scan-initial-mellow.py
+++ b/scripts/mellow/scan-initial-mellow.py
@@ -968,9 +968,9 @@ def render_manual_price_rows(rows: list[CoreVaultRow], end_block: int) -> str:
                 "Vault": row.lead.vault,
                 "Block": end_block,
                 "Supply": format_decimal(row.total_supply),
-                "Share price": "n/a",
+                "Share price": "see historical reader",
                 "Total assets": format_money(row.api_vault.tvl_usd if row.api_vault else None),
-                "Error": "Mellow oracle price orientation is not implemented in the initial mapping script",
+                "Error": "Manual mapping script does not run the historical multicall reader",
             }
         )
 

--- a/tests/erc_4626/vault_protocol/test_mellow.py
+++ b/tests/erc_4626/vault_protocol/test_mellow.py
@@ -1,0 +1,107 @@
+"""Test Mellow Core Vault metadata."""
+
+import os
+from decimal import Decimal
+
+import flaky
+import pytest
+from web3 import Web3
+
+from eth_defi.erc_4626.classification import create_vault_instance_autodetect
+from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.mellow.vault import MellowVault
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+
+JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
+
+FORK_BLOCK = 25_431_636
+LIDO_EARN_USD_VAULT = "0x014e6DA8F283C4aF65B2AA0f201438680A004452"
+LIDO_EARN_USD_SHARE_MANAGER = "0x4Ce1ac8F43E0E5BD7A346A98aF777bF8fbeA1981"
+SHARE_TOKEN_DECIMALS = 18
+USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+USDT = "0xdAC17F958D2ee523a2206206994597C13D831ec7"
+USDE = "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3"
+
+pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests")
+
+
+@pytest.fixture(scope="module")
+def anvil_ethereum_fork() -> AnvilLaunch:
+    """Fork at a specific block for reproducibility.
+
+    Lido Earn USD was created through the Mellow Core Vault factory before this
+    block. The fixed block pins the component graph and share supply values.
+    """
+
+    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=FORK_BLOCK)
+    try:
+        yield launch
+    finally:
+        launch.close()
+
+
+@pytest.fixture(scope="module")
+def web3(anvil_ethereum_fork) -> Web3:
+    """Create Web3 connection to the Ethereum fork."""
+
+    return create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url, retries=2)
+
+
+@flaky.flaky
+def test_mellow_lido_earn_usd(web3: Web3) -> None:
+    """Read Lido Earn USD Mellow vault metadata on a fixed Ethereum fork."""
+
+    vault = create_vault_instance_autodetect(
+        web3,
+        vault_address=LIDO_EARN_USD_VAULT,
+    )
+
+    assert isinstance(vault, MellowVault)
+    assert vault.get_protocol_name() == "Mellow"
+    assert vault.features == {ERC4626Feature.mellow_like}
+    assert vault.address == LIDO_EARN_USD_VAULT
+    assert vault.vault_address == LIDO_EARN_USD_VAULT
+
+    assert vault.name == "Lido Earn USD"
+    assert vault.symbol == "earnUSD"
+    assert vault.share_manager_address == LIDO_EARN_USD_SHARE_MANAGER
+    assert vault.fetch_share_token_address(FORK_BLOCK) == LIDO_EARN_USD_SHARE_MANAGER
+    assert vault.fetch_total_supply(FORK_BLOCK) == Decimal("21518125.250450660540252819")
+
+    share_token = vault.share_token
+    assert share_token.address == LIDO_EARN_USD_SHARE_MANAGER
+    assert share_token.name == "Lido Earn USD"
+    assert share_token.symbol == "earnUSD"
+    assert share_token.decimals == SHARE_TOKEN_DECIMALS
+
+    assert vault.fetch_denomination_token_address() == USDC
+    assert vault.fetch_assets() == [USDC, USDT, USDE]
+
+    info = vault.fetch_info()
+    assert info["vault"] == LIDO_EARN_USD_VAULT
+    assert info["share_manager"] == LIDO_EARN_USD_SHARE_MANAGER
+    assert info["fee_manager"] == "0x72fa23f40e08eB9E45953233b2Dd9665E347e8Dc"
+    assert info["risk_manager"] == "0x7b1e06C46d4510277FC37a37bBeF65F3794fdDE4"
+    assert info["oracle"] == "0x827044735c9708a2cf850e7Ea37EBa43bc786028"
+    assert info["assets"] == [USDC, USDT, USDE]
+    assert info["deposit_queues"] == {
+        USDC: [
+            "0xC75E7E73B25fEa8bB23EB55CC48BA55067b5be76",
+            "0xf6AFAf6afcAe116dD37A779D50fE6c5fa6f8C8f5",
+        ],
+        USDT: [
+            "0xEeC5041c47Cba1e31321AC6941Bf09Ad60645B73",
+            "0x534d0bEb82C47cf703BFb9E959297658b65Ec8E9",
+        ],
+        USDE: [
+            "0xeEc37568b01e0C4d5028501A49E024B475E2D7cA",
+        ],
+    }
+    assert info["redeem_queues"] == {
+        USDC: [
+            "0x9e36A74FE278906a76e7615263e46a83fC40c47F",
+        ],
+        USDT: [],
+        USDE: [],
+    }

--- a/tests/erc_4626/vault_protocol/test_mellow.py
+++ b/tests/erc_4626/vault_protocol/test_mellow.py
@@ -99,6 +99,7 @@ def test_mellow_lido_earn_usd(web3: Web3) -> None:
     assert vault.get_performance_fee(FORK_BLOCK) == 0.0
     assert vault.get_deposit_fee(FORK_BLOCK) == 0.0
     assert vault.get_withdraw_fee(FORK_BLOCK) == 0.0
+    assert vault.has_custom_fees() is True
 
     fee_data = vault.get_fee_data()
     assert fee_data.fee_mode == VaultFeeMode.internalised_minting

--- a/tests/erc_4626/vault_protocol/test_mellow.py
+++ b/tests/erc_4626/vault_protocol/test_mellow.py
@@ -1,24 +1,37 @@
 """Test Mellow Core Vault metadata."""
 
+import datetime
 import os
 from decimal import Decimal
+from pathlib import Path
 
 import flaky
 import pytest
 from web3 import Web3
 
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
-from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
+from eth_defi.erc_4626.scan import create_vault_scan_record
 from eth_defi.mellow.vault import MellowVault
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.token import TokenDiskCache
+from eth_defi.vault.fee import VaultFeeMode
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 
 FORK_BLOCK = 25_431_636
+SHARE_PRICE_START_BLOCK = 25_000_000
+SHARE_PRICE_END_BLOCK = 25_100_000
 LIDO_EARN_USD_VAULT = "0x014e6DA8F283C4aF65B2AA0f201438680A004452"
 LIDO_EARN_USD_SHARE_MANAGER = "0x4Ce1ac8F43E0E5BD7A346A98aF777bF8fbeA1981"
+LIDO_EARN_USD_FEE_MANAGER = "0x72fa23f40e08eB9E45953233b2Dd9665E347e8Dc"
+LIDO_EARN_USD_FEE_RECIPIENT = "0xcCf2daba8Bb04a232a2fDA0D01010D4EF6C69B85"
 SHARE_TOKEN_DECIMALS = 18
+EXPECTED_START_SHARE_PRICE = Decimal("1.008280253418576")
+EXPECTED_END_SHARE_PRICE = Decimal("1.009843353086236")
+EXPECTED_FEE_MANAGER_TIMESTAMP = 1_782_802_559
+EXPECTED_FEE_MANAGER_MIN_PRICE_D18 = 983_334_787_364_413_344_512_750_452_124
 USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 USDT = "0xdAC17F958D2ee523a2206206994597C13D831ec7"
 USDE = "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3"
@@ -66,8 +79,33 @@ def test_mellow_lido_earn_usd(web3: Web3) -> None:
     assert vault.name == "Lido Earn USD"
     assert vault.symbol == "earnUSD"
     assert vault.share_manager_address == LIDO_EARN_USD_SHARE_MANAGER
+    assert vault.fee_manager_address == LIDO_EARN_USD_FEE_MANAGER
     assert vault.fetch_share_token_address(FORK_BLOCK) == LIDO_EARN_USD_SHARE_MANAGER
     assert vault.fetch_total_supply(FORK_BLOCK) == Decimal("21518125.250450660540252819")
+    assert vault.fetch_share_price(FORK_BLOCK) == pytest.approx(Decimal("1.016947648806622261909260417"))
+
+    fee_configuration = vault.fetch_fee_configuration(FORK_BLOCK)
+    assert fee_configuration is not None
+    assert fee_configuration.fee_recipient == LIDO_EARN_USD_FEE_RECIPIENT
+    assert fee_configuration.deposit_fee_d6 == 0
+    assert fee_configuration.redeem_fee_d6 == 0
+    assert fee_configuration.performance_fee_d6 == 0
+    assert fee_configuration.protocol_fee_d6 == 0
+    assert fee_configuration.base_asset == USDC
+    assert fee_configuration.timestamp == EXPECTED_FEE_MANAGER_TIMESTAMP
+    assert fee_configuration.min_price_d18 == EXPECTED_FEE_MANAGER_MIN_PRICE_D18
+
+    assert vault.get_management_fee(FORK_BLOCK) == 0.0
+    assert vault.get_performance_fee(FORK_BLOCK) == 0.0
+    assert vault.get_deposit_fee(FORK_BLOCK) == 0.0
+    assert vault.get_withdraw_fee(FORK_BLOCK) == 0.0
+
+    fee_data = vault.get_fee_data()
+    assert fee_data.fee_mode == VaultFeeMode.internalised_minting
+    assert fee_data.management == 0.0
+    assert fee_data.performance == 0.0
+    assert fee_data.deposit == 0.0
+    assert fee_data.withdraw == 0.0
 
     share_token = vault.share_token
     assert share_token.address == LIDO_EARN_USD_SHARE_MANAGER
@@ -81,7 +119,7 @@ def test_mellow_lido_earn_usd(web3: Web3) -> None:
     info = vault.fetch_info()
     assert info["vault"] == LIDO_EARN_USD_VAULT
     assert info["share_manager"] == LIDO_EARN_USD_SHARE_MANAGER
-    assert info["fee_manager"] == "0x72fa23f40e08eB9E45953233b2Dd9665E347e8Dc"
+    assert info["fee_manager"] == LIDO_EARN_USD_FEE_MANAGER
     assert info["risk_manager"] == "0x7b1e06C46d4510277FC37a37bBeF65F3794fdDE4"
     assert info["oracle"] == "0x827044735c9708a2cf850e7Ea37EBa43bc786028"
     assert info["assets"] == [USDC, USDT, USDE]
@@ -105,3 +143,74 @@ def test_mellow_lido_earn_usd(web3: Web3) -> None:
         USDT: [],
         USDE: [],
     }
+
+
+@flaky.flaky
+def test_mellow_lido_earn_usd_share_price_increases_between_fixed_blocks() -> None:
+    """Read two historical Lido Earn USD oracle prices and check appreciation."""
+
+    web3 = create_multi_provider_web3(JSON_RPC_ETHEREUM, retries=2)
+    vault = create_vault_instance_autodetect(
+        web3,
+        vault_address=LIDO_EARN_USD_VAULT,
+    )
+
+    assert isinstance(vault, MellowVault)
+
+    start_share_price = vault.fetch_share_price(SHARE_PRICE_START_BLOCK)
+    end_share_price = vault.fetch_share_price(SHARE_PRICE_END_BLOCK)
+
+    assert start_share_price is not None
+    assert end_share_price is not None
+    assert start_share_price == pytest.approx(EXPECTED_START_SHARE_PRICE)
+    assert end_share_price == pytest.approx(EXPECTED_END_SHARE_PRICE)
+    assert end_share_price > start_share_price
+
+
+@flaky.flaky
+def test_mellow_lido_earn_usd_scan_record(web3: Web3, tmp_path: Path) -> None:
+    """Create a shared vault scan row for a Mellow vault.
+
+    Mellow is routed through ``ERC4626Feature.mellow_like`` but the adapter is
+    a :py:class:`eth_defi.vault.base.VaultBase` subclass, not an ERC-4626
+    subclass. This test checks ``create_vault_scan_record()`` does not need a
+    separate Mellow branch to populate the common scan row fields.
+    """
+
+    detection = ERC4262VaultDetection(
+        chain=1,
+        address=LIDO_EARN_USD_VAULT,
+        first_seen_at_block=FORK_BLOCK,
+        first_seen_at=datetime.datetime(2026, 6, 20),  # noqa: DTZ001
+        features={ERC4626Feature.mellow_like},
+        updated_at=datetime.datetime(2026, 6, 20),  # noqa: DTZ001
+        deposit_count=0,
+        redeem_count=0,
+    )
+
+    record = create_vault_scan_record(
+        web3,
+        detection,
+        FORK_BLOCK,
+        token_cache=TokenDiskCache(tmp_path / "tokens.sqlite"),
+    )
+
+    assert record["Protocol"] == "Mellow"
+    assert record["Symbol"] == "earnUSD"
+    assert record["Name"] == "Lido Earn USD"
+    assert record["Address"] == LIDO_EARN_USD_VAULT
+    assert record["Denomination"] == "USDC"
+    assert record["Share token"] == "earnUSD"
+    assert record["NAV"] is None
+    assert record["Mgmt fee"] == 0.0
+    assert record["Perf fee"] == 0.0
+    assert record["Deposit fee"] == 0.0
+    assert record["Withdraw fee"] == 0.0
+    assert record["Shares"] == Decimal("21518125.250450660540252819")
+    assert record["Features"] == "mellow_like"
+    assert record["_detection_data"] == detection
+    assert record["_denomination_token"]["symbol"] == "USDC"
+    assert record["_share_token"]["address"] == LIDO_EARN_USD_SHARE_MANAGER
+    assert record["_mellow_info"]["share_manager"] == LIDO_EARN_USD_SHARE_MANAGER
+    assert record["_mellow_info"]["assets"] == [USDC, USDT, USDE]
+    assert record["_morpho_offchain_data"] is None

--- a/tests/erc_4626/vault_protocol/test_mellow.py
+++ b/tests/erc_4626/vault_protocol/test_mellow.py
@@ -28,6 +28,7 @@ LIDO_EARN_USD_SHARE_MANAGER = "0x4Ce1ac8F43E0E5BD7A346A98aF777bF8fbeA1981"
 LIDO_EARN_USD_FEE_MANAGER = "0x72fa23f40e08eB9E45953233b2Dd9665E347e8Dc"
 LIDO_EARN_USD_FEE_RECIPIENT = "0xcCf2daba8Bb04a232a2fDA0D01010D4EF6C69B85"
 SHARE_TOKEN_DECIMALS = 18
+EXPECTED_TOTAL_ASSETS = Decimal("21882806.88017220903802179622")
 EXPECTED_START_SHARE_PRICE = Decimal("1.008280253418576")
 EXPECTED_END_SHARE_PRICE = Decimal("1.009843353086236")
 EXPECTED_FEE_MANAGER_TIMESTAMP = 1_782_802_559
@@ -83,6 +84,8 @@ def test_mellow_lido_earn_usd(web3: Web3) -> None:
     assert vault.fetch_share_token_address(FORK_BLOCK) == LIDO_EARN_USD_SHARE_MANAGER
     assert vault.fetch_total_supply(FORK_BLOCK) == Decimal("21518125.250450660540252819")
     assert vault.fetch_share_price(FORK_BLOCK) == pytest.approx(Decimal("1.016947648806622261909260417"))
+    assert vault.fetch_total_assets(FORK_BLOCK) == pytest.approx(EXPECTED_TOTAL_ASSETS)
+    assert vault.fetch_nav(FORK_BLOCK) == pytest.approx(EXPECTED_TOTAL_ASSETS)
 
     fee_configuration = vault.fetch_fee_configuration(FORK_BLOCK)
     assert fee_configuration is not None
@@ -202,7 +205,7 @@ def test_mellow_lido_earn_usd_scan_record(web3: Web3, tmp_path: Path) -> None:
     assert record["Address"] == LIDO_EARN_USD_VAULT
     assert record["Denomination"] == "USDC"
     assert record["Share token"] == "earnUSD"
-    assert record["NAV"] is None
+    assert record["NAV"] == pytest.approx(EXPECTED_TOTAL_ASSETS)
     assert record["Mgmt fee"] == 0.0
     assert record["Perf fee"] == 0.0
     assert record["Deposit fee"] == 0.0

--- a/tests/erc_4626/vault_protocol/test_mellow.py
+++ b/tests/erc_4626/vault_protocol/test_mellow.py
@@ -99,7 +99,7 @@ def test_mellow_lido_earn_usd(web3: Web3) -> None:
     assert vault.get_performance_fee(FORK_BLOCK) == 0.0
     assert vault.get_deposit_fee(FORK_BLOCK) == 0.0
     assert vault.get_withdraw_fee(FORK_BLOCK) == 0.0
-    assert vault.has_custom_fees() is True
+    assert vault.has_custom_fees() is False
 
     fee_data = vault.get_fee_data()
     assert fee_data.fee_mode == VaultFeeMode.internalised_minting

--- a/tests/ipor/test_ipor_curators.py
+++ b/tests/ipor/test_ipor_curators.py
@@ -298,6 +298,11 @@ class _FakeIPORVault:
         """Return a deterministic vault link."""
         return "https://app.ipor.io/fusion/ethereum/0xdf8a0d3c90462c4c9b5a8697c119fa67cb84a874"
 
+    @staticmethod
+    def fetch_scan_record_extra_data() -> dict[str, object]:
+        """Return no protocol-specific scan columns."""
+        return {}
+
 
 def test_vault_scan_record_sets_manager_name_for_ipor_vault(monkeypatch: pytest.MonkeyPatch) -> None:
     """IPOR atomist flows through scan rows as the vault manager name.

--- a/tests/mellow/test_mellow_classification.py
+++ b/tests/mellow/test_mellow_classification.py
@@ -5,12 +5,15 @@ import inspect
 from types import SimpleNamespace
 
 import pytest
+from eth_abi import encode
+from eth_abi.exceptions import DecodingError
+from web3 import Web3
 
 from eth_defi.abi import get_abi_by_filename
 from eth_defi.erc_4626.classification import _ProbeResultsDict, create_probe_calls, create_vault_instance, identify_vault_features  # noqa: PLC2701
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature, get_vault_protocol_name, is_activity_filter_exempt
 from eth_defi.mellow.abi import ERC20_ABI_FILENAME, FACTORY_ABI_FILENAME, FEE_MANAGER_ABI_FILENAME, ORACLE_ABI_FILENAME, VAULT_ABI_FILENAME
-from eth_defi.mellow.discovery import fetch_mellow_created_event_topic, fetch_mellow_factories_for_chain
+from eth_defi.mellow.discovery import decode_mellow_created_event, fetch_mellow_created_event_topic, fetch_mellow_factories_for_chain
 from eth_defi.mellow.vault import MellowVault
 from eth_defi.vault.base import VaultBase, VaultSpec
 from eth_defi.vault.risk import VaultTechnicalRisk, get_vault_risk
@@ -25,6 +28,7 @@ POLYGON_CHAIN_ID = 137
 DEFAULT_CORE_FACTORY = "0x4E38F679e46B3216f0bd4B314E9C429AFfB1dEE3"
 MONAD_CORE_FACTORY = "0x04c0287DEdE16e0C04A1C2A52F31400a88f1dF4c"
 LIDO_EARN_USD_VAULT = "0x014e6DA8F283C4aF65B2AA0f201438680A004452"
+LIDO_EARN_USD_OWNER = Web3.to_checksum_address("0xf067739E4F3C7f496065Ed6518548a1052F99BC7")
 FACTORY_ENV_VARS = (
     "MELLOW_ETHEREUM_VAULT_FACTORY",
     "MELLOW_PLASMA_VAULT_FACTORY",
@@ -106,6 +110,57 @@ def test_mellow_abi_files_load() -> None:
     assert any(item["type"] == "function" and item["name"] == "getReport" for item in oracle_abi)
     assert any(item["type"] == "function" and item["name"] == "protocolFeeD6" for item in fee_manager_abi)
     assert any(item["type"] == "function" and item["name"] == "totalSupply" for item in erc20_abi)
+
+
+def test_mellow_created_decoder_accepts_documented_layout() -> None:
+    """Mellow factory decoder accepts the documented non-indexed event layout."""
+
+    init_params = b"\x12\x34"
+    log = SimpleNamespace(
+        topics=[fetch_mellow_created_event_topic()],
+        data=Web3.to_hex(encode(["address", "uint256", "address", "bytes"], [LIDO_EARN_USD_VAULT, 1, LIDO_EARN_USD_OWNER, init_params])),
+    )
+
+    instance, version, owner, decoded_init_params = decode_mellow_created_event(Web3(), log)
+
+    assert instance == LIDO_EARN_USD_VAULT
+    assert version == 1
+    assert owner == LIDO_EARN_USD_OWNER
+    assert decoded_init_params == init_params
+
+
+def test_mellow_created_decoder_accepts_indexed_compatibility_layout() -> None:
+    """Mellow factory decoder accepts defensive indexed event topics."""
+
+    init_params = b"\x12\x34"
+    log = SimpleNamespace(
+        topics=[
+            fetch_mellow_created_event_topic(),
+            "0x" + LIDO_EARN_USD_VAULT[2:].lower().rjust(64, "0"),
+            "0x" + format(1, "064x"),
+            "0x" + LIDO_EARN_USD_OWNER[2:].lower().rjust(64, "0"),
+        ],
+        data=Web3.to_hex(init_params),
+    )
+
+    instance, version, owner, decoded_init_params = decode_mellow_created_event(Web3(), log)
+
+    assert instance == LIDO_EARN_USD_VAULT
+    assert version == 1
+    assert owner == LIDO_EARN_USD_OWNER
+    assert decoded_init_params == init_params
+
+
+def test_mellow_created_decoder_rejects_malformed_data() -> None:
+    """Mellow factory decoder rejects malformed non-indexed event data."""
+
+    log = SimpleNamespace(
+        topics=[fetch_mellow_created_event_topic()],
+        data="0x1234",
+    )
+
+    with pytest.raises(DecodingError):
+        decode_mellow_created_event(Web3(), log)
 
 
 def test_mellow_fee_accessors_match_vault_base_surface() -> None:

--- a/tests/mellow/test_mellow_classification.py
+++ b/tests/mellow/test_mellow_classification.py
@@ -15,7 +15,8 @@ from eth_defi.erc_4626.classification import _ProbeResultsDict, create_probe_cal
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature, get_vault_protocol_name, is_activity_filter_exempt
 from eth_defi.mellow.abi import ERC20_ABI_FILENAME, FACTORY_ABI_FILENAME, FEE_MANAGER_ABI_FILENAME, ORACLE_ABI_FILENAME, VAULT_ABI_FILENAME
 from eth_defi.mellow.discovery import decode_mellow_created_event, fetch_mellow_created_event_topic, fetch_mellow_factories_for_chain
-from eth_defi.mellow.vault import MellowApiVaultMetadata, MellowVault
+from eth_defi.mellow.offchain_metadata import MellowApiVaultMetadata
+from eth_defi.mellow.vault import MellowVault
 from eth_defi.vault.base import VaultBase, VaultSpec
 from eth_defi.vault.risk import VaultTechnicalRisk, get_vault_risk
 
@@ -294,15 +295,26 @@ def test_mellow_vault_exposes_vault_address_alias() -> None:
     assert vault.vault_address == vault.address
 
 
-def test_mellow_fetch_nav_does_not_use_api_tvl() -> None:
-    """Mellow API TVL is diagnostic metadata, not production NAV."""
+def test_mellow_fetch_nav_uses_onchain_price_and_supply_not_api_tvl() -> None:
+    """Mellow API USD TVL is diagnostic metadata, not production NAV."""
 
     web3 = SimpleNamespace(eth=SimpleNamespace(chain_id=1))
     vault = MellowVault(
         web3,
         VaultSpec(1, "0x014e6da8f283c4af65b2aa0f201438680a004452"),
         features={ERC4626Feature.mellow_like},
-        api_metadata=MellowApiVaultMetadata(tvl=Decimal("21897383.50")),
+        api_metadata=MellowApiVaultMetadata(tvl_usd=Decimal("21897383.50")),
     )
 
-    assert vault.fetch_nav("latest") is None
+    def fetch_share_price(_block_identifier="latest") -> Decimal:
+        return Decimal("1.2")
+
+    def fetch_total_supply(_block_identifier="latest") -> Decimal:
+        return Decimal("10")
+
+    vault.fetch_share_price = fetch_share_price
+    vault.fetch_total_supply = fetch_total_supply
+
+    assert vault.fetch_total_assets("latest") == Decimal("12.0")
+    assert vault.fetch_nav("latest") == Decimal("12.0")
+    assert vault.fetch_nav("latest") != vault.api_metadata.tvl_usd

--- a/tests/mellow/test_mellow_classification.py
+++ b/tests/mellow/test_mellow_classification.py
@@ -1,0 +1,190 @@
+"""Test Mellow vault classification and routing."""
+
+import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from eth_defi.erc_4626.classification import _ProbeResultsDict, create_probe_calls, create_vault_instance, identify_vault_features  # noqa: PLC2701
+from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature, get_vault_protocol_name, is_activity_filter_exempt
+from eth_defi.mellow.discovery import fetch_mellow_created_event_topic, fetch_mellow_factories_for_chain
+from eth_defi.mellow.vault import MellowVault
+from eth_defi.vault.base import VaultSpec
+
+TOPIC_HEX_LENGTH = 66
+ETHEREUM_CHAIN_ID = 1
+PLASMA_CHAIN_ID = 9745
+ARBITRUM_CHAIN_ID = 42161
+MONAD_CHAIN_ID = 143
+BASE_CHAIN_ID = 8453
+POLYGON_CHAIN_ID = 137
+DEFAULT_CORE_FACTORY = "0x4E38F679e46B3216f0bd4B314E9C429AFfB1dEE3"
+MONAD_CORE_FACTORY = "0x04c0287DEdE16e0C04A1C2A52F31400a88f1dF4c"
+FACTORY_ENV_VARS = (
+    "MELLOW_ETHEREUM_VAULT_FACTORY",
+    "MELLOW_PLASMA_VAULT_FACTORY",
+    "MELLOW_ARBITRUM_VAULT_FACTORY",
+    "MELLOW_MONAD_VAULT_FACTORY",
+    "MELLOW_BASE_VAULT_FACTORY",
+)
+
+
+class FakeCallResult:
+    """Minimal call result for feature identification tests."""
+
+    def __init__(self, success: bool, result: bytes = b""):  # noqa: FBT001
+        """Create fake call result.
+
+        :param success:
+            Whether the probe succeeded.
+
+        :param result:
+            Raw return bytes.
+        """
+
+        self._success = success
+        self._result = result
+
+    @property
+    def success(self) -> bool:
+        """Whether the call succeeded."""
+
+        return self._success
+
+    @property
+    def result(self) -> bytes:
+        """Raw call result."""
+
+        return self._result
+
+
+def test_mellow_protocol_name() -> None:
+    """Mellow feature maps to protocol name."""
+
+    assert get_vault_protocol_name({ERC4626Feature.mellow_like}) == "Mellow"
+
+
+def test_mellow_created_topic_is_hypersync_hex() -> None:
+    """Mellow factory topic is encoded with ``0x`` for Hypersync."""
+
+    topic = fetch_mellow_created_event_topic()
+
+    assert topic.startswith("0x")
+    assert len(topic) == TOPIC_HEX_LENGTH
+
+
+def test_mellow_factory_registry_matches_documented_core_deployments(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Factory defaults cover all documented Mellow Core deployment chains."""
+
+    for env_var in FACTORY_ENV_VARS:
+        monkeypatch.delenv(env_var, raising=False)
+
+    assert fetch_mellow_factories_for_chain(ETHEREUM_CHAIN_ID) == [DEFAULT_CORE_FACTORY]
+    assert fetch_mellow_factories_for_chain(PLASMA_CHAIN_ID) == [DEFAULT_CORE_FACTORY]
+    assert fetch_mellow_factories_for_chain(ARBITRUM_CHAIN_ID) == [DEFAULT_CORE_FACTORY]
+    assert fetch_mellow_factories_for_chain(MONAD_CHAIN_ID) == [MONAD_CORE_FACTORY]
+    assert fetch_mellow_factories_for_chain(BASE_CHAIN_ID) == []
+
+
+def test_mellow_probes_are_limited_to_official_core_deployment_chains() -> None:
+    """Mellow probes are only emitted on chains listed in official Core deployments."""
+
+    vault_address = "0x014e6da8f283c4af65b2aa0f201438680a004452"
+    supported_chains = (ETHEREUM_CHAIN_ID, PLASMA_CHAIN_ID, ARBITRUM_CHAIN_ID, MONAD_CHAIN_ID)
+    unsupported_chains = (BASE_CHAIN_ID, POLYGON_CHAIN_ID)
+
+    for chain_id in supported_chains:
+        call_names = {call.func_name for call in create_probe_calls([vault_address], chain_id=chain_id)}
+        assert "shareManager" in call_names
+        assert "getAssetCount" in call_names
+
+    for chain_id in unsupported_chains:
+        call_names = {call.func_name for call in create_probe_calls([vault_address], chain_id=chain_id)}
+        assert "shareManager" not in call_names
+        assert "getAssetCount" not in call_names
+
+
+def test_mellow_detection_is_activity_filter_exempt() -> None:
+    """Mellow detections bypass deposit/redeem activity count filters."""
+
+    detection = ERC4262VaultDetection(
+        chain=1,
+        address="0x014e6da8f283c4af65b2aa0f201438680a004452",
+        first_seen_at_block=23_000_000,
+        first_seen_at=datetime.datetime(2026, 1, 1),  # noqa: DTZ001
+        features={ERC4626Feature.mellow_like},
+        updated_at=datetime.datetime(2026, 1, 1),  # noqa: DTZ001
+        deposit_count=0,
+        redeem_count=0,
+    )
+
+    assert is_activity_filter_exempt(detection) is True
+
+
+def test_mellow_probe_classifies_before_broken_erc4626() -> None:
+    """Mellow probes classify even when ERC-4626 convertToShares fails."""
+
+    calls = _ProbeResultsDict(
+        {
+            "shareManager": FakeCallResult(True, b"\x00" * 32),
+            "getAssetCount": FakeCallResult(True, b"\x00" * 32),
+            "convertToShares": FakeCallResult(False, b""),
+            "EVM IS BROKEN SHIT": FakeCallResult(False),
+        }
+    )
+
+    features = identify_vault_features(
+        "0x014e6da8f283c4af65b2aa0f201438680a004452",
+        calls,
+        debug_text="mellow",
+    )
+
+    assert features == {ERC4626Feature.mellow_like}
+
+
+def test_mellow_probe_does_not_override_broken_impossible_function() -> None:
+    """All-success broken contracts are not misrouted as Mellow."""
+
+    calls = _ProbeResultsDict(
+        {
+            "shareManager": FakeCallResult(True, b"\x00" * 32),
+            "getAssetCount": FakeCallResult(True, b"\x00" * 32),
+            "convertToShares": FakeCallResult(True, b"\x00" * 32),
+            "EVM IS BROKEN SHIT": FakeCallResult(True, b"\x00" * 32),
+        }
+    )
+
+    features = identify_vault_features(
+        "0x014e6da8f283c4af65b2aa0f201438680a004452",
+        calls,
+        debug_text="broken",
+    )
+
+    assert features == {ERC4626Feature.broken}
+
+
+def test_create_vault_instance_routes_mellow() -> None:
+    """Adapter factory returns MellowVault for mellow_like detections."""
+
+    web3 = SimpleNamespace(eth=SimpleNamespace(chain_id=1))
+    vault = create_vault_instance(
+        web3,
+        "0x014e6da8f283c4af65b2aa0f201438680a004452",
+        features={ERC4626Feature.mellow_like},
+    )
+
+    assert isinstance(vault, MellowVault)
+    assert vault.address == "0x014e6DA8F283C4aF65B2AA0f201438680A004452"
+
+
+def test_mellow_vault_exposes_vault_address_alias() -> None:
+    """Shared historical scanners can use the ERC-4626-style address alias."""
+
+    web3 = SimpleNamespace(eth=SimpleNamespace(chain_id=1))
+    vault = MellowVault(
+        web3,
+        VaultSpec(1, "0x014e6da8f283c4af65b2aa0f201438680a004452"),
+        features={ERC4626Feature.mellow_like},
+    )
+
+    assert vault.vault_address == vault.address

--- a/tests/mellow/test_mellow_classification.py
+++ b/tests/mellow/test_mellow_classification.py
@@ -2,6 +2,7 @@
 
 import datetime
 import inspect
+from decimal import Decimal
 from types import SimpleNamespace
 
 import pytest
@@ -14,7 +15,7 @@ from eth_defi.erc_4626.classification import _ProbeResultsDict, create_probe_cal
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature, get_vault_protocol_name, is_activity_filter_exempt
 from eth_defi.mellow.abi import ERC20_ABI_FILENAME, FACTORY_ABI_FILENAME, FEE_MANAGER_ABI_FILENAME, ORACLE_ABI_FILENAME, VAULT_ABI_FILENAME
 from eth_defi.mellow.discovery import decode_mellow_created_event, fetch_mellow_created_event_topic, fetch_mellow_factories_for_chain
-from eth_defi.mellow.vault import MellowVault
+from eth_defi.mellow.vault import MellowApiVaultMetadata, MellowVault
 from eth_defi.vault.base import VaultBase, VaultSpec
 from eth_defi.vault.risk import VaultTechnicalRisk, get_vault_risk
 
@@ -291,3 +292,17 @@ def test_mellow_vault_exposes_vault_address_alias() -> None:
     )
 
     assert vault.vault_address == vault.address
+
+
+def test_mellow_fetch_nav_does_not_use_api_tvl() -> None:
+    """Mellow API TVL is diagnostic metadata, not production NAV."""
+
+    web3 = SimpleNamespace(eth=SimpleNamespace(chain_id=1))
+    vault = MellowVault(
+        web3,
+        VaultSpec(1, "0x014e6da8f283c4af65b2aa0f201438680a004452"),
+        features={ERC4626Feature.mellow_like},
+        api_metadata=MellowApiVaultMetadata(tvl=Decimal("21897383.50")),
+    )
+
+    assert vault.fetch_nav("latest") is None

--- a/tests/mellow/test_mellow_classification.py
+++ b/tests/mellow/test_mellow_classification.py
@@ -5,8 +5,10 @@ from types import SimpleNamespace
 
 import pytest
 
+from eth_defi.abi import get_abi_by_filename
 from eth_defi.erc_4626.classification import _ProbeResultsDict, create_probe_calls, create_vault_instance, identify_vault_features  # noqa: PLC2701
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature, get_vault_protocol_name, is_activity_filter_exempt
+from eth_defi.mellow.abi import ERC20_ABI_FILENAME, FACTORY_ABI_FILENAME, FEE_MANAGER_ABI_FILENAME, ORACLE_ABI_FILENAME, VAULT_ABI_FILENAME
 from eth_defi.mellow.discovery import fetch_mellow_created_event_topic, fetch_mellow_factories_for_chain
 from eth_defi.mellow.vault import MellowVault
 from eth_defi.vault.base import VaultSpec
@@ -71,6 +73,22 @@ def test_mellow_created_topic_is_hypersync_hex() -> None:
 
     assert topic.startswith("0x")
     assert len(topic) == TOPIC_HEX_LENGTH
+
+
+def test_mellow_abi_files_load() -> None:
+    """Mellow ABI fragments are loaded from bundled JSON files."""
+
+    factory_abi = get_abi_by_filename(FACTORY_ABI_FILENAME)
+    vault_abi = get_abi_by_filename(VAULT_ABI_FILENAME)
+    oracle_abi = get_abi_by_filename(ORACLE_ABI_FILENAME)
+    fee_manager_abi = get_abi_by_filename(FEE_MANAGER_ABI_FILENAME)
+    erc20_abi = get_abi_by_filename(ERC20_ABI_FILENAME)
+
+    assert any(item["type"] == "event" and item["name"] == "Created" for item in factory_abi)
+    assert any(item["type"] == "function" and item["name"] == "shareManager" for item in vault_abi)
+    assert any(item["type"] == "function" and item["name"] == "getReport" for item in oracle_abi)
+    assert any(item["type"] == "function" and item["name"] == "protocolFeeD6" for item in fee_manager_abi)
+    assert any(item["type"] == "function" and item["name"] == "totalSupply" for item in erc20_abi)
 
 
 def test_mellow_factory_registry_matches_documented_core_deployments(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/mellow/test_mellow_classification.py
+++ b/tests/mellow/test_mellow_classification.py
@@ -13,6 +13,7 @@ from eth_defi.mellow.abi import ERC20_ABI_FILENAME, FACTORY_ABI_FILENAME, FEE_MA
 from eth_defi.mellow.discovery import fetch_mellow_created_event_topic, fetch_mellow_factories_for_chain
 from eth_defi.mellow.vault import MellowVault
 from eth_defi.vault.base import VaultBase, VaultSpec
+from eth_defi.vault.risk import VaultTechnicalRisk, get_vault_risk
 
 TOPIC_HEX_LENGTH = 66
 ETHEREUM_CHAIN_ID = 1
@@ -23,6 +24,7 @@ BASE_CHAIN_ID = 8453
 POLYGON_CHAIN_ID = 137
 DEFAULT_CORE_FACTORY = "0x4E38F679e46B3216f0bd4B314E9C429AFfB1dEE3"
 MONAD_CORE_FACTORY = "0x04c0287DEdE16e0C04A1C2A52F31400a88f1dF4c"
+LIDO_EARN_USD_VAULT = "0x014e6DA8F283C4aF65B2AA0f201438680A004452"
 FACTORY_ENV_VARS = (
     "MELLOW_ETHEREUM_VAULT_FACTORY",
     "MELLOW_PLASMA_VAULT_FACTORY",
@@ -73,6 +75,12 @@ def test_mellow_protocol_name() -> None:
     """Mellow feature maps to protocol name."""
 
     assert get_vault_protocol_name({ERC4626Feature.mellow_like}) == "Mellow"
+
+
+def test_mellow_risk_level() -> None:
+    """Mellow protocol is classified as low technical risk."""
+
+    assert get_vault_risk("Mellow", LIDO_EARN_USD_VAULT) is VaultTechnicalRisk.low
 
 
 def test_mellow_created_topic_is_hypersync_hex() -> None:

--- a/tests/mellow/test_mellow_classification.py
+++ b/tests/mellow/test_mellow_classification.py
@@ -1,6 +1,7 @@
 """Test Mellow vault classification and routing."""
 
 import datetime
+import inspect
 from types import SimpleNamespace
 
 import pytest
@@ -11,7 +12,7 @@ from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature, get_va
 from eth_defi.mellow.abi import ERC20_ABI_FILENAME, FACTORY_ABI_FILENAME, FEE_MANAGER_ABI_FILENAME, ORACLE_ABI_FILENAME, VAULT_ABI_FILENAME
 from eth_defi.mellow.discovery import fetch_mellow_created_event_topic, fetch_mellow_factories_for_chain
 from eth_defi.mellow.vault import MellowVault
-from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.base import VaultBase, VaultSpec
 
 TOPIC_HEX_LENGTH = 66
 ETHEREUM_CHAIN_ID = 1
@@ -28,6 +29,14 @@ FACTORY_ENV_VARS = (
     "MELLOW_ARBITRUM_VAULT_FACTORY",
     "MELLOW_MONAD_VAULT_FACTORY",
     "MELLOW_BASE_VAULT_FACTORY",
+)
+VAULT_BASE_FEE_ACCESSOR_METHODS = (
+    "has_custom_fees",
+    "get_management_fee",
+    "get_performance_fee",
+    "get_deposit_fee",
+    "get_withdraw_fee",
+    "get_fee_data",
 )
 
 
@@ -89,6 +98,19 @@ def test_mellow_abi_files_load() -> None:
     assert any(item["type"] == "function" and item["name"] == "getReport" for item in oracle_abi)
     assert any(item["type"] == "function" and item["name"] == "protocolFeeD6" for item in fee_manager_abi)
     assert any(item["type"] == "function" and item["name"] == "totalSupply" for item in erc20_abi)
+
+
+def test_mellow_fee_accessors_match_vault_base_surface() -> None:
+    """Mellow fee accessors keep the shared VaultBase method contract."""
+
+    for method_name in VAULT_BASE_FEE_ACCESSOR_METHODS:
+        base_method = getattr(VaultBase, method_name)
+        mellow_method = getattr(MellowVault, method_name)
+        assert mellow_method is not base_method
+
+        base_parameters = tuple(inspect.signature(base_method).parameters)
+        mellow_parameters = tuple(inspect.signature(mellow_method).parameters)
+        assert mellow_parameters == base_parameters
 
 
 def test_mellow_factory_registry_matches_documented_core_deployments(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/mellow/test_mellow_hypersync_integration.py
+++ b/tests/mellow/test_mellow_hypersync_integration.py
@@ -1,0 +1,146 @@
+"""Integration tests for Mellow vault discovery and historical price rows."""
+
+import os
+from pathlib import Path
+
+import flaky
+import hypersync
+import pandas as pd
+import pytest
+
+from eth_defi.erc_4626.classification import create_vault_instance
+from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.erc_4626.hypersync_discovery import HypersyncVaultDiscover
+from eth_defi.hypersync.server import get_hypersync_server
+from eth_defi.mellow.vault import MellowVault
+from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
+from eth_defi.token import TokenDiskCache
+from eth_defi.vault.base import VaultHistoricalRead
+from eth_defi.vault.historical import scan_historical_prices_to_parquet
+
+JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
+HYPERSYNC_API_KEY = os.environ.get("HYPERSYNC_API_KEY")
+
+ETHEREUM_CHAIN_ID = 1
+LIDO_EARN_USD_VAULT = "0x014e6DA8F283C4aF65B2AA0f201438680A004452"
+LIDO_EARN_USD_VAULT_LOWER = LIDO_EARN_USD_VAULT.lower()
+LIDO_EARN_USD_CREATED_BLOCK = 24_602_425
+LIDO_EARN_USD_CREATED_AT = pd.Timestamp("2026-03-07 01:54:35")
+DISCOVERY_START_BLOCK = 24_602_420
+DISCOVERY_END_BLOCK = 24_602_430
+PRICE_END_BLOCK = 24_602_445
+PRICE_STEP_BLOCKS = 10
+EXPECTED_MAX_DETECTIONS = 10
+MELLOW_PRICE_UNSUPPORTED_ERROR = "Mellow share price and TVL require oracle report orientation and subvault accounting confirmation"
+
+pytestmark = pytest.mark.skipif(
+    JSON_RPC_ETHEREUM is None or HYPERSYNC_API_KEY is None,
+    reason="JSON_RPC_ETHEREUM and HYPERSYNC_API_KEY needed to run these tests",
+)
+
+
+def _create_hypersync_client() -> hypersync.HypersyncClient:
+    """Create an Ethereum Hypersync client."""
+
+    return hypersync.HypersyncClient(
+        hypersync.ClientConfig(
+            url=get_hypersync_server(ETHEREUM_CHAIN_ID),
+            bearer_token=HYPERSYNC_API_KEY,
+        )
+    )
+
+
+@flaky.flaky
+def test_mellow_hypersync_discovery_and_historical_reader_price_row(tmp_path: Path) -> None:
+    """Discover Lido Earn USD and write the current Mellow historical row.
+
+    This test intentionally asserts the current partial Mellow reader contract:
+    ``total_supply`` is filled from ``ShareManager.totalSupply()``, while
+    ``share_price`` and ``total_assets`` stay empty with an explicit error until
+    Mellow oracle/NAV accounting is implemented.
+    """
+
+    web3 = create_multi_provider_web3(JSON_RPC_ETHEREUM)
+    web3factory = MultiProviderWeb3Factory(
+        JSON_RPC_ETHEREUM,
+        retries=2,
+        skip_verification=True,
+        expected_chain_id=ETHEREUM_CHAIN_ID,
+    )
+    hypersync_client = _create_hypersync_client()
+    token_cache = TokenDiskCache(tmp_path / "tokens.sqlite")
+
+    discover = HypersyncVaultDiscover(
+        web3=web3,
+        web3factory=web3factory,
+        client=hypersync_client,
+        max_workers=2,
+        recv_timeout=60,
+    )
+    report = discover.scan_vaults(
+        start_block=DISCOVERY_START_BLOCK,
+        end_block=DISCOVERY_END_BLOCK,
+        display_progress=False,
+    )
+
+    assert len(report.detections) <= EXPECTED_MAX_DETECTIONS
+    detection = report.detections[LIDO_EARN_USD_VAULT_LOWER]
+    assert detection.address == LIDO_EARN_USD_VAULT_LOWER
+    assert detection.first_seen_at_block == LIDO_EARN_USD_CREATED_BLOCK
+    assert detection.first_seen_at == LIDO_EARN_USD_CREATED_AT.to_pydatetime()
+    assert detection.features == {ERC4626Feature.mellow_like}
+    assert detection.deposit_count == 0
+    assert detection.redeem_count == 0
+
+    vault = create_vault_instance(
+        web3,
+        detection.address,
+        features=detection.features,
+        token_cache=token_cache,
+    )
+    assert isinstance(vault, MellowVault)
+    vault.first_seen_at_block = detection.first_seen_at_block
+
+    parquet_file = tmp_path / "mellow-prices.parquet"
+    scan_result = scan_historical_prices_to_parquet(
+        output_fname=parquet_file,
+        web3=web3,
+        web3factory=web3factory,
+        vaults=[vault],
+        token_cache=token_cache,
+        start_block=LIDO_EARN_USD_CREATED_BLOCK,
+        end_block=PRICE_END_BLOCK,
+        step=PRICE_STEP_BLOCKS,
+        max_workers=2,
+        require_multicall_result=True,
+        hypersync_client=hypersync_client,
+        timestamp_cache_file=tmp_path / "timestamps",
+        vault_addresses={LIDO_EARN_USD_VAULT_LOWER},
+    )
+
+    assert scan_result["rows_written"] == 1
+    prices = pd.read_parquet(parquet_file)
+    assert list(prices.columns) == VaultHistoricalRead.to_pyarrow_schema().names
+    assert len(prices) == 1
+
+    row = prices.iloc[0]
+    assert row.chain == ETHEREUM_CHAIN_ID
+    assert row.address == LIDO_EARN_USD_VAULT_LOWER
+    assert row.block_number == LIDO_EARN_USD_CREATED_BLOCK
+    assert row.timestamp == LIDO_EARN_USD_CREATED_AT
+    assert row.total_supply == 0.0
+    assert row.errors == MELLOW_PRICE_UNSUPPORTED_ERROR
+    assert row.vault_poll_frequency == "first_read"
+    assert row.deposits_open == ""
+    assert row.redemption_open == ""
+    assert row.trading == ""
+    assert pd.notna(row.written_at)
+
+    assert pd.isna(row.share_price)
+    assert pd.isna(row.total_assets)
+    assert pd.isna(row.performance_fee)
+    assert pd.isna(row.management_fee)
+    assert pd.isna(row.max_deposit)
+    assert pd.isna(row.max_redeem)
+    assert pd.isna(row.available_liquidity)
+    assert pd.isna(row.utilisation)

--- a/tests/mellow/test_mellow_hypersync_integration.py
+++ b/tests/mellow/test_mellow_hypersync_integration.py
@@ -12,6 +12,7 @@ from eth_defi.erc_4626.classification import create_vault_instance
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.hypersync_discovery import HypersyncVaultDiscover
 from eth_defi.hypersync.server import get_hypersync_server
+from eth_defi.hypersync.session import ThrottledHypersyncClient, create_throttled_hypersync_client
 from eth_defi.mellow.vault import MellowVault
 from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
 from eth_defi.token import TokenDiskCache
@@ -28,10 +29,14 @@ LIDO_EARN_USD_CREATED_BLOCK = 24_602_425
 LIDO_EARN_USD_CREATED_AT = pd.Timestamp("2026-03-07 01:54:35")
 DISCOVERY_START_BLOCK = 24_602_420
 DISCOVERY_END_BLOCK = 24_602_430
-PRICE_END_BLOCK = 24_602_445
-PRICE_STEP_BLOCKS = 10
+PRICE_START_BLOCK = 24_999_754
+PRICE_SECOND_BLOCK = 24_999_755
+PRICE_EXCLUSIVE_END_BLOCK = 24_999_756
+PRICE_STEP_BLOCKS = 1
 EXPECTED_MAX_DETECTIONS = 10
-MELLOW_PRICE_UNSUPPORTED_ERROR = "Mellow share price and TVL require oracle report orientation and subvault accounting confirmation"
+EXPECTED_PRICE_ROWS = 2
+EXPECTED_START_SHARE_PRICE = 1.0080417560461396
+EXPECTED_END_SHARE_PRICE = 1.008280253418576
 
 pytestmark = pytest.mark.skipif(
     JSON_RPC_ETHEREUM is None or HYPERSYNC_API_KEY is None,
@@ -39,25 +44,31 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def _create_hypersync_client() -> hypersync.HypersyncClient:
-    """Create an Ethereum Hypersync client."""
+def _create_hypersync_client() -> ThrottledHypersyncClient:
+    """Create an Ethereum Hypersync client.
 
-    return hypersync.HypersyncClient(
+    Keep stream concurrency at one request so this real-chain integration test
+    does not burst against the shared Hypersync rate limit.
+    """
+
+    return create_throttled_hypersync_client(
         hypersync.ClientConfig(
             url=get_hypersync_server(ETHEREUM_CHAIN_ID),
             bearer_token=HYPERSYNC_API_KEY,
-        )
+        ),
+        concurrency=1,
     )
 
 
 @flaky.flaky
 def test_mellow_hypersync_discovery_and_historical_reader_price_row(tmp_path: Path) -> None:
-    """Discover Lido Earn USD and write the current Mellow historical row.
+    """Discover Lido Earn USD and write Mellow historical share-price rows.
 
-    This test intentionally asserts the current partial Mellow reader contract:
-    ``total_supply`` is filled from ``ShareManager.totalSupply()``, while
-    ``share_price`` and ``total_assets`` stay empty with an explicit error until
-    Mellow oracle/NAV accounting is implemented.
+    The discovery range is kept around the factory creation event. The price
+    range then samples two neighbouring fixed blocks where
+    ``Oracle.getReport(USDC)`` shows the share price increasing. The range is
+    intentionally short because the historical pipeline fills a timestamp cache
+    for every block in the requested range.
     """
 
     web3 = create_multi_provider_web3(JSON_RPC_ETHEREUM)
@@ -108,8 +119,8 @@ def test_mellow_hypersync_discovery_and_historical_reader_price_row(tmp_path: Pa
         web3factory=web3factory,
         vaults=[vault],
         token_cache=token_cache,
-        start_block=LIDO_EARN_USD_CREATED_BLOCK,
-        end_block=PRICE_END_BLOCK,
+        start_block=PRICE_START_BLOCK,
+        end_block=PRICE_EXCLUSIVE_END_BLOCK,
         step=PRICE_STEP_BLOCKS,
         max_workers=2,
         require_multicall_result=True,
@@ -118,29 +129,36 @@ def test_mellow_hypersync_discovery_and_historical_reader_price_row(tmp_path: Pa
         vault_addresses={LIDO_EARN_USD_VAULT_LOWER},
     )
 
-    assert scan_result["rows_written"] == 1
+    assert scan_result["rows_written"] == EXPECTED_PRICE_ROWS
     prices = pd.read_parquet(parquet_file)
     assert list(prices.columns) == VaultHistoricalRead.to_pyarrow_schema().names
-    assert len(prices) == 1
+    assert len(prices) == EXPECTED_PRICE_ROWS
 
-    row = prices.iloc[0]
-    assert row.chain == ETHEREUM_CHAIN_ID
-    assert row.address == LIDO_EARN_USD_VAULT_LOWER
-    assert row.block_number == LIDO_EARN_USD_CREATED_BLOCK
-    assert row.timestamp == LIDO_EARN_USD_CREATED_AT
-    assert row.total_supply == 0.0
-    assert row.errors == MELLOW_PRICE_UNSUPPORTED_ERROR
-    assert row.vault_poll_frequency == "first_read"
-    assert row.deposits_open == ""
-    assert row.redemption_open == ""
-    assert row.trading == ""
-    assert pd.notna(row.written_at)
+    prices = prices.sort_values("block_number").reset_index(drop=True)
+    assert prices["chain"].tolist() == [ETHEREUM_CHAIN_ID, ETHEREUM_CHAIN_ID]
+    assert prices["address"].tolist() == [LIDO_EARN_USD_VAULT_LOWER, LIDO_EARN_USD_VAULT_LOWER]
+    assert prices["block_number"].tolist() == [PRICE_START_BLOCK, PRICE_SECOND_BLOCK]
+    assert prices["errors"].tolist() == ["", ""]
+    assert prices["share_price"].notna().all()
+    assert prices["total_assets"].notna().all()
+    assert prices["total_supply"].notna().all()
+    assert prices["written_at"].notna().all()
 
-    assert pd.isna(row.share_price)
-    assert pd.isna(row.total_assets)
-    assert pd.isna(row.performance_fee)
-    assert pd.isna(row.management_fee)
-    assert pd.isna(row.max_deposit)
-    assert pd.isna(row.max_redeem)
-    assert pd.isna(row.available_liquidity)
-    assert pd.isna(row.utilisation)
+    start_row = prices.iloc[0]
+    end_row = prices.iloc[1]
+    assert start_row.share_price == pytest.approx(EXPECTED_START_SHARE_PRICE)
+    assert end_row.share_price == pytest.approx(EXPECTED_END_SHARE_PRICE)
+    assert end_row.share_price > start_row.share_price
+    assert end_row.total_assets != start_row.total_assets
+    assert end_row.total_supply != start_row.total_supply
+
+    assert (prices["vault_poll_frequency"] == "first_read").all()
+    assert (prices["deposits_open"] == "").all()
+    assert (prices["redemption_open"] == "").all()
+    assert (prices["trading"] == "").all()
+    assert (prices["performance_fee"] == 0.0).all()
+    assert (prices["management_fee"] == 0.0).all()
+    assert prices["max_deposit"].isna().all()
+    assert prices["max_redeem"].isna().all()
+    assert prices["available_liquidity"].isna().all()
+    assert prices["utilisation"].isna().all()

--- a/tests/mellow/test_mellow_offchain_metadata.py
+++ b/tests/mellow/test_mellow_offchain_metadata.py
@@ -1,0 +1,67 @@
+"""Test Mellow offchain metadata API parsing and caching."""
+
+import datetime
+from decimal import Decimal
+from types import SimpleNamespace
+
+from eth_defi.mellow.offchain_metadata import fetch_mellow_api_vaults
+
+LIDO_EARN_USD_VAULT = "0x014e6DA8F283C4aF65B2AA0f201438680A004452"
+USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+
+
+def test_fetch_mellow_api_vaults_parses_and_caches(monkeypatch, tmp_path) -> None:
+    """Parse Mellow public API metadata and reuse the disk cache.
+
+    Mellow API USD TVL is off-chain metadata. The parser keeps it
+    available for diagnostics while the adapter reads comparable TVL from
+    on-chain share price and supply.
+    """
+
+    raw_vaults = [
+        {
+            "chain_id": 1,
+            "address": LIDO_EARN_USD_VAULT,
+            "symbol": "earnUSD",
+            "name": "Lido Earn USD",
+            "layer": "mellow",
+            "tvl_usd": "21897383.50",
+            "base_token": {
+                "symbol": "USDC",
+                "address": USDC,
+            },
+        }
+    ]
+    calls = []
+
+    def fake_get(url: str, **kwargs):
+        """Return a Mellow API response fixture."""
+
+        calls.append((url, kwargs))
+        return SimpleNamespace(
+            raise_for_status=lambda: None,
+            json=lambda: raw_vaults,
+        )
+
+    monkeypatch.setattr("eth_defi.mellow.offchain_metadata.requests.get", fake_get)
+
+    api_vaults = fetch_mellow_api_vaults(cache_path=tmp_path, api_base_url="https://example.invalid")
+    api_vault = api_vaults[1, LIDO_EARN_USD_VAULT.lower()]
+
+    assert api_vault.address == LIDO_EARN_USD_VAULT
+    assert api_vault.name == "Lido Earn USD"
+    assert api_vault.symbol == "earnUSD"
+    assert api_vault.layer == "mellow"
+    assert api_vault.tvl_usd == Decimal("21897383.50")
+    assert api_vault.base_token_address == USDC
+    assert api_vault.base_token_symbol == "USDC"
+    assert len(calls) == 1
+
+    cached_vaults = fetch_mellow_api_vaults(
+        cache_path=tmp_path,
+        api_base_url="https://should-not-be-called.invalid",
+        max_cache_duration=datetime.timedelta(days=36500),
+    )
+
+    assert cached_vaults[1, LIDO_EARN_USD_VAULT.lower()] == api_vault
+    assert len(calls) == 1


### PR DESCRIPTION
## Why

Mellow Core Vaults need to be handled as a sibling vault architecture to ERC-4626 while still flowing through the same EVM vault discovery, metadata and price scanning cycle. The official [Mellow Core Vault overview](https://docs.mellow.finance/core-vaults/overview) describes Core Vaults as onchain structured product infrastructure, and the implementation model is not the ERC-4626 accounting model.

For Mellow Core Vaults, the canonical vault address is created by the Core Vault factory and emitted through the documented [Factory `Created(address,uint256,address,bytes)` event](https://docs.mellow.finance/core-vaults/architecture/factory). Share accounting lives on `ShareManager`, user flow events live on queue contracts, pricing comes from the vault oracle, and fee settings live on `FeeManager`. The scanner therefore needs a `MellowVault(VaultBase)` adapter and factory-led discovery path without a separate `SCAN_MELLOW` switch.

This PR intentionally targets Mellow Core Vaults. The factory registry follows the official [Mellow Core deployments](https://docs.mellow.finance/core-vaults/core-deployments) page for Ethereum mainnet, Plasma, Arbitrum and Monad. Base remains configuration-only until Mellow publishes a canonical Base Core Vault factory.

## Lessons learnt

Mellow factory discovery can share the same Hypersync query pipeline as ERC-4626 lead discovery, but Mellow log selections must be address-restricted to configured Core Vault factory contracts. The factory event topic also needs to be normalised as a `0x`-prefixed Hypersync topic.

Mellow vaults should still go through the shared probe/classification path. `ERC4626Feature.mellow_like` is a routing marker for the existing vault database and scanner, not a claim that the contract is ERC-4626. Factory leads are probed, then forced to `mellow_like` so `create_vault_instance()` and autodetection route to `MellowVault` instead of the generic `ERC4626Vault`.

Mellow current and historical TVL should be comparable with other vault protocols. The adapter does not use public API USD TVL for production NAV. `MellowVault.fetch_total_assets()` reads denomination-token TVL as on-chain oracle share price multiplied by tokenised `ShareManager.totalSupply()`, and `fetch_nav()` is a `VaultBase`-compatible alias for the same value.

Mellow historical price support needs protocol-specific accounting. The oracle report exposes `priceD18` as raw shares per raw asset, while our shared price schema expects assets per one share. The reader converts the Mellow orientation using share-token and asset decimals, reads `ShareManager.totalSupply()`, and maps `FeeManager` D6 fees into the shared management/performance/deposit/withdraw fields.

Mellow API data belongs behind the same off-chain metadata pattern as other API-backed integrations. `eth_defi.mellow.offchain_metadata` now owns the public [Mellow API](https://docs.mellow.finance/resources/api) read/cache path, and the manual scanner consumes it only for diagnostics and mapping output.

## Summary

- Add `eth_defi.mellow` with Mellow ABI fragments, factory discovery helpers, `MellowVault`, `MellowVaultHistoricalReader`, off-chain metadata helpers and queue-flow stubs.
- Add `ERC4626Feature.mellow_like` as a compatibility/routing marker and integrate Mellow factory leads into the existing Hypersync and JSON-RPC EVM vault discovery paths.
- Route `mellow_like` detections through `create_vault_instance()` and autodetection to `MellowVault`, while keeping Mellow on the same metadata row creation and price scan paths as other smart-contract vaults.
- Read Mellow `ShareManager.totalSupply()`, oracle share price and `FeeManager` fees; map `protocolFeeD6` as management-like, `performanceFeeD6` as performance-like, and deposit/redeem fees to the shared fee fields.
- Populate Mellow current scan-record NAV from on-chain `share_price * total_supply`; keep public API USD TVL out of `MellowVault.fetch_nav()` and `fetch_total_assets()`.
- Store Mellow discovery `deposit_count=0` and `redeem_count=0`, with a central `mellow_like` exemption from activity filters because real deposit/redeem events are emitted by queue contracts instead of the canonical vault address.
- Add `scripts/mellow/scan-initial-mellow.py` for read-only Hypersync initial mapping with tabulate output and optional Mellow API USD TVL diagnostics.
- Add fixed-block Anvil coverage for Lido Earn USD, Hypersync discovery coverage, historical share-price increase checks, fee accessor tests, low risk classification, off-chain metadata tests, API docs and the protocol research plan.
- Validated locally with focused tests and a 1,000,000-block Ethereum Mellow scan that found 33 Core factory leads and Lido Earn USD at $21,897,383.50 API USD TVL.

## Related issues and PRs

N/A

## Unrelated CI and test fixes

N/A
