### PR TITLE
fix: timestamp vault scanner startup banner

### DIFF
--- a/scripts/erc-4626/scan-vaults-all-chains.py
+++ b/scripts/erc-4626/scan-vaults-all-chains.py
@@ -127,13 +127,15 @@ Example CHAIN_ORDER for all chains:
     CHAIN_ORDER="Sonic, Monad, Hyperliquid, Base, Arbitrum, Ethereum, Linea, Gnosis, Zora, Polygon, Avalanche, Berachain, Unichain, Hemi, Plasma, Binance, Mantle, Katana, Ink, Blast, Soneium, Optimism"
 """
 
+import datetime
 import os
 
 
 def _print_early_startup_banner() -> None:
     """Print a boot marker before importing the scanner implementation."""
     log_level = os.environ.get("LOG_LEVEL", "warning")
-    print(f"Starting vault scanner, LOG_LEVEL={log_level}", flush=True)
+    timestamp = datetime.datetime.now(datetime.UTC).replace(tzinfo=None).strftime("%Y-%m-%d %H:%M:%S")
+    print(f"{timestamp} Starting vault scanner, LOG_LEVEL={log_level}", flush=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

The early vault scanner startup marker is printed before the normal logging setup runs. In Docker Compose logs this left the `Starting vault scanner, LOG_LEVEL=...` line without a timestamp, making scanner restarts harder to correlate with surrounding events.

## Lessons learnt

The startup marker intentionally runs before importing the scanner implementation, so the timestamp needs to be added directly in the wrapper without depending on the later logging configuration.

## Summary

- Added a naive UTC timestamp prefix to the early vault scanner startup banner.
- Kept the existing startup marker and `LOG_LEVEL` output intact.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.