### PR TITLE
Update T3tris protocol descriptions

### DIFF
--- a/eth_defi/data/vaults/metadata/t3tris.yaml
+++ b/eth_defi/data/vaults/metadata/t3tris.yaml
@@ -1,12 +1,12 @@
 name: T3tris
 slug: t3tris
 short_description: |
-  Permissionless async ERC-4626 vault infrastructure for asset managers.
+  Vault protocol built by curators for curators.
 long_description: |
-  T3tris helps asset managers deploy and operate asynchronous ERC-4626 vaults across EVM chains.
-  The protocol is designed for curators who need white-label vaults, async deposits and withdrawals,
-  and support for off-chain or cross-chain execution models such as CEX, RWA, OTC, options,
-  staking and epoch-based strategies.
+  T3tris is a vault protocol built by curators for curators. It helps professional asset managers
+  deploy and operate asynchronous ERC-4626 vaults across EVM chains, with support for white-label
+  vaults, async deposits and withdrawals, and off-chain or cross-chain execution models such as
+  CEX, RWA, OTC, options, staking and epoch-based strategies.
 
   T3tris states that it charges zero protocol fees to curators and instead earns on idle capital
   yield during async settlement windows. The public app lists T3tris vaults and exposes off-chain


### PR DESCRIPTION
## Why

Refresh the T3tris protocol page copy to use the requested curator-focused positioning.

## Lessons learnt

Protocol page descriptions are sourced from `eth_defi/data/vaults/metadata/*.yaml` and exported through the vault protocol metadata path.

## Summary

- Updated the T3tris short description to "Vault protocol built by curators for curators."
- Updated the T3tris long description to align with the same curator-focused positioning while keeping the existing async ERC-4626 protocol details.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.