### PR TITLE
fix: add CHF source rates for Swiss franc stablecoins

### DIFF
--- a/eth_defi/data/stablecoins/jchf.yaml
+++ b/eth_defi/data/stablecoins/jchf.yaml
@@ -33,6 +33,12 @@ contract_addresses:
   - chain: ethereum
     address: '0x53dfEa0A8CC2A2A2e425E1C174Bc162999723ea0'
 slug: jchf
+source_currency: chf
+source_currency_source: manual
+source_currency_usd_rate: ''
+source_currency_usd_rate_date: ''
+source_currency_usd_rate_fetched_at: ''
+source_currency_usd_rate_source: ''
 depegged_at: '2026-06-26T12:13:31'
 coingecko_id: ''
 coingecko_link: ''

--- a/eth_defi/data/stablecoins/zchf.yaml
+++ b/eth_defi/data/stablecoins/zchf.yaml
@@ -30,9 +30,13 @@ links:
 contract_addresses:
   - chain: ethereum
     address: '0xB58E61C3098d85632Df34EecfB899A1Ed80921cB'
+  - chain: base
+    address: '0xD4dD9e2F021BB459D5A5f6c24C12fE09c5D45553'
+  - chain: gnosis
+    address: '0xD4dD9e2F021BB459D5A5f6c24C12fE09c5D45553'
 slug: zchf
-source_currency: ''
-source_currency_source: ''
+source_currency: chf
+source_currency_source: manual
 source_currency_usd_rate: ''
 source_currency_usd_rate_date: ''
 source_currency_usd_rate_fetched_at: ''
@@ -48,8 +52,8 @@ usd_rate_fetched_at: '2026-07-03T19:11:04'
 usd_rate_updated_at: '2026-07-03T19:10:47'
 peg_rate: ''
 peg_rate_currency: ''
-rate_fetch_failed_at: '2026-07-03T19:11:04'
-rate_fetch_failed_reason: missing_source_currency
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
 depegged_at: ''
 checks:
   twitter_last_post_at: '2026-03-01'

--- a/scripts/erc-4626/export-protocol-metadata.py
+++ b/scripts/erc-4626/export-protocol-metadata.py
@@ -22,6 +22,8 @@ Environment variables:
     - REFRESH_STABLECOIN_RATES: Refresh stablecoin rates before uploading the stablecoin JSON bundle (default: true)
     - FORCE_STABLECOIN_RATE_REFRESH: Bypass the per-entry same-day stablecoin rate gate (default: false)
     - STABLECOIN_RATE_TIMEOUT: CoinGecko timeout in seconds (default: 20)
+    - CURRENCY_API_DB_PATH / CURRENCY_API_DATABASE_PATH: DuckDB path for non-USD peg FX rates
+    - CURRENCY_API_SOURCE: Currency API source column for non-USD peg FX rates
     - COINGECKO_DEMO_API_KEY: Optional CoinGecko demo API key used by the rate module
 """
 
@@ -34,6 +36,7 @@ from strictyaml import YAMLError
 from tabulate import tabulate
 from tqdm_loggable.auto import tqdm
 
+from eth_defi.currency_api.constants import SOURCE_NAME
 from eth_defi.feed.stablecoin_rate import StablecoinRateRefreshSummary, refresh_stablecoin_rates
 from eth_defi.stablecoin_metadata import STABLECOINS_DATA_DIR, process_and_upload_stablecoin_metadata, upload_stablecoin_index
 from eth_defi.utils import setup_console_logging
@@ -94,6 +97,22 @@ def _env_float(name: str, *, default: float) -> float:
         return default
 
 
+def _env_path(*names: str) -> Path | None:
+    """Resolve a path from the first populated environment variable.
+
+    :param names:
+        Environment variable names to inspect in order.
+
+    :return:
+        Expanded path, or ``None`` when no value is configured.
+    """
+    for name in names:
+        raw_value = os.environ.get(name)
+        if raw_value and raw_value.strip():
+            return Path(raw_value).expanduser()
+    return None
+
+
 def refresh_stablecoin_rates_for_metadata_export() -> StablecoinRateRefreshSummary | None:
     """Refresh stablecoin rates before uploading stablecoin metadata.
 
@@ -112,12 +131,16 @@ def refresh_stablecoin_rates_for_metadata_export() -> StablecoinRateRefreshSumma
 
     timeout = _env_float("STABLECOIN_RATE_TIMEOUT", default=20.0)
     force = _env_flag("FORCE_STABLECOIN_RATE_REFRESH", default=False)
+    currency_db_path = _env_path("CURRENCY_API_DB_PATH", "CURRENCY_API_DATABASE_PATH")
+    currency_source = os.environ.get("CURRENCY_API_SOURCE", SOURCE_NAME)
     try:
         summary = refresh_stablecoin_rates(
             data_dir=STABLECOINS_DATA_DIR,
             force=force,
             timeout=timeout,
             progress_bar=True,
+            currency_db_path=currency_db_path,
+            currency_source=currency_source,
         )
     except _STABLECOIN_RATE_EXPORT_ERROR_TYPES as e:
         logger.warning("Stablecoin rate refresh failed before metadata export, continuing with existing metadata: %s", e)

--- a/tests/erc_4626/test_export_protocol_metadata.py
+++ b/tests/erc_4626/test_export_protocol_metadata.py
@@ -41,6 +41,8 @@ def test_stablecoin_rate_refresh_runs_before_metadata_export(
     monkeypatch.setenv("REFRESH_STABLECOIN_RATES", "true")
     monkeypatch.setenv("FORCE_STABLECOIN_RATE_REFRESH", "true")
     monkeypatch.setenv("STABLECOIN_RATE_TIMEOUT", str(STABLECOIN_RATE_TIMEOUT))
+    monkeypatch.setenv("CURRENCY_API_DB_PATH", str(tmp_path / "exchange-rates.duckdb"))
+    monkeypatch.setenv("CURRENCY_API_SOURCE", "test-source")
     monkeypatch.chdir(tmp_path)
 
     summary = module.refresh_stablecoin_rates_for_metadata_export()
@@ -52,6 +54,8 @@ def test_stablecoin_rate_refresh_runs_before_metadata_export(
     assert calls[0]["force"] is True
     assert calls[0]["timeout"] == STABLECOIN_RATE_TIMEOUT
     assert calls[0]["progress_bar"] is True
+    assert calls[0]["currency_db_path"] == tmp_path / "exchange-rates.duckdb"
+    assert calls[0]["currency_source"] == "test-source"
 
 
 def test_stablecoin_rate_refresh_timeout_falls_back_to_default(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/feed/test_stablecoin_rate.py
+++ b/tests/feed/test_stablecoin_rate.py
@@ -41,6 +41,7 @@ def _coins_list_response() -> DummyCoinGeckoResponse:
         "usdx",
         "usdx-money-usdx",
         "cad-coin",
+        "frankencoin",
         "convertible-jpy-token",
         "tokenised-gbp",
         "magic-internet-money",
@@ -602,6 +603,7 @@ checks:
     ("symbol", "name", "coingecko_id", "peg_currency", "usd_rate"),
     [
         ("CADC", "PayTrie CADC Canadian Dollar stablecoin", "cad-coin", "cad", 0.73),
+        ("ZCHF", "Frankencoin Swiss Franc stablecoin", "frankencoin", "chf", 1.24),
         ("CJPY", "Yamato CJPY Japanese Yen stablecoin", "convertible-jpy-token", "jpy", 0.0064),
         ("tGBP", "Tokenised GBP British Pound stablecoin", "tokenised-gbp", "gbp", 1.32),
     ],
@@ -659,6 +661,28 @@ def test_non_usd_fiat_stablecoins_compare_against_their_peg_currency(
     assert rate.source_currency_usd_rate == pytest.approx(usd_rate)
     assert rate.source_currency_usd_rate_fetched_at == now_
     assert rate.source_currency_usd_rate_source == "fawazahmed0"
+
+
+def test_packaged_chf_stablecoins_have_chf_source_currency() -> None:
+    """Packaged CHF stablecoins carry source-currency metadata for native rate conversion."""
+    targets = {target.symbol: target for target in iter_stablecoin_rate_targets()}
+
+    for symbol in ("JCHF", "ZCHF"):
+        target = targets[symbol]
+
+        assert target.source_currency == "chf"
+        assert target.source_currency_source == "manual"
+
+    feeder = StablecoinRateFeeder()
+    for chain_id, address in (
+        (1, "0xB58E61C3098d85632Df34EecfB899A1Ed80921cB"),
+        (8453, "0xD4dD9e2F021BB459D5A5f6c24C12fE09c5D45553"),
+        (100, "0xD4dD9e2F021BB459D5A5f6c24C12fE09c5D45553"),
+    ):
+        rate = feeder.get_denomination_token_rate_section(chain_id, address, "ZCHF")
+
+        assert rate.source_currency == "chf"
+        assert rate.coingecko_id == "frankencoin"
 
 
 def test_eur_stablecoin_depegs_against_native_currency_from_duckdb(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Why

ZCHF and JCHF are Swiss franc stablecoins, but their metadata did not mark CHF as the source currency. This meant denomination rate exports could carry a USD CoinGecko rate while missing the CHF-native rate fields used for non-USD peg checks.

## Lessons learnt

Swiss franc vault denominations need both stablecoin metadata and the currency-rate DuckDB path to be present in every stablecoin refresh entry point. The post scanner already passed the FX database through, but the standalone metadata exporter did not.

## Summary

- Marked ZCHF and JCHF as manually curated CHF-pegged stablecoins.
- Added Base and Gnosis ZCHF contract mappings verified from the Frankencoin svZCHF vaults' `asset()` calls.
- Passed `CURRENCY_API_DB_PATH` / `CURRENCY_API_DATABASE_PATH` and `CURRENCY_API_SOURCE` through the metadata exporter stablecoin refresh.
- Added regression coverage for CHF-native stablecoin rate conversion and packaged CHF metadata.

## Related issues and PRs

Continues the Frankencoin vault protocol work from PR #1227.

## Unrelated CI and test fixes

None.
