### PR TITLE
docs: Mark EURA stablecoin as phased out

### DIFF
--- a/eth_defi/data/stablecoins/eura.yaml
+++ b/eth_defi/data/stablecoins/eura.yaml
@@ -1,11 +1,14 @@
 symbol: EURA
 name: Angle EURA
-short_description: EURA (formerly agEUR) is a Euro-pegged stablecoin issued by Angle Protocol. It is backed by a combination of overcollateralised loans and yield-bearing reserves. EURA is available on multiple
-  chains including Ethereum, Polygon, and Arbitrum.
+short_description: EURA (formerly agEUR) is a Euro-pegged stablecoin issued by Angle Protocol, but it is being phased out after a February 2026 wind-down announcement. Existing holders should treat EURA as a legacy token and verify redemption options before relying on its Euro peg.
 long_description: |
   [EURA](https://www.angle.money/) (formerly known as agEUR) is a Euro-pegged stablecoin issued by [Angle Protocol](https://www.angle.money/), a decentralised stablecoin framework on Ethereum.
   It was rebranded from agEUR to EURA in 2023.
   The token address on Ethereum did not change with the rebrand.
+
+  Angle Protocol announced in February 2026 that EURA is being phased out through an orderly wind-down.
+  The token may still appear in wallets, vaults, and historical on-chain data, but it should be treated as a legacy stablecoin rather than an actively supported Euro stablecoin.
+  Users should verify current redemption paths and liquidity before assuming EURA trades or redeems at its Euro peg.
 
   Angle Protocol uses a combination of mechanisms to maintain the Euro peg:
   overcollateralised positions (similar to Maker Vaults), yield-bearing reserves, and algorithmic rebalancing across supported chains.


### PR DESCRIPTION
## Why

EURA is being phased out after Angle Protocol's February 2026 wind-down announcement. The stablecoin metadata still described it as an actively supported Euro stablecoin, which could mislead downstream users reviewing token or vault metadata.

## Lessons learnt

Metadata for legacy stablecoins needs to call out wind-down and redemption risk prominently, not only preserve historical issuer details.

## Summary

- Updated the EURA short description to state that it is being phased out.
- Added long-description guidance that EURA should be treated as a legacy stablecoin and that users should verify redemption paths and liquidity before relying on the Euro peg.

## Related issues and PRs

- Announcement: https://x.com/pablo_veyrat/status/2024789260054692114

## Unrelated CI and test fixes

None.