### PR TITLE
fix: refresh stablecoin rates before metadata upload

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,12 @@ services:
       # Hyperliquid backfill script
       WEBSHARE_API_KEY: ${WEBSHARE_API_KEY:-}
 
+      # Stablecoin metadata bundle exchange-rate refresh.
+      REFRESH_STABLECOIN_RATES: ${REFRESH_STABLECOIN_RATES:-true}
+      FORCE_STABLECOIN_RATE_REFRESH: ${FORCE_STABLECOIN_RATE_REFRESH:-false}
+      STABLECOIN_RATE_TIMEOUT: ${STABLECOIN_RATE_TIMEOUT:-20}
+      COINGECKO_DEMO_API_KEY: ${COINGECKO_DEMO_API_KEY:-}
+
       # Hyperliquid manual vault review Google Sheet sync.
       #
       # When all three variables are set, the Hypercore branch of
@@ -169,6 +175,8 @@ services:
       - ./logs:/usr/src/web3-ethereum-defi/logs:rw
       # Expose token cache files and other cache files reused by the vault scanner
       - ${HOME}/.cache:/root/.cache:rw
+      # Persist daily CoinGecko stablecoin rate refreshes written before metadata upload.
+      - ./eth_defi/data/stablecoins:/usr/src/web3-ethereum-defi/eth_defi/data/stablecoins:rw
 
   # Persistent: looped vault scanner, ticks every 1h, scans chains on configurable cycles.
   # Ethereum/Base/Arbitrum on 8h, Hyperliquid/GRVT/Lighter/Hibachi on 4h, other EVM chains on 24h.
@@ -226,6 +234,10 @@ services:
       MAX_WORKERS: ${MAX_WORKERS:-50}
       HYPERSYNC_CONCURRENCY: ${HYPERSYNC_CONCURRENCY:-1}
       WEBSHARE_API_KEY: ${WEBSHARE_API_KEY:-}
+      REFRESH_STABLECOIN_RATES: ${REFRESH_STABLECOIN_RATES:-true}
+      FORCE_STABLECOIN_RATE_REFRESH: ${FORCE_STABLECOIN_RATE_REFRESH:-false}
+      STABLECOIN_RATE_TIMEOUT: ${STABLECOIN_RATE_TIMEOUT:-20}
+      COINGECKO_DEMO_API_KEY: ${COINGECKO_DEMO_API_KEY:-}
 
       R2_SPARKLINE_BUCKET_NAME: ${R2_SPARKLINE_BUCKET_NAME:-}
       R2_SPARKLINE_ENDPOINT_URL: ${R2_SPARKLINE_ENDPOINT_URL:-}
@@ -293,6 +305,7 @@ services:
       - ${HOME}/.tradingstrategy:/root/.tradingstrategy:rw
       - ./logs:/usr/src/web3-ethereum-defi/logs:rw
       - ${HOME}/.cache:/root/.cache:rw
+      - ./eth_defi/data/stablecoins:/usr/src/web3-ethereum-defi/eth_defi/data/stablecoins:rw
 
   # Persistent: continuously collects vault-related posts from RSS, LinkedIn, and X/Twitter.
   # Started by `docker compose up -d`.
@@ -316,6 +329,10 @@ services:
       LOOP_INTERVAL_SECONDS: ${POST_SCAN_LOOP_INTERVAL:-28800}
       LOG_LEVEL: ${LOG_LEVEL:-warning}
       WEBSHARE_API_KEY: ${WEBSHARE_API_KEY:-}
+      REFRESH_STABLECOIN_RATES: ${REFRESH_STABLECOIN_RATES:-true}
+      FORCE_STABLECOIN_RATE_REFRESH: ${FORCE_STABLECOIN_RATE_REFRESH:-false}
+      STABLECOIN_RATE_TIMEOUT: ${STABLECOIN_RATE_TIMEOUT:-20}
+      COINGECKO_DEMO_API_KEY: ${COINGECKO_DEMO_API_KEY:-}
     mem_limit: 2g
     mem_reservation: 512m
     volumes:
@@ -323,4 +340,6 @@ services:
       # The scanner will update YAML files with failed RSS feeds and Twitter accounts,
       # then we manually push them to github now and then
       - ./eth_defi/data/feeds:/usr/src/web3-ethereum-defi/eth_defi/data/feeds:rw
+      # Persist daily CoinGecko stablecoin rate refreshes written by the post scanner.
+      - ./eth_defi/data/stablecoins:/usr/src/web3-ethereum-defi/eth_defi/data/stablecoins:rw
       - ./logs:/usr/src/web3-ethereum-defi/logs:rw

--- a/scripts/erc-4626/export-protocol-metadata.py
+++ b/scripts/erc-4626/export-protocol-metadata.py
@@ -19,6 +19,10 @@ Environment variables:
     - R2_ALTERNATIVE_VAULT_METADATA_BUCKET_NAME: Alternative R2 bucket for the upcoming private
       commercial professional vault data bucket (optional, uses same credentials as primary)
     - MAX_WORKERS: Number of parallel upload workers (default: 20)
+    - REFRESH_STABLECOIN_RATES: Refresh stablecoin rates before uploading the stablecoin JSON bundle (default: true)
+    - FORCE_STABLECOIN_RATE_REFRESH: Bypass the per-entry same-day stablecoin rate gate (default: false)
+    - STABLECOIN_RATE_TIMEOUT: CoinGecko timeout in seconds (default: 20)
+    - COINGECKO_DEMO_API_KEY: Optional CoinGecko demo API key used by the rate module
 """
 
 import logging
@@ -26,15 +30,110 @@ import os
 from pathlib import Path
 
 from joblib import Parallel, delayed
+from strictyaml import YAMLError
 from tabulate import tabulate
 from tqdm_loggable.auto import tqdm
 
+from eth_defi.feed.stablecoin_rate import StablecoinRateRefreshSummary, refresh_stablecoin_rates
 from eth_defi.stablecoin_metadata import STABLECOINS_DATA_DIR, process_and_upload_stablecoin_metadata, upload_stablecoin_index
 from eth_defi.utils import setup_console_logging
 from eth_defi.vault.curator import CURATORS_DATA_DIR, process_and_upload_curator_metadata, upload_curator_index, upload_protocol_curator_metadata
 from eth_defi.vault.protocol_metadata import METADATA_DIR, get_available_logos, process_and_upload_protocol_metadata
 
 logger = logging.getLogger(__name__)
+
+_STABLECOIN_RATE_EXPORT_ERROR_TYPES = (
+    YAMLError,
+    OSError,
+    RuntimeError,
+    ValueError,
+    TypeError,
+    KeyError,
+    AttributeError,
+    IndexError,
+)
+
+
+def _env_flag(name: str, *, default: bool) -> bool:
+    """Parse a boolean environment flag.
+
+    :param name:
+        Environment variable name.
+
+    :param default:
+        Value used when the environment variable is missing.
+
+    :return:
+        ``True`` when the variable value is one of the accepted truthy strings.
+    """
+    raw_value = os.environ.get(name)
+    if raw_value is None:
+        return default
+    return raw_value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_float(name: str, *, default: float) -> float:
+    """Parse a floating-point environment value.
+
+    :param name:
+        Environment variable name.
+
+    :param default:
+        Value used when the environment variable is missing or malformed.
+
+    :return:
+        Parsed float value.
+    """
+    raw_value = os.environ.get(name)
+    if raw_value is None or not raw_value.strip():
+        return default
+    try:
+        return float(raw_value)
+    except ValueError:
+        logger.warning("Invalid %s=%r, using default %s", name, raw_value, default)
+        return default
+
+
+def refresh_stablecoin_rates_for_metadata_export() -> StablecoinRateRefreshSummary | None:
+    """Refresh stablecoin rates before uploading stablecoin metadata.
+
+    The stablecoin JSON bundle contains mutable exchange-rate fields sourced
+    from CoinGecko. Refreshing them inside the metadata exporter ensures the
+    bundle upload does not depend on a separate post-scanner container having
+    persisted YAML changes to the host filesystem.
+
+    :return:
+        Refresh counters, or ``None`` when disabled with
+        ``REFRESH_STABLECOIN_RATES=false``.
+    """
+    if not _env_flag("REFRESH_STABLECOIN_RATES", default=True):
+        logger.info("Skipping stablecoin rate refresh (REFRESH_STABLECOIN_RATES=false)")
+        return None
+
+    timeout = _env_float("STABLECOIN_RATE_TIMEOUT", default=20.0)
+    force = _env_flag("FORCE_STABLECOIN_RATE_REFRESH", default=False)
+    try:
+        summary = refresh_stablecoin_rates(
+            data_dir=STABLECOINS_DATA_DIR,
+            force=force,
+            timeout=timeout,
+            progress_bar=True,
+        )
+    except _STABLECOIN_RATE_EXPORT_ERROR_TYPES as e:
+        logger.warning("Stablecoin rate refresh failed before metadata export, continuing with existing metadata: %s", e)
+        return None
+
+    logger.info(
+        "Stablecoin rate refresh complete: files_scanned=%d entries_seen=%d due=%d fetched=%d files_updated=%d failed=%d depegged=%d",
+        summary.files_scanned,
+        summary.entries_seen,
+        summary.due_count,
+        summary.rates_fetched,
+        summary.files_updated,
+        summary.failed_count,
+        summary.depegged_count,
+    )
+    return summary
 
 
 def main():  # noqa: PLR0914
@@ -69,6 +168,10 @@ def main():  # noqa: PLR0914
 
     stablecoin_files = list(STABLECOINS_DATA_DIR.glob("*.yaml"))
     logger.info("Found %d stablecoin metadata files", len(stablecoin_files))
+
+    # Keep mutable stablecoin exchange rates fresh in the exact process that
+    # builds and uploads the JSON bundle.
+    refresh_stablecoin_rates_for_metadata_export()
 
     for current_bucket in bucket_names:
         if len(bucket_names) > 1:

--- a/scripts/erc-4626/scan-vault-posts.py
+++ b/scripts/erc-4626/scan-vault-posts.py
@@ -70,6 +70,8 @@ from eth_defi.utils import setup_console_logging
 
 logger = logging.getLogger(__name__)
 
+SECONDS_PER_MINUTE = 60
+
 
 def _parse_csv(raw_value: str | None) -> list[str]:
     """Parse a comma-separated environment variable into a list."""
@@ -77,6 +79,18 @@ def _parse_csv(raw_value: str | None) -> list[str]:
     if not raw_value:
         return []
     return [item.strip() for item in raw_value.split(",") if item.strip()]
+
+
+def _parse_float_env(name: str, *, default: float) -> float:
+    """Parse an optional floating-point environment variable."""
+    raw_value = os.environ.get(name)
+    if raw_value is None or not raw_value.strip():
+        return default
+    try:
+        return float(raw_value)
+    except ValueError:
+        logger.warning("Invalid %s=%r, using default %s", name, raw_value, default)
+        return default
 
 
 def _format_datetime(value) -> str:
@@ -91,10 +105,10 @@ def _format_duration(seconds: float | None) -> str:
     """Format duration in seconds to human-readable string."""
     if seconds is None:
         return "-"
-    if seconds < 60:
+    if seconds < SECONDS_PER_MINUTE:
         return f"{seconds:.1f}s"
-    minutes = int(seconds // 60)
-    secs = seconds % 60
+    minutes = int(seconds // SECONDS_PER_MINUTE)
+    secs = seconds % SECONDS_PER_MINUTE
     return f"{minutes}m {secs:.0f}s"
 
 
@@ -234,7 +248,7 @@ def _build_config() -> PostScanConfig:
         refresh_stablecoin_rates=os.environ.get("REFRESH_STABLECOIN_RATES", "true").lower() == "true",
         force_stablecoin_rate_refresh=os.environ.get("FORCE_STABLECOIN_RATE_REFRESH", "false").lower() == "true",
         stablecoin_data_dir=Path(stablecoin_data_dir_str).expanduser() if stablecoin_data_dir_str else STABLECOINS_DATA_DIR,
-        stablecoin_rate_timeout=float(os.environ.get("STABLECOIN_RATE_TIMEOUT", "20")),
+        stablecoin_rate_timeout=_parse_float_env("STABLECOIN_RATE_TIMEOUT", default=20.0),
         stablecoin_rate_gate_path=Path(stablecoin_rate_gate_path_str).expanduser() if stablecoin_rate_gate_path_str else None,
     )
 

--- a/scripts/erc-4626/scan-vaults-all-chains.py
+++ b/scripts/erc-4626/scan-vaults-all-chains.py
@@ -108,6 +108,10 @@ Environment variables:
     - SKIP_SPARKLINES: "true" to skip sparkline image export to R2 (default: "false")
     - SKIP_METADATA: "true" to skip protocol/stablecoin metadata export to R2 (default: "false")
     - SKIP_DATA: "true" to skip data file (parquet, pickle) export to R2 (default: "false")
+    - REFRESH_STABLECOIN_RATES: "false" to skip CoinGecko stablecoin rate refresh before metadata export (default: "true")
+    - FORCE_STABLECOIN_RATE_REFRESH: "true" to bypass the same-day stablecoin rate gate (default: "false")
+    - STABLECOIN_RATE_TIMEOUT: CoinGecko timeout in seconds for stablecoin rate refresh (default: "20")
+    - COINGECKO_DEMO_API_KEY: Optional CoinGecko demo API key for stablecoin rate refreshes
     - JSON_RPC_<CHAIN>: RPC URL for each chain (required per chain)
     - LOOP_INTERVAL_SECONDS: Seconds between ticks in looped mode (default: "0" = single run)
     - SCAN_CYCLES: Per-chain/protocol cycle overrides, e.g. "Ethereum=8h,Base=8h,Arbitrum=8h,Hypercore=4h,GRVT=4h,Lighter=4h"

--- a/tests/erc_4626/test_export_protocol_metadata.py
+++ b/tests/erc_4626/test_export_protocol_metadata.py
@@ -1,0 +1,110 @@
+"""Tests for protocol and stablecoin metadata export helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from eth_defi.feed.stablecoin_rate import StablecoinRateRefreshSummary
+
+STABLECOIN_RATE_TIMEOUT = 7.5
+DEFAULT_STABLECOIN_RATE_TIMEOUT = 20.0
+
+
+def _load_export_protocol_metadata_module():
+    """Load the metadata export script as a Python module."""
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "erc-4626" / "export-protocol-metadata.py"
+    spec = importlib.util.spec_from_file_location("export_protocol_metadata", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_stablecoin_rate_refresh_runs_before_metadata_export(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Metadata exporter refreshes stablecoin rates with configured CoinGecko options."""
+    module = _load_export_protocol_metadata_module()
+    calls: list[dict] = []
+
+    def fake_refresh_stablecoin_rates(**kwargs: object) -> StablecoinRateRefreshSummary:
+        calls.append(kwargs)
+        return StablecoinRateRefreshSummary(files_scanned=1, entries_seen=1, due_count=1, rates_fetched=1)
+
+    monkeypatch.setattr(module, "refresh_stablecoin_rates", fake_refresh_stablecoin_rates)
+    monkeypatch.setenv("REFRESH_STABLECOIN_RATES", "true")
+    monkeypatch.setenv("FORCE_STABLECOIN_RATE_REFRESH", "true")
+    monkeypatch.setenv("STABLECOIN_RATE_TIMEOUT", str(STABLECOIN_RATE_TIMEOUT))
+    monkeypatch.chdir(tmp_path)
+
+    summary = module.refresh_stablecoin_rates_for_metadata_export()
+
+    assert summary is not None
+    assert summary.rates_fetched == 1
+    assert len(calls) == 1
+    assert calls[0]["data_dir"] == module.STABLECOINS_DATA_DIR
+    assert calls[0]["force"] is True
+    assert calls[0]["timeout"] == STABLECOIN_RATE_TIMEOUT
+    assert calls[0]["progress_bar"] is True
+
+
+def test_stablecoin_rate_refresh_timeout_falls_back_to_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Malformed STABLECOIN_RATE_TIMEOUT does not abort metadata export."""
+    module = _load_export_protocol_metadata_module()
+    calls: list[dict] = []
+
+    def fake_refresh_stablecoin_rates(**kwargs: object) -> StablecoinRateRefreshSummary:
+        calls.append(kwargs)
+        return StablecoinRateRefreshSummary(files_scanned=1)
+
+    monkeypatch.setattr(module, "refresh_stablecoin_rates", fake_refresh_stablecoin_rates)
+    monkeypatch.setenv("REFRESH_STABLECOIN_RATES", "true")
+    monkeypatch.setenv("STABLECOIN_RATE_TIMEOUT", "not-a-number")
+
+    summary = module.refresh_stablecoin_rates_for_metadata_export()
+
+    assert summary is not None
+    assert calls[0]["timeout"] == DEFAULT_STABLECOIN_RATE_TIMEOUT
+
+
+def test_stablecoin_rate_refresh_failure_does_not_abort_metadata_export(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stablecoin refresh failures are logged and existing metadata can still upload."""
+    module = _load_export_protocol_metadata_module()
+
+    def fake_refresh_stablecoin_rates(**kwargs: object) -> StablecoinRateRefreshSummary:
+        assert isinstance(kwargs, dict)
+        message = "cannot write stablecoin metadata"
+        raise OSError(message)
+
+    monkeypatch.setattr(module, "refresh_stablecoin_rates", fake_refresh_stablecoin_rates)
+    monkeypatch.setenv("REFRESH_STABLECOIN_RATES", "true")
+
+    summary = module.refresh_stablecoin_rates_for_metadata_export()
+
+    assert summary is None
+
+
+def test_stablecoin_rate_refresh_can_be_disabled_for_metadata_export(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Metadata exporter honours REFRESH_STABLECOIN_RATES=false."""
+    module = _load_export_protocol_metadata_module()
+    called = False
+
+    def fake_refresh_stablecoin_rates(**kwargs: object) -> StablecoinRateRefreshSummary:
+        nonlocal called
+        assert isinstance(kwargs, dict)
+        called = True
+        return StablecoinRateRefreshSummary()
+
+    monkeypatch.setattr(module, "refresh_stablecoin_rates", fake_refresh_stablecoin_rates)
+    monkeypatch.setenv("REFRESH_STABLECOIN_RATES", "false")
+
+    summary = module.refresh_stablecoin_rates_for_metadata_export()
+
+    assert summary is None
+    assert called is False

--- a/tests/erc_4626/test_scan_vault_posts_config.py
+++ b/tests/erc_4626/test_scan_vault_posts_config.py
@@ -1,0 +1,32 @@
+"""Tests for the vault post scanner script configuration."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+DEFAULT_STABLECOIN_RATE_TIMEOUT = 20.0
+
+
+def _load_scan_vault_posts_module():
+    """Load the post scanner script as a Python module."""
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "erc-4626" / "scan-vault-posts.py"
+    spec = importlib.util.spec_from_file_location("scan_vault_posts", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_stablecoin_rate_timeout_config_falls_back_to_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Malformed STABLECOIN_RATE_TIMEOUT does not abort post scanner config loading."""
+    module = _load_scan_vault_posts_module()
+    monkeypatch.setenv("STABLECOIN_RATE_TIMEOUT", "not-a-number")
+
+    config = module._build_config()
+
+    assert config.stablecoin_rate_timeout == DEFAULT_STABLECOIN_RATE_TIMEOUT


### PR DESCRIPTION
## Why

Stablecoin exchange rates were refreshed by the post scanner, but the metadata bundle upload path did not refresh rates itself. In Docker, the post scanner also did not persist `eth_defi/data/stablecoins`, so the vault scanner could upload stale stablecoin JSON metadata even when CoinGecko refreshes had run elsewhere.

## Lessons learnt

The stablecoin rate refresh must run in the same process that builds and uploads the stablecoin metadata bundle, or the upload can depend on another container's writable layer. The refresh should remain best-effort so a rate-side failure does not block unrelated protocol and curator metadata uploads. The shared Docker env vars also need tolerant parsing in every process that consumes them.

## Summary

- Refresh CoinGecko-backed stablecoin rates before `export-protocol-metadata.py` builds and uploads stablecoin JSON metadata.
- Make the metadata-export refresh best-effort, with malformed timeout values falling back to the default.
- Mount `eth_defi/data/stablecoins` and expose stablecoin refresh env vars in scanner Docker services.
- Harden the post-scanner stablecoin timeout parser for the same env var.
- Add focused tests for refresh wiring, disable mode, timeout fallback, non-fatal refresh failures, and post-scanner config parsing.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.