### PR TITLE
Initial t3tris research

### DIFF
--- a/eth_defi/abi/t3tris/IVault.json
+++ b/eth_defi/abi/t3tris/IVault.json
@@ -1,0 +1,7194 @@
+[
+  {
+    "type": "function",
+    "name": "acceptAdminRole",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "allowance",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "applyAdminBurn",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "approve",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "asset",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "assetTokenAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "cancelGrantAdminRole",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "claimDeposit",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "claimedShares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "claimFees",
+    "inputs": [
+      {
+        "name": "unsafe",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "sharesFeeToClaim",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "minAssetsOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "permit2ClaimFees",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "claimedAssets_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "claimRedeem",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "unsafe",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "withdrawnAssets_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "claimSilosPnl",
+    "inputs": [
+      {
+        "name": "claimSync",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "claimDepositSiloPnl",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "unsafe",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "redeemRequestId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "claimedSilosPnl_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.ClaimedSilosPnl",
+        "components": [
+          {
+            "name": "syncSiloPnl",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.SiloPnl",
+            "components": [
+              {
+                "name": "pnl",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "isProfit",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "depositSiloPnl",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.SiloPnl",
+            "components": [
+              {
+                "name": "pnl",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "isProfit",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "redeemSiloPnl",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.SiloPnl",
+            "components": [
+              {
+                "name": "pnl",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "isProfit",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "close",
+    "inputs": [
+      {
+        "name": "unsafe",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "minAssetsOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "returnedAssets_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "computeEntryFee",
+    "inputs": [
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "entryFeeAssets_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "computeEntryFees",
+    "inputs": [
+      {
+        "name": "requestedDepositAssets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "entryFees_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.EntryFees",
+        "components": [
+          {
+            "name": "entryFeeAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "entryFeeShares",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "computeExitFee",
+    "inputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "exitFeeShares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "computeExitFees",
+    "inputs": [
+      {
+        "name": "requestedRedeemShares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "exitFees_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.ExitFees",
+        "components": [
+          {
+            "name": "exitFeeAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "exitFeeShares",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "computeManagementFee",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "feeShares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "feeAssets_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "computeNetDeposit",
+    "inputs": [
+      {
+        "name": "requestedDepositAssets",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "entryFeeAssets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "netDepositFlowData_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.NetDepositFlowData",
+        "components": [
+          {
+            "name": "netDepositAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "netDepositShares",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "computeNetRedeem",
+    "inputs": [
+      {
+        "name": "requestedRedeemShares",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "exitFeeShares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "netRedeemFlowData_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.NetRedeemFlowData",
+        "components": [
+          {
+            "name": "netRedeemAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "netRedeemShares",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "computePerformanceFee",
+    "inputs": [
+      {
+        "name": "pnl",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "performanceFeeOnPnl_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "computeSettleFees",
+    "inputs": [
+      {
+        "name": "requestedDepositAssets",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "requestedRedeemShares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "entryFees_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.EntryFees",
+        "components": [
+          {
+            "name": "entryFeeAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "entryFeeShares",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      },
+      {
+        "name": "exitFees_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.ExitFees",
+        "components": [
+          {
+            "name": "exitFeeAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "exitFeeShares",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "computeUnclaimedAssetsFee",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "unclaimedAssetFee_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "convertToAssets",
+    "inputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "convertToShares",
+    "inputs": [
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "decimals",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "decreaseDepositRequest",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "unsafe",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "minAmountOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "receiverAmount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "recoveredSiloShares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "decreaseRedeemRequest",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "newPendingShares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "deposit",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "permit2Data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "shares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "deposit",
+    "inputs": [
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "disableEndOfFund",
+    "inputs": [
+      {
+        "name": "unsafe",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "closeVault",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "minAssetsOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "returnedAssets_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "enableEndOfFund",
+    "inputs": [
+      {
+        "name": "feeClaimType",
+        "type": "uint8",
+        "internalType": "enum IVaultTypes.FeeClaimType"
+      },
+      {
+        "name": "unsafe",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "permit2DataOpen",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "openResult_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.OpenResult",
+        "components": [
+          {
+            "name": "lastPeriodData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.LastPeriodData",
+            "components": [
+              {
+                "name": "oldTotalNetAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "oldTotalNetSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "managementFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "managementFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "performanceFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "performanceFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "periodFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "pnl",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "updatedPps",
+                "type": "uint128",
+                "internalType": "uint128"
+              },
+              {
+                "name": "isProfit",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "entryFees",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.EntryFees",
+            "components": [
+              {
+                "name": "entryFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "entryFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "exitFees",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.ExitFees",
+            "components": [
+              {
+                "name": "exitFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "exitFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netDepositFlowData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetDepositFlowData",
+            "components": [
+              {
+                "name": "netDepositAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "netDepositShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netRedeemFlowData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetRedeemFlowData",
+            "components": [
+              {
+                "name": "netRedeemAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "netRedeemShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "grossTvlData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.GrossTvlData",
+            "components": [
+              {
+                "name": "totalAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netTvlData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetTvlData",
+            "components": [
+              {
+                "name": "totalNetAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "totalNetSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "unclaimedFeesData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.UnclaimedFeesData",
+            "components": [
+              {
+                "name": "settlementFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "unclaimedSharesFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "sharesToBurn",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sharesToMint",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToT3treasury",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToSilo",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToFeeRecipient",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsFromCurator",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "actualDepositedAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "ppsHighWaterMark",
+            "type": "uint128",
+            "internalType": "uint128"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "forceClaimDeposit",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "claimedShares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getAllSilosPnl",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "allSilosPnl_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.AllSilosPnl",
+        "components": [
+          {
+            "name": "syncSiloPnl",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.SiloPnl",
+            "components": [
+              {
+                "name": "pnl",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "isProfit",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "depositSiloPnl",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.SiloPnl",
+            "components": [
+              {
+                "name": "pnl",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "isProfit",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "redeemSiloPnl",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.SiloPnl",
+            "components": [
+              {
+                "name": "pnl",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "isProfit",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "totalSiloPnl",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.SiloPnl",
+            "components": [
+              {
+                "name": "pnl",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "isProfit",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getCurator",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "curator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getCurrentDepositRequestId",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "currentDepositRequestId_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getCurrentRedeemRequestId",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "currentRedeemRequestId_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getDepositSilo",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "depositSilo_",
+        "type": "address",
+        "internalType": "contract IERC4626"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getEntryFee",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "entryFeeWad_",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getExitFee",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "exitFeeWad_",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getFeeRecipient",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "feeRecipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getFullBalanceOf",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "fullBalance_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.FullBalance",
+        "components": [
+          {
+            "name": "pendingDepositAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "claimableDepositShares",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "ownedShares",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "pendingRedeemShares",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "claimableRedeemAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "recoverableRedeemSiloShares",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getGrossTVL",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "breakdown_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.GrossTvlBreakdown",
+        "components": [
+          {
+            "name": "totalManagedAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "pendingDeposits",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "claimableRedeems",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "grossTvl",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getInitialAssets",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "initialAssets_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getIpfsHash",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "ipfsHash_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getLastDepositRequestId",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "lastDepositRequestId_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getLastRedeemRequestId",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "lastRedeemRequestId_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getLastSettlementTimestamp",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "lastSettlementTimestamp_",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getManagementFee",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "managementFeeWad_",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "managementFeeDays_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getNextDefaultAdminRecipient",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "nextDefaultAdminRecipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getNextEntryFee",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "isPending_",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "nextEntryFeeWad_",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getNextExitFee",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "isPending_",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "nextExitFeeWad_",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getNextGovernanceAdminRecipient",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "nextGovernanceAdminRecipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getNextManagementFee",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "nextManagementFee_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.NextManagementFee",
+        "components": [
+          {
+            "name": "isFeePending",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "isDaysPending",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "nextManagementFeeWad",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "nextManagementFeeDays",
+            "type": "uint32",
+            "internalType": "uint32"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getNextPerformanceFee",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "isPending_",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "nextPerformanceFeeWad_",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getOracle",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "oracle_",
+        "type": "address",
+        "internalType": "contract IOracle"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPerformanceFee",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "performanceFeeWad_",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPpsHighWaterMark",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "ppsHighWaterMark_",
+        "type": "uint128",
+        "internalType": "uint128"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getProtocol",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "protocol_",
+        "type": "address",
+        "internalType": "contract IT3tris"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRedeemSilo",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "redeemSilo_",
+        "type": "address",
+        "internalType": "contract IERC4626"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRequestDepositAmount",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "requestId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "pendingAssets_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRequestRedeemAmount",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "requestId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "depositedVaultShares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRoleAdmin",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getSettledDepositShares",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "requestId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "mintedShares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getSettledRedeemAssets",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "requestId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "redeemedAssets_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getShareName",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "shareName_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getShareSymbol",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "shareSymbol_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getSiloSharesBalances",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "siloSharesBalances_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.SiloSharesBalances",
+        "components": [
+          {
+            "name": "syncSiloShares",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "depositSiloShares",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "redeemSiloShares",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getSyncSilo",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "syncSilo_",
+        "type": "address",
+        "internalType": "contract IERC4626"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getT3treasury",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "t3treasury_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getTotalDepositedVaultShares",
+    "inputs": [
+      {
+        "name": "requestId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "totalDepositedVaultShares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getTotalRedeemRequestSettled",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "totalAssetsSettled_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getTotalRequestDeposit",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "totalRequestDeposit_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getTotalVaultSharesMinted",
+    "inputs": [
+      {
+        "name": "requestId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "totalVaultSharesMinted_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getUnclaimedSharesFee",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "unclaimedSharesFee_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "grantRole",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "hasClaimableDeposit",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "hasClaimable_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "hasClaimableRedeem",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "hasClaimable_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "hasRole",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initGrantAdminRole",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "params",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.VaultInitParams",
+        "components": [
+          {
+            "name": "shareName",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "shareSymbol",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "ipfsHash",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "globalFeesParams",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.GlobalFeesParams",
+            "components": [
+              {
+                "name": "entryFeeWad",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "exitFeeWad",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "managementFeeWad",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "performanceFeeWad",
+                "type": "uint64",
+                "internalType": "uint64"
+              },
+              {
+                "name": "managementFeeDays",
+                "type": "uint32",
+                "internalType": "uint32"
+              }
+            ]
+          },
+          {
+            "name": "underlyingAsset",
+            "type": "address",
+            "internalType": "contract IERC20Metadata"
+          },
+          {
+            "name": "permit2",
+            "type": "address",
+            "internalType": "contract IAllowanceTransfer"
+          },
+          {
+            "name": "t3trisProtocol",
+            "type": "address",
+            "internalType": "contract IT3tris"
+          },
+          {
+            "name": "oracle",
+            "type": "address",
+            "internalType": "contract IOracle"
+          },
+          {
+            "name": "syncSilo",
+            "type": "address",
+            "internalType": "contract IERC4626"
+          },
+          {
+            "name": "depositSilo",
+            "type": "address",
+            "internalType": "contract IERC4626"
+          },
+          {
+            "name": "redeemSilo",
+            "type": "address",
+            "internalType": "contract IERC4626"
+          },
+          {
+            "name": "vaultOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "governanceOwner",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "t3treasury",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "curator",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "feeRecipient",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "transferEnabled",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "depositEnabled",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "depositWhitelistEnabled",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "withdrawWhitelistEnabled",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "vaultOpened",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "version",
+            "type": "uint16",
+            "internalType": "uint16"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isDepositEnabled",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "depositEnabled_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isDepositWhitelistEnabled",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "enabled_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isDepositWhitelisted",
+    "inputs": [
+      {
+        "name": "addr",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "whitelisted_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isEndOfFund",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "endOfFund_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isTransferEnabled",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "transferEnabled_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isVaultOpen",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "isVaultOpen_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isWithdrawWhitelistEnabled",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "enabled_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isWithdrawWhitelisted",
+    "inputs": [
+      {
+        "name": "addr",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "whitelisted_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "maxDeposit",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "maxAssets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "maxMint",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "maxShares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "maxRedeem",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "maxShares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "maxWithdraw",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "maxAssets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "mint",
+    "inputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "mint",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "permit2Data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "assets_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "name",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "open",
+    "inputs": [
+      {
+        "name": "feeClaimType",
+        "type": "uint8",
+        "internalType": "enum IVaultTypes.FeeClaimType"
+      },
+      {
+        "name": "unsafe",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "permit2DataOpen",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "openResult_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.OpenResult",
+        "components": [
+          {
+            "name": "lastPeriodData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.LastPeriodData",
+            "components": [
+              {
+                "name": "oldTotalNetAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "oldTotalNetSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "managementFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "managementFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "performanceFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "performanceFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "periodFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "pnl",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "updatedPps",
+                "type": "uint128",
+                "internalType": "uint128"
+              },
+              {
+                "name": "isProfit",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "entryFees",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.EntryFees",
+            "components": [
+              {
+                "name": "entryFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "entryFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "exitFees",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.ExitFees",
+            "components": [
+              {
+                "name": "exitFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "exitFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netDepositFlowData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetDepositFlowData",
+            "components": [
+              {
+                "name": "netDepositAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "netDepositShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netRedeemFlowData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetRedeemFlowData",
+            "components": [
+              {
+                "name": "netRedeemAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "netRedeemShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "grossTvlData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.GrossTvlData",
+            "components": [
+              {
+                "name": "totalAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netTvlData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetTvlData",
+            "components": [
+              {
+                "name": "totalNetAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "totalNetSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "unclaimedFeesData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.UnclaimedFeesData",
+            "components": [
+              {
+                "name": "settlementFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "unclaimedSharesFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "sharesToBurn",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sharesToMint",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToT3treasury",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToSilo",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToFeeRecipient",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsFromCurator",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "actualDepositedAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "ppsHighWaterMark",
+            "type": "uint128",
+            "internalType": "uint128"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "pause",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "isPaused_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewClaimDeposit",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "claimableShares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewClaimFees",
+    "inputs": [
+      {
+        "name": "sharesFeeToClaim",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "claimableAssets_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewClaimRedeem",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "withdrawableAssets_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "recoverableSiloShares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewClaimSiloPnl",
+    "inputs": [
+      {
+        "name": "claimSync",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "claimDepositSiloPnl",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "redeemRequestId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "claimedSilosPnl_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.ClaimedSilosPnl",
+        "components": [
+          {
+            "name": "syncSiloPnl",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.SiloPnl",
+            "components": [
+              {
+                "name": "pnl",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "isProfit",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "depositSiloPnl",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.SiloPnl",
+            "components": [
+              {
+                "name": "pnl",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "isProfit",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "redeemSiloPnl",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.SiloPnl",
+            "components": [
+              {
+                "name": "pnl",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "isProfit",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewClose",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "returnableAssets_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewDecreaseDepositRequest",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "receiverAmount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "recoverableSiloShares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewDecreaseRedeemRequest",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "newPendingShares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewDeposit",
+    "inputs": [
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewEnableEndOfFund",
+    "inputs": [
+      {
+        "name": "feeClaimType",
+        "type": "uint8",
+        "internalType": "enum IVaultTypes.FeeClaimType"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "openResult_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.OpenResult",
+        "components": [
+          {
+            "name": "lastPeriodData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.LastPeriodData",
+            "components": [
+              {
+                "name": "oldTotalNetAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "oldTotalNetSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "managementFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "managementFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "performanceFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "performanceFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "periodFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "pnl",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "updatedPps",
+                "type": "uint128",
+                "internalType": "uint128"
+              },
+              {
+                "name": "isProfit",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "entryFees",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.EntryFees",
+            "components": [
+              {
+                "name": "entryFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "entryFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "exitFees",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.ExitFees",
+            "components": [
+              {
+                "name": "exitFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "exitFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netDepositFlowData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetDepositFlowData",
+            "components": [
+              {
+                "name": "netDepositAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "netDepositShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netRedeemFlowData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetRedeemFlowData",
+            "components": [
+              {
+                "name": "netRedeemAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "netRedeemShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "grossTvlData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.GrossTvlData",
+            "components": [
+              {
+                "name": "totalAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netTvlData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetTvlData",
+            "components": [
+              {
+                "name": "totalNetAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "totalNetSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "unclaimedFeesData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.UnclaimedFeesData",
+            "components": [
+              {
+                "name": "settlementFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "unclaimedSharesFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "sharesToBurn",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sharesToMint",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToT3treasury",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToSilo",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToFeeRecipient",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsFromCurator",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "actualDepositedAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "ppsHighWaterMark",
+            "type": "uint128",
+            "internalType": "uint128"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewMint",
+    "inputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewOpen",
+    "inputs": [
+      {
+        "name": "feeClaimType",
+        "type": "uint8",
+        "internalType": "enum IVaultTypes.FeeClaimType"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "openResult_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.OpenResult",
+        "components": [
+          {
+            "name": "lastPeriodData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.LastPeriodData",
+            "components": [
+              {
+                "name": "oldTotalNetAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "oldTotalNetSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "managementFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "managementFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "performanceFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "performanceFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "periodFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "pnl",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "updatedPps",
+                "type": "uint128",
+                "internalType": "uint128"
+              },
+              {
+                "name": "isProfit",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "entryFees",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.EntryFees",
+            "components": [
+              {
+                "name": "entryFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "entryFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "exitFees",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.ExitFees",
+            "components": [
+              {
+                "name": "exitFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "exitFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netDepositFlowData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetDepositFlowData",
+            "components": [
+              {
+                "name": "netDepositAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "netDepositShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netRedeemFlowData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetRedeemFlowData",
+            "components": [
+              {
+                "name": "netRedeemAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "netRedeemShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "grossTvlData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.GrossTvlData",
+            "components": [
+              {
+                "name": "totalAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netTvlData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetTvlData",
+            "components": [
+              {
+                "name": "totalNetAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "totalNetSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "unclaimedFeesData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.UnclaimedFeesData",
+            "components": [
+              {
+                "name": "settlementFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "unclaimedSharesFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "sharesToBurn",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sharesToMint",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToT3treasury",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToSilo",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToFeeRecipient",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsFromCurator",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "actualDepositedAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "ppsHighWaterMark",
+            "type": "uint128",
+            "internalType": "uint128"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewRedeem",
+    "inputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewSettle",
+    "inputs": [
+      {
+        "name": "feeClaimType",
+        "type": "uint8",
+        "internalType": "enum IVaultTypes.FeeClaimType"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "result_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.SettleResult",
+        "components": [
+          {
+            "name": "lastPeriodData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.LastPeriodData",
+            "components": [
+              {
+                "name": "oldTotalNetAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "oldTotalNetSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "managementFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "managementFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "performanceFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "performanceFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "periodFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "pnl",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "updatedPps",
+                "type": "uint128",
+                "internalType": "uint128"
+              },
+              {
+                "name": "isProfit",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "entryFees",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.EntryFees",
+            "components": [
+              {
+                "name": "entryFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "entryFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "exitFees",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.ExitFees",
+            "components": [
+              {
+                "name": "exitFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "exitFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netDepositFlowData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetDepositFlowData",
+            "components": [
+              {
+                "name": "netDepositAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "netDepositShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netRedeemFlowData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetRedeemFlowData",
+            "components": [
+              {
+                "name": "netRedeemAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "netRedeemShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "grossTvlData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.GrossTvlData",
+            "components": [
+              {
+                "name": "totalAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netTvlData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetTvlData",
+            "components": [
+              {
+                "name": "totalNetAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "totalNetSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "unclaimedFeesData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.UnclaimedFeesData",
+            "components": [
+              {
+                "name": "settlementFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "unclaimedSharesFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "sharesToBurn",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sharesToMint",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToT3treasury",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToCurator",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToFeeRecipient",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsFromCurator",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "actualDepositedAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "ppsHighWaterMark",
+            "type": "uint128",
+            "internalType": "uint128"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewSettleDeposits",
+    "inputs": [
+      {
+        "name": "feeClaimType",
+        "type": "uint8",
+        "internalType": "enum IVaultTypes.FeeClaimType"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "result_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.SettleDepositsResult",
+        "components": [
+          {
+            "name": "lastPeriodData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.LastPeriodData",
+            "components": [
+              {
+                "name": "oldTotalNetAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "oldTotalNetSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "managementFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "managementFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "performanceFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "performanceFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "periodFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "pnl",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "updatedPps",
+                "type": "uint128",
+                "internalType": "uint128"
+              },
+              {
+                "name": "isProfit",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "entryFees",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.EntryFees",
+            "components": [
+              {
+                "name": "entryFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "entryFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netDepositFlowData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetDepositFlowData",
+            "components": [
+              {
+                "name": "netDepositAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "netDepositShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "grossTvlData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.GrossTvlData",
+            "components": [
+              {
+                "name": "totalAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netTvlData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetTvlData",
+            "components": [
+              {
+                "name": "totalNetAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "totalNetSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "unclaimedFeesData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.UnclaimedFeesData",
+            "components": [
+              {
+                "name": "settlementFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "unclaimedSharesFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "assetsToT3treasury",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToCurator",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToFeeRecipient",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsFromCurator",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sharesToFeeRecipient",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sharesToMint",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sharesToBurn",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewSettleRedemptions",
+    "inputs": [
+      {
+        "name": "fullClaim",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "result_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.SettleRedemptionsResult",
+        "components": [
+          {
+            "name": "lastPeriodData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.LastPeriodData",
+            "components": [
+              {
+                "name": "oldTotalNetAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "oldTotalNetSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "managementFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "managementFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "performanceFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "performanceFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "periodFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "pnl",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "updatedPps",
+                "type": "uint128",
+                "internalType": "uint128"
+              },
+              {
+                "name": "isProfit",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "exitFees",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.ExitFees",
+            "components": [
+              {
+                "name": "exitFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "exitFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netRedeemFlowData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetRedeemFlowData",
+            "components": [
+              {
+                "name": "netRedeemAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "netRedeemShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "grossTvlData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.GrossTvlData",
+            "components": [
+              {
+                "name": "totalAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netTvlData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetTvlData",
+            "components": [
+              {
+                "name": "totalNetAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "totalNetSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "unclaimedFeesData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.UnclaimedFeesData",
+            "components": [
+              {
+                "name": "settlementFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "unclaimedSharesFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "currentRequestId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sharesToRedeem",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsFromCurator",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sharesToMint",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sharesToBurn",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToFeeRecipient",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToSilo",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewUpdateAccruedFees",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "lastPeriodData_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.LastPeriodData",
+        "components": [
+          {
+            "name": "oldTotalNetAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "oldTotalNetSupply",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "managementFeeAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "managementFeeShares",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "performanceFeeAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "performanceFeeShares",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "periodFeeShares",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "pnl",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "updatedPps",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "isProfit",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      },
+      {
+        "name": "netTvlData_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.NetTvlData",
+        "components": [
+          {
+            "name": "totalNetAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "totalNetSupply",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "previewWithdraw",
+    "inputs": [
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "redeem",
+    "inputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "renounceRole",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "callerConfirmation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "requestDeposit",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "unsafe",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "permit2Data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "requestRedeem",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "previousClaimReceiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "unsafe",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "revokeRole",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setCurator",
+    "inputs": [
+      {
+        "name": "curator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setDepositEnabled",
+    "inputs": [
+      {
+        "name": "enabled",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setDepositSilo",
+    "inputs": [
+      {
+        "name": "depositSilo",
+        "type": "address",
+        "internalType": "contract IERC4626"
+      },
+      {
+        "name": "unsafeOut",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "unsafeIn",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setDepositWhitelistEnabled",
+    "inputs": [
+      {
+        "name": "enabled",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setDepositWhitelisted",
+    "inputs": [
+      {
+        "name": "addr",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "whitelisted",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setFeeRecipient",
+    "inputs": [
+      {
+        "name": "feeRecipient",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setIpfsHash",
+    "inputs": [
+      {
+        "name": "ipfsHash",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setNextEntryFee",
+    "inputs": [
+      {
+        "name": "entryFeeWad",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setNextExitFee",
+    "inputs": [
+      {
+        "name": "exitFeeWad",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setNextManagementFee",
+    "inputs": [
+      {
+        "name": "managementFeeWad",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "managementFeeDays",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setNextPerformanceFee",
+    "inputs": [
+      {
+        "name": "performanceFeeWad",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setOracle",
+    "inputs": [
+      {
+        "name": "oracle",
+        "type": "address",
+        "internalType": "contract IOracle"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setRedeemSilo",
+    "inputs": [
+      {
+        "name": "redeemSilo",
+        "type": "address",
+        "internalType": "contract IERC4626"
+      },
+      {
+        "name": "unsafeOut",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "unsafeIn",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setShareNameAndSymbol",
+    "inputs": [
+      {
+        "name": "newName",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "newSymbol",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setSyncSilo",
+    "inputs": [
+      {
+        "name": "syncSilo",
+        "type": "address",
+        "internalType": "contract IERC4626"
+      },
+      {
+        "name": "unsafeOut",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "unsafeIn",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setT3treasury",
+    "inputs": [
+      {
+        "name": "t3treasury",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setTransferEnabled",
+    "inputs": [
+      {
+        "name": "enabled",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setWithdrawWhitelistEnabled",
+    "inputs": [
+      {
+        "name": "enabled",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setWithdrawWhitelisted",
+    "inputs": [
+      {
+        "name": "addr",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "whitelisted",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settle",
+    "inputs": [
+      {
+        "name": "feeClaimType",
+        "type": "uint8",
+        "internalType": "enum IVaultTypes.FeeClaimType"
+      },
+      {
+        "name": "unsafe",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "permit2Data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "result_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.SettleResult",
+        "components": [
+          {
+            "name": "lastPeriodData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.LastPeriodData",
+            "components": [
+              {
+                "name": "oldTotalNetAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "oldTotalNetSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "managementFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "managementFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "performanceFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "performanceFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "periodFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "pnl",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "updatedPps",
+                "type": "uint128",
+                "internalType": "uint128"
+              },
+              {
+                "name": "isProfit",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "entryFees",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.EntryFees",
+            "components": [
+              {
+                "name": "entryFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "entryFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "exitFees",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.ExitFees",
+            "components": [
+              {
+                "name": "exitFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "exitFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netDepositFlowData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetDepositFlowData",
+            "components": [
+              {
+                "name": "netDepositAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "netDepositShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netRedeemFlowData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetRedeemFlowData",
+            "components": [
+              {
+                "name": "netRedeemAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "netRedeemShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "grossTvlData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.GrossTvlData",
+            "components": [
+              {
+                "name": "totalAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netTvlData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetTvlData",
+            "components": [
+              {
+                "name": "totalNetAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "totalNetSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "unclaimedFeesData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.UnclaimedFeesData",
+            "components": [
+              {
+                "name": "settlementFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "unclaimedSharesFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "sharesToBurn",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sharesToMint",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToT3treasury",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToCurator",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToFeeRecipient",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsFromCurator",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "actualDepositedAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "ppsHighWaterMark",
+            "type": "uint128",
+            "internalType": "uint128"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settleDeposits",
+    "inputs": [
+      {
+        "name": "feeClaimType",
+        "type": "uint8",
+        "internalType": "enum IVaultTypes.FeeClaimType"
+      },
+      {
+        "name": "unsafe",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "permit2Data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "result_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.SettleDepositsResult",
+        "components": [
+          {
+            "name": "lastPeriodData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.LastPeriodData",
+            "components": [
+              {
+                "name": "oldTotalNetAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "oldTotalNetSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "managementFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "managementFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "performanceFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "performanceFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "periodFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "pnl",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "updatedPps",
+                "type": "uint128",
+                "internalType": "uint128"
+              },
+              {
+                "name": "isProfit",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "entryFees",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.EntryFees",
+            "components": [
+              {
+                "name": "entryFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "entryFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netDepositFlowData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetDepositFlowData",
+            "components": [
+              {
+                "name": "netDepositAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "netDepositShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "grossTvlData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.GrossTvlData",
+            "components": [
+              {
+                "name": "totalAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netTvlData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetTvlData",
+            "components": [
+              {
+                "name": "totalNetAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "totalNetSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "unclaimedFeesData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.UnclaimedFeesData",
+            "components": [
+              {
+                "name": "settlementFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "unclaimedSharesFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "assetsToT3treasury",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToCurator",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToFeeRecipient",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsFromCurator",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sharesToFeeRecipient",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sharesToMint",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sharesToBurn",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settleRedemptions",
+    "inputs": [
+      {
+        "name": "fullClaim",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "unsafe",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "permit2Data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "result_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.SettleRedemptionsResult",
+        "components": [
+          {
+            "name": "lastPeriodData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.LastPeriodData",
+            "components": [
+              {
+                "name": "oldTotalNetAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "oldTotalNetSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "managementFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "managementFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "performanceFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "performanceFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "periodFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "pnl",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "updatedPps",
+                "type": "uint128",
+                "internalType": "uint128"
+              },
+              {
+                "name": "isProfit",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          },
+          {
+            "name": "exitFees",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.ExitFees",
+            "components": [
+              {
+                "name": "exitFeeAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "exitFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netRedeemFlowData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetRedeemFlowData",
+            "components": [
+              {
+                "name": "netRedeemAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "netRedeemShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "grossTvlData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.GrossTvlData",
+            "components": [
+              {
+                "name": "totalAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "totalSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "netTvlData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.NetTvlData",
+            "components": [
+              {
+                "name": "totalNetAssets",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "totalNetSupply",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "unclaimedFeesData",
+            "type": "tuple",
+            "internalType": "struct IVaultTypes.UnclaimedFeesData",
+            "components": [
+              {
+                "name": "settlementFeeShares",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "unclaimedSharesFee",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "currentRequestId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sharesToRedeem",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsFromCurator",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sharesToMint",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "sharesToBurn",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToFeeRecipient",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "assetsToSilo",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "sharesBalanceInAsset",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "assets_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "sweep",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "contract IERC20"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "symbol",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalAssets",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "totalManagedAssets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalNetAssets",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "totalNetAssets_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalNetSupply",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "totalNetSupply_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalSupply",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transfer",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unpause",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unsafeRedeem",
+    "inputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "assets_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "unsafeWithdraw",
+    "inputs": [
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "shares_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateAccruedFees",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "lastPeriodData_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.LastPeriodData",
+        "components": [
+          {
+            "name": "oldTotalNetAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "oldTotalNetSupply",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "managementFeeAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "managementFeeShares",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "performanceFeeAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "performanceFeeShares",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "periodFeeShares",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "pnl",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "updatedPps",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "isProfit",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      },
+      {
+        "name": "netTvlData_",
+        "type": "tuple",
+        "internalType": "struct IVaultTypes.NetTvlData",
+        "components": [
+          {
+            "name": "totalNetAssets",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "totalNetSupply",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateSharesBatched",
+    "inputs": [
+      {
+        "name": "receivers",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "values",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "version",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "withdraw",
+    "inputs": [
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "shares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "AdminRoleGrantCancelled",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AdminRoleGrantInitiated",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Approval",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AssetsRecovered",
+    "inputs": [
+      {
+        "name": "requestId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "curator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "netRedeemShares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClaimDeposit",
+    "inputs": [
+      {
+        "name": "requestId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "assets",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClaimRedeem",
+    "inputs": [
+      {
+        "name": "requestId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "assets",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "CuratorUpdated",
+    "inputs": [
+      {
+        "name": "curator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DecreaseDepositRequest",
+    "inputs": [
+      {
+        "name": "requestId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newRequestedAssets",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DecreaseRedeemRequest",
+    "inputs": [
+      {
+        "name": "requestId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "newRequestedShares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Deposit",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "assets",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DepositEnabledUpdated",
+    "inputs": [
+      {
+        "name": "enabled",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DepositRequest",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "requestId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "assets",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DepositSiloPnl",
+    "inputs": [
+      {
+        "name": "requestId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "silo",
+        "type": "address",
+        "indexed": true,
+        "internalType": "contract IERC4626"
+      },
+      {
+        "name": "isProfit",
+        "type": "bool",
+        "indexed": true,
+        "internalType": "bool"
+      },
+      {
+        "name": "pnl",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DepositSiloUpdated",
+    "inputs": [
+      {
+        "name": "depositSilo",
+        "type": "address",
+        "indexed": false,
+        "internalType": "contract IERC4626"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DepositWhitelistStatusUpdated",
+    "inputs": [
+      {
+        "name": "enabled",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DepositWhitelistUpdated",
+    "inputs": [
+      {
+        "name": "addr",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "whitelisted",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DepositsSettled",
+    "inputs": [
+      {
+        "name": "requestId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "assetsDeposited",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "sharesMinted",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "entryFees",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "unclaimedFees",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "EndOfFundToggled",
+    "inputs": [
+      {
+        "name": "enabled",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "EntryFeeUpdated",
+    "inputs": [
+      {
+        "name": "entryFeeWad",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ExitFeeUpdated",
+    "inputs": [
+      {
+        "name": "exitFeeWad",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "FeeRecipientUpdated",
+    "inputs": [
+      {
+        "name": "feeRecipient",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "FeesClaimed",
+    "inputs": [
+      {
+        "name": "claimer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "feeRecipient",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "sharesFeeClaimed",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "assetsClaimed",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "IpfsHashUpdated",
+    "inputs": [
+      {
+        "name": "ipfsHash",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ManagementFeeDaysUpdated",
+    "inputs": [
+      {
+        "name": "managementFeeDays",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ManagementFeeUpdated",
+    "inputs": [
+      {
+        "name": "managementFeeWad",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NameSymbolUpdated",
+    "inputs": [
+      {
+        "name": "name",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "symbol",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NavUpdated",
+    "inputs": [
+      {
+        "name": "managementFeeShares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "performanceFeeShares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "totalNetAssets",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "totalNetSupply",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "updatedPps",
+        "type": "uint128",
+        "indexed": false,
+        "internalType": "uint128"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NextEntryFeeSet",
+    "inputs": [
+      {
+        "name": "nextEntryFeeWad",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NextExitFeeSet",
+    "inputs": [
+      {
+        "name": "nextExitFeeWad",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NextManagementFeeDaysSet",
+    "inputs": [
+      {
+        "name": "nextManagementFeeDays",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NextManagementFeeSet",
+    "inputs": [
+      {
+        "name": "nextManagementFeeWad",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NextPerformanceFeeSet",
+    "inputs": [
+      {
+        "name": "nextPerformanceFeeWad",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OracleUpdated",
+    "inputs": [
+      {
+        "name": "oracle",
+        "type": "address",
+        "indexed": false,
+        "internalType": "contract IOracle"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PerformanceFeeUpdated",
+    "inputs": [
+      {
+        "name": "performanceFeeWad",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PpsHighWaterMarkReanchored",
+    "inputs": [],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RedeemRequest",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "requestId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RedeemSiloMigrationInsolvent",
+    "inputs": [
+      {
+        "name": "oldSilo",
+        "type": "address",
+        "indexed": true,
+        "internalType": "contract IERC4626"
+      },
+      {
+        "name": "newSilo",
+        "type": "address",
+        "indexed": true,
+        "internalType": "contract IERC4626"
+      },
+      {
+        "name": "barrierRequestId",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RedeemSiloPnl",
+    "inputs": [
+      {
+        "name": "requestId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "silo",
+        "type": "address",
+        "indexed": true,
+        "internalType": "contract IERC4626"
+      },
+      {
+        "name": "isProfit",
+        "type": "bool",
+        "indexed": true,
+        "internalType": "bool"
+      },
+      {
+        "name": "pnl",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RedeemSiloUpdated",
+    "inputs": [
+      {
+        "name": "redeemSilo",
+        "type": "address",
+        "indexed": false,
+        "internalType": "contract IERC4626"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RedemptionsSettled",
+    "inputs": [
+      {
+        "name": "requestId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "sharesToRedeem",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "assetsWithdrawn",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "sharesBurned",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "exitFeeAssets",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "unclaimedSharesFee",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "feeRecipientAmount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RoleAdminChanged",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "previousAdminRole",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "newAdminRole",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RoleGranted",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RoleRevoked",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SiloAssetsRecovered",
+    "inputs": [
+      {
+        "name": "silo",
+        "type": "address",
+        "indexed": true,
+        "internalType": "contract IERC4626"
+      },
+      {
+        "name": "recipient",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "asset",
+        "type": "address",
+        "indexed": true,
+        "internalType": "contract IERC20"
+      },
+      {
+        "name": "assets",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SiloSharesRecovered",
+    "inputs": [
+      {
+        "name": "silo",
+        "type": "address",
+        "indexed": true,
+        "internalType": "contract IERC4626"
+      },
+      {
+        "name": "recipient",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SiloSharesRecoveryDeferred",
+    "inputs": [
+      {
+        "name": "silo",
+        "type": "address",
+        "indexed": true,
+        "internalType": "contract IERC4626"
+      },
+      {
+        "name": "recipient",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Sweep",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "contract IERC20"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SyncSiloPnl",
+    "inputs": [
+      {
+        "name": "silo",
+        "type": "address",
+        "indexed": true,
+        "internalType": "contract IERC4626"
+      },
+      {
+        "name": "isProfit",
+        "type": "bool",
+        "indexed": true,
+        "internalType": "bool"
+      },
+      {
+        "name": "pnl",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SyncSiloUpdated",
+    "inputs": [
+      {
+        "name": "syncSilo",
+        "type": "address",
+        "indexed": false,
+        "internalType": "contract IERC4626"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "T3treasuryUpdated",
+    "inputs": [
+      {
+        "name": "t3treasury",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "T3trisProfit",
+    "inputs": [
+      {
+        "name": "profit",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Transfer",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "TransferEnabledUpdated",
+    "inputs": [
+      {
+        "name": "enabled",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "VaultClosed",
+    "inputs": [
+      {
+        "name": "returnedAssets",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "VaultCreated",
+    "inputs": [
+      {
+        "name": "vaultAddress",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "oracle",
+        "type": "address",
+        "indexed": false,
+        "internalType": "contract IOracle"
+      },
+      {
+        "name": "referralCode",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "VaultOpened",
+    "inputs": [
+      {
+        "name": "depositedAssets",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Withdraw",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "receiver",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "assets",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "shares",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WithdrawWhitelistStatusUpdated",
+    "inputs": [
+      {
+        "name": "enabled",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WithdrawWhitelistUpdated",
+    "inputs": [
+      {
+        "name": "addr",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "whitelisted",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AccessControlBadConfirmation",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "AccessControlUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "neededRole",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "Vault__ArrayLengthMismatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__BurnNotInitiated",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__DeceptiveMint",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__DeceptiveRedeem",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__DeceptiveWithdraw",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__DepositAmountMismatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__DepositDisabled",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__DepositZeroSiloSharesMinted",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__DowngradeNotAllowed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__EndOfFundActive",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__ExceededAvailableFee",
+    "inputs": [
+      {
+        "name": "sharesToClaim",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "availableShares",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "Vault__ExceedsPendingAssets",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "requested",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "available",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "Vault__ExceedsPendingShares",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "requested",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "available",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "Vault__ImplementationNotRegistered",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__InsufficientSiloLiquidity",
+    "inputs": [
+      {
+        "name": "assetsToClaim",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "availableLiquidity",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "Vault__InvalidAddress",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__InvalidDeltaReceiverConfig",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__InvalidFeeWad",
+    "inputs": [
+      {
+        "name": "feeWad",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "Vault__InvalidManagementFee",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__InvalidPendingRecipient",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__InvalidReceiver",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__InvalidSilo",
+    "inputs": [
+      {
+        "name": "silo",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "Vault__MigrationDepositZeroShares",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__NoClaimDepositAvailable",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "Vault__NoClaimRedeemAvailable",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "Vault__NoPendingRequest",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "Vault__NotAdminRole",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__NotWhitelisted",
+    "inputs": [
+      {
+        "name": "addr",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "Vault__RedeemAmountMismatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__RedeemZeroSiloAssetsReceived",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__SameSilo",
+    "inputs": [
+      {
+        "name": "silo",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "Vault__SettlementAlreadyDoneThisBlock",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__SlippageExceeded",
+    "inputs": [
+      {
+        "name": "actualAssets",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "minAssetsOut",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "Vault__StaleValuation",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__SuperAdminRoleDirectGrantNotAllowed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__SuperAdminRoleDirectRevokeNotAllowed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__TokenNotSweepable",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__TransferDisabled",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__VaultIsClosed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__VaultIsEmpty",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__VaultIsInsolvent",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__VaultIsOpen",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__VersionNotWhitelisted",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__WithdrawAmountMismatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__ZeroAssets",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__ZeroAssetsToClaim",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__ZeroManagementFeeDays",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Vault__ZeroRedeemableShares",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "assets",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "Vault__ZeroShares",
+    "inputs": []
+  }
+]

--- a/eth_defi/abi/t3tris/Multicall.json
+++ b/eth_defi/abi/t3tris/Multicall.json
@@ -1,0 +1,21 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "data",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "multicall",
+    "outputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "",
+        "type": "bytes[]"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  }
+]

--- a/eth_defi/abi/t3tris/README.md
+++ b/eth_defi/abi/t3tris/README.md
@@ -1,0 +1,47 @@
+# T3tris ABI files
+
+T3tris contract source code was not verified on public block explorers during
+the initial integration research. The public T3tris documentation says that only
+interfaces are published, so these ABI files are sourced from the live frontend
+and checked against the published interface documentation.
+
+## Files
+
+| File | Source | Notes |
+| --- | --- | --- |
+| `IVault.json` | `IVaultAbi` export in the T3tris app chunk `https://app.t3tris.finance/_next/static/chunks/13etv-4ylf72t.js` | Full vault ABI used by the live T3tris frontend. Refreshed from the production app before saving. |
+| `Multicall.json` | Separate `multicall(bytes[])` fragment used by the same app chunk against vault addresses | The frontend keeps this as a small local ABI fragment instead of including it in `IVaultAbi`. |
+
+The chunk filename is content-hashed and may change after a frontend deploy.
+When updating these files, start from `https://app.t3tris.finance/vaults`, fetch
+the current chunk list, and locate the current export named `IVaultAbi`.
+
+## Reference links
+
+- T3tris homepage: https://t3tris.finance/
+- T3tris vault app: https://app.t3tris.finance/vaults
+- T3tris GraphQL endpoint: https://api.t3tris.finance/graphql
+- T3tris docs repository: https://github.com/t3tris-finance/mdoc-t3tris
+- Introduction: https://raw.githubusercontent.com/t3tris-finance/mdoc-t3tris/main/docs/en/01-introduction.md
+- Vault interface: https://raw.githubusercontent.com/t3tris-finance/mdoc-t3tris/main/docs/en/04-developers/02-vault-interface.md
+- Vault getters: https://raw.githubusercontent.com/t3tris-finance/mdoc-t3tris/main/docs/en/04-developers/03-vault-getters.md
+- Events reference: https://raw.githubusercontent.com/t3tris-finance/mdoc-t3tris/main/docs/en/04-developers/08-events-reference.md
+
+## Known documentation drift
+
+The Markdown interface documentation is useful, but some signatures differ from
+the ABI used by the live app:
+
+- Docs list `requestDeposit(uint256 assets, address receiver, bytes permit2Data)`;
+  the live ABI has `requestDeposit(address receiver, bool unsafe, uint256 assets,
+  bytes permit2Data)`.
+- Docs list `requestRedeem(uint256 shares, address receiver, address owner,
+  address previousClaimReceiver)`; the live ABI has `requestRedeem(address
+  receiver, address owner, address previousClaimReceiver, bool unsafe, uint256
+  shares)`.
+- Docs list `getPerfFee()`; the live ABI has `getPerformanceFee()`.
+- Docs list some request getter arguments as `(uint256 requestId, address user)`;
+  the live ABI uses `(address owner, uint256 requestId)`.
+
+Use `IVault.json` as the implementation source for selector generation unless
+T3tris later publishes verified contracts or canonical JSON ABI artefacts.

--- a/eth_defi/vault_protocols/__init__.py
+++ b/eth_defi/vault_protocols/__init__.py
@@ -1,0 +1,1 @@
+"""Vault protocol research and integration notes."""

--- a/eth_defi/vault_protocols/t3tris/README-t3tris.md
+++ b/eth_defi/vault_protocols/t3tris/README-t3tris.md
@@ -1,0 +1,518 @@
+# T3tris vault protocol
+
+T3tris is a tokenised vault protocol for professional asset managers. It builds
+vaults around ERC-4626 shares and adds a dual-mode operational model:
+
+- open vault mode, where users can use synchronous ERC-4626 style deposit and
+  redemption flows;
+- closed or asynchronous mode, where users submit deposit and redemption
+  requests, wait for a settlement, and then claim shares or assets.
+
+The public product is at [t3tris.finance](https://t3tris.finance/) and the live
+vault application is at [app.t3tris.finance/vaults](https://app.t3tris.finance/vaults).
+The public developer documentation lives in the
+[t3tris-finance/mdoc-t3tris](https://github.com/t3tris-finance/mdoc-t3tris)
+repository.
+
+T3tris documentation describes the protocol architecture as:
+
+- `T3tris`, a factory and registry contract;
+- `Vault`, an ERC-4626, ERC-20, AccessControl and UUPS proxy vault;
+- `SafeOracle`, a NAV oracle;
+- `SyncSilo`, `DepositSilo` and `RedeemSilo`, ERC-4626 silo contracts used for
+  open, pending deposit and pending redemption liquidity.
+
+The docs state that T3tris smart contract source code is not verified on-chain
+and that only interfaces are published. Treat the public interface docs and the
+live application ABI as the integration sources, not explorer-verified Solidity.
+
+## ERC-7540 compatibility
+
+[ERC-7540](https://eips.ethereum.org/EIPS/eip-7540) extends ERC-4626 with
+asynchronous deposit and redemption requests. Its model has:
+
+- `requestDeposit` and `requestRedeem` to create requests;
+- pending, claimable and claimed lifecycle states;
+- request identifiers;
+- `DepositRequest` and `RedeemRequest` events;
+- ERC-4626 claim functions, using overloaded `deposit`, `mint`, `withdraw` and
+  `redeem` methods with a controller argument;
+- optional async deposit and async redemption support, with ERC-165 interface
+  detection.
+
+T3tris matches the high-level ERC-7540 lifecycle:
+
+- deposits and redemptions can be requested asynchronously;
+- requests are settled in batches;
+- users explicitly claim after settlement;
+- request ids are emitted in events and exposed by getters;
+- the vault keeps pending deposit, claimable deposit, pending redeem and
+  claimable redeem accounting.
+
+However, T3tris does not match the final ERC-7540 ABI exactly. It needs a
+T3tris-specific adapter instead of using generic ERC-7540 method calls.
+
+Current live app ABI signatures:
+
+```solidity
+function requestDeposit(
+    address receiver,
+    bool unsafe,
+    uint256 assets,
+    bytes calldata permit2Data
+) external;
+
+function requestRedeem(
+    address receiver,
+    address owner,
+    address previousClaimReceiver,
+    bool unsafe,
+    uint256 shares
+) external;
+
+function claimDeposit(address receiver)
+    external
+    returns (uint256 claimedShares_);
+
+function claimRedeem(address owner, address receiver, bool unsafe)
+    external
+    returns (uint256 withdrawnAssets_);
+```
+
+Main differences from ERC-7540:
+
+| Area | ERC-7540 | T3tris live ABI |
+| --- | --- | --- |
+| Deposit request | `requestDeposit(uint256 assets, address controller, address owner) returns (uint256 requestId)` | `requestDeposit(address receiver, bool unsafe, uint256 assets, bytes permit2Data)` returns nothing |
+| Redeem request | `requestRedeem(uint256 shares, address controller, address owner) returns (uint256 requestId)` | `requestRedeem(address receiver, address owner, address previousClaimReceiver, bool unsafe, uint256 shares)` returns nothing |
+| Claim deposit | overloaded ERC-4626 `deposit(uint256 assets, address receiver, address controller)` or `mint(...)` | `claimDeposit(address receiver)` |
+| Claim redeem | overloaded ERC-4626 `redeem(uint256 shares, address receiver, address controller)` or `withdraw(...)` | `claimRedeem(address owner, address receiver, bool unsafe)` |
+| Request status getters | `pendingDepositRequest`, `claimableDepositRequest`, `pendingRedeemRequest`, `claimableRedeemRequest` | T3tris getters such as `getRequestDepositAmount`, `getSettledDepositShares`, `hasClaimableDeposit`, `previewClaimDeposit`, `getRequestRedeemAmount`, `getSettledRedeemAssets`, `hasClaimableRedeem`, `previewClaimRedeem` |
+| Operator support | `isOperator`, `setOperator`, ERC-165 support | Not present in the live `IVaultAbi` found in the app bundle |
+| Extra controls | Not part of ERC-7540 | `unsafe` booleans, Permit2 calldata, settlement/admin methods and silo accounting |
+
+The request events are close to the ERC-7540 shape:
+
+```solidity
+event DepositRequest(
+    address indexed receiver,
+    address indexed owner,
+    uint256 indexed requestId,
+    address sender,
+    uint256 assets
+);
+
+event RedeemRequest(
+    address indexed receiver,
+    address indexed owner,
+    uint256 indexed requestId,
+    address sender,
+    uint256 shares
+);
+```
+
+`receiver` appears to be the closest T3tris equivalent of the ERC-7540
+controller for request accounting, but the naming differs from the standard.
+Do not assume generic ERC-7540 code can substitute `controller` without checking
+the exact flow being implemented.
+
+For `eth_defi`, model T3tris as an ERC-4626-derived asynchronous vault protocol
+with ERC-7540-like lifecycle semantics, but protocol-specific method selectors.
+
+## Interface map
+
+Useful ERC-4626 and ERC-20 methods present in the live app ABI:
+
+```solidity
+asset()
+totalAssets()
+totalSupply()
+balanceOf(address)
+allowance(address,address)
+approve(address,uint256)
+transfer(address,uint256)
+transferFrom(address,address,uint256)
+convertToAssets(uint256)
+convertToShares(uint256)
+deposit(uint256,address)
+deposit(address,uint256,bytes)
+mint(uint256,address)
+mint(address,uint256,bytes)
+withdraw(uint256,address,address)
+redeem(uint256,address,address)
+```
+
+Useful T3tris read methods:
+
+```solidity
+getProtocol() returns (address protocol_)
+getGrossTVL() returns (GrossTvlBreakdown memory breakdown_)
+getEntryFee() returns (uint64 entryFeeWad_)
+getExitFee() returns (uint64 exitFeeWad_)
+getPerformanceFee() returns (uint64 performanceFeeWad_)
+getManagementFee() returns (uint64 managementFeeWad_, uint32 managementFeeDays_)
+getCurrentDepositRequestId() returns (uint256)
+getLastDepositRequestId(address receiver) returns (uint256)
+getRequestDepositAmount(address owner, uint256 requestId) returns (uint256)
+getSettledDepositShares(address owner, uint256 requestId) returns (uint256)
+hasClaimableDeposit(address owner) returns (bool)
+previewClaimDeposit(address owner) returns (uint256)
+getCurrentRedeemRequestId() returns (uint256)
+getLastRedeemRequestId(address receiver) returns (uint256)
+getRequestRedeemAmount(address owner, uint256 requestId) returns (uint256)
+getSettledRedeemAssets(address owner, uint256 requestId) returns (uint256)
+hasClaimableRedeem(address owner) returns (bool)
+previewClaimRedeem(address owner) returns (uint256, uint256)
+isVaultOpen() returns (bool)
+isEndOfFund() returns (bool)
+isDepositEnabled() returns (bool)
+isTransferEnabled() returns (bool)
+isDepositWhitelistEnabled() returns (bool)
+isWithdrawWhitelistEnabled() returns (bool)
+getSyncSilo() returns (address)
+getDepositSilo() returns (address)
+getRedeemSilo() returns (address)
+getIpfsHash() returns (string)
+getShareName() returns (string)
+getShareSymbol() returns (string)
+```
+
+`getGrossTVL()` returns a tuple with:
+
+| Field | Meaning |
+| --- | --- |
+| `totalManagedAssets` | assets currently managed by the vault |
+| `pendingDeposits` | asset amount in pending deposit requests |
+| `claimableRedeems` | asset amount claimable by redeem request owners |
+| `grossTvl` | aggregate gross TVL figure used by T3tris |
+
+## Offchain data
+
+T3tris exposes a public GraphQL endpoint:
+
+```text
+https://api.t3tris.finance/graphql
+```
+
+The endpoint is a Ponder-style indexer and currently exposes these query roots:
+
+```text
+vault
+vaults
+asset
+assets
+position
+positions
+roleAssignment
+roleAssignments
+roleAdmin
+roleAdmins
+oracleOwner
+oracleOwners
+pendingAdminGrant
+pendingAdminGrants
+whitelistEntry
+whitelistEntrys
+vaultSnapshot
+vaultSnapshots
+activity
+activitys
+pendingRequest
+pendingRequests
+requestTx
+requestTxs
+_meta
+```
+
+Use GraphQL for discovery, metadata enrichment and sanity checks. Do not treat it
+as authoritative for transaction execution or final accounting; onchain vault
+calls and events remain the source of truth.
+
+### Vault page metadata
+
+The vault detail page uses a separate REST endpoint for the offchain metadata
+shown in the application:
+
+```text
+GET https://api.t3tris.finance/api/v1/pages/vault/{chainId}/{vaultAddress}
+```
+
+For example:
+
+```shell
+curl -sS \
+  "https://api.t3tris.finance/api/v1/pages/vault/42161/0x9984ad74c5fb6bec3888e14b4e453707d3be7f8f" \
+  | jq ".vault | {description, curatorName, curatorUrl, verified, depositsDisabled, showComposition, displayName, displaySymbol, category, attributes, rating, ipfsHash, visibility, visibilityLocked}"
+```
+
+The response is a page view model with these top-level keys:
+
+```text
+performance
+positions
+roles
+snapshots
+vault
+```
+
+`vault.description` is Markdown and should be rendered with the same precautions
+as any third-party HTML-producing content. The example Arbitrum vault
+`0x9984ad74c5fb6bec3888e14b4e453707d3be7f8f` returns a non-empty Markdown
+description, curator profile fields and a public visibility flag from this REST
+endpoint, while `vault.ipfsHash` is an empty string. This means the current page
+description for that vault is backend-curated REST metadata, not data read from
+IPFS through the indexed `ipfsHash` field.
+
+Important REST metadata fields:
+
+| Field | Meaning |
+| --- | --- |
+| `description` | Markdown text shown on the vault page. |
+| `curatorName` | Human-readable curator or manager name. |
+| `curatorUrl` | Curator website URL shown by the app. |
+| `verified` | T3tris UI verification flag. |
+| `depositsDisabled` | UI-level deposit disable flag. Check onchain `isDepositEnabled()` or GraphQL `depositEnabled` before execution. |
+| `showComposition` | Whether the UI should show vault composition data. |
+| `displayName`, `displaySymbol` | Optional UI overrides for onchain vault name and symbol. |
+| `onchainName`, `onchainSymbol` | Onchain name and symbol copied into the page model. |
+| `category`, `attributes`, `rating` | Additional T3tris curation and risk classification fields. |
+| `visibility`, `visibilityLocked` | Listing and visibility controls used by the app. |
+| `apy` | App-level APY view. The detail endpoint currently returns `D`, `W`, `M`, `Y` and `ALL` buckets. |
+| `depositorCount` | App-indexed depositor count. |
+| `ppsEffectiveWad` | Effective price per share used by the app view. |
+
+Adding an account query parameter can include account-specific page data:
+
+```text
+GET https://api.t3tris.finance/api/v1/pages/vault/{chainId}/{vaultAddress}?account={address}
+```
+
+The vault list endpoint also includes the same offchain metadata for discovery:
+
+```text
+GET https://api.t3tris.finance/api/v1/vaults
+```
+
+This endpoint returns an object with a `vaults` array. Its vault items include
+`description`, `curatorName`, `curatorUrl`, `verified`, `depositsDisabled`,
+`showComposition`, `displayName`, `displaySymbol`, `category`, `attributes`,
+`rating`, `visibility` and `visibilityLocked`. The list APY object currently has
+a different shape from the detail endpoint, using `m` and `allTime` fields.
+
+Related page endpoints discovered from the app bundle:
+
+| Endpoint | Use |
+| --- | --- |
+| `/api/v1/vaults/{chainId}/{vaultAddress}/performance?window={window}` | Performance chart data. |
+| `/api/v1/vaults/{chainId}/{vaultAddress}/composition` | Vault composition data, used when `showComposition` is true. |
+| `/api/v1/activity/{chainId}/{vaultAddress}?limit={limit}` | Vault activity feed. |
+| `/api/v1/events/{chainId}/{vaultAddress}` | Curator/admin event timeline. This is separate from the Markdown description and was empty for the example vault during research. |
+| `/api/v1/config` | App configuration, including chains, features, governance and pricing. |
+
+GraphQL still exposes `ipfsHash` and the onchain `getIpfsHash()` getter exists
+in the live ABI, so future vaults may use IPFS-backed metadata. For the current
+application page, prefer the REST page endpoint when matching what users see in
+the T3tris app.
+
+Useful `vault` fields:
+
+| Field group | Fields |
+| --- | --- |
+| Identity | `chainId`, `address`, `asset`, `name`, `symbol`, `shareName`, `shareSymbol`, `version` |
+| Operators | `owner`, `curator`, `feeRecipient`, `protocol`, `oracle`, `isSafeOracle` |
+| Silos | `syncSilo`, `depositSilo`, `redeemSilo` |
+| Fees | `entryFeeWad`, `exitFeeWad`, `performanceFeeWad`, `managementFeeWad`, `managementFeeDays`, `unclaimedSharesFee`, `pendingFeeShares` |
+| Status | `transferEnabled`, `depositWhitelistEnabled`, `withdrawWhitelistEnabled`, `depositEnabled`, `paused`, `vaultOpen`, `endOfFund` |
+| Accounting | `totalAssets`, `totalSupply`, `totalNetAssets`, `totalNetSupply`, `pricePerShareWad`, `hwmWad`, `lastSettlementTs` |
+| Gross TVL | `grossTvl`, `grossManagedAssets`, `grossPendingDeposits`, `grossClaimableRedeems` |
+| Polling | `pollLastTotalAssets`, `lastValuationTs`, `lastPollOkTs`, `pollFailures` |
+| Deployment | `referralCode`, `salt`, `deployCalldata`, `createdAtBlock`, `createdAtTs`, `updatedAtBlock`, `updatedAtTs` |
+
+Useful `asset` fields:
+
+```text
+id
+chainId
+address
+symbol
+name
+decimals
+canonicalId
+logoUri
+source
+priceUsd
+priceUpdatedAt
+```
+
+Useful `position` fields:
+
+```text
+chainId
+vault
+account
+pendingDepositAssets
+claimableDepositShares
+ownedShares
+pendingRedeemShares
+claimableRedeemAssets
+recoverableRedeemSiloShares
+depositedAssets
+withdrawnAssets
+costBasisAssets
+realizedPnlAssets
+firstDepositTs
+lastUpdatedBlock
+lastUpdatedTs
+```
+
+Useful request and activity tables:
+
+| Type | Useful fields |
+| --- | --- |
+| `pendingRequest` | `chainId`, `vault`, `side`, `requestId`, `account`, `amount`, `updatedAtBlock`, `updatedAtTs` |
+| `requestTx` | `chainId`, `vault`, `side`, `requestId`, `account`, `txHash`, `logIndex`, `amount`, `timestamp` |
+| `vaultSnapshot` | `chainId`, `vault`, `tier`, `ts`, `blockNumber`, `pricePerShareWad`, `ppsEffectiveWad`, `totalAssets`, `totalSupply` |
+| `activity` | `chainId`, `txHash`, `logIndex`, `vault`, `kind`, `category`, `account`, `amount`, `extra`, `blockNumber`, `timestamp` |
+
+Example discovery query:
+
+```graphql
+{
+  vaults(limit: 100) {
+    items {
+      chainId
+      address
+      asset
+      name
+      symbol
+      shareName
+      shareSymbol
+      owner
+      curator
+      protocol
+      oracle
+      version
+      vaultOpen
+      totalAssets
+      totalSupply
+      totalNetAssets
+      totalNetSupply
+      pricePerShareWad
+      grossTvl
+      grossManagedAssets
+      grossPendingDeposits
+      grossClaimableRedeems
+      createdAtBlock
+      createdAtTs
+      updatedAtBlock
+      updatedAtTs
+    }
+  }
+}
+```
+
+As of the initial research, the app-indexed live vaults were on Arbitrum
+(`chainId = 42161`) and shared protocol address
+`0x0000000000cc53b5fd649b80f08b05405779cc71`.
+
+Example vaults seen in the API:
+
+| Vault | Notes |
+| --- | --- |
+| `0x394c4db21b6b429848e123272f206f1f9d8d74b0` | Arbitrum USDC test vault with non-zero accounting and pending deposits during research |
+| `0x98e43a491a464f0886bc5e57207c340bbed0d01f` | Arbitrum USDC vault observed in earlier app data |
+
+## ABI files and sources
+
+No verified Solidity source or canonical JSON ABI was found on public block
+explorers during the initial research. Sourcify and Routescan did not expose a
+usable verified implementation ABI for the sampled vault and protocol contracts.
+The public T3tris GitHub repositories also did not contain Solidity source or
+JSON ABI artefacts for the deployed vault protocol.
+
+Local ABI files:
+
+| File | Source | Notes |
+| --- | --- | --- |
+| `eth_defi/abi/t3tris/IVault.json` | `IVaultAbi` exported by the live app chunk `https://app.t3tris.finance/_next/static/chunks/13etv-4ylf72t.js` | Best current source found for deployed vault ABI. The chunk filename is content-hashed and may change, so re-check the current app bundle before committing an ABI update. |
+| `eth_defi/abi/t3tris/Multicall.json` | Separate `multicall(bytes[])` fragment used by the same app chunk against vault addresses | The frontend keeps this as a small local ABI fragment instead of including it in `IVaultAbi`. |
+
+Other T3tris contract ABIs were not saved yet:
+
+| ABI | Reason |
+| --- | --- |
+| `IT3tris.json` | Not present as a frontend ABI export in the researched app bundle. Needed only for factory discovery/deployment features. For scanner support, vault-level GraphQL discovery may be enough. |
+| `ISafeOracle.json` | Not present as a frontend ABI export in the researched app bundle. Needed only if we read oracle state directly. |
+| `ISilo.json` | Not present as a frontend ABI export in the researched app bundle. Needed only if we inspect silo internals. |
+
+ABI source priority:
+
+1. Live app bundle ABI, because it matches the frontend currently used against
+   deployed vaults.
+2. Published interface docs in
+   [mdoc-t3tris](https://github.com/t3tris-finance/mdoc-t3tris), because T3tris
+   explicitly publishes interfaces rather than verified Solidity.
+3. Block explorer ABI if T3tris later verifies implementation contracts.
+
+Known doc drift:
+
+- The Markdown docs list `requestDeposit(uint256 assets, address receiver, bytes
+  permit2Data)`, but the live app ABI uses `requestDeposit(address receiver,
+  bool unsafe, uint256 assets, bytes permit2Data)`.
+- The Markdown docs list `requestRedeem(uint256 shares, address receiver,
+  address owner, address previousClaimReceiver)`, but the live app ABI uses
+  `requestRedeem(address receiver, address owner, address previousClaimReceiver,
+  bool unsafe, uint256 shares)`.
+- The Markdown docs list `getPerfFee()`, but the live app ABI exposes
+  `getPerformanceFee()`.
+- Some getter argument order in the Markdown docs is stale. The live app ABI has
+  `getRequestDepositAmount(address owner, uint256 requestId)` and
+  `getRequestRedeemAmount(address owner, uint256 requestId)`.
+
+Because of this drift, do not generate integration code directly from the
+Markdown signatures without comparing them to the current live app ABI.
+
+## Integration notes for eth_defi
+
+Initial scanner support can start with:
+
+1. Discover vaults from GraphQL `vaults`.
+2. Confirm each vault onchain with `asset()`, `totalAssets()`, `totalSupply()`,
+   `getProtocol()` and, if needed, `version()`.
+3. Classify T3tris vaults by `getProtocol()` returning the known T3tris protocol
+   address or by the presence of uniquely T3tris getters such as
+   `getGrossTVL()` and `getCurrentDepositRequestId()`.
+4. Use onchain values for final TVL/accounting and GraphQL values as metadata
+   or sanity checks.
+
+Trading support needs a protocol-specific async deposit and redeem manager:
+
+| Flow step | T3tris call |
+| --- | --- |
+| Request deposit | `requestDeposit(receiver, unsafe, assets, permit2Data)` |
+| Check pending deposit | `getRequestDepositAmount(owner, requestId)` |
+| Check claimable deposit | `hasClaimableDeposit(owner)` or `previewClaimDeposit(owner)` |
+| Claim deposit | `claimDeposit(receiver)` |
+| Request redeem | `requestRedeem(receiver, owner, previousClaimReceiver, unsafe, shares)` |
+| Check pending redeem | `getRequestRedeemAmount(owner, requestId)` |
+| Check claimable redeem | `hasClaimableRedeem(owner)` or `previewClaimRedeem(owner)` |
+| Claim redeem | `claimRedeem(owner, receiver, unsafe)` |
+
+Guard and transaction whitelisting must use the T3tris selectors above. Existing
+ERC-7540 whitelists for standard `requestDeposit(uint256,address,address)` or
+`requestRedeem(uint256,address,address)` will not cover T3tris.
+
+## Reference links
+
+- T3tris homepage: https://t3tris.finance/
+- T3tris vault app: https://app.t3tris.finance/vaults
+- T3tris GraphQL endpoint: https://api.t3tris.finance/graphql
+- T3tris docs repository: https://github.com/t3tris-finance/mdoc-t3tris
+- Introduction: https://raw.githubusercontent.com/t3tris-finance/mdoc-t3tris/main/docs/en/01-introduction.md
+- Architecture: https://raw.githubusercontent.com/t3tris-finance/mdoc-t3tris/main/docs/en/04-developers/01-architecture.md
+- Vault interface: https://raw.githubusercontent.com/t3tris-finance/mdoc-t3tris/main/docs/en/04-developers/02-vault-interface.md
+- Vault getters: https://raw.githubusercontent.com/t3tris-finance/mdoc-t3tris/main/docs/en/04-developers/03-vault-getters.md
+- Protocol factory: https://raw.githubusercontent.com/t3tris-finance/mdoc-t3tris/main/docs/en/04-developers/05-protocol-factory.md
+- Events reference: https://raw.githubusercontent.com/t3tris-finance/mdoc-t3tris/main/docs/en/04-developers/08-events-reference.md
+- Integration guide: https://raw.githubusercontent.com/t3tris-finance/mdoc-t3tris/main/docs/en/04-developers/10-integration-guide.md
+- ERC-7540: https://eips.ethereum.org/EIPS/eip-7540

--- a/eth_defi/vault_protocols/t3tris/__init__.py
+++ b/eth_defi/vault_protocols/t3tris/__init__.py
@@ -1,0 +1,1 @@
+"""T3tris vault protocol integration notes."""


### PR DESCRIPTION
## Why

Document the initial T3tris vault protocol research so future ERC-7540-style integration work has protocol notes, ABI provenance, and offchain metadata discovery in the repository.

## Lessons learnt

T3tris follows an ERC-7540-like asynchronous vault lifecycle, but the live vault ABI differs from final ERC-7540 method signatures and needs a protocol-specific adapter.

The vault page description and curator metadata are served by the T3tris REST page endpoint, while GraphQL is better suited for indexed onchain state and discovery. For the researched example vault, `ipfsHash` is empty even though the REST page endpoint returns Markdown metadata.

## Summary

- Added T3tris vault protocol research notes under `eth_defi/vault_protocols/t3tris`.
- Saved the T3tris live app vault ABI and multicall fragment under `eth_defi/abi/t3tris` with source notes.
- Documented ERC-7540 compatibility differences, GraphQL fields, REST page metadata endpoints, and integration considerations.
- Validated ABI JSON parsing and ran Ruff format/check on the new Python package stubs.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.