### PR TITLE
fix: classify Ember Y10K vault

### DIFF
--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -2100,6 +2100,9 @@ HARDCODED_PROTOCOLS = {
     # Ember Protocol - Ember Apollo ACRED (eACRED) on Ethereum
     # https://etherscan.io/address/0x2b13311fd553e74b421d4ccc96e348f71e179dcf
     "0x2b13311fd553e74b421d4ccc96e348f71e179dcf": {ERC4626Feature.ember_like},
+    # Ember Protocol - Ember Y10K (eY10K) on Ethereum
+    # https://etherscan.io/address/0x953972ea0C1703c58F09FB6fD2477Fdcf0FEe074
+    "0x953972ea0c1703c58f09fb6fd2477fdcf0fee074": {ERC4626Feature.ember_like},
     # Inverse Finance - sDOLA vault on Ethereum
     # https://etherscan.io/address/0xb45ad160634c528Cc3D2926d9807104FA3157305
     "0xb45ad160634c528cc3d2926d9807104fa3157305": {ERC4626Feature.inverse_finance_like},

--- a/tests/erc_4626/vault_protocol/test_ember_classification.py
+++ b/tests/erc_4626/vault_protocol/test_ember_classification.py
@@ -1,0 +1,22 @@
+"""Test Ember vault classification."""
+
+from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS
+from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name
+
+EMBER_Y10K_ADDRESS = "0x953972ea0c1703c58f09fb6fd2477fdcf0fee074"
+
+
+def test_ember_y10k_hardcoded_protocol() -> None:
+    """Ember Y10K resolves to the Ember protocol.
+
+    The website protocol export relies on ``HARDCODED_PROTOCOLS`` for Ember
+    vaults whose contract shape cannot be identified by generic probes alone.
+
+    :return:
+        None
+    """
+
+    features = HARDCODED_PROTOCOLS[EMBER_Y10K_ADDRESS]
+
+    assert features == {ERC4626Feature.ember_like}
+    assert get_vault_protocol_name(features) == "Ember"


### PR DESCRIPTION
## Why

Ember Y10K was shown as an unknown vault protocol on the website because its vault address was not included in the existing Ember hardcoded protocol classification table.

## Lessons learnt

Some Ember vaults need address-based classification even though Ember protocol support already exists. Curator mapping alone does not populate the exported vault protocol.

## Summary

- Added the Ember Y10K Ethereum vault address to `HARDCODED_PROTOCOLS` as `ERC4626Feature.ember_like`.
- Added a focused regression test asserting the address resolves to the Ember protocol name.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.