### PR TITLE
notes: flag Resolv vault as illiquid

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -256,6 +256,8 @@ APOSTRO_USDC_FRONTIER_ILLIQUID = "Apostro USDC Frontier is illiquid"
 
 HYUSDT0_HWHLP_ILLIQUID = "hyUSD₮0 (hwHLP) vault is illiquid"
 
+RESOLV_ILLIQUID = "Resolv vault is illiquid"
+
 RESOLV_USDC_ILLIQUID = "Resolv USDC vault is illiquid"
 
 
@@ -583,6 +585,8 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0x93c8201c35666f9af8b3b943bad67b42ad0159a1": (VaultFlag.illiquid, XUSD_MESSAGE),
     # hyUSD₮0 (hwHLP) - 11 (Hyperliquid)
     "0x2c910f67dbf81099e6f8e126e7265d7595dc20ad": (VaultFlag.illiquid, HYUSDT0_HWHLP_ILLIQUID),
+    # Resolv (Euler on Ethereum)
+    "0xcbc9b61177444a793b85442d3a953b90f6170b7d": (VaultFlag.illiquid, RESOLV_ILLIQUID),
     # Resolv USDC (Ethereum)
     "0xf0795c47fa58d00f5f77f4d5c01f31ee891e21b4": (VaultFlag.illiquid, RESOLV_USDC_ILLIQUID),
     # Mainstreet USDC (msUSDC, Morpho on Ethereum)

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -59,6 +59,7 @@ def test_summer_fi_protocol_vaults_are_blacklisted() -> None:
         ("0x3094b241aade60f91f1c82b0628a10d9501462f9", "Morpho", VaultFlag.illiquid, "illiquid"),
         ("0xfa17f7aadbfac2c5d3c8125555404c1ae17df853", "Morpho", VaultFlag.illiquid, "illiquid"),
         ("0xed9278c5188f37670b33ef3b00729e38260cd5d5", "Euler", VaultFlag.illiquid, "illiquid"),
+        ("0xcbc9b61177444a793b85442d3a953b90f6170b7d", "Euler", VaultFlag.illiquid, "illiquid"),
         ("0xd0ee0cf300dfb598270cd7f4d0c6e0d8f6e13f29", "Altura", VaultFlag.controversial, "controversial"),
         ("0xc9f01b5c6048b064e6d925d1c2d7206d4feef8a3", "Yearn", VaultFlag.subvault, "not intended"),
         ("0xad755c6c31515aef8d2f830767d846774f7e9ea9", "Morpho", VaultFlag.malicious, "malicious"),


### PR DESCRIPTION
## Why

The Trading Strategy vault page for Resolv should be marked as illiquid so it is blacklisted from normal vault selection.

## Lessons learnt

The `resolv` vault slug resolves to the Euler vault at `0xcbc9b61177444a793b85442d3a953b90f6170b7d`; this is separate from the existing Resolv USDC Gearbox vault flag.

## Summary

- Added a manual illiquid note for the Resolv Euler vault.
- Added the vault to the manual flag regression test.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.
