### PR TITLE
Update JLTXX short description

### DIFF
--- a/eth_defi/oda_fact/vault.py
+++ b/eth_defi/oda_fact/vault.py
@@ -64,6 +64,9 @@ class OdaFactVaultInfo(VaultInfo, total=False):
 #: Human-readable JLTXX product name.
 JLTXX_PRODUCT_NAME = "JPMorgan OnChain Liquidity-Token Money Market Fund"
 
+#: JLTXX fact sheet short product description.
+JLTXX_SHORT_DESCRIPTION = "Vaulted strategy investing in U.S. Treasury bills, bonds and overnight repurchase agreements"
+
 #: JLTXX issuer/platform display name.
 JLTXX_MANAGER_NAME = "J.P. Morgan Kinexys"
 
@@ -218,7 +221,7 @@ class OdaFactVault(VaultBase):
     def short_description(self) -> str | None:
         """Short product description."""
 
-        return "Tokenised JPMorgan money market fund tracked through ODA-FACT ERC-20 supply."
+        return JLTXX_SHORT_DESCRIPTION
 
     @property
     def manager_name(self) -> str | None:

--- a/tests/oda_fact/test_oda_fact_vault.py
+++ b/tests/oda_fact/test_oda_fact_vault.py
@@ -198,6 +198,7 @@ def test_oda_fact_scan_record_live_jltxx(web3: Web3) -> None:
     assert record["_manager_name"] == "J.P. Morgan Kinexys"
     assert record["_deposit_closed_reason"] == KINEXYS_WHITELISTED_FLOW_REASON
     assert record["_redemption_closed_reason"] == KINEXYS_WHITELISTED_FLOW_REASON
+    assert record["_short_description"] == "Vaulted strategy investing in U.S. Treasury bills, bonds and overnight repurchase agreements"
     assert "**Curator:** J.P. Morgan" in record["_notes"]
     assert "JLTXX fact sheet" in record["_notes"]
     assert record["_nav_source"] == "estimated_jltxx_usd_1"


### PR DESCRIPTION
## Why

JLTXX should use a concise vault short description based on the strategy described in the J.P. Morgan fact sheet, instead of the implementation-focused ODA-FACT supply tracking wording.

## Lessons learnt

The JLTXX fact sheet describes permissible investments as U.S. Treasury bills, bonds, notes and overnight repurchase agreements, which is a better user-facing summary than the contract integration detail.

## Summary

- Added a dedicated JLTXX short description constant.
- Exported the new short description through the ODA-FACT vault adapter.
- Pinned the scan-record short description in the JLTXX regression test.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.