### PR TITLE
fix: export no denomination token for Kinexys vaults

### DIFF
--- a/eth_defi/feed/stablecoin_rate.py
+++ b/eth_defi/feed/stablecoin_rate.py
@@ -97,6 +97,7 @@ MIN_PLAUSIBLE_STABLECOIN_RATE = 0.01
 MAX_SOURCE_CURRENCY_RATE_AGE_DAYS = 7
 NATIVE_RATE_CROSS_CHECK_RELATIVE_TOLERANCE = 0.02
 STABLECOIN_RATE_SOURCE_COINGECKO = "coingecko"
+STABLECOIN_RATE_SOURCE_FIXED = "fixed"
 
 _RATE_FIELDS = (
     "source_currency",
@@ -328,6 +329,44 @@ class DenominationTokenRate:
 class StablecoinRateFeeder:
     """Cached stablecoin rate/depeg lookup helper for vault metrics."""
 
+    @staticmethod
+    def _get_fixed_usd_rate(address: HexAddress | str | None, symbol: str | None) -> DenominationTokenRate | None:
+        """Return fixed fiat USD rate metadata for synthetic USD denominations.
+
+        Some scan-only integrations, such as ODA-FACT tokenised funds, report
+        accounting values in USD without exposing an ERC-20 denomination token.
+        These rows have no token address, but their USD conversion rate is
+        still known exactly.
+
+        :param symbol:
+            Denomination symbol.
+
+        :param address:
+            Denomination token address. Must be ``None`` for synthetic USD.
+
+        :return:
+            Fixed USD rate section, or ``None`` for non-USD symbols.
+        """
+        if address:
+            return None
+        if normalise_token_symbol(symbol) != "USD":
+            return None
+
+        return DenominationTokenRate(
+            coingecko_id=None,
+            source_currency="usd",
+            usd_rate=1.0,
+            usd_rate_fetched_at=None,
+            usd_rate_source=STABLECOIN_RATE_SOURCE_FIXED,
+            native_rate=None,
+            native_rate_currency=None,
+            native_rate_fetched_at=None,
+            native_rate_source=None,
+            source_currency_usd_rate=1.0,
+            source_currency_usd_rate_fetched_at=None,
+            source_currency_usd_rate_source=STABLECOIN_RATE_SOURCE_FIXED,
+        )
+
     data_dir: Path = STABLECOINS_DATA_DIR
     _depegged_contracts: set[tuple[int, str]] | None = field(default=None, init=False, repr=False)
     _depegged_symbols: set[str] | None = field(default=None, init=False, repr=False)
@@ -341,6 +380,10 @@ class StablecoinRateFeeder:
         symbol: str | None,
     ) -> DenominationTokenRate:
         """Resolve a vault denomination token to exported rate metadata."""
+        fixed_usd_rate = self._get_fixed_usd_rate(address, symbol)
+        if fixed_usd_rate is not None:
+            return fixed_usd_rate
+
         if self._rate_contracts is None or self._rate_symbols is None:
             self._rate_contracts, self._rate_symbols = build_stablecoin_rate_lookups(self.data_dir)
 

--- a/eth_defi/oda_fact/vault.py
+++ b/eth_defi/oda_fact/vault.py
@@ -124,6 +124,21 @@ ODA_FACT_FEES_BY_ADDRESS = {
     ODA_FACT_JLTXX_ADDRESS: JLTXX_FEE_DATA,
 }
 
+#: Synthetic accounting denomination exported for ODA-FACT instruments.
+#:
+#: This is intentionally not an ERC-20 token. The ``address`` and ``decimals``
+#: fields stay ``None`` so downstream consumers do not attempt raw token amount
+#: conversions or on-chain transfers.
+ODA_FACT_USD_DENOMINATION = {
+    "address": None,
+    "chain": None,
+    "name": "United States Dollar",
+    "symbol": "USD",
+    "decimals": None,
+    "total_supply": None,
+    "extra_data": {"synthetic": True},
+}
+
 
 class OdaFactVault(VaultBase):
     """Scan-only adapter for ODA-FACT tokenised fund contracts.
@@ -356,6 +371,8 @@ class OdaFactVault(VaultBase):
         """
 
         return {
+            "Denomination": "USD",
+            "_denomination_token": dict(ODA_FACT_USD_DENOMINATION, chain=self.chain_id),
             "_notes": self.get_notes(),
             "_deposit_closed_reason": self.fetch_deposit_closed_reason(),
             "_redemption_closed_reason": self.fetch_redemption_closed_reason(),

--- a/eth_defi/oda_fact/vault.py
+++ b/eth_defi/oda_fact/vault.py
@@ -27,10 +27,10 @@ from decimal import Decimal
 from eth_typing import BlockIdentifier, HexAddress
 from web3 import Web3
 
-from eth_defi.erc_4626.classification import ODA_FACT_JLTXX_ADDRESS, ODA_FACT_JLTXX_CHAIN_ID
+from eth_defi.erc_4626.classification import ODA_FACT_JLTXX_ADDRESS
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.oda_fact.historical import OdaFactVaultHistoricalReader
-from eth_defi.token import USDC_NATIVE_TOKEN, TokenDetails, fetch_erc20_details
+from eth_defi.token import TokenDetails, fetch_erc20_details
 from eth_defi.types import Percent
 from eth_defi.vault.base import TradingUniverse, VaultBase, VaultDepositManager, VaultFlowManager, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
 from eth_defi.vault.fee import BROKEN_FEE_DATA, FeeData, VaultFeeMode
@@ -48,10 +48,10 @@ class OdaFactVaultInfo(VaultInfo, total=False):
     #: Chain id.
     chain_id: int
 
-    #: Read-only denomination token surrogate used by current pipeline.
+    #: ODA-FACT instruments do not expose an ERC-20 denomination token.
     denomination_token: HexAddress | None
 
-    #: Whether denomination token is a surrogate for USD fund accounting.
+    #: Whether NAV is a USD estimate without an ERC-20 denomination token.
     synthetic_usd_denomination: bool
 
     #: NAV source label.
@@ -258,39 +258,28 @@ class OdaFactVault(VaultBase):
         )
 
     def fetch_denomination_token_address(self) -> HexAddress | None:
-        """Return the read-only denomination token surrogate.
+        """Return the ERC-20 denomination token address.
 
         ODA-FACT fund accounting is USD-denominated but does not expose an
-        ERC-4626 ``asset()`` token. The current pipeline expects a concrete
-        ERC-20 denomination token for cache warmup, so Ethereum USDC is used as
-        a display/aggregation surrogate for the initial implementation.
+        ERC-4626 ``asset()`` token or any other ERC-20 denomination token.
+        Exporting a surrogate token would make the vault appear to accept or
+        redeem that asset, so this adapter reports no denomination token.
 
         :return:
-            Ethereum USDC for the supported JLTXX contract.
+            Always ``None``.
         """
 
-        if self.chain_id == ODA_FACT_JLTXX_CHAIN_ID and self.address.lower() == ODA_FACT_JLTXX_ADDRESS:
-            return HexAddress(Web3.to_checksum_address(USDC_NATIVE_TOKEN[ODA_FACT_JLTXX_CHAIN_ID]))
         return None
 
     def fetch_denomination_token(self) -> TokenDetails | None:
-        """Fetch read-only denomination token metadata.
+        """Fetch ERC-20 denomination token metadata.
 
         :return:
-            Token details for the configured denomination surrogate.
+            Always ``None`` because ODA-FACT instruments do not expose a
+            denomination token.
         """
 
-        token_address = self.fetch_denomination_token_address()
-        if token_address is None:
-            return None
-        return fetch_erc20_details(
-            self.web3,
-            token_address,
-            chain_id=self.chain_id,
-            raise_on_error=False,
-            cache=self.token_cache,
-            cause_diagnostics_message=f"ODA-FACT denomination surrogate for vault {self.address}",
-        )
+        return None
 
     def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
         """Fetch ODA-FACT share price estimate.

--- a/eth_defi/stablecoin_metadata.py
+++ b/eth_defi/stablecoin_metadata.py
@@ -308,6 +308,7 @@ STABLECOIN_LIKE = set(
         "TRYB",
         "TUSD",
         "USC",
+        "USD",
         "USD+",
         "USD0",
         "USD1",

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -2028,16 +2028,8 @@ def main():
     skip_data = os.environ.get("SKIP_DATA", "false").lower() == "true"
     skip_samples = os.environ.get("SKIP_SAMPLES", "false").lower() == "true"
     scan_vault_settlements = os.environ.get("SCAN_VAULT_SETTLEMENTS", "false").lower() == "true"
-    settlement_start_block = (
-        int(os.environ["VAULT_SETTLEMENT_START_BLOCK"])
-        if os.environ.get("VAULT_SETTLEMENT_START_BLOCK")
-        else None
-    )
-    settlement_end_block = (
-        int(os.environ["VAULT_SETTLEMENT_END_BLOCK"])
-        if os.environ.get("VAULT_SETTLEMENT_END_BLOCK")
-        else None
-    )
+    settlement_start_block = int(os.environ["VAULT_SETTLEMENT_START_BLOCK"]) if os.environ.get("VAULT_SETTLEMENT_START_BLOCK") else None
+    settlement_end_block = int(os.environ["VAULT_SETTLEMENT_END_BLOCK"]) if os.environ.get("VAULT_SETTLEMENT_END_BLOCK") else None
 
     # Fail-fast: refuse to start the scan loop if the top-vaults R2 upload
     # is not configured. Discovering at the end of a multi-hour scan that

--- a/eth_defi/vault/settlement_data.py
+++ b/eth_defi/vault/settlement_data.py
@@ -387,10 +387,7 @@ def annotate_prices_with_vault_settlements(
     settlements["timestamp"] = pd.to_datetime(settlements["timestamp"])
 
     for (chain_id, address), row_indexes in result.groupby(["chain", "address"]).groups.items():
-        vault_settlements = settlements[
-            (settlements["chain_id"] == chain_id)
-            & (settlements["address"] == address)
-        ].sort_values("timestamp")
+        vault_settlements = settlements[(settlements["chain_id"] == chain_id) & (settlements["address"] == address)].sort_values("timestamp")
         if vault_settlements.empty:
             continue
 

--- a/eth_defi/vault/settlement_scan.py
+++ b/eth_defi/vault/settlement_scan.py
@@ -264,10 +264,7 @@ def fetch_and_store_vault_settlements(
                 rows_written=0,
             )
 
-        rows_by_key = {
-            (int(row["_detection_data"].chain), str(row["_detection_data"].address).lower()): row
-            for row in vault_db.rows.values()
-        }
+        rows_by_key = {(int(row["_detection_data"].chain), str(row["_detection_data"].address).lower()): row for row in vault_db.rows.values()}
         web3_by_chain = {}
         token_cache = TokenDiskCache()
         rows_written = 0
@@ -275,9 +272,7 @@ def fetch_and_store_vault_settlements(
         for scan_range in ranges:
             rpc_url = rpc_urls_by_chain.get(scan_range.chain_id)
             if not rpc_url:
-                raise RuntimeError(
-                    f"No JSON-RPC URL configured for chain {scan_range.chain_id} needed by vault {scan_range.address}"
-                )
+                raise RuntimeError(f"No JSON-RPC URL configured for chain {scan_range.chain_id} needed by vault {scan_range.address}")
 
             web3 = web3_by_chain.get(scan_range.chain_id)
             if web3 is None:
@@ -325,16 +320,8 @@ def _count_supported_vaults_with_raw_prices(
     supported_features: set[ERC4626Feature] | frozenset[ERC4626Feature] = SUPPORTED_SETTLEMENT_FEATURES,
 ) -> int:
     """Count supported protocol metadata rows that also have raw price rows."""
-    raw_keys = {
-        (int(row["chain"]), str(row["address"]).lower())
-        for row in raw_prices_df[["chain", "address"]].drop_duplicates().to_dict("records")
-    }
-    return sum(
-        1
-        for row in vault_db.rows.values()
-        if _get_vault_features(row).intersection(supported_features)
-        and (int(row["_detection_data"].chain), str(row["_detection_data"].address).lower()) in raw_keys
-    )
+    raw_keys = {(int(row["chain"]), str(row["address"]).lower()) for row in raw_prices_df[["chain", "address"]].drop_duplicates().to_dict("records")}
+    return sum(1 for row in vault_db.rows.values() if _get_vault_features(row).intersection(supported_features) and (int(row["_detection_data"].chain), str(row["_detection_data"].address).lower()) in raw_keys)
 
 
 def _update_settlement_database_for_vault(

--- a/scripts/lagoon/analyse-vault-queues.py
+++ b/scripts/lagoon/analyse-vault-queues.py
@@ -653,11 +653,7 @@ def analyse_queue_events(
     deposit_queue_lots: deque[QueueLot] = deque()
     redemption_queue_lots: deque[QueueLot] = deque()
     pending_settlement_events: list[QueueEvent] = []
-    deposit_request_keys = {
-        (event.tx_hash, event.args.get("requestId"))
-        for event in events
-        if event.event_name == "DepositRequest"
-    }
+    deposit_request_keys = {(event.tx_hash, event.args.get("requestId")) for event in events if event.event_name == "DepositRequest"}
 
     def flush_settlement_group() -> None:
         nonlocal deposit_queue_raw
@@ -820,6 +816,7 @@ def calculate_weighted_wait_stats(
 
 def settlement_row_to_dict(row: SettlementRow, underlying_symbol: str) -> dict[str, str]:
     """Convert a settlement row for display or CSV."""
+
     def optional_decimal_to_str(value: Decimal | None) -> str:
         """Format optional decimal without treating zero as missing."""
         return "" if value is None else str(value)

--- a/tests/erc_4626/test_export_data_files.py
+++ b/tests/erc_4626/test_export_data_files.py
@@ -5,6 +5,28 @@ from pathlib import Path
 import pytest
 
 from eth_defi.vault import data_file_export
+from eth_defi.vault.settlement_data import VAULT_SETTLEMENT_DATABASE_FILENAME, VaultSettlementDatabase
+
+
+def write_export_test_file(path: Path) -> None:
+    """Create a valid export fixture file.
+
+    Most export files can be byte placeholders because upload tests mock the
+    R2 calls. The settlement database is checkpointed before export, so it must
+    be a valid DuckDB file instead of arbitrary bytes.
+
+    :param path:
+        File path to create.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.name == VAULT_SETTLEMENT_DATABASE_FILENAME:
+        db = VaultSettlementDatabase(path)
+        try:
+            db.save()
+        finally:
+            db.close()
+    else:
+        path.write_bytes(b"data")
 
 
 def test_core3_duckdb_is_in_data_file_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
@@ -106,8 +128,7 @@ def test_core3_duckdb_upload_gets_alternative_daily_backup(
     core3_path.parent.mkdir(parents=True)
 
     for path in data_file_export.get_data_file_paths(tmp_path, core3_db_path=core3_path):
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_bytes(b"data")
+        write_export_test_file(path)
 
     monkeypatch.setenv("PIPELINE_DATA_DIR", str(tmp_path))
     monkeypatch.setenv("CORE3_DATABASE_PATH", str(core3_path))
@@ -164,8 +185,7 @@ def test_exchange_rate_duckdb_upload_gets_alternative_daily_backup(
         core3_db_path=core3_path,
         exchange_rate_db_path=exchange_rate_path,
     ):
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_bytes(b"data")
+        write_export_test_file(path)
 
     monkeypatch.setenv("PIPELINE_DATA_DIR", str(tmp_path))
     monkeypatch.setenv("CORE3_DATABASE_PATH", str(core3_path))

--- a/tests/feed/test_stablecoin_rate.py
+++ b/tests/feed/test_stablecoin_rate.py
@@ -250,6 +250,36 @@ def test_refresh_stablecoin_rates_updates_usdc_happy_path(tmp_path: Path, monkey
     assert feeder.is_depegged_stablecoin_token(1, USDC_ADDRESS, "USDC") is False
 
 
+def test_get_denomination_token_rate_section_handles_fiat_usd_without_token_address(tmp_path: Path) -> None:
+    """Plain USD accounting denominations have a fixed 1:1 USD rate.
+
+    Some scan-only vault integrations have USD accounting but no ERC-20
+    denomination token address. These rows should still export an explicit
+    rate section for downstream metrics.
+    """
+    feeder = StablecoinRateFeeder(data_dir=tmp_path)
+
+    rate = feeder.get_denomination_token_rate_section(chain_id=1, address=None, symbol="USD")
+
+    assert rate.coingecko_id is None
+    assert rate.source_currency == "usd"
+    assert rate.usd_rate == pytest.approx(1.0)
+    assert rate.usd_rate_fetched_at is None
+    assert rate.usd_rate_source == "fixed"
+    assert rate.native_rate is None
+    assert rate.native_rate_currency is None
+    assert rate.native_rate_fetched_at is None
+    assert rate.native_rate_source is None
+    assert rate.source_currency_usd_rate == pytest.approx(1.0)
+    assert rate.source_currency_usd_rate_fetched_at is None
+    assert rate.source_currency_usd_rate_source == "fixed"
+    assert feeder.is_depegged_stablecoin_token(chain_id=1, address=None, symbol="USD") is False
+
+    erc20_rate = feeder.get_denomination_token_rate_section(chain_id=1, address="0x2222222222222222222222222222222222222222", symbol="USD")
+    assert erc20_rate.usd_rate is None
+    assert erc20_rate.usd_rate_source is None
+
+
 def test_refresh_stablecoin_rates_marks_usdx_depegged(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """USDX depeg refresh stamps ``depegged_at`` and blacklisting lookups."""
     _write_usdx_yaml(tmp_path)

--- a/tests/lagoon/test_lagoon_settlement.py
+++ b/tests/lagoon/test_lagoon_settlement.py
@@ -135,11 +135,7 @@ def test_lagoon_fetch_settlement_events_from_hypersync_live_1000_blocks() -> Non
         use_hypersync=True,
     )
 
-    matching_rows = [
-        row
-        for row in rows
-        if row.block_number == HUB_SETTLEMENT_BLOCK and row.tx_hash == HUB_SETTLEMENT_TX_HASH
-    ]
+    matching_rows = [row for row in rows if row.block_number == HUB_SETTLEMENT_BLOCK and row.tx_hash == HUB_SETTLEMENT_TX_HASH]
 
     assert {row.event_name for row in matching_rows} == {"SettleDeposit", "SettleRedeem"}
     assert all(row.address.lower() == HUB_CAPITAL_USDC_VAULT for row in matching_rows)

--- a/tests/oda_fact/test_oda_fact_vault.py
+++ b/tests/oda_fact/test_oda_fact_vault.py
@@ -106,6 +106,9 @@ def test_oda_fact_live_supply_nav_and_unsupported_actions(web3: Web3) -> None:
     assert vault.get_fee_data().deposit == 0
     assert vault.get_fee_data().withdraw == 0
     assert vault.fetch_info()["denomination_token"] is None
+    assert vault.fetch_scan_record_extra_data()["Denomination"] == "USD"
+    assert vault.fetch_scan_record_extra_data()["_denomination_token"]["symbol"] == "USD"
+    assert vault.fetch_scan_record_extra_data()["_denomination_token"]["address"] is None
     assert vault.fetch_info()["nav_source"] == "estimated_jltxx_usd_1"
     assert vault.fetch_info()["nav_estimated"] is True
     assert "**Curator:** J.P. Morgan" in vault.get_notes()
@@ -183,7 +186,7 @@ def test_oda_fact_scan_record_live_jltxx(web3: Web3) -> None:
     assert record["Symbol"] == "JLTXX"
     assert record["Name"] == "JPMorgan OnChain Liquidity-Token Money Market Fund"
     assert record["Protocol"] == "Kinexys"
-    assert record["Denomination"] is None
+    assert record["Denomination"] == "USD"
     assert record["Share token"] == "JLTXX"
     assert record["NAV"] == JLTXX_EXPECTED_TOTAL_SUPPLY
     assert record["Mgmt fee"] == JLTXX_EXPECTED_MANAGEMENT_FEE
@@ -193,7 +196,9 @@ def test_oda_fact_scan_record_live_jltxx(web3: Web3) -> None:
     assert record["Shares"] == JLTXX_EXPECTED_TOTAL_SUPPLY
     assert record["Features"] == "oda_fact_like"
     assert record["_detection_data"] == detection
-    assert record["_denomination_token"] is None
+    assert record["_denomination_token"]["symbol"] == "USD"
+    assert record["_denomination_token"]["address"] is None
+    assert record["_denomination_token"]["decimals"] is None
     assert record["_share_token"]["symbol"] == "JLTXX"
     assert record["_manager_name"] == "J.P. Morgan Kinexys"
     assert record["_deposit_closed_reason"] == KINEXYS_WHITELISTED_FLOW_REASON

--- a/tests/oda_fact/test_oda_fact_vault.py
+++ b/tests/oda_fact/test_oda_fact_vault.py
@@ -39,9 +39,6 @@ JLTXX_TEST_BLOCK = 25_452_271
 #: JLTXX has 2 decimals.
 JLTXX_EXPECTED_DECIMALS = 2
 
-#: Ethereum USDC has 6 decimals.
-USDC_EXPECTED_DECIMALS = 6
-
 #: Raw total supply for JLTXX at :py:data:`JLTXX_TEST_BLOCK`.
 JLTXX_EXPECTED_RAW_TOTAL_SUPPLY = 69_522_262_199
 
@@ -83,8 +80,9 @@ def test_oda_fact_autodetect_live_jltxx(web3: Web3) -> None:
     assert vault.share_token.name == "JPMorgan OnChain Liquidity-Token Money Market Fund"
     assert vault.share_token.symbol == "JLTXX"
     assert vault.share_token.decimals == JLTXX_EXPECTED_DECIMALS
-    assert vault.denomination_token.symbol == "USDC"
-    assert vault.denomination_token.decimals == USDC_EXPECTED_DECIMALS
+    assert vault.fetch_denomination_token_address() is None
+    assert vault.fetch_denomination_token() is None
+    assert vault.denomination_token is None
 
 
 @flaky.flaky
@@ -107,6 +105,7 @@ def test_oda_fact_live_supply_nav_and_unsupported_actions(web3: Web3) -> None:
     assert vault.get_fee_data().performance == JLTXX_EXPECTED_PERFORMANCE_FEE
     assert vault.get_fee_data().deposit == 0
     assert vault.get_fee_data().withdraw == 0
+    assert vault.fetch_info()["denomination_token"] is None
     assert vault.fetch_info()["nav_source"] == "estimated_jltxx_usd_1"
     assert vault.fetch_info()["nav_estimated"] is True
     assert "**Curator:** J.P. Morgan" in vault.get_notes()
@@ -184,7 +183,7 @@ def test_oda_fact_scan_record_live_jltxx(web3: Web3) -> None:
     assert record["Symbol"] == "JLTXX"
     assert record["Name"] == "JPMorgan OnChain Liquidity-Token Money Market Fund"
     assert record["Protocol"] == "Kinexys"
-    assert record["Denomination"] == "USDC"
+    assert record["Denomination"] is None
     assert record["Share token"] == "JLTXX"
     assert record["NAV"] == JLTXX_EXPECTED_TOTAL_SUPPLY
     assert record["Mgmt fee"] == JLTXX_EXPECTED_MANAGEMENT_FEE
@@ -194,7 +193,7 @@ def test_oda_fact_scan_record_live_jltxx(web3: Web3) -> None:
     assert record["Shares"] == JLTXX_EXPECTED_TOTAL_SUPPLY
     assert record["Features"] == "oda_fact_like"
     assert record["_detection_data"] == detection
-    assert record["_denomination_token"]["symbol"] == "USDC"
+    assert record["_denomination_token"] is None
     assert record["_share_token"]["symbol"] == "JLTXX"
     assert record["_manager_name"] == "J.P. Morgan Kinexys"
     assert record["_deposit_closed_reason"] == KINEXYS_WHITELISTED_FLOW_REASON

--- a/tests/research/test_vault_metrics_stablecoin_rate.py
+++ b/tests/research/test_vault_metrics_stablecoin_rate.py
@@ -170,7 +170,12 @@ checks:
     )
 
 
-def _calculate_bad_stablecoin_vault_metrics(data_dir: Path, token_symbol: str = "USDX", token_address: str = USDX_ADDRESS) -> pd.DataFrame:
+def _calculate_bad_stablecoin_vault_metrics(
+    data_dir: Path,
+    token_symbol: str = "USDX",
+    token_address: str | None = USDX_ADDRESS,
+    token_decimals: int | None = 6,
+) -> pd.DataFrame:
     """Calculate lifetime metrics for a vault that uses a bad stablecoin denomination."""
     chain_id = 1
     vault_id = f"{chain_id}-{VAULT_ADDRESS}"
@@ -209,7 +214,7 @@ def _calculate_bad_stablecoin_vault_metrics(data_dir: Path, token_symbol: str = 
         "Withdraw fee": 0.0,
         "Features": "",
         "_detection_data": detection,
-        "_denomination_token": {"address": token_address, "symbol": token_symbol, "decimals": 6},
+        "_denomination_token": {"address": token_address, "symbol": token_symbol, "decimals": token_decimals},
         "_share_token": {"address": VAULT_ADDRESS, "symbol": f"BAD{token_symbol.upper()}", "decimals": 18},
         "_fees": fee_data,
         "_flags": set(),
@@ -332,6 +337,58 @@ def test_calculate_lifetime_metrics_blacklists_depegged_stablecoin_denomination(
         expected_native_rate_currency=expected_native_rate_currency,
         expected_source_currency_usd_rate=expected_source_currency_usd_rate,
     )
+
+
+def test_calculate_lifetime_metrics_handles_usd_denomination_without_token_address(tmp_path: Path) -> None:
+    """USD-denominated scan-only vaults can omit ERC-20 denomination address.
+
+    Kinexys ODA-FACT instruments expose USD fund accounting but no on-chain
+    denomination token. Metrics must preserve the missing token address and
+    still export a fixed USD rate section.
+    """
+    metrics = _calculate_bad_stablecoin_vault_metrics(
+        tmp_path,
+        token_symbol="USD",
+        token_address=None,
+        token_decimals=None,
+    )
+
+    assert len(metrics) == 1
+    row = metrics.iloc[0]
+    assert row["risk"] != VaultTechnicalRisk.blacklisted
+    assert VaultFlag.depegged_denomination_token not in row["flags"]
+    assert row["denomination"] == "USD"
+    assert row["normalised_denomination"] == "USD"
+    assert row["denomination_slug"] == "usd"
+    assert row["denomination_token_address"] is None
+    assert row["denomination_decimals"] is None
+
+    denomination_token_rate = row["denomination_token_rate"]
+    assert denomination_token_rate.source_currency == "usd"
+    assert denomination_token_rate.usd_rate == pytest.approx(1.0)
+    assert denomination_token_rate.usd_rate_fetched_at is None
+    assert denomination_token_rate.usd_rate_source == "fixed"
+    assert denomination_token_rate.source_currency_usd_rate == pytest.approx(1.0)
+    assert denomination_token_rate.source_currency_usd_rate_fetched_at is None
+    assert denomination_token_rate.source_currency_usd_rate_source == "fixed"
+
+    exported = export_lifetime_row(row)
+    assert exported["denomination_token_address"] is None
+    assert exported["denomination_decimals"] is None
+    assert exported["denomination_token_rate"] == {
+        "coingecko_id": None,
+        "source_currency": "usd",
+        "usd_rate": 1.0,
+        "usd_rate_fetched_at": None,
+        "usd_rate_source": "fixed",
+        "native_rate": None,
+        "native_rate_currency": None,
+        "native_rate_fetched_at": None,
+        "native_rate_source": None,
+        "source_currency_usd_rate": 1.0,
+        "source_currency_usd_rate_fetched_at": None,
+        "source_currency_usd_rate_source": "fixed",
+    }
 
 
 @pytest.mark.live


### PR DESCRIPTION
## Why

Kinexys ODA-FACT instruments do not expose an ERC-20 denomination token. The JLTXX scan adapter was exporting Ethereum USDC as a surrogate, which made the vault page show a denomination token that does not actually exist for deposits or redemptions.

## Lessons learnt

Do not use display or accounting surrogates for denomination token exports. For ODA-FACT, the USD NAV estimate and the ERC-20 denomination-token address need to remain separate concepts: export the denomination symbol as `USD`, but keep the token address and decimals as `None`.

`calculate_lifetime_metrics()` can carry a null denomination token address as long as the symbol is present. The risks are downstream code indexing `_denomination_token["symbol"]`, report filters using stablecoin-like symbols, and rate exports losing the USD rate section. This PR keeps `_denomination_token` structured, treats `USD` as stablecoin-like for filtering, and gives address-less USD denominations a fixed 1.0 USD rate.

## Summary

- Return no ERC-20 denomination token from ODA-FACT on-chain token reads.
- Export Kinexys/JLTXX scan rows with `Denomination = "USD"` and `_denomination_token.address = None`.
- Add fixed USD rate handling for synthetic USD accounting denominations with no token address.
- Add regression coverage for Kinexys scan records and `calculate_lifetime_metrics()` with a null denomination token address.

## Related issues and PRs

- Continues the Kinexys JLTXX vault metadata work.

## Unrelated CI and test fixes

- Applied `ruff format` to five pre-existing files flagged by CI on the PR merge ref.
- Fixed data export tests to create a valid `vault-settlements.duckdb` fixture before the export code checkpoints it.