### PR TITLE
fix: tolerate Hyperliquid info API outages

### DIFF
--- a/eth_defi/hyperliquid/session.py
+++ b/eth_defi/hyperliquid/session.py
@@ -65,10 +65,22 @@ DEFAULT_RETRIES = 5
 DEFAULT_BACKOFF_FACTOR = 0.5
 
 #: Extra outer retries for ``/info`` calls after urllib3 exhausts its retry budget.
-DEFAULT_POST_INFO_RETRY_ATTEMPTS = 3
+#:
+#: Incident note: on 2026-07-04 the live ``hyper-ai`` executor witnessed
+#: repeated Hyperliquid ``/info`` HTTP 502 responses while reading
+#: ``userVaultEquities`` for HyperCore vault accounting. The earlier retry
+#: window was short enough that this read-only account check crashed the live
+#: scheduler. Keep the default outage window above 10 minutes for fast 5xx
+#: storms, while retaining the lower-level per-request timeout for stuck sockets.
+DEFAULT_POST_INFO_RETRY_ATTEMPTS = 6
 
 #: Backoff factor for extra outer ``/info`` retries.
-DEFAULT_POST_INFO_RETRY_BACKOFF_FACTOR = 5.0
+#:
+#: With ``DEFAULT_RETRIES=5`` each outer attempt already performs six HTTP
+#: attempts. A 10 second outer factor gives sleeps of 10, 20, 40, 80, 160 and
+#: 320 seconds, so quick upstream 502/503/504 storms are retried for around
+#: twelve minutes before surfacing to the caller.
+DEFAULT_POST_INFO_RETRY_BACKOFF_FACTOR = 10.0
 
 #: Default rate limit for Hyperliquid API requests per second.
 #:
@@ -277,10 +289,14 @@ class HyperliquidSession(Session):
           current proxy as dead via the state manager, because the
           proxy itself is unreachable.
         - **Adapter retry exhaustion** (``requests.RetryError``): sleep
-          and retry the whole ``/info`` request a small number of extra
-          times. This handles CI/public-IP bursts where the Hyperliquid
-          API keeps returning HTTP 429 longer than the urllib3 retry
-          budget covers.
+          and retry the whole ``/info`` request with a longer outage
+          tolerance than the urllib3 adapter alone can provide. This
+          handles CI/public-IP bursts where the Hyperliquid API keeps
+          returning HTTP 429 longer than the urllib3 retry budget covers.
+          It also covers the 2026-07-04 live ``hyper-ai`` incident, where
+          ``userVaultEquities`` returned repeated HTTP 502 responses during
+          HyperCore vault account checks and the previous short retry window
+          allowed a transient read failure to terminate the scheduler.
 
         After :data:`MAX_PROXY_ROTATIONS` consecutive rotations in a
         single call, returns whatever response comes back (or re-raises
@@ -329,6 +345,11 @@ class HyperliquidSession(Session):
             except requests_lib.exceptions.RetryError as exc:
                 if outer_retries < self.post_info_retry_attempts:
                     outer_retries += 1
+                    # Production incident, 2026-07-04: Hyperliquid returned
+                    # repeated 502 Bad Gateway responses for ``userVaultEquities``.
+                    # Sleep outside the adapter retry loop so live trading can
+                    # ride through short upstream outages instead of crashing
+                    # after a single urllib3 retry budget is exhausted.
                     sleep_seconds = self.post_info_retry_backoff_factor * (2 ** (outer_retries - 1))
                     logger.warning(
                         "Hyperliquid /info request type %s exhausted adapter retries: %s. Sleeping %.1f seconds before outer retry %d/%d",

--- a/tests/hyperliquid/test_session.py
+++ b/tests/hyperliquid/test_session.py
@@ -11,7 +11,11 @@ import pytest
 import requests
 
 from eth_defi.event_reader.webshare import ProxyRotator, WebshareProxy
-from eth_defi.hyperliquid.session import create_hyperliquid_session
+from eth_defi.hyperliquid.session import (
+    DEFAULT_POST_INFO_RETRY_ATTEMPTS,
+    DEFAULT_POST_INFO_RETRY_BACKOFF_FACTOR,
+    create_hyperliquid_session,
+)
 
 
 def _make_proxy(idx: int) -> WebshareProxy:
@@ -181,6 +185,36 @@ def test_retry_error_budget_is_respected_without_proxy():
 
     assert m.call_count == 3
     assert sleep.call_count == 2
+
+
+def test_default_post_info_retry_window_covers_ten_minute_502_outage() -> None:
+    """Test the default Hyperliquid /info retry window covers the 2026-07-04 outage class.
+
+    1. Create a default Hyperliquid session using production retry constants.
+    2. Mock repeated adapter retry exhaustion followed by one successful response.
+    3. Verify the outer sleeps keep retrying long enough for a ten minute fast-502 outage.
+    """
+
+    # 1. Create a default Hyperliquid session using production retry constants.
+    session = create_hyperliquid_session()
+    ok_response = MagicMock(status_code=200)
+    retry_error = requests.exceptions.RetryError("too many 502 error responses")
+
+    # 2. Mock repeated adapter retry exhaustion followed by one successful response.
+    side_effects = [retry_error] * DEFAULT_POST_INFO_RETRY_ATTEMPTS + [ok_response]
+    with (
+        patch("eth_defi.hyperliquid.session.time.sleep") as sleep,
+        patch.object(session, "post", side_effect=side_effects) as m,
+    ):
+        resp = session.post_info({"type": "userVaultEquities"})
+
+    # 3. Verify the outer sleeps keep retrying long enough for a ten minute fast-502 outage.
+    expected_sleeps = [DEFAULT_POST_INFO_RETRY_BACKOFF_FACTOR * (2**i) for i in range(DEFAULT_POST_INFO_RETRY_ATTEMPTS)]
+    fast_5xx_outer_sleep_window = sum(expected_sleeps)
+    assert resp is ok_response
+    assert m.call_count == DEFAULT_POST_INFO_RETRY_ATTEMPTS + 1
+    assert [call.args[0] for call in sleep.call_args_list] == expected_sleeps
+    assert fast_5xx_outer_sleep_window >= 600
 
 
 def test_successful_200_short_circuits(session_with_proxies):


### PR DESCRIPTION
## Why

On 2026-07-04 the live `hyper-ai` executor witnessed repeated Hyperliquid `/info` HTTP 502 responses while reading `userVaultEquities` for HyperCore vault accounting. The previous `/info` retry window exhausted quickly, the read-only account check raised `RetryError`, and the live scheduler terminated.

The `/info` client needs to tolerate short upstream outage windows without surfacing transient 5xx storms to live trading code.

## Lessons learnt (memory)

Hyperliquid Info API 502 bursts can last longer than the urllib3 adapter retry budget. Keep `post_info()` as the single retry standard for `/info` callers, and size its outer retry budget for live trading outages, not only CI/public-IP throttling.

When adding new Hyperliquid `/info` endpoints, route them through `HyperliquidSession.post_info()` instead of direct `session.post()` so they inherit this outage tolerance.

## Summary

Increase default `/info` outer retries from 3 to 6 and backoff from 5 seconds to 10 seconds, giving a 630 second outer sleep window for fast 5xx storms.

Document the `hyper-ai` incident in constants, the `post_info()` docstring, and retry-loop comments.

Add a regression test that simulates repeated `too many 502 error responses` for `userVaultEquities` and verifies the default retry window covers at least ten minutes.

Local checks run: `poetry run ruff format --check eth_defi/hyperliquid/session.py tests/hyperliquid/test_session.py`; `source .local-test.env && poetry run pytest deps/web3-ethereum-defi/tests/hyperliquid/test_session.py`.