### PR TITLE
feat: add Kinexys vault tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Current
 
+- feat: Add scan-only Kinexys support for the JPMorgan JLTXX tokenised money market fund using ODA-FACT contracts, with hardcoded production discovery, `VaultBase` adapter routing, historical supply/NAV reads, protocol metadata and unit tests (2026-07-03)
+
 - feat: Upload the exchange-rate DuckDB bundle with the vault data artefacts to both primary and alternative R2 buckets, and include it in alternative daily backups using the same `CURRENCY_API_DB_PATH` / `CURRENCY_API_DATABASE_PATH` path configuration as the currency-rate scanner (2026-07-02)
 
 - fix: Widen the HyperCore vault deposit verification relative tolerance from 1% to 5%. `wait_for_vault_deposit_confirmation` measures the deposit as an equity increase against a baseline snapshotted minutes earlier, but live perp-trading vaults mark-to-market every block, so the vault's own NAV drift over the confirmation window was being subtracted from the apparent deposit. A production incident (trade #1240, Loop Fund vault, 2026-07-01) saw an 8.06806 USDC deposit credited to the cent but reported ~0.22 USDC short after the pre-existing ~750 USDC position marked down, tripping the old 1% band, raising `HypercoreDepositVerificationError` and crashing the whole live trading loop even though the funds were safely in the vault (2026-07-02)

--- a/docs/protocol-research/oda-fact-vault-integration-plan.md
+++ b/docs/protocol-research/oda-fact-vault-integration-plan.md
@@ -1,0 +1,76 @@
+# Kinexys vault integration plan
+
+## Summary
+
+This note documents the minimal ODA-FACT integration needed for the existing
+vault matching and historical price pipeline.
+
+ODA-FACT comes from J.P. Morgan's token-standard terminology. Current Kinexys
+material describes it as Kinexys Digital Assets Fungible Asset Contract, while
+the ODA prefix reflects the earlier Onyx Digital Assets branding before Onyx
+was renamed to Kinexys.
+
+The first supported contract is JPMorgan's OnChain Liquidity-Token Money Market
+Fund token, JLTXX:
+
+- Chain: Ethereum mainnet
+- Token and diamond address: `0x09864f52B035AE22eE739dFa5c748fA080D07bD8`
+- Token decimals: `2`
+- First seen block: `25042223`
+- Verified source package reference: `@odaplatform/da-fact-smartcontracts`
+
+## Scope
+
+The integration is intentionally scan-only.
+
+It should:
+
+- hardcode the single production JLTXX lead in `classification.py`;
+- route the hardcoded address to `ERC4626Feature.oda_fact_like`;
+- create an `OdaFactVault` through the normal vault classifier;
+- read ERC-20 `totalSupply()` for current and historical supply;
+- report JLTXX share price as an explicitly labelled `1.00` USD estimate until
+  an official NAV source is integrated;
+- hardcode JLTXX Token Class prospectus fees by address: `0.16%` current net
+  annual expenses after waivers, with `0.71%` gross expenses kept as scan-row
+  diagnostics;
+- export rows through the shared vault scan-record path;
+- keep active deposit, redemption and flow accounting unsupported.
+
+It should not:
+
+- pretend ODA-FACT is ERC-4626;
+- map ERC-20 mint/burn/transfer events to generic vault deposits or redemptions;
+- add a generic discovery scanner before there is more than one production
+  contract;
+- add a placeholder NAV provider abstraction before there is a real NAV source.
+
+## Why this is not ERC-4626
+
+ODA-FACT exposes an ERC-20-compatible token surface, but not the standard
+ERC-4626 accounting and investor flow surface.
+
+ERC-4626 assumes methods such as `asset()`, `totalAssets()`,
+`convertToAssets()`, `deposit()`, `withdraw()` and canonical `Deposit` /
+`Withdraw` events. JLTXX does not expose this surface. It is a permissioned
+tokenised fund share contract where subscription, redemption and NAV accounting
+are handled outside the generic DeFi vault interface.
+
+## Pipeline fit
+
+The implementation follows the same shape as the recent Mellow adapter work:
+
+- use a `VaultBase` adapter instead of forcing ERC-4626 methods;
+- reuse `create_vault_scan_record()` for row export;
+- provide a protocol-specific historical reader;
+- use a feature flag only as a routing marker.
+
+The only special discovery rule is the hardcoded JLTXX lead. Because there is
+one production contract, a separate ODA-FACT discovery module is unnecessary.
+
+## Open follow-up
+
+Historical TVL is currently based on `totalSupply() * 1.00`. This is useful for
+pipeline compatibility, but it is still an estimate. The next meaningful
+improvement is an official JPMorgan, Kinexys or transfer-agent NAV source that
+can provide block- or date-aligned NAV per share.

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -42,6 +42,7 @@ See :ref:`tutorials <tutorials>` for guides and examples on how to use the libra
    lagoon/index
    mellow/index
    ipor/index
+   oda_fact/index
    royco/index
    velvet/index
    morpho/index

--- a/docs/source/api/oda_fact/index.rst
+++ b/docs/source/api/oda_fact/index.rst
@@ -1,0 +1,32 @@
+Kinexys API
+-----------
+
+`Kinexys Digital Assets <https://www.jpmorgan.com/kinexys>`__ tokenised fund
+integration using ODA-FACT contracts.
+
+The ODA-FACT name comes from J.P. Morgan's token-standard terminology. Current
+Kinexys material describes it as `Kinexys Digital Assets Fungible Asset Contract
+<https://www.jpmorgan.com/kinexys/documents/portfolio-management-powered-by-tokenization.pdf>`__,
+while the ODA prefix reflects the earlier Onyx Digital Assets branding before
+Onyx was renamed to Kinexys.
+
+The ODA-FACT adapter tracks permissioned ERC-20-compatible tokenised fund
+contracts through the shared vault price pipeline. It is not an ERC-4626
+implementation: historical reads use token supply from the ODA-FACT contract
+and an explicitly labelled ``1.00`` USD NAV estimate for JLTXX until an
+official NAV source is integrated.
+
+JLTXX fees are not available from the token contract. The adapter hardcodes the
+Token Class fee disclosure from the `May 13, 2026 SEC prospectus
+<https://www.sec.gov/Archives/edgar/data/1659326/000119312526217424/d44657d485bpos.htm>`__:
+``0.71%`` gross total annual fund operating expenses and ``0.16%`` net total
+annual fund operating expenses after waivers through June 30, 2028. The shared
+vault fee model exposes the current net expense ratio as the management-like
+annual fee.
+
+.. autosummary::
+   :toctree: _autosummary_oda_fact
+   :recursive:
+
+   eth_defi.oda_fact.vault
+   eth_defi.oda_fact.historical

--- a/eth_defi/data/vaults/metadata/kinexys.yaml
+++ b/eth_defi/data/vaults/metadata/kinexys.yaml
@@ -1,0 +1,38 @@
+name: Kinexys
+slug: kinexys
+short_description: |
+  Permissioned tokenised fund contracts using Kinexys Digital Assets Fungible Asset Contract.
+long_description: |
+  Kinexys Digital Assets Fungible Asset Contract, or ODA-FACT, is a standardised
+  token contract surface used for tokenised institutional fund products. The
+  ODA-FACT name comes from J.P. Morgan's token-standard terminology: current
+  Kinexys material calls it Kinexys Digital Assets Fungible Asset Contract,
+  while the ODA prefix reflects the earlier Onyx Digital Assets branding before
+  Onyx was renamed to Kinexys. The initial integration tracks JPMorgan's OnChain
+  Liquidity-Token Money Market Fund token, JLTXX, on Ethereum.
+
+  ODA-FACT contracts are ERC-20-compatible tokenised fund contracts, not
+  ERC-4626 vaults. The integration reads token supply on-chain and currently
+  combines it with an explicitly labelled 1.00 USD NAV estimate for JLTXX until
+  an official NAV source is integrated.
+fee_description: |
+  Fee terms are not readable from the ODA-FACT token contract surface. For the
+  JLTXX Token Class, the May 13, 2026 prospectus advertises 0.71% gross total
+  annual fund operating expenses and 0.16% net total annual fund operating
+  expenses after waivers through June 30, 2028. The adapter maps the current
+  net expense ratio to the shared management-like fee field and reports no
+  separate performance, deposit or withdrawal fee.
+links:
+  homepage: https://www.jpmorgan.com/kinexys
+  app:
+  twitter: https://x.com/ethereuminsti
+  github:
+  documentation: https://www.jpmorgan.com/kinexys/documents/portfolio-management-powered-by-tokenization.pdf
+  fact_sheet: https://am.jpmorgan.com/content/dam/jpm-am-aem/americas/us/en/literature/fact-sheet/money-market/fs-ocltmm-t.pdf
+  defillama:
+  audits:
+  fees: https://www.sec.gov/Archives/edgar/data/1659326/000119312526217424/d44657d485bpos.htm
+  trading_strategy: https://tradingstrategy.ai/trading-view/vaults/protocols/kinexys
+  integration_documentation: https://web3-ethereum-defi.readthedocs.io/api/oda_fact/index.html
+example_smart_contracts:
+  - https://eth.blockscout.com/address/0x09864f52B035AE22eE739dFa5c748fA080D07bD8

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -4,6 +4,7 @@
 - Use multicall based apporach to probe contracts
 """
 
+import datetime
 import logging
 from collections import defaultdict
 from collections.abc import Iterable
@@ -22,6 +23,39 @@ from eth_defi.vault.base import VaultBase, VaultSpec
 from eth_defi.vault.risk import BROKEN_VAULT_CONTRACTS
 
 logger = logging.getLogger(__name__)
+
+#: JPMorgan OnChain Liquidity-Token Money Market Fund (JLTXX) ODA-FACT diamond.
+#:
+#: https://eth.blockscout.com/address/0x09864f52B035AE22eE739dFa5c748fA080D07bD8
+ODA_FACT_JLTXX_ADDRESS = HexAddress("0x09864f52b035ae22ee739dfa5c748fa080d07bd8")
+
+#: Ethereum mainnet chain id.
+ODA_FACT_JLTXX_CHAIN_ID = 1
+
+#: JLTXX ODA-FACT deployment block.
+#:
+#: Source: Blockscout creation transaction
+#: ``0xb15855289d18025769583dee24f16e5cdd33be9c0e20586cc9d2c20a103f4f43``.
+ODA_FACT_JLTXX_FIRST_SEEN_AT_BLOCK = 25_042_223
+
+#: JLTXX deployment timestamp, stored as naive UTC.
+ODA_FACT_JLTXX_FIRST_SEEN_AT = datetime.datetime(2026, 5, 7, 9, 20, 11, tzinfo=datetime.UTC).replace(tzinfo=None)
+
+#: Hardcoded ODA-FACT lead data used because the single production contract does
+#: not emit ERC-4626 ``Deposit``/``Withdraw`` discovery events.
+ODA_FACT_HARDCODED_LEADS = (
+    (
+        ODA_FACT_JLTXX_CHAIN_ID,
+        ODA_FACT_JLTXX_ADDRESS,
+        ODA_FACT_JLTXX_FIRST_SEEN_AT_BLOCK,
+        ODA_FACT_JLTXX_FIRST_SEEN_AT,
+    ),
+)
+
+#: ODA-FACT hardcoded classification flags.
+ODA_FACT_HARDCODED_PROTOCOLS = {
+    ODA_FACT_JLTXX_ADDRESS: {ERC4626Feature.oda_fact_like},
+}
 
 
 #: Royco chains that may host WrappedVault or tranche vault markets.
@@ -1390,6 +1424,10 @@ def create_vault_instance(
         from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
 
         return LagoonVault(web3, spec, **kwargs)
+    elif ERC4626Feature.oda_fact_like in features:
+        from eth_defi.oda_fact.vault import OdaFactVault
+
+        return OdaFactVault(web3, spec, **kwargs)
 
     # TODO: Some module deadlock sheningans for Morpho
     elif ERC4626Feature.morpho_like in features:
@@ -1809,6 +1847,7 @@ def create_vault_instance_autodetect(
 #: For these, we need to do by vault contract address whitelisting here.
 #:
 HARDCODED_PROTOCOLS = {
+    **ODA_FACT_HARDCODED_PROTOCOLS,
     # 3Jane - USD3 senior tranche credit vault on Ethereum
     # https://etherscan.io/address/0x056B269Eb1f75477a8666ae8C7fE01b64dD55eCc
     "0x056b269eb1f75477a8666ae8c7fe01b64dd55ecc": {ERC4626Feature.threejane_like},

--- a/eth_defi/erc_4626/core.py
+++ b/eth_defi/erc_4626/core.py
@@ -44,6 +44,12 @@ class ERC4626Feature(enum.Enum):
     #: https://app.lagoon.finance/
     lagoon_like = "lagoon_like"
 
+    #: Kinexys tokenised fund contract using the ODA-FACT surface.
+    #:
+    #: Routing marker for non-ERC-4626 ODA-FACT instruments that are read
+    #: through a :py:class:`eth_defi.vault.base.VaultBase` adapter.
+    oda_fact_like = "oda_fact_like"
+
     #: Ipor protocol
     #:
     #: https://app.ipor.io/fusion
@@ -746,6 +752,8 @@ def get_vault_protocol_name(features: set[ERC4626Feature]) -> str:
         return "IPOR Fusion"
     elif ERC4626Feature.lagoon_like in features:
         return "Lagoon Finance"
+    elif ERC4626Feature.oda_fact_like in features:
+        return "Kinexys"
     elif ERC4626Feature.morpho_like in features:
         return "Morpho"
     elif ERC4626Feature.panoptic_like in features:

--- a/eth_defi/erc_4626/discovery_base.py
+++ b/eth_defi/erc_4626/discovery_base.py
@@ -23,7 +23,7 @@ from web3.contract.contract import ContractEvent
 
 from eth_defi.abi import get_contract
 from eth_defi.compat import native_datetime_utc_now
-from eth_defi.erc_4626.classification import probe_vaults
+from eth_defi.erc_4626.classification import ODA_FACT_HARDCODED_LEADS, probe_vaults
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature, get_erc_4626_contract
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.risk import BROKEN_VAULT_CONTRACTS
@@ -516,6 +516,21 @@ class VaultDiscoveryBase(abc.ABC):
         leads = report.leads
 
         assert type(leads) == dict, f"Expected dict, got {type(leads)}"
+
+        for lead_chain, address, first_seen_at_block, first_seen_at in ODA_FACT_HARDCODED_LEADS:
+            if lead_chain != chain or end_block < first_seen_at_block:
+                continue
+            if address not in leads:
+                leads[address] = PotentialVaultMatch(
+                    chain=chain,
+                    address=address,
+                    first_seen_at_block=first_seen_at_block,
+                    first_seen_at=first_seen_at,
+                    deposit_count=0,
+                    withdrawal_count=0,
+                )
+                report.new_leads += 1
+                logger.info("Added hardcoded ODA-FACT vault lead %s", address)
 
         addresses, leads_by_address, mellow_lead_count = _prepare_probe_leads(leads)
         logger.info("Found %d vault leads, of which %d are Mellow factory leads", len(leads), mellow_lead_count)

--- a/eth_defi/oda_fact/__init__.py
+++ b/eth_defi/oda_fact/__init__.py
@@ -1,0 +1,1 @@
+"""Kinexys ODA-FACT tokenised fund integration."""

--- a/eth_defi/oda_fact/historical.py
+++ b/eth_defi/oda_fact/historical.py
@@ -1,0 +1,109 @@
+"""Historical reader for ODA-FACT tokenised fund contracts."""
+
+# Reader classes intentionally mirror :class:`VaultHistoricalReader` signatures.
+# ruff: noqa: FBT001
+
+import datetime
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+from eth_defi.erc_4626.vault import VaultReaderState
+from eth_defi.event_reader.conversion import convert_int256_bytes_to_int
+from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
+from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
+
+if TYPE_CHECKING:
+    from eth_defi.oda_fact.vault import OdaFactVault
+
+
+class OdaFactVaultHistoricalReader(VaultHistoricalReader):
+    """Read ODA-FACT historical supply and estimated share price.
+
+    The on-chain part of ODA-FACT price history is ERC-20 ``totalSupply()``.
+    Share price is currently an explicit adapter-level estimate because the
+    known ODA-FACT token surface does not expose ERC-4626-style share conversion
+    or NAV history.
+    """
+
+    def __init__(self, vault: "OdaFactVault", stateful: bool):
+        """Create an ODA-FACT historical reader.
+
+        :param vault:
+            ODA-FACT vault adapter.
+
+        :param stateful:
+            Whether to attach adaptive reader state used by the shared
+            historical multicaller.
+        """
+
+        super().__init__(vault)
+        if stateful:
+            self.reader_state = VaultReaderState(vault)
+        else:
+            self.reader_state = None
+
+    def construct_multicalls(self) -> Iterable[EncodedCall]:
+        """Construct ODA-FACT historical multicalls.
+
+        :return:
+            Multicall batch reading ERC-20 ``totalSupply()``.
+        """
+
+        yield EncodedCall.from_contract_call(
+            self.vault.share_token.contract.functions.totalSupply(),
+            extra_data={
+                "function": "totalSupply",
+                "vault": self.vault.address,
+            },
+            first_block_number=self.first_block,
+        )
+
+    def process_result(
+        self,
+        block_number: int,
+        timestamp: datetime.datetime,
+        call_results: list[EncodedCallResult],
+    ) -> VaultHistoricalRead:
+        """Convert ODA-FACT multicall results to a vault price row.
+
+        :param block_number:
+            Historical block number.
+
+        :param timestamp:
+            Naive UTC block timestamp.
+
+        :param call_results:
+            Multicall results for calls from :py:meth:`construct_multicalls`.
+
+        :return:
+            :py:class:`VaultHistoricalRead` with ODA-FACT share price and supply.
+        """
+
+        total_supply = None
+        errors: list[str] = []
+
+        for result in call_results:
+            function = result.call.extra_data.get("function")
+            if function != "totalSupply":
+                continue
+
+            if result.success:
+                raw_total_supply = convert_int256_bytes_to_int(result.result)
+                total_supply = self.vault.share_token.convert_to_decimals(raw_total_supply)
+            else:
+                errors.append("ODA-FACT totalSupply call failed")
+
+        share_price = self.vault.fetch_share_price(block_number)
+        total_assets = share_price * total_supply if total_supply is not None else None
+
+        return VaultHistoricalRead(
+            vault=self.vault,
+            block_number=block_number,
+            timestamp=timestamp,
+            share_price=share_price,
+            total_assets=total_assets,
+            total_supply=total_supply,
+            performance_fee=self.vault.get_performance_fee(block_number),
+            management_fee=self.vault.get_management_fee(block_number),
+            errors=errors or None,
+        )

--- a/eth_defi/oda_fact/vault.py
+++ b/eth_defi/oda_fact/vault.py
@@ -1,0 +1,526 @@
+"""ODA-FACT tokenised fund vault adapter.
+
+Kinexys Digital Assets Fungible Asset Contract, or ODA-FACT, instruments are
+permissioned ERC-20-compatible tokenised fund contracts. They are not ERC-4626
+vaults, but the shared vault database and price scanner can track them through
+the :class:`eth_defi.vault.base.VaultBase` interface.
+
+The first supported production contract is JPMorgan's OnChain Liquidity-Token
+Money Market Fund token ``JLTXX``:
+
+- Ethereum address: ``0x09864f52B035AE22eE739dFa5c748fA080D07bD8``
+- Contract architecture: EIP-2535 diamond
+- Token decimals: ``2``
+- Verified source package reference: ``@odaplatform/da-fact-smartcontracts``
+
+The adapter is scan-only. Active subscription, redemption and portfolio
+execution are intentionally unsupported.
+"""
+
+# Adapter classes intentionally mirror :class:`VaultBase` method signatures.
+# ruff: noqa: ARG002, FBT001, FBT002, PLR0904, PLR0917, PLR6301
+
+import datetime
+import logging
+from decimal import Decimal
+
+from eth_typing import BlockIdentifier, HexAddress
+from web3 import Web3
+
+from eth_defi.erc_4626.classification import ODA_FACT_JLTXX_ADDRESS, ODA_FACT_JLTXX_CHAIN_ID
+from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.oda_fact.historical import OdaFactVaultHistoricalReader
+from eth_defi.token import USDC_NATIVE_TOKEN, TokenDetails, fetch_erc20_details
+from eth_defi.types import Percent
+from eth_defi.vault.base import TradingUniverse, VaultBase, VaultDepositManager, VaultFlowManager, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
+from eth_defi.vault.fee import BROKEN_FEE_DATA, FeeData, VaultFeeMode
+from eth_defi.vault.lower_case_dict import LowercaseDict
+
+logger = logging.getLogger(__name__)
+
+
+class OdaFactVaultInfo(VaultInfo, total=False):
+    """ODA-FACT token metadata and compatibility settings."""
+
+    #: ODA-FACT token and diamond address.
+    token: HexAddress
+
+    #: Chain id.
+    chain_id: int
+
+    #: Read-only denomination token surrogate used by current pipeline.
+    denomination_token: HexAddress | None
+
+    #: Whether denomination token is a surrogate for USD fund accounting.
+    synthetic_usd_denomination: bool
+
+    #: NAV source label.
+    nav_source: str
+
+    #: Whether NAV is estimated.
+    nav_estimated: bool
+
+
+#: Human-readable JLTXX product name.
+JLTXX_PRODUCT_NAME = "JPMorgan OnChain Liquidity-Token Money Market Fund"
+
+#: JLTXX issuer/platform display name.
+JLTXX_MANAGER_NAME = "J.P. Morgan Kinexys"
+
+#: Public Kinexys platform URL.
+JLTXX_HOMEPAGE = "https://www.jpmorgan.com/kinexys"
+
+#: Temporary JLTXX NAV estimate used until an official historical NAV source is
+#: wired in. JLTXX is a tokenised money-market fund share, but the ODA-FACT
+#: contract surface does not expose NAV on-chain.
+JLTXX_ESTIMATED_NAV_PER_SHARE = Decimal("1")
+
+#: Diagnostic label for the temporary NAV estimate.
+JLTXX_ESTIMATED_NAV_SOURCE = "estimated_jltxx_usd_1"
+
+#: JLTXX prospectus/fact sheet source URL.
+JLTXX_FACT_SHEET_URL = "https://am.jpmorgan.com/content/dam/jpm-am-aem/americas/us/en/literature/fact-sheet/money-market/fs-ocltmm-t.pdf"
+
+#: JLTXX SEC prospectus source URL.
+JLTXX_PROSPECTUS_URL = "https://www.sec.gov/Archives/edgar/data/1659326/000119312526217424/d44657d485bpos.htm"
+
+#: Prospectus management fee, ``0.08%`` expressed as a fraction.
+JLTXX_PROSPECTUS_MANAGEMENT_FEE: Percent = 0.0008
+
+#: Prospectus service fee, ``0.10%`` expressed as a fraction.
+JLTXX_PROSPECTUS_SERVICE_FEE: Percent = 0.0010
+
+#: Prospectus gross total annual fund operating expenses, ``0.71%`` expressed as a fraction.
+JLTXX_PROSPECTUS_GROSS_EXPENSE_RATIO: Percent = 0.0071
+
+#: Prospectus net total annual fund operating expenses after waivers, ``0.16%`` expressed as a fraction.
+JLTXX_PROSPECTUS_NET_EXPENSE_RATIO: Percent = 0.0016
+
+#: Prospectus fee waiver expiry date.
+JLTXX_PROSPECTUS_FEE_WAIVER_UNTIL = datetime.date(2028, 6, 30)
+
+#: Shared vault fee model for JLTXX.
+#:
+#: ``FeeData`` has only one annual management-like field. Use the prospectus
+#: net total annual fund operating expense after waivers because this is the
+#: investor-facing cost currently advertised for Token Class shares. Keep the
+#: gross expense ratio and prospectus breakdown in scan diagnostics.
+JLTXX_FEE_DATA = FeeData(
+    fee_mode=VaultFeeMode.internalised_skimming,
+    management=JLTXX_PROSPECTUS_NET_EXPENSE_RATIO,
+    performance=0,
+    deposit=0,
+    withdraw=0,
+)
+
+#: Hardcoded ODA-FACT fee lookup by lower-case contract address.
+ODA_FACT_FEES_BY_ADDRESS = {
+    ODA_FACT_JLTXX_ADDRESS: JLTXX_FEE_DATA,
+}
+
+
+class OdaFactVault(VaultBase):
+    """Scan-only adapter for ODA-FACT tokenised fund contracts.
+
+    The adapter reads ERC-20 supply from the ODA-FACT token itself. For the
+    initial JLTXX integration, share price is an explicitly labelled ``1.00``
+    USD estimate until an official NAV feed is available.
+    """
+
+    def __init__(
+        self,
+        web3: Web3,
+        spec: VaultSpec,
+        token_cache: dict | None = None,
+        features: set[ERC4626Feature] | None = None,
+        default_block_identifier: BlockIdentifier | None = None,
+        require_denomination_token: bool = False,
+    ):
+        """Create an ODA-FACT vault adapter.
+
+        :param web3:
+            Web3 connection.
+
+        :param spec:
+            Chain and ODA-FACT token address.
+
+        :param token_cache:
+            Token metadata cache used by :py:func:`fetch_erc20_details`.
+
+        :param features:
+            Shared pipeline feature flags. Expected to contain
+            :py:data:`ERC4626Feature.oda_fact_like`.
+
+        :param default_block_identifier:
+            Default block for metadata reads.
+
+        :param require_denomination_token:
+            Whether missing denomination token should raise through
+            :py:attr:`VaultBase.denomination_token`.
+        """
+
+        super().__init__(token_cache=token_cache, require_denomination_token=require_denomination_token)
+        self.web3 = web3
+        self.spec = spec
+        self.features = features or {ERC4626Feature.oda_fact_like}
+        self.default_block_identifier = default_block_identifier
+
+    def _get_block_identifier(self) -> BlockIdentifier:
+        """Resolve the block identifier used for metadata reads.
+
+        :return:
+            Configured default block or ``latest``.
+        """
+
+        return self.default_block_identifier or "latest"
+
+    @property
+    def chain_id(self) -> int:
+        """EVM chain id for this ODA-FACT contract."""
+
+        return self.spec.chain_id
+
+    @property
+    def address(self) -> HexAddress:
+        """ODA-FACT token and diamond address."""
+
+        return HexAddress(Web3.to_checksum_address(self.spec.vault_address))
+
+    @property
+    def vault_address(self) -> HexAddress:
+        """Compatibility alias for scanner code that expects ``vault_address``."""
+
+        return self.address
+
+    @property
+    def name(self) -> str:
+        """Token name, falling back to static product metadata."""
+
+        token_name = self.share_token.name
+        return token_name or JLTXX_PRODUCT_NAME
+
+    @property
+    def symbol(self) -> str:
+        """Token symbol."""
+
+        return self.share_token.symbol
+
+    @property
+    def description(self) -> str | None:
+        """Human-readable product description."""
+
+        return JLTXX_PRODUCT_NAME
+
+    @property
+    def short_description(self) -> str | None:
+        """Short product description."""
+
+        return "Tokenised JPMorgan money market fund tracked through ODA-FACT ERC-20 supply."
+
+    @property
+    def manager_name(self) -> str | None:
+        """Issuer or platform display name."""
+
+        return JLTXX_MANAGER_NAME
+
+    def fetch_share_token_address(self, block_identifier: BlockIdentifier = "latest") -> HexAddress:
+        """Return the ODA-FACT token address.
+
+        :param block_identifier:
+            Accepted for compatibility with the shared historical scanner.
+
+        :return:
+            ODA-FACT token address.
+        """
+
+        return self.address
+
+    def fetch_share_token(self) -> TokenDetails:
+        """Fetch ERC-20 metadata for the ODA-FACT token.
+
+        :return:
+            Token details for the ODA-FACT share token.
+        """
+
+        return fetch_erc20_details(
+            self.web3,
+            self.address,
+            chain_id=self.chain_id,
+            raise_on_error=False,
+            cache=self.token_cache,
+            cause_diagnostics_message=f"ODA-FACT share token for vault {self.address}",
+        )
+
+    def fetch_denomination_token_address(self) -> HexAddress | None:
+        """Return the read-only denomination token surrogate.
+
+        ODA-FACT fund accounting is USD-denominated but does not expose an
+        ERC-4626 ``asset()`` token. The current pipeline expects a concrete
+        ERC-20 denomination token for cache warmup, so Ethereum USDC is used as
+        a display/aggregation surrogate for the initial implementation.
+
+        :return:
+            Ethereum USDC for the supported JLTXX contract.
+        """
+
+        if self.chain_id == ODA_FACT_JLTXX_CHAIN_ID and self.address.lower() == ODA_FACT_JLTXX_ADDRESS:
+            return HexAddress(Web3.to_checksum_address(USDC_NATIVE_TOKEN[ODA_FACT_JLTXX_CHAIN_ID]))
+        return None
+
+    def fetch_denomination_token(self) -> TokenDetails | None:
+        """Fetch read-only denomination token metadata.
+
+        :return:
+            Token details for the configured denomination surrogate.
+        """
+
+        token_address = self.fetch_denomination_token_address()
+        if token_address is None:
+            return None
+        return fetch_erc20_details(
+            self.web3,
+            token_address,
+            chain_id=self.chain_id,
+            raise_on_error=False,
+            cache=self.token_cache,
+            cause_diagnostics_message=f"ODA-FACT denomination surrogate for vault {self.address}",
+        )
+
+    def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
+        """Fetch ODA-FACT share price estimate.
+
+        :param block_identifier:
+            Historical or latest block identifier. The current implementation
+            does not have block-specific NAV data.
+
+        :return:
+            Estimated NAV per one human-readable ODA-FACT share.
+        """
+
+        return JLTXX_ESTIMATED_NAV_PER_SHARE
+
+    def fetch_total_supply(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
+        """Fetch total outstanding ODA-FACT token supply.
+
+        :param block_identifier:
+            Historical or latest block identifier.
+
+        :return:
+            Human-readable token supply.
+        """
+
+        raw_supply = self.share_token.contract.functions.totalSupply().call(block_identifier=block_identifier)
+        return self.share_token.convert_to_decimals(raw_supply)
+
+    def fetch_total_assets(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
+        """Fetch ODA-FACT TVL using supply multiplied by NAV per share.
+
+        :param block_identifier:
+            Historical or latest block identifier.
+
+        :return:
+            Estimated total assets in USD-denomination units.
+        """
+
+        return self.fetch_total_supply(block_identifier) * self.fetch_share_price(block_identifier)
+
+    def fetch_nav(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
+        """Fetch ODA-FACT NAV.
+
+        :param block_identifier:
+            Historical or latest block identifier.
+
+        :return:
+            Estimated total assets in USD-denomination units.
+        """
+
+        return self.fetch_total_assets(block_identifier)
+
+    def fetch_info(self) -> OdaFactVaultInfo:
+        """Return ODA-FACT metadata for this scan-only adapter.
+
+        :return:
+            Token and NAV-source metadata.
+        """
+
+        return OdaFactVaultInfo(
+            token=self.address,
+            chain_id=self.chain_id,
+            denomination_token=self.fetch_denomination_token_address(),
+            synthetic_usd_denomination=True,
+            nav_source=JLTXX_ESTIMATED_NAV_SOURCE,
+            nav_estimated=True,
+        )
+
+    def fetch_scan_record_extra_data(self) -> dict[str, object]:
+        """Return ODA-FACT-specific scan-row diagnostics.
+
+        :return:
+            Private scan-row fields that make the temporary NAV and
+            denomination assumptions explicit.
+        """
+
+        return {
+            "_notes": self.get_notes(),
+            "_nav_source": JLTXX_ESTIMATED_NAV_SOURCE,
+            "_nav_estimated": True,
+            "_synthetic_usd_denomination": True,
+            "_fee_source": JLTXX_PROSPECTUS_URL,
+            "_fee_fact_sheet": JLTXX_FACT_SHEET_URL,
+            "_fee_waiver_until": JLTXX_PROSPECTUS_FEE_WAIVER_UNTIL.isoformat(),
+            "_gross_expense_ratio": JLTXX_PROSPECTUS_GROSS_EXPENSE_RATIO,
+            "_net_expense_ratio": JLTXX_PROSPECTUS_NET_EXPENSE_RATIO,
+            "_prospectus_management_fee": JLTXX_PROSPECTUS_MANAGEMENT_FEE,
+            "_prospectus_service_fee": JLTXX_PROSPECTUS_SERVICE_FEE,
+        }
+
+    def fetch_portfolio(
+        self,
+        universe: TradingUniverse,
+        block_identifier: BlockIdentifier | None = None,
+    ) -> VaultPortfolio:
+        """Return an empty portfolio for the scan-only adapter.
+
+        ODA-FACT fund assets are not represented as on-chain ERC-20 holdings of
+        the token contract. Portfolio composition requires an off-chain fund
+        accounting feed and is intentionally out of scope.
+
+        :param universe:
+            Ignored.
+
+        :param block_identifier:
+            Ignored.
+
+        :return:
+            Empty spot portfolio.
+        """
+
+        return VaultPortfolio(spot_erc20=LowercaseDict())
+
+    def has_block_range_event_support(self) -> bool:
+        """Whether event-based deposit/redemption flow accounting is implemented."""
+
+        return False
+
+    def has_deposit_distribution_to_all_positions(self) -> bool:
+        """Whether deposits are automatically distributed to positions."""
+
+        return False
+
+    def get_flow_manager(self) -> VaultFlowManager:
+        """Get flow manager.
+
+        :raises NotImplementedError:
+            Always, because ODA-FACT flow accounting is not implemented yet.
+        """
+
+        message = "ODA-FACT flow accounting is not implemented"
+        raise NotImplementedError(message)
+
+    def get_deposit_manager(self) -> VaultDepositManager:
+        """Get deposit manager.
+
+        :raises NotImplementedError:
+            Always, because active ODA-FACT subscription and redemption are not
+            implemented.
+        """
+
+        message = "ODA-FACT active subscription/redemption is not implemented"
+        raise NotImplementedError(message)
+
+    def get_historical_reader(self, stateful: bool) -> VaultHistoricalReader:
+        """Get ODA-FACT historical reader.
+
+        :param stateful:
+            Whether to attach adaptive reader state.
+
+        :return:
+            Historical reader.
+        """
+
+        return OdaFactVaultHistoricalReader(self, stateful=stateful)
+
+    def get_fee_data(self) -> FeeData:
+        """Return hardcoded JLTXX prospectus fee data.
+
+        ODA-FACT product fees are not available from the on-chain token
+        surface. J.P. Morgan's JLTXX prospectus advertises ``0.71%`` gross
+        total annual fund operating expenses and ``0.16%`` net total annual
+        fund operating expenses after waivers through
+        :py:data:`JLTXX_PROSPECTUS_FEE_WAIVER_UNTIL`. The shared vault fee
+        model has only one annual management-like field, so the current net
+        expense ratio is exposed as ``management``. ``performance``,
+        ``deposit`` and ``withdraw`` are reported as zero because they are not
+        advertised as separate Token Class fees.
+
+        :return:
+            Hardcoded fee data for the known ODA-FACT contract, or broken fee
+            data for unknown ODA-FACT addresses.
+        """
+
+        return ODA_FACT_FEES_BY_ADDRESS.get(self.address.lower(), BROKEN_FEE_DATA)
+
+    def get_management_fee(self, block_identifier: BlockIdentifier) -> Percent | None:
+        """Return JLTXX net annual expense ratio.
+
+        The fee is hardcoded from the JLTXX prospectus, because it is not
+        readable from the ODA-FACT token contract.
+
+        :param block_identifier:
+            Ignored. Prospectus fee disclosure is not block-specific.
+
+        :return:
+            ``0.0016`` for JLTXX, representing ``0.16%`` net annual fund
+            operating expenses after waivers.
+        """
+
+        return self.get_fee_data().management
+
+    def get_performance_fee(self, block_identifier: BlockIdentifier) -> Percent | None:
+        """Return JLTXX performance fee.
+
+        :param block_identifier:
+            Ignored. Prospectus fee disclosure is not block-specific.
+
+        :return:
+            ``0`` because the JLTXX Token Class prospectus does not advertise a
+            separate performance fee.
+        """
+
+        return self.get_fee_data().performance
+
+    def get_notes(self) -> str | None:
+        """Return markdown notes for the known ODA-FACT vault.
+
+        The notes are stored in the shared vault notes matrix so both direct
+        adapter users and downstream vault metric exports see the same
+        vault-specific description.
+
+        :return:
+            Markdown note for JLTXX, or ``None`` for unknown ODA-FACT addresses.
+        """
+
+        return super().get_notes()
+
+    def get_estimated_lock_up(self) -> datetime.timedelta | None:
+        """Return unknown lock-up.
+
+        :return:
+            ``None`` because subscription/redemption terms are off-chain.
+        """
+
+        return None
+
+    def get_link(self, referral: str | None = None) -> str:
+        """Return product/platform link.
+
+        :param referral:
+            Ignored.
+
+        :return:
+            Kinexys platform URL.
+        """
+
+        if self.address.lower() == ODA_FACT_JLTXX_ADDRESS:
+            return JLTXX_HOMEPAGE
+        return f"https://eth.blockscout.com/address/{self.address}"

--- a/eth_defi/vault/fee.py
+++ b/eth_defi/vault/fee.py
@@ -52,6 +52,9 @@ VAULT_PROTOCOL_FEE_MATRIX = {
     "Morpho": VaultFeeMode.internalised_skimming,
     "Enzyme": VaultFeeMode.internalised_skimming,
     "Lagoon": VaultFeeMode.externalised,
+    # Kinexys ODA-FACT JLTXX prospectus expenses are reflected in fund returns, not as
+    # explicit on-chain deposit/withdrawal fees.
+    "Kinexys": VaultFeeMode.internalised_skimming,
     "Velvet Capital": VaultFeeMode.internalised_skimming,
     "Umami": VaultFeeMode.externalised,
     # Unverified contracts, no open source repo

--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -108,6 +108,25 @@ BAD_FLAGS = {
 _empty_set = set()
 
 
+JLTXX_FACT_SHEET_URL = "https://am.jpmorgan.com/content/dam/jpm-am-aem/americas/us/en/literature/fact-sheet/money-market/fs-ocltmm-t.pdf"
+
+ODA_FACT_JLTXX_NOTE = f"""JPMorgan OnChain Liquidity-Token Money Market Fund (JLTXX).
+
+- **Curator:** J.P. Morgan Asset Management / Kinexys.
+- **Vault strategy:** Registered government money market fund investing in U.S. Treasury securities and overnight repurchase agreements collateralised by U.S. Treasury securities and/or cash.
+- **Fee structure:** Token Class prospectus advertises 0.71% gross total annual fund operating expenses and 0.16% net total annual fund operating expenses after waivers through 2028-06-30. These are off-chain fund expenses, not ODA-FACT token contract methods.
+- **Fact sheet:** [JLTXX fact sheet]({JLTXX_FACT_SHEET_URL}).
+"""
+
+#: Vault-specific notes without special risk flags.
+#:
+#: Unlike :py:data:`VAULT_FLAGS_AND_NOTES`, entries here do not make the vault
+#: "flagged"; they only add descriptive markdown to vault exports.
+VAULT_NOTES: dict[str, str] = {
+    "0x09864f52b035ae22ee739dfa5c748fa080d07bd8": ODA_FACT_JLTXX_NOTE,
+}
+
+
 def get_vault_special_flags(address: str | HexAddress) -> set[VaultFlag]:
     """Get all special vault flags."""
     entry = VAULT_FLAGS_AND_NOTES.get(address.lower())
@@ -118,7 +137,10 @@ def get_vault_special_flags(address: str | HexAddress) -> set[VaultFlag]:
 
 
 def get_notes(address: HexAddress | str, chain_id: int | None = None) -> str | None:
-    """Get notes related to the flags.
+    """Get vault-specific notes.
+
+    Notes can come from the descriptive notes matrix, special vault flags or
+    chain-wide defaults. Descriptive notes do not make a vault flagged.
 
     :param address:
         Vault address (will be lowercased).
@@ -126,7 +148,12 @@ def get_notes(address: HexAddress | str, chain_id: int | None = None) -> str | N
         Chain ID of the vault. Used to apply chain-wide default notes
         (e.g. all Hypercore vaults get :py:data:`HYPERCORE_VAULT_NOTE`).
     """
-    entry = VAULT_FLAGS_AND_NOTES.get(address.lower())
+    address = address.lower()
+    note = VAULT_NOTES.get(address)
+    if note:
+        return note
+
+    entry = VAULT_FLAGS_AND_NOTES.get(address)
     if entry:
         return entry[1]
 

--- a/eth_defi/vault/protocol_metadata.py
+++ b/eth_defi/vault/protocol_metadata.py
@@ -31,6 +31,7 @@ LINK_FIELDS = [
     "twitter",
     "github",
     "documentation",
+    "fact_sheet",
     "defillama",
     "audits",
     "fees",
@@ -59,6 +60,9 @@ class VaultProtocolLinks(TypedDict):
 
     #: Link to developer documentation
     documentation: str | None
+
+    #: Link to protocol or product fact sheet
+    fact_sheet: str | None
 
     #: Link to DefiLlama protocol page
     defillama: str | None

--- a/eth_defi/vault/risk.py
+++ b/eth_defi/vault/risk.py
@@ -63,6 +63,8 @@ VAULT_PROTOCOL_RISK_MATRIX = {
     "Enzyme": VaultTechnicalRisk.negligible,
     "Lagoon Finance": VaultTechnicalRisk.minimal,
     "IPOR Fusion": VaultTechnicalRisk.minimal,
+    # Kinexys ODA-FACT contracts are permissioned RWA tokens for institutional fund products.
+    "Kinexys": VaultTechnicalRisk.low,
     "Velvet Capital": VaultTechnicalRisk.high,
     "Umami": VaultTechnicalRisk.severe,
     # Unverified contracts, no open source repo
@@ -204,12 +206,12 @@ def get_vault_risk(
 
     from eth_defi.vault.flag import BAD_FLAGS, get_vault_special_flags
 
-    # Check for xUSD incidents
-    flags = get_vault_special_flags(vault_address)
-    if flags & BAD_FLAGS:
-        return VaultTechnicalRisk.blacklisted
-
     if vault_address:
+        # Check for xUSD incidents and other address-specific manual flags.
+        flags = get_vault_special_flags(vault_address)
+        if flags & BAD_FLAGS:
+            return VaultTechnicalRisk.blacklisted
+
         risk = VAULT_SPECIFIC_RISK.get(vault_address.lower())
         if risk:
             return risk

--- a/tests/oda_fact/test_oda_fact_vault.py
+++ b/tests/oda_fact/test_oda_fact_vault.py
@@ -1,0 +1,207 @@
+"""Test ODA-FACT vault tracking against the live JLTXX contract."""
+
+import datetime
+import os
+from decimal import Decimal
+
+import flaky
+import pytest
+from web3 import Web3
+
+from eth_defi.erc_4626.classification import (
+    ODA_FACT_JLTXX_ADDRESS,
+    ODA_FACT_JLTXX_FIRST_SEEN_AT,
+    ODA_FACT_JLTXX_FIRST_SEEN_AT_BLOCK,
+    create_vault_instance_autodetect,
+)
+from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
+from eth_defi.erc_4626.scan import create_vault_scan_record
+from eth_defi.oda_fact.historical import OdaFactVaultHistoricalReader
+from eth_defi.oda_fact.vault import OdaFactVault
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+
+JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
+JLTXX_EXPECTED_MANAGEMENT_FEE = 0.0016
+JLTXX_EXPECTED_PERFORMANCE_FEE = 0
+
+pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests")
+
+#: Fixed block used for deterministic JLTXX assertions.
+#:
+#: Blockscout token metadata reported raw total supply ``69522262199`` for
+#: JLTXX when this integration was written.
+JLTXX_TEST_BLOCK = 25_452_271
+
+#: JLTXX has 2 decimals.
+JLTXX_EXPECTED_DECIMALS = 2
+
+#: Ethereum USDC has 6 decimals.
+USDC_EXPECTED_DECIMALS = 6
+
+#: Raw total supply for JLTXX at :py:data:`JLTXX_TEST_BLOCK`.
+JLTXX_EXPECTED_RAW_TOTAL_SUPPLY = 69_522_262_199
+
+#: Human-readable total supply at :py:data:`JLTXX_TEST_BLOCK`.
+JLTXX_EXPECTED_TOTAL_SUPPLY = Decimal("695222621.99")
+
+
+@pytest.fixture(scope="module")
+def anvil_ethereum_fork() -> AnvilLaunch:
+    """Fork Ethereum mainnet at a fixed block for JLTXX integration tests."""
+
+    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=JLTXX_TEST_BLOCK)
+    try:
+        yield launch
+    finally:
+        launch.close()
+
+
+@pytest.fixture(scope="module")
+def web3(anvil_ethereum_fork: AnvilLaunch) -> Web3:
+    """Create a Web3 connection to the fixed-block Anvil fork."""
+
+    return create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url, retries=2)
+
+
+@flaky.flaky
+def test_oda_fact_autodetect_live_jltxx(web3: Web3) -> None:
+    """Autodetect the live JLTXX ODA-FACT contract."""
+
+    vault = create_vault_instance_autodetect(
+        web3,
+        vault_address=ODA_FACT_JLTXX_ADDRESS,
+    )
+
+    assert isinstance(vault, OdaFactVault)
+    assert vault.features == {ERC4626Feature.oda_fact_like}
+    assert vault.get_protocol_name() == "Kinexys"
+    assert vault.address == Web3.to_checksum_address(ODA_FACT_JLTXX_ADDRESS)
+    assert vault.share_token.name == "JPMorgan OnChain Liquidity-Token Money Market Fund"
+    assert vault.share_token.symbol == "JLTXX"
+    assert vault.share_token.decimals == JLTXX_EXPECTED_DECIMALS
+    assert vault.denomination_token.symbol == "USDC"
+    assert vault.denomination_token.decimals == USDC_EXPECTED_DECIMALS
+
+
+@flaky.flaky
+def test_oda_fact_live_supply_nav_and_unsupported_actions(web3: Web3) -> None:
+    """Read live JLTXX supply/NAV and ensure active flows stay unsupported."""
+
+    vault = create_vault_instance_autodetect(
+        web3,
+        vault_address=ODA_FACT_JLTXX_ADDRESS,
+    )
+
+    raw_supply = vault.share_token.contract.functions.totalSupply().call(block_identifier=JLTXX_TEST_BLOCK)
+    assert raw_supply == JLTXX_EXPECTED_RAW_TOTAL_SUPPLY
+
+    assert vault.fetch_share_price(JLTXX_TEST_BLOCK) == Decimal("1")
+    assert vault.fetch_total_supply(JLTXX_TEST_BLOCK) == JLTXX_EXPECTED_TOTAL_SUPPLY
+    assert vault.fetch_total_assets(JLTXX_TEST_BLOCK) == JLTXX_EXPECTED_TOTAL_SUPPLY
+    assert vault.fetch_nav(JLTXX_TEST_BLOCK) == JLTXX_EXPECTED_TOTAL_SUPPLY
+    assert vault.get_fee_data().management == JLTXX_EXPECTED_MANAGEMENT_FEE
+    assert vault.get_fee_data().performance == JLTXX_EXPECTED_PERFORMANCE_FEE
+    assert vault.get_fee_data().deposit == 0
+    assert vault.get_fee_data().withdraw == 0
+    assert vault.fetch_info()["nav_source"] == "estimated_jltxx_usd_1"
+    assert vault.fetch_info()["nav_estimated"] is True
+    assert "**Curator:** J.P. Morgan" in vault.get_notes()
+    assert "JLTXX fact sheet" in vault.get_notes()
+
+    with pytest.raises(NotImplementedError):
+        vault.get_deposit_manager()
+
+    with pytest.raises(NotImplementedError):
+        vault.get_flow_manager()
+
+
+@flaky.flaky
+def test_oda_fact_historical_reader_live_jltxx(web3: Web3) -> None:
+    """Read a historical JLTXX sample through the ODA-FACT historical reader."""
+
+    vault = create_vault_instance_autodetect(
+        web3,
+        vault_address=ODA_FACT_JLTXX_ADDRESS,
+    )
+    reader = vault.get_historical_reader(stateful=False)
+
+    assert isinstance(reader, OdaFactVaultHistoricalReader)
+
+    call_results = [
+        call.call_as_result(
+            web3,
+            block_identifier=JLTXX_TEST_BLOCK,
+            ignore_error=True,
+        )
+        for call in reader.construct_multicalls()
+    ]
+    timestamp = datetime.datetime.fromtimestamp(
+        web3.eth.get_block(JLTXX_TEST_BLOCK)["timestamp"],
+        tz=datetime.UTC,
+    ).replace(tzinfo=None)
+    read = reader.process_result(
+        block_number=JLTXX_TEST_BLOCK,
+        timestamp=timestamp,
+        call_results=call_results,
+    )
+
+    assert read.block_number == JLTXX_TEST_BLOCK
+    assert read.share_price == Decimal("1")
+    assert read.total_supply == JLTXX_EXPECTED_TOTAL_SUPPLY
+    assert read.total_assets == JLTXX_EXPECTED_TOTAL_SUPPLY
+    assert read.performance_fee == JLTXX_EXPECTED_PERFORMANCE_FEE
+    assert read.management_fee == JLTXX_EXPECTED_MANAGEMENT_FEE
+    assert read.errors is None
+
+
+@flaky.flaky
+def test_oda_fact_scan_record_live_jltxx(web3: Web3) -> None:
+    """Create the shared vault scan record for JLTXX."""
+
+    detection = ERC4262VaultDetection(
+        chain=web3.eth.chain_id,
+        address=ODA_FACT_JLTXX_ADDRESS,
+        first_seen_at_block=ODA_FACT_JLTXX_FIRST_SEEN_AT_BLOCK,
+        first_seen_at=ODA_FACT_JLTXX_FIRST_SEEN_AT,
+        features={ERC4626Feature.oda_fact_like},
+        updated_at=ODA_FACT_JLTXX_FIRST_SEEN_AT,
+        deposit_count=0,
+        redeem_count=0,
+    )
+
+    record = create_vault_scan_record(
+        web3,
+        detection,
+        block_identifier=JLTXX_TEST_BLOCK,
+        token_cache={},
+    )
+
+    assert record["Symbol"] == "JLTXX"
+    assert record["Name"] == "JPMorgan OnChain Liquidity-Token Money Market Fund"
+    assert record["Protocol"] == "Kinexys"
+    assert record["Denomination"] == "USDC"
+    assert record["Share token"] == "JLTXX"
+    assert record["NAV"] == JLTXX_EXPECTED_TOTAL_SUPPLY
+    assert record["Mgmt fee"] == JLTXX_EXPECTED_MANAGEMENT_FEE
+    assert record["Perf fee"] == JLTXX_EXPECTED_PERFORMANCE_FEE
+    assert record["Deposit fee"] == 0
+    assert record["Withdraw fee"] == 0
+    assert record["Shares"] == JLTXX_EXPECTED_TOTAL_SUPPLY
+    assert record["Features"] == "oda_fact_like"
+    assert record["_detection_data"] == detection
+    assert record["_denomination_token"]["symbol"] == "USDC"
+    assert record["_share_token"]["symbol"] == "JLTXX"
+    assert record["_manager_name"] == "J.P. Morgan Kinexys"
+    assert "**Curator:** J.P. Morgan" in record["_notes"]
+    assert "JLTXX fact sheet" in record["_notes"]
+    assert record["_nav_source"] == "estimated_jltxx_usd_1"
+    assert record["_nav_estimated"] is True
+    assert record["_synthetic_usd_denomination"] is True
+    assert record["_gross_expense_ratio"] == 0.0071
+    assert record["_net_expense_ratio"] == JLTXX_EXPECTED_MANAGEMENT_FEE
+    assert record["_prospectus_management_fee"] == 0.0008
+    assert record["_prospectus_service_fee"] == 0.001
+    assert record["_fee_waiver_until"] == "2028-06-30"
+    assert record["_fee_source"].startswith("https://www.sec.gov/")
+    assert record["_fee_fact_sheet"].endswith("fs-ocltmm-t.pdf")

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -21,6 +21,22 @@ def test_paused_is_bad_flag():
     assert VaultFlag.paused in BAD_FLAGS
 
 
+def test_oda_fact_risk_is_low() -> None:
+    """ODA-FACT protocol risk is classified as low."""
+    assert get_vault_risk("Kinexys") == VaultTechnicalRisk.low
+
+
+def test_oda_fact_vault_note_is_not_bad_flag() -> None:
+    """ODA-FACT JLTXX note is descriptive and does not flag the vault."""
+    address = "0x09864f52b035ae22ee739dfa5c748fa080d07bd8"
+    note = get_notes(address)
+
+    assert note is not None
+    assert "**Curator:** J.P. Morgan" in note
+    assert "JLTXX fact sheet" in note
+    assert not is_flagged_vault(address)
+
+
 @pytest.mark.parametrize(
     ("address", "protocol", "expected_flag", "expected_note"),
     [


### PR DESCRIPTION
## Why

Kinexys JLTXX is an ERC-20 share-token product using the ODA-FACT contract surface. It does not expose ERC-4626 deposit/redeem events or canonical asset accessors, but we still want it tracked through the existing vault matching and price pipeline.

## Lessons learnt

ODA-FACT discovery can stay hardcoded for now because there is only one production contract. Keeping the production address, first-seen block, and feature mapping in `classification.py` makes the special case visible to the same classifier that creates the vault adapter.

The current JLTXX share price is an explicitly labelled `1.00` USD estimate. This is enough to wire the pipeline and validate supply tracking, but it should be replaced by an official JPMorgan, Kinexys or transfer-agent NAV source before we treat historical TVL as official NAV history.

JLTXX Token Class fees are disclosed off-chain in the May 13, 2026 prospectus, not on the token contract. The adapter hardcodes the current `0.16%` net annual expense ratio by address and preserves the `0.71%` gross expense ratio plus source URLs in scan diagnostics and metadata.

JLTXX also needs descriptive markdown notes even though it is not a flagged vault. A separate notes matrix keeps curator, strategy, fee, and fact sheet context available to exports without marking the address as risky.

The local worktree does not have `.local-test.env`, so the Anvil/mainnet-fork pytest cases were added but not executed locally in this worktree.

## Summary

- Added scan-only Kinexys support for the ODA-FACT JLTXX contract with a `VaultBase` adapter, historical supply reader, protocol metadata, docs, and API index entries.
- Routed the production JLTXX contract through `classification.py` using a hardcoded ODA-FACT feature mapping and hardcoded lead metadata.
- Renamed the exported protocol name, risk lookup, fee lookup, and metadata slug to `Kinexys`, while retaining ODA-FACT in YAML and docstrings as the contract-surface terminology.
- Hardcoded prospectus-disclosed JLTXX Token Class fees by contract address and linked the SEC prospectus plus fact sheet from metadata.
- Added a vault-specific markdown notes matrix for JLTXX covering JPMorgan/Kinexys curation, strategy, fees, and the fact sheet link.
- Kept the implementation lean: no separate ODA-FACT discovery module, no placeholder NAV provider abstraction, and no unused flow-event classifier.
- Added fixed-block Anvil integration tests against the existing Ethereum mainnet JLTXX vault instead of mock contract tests.
- Reused the shared scan-record path so Kinexys aligns with the recent Mellow-style vault integration surface.

## Related issues and PRs

Continues the ERC-4626 vault matching pipeline work and the recent Mellow protocol integration pattern.

## Unrelated CI and test fixes

None.