### PR TITLE
Fix Linea historical block header reads

### DIFF
--- a/eth_defi/chain.py
+++ b/eth_defi/chain.py
@@ -27,6 +27,26 @@ POA_MIDDLEWARE_NEEDED_CHAIN_IDS = {
     56,  # BNB Chain
     137,  # Polygon
     43114,  # Avalanche C-chain
+    # Linea needed Clique PoA extraData handling for historical blocks before
+    # the Beta v4.0 Paris upgrade. The upgrade happened at block 24787631
+    # on 2025-10-22 and switched Linea from the Clique proof-of-authority
+    # sequencer mechanism to the Maru/QBFT consensus client.
+    #
+    # Raw JSON-RPC examples from production investigation:
+    # - block 24787631 at 2025-10-22 05:47:11 UTC has 97-byte extraData
+    # - block 24787632 at 2025-10-22 05:47:35 UTC has 32-byte extraData
+    #
+    # Web3.py validates block.extraData as 32 bytes unless
+    # ExtraDataToPOAMiddleware is installed. Without this middleware, historical
+    # Linea reads like web3.eth.get_block(23146362) fail while current block
+    # reads may appear fine because post-upgrade blocks use 32-byte extraData.
+    #
+    # This matters for historical backfills: the ERC-4626 vault settlement
+    # scanner may fetch old Lagoon/D2 logs with Hypersync and then use
+    # eth_getBlockByNumber to fill missing block hashes. Keep Linea here until
+    # all historical Linea block reads avoid Web3.py's fixed extraData
+    # formatter, or until Web3.py handles this chain transition natively.
+    59144,  # Linea historical Clique-era blocks before Maru/QBFT
 }
 
 #: Known testnet chain IDs — used to guard operations that should never

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -453,6 +453,23 @@ Vault settlement scanning is enabled by default in both the one-shot and looped
 Docker Compose services with `SCAN_VAULT_SETTLEMENTS=true`, so Lagoon and D2
 settlement markers are populated before cleaned price data is exported.
 
+### Linea historical block headers
+
+Linea changed its block header `extraData` shape during the
+[Beta v4.0 Paris upgrade](https://docs.linea.build/changelog/release-notes#beta-v40)
+on 2025-10-22. The last pre-upgrade block is `24787631`
+(`2025-10-22 05:47:11` UTC) and still has 97-byte Clique-style
+`extraData`; the first post-upgrade block is `24787632`
+(`2025-10-22 05:47:35` UTC) and has 32-byte `extraData`.
+
+The reason is Linea's move from the Clique proof-of-authority sequencer
+mechanism to the Maru/QBFT consensus client, documented in the
+[Linea Maru node guide](https://docs.linea.build/network/how-to/run-a-node/maru).
+When backfilling Linea vault settlement events before block `24787632`, raw
+JSON-RPC block headers may therefore need Web3.py's
+`ExtraDataToPOAMiddleware` or another path that avoids formatting the historical
+`extraData` as a fixed 32-byte field.
+
 To run a **single-chain** script or override the command, you must use `--entrypoint`
 because the Dockerfile sets `ENTRYPOINT` (not just `CMD`). Without `--entrypoint`,
 any command you pass is appended as arguments to the all-chains script.


### PR DESCRIPTION
## Why

Linea changed its historical block header shape at the Beta v4.0 Paris upgrade. Pre-upgrade blocks can have 97-byte Clique-style `extraData`, while Web3.py expects 32 bytes unless `ExtraDataToPOAMiddleware` is installed. This broke vault settlement backfills when the scanner fetched old Linea settlement logs and then called `eth_getBlockByNumber` to fill block hashes.

## Lessons learnt

Recent Linea blocks may look fine because post-upgrade headers use 32-byte `extraData`, but historical backfills before block `24787632` still need PoA extra-data handling. The transition happened between blocks `24787631` and `24787632` on 2025-10-22.

## Summary

- Add Linea chain ID `59144` to the chain IDs that receive Web3.py `ExtraDataToPOAMiddleware`.
- Document the Linea header transition, exact blocks, timestamps, and Maru/QBFT reason near the vault scanner settlement docs.
- Add detailed code comments next to the Linea chain ID so the historical-only failure mode is not removed accidentally.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.