### PR TITLE
Fix RockawayX OnRe and Upshift vault mapping

### DIFF
--- a/eth_defi/abi/upshift/IMultiAssetVaultEvents.json
+++ b/eth_defi/abi/upshift/IMultiAssetVaultEvents.json
@@ -1,0 +1,85 @@
+{
+  "abi": [
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "assetIn",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amountIn",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "shares",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "senderAddr",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "receiverAddr",
+          "type": "address"
+        }
+      ],
+      "name": "Deposit",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "shares",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "holderAddr",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "receiverAddr",
+          "type": "address"
+        }
+      ],
+      "name": "WithdrawalRequested",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "assetsAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "receiverAddr",
+          "type": "address"
+        }
+      ],
+      "name": "WithdrawalProcessed",
+      "type": "event"
+    }
+  ]
+}

--- a/eth_defi/abi/upshift/README.md
+++ b/eth_defi/abi/upshift/README.md
@@ -1,0 +1,38 @@
+# Upshift ABI files
+
+`TokenizedAccount.json` is the existing narrow ERC-4626-like interface used by
+the Upshift vault integration.
+
+`IMultiAssetVaultEvents.json` is an event-only interface for Upshift
+`multiAssetVault` discovery. It contains the custom multi-asset deposit event
+and the matching withdrawal request/processed events:
+
+```solidity
+event Deposit(address assetIn, uint256 amountIn, uint256 shares, address indexed senderAddr, address indexed receiverAddr);
+event WithdrawalRequested(uint256 shares, address indexed holderAddr, address indexed receiverAddr);
+event WithdrawalProcessed(uint256 assetsAmount, address indexed receiverAddr);
+```
+
+The deposit event topic is
+`0xc436f473cd90c9b4dd731856a14b80f713d384a1688a506d4230140c5b36d5cd`.
+This topic has been observed in Tori and Earn ctUSD proxy logs. The withdrawal
+event topics are included from the fetched shared implementation ABI so vaults
+that later emit Upshift-native withdrawal events get accurate redemption
+counters.
+
+Relevant sources:
+
+- Upshift API docs: <https://docs.upshift.finance/developer-docs/api-reference>
+- Tori Ecosystem Vault: <https://api.upshift.finance/v1/tokenized_vaults/0xcd69123b3FBBfC666E1f6a501da27B564C00De54>
+- Earn ctUSD: <https://api.upshift.finance/v1/tokenized_vaults/0xc87DBBB8C67e4F19fCD2E297c05937567b2572Ce>
+- Tori proxy ABI on Sourcify: <https://repo.sourcify.dev/contracts/partial_match/1/0xcd69123b3FBBfC666E1f6a501da27B564C00De54/metadata.json>
+- Earn ctUSD proxy ABI on Sourcify: <https://repo.sourcify.dev/contracts/partial_match/1/0xc87DBBB8C67e4F19fCD2E297c05937567b2572Ce/metadata.json>
+- Shared implementation on Etherscan: <https://etherscan.io/address/0xEB5f80aCEa6060764E91c185bE93752Ab40F01c2#code>
+- Shared implementation ABI via Routescan API: <https://api.routescan.io/v2/network/mainnet/evm/1/etherscan/api?module=contract&action=getabi&address=0xEB5f80aCEa6060764E91c185bE93752Ab40F01c2>
+
+The public explorer/Sourcify ABI for Tori and Earn ctUSD is the
+`TransparentUpgradeableProxy` ABI, so it exposes only proxy administration
+events. Routescan reports both proxies use the shared implementation
+`0xEB5f80aCEa6060764E91c185bE93752Ab40F01c2`. Discovery needs an
+implementation-level event interface because logs are emitted at the proxy
+address but decoded with the implementation event ABI.

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -78,8 +78,8 @@ CHAIN_RESTRICTED_PROBES: dict[str, set[int]] = {
     "routerRegistry": {8453},  # Singularity Finance - Base only
     "strategist": {5000},  # Brink - Mantle only
     "vaultManager": {5000},  # Brink - Mantle only
-    "strategy": {143},  # Accountable - Monad only
-    "queue": {143},  # Accountable - Monad only
+    "strategy": {1, 143},  # Accountable - Ethereum, Monad
+    "queue": {1, 143},  # Accountable - Ethereum, Monad
     "POOL": {999},  # Sentiment - HyperEVM only
     "shareManager": MELLOW_CORE_CHAIN_IDS,  # Mellow Core - Ethereum, Plasma, Arbitrum, Monad
     "getAssetCount": MELLOW_CORE_CHAIN_IDS,  # Mellow Core - Ethereum, Plasma, Arbitrum, Monad
@@ -756,9 +756,10 @@ def create_probe_calls(
                 extra_data=None,
             )
 
-        # Accountable Capital - Monad only
+        # Accountable Capital - Ethereum, Monad
         # AccountableAsyncRedeemVault with ERC-7540 async redemption queue
         # https://monadscan.com/address/0x58ba69b289De313E66A13B7D1F822Fc98b970554
+        # https://etherscan.io/address/0xb9c317cAE7dd05eCb0c0925020e529934c96f84D
         if _should_yield_probe("strategy", chain_id):
             yield EncodedCall.from_keccak_signature(
                 address=address,

--- a/eth_defi/erc_4626/discovery_base.py
+++ b/eth_defi/erc_4626/discovery_base.py
@@ -6,6 +6,7 @@
 - Supports EmberVault VaultDeposit/RequestRedeemed events
 - Supports TokenGateway Deposit(5-arg)/RedeemRequested/RedeemTokenGatewayDepreciated events
 - Supports Royco tranche Redeem event
+- Supports Upshift multi-asset Deposit/WithdrawalRequested/WithdrawalProcessed events
 """
 
 import abc
@@ -63,7 +64,17 @@ class PotentialVaultMatch:
 
     def is_candidate(self) -> bool:
         # Compatibility shim: older persisted lead objects may not have this slot; remove after reader state migration.
-        return getattr(self, "mellow_factory_candidate", None) is not None or (self.deposit_count > 0 and self.withdrawal_count > 0)
+        if getattr(self, "mellow_factory_candidate", None) is not None:
+            return True
+
+        # Deposit-only event streams are valid vault leads.
+        # Large curated vaults can have deposits but no withdrawals yet because
+        # they are in a pre-deposit phase, have an initial lock-up, or use a
+        # delayed withdrawal process. Requiring withdrawal events made us miss
+        # RockawayX/Upshift vaults such as Tori Ecosystem Vault and Earn ctUSD.
+        # Extra deposit-only matches are still filtered by the later
+        # ``probe_vaults()`` feature-detection stage before export.
+        return self.deposit_count > 0
 
 
 def get_brink_vault_contract(web3):
@@ -113,6 +124,38 @@ def get_royco_tranche_event_contract(web3):
     return get_contract(
         web3,
         "royco/RoycoSeniorTranche.json",
+    )
+
+
+def get_upshift_multi_asset_event_contract(web3):
+    """Get Upshift multi-asset vault interface for custom flow events.
+
+    Upshift ``multiAssetVault`` contracts can accept multiple deposit assets and
+    therefore do not emit the standard ERC-4626
+    ``Deposit(address,address,uint256,uint256)`` event. Their vault-local
+    deposit event is:
+
+    - ``Deposit(address assetIn, uint256 amountIn, uint256 shares, address indexed senderAddr, address indexed receiverAddr)``
+    - ``WithdrawalRequested(uint256 shares, address indexed holderAddr, address indexed receiverAddr)``
+    - ``WithdrawalProcessed(uint256 assetsAmount, address indexed receiverAddr)``
+
+    The deposit event topic is
+    ``0xc436f473cd90c9b4dd731856a14b80f713d384a1688a506d4230140c5b36d5cd``.
+    This was observed on Ethereum mainnet Upshift/RockawayX vaults:
+
+    - `Tori Ecosystem Vault on Etherscan <https://etherscan.io/address/0xcd69123b3FBBfC666E1f6a501da27B564C00De54>`__
+    - `Earn ctUSD on Etherscan <https://etherscan.io/address/0xc87DBBB8C67e4F19fCD2E297c05937567b2572Ce>`__
+    - `Shared implementation on Etherscan <https://etherscan.io/address/0xEB5f80aCEa6060764E91c185bE93752Ab40F01c2#code>`__
+    - `Upshift API reference <https://docs.upshift.finance/developer-docs/api-reference>`__
+
+    Both vault addresses are TransparentUpgradeableProxy contracts whose public
+    explorer ABI exposes only proxy events. We keep this event-only ABI so lead
+    discovery can match the implementation-level log topic emitted at the proxy
+    address without depending on a single implementation address.
+    """
+    return get_contract(
+        web3,
+        "upshift/IMultiAssetVaultEvents.json",
     )
 
 
@@ -212,6 +255,35 @@ def get_royco_tranche_discovery_events(web3) -> list[Type[ContractEvent]]:
     ]
 
 
+def get_upshift_multi_asset_discovery_events(web3) -> list[Type[ContractEvent]]:
+    """Get Upshift multi-asset events we use in vault discovery.
+
+    Upshift has two vault families relevant for discovery:
+
+    - Older TokenizedAccount/ERC-4626-like vaults, such as Upshift AZT, emit
+      the standard ERC-4626 ``Deposit``/``Withdraw`` topics and are already
+      covered by :py:func:`get_standard_erc_4626_vault_discovery_events`.
+    - Newer ``multiAssetVault`` vaults emit a custom multi-asset ``Deposit``
+      topic because the event needs to include ``assetIn``. Some large vaults
+      have not emitted withdrawal events yet due to lock-up/pre-deposit
+      mechanics, so the deposit event alone must be enough to seed a lead.
+      When withdrawal request/processed events exist, we still scan them to
+      keep the diagnostic redemption counter useful.
+
+    `Upshift vault API <https://api.upshift.finance/v1/tokenized_vaults/0xcd69123b3FBBfC666E1f6a501da27B564C00De54>`__
+    reports Tori Ecosystem Vault as ``internal_type=multiAssetVault``.
+
+    :return:
+        List of Upshift multi-asset event types used for lead discovery.
+    """
+    IUpshiftMultiAssetVaultEvents = get_upshift_multi_asset_event_contract(web3)
+    return [
+        IUpshiftMultiAssetVaultEvents.events.Deposit,
+        IUpshiftMultiAssetVaultEvents.events.WithdrawalRequested,
+        IUpshiftMultiAssetVaultEvents.events.WithdrawalProcessed,
+    ]
+
+
 def get_vault_discovery_events(web3) -> list[Type[ContractEvent]]:
     """Get all events used in vault discovery, including protocol-specific ones.
 
@@ -221,15 +293,18 @@ def get_vault_discovery_events(web3) -> list[Type[ContractEvent]]:
     - EmberVault VaultDeposit/RequestRedeemed events
     - TokenGateway Deposit(5-arg)/RedeemRequested/RedeemTokenGatewayDepreciated events
     - Royco tranche Redeem event
+    - Upshift multi-asset Deposit/WithdrawalRequested/WithdrawalProcessed events
 
     :return:
         List of contract event types in order:
         [ERC4626.Deposit, ERC4626.Withdraw, BrinkVault.Deposited, BrinkVault.Withdrawal,
          EmberVault.VaultDeposit, EmberVault.RequestRedeemed,
          TokenGateway.Deposit, TokenGateway.RedeemRequested, TokenGateway.RedeemTokenGatewayDepreciated,
-         RoycoTranche.Redeem]
+         RoycoTranche.Redeem,
+         UpshiftMultiAsset.Deposit, UpshiftMultiAsset.WithdrawalRequested,
+         UpshiftMultiAsset.WithdrawalProcessed]
     """
-    return get_standard_erc_4626_vault_discovery_events(web3) + get_brink_vault_discovery_events(web3) + get_ember_vault_discovery_events(web3) + get_token_gateway_discovery_events(web3) + get_royco_tranche_discovery_events(web3)
+    return get_standard_erc_4626_vault_discovery_events(web3) + get_brink_vault_discovery_events(web3) + get_ember_vault_discovery_events(web3) + get_token_gateway_discovery_events(web3) + get_royco_tranche_discovery_events(web3) + get_upshift_multi_asset_discovery_events(web3)
 
 
 def get_vault_event_topic_map(web3) -> dict[str, VaultEventKind]:
@@ -247,6 +322,7 @@ def get_vault_event_topic_map(web3) -> dict[str, VaultEventKind]:
     ember_events = get_ember_vault_discovery_events(web3)
     token_gateway_events = get_token_gateway_discovery_events(web3)
     royco_tranche_events = get_royco_tranche_discovery_events(web3)
+    upshift_multi_asset_events = get_upshift_multi_asset_discovery_events(web3)
 
     return {
         get_topic_signature_from_event(erc4626_events[0]): VaultEventKind.deposit,
@@ -259,6 +335,9 @@ def get_vault_event_topic_map(web3) -> dict[str, VaultEventKind]:
         get_topic_signature_from_event(token_gateway_events[1]): VaultEventKind.withdraw,
         get_topic_signature_from_event(token_gateway_events[2]): VaultEventKind.withdraw,
         get_topic_signature_from_event(royco_tranche_events[0]): VaultEventKind.withdraw,
+        get_topic_signature_from_event(upshift_multi_asset_events[0]): VaultEventKind.deposit,
+        get_topic_signature_from_event(upshift_multi_asset_events[1]): VaultEventKind.withdraw,
+        get_topic_signature_from_event(upshift_multi_asset_events[2]): VaultEventKind.withdraw,
     }
 
 

--- a/eth_defi/erc_4626/hypersync_discovery.py
+++ b/eth_defi/erc_4626/hypersync_discovery.py
@@ -92,13 +92,14 @@ class HypersyncVaultDiscover(VaultDiscoveryBase):
         self.recv_timeout = recv_timeout
 
     def get_topic_signatures(self) -> list[HexStr]:
-        """Contracts must have at least one event of both these signatures
+        """Get topic signatures that can seed vault leads.
 
         - Find contracts emitting these events
         - Later prod these contracts to see which of them are proper vaults
-        - We are likely having a real ERC-4262 contract if both events match,
-          ``Deposit`` event might have few similar contracts
-        - Also includes BrinkVault DepositFunds/WithdrawFunds events
+        - A deposit event is enough to create a lead. Some large vaults have
+          not emitted withdrawal events yet because funds are still locked or
+          the vault is in a pre-deposit phase.
+        - Also includes protocol-specific vault flow events
         """
         return [get_topic_signature_from_event(e) for e in get_vault_discovery_events(self.web3)]
 

--- a/eth_defi/erc_4626/rpc_discovery.py
+++ b/eth_defi/erc_4626/rpc_discovery.py
@@ -73,7 +73,8 @@ class JSONRPCVaultDiscover(VaultDiscoveryBase):
     def build_query(self, executor: ThreadPoolExecutor, start_block: int, end_block: int) -> dict:
         """Create a read_events_concurrent arguments to discover new vaults.
 
-        Includes both standard ERC-4626 events and BrinkVault events.
+        Includes standard ERC-4626 events and all configured protocol-specific
+        vault flow events.
 
         See :py:func:`eth_defi.event_reader.reader.read_events_concurrent`
         """

--- a/eth_defi/vault/curator.py
+++ b/eth_defi/vault/curator.py
@@ -308,6 +308,8 @@ CURATOR_ADDRESS_OVERRIDES: dict[tuple[int, str], str] = {
     (1, "0xe0181090c22579b6a217f1522cbf8c9f1f0c1965"): "rockawayx",
     (1, "0x67e1f506b148d0fc95a4e3ffb49068ceb6855c05"): "rockawayx",
     (1, "0x0f0a9d3f0bc6006143c96e6995572b51413cb3c4"): "rockawayx",
+    # Accountable API maps the Dune loan address above to this ERC-4626 share vault.
+    (1, "0xb9c317cae7dd05ecb0c0925020e529934c96f84d"): "rockawayx",
     (1, "0x64c18dcc4ccb3b8d27877a4aebb4c3126cb39cb9"): "rockawayx",
     (56, "0xb5a30e1fa2cf3c8dea882124b3ab5a47a27c5dd2"): "rockawayx",
     (1, "0xd65d6e8dbc3cd3d12418199e6f4014db3aaa0097"): "rockawayx",

--- a/tests/erc_4626/test_classification.py
+++ b/tests/erc_4626/test_classification.py
@@ -54,10 +54,12 @@ def test_chain_probe_filtering():
     assert _should_yield_probe("getPerformanceFeeData", ARBITRUM) is True
     assert _should_yield_probe("getPerformanceFeeData", POLYGON) is False
 
-    # Accountable restricted to Monad
+    # Accountable restricted to Ethereum and Monad
+    assert _should_yield_probe("strategy", ETHEREUM_MAINNET) is True
+    assert _should_yield_probe("queue", ETHEREUM_MAINNET) is True
     assert _should_yield_probe("strategy", MONAD) is True
     assert _should_yield_probe("queue", MONAD) is True
-    assert _should_yield_probe("strategy", ETHEREUM_MAINNET) is False
+    assert _should_yield_probe("strategy", BASE) is False
 
     # Brink restricted to Mantle
     assert _should_yield_probe("strategist", MANTLE) is True
@@ -74,11 +76,11 @@ def test_chain_probe_filtering():
     assert "strategy" in func_names_monad
     assert "queue" in func_names_monad
 
-    # Accountable probes excluded on Ethereum
+    # Accountable probes included on Ethereum for OnRe Core Vault.
     probes_eth = list(create_probe_calls([test_address], chain_id=ETHEREUM_MAINNET))
     func_names_eth = [p.func_name for p in probes_eth]
-    assert "strategy" not in func_names_eth
-    assert "queue" not in func_names_eth
+    assert "strategy" in func_names_eth
+    assert "queue" in func_names_eth
 
     royco_tranche_probe_names = ["getRawNAV"]
     assert sum(1 for func_name in func_names_eth if func_name in royco_tranche_probe_names) == 1

--- a/tests/erc_4626/test_upshift_multi_asset_events.py
+++ b/tests/erc_4626/test_upshift_multi_asset_events.py
@@ -1,0 +1,106 @@
+"""Test Upshift multi-asset event discovery."""
+
+import datetime
+
+from web3 import Web3
+
+from eth_defi.abi import get_topic_signature_from_event
+from eth_defi.erc_4626.discovery_base import (
+    PotentialVaultMatch,
+    VaultEventKind,
+    get_standard_erc_4626_vault_discovery_events,
+    get_upshift_multi_asset_discovery_events,
+    get_vault_discovery_events,
+    get_vault_event_topic_map,
+)
+
+
+def _native_datetime(year: int, month: int, day: int) -> datetime.datetime:
+    """Create a fixed naive UTC datetime for lead metadata."""
+    return datetime.datetime(year, month, day, tzinfo=datetime.timezone.utc).replace(tzinfo=None)
+
+
+def test_upshift_multi_asset_deposit_topic_is_deposit():
+    """Verify the Upshift multi-asset deposit event topic.
+
+    Upshift ``multiAssetVault`` contracts emit a custom deposit event whose
+    first argument is the deposited asset. This topic must be treated as a
+    deposit-like vault lead event by both JSON-RPC and Hypersync discovery.
+    """
+    web3 = Web3()
+    upshift_events = get_upshift_multi_asset_discovery_events(web3)
+    topic_map = get_vault_event_topic_map(web3)
+
+    deposit_topic = get_topic_signature_from_event(upshift_events[0])
+
+    assert deposit_topic == "0xc436f473cd90c9b4dd731856a14b80f713d384a1688a506d4230140c5b36d5cd"
+    assert topic_map[deposit_topic] == VaultEventKind.deposit
+
+
+def test_upshift_multi_asset_deposit_topic_is_distinct_from_standard_erc4626():
+    """Verify Upshift multi-asset deposits cannot collide with ERC-4626 deposits."""
+    web3 = Web3()
+    erc4626_events = get_standard_erc_4626_vault_discovery_events(web3)
+    upshift_events = get_upshift_multi_asset_discovery_events(web3)
+
+    erc4626_deposit_topic = get_topic_signature_from_event(erc4626_events[0])
+    upshift_deposit_topic = get_topic_signature_from_event(upshift_events[0])
+
+    assert upshift_deposit_topic != erc4626_deposit_topic
+
+
+def test_upshift_multi_asset_topics_are_in_aggregate_discovery_events():
+    """Verify aggregate discovery scans include all Upshift multi-asset topics."""
+    web3 = Web3()
+    all_topics = {get_topic_signature_from_event(event) for event in get_vault_discovery_events(web3)}
+    upshift_topics = {get_topic_signature_from_event(event) for event in get_upshift_multi_asset_discovery_events(web3)}
+
+    assert upshift_topics <= all_topics
+
+
+def test_upshift_multi_asset_withdraw_topics_are_withdrawals():
+    """Verify Upshift multi-asset withdrawal events are counted as redemptions."""
+    web3 = Web3()
+    upshift_events = get_upshift_multi_asset_discovery_events(web3)
+    topic_map = get_vault_event_topic_map(web3)
+
+    withdrawal_requested_topic = get_topic_signature_from_event(upshift_events[1])
+    withdrawal_processed_topic = get_topic_signature_from_event(upshift_events[2])
+
+    assert withdrawal_requested_topic == "0xcf41fab81bee2456b7007d9d1a9e2261a6627a41eba8c3302b6b07f9a7a46395"
+    assert withdrawal_processed_topic == "0x2e06b2c9d4ccae2592eda2017cb2fb604b8d7418e85f023375514ab25ff2cc4c"
+    assert topic_map[withdrawal_requested_topic] == VaultEventKind.withdraw
+    assert topic_map[withdrawal_processed_topic] == VaultEventKind.withdraw
+
+
+def test_deposit_only_lead_is_candidate():
+    """Deposit-only vault leads are eligible for protocol probing.
+
+    Large curated vaults can have deposits but no withdrawals yet due to
+    pre-deposit phases or lock-ups. The scan must not wait for a withdrawal
+    before probing the contract and classifying the vault.
+    """
+    lead = PotentialVaultMatch(
+        chain=1,
+        address="0xcd69123b3FBBfC666E1f6a501da27B564C00De54",
+        first_seen_at_block=22_000_000,
+        first_seen_at=_native_datetime(2026, 6, 10),
+        deposit_count=1,
+        withdrawal_count=0,
+    )
+
+    assert lead.is_candidate()
+
+
+def test_withdraw_only_lead_is_not_candidate():
+    """Withdraw-only logs do not seed a vault candidate without a deposit."""
+    lead = PotentialVaultMatch(
+        chain=1,
+        address="0xc87DBBB8C67e4F19fCD2E297c05937567b2572Ce",
+        first_seen_at_block=22_000_000,
+        first_seen_at=_native_datetime(2026, 5, 1),
+        deposit_count=0,
+        withdrawal_count=1,
+    )
+
+    assert not lead.is_candidate()

--- a/tests/vault/test_curator.py
+++ b/tests/vault/test_curator.py
@@ -159,6 +159,7 @@ def test_identify_rockawayx_dashboard_vaults_by_address() -> None:
         (1, "RockawayX YIELD USDC", "0xE0181090c22579B6A217f1522cbf8c9f1F0C1965", "morpho"),
         (1, "mROX", "0x67E1F506B148d0Fc95a4E3fFb49068ceB6855c05", "midas"),
         (1, "OnRe Core Vault", "0x0F0a9d3F0bc6006143c96E6995572b51413CB3c4", "accountable"),
+        (1, "OnRe Core Vault", "0xb9c317cAE7dd05eCb0c0925020e529934c96f84D", "accountable"),
         (1, "RockawayX wETH", "0x64C18DCC4Ccb3b8D27877a4aeBB4C3126CB39cB9", "morpho"),
         (56, "RockawayX YIELD PT", "0xb5a30e1fa2cf3c8dea882124b3ab5a47a27c5dd2", "lista"),
         (1, "Figure USDC Main", "0xd65d6E8dbC3Cd3D12418199E6f4014dB3aaa0097", "morpho"),


### PR DESCRIPTION
## Why

RockawayX OnRe Core Vault appears in the production export under its Accountable ERC-4626 share address, but it was classified as a generic ERC-7540/ERC-7575 vault instead of Accountable. This left the row without the RockawayX curator and without Accountable's corrected NAV handling.

RockawayX also curates large Upshift multi-asset vaults on Ethereum, including Tori Ecosystem Vault and Earn ctUSD. These vaults emit Upshift's custom multi-asset deposit event and can have deposits without withdrawals while funds are locked or the vault is in pre-deposit, so the generic discovery path missed them.

## Lessons learnt

Accountable's Dune and app-facing address for OnRe is the loan/strategy contract, while the ERC-4626 pipeline keys the vault by the share contract from Accountable's API. Accountable is also deployed on Ethereum now, not only Monad.

Upshift `multiAssetVault` contracts share an implementation behind TransparentUpgradeableProxy addresses. The public proxy ABI exposes only proxy admin events, so scanner support needs an implementation-level event interface for `Deposit(address,uint256,uint256,address,address)` and related Upshift withdrawal events. Deposit-only lead discovery is needed because curated vaults can be economically active before any withdrawal event exists.

## Summary

- Enables Accountable `strategy()` and `queue()` classification probes on Ethereum as well as Monad.
- Adds the OnRe Core Vault ERC-4626 share address to the RockawayX exact curator overrides.
- Adds Upshift multi-asset vault event ABI documentation and discovery events.
- Allows deposit-only event streams to seed vault leads, with downstream feature probing still filtering non-vault false positives.
- Updates classification, curator, and Upshift event discovery regression coverage.

## Related issues and PRs

Follow-up to #1173.

## Unrelated CI and test fixes

None.
