### PR TITLE
fix: update scan record test doubles for notes

### DIFF
--- a/tests/erc_4626/test_scan_features.py
+++ b/tests/erc_4626/test_scan_features.py
@@ -69,6 +69,11 @@ class _FakeVault:
         return "https://example.com/vault"
 
     @staticmethod
+    def get_notes() -> None:
+        """Return no vault notes."""
+        return None
+
+    @staticmethod
     def fetch_scan_record_extra_data() -> dict:
         """Return no protocol-specific scan fields."""
         return {}

--- a/tests/ipor/test_ipor_curators.py
+++ b/tests/ipor/test_ipor_curators.py
@@ -407,6 +407,11 @@ class _FakeIPORVault:
         return "https://app.ipor.io/fusion/ethereum/0xdf8a0d3c90462c4c9b5a8697c119fa67cb84a874"
 
     @staticmethod
+    def get_notes() -> None:
+        """Return no vault notes."""
+        return None
+
+    @staticmethod
     def fetch_scan_record_extra_data() -> dict[str, object]:
         """Return no protocol-specific scan columns."""
         return {}


### PR DESCRIPTION
## Why

The post-merge CI run for PR #1228 failed in two scan-record tests because their fake vault classes did not implement the current vault interface. `create_vault_scan_record()` now reads `get_notes()`, and the missing method sent the fake rows through the broken-vault fallback path.

## Lessons learnt

When the scan-record interface grows, unit-test doubles need to grow with it. Otherwise unrelated assertions can fail because the scanner emits an empty broken-vault row before reaching the behaviour under test.

## Summary

- Add `get_notes()` to the ERC-4626 scan-record fake vault.
- Add `get_notes()` to the IPOR scan-record fake vault.
- Confirm the two previously failing CI tests pass locally.

## Related issues and PRs

Follows up PR #1228 post-merge CI failure.

## Unrelated CI and test fixes

Fixes unrelated scan-record test-double failures exposed by the PR #1228 CI run.
