### PR TITLE
fix: export blacklisted vault rows

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -87,6 +87,7 @@ class VaultFlag(str, enum.Enum):
 
 #: Don't touch vaults with these flags
 BAD_FLAGS = {
+    VaultFlag.paused,
     VaultFlag.illiquid,
     VaultFlag.broken,
     VaultFlag.malicious,

--- a/eth_defi/vault/top_vaults_json.py
+++ b/eth_defi/vault/top_vaults_json.py
@@ -79,6 +79,7 @@ DEFAULT_OUTPUT_FILENAME = "stablecoin-vault-metrics.json"
 STICKY_EXPORT_STATE_SCHEMA_VERSION = 1
 STICKY_STALE_WARNING_AGE_DAYS_DEFAULT = 14
 BLACKLISTED_RISK_LABEL = VaultTechnicalRisk.blacklisted.get_risk_level_name()
+LEGACY_BLACKLIST_SUPPRESSION_REASONS = {"current_blacklisted_record", "stale_blacklisted_record"}
 
 
 @dataclass(slots=True)
@@ -706,7 +707,7 @@ def apply_sticky_export_state(
     Current rows passing the peak TVL filter qualify a vault forever.
     Later missing, stale, below-threshold, or structurally incomplete rows
     do not make a previously qualified vault disappear unless exact
-    blacklist/invalid-fallback suppression applies.
+    invalid-fallback suppression applies.
 
     :param lifetime_data_df:
         Calculated lifetime metrics.
@@ -747,11 +748,6 @@ def apply_sticky_export_state(
         key = current_row.key
         existing_entry = state_vaults.get(key)
 
-        if is_blacklisted_record(current_row.record):
-            mark_state_entry_suppressed(state, key, "current_blacklisted_record", now_text, current_row, threshold_tvl)
-            stats.structurally_suppressed_vaults += 1
-            continue
-
         if existing_entry and existing_entry.get("status") == "suppressed" and not current_row.export_safe:
             stats.structurally_suppressed_vaults += 1
             continue
@@ -772,17 +768,39 @@ def apply_sticky_export_state(
 
     for key, entry in list(state_vaults.items()):
         if entry.get("status") != "active":
+            if entry.get("suppression_reason") in LEGACY_BLACKLIST_SUPPRESSION_REASONS:
+                current_row = current_rows.get(key)
+                if current_row and current_row.export_safe and is_blacklisted_record(current_row.record):
+                    entry = make_state_entry_from_current_row(current_row, now_text, threshold_tvl, entry)
+                    state_vaults[key] = entry
+                    annotated = annotate_sticky_record(current_row.record, entry, current_row.fresh)
+                    if not current_row.fresh:
+                        stats.stale_warning_vaults += 1
+                    add_exported_vault(vaults_by_key, key, 20 if current_row.fresh else 10, annotated)
+                    continue
+
+                fallback_record = entry.get("last_exported_record")
+                fallback_safe = isinstance(fallback_record, dict) and bool(fallback_record)
+                if fallback_safe:
+                    fallback_safe, _reason = is_export_record_key_safe(fallback_record)
+                if fallback_safe and is_blacklisted_record(fallback_record):
+                    entry["status"] = "active"
+                    entry.pop("suppression_reason", None)
+                    entry.pop("suppressed_at", None)
+                    if entry.get("stale_since") is None:
+                        entry["stale_since"] = now_text
+                    entry["last_exported_at"] = now_text
+                    state_vaults[key] = entry
+                    annotated = annotate_fallback_record(fallback_record, entry, "legacy_blacklist_suppression_recovered")
+                    stats.sticky_fallback_exports += 1
+                    stats.stale_warning_vaults += 1
+                    add_exported_vault(vaults_by_key, key, 5, annotated)
+                    continue
             continue
         if key in vaults_by_key:
             continue
         current_row = current_rows.get(key)
         fallback_reason = None
-        if current_row and is_blacklisted_record(current_row.record):
-            mark_state_entry_suppressed(state, key, "current_blacklisted_record", now_text, current_row, threshold_tvl)
-            stats.structurally_suppressed_vaults += 1
-            vaults_by_key.pop(key, None)
-            continue
-
         if current_row and current_row.export_safe:
             entry = make_state_entry_from_current_row(current_row, now_text, threshold_tvl, entry)
             state_vaults[key] = entry
@@ -803,12 +821,6 @@ def apply_sticky_export_state(
 
         if not fallback_safe:
             mark_state_entry_suppressed(state, key, "invalid_last_exported_record", now_text)
-            stats.structurally_suppressed_vaults += 1
-            vaults_by_key.pop(key, None)
-            continue
-
-        if is_blacklisted_record(fallback_record):
-            mark_state_entry_suppressed(state, key, "stale_blacklisted_record", now_text)
             stats.structurally_suppressed_vaults += 1
             vaults_by_key.pop(key, None)
             continue

--- a/scripts/erc-4626/list-blacklisted-vaults.py
+++ b/scripts/erc-4626/list-blacklisted-vaults.py
@@ -5,8 +5,8 @@ vaults whose final metrics risk is
 :py:data:`eth_defi.vault.risk.VaultTechnicalRisk.blacklisted`.
 
 This script intentionally reads the cleaned parquet and vault metadata database
-instead of ``top_vaults_by_chain.json``. The public JSON export suppresses
-blacklisted rows, so it cannot be used to audit what was removed.
+instead of ``top_vaults_by_chain.json`` so operators can audit blacklist inputs
+before sticky JSON export state is applied.
 
 Usage:
 

--- a/tests/erc_4626/test_vault_analysis_sticky_export.py
+++ b/tests/erc_4626/test_vault_analysis_sticky_export.py
@@ -24,6 +24,7 @@ def make_metrics_row(
     peak_nav: float = 10_000.0,
     last_updated_at: object | None = None,
     risk: object | None = None,
+    risk_numeric: int | None = None,
     protocol_slug: str | None = "morpho",
     curator_slug: str | None = "gauntlet",
 ) -> dict:
@@ -42,6 +43,7 @@ def make_metrics_row(
         "current_nav": peak_nav,
         "last_updated_at": last_updated_at,
         "risk": risk,
+        "risk_numeric": risk_numeric,
     }
 
 
@@ -376,20 +378,32 @@ def test_sticky_export_structural_suppression_recovers_on_clean_current_row():
     assert "suppressed_at" not in entry
 
 
-def test_sticky_export_blacklisted_rows_are_suppressed():
-    """Blacklisted rows are suppressed using the real exported risk label.
+def test_sticky_export_blacklisted_rows_are_exported():
+    """Blacklisted rows are exported using the real exported risk label.
 
     1. Run a current qualifying row with the blacklist enum
-    2. Assert it is suppressed immediately
-    3. Seed a stale fallback row with the serialised Blacklisted label
-    4. Assert stale fallback is also suppressed
+    2. Assert it is exported immediately
+    3. Seed a clean fallback row and current below-threshold blacklisted row
+    4. Assert current blacklist replaces the clean fallback
+    5. Seed a legacy suppressed blacklist state with a current blacklisted row
+    6. Assert legacy blacklist suppression recovers
+    7. Seed a legacy stale blacklist suppression with no current row
+    8. Assert legacy stale blacklist suppression recovers
+    9. Seed a stale fallback row with the serialised Blacklisted label
+    10. Assert stale blacklisted fallback remains visible
     """
     # 1. Run a current qualifying row with the blacklist enum
     module = get_top_vaults_json_module()
     now = datetime.datetime(2026, 6, 24, 12, 0, 0)
     state = module.make_empty_sticky_export_state(now)
     key = "1-0xabcd000000000000000000000000000000000001"
-    df = make_lifetime_df(make_metrics_row(risk=module.VaultTechnicalRisk.blacklisted))
+    assert module.VaultTechnicalRisk.blacklisted.value == 999
+    df = make_lifetime_df(
+        make_metrics_row(
+            risk=module.VaultTechnicalRisk.blacklisted,
+            risk_numeric=module.VaultTechnicalRisk.blacklisted.value,
+        )
+    )
 
     first = module.apply_sticky_export_state(
         df,
@@ -399,11 +413,109 @@ def test_sticky_export_blacklisted_rows_are_suppressed():
         stale_warning_age_days=14,
     )
 
-    # 2. Assert it is suppressed immediately
-    assert first.vaults == []
-    assert first.state["vaults"][key]["suppression_reason"] == "current_blacklisted_record"
+    # 2. Assert it is exported immediately
+    assert len(first.vaults) == 1
+    assert first.vaults[0]["risk"] == "Blacklisted"
+    assert first.vaults[0]["risk_numeric"] == module.VaultTechnicalRisk.blacklisted.value
+    assert first.state["vaults"][key]["status"] == "active"
+    assert "suppression_reason" not in first.state["vaults"][key]
 
-    # 3. Seed a stale fallback row with the serialised Blacklisted label
+    # 3. Seed a clean fallback row and current below-threshold blacklisted row
+    below_threshold_state = module.make_empty_sticky_export_state(now)
+    below_threshold_state["vaults"][key] = {
+        "chain_id": 1,
+        "address": "0xabcd000000000000000000000000000000000001",
+        "status": "active",
+        "first_qualified_at": "2026-06-20T00:00:00Z",
+        "last_qualified_at": "2026-06-20T00:00:00Z",
+        "last_exported_record": make_export_record(module, address="0xabcd000000000000000000000000000000000001", risk=module.VaultTechnicalRisk.low),
+    }
+    below_threshold = module.apply_sticky_export_state(
+        make_lifetime_df(
+            make_metrics_row(
+                address="0xabcd000000000000000000000000000000000001",
+                peak_nav=1_000.0,
+                risk=module.VaultTechnicalRisk.blacklisted,
+                risk_numeric=module.VaultTechnicalRisk.blacklisted.value,
+            )
+        ),
+        below_threshold_state,
+        now=now,
+        threshold_tvl=5_000.0,
+        stale_warning_age_days=14,
+    )
+
+    # 4. Assert current blacklist replaces the clean fallback
+    assert len(below_threshold.vaults) == 1
+    assert below_threshold.vaults[0]["risk"] == "Blacklisted"
+    assert below_threshold.vaults[0]["stale_export"] is False
+
+    # 5. Seed a legacy suppressed blacklist state with a current blacklisted row
+    legacy_state = module.make_empty_sticky_export_state(now)
+    legacy_state["vaults"][key] = {
+        "chain_id": 1,
+        "address": "0xabcd000000000000000000000000000000000001",
+        "status": "suppressed",
+        "suppression_reason": "current_blacklisted_record",
+        "suppressed_at": "2026-06-20T00:00:00Z",
+        "first_qualified_at": "2026-06-20T00:00:00Z",
+        "last_qualified_at": "2026-06-20T00:00:00Z",
+    }
+    legacy = module.apply_sticky_export_state(
+        make_lifetime_df(
+            make_metrics_row(
+                address="0xabcd000000000000000000000000000000000001",
+                peak_nav=1_000.0,
+                risk=module.VaultTechnicalRisk.blacklisted,
+                risk_numeric=module.VaultTechnicalRisk.blacklisted.value,
+            )
+        ),
+        legacy_state,
+        now=now,
+        threshold_tvl=5_000.0,
+        stale_warning_age_days=14,
+    )
+
+    # 6. Assert legacy blacklist suppression recovers
+    assert len(legacy.vaults) == 1
+    assert legacy.vaults[0]["risk"] == "Blacklisted"
+    assert legacy.state["vaults"][key]["status"] == "active"
+    assert "suppression_reason" not in legacy.state["vaults"][key]
+
+    # 7. Seed a legacy stale blacklist suppression with no current row
+    legacy_stale_state = module.make_empty_sticky_export_state(now)
+    legacy_stale_state["vaults"][key] = {
+        "chain_id": 1,
+        "address": "0xabcd000000000000000000000000000000000001",
+        "status": "suppressed",
+        "suppression_reason": "stale_blacklisted_record",
+        "suppressed_at": "2026-06-20T00:00:00Z",
+        "first_qualified_at": "2026-06-20T00:00:00Z",
+        "last_qualified_at": "2026-06-20T00:00:00Z",
+        "last_exported_record": make_export_record(
+            module,
+            address="0xabcd000000000000000000000000000000000001",
+            risk="Blacklisted",
+            risk_numeric=module.VaultTechnicalRisk.blacklisted.value,
+        ),
+    }
+    legacy_stale = module.apply_sticky_export_state(
+        make_lifetime_df(),
+        legacy_stale_state,
+        now=now,
+        threshold_tvl=5_000.0,
+        stale_warning_age_days=14,
+    )
+
+    # 8. Assert legacy stale blacklist suppression recovers
+    assert len(legacy_stale.vaults) == 1
+    assert legacy_stale.vaults[0]["risk"] == "Blacklisted"
+    assert legacy_stale.vaults[0]["risk_numeric"] == module.VaultTechnicalRisk.blacklisted.value
+    assert legacy_stale.vaults[0]["fallback_reason"] == "legacy_blacklist_suppression_recovered"
+    assert legacy_stale.state["vaults"][key]["status"] == "active"
+    assert "suppression_reason" not in legacy_stale.state["vaults"][key]
+
+    # 9. Seed a stale fallback row with the serialised Blacklisted label
     fallback_state = module.make_empty_sticky_export_state(now)
     fallback_state["vaults"][key] = {
         "chain_id": 1,
@@ -411,10 +523,15 @@ def test_sticky_export_blacklisted_rows_are_suppressed():
         "status": "active",
         "first_qualified_at": "2026-06-20T00:00:00Z",
         "last_qualified_at": "2026-06-20T00:00:00Z",
-        "last_exported_record": make_export_record(module, address="0xabcd000000000000000000000000000000000001", risk="Blacklisted"),
+        "last_exported_record": make_export_record(
+            module,
+            address="0xabcd000000000000000000000000000000000001",
+            risk="Blacklisted",
+            risk_numeric=module.VaultTechnicalRisk.blacklisted.value,
+        ),
     }
 
-    # 4. Assert stale fallback is also suppressed
+    # 10. Assert stale blacklisted fallback remains visible
     second = module.apply_sticky_export_state(
         make_lifetime_df(),
         fallback_state,
@@ -422,8 +539,11 @@ def test_sticky_export_blacklisted_rows_are_suppressed():
         threshold_tvl=5_000.0,
         stale_warning_age_days=14,
     )
-    assert second.vaults == []
-    assert second.state["vaults"][key]["suppression_reason"] == "stale_blacklisted_record"
+    assert len(second.vaults) == 1
+    assert second.vaults[0]["risk"] == "Blacklisted"
+    assert second.vaults[0]["risk_numeric"] == module.VaultTechnicalRisk.blacklisted.value
+    assert second.vaults[0]["stale_export"] is True
+    assert second.state["vaults"][key]["status"] == "active"
 
 
 def test_sticky_export_uses_single_state_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -16,6 +16,11 @@ def test_controversial_is_bad_flag():
     assert VaultFlag.controversial in BAD_FLAGS
 
 
+def test_paused_is_bad_flag():
+    """Paused vaults are blacklisted."""
+    assert VaultFlag.paused in BAD_FLAGS
+
+
 @pytest.mark.parametrize(
     ("address", "protocol", "expected_flag", "expected_note"),
     [


### PR DESCRIPTION
## Why

Production `top_vaults_by_chain.json` still showed zero explicit blacklisted vaults because sticky JSON export suppressed rows carrying `risk: Blacklisted` after lifetime metrics had classified them.

This made frontend data checks look like the deployed blacklist fix had not landed, even when metric-level blacklisting worked.

## Lessons learnt

Blacklist status needs to be visible in the public JSON export, not only used as an internal suppression signal. Sticky export state can also preserve old suppression decisions, so exporter policy changes must migrate or recover legacy state on the next run.

## Summary

- Keep blacklisted vault rows in sticky JSON export instead of suppressing them.
- Recover legacy sticky state entries suppressed with `current_blacklisted_record` or `stale_blacklisted_record`.
- Treat paused vault scan flags as bad flags.
- Keep Summer.fi protocol risk unchanged; only vault-specific/manual flags or scanned bad flags blacklist individual Summer vaults.
- Extend existing sticky export and vault flag tests for explicit blacklist projection and legacy suppression recovery.
- Update the blacklist audit script wording now that public JSON no longer suppresses blacklisted rows.

Focused checks run locally: `source .local-test.env && /home/mikko/.cache/pypoetry/virtualenvs/web3-ethereum-defi-W6V8IoRX-py3.14/bin/python -m pytest tests/erc_4626/test_vault_analysis_sticky_export.py tests/vault/test_flag.py tests/research/test_vault_metrics_stablecoin_rate.py -q`.

## Related issues and PRs

Continues the vault blacklist export follow-up after production data still showed zero explicit blacklisted rows at exporter commit `700c722a17f608bd0484e23c90cf19e9096be941`.

## Unrelated CI and test fixes

None.
