### PR TITLE
fix: widen HyperCore vault deposit verification tolerance to 5%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- fix: Widen the HyperCore vault deposit verification relative tolerance from 1% to 5%. `wait_for_vault_deposit_confirmation` measures the deposit as an equity increase against a baseline snapshotted minutes earlier, but live perp-trading vaults mark-to-market every block, so the vault's own NAV drift over the confirmation window was being subtracted from the apparent deposit. A production incident (trade #1240, Loop Fund vault, 2026-07-01) saw an 8.06806 USDC deposit credited to the cent but reported ~0.22 USDC short after the pre-existing ~750 USDC position marked down, tripping the old 1% band, raising `HypercoreDepositVerificationError` and crashing the whole live trading loop even though the funds were safely in the vault (2026-07-02)
+
 - feat: Add Mellow vault protocol metadata, official media-kit logo assets, feed collection metadata and vault documentation so the merged Mellow Core Vault adapter is represented in the protocol database and public metadata exports (2026-07-01)
 
 - feat: Expand the `eth_defi.currency_api` default USD quote set with SGD, TRY, CHF and CAD, so the scheduled currency-rate scan backfills Singapore dollar, Turkish lira, Swiss franc and Canadian dollar rates alongside EUR, GBP, JPY, AUD, BTC and ETH. Replace the scanner DuckDB primary-key indexes with transactional delete-then-insert idempotence, avoiding a DuckDB 1.5.0 native abort when closing the larger ten-currency full-history database (2026-06-30)

--- a/eth_defi/hyperliquid/api.py
+++ b/eth_defi/hyperliquid/api.py
@@ -41,9 +41,28 @@ DEFAULT_VAULT_EQUITY_CACHE_TIMEOUT = 15 * 60
 #: Module-level cache: ``(api_url, user) -> (timestamp, list[UserVaultEquity])``
 _vault_equity_cache: dict[tuple, tuple[float, list["UserVaultEquity"]]] = {}
 
-#: Accept up to 1% equity drift when verifying a deposit into an existing vault
-#: because live vault equity can move during the HyperCore confirmation window.
-DEFAULT_VAULT_DEPOSIT_RELATIVE_TOLERANCE = Decimal("0.01")
+#: Accept up to 5% equity drift when verifying a deposit into an existing vault.
+#:
+#: When we deposit into an *existing* HyperCore vault position we confirm the
+#: deposit by checking that our USD equity increased by roughly the deposited
+#: amount.  The problem: live perp-trading vaults (e.g. copy-trading leader
+#: vaults) mark-to-market every block, so the vault's *existing* holdings drift
+#: in value during the minutes between snapshotting the baseline equity and
+#: running the verification poll loop.  That drift is subtracted from the
+#: apparent deposit and can make a fully-credited deposit look short.
+#:
+#: Real production incident (trade #1240, Loop Fund vault, 2026-07-01): an
+#: 8.06806 USDC deposit was credited essentially to the cent (the equity jump
+#: across two consecutive polls was 8.06608 USDC), but the vault's pre-existing
+#: ~750 USDC position had already marked down ~0.22 USDC (≈0.03%) versus the
+#: baseline snapshot.  Measured against the stale baseline, the apparent
+#: increase was only ~7.85 USDC, short of the 1% (0.08 USDC) tolerance band, so
+#: verification timed out, raised ``HypercoreDepositVerificationError`` and
+#: crashed the whole live trading loop even though the funds were safely in the
+#: vault.  Widening the band to 5% absorbs normal perp-vault NAV volatility over
+#: the confirmation window while still catching genuinely rejected / stranded
+#: deposits (which show ~0% increase, not a few-percent shortfall).
+DEFAULT_VAULT_DEPOSIT_RELATIVE_TOLERANCE = Decimal("0.05")
 
 
 class HypercoreDepositVerificationError(Exception):
@@ -597,7 +616,8 @@ def wait_for_vault_deposit_confirmation(
         Acceptable relative difference for existing vault deposits.
         The larger of ``tolerance`` and ``expected_deposit * relative_tolerance``
         is used, because live vault equity can drift during confirmation.
-        Defaults to 1%.
+        Defaults to 5% (see
+        :py:data:`DEFAULT_VAULT_DEPOSIT_RELATIVE_TOLERANCE` for why).
 
     :return:
         The confirmed :py:class:`UserVaultEquity` after the deposit.

--- a/eth_defi/hyperliquid/api.py
+++ b/eth_defi/hyperliquid/api.py
@@ -41,15 +41,17 @@ DEFAULT_VAULT_EQUITY_CACHE_TIMEOUT = 15 * 60
 #: Module-level cache: ``(api_url, user) -> (timestamp, list[UserVaultEquity])``
 _vault_equity_cache: dict[tuple, tuple[float, list["UserVaultEquity"]]] = {}
 
-#: Accept up to 5% equity drift when verifying a deposit into an existing vault.
+#: Accept up to 5% equity drift when verifying a deposit into an *existing* vault
+#: position.
 #:
-#: When we deposit into an *existing* HyperCore vault position we confirm the
+#: When we deposit into an existing HyperCore vault position we confirm the
 #: deposit by checking that our USD equity increased by roughly the deposited
-#: amount.  The problem: live perp-trading vaults (e.g. copy-trading leader
-#: vaults) mark-to-market every block, so the vault's *existing* holdings drift
-#: in value during the minutes between snapshotting the baseline equity and
-#: running the verification poll loop.  That drift is subtracted from the
-#: apparent deposit and can make a fully-credited deposit look short.
+#: amount, measured against a baseline equity snapshotted before the deposit.
+#: The problem: live perp-trading vaults (e.g. copy-trading leader vaults)
+#: mark-to-market every block, so the vault's *existing* holdings drift in value
+#: during the minutes between snapshotting the baseline equity and running the
+#: verification poll loop.  That drift is subtracted from the apparent deposit
+#: and can make a fully-credited deposit look short.
 #:
 #: Real production incident (trade #1240, Loop Fund vault, 2026-07-01): an
 #: 8.06806 USDC deposit was credited essentially to the cent (the equity jump
@@ -62,7 +64,20 @@ _vault_equity_cache: dict[tuple, tuple[float, list["UserVaultEquity"]]] = {}
 #: vault.  Widening the band to 5% absorbs normal perp-vault NAV volatility over
 #: the confirmation window while still catching genuinely rejected / stranded
 #: deposits (which show ~0% increase, not a few-percent shortfall).
+#:
+#: This applies only to the existing-position branch; first deposits keep the
+#: tighter :py:data:`DEFAULT_FIRST_VAULT_DEPOSIT_RELATIVE_TOLERANCE`.
 DEFAULT_VAULT_DEPOSIT_RELATIVE_TOLERANCE = Decimal("0.05")
+
+#: Accept up to 1% shortfall when verifying a *first* deposit into a vault.
+#:
+#: A first deposit has no pre-existing position to mark-to-market, so the
+#: NAV-drift-against-a-stale-baseline problem that motivates the wider
+#: existing-position tolerance (see
+#: :py:data:`DEFAULT_VAULT_DEPOSIT_RELATIVE_TOLERANCE`) does not apply here.  We
+#: keep this a tight "loud guard" so a dust / partial / silently-rejected first
+#: deposit is not falsely confirmed as success.
+DEFAULT_FIRST_VAULT_DEPOSIT_RELATIVE_TOLERANCE = Decimal("0.01")
 
 
 class HypercoreDepositVerificationError(Exception):
@@ -568,6 +583,7 @@ def wait_for_vault_deposit_confirmation(
     poll_interval: float = 2.0,
     tolerance: Decimal = Decimal("0.01"),
     relative_tolerance: Decimal = DEFAULT_VAULT_DEPOSIT_RELATIVE_TOLERANCE,
+    first_deposit_relative_tolerance: Decimal = DEFAULT_FIRST_VAULT_DEPOSIT_RELATIVE_TOLERANCE,
 ) -> UserVaultEquity:
     """Wait for a vault deposit to be confirmed on HyperCore.
 
@@ -613,11 +629,18 @@ def wait_for_vault_deposit_confirmation(
         the wait).  Defaults to 0.01 USDC.
 
     :param relative_tolerance:
-        Acceptable relative difference for existing vault deposits.
-        The larger of ``tolerance`` and ``expected_deposit * relative_tolerance``
-        is used, because live vault equity can drift during confirmation.
-        Defaults to 5% (see
+        Acceptable relative difference for deposits into an *existing* vault
+        position.  The larger of ``tolerance`` and
+        ``expected_deposit * relative_tolerance`` is used, because live vault
+        equity can drift during confirmation.  Defaults to 5% (see
         :py:data:`DEFAULT_VAULT_DEPOSIT_RELATIVE_TOLERANCE` for why).
+
+    :param first_deposit_relative_tolerance:
+        Acceptable relative difference for a *first* deposit (no existing
+        position).  Kept tighter than ``relative_tolerance`` because there is no
+        pre-existing position to mark-to-market against a stale baseline.
+        Defaults to 1% (see
+        :py:data:`DEFAULT_FIRST_VAULT_DEPOSIT_RELATIVE_TOLERANCE`).
 
     :return:
         The confirmed :py:class:`UserVaultEquity` after the deposit.
@@ -628,7 +651,12 @@ def wait_for_vault_deposit_confirmation(
     deadline = time.time() + timeout
     attempt = 0
     baseline = existing_equity or Decimal(0)
-    accepted_tolerance = max(tolerance, expected_deposit * relative_tolerance)
+    # First deposits have no pre-existing position that can mark-to-market
+    # against a stale baseline, so they keep the tighter "loud guard" band;
+    # existing-position deposits get the wider band to absorb live NAV drift.
+    # ``existing_equity`` is fixed for the whole call, so this is computed once.
+    effective_relative_tolerance = first_deposit_relative_tolerance if existing_equity is None else relative_tolerance
+    accepted_tolerance = max(tolerance, expected_deposit * effective_relative_tolerance)
 
     # Initial delay: give HyperCore time to process the deposit
     # before first poll (API can lag behind HyperCore state).

--- a/tests/hyperliquid/test_vault_deposit_confirmation.py
+++ b/tests/hyperliquid/test_vault_deposit_confirmation.py
@@ -147,7 +147,9 @@ def test_existing_deposit_rejects_large_relative_shortfall(
     3. Verify the helper raises ``HypercoreDepositVerificationError``.
     """
     session = MagicMock()
-    mock_fetch.return_value = _make_equity(Decimal("620.0"))
+    # Increase = 580.0 - 59.559287 = 520.44 vs expected 570.69, an ~8.8% shortfall
+    # that exceeds the 5% existing-position relative tolerance, so this must reject.
+    mock_fetch.return_value = _make_equity(Decimal("580.0"))
     mock_time.side_effect = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
 
     # 1. Mock an existing-position equity increase that stays materially below the expected amount.
@@ -163,3 +165,41 @@ def test_existing_deposit_rejects_large_relative_shortfall(
             timeout=3.0,
             poll_interval=1.0,
         )
+
+
+@patch("eth_defi.hyperliquid.api.time.sleep")
+@patch("eth_defi.hyperliquid.api.fetch_user_vault_equity")
+def test_existing_deposit_confirms_despite_nav_drift(
+    mock_fetch,
+    _mock_sleep,
+):
+    """Confirm an existing-position deposit even when vault NAV drifted against the stale baseline (regression for trade #1240).
+
+    Reproduces the production incident that crashed the live loop on 2026-07-01:
+    a fully-credited 8.06806 USDC deposit into the Loop Fund vault looked ~2.7%
+    short because the pre-existing ~750 USDC position marked down ~0.22 USDC
+    between the baseline snapshot and verification. The old 1% band rejected it
+    (0.08 USDC tolerance); the widened 5% band (0.40 USDC tolerance) must accept
+    it, since the increase 7.846518 exceeds the threshold 8.06806 - 0.40 = 7.665.
+
+    1. Mock the vault equity to the production value observed at the final poll.
+    2. Call ``wait_for_vault_deposit_confirmation()`` with the production baseline.
+    3. Verify the helper confirms the deposit under the default 5% tolerance.
+    """
+    session = MagicMock()
+    # 1. Mock the vault equity to the production value observed at the final poll.
+    mock_fetch.return_value = _make_equity(Decimal("757.794214"))
+
+    # 2. Call wait_for_vault_deposit_confirmation() with the production baseline.
+    result = wait_for_vault_deposit_confirmation(
+        session,
+        user=USER_ADDR,
+        vault_address=VAULT_ADDR,
+        expected_deposit=Decimal("8.06806"),
+        existing_equity=Decimal("749.947696"),
+        timeout=10.0,
+        poll_interval=1.0,
+    )
+
+    # 3. Verify the helper confirms the deposit under the default 5% tolerance.
+    assert result.equity == Decimal("757.794214")


### PR DESCRIPTION
## Why

A live production trade-executor loop crashed on **2026-07-01 19:47:39** while depositing into a HyperCore native vault, even though the deposit had actually succeeded and the funds were safely in the vault.

The crash originated in `wait_for_vault_deposit_confirmation` (`eth_defi.hyperliquid.api`). When depositing into an **existing** vault position, it confirms the deposit by checking that our USD equity increased by roughly the deposited amount, accepting a shortfall of `max(tolerance, expected_deposit * relative_tolerance)`. The relative tolerance was **1%**.

The problem: the "increase" is measured against a **baseline equity snapshotted minutes earlier** (before phase 1). Live perp-trading vaults — such as the copy-trading leader vault involved here — mark-to-market **every block**, so the vault's *existing* holdings drift in value during the confirmation window. That drift is subtracted from the apparent deposit, so a fully-credited deposit can look short whenever the vault's own NAV ticks down in the meantime.

### Root cause, with the production data

Trade **#1240**, Loop Fund vault (`0xfeab64de8cdf9dcebc0f49812499e396273efc06`), Safe `0xa8F8DEbb722c6174B814b432169BF569603F673F`.

All three on-chain transactions succeeded (`status=True`): approval, phase-1 bridge to HyperCore spot, phase-2 `vaultTransfer` into the vault. The failure was purely in post-deposit verification.

- `expected_deposit` = **8.06806 USDC**
- baseline `existing_equity` = **749.947696 USDC** (snapshotted pre phase 1)
- `accepted_tolerance` = `max(0.01, 8.06806 × 1%)` = **0.0807 USDC**

Poll-by-poll equity during the 60s window:

| Poll | Time | Equity | Increase vs baseline |
|------|------|--------|------|
| #1 | 19:46:34 | 749.732096 | **−0.2156** (deposit not yet reflected — vault already down 0.22 vs baseline) |
| #2 | 19:46:36 | 757.798176 | +7.850480 (deposit now credited) |
| … | … | ~757.69–757.80 | ~7.74–7.82 (perp marks oscillating) |
| #26 | 19:47:30 | 757.794214 | +7.846518 |

The decisive number: **poll#2 − poll#1 = 757.798176 − 749.732096 = 8.06608 USDC**, versus the expected 8.06806 — the deposit landed to within **0.002 USDC**.

But by poll #1, *before* the deposit was even reflected, the vault's existing ~750 USDC position had already marked down to 749.732096, i.e. **0.2156 USDC (≈0.03%) below the stale baseline**. So the absolute-increase check needed:

```
threshold equity = 749.947696 (stale baseline) + 8.06806 − 0.0807 = 757.9354
max observed equity ≈ 757.798    →  never reached
```

Verification timed out after 60s, raised `HypercoreDepositVerificationError`, which propagated as `ExecutionHaltableIssue` → `LiveSchedulingTaskFailed`, halting sequential execution and dropping the executor into web-server wait mode. The diagnostics even mislabelled 8.06806 USDC as "stranded in hypercore_spot_or_perp" — but spot/perp were empty and vault equity was up ~7.85; the money was in the vault the whole time.

This was **not** a fee, haircut, or partial deposit — it was mark-to-market drift of the vault's pre-existing holdings, measured against a baseline snapshotted before the deposit.

## Lessons learnt

- Confirming a deposit by an **absolute equity increase against a stale baseline** is unreliable for any asset whose NAV moves every block. The metric conflates two things: the deposit itself, and the vault's NAV change since the snapshot.
- A 1% band (0.08 USDC on a ~750 USDC position) is far too tight to absorb ordinary perp-vault volatility — a 0.03% adverse tick over a few minutes is enough to trip it.
- Widening to 5% still cleanly distinguishes a genuinely rejected/stranded deposit (which shows **~0%** increase) from a landed deposit with a few-percent NAV shortfall.
- A more robust follow-up (not in this PR) would measure the deposit as the **jump between consecutive polls**, or track the **vault share-token balance increase** instead of USD equity, so NAV drift cannot contaminate the measurement.

## Summary

- Raised `DEFAULT_VAULT_DEPOSIT_RELATIVE_TOLERANCE` from `Decimal("0.01")` (1%) to `Decimal("0.05")` (5%) in `eth_defi/hyperliquid/api.py`.
- Documented the constant with a detailed line comment covering the NAV-drift mechanism and the production incident, and updated the `wait_for_vault_deposit_confirmation` docstring.
- Added a `CHANGELOG.md` entry.

A companion trade-executor PR updates `.claude/docs/hypercore-vault.md` with a "Deposit verification tolerance and NAV drift" section describing the same incident.

## Related issues and PRs

- Companion doc PR in `trade-executor` (`.claude/docs/hypercore-vault.md`).

## Unrelated CI and test fixes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
