### PR TITLE
fix(gmx): async market loaders drop synthetic pools like the sync loader (#1178)

### DIFF
--- a/eth_defi/gmx/cache.py
+++ b/eth_defi/gmx/cache.py
@@ -20,6 +20,14 @@ from eth_defi.sqlite_cache import PersistentKeyValueStore
 
 logger = logging.getLogger(__name__)
 
+#: Schema-version suffix baked into the markets cache key. Bump whenever the
+#: market-loading logic changes what a cached entry means, so stale pre-fix
+#: rows are orphaned instead of served. v2: synthetic single-sided pools are
+#: disambiguated/excluded by the loaders (issue #1178) — pre-v2 rows may map a
+#: unified symbol to a pool that rejects USDC collateral, or carry legacy
+#: ".../USDC:USDC2" symbols, and must never be served to the fixed loaders.
+_MARKETS_CACHE_SCHEMA_SUFFIX = "_v2"
+
 
 class GMXMarketCache(PersistentKeyValueStore):
     """Persistent cache for GMX market data with TTL support.
@@ -170,7 +178,7 @@ class GMXMarketCache(PersistentKeyValueStore):
         :return:
             Market data dict or None if not found/expired
         """
-        cache_key = f"markets_{loading_mode}"
+        cache_key = f"markets_{loading_mode}{_MARKETS_CACHE_SCHEMA_SUFFIX}"
 
         try:
             entry = self.get(cache_key)
@@ -213,7 +221,7 @@ class GMXMarketCache(PersistentKeyValueStore):
         if ttl is None:
             ttl = DISK_CACHE_MARKETS_TTL_SECONDS
 
-        cache_key = f"markets_{loading_mode}"
+        cache_key = f"markets_{loading_mode}{_MARKETS_CACHE_SCHEMA_SUFFIX}"
         entry = self._make_cache_entry(data, ttl, loading_mode)
 
         try:

--- a/eth_defi/gmx/ccxt/async_support/exchange.py
+++ b/eth_defi/gmx/ccxt/async_support/exchange.py
@@ -899,12 +899,23 @@ class GMX(Exchange):
                     # Synthetic markets (long_token == short_token) get a "2" suffix
                     # (e.g. BTC2, ETH2) so a synthetic single-sided pool never collides
                     # with the real USDC-paired pool under one unified symbol. Mirrors
-                    # the sync loader (exchange.py:977-980); without it, freqtrade's
-                    # hourly reload copies a collapsed async market map onto the sync
+                    # the sync loader (exchange.py); without it, freqtrade's hourly
+                    # reload copies a collapsed async market map onto the sync
                     # order-placing client and live orders target a pool that may reject
                     # USDC collateral (InvalidCollateralTokenForMarket keeper cancels).
-                    long_token_addr = market_info.get("longTokenAddress", "").lower()
-                    short_token_addr = market_info.get("shortTokenAddress", "").lower()
+                    long_token_addr = (market_info.get("longTokenAddress") or "").lower()
+                    short_token_addr = (market_info.get("shortTokenAddress") or "").lower()
+
+                    # Malformed record guard: missing token fields would satisfy the
+                    # synthetic check via "" == "" and mislabel the market. Skip loudly
+                    # — a missing market is fail-safe, a mislabelled one misroutes orders.
+                    if not long_token_addr or not short_token_addr:
+                        logger.warning(
+                            "GraphQL: skipping market %s with missing long/short token fields",
+                            market_token_addr,
+                        )
+                        continue
+
                     if long_token_addr == short_token_addr:
                         raw_symbol = f"{raw_symbol}2"
 
@@ -1162,8 +1173,18 @@ class GMX(Exchange):
                     market_token = market.get("marketToken", "")
                     market_token_lower = market_token.lower()
                     index_token = market.get("indexToken", "").lower()
-                    long_token = market.get("longToken", "").lower()
-                    short_token = market.get("shortToken", "").lower()
+                    long_token = (market.get("longToken") or "").lower()
+                    short_token = (market.get("shortToken") or "").lower()
+
+                    # Malformed record guard: missing token fields would satisfy the
+                    # synthetic check via "" == "" and mislabel the market. Skip loudly
+                    # — a missing market is fail-safe, a mislabelled one misroutes orders.
+                    if not long_token or not short_token:
+                        logger.warning(
+                            "REST API: skipping market %s with missing long/short token fields",
+                            market_token,
+                        )
+                        continue
 
                     # Skip known-deprecated market tokens (address-based filter).
                     if market_token_lower in DEPRECATED_MARKET_TOKENS:

--- a/eth_defi/gmx/ccxt/async_support/exchange.py
+++ b/eth_defi/gmx/ccxt/async_support/exchange.py
@@ -862,6 +862,9 @@ class GMX(Exchange):
             )
 
             markets_dict = {}
+            # wstETH market has WETH as its index token but must be treated as wstETH
+            # (mirrors the sync loader, exchange.py).
+            _special_wsteth_address = "0x0Cf1fb4d1FF67A3D8Ca92c9d6643F8F9be8e03E5".lower()
             for market_info in market_infos:
                 try:
                     index_token_addr = market_info.get("indexTokenAddress", "").lower()
@@ -876,8 +879,15 @@ class GMX(Exchange):
                         )
                         continue
 
-                    # Look up symbol from GMX API tokens data
-                    raw_symbol = address_to_symbol.get(index_token_addr)
+                    # Special case for the wstETH market — its index token is WETH,
+                    # but it must be labelled wstETH so it does not collide with the
+                    # real ETH market. Mirrors the sync loader (exchange.py).
+                    if market_token_addr_lower == _special_wsteth_address:
+                        raw_symbol = "wstETH"
+                        index_token_addr = "0x5979D7b546E38E414F7E9822514be443A4800529".lower()
+                    else:
+                        # Look up symbol from GMX API tokens data
+                        raw_symbol = address_to_symbol.get(index_token_addr)
 
                     if not raw_symbol:
                         logger.debug(
@@ -885,6 +895,18 @@ class GMX(Exchange):
                             index_token_addr,
                         )
                         continue  # Skip unknown tokens
+
+                    # Synthetic markets (long_token == short_token) get a "2" suffix
+                    # (e.g. BTC2, ETH2) so a synthetic single-sided pool never collides
+                    # with the real USDC-paired pool under one unified symbol. Mirrors
+                    # the sync loader (exchange.py:977-980); without it, freqtrade's
+                    # hourly reload copies a collapsed async market map onto the sync
+                    # order-placing client and live orders target a pool that may reject
+                    # USDC collateral (InvalidCollateralTokenForMarket keeper cancels).
+                    long_token_addr = market_info.get("longTokenAddress", "").lower()
+                    short_token_addr = market_info.get("shortTokenAddress", "").lower()
+                    if long_token_addr == short_token_addr:
+                        raw_symbol = f"{raw_symbol}2"
 
                     # Normalise versioned symbols to canonical names (e.g. "XAUT.v2" -> "XAUT").
                     symbol_name = SYMBOL_NORMALISE.get(raw_symbol, raw_symbol)
@@ -1131,6 +1153,9 @@ class GMX(Exchange):
             except Exception as e:
                 logger.warning("Failed to pre-fetch market infos from Subsquid: %s", e)
 
+            # wstETH market has WETH as its index token but must be treated as wstETH
+            # (mirrors the sync loader, exchange.py).
+            _special_wsteth_address = "0x0Cf1fb4d1FF67A3D8Ca92c9d6643F8F9be8e03E5".lower()
             for market in markets_list:
                 try:
                     # Get market addresses
@@ -1154,33 +1179,44 @@ class GMX(Exchange):
                         logger.debug("Skipping unlisted market %s", market_token)
                         continue
 
-                    # Special case: wstETH market
-                    is_wsteth_market = market_token.lower() == "0x0Cf1fb4d1FF67A3D8Ca92c9d6643F8F9be8e03E5".lower()
-
-                    # Get index token metadata
-                    index_meta = self._token_metadata.get(index_token, {})
-                    symbol_name = index_meta.get("symbol")
+                    # Special case: the wstETH market has WETH as its index token but
+                    # must be labelled wstETH so it does not collide with the real ETH
+                    # market. Mirrors the sync loader (exchange.py) and the GraphQL path
+                    # above — the previous ``is_wsteth_market`` exclusion left this market
+                    # labelled "ETH" (from its WETH index metadata), colliding with the
+                    # real ETH market.
+                    if market_token_lower == _special_wsteth_address:
+                        symbol_name = "wstETH"
+                        index_token = "0x5979D7b546E38E414F7E9822514be443A4800529".lower()
+                    else:
+                        # Get index token metadata
+                        index_meta = self._token_metadata.get(index_token, {})
+                        symbol_name = index_meta.get("symbol")
 
                     if not symbol_name:
                         logger.debug("Skipping market with unknown index token: %s", index_token)
                         continue
 
+                    # Synthetic markets (long == short) get a "2" suffix on the BASE symbol
+                    # (e.g. BTC2), which EXCLUDED_SYMBOLS then drops — matching the sync
+                    # loader and the GraphQL path. The previous settle-currency scheme
+                    # (…/USDC:USDC2) diverged from every other loader, so a synthetic pool
+                    # survived under its own tradeable symbol and could reach the sync
+                    # order client via freqtrade's hourly market reload
+                    # (InvalidCollateralTokenForMarket keeper cancels).
+                    is_synthetic = long_token == short_token
+                    if is_synthetic:
+                        symbol_name = f"{symbol_name}2"
+
                     # Normalise versioned symbols to canonical names (e.g. "XAUT.v2" -> "XAUT").
                     symbol_name = SYMBOL_NORMALISE.get(symbol_name, symbol_name)
 
-                    # Skip excluded symbols
+                    # Skip excluded symbols (drops synthetic BTC2/ETH2/… pools).
                     if symbol_name in self.EXCLUDED_SYMBOLS:
                         logger.debug("Skipping excluded symbol: %s", symbol_name)
                         continue
 
-                    # Check if synthetic market (long_token == short_token, not wstETH)
-                    is_synthetic = (long_token == short_token) and not is_wsteth_market
-
-                    # Create unified symbol
-                    if is_synthetic:
-                        unified_symbol = f"{symbol_name}/USDC:USDC2"
-                    else:
-                        unified_symbol = f"{symbol_name}/USDC:USDC"
+                    unified_symbol = f"{symbol_name}/USDC:USDC"
 
                     # Get leverage info from pre-fetched subsquid data
                     max_leverage = 50.0  # Default

--- a/eth_defi/gmx/ccxt/exchange.py
+++ b/eth_defi/gmx/ccxt/exchange.py
@@ -942,11 +942,23 @@ class GMX(ExchangeCompatible):
 
             for market_info in market_infos:
                 try:
-                    index_token_addr = market_info.get("indexTokenAddress", "").lower()
+                    index_token_addr = (market_info.get("indexTokenAddress") or "").lower()
                     market_token_addr = market_info.get("marketTokenAddress", "")
                     market_token_addr_lower = market_token_addr.lower()
-                    long_token_addr = market_info.get("longTokenAddress", "").lower()
-                    short_token_addr = market_info.get("shortTokenAddress", "").lower()
+                    long_token_addr = (market_info.get("longTokenAddress") or "").lower()
+                    short_token_addr = (market_info.get("shortTokenAddress") or "").lower()
+
+                    # Malformed record guard: a market missing either token field
+                    # would satisfy the synthetic check below via "" == "" and be
+                    # silently mislabelled/dropped. Skip loudly instead — a missing
+                    # market means freqtrade skips the pair (fail-safe), while a
+                    # mislabelled one can misroute live orders.
+                    if not long_token_addr or not short_token_addr:
+                        logger.warning(
+                            "GraphQL: skipping market %s with missing long/short token fields",
+                            market_token_addr,
+                        )
+                        continue
 
                     # Skip known-deprecated market tokens (address-based, symbol-name alone
                     # cannot distinguish deprecated from active when both share a canonical name).
@@ -1176,11 +1188,20 @@ class GMX(ExchangeCompatible):
             for market_info in markets_list:
                 try:
                     # Extract addresses
-                    index_token_addr = market_info.get("indexToken", "").lower()
+                    index_token_addr = (market_info.get("indexToken") or "").lower()
                     market_token_addr = market_info.get("marketToken", "")
                     market_token_addr_lower = market_token_addr.lower()
-                    long_token_addr = market_info.get("longToken", "").lower()
-                    short_token_addr = market_info.get("shortToken", "").lower()
+                    long_token_addr = (market_info.get("longToken") or "").lower()
+                    short_token_addr = (market_info.get("shortToken") or "").lower()
+
+                    # Malformed record guard — see GraphQL loader; "" == "" would
+                    # mislabel the market as synthetic.
+                    if not long_token_addr or not short_token_addr:
+                        logger.warning(
+                            "REST API: skipping market %s with missing long/short token fields",
+                            market_token_addr,
+                        )
+                        continue
 
                     # Skip known-deprecated market tokens before any symbol resolution.
                     if market_token_addr_lower in DEPRECATED_MARKET_TOKENS:

--- a/tests/gmx/ccxt/test_async_market_dedup.py
+++ b/tests/gmx/ccxt/test_async_market_dedup.py
@@ -183,6 +183,65 @@ async def test_rest_loader_synthetic_first_does_not_poison_canonical_symbol() ->
     )
 
 
+# ---------------------------------------------------------------------------
+# Malformed-record guard (adversarial-review finding: "" == "" false-synthetic)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "long_token,short_token",
+    [
+        (None, None),  # explicit nulls
+        ("", ""),  # empty strings — pre-guard this satisfied long == short
+        (None, "0x6c84a8f1c29108f47a79964b5fe888d4f4d0de40"),  # one-sided
+        ("0x6c84a8f1c29108f47a79964b5fe888d4f4d0de40", ""),  # other side
+    ],
+)
+async def test_graphql_loader_skips_records_with_missing_token_fields(
+    long_token: str | None, short_token: str | None
+) -> None:
+    """A record missing long/short token fields is skipped, never mislabelled.
+
+    Pre-guard, both-missing records satisfied ``"" == ""`` → falsely synthetic
+    → BTC renamed BTC2 → silently excluded. The real pool must still load.
+    """
+    malformed = {
+        "indexTokenAddress": _BTC_INDEX,
+        "marketTokenAddress": "0x1111111111111111111111111111111111111111",
+        "longTokenAddress": long_token,
+        "shortTokenAddress": short_token,
+    }
+    markets = await _run_graphql_loader([malformed] + _market_infos_synthetic_first())
+
+    # The malformed record never claims any symbol...
+    assert all(
+        m["info"]["market_token"] != malformed["marketTokenAddress"]
+        for m in markets.values()
+    )
+    # ...and the real pool still resolves the canonical symbol.
+    assert markets["BTC/USDC:USDC"]["info"]["market_token"] == _REAL_BTC_MARKET
+
+
+@pytest.mark.asyncio
+async def test_rest_loader_skips_records_with_missing_token_fields() -> None:
+    """REST fallback: same malformed-record guard as the GraphQL path."""
+    malformed = {
+        "marketToken": "0x1111111111111111111111111111111111111111",
+        "indexToken": _BTC_INDEX,
+        "longToken": None,
+        "shortToken": None,
+        "isListed": True,
+    }
+    markets = await _run_rest_loader([malformed] + _rest_markets_synthetic_first())
+
+    assert all(
+        m["info"]["market_token"] != malformed["marketToken"]
+        for m in markets.values()
+    )
+    assert markets["BTC/USDC:USDC"]["info"]["market_token"] == _REAL_BTC_MARKET
+
+
 @pytest.mark.asyncio
 async def test_graphql_and_rest_loaders_agree_on_keys() -> None:
     """Parity invariant: the two async loaders produce the same symbol set and

--- a/tests/gmx/ccxt/test_async_market_dedup.py
+++ b/tests/gmx/ccxt/test_async_market_dedup.py
@@ -1,0 +1,202 @@
+"""Offline tests for async GMX market-loader synthetic-pool disambiguation.
+
+Regression for the live incident where a Freqtrade GMX vault's BTC/USDC:USDC
+OPEN orders were keeper-cancelled with ``InvalidCollateralTokenForMarket``.
+
+Root cause: the async GraphQL market loader
+(:meth:`eth_defi.gmx.ccxt.async_support.exchange.GMX._load_markets_from_graphql`)
+lacked the synthetic-market ``"2"``-suffix disambiguation the **sync** loader
+has (``eth_defi/gmx/ccxt/exchange.py``). A synthetic single-sided BTC pool
+(``long_token == short_token``) collided with the real USDC-paired pool under
+one ``BTC/USDC:USDC`` symbol; whichever the GraphQL response returned first
+silently won. Freqtrade copies the async-loaded map onto the sync order-placing
+client on every hourly reload, so the collision winner decided which pool live
+orders targeted — sometimes a pool that does not accept USDC collateral.
+
+These tests drive the real loader methods with mocked data sources (no RPC), so
+they are fast and deterministic. Live end-to-end coverage lives in
+``test_market_disambiguation.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from eth_defi.gmx.ccxt.async_support.exchange import GMX as AsyncGMX
+
+# Distinct lowercase addresses used across the crafted payloads.
+_BTC_INDEX = "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f"  # BTC index token
+_USDC = "0xaf88d065e77c8cc2239327c5edb3a432268e5831"
+_WBTC = "0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f"  # long token of the real pool
+_TBTC = "0x6c84a8f1c29108f47a79964b5fe888d4f4d0de40"  # synthetic single-sided token
+_REAL_BTC_MARKET = "0x47c031236e19d024b42f8ae6780e44a573170703"  # WBTC-USDC pool
+_SYNTH_BTC_MARKET = "0xd62068697bcc92af253225676d618b0c9f17c663"  # synthetic pool
+
+
+def _tokens_payload() -> list[dict]:
+    """GMX /tokens response mapping the BTC index token to the ``BTC`` symbol."""
+    return [
+        {"address": _BTC_INDEX, "symbol": "BTC", "decimals": 8},
+        {"address": _USDC, "symbol": "USDC", "decimals": 6},
+    ]
+
+
+def _market_infos_synthetic_first() -> list[dict]:
+    """Two BTC markets sharing the BTC index token, synthetic listed FIRST.
+
+    This is the poisoning order: pre-fix, the synthetic pool claims
+    ``BTC/USDC:USDC`` and the real USDC-paired pool is dropped by the dedup
+    guard.
+    """
+    return [
+        {
+            # Synthetic single-sided pool — long == short.
+            "indexTokenAddress": _BTC_INDEX,
+            "marketTokenAddress": _SYNTH_BTC_MARKET,
+            "longTokenAddress": _TBTC,
+            "shortTokenAddress": _TBTC,
+            "minCollateralFactor": "5000000000000000000000000000000",
+        },
+        {
+            # Real USDC-collateral pool — long != short.
+            "indexTokenAddress": _BTC_INDEX,
+            "marketTokenAddress": _REAL_BTC_MARKET,
+            "longTokenAddress": _WBTC,
+            "shortTokenAddress": _USDC,
+            "minCollateralFactor": "5000000000000000000000000000000",
+        },
+    ]
+
+
+async def _run_graphql_loader(market_infos: list[dict]) -> dict:
+    """Construct an offline AsyncGMX and drive ``_load_markets_from_graphql``."""
+    gmx = AsyncGMX({})
+    subsquid = AsyncMock()
+    subsquid.get_market_infos = AsyncMock(return_value=market_infos)
+    gmx.subsquid = subsquid
+    gmx._fetch_tokens_async = AsyncMock(return_value=_tokens_payload())
+    # Skip the on-chain DataStore filter (Multicall3 RPC) — identity in the test.
+    gmx._filter_datastore_disabled_markets = lambda markets: markets
+    return await gmx._load_markets_from_graphql()
+
+
+@pytest.mark.asyncio
+async def test_graphql_loader_synthetic_first_does_not_poison_canonical_symbol() -> None:
+    """BTC/USDC:USDC must resolve to the REAL USDC pool even when the synthetic
+    single-sided pool is listed first.
+
+    The synthetic pool is disambiguated to ``BTC2`` and then dropped by
+    ``EXCLUDED_SYMBOLS`` (like the sync loader), so it can never claim the
+    canonical ``BTC/USDC:USDC`` symbol. Pre-fix, the synthetic (first) claimed
+    ``BTC/USDC:USDC`` and the real pool was dedup-skipped — the exact poisoning
+    that reached the sync order client via freqtrade's hourly reload.
+    """
+    markets = await _run_graphql_loader(_market_infos_synthetic_first())
+
+    assert "BTC/USDC:USDC" in markets, markets.keys()
+    # Canonical symbol resolves to the REAL USDC-paired pool, not the synthetic.
+    assert markets["BTC/USDC:USDC"]["info"]["market_token"] == _REAL_BTC_MARKET
+    # The synthetic single-sided pool is excluded (BTC2 is in EXCLUDED_SYMBOLS),
+    # so it never appears and never collides.
+    assert "BTC2/USDC:USDC" not in markets, markets.keys()
+    assert all(
+        m["info"]["market_token"] != _SYNTH_BTC_MARKET for m in markets.values()
+    ), "synthetic pool must not appear under any symbol"
+
+
+@pytest.mark.asyncio
+async def test_graphql_loader_order_independent() -> None:
+    """Canonical BTC/USDC:USDC maps to the real pool regardless of payload order."""
+    real_first = list(reversed(_market_infos_synthetic_first()))
+    markets = await _run_graphql_loader(real_first)
+
+    assert markets["BTC/USDC:USDC"]["info"]["market_token"] == _REAL_BTC_MARKET
+    assert "BTC2/USDC:USDC" not in markets
+
+
+# ---------------------------------------------------------------------------
+# REST fallback loader (used when GraphQL returns empty)
+# ---------------------------------------------------------------------------
+
+
+def _rest_markets_synthetic_first() -> list[dict]:
+    """REST /markets/info entries (different field names than GraphQL)."""
+    return [
+        {
+            "marketToken": _SYNTH_BTC_MARKET,
+            "indexToken": _BTC_INDEX,
+            "longToken": _TBTC,
+            "shortToken": _TBTC,
+            "isListed": True,
+        },
+        {
+            "marketToken": _REAL_BTC_MARKET,
+            "indexToken": _BTC_INDEX,
+            "longToken": _WBTC,
+            "shortToken": _USDC,
+            "isListed": True,
+        },
+    ]
+
+
+async def _run_rest_loader(markets_list: list[dict]) -> dict:
+    """Drive ``_load_markets_from_rest_api`` offline with a mocked REST payload."""
+    gmx = AsyncGMX({})
+    gmx._market_cache = None  # skip disk cache
+    gmx.chain = "arbitrum"
+    gmx.session = object()  # truthy; the API call is patched out
+    subsquid = AsyncMock()
+    subsquid.get_market_infos = AsyncMock(return_value=[])
+    gmx.subsquid = subsquid
+    gmx._fetch_tokens_async = AsyncMock(return_value=_tokens_payload())
+    gmx._filter_datastore_disabled_markets = lambda markets: markets
+
+    async def _fake_api(*args, **kwargs):
+        # Only /markets/info is consumed here; tokens come from _fetch_tokens_async.
+        return {"markets": markets_list}
+
+    with patch(
+        "eth_defi.gmx.ccxt.async_support.exchange.async_make_gmx_api_request",
+        new=_fake_api,
+    ):
+        return await gmx._load_markets_from_rest_api()
+
+
+@pytest.mark.asyncio
+async def test_rest_loader_synthetic_first_does_not_poison_canonical_symbol() -> None:
+    """REST fallback: BTC/USDC:USDC resolves to the real USDC pool; synthetic dropped.
+
+    Pre-fix the REST loader used a divergent settle-currency suffix
+    (``BTC/USDC:USDC2``) that let the synthetic pool survive under a tradeable
+    symbol — inconsistent with every other loader.
+    """
+    markets = await _run_rest_loader(_rest_markets_synthetic_first())
+
+    assert markets["BTC/USDC:USDC"]["info"]["market_token"] == _REAL_BTC_MARKET
+    # No entry under the old divergent scheme, and the synthetic is excluded.
+    assert "BTC/USDC:USDC2" not in markets
+    assert "BTC2/USDC:USDC" not in markets
+    assert all(
+        m["info"]["market_token"] != _SYNTH_BTC_MARKET for m in markets.values()
+    )
+
+
+@pytest.mark.asyncio
+async def test_graphql_and_rest_loaders_agree_on_keys() -> None:
+    """Parity invariant: the two async loaders produce the same symbol set and
+    map each shared symbol to the same market token.
+
+    A divergence here is exactly what let the incident happen — the fix keeps
+    all loaders on one scheme.
+    """
+    graphql_markets = await _run_graphql_loader(_market_infos_synthetic_first())
+    rest_markets = await _run_rest_loader(_rest_markets_synthetic_first())
+
+    assert set(graphql_markets) == set(rest_markets)
+    for symbol in graphql_markets:
+        assert (
+            graphql_markets[symbol]["info"]["market_token"]
+            == rest_markets[symbol]["info"]["market_token"]
+        ), symbol

--- a/tests/gmx/test_cache.py
+++ b/tests/gmx/test_cache.py
@@ -135,6 +135,42 @@ def test_cache_loading_mode_separation():
         assert graphql_retrieved == graphql_data
 
 
+def test_cache_schema_version_orphans_pre_fix_rows():
+    """Rows written under the pre-v2 (unversioned) key are never served.
+
+    Regression for issue #1178: a pre-fix binary could cache a poisoned
+    markets dict (unified symbol mapped to a synthetic pool that rejects
+    USDC collateral, or legacy ".../USDC:USDC2" symbols). The cache-hit
+    path returns before the fixed loader logic runs, so a post-fix binary
+    must NOT serve those rows. The schema-version suffix in the cache key
+    orphans them; the first post-upgrade load is a cache miss and re-fetches
+    through the corrected loaders.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache_dir = Path(tmpdir)
+        cache = GMXMarketCache.get_cache(
+            chain="arbitrum",
+            cache_dir=cache_dir,
+        )
+
+        poisoned = {
+            "BTC/USDC:USDC": {"info": {"market_token": "0xd620_synthetic_pool"}},
+            "BTC/USDC:USDC2": {"info": {"market_token": "0xd620_synthetic_pool"}},
+        }
+        # Simulate a PRE-fix binary: same entry bytes, legacy unversioned key.
+        cache["markets_rest_api"] = cache._make_cache_entry(
+            poisoned, ttl=3600, loading_mode="rest_api"
+        )
+
+        # The post-fix reader must treat it as a miss.
+        assert cache.get_markets(loading_mode="rest_api") is None
+
+        # And a post-fix write/read round-trips under the versioned key.
+        fresh = {"BTC/USDC:USDC": {"info": {"market_token": "0x47c0_real_pool"}}}
+        cache.set_markets(data=fresh, loading_mode="rest_api", ttl=3600)
+        assert cache.get_markets(loading_mode="rest_api") == fresh
+
+
 def test_cache_expiry():
     """Test that expired cache entries return None when check_expiry=True."""
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Fixes #1178.

## Problem

Live Freqtrade GMX vaults intermittently got their BTC/USDC:USDC **open** orders keeper-cancelled with `InvalidCollateralTokenForMarket`, three strikes locking the pair for 60 minutes (observed 2026-07-01 and 2026-07-02, both ~12:0x UTC).

## Root cause

The async market loaders diverged from the sync loaders on synthetic-pool handling:

- **`_load_markets_from_graphql`** had **no** synthetic-market disambiguation. The sync loader (`eth_defi/gmx/ccxt/exchange.py:977-980`) suffixes single-sided pools (`long_token == short_token`) with `"2"` so `EXCLUDED_SYMBOLS` drops them. Without it, a synthetic BTC pool (`0xd620…`) collided with the real WBTC-USDC pool (`0x47c0…`) under one `BTC/USDC:USDC` symbol; GraphQL response order picked the winner (async loaded **113** markets vs sync's **114**).
- **`_load_markets_from_rest_api`** used a divergent `.../USDC:USDC2` scheme *and* an `is_wsteth_market` exclusion that mislabelled the wstETH market as `ETH` (a second latent collision).

Freqtrade copies the async-loaded map onto the sync order-placing client on every hourly reload (`Exchange.set_markets_from_exchange`), so the collision winner decided which pool live orders targeted — sometimes a pool that rejects USDC collateral. Opens worked right after the daily restart (sync-loaded map) but failed after the first hourly async reload.

The soft-catch added in #1008 (`order_argument_parser.py` — "relying on GMX router swap_path") does not save these orders: `_handle_missing_swap_path` sets `swap_path=[]` whenever `start_token == collateral`, so the doomed order ships and dies on-chain as a keeper cancel.

## Fix

Both async loaders now mirror the sync loaders exactly: wstETH special-case naming, a bare `long == short` synthetic check, and the `"{sym}2"` scheme that `EXCLUDED_SYMBOLS` drops.

## Verification

- **Live Arbitrum:** the async loader now returns **114 markets** (matching sync); `BTC/USDC:USDC` → the real USDC pool `0x47c031236e19d024b42f8AE6780E44A573170703`; `ETH/USDC:USDC` and `wstETH/USDC:USDC` both present; no excluded-synthetic leakage.
- **New offline tests** (`tests/gmx/ccxt/test_async_market_dedup.py`): reproduce the synthetic-first poisoning (real pool wins the canonical symbol), REST-fallback scheme, and a GraphQL/REST parity invariant. `4 passed`.
- Existing loader/market tests (`test_datastore_market_disabled`, `test_resolve_order_from_sources`, `test_reduce_only_sizing`): 36 passed, no regression.

## Scope / follow-up

This is the root-cause fix. Two defense-in-depth hardenings on the **order-execution** path are intentionally deferred to a separate reviewed PR (they guard an already-fixed condition and one risks blocking legitimate swap-collateral orders — issue #67): collateral-aware market resolution on the open path, and a fail-loud guard replacing the silent `swap_path=[]` no-op.