### PR TITLE
Reduce Lagoon empty vault log severity

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/lagoon/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/offchain_metadata.py
@@ -275,7 +275,7 @@ def fetch_lagoon_vaults_for_chain(
             logger.info("Fetched metadata for %d Lagoon vaults on chain %d", len(result), chain_id)
 
             if not result:
-                logger.warning("Lagoon API returned 0 vaults for chain %d, skipping cache write to avoid poisoning the cache", chain_id)
+                logger.info("Lagoon API returned 0 vaults for chain %d, skipping cache write to avoid poisoning the cache", chain_id)
                 return {}
 
             # Serialise result dict so that TypedDict values are JSON-compatible


### PR DESCRIPTION
## Why

Lagoon can legitimately return zero vaults for some chains during scanner operation. Logging this as a warning creates noisy alerts even though the scanner handles the response by skipping the cache write.

## Lessons learnt

Empty Lagoon vault responses are already handled defensively to avoid cache poisoning, so this path can be informational instead of warning-level.

## Summary

Changed the Lagoon empty vault response log from warning to info.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.