### PR TITLE
Support source currency rates for stablecoin depeg checks

### DIFF
--- a/docs/claude-plans/2026-06-30-stablecoin-source-currency-rates.md
+++ b/docs/claude-plans/2026-06-30-stablecoin-source-currency-rates.md
@@ -1,0 +1,412 @@
+# Stablecoin source currency rate plan
+
+Date: 2026-06-30
+
+## Goal
+
+Make stablecoin depeg monitoring currency-aware as part of the scanner
+pipeline.
+
+Stablecoin metadata should explicitly say which fiat/source currency the token
+is meant to track, for example `usd`, `eur`, `jpy` or `chf`. For non-USD
+stablecoins the daily rate updater should also persist the USD/source-currency
+FX rate used for the check, so operators can audit why a token was or was not
+marked as depegged.
+
+The implementation should use the new `eth_defi.currency_api` DuckDB database
+as the USD/native exchange-rate source, instead of treating every stablecoin as
+if its nominal unit was one US dollar.
+
+## Current state
+
+- Stablecoin rate metadata lives in `eth_defi/data/stablecoins/*.yaml`.
+- `eth_defi/feed/stablecoin_rate.py` writes mutable rate fields such as
+  `usd_rate`, `peg_rate`, `peg_rate_currency`, `rate_fetch_failed_at` and
+  `depegged_at`.
+- `StablecoinRateTarget.peg_currency` is currently inferred from the token
+  symbol/name by `_guess_peg_currency()`.
+- `refresh_stablecoin_rates()` asks CoinGecko for `usd` and the inferred peg
+  currency, then compares `peg_rate < DEPEG_THRESHOLD`.
+- The YAML schema does not store the token's intended source currency as a
+  first-class metadata field.
+- The YAML schema does not store the external USD/source-currency exchange rate
+  used to audit non-USD stablecoin checks.
+- The new `eth_defi.currency_api` package stores raw exchange rates in DuckDB as
+  `quote_currency` units per one `base_currency`. With the default
+  `base_currency=usd`, the EUR row is `eur per 1 USD`; USD per EUR is the
+  inverse.
+
+The code is already partly protected against obvious non-USD false positives by
+requesting CoinGecko's native `vs_currencies` value. The remaining gap is that
+the native currency is inferred, not metadata, and the scanner does not record
+the independent FX rate that should explain the native comparison.
+
+The implementation must never silently default an unknown source currency to
+`usd`. If the metadata does not have a trusted source currency, the scanner may
+refresh `usd_rate`, but it must skip the depeg decision.
+
+## Manual checks
+
+I checked the EUR stablecoin YAML rows after pulling `origin/master`.
+
+For `2026-06-26`, the currency API source reports:
+
+```text
+1 USD = 0.87934359 EUR
+1 EUR = 1.137211905985 USD
+```
+
+Sample current YAML values:
+
+```text
+ageur  agEUR   usd=1.140000  stored_eur=0.996731  implied_eur=1.002452  depeg_native=False  dollar_threshold=False
+ceur   CEUR    usd=1.140000  stored_eur=0.998119  implied_eur=1.002452  depeg_native=False  dollar_threshold=False
+eura   EURA    usd=1.140000  stored_eur=0.996731  implied_eur=1.002452  depeg_native=False  dollar_threshold=False
+eure   EURe    usd=1.140000  stored_eur=0.999365  implied_eur=1.002452  depeg_native=False  dollar_threshold=False
+eurs   EURS    usd=1.210000  stored_eur=1.063000  implied_eur=1.064006  depeg_native=False  dollar_threshold=False
+par    PAR     usd=1.180000  stored_eur=1.037000  implied_eur=1.037625  depeg_native=False  dollar_threshold=False
+eurt   EURT    usd=0.054311  stored_eur=0.047636  implied_eur=0.047758  depeg_native=True   dollar_threshold=True
+jeur   jEUR    usd=0.533557  stored_eur=0.467979  implied_eur=0.469180  depeg_native=True   dollar_threshold=True
+seur   SEUR    usd=0.018311  stored_eur=0.016061  implied_eur=0.016102  depeg_native=True   dollar_threshold=True
+```
+
+The healthy EUR rows are consistent: `usd_rate / EURUSD` is close to the stored
+native EUR rate. The small differences are expected because CoinGecko and the
+currency API update on different schedules and CoinGecko rounds some returned
+USD prices.
+
+The operational problem is visible at the threshold boundary:
+
+- At `1 EUR = 1.137211905985 USD`, a EUR stablecoin at `1.00 USD` is only
+  `0.87934359 EUR`.
+- A dollar-only `usd_rate < 0.90` check would not mark it depegged.
+- A native EUR check would mark it depegged because `0.87934359 < 0.90`.
+
+JPY is the opposite kind of risk: a healthy 1 JPY stablecoin is roughly
+`0.006` to `0.007 USD`, so a dollar-only check marks it depegged even when it is
+near `1.0 JPY`.
+
+## Proposed yaml schema
+
+Add source-currency and FX audit fields to every stablecoin metadata entry:
+
+```yaml
+source_currency: eur
+source_currency_source: manual
+source_currency_usd_rate: 1.137211905985
+source_currency_usd_rate_date: '2026-06-26'
+source_currency_usd_rate_fetched_at: '2026-06-30T12:00:00'
+source_currency_usd_rate_source: fawazahmed0
+```
+
+Field semantics:
+
+- `source_currency`: lower-case ISO-like ticker for the intended nominal unit,
+  e.g. `usd`, `eur`, `jpy`, `gbp`, `chf`, `cad`, `aud`, `sgd`, `try`, `hkd`,
+  or `nzd`. Exclude `xau` from the v1 automated depeg path until we have an
+  explicit metal unit policy, because gold-backed tokens may represent one
+  troy ounce, grams, or another unit.
+- `source_currency_source`: how the source currency was selected. Use `manual`
+  for curated YAML, `inferred` only for review output during migration/backfill,
+  and leave empty only when unknown. `inferred` values must not stamp
+  `depegged_at` until an operator promotes them to `manual`. Production depeg
+  stamping must require `source_currency_source: manual`; any other value,
+  including an empty value, skips the native depeg decision.
+- `source_currency_usd_rate`: USD per one source-currency unit. For EUR this is
+  EURUSD, for JPY this is USD per JPY. For `source_currency: usd`, this may be
+  `1.0` or omitted; prefer writing `1.0` for a uniform schema.
+- `source_currency_usd_rate_date`: the currency API calendar date used for the
+  FX value.
+- `source_currency_usd_rate_fetched_at`: naive UTC timestamp when our scanner
+  read the value from the currency DB.
+- `source_currency_usd_rate_source`: provider/source string from the currency
+  API row, initially `fawazahmed0`.
+
+Keep existing fields:
+
+- `usd_rate`: token price in USD from CoinGecko.
+- `peg_rate`: token price in the native source currency used for the depeg
+  decision. After this change it should be derived from
+  `usd_rate / source_currency_usd_rate` when `source_currency != usd`, unless a
+  future source explicitly overrides it.
+- `peg_rate_currency`: keep as an audit alias for the actual depeg comparison
+  currency. It should equal `source_currency` when the source currency is known.
+- `depegged_at`: sticky operator-cleared marker.
+
+Example for PAR:
+
+```yaml
+source_currency: eur
+source_currency_source: manual
+usd_rate: 1.18
+source_currency_usd_rate: 1.137211905985
+source_currency_usd_rate_date: '2026-06-26'
+source_currency_usd_rate_fetched_at: '2026-06-30T12:00:00'
+source_currency_usd_rate_source: fawazahmed0
+peg_rate: 1.037625
+peg_rate_currency: eur
+depegged_at: ''
+```
+
+Example for a healthy JPY stablecoin:
+
+```yaml
+source_currency: jpy
+source_currency_source: manual
+usd_rate: 0.0064
+source_currency_usd_rate: 0.006181
+source_currency_usd_rate_date: '2026-06-26'
+source_currency_usd_rate_fetched_at: '2026-06-30T12:00:00'
+source_currency_usd_rate_source: fawazahmed0
+peg_rate: 1.03543
+peg_rate_currency: jpy
+depegged_at: ''
+```
+
+## Scanner design
+
+Add currency-aware rate resolution to `eth_defi/feed/stablecoin_rate.py`.
+
+1. Extend `StablecoinRateTarget` with:
+   - `source_currency: str | None`
+   - `source_currency_source: str | None`
+   - `source_currency_usd_rate: float | None`
+   - `source_currency_usd_rate_date: datetime.date | None`
+   - `source_currency_usd_rate_fetched_at: datetime.datetime | None`
+   - `source_currency_usd_rate_source: str | None`
+
+2. Add the new fields to `_RATE_FIELDS` and to
+   `eth_defi/stablecoin_metadata.py::StablecoinMetadata` export parsing.
+
+3. Replace `_guess_peg_currency()` usage with:
+   - read `source_currency` from YAML first;
+   - if missing, infer with the existing conservative heuristic only for a
+     migration/review report;
+   - do not use `usd` as a default for unknown currencies;
+   - do not write `source_currency_source: inferred` during normal scanner
+     refreshes;
+   - stamp `depegged_at` only when `source_currency_source == "manual"`;
+   - skip depeg decisions for `source_currency_source: inferred`, empty, or any
+     other non-manual value;
+   - log and skip depeg decisions when source currency is still unknown.
+
+4. Add a small resolver around `CurrencyRateDatabase`:
+   - input: `source_currency`, `coingecko_fetch_date`, `currency_db_path`,
+     `source`;
+   - output: USD per one source-currency unit plus rate date/source;
+   - for `usd`, return `1.0` without a DB lookup;
+   - for non-USD, read the latest available `exchange_rates` row at or before
+     the CoinGecko fetch date, where `base_currency='usd'` and
+     `quote_currency=source_currency`;
+   - always read source-currency FX rates from the local DuckDB database through
+     `CurrencyRateDatabase`; do not call the currency API network source from
+     the stablecoin rate refresher;
+   - invert the raw stored rate, because the DB stores source units per USD;
+   - define `MAX_SOURCE_CURRENCY_RATE_AGE_DAYS = 7` and treat older FX rows as
+     stale when `(coingecko_fetch_date - source_currency_usd_rate_date).days`
+     is greater than the max age;
+   - use one reference date for both lookup and staleness. In the first
+     implementation this is `now_.date()`, because CoinGecko `/simple/price`
+     returns only one `last_updated_at` for the token quote and the refresh is a
+     daily operational snapshot. If later code stores per-token upstream dates,
+     pass that same date into both lookup and staleness checks.
+   - fail closed for missing/stale FX data: persist `usd_rate`, stamp a
+     currency-rate failure reason, but do not stamp `depegged_at`.
+
+5. Extend `refresh_stablecoin_rates()` parameters:
+
+```python
+def refresh_stablecoin_rates(
+    data_dir: Path = STABLECOINS_DATA_DIR,
+    now_: datetime.datetime | None = None,
+    force: bool = False,
+    timeout: float = 20.0,
+    progress_bar: bool = False,
+    currency_db_path: Path | None = None,
+    currency_source: str = SOURCE_NAME,
+) -> StablecoinRateRefreshSummary:
+    ...
+```
+
+6. Compute depeg rate as:
+
+```python
+if source_currency is None:
+    increment_skipped_missing_source_currency(...)
+    return skip_depeg_decision(...)
+elif source_currency_source != "manual":
+    return skip_depeg_decision(...)
+elif source_currency == "usd":
+    peg_rate = usd_rate
+    source_currency_usd_rate = 1.0
+else:
+    source_currency_rate = read_latest_usd_per_source_currency(...)
+    if source_currency_rate is None:
+        increment_skipped_missing_source_currency_rate(...)
+        return skip_depeg_decision(...)
+    if source_currency_rate.is_stale:
+        increment_source_currency_rates_stale(...)
+        return skip_depeg_decision(...)
+    source_currency_usd_rate = source_currency_rate.usd_per_source_currency
+    peg_rate = usd_rate / source_currency_usd_rate
+
+depegged = peg_rate < DEPEG_THRESHOLD
+```
+
+7. Preserve the existing sticky `depegged_at` behaviour. Never clear it
+   automatically.
+
+8. Keep CoinGecko as the token-price source. Stop depending on CoinGecko's
+   `vs_currencies=eur,jpy,...` value for the authoritative depeg decision once
+   the currency DB path is available. Keep CoinGecko native quotes as a rollout
+   cross-check, but compare in USD space to reduce false alarms from heavily
+   rounded low-priced quotes:
+   `abs(usd_rate - coingecko_native_rate * source_currency_usd_rate) / usd_rate`.
+   Warn when this relative difference is greater than `2%`; smaller source
+   timing and quote rounding differences are expected.
+
+9. Add summary counters:
+   - `skipped_missing_source_currency`
+   - `skipped_missing_source_currency_rate`
+   - `source_currency_rates_fetched`
+   - `source_currency_rates_stale`
+
+## Pipeline integration
+
+Use the all-chain scanner's existing currency API integration as the source of
+truth for FX rates.
+
+- `eth_defi/vault/scan_all_chains.py` already resolves
+  `currency_api_db_path` from `PIPELINE_DATA_DIR` or `CURRENCY_API_DB_PATH`.
+- It already runs `scan_currency_rates_fn()` as a best-effort auxiliary scan.
+- Make the stablecoin rate side job accept the same `currency_api_db_path`.
+- Ensure the scan order is:
+  1. currency API scan updates `exchange-rates.duckdb`;
+  2. stablecoin rate refresh reads that DB for non-USD FX rates;
+  3. vault metrics/depeg blacklisting reads updated stablecoin YAML.
+
+The post-feed scanner path in `eth_defi/feed/scanner.py` currently runs
+`refresh_stablecoin_rates()` without a currency DB path. Add config fields:
+
+```python
+currency_api_db_path: Path | None = None
+currency_api_source: str = SOURCE_NAME
+```
+
+If `currency_api_db_path` is not configured, the side job should still refresh
+USD stablecoins and token USD prices, but it should skip non-USD depeg
+decisions with a clear failure reason instead of falling back to dollar checks.
+On any skipped non-USD depeg decision, leave `peg_rate` and
+`peg_rate_currency` empty for that refresh rather than carrying forward stale
+native comparison fields or defaulting them to USD.
+
+The depeg threshold remains intentionally one-sided: it detects downside loss
+of peg only. A token trading far above its source-currency unit is not marked by
+this monitor unless a separate over-peg policy is added later.
+
+## Migration
+
+1. Add the schema fields to the code, parser and exporter.
+2. Write a migration/helper script that annotates source currencies in
+   `eth_defi/data/stablecoins/*.yaml`.
+3. Seed obvious manual mappings first:
+   - EUR: `ageur`, `ceur`, `eura`, `eurcv`, `eure`, `euroc`, `euroe`, `eurs`,
+     `eurt`, `jeur`, `par`, `seur`, `veur`, `eurr`.
+   - JPY: `cjpy`, `gyen`, `jpyc`.
+   - GBP: `gbpt`, `tgbp`.
+   - CHF: `jchf`, `zchf`.
+   - CAD: `cadc`.
+   - CNH: `cnht`, `tcnh`.
+   - AUD: `audt`.
+4. Before committing the non-USD seed list, check the local currency API
+   database or upstream currency API response for each source ticker. Pay
+   special attention to less-common tickers such as `cnh`, `try`, `sgd`, and
+   `hkd`, because the provider may use a different quote key (for example
+   `cny` instead of `cnh`) or omit the quote. Missing provider coverage is not a
+   scanner bug, but it must be recorded as an intentional data gap before
+   migration.
+5. Mark migrated values as `source_currency_source: manual` when curated by
+   file review.
+6. For remaining tokens, use the existing heuristic only to produce a review
+   report. Do not silently commit heuristic guesses as `manual`, and do not let
+   `inferred` values participate in production depeg stamping.
+7. Run the stablecoin rate refresh with a prepared currency DB and review the
+   diff before committing mass YAML updates.
+
+## Tests
+
+Add focused tests in `tests/feed/test_stablecoin_rate.py`:
+
+- EUR token at `usd_rate=1.00`, DB EURUSD=`1.1372`: stamps `depegged_at`
+  because native rate is below `0.90 EUR`.
+- JPY token at `usd_rate=0.0064`, DB USDJPY implying `USD per JPY=0.00618`:
+  does not stamp `depegged_at` because native rate is near `1.0 JPY`.
+- Missing `source_currency` persists `usd_rate` but skips depeg and increments
+  `skipped_missing_source_currency`.
+- Missing FX row for non-USD source currency persists `usd_rate`, stamps a
+  machine-readable rate failure, and does not stamp `depegged_at`.
+- Stale FX row older than `MAX_SOURCE_CURRENCY_RATE_AGE_DAYS` persists
+  `usd_rate`, increments `source_currency_rates_stale`, and does not stamp
+  `depegged_at`.
+- `source_currency_source: inferred` does not stamp `depegged_at`.
+- Empty or otherwise non-manual `source_currency_source` does not stamp
+  `depegged_at`.
+- Unknown, inferred, missing-FX and stale-FX skip paths clear `peg_rate` and
+  `peg_rate_currency` for the current refresh.
+- `source_currency: usd` does not need a DB lookup and behaves like the current
+  USD path.
+- YAML writer updates top-level and `entries:` files without duplicating fields.
+- Stablecoin metadata JSON export converts the new numeric fields to JSON
+  numbers and empty strings to `None`.
+
+Test setup for non-USD source-currency cases should create a temporary DuckDB
+database using `CurrencyRateDatabase(tmp_path / "exchange-rates.duckdb")` and
+insert fixture rows through the database API. Tests should pass that temporary
+`currency_db_path` into `refresh_stablecoin_rates()` instead of relying on the
+operator's real currency database.
+
+Add scanner tests:
+
+- `eth_defi/feed/scanner.py` passes `currency_api_db_path` through to
+  `refresh_stablecoin_rates()`.
+- all-chain scanner order keeps `CurrencyRates` before stablecoin depeg
+  refresh when both are enabled.
+
+Use specific tests only, for example:
+
+```shell
+source .local-test.env && poetry run pytest tests/feed/test_stablecoin_rate.py --log-cli-level=info
+source .local-test.env && poetry run pytest tests/feed/test_stablecoin_rate_scanner.py --log-cli-level=info
+source .local-test.env && poetry run pytest tests/vault/test_scan_all_chains_core3.py --log-cli-level=info
+```
+
+## Rollout notes
+
+- Do not compare non-USD stablecoins directly against `0.90 USD` at any point.
+- Do not mark non-USD stablecoins healthy merely because `usd_rate > 0.90`.
+- Missing FX data is an operational data gap, not proof of health or depeg.
+- Keep `depegged_at` sticky and operator-cleared.
+- Keep the existing contract-aware blacklisting logic; this change only changes
+  how the stablecoin YAML gets marked as depegged.
+- Consider logging both native and USD threshold equivalents:
+  `source_currency=eur peg_rate=0.8793 source_currency_usd_rate=1.1372 usd_rate=1.0 usd_threshold_equivalent=1.02349`.
+
+## Implementation checklist
+
+- [ ] Add source-currency fields to `StablecoinRateTarget`, `_RATE_FIELDS` and
+      YAML parsing.
+- [ ] Add source-currency fields to stablecoin JSON export and docs.
+- [ ] Add currency DB lookup helper for latest USD/source-currency rate.
+- [ ] Change depeg comparison to derive native `peg_rate` from `usd_rate` and
+      `source_currency_usd_rate`.
+- [ ] Add staleness handling with `MAX_SOURCE_CURRENCY_RATE_AGE_DAYS = 7`.
+- [ ] Add temporary DuckDB fixture setup for source-currency rate tests.
+- [ ] Add CoinGecko native quote rollout warnings for USD-space divergence
+      greater than `2%`.
+- [ ] Thread `currency_api_db_path` through post/feed scanner configuration.
+- [ ] Thread `currency_api_db_path` through all-chain scanner stablecoin refresh
+      flow, after currency API scanning.
+- [ ] Add migration/backfill helper and review report for source currencies.
+- [ ] Seed curated non-USD stablecoin `source_currency` values.
+- [ ] Add tests for EUR, JPY, missing source currency and missing FX rows.
+- [ ] Run focused tests with `.local-test.env`.

--- a/eth_defi/feed/scanner.py
+++ b/eth_defi/feed/scanner.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from strictyaml import YAMLError
 
 from eth_defi.compat import native_datetime_utc_now
+from eth_defi.currency_api.constants import SOURCE_NAME
 from eth_defi.feed.collector import CollectorRunSummary, collect_posts, collect_twitter_list_posts, fetch_feed_proxy_rotator
 from eth_defi.feed.constants import DEFAULT_X_LIST_NAME
 from eth_defi.feed.database import DEFAULT_VAULT_POST_DATABASE, VaultPostDatabase
@@ -27,9 +28,9 @@ from eth_defi.feed.sources import (
     auto_disable_failed_linkedin_sources,
     build_twitter_source_file_lookup,
     load_post_sources,
-    mark_suspended_twitter_handle,
     mark_rss_source_dead,
     mark_rss_source_failure,
+    mark_suspended_twitter_handle,
     mark_twitter_handle_unknown,
     mark_twitter_source_dead,
 )
@@ -111,6 +112,10 @@ class PostScanConfig:
     stablecoin_rate_timeout: float = 20.0
     #: Durable state file for scanner-level 24h stablecoin refresh gate.
     stablecoin_rate_gate_path: Path | None = None
+    #: Local currency API DuckDB path used for non-USD source-currency rates.
+    currency_api_db_path: Path | None = None
+    #: Currency API source column to use for non-USD source-currency rates.
+    currency_api_source: str = SOURCE_NAME
 
 
 def run_post_scan_cycle(config: PostScanConfig) -> CollectorRunSummary:
@@ -581,6 +586,8 @@ def _run_stablecoin_rate_side_job(config: PostScanConfig, summary: CollectorRunS
             now_=now_,
             force=config.force_stablecoin_rate_refresh,
             timeout=config.stablecoin_rate_timeout,
+            currency_db_path=config.currency_api_db_path,
+            currency_source=config.currency_api_source,
         )
         if _stablecoin_rate_summary_failed(stablecoin_summary):
             _record_stablecoin_rate_side_job_failure(

--- a/eth_defi/feed/stablecoin_rate.py
+++ b/eth_defi/feed/stablecoin_rate.py
@@ -4,11 +4,17 @@ This module maintains mutable rate metadata in
 ``eth_defi/data/stablecoins/*.yaml``. It fetches stablecoin prices from the
 CoinGecko simple price API, stores the latest USD rate and fetch timestamp, and
 marks a sticky ``depegged_at`` timestamp when a token trades below the
-configured threshold in its inferred peg currency.
+configured threshold in its manually curated source currency. Non-USD source
+currencies are converted through the local
+:py:class:`~eth_defi.currency_api.database.CurrencyRateDatabase` before depeg
+checks are made.
 
 Vault metric calculation should use :class:`StablecoinRateFeeder` instead of
 reading YAML files directly. The feeder owns the in-process lookup caches used
-to resolve a vault denomination token to stablecoin rate metadata.
+to resolve a vault denomination token to stablecoin rate metadata. The returned
+:class:`DenominationTokenRate` is exported by
+:py:func:`eth_defi.research.vault_metrics.calculate_lifetime_metrics` under the
+``denomination_token_rate`` JSON field.
 
 See `CoinGecko simple price documentation <https://docs.coingecko.com/reference/simple-price>`__
 and `CoinGecko coins list documentation <https://docs.coingecko.com/reference/coins-list>`__.
@@ -33,6 +39,8 @@ from strictyaml import YAMLError
 from tqdm_loggable.auto import tqdm
 
 from eth_defi.compat import native_datetime_utc_fromtimestamp, native_datetime_utc_now
+from eth_defi.currency_api.constants import SOURCE_NAME
+from eth_defi.currency_api.database import CurrencyRateDatabase
 from eth_defi.stablecoin_metadata import STABLECOINS_DATA_DIR, normalise_token_symbol, read_stablecoin_metadata
 
 try:
@@ -86,9 +94,17 @@ COINGECKO_COINS_LIST_URL = "https://api.coingecko.com/api/v3/coins/list"
 COINGECKO_LINK_PREFIX = "https://www.coingecko.com/en/coins/"
 DEPEG_THRESHOLD = 0.90
 MIN_PLAUSIBLE_STABLECOIN_RATE = 0.01
+MAX_SOURCE_CURRENCY_RATE_AGE_DAYS = 7
+NATIVE_RATE_CROSS_CHECK_RELATIVE_TOLERANCE = 0.02
 STABLECOIN_RATE_SOURCE_COINGECKO = "coingecko"
 
 _RATE_FIELDS = (
+    "source_currency",
+    "source_currency_source",
+    "source_currency_usd_rate",
+    "source_currency_usd_rate_date",
+    "source_currency_usd_rate_fetched_at",
+    "source_currency_usd_rate_source",
     "coingecko_id",
     "coingecko_link",
     "coingecko_id_source",
@@ -152,6 +168,26 @@ class StablecoinRateTarget:
     coingecko_id_verified_at: datetime.datetime | None
     coingecko_id_verification_failed_at: datetime.datetime | None
     coingecko_id_verification_failed_reason: str | None
+
+    #: Curated source currency ticker read from
+    #: :py:class:`eth_defi.stablecoin_metadata.StablecoinMetadata`.
+    source_currency: str | None
+
+    #: Source of ``source_currency``. Only ``manual`` values drive depeg checks.
+    source_currency_source: str | None
+
+    #: USD per one ``source_currency`` unit from the local currency database.
+    source_currency_usd_rate: float | None
+
+    #: Calendar date of ``source_currency_usd_rate``.
+    source_currency_usd_rate_date: datetime.date | None
+
+    #: Naive UTC timestamp when ``source_currency_usd_rate`` was read.
+    source_currency_usd_rate_fetched_at: datetime.datetime | None
+
+    #: Currency API source column used for ``source_currency_usd_rate``.
+    source_currency_usd_rate_source: str | None
+
     peg_currency: str | None
     usd_rate: float | None
     usd_rate_fetched_at: datetime.datetime | None
@@ -193,6 +229,22 @@ class StablecoinRateRefreshSummary:
     unactionable_depegged_count: int = 0
     skipped_missing_coingecko: int = 0
     skipped_unknown_peg: int = 0
+
+    #: Entries skipped because no source currency is known.
+    skipped_missing_source_currency: int = 0
+
+    #: Non-USD entries skipped because no usable currency database row existed.
+    skipped_missing_source_currency_rate: int = 0
+
+    #: Entries skipped because ``source_currency`` was not manually curated.
+    skipped_inferred_source_currency: int = 0
+
+    #: Source-currency FX rows accepted from the local currency database.
+    source_currency_rates_fetched: int = 0
+
+    #: Source-currency FX rows rejected because they were older than the allowed delay.
+    source_currency_rates_stale: int = 0
+
     failed_count: int = 0
     coingecko_ids_checked: int = 0
     coingecko_ids_valid: int = 0
@@ -200,13 +252,76 @@ class StablecoinRateRefreshSummary:
 
 
 @dataclass(slots=True)
-class DenominationTokenRate:
-    """Rate data section exported for a vault denomination token."""
+class SourceCurrencyRate:
+    """USD/source-currency rate read from the local currency DuckDB."""
 
+    #: Lower-case source currency ticker, e.g. ``eur`` or ``jpy``.
+    source_currency: str
+
+    #: USD per one ``source_currency`` unit.
+    usd_per_source_currency: float
+
+    #: Currency API calendar date for ``usd_per_source_currency``.
+    date: datetime.date
+
+    #: Currency API provider/source column.
+    source: str
+
+    #: ``True`` when the FX row is older than the accepted refresh delay.
+    is_stale: bool
+
+
+@dataclass(slots=True)
+class DenominationTokenRate:
+    """Rate data section exported for a vault denomination token.
+
+    This dataclass is returned by
+    :py:meth:`StablecoinRateFeeder.get_denomination_token_rate_section` and is
+    serialised by :py:func:`eth_defi.research.vault_metrics.export_lifetime_row`
+    for the ``denomination_token_rate`` field in lifetime metrics JSON output.
+    Source-currency values originate from
+    :py:class:`eth_defi.stablecoin_metadata.StablecoinMetadata` and are updated
+    by :py:func:`refresh_stablecoin_rates`.
+    """
+
+    #: CoinGecko coin id used to fetch ``usd_rate``.
     coingecko_id: str | None
+
+    #: Stablecoin source currency ticker, e.g. ``usd``, ``eur`` or ``jpy``.
+    source_currency: str | None
+
+    #: Latest token price in USD from CoinGecko.
     usd_rate: float | None
+
+    #: Naive UTC timestamp when ``usd_rate`` was fetched.
     usd_rate_fetched_at: datetime.datetime | None
+
+    #: Provider/source for ``usd_rate``. Currently ``coingecko`` when present.
     usd_rate_source: str | None
+
+    #: Latest token price in ``source_currency`` for non-USD stablecoins.
+    #:
+    #: This is omitted for ``source_currency == "usd"`` because ``usd_rate``
+    #: already carries the native value.
+    native_rate: float | None
+
+    #: Currency ticker for ``native_rate``. Populated only for non-USD source currencies.
+    native_rate_currency: str | None
+
+    #: Naive UTC timestamp for ``native_rate``. Matches ``usd_rate_fetched_at`` when populated.
+    native_rate_fetched_at: datetime.datetime | None
+
+    #: Provider chain for ``native_rate``, e.g. ``coingecko+fawazahmed0``.
+    native_rate_source: str | None
+
+    #: USD per one ``source_currency`` unit used to derive ``native_rate``.
+    source_currency_usd_rate: float | None
+
+    #: Naive UTC timestamp when ``source_currency_usd_rate`` was read from the currency database.
+    source_currency_usd_rate_fetched_at: datetime.datetime | None
+
+    #: Currency database provider/source for ``source_currency_usd_rate``.
+    source_currency_usd_rate_source: str | None
 
 
 @dataclass(slots=True)
@@ -237,7 +352,20 @@ class StablecoinRateFeeder:
         if normalised_symbol and normalised_symbol in self._rate_symbols:
             return self._rate_symbols[normalised_symbol]
 
-        return DenominationTokenRate(coingecko_id=None, usd_rate=None, usd_rate_fetched_at=None, usd_rate_source=None)
+        return DenominationTokenRate(
+            coingecko_id=None,
+            source_currency=None,
+            usd_rate=None,
+            usd_rate_fetched_at=None,
+            usd_rate_source=None,
+            native_rate=None,
+            native_rate_currency=None,
+            native_rate_fetched_at=None,
+            native_rate_source=None,
+            source_currency_usd_rate=None,
+            source_currency_usd_rate_fetched_at=None,
+            source_currency_usd_rate_source=None,
+        )
 
     @property
     def depegged_contracts(self) -> set[tuple[int, str]]:
@@ -401,12 +529,87 @@ def fetch_valid_coingecko_ids(coin_ids: Sequence[str], timeout: float = 20.0, pr
     return requested_ids & listed_ids
 
 
+def read_latest_usd_per_source_currency(
+    currency_db_path: Path,
+    source_currency: str,
+    coingecko_fetch_date: datetime.date,
+    source: str = SOURCE_NAME,
+    max_age_days: int = MAX_SOURCE_CURRENCY_RATE_AGE_DAYS,
+) -> SourceCurrencyRate | None:
+    """Read the latest USD/source-currency FX rate from local DuckDB.
+
+    The currency API database stores raw rows as ``quote`` units per one
+    ``base`` unit. With the production base ``usd`` this means, for example,
+    EUR rows are ``EUR per 1 USD``. Stablecoin depeg checks need USD per one
+    source-currency unit, so this helper inverts the stored raw rate.
+
+    :param currency_db_path:
+        DuckDB path populated by :mod:`eth_defi.currency_api`.
+    :param source_currency:
+        Lower-case source currency ticker, e.g. ``eur`` or ``jpy``.
+    :param coingecko_fetch_date:
+        Calendar date of the CoinGecko token price fetch.
+    :param source:
+        Currency API source column to read.
+    :param max_age_days:
+        Maximum allowed age between the token price date and FX row date.
+    :return:
+        USD per one source-currency unit, or ``None`` when no local row exists.
+    """
+    source_currency = source_currency.lower()
+    if source_currency == "usd":
+        return SourceCurrencyRate(
+            source_currency="usd",
+            usd_per_source_currency=1.0,
+            date=coingecko_fetch_date,
+            source=source,
+            is_stale=False,
+        )
+
+    db = CurrencyRateDatabase(currency_db_path)
+    try:
+        row = db.con.execute(
+            """
+            SELECT date, rate, source
+            FROM exchange_rates
+            WHERE base_currency = 'usd'
+              AND quote_currency = ?
+              AND source = ?
+              AND date <= ?
+            ORDER BY date DESC
+            LIMIT 1
+            """,
+            [source_currency, source, coingecko_fetch_date],
+        ).fetchone()
+    finally:
+        db.close()
+
+    if row is None:
+        return None
+
+    row_date, raw_rate, row_source = row
+    raw_rate_float = _parse_price(raw_rate)
+    if raw_rate_float is None:
+        return None
+
+    age_days = (coingecko_fetch_date - row_date).days
+    return SourceCurrencyRate(
+        source_currency=source_currency,
+        usd_per_source_currency=1.0 / raw_rate_float,
+        date=row_date,
+        source=row_source,
+        is_stale=age_days > max_age_days,
+    )
+
+
 def refresh_stablecoin_rates(
     data_dir: Path = STABLECOINS_DATA_DIR,
     now_: datetime.datetime | None = None,
     force: bool = False,
     timeout: float = 20.0,
     progress_bar: bool = False,
+    currency_db_path: Path | None = None,
+    currency_source: str = SOURCE_NAME,
 ) -> StablecoinRateRefreshSummary:
     """Refresh stablecoin rates and persist YAML metadata updates.
 
@@ -491,13 +694,60 @@ def refresh_stablecoin_rates(
             updates[(target.yaml_path, target.entry_index)] = _failure_update(now_, "coingecko_price_missing", target)
             continue
 
-        peg_currency = target.peg_currency
-        peg_rate = _parse_price(price_data.get(peg_currency)) if peg_currency else None
-        if peg_currency is None or peg_rate is None:
-            summary.skipped_unknown_peg += 1
-
         upstream_updated_at = _parse_upstream_timestamp(price_data.get("last_updated_at"))
-        update = _success_update(target, usd_rate, peg_rate, peg_currency if peg_rate is not None else None, upstream_updated_at, now_)
+        source_currency = target.source_currency
+        source_currency_rate: SourceCurrencyRate | None = None
+        peg_rate: float | None = None
+        peg_currency: str | None = None
+        rate_failure_reason: str | None = None
+
+        if not source_currency:
+            summary.skipped_missing_source_currency += 1
+            summary.skipped_unknown_peg += 1
+            rate_failure_reason = "missing_source_currency"
+        elif target.source_currency_source != "manual":
+            summary.skipped_inferred_source_currency += 1
+            summary.skipped_unknown_peg += 1
+            rate_failure_reason = "inferred_source_currency" if target.source_currency_source == "inferred" else "untrusted_source_currency"
+        elif source_currency == "usd":
+            source_currency_rate = SourceCurrencyRate(
+                source_currency="usd",
+                usd_per_source_currency=1.0,
+                date=now_.date(),
+                source=currency_source,
+                is_stale=False,
+            )
+            peg_rate = usd_rate
+            peg_currency = "usd"
+        elif currency_db_path is None:
+            summary.skipped_missing_source_currency_rate += 1
+            summary.skipped_unknown_peg += 1
+            summary.failed_count += 1
+            rate_failure_reason = "missing_source_currency_rate"
+        else:
+            source_currency_rate = read_latest_usd_per_source_currency(
+                currency_db_path=currency_db_path,
+                source_currency=source_currency,
+                coingecko_fetch_date=now_.date(),
+                source=currency_source,
+            )
+            if source_currency_rate is None:
+                summary.skipped_missing_source_currency_rate += 1
+                summary.skipped_unknown_peg += 1
+                summary.failed_count += 1
+                rate_failure_reason = "missing_source_currency_rate"
+            elif source_currency_rate.is_stale:
+                summary.source_currency_rates_stale += 1
+                summary.skipped_unknown_peg += 1
+                summary.failed_count += 1
+                rate_failure_reason = "stale_source_currency_rate"
+            else:
+                summary.source_currency_rates_fetched += 1
+                peg_rate = usd_rate / source_currency_rate.usd_per_source_currency
+                peg_currency = source_currency
+                _warn_on_native_rate_divergence(target, price_data, usd_rate, source_currency_rate)
+
+        update = _success_update(target, usd_rate, peg_rate, peg_currency, source_currency_rate, upstream_updated_at, now_, rate_failure_reason=rate_failure_reason)
 
         should_check_depeg = peg_rate is not None and target.category == "stablecoin"
         if should_check_depeg and _is_wrong_asset_guard_failure(target, peg_rate):
@@ -669,7 +919,8 @@ def apply_coingecko_mapping_file(data_dir: Path, mapping_path: Path, progress_ba
 
 def _build_target(yaml_path: Path, entry_index: int | None, slug: str, symbol: str, category: str, entry: dict[str, Any]) -> StablecoinRateTarget:
     coingecko_id, coingecko_link, coingecko_id_source = resolve_coingecko_metadata(entry)
-    peg_currency = _guess_peg_currency(symbol, f"{entry.get('name', '')} {entry.get('short_description', '')}")
+    source_currency = _clean_currency_code(entry.get("source_currency"))
+    source_currency_source = _clean_currency_code(entry.get("source_currency_source"))
     return StablecoinRateTarget(
         yaml_path=yaml_path,
         entry_index=entry_index,
@@ -683,7 +934,13 @@ def _build_target(yaml_path: Path, entry_index: int | None, slug: str, symbol: s
         coingecko_id_verified_at=_parse_datetime(entry.get("coingecko_id_verified_at")),
         coingecko_id_verification_failed_at=_parse_datetime(entry.get("coingecko_id_verification_failed_at")),
         coingecko_id_verification_failed_reason=_clean_string(entry.get("coingecko_id_verification_failed_reason")),
-        peg_currency=peg_currency,
+        source_currency=source_currency,
+        source_currency_source=source_currency_source,
+        source_currency_usd_rate=_parse_float(entry.get("source_currency_usd_rate")),
+        source_currency_usd_rate_date=_parse_date(entry.get("source_currency_usd_rate_date")),
+        source_currency_usd_rate_fetched_at=_parse_datetime(entry.get("source_currency_usd_rate_fetched_at")),
+        source_currency_usd_rate_source=_clean_string(entry.get("source_currency_usd_rate_source")),
+        peg_currency=source_currency,
         usd_rate=_parse_float(entry.get("usd_rate")),
         usd_rate_fetched_at=_parse_datetime(entry.get("usd_rate_fetched_at")),
         usd_rate_updated_at=_parse_datetime(entry.get("usd_rate_updated_at")),
@@ -757,12 +1014,28 @@ def _clean_coingecko_id(value: Any) -> str | None:
     return text.lower() if text else None
 
 
+def _clean_currency_code(value: Any) -> str | None:
+    """Return a lower-case source currency code."""
+    text = _clean_string(value)
+    return text.lower() if text else None
+
+
 def _parse_datetime(value: Any) -> datetime.datetime | None:
     text = _clean_string(value)
     if not text:
         return None
     try:
         return datetime.datetime.fromisoformat(text.replace("Z", ""))
+    except ValueError:
+        return None
+
+
+def _parse_date(value: Any) -> datetime.date | None:
+    text = _clean_string(value)
+    if not text:
+        return None
+    try:
+        return datetime.date.fromisoformat(text)
     except ValueError:
         return None
 
@@ -862,10 +1135,18 @@ def _success_update(
     usd_rate: float,
     peg_rate: float | None,
     peg_currency: str | None,
+    source_currency_rate: SourceCurrencyRate | None,
     upstream_updated_at: datetime.datetime | None,
     now_: datetime.datetime,
+    rate_failure_reason: str | None = None,
 ) -> dict[str, Any]:
     update: dict[str, Any] = {
+        "source_currency": target.source_currency or "",
+        "source_currency_source": target.source_currency_source or "",
+        "source_currency_usd_rate": source_currency_rate.usd_per_source_currency if source_currency_rate is not None else "",
+        "source_currency_usd_rate_date": source_currency_rate.date if source_currency_rate is not None else "",
+        "source_currency_usd_rate_fetched_at": now_ if source_currency_rate is not None else "",
+        "source_currency_usd_rate_source": source_currency_rate.source if source_currency_rate is not None else "",
         "coingecko_id": target.coingecko_id or "",
         "coingecko_link": target.coingecko_link or (f"{COINGECKO_LINK_PREFIX}{target.coingecko_id}" if target.coingecko_id else ""),
         "coingecko_id_source": target.coingecko_id_source or "",
@@ -877,8 +1158,8 @@ def _success_update(
         "usd_rate_updated_at": upstream_updated_at,
         "peg_rate": peg_rate,
         "peg_rate_currency": peg_currency or "",
-        "rate_fetch_failed_at": "",
-        "rate_fetch_failed_reason": "",
+        "rate_fetch_failed_at": now_ if rate_failure_reason else "",
+        "rate_fetch_failed_reason": rate_failure_reason or "",
         "depegged_at": target.depegged_at,
     }
     return update
@@ -933,12 +1214,52 @@ def _target_is_actionable(target: StablecoinRateTarget) -> bool:
     return target.entry_index is None and bool(normalise_token_symbol(target.symbol))
 
 
+def _warn_on_native_rate_divergence(target: StablecoinRateTarget, price_data: dict[str, Any], usd_rate: float, source_currency_rate: SourceCurrencyRate) -> None:
+    """Warn if CoinGecko native and locally-derived native rates materially diverge."""
+    if source_currency_rate.source_currency == "usd":
+        return
+
+    native_rate = _parse_price(price_data.get(source_currency_rate.source_currency))
+    if native_rate is None:
+        return
+
+    implied_usd_rate = native_rate * source_currency_rate.usd_per_source_currency
+    relative_diff = abs(usd_rate - implied_usd_rate) / usd_rate
+    if relative_diff > NATIVE_RATE_CROSS_CHECK_RELATIVE_TOLERANCE:
+        logger.warning(
+            "Stablecoin native rate cross-check diverged for %s/%s: usd_rate=%s source_currency=%s native_rate=%s source_currency_usd_rate=%s relative_diff=%s",
+            target.slug,
+            target.name,
+            usd_rate,
+            source_currency_rate.source_currency,
+            native_rate,
+            source_currency_rate.usd_per_source_currency,
+            relative_diff,
+        )
+
+
 def _target_to_denomination_rate(target: StablecoinRateTarget) -> DenominationTokenRate:
+    native_rate_source = None
+    has_native_rate = target.peg_rate is not None and target.peg_rate_currency != "usd"
+    if has_native_rate:
+        if target.source_currency_usd_rate_source:
+            native_rate_source = f"{STABLECOIN_RATE_SOURCE_COINGECKO}+{target.source_currency_usd_rate_source}"
+        else:
+            native_rate_source = STABLECOIN_RATE_SOURCE_COINGECKO
+
     return DenominationTokenRate(
         coingecko_id=target.coingecko_id,
+        source_currency=target.source_currency,
         usd_rate=target.usd_rate,
         usd_rate_fetched_at=target.usd_rate_fetched_at,
         usd_rate_source=STABLECOIN_RATE_SOURCE_COINGECKO if target.usd_rate is not None else None,
+        native_rate=target.peg_rate if has_native_rate else None,
+        native_rate_currency=target.peg_rate_currency if has_native_rate else None,
+        native_rate_fetched_at=target.usd_rate_fetched_at if has_native_rate else None,
+        native_rate_source=native_rate_source,
+        source_currency_usd_rate=target.source_currency_usd_rate,
+        source_currency_usd_rate_fetched_at=target.source_currency_usd_rate_fetched_at,
+        source_currency_usd_rate_source=target.source_currency_usd_rate_source,
     )
 
 
@@ -975,6 +1296,8 @@ def _format_yaml_value(value: Any) -> str:
         return "''"
     if isinstance(value, datetime.datetime):
         return f"'{_format_datetime(value)}'"
+    if isinstance(value, datetime.date):
+        return f"'{value.isoformat()}'"
     if isinstance(value, float):
         return f"{value:.12g}"
     if isinstance(value, int):

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -1920,6 +1920,12 @@ def calculate_lifetime_metrics(
 
     Lookback based on the last entry.
 
+    Each output row contains a ``denomination_token_rate`` value produced by
+    :py:meth:`eth_defi.feed.stablecoin_rate.StablecoinRateFeeder.get_denomination_token_rate_section`.
+    The value is a :py:class:`eth_defi.feed.stablecoin_rate.DenominationTokenRate`
+    carrying both USD rate fields and, for non-USD stablecoins, native source
+    currency rate fields.
+
     :param df:
         Cleaned price DataFrame conforming to
         :py:class:`~eth_defi.research.wrangle_vault_prices.CleanedVaultPriceRow`.
@@ -3141,11 +3147,17 @@ def display_vault_chart_and_tearsheet(
 
 
 def export_lifetime_row(row: pd.Series) -> dict:
-    """Export lifetime metrics row to a fully JSON-serializable dict.
+    """Export lifetime metrics row to a fully JSON-serialisable dict.
 
     - Recursively handles nested dicts, lists, tuples, sets, and dataclasses.
-    - Normalizes pandas, numpy, datetime, and custom types.
+    - Normalises pandas, numpy, datetime, and custom types.
     - Preserves legacy fee field names.
+
+    The ``denomination_token_rate`` dataclass from
+    :py:class:`eth_defi.feed.stablecoin_rate.DenominationTokenRate` is converted
+    to JSON fields here. This includes ``usd_rate``/``usd_rate_fetched_at`` for
+    all stablecoins and ``native_rate``/``native_rate_fetched_at`` only when the
+    native source currency is not USD.
     """
 
     def _serialize(value):

--- a/eth_defi/stablecoin_metadata.py
+++ b/eth_defi/stablecoin_metadata.py
@@ -85,6 +85,17 @@ Files come in two shapes: *standard* (one project per symbol) and *entries*
     contract_addresses:                   # known on-chain deployments
       - chain: ethereum                   # chain slug (ethereum, arbitrum, base, …)
         address: '0xA0b8...'             # checksummed ERC-20 address
+    source_currency: usd                  # nominal currency this token tracks, e.g. usd, eur, jpy
+    source_currency_source: manual        # manual values can drive depeg checks; inferred/empty values cannot
+    source_currency_usd_rate: 1.0         # USD per one source-currency unit used for native depeg checks
+    source_currency_usd_rate_date: '2026-06-26'  # currency API calendar date for the FX rate
+    source_currency_usd_rate_fetched_at: '2026-06-26T12:00:00'  # when our updater read the FX rate
+    source_currency_usd_rate_source: fawazahmed0 # currency API source column for the FX rate
+    usd_rate: 0.9998                      # latest token price in USD from CoinGecko
+    usd_rate_fetched_at: '2026-06-26T12:00:00' # when our updater fetched the USD rate
+    peg_rate: 0.9998                      # latest token price in source_currency units
+    peg_rate_currency: usd                # currency key used for the native depeg check
+    depegged_at: ''                       # sticky depeg marker, manually cleared by operators
     checks:                               # automated liveness checks (omitted if checks not run yet)
       twitter_last_post_at: '2026-03-17' # YYYY-MM-DD of most recent post, or empty string
       domain_up_at: '2026-03-17'         # YYYY-MM-DD when homepage last responded, or empty string
@@ -113,6 +124,17 @@ The top level holds only ``symbol``, ``slug``, ``category``, and optionally
         contract_addresses:
           - chain: ethereum
             address: '0x09D4...'
+        source_currency: usd
+        source_currency_source: manual
+        source_currency_usd_rate: 1.0
+        source_currency_usd_rate_date: '2026-06-26'
+        source_currency_usd_rate_fetched_at: '2026-06-26T12:00:00'
+        source_currency_usd_rate_source: fawazahmed0
+        usd_rate: 0.9998
+        usd_rate_fetched_at: '2026-06-26T12:00:00'
+        peg_rate: 0.9998
+        peg_rate_currency: usd
+        depegged_at: ''
         checks:
           twitter_last_post_at: ''
           domain_up_at: '2026-03-17'
@@ -508,6 +530,43 @@ class StablecoinMetadata(TypedDict):
     #: Automated liveness checks (``None`` if checks have not been run yet)
     checks: StablecoinChecks | None
 
+    #: Source currency this stablecoin is intended to track, e.g. ``usd`` or ``eur``.
+    #:
+    #: Used by :py:func:`eth_defi.feed.stablecoin_rate.refresh_stablecoin_rates`
+    #: to choose the native depeg-check currency and exported through
+    #: :py:func:`build_stablecoin_metadata_json`.
+    source_currency: str | None
+
+    #: How ``source_currency`` was selected, e.g. ``manual``.
+    #:
+    #: Only manually curated values are allowed to drive depeg decisions in
+    #: :py:func:`eth_defi.feed.stablecoin_rate.refresh_stablecoin_rates`.
+    source_currency_source: str | None
+
+    #: USD per one source-currency unit used for native depeg checks.
+    #:
+    #: For non-USD stablecoins this is read from
+    #: :py:class:`eth_defi.currency_api.database.CurrencyRateDatabase` by
+    #: :py:func:`eth_defi.feed.stablecoin_rate.refresh_stablecoin_rates`.
+    source_currency_usd_rate: float | None
+
+    #: Calendar date of the source-currency FX rate.
+    #:
+    #: Rows older than the refresh policy are ignored by
+    #: :py:func:`eth_defi.feed.stablecoin_rate.read_latest_usd_per_source_currency`.
+    source_currency_usd_rate_date: ISODateString | None
+
+    #: Time when the source-currency FX rate was read by our updater.
+    #:
+    #: Exported as an ISO timestamp by :py:func:`build_stablecoin_metadata_json`.
+    source_currency_usd_rate_fetched_at: ISODateTimeString | None
+
+    #: Provider/source for the source-currency FX rate.
+    #:
+    #: Matches the currency API source column selected by
+    #: :py:func:`eth_defi.feed.stablecoin_rate.refresh_stablecoin_rates`.
+    source_currency_usd_rate_source: str | None
+
     #: CoinGecko API coin id used for price refreshes.
     coingecko_id: str | None
 
@@ -720,6 +779,11 @@ def get_stablecoin_available_logos(slug: str) -> dict[str, bool]:
 def build_stablecoin_metadata_json(yaml_path: Path, public_url: str = "") -> list[StablecoinMetadata]:
     """Build StablecoinMetadata list from a YAML file.
 
+    The returned dictionaries expose the public
+    :py:class:`StablecoinMetadata` JSON contract, including source-currency
+    fields maintained by
+    :py:func:`eth_defi.feed.stablecoin_rate.refresh_stablecoin_rates`.
+
     :param yaml_path:
         Path to the stablecoin metadata YAML file
 
@@ -727,7 +791,7 @@ def build_stablecoin_metadata_json(yaml_path: Path, public_url: str = "") -> lis
         Public base URL for constructing logo URLs (e.g. ``https://pub-xyz.r2.dev``)
 
     :return:
-        List of StablecoinMetadata dicts ready for JSON export
+        List of :py:class:`StablecoinMetadata` dicts ready for JSON export.
     """
     data = read_stablecoin_metadata(yaml_path)
     symbol = data["symbol"]
@@ -753,6 +817,12 @@ def build_stablecoin_metadata_json(yaml_path: Path, public_url: str = "") -> lis
 
     def parse_rate_fields(source: dict) -> dict[str, str | float | None]:
         return {
+            "source_currency": normalise(source.get("source_currency")),
+            "source_currency_source": normalise(source.get("source_currency_source")),
+            "source_currency_usd_rate": normalise_float(source.get("source_currency_usd_rate")),
+            "source_currency_usd_rate_date": normalise(source.get("source_currency_usd_rate_date")),
+            "source_currency_usd_rate_fetched_at": normalise(source.get("source_currency_usd_rate_fetched_at")),
+            "source_currency_usd_rate_source": normalise(source.get("source_currency_usd_rate_source")),
             "coingecko_id": normalise(source.get("coingecko_id")),
             "coingecko_link": normalise(source.get("coingecko_link")),
             "coingecko_id_source": normalise(source.get("coingecko_id_source")),

--- a/scripts/erc-4626/populate-stablecoin-rates.py
+++ b/scripts/erc-4626/populate-stablecoin-rates.py
@@ -10,6 +10,8 @@ Environment variables:
 - ``FORCE``: Optional. Set to ``true`` to bypass per-entry daily gates.
 - ``STABLECOIN_RATE_TIMEOUT``: Optional. CoinGecko timeout in seconds. Default: 20.
 - ``COINGECKO_ID_MAPPING_FILE``: Optional. JSON file with explicit id mappings.
+- ``CURRENCY_API_DB_PATH`` / ``CURRENCY_API_DATABASE_PATH``: Optional. Local FX DuckDB path for non-USD source-currency rates.
+- ``CURRENCY_API_SOURCE``: Optional. FX source column. Default: fawazahmed0.
 - ``COINGECKO_DEMO_API_KEY``: Optional. CoinGecko demo API key read by the rate module.
 - ``PROGRESS``: Optional. Set to ``false`` to hide tqdm progress bars. Default: true.
 - ``LOG_LEVEL``: Optional. Default: info.
@@ -22,6 +24,7 @@ from pathlib import Path
 
 from tabulate import tabulate
 
+from eth_defi.currency_api.constants import SOURCE_NAME
 from eth_defi.feed.stablecoin_rate import apply_coingecko_mapping_file, iter_stablecoin_rate_targets, refresh_stablecoin_rates
 from eth_defi.stablecoin_metadata import STABLECOINS_DATA_DIR
 from eth_defi.utils import setup_console_logging
@@ -49,12 +52,17 @@ def main() -> int:
     force = _env_bool("FORCE")
     progress_bar = _env_bool("PROGRESS", default=True)
     timeout = float(os.environ.get("STABLECOIN_RATE_TIMEOUT", "20"))
+    currency_db_path_raw = os.environ.get("CURRENCY_API_DB_PATH") or os.environ.get("CURRENCY_API_DATABASE_PATH")
+    currency_db_path = Path(currency_db_path_raw).expanduser() if currency_db_path_raw else None
+    currency_source = os.environ.get("CURRENCY_API_SOURCE", SOURCE_NAME)
 
     logger.info("Starting stablecoin rate population")
     logger.info("Stablecoin data directory: %s", data_dir)
     logger.info("Force refresh: %s", force)
     logger.info("CoinGecko timeout: %.1f seconds", timeout)
     logger.info("Progress bars: %s", progress_bar)
+    logger.info("Currency API database: %s", currency_db_path)
+    logger.info("Currency API source: %s", currency_source)
 
     mapping_path_raw = os.environ.get("COINGECKO_ID_MAPPING_FILE")
     mappings_applied = 0
@@ -70,6 +78,8 @@ def main() -> int:
         force=force,
         timeout=timeout,
         progress_bar=progress_bar,
+        currency_db_path=currency_db_path,
+        currency_source=currency_source,
     )
     logger.info(
         "Stablecoin rate population finished: files_scanned=%d entries_seen=%d rates_fetched=%d files_updated=%d failures=%d depegged=%d",
@@ -95,6 +105,11 @@ def main() -> int:
         ["Unactionable depegged", summary.unactionable_depegged_count],
         ["Missing CoinGecko ids", summary.skipped_missing_coingecko],
         ["Unknown pegs", summary.skipped_unknown_peg],
+        ["Missing source currency", summary.skipped_missing_source_currency],
+        ["Missing source currency rate", summary.skipped_missing_source_currency_rate],
+        ["Inferred source currency skipped", summary.skipped_inferred_source_currency],
+        ["Source currency rates fetched", summary.source_currency_rates_fetched],
+        ["Source currency rates stale", summary.source_currency_rates_stale],
         ["Failures", summary.failed_count],
     ]
     print(tabulate(rows, headers=["Metric", "Value"], tablefmt="fancy_grid"))

--- a/scripts/erc-4626/scan-vault-posts.py
+++ b/scripts/erc-4626/scan-vault-posts.py
@@ -51,6 +51,8 @@ Environment variables:
 - ``STABLECOIN_RATE_TIMEOUT``: Optional. CoinGecko timeout. Default: 20.
 - ``STABLECOIN_DATA_DIR``: Optional. Stablecoin YAML directory.
 - ``STABLECOIN_RATE_GATE_PATH``: Optional. Durable stablecoin refresh gate JSON path.
+- ``CURRENCY_API_DB_PATH`` / ``CURRENCY_API_DATABASE_PATH``: Optional. Local FX DuckDB path for non-USD stablecoin depeg checks.
+- ``CURRENCY_API_SOURCE``: Optional. FX source column. Default: fawazahmed0.
 - ``COINGECKO_DEMO_API_KEY``: Optional. CoinGecko demo API key used by the rate module.
 """
 
@@ -61,6 +63,7 @@ from pathlib import Path
 
 from tabulate import tabulate
 
+from eth_defi.currency_api.constants import SOURCE_NAME
 from eth_defi.feed.constants import DEFAULT_X_LIST_NAME
 from eth_defi.feed.database import DEFAULT_VAULT_POST_DATABASE
 from eth_defi.feed.scanner import PostScanConfig, run_post_scan_cycle
@@ -206,6 +209,7 @@ def _build_config() -> PostScanConfig:
     mappings_dir_str = os.environ.get("MAPPINGS_DIR")
     stablecoin_data_dir_str = os.environ.get("STABLECOIN_DATA_DIR")
     stablecoin_rate_gate_path_str = os.environ.get("STABLECOIN_RATE_GATE_PATH")
+    currency_api_db_path_str = os.environ.get("CURRENCY_API_DB_PATH") or os.environ.get("CURRENCY_API_DATABASE_PATH")
     limit_str = os.environ.get("LIMIT")
 
     return PostScanConfig(
@@ -236,6 +240,8 @@ def _build_config() -> PostScanConfig:
         stablecoin_data_dir=Path(stablecoin_data_dir_str).expanduser() if stablecoin_data_dir_str else STABLECOINS_DATA_DIR,
         stablecoin_rate_timeout=float(os.environ.get("STABLECOIN_RATE_TIMEOUT", "20")),
         stablecoin_rate_gate_path=Path(stablecoin_rate_gate_path_str).expanduser() if stablecoin_rate_gate_path_str else None,
+        currency_api_db_path=Path(currency_api_db_path_str).expanduser() if currency_api_db_path_str else None,
+        currency_api_source=os.environ.get("CURRENCY_API_SOURCE", SOURCE_NAME),
     )
 
 

--- a/tests/feed/test_stablecoin_rate.py
+++ b/tests/feed/test_stablecoin_rate.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import pytest
 
+from eth_defi.currency_api.client import DateRates
+from eth_defi.currency_api.database import CurrencyRateDatabase
 from eth_defi.feed import stablecoin_rate
 from eth_defi.feed.stablecoin_rate import StablecoinRateFeeder, build_depegged_stablecoin_lookups, iter_stablecoin_rate_targets, refresh_stablecoin_rates
 from eth_defi.stablecoin_metadata import build_stablecoin_metadata_json
@@ -55,6 +57,8 @@ name: Circle USDC
 short_description: USD Coin
 long_description: ''
 category: stablecoin
+source_currency: usd
+source_currency_source: manual
 links:
   homepage: https://www.circle.com/usdc
   coingecko: https://www.coingecko.com/en/coins/usd-coin
@@ -84,6 +88,8 @@ entries:
 - name: Stables Labs USDX
   short_description: Stables Labs USDX
   long_description: ''
+  source_currency: usd
+  source_currency_source: manual
   coingecko_id: usdx-money-usdx
   coingecko_link: https://www.coingecko.com/en/coins/usdx-money-usdx
   coingecko_id_source: manual
@@ -100,6 +106,8 @@ entries:
 - name: Kava USDX
   short_description: Kava USDX
   long_description: ''
+  source_currency: usd
+  source_currency_source: manual
   coingecko_id: usdx
   coingecko_link: https://www.coingecko.com/en/coins/usdx
   coingecko_id_source: manual
@@ -124,6 +132,7 @@ slug: usdx
 
 def _write_fiat_stablecoin_yaml(data_dir: Path, symbol: str, name: str, coingecko_id: str) -> Path:
     """Create a minimal non-USD fiat stablecoin YAML file."""
+    source_currency = stablecoin_rate._guess_peg_currency(symbol, name)
     yaml_path = data_dir / f"{symbol.lower()}.yaml"
     yaml_path.write_text(
         f"""symbol: {symbol}
@@ -131,6 +140,8 @@ name: {name}
 short_description: {name}
 long_description: ''
 category: stablecoin
+source_currency: {source_currency}
+source_currency_source: manual
 coingecko_id: {coingecko_id}
 coingecko_link: https://www.coingecko.com/en/coins/{coingecko_id}
 coingecko_id_source: manual
@@ -148,6 +159,23 @@ checks:
 """
     )
     return yaml_path
+
+
+def _write_currency_rate_db(path: Path, date: datetime.date, quote_currency: str, usd_per_source_currency: float) -> None:
+    """Create a temporary currency API DuckDB with one USD/source FX row."""
+    db = CurrencyRateDatabase(path)
+    try:
+        db.upsert_rates(
+            DateRates(
+                date=date,
+                base_currency="usd",
+                source="fawazahmed0",
+                rows=[(quote_currency, 1.0 / usd_per_source_currency)],
+            )
+        )
+        db.save()
+    finally:
+        db.close()
 
 
 def test_refresh_stablecoin_rates_updates_usdc_happy_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -194,6 +222,12 @@ def test_refresh_stablecoin_rates_updates_usdc_happy_path(tmp_path: Path, monkey
     assert target.depegged_at is None
 
     metadata = build_stablecoin_metadata_json(tmp_path / "usdc.yaml")[0]
+    assert metadata["source_currency"] == "usd"
+    assert metadata["source_currency_source"] == "manual"
+    assert metadata["source_currency_usd_rate"] == pytest.approx(1.0)
+    assert metadata["source_currency_usd_rate_date"] == "2026-06-26"
+    assert metadata["source_currency_usd_rate_fetched_at"] == "2026-06-26T12:00:00"
+    assert metadata["source_currency_usd_rate_source"] == "fawazahmed0"
     assert metadata["coingecko_id"] == "usd-coin"
     assert metadata["usd_rate"] == pytest.approx(0.9998)
     assert metadata["usd_rate_fetched_at"] == "2026-06-26T12:00:00"
@@ -201,9 +235,17 @@ def test_refresh_stablecoin_rates_updates_usdc_happy_path(tmp_path: Path, monkey
     feeder = StablecoinRateFeeder(data_dir=tmp_path)
     rate = feeder.get_denomination_token_rate_section(1, USDC_ADDRESS, "USDC")
     assert rate.coingecko_id == "usd-coin"
+    assert rate.source_currency == "usd"
     assert rate.usd_rate == pytest.approx(0.9998)
     assert rate.usd_rate_fetched_at == now_
     assert rate.usd_rate_source == "coingecko"
+    assert rate.native_rate is None
+    assert rate.native_rate_currency is None
+    assert rate.native_rate_fetched_at is None
+    assert rate.native_rate_source is None
+    assert rate.source_currency_usd_rate == pytest.approx(1.0)
+    assert rate.source_currency_usd_rate_fetched_at == now_
+    assert rate.source_currency_usd_rate_source == "fawazahmed0"
     assert feeder.is_depegged_stablecoin_token(1, USDC_ADDRESS, "USDC") is False
 
 
@@ -245,7 +287,10 @@ def test_refresh_stablecoin_rates_marks_usdx_depegged(tmp_path: Path, monkeypatc
 
     rate = feeder.get_denomination_token_rate_section(2222, USDX_ADDRESS, "USDX")
     assert rate.coingecko_id == "usdx"
+    assert rate.source_currency == "usd"
     assert rate.usd_rate == pytest.approx(0.646809)
+    assert rate.native_rate is None
+    assert rate.native_rate_currency is None
     assert rate.usd_rate_source == "coingecko"
 
 
@@ -356,6 +401,8 @@ name: Acala Dollar
 short_description: Acala Dollar
 long_description: ''
 category: stablecoin
+source_currency: usd
+source_currency_source: manual
 coingecko_id: acala-dollar
 coingecko_link: https://www.coingecko.com/en/coins/acala-dollar
 coingecko_id_source: url
@@ -434,6 +481,8 @@ name: Circle USDC
 short_description: USD Coin
 long_description: ''
 category: stablecoin
+source_currency: usd
+source_currency_source: manual
 coingecko_id: USD-COIN
 coingecko_link: ''
 coingecko_id_source: manual
@@ -536,6 +585,8 @@ def test_non_usd_fiat_stablecoins_compare_against_their_peg_currency(
 ) -> None:
     """Non-USD fiat stablecoins do not depeg merely because their USD price is below one."""
     _write_fiat_stablecoin_yaml(tmp_path, symbol, name, coingecko_id)
+    currency_db_path = tmp_path / "exchange-rates.duckdb"
+    _write_currency_rate_db(currency_db_path, datetime.date(2026, 6, 26), peg_currency, usd_rate)
 
     def fake_get(url: str, params: dict[str, str], headers: dict[str, str], timeout: float) -> DummyCoinGeckoResponse:
         if url == stablecoin_rate.COINGECKO_COINS_LIST_URL:
@@ -550,7 +601,7 @@ def test_non_usd_fiat_stablecoins_compare_against_their_peg_currency(
     monkeypatch.setattr(stablecoin_rate.requests, "get", fake_get)
     now_ = datetime.datetime(2026, 6, 26, 12, 0, 0)
 
-    summary = refresh_stablecoin_rates(data_dir=tmp_path, now_=now_, force=True)
+    summary = refresh_stablecoin_rates(data_dir=tmp_path, now_=now_, force=True, currency_db_path=currency_db_path)
 
     assert summary.failed_count == 0
     assert summary.depegged_count == 0
@@ -558,6 +609,170 @@ def test_non_usd_fiat_stablecoins_compare_against_their_peg_currency(
     assert target.usd_rate == pytest.approx(usd_rate)
     assert target.peg_rate == pytest.approx(1.0)
     assert target.peg_rate_currency == peg_currency
+    assert target.source_currency == peg_currency
+    assert target.source_currency_usd_rate == pytest.approx(usd_rate)
+    assert target.source_currency_usd_rate_date == datetime.date(2026, 6, 26)
+    assert target.depegged_at is None
+
+
+def test_eur_stablecoin_depegs_against_native_currency_from_duckdb(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """EUR stablecoin at 1.00 USD depegs because it is below 0.90 EUR."""
+    _write_fiat_stablecoin_yaml(tmp_path, "EURe", "Monerium EUR emoney", "monerium-eur-money")
+    currency_db_path = tmp_path / "exchange-rates.duckdb"
+    _write_currency_rate_db(currency_db_path, datetime.date(2026, 6, 26), "eur", 1.137211905985)
+
+    def fake_get(url: str, params: dict[str, str], headers: dict[str, str], timeout: float) -> DummyCoinGeckoResponse:
+        if url == stablecoin_rate.COINGECKO_COINS_LIST_URL:
+            return DummyCoinGeckoResponse([{"id": "monerium-eur-money"}])
+        assert url == stablecoin_rate.COINGECKO_SIMPLE_PRICE_URL
+        assert set(params["vs_currencies"].split(",")) == {"usd", "eur"}
+        assert isinstance(headers, dict)
+        assert timeout > 0
+        return DummyCoinGeckoResponse({"monerium-eur-money": {"usd": 1.0, "eur": 0.87934359, "last_updated_at": 1782464168}})
+
+    monkeypatch.setattr(stablecoin_rate.requests, "get", fake_get)
+    now_ = datetime.datetime(2026, 6, 26, 12, 0, 0)
+
+    summary = refresh_stablecoin_rates(data_dir=tmp_path, now_=now_, force=True, currency_db_path=currency_db_path)
+
+    assert summary.failed_count == 0
+    assert summary.depegged_count == 1
+    target = next(iter_stablecoin_rate_targets(tmp_path))
+    assert target.usd_rate == pytest.approx(1.0)
+    assert target.peg_rate == pytest.approx(0.87934359)
+    assert target.peg_rate_currency == "eur"
+    assert target.depegged_at == now_
+
+    feeder = StablecoinRateFeeder(data_dir=tmp_path)
+    rate = feeder.get_denomination_token_rate_section(None, None, "EURe")
+    assert rate.usd_rate == pytest.approx(1.0)
+    assert rate.usd_rate_fetched_at == now_
+    assert rate.native_rate == pytest.approx(0.87934359)
+    assert rate.native_rate_currency == "eur"
+    assert rate.native_rate_fetched_at == now_
+    assert rate.native_rate_source == "coingecko+fawazahmed0"
+
+
+def test_non_usd_stablecoin_missing_fx_rate_skips_depeg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing DuckDB FX rows keep USD price but skip native depeg checks."""
+    _write_fiat_stablecoin_yaml(tmp_path, "EURe", "Monerium EUR emoney", "monerium-eur-money")
+    currency_db_path = tmp_path / "exchange-rates.duckdb"
+    CurrencyRateDatabase(currency_db_path).close()
+
+    def fake_get(url: str, params: dict[str, str], headers: dict[str, str], timeout: float) -> DummyCoinGeckoResponse:
+        if url == stablecoin_rate.COINGECKO_COINS_LIST_URL:
+            return DummyCoinGeckoResponse([{"id": "monerium-eur-money"}])
+        assert url == stablecoin_rate.COINGECKO_SIMPLE_PRICE_URL
+        assert isinstance(params, dict)
+        assert isinstance(headers, dict)
+        assert timeout > 0
+        return DummyCoinGeckoResponse({"monerium-eur-money": {"usd": 1.0, "eur": 0.87934359, "last_updated_at": 1782464168}})
+
+    monkeypatch.setattr(stablecoin_rate.requests, "get", fake_get)
+    now_ = datetime.datetime(2026, 6, 26, 12, 0, 0)
+
+    summary = refresh_stablecoin_rates(data_dir=tmp_path, now_=now_, force=True, currency_db_path=currency_db_path)
+
+    assert summary.rates_fetched == 1
+    assert summary.failed_count == 1
+    assert summary.skipped_missing_source_currency_rate == 1
+    assert summary.depegged_count == 0
+    target = next(iter_stablecoin_rate_targets(tmp_path))
+    assert target.usd_rate == pytest.approx(1.0)
+    assert target.peg_rate is None
+    assert target.peg_rate_currency is None
+    assert target.rate_fetch_failed_reason == "missing_source_currency_rate"
+    assert target.depegged_at is None
+
+
+def test_non_usd_stablecoin_stale_fx_rate_skips_depeg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """FX rows older than one week are stale and do not drive depeg checks."""
+    _write_fiat_stablecoin_yaml(tmp_path, "EURe", "Monerium EUR emoney", "monerium-eur-money")
+    currency_db_path = tmp_path / "exchange-rates.duckdb"
+    _write_currency_rate_db(currency_db_path, datetime.date(2026, 6, 18), "eur", 1.137211905985)
+
+    def fake_get(url: str, params: dict[str, str], headers: dict[str, str], timeout: float) -> DummyCoinGeckoResponse:
+        if url == stablecoin_rate.COINGECKO_COINS_LIST_URL:
+            return DummyCoinGeckoResponse([{"id": "monerium-eur-money"}])
+        assert url == stablecoin_rate.COINGECKO_SIMPLE_PRICE_URL
+        assert isinstance(params, dict)
+        assert isinstance(headers, dict)
+        assert timeout > 0
+        return DummyCoinGeckoResponse({"monerium-eur-money": {"usd": 1.0, "eur": 0.87934359, "last_updated_at": 1782464168}})
+
+    monkeypatch.setattr(stablecoin_rate.requests, "get", fake_get)
+    now_ = datetime.datetime(2026, 6, 26, 12, 0, 0)
+
+    summary = refresh_stablecoin_rates(data_dir=tmp_path, now_=now_, force=True, currency_db_path=currency_db_path)
+
+    assert summary.failed_count == 1
+    assert summary.source_currency_rates_stale == 1
+    assert summary.depegged_count == 0
+    target = next(iter_stablecoin_rate_targets(tmp_path))
+    assert target.usd_rate == pytest.approx(1.0)
+    assert target.peg_rate is None
+    assert target.peg_rate_currency is None
+    assert target.rate_fetch_failed_reason == "stale_source_currency_rate"
+    assert target.depegged_at is None
+
+
+def test_inferred_source_currency_skips_depeg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Heuristic source-currency values are review-only until promoted to manual."""
+    _write_fiat_stablecoin_yaml(tmp_path, "EURe", "Monerium EUR emoney", "monerium-eur-money")
+    stablecoin_rate._update_yaml_entry_fields(tmp_path / "eure.yaml", None, {"source_currency_source": "inferred"})
+    currency_db_path = tmp_path / "exchange-rates.duckdb"
+    _write_currency_rate_db(currency_db_path, datetime.date(2026, 6, 26), "eur", 1.137211905985)
+
+    def fake_get(url: str, params: dict[str, str], headers: dict[str, str], timeout: float) -> DummyCoinGeckoResponse:
+        if url == stablecoin_rate.COINGECKO_COINS_LIST_URL:
+            return DummyCoinGeckoResponse([{"id": "monerium-eur-money"}])
+        assert url == stablecoin_rate.COINGECKO_SIMPLE_PRICE_URL
+        assert isinstance(params, dict)
+        assert isinstance(headers, dict)
+        assert timeout > 0
+        return DummyCoinGeckoResponse({"monerium-eur-money": {"usd": 1.0, "eur": 0.87934359, "last_updated_at": 1782464168}})
+
+    monkeypatch.setattr(stablecoin_rate.requests, "get", fake_get)
+    now_ = datetime.datetime(2026, 6, 26, 12, 0, 0)
+
+    summary = refresh_stablecoin_rates(data_dir=tmp_path, now_=now_, force=True, currency_db_path=currency_db_path)
+
+    assert summary.skipped_inferred_source_currency == 1
+    assert summary.depegged_count == 0
+    target = next(iter_stablecoin_rate_targets(tmp_path))
+    assert target.usd_rate == pytest.approx(1.0)
+    assert target.peg_rate is None
+    assert target.rate_fetch_failed_reason == "inferred_source_currency"
+    assert target.depegged_at is None
+
+
+def test_empty_source_currency_source_skips_depeg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Source currency without manual provenance is not trusted for depeg stamping."""
+    _write_fiat_stablecoin_yaml(tmp_path, "EURe", "Monerium EUR emoney", "monerium-eur-money")
+    stablecoin_rate._update_yaml_entry_fields(tmp_path / "eure.yaml", None, {"source_currency_source": ""})
+    currency_db_path = tmp_path / "exchange-rates.duckdb"
+    _write_currency_rate_db(currency_db_path, datetime.date(2026, 6, 26), "eur", 1.137211905985)
+
+    def fake_get(url: str, params: dict[str, str], headers: dict[str, str], timeout: float) -> DummyCoinGeckoResponse:
+        if url == stablecoin_rate.COINGECKO_COINS_LIST_URL:
+            return DummyCoinGeckoResponse([{"id": "monerium-eur-money"}])
+        assert url == stablecoin_rate.COINGECKO_SIMPLE_PRICE_URL
+        assert isinstance(params, dict)
+        assert isinstance(headers, dict)
+        assert timeout > 0
+        return DummyCoinGeckoResponse({"monerium-eur-money": {"usd": 1.0, "eur": 0.87934359, "last_updated_at": 1782464168}})
+
+    monkeypatch.setattr(stablecoin_rate.requests, "get", fake_get)
+    now_ = datetime.datetime(2026, 6, 26, 12, 0, 0)
+
+    summary = refresh_stablecoin_rates(data_dir=tmp_path, now_=now_, force=True, currency_db_path=currency_db_path)
+
+    assert summary.skipped_inferred_source_currency == 1
+    assert summary.depegged_count == 0
+    target = next(iter_stablecoin_rate_targets(tmp_path))
+    assert target.usd_rate == pytest.approx(1.0)
+    assert target.peg_rate is None
+    assert target.rate_fetch_failed_reason == "untrusted_source_currency"
     assert target.depegged_at is None
 
 
@@ -602,6 +817,8 @@ name: Stables Labs USDX
 short_description: USDX is a USD stablecoin.
 long_description: ''
 category: stablecoin
+source_currency: usd
+source_currency_source: manual
 coingecko_id: usdx-money-usdx
 coingecko_link: https://www.coingecko.com/en/coins/usdx-money-usdx
 coingecko_id_source: manual
@@ -648,6 +865,8 @@ name: Abracadabra MIM
 short_description: Magic Internet Money is a USD-pegged stablecoin.
 long_description: ''
 category: stablecoin
+source_currency: usd
+source_currency_source: manual
 coingecko_id: magic-internet-money
 coingecko_link: https://www.coingecko.com/en/coins/magic-internet-money
 coingecko_id_source: manual
@@ -695,6 +914,8 @@ name: Compound USDC
 short_description: Compound USDC
 long_description: ''
 category: yield_bearing
+source_currency: usd
+source_currency_source: manual
 coingecko_id: compound-usd-coin
 coingecko_link: https://www.coingecko.com/en/coins/compound-usd-coin
 coingecko_id_source: manual

--- a/tests/feed/test_stablecoin_rate_scanner.py
+++ b/tests/feed/test_stablecoin_rate_scanner.py
@@ -53,6 +53,8 @@ def test_stablecoin_rate_side_job_uses_24h_gate(tmp_path: Path, monkeypatch: pyt
         stablecoin_data_dir=tmp_path / "stablecoins",
         stablecoin_rate_gate_path=gate_path,
         stablecoin_rate_timeout=7.5,
+        currency_api_db_path=tmp_path / "exchange-rates.duckdb",
+        currency_api_source="test-source",
     )
 
     first_summary = CollectorRunSummary()
@@ -63,6 +65,8 @@ def test_stablecoin_rate_side_job_uses_24h_gate(tmp_path: Path, monkeypatch: pyt
     assert calls[0]["data_dir"] == tmp_path / "stablecoins"
     assert calls[0]["force"] is False
     assert calls[0]["timeout"] == 7.5
+    assert calls[0]["currency_db_path"] == tmp_path / "exchange-rates.duckdb"
+    assert calls[0]["currency_source"] == "test-source"
     assert json.loads(gate_path.read_text())["last_succeeded_at"]
 
     second_summary = CollectorRunSummary()

--- a/tests/research/test_vault_metrics_stablecoin_rate.py
+++ b/tests/research/test_vault_metrics_stablecoin_rate.py
@@ -28,6 +28,8 @@ name: Kava USDX
 short_description: Kava USDX
 long_description: ''
 category: stablecoin
+source_currency: usd
+source_currency_source: manual
 coingecko_id: usdx
 coingecko_link: https://www.coingecko.com/en/coins/usdx
 coingecko_id_source: manual
@@ -37,6 +39,9 @@ usd_rate_fetched_at: '2026-06-26T12:00:00'
 usd_rate_updated_at: '2026-06-26T08:56:08'
 peg_rate: 0.646809
 peg_rate_currency: usd
+source_currency_usd_rate: 1.0
+source_currency_usd_rate_fetched_at: '2026-06-26T12:00:00'
+source_currency_usd_rate_source: fawazahmed0
 rate_fetch_failed_at: ''
 rate_fetch_failed_reason: ''
 depegged_at: '2026-06-26T12:00:00'
@@ -66,6 +71,8 @@ name: Circle USDC
 short_description: USD Coin
 long_description: ''
 category: stablecoin
+source_currency: usd
+source_currency_source: manual
 coingecko_id: usd-coin
 coingecko_link: https://www.coingecko.com/en/coins/usd-coin
 coingecko_id_source: manual
@@ -95,6 +102,8 @@ name: Kava USDX
 short_description: Kava USDX
 long_description: ''
 category: stablecoin
+source_currency: usd
+source_currency_source: manual
 coingecko_id: usdx
 coingecko_link: https://www.coingecko.com/en/coins/usdx
 coingecko_id_source: manual
@@ -204,17 +213,33 @@ def _assert_bad_usdx_vault_blacklisted(metrics: pd.DataFrame, expected_usd_rate:
 
     denomination_token_rate = row["denomination_token_rate"]
     assert denomination_token_rate.coingecko_id == "usdx"
+    assert denomination_token_rate.source_currency == "usd"
     assert denomination_token_rate.usd_rate == pytest.approx(expected_usd_rate)
     assert denomination_token_rate.usd_rate_fetched_at == expected_fetched_at
     assert denomination_token_rate.usd_rate_source == "coingecko"
+    assert denomination_token_rate.native_rate is None
+    assert denomination_token_rate.native_rate_currency is None
+    assert denomination_token_rate.native_rate_fetched_at is None
+    assert denomination_token_rate.native_rate_source is None
+    assert denomination_token_rate.source_currency_usd_rate == pytest.approx(1.0)
+    assert denomination_token_rate.source_currency_usd_rate_fetched_at == expected_fetched_at
+    assert denomination_token_rate.source_currency_usd_rate_source == "fawazahmed0"
 
     exported = export_lifetime_row(row)
     assert exported["risk"] == "Blacklisted"
     assert exported["denomination_token_rate"] == {
         "coingecko_id": "usdx",
+        "source_currency": "usd",
         "usd_rate": expected_usd_rate,
         "usd_rate_fetched_at": expected_fetched_at.isoformat(),
         "usd_rate_source": "coingecko",
+        "native_rate": None,
+        "native_rate_currency": None,
+        "native_rate_fetched_at": None,
+        "native_rate_source": None,
+        "source_currency_usd_rate": 1.0,
+        "source_currency_usd_rate_fetched_at": expected_fetched_at.isoformat(),
+        "source_currency_usd_rate_source": "fawazahmed0",
     }
     assert "depegged_denomination_token" in exported["flags"]
 


### PR DESCRIPTION
## Why

Stablecoin depeg checks treated every stablecoin as USD-denominated, which gives wrong results for EUR, JPY, and other fiat-backed stablecoins. The scanner now needs trusted source-currency metadata and an auditable USD/source-currency FX rate from the local DuckDB currency database before making non-USD depeg decisions.

## Lessons learnt

The stablecoin metadata JSON and vault lifetime metrics JSON are separate public surfaces. Source-currency fields need to be documented and exported in stablecoin metadata, while lifetime metrics should expose USD price data for all tokens and native price data only when the source currency is not USD.

## Summary

- Added source-currency metadata fields and USD/source-currency FX audit fields to stablecoin YAML/JSON metadata.
- Updated stablecoin rate refresh logic to use the local currency API DuckDB for non-USD depeg checks, allowing a one-week FX data delay.
- Threaded currency database configuration through scanner and stablecoin rate population scripts.
- Exported expanded denomination token rate data in lifetime metrics, with native rate fields omitted for USD-native tokens.
- Added focused unit coverage for EUR depeg behaviour, missing/stale FX rows, untrusted source currencies, scanner config pass-through, and lifetime metrics JSON output.
- Added the implementation plan under docs/claude-plans.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.

Local pytest was not run because `.local-test.env` is not present in this worktree. Static formatting, lint, compile, and diff checks were run locally.