### PR TITLE
fix: enable vault settlement scans by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
       SCAN_GRVT: ${SCAN_GRVT:-false}
       SCAN_LIGHTER: ${SCAN_LIGHTER:-false}
       SCAN_HIBACHI: ${SCAN_HIBACHI:-false}
+      SCAN_VAULT_SETTLEMENTS: ${SCAN_VAULT_SETTLEMENTS:-true}
       LOG_LEVEL: ${LOG_LEVEL:-warning}
 
       # Export vault sparkline images to the frontend
@@ -231,6 +232,7 @@ services:
       SCAN_GRVT: ${SCAN_GRVT:-true}
       SCAN_LIGHTER: ${SCAN_LIGHTER:-true}
       SCAN_HIBACHI: ${SCAN_HIBACHI:-true}
+      SCAN_VAULT_SETTLEMENTS: ${SCAN_VAULT_SETTLEMENTS:-true}
 
       LOG_LEVEL: ${LOG_LEVEL:-warning}
       MAX_WORKERS: ${MAX_WORKERS:-50}

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -1587,7 +1587,7 @@ def run_scan_tick(
     feed_db_path: Path | None = None,
     currency_api_db_path: Path | None = None,
     settlement_db_path: Path | None = None,
-    scan_vault_settlements: bool = False,
+    scan_vault_settlements: bool = True,
     settlement_rpc_env_vars: list[str] | None = None,
     settlement_start_block: int | None = None,
     settlement_end_block: int | None = None,
@@ -2027,7 +2027,7 @@ def main():
     skip_metadata = os.environ.get("SKIP_METADATA", "false").lower() == "true"
     skip_data = os.environ.get("SKIP_DATA", "false").lower() == "true"
     skip_samples = os.environ.get("SKIP_SAMPLES", "false").lower() == "true"
-    scan_vault_settlements = os.environ.get("SCAN_VAULT_SETTLEMENTS", "false").lower() == "true"
+    scan_vault_settlements = os.environ.get("SCAN_VAULT_SETTLEMENTS", "true").lower() == "true"
     settlement_start_block = int(os.environ["VAULT_SETTLEMENT_START_BLOCK"]) if os.environ.get("VAULT_SETTLEMENT_START_BLOCK") else None
     settlement_end_block = int(os.environ["VAULT_SETTLEMENT_END_BLOCK"]) if os.environ.get("VAULT_SETTLEMENT_END_BLOCK") else None
 

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -110,6 +110,9 @@ poetry run python scripts/erc-4626/scan-vaults-all-chains.py
 | `SCAN_GRVT` | Optional. Enable GRVT native vault scanning. Default: false. |
 | `SCAN_LIGHTER` | Optional. Enable Lighter native pool scanning. Default: false. |
 | `SCAN_HIBACHI` | Optional. Enable Hibachi native vault scanning. Default: false. |
+| `SCAN_VAULT_SETTLEMENTS` | Optional. Scan Lagoon and D2 settlement events before price cleaning. Default: true. Set to `false` only for debugging runs where settlement markers are deliberately skipped. |
+| `VAULT_SETTLEMENT_START_BLOCK` | Optional. Inclusive settlement scan start block for forced backfills. Normally unset so scans continue incrementally from `vault-settlements.duckdb`. |
+| `VAULT_SETTLEMENT_END_BLOCK` | Optional. Inclusive settlement scan end block for forced backfills. Normally unset so scans continue up to the latest raw price block. |
 | `SKIP_CORE3` | Optional. Skip Core3 risk intelligence enrichment. Default: false. Core3 is default-on enrichment for the top-vaults JSON, unlike optional native vault sources that use opt-in `SCAN_*` flags. |
 | `CORE3_API_KEY` | Optional. Core3 API key. If missing, Core3 is disabled for the run with a warning. |
 | `CORE3_DATABASE_PATH` | Optional. Core3 DuckDB path. Default: `~/.tradingstrategy/vaults/core3/core3.duckdb`. |
@@ -446,6 +449,9 @@ poetry run python scripts/erc-4626/scan-vault-posts.py
 
 The vault scanner is packaged as a Docker image via `Dockerfile.vault-scanner`.
 The default entrypoint is `scan-vaults-all-chains.py`, which scans **all chains**.
+Vault settlement scanning is enabled by default in both the one-shot and looped
+Docker Compose services with `SCAN_VAULT_SETTLEMENTS=true`, so Lagoon and D2
+settlement markers are populated before cleaned price data is exported.
 
 To run a **single-chain** script or override the command, you must use `--entrypoint`
 because the Dockerfile sets `ENTRYPOINT` (not just `CMD`). Without `--entrypoint`,

--- a/scripts/erc-4626/scan-vaults-all-chains.py
+++ b/scripts/erc-4626/scan-vaults-all-chains.py
@@ -89,6 +89,9 @@ Environment variables:
     - SCAN_HYPERCORE: "true" to scan Hyperliquid native (Hypercore) vaults via REST API (default: "false")
     - SCAN_GRVT: "true" to scan GRVT native vaults via public endpoints (default: "false")
     - SCAN_LIGHTER: "true" to scan Lighter native pools via public endpoints (default: "false")
+    - SCAN_VAULT_SETTLEMENTS: "false" to skip Lagoon and D2 settlement event scanning before price cleaning (default: "true")
+    - VAULT_SETTLEMENT_START_BLOCK: Optional inclusive settlement scan start block for forced backfills.
+    - VAULT_SETTLEMENT_END_BLOCK: Optional inclusive settlement scan end block for forced backfills.
     - SKIP_CORE3: "true" to skip Core3 risk intelligence enrichment (default: "false").
       Core3 is default-on enrichment data for the top-vaults JSON, unlike optional native
       vault sources that use opt-in SCAN_* flags.


### PR DESCRIPTION
## Why

Live vault data did not yet have Lagoon and D2 settlement markers flowing because the all-chain scanner defaulted `SCAN_VAULT_SETTLEMENTS` off and Docker Compose did not expose the switch.

## Lessons learnt

The settlement scanner code and export path can be present while production still skips the event scan if the runtime default is not enabled explicitly.

## Summary

- Defaulted `SCAN_VAULT_SETTLEMENTS` to true in the all-chain scanner and direct scan tick helper.
- Added `SCAN_VAULT_SETTLEMENTS=true` defaults to both one-shot and looped Docker Compose vault scanner services.
- Documented the settlement scan switch and forced backfill block range variables in the vault scanner README and CLI help.

## Related issues and PRs

Continues #1215.

## Unrelated CI and test fixes

None.