### PR TITLE
fix: Update Ember protocol Twitter link

### DIFF
--- a/docs/source/vaults/ember/index.rst
+++ b/docs/source/vaults/ember/index.rst
@@ -20,7 +20,7 @@ Links
 - `Homepage <https://ember.so/>`__
 - `App <https://ember.so/earn>`__
 - `Documentation <https://learn.ember.so/>`__
-- `Twitter <https://x.com/EmberProtocol_>`__
+- `Twitter <https://x.com/EmberProtocol>`__
 - `Audit report <https://ember.so/documents/ember_protocol_audit.pdf>`__
 - `DefiLlama <https://defillama.com/protocol/ember>`__
 - `Example vault on Etherscan <https://etherscan.io/address/0xf3190a3ecc109f88e7947b849b281918c798a0c4>`__

--- a/eth_defi/data/feeds/protocols/ember.yaml
+++ b/eth_defi/data/feeds/protocols/ember.yaml
@@ -1,11 +1,10 @@
 # Ember Protocol is active - vault platform on Sui, incubated by Upshift/Bluewater
-# Twitter handle confirmed via DefiLlama API
+# Twitter handle confirmed from Ember website and live X profile
 feeder-id: ember
 name: Ember
 role: protocol
 website: https://ember.so/
-twitter: EmberProtocol_
+twitter: EmberProtocol
 linkedin: ember-protocol
 # rss: not found
 linkedin-rss-hub-disabled-at: 2026-04-04
-twitter-handle-resolved-unknown-at: 2026-04-06

--- a/eth_defi/data/feeds/tracking.md
+++ b/eth_defi/data/feeds/tracking.md
@@ -45,7 +45,7 @@ YAML files are written to:
 | ✅ | decentralized-usd | Decentralized USD | https://usdd.io/ | usddio | | https://medium.com/feed/@usddio |
 | ⚠️ | deltr | Deltr | | | | |
 | ✅ | dolomite | Dolomite | https://dolomite.io/ | dolomite_io | dolomiteio | https://medium.com/feed/dolomite-official |
-| ✅ | ember | Ember | https://ember.so/ | EmberProtocol_ | ember-protocol | |
+| ✅ | ember | Ember | https://ember.so/ | EmberProtocol | ember-protocol | |
 | ✅ | eth-strategy | ETH Strategy | https://www.ethstrat.xyz/ | eth_strategy | | https://blog.ethstrat.xyz/feed |
 | ✅ | ethena | Ethena | https://ethena.fi/ | ethena_labs | ethena-labs | https://ethena.fi/blog/feed |
 | ✅ | euler | Euler | https://www.euler.finance/ | eulerfinance | euler-xyz | https://newsletter.euler.finance/feed |

--- a/eth_defi/data/feeds/updated-tracking.md
+++ b/eth_defi/data/feeds/updated-tracking.md
@@ -42,7 +42,7 @@ These handles were wrong or outdated - the X API correctly reported them as unkn
 | usdf-falcon | FalconStable | Active, confirmed correct |
 | tfusdc | TrueFi_DAO | Active, confirmed correct |
 | infinifi | infinifi_ | Active, confirmed correct |
-| ember | EmberProtocol_ | Active, confirmed correct |
+| ember | EmberProtocol | Active, confirmed correct |
 | smardex | every_thing | Repointed after SmarDex rebrand to Everything |
 
 ## RSS feed fixes

--- a/eth_defi/data/vaults/metadata/ember.yaml
+++ b/eth_defi/data/vaults/metadata/ember.yaml
@@ -19,7 +19,7 @@ fee_description: |
 links:
   homepage: https://ember.so/
   app: https://ember.so/earn
-  twitter: https://x.com/EmberProtocol_
+  twitter: https://x.com/EmberProtocol
   github: https://github.com/ember-protocol/Ember-Vaults-EVM
   documentation: https://learn.ember.so/
   defillama: https://defillama.com/protocol/ember


### PR DESCRIPTION
## Why

Ember Protocol's active X profile is https://x.com/EmberProtocol, while the vault protocol metadata and feed tracking still pointed to the stale EmberProtocol_ handle. The stale feed marker also disabled the Twitter feed source.

## Lessons learnt

The Ember handle changed from the earlier underscore variant to EmberProtocol. The stablecoin metadata for eEARN already used the current handle, so protocol metadata should match it.

## Summary

- Update Ember protocol metadata and documentation to https://x.com/EmberProtocol.
- Update the Ember feed source to EmberProtocol and remove the stale handle-unknown marker.
- Update feed tracking tables to the same handle.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.
