### PR TITLE
fix: reduce vault scanner log noise and share Hyperliquid throttling

### DIFF
--- a/eth_defi/core3/scanner.py
+++ b/eth_defi/core3/scanner.py
@@ -28,10 +28,9 @@ from pathlib import Path
 import requests
 from joblib import Parallel, delayed
 from tqdm_loggable.auto import tqdm
+from tqdm_loggable.tqdm_logging import tqdm_logging
 
 from eth_defi.compat import native_datetime_utc_now
-from eth_defi.core3.constants import CORE3_DATABASE_PATH, CORE3_DEFAULT_TIMEOUT, INDEX_SLUG, SECTIONS
-from eth_defi.core3.database import Core3Database
 from eth_defi.core3.api import (
     fetch_index_pol_history,
     fetch_index_pol_history_incremental,
@@ -43,6 +42,8 @@ from eth_defi.core3.api import (
     fetch_project_list,
     fetch_section_detail,
 )
+from eth_defi.core3.constants import CORE3_DATABASE_PATH, CORE3_DEFAULT_TIMEOUT, INDEX_SLUG, SECTIONS
+from eth_defi.core3.database import Core3Database
 from eth_defi.core3.session import Core3Session
 
 logger = logging.getLogger(__name__)
@@ -280,19 +281,24 @@ def scan_projects(
 
     # Parallel per-project processing
     desc = f"Scanning Core3 projects ({max_workers} workers)"
-    Parallel(n_jobs=max_workers, backend="threading")(
-        delayed(_process_project)(
-            session,
-            db,
-            slug,
-            fetched_at,
-            fetch_pol=fetch_pol_history,
-            fetch_categories=fetch_category_history,
-            fetch_sections_flag=fetch_sections,
-            timeout=timeout,
+    previous_tqdm_log_level = tqdm_logging.log_level
+    tqdm_logging.set_level(logging.DEBUG)
+    try:
+        Parallel(n_jobs=max_workers, backend="threading")(
+            delayed(_process_project)(
+                session,
+                db,
+                slug,
+                fetched_at,
+                fetch_pol=fetch_pol_history,
+                fetch_categories=fetch_category_history,
+                fetch_sections_flag=fetch_sections,
+                timeout=timeout,
+            )
+            for slug in tqdm(slugs, desc=desc)
         )
-        for slug in tqdm(slugs, desc=desc)
-    )
+    finally:
+        tqdm_logging.set_level(previous_tqdm_log_level)
 
     # Index-level PoL history (single request, not parallelised)
     if fetch_index_pol:

--- a/eth_defi/hyperliquid/session.py
+++ b/eth_defi/hyperliquid/session.py
@@ -383,24 +383,28 @@ class HyperliquidSession(Session):
         :py:class:`~eth_defi.event_reader.webshare.ProxyStateManager` is
         shared, so failures recorded by any worker are persisted globally.
 
-        Each clone gets its own **independent rate limiter** because
-        Hyperliquid rate limits are per IP. When workers use different
-        proxies, each proxy IP gets its full rate allowance.
+        With proxies, each clone gets an independent rate limiter because
+        Hyperliquid rate limits are per IP and each worker should use its
+        proxy IP's full allowance. Without proxies, clones share the parent
+        adapters so all direct workers coordinate through the same limiter.
 
         :param proxy_start_index:
             Starting proxy index for this worker (typically the worker
             ordinal: 0, 1, 2, ...).
         :return:
-            A new :py:class:`HyperliquidSession` with its own proxy
-            rotation state and rate limiter.
+            A new :py:class:`HyperliquidSession` with worker-local proxy
+            rotation state. The rate limiter is independent only when proxy
+            support is enabled.
         """
         clone = HyperliquidSession(api_url=self.api_url)
 
-        # Each worker gets its own rate limiter since rate limits are per IP.
-        # When using proxies, each proxy is a different IP so they need
-        # independent rate limiting.
-        if self._adapter_config is not None:
-            # Create a fresh adapter with a unique SQLite database for this worker
+        # With proxies, each worker should have an independent limiter for its
+        # proxy IP. Without proxies, every worker shares the same public IP, so
+        # clones must share the parent adapter/rate limiter to avoid multiplying
+        # the direct-IP request budget.
+        if self._adapter_config is not None and self.proxy_enabled:
+            # Create a fresh adapter with a unique SQLite database for this
+            # worker/proxy.
             fd, tmp_path = tempfile.mkstemp(
                 suffix=".sqlite",
                 prefix=f"hl-rate-limit-worker-{proxy_start_index}-",
@@ -420,7 +424,8 @@ class HyperliquidSession(Session):
             clone.mount("https://", adapter)
             clone._adapter_config = self._adapter_config
         else:
-            # No adapter config stored — share the parent's adapters (fallback)
+            # Direct-IP mode, or no adapter config stored: share the parent's
+            # adapters so all clones coordinate through one limiter.
             clone.adapters = self.adapters.copy()
 
         # Propagate proxy rotation budget
@@ -429,7 +434,7 @@ class HyperliquidSession(Session):
         clone.post_info_retry_backoff_factor = self.post_info_retry_backoff_factor
 
         # Each worker gets its own rotator clone starting at a different proxy,
-        # but sharing the same ProxyStateManager for persistent failure tracking
+        # but sharing the same ProxyStateManager for persistent failure tracking.
         if self._rotator is not None:
             clone._rotator = self._rotator.clone_for_worker(start_index=proxy_start_index)
 

--- a/eth_defi/logging_retry.py
+++ b/eth_defi/logging_retry.py
@@ -31,6 +31,18 @@ class LoggingRetry(Retry):
         self.log_level = kwargs.pop("log_level", logging.WARNING)
         super().__init__(*args, **kwargs)
 
+    def new(self, **kw: object) -> "LoggingRetry":
+        """Create a retry clone that preserves custom logging configuration.
+
+        ``urllib3.Retry.increment()`` returns a cloned retry object after each
+        failed attempt. Without carrying these attributes forward, only the
+        first retry uses the caller-provided logger and log level.
+        """
+        retry = super().new(**kw)
+        retry.logger = self.logger
+        retry.log_level = self.log_level
+        return retry
+
     def increment(self, method=None, url=None, response=None, error=None, _pool=None, _stacktrace=None):
         if response:
             status = response.status

--- a/eth_defi/stablecoin_metadata.py
+++ b/eth_defi/stablecoin_metadata.py
@@ -972,7 +972,7 @@ def process_and_upload_stablecoin_metadata(
         content_type="application/json",
         skip_if_current=True,
     )
-    logger.info("%s stablecoin metadata for: %s", "Uploaded" if metadata_uploaded else "Skipped unchanged", slug)
+    logger.debug("%s stablecoin metadata for: %s", "Uploaded" if metadata_uploaded else "Skipped unchanged", slug)
 
     # Upload logo if available
     logo_path = STABLECOIN_FORMATTED_LOGOS_DIR / slug / "light.png"

--- a/eth_defi/vault/curator.py
+++ b/eth_defi/vault/curator.py
@@ -1004,12 +1004,10 @@ def process_and_upload_curator_metadata(  # noqa: PLR0917
                 content_type="image/png",
                 skip_if_current=True,
             )
-            logger.info(
-                "%s %s logo for curator: %s",
-                "Uploaded" if logo_uploaded else "Skipped unchanged",
-                variant,
-                slug,
-            )
+            if logo_uploaded:
+                logger.info("Uploaded %s logo for curator: %s", variant, slug)
+            else:
+                logger.debug("Skipped unchanged %s logo for curator: %s", variant, slug)
 
     return metadata
 

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -924,7 +924,7 @@ def scan_hypercore_fn(
     """
     from eth_defi.hyperliquid.constants import HYPERLIQUID_DAILY_METRICS_DATABASE
 
-    session = create_hyperliquid_session(requests_per_second=2.75)
+    session = create_hyperliquid_session(requests_per_second=1.0)
     return _run_hypercore_scan(
         name="Hypercore",
         scan_fn=hyperliquid_run_daily_scan,

--- a/tests/hyperliquid/test_session.py
+++ b/tests/hyperliquid/test_session.py
@@ -5,6 +5,7 @@ bulk downloads: throttled responses must rotate without marking the
 proxy as dead; connection errors still mark it dead.
 """
 
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,6 +17,7 @@ from eth_defi.hyperliquid.session import (
     DEFAULT_POST_INFO_RETRY_BACKOFF_FACTOR,
     create_hyperliquid_session,
 )
+from eth_defi.logging_retry import LoggingRetry
 
 
 def _make_proxy(idx: int) -> WebshareProxy:
@@ -231,3 +233,49 @@ def test_successful_200_short_circuits(session_with_proxies):
     assert m.call_count == 1
     assert rotator.current() == initial_proxy
     state_mgr.record_failure.assert_not_called()
+
+
+def test_logging_retry_preserves_logger_when_cloned() -> None:
+    """Retry clones must keep caller-provided logger configuration.
+
+    ``urllib3.Retry`` clones itself after each retry attempt. Hyperliquid
+    sessions pass their module logger and proxy-aware log level to
+    :class:`LoggingRetry`, so those values must survive clone creation.
+    """
+    logger = logging.getLogger("test.hyperliquid.retry")
+    retry = LoggingRetry(total=5, logger=logger, log_level=logging.DEBUG)
+
+    cloned = retry.new(total=4)
+
+    assert cloned.logger is logger
+    assert cloned.log_level == logging.DEBUG
+
+
+def test_direct_worker_clone_shares_rate_limiter_adapter(tmp_path) -> None:
+    """Direct-IP worker clones share one rate limiter.
+
+    Without proxies, all workers use the same public IP. Giving every clone a
+    private limiter would multiply the effective Hyperliquid request budget and
+    cause concurrent 429 bursts.
+    """
+    session = create_hyperliquid_session(rate_limit_db_path=tmp_path / "direct.sqlite")
+
+    clone = session.clone_for_worker(proxy_start_index=1)
+
+    assert not session.proxy_enabled
+    assert clone.get_adapter("https://api.hyperliquid.xyz") is session.get_adapter("https://api.hyperliquid.xyz")
+
+
+def test_proxy_worker_clone_uses_independent_rate_limiter_adapter(tmp_path) -> None:
+    """Proxy worker clones keep independent limiters for independent IPs."""
+    session = create_hyperliquid_session(
+        rate_limit_db_path=tmp_path / "proxy.sqlite",
+        rotator=_fake_rotator(n_proxies=2),
+    )
+
+    clone = session.clone_for_worker(proxy_start_index=1)
+
+    assert session.proxy_enabled
+    assert clone.proxy_enabled
+    assert clone.active_proxy_url != session.active_proxy_url
+    assert clone.get_adapter("https://api.hyperliquid.xyz") is not session.get_adapter("https://api.hyperliquid.xyz")


### PR DESCRIPTION
## Why

Vault scanner logs were too noisy for unchanged uploads and Core3 progress output. Hyperliquid direct-IP worker clones also needed to share retry and throttling state so parallel workers do not multiply the effective request budget and trigger 429 bursts.

## Lessons learnt

`urllib3.Retry` clones retry instances between attempts, so custom logger state must be carried forward explicitly. Hyperliquid worker sessions should only get independent rate limiters when proxy IPs are enabled.

## Summary

- Move unchanged curator logo uploads, stablecoin metadata uploads, and Core3 progress logs to DEBUG.
- Preserve `LoggingRetry` logger and log level across retry clones.
- Share Hyperliquid direct-IP rate limiter adapters across worker clones while keeping proxy worker limiters independent.
- Lower the Hypercore direct scan session rate limit and cover the session clone behaviour with tests.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.