### PR TITLE
fix: add EUR and GBP stablecoin rate metadata

### DIFF
--- a/eth_defi/data/stablecoins/ageur.yaml
+++ b/eth_defi/data/stablecoins/ageur.yaml
@@ -24,6 +24,8 @@ long_description: |
   - [Etherscan: EURA/agEUR on Ethereum](https://etherscan.io/token/0x1a7e4e63778B4f12a199C062f3eFdD288afCBce8)
   - [DeFiLlama: agEUR stablecoin page](https://defillama.com/stablecoin/ageur)
 category: stablecoin
+source_currency: eur
+source_currency_source: manual
 links:
   homepage: https://www.angle.money/
   coingecko: https://www.coingecko.com/en/coins/ageur

--- a/eth_defi/data/stablecoins/ceur.yaml
+++ b/eth_defi/data/stablecoins/ceur.yaml
@@ -19,6 +19,8 @@ long_description: |
   - [Mento Protocol documentation](https://docs.mento.org/)
   - [DeFiLlama: Celo Euro](https://defillama.com/stablecoin/celo-euro)
 category: stablecoin
+source_currency: eur
+source_currency_source: manual
 links:
   homepage: https://mento.org/
   coingecko: https://www.coingecko.com/en/coins/celo-euro

--- a/eth_defi/data/stablecoins/eura.yaml
+++ b/eth_defi/data/stablecoins/eura.yaml
@@ -11,6 +11,8 @@ long_description: |
   overcollateralised positions (similar to Maker Vaults), yield-bearing reserves, and algorithmic rebalancing across supported chains.
   EURA can be bridged across multiple EVM networks via the LayerZero-based Angle bridge.
 category: stablecoin
+source_currency: eur
+source_currency_source: manual
 links:
   homepage: https://www.angle.money/
   coingecko: https://www.coingecko.com/en/coins/ageur

--- a/eth_defi/data/stablecoins/eurcv.yaml
+++ b/eth_defi/data/stablecoins/eurcv.yaml
@@ -11,6 +11,8 @@ long_description: |
   SG-FORGE has subsequently deployed EURCV in DeFi protocols including MakerDAO (now Sky) and Aave.
   In 2025, SG-FORGE expanded EURCV to the Stellar blockchain and also announced a USD-denominated stablecoin (USDCV) with BNY as custodian.
 category: stablecoin
+source_currency: eur
+source_currency_source: manual
 links:
   homepage: https://www.sgforge.com/
   coingecko: ''

--- a/eth_defi/data/stablecoins/eure.yaml
+++ b/eth_defi/data/stablecoins/eure.yaml
@@ -11,6 +11,8 @@ long_description: |
   EURe is available on Ethereum, Gnosis Chain, Polygon, and Arbitrum.
   The token was upgraded to V2 on Ethereum in December 2024; V1 continues to work.
 category: stablecoin
+source_currency: eur
+source_currency_source: manual
 links:
   homepage: https://monerium.com/
   coingecko: https://www.coingecko.com/en/coins/monerium-eur-money

--- a/eth_defi/data/stablecoins/euroc.yaml
+++ b/eth_defi/data/stablecoins/euroc.yaml
@@ -11,6 +11,8 @@ long_description: |
   EURC is available on Ethereum, Base, Avalanche, Solana, and other networks.
   It is Circle's Euro-denominated equivalent of USDC.
 category: stablecoin
+source_currency: eur
+source_currency_source: manual
 links:
   homepage: https://www.circle.com/eurc
   coingecko: ''

--- a/eth_defi/data/stablecoins/euroe.yaml
+++ b/eth_defi/data/stablecoins/euroe.yaml
@@ -19,6 +19,8 @@ long_description: |
   The EUROe Account portal closed on 31 July 2025, the final date for direct redemptions.
   Paxos redirected European stablecoin efforts to its USDG (Global Dollar) product.
 category: stablecoin
+source_currency: eur
+source_currency_source: manual
 links:
   homepage: https://www.euroe.com/
   coingecko: ''

--- a/eth_defi/data/stablecoins/eurr.yaml
+++ b/eth_defi/data/stablecoins/eurr.yaml
@@ -14,6 +14,8 @@ long_description: |
 
   - [CoinGecko — StablR Euro](https://www.coingecko.com/en/coins/stablr-euro)
 category: stablecoin
+source_currency: eur
+source_currency_source: manual
 links:
   homepage: https://stablr.com/
   coingecko: https://www.coingecko.com/en/coins/stablr-euro

--- a/eth_defi/data/stablecoins/eurs.yaml
+++ b/eth_defi/data/stablecoins/eurs.yaml
@@ -11,6 +11,8 @@ long_description: |
   It is targeted at institutional and retail users seeking Euro-denominated digital asset exposure.
   STASIS provides transparency reports and redemption services directly to verified users.
 category: stablecoin
+source_currency: eur
+source_currency_source: manual
 links:
   homepage: https://stasis.net/
   coingecko: https://www.coingecko.com/en/coins/stasis-eurs

--- a/eth_defi/data/stablecoins/eurt.yaml
+++ b/eth_defi/data/stablecoins/eurt.yaml
@@ -11,6 +11,8 @@ long_description: |
   EURt has significantly lower market cap and trading volume compared to USDT, reflecting lower demand for Euro-pegged Tether products relative to USD-pegged ones.
   It is available on Ethereum and other supported Tether networks.
 category: stablecoin
+source_currency: eur
+source_currency_source: manual
 links:
   homepage: https://tether.to/
   coingecko: https://www.coingecko.com/en/coins/tether-eurt

--- a/eth_defi/data/stablecoins/gbpt.yaml
+++ b/eth_defi/data/stablecoins/gbpt.yaml
@@ -9,6 +9,8 @@ long_description: |
 
   The original GBPT token was deployed on Ethereum. The rebrand introduced a new 1GBP token contract.
 category: stablecoin
+source_currency: gbp
+source_currency_source: manual
 links:
   homepage: https://poundtoken.io/
   coingecko: ''

--- a/eth_defi/data/stablecoins/jeur.yaml
+++ b/eth_defi/data/stablecoins/jeur.yaml
@@ -34,6 +34,8 @@ long_description: |
   - [Etherscan — jEUR token](https://etherscan.io/token/0x0f17BC9a994b87b5225cFb6a2Cd4D667ADb4F20B)
   - [CoinTelegraph — Jarvis jFIAT stablecoins](https://cointelegraph.com/press-releases/jarvis-network-launches-liquid-cad-sgd-and-php-stablecoins-on-polygon)
 category: stablecoin
+source_currency: eur
+source_currency_source: manual
 links:
   homepage: https://www.jarvis.network/
   coingecko: https://www.coingecko.com/en/coins/jarvis-synthetic-euro

--- a/eth_defi/data/stablecoins/par.yaml
+++ b/eth_defi/data/stablecoins/par.yaml
@@ -24,6 +24,8 @@ long_description: |
   - [CoinGecko — PAR](https://www.coingecko.com/en/coins/par-stablecoin)
   - [Etherscan — PAR](https://etherscan.io/token/0x68037790A0229e9Ce6EaA8A99ea92964106C4703)
 category: stablecoin
+source_currency: eur
+source_currency_source: manual
 links:
   homepage: https://par.mimo.capital/
   coingecko: https://www.coingecko.com/en/coins/par-stablecoin

--- a/eth_defi/data/stablecoins/seur.yaml
+++ b/eth_defi/data/stablecoins/seur.yaml
@@ -8,6 +8,8 @@ long_description: |
 
   The Ethereum mainnet version of sEUR remains on-chain but with greatly reduced activity as Synthetix transitions away from legacy synth infrastructure.
 category: stablecoin
+source_currency: eur
+source_currency_source: manual
 links:
   homepage: https://synthetix.io/
   coingecko: https://www.coingecko.com/en/coins/seur

--- a/eth_defi/data/stablecoins/tgbp.yaml
+++ b/eth_defi/data/stablecoins/tgbp.yaml
@@ -14,6 +14,8 @@ long_description: |
   tGBP is deployed natively across multiple EVM chains — Ethereum, Base, Polygon, BNB Chain and Avalanche — sharing the
   same token contract address, and is also available on Solana. The issuer is a member of the Digital Pound Foundation.
 category: stablecoin
+source_currency: gbp
+source_currency_source: manual
 links:
   homepage: https://www.tokenisedgbp.com/
   coingecko: https://www.coingecko.com/en/coins/tokenised-gbp
@@ -31,6 +33,9 @@ contract_addresses:
   - chain: avalanche
     address: '0x27f6c8289550fCE67f6B50BeD1F519966aFE5287'
 slug: tgbp
+coingecko_id: tokenised-gbp
+coingecko_link: https://www.coingecko.com/en/coins/tokenised-gbp
+coingecko_id_source: url
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/veur.yaml
+++ b/eth_defi/data/stablecoins/veur.yaml
@@ -17,6 +17,8 @@ long_description: |
   - [DefiLlama — VNX EURO](https://defillama.com/stablecoin/vnx-euro)
   - [CoinGecko — VNX Euro](https://www.coingecko.com/en/coins/vnx-euro)
 category: stablecoin
+source_currency: eur
+source_currency_source: manual
 links:
   homepage: https://vnx.li/
   coingecko: https://www.coingecko.com/en/coins/vnx-euro

--- a/scripts/erc-4626/scan-vaults-all-chains.py
+++ b/scripts/erc-4626/scan-vaults-all-chains.py
@@ -131,6 +131,7 @@ def _print_early_startup_banner() -> None:
     log_level = os.environ.get("LOG_LEVEL", "warning")
     print(f"Starting vault scanner, LOG_LEVEL={log_level}", flush=True)
 
+
 if __name__ == "__main__":
     _print_early_startup_banner()
     from eth_defi.vault.scan_all_chains import main

--- a/tests/feed/test_stablecoin_rate.py
+++ b/tests/feed/test_stablecoin_rate.py
@@ -42,6 +42,7 @@ def _coins_list_response() -> DummyCoinGeckoResponse:
         "usdx-money-usdx",
         "cad-coin",
         "convertible-jpy-token",
+        "tokenised-gbp",
         "magic-internet-money",
         "compound-usd-coin",
     ]
@@ -572,6 +573,7 @@ checks:
     [
         ("CADC", "PayTrie CADC Canadian Dollar stablecoin", "cad-coin", "cad", 0.73),
         ("CJPY", "Yamato CJPY Japanese Yen stablecoin", "convertible-jpy-token", "jpy", 0.0064),
+        ("tGBP", "Tokenised GBP British Pound stablecoin", "tokenised-gbp", "gbp", 1.32),
     ],
 )
 def test_non_usd_fiat_stablecoins_compare_against_their_peg_currency(
@@ -613,6 +615,20 @@ def test_non_usd_fiat_stablecoins_compare_against_their_peg_currency(
     assert target.source_currency_usd_rate == pytest.approx(usd_rate)
     assert target.source_currency_usd_rate_date == datetime.date(2026, 6, 26)
     assert target.depegged_at is None
+
+    rate = StablecoinRateFeeder(data_dir=tmp_path).get_denomination_token_rate_section(None, None, symbol)
+    assert rate.coingecko_id == coingecko_id
+    assert rate.source_currency == peg_currency
+    assert rate.usd_rate == pytest.approx(usd_rate)
+    assert rate.usd_rate_fetched_at == now_
+    assert rate.usd_rate_source == "coingecko"
+    assert rate.native_rate == pytest.approx(1.0)
+    assert rate.native_rate_currency == peg_currency
+    assert rate.native_rate_fetched_at == now_
+    assert rate.native_rate_source == "coingecko+fawazahmed0"
+    assert rate.source_currency_usd_rate == pytest.approx(usd_rate)
+    assert rate.source_currency_usd_rate_fetched_at == now_
+    assert rate.source_currency_usd_rate_source == "fawazahmed0"
 
 
 def test_eur_stablecoin_depegs_against_native_currency_from_duckdb(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Why

`calculate_lifetime_metrics()` exports denomination token exchange-rate fields from `StablecoinRateFeeder`. The stablecoin rate refresh path only populates native non-USD fields when the YAML entry has trusted manual `source_currency` metadata.

The GBP tGBP entry and existing EUR stablecoin entries were missing these source-currency fields, so future refreshes could leave `native_rate` and `source_currency_usd_rate` fields empty even when Currency API data exists.

## Lessons learnt

Existing `peg_rate_currency` values are refresh outputs and do not drive future refreshes. The refresh path needs static `source_currency` and `source_currency_source: manual` metadata.

CoinGecko id validation uses the CoinGecko `/coins/list` API. The current API list confirms `tokenised-gbp` and the populated EUR ids, but not the unresolved `EURCV`, `EUROC`, `EUROe`, or `GBPT` ids.

## Summary

- Add manual EUR source-currency metadata to EUR-denominated stablecoin YAML files.
- Add manual GBP source-currency metadata to GBP-denominated stablecoin YAML files.
- Add explicit tGBP CoinGecko metadata for future rate refreshes.
- Extend the stablecoin rate test coverage to include tGBP and exported native rate fields.

## Related issues and PRs

Continues the recently merged tGBP stablecoin metadata work.

## Unrelated CI and test fixes

- Add the Ruff-required blank line before the top-level entrypoint in `scripts/erc-4626/scan-vaults-all-chains.py`.
