### PR TITLE
notes: blacklist Summer.fi vaults after exploit report

### DIFF
--- a/docs/source/vaults/summer/index.rst
+++ b/docs/source/vaults/summer/index.rst
@@ -12,6 +12,15 @@ Summer.fi is an app designed to simplify and enhance users' interactions with le
 and yield generation. The protocol provides access to DeFi yields continually rebalanced by AI
 powered Keepers.
 
+Security note
+~~~~~~~~~~~~~
+
+On 2026-07-06, `CryptoBriefing reported <https://cryptobriefing.com/blockaid-detects-6m-exploit-summer-fi/>`__
+that Blockaid flagged an active Summer.fi exploit on Ethereum, with approximately USD 6 million
+in DAI drained from three contracts including ``0x98C49e13bf99D7CAd8069faa2A370933EC9EcF17``.
+Until the incident is fully resolved and an official post-mortem is available, Summer.fi vaults
+are treated as illiquid and blacklisted in the vault risk metadata.
+
 Links
 ~~~~~
 
@@ -27,4 +36,3 @@ Links
    :recursive:
 
    eth_defi.erc_4626.vault_protocol.summer.vault
-

--- a/eth_defi/data/vaults/metadata/summer-fi.yaml
+++ b/eth_defi/data/vaults/metadata/summer-fi.yaml
@@ -1,5 +1,10 @@
 name: Summer.fi
 slug: summer-fi
+# Incident note:
+# 2026-07-06: CryptoBriefing reported that Blockaid flagged an active Summer.fi exploit.
+# The report said approx. $6M DAI was drained from Ethereum contracts, including
+# 0x98C49e13bf99D7CAd8069faa2A370933EC9EcF17.
+# Source: https://cryptobriefing.com/blockaid-detects-6m-exploit-summer-fi/
 short_description: |
   Unified frontend for passive lending and advanced DeFi operations.
 long_description: |

--- a/eth_defi/vault/base.py
+++ b/eth_defi/vault/base.py
@@ -1455,11 +1455,11 @@ class VaultBase(ABC):
 
             Do not modify in place.
         """
-        return get_vault_special_flags(self.address)
+        return get_vault_special_flags(self.address, self.get_protocol_name())
 
     def get_notes(self) -> str | None:
         """Get a human readable message if we know somethign special is going on with this vault."""
-        return get_notes(self.address)
+        return get_notes(self.address, protocol_name=self.get_protocol_name())
 
     def get_link(self, referral: str | None = None) -> str:
         """Get a link to the vault dashboard on its native site.

--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -127,16 +127,30 @@ VAULT_NOTES: dict[str, str] = {
 }
 
 
-def get_vault_special_flags(address: str | HexAddress) -> set[VaultFlag]:
-    """Get all special vault flags."""
+def get_vault_special_flags(address: str | HexAddress, protocol_name: str | None = None) -> set[VaultFlag]:
+    """Get all special vault flags.
+
+    Vault flags can be address-specific or protocol-wide. Protocol-wide flags
+    are used when all vaults under a detected protocol should inherit the same
+    manual warning, such as the Summer.fi illiquid flag added after the
+    2026-07-06 exploit reporting.
+    """
+    flags = set()
     entry = VAULT_FLAGS_AND_NOTES.get(address.lower())
     if entry:
         if entry[0]:
-            return {entry[0]}
-    return _empty_set
+            flags.add(entry[0])
+
+    if protocol_name:
+        protocol_entry = PROTOCOL_FLAGS_AND_NOTES.get(protocol_name)
+        if protocol_entry:
+            if protocol_entry[0]:
+                flags.add(protocol_entry[0])
+
+    return flags or _empty_set
 
 
-def get_notes(address: HexAddress | str, chain_id: int | None = None) -> str | None:
+def get_notes(address: HexAddress | str, chain_id: int | None = None, protocol_name: str | None = None) -> str | None:
     """Get vault-specific notes.
 
     Notes can come from the descriptive notes matrix, special vault flags or
@@ -157,6 +171,11 @@ def get_notes(address: HexAddress | str, chain_id: int | None = None) -> str | N
     if entry:
         return entry[1]
 
+    if protocol_name:
+        protocol_entry = PROTOCOL_FLAGS_AND_NOTES.get(protocol_name)
+        if protocol_entry:
+            return protocol_entry[1]
+
     # Default note for all Hypercore vaults
     from eth_defi.hyperliquid.constants import HYPERCORE_CHAIN_ID
 
@@ -166,13 +185,13 @@ def get_notes(address: HexAddress | str, chain_id: int | None = None) -> str | N
     return None
 
 
-def is_flagged_vault(address: HexAddress | str) -> bool:
+def is_flagged_vault(address: HexAddress | str, protocol_name: str | None = None) -> bool:
     """Is this vault flagged for any special reason?
 
     Supports both EVM (``0x``-prefixed) and non-EVM addresses (e.g. GRVT ``vlt:`` prefix).
     """
     address = address.lower()
-    return VAULT_FLAGS_AND_NOTES.get(address) is not None
+    return VAULT_FLAGS_AND_NOTES.get(address) is not None or bool(protocol_name and PROTOCOL_FLAGS_AND_NOTES.get(protocol_name))
 
 
 IRREGULAR_REPORTING = "The share price of this vault is updated too irregularly onchain. This makes it difficult to compare it against other vaults. Having no onchain transparency to the value of the vault poses a risk to users."
@@ -238,6 +257,22 @@ APOSTRO_USDC_FRONTIER_ILLIQUID = "Apostro USDC Frontier is illiquid"
 HYUSDT0_HWHLP_ILLIQUID = "hyUSD₮0 (hwHLP) vault is illiquid"
 
 RESOLV_USDC_ILLIQUID = "Resolv USDC vault is illiquid"
+
+
+#: Protocol-wide flags and notes.
+#:
+#: Unlike :py:data:`VAULT_FLAGS_AND_NOTES`, these entries apply to all vaults
+#: under a protocol name returned by vault detection.
+#:
+#: Summer.fi incident context: CryptoBriefing reported on 2026-07-06 that
+#: Blockaid flagged an active exploit against Summer.fi, with approx. $6M DAI
+#: drained from Ethereum contracts including
+#: 0x98C49e13bf99D7CAd8069faa2A370933EC9EcF17.
+#:
+#: Source: https://cryptobriefing.com/blockaid-detects-6m-exploit-summer-fi/
+PROTOCOL_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
+    "Summer.fi": (VaultFlag.illiquid, SUMMER_FI_ILLIQUID),
+}
 
 YIELDNEST_YNRWAX = """ynRWAx: Tokenized Australian residential real estate credit earning 11% APY, allocated to mortgage-backed loans on verified house-and-land developments. Made safe in collaboration with a fully licensed and insured fund manager, [Kimber Capital](https://kimbercapital.au/) (AFS Licence No. 425278).
 

--- a/eth_defi/vault/risk.py
+++ b/eth_defi/vault/risk.py
@@ -84,7 +84,14 @@ VAULT_PROTOCOL_RISK_MATRIX = {
     "AUTO Finance": VaultTechnicalRisk.low,
     "NashPoint": VaultTechnicalRisk.low,
     "Silo Finance": VaultTechnicalRisk.low,
-    "Summer.fi": VaultTechnicalRisk.low,
+    # Summer.fi was blacklisted after 2026-07-06 exploit reporting.
+    #
+    # CryptoBriefing reported that Blockaid flagged an active Summer.fi exploit
+    # with approx. $6M DAI drained from Ethereum contracts including
+    # 0x98C49e13bf99D7CAd8069faa2A370933EC9EcF17.
+    #
+    # Source: https://cryptobriefing.com/blockaid-detects-6m-exploit-summer-fi/
+    "Summer.fi": VaultTechnicalRisk.blacklisted,
     "Llama Lend": VaultTechnicalRisk.low,
     "Foxify": VaultTechnicalRisk.dangerous,
     "Liquid Royalty": VaultTechnicalRisk.severe,
@@ -210,7 +217,7 @@ def get_vault_risk(
 
     if vault_address:
         # Check for xUSD incidents and other address-specific manual flags.
-        flags = get_vault_special_flags(vault_address)
+        flags = get_vault_special_flags(vault_address, protocol_name)
         if flags & BAD_FLAGS:
             return VaultTechnicalRisk.blacklisted
 

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -37,6 +37,17 @@ def test_oda_fact_vault_note_is_not_bad_flag() -> None:
     assert not is_flagged_vault(address)
 
 
+def test_summer_fi_protocol_vaults_are_blacklisted() -> None:
+    """Summer.fi vaults are blacklisted after the 2026-07-06 exploit report."""
+    address = "0x98c49e13bf99d7cad8069faa2a370933ec9ecf17"
+    protocol = "Summer.fi"
+
+    assert get_vault_special_flags(address, protocol) == {VaultFlag.illiquid}
+    assert is_flagged_vault(address, protocol)
+    assert "illiquid" in get_notes(address, protocol_name=protocol)
+    assert get_vault_risk(protocol, address) == VaultTechnicalRisk.blacklisted
+
+
 @pytest.mark.parametrize(
     ("address", "protocol", "expected_flag", "expected_note"),
     [


### PR DESCRIPTION
## Why

On 2026-07-06, CryptoBriefing reported that Blockaid flagged an active Summer.fi exploit on Ethereum, with approximately USD 6 million in DAI drained from three contracts including `0x98C49e13bf99D7CAd8069faa2A370933EC9EcF17`.

Source: https://cryptobriefing.com/blockaid-detects-6m-exploit-summer-fi/

Until the incident is fully resolved and an official post-mortem is available, Summer.fi vaults should not appear as normal low-risk vaults.

## Lessons learnt

Protocol-wide incidents need protocol-wide flags. Address-specific vault notes were not enough because Summer.fi has multiple vaults across chains and the scanner resolves risk through the detected protocol name.

## Summary

- Marked Summer.fi protocol risk as blacklisted.
- Added protocol-wide manual flag support and assigned `VaultFlag.illiquid` to Summer.fi vaults.
- Documented the July 6, 2026 incident in Summer.fi vault docs and metadata comments.
- Added focused test coverage for Summer.fi protocol-wide blacklisting.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.
