### PR TITLE
fix: print vault scanner startup banner

### DIFF
--- a/scripts/erc-4626/scan-vaults-all-chains.py
+++ b/scripts/erc-4626/scan-vaults-all-chains.py
@@ -123,7 +123,16 @@ Example CHAIN_ORDER for all chains:
     CHAIN_ORDER="Sonic, Monad, Hyperliquid, Base, Arbitrum, Ethereum, Linea, Gnosis, Zora, Polygon, Avalanche, Berachain, Unichain, Hemi, Plasma, Binance, Mantle, Katana, Ink, Blast, Soneium, Optimism"
 """
 
-from eth_defi.vault.scan_all_chains import main
+import os
+
+
+def _print_early_startup_banner() -> None:
+    """Print a boot marker before importing the scanner implementation."""
+    log_level = os.environ.get("LOG_LEVEL", "warning")
+    print(f"Starting vault scanner, LOG_LEVEL={log_level}", flush=True)
 
 if __name__ == "__main__":
+    _print_early_startup_banner()
+    from eth_defi.vault.scan_all_chains import main
+
     main()


### PR DESCRIPTION
## Why

Production Docker Compose can attach to `vault-scanner-looped` before the Python scanner emits any configured logging. If startup hangs during heavy imports, operators see no early confirmation that the process has started or which `LOG_LEVEL` was passed in.

## Lessons learnt

Long-running Docker entrypoints should print a minimal flushed boot marker before importing heavier scanner modules.

## Summary

- Print `Starting vault scanner, LOG_LEVEL=...` immediately from the wrapper script.
- Defer importing `eth_defi.vault.scan_all_chains.main` until after the early boot marker has been emitted.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.