### PR TITLE
notes: clarify missing JLTXX profit data

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -115,6 +115,7 @@ ODA_FACT_JLTXX_NOTE = f"""JPMorgan OnChain Liquidity-Token Money Market Fund (JL
 - **Curator:** J.P. Morgan Asset Management / Kinexys.
 - **Vault strategy:** Registered government money market fund investing in U.S. Treasury securities and overnight repurchase agreements collateralised by U.S. Treasury securities and/or cash.
 - **Fee structure:** Token Class prospectus advertises 0.71% gross total annual fund operating expenses and 0.16% net total annual fund operating expenses after waivers through 2028-06-30. These are off-chain fund expenses, not ODA-FACT token contract methods.
+- Equity curve and profit information for this vault are missing because they are not publicly available and proprietary to J.P. Morgan.
 - **Fact sheet:** [JLTXX fact sheet]({JLTXX_FACT_SHEET_URL}).
 """
 

--- a/tests/oda_fact/test_oda_fact_vault.py
+++ b/tests/oda_fact/test_oda_fact_vault.py
@@ -110,6 +110,7 @@ def test_oda_fact_live_supply_nav_and_unsupported_actions(web3: Web3) -> None:
     assert vault.fetch_info()["nav_source"] == "estimated_jltxx_usd_1"
     assert vault.fetch_info()["nav_estimated"] is True
     assert "**Curator:** J.P. Morgan" in vault.get_notes()
+    assert "Equity curve and profit information for this vault are missing" in vault.get_notes()
     assert "JLTXX fact sheet" in vault.get_notes()
 
     with pytest.raises(NotImplementedError):
@@ -200,6 +201,7 @@ def test_oda_fact_scan_record_live_jltxx(web3: Web3) -> None:
     assert record["_redemption_closed_reason"] == KINEXYS_WHITELISTED_FLOW_REASON
     assert record["_short_description"] == "Vaulted strategy investing in U.S. Treasury bills, bonds and overnight repurchase agreements"
     assert "**Curator:** J.P. Morgan" in record["_notes"]
+    assert "Equity curve and profit information for this vault are missing" in record["_notes"]
     assert "JLTXX fact sheet" in record["_notes"]
     assert record["_nav_source"] == "estimated_jltxx_usd_1"
     assert record["_nav_estimated"] is True

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -33,6 +33,7 @@ def test_oda_fact_vault_note_is_not_bad_flag() -> None:
 
     assert note is not None
     assert "**Curator:** J.P. Morgan" in note
+    assert "Equity curve and profit information for this vault are missing" in note
     assert "JLTXX fact sheet" in note
     assert not is_flagged_vault(address)
 


### PR DESCRIPTION
## Why

JLTXX does not expose public on-chain equity curve or profit data. The vault notes should say this explicitly so downstream users do not mistake the fixed estimated share price or supply tracking for public profit history.

## Lessons learnt

The Kinexys adapter can report supply and an estimated one-dollar NAV per share, but equity curve and profit information are proprietary to J.P. Morgan and not publicly available from the current integration surface.

## Summary

- Added an explicit JLTXX note bullet for missing equity curve and profit information.
- Pinned the note text in vault flag and ODA-FACT scan-record tests.

## Related issues and PRs

Continues the Kinexys JLTXX vault tracking work.

## Unrelated CI and test fixes

None.