### PR TITLE
fix: blacklist broken HyperEVM HFY vault

### DIFF
--- a/eth_defi/vault/risk.py
+++ b/eth_defi/vault/risk.py
@@ -344,6 +344,7 @@ _BROKEN_VAULT_CONTRACTS = {
     "0x6949bcab16c0B389095C5b744f6FBF9741A1b3b6",  # Test vault on Monad
     "0x5a8aFb250525aB8Fa85EF9a5f260Eb11B77a409a",  # Age old mainnet contract from 2017 (block 4,655,173) - burns all forwarded gas before reverting, poisoning the multicall probe batch with out-of-gas (-32003)
     "0x162428775A4C6c513FF8722B91D1aF45a9Caff41",  # Unverified old mainnet EtherDelta-style DEX from 2018 (block 4,934,650) - deposit/trade/withdraw methods, not a vault
+    "0xd3F41DAC84594332E4fF3C7fd2242DeAF7857e79",  # HYPE Funding Yield (HFY) HyperEVM USDt0 vault - totalAssets() and convertToAssets() hit HyperCore SpotBalance precompile revert at block 39,542,844, poisoning Multicall3 scanner batches with out-of-gas (-32003)
 }
 
 #: Cause excessive gas fees, RPC havoc.


### PR DESCRIPTION
## Why

The HyperEVM vault scanner can fail when probing HYPE Funding Yield (HFY), because historical ERC-4626-style calls against this contract poison Multicall3 batches with provider out-of-gas errors.

## Lessons learnt

Manual onchain probing showed that `maxDeposit()` itself is not the failing selector for the visible log addresses. The reproducible failure is on `totalAssets()` and `convertToAssets()` for the HFY vault at block 39,542,844, where the contract hits a HyperCore SpotBalance precompile revert.

## Summary

- Added the HFY HyperEVM USDt0 vault address to the broken vault contract blacklist.
- Documented the vault name, symbol, failing methods, block number, and scanner failure mode in the inline blacklist comment.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.
