### PR TITLE
notes: flag Liquity WETH stability pool as illiquid

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -263,6 +263,8 @@ RESOLV_USDC_ILLIQUID = "Resolv USDC vault is illiquid"
 
 STEAKHOUSE_PRIME_AUSD_ILLIQUID = "Steakhouse Prime AUSD vault is illiquid"
 
+LIQUITY_V2_WETH_STABILITY_POOL_ILLIQUID = "Liquity V2 WETH Stability Pool vault is illiquid"
+
 
 #: Protocol-wide flags and notes.
 #:
@@ -582,6 +584,8 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0x3094b241aade60f91f1c82b0628a10d9501462f9": (VaultFlag.illiquid, MO_EARN_MAX_USDC_ILLIQUID),
     # Clearstar Yield USDC (Morpho on Ethereum)
     "0xfa17f7aadbfac2c5d3c8125555404c1ae17df853": (VaultFlag.illiquid, CLEARSTAR_YIELD_USDC_ILLIQUID),
+    # Liquity V2 WETH Stability Pool (Ethereum)
+    "0xc5e7d3f76a03006540f17668a0267c668ffb5b75": (VaultFlag.illiquid, LIQUITY_V2_WETH_STABILITY_POOL_ILLIQUID),
     # Steakhouse Prime AUSD (Morpho on Katana)
     "0x82c4c641ccc38719ae1f0fbd16a64808d838fdfd": (VaultFlag.illiquid, STEAKHOUSE_PRIME_AUSD_ILLIQUID),
     # Borrowable USDC Deposit, SiloId: 149 (Arbitrum)

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -59,6 +59,7 @@ def test_summer_fi_protocol_vaults_are_blacklisted() -> None:
         ("0x25b4dc5f96312c7083a58d80d8ecad6ecddbbdfb", "<unknown ERC-7540>", VaultFlag.unofficial, "test vault"),
         ("0x3094b241aade60f91f1c82b0628a10d9501462f9", "Morpho", VaultFlag.illiquid, "illiquid"),
         ("0xfa17f7aadbfac2c5d3c8125555404c1ae17df853", "Morpho", VaultFlag.illiquid, "illiquid"),
+        ("0xc5e7d3f76a03006540f17668a0267c668ffb5b75", "Liquity", VaultFlag.illiquid, "illiquid"),
         ("0x82c4c641ccc38719ae1f0fbd16a64808d838fdfd", "Morpho", VaultFlag.illiquid, "illiquid"),
         ("0xed9278c5188f37670b33ef3b00729e38260cd5d5", "Euler", VaultFlag.illiquid, "illiquid"),
         ("0xcbc9b61177444a793b85442d3a953b90f6170b7d", "Euler", VaultFlag.illiquid, "illiquid"),


### PR DESCRIPTION
## Why

Liquity V2 WETH Stability Pool should be manually flagged as illiquid so it is not presented to users without the appropriate warning.

## Lessons learnt

The requested `liquity-v2-weth-stability-pool-2` slug resolves to Ethereum address `0xc5e7d3f76a03006540f17668a0267c668ffb5b75` in the top vault export.

## Summary

- Added a Liquity V2 WETH Stability Pool illiquid note constant.
- Marked `0xc5e7d3f76a03006540f17668a0267c668ffb5b75` as `VaultFlag.illiquid`.
- Added vault flag test coverage for the address.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.