### PR TITLE
fix: blacklist vaults with bad scan flags

### DIFF
--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -40,6 +40,7 @@ from eth_defi.vault.flag import (
     ABNORMAL_SHARE_PRICE,
     ABNORMAL_TVL,
     ABNORMAL_VOLATILITY,
+    BAD_FLAGS,
     NOT_IN_MORPHO_API,
     VaultFlag,
     get_notes,
@@ -1337,6 +1338,40 @@ def apply_morpho_not_in_api_check(
     return risk, notes, flags
 
 
+def apply_bad_flag_check(
+    risk: VaultTechnicalRisk | None,
+    notes: str | None,
+    flags: set[VaultFlag],
+) -> tuple[VaultTechnicalRisk | None, str | None, set[VaultFlag]]:
+    """Blacklist vaults that carry scanned bad flags.
+
+    Scan-time flags may come from protocol adapters and are not visible to
+    :py:func:`get_vault_risk`, which only checks the static manual flag table.
+    Any flag listed in :py:data:`eth_defi.vault.flag.BAD_FLAGS` means the vault
+    must not be exported as a normal investable row.
+
+    :param risk:
+        Current risk classification.
+
+    :param notes:
+        Current note, if any. Existing notes are preserved.
+
+    :param flags:
+        Scan-time and manual flags collected for the vault.
+
+    :return:
+        Updated risk, notes, and flags.
+    """
+    bad_flags = flags & BAD_FLAGS
+    if bad_flags:
+        risk = VaultTechnicalRisk.blacklisted
+        if not notes:
+            flag_names = ", ".join(sorted(flag.value for flag in bad_flags))
+            notes = f"Vault has bad scan flags: {flag_names}"
+
+    return risk, notes, flags
+
+
 def calculate_vault_record(
     prices_df: pd.DataFrame,
     vault_metadata_rows: dict[VaultSpec, VaultRow],
@@ -1441,7 +1476,12 @@ def calculate_vault_record(
     risk = vault_metadata.get("_risk") or get_vault_risk(protocol, vault_address)
     notes = get_notes(vault_address, chain_id=chain_id)
 
-    flags = vault_metadata.get("_flags", set())
+    flags = set(vault_metadata.get("_flags") or set())
+    risk, notes, flags = apply_bad_flag_check(
+        risk=risk,
+        notes=notes,
+        flags=flags,
+    )
 
     current_share_price = prices_df.iloc[-1]["share_price"]
     risk, notes, flags = apply_abnormal_value_checks(

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -1366,10 +1366,26 @@ def apply_bad_flag_check(
     if bad_flags:
         risk = VaultTechnicalRisk.blacklisted
         if not notes:
-            flag_names = ", ".join(sorted(flag.value for flag in bad_flags))
-            notes = f"Vault has bad scan flags: {flag_names}"
+            notes = format_bad_flag_note(bad_flags)
 
     return risk, notes, flags
+
+
+def format_bad_flag_note(bad_flags: set[VaultFlag]) -> str:
+    """Create a generic note for vaults that carry bad scan flags.
+
+    This note is used before any protocol-specific metadata has been analysed.
+    Later checks may replace it with a richer note if the generic bad flag and
+    the protocol-specific warning describe the same underlying issue.
+
+    :param bad_flags:
+        Bad vault flags to report.
+
+    :return:
+        Human-readable note.
+    """
+    flag_names = ", ".join(sorted(flag.value for flag in bad_flags))
+    return f"Vault has bad scan flags: {flag_names}"
 
 
 def calculate_vault_record(
@@ -1622,8 +1638,8 @@ def calculate_vault_record(
             # (bad debt, compromised oracle, governance attack window) and should not be used
             risk = VaultTechnicalRisk.blacklisted
             risk_numeric = VaultTechnicalRisk.blacklisted.value
-            # Only generate the note text when no existing manual or abnormal-metric note is set
-            if not notes:
+            # Replace only the generic Morpho bad-flag note with richer source metadata.
+            if not notes or notes == format_bad_flag_note({VaultFlag.morpho_issues}):
                 notes = morpho_analytics.note
 
     vault_display_flags = make_vault_display_flags(

--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -98,6 +98,7 @@ BAD_FLAGS = {
     VaultFlag.abnormal_volatility,
     VaultFlag.subvault,
     VaultFlag.irregular_reporting,
+    VaultFlag.morpho_issues,
     VaultFlag.not_in_morpho_api,
     VaultFlag.depegged_denomination_token,
 }

--- a/scripts/erc-4626/list-blacklisted-vaults.py
+++ b/scripts/erc-4626/list-blacklisted-vaults.py
@@ -1,0 +1,172 @@
+"""List blacklisted vaults from lifetime metrics.
+
+Recalculates lifetime metrics from the local pipeline inputs, then prints all
+vaults whose final metrics risk is
+:py:data:`eth_defi.vault.risk.VaultTechnicalRisk.blacklisted`.
+
+This script intentionally reads the cleaned parquet and vault metadata database
+instead of ``top_vaults_by_chain.json``. The public JSON export suppresses
+blacklisted rows, so it cannot be used to audit what was removed.
+
+Usage:
+
+.. code-block:: shell
+
+    poetry run python scripts/erc-4626/list-blacklisted-vaults.py
+
+Environment variables:
+
+- ``PIPELINE_DATA_DIR``: Optional. Base directory for default pipeline files.
+- ``VAULT_DB_PATH``: Optional. Vault metadata pickle path.
+- ``PARQUET_FILE``: Optional. Cleaned vault prices parquet path.
+- ``STABLECOINS_DIR``: Optional. Stablecoin metadata YAML directory.
+- ``STABLECOINS_ONLY``: Optional. Keep the top-vault export filter. Default: true.
+- ``LOG_LEVEL``: Optional. Default: warning.
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+from tabulate import tabulate
+
+from eth_defi.feed.stablecoin_rate import STABLECOINS_DATA_DIR, StablecoinRateFeeder
+from eth_defi.research.vault_metrics import calculate_hourly_returns_for_all_vaults, calculate_lifetime_metrics
+from eth_defi.token import is_stablecoin_like
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.risk import VaultTechnicalRisk
+from eth_defi.vault.vaultdb import VaultDatabase, get_pipeline_data_dir
+
+logger = logging.getLogger(__name__)
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    """Parse a boolean environment flag.
+
+    :param name:
+        Environment variable name.
+    :param default:
+        Fallback value when the variable is unset.
+    :return:
+        Parsed boolean.
+    """
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _format_usd(value: float | int | None) -> str:
+    """Format a USD amount for tabular output.
+
+    :param value:
+        USD value, or ``None`` for missing data.
+    :return:
+        Formatted string.
+    """
+    if value is None or pd.isna(value):
+        return "-"
+    return f"${float(value):,.0f}"
+
+
+def _format_flags(value: Any) -> str:
+    """Format vault flags for tabular output.
+
+    :param value:
+        Iterable of flag enums or strings.
+    :return:
+        Comma-separated flag values.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, float) and pd.isna(value):
+        return ""
+    return ", ".join(sorted(getattr(flag, "value", str(flag)) for flag in value))
+
+
+def _resolve_paths() -> tuple[Path, Path, Path]:
+    """Resolve input paths from environment variables.
+
+    :return:
+        Tuple ``(vault_db_path, parquet_path, stablecoins_dir)``.
+    """
+    pipeline_data_dir = get_pipeline_data_dir()
+    vault_db_path = Path(os.environ.get("VAULT_DB_PATH", str(pipeline_data_dir / "vault-metadata-db.pickle"))).expanduser()
+    parquet_path = Path(os.environ.get("PARQUET_FILE", str(pipeline_data_dir / "cleaned-vault-prices-1h.parquet"))).expanduser()
+    stablecoins_dir = Path(os.environ.get("STABLECOINS_DIR", str(STABLECOINS_DATA_DIR))).expanduser()
+    return vault_db_path, parquet_path, stablecoins_dir
+
+
+def main() -> None:
+    """Calculate and print blacklisted vault rows."""
+    setup_console_logging(default_log_level=os.environ.get("LOG_LEVEL", "warning"))
+
+    vault_db_path, parquet_path, stablecoins_dir = _resolve_paths()
+    stablecoins_only = _env_flag("STABLECOINS_ONLY", default=True)
+
+    assert vault_db_path.exists(), f"Vault database not found: {vault_db_path}"
+    assert parquet_path.exists(), f"Cleaned vault prices parquet not found: {parquet_path}"
+    assert stablecoins_dir.exists(), f"Stablecoin metadata directory not found: {stablecoins_dir}"
+
+    logger.info("Reading vault database from %s", vault_db_path)
+    vault_db = VaultDatabase.read(vault_db_path)
+
+    logger.info("Reading cleaned vault prices from %s", parquet_path)
+    prices_df = pd.read_parquet(parquet_path)
+
+    if stablecoins_only:
+        allowed_vault_ids = {f"{row['_detection_data'].chain}-{row['_detection_data'].address}" for row in vault_db.values() if is_stablecoin_like(row["Denomination"])}
+        prices_df = prices_df.loc[prices_df["id"].isin(allowed_vault_ids)]
+
+    returns_df = calculate_hourly_returns_for_all_vaults(prices_df)
+    metrics = calculate_lifetime_metrics(
+        returns_df,
+        vault_db,
+        stablecoin_rate_feeder=StablecoinRateFeeder(data_dir=stablecoins_dir),
+    )
+
+    blacklisted = metrics.loc[metrics["risk"] == VaultTechnicalRisk.blacklisted].copy()
+    if not blacklisted.empty:
+        blacklisted = blacklisted.sort_values(["chain", "protocol", "current_nav"], ascending=[True, True, False])
+
+    rows: list[list[Any]] = []
+    total_tvl = 0.0
+    for _, row in blacklisted.iterrows():
+        tvl = row.get("current_nav")
+        if tvl is not None and pd.notna(tvl):
+            total_tvl += float(tvl)
+        rows.append(
+            [
+                row.get("chain"),
+                row.get("protocol"),
+                row.get("name"),
+                row.get("denomination"),
+                _format_flags(row.get("flags")),
+                _format_usd(tvl),
+                row.get("address"),
+                row.get("notes") or "",
+            ]
+        )
+
+    rows.append(["TOTAL", "", f"{len(blacklisted):,} vaults", "", "", _format_usd(total_tvl), "", ""])
+
+    print()
+    print(f"Vault database: {vault_db_path}")
+    print(f"Cleaned prices: {parquet_path}")
+    print(f"Stablecoin metadata: {stablecoins_dir}")
+    print(f"Stablecoin-denominated only: {stablecoins_only}")
+    print()
+    print(
+        tabulate(
+            rows,
+            headers=["Chain", "Protocol", "Vault", "Denomination", "Flags", "TVL", "Address", "Notes"],
+            tablefmt="grid",
+            colalign=("left", "left", "left", "left", "left", "right", "left", "left"),
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -248,6 +248,31 @@ def test_calculate_lifetime_metrics(
     # assert "period_results" not in formatted.columns
 
 
+def test_calculate_lifetime_metrics_blacklists_scanned_bad_flags(
+    vault_db: VaultDatabase,
+    price_df: pd.DataFrame,
+):
+    """Scanned bad flags override a cached non-blacklisted risk classification."""
+    vault_id = "43111-0x614eb485de3c6c49701b40806ac1b985ad6f0a2f"
+    spec = VaultSpec.parse_string(vault_id)
+    vault_row = dict(vault_db.rows[spec])
+    vault_row["_risk"] = VaultTechnicalRisk.low
+    vault_row["_flags"] = {VaultFlag.unofficial}
+    vault_rows = {spec: vault_row}
+    vault_prices = price_df.loc[price_df["id"] == vault_id]
+
+    metrics = calculate_lifetime_metrics(
+        vault_prices,
+        vault_rows,
+    )
+
+    row = metrics.iloc[0]
+    assert row["risk"] == VaultTechnicalRisk.blacklisted
+    assert row["risk_numeric"] == VaultTechnicalRisk.blacklisted.value
+    assert row["flags"] == {VaultFlag.unofficial}
+    assert row["notes"] == "Vault has bad scan flags: unofficial"
+
+
 def test_calculate_period_metrics(
     vault_db: VaultDatabase,
     price_df: pd.DataFrame,

--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -248,16 +248,25 @@ def test_calculate_lifetime_metrics(
     # assert "period_results" not in formatted.columns
 
 
+@pytest.mark.parametrize(
+    ("bad_flag", "expected_note"),
+    [
+        (VaultFlag.unofficial, "Vault has bad scan flags: unofficial"),
+        (VaultFlag.morpho_issues, "Vault has bad scan flags: morpho_issues"),
+    ],
+)
 def test_calculate_lifetime_metrics_blacklists_scanned_bad_flags(
     vault_db: VaultDatabase,
     price_df: pd.DataFrame,
+    bad_flag: VaultFlag,
+    expected_note: str,
 ):
     """Scanned bad flags override a cached non-blacklisted risk classification."""
     vault_id = "43111-0x614eb485de3c6c49701b40806ac1b985ad6f0a2f"
     spec = VaultSpec.parse_string(vault_id)
     vault_row = dict(vault_db.rows[spec])
     vault_row["_risk"] = VaultTechnicalRisk.low
-    vault_row["_flags"] = {VaultFlag.unofficial}
+    vault_row["_flags"] = {bad_flag}
     vault_rows = {spec: vault_row}
     vault_prices = price_df.loc[price_df["id"] == vault_id]
 
@@ -269,8 +278,8 @@ def test_calculate_lifetime_metrics_blacklists_scanned_bad_flags(
     row = metrics.iloc[0]
     assert row["risk"] == VaultTechnicalRisk.blacklisted
     assert row["risk_numeric"] == VaultTechnicalRisk.blacklisted.value
-    assert row["flags"] == {VaultFlag.unofficial}
-    assert row["notes"] == "Vault has bad scan flags: unofficial"
+    assert row["flags"] == {bad_flag}
+    assert row["notes"] == expected_note
 
 
 def test_calculate_period_metrics(

--- a/tests/research/test_vault_metrics_stablecoin_rate.py
+++ b/tests/research/test_vault_metrics_stablecoin_rate.py
@@ -1,6 +1,7 @@
 """Vault metrics integration tests for stablecoin depeg data."""
 
 import datetime
+from collections.abc import Callable
 from decimal import Decimal
 from pathlib import Path
 
@@ -18,6 +19,7 @@ from eth_defi.vault.risk import VaultTechnicalRisk
 VAULT_ADDRESS = "0x2222222222222222222222222222222222222222"
 USDC_ADDRESS = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 USDX_ADDRESS = "0x1111111111111111111111111111111111111111"
+EURE_ADDRESS = "0x3333333333333333333333333333333333333333"
 
 
 def _write_depegged_usdx_yaml(data_dir: Path) -> None:
@@ -54,6 +56,49 @@ slug: usdx
 contract_addresses:
   - chain: ethereum
     address: '{USDX_ADDRESS}'
+checks:
+  twitter_last_post_at: ''
+  domain_up_at: ''
+  marked_dead_at: ''
+  information_found_missing_at: ''
+"""
+    )
+
+
+def _write_depegged_eure_yaml(data_dir: Path) -> None:
+    """Create a EUR stablecoin fixture marked as depegged in its native currency."""
+    (data_dir / "eure.yaml").write_text(
+        f"""symbol: EURe
+name: Monerium EUR emoney
+short_description: Monerium EUR emoney
+long_description: ''
+category: stablecoin
+source_currency: eur
+source_currency_source: manual
+coingecko_id: monerium-eur-money
+coingecko_link: https://www.coingecko.com/en/coins/monerium-eur-money
+coingecko_id_source: manual
+coingecko_id_verified_at: '2026-06-26T12:00:00'
+usd_rate: 1.0
+usd_rate_fetched_at: '2026-06-26T12:00:00'
+usd_rate_updated_at: '2026-06-26T08:56:08'
+peg_rate: 0.87934359
+peg_rate_currency: eur
+source_currency_usd_rate: 1.137211905985
+source_currency_usd_rate_fetched_at: '2026-06-26T12:00:00'
+source_currency_usd_rate_source: fawazahmed0
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: '2026-06-26T12:00:00'
+links:
+  homepage: https://monerium.com/
+  coingecko: https://www.coingecko.com/en/coins/monerium-eur-money
+  defillama: ''
+  twitter: https://x.com/monerium
+slug: eure
+contract_addresses:
+  - chain: ethereum
+    address: '{EURE_ADDRESS}'
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''
@@ -125,8 +170,8 @@ checks:
     )
 
 
-def _calculate_bad_usdx_vault_metrics(data_dir: Path) -> pd.DataFrame:
-    """Calculate lifetime metrics for a vault that uses USDX as denomination."""
+def _calculate_bad_stablecoin_vault_metrics(data_dir: Path, token_symbol: str = "USDX", token_address: str = USDX_ADDRESS) -> pd.DataFrame:
+    """Calculate lifetime metrics for a vault that uses a bad stablecoin denomination."""
     chain_id = 1
     vault_id = f"{chain_id}-{VAULT_ADDRESS}"
     spec = VaultSpec(chain_id=chain_id, vault_address=VAULT_ADDRESS)
@@ -148,11 +193,11 @@ def _calculate_bad_usdx_vault_metrics(data_dir: Path) -> pd.DataFrame:
         withdraw=0.0,
     )
     vault_row = {
-        "Symbol": "BADUSDX",
-        "Name": "Bad USDX Vault",
+        "Symbol": f"BAD{token_symbol.upper()}",
+        "Name": f"Bad {token_symbol} Vault",
         "Address": VAULT_ADDRESS,
-        "Denomination": "USDX",
-        "Share token": "BADUSDX",
+        "Denomination": token_symbol,
+        "Share token": f"BAD{token_symbol.upper()}",
         "NAV": Decimal("1000"),
         "Shares": Decimal("1000"),
         "Protocol": "Example protocol",
@@ -164,8 +209,8 @@ def _calculate_bad_usdx_vault_metrics(data_dir: Path) -> pd.DataFrame:
         "Withdraw fee": 0.0,
         "Features": "",
         "_detection_data": detection,
-        "_denomination_token": {"address": USDX_ADDRESS, "symbol": "USDX", "decimals": 6},
-        "_share_token": {"address": VAULT_ADDRESS, "symbol": "BADUSDX", "decimals": 18},
+        "_denomination_token": {"address": token_address, "symbol": token_symbol, "decimals": 6},
+        "_share_token": {"address": VAULT_ADDRESS, "symbol": f"BAD{token_symbol.upper()}", "decimals": 18},
         "_fees": fee_data,
         "_flags": set(),
         "_lockup": None,
@@ -202,55 +247,91 @@ def _calculate_bad_usdx_vault_metrics(data_dir: Path) -> pd.DataFrame:
     return metrics
 
 
-def _assert_bad_usdx_vault_blacklisted(metrics: pd.DataFrame, expected_usd_rate: float, expected_fetched_at: datetime.datetime) -> None:
-    """Assert depegged USDX makes the vault blacklisted and exports rate data."""
+def _assert_bad_stablecoin_vault_blacklisted(
+    metrics: pd.DataFrame,
+    expected_symbol: str,
+    expected_usd_rate: float,
+    expected_fetched_at: datetime.datetime,
+    expected_source_currency: str = "usd",
+    expected_native_rate: float | None = None,
+    expected_native_rate_currency: str | None = None,
+    expected_source_currency_usd_rate: float = 1.0,
+) -> None:
+    """Assert depegged denomination stablecoins make the vault blacklisted and export rate data."""
     assert len(metrics) == 1
     row = metrics.iloc[0]
     assert row["risk"] == VaultTechnicalRisk.blacklisted
     assert row["risk_numeric"] == VaultTechnicalRisk.blacklisted.value
     assert VaultFlag.depegged_denomination_token in row["flags"]
-    assert "Denomination stablecoin USDX is marked as depegged" in row["notes"]
+    assert f"Denomination stablecoin {expected_symbol.upper()} is marked as depegged" in row["notes"]
 
     denomination_token_rate = row["denomination_token_rate"]
-    assert denomination_token_rate.coingecko_id == "usdx"
-    assert denomination_token_rate.source_currency == "usd"
+    assert denomination_token_rate.source_currency == expected_source_currency
     assert denomination_token_rate.usd_rate == pytest.approx(expected_usd_rate)
     assert denomination_token_rate.usd_rate_fetched_at == expected_fetched_at
     assert denomination_token_rate.usd_rate_source == "coingecko"
-    assert denomination_token_rate.native_rate is None
-    assert denomination_token_rate.native_rate_currency is None
-    assert denomination_token_rate.native_rate_fetched_at is None
-    assert denomination_token_rate.native_rate_source is None
-    assert denomination_token_rate.source_currency_usd_rate == pytest.approx(1.0)
+    assert denomination_token_rate.native_rate == (pytest.approx(expected_native_rate) if expected_native_rate is not None else None)
+    assert denomination_token_rate.native_rate_currency == expected_native_rate_currency
+    assert denomination_token_rate.native_rate_fetched_at == (expected_fetched_at if expected_native_rate is not None else None)
+    expected_native_rate_source = "coingecko+fawazahmed0" if expected_native_rate is not None else None
+    assert denomination_token_rate.native_rate_source == expected_native_rate_source
+    assert denomination_token_rate.source_currency_usd_rate == pytest.approx(expected_source_currency_usd_rate)
     assert denomination_token_rate.source_currency_usd_rate_fetched_at == expected_fetched_at
     assert denomination_token_rate.source_currency_usd_rate_source == "fawazahmed0"
 
     exported = export_lifetime_row(row)
     assert exported["risk"] == "Blacklisted"
-    assert exported["denomination_token_rate"] == {
-        "coingecko_id": "usdx",
-        "source_currency": "usd",
+    expected_exported_rate = {
+        "coingecko_id": denomination_token_rate.coingecko_id,
+        "source_currency": expected_source_currency,
         "usd_rate": expected_usd_rate,
         "usd_rate_fetched_at": expected_fetched_at.isoformat(),
         "usd_rate_source": "coingecko",
-        "native_rate": None,
-        "native_rate_currency": None,
-        "native_rate_fetched_at": None,
-        "native_rate_source": None,
-        "source_currency_usd_rate": 1.0,
+        "native_rate": expected_native_rate,
+        "native_rate_currency": expected_native_rate_currency,
+        "native_rate_fetched_at": expected_fetched_at.isoformat() if expected_native_rate is not None else None,
+        "native_rate_source": expected_native_rate_source,
+        "source_currency_usd_rate": expected_source_currency_usd_rate,
         "source_currency_usd_rate_fetched_at": expected_fetched_at.isoformat(),
         "source_currency_usd_rate_source": "fawazahmed0",
     }
+    assert exported["denomination_token_rate"] == expected_exported_rate
     assert "depegged_denomination_token" in exported["flags"]
 
 
-def test_calculate_lifetime_metrics_blacklists_depegged_usdx_denomination(tmp_path: Path) -> None:
-    """A vault denominated in depegged USDX is blacklisted in lifetime metrics."""
-    _write_depegged_usdx_yaml(tmp_path)
+@pytest.mark.parametrize(
+    ("writer", "symbol", "address", "expected_usd_rate", "expected_source_currency", "expected_native_rate", "expected_native_rate_currency", "expected_source_currency_usd_rate"),
+    [
+        (_write_depegged_usdx_yaml, "USDX", USDX_ADDRESS, 0.646809, "usd", None, None, 1.0),
+        (_write_depegged_eure_yaml, "EURe", EURE_ADDRESS, 1.0, "eur", 0.87934359, "eur", 1.137211905985),
+    ],
+)
+def test_calculate_lifetime_metrics_blacklists_depegged_stablecoin_denomination(
+    tmp_path: Path,
+    writer: Callable[[Path], None],
+    symbol: str,
+    address: str,
+    expected_usd_rate: float,
+    expected_source_currency: str,
+    expected_native_rate: float | None,
+    expected_native_rate_currency: str | None,
+    expected_source_currency_usd_rate: float,
+) -> None:
+    """A vault denominated in a depegged stablecoin is blacklisted in lifetime metrics."""
+    writer(tmp_path)
 
-    metrics = _calculate_bad_usdx_vault_metrics(tmp_path)
+    metrics = _calculate_bad_stablecoin_vault_metrics(tmp_path, token_symbol=symbol, token_address=address)
 
-    _assert_bad_usdx_vault_blacklisted(metrics, expected_usd_rate=0.646809, expected_fetched_at=datetime.datetime(2026, 6, 26, 12, 0, 0))
+    _assert_bad_stablecoin_vault_blacklisted(
+        metrics,
+        expected_symbol=symbol,
+        expected_usd_rate=expected_usd_rate,
+        expected_fetched_at=datetime.datetime(2026, 6, 26, 12, 0, 0),
+        expected_source_currency=expected_source_currency,
+        expected_native_rate=expected_native_rate,
+        expected_native_rate_currency=expected_native_rate_currency,
+        expected_source_currency_usd_rate=expected_source_currency_usd_rate,
+    )
 
 
 @pytest.mark.live
@@ -283,6 +364,6 @@ def test_live_coingecko_refresh_blacklists_usdx_denomination_and_keeps_usdc_heal
     assert feeder.is_depegged_stablecoin_token(1, USDC_ADDRESS, "USDC") is False
     assert feeder.is_depegged_stablecoin_token(1, USDX_ADDRESS, "USDX") is True
 
-    metrics = _calculate_bad_usdx_vault_metrics(tmp_path)
+    metrics = _calculate_bad_stablecoin_vault_metrics(tmp_path)
 
-    _assert_bad_usdx_vault_blacklisted(metrics, expected_usd_rate=usdx_target.usd_rate, expected_fetched_at=now_)
+    _assert_bad_stablecoin_vault_blacklisted(metrics, expected_symbol="USDX", expected_usd_rate=usdx_target.usd_rate, expected_fetched_at=now_)


### PR DESCRIPTION
## Why

The top vaults JSON could carry scan-time bad flags, such as `unofficial`, while keeping a non-blacklisted protocol risk like `Minimal` or `Low`. These rows were not removed by the export blacklist suppression because the lifetime metrics row never became `VaultTechnicalRisk.blacklisted`.

Morpho RED warnings and depegged denomination stablecoins need the same metrics-stage escalation, including non-USD stablecoins whose depeg check is based on their native source currency instead of USD price alone.

## Lessons learnt

`get_vault_risk()` only sees static manual flag tables. Dynamic scan flags from protocol adapters need their own metrics-stage blacklist escalation before JSON export. For non-USD stablecoins, the native `peg_rate` is the depeg signal; USD price alone is not enough.

## Summary

- Added a lifetime metrics check that turns scanned `BAD_FLAGS` into `VaultTechnicalRisk.blacklisted`.
- Added `morpho_issues` to `BAD_FLAGS` so cached/scanned Morpho RED flags are blacklisted.
- Kept Morpho RED source metadata notes when offchain RED data is available.
- Extended depegged-denomination coverage to include a EUR stablecoin case with native exchange-rate fields.
- Added `scripts/erc-4626/list-blacklisted-vaults.py` to tabulate blacklisted vaults and a final total count/TVL row.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.
