### PR TITLE
Map RockawayX curated vaults

### DIFF
--- a/eth_defi/data/feeds/curators/rockawayx.yaml
+++ b/eth_defi/data/feeds/curators/rockawayx.yaml
@@ -1,10 +1,15 @@
 feeder-id: rockawayx
 name: RockawayX
 role: curator
+morpho-curator: RockawayX
 website: https://www.rockawayx.com
 short_description: 'RockawayX is a digital asset investment and engineering firm spanning venture, liquidity, and blockchain infrastructure.'
 long_description: |
   RockawayX says it runs blockchains and provides liquidity to fuel protocols. Its homepage describes early-stage investing, validator and bare-metal infrastructure, and on-chain liquidity services for blockchain ecosystems, with a focus on building alongside portfolio projects rather than only providing capital.
+  RockawayX also publishes a [Dune dashboard](https://dune.com/rockawayxvault/rockawayx-dashboard) tracking vaults associated with its on-chain vault activity across protocols and chains.
 twitter: Rockaway_X
 linkedin: rockawayx
+other-links:
+  - title: RockawayX Dune dashboard - vault TVL, APY and holder analytics
+    url: https://dune.com/rockawayxvault/rockawayx-dashboard
 linkedin-rss-hub-disabled-at: 2026-06-09

--- a/eth_defi/vault/curator.py
+++ b/eth_defi/vault/curator.py
@@ -292,6 +292,30 @@ PROTOCOL_MANAGER_YAML_FIELDS: dict[str, str] = {
     "lagoon-finance": "lagoon-curator",
 }
 
+#: Exact vault address to curator overrides from Dune dashboards.
+#:
+#: Used when the public vault display name does not carry the curator brand, or
+#: carries a co-branded protocol/issuer name that would otherwise win fuzzy
+#: matching.  Keys are ``(chain_id, lowercase_vault_address)``.
+CURATOR_ADDRESS_OVERRIDES: dict[tuple[int, str], str] = {
+    # RockawayX Dune dashboard, query 6932634, checked 2026-07-01.
+    # https://dune.com/rockawayxvault/rockawayx-dashboard
+    (1, "0xcd69123b3fbbfc666e1f6a501da27b564c00de54"): "rockawayx",
+    (1, "0xc87dbbb8c67e4f19fcd2e297c05937567b2572ce"): "rockawayx",
+    (1329, "0x6137dcfdd3c83fe2922b1cba4105d2e92b327a06"): "rockawayx",
+    (1, "0x953972ea0c1703c58f09fb6fd2477fdcf0fee074"): "rockawayx",
+    (1, "0x8ac91877b93330f52b2979a31a4879506021475c"): "rockawayx",
+    (1, "0xe0181090c22579b6a217f1522cbf8c9f1f0c1965"): "rockawayx",
+    (1, "0x67e1f506b148d0fc95a4e3ffb49068ceb6855c05"): "rockawayx",
+    (1, "0x0f0a9d3f0bc6006143c96e6995572b51413cb3c4"): "rockawayx",
+    (1, "0x64c18dcc4ccb3b8d27877a4aebb4c3126cb39cb9"): "rockawayx",
+    (56, "0xb5a30e1fa2cf3c8dea882124b3ab5a47a27c5dd2"): "rockawayx",
+    (1, "0xd65d6e8dbc3cd3d12418199e6f4014db3aaa0097"): "rockawayx",
+    (1, "0x5f829b1b473cba86838e1b7bb7e144dbde228e21"): "rockawayx",
+    (1, "0xe99a27169c2aa26a8f2757949d09fa3f9a8f0b3b"): "rockawayx",
+    (8453, "0xae4181cfb5aaa08bbe77d269c6b595672b9f9edc"): "rockawayx",
+}
+
 
 class CuratorInfo(TypedDict):
     """Metadata for a single curator loaded from YAML.
@@ -589,6 +613,32 @@ def _identify_curator_by_patterns(
     return None
 
 
+def _identify_curator_by_address(chain_id: int, vault_address: str | None) -> str | None:
+    """Identify a curator from an exact vault address override.
+
+    Address overrides cover public dashboards and protocol-specific metadata
+    where the vault name alone is not reliable enough for fuzzy matching.
+
+    :param chain_id:
+        Chain ID where the vault is deployed.
+
+    :param vault_address:
+        Vault contract address or synthetic address.
+
+    :return:
+        Curator slug, or ``None`` if no override is configured.
+    """
+    if not vault_address:
+        return None
+
+    try:
+        chain_id_int = int(chain_id)
+    except (TypeError, ValueError):
+        return None
+
+    return CURATOR_ADDRESS_OVERRIDES.get((chain_id_int, vault_address.lower()))
+
+
 def identify_curator(  # noqa: PLR0917
     chain_id: int,
     vault_token_symbol: str,
@@ -644,44 +694,49 @@ def identify_curator(  # noqa: PLR0917
         from third-party curators.
     """
 
-    del chain_id, vault_token_symbol
+    del vault_token_symbol
 
     protocol_slug = PROTOCOL_CURATOR_SLUG_ALIASES.get(protocol_slug, protocol_slug)
 
-    # 1. Blanket protocol-curated protocols (all vaults are protocol-operated)
+    # 1. Exact address overrides, e.g. dashboards where the curator brand is
+    #    external to the vault name.
+    if address_slug := _identify_curator_by_address(chain_id, vault_address):
+        return address_slug
+
+    # 2. Blanket protocol-curated protocols (all vaults are protocol-operated)
     if protocol_slug in PROTOCOL_CURATED_SLUGS:
         return protocol_slug
 
-    # 2. Hyperliquid system vaults (HLP parent, children, Liquidator)
+    # 3. Hyperliquid system vaults (HLP parent, children, Liquidator)
     if protocol_slug == "hyperliquid":
         if vault_address.lower() in HYPERLIQUID_SYSTEM_VAULT_ADDRESSES:
             return "hyperliquid"
 
-    # 3. Lighter system pools (LLP, XLP)
+    # 4. Lighter system pools (LLP, XLP)
     if protocol_slug == "lighter":
         if vault_address in LIGHTER_SYSTEM_POOL_ADDRESSES:
             return "lighter"
 
-    # 4. GRVT system vaults (GLP, the protocol's in-house market maker)
+    # 5. GRVT system vaults (GLP, the protocol's in-house market maker)
     if protocol_slug == "grvt":
         if vault_address.lower() in GRVT_SYSTEM_VAULT_ADDRESSES:
             return "grvt"
 
-    # 5. Priority vault-name matches, e.g. Frax-branded Morpho vaults with a
+    # 6. Priority vault-name matches, e.g. Frax-branded Morpho vaults with a
     #    third-party UI curator.
     patterns = _build_matching_patterns()
     if priority_slug := _identify_curator_by_patterns(vault_name, patterns, include_slugs=PRIORITY_CURATOR_SLUGS):
         return priority_slug
 
-    # 6. Exact protocol-specific manager name mapping from offchain APIs.
+    # 7. Exact protocol-specific manager name mapping from offchain APIs.
     if manager_slug := _identify_curator_by_protocol_manager_name(protocol_slug, manager_name):
         return manager_slug
 
-    # 7. Ordinary vault-name fuzzy matching.
+    # 8. Ordinary vault-name fuzzy matching.
     if vault_slug := _identify_curator_by_patterns(vault_name, patterns, exclude_slugs=PRIORITY_CURATOR_SLUGS):
         return vault_slug
 
-    # 8. Legacy fuzzy matching against manager name for native marketplaces like GRVT.
+    # 9. Legacy fuzzy matching against manager name for native marketplaces like GRVT.
     if manager_slug := _identify_curator_by_patterns(manager_name, patterns):
         return manager_slug
 

--- a/tests/vault/test_curator.py
+++ b/tests/vault/test_curator.py
@@ -138,6 +138,61 @@ def test_identify_lagoon_curator_by_curator_metadata() -> None:
     assert slug == "722-capital"
 
 
+def test_identify_rockawayx_dashboard_vaults_by_address() -> None:
+    """RockawayX Dune dashboard vaults resolve by exact address.
+
+    Some RockawayX curated vaults carry partner or asset names instead of the
+    RockawayX brand, and two Midas Prime Morpho vaults would otherwise resolve
+    to the Midas curator by fuzzy matching. The address override preserves the
+    dashboard's curator assignment.
+
+    1. Resolve all EVM rows found on the RockawayX Dune dashboard.
+    2. Confirm co-branded and partner rows are overridden to RockawayX.
+    """
+
+    cases = [
+        (1, "Tori Ecosystem Vault", "0xcd69123b3FBBfC666E1f6a501da27B564C00De54", "upshift"),
+        (1, "Upshift ctUSD", "0xc87DBBB8C67e4F19fCD2E297c05937567b2572Ce", "upshift"),
+        (1329, "Feather PYUSD0", "0x6137dcfdd3c83fe2922b1cba4105d2e92b327a06", "feather"),
+        (1, "Y10K", "0x953972ea0C1703c58F09FB6fD2477Fdcf0FEe074", "ember"),
+        (1, "Huma USDC Main", "0x8aC91877b93330f52b2979a31a4879506021475c", "morpho"),
+        (1, "RockawayX YIELD USDC", "0xE0181090c22579B6A217f1522cbf8c9f1F0C1965", "morpho"),
+        (1, "mROX", "0x67E1F506B148d0Fc95a4E3fFb49068ceB6855c05", "midas"),
+        (1, "OnRe Core Vault", "0x0F0a9d3F0bc6006143c96E6995572b51413CB3c4", "accountable"),
+        (1, "RockawayX wETH", "0x64C18DCC4Ccb3b8D27877a4aeBB4C3126CB39cB9", "morpho"),
+        (56, "RockawayX YIELD PT", "0xb5a30e1fa2cf3c8dea882124b3ab5a47a27c5dd2", "lista"),
+        (1, "Figure USDC Main", "0xd65d6E8dbC3Cd3D12418199E6f4014dB3aaa0097", "morpho"),
+        (1, "RockawayX PRIME USDC", "0x5f829B1B473cBA86838E1B7BB7E144DbDE228e21", "morpho"),
+        (1, "Midas USDC Prime (Ethereum)", "0xe99A27169c2aA26a8f2757949d09Fa3f9A8f0B3B", "morpho"),
+        (8453, "Midas USDC Prime (Base)", "0xAE4181CFB5aaA08bbE77d269c6B595672b9F9Edc", "morpho"),
+    ]
+
+    for chain_id, vault_name, vault_address, protocol_slug in cases:
+        slug = identify_curator(
+            chain_id=chain_id,
+            vault_token_symbol="",
+            vault_name=vault_name,
+            vault_address=vault_address,
+            protocol_slug=protocol_slug,
+        )
+        assert slug == "rockawayx", f"{vault_name!r} resolved to {slug!r}"
+
+
+def test_identify_rockawayx_morpho_curator_metadata() -> None:
+    """RockawayX Morpho manager metadata resolves to the RockawayX curator."""
+
+    slug = identify_curator(
+        chain_id=1,
+        vault_token_symbol="",
+        vault_name="Unbranded USDC Vault",
+        vault_address="0x0000000000000000000000000000000000000012",
+        protocol_slug="morpho",
+        manager_name="RockawayX",
+    )
+
+    assert slug == "rockawayx"
+
+
 def test_identify_smokehouse_as_steakhouse_financial() -> None:
     """Smokehouse vault names resolve to Steakhouse Financial."""
 


### PR DESCRIPTION
## Why

RockawayX publishes a Dune dashboard of curated vaults across protocols and chains. Several EVM vaults on that dashboard do not carry the RockawayX brand in their vault names, so fuzzy curator detection either missed them or attributed them to partner protocols/issuers.

## Lessons learnt

The dashboard includes co-branded and partner-branded vault names, so exact address mapping is the clearest way to preserve RockawayX curator attribution where there is no clean naming pattern. Claude CLI reviewed the worktree and found no high-confidence correctness bugs; it suggested adding direct coverage for the new Morpho manager metadata path, which is included.

## Summary

- Added exact RockawayX curator address overrides for all 14 EVM vault rows from the Dune dashboard.
- Linked the dashboard in the RockawayX long description and `other-links` metadata.
- Added `morpho-curator: RockawayX` and tests for both address overrides and Morpho manager metadata.
- Ran `ruff format`, `ruff check`, and direct import-level validation of the RockawayX YAML, all 14 EVM dashboard mappings, and Morpho manager metadata. Pytest was not run because `.local-test.env` is absent in this worktree.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.
