### PR TITLE
fix(gmx): collateral-aware open-path market resolution + fail-loud guard (#1178 B2/B3)

### DIFF
--- a/eth_defi/gmx/ccxt/exchange.py
+++ b/eth_defi/gmx/ccxt/exchange.py
@@ -5757,9 +5757,84 @@ class GMX(ExchangeCompatible):
                 "short_token": m["short_token_address"],
             }
 
-        # Default: use the pool already in self.markets for this symbol
+        # Default branch: collateral-aware pool selection (issue #1178).
+        #
+        # This is the ONLY market-selection logic that runs on the live ccxt
+        # order path — ``market_key`` is injected into ``OrderArgumentParser``
+        # from here, so the parser's own USDC-preference disambiguation
+        # (``_handle_missing_market_key``) never executes. We therefore apply
+        # the same strategy it documents: keep the mapped pool if it accepts
+        # the order's collateral; otherwise pick a sibling pool (same index
+        # token) that does, defaulting to USDC — the ``<base>-USDC`` pools have
+        # orders-of-magnitude deeper liquidity than synthetic single-sided
+        # pools. Any lookup failure falls back to the mapped pool (never crash
+        # the order path here — B3 fails loudly downstream if it is unusable).
         normalized_symbol = self._normalize_symbol(symbol)
-        return self.markets[normalized_symbol].get("info", {})
+        default_info = self.markets.get(normalized_symbol, {}).get("info", {})
+
+        # The order's collateral token. Default USDC (deepest liquidity) when
+        # the caller names none — mirrors OrderArgumentParser's USDC_PAIRED
+        # default; an explicit ``collateral_symbol`` wins.
+        collateral_symbol = (params.get("collateral_symbol") or "USDC").upper()
+
+        try:
+            pools = self.fetch_pools_for_symbol(symbol)
+        except Exception as exc:  # noqa: BLE001 - never block the order on a scan error
+            logger.warning(
+                "OPEN: pool scan failed for %s (%r) — using mapped pool %s unverified",
+                symbol,
+                exc,
+                default_info.get("market_token"),
+            )
+            return default_info
+
+        if not pools:
+            return default_info
+
+        def _accepts(pool: dict) -> bool:
+            return collateral_symbol in (
+                (pool.get("long_token_symbol") or "").upper(),
+                (pool.get("short_token_symbol") or "").upper(),
+            )
+
+        # If the mapped pool already accepts the collateral, keep it — never
+        # override an acceptable pool (avoids churn when several pools qualify).
+        mapped_token = (default_info.get("market_token") or "").lower()
+        mapped_pool = next(
+            (p for p in pools if (p.get("market_address") or "").lower() == mapped_token),
+            None,
+        )
+        if mapped_pool is not None and _accepts(mapped_pool):
+            return default_info
+
+        accepting = [p for p in pools if _accepts(p)]
+        if not accepting:
+            logger.warning(
+                "OPEN: no pool for %s accepts collateral %s — using mapped pool %s "
+                "(order may be rejected pre-flight; see InvalidCollateralForMarketError)",
+                symbol,
+                collateral_symbol,
+                mapped_token or "<none>",
+            )
+            return default_info
+
+        chosen = accepting[0]
+        logger.warning(
+            "OPEN: overriding market_key for %s — mapped pool %s does not accept "
+            "collateral %s; using %s (long=%s, short=%s) instead",
+            symbol,
+            mapped_token or "<none>",
+            collateral_symbol,
+            chosen["market_address"],
+            chosen.get("long_token_symbol"),
+            chosen.get("short_token_symbol"),
+        )
+        return {
+            "market_token": chosen["market_address"],
+            "index_token": chosen["index_token"],
+            "long_token": chosen["long_token"],
+            "short_token": chosen["short_token"],
+        }
 
     def fetch_pools_for_symbol(self, symbol: str) -> list[dict]:
         """Return all available GMX pools for a given market symbol.

--- a/eth_defi/gmx/order/order_argument_parser.py
+++ b/eth_defi/gmx/order/order_argument_parser.py
@@ -18,6 +18,24 @@ from eth_defi.gmx.contracts import get_tokens_metadata_dict
 
 logger = logging.getLogger(__name__)
 
+
+class InvalidCollateralForMarketError(Exception):
+    """The selected GMX market definitively does not accept the collateral token.
+
+    Raised by :meth:`OrderArgumentParser._check_if_valid_collateral_for_market`
+    when the market resolved cleanly and the collateral matches neither its
+    long nor short token — a **definitive** rejection, as opposed to an
+    *indeterminate* lookup failure (``KeyError`` — market absent from the
+    markets snapshot), which callers must tolerate.
+
+    Also raised by :meth:`OrderArgumentParser._handle_missing_swap_path` when a
+    definitively rejected collateral has ``start_token == collateral`` — no
+    swap leg will ever be built in that configuration, so shipping the order
+    would burn gas and die on-chain as an ``InvalidCollateralTokenForMarket``
+    keeper cancellation, feeding the circuit breaker (issue #1178, live
+    incident 2026-07-01/02). Failing loudly pre-flight is strictly better.
+    """
+
 # Module-level cache for token metadata only.  The previous ``_MARKETS_CACHE``
 # was removed in the issue-#67 fix — :class:`Markets` now owns a TTL'd cache
 # that is invalidated centrally via :meth:`Markets.invalidate_cache`, so a
@@ -128,6 +146,16 @@ class OrderArgumentParser:
         #: instance prevents an infinite loop when the index token is
         #: structurally absent from GMX.
         self._market_key_refresh_attempted: bool = False
+
+        #: Tri-state collateral-acceptance verdict recorded by
+        #: :meth:`_handle_missing_collateral_address`: ``True`` = the market
+        #: verifiably accepts the collateral; ``False`` = **definitively
+        #: rejected** (market resolved, collateral matches neither token);
+        #: ``None`` = indeterminate (could not verify — e.g. market absent
+        #: from the markets snapshot) or the check never ran (caller supplied
+        #: ``collateral_address`` directly).  Only ``False`` may block an
+        #: order (see :meth:`_handle_missing_swap_path`).
+        self._collateral_directly_supported: bool | None = None
 
         if is_increase:
             self.required_keys = [
@@ -408,21 +436,39 @@ class OrderArgumentParser:
         tokens = _get_token_metadata_dict(self.web3, self.parameters_dict["chain"])
         collateral_address = self.find_key_by_symbol(tokens, collateral_token_symbol)
 
-        # Try strict collateral validation.  If the collateral is not directly
-        # held by the market, _check_if_valid_collateral_for_market raises with
-        # context.  We catch that here and continue — the GMX router auto-swaps
-        # via ``swap_path`` so the order is still valid (issue #67, 2026-05-14:
-        # ``Not a valid collateral for selected market!`` BTC/USDC:USDC vs
-        # tBTC-tBTC).  Always set collateral_address so the router has a target.
+        # Strict collateral validation with exception CLASSIFICATION (issue
+        # #1178). Two very different failures used to be conflated by a bare
+        # ``except Exception`` here:
+        #
+        # - InvalidCollateralForMarketError — the market resolved and the
+        #   collateral matches neither of its tokens: a DEFINITIVE rejection.
+        #   Recorded as ``False`` so _handle_missing_swap_path can fail loudly
+        #   when no swap leg will be built (start == collateral). When a real
+        #   swap leg exists (start != collateral), the GMX router converts via
+        #   ``swap_path`` and the order is still valid (issue #67 flow).
+        # - KeyError — market_key absent from the markets snapshot: we could
+        #   NOT verify either way (stale/partial snapshot). Recorded as
+        #   ``None`` and tolerated — never block an order on "couldn't check".
+        #
+        # Always set collateral_address so the router has a target.
         try:
             is_directly_supported = self._check_if_valid_collateral_for_market(collateral_address)
-        except Exception:
+        except InvalidCollateralForMarketError:
             is_directly_supported = False
             logger.info(
-                "COLLATERAL_TRACE: collateral %s not directly accepted by market_key %s — relying on GMX router swap_path to convert at order time",
+                "COLLATERAL_TRACE: collateral %s not directly accepted by market_key %s — a swap_path can convert it only when start_token differs from the collateral",
                 collateral_token_symbol,
                 self.parameters_dict.get("market_key"),
             )
+        except KeyError as exc:
+            is_directly_supported = None
+            logger.warning(
+                "COLLATERAL_TRACE: could not verify collateral %s against market_key %s (%r missing from markets snapshot) — proceeding unverified",
+                collateral_token_symbol,
+                self.parameters_dict.get("market_key"),
+                exc,
+            )
+        self._collateral_directly_supported = is_directly_supported
         logger.info(
             "COLLATERAL_TRACE: Resolved collateral address:\n  collateral_token_symbol=%s → collateral_address=%s\n  is_directly_supported_by_market=%s",
             collateral_token_symbol,
@@ -454,6 +500,23 @@ class OrderArgumentParser:
 
         # No swap needed if start token == collateral token
         elif self.parameters_dict["start_token_address"] == self.parameters_dict["collateral_address"]:
+            # Fail loud on a definitively-rejected collateral (issue #1178).
+            # When start == collateral, NO swap leg will be built below — so the
+            # issue-#67 "router converts via swap_path" fallback cannot apply.
+            # Shipping the order would burn gas and die on-chain as an
+            # InvalidCollateralTokenForMarket keeper cancel + circuit-breaker
+            # lock. Only ``False`` (definitive rejection) blocks; ``None``
+            # (indeterminate / unchecked) and ``True`` proceed as before.
+            if self._collateral_directly_supported is False:
+                raise InvalidCollateralForMarketError(
+                    "Collateral is not accepted by the selected market and no "
+                    "swap path can convert it (start_token == collateral_address):\n"
+                    f"  market_key: {self.parameters_dict.get('market_key')}\n"
+                    f"  collateral_address: {self.parameters_dict['collateral_address']}\n"
+                    "  Hint: choose a market that accepts this collateral, or "
+                    "supply a start_token different from the collateral so a "
+                    "swap route can be built."
+                )
             self.parameters_dict["swap_path"] = []
 
         else:
@@ -481,15 +544,20 @@ class OrderArgumentParser:
         """Check whether ``collateral_address`` is directly held by the market.
 
         Returns ``True`` when the collateral matches the market's long or short
-        token.  Raises ``Exception`` with actionable context when it does not —
-        callers that want to soft-fail (e.g. :meth:`_handle_missing_collateral_address`)
-        should catch and continue.
+        token — a **definitive accept**. Raises
+        :class:`InvalidCollateralForMarketError` (a definitive *reject*) when
+        the market resolves but the collateral matches neither token. Lets a
+        ``KeyError`` propagate when ``market_key`` is absent from the markets
+        snapshot — an *indeterminate* result the caller must distinguish from a
+        reject (see :meth:`_handle_missing_collateral_address`).
 
         :param collateral_address: Collateral token contract address.
         :returns: ``True`` when the collateral is directly accepted.
-        :raises Exception: When ``collateral_address`` is not the long or short
-            token of the selected market, with market_key, valid token addresses,
-            and a hint in the message.
+        :raises InvalidCollateralForMarketError: When ``collateral_address`` is
+            not the long or short token of the selected market, with market_key,
+            valid token addresses, and a hint in the message.
+        :raises KeyError: When ``market_key`` is not present in the markets
+            snapshot — the caller treats this as indeterminate, not a reject.
         """
         market_key = self.parameters_dict["market_key"]
 
@@ -506,7 +574,7 @@ class OrderArgumentParser:
             return True
 
         msg = f"Not a valid collateral for selected market!\n  market_key: {market_key}\n  collateral_address: {collateral_address}\n  valid long_token: {market['long_token_address']} ({market['long_token_metadata'].get('symbol', '?')})\n  valid short_token: {market['short_token_address']} ({market['short_token_metadata'].get('symbol', '?')})\n  Hint: set collateral_symbol to the long or short token symbol of this market."
-        raise Exception(msg)
+        raise InvalidCollateralForMarketError(msg)
 
     @staticmethod
     def find_key_by_symbol(input_dict: dict, search_symbol: str):

--- a/tests/gmx/ccxt/test_open_market_resolution.py
+++ b/tests/gmx/ccxt/test_open_market_resolution.py
@@ -1,0 +1,221 @@
+"""Collateral-aware market resolution on the OPEN path (issue #1178, B2).
+
+``_resolve_market_info``'s default branch is the ONLY market-selection logic
+that executes on the live ccxt order path — it feeds ``market_key`` straight
+into ``OrderArgumentParser``, bypassing the parser's own USDC-preference
+disambiguation (``_handle_missing_market_key``, which never runs because
+``market_key`` arrives pre-injected). Pre-B2 it blindly returned
+``self.markets[symbol]["info"]``, so a poisoned or synthetic-only mapping
+handed ``create_order()`` a pool that rejects USDC (the incident).
+
+B2 applies the same selection strategy ``_handle_missing_market_key`` already
+documents: keep the mapped pool if it accepts the order's collateral; else
+scan sibling pools (same index token) and pick one that accepts it, defaulting
+to USDC (deepest liquidity) when the caller names no collateral. Selection
+failures (RPC/scan errors, no candidate) fall back to the mapped pool — the
+open never crashes here; B3 fails loudly downstream if the pool is unusable.
+
+Offline: ``fetch_pools_for_symbol`` / ``self.markets`` are stubbed, no RPC.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from eth_defi.gmx.ccxt.exchange import GMX
+
+_BTC_INDEX = "0x47904963fc8b2340414262125aF798B9655E58Cd"
+_USDC = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+_WBTC = "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f"
+_TBTC = "0x6c84a8f1c29108F47a79964b5Fe888D4f4D0dE40"
+_REAL_BTC_MARKET = "0x47c031236e19d024b42f8AE6780E44A573170703"
+_SYNTH_BTC_MARKET = "0xd62068697bCc92AF253225676D618B0C9f17C663"
+
+
+def _make_exchange() -> GMX:
+    """A GMX instance with only the attributes ``_resolve_market_info`` touches."""
+    return GMX.__new__(GMX)
+
+
+def _synthetic_info() -> dict:
+    """info dict for the poisoned/synthetic pool (rejects USDC)."""
+    return {
+        "market_token": _SYNTH_BTC_MARKET,
+        "index_token": _BTC_INDEX,
+        "long_token": _TBTC,
+        "short_token": _TBTC,
+    }
+
+
+def _usdc_info() -> dict:
+    return {
+        "market_token": _REAL_BTC_MARKET,
+        "index_token": _BTC_INDEX,
+        "long_token": _WBTC,
+        "short_token": _USDC,
+    }
+
+
+def _pools_both() -> list[dict]:
+    """fetch_pools_for_symbol output: synthetic listed FIRST, then real USDC pool."""
+    return [
+        {
+            "market_address": _SYNTH_BTC_MARKET,
+            "index_token": _BTC_INDEX,
+            "long_token": _TBTC,
+            "long_token_symbol": "tBTC",
+            "short_token": _TBTC,
+            "short_token_symbol": "tBTC",
+        },
+        {
+            "market_address": _REAL_BTC_MARKET,
+            "index_token": _BTC_INDEX,
+            "long_token": _WBTC,
+            "long_token_symbol": "WBTC",
+            "short_token": _USDC,
+            "short_token_symbol": "USDC",
+        },
+    ]
+
+
+def _install(gmx: GMX, mapped_info: dict, pools: list[dict]) -> None:
+    gmx.markets = {"BTC/USDC:USDC": {"info": mapped_info}}
+    gmx._normalize_symbol = lambda s: "BTC/USDC:USDC"
+    gmx.fetch_pools_for_symbol = lambda s: list(pools)
+
+
+def test_default_overrides_synthetic_mapping_to_usdc_pool(caplog):
+    """No collateral named → default USDC. Mapped synthetic pool → override + WARN."""
+    gmx = _make_exchange()
+    _install(gmx, _synthetic_info(), _pools_both())
+
+    with caplog.at_level(logging.WARNING):
+        info = gmx._resolve_market_info("BTC/USDC:USDC", {})
+
+    assert info["market_token"] == _REAL_BTC_MARKET
+    assert any("overriding" in r.message.lower() for r in caplog.records), [
+        r.message for r in caplog.records
+    ]
+
+
+def test_mapped_usdc_pool_is_kept_no_override(caplog):
+    """Mapped pool already accepts USDC → keep it, no override warning."""
+    gmx = _make_exchange()
+    _install(gmx, _usdc_info(), _pools_both())
+
+    with caplog.at_level(logging.WARNING):
+        info = gmx._resolve_market_info("BTC/USDC:USDC", {})
+
+    assert info["market_token"] == _REAL_BTC_MARKET
+    assert not any("overriding" in r.message.lower() for r in caplog.records)
+
+
+def test_case_insensitive_collateral_match_avoids_spurious_override():
+    """Lowercase-stored tokens (REST/GraphQL shape) still recognised as accepting.
+
+    A blind equality check would miss the match and wrongly override a good pool.
+    """
+    gmx = _make_exchange()
+    lower_pools = [
+        {
+            "market_address": _REAL_BTC_MARKET.lower(),
+            "index_token": _BTC_INDEX.lower(),
+            "long_token": _WBTC.lower(),
+            "long_token_symbol": "usdc".upper() and "WBTC",
+            "short_token": _USDC.lower(),
+            "short_token_symbol": "usdc",  # lowercase symbol
+        }
+    ]
+    lower_info = {
+        "market_token": _REAL_BTC_MARKET.lower(),
+        "index_token": _BTC_INDEX.lower(),
+        "long_token": _WBTC.lower(),
+        "short_token": _USDC.lower(),
+    }
+    _install(gmx, lower_info, lower_pools)
+
+    info = gmx._resolve_market_info("BTC/USDC:USDC", {})
+    assert (info["market_token"] or "").lower() == _REAL_BTC_MARKET.lower()
+
+
+def test_empty_mapping_selects_usdc_pool():
+    """Symbol not in self.markets (empty mapped info) → still picks the USDC pool."""
+    gmx = _make_exchange()
+    _install(gmx, {}, _pools_both())
+
+    info = gmx._resolve_market_info("BTC/USDC:USDC", {})
+    assert info["market_token"] == _REAL_BTC_MARKET
+
+
+def test_explicit_collateral_symbol_selects_matching_pool():
+    """Explicit non-USDC collateral wins: tBTC order keeps the synthetic pool."""
+    gmx = _make_exchange()
+    _install(gmx, _usdc_info(), _pools_both())  # mapped USDC, but user wants tBTC
+
+    info = gmx._resolve_market_info("BTC/USDC:USDC", {"collateral_symbol": "tBTC"})
+    assert info["market_token"] == _SYNTH_BTC_MARKET
+
+
+def test_no_accepting_pool_returns_mapped_info(caplog):
+    """No sibling accepts USDC → return mapped info unchanged (B3 fails it later)."""
+    gmx = _make_exchange()
+    only_synth = [_pools_both()[0]]  # tBTC-tBTC only
+    _install(gmx, _synthetic_info(), only_synth)
+
+    with caplog.at_level(logging.WARNING):
+        info = gmx._resolve_market_info("BTC/USDC:USDC", {})
+
+    assert info["market_token"] == _SYNTH_BTC_MARKET
+
+
+def test_scan_failure_falls_back_to_mapped_info():
+    """fetch_pools_for_symbol raising must not crash the open — fall back."""
+    gmx = _make_exchange()
+    gmx.markets = {"BTC/USDC:USDC": {"info": _usdc_info()}}
+    gmx._normalize_symbol = lambda s: "BTC/USDC:USDC"
+
+    def _boom(_s):
+        raise RuntimeError("RPC down")
+
+    gmx.fetch_pools_for_symbol = _boom
+
+    info = gmx._resolve_market_info("BTC/USDC:USDC", {})
+    assert info["market_token"] == _REAL_BTC_MARKET  # mapped info, no crash
+
+
+def test_explicit_market_address_bypasses_collateral_scan():
+    """An explicit ``market_address`` param must win — B2 never overrides it."""
+    gmx = _make_exchange()
+    called = {"scan": False}
+
+    class _M:
+        def __init__(self, *a, **k):
+            pass
+
+        def get_available_markets(self):
+            return {
+                _SYNTH_BTC_MARKET: {
+                    "gmx_market_address": _SYNTH_BTC_MARKET,
+                    "index_token_address": _BTC_INDEX,
+                    "long_token_address": _TBTC,
+                    "short_token_address": _TBTC,
+                }
+            }
+
+    import eth_defi.gmx.ccxt.exchange as exch_mod
+
+    orig = exch_mod.Markets
+    exch_mod.Markets = _M
+    try:
+        gmx.config = object()
+        gmx.fetch_pools_for_symbol = lambda s: called.__setitem__("scan", True) or []
+        info = gmx._resolve_market_info(
+            "BTC/USDC:USDC", {"market_address": _SYNTH_BTC_MARKET}
+        )
+    finally:
+        exch_mod.Markets = orig
+
+    assert info["market_token"] == _SYNTH_BTC_MARKET
+    assert called["scan"] is False

--- a/tests/gmx/test_collateral_validation.py
+++ b/tests/gmx/test_collateral_validation.py
@@ -1,0 +1,285 @@
+"""Fail-loud collateral validation in ``OrderArgumentParser`` (issue #1178, B3).
+
+The 2026-07-01/02 live incident: a poisoned symbol→market mapping handed the
+parser a ``market_key`` whose pool rejects USDC. ``_check_if_valid_collateral_for_market``
+**correctly detected** the mismatch and raised — but ``_handle_missing_collateral_address``
+swallowed the exception behind a bare ``except Exception`` ("relying on GMX
+router swap_path"), and ``_handle_missing_swap_path`` short-circuits to
+``swap_path = []`` whenever ``start_token == collateral`` (always true for the
+USDC-only bot). The doomed order shipped, burned gas, and died on-chain as an
+``InvalidCollateralTokenForMarket`` keeper cancel — three strikes locking the
+pair for 60 minutes.
+
+B3 restores a loud local failure for exactly that case, with exception
+classification so an *indeterminate* lookup (market_key absent from the RPC
+markets snapshot — ``KeyError``) is tolerated, while a *definitive* rejection
+(market resolved, collateral matches neither token) fails pre-flight:
+
+- definitive rejection + ``start == collateral`` (no swap leg will ever be
+  built) → raise :class:`InvalidCollateralForMarketError` before submission;
+- definitive rejection + ``start != collateral`` → a real swap route is built
+  (issue #67 flow) — unchanged;
+- indeterminate (``KeyError``) → warn and proceed — never block on "couldn't
+  verify";
+- decrease orders never run ``_handle_missing_swap_path`` (``swap_path`` is
+  not in their required keys), so closes can never be blocked by this guard.
+
+All tests run offline — ``Markets`` / ``GMXConfig`` / token metadata are
+patched, following ``test_order_argument_parser_refresh_on_miss.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+# Checksummed fixture addresses (same convention as the refresh-on-miss tests).
+_BTC_INDEX = "0x47904963fc8b2340414262125aF798B9655E58Cd"
+_USDC = "0xaf88d065e77c8cC2239327C5EDb3A432268e5831"
+_WBTC = "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f"
+_TBTC = "0x6c84a8f1c29108F47a79964b5Fe888D4f4D0dE40"
+_REAL_BTC_MARKET = "0x47c031236e19d024b42f8AE6780E44A573170703"
+_SYNTH_BTC_MARKET = "0xd62068697bCc92AF253225676D618B0C9f17C663"
+
+
+def _usdc_market() -> dict:
+    """A market that accepts USDC (long WBTC / short USDC)."""
+    return {
+        "gmx_market_address": _REAL_BTC_MARKET,
+        "market_symbol": "BTC",
+        "index_token_address": _BTC_INDEX,
+        "long_token_address": _WBTC,
+        "short_token_address": _USDC,
+        "market_metadata": {"symbol": "BTC", "decimals": 8},
+        "long_token_metadata": {"symbol": "WBTC", "decimals": 8},
+        "short_token_metadata": {"symbol": "USDC", "decimals": 6},
+    }
+
+
+def _synthetic_market() -> dict:
+    """A single-sided market that does NOT accept USDC (tBTC-tBTC)."""
+    return {
+        "gmx_market_address": _SYNTH_BTC_MARKET,
+        "market_symbol": "BTC2",
+        "index_token_address": _BTC_INDEX,
+        "long_token_address": _TBTC,
+        "short_token_address": _TBTC,
+        "market_metadata": {"symbol": "BTC2", "decimals": 8},
+        "long_token_metadata": {"symbol": "tBTC", "decimals": 8},
+        "short_token_metadata": {"symbol": "tBTC", "decimals": 8},
+    }
+
+
+def _build_config() -> MagicMock:
+    config = MagicMock()
+    config.chain = "arbitrum"
+    config.web3 = MagicMock()
+    config.web3.eth.chain_id = 42161
+    config.user_wallet_address = None
+    return config
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    """Reset the class-level markets cache around every test."""
+    from eth_defi.gmx.core.markets import Markets
+
+    Markets.invalidate_cache()
+    yield
+    Markets.invalidate_cache()
+
+
+def _build_parser(monkeypatch, markets: dict):
+    """Offline ``OrderArgumentParser`` whose markets snapshot is ``markets``."""
+    from eth_defi.gmx.order import order_argument_parser as parser_mod
+    from eth_defi.gmx.order.order_argument_parser import OrderArgumentParser
+
+    monkeypatch.setattr(
+        parser_mod.Markets,
+        "get_available_markets",
+        lambda self: markets,
+    )
+    monkeypatch.setattr(parser_mod, "GMXConfig", MagicMock())
+    # Token metadata for find_key_by_symbol (offline).
+    monkeypatch.setattr(
+        parser_mod,
+        "_get_token_metadata_dict",
+        lambda web3, chain, use_cache=True: {
+            _USDC: {"symbol": "USDC", "decimals": 6},
+            _WBTC: {"symbol": "WBTC", "decimals": 8},
+            _TBTC: {"symbol": "tBTC", "decimals": 8},
+        },
+    )
+    return OrderArgumentParser(_build_config(), is_increase=True)
+
+
+# ---------------------------------------------------------------------------
+# _check_if_valid_collateral_for_market — dedicated exception class
+# ---------------------------------------------------------------------------
+
+
+def test_rejection_raises_dedicated_exception_class(monkeypatch):
+    """Definitive rejection raises InvalidCollateralForMarketError with context.
+
+    Must stay a subclass of Exception with market_key / collateral / Hint in
+    the message — the live-RPC contract test in test_market_disambiguation.py
+    pins that message shape.
+    """
+    from eth_defi.gmx.order.order_argument_parser import (
+        InvalidCollateralForMarketError,
+    )
+
+    parser = _build_parser(
+        monkeypatch, {_SYNTH_BTC_MARKET: _synthetic_market()}
+    )
+    parser.parameters_dict = {"chain": "arbitrum", "market_key": _SYNTH_BTC_MARKET}
+
+    with pytest.raises(InvalidCollateralForMarketError) as exc_info:
+        parser._check_if_valid_collateral_for_market(_USDC)
+
+    message = str(exc_info.value)
+    assert _SYNTH_BTC_MARKET in message
+    assert _USDC in message
+    assert "Hint" in message
+    assert isinstance(exc_info.value, Exception)
+
+
+# ---------------------------------------------------------------------------
+# _handle_missing_collateral_address — exception classification
+# ---------------------------------------------------------------------------
+
+
+def test_definitive_rejection_sets_flag_false(monkeypatch):
+    """Market resolved, collateral matches neither token → flag False."""
+    parser = _build_parser(
+        monkeypatch, {_SYNTH_BTC_MARKET: _synthetic_market()}
+    )
+    parser.parameters_dict = {
+        "chain": "arbitrum",
+        "market_key": _SYNTH_BTC_MARKET,
+        "collateral_token_symbol": "USDC",
+    }
+    parser._handle_missing_collateral_address()
+
+    assert parser._collateral_directly_supported is False
+    # collateral_address is still set — downstream handlers decide the outcome.
+    assert parser.parameters_dict["collateral_address"] == _USDC
+
+
+def test_accepted_collateral_sets_flag_true(monkeypatch):
+    """Market accepts USDC → flag True, order proceeds untouched."""
+    parser = _build_parser(monkeypatch, {_REAL_BTC_MARKET: _usdc_market()})
+    parser.parameters_dict = {
+        "chain": "arbitrum",
+        "market_key": _REAL_BTC_MARKET,
+        "collateral_token_symbol": "USDC",
+    }
+    parser._handle_missing_collateral_address()
+
+    assert parser._collateral_directly_supported is True
+
+
+def test_unknown_market_key_is_indeterminate_not_rejection(monkeypatch):
+    """market_key absent from the RPC snapshot (KeyError) → flag None.
+
+    A stale/partial Markets snapshot must NOT be classified as a rejection —
+    we could not verify either way, so the order must not be blocked.
+    """
+    parser = _build_parser(monkeypatch, {_REAL_BTC_MARKET: _usdc_market()})
+    parser.parameters_dict = {
+        "chain": "arbitrum",
+        "market_key": "0x0000000000000000000000000000000000000bad",
+        "collateral_token_symbol": "USDC",
+    }
+    parser._handle_missing_collateral_address()
+
+    assert parser._collateral_directly_supported is None
+
+
+# ---------------------------------------------------------------------------
+# _handle_missing_swap_path — the fail-loud gate
+# ---------------------------------------------------------------------------
+
+
+def _swap_path_parser(monkeypatch, flag: bool | None):
+    parser = _build_parser(monkeypatch, {_REAL_BTC_MARKET: _usdc_market()})
+    parser._collateral_directly_supported = flag
+    parser.parameters_dict = {
+        "chain": "arbitrum",
+        "market_key": _SYNTH_BTC_MARKET,
+        "start_token_address": _USDC,
+        "collateral_address": _USDC,  # start == collateral → no swap leg
+    }
+    return parser
+
+
+def test_swap_path_raises_on_definitive_rejection(monkeypatch):
+    """Rejected collateral + start == collateral → loud pre-flight failure.
+
+    Pre-B3 this shipped swap_path=[] and died on-chain as a keeper cancel.
+    """
+    from eth_defi.gmx.order.order_argument_parser import (
+        InvalidCollateralForMarketError,
+    )
+
+    parser = _swap_path_parser(monkeypatch, flag=False)
+
+    with pytest.raises(InvalidCollateralForMarketError) as exc_info:
+        parser._handle_missing_swap_path()
+
+    message = str(exc_info.value)
+    assert _SYNTH_BTC_MARKET in message
+    assert "swap" in message.lower()
+    assert "swap_path" not in parser.parameters_dict  # order never completed
+
+
+def test_swap_path_proceeds_when_indeterminate(monkeypatch):
+    """Flag None (couldn't verify) → tolerate, swap_path=[] as before."""
+    parser = _swap_path_parser(monkeypatch, flag=None)
+    parser._handle_missing_swap_path()
+    assert parser.parameters_dict["swap_path"] == []
+
+
+def test_swap_path_proceeds_when_accepted(monkeypatch):
+    """Flag True (verified accepted) → swap_path=[] as before."""
+    parser = _swap_path_parser(monkeypatch, flag=True)
+    parser._handle_missing_swap_path()
+    assert parser.parameters_dict["swap_path"] == []
+
+
+def test_swap_path_default_flag_is_tolerant(monkeypatch):
+    """A parser whose collateral handler never ran must behave as indeterminate.
+
+    Callers may pre-supply collateral_address (so _handle_missing_collateral_address
+    is skipped); the guard must not fire from an unset attribute.
+    """
+    parser = _build_parser(monkeypatch, {_REAL_BTC_MARKET: _usdc_market()})
+    parser.parameters_dict = {
+        "chain": "arbitrum",
+        "start_token_address": _USDC,
+        "collateral_address": _USDC,
+    }
+    parser._handle_missing_swap_path()
+    assert parser.parameters_dict["swap_path"] == []
+
+
+def test_real_swap_leg_still_built_when_start_differs(monkeypatch):
+    """Rejected collateral + start != collateral → issue-#67 swap flow intact."""
+    from eth_defi.gmx.order import order_argument_parser as parser_mod
+
+    parser = _build_parser(monkeypatch, {_REAL_BTC_MARKET: _usdc_market()})
+    parser._collateral_directly_supported = False
+    parser.parameters_dict = {
+        "chain": "arbitrum",
+        "market_key": _SYNTH_BTC_MARKET,
+        "start_token_address": _USDC,
+        "collateral_address": _TBTC,  # start != collateral → real route
+    }
+    monkeypatch.setattr(
+        parser_mod,
+        "determine_swap_route",
+        lambda markets, start, out, chain: ([_REAL_BTC_MARKET], False),
+    )
+    parser._handle_missing_swap_path()
+    assert parser.parameters_dict["swap_path"] == [_REAL_BTC_MARKET]


### PR DESCRIPTION
Defense-in-depth for #1178, complementing the root-cause loader fix in PR #1179. Independent code paths (order resolution + parser), so this can merge independently.

## Background
The market cache knows each pool's tokens, but on **opens** the collateral and the market are resolved on two separate tracks that never cross-check: collateral is a fixed `"USDC"` default (`exchange.py:5866`), while the market comes from the symbol→pool map. When that map points at a synthetic pool that rejects USDC, nothing reconciles them until the GMX keeper cancels on-chain (`InvalidCollateralTokenForMarket` → 60-min circuit-breaker lock). Closes are immune because they derive collateral from the on-chain position.

## B2 — collateral-aware market resolution (the fix)
`_resolve_market_info`'s default branch is the **only** market-selection logic that runs on the live ccxt path (it injects `market_key`, so the parser's own `_handle_missing_market_key` USDC-preference never executes). It now applies that same documented strategy: keep the mapped pool if it accepts the order's collateral; otherwise pick a sibling pool (same index token) that does, **defaulting to USDC** — the `<base>-USDC` pools carry orders-of-magnitude deeper liquidity than synthetic single-sided pools. Explicit `collateral_symbol` wins; explicit `market_address` bypasses; scan failure / no-candidate falls back to the mapped pool. Case-insensitive.

**Verified live:** BTC has 3 pools (WBTC.b/USDC, tBTC/tBTC, WBTC.b/WBTC.b); B2 resolves the WBTC.b-USDC pool.

## B3 — fail-loud backstop
The collateral check already *detected* rejection correctly but the result was swallowed. Now `InvalidCollateralForMarketError` is raised pre-flight when a market **definitively** rejects the collateral and no swap leg will be built (`start == collateral`) — failing locally (no gas, no keeper cancel, no lock) instead of on-chain. An **indeterminate** lookup (`KeyError` — market absent from the snapshot) is tolerated, never blocking an order on "couldn't verify". Real swap legs (`start != collateral`, issue #67) and closes are unaffected.

## Tests
- `test_open_market_resolution.py` (8) — override/keep/case-insensitive/explicit-collateral/no-candidate/scan-failure/explicit-address.
- `test_collateral_validation.py` (9) — exception class + classification (reject/accept/indeterminate) + swap-path gate (raise/tolerate/proceed) + real-swap-leg intact.
- Full offline regression: **76 passed, 3 skipped**, no regression.

## Related
- #1179 (root-cause loader fix), #1178 (issue), gmx-strategies#195 (vault symptom)