### PR TITLE
notes: flag USDC to sUSDS depositor as subvault

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -539,6 +539,8 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0xf6e1443e3f70724cec8c0a779c7c35a8dcda928b": (VaultFlag.subvault, SUBVAULT),
     # Morpho Yearn OG USDC Compounder 2
     "0x0e297de4005883c757c9f09fdf7cf1363c20e626": (VaultFlag.subvault, SUBVAULT),
+    # USDC To sUSDS Depositor (Yearn on Ethereum)
+    "0xda2f1b3cba732d779cff56f0cf9d3bc8aea6cd8d": (VaultFlag.subvault, SUBVAULT),
     # Morpho Gauntlet USDT Prime Compounder
     "0x6d2981ff9b8d7edbb7604de7a65bac8694ac849f": (VaultFlag.subvault, SUBVAULT),
     # Hyperliquidity Trader (HLT) - irregular share price action due to epoch resets

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -62,6 +62,7 @@ def test_summer_fi_protocol_vaults_are_blacklisted() -> None:
         ("0xed9278c5188f37670b33ef3b00729e38260cd5d5", "Euler", VaultFlag.illiquid, "illiquid"),
         ("0xcbc9b61177444a793b85442d3a953b90f6170b7d", "Euler", VaultFlag.illiquid, "illiquid"),
         ("0xd0ee0cf300dfb598270cd7f4d0c6e0d8f6e13f29", "Altura", VaultFlag.controversial, "controversial"),
+        ("0xda2f1b3cba732d779cff56f0cf9d3bc8aea6cd8d", "Yearn", VaultFlag.subvault, "not intended"),
         ("0xc9f01b5c6048b064e6d925d1c2d7206d4feef8a3", "Yearn", VaultFlag.subvault, "not intended"),
         ("0xad755c6c31515aef8d2f830767d846774f7e9ea9", "Morpho", VaultFlag.malicious, "malicious"),
     ],


### PR DESCRIPTION
## Why

USDC To sUSDS Depositor should be treated as a subvault and not directly exposed to end users.

## Lessons learnt

The vault slug resolves to Ethereum address `0xda2f1b3cba732d779cff56f0cf9d3bc8aea6cd8d` in the top vault export.

## Summary

- Added the vault to `VAULT_FLAGS_AND_NOTES` with `VaultFlag.subvault`.
- Added coverage in the vault flag tests.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.