### PR TITLE
feat: add more currency API default pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- feat: Expand the `eth_defi.currency_api` default USD quote set with SGD, TRY, CHF and CAD, so the scheduled currency-rate scan backfills Singapore dollar, Turkish lira, Swiss franc and Canadian dollar rates alongside EUR, GBP, JPY, AUD, BTC and ETH. Replace the scanner DuckDB primary-key indexes with transactional delete-then-insert idempotence, avoiding a DuckDB 1.5.0 native abort when closing the larger ten-currency full-history database (2026-06-30)
+
 - fix: Resolve the unactionable-depeg warnings for `AUSD`, `dUSD`, `USDN` and `USDX`. Pin the dead DefiDollar (`DUSD`) and Neutrino USD (`USDN`) tokens by their on-chain-verified Ethereum contract addresses so their depegged vaults are now blacklisted, and add a `non_evm: true` flag for natively non-EVM dead tokens (Acala `aUSD` on Polkadot, Kava `USDX` on Cosmos) that have no ERC-20 on any indexed chain, silencing the warning that no contract address could ever resolve (2026-06-30)
 
 - feat: Run the `eth_defi.currency_api` exchange-rate fetcher as a default-on `scan-vaults-all-chains` scheduled item, with a built-in 24h cycle, pipeline-local DuckDB path, backup coverage, configurable `CURRENCY_API_*` environment overrides and best-effort failure handling so currency API outages do not stop vault scans (2026-06-30)

--- a/docs/source/api/currency_api/index.rst
+++ b/docs/source/api/currency_api/index.rst
@@ -6,8 +6,8 @@ Historical exchange rate ingestion from the free, no-API-key
 (``@fawazahmed0/currency-api``).
 
 This module incrementally scans daily historical exchange rates for a
-configurable set of named currencies (default: EUR, GBP, JPY, AUD, BTC, ETH against
-USD) and stores them in DuckDB:
+configurable set of named currencies (default: EUR, GBP, JPY, AUD, SGD, TRY,
+CHF, CAD, BTC, ETH against USD) and stores them in DuckDB:
 
 - One HTTP request per date returns the base currency against ~200 fiat and
   crypto currencies, with a jsDelivr → Cloudflare Pages host fallback

--- a/eth_defi/currency_api/README-currency-api.md
+++ b/eth_defi/currency_api/README-currency-api.md
@@ -3,8 +3,8 @@
 ## Overview
 
 Incrementally scans daily historical exchange rates for a configurable set of
-named currencies (default: EUR, GBP, JPY, AUD, BTC, ETH against USD) and stores them
-in a DuckDB database. The data is sourced from the **fawazahmed0 Exchange API**
+named currencies (default: EUR, GBP, JPY, AUD, SGD, TRY, CHF, CAD, BTC, ETH
+against USD) and stores them in a DuckDB database. The data is sourced from the **fawazahmed0 Exchange API**
 (`@fawazahmed0/currency-api`).
 
 The schema carries a `source` column so additional rate sources (e.g.
@@ -64,7 +64,7 @@ crypto currencies:
 ```json
 {
   "date": "2026-06-28",
-  "usd": { "eur": 0.87803784, "gbp": 0.75771599, "jpy": 161.75, "btc": 0.000016638, "eth": 0.00063644, ... }
+  "usd": { "eur": 0.87803784, "gbp": 0.75771599, "jpy": 161.75, "sgd": 1.28, "chf": 0.80, "cad": 1.37, "btc": 0.000016638, "eth": 0.00063644, ... }
 }
 ```
 
@@ -85,7 +85,7 @@ exchange_rates                              unavailable_rates
 ==============                              =================
 date           DATE     \                   date           DATE     \
 base_currency  VARCHAR   \                  base_currency  VARCHAR    \
-quote_currency VARCHAR    > composite PK    quote_currency VARCHAR     > composite PK
+quote_currency VARCHAR    > logical key     quote_currency VARCHAR     > logical key
 source         VARCHAR   /                  source         VARCHAR    /
 rate           DOUBLE                        reason         VARCHAR
 written_at     TIMESTAMP                     http_status    INTEGER
@@ -93,7 +93,9 @@ written_at     TIMESTAMP                     http_status    INTEGER
 ```
 
 - `rate` — raw API value, `quote` units per 1 `base`.
-- `source` — part of the primary key so multiple sources coexist.
+- `source` — part of the logical key so multiple sources coexist. Idempotence is
+  enforced by transactional delete-then-insert writes instead of DuckDB primary
+  key indexes.
 - `unavailable_rates` — rate cells confirmed to have no data (older than the grace
   window), tracked at `(date, base, quote, source)` granularity. `reason` is
   `date_404` (whole date 404 on both hosts), `quote_missing` (a single quote
@@ -176,7 +178,7 @@ LOG_LEVEL=info START_DATE=2026-06-01 END_DATE=2026-06-05 \
   poetry run scan-currencies
 
 # Add more currencies (no schema change; history backfills automatically)
-QUOTE_CURRENCIES=eur,gbp,jpy,chf,btc,eth,sol \
+QUOTE_CURRENCIES=eur,gbp,jpy,aud,sgd,try,chf,cad,btc,eth,sol \
   poetry run scan-currencies
 
 # Use a non-USD base
@@ -194,7 +196,7 @@ poetry run python -m eth_defi.currency_api.cli
 | `LOG_LEVEL` | `warning` | Logging level |
 | `DB_PATH` | `~/.tradingstrategy/currency-api/exchange-rates.duckdb` | DuckDB database path |
 | `BASE_CURRENCY` | `usd` | Base currency |
-| `QUOTE_CURRENCIES` | `eur,gbp,jpy,aud,btc,eth` | Comma-separated quote currencies |
+| `QUOTE_CURRENCIES` | `eur,gbp,jpy,aud,sgd,try,chf,cad,btc,eth` | Comma-separated quote currencies |
 | `START_DATE` | *(resume / earliest)* | `YYYY-MM-DD` lower bound (small-batch testing) |
 | `END_DATE` | *(today, UTC)* | `YYYY-MM-DD` upper bound (small-batch testing) |
 | `MAX_WORKERS` | `8` | Parallel date fetchers (threaded) |

--- a/eth_defi/currency_api/__init__.py
+++ b/eth_defi/currency_api/__init__.py
@@ -1,8 +1,8 @@
 """Historical exchange rate ingestion from the fawazahmed0 Exchange API.
 
 This package incrementally scans daily historical exchange rates for a
-configurable set of named currencies (default: EUR, GBP, JPY, AUD, BTC, ETH against
-USD) and stores them in a DuckDB database.
+configurable set of named currencies (default: EUR, GBP, JPY, AUD, SGD, TRY,
+CHF, CAD, BTC, ETH against USD) and stores them in a DuckDB database.
 
 The data is sourced from the free, no-API-key
 `fawazahmed0 Exchange API <https://github.com/fawazahmed0/exchange-api>`__

--- a/eth_defi/currency_api/cli.py
+++ b/eth_defi/currency_api/cli.py
@@ -1,7 +1,7 @@
 """Command-line entry point for the currency_api exchange rate scanner.
 
 Fetches daily exchange rates for a configurable set of named currencies
-(default: EUR, GBP, JPY, AUD, BTC, ETH against USD) from the free, no-API-key
+(default: EUR, GBP, JPY, AUD, SGD, TRY, CHF, CAD, BTC, ETH against USD) from the free, no-API-key
 fawazahmed0 Exchange API and stores them in a DuckDB database. Resume is
 completeness-driven, so re-running only fetches missing dates/currencies.
 
@@ -17,7 +17,7 @@ Installed as the ``scan-currencies`` Poetry console script
     LOG_LEVEL=info START_DATE=2026-06-01 END_DATE=2026-06-05 poetry run scan-currencies
 
     # Add more currencies (history backfills automatically)
-    QUOTE_CURRENCIES=eur,gbp,jpy,chf,btc,eth,sol poetry run scan-currencies
+    QUOTE_CURRENCIES=eur,gbp,jpy,aud,sgd,try,chf,cad,btc,eth,sol poetry run scan-currencies
 
 It can also be run as a module: ``poetry run python -m eth_defi.currency_api.cli``.
 
@@ -26,7 +26,7 @@ Environment variables:
 - ``LOG_LEVEL``: Logging level (debug, info, warning, error). Default: warning
 - ``DB_PATH``: DuckDB database file. Default: ~/.tradingstrategy/currency-api/exchange-rates.duckdb
 - ``BASE_CURRENCY``: Base currency. Default: usd
-- ``QUOTE_CURRENCIES``: Comma-separated quote currencies. Default: eur,gbp,jpy,aud,btc,eth
+- ``QUOTE_CURRENCIES``: Comma-separated quote currencies. Default: eur,gbp,jpy,aud,sgd,try,chf,cad,btc,eth
 - ``START_DATE``: ``YYYY-MM-DD`` lower bound. Default: resume / earliest available
 - ``END_DATE``: ``YYYY-MM-DD`` upper bound. Default: today (UTC)
 - ``MAX_WORKERS``: Parallel date fetchers. Default: 8

--- a/eth_defi/currency_api/constants.py
+++ b/eth_defi/currency_api/constants.py
@@ -28,7 +28,7 @@ SOURCE_NAME = "fawazahmed0"
 DEFAULT_BASE_CURRENCY = "usd"
 
 #: Default set of named quote currencies to scan.
-DEFAULT_QUOTE_CURRENCIES = ("eur", "gbp", "jpy", "aud", "btc", "eth")
+DEFAULT_QUOTE_CURRENCIES = ("eur", "gbp", "jpy", "aud", "sgd", "try", "chf", "cad", "btc", "eth")
 
 #: Earliest date for which the source publishes data: 2024-03-02.
 #:

--- a/eth_defi/currency_api/database.py
+++ b/eth_defi/currency_api/database.py
@@ -26,7 +26,7 @@ class CurrencyRateDatabase:
 
     Three tables:
 
-    - ``exchange_rates`` — the data, keyed by
+    - ``exchange_rates`` — the data, uniquely maintained by
       ``(date, base_currency, quote_currency, source)``. ``rate`` is the raw API
       value (units of quote per 1 unit of base).
     - ``unavailable_rates`` — quote-level gap tracking for cells confirmed to
@@ -75,8 +75,7 @@ class CurrencyRateDatabase:
                 quote_currency VARCHAR NOT NULL,
                 rate DOUBLE NOT NULL,
                 source VARCHAR NOT NULL,
-                written_at TIMESTAMP,
-                PRIMARY KEY (date, base_currency, quote_currency, source)
+                written_at TIMESTAMP
             )
         """)
 
@@ -88,8 +87,7 @@ class CurrencyRateDatabase:
                 source VARCHAR NOT NULL,
                 reason VARCHAR,
                 http_status INTEGER,
-                checked_at TIMESTAMP,
-                PRIMARY KEY (date, base_currency, quote_currency, source)
+                checked_at TIMESTAMP
             )
         """)
 
@@ -103,10 +101,105 @@ class CurrencyRateDatabase:
                 base_currency VARCHAR NOT NULL,
                 source VARCHAR NOT NULL,
                 transient_attempts INTEGER NOT NULL,
-                last_attempt_at TIMESTAMP,
-                PRIMARY KEY (date, base_currency, source)
+                last_attempt_at TIMESTAMP
             )
         """)
+
+        # DuckDB 1.5.0 can abort in native code while serialising ART primary-key
+        # indexes for this write pattern. Keep idempotence in application SQL and
+        # migrate any early databases that were created with PRIMARY KEY clauses.
+        self._rewrite_primary_key_table(
+            table_name="exchange_rates",
+            columns=("date", "base_currency", "quote_currency", "rate", "source", "written_at"),
+            key_columns=("date", "base_currency", "quote_currency", "source"),
+            order_column="written_at",
+        )
+        self._rewrite_primary_key_table(
+            table_name="unavailable_rates",
+            columns=("date", "base_currency", "quote_currency", "source", "reason", "http_status", "checked_at"),
+            key_columns=("date", "base_currency", "quote_currency", "source"),
+            order_column="checked_at",
+        )
+        self._rewrite_primary_key_table(
+            table_name="fetch_attempts",
+            columns=("date", "base_currency", "source", "transient_attempts", "last_attempt_at"),
+            key_columns=("date", "base_currency", "source"),
+            order_column="last_attempt_at",
+        )
+
+    def _rewrite_primary_key_table(
+        self,
+        table_name: str,
+        columns: tuple[str, ...],
+        key_columns: tuple[str, ...],
+        order_column: str,
+    ) -> None:
+        """Rewrite an early primary-key table as a plain DuckDB table.
+
+        DuckDB does not support dropping primary-key constraints in place. If a
+        primary-key table is found, copy the latest row for each logical key to a
+        replacement table and keep the original as a backup table.
+
+        :param table_name:
+            Table to inspect and rewrite.
+        :param columns:
+            Columns to copy, in storage order.
+        :param key_columns:
+            Logical uniqueness columns.
+        :param order_column:
+            Timestamp column used to choose the latest duplicate if any exist.
+        """
+        has_primary_key = self.con.execute(
+            """
+            SELECT COUNT(*) FROM duckdb_constraints()
+            WHERE table_name = ? AND constraint_type = 'PRIMARY KEY'
+            """,
+            [table_name],
+        ).fetchone()[0]
+        if not has_primary_key:
+            return
+
+        logger.warning("Rewriting %s without DuckDB PRIMARY KEY constraints", table_name)
+
+        replacement_table = f"{table_name}__without_primary_key"
+        backup_table = f"{table_name}__primary_key_backup"
+        suffix = 1
+        while self.con.execute(
+            "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = ?",
+            [backup_table],
+        ).fetchone()[0]:
+            suffix += 1
+            backup_table = f"{table_name}__primary_key_backup_{suffix}"
+
+        column_sql = ", ".join(columns)
+        key_sql = ", ".join(key_columns)
+
+        self.con.execute("BEGIN TRANSACTION")
+        try:
+            self.con.execute(f"DROP TABLE IF EXISTS {replacement_table}")
+            self.con.execute(f"CREATE TABLE {replacement_table} AS SELECT {column_sql} FROM {table_name} WHERE FALSE")
+            self.con.execute(
+                f"""
+                INSERT INTO {replacement_table}
+                SELECT {column_sql}
+                FROM (
+                    SELECT
+                        {column_sql},
+                        ROW_NUMBER() OVER (
+                            PARTITION BY {key_sql}
+                            ORDER BY {order_column} DESC NULLS LAST
+                        ) AS rn
+                    FROM {table_name}
+                )
+                WHERE rn = 1
+                """
+            )
+            self.con.execute(f"ALTER TABLE {table_name} RENAME TO {backup_table}")
+            self.con.execute(f"ALTER TABLE {replacement_table} RENAME TO {table_name}")
+            self.con.execute("COMMIT")
+        except Exception:
+            self.con.execute("ROLLBACK")
+            raise
 
     def save(self) -> None:
         """Force a checkpoint so data is flushed to disk."""
@@ -122,8 +215,9 @@ class CurrencyRateDatabase:
     def upsert_rates(self, date_rates: DateRates) -> None:
         """Idempotently upsert the rates for one date.
 
-        Re-running with the same key overwrites the value and ``written_at``
-        (``ON CONFLICT DO UPDATE``), so a repeated scan produces no duplicates.
+        Re-running with the same key overwrites the value and ``written_at`` via
+        transactional delete-then-insert, so a repeated scan produces no
+        duplicates without relying on DuckDB primary-key indexes.
 
         :param date_rates:
             Parsed rates to store.
@@ -144,29 +238,40 @@ class CurrencyRateDatabase:
             for quote, rate in date_rates.rows
         ]
 
-        self.con.executemany(
-            """
-            INSERT INTO exchange_rates (
-                date, base_currency, quote_currency, rate, source, written_at
-            ) VALUES (?, ?, ?, ?, ?, ?)
-            ON CONFLICT (date, base_currency, quote_currency, source)
-            DO UPDATE SET
-                rate = EXCLUDED.rate,
-                written_at = EXCLUDED.written_at
-            """,
-            params,
-        )
+        key_params = [(date_rates.date, date_rates.base_currency, quote, date_rates.source) for quote, _ in date_rates.rows]
 
-        # A cell that now has data is no longer a gap: keep exchange_rates and
-        # unavailable_rates mutually exclusive so a previously-recorded gap
-        # (quote_missing / date_404 / persistent_error) cannot linger as a stale row.
-        self.con.executemany(
-            """
-            DELETE FROM unavailable_rates
-            WHERE date = ? AND base_currency = ? AND quote_currency = ? AND source = ?
-            """,
-            [(date_rates.date, date_rates.base_currency, quote, date_rates.source) for quote, _ in date_rates.rows],
-        )
+        self.con.execute("BEGIN TRANSACTION")
+        try:
+            self.con.executemany(
+                """
+                DELETE FROM exchange_rates
+                WHERE date = ? AND base_currency = ? AND quote_currency = ? AND source = ?
+                """,
+                key_params,
+            )
+            self.con.executemany(
+                """
+                INSERT INTO exchange_rates (
+                    date, base_currency, quote_currency, rate, source, written_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                params,
+            )
+
+            # A cell that now has data is no longer a gap: keep exchange_rates
+            # and unavailable_rates mutually exclusive so a previously-recorded
+            # gap cannot linger as a stale row.
+            self.con.executemany(
+                """
+                DELETE FROM unavailable_rates
+                WHERE date = ? AND base_currency = ? AND quote_currency = ? AND source = ?
+                """,
+                key_params,
+            )
+            self.con.execute("COMMIT")
+        except Exception:
+            self.con.execute("ROLLBACK")
+            raise
 
     def record_unavailable(
         self,
@@ -200,36 +305,44 @@ class CurrencyRateDatabase:
         never recorded as both present and unavailable (e.g. when a date that
         already has stored data later 404s on a tail refetch, or hits give-up).
         """
-        self.con.execute(
-            """
-            INSERT INTO unavailable_rates (
-                date, base_currency, quote_currency, source, reason, http_status, checked_at
-            )
-            SELECT ?, ?, ?, ?, ?, ?, ?
-            WHERE NOT EXISTS (
-                SELECT 1 FROM exchange_rates
+        self.con.execute("BEGIN TRANSACTION")
+        try:
+            self.con.execute(
+                """
+                DELETE FROM unavailable_rates
                 WHERE date = ? AND base_currency = ? AND quote_currency = ? AND source = ?
+                """,
+                [date, base_currency, quote_currency, source],
             )
-            ON CONFLICT (date, base_currency, quote_currency, source)
-            DO UPDATE SET
-                reason = EXCLUDED.reason,
-                http_status = EXCLUDED.http_status,
-                checked_at = EXCLUDED.checked_at
-            """,
-            [
-                date,
-                base_currency,
-                quote_currency,
-                source,
-                reason,
-                http_status,
-                native_datetime_utc_now(),
-                date,
-                base_currency,
-                quote_currency,
-                source,
-            ],
-        )
+            self.con.execute(
+                """
+                INSERT INTO unavailable_rates (
+                    date, base_currency, quote_currency, source, reason, http_status, checked_at
+                )
+                SELECT ?, ?, ?, ?, ?, ?, ?
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM exchange_rates
+                    WHERE date = ? AND base_currency = ? AND quote_currency = ? AND source = ?
+                )
+                """,
+                [
+                    date,
+                    base_currency,
+                    quote_currency,
+                    source,
+                    reason,
+                    http_status,
+                    native_datetime_utc_now(),
+                    date,
+                    base_currency,
+                    quote_currency,
+                    source,
+                ],
+            )
+            self.con.execute("COMMIT")
+        except Exception:
+            self.con.execute("ROLLBACK")
+            raise
 
     def get_transient_attempts(self, base_currency: str, source: str) -> dict[datetime.date, int]:
         """Return the consecutive transient-failure count per date.
@@ -269,18 +382,27 @@ class CurrencyRateDatabase:
         :param attempts:
             New cumulative count of consecutive transient failures.
         """
-        self.con.execute(
-            """
-            INSERT INTO fetch_attempts (
-                date, base_currency, source, transient_attempts, last_attempt_at
-            ) VALUES (?, ?, ?, ?, ?)
-            ON CONFLICT (date, base_currency, source)
-            DO UPDATE SET
-                transient_attempts = EXCLUDED.transient_attempts,
-                last_attempt_at = EXCLUDED.last_attempt_at
-            """,
-            [date, base_currency, source, attempts, native_datetime_utc_now()],
-        )
+        self.con.execute("BEGIN TRANSACTION")
+        try:
+            self.con.execute(
+                """
+                DELETE FROM fetch_attempts
+                WHERE date = ? AND base_currency = ? AND source = ?
+                """,
+                [date, base_currency, source],
+            )
+            self.con.execute(
+                """
+                INSERT INTO fetch_attempts (
+                    date, base_currency, source, transient_attempts, last_attempt_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                [date, base_currency, source, attempts, native_datetime_utc_now()],
+            )
+            self.con.execute("COMMIT")
+        except Exception:
+            self.con.execute("ROLLBACK")
+            raise
 
     def clear_transient_attempts(self, date: datetime.date, base_currency: str, source: str) -> None:
         """Reset the transient-failure counter for a date once it resolves.

--- a/tests/currency_api/test_currency_api.py
+++ b/tests/currency_api/test_currency_api.py
@@ -49,6 +49,10 @@ RATE_BOUNDS = {
     "gbp": (0.5, 1.5),
     "jpy": (50.0, 500.0),
     "aud": (1.0, 2.5),
+    "sgd": (1.0, 2.0),
+    "try": (10.0, 100.0),
+    "chf": (0.5, 1.5),
+    "cad": (1.0, 2.5),
     "btc": (0.0, 1.0),
     "eth": (0.0, 1.0),
 }
@@ -64,7 +68,7 @@ def test_limited_end_to_end_scan(db_path: Path):
     """Limited real-network end-to-end scan stores and is idempotent.
 
     1. Run a 3-day scan (2026-06-01..03) for the default currencies into a temp DB.
-    2. Assert every (date, quote) cell is present (3 dates x 6 quotes = 18 rows),
+    2. Assert every (date, quote) cell is present (3 dates x 10 quotes = 30 rows),
        the source column is populated, rates are within loose sanity bounds, and
        there were no transient failures.
     3. Re-run the identical scan and assert the row count is unchanged (idempotent
@@ -77,9 +81,10 @@ def test_limited_end_to_end_scan(db_path: Path):
         # 2. Assert completeness, source, bounds and no transient failures.
         assert result.transient_failures == 0
         df = _rates_with_python_dates(result.db)
-        assert len(df) == 18  # 3 dates x 6 default quotes
-
         expected_dates = {WINDOW_START, WINDOW_START + datetime.timedelta(days=1), WINDOW_END}
+        expected_row_count = len(expected_dates) * len(RATE_BOUNDS)
+        assert len(df) == expected_row_count
+
         present_pairs = {(row.date, row.quote_currency) for row in df.itertuples()}
         for date in expected_dates:
             for quote in RATE_BOUNDS:
@@ -94,7 +99,7 @@ def test_limited_end_to_end_scan(db_path: Path):
         # 3. Re-run the identical scan: idempotent, no duplicate rows.
         rerun = run_incremental_scan(db_path=db_path, start_date=WINDOW_START, end_date=WINDOW_END)
         try:
-            assert rerun.db.row_count() == 18
+            assert rerun.db.row_count() == expected_row_count
         finally:
             rerun.db.close()
     finally:


### PR DESCRIPTION
## Why

The currency API scanner has landed on master with EUR, GBP, JPY, AUD, BTC and ETH as default USD quotes. We also need Singapore dollar, Turkish lira, Swiss franc and Canadian dollar rates in the default scheduled scan.

The ten-currency full-history scan exposed a DuckDB 1.5.0 native abort while closing the database, caused by serialising the scanner's primary-key ART indexes. The scanner still needs idempotent writes, but it does not need physical DuckDB primary-key indexes to achieve them.

## Lessons learnt

Rebasing showed the scanner implementation had already landed on master, so this branch keeps master's implementation and expands the default quote set plus matching docs and tests. CI then caught the larger full-history database close path, which the earlier one-day smoke test did not exercise.

Claude CLI found no high-confidence correctness bugs in the earlier full scanner diff; its residual concerns were mostly around live-network test fragility.

## Summary

- Add `sgd`, `try`, `chf` and `cad` to `DEFAULT_QUOTE_CURRENCIES`.
- Update CLI docs, API docs and README examples/defaults to match the ten-currency default set.
- Extend currency API integration-test sanity bounds and expected default row count for the four added quotes.
- Replace DuckDB primary-key indexes with transactional delete-then-insert idempotence and migrate early primary-key tables to plain tables while keeping backup copies.
- Ran `poetry run ruff format eth_defi/currency_api tests/currency_api`, `poetry run python -m compileall -q eth_defi/currency_api tests/currency_api`, one-day idempotence smoke, old primary-key schema migration smoke, and a full-history ten-currency scanner close reproduction for 2024-03-02..2026-07-01.

## Related issues and PRs

Continues the currency API scanner work that landed in #1158.

## Unrelated CI and test fixes

None.
