### PR TITLE
fix: harden Lagoon deposit manager request gates

### DIFF
--- a/eth_defi/erc_4626/core.py
+++ b/eth_defi/erc_4626/core.py
@@ -732,17 +732,34 @@ def is_activity_filter_exempt(detection: "ERC4262VaultDetection") -> bool:
     )
 
 
+GENERIC_ERC4626_PROTOCOL_NAME = "ERC-4626"
+GENERIC_ERC4626_PROTOCOL_SLUG = "erc-4626"
+GENERIC_ERC4626_PROTOCOL_SLUG_ALIASES = frozenset(
+    {
+        GENERIC_ERC4626_PROTOCOL_SLUG,
+        "erc4626",
+    }
+)
+
+
+def is_generic_erc4626_protocol_slug(protocol_slug: str | None) -> bool:
+    """Is this protocol slug an explicit generic ERC-4626 marker."""
+    return protocol_slug in GENERIC_ERC4626_PROTOCOL_SLUG_ALIASES
+
+
 def get_vault_protocol_name(features: set[ERC4626Feature]) -> str:
     """Deduct vault protocol name based on Vault smart contract features.
 
-    At least one feature must match.
+    Empty features mean a generic synchronous ERC-4626 vault.
 
     See :py:func:`eth_defi.erc_4626.classification.identify_vault_features`.
 
     :param features:
         List of detected features for a vault
     """
-    if ERC4626Feature.broken in features:
+    if not features:
+        return GENERIC_ERC4626_PROTOCOL_NAME
+    elif ERC4626Feature.broken in features:
         return "<not ERC-4626>"
     elif ERC4626Feature.mellow_like in features:
         return "Mellow"

--- a/eth_defi/erc_4626/deposit_redeem.py
+++ b/eth_defi/erc_4626/deposit_redeem.py
@@ -120,6 +120,9 @@ class ERC4626DepositManager(VaultDepositManager):
         """Synchronous redemptions can be finished immediately."""
         return True
 
+    def can_create_deposit_request(self, owner: HexAddress) -> bool:
+        return True
+
     def can_create_redemption_request(self, owner: HexAddress) -> bool:
         return True
 

--- a/eth_defi/erc_4626/vault_protocol/lagoon/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/deposit_redeem.py
@@ -485,10 +485,10 @@ class ERC7540DepositManager(VaultDepositManager):
         return AsyncVaultRequestStatus.none
 
     def can_create_deposit_request(self, owner: HexAddress) -> bool:
-        return True
+        return not self.vault.vault_contract.functions.paused().call()
 
     def can_create_redemption_request(self, owner: HexAddress) -> bool:
-        return True
+        return not self.vault.vault_contract.functions.paused().call()
 
     def has_synchronous_deposit(self) -> bool:
         """Does this vault support synchronous deposits?

--- a/eth_defi/erc_4626/vault_protocol/lagoon/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/deposit_redeem.py
@@ -13,9 +13,12 @@ from hexbytes import HexBytes
 from web3 import Web3
 from web3._utils.events import EventLogErrorFlags
 from web3.contract.contract import ContractFunction
+from web3.exceptions import BadFunctionCallOutput
 
 from eth_defi.abi import ZERO_ADDRESS_STR, get_topic_signature_from_event
-from eth_defi.event_reader.conversion import convert_bytes32_to_address, convert_bytes32_to_uint
+from eth_defi.event_reader.conversion import BadAddressError, convert_bytes32_to_address, convert_bytes32_to_uint, convert_int256_bytes_to_int
+from eth_defi.event_reader.multicall_batcher import EncodedCall
+from eth_defi.middleware import ProbablyNodeHasNoBlock
 from eth_defi.timestamp import get_block_timestamp
 from eth_defi.vault.flow_events import (
     PendingVaultFlow,
@@ -485,10 +488,30 @@ class ERC7540DepositManager(VaultDepositManager):
         return AsyncVaultRequestStatus.none
 
     def can_create_deposit_request(self, owner: HexAddress) -> bool:
-        return not self.vault.vault_contract.functions.paused().call()
+        return not self._is_vault_paused()
 
     def can_create_redemption_request(self, owner: HexAddress) -> bool:
-        return not self.vault.vault_contract.functions.paused().call()
+        return not self._is_vault_paused()
+
+    def _is_vault_paused(self) -> bool:
+        """Read Lagoon's optional paused() flag defensively."""
+        paused_call = EncodedCall.from_keccak_signature(
+            address=self.vault.vault_address,
+            signature=Web3.keccak(text="paused()")[0:4],
+            function="paused",
+            data=b"",
+            extra_data=None,
+        )
+        try:
+            result = paused_call.call(
+                self.vault.web3,
+                block_identifier="latest",
+                silent_error=True,
+                ignore_error=True,
+            )
+            return convert_int256_bytes_to_int(result) != 0
+        except (ValueError, BadFunctionCallOutput, BadAddressError, ProbablyNodeHasNoBlock):
+            return False
 
     def has_synchronous_deposit(self) -> bool:
         """Does this vault support synchronous deposits?


### PR DESCRIPTION
## Why

Trade-executor live vault pricing now gates async vault deposit and redemption requests through eth-defi `DepositManager` abstractions. Lagoon vaults need this abstraction to report request windows from on-chain paused state, and generic synchronous ERC-4626 vaults need an explicit protocol slug so empty feature metadata is not confused with unknown metadata.

## Lessons learnt

A raw `paused().call()` works for the happy path, but the production probe needs to tolerate optional selectors and transient read failures in the same style as other vault status checks. Empty ERC-4626 feature metadata also needs a named generic protocol marker so downstream code can distinguish known synchronous vaults from unclassified vaults.

## Summary

- Added generic ERC-4626 protocol name and slug helpers.
- Made the base ERC-4626 deposit manager explicitly allow synchronous deposit requests.
- Added Lagoon deposit and redemption request gating through a defensive paused-state probe.

## Related issues and PRs

- Supports tradingstrategy-ai/trade-executor#1556.

## Unrelated CI and test fixes

None.
