### PR TITLE
fix: update Atoma homepage metadata

### DIFF
--- a/eth_defi/data/feeds/protocols/atoma.yaml
+++ b/eth_defi/data/feeds/protocols/atoma.yaml
@@ -1,7 +1,7 @@
 feeder-id: atoma
 name: Atoma
 role: protocol
-website: https://app.atoma.fi/
+website: https://atoma.fi/
 twitter: atoma_fi
 # linkedin: not found
 # rss: not found

--- a/eth_defi/data/vaults/metadata/atoma.yaml
+++ b/eth_defi/data/vaults/metadata/atoma.yaml
@@ -21,7 +21,7 @@ fee_description: |
   dilution; the separate withdrawal fee is still modelled explicitly as a net redemption
   fee.
 links:
-  homepage: https://app.atoma.fi/
+  homepage: https://atoma.fi/
   app: https://app.atoma.fi/
   twitter: https://x.com/atoma_fi
   documentation:


### PR DESCRIPTION
## Why

Atoma now has a public marketing homepage at https://atoma.fi/ while the vault app remains at https://app.atoma.fi/. The metadata should distinguish the public homepage from the dapp link.

## Lessons learnt

Atoma exposes the same official short SVG brandmark on the app and public site, so no logo update is needed for this metadata fix.

## Summary

- Updated Atoma vault protocol `homepage` to `https://atoma.fi/`.
- Updated the Atoma protocol feeder `website` to `https://atoma.fi/`.
- Kept the Atoma dapp link as `https://app.atoma.fi/`.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.