### PR TITLE
feat: scan all Midas registry vaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.2
 
 - feat: Batch ERC-4626 vault settlement event scans by chain, track empty settlement scan watermarks, avoid per-chain raw price parquet rereads, and make settlement scan failures non-fatal for the vault scanner cycle (2026-07-10)
+- feat: Expand Midas vault scanning to all registry-scannable products with custom feed fallback and explicit unscannable feed exclusions (2026-07-10)
 - feat: Add Midas vault protocol support with registry metadata, live NAV/share-price history scanning and fee-preserving lifetime metrics export (2026-07-10)
 - feat: Add Frankencoin ERC-4626 savings vault protocol support with hardcoded Ethereum, Base and Gnosis svZCHF vault addresses (2026-07-09)
 - feat: Add stale-NAV corrected historical share price reading for T3tris async vaults (2026-07-09)

--- a/eth_defi/midas/constants.py
+++ b/eth_defi/midas/constants.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 
 from eth_typing import HexAddress
 
+from eth_defi.midas.registry import MidasRegistryProduct, iter_midas_registry_products
+
 
 @dataclass(slots=True, frozen=True)
 class MidasProduct:
@@ -32,13 +34,13 @@ class MidasProduct:
     data_feed: HexAddress
 
     #: Chainlink-compatible public oracle contract for the same NAV feed.
-    oracle: HexAddress
+    oracle: HexAddress | None
 
     #: Midas issuance vault contract.
-    issuance_vault: HexAddress
+    issuance_vault: HexAddress | None
 
     #: Midas redemption vault contract.
-    redemption_vault: HexAddress
+    redemption_vault: HexAddress | None
 
     #: First block where the mToken bytecode exists.
     first_seen_at_block: int
@@ -50,40 +52,73 @@ class MidasProduct:
     denomination: str = "USD"
 
 
+def _optional_hex_address(address: str | None) -> HexAddress | None:
+    """Convert an optional registry address to a lower-case hex address.
+
+    :param address:
+        Address from the Pythonised Midas registry.
+    :return:
+        Lower-case hex address or ``None``.
+    """
+
+    if address is None:
+        return None
+
+    return HexAddress(address.lower())
+
+
+def create_midas_product_from_registry(product: MidasRegistryProduct) -> MidasProduct:
+    """Create adapter metadata from a registry product row.
+
+    The shared vault scanner only needs the mToken, Midas datafeed and
+    deployment metadata to scan historical share price and TVL. Operational
+    issuance/redemption contracts are kept as optional diagnostics because some
+    registry products use specialised vault variants or omit public vault
+    contracts.
+
+    :param product:
+        Registry product promoted by
+        :py:meth:`eth_defi.midas.registry.MidasRegistryProduct.has_required_adapter_data`.
+    :return:
+        Midas adapter product metadata.
+    """
+
+    assert product.token is not None
+    assert product.data_feed is not None
+    assert product.first_seen_at_block is not None
+    assert product.first_seen_at is not None
+
+    return MidasProduct(
+        chain_id=product.chain_id,
+        token=HexAddress(product.token.lower()),
+        symbol=product.symbol,
+        product_name=f"Midas {product.symbol}",
+        data_feed=HexAddress(product.data_feed.lower()),
+        oracle=_optional_hex_address(product.custom_feed),
+        issuance_vault=_optional_hex_address(product.deposit_vault),
+        redemption_vault=_optional_hex_address(product.redemption_vault),
+        first_seen_at_block=product.first_seen_at_block,
+        first_seen_at=product.first_seen_at,
+    )
+
+
+#: All registry products supported by the Midas vault scanner adapter.
+MIDAS_PRODUCTS: dict[tuple[int, HexAddress], MidasProduct] = {
+    (product.chain_id, product.token): product
+    for product in (
+        create_midas_product_from_registry(registry_product)
+        for registry_product in iter_midas_registry_products(
+            require_historical_contracts=True,
+            require_adapter_data=True,
+        )
+    )
+}
+
 #: mTBILL on Ethereum.
-MIDAS_MTBILL_ETHEREUM = MidasProduct(
-    chain_id=1,
-    token=HexAddress("0xdd629e5241cbc5919847783e6c96b2de4754e438"),
-    symbol="mTBILL",
-    product_name="Midas US Treasury Bill Token",
-    data_feed=HexAddress("0xfcee9754e8c375e145303b7ce7beca3201734a2b"),
-    oracle=HexAddress("0x056339c044055819e8db84e71f5f2e1f536b2e5b"),
-    issuance_vault=HexAddress("0x99361435420711723af805f08187c9e6bf796683"),
-    redemption_vault=HexAddress("0xf6e51d24f4793ac5e71e0502213a9bbe3a6d4517"),
-    first_seen_at_block=18_691_255,
-    first_seen_at=datetime.datetime(2023, 12, 1, 11, 25, 59, tzinfo=datetime.UTC).replace(tzinfo=None),
-)
+MIDAS_MTBILL_ETHEREUM = MIDAS_PRODUCTS[1, HexAddress("0xdd629e5241cbc5919847783e6c96b2de4754e438")]
 
 #: mBASIS on Ethereum.
-MIDAS_MBASIS_ETHEREUM = MidasProduct(
-    chain_id=1,
-    token=HexAddress("0x2a8c22e3b10036f3aef5875d04f8441d4188b656"),
-    symbol="mBASIS",
-    product_name="Midas Basis Trading Token",
-    data_feed=HexAddress("0x1615cbc603192ae8a9ff20e98dd0e40a405d76e4"),
-    oracle=HexAddress("0xe4f2ae539442e1d3fb40f03ceebf4a372a390d24"),
-    issuance_vault=HexAddress("0xa8a5c4ff4c86a459ebbdc39c5be77833b3a15d88"),
-    redemption_vault=HexAddress("0x19ab19e61a930bc5c7b75bf06cdd954218ca9f0b"),
-    first_seen_at_block=20_068_373,
-    first_seen_at=datetime.datetime(2024, 6, 11, 11, 46, 11, tzinfo=datetime.UTC).replace(tzinfo=None),
-)
-
-
-#: Initial set of supported Midas products.
-MIDAS_PRODUCTS: dict[tuple[int, HexAddress], MidasProduct] = {
-    (MIDAS_MTBILL_ETHEREUM.chain_id, MIDAS_MTBILL_ETHEREUM.token): MIDAS_MTBILL_ETHEREUM,
-    (MIDAS_MBASIS_ETHEREUM.chain_id, MIDAS_MBASIS_ETHEREUM.token): MIDAS_MBASIS_ETHEREUM,
-}
+MIDAS_MBASIS_ETHEREUM = MIDAS_PRODUCTS[1, HexAddress("0x2a8c22e3b10036f3aef5875d04f8441d4188b656")]
 
 #: Lookup by token address for single-chain call sites.
 MIDAS_PRODUCTS_BY_TOKEN: dict[HexAddress, MidasProduct] = {product.token: product for product in MIDAS_PRODUCTS.values()}

--- a/eth_defi/midas/registry.py
+++ b/eth_defi/midas/registry.py
@@ -70,10 +70,13 @@ Manual update process
       poetry run ruff format eth_defi/midas/registry.py
       poetry run ruff check eth_defi/midas/registry.py
 
-The registry is intentionally not used as the active vault scanner allow-list
-by itself. Scanner support still needs product-specific validation, including
-whether the product exposes a suitable Midas datafeed and whether deployment
-metadata has been scanned for its chain.
+The active vault scanner allow-list is generated from this registry. A product
+is promoted to the shared scanner once it has an mToken, a Midas datafeed and
+deployment metadata. Products without a local RPC mapping or deployment scan
+remain visible here, but are not used by the scanner until the missing metadata
+is generated. If a product's registry feeds cannot currently produce a positive
+NAV/share, record it in :data:`MIDAS_PRODUCT_SCAN_EXCLUSIONS` with the observed
+reason instead of silently letting production scans fail.
 """
 
 import datetime
@@ -1995,6 +1998,14 @@ MIDAS_REDEMPTION_VAULT_FIELDS: Final[tuple[str, ...]] = (
     "redemptionVaultBuidl",
 )
 
+#: Custom oracle fields in preference order for share price fallback reads.
+MIDAS_CUSTOM_FEED_FIELDS: Final[tuple[str, ...]] = (
+    "customFeed",
+    "customFeedGrowth",
+    "customFeedDv",
+    "customFeedRv",
+)
+
 #: Deposit vault fields in preference order for scanner diagnostics.
 MIDAS_DEPOSIT_VAULT_FIELDS: Final[tuple[str, ...]] = (
     "depositVault",
@@ -2003,6 +2014,19 @@ MIDAS_DEPOSIT_VAULT_FIELDS: Final[tuple[str, ...]] = (
     "depositVaultAave",
     "depositVaultMorpho",
 )
+
+#: Products whose registry entries are intentionally not promoted to scanning.
+#:
+#: These rows stay in :data:`MIDAS_ADDRESSES_PER_NETWORK`, but the shared vault
+#: adapter cannot produce a reliable NAV/share from their current on-chain
+#: feeds. Re-check this list with:
+#:
+#: .. code-block:: shell
+#:
+#:    source .local-test.env && DAYS=4 REQUIRE_ALL_SUCCESS=true poetry run python scripts/midas/scan-history.py
+MIDAS_PRODUCT_SCAN_EXCLUSIONS: Final[dict[tuple[str, str], str]] = {
+    ("base", "mRE7"): "dataFeed is deprecated and customFeed.latestRoundData() returns a zero answer",
+}
 
 
 @dataclass(slots=True, frozen=True)
@@ -2054,6 +2078,12 @@ class MidasRegistryProduct:
 
         return bool(self.token and self.data_feed)
 
+    @property
+    def has_required_adapter_data(self) -> bool:
+        """Can this product be promoted to the shared vault scanner adapter."""
+
+        return bool(self.token and self.data_feed and self.first_seen_at_block and self.first_seen_at and (self.network, self.symbol) not in MIDAS_PRODUCT_SCAN_EXCLUSIONS)
+
 
 def _pick_first_address(raw: dict[str, Any], fields: tuple[str, ...]) -> str | None:
     """Pick the first available address from a registry entry.
@@ -2074,16 +2104,24 @@ def _pick_first_address(raw: dict[str, Any], fields: tuple[str, ...]) -> str | N
     return None
 
 
-def iter_midas_registry_products(*, require_historical_contracts: bool = False) -> Iterator[MidasRegistryProduct]:
+def iter_midas_registry_products(
+    *,
+    require_historical_contracts: bool = False,
+    require_adapter_data: bool = False,
+) -> Iterator[MidasRegistryProduct]:
     """Iterate product-like entries from the Pythonised Midas registry.
 
     Payment token and access-control sections are skipped. If
     ``require_historical_contracts`` is true, only entries with both ``token``
     and ``dataFeed`` are yielded. These are the minimum contracts needed for
-    historical share price and TVL reads.
+    historical share price and TVL reads. If ``require_adapter_data`` is true,
+    deployment metadata is also required so the shared scanner can create a
+    historical lead with a deterministic start block.
 
     :param require_historical_contracts:
         Filter to entries that can be sampled by the Midas datafeed scanner.
+    :param require_adapter_data:
+        Filter to entries that can be exposed through :mod:`eth_defi.midas`.
     :return:
         Iterator of typed registry product entries.
     """
@@ -2109,7 +2147,7 @@ def iter_midas_registry_products(*, require_historical_contracts: bool = False) 
                 symbol=symbol,
                 token=raw.get("token") if isinstance(raw.get("token"), str) else None,
                 data_feed=raw.get("dataFeed") if isinstance(raw.get("dataFeed"), str) else None,
-                custom_feed=raw.get("customFeed") if isinstance(raw.get("customFeed"), str) else None,
+                custom_feed=_pick_first_address(raw, MIDAS_CUSTOM_FEED_FIELDS),
                 deposit_vault=_pick_first_address(raw, MIDAS_DEPOSIT_VAULT_FIELDS),
                 redemption_vault=_pick_first_address(raw, MIDAS_REDEMPTION_VAULT_FIELDS),
                 first_seen_at_block=deployment[0] if deployment else None,
@@ -2120,20 +2158,32 @@ def iter_midas_registry_products(*, require_historical_contracts: bool = False) 
             if require_historical_contracts and not product.has_required_historical_contracts:
                 continue
 
+            if require_adapter_data and not product.has_required_adapter_data:
+                continue
+
             yield product
 
 
-def get_midas_registry_products_by_chain(*, require_historical_contracts: bool = False) -> dict[int, list[MidasRegistryProduct]]:
+def get_midas_registry_products_by_chain(
+    *,
+    require_historical_contracts: bool = False,
+    require_adapter_data: bool = False,
+) -> dict[int, list[MidasRegistryProduct]]:
     """Group Midas registry products by chain id.
 
     :param require_historical_contracts:
         Filter to products with both mToken and datafeed addresses.
+    :param require_adapter_data:
+        Filter to products with token, datafeed and deployment metadata.
     :return:
         Mapping of chain id to products.
     """
 
     products_by_chain: dict[int, list[MidasRegistryProduct]] = {}
-    for product in iter_midas_registry_products(require_historical_contracts=require_historical_contracts):
+    for product in iter_midas_registry_products(
+        require_historical_contracts=require_historical_contracts,
+        require_adapter_data=require_adapter_data,
+    ):
         products_by_chain.setdefault(product.chain_id, []).append(product)
 
     return products_by_chain

--- a/eth_defi/midas/vault.py
+++ b/eth_defi/midas/vault.py
@@ -16,6 +16,7 @@ from decimal import Decimal
 from eth_typing import BlockIdentifier, HexAddress
 from web3 import Web3
 from web3.contract import Contract
+from web3.exceptions import BadFunctionCallOutput, ContractLogicError, Web3Exception
 
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.midas.constants import MIDAS_PRODUCTS
@@ -39,6 +40,29 @@ MIDAS_DATA_FEED_ABI = [
         "inputs": [],
         "name": "getDataInBase18",
         "outputs": [{"internalType": "uint256", "name": "answer", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+]
+
+MIDAS_AGGREGATOR_V3_ABI = [
+    {
+        "inputs": [],
+        "name": "decimals",
+        "outputs": [{"internalType": "uint8", "name": "", "type": "uint8"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "latestRoundData",
+        "outputs": [
+            {"internalType": "uint80", "name": "roundId", "type": "uint80"},
+            {"internalType": "int256", "name": "answer", "type": "int256"},
+            {"internalType": "uint256", "name": "startedAt", "type": "uint256"},
+            {"internalType": "uint256", "name": "updatedAt", "type": "uint256"},
+            {"internalType": "uint80", "name": "answeredInRound", "type": "uint80"},
+        ],
         "stateMutability": "view",
         "type": "function",
     },
@@ -68,13 +92,13 @@ class MidasVaultInfo(VaultInfo, total=False):
     data_feed: HexAddress
 
     #: Chainlink-compatible public oracle for NAV/share.
-    oracle: HexAddress
+    oracle: HexAddress | None
 
     #: Midas issuance vault contract.
-    issuance_vault: HexAddress
+    issuance_vault: HexAddress | None
 
     #: Midas redemption vault contract.
-    redemption_vault: HexAddress
+    redemption_vault: HexAddress | None
 
     #: Whether NAV uses a synthetic denomination token in scanner output.
     synthetic_usd_denomination: bool
@@ -123,6 +147,21 @@ def export_midas_usd_denomination(chain_id: int) -> dict[str, object]:
         "total_supply": None,
         "extra_data": {"synthetic": True},
     }
+
+
+def _checksum_or_none(address: HexAddress | None) -> HexAddress | None:
+    """Convert an optional address to its checksum form.
+
+    :param address:
+        Lower-case address or ``None``.
+    :return:
+        Checksum address or ``None``.
+    """
+
+    if address is None:
+        return None
+
+    return HexAddress(Web3.to_checksum_address(address))
 
 
 class MidasVault(VaultBase):
@@ -201,8 +240,23 @@ class MidasVault(VaultBase):
         )
 
     @property
-    def issuance_vault_contract(self) -> Contract:
+    def custom_feed_contract(self) -> Contract | None:
+        """Chainlink-compatible public oracle contract for this product."""
+
+        if self.product.oracle is None:
+            return None
+
+        return self.web3.eth.contract(
+            address=Web3.to_checksum_address(self.product.oracle),
+            abi=MIDAS_AGGREGATOR_V3_ABI,
+        )
+
+    @property
+    def issuance_vault_contract(self) -> Contract | None:
         """Midas issuance vault contract for this product."""
+
+        if self.product.issuance_vault is None:
+            return None
 
         return self.web3.eth.contract(
             address=Web3.to_checksum_address(self.product.issuance_vault),
@@ -210,8 +264,11 @@ class MidasVault(VaultBase):
         )
 
     @property
-    def redemption_vault_contract(self) -> Contract:
+    def redemption_vault_contract(self) -> Contract | None:
         """Midas redemption vault contract for this product."""
+
+        if self.product.redemption_vault is None:
+            return None
 
         return self.web3.eth.contract(
             address=Web3.to_checksum_address(self.product.redemption_vault),
@@ -302,14 +359,33 @@ class MidasVault(VaultBase):
     def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
         """Fetch Midas NAV per mToken.
 
+        The primary source is Midas ``IDataFeed.getDataInBase18()``. Some
+        registry products expose a datafeed that currently reverts as
+        unhealthy or deprecated, while the paired public ``customFeed`` still
+        exposes a positive Chainlink-style round answer. In that case the
+        adapter falls back to ``latestRoundData()`` so historical TVL scans can
+        still cover the registry-supported product.
+
         :param block_identifier:
             Historical or latest block identifier.
         :return:
             NAV/share in the product denomination.
         """
 
-        raw_price = self.data_feed_contract.functions.getDataInBase18().call(block_identifier=block_identifier)
-        return Decimal(raw_price) / Decimal(10**18)
+        try:
+            raw_price = self.data_feed_contract.functions.getDataInBase18().call(block_identifier=block_identifier)
+            return Decimal(raw_price) / Decimal(10**18)
+        except (BadFunctionCallOutput, ContractLogicError, ValueError, Web3Exception):
+            custom_feed = self.custom_feed_contract
+            if custom_feed is None:
+                raise
+
+            _round_id, answer, _started_at, updated_at, _answered_in_round = custom_feed.functions.latestRoundData().call(block_identifier=block_identifier)
+            if answer <= 0 or updated_at == 0:
+                raise
+
+            decimals = custom_feed.functions.decimals().call(block_identifier=block_identifier)
+            return Decimal(answer) / Decimal(10**decimals)
 
     def fetch_total_supply(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
         """Fetch total outstanding mToken supply.
@@ -356,9 +432,9 @@ class MidasVault(VaultBase):
             token=self.address,
             chain_id=self.chain_id,
             data_feed=Web3.to_checksum_address(self.product.data_feed),
-            oracle=Web3.to_checksum_address(self.product.oracle),
-            issuance_vault=Web3.to_checksum_address(self.product.issuance_vault),
-            redemption_vault=Web3.to_checksum_address(self.product.redemption_vault),
+            oracle=_checksum_or_none(self.product.oracle),
+            issuance_vault=_checksum_or_none(self.product.issuance_vault),
+            redemption_vault=_checksum_or_none(self.product.redemption_vault),
             denomination_token=self.fetch_denomination_token_address(),
             synthetic_usd_denomination=self.product.denomination == "USD",
             nav_source=MIDAS_NAV_SOURCE,
@@ -383,9 +459,9 @@ class MidasVault(VaultBase):
             "_nav_estimated": False,
             "_synthetic_usd_denomination": self.product.denomination == "USD",
             "_midas_data_feed": Web3.to_checksum_address(self.product.data_feed),
-            "_midas_oracle": Web3.to_checksum_address(self.product.oracle),
-            "_midas_issuance_vault": Web3.to_checksum_address(self.product.issuance_vault),
-            "_midas_redemption_vault": Web3.to_checksum_address(self.product.redemption_vault),
+            "_midas_oracle": _checksum_or_none(self.product.oracle),
+            "_midas_issuance_vault": _checksum_or_none(self.product.issuance_vault),
+            "_midas_redemption_vault": _checksum_or_none(self.product.redemption_vault),
         }
 
     def fetch_portfolio(
@@ -514,28 +590,38 @@ class MidasVault(VaultBase):
 
         return None
 
-    def get_deposit_fee(self, block_identifier: BlockIdentifier) -> Percent:
+    def get_deposit_fee(self, block_identifier: BlockIdentifier) -> Percent | None:
         """Return instant issuance fee.
 
         :param block_identifier:
             Historical or latest block identifier.
         :return:
-            Instant issuance fee as a fraction.
+            Instant issuance fee as a fraction, if exposed by the registry
+            issuance vault.
         """
 
-        raw_fee = self.issuance_vault_contract.functions.instantFee().call(block_identifier=block_identifier)
+        contract = self.issuance_vault_contract
+        if contract is None:
+            return None
+
+        raw_fee = contract.functions.instantFee().call(block_identifier=block_identifier)
         return convert_midas_fee_to_percent(raw_fee)
 
-    def get_withdraw_fee(self, block_identifier: BlockIdentifier) -> Percent:
+    def get_withdraw_fee(self, block_identifier: BlockIdentifier) -> Percent | None:
         """Return instant redemption fee.
 
         :param block_identifier:
             Historical or latest block identifier.
         :return:
-            Instant redemption fee as a fraction.
+            Instant redemption fee as a fraction, if exposed by the registry
+            redemption vault.
         """
 
-        raw_fee = self.redemption_vault_contract.functions.instantFee().call(block_identifier=block_identifier)
+        contract = self.redemption_vault_contract
+        if contract is None:
+            return None
+
+        raw_fee = contract.functions.instantFee().call(block_identifier=block_identifier)
         return convert_midas_fee_to_percent(raw_fee)
 
     def get_link(self, referral: str | None = None) -> str:

--- a/scripts/midas/backfill-history.py
+++ b/scripts/midas/backfill-history.py
@@ -3,7 +3,8 @@
 
 This script is a targeted production backfill tool for Midas products supported
 by the :mod:`eth_defi.midas` adapter. It avoids whole-chain rediscovery and only
-touches Midas vault ids listed in :data:`eth_defi.midas.constants.MIDAS_PRODUCTS`.
+touches Midas vault ids generated from the Pythonised registry into
+:data:`eth_defi.midas.constants.MIDAS_PRODUCTS`.
 
 The script:
 
@@ -267,7 +268,7 @@ def read_reader_states(path: Path) -> dict[VaultSpec, dict]:
     if not path.exists():
         return {}
     with path.open("rb") as inp:
-        return pickle.load(inp)
+        return pickle.load(inp)  # noqa: S301 - trusted local production reader-state pickle.
 
 
 def write_reader_states(path: Path, states: dict[VaultSpec, dict]) -> None:
@@ -313,7 +314,7 @@ def build_vaults(web3, products: list[MidasProduct], token_cache: TokenDiskCache
     return vaults
 
 
-def backfill_chain(
+def backfill_chain(  # noqa: PLR0914
     chain_id: int,
     products: list[MidasProduct],
     *,

--- a/scripts/midas/scan-history.py
+++ b/scripts/midas/scan-history.py
@@ -1,8 +1,8 @@
 """Scan Midas product share price and TVL history.
 
 Manual script for validating the Pythonised Midas registry against live
-on-chain data. The script samples all registry products that expose both an
-mToken and a Midas ``dataFeed`` contract, then prints tabulated daily history.
+on-chain data. The script samples every registry product that the Midas vault
+adapter can expose, then prints tabulated daily history.
 
 Configuration is through environment variables:
 
@@ -17,6 +17,9 @@ Configuration is through environment variables:
 
 ``MAX_PRODUCTS``
     Optional cap for debugging.
+
+``REQUIRE_ALL_SUCCESS``
+    If ``true``, exit with an error if any selected product sample fails.
 
 ``LOG_LEVEL``
     Python logging level. Defaults to ``info``.
@@ -42,7 +45,7 @@ from decimal import Decimal
 
 from tabulate import tabulate
 from web3 import Web3
-from web3.exceptions import BadFunctionCallOutput, ContractLogicError
+from web3.exceptions import BadFunctionCallOutput, ContractLogicError, Web3Exception
 
 from eth_defi.chain import EVM_BLOCK_TIMES
 from eth_defi.midas.registry import MidasRegistryProduct, iter_midas_registry_products
@@ -56,6 +59,29 @@ DATA_FEED_ABI = [
         "inputs": [],
         "name": "getDataInBase18",
         "outputs": [{"internalType": "uint256", "name": "answer", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+]
+
+AGGREGATOR_V3_ABI = [
+    {
+        "inputs": [],
+        "name": "decimals",
+        "outputs": [{"internalType": "uint8", "name": "", "type": "uint8"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "latestRoundData",
+        "outputs": [
+            {"internalType": "uint80", "name": "roundId", "type": "uint80"},
+            {"internalType": "int256", "name": "answer", "type": "int256"},
+            {"internalType": "uint256", "name": "startedAt", "type": "uint256"},
+            {"internalType": "uint256", "name": "updatedAt", "type": "uint256"},
+            {"internalType": "uint80", "name": "answeredInRound", "type": "uint80"},
+        ],
         "stateMutability": "view",
         "type": "function",
     },
@@ -144,7 +170,7 @@ def iter_products() -> Iterator[MidasRegistryProduct]:
     max_products = int(os.environ.get("MAX_PRODUCTS", "0") or "0")
     yielded = 0
 
-    for product in iter_midas_registry_products(require_historical_contracts=True):
+    for product in iter_midas_registry_products(require_historical_contracts=True, require_adapter_data=True):
         if networks and product.network.lower() not in networks:
             continue
         if products and product.symbol.lower() not in products:
@@ -182,6 +208,42 @@ def get_sample_blocks(web3: Web3, chain_id: int, days: int) -> list[int]:
     return [max(1, latest_block - blocks_per_day * day) for day in range(days, -1, -1)]
 
 
+def fetch_share_price(web3: Web3, product: MidasRegistryProduct, block_number: int) -> Decimal:
+    """Fetch Midas share price using the adapter source order.
+
+    The primary source is ``dataFeed.getDataInBase18()``. If this reverts and
+    the product exposes ``customFeed``, fall back to
+    ``customFeed.latestRoundData()`` when the oracle answer is positive.
+
+    :param web3:
+        Web3 connection.
+    :param product:
+        Product to sample.
+    :param block_number:
+        Historical block.
+    :return:
+        NAV/share in product denomination.
+    """
+
+    assert product.data_feed is not None
+
+    data_feed = web3.eth.contract(address=Web3.to_checksum_address(product.data_feed), abi=DATA_FEED_ABI)
+    try:
+        raw_share_price = data_feed.functions.getDataInBase18().call(block_identifier=block_number)
+        return Decimal(raw_share_price) / Decimal(10**18)
+    except (BadFunctionCallOutput, ContractLogicError, ValueError, Web3Exception):
+        if product.custom_feed is None:
+            raise
+
+        custom_feed = web3.eth.contract(address=Web3.to_checksum_address(product.custom_feed), abi=AGGREGATOR_V3_ABI)
+        _round_id, answer, _started_at, updated_at, _answered_in_round = custom_feed.functions.latestRoundData().call(block_identifier=block_number)
+        if answer <= 0 or updated_at == 0:
+            raise
+
+        decimals = custom_feed.functions.decimals().call(block_identifier=block_number)
+        return Decimal(answer) / Decimal(10**decimals)
+
+
 def fetch_product_read(web3: Web3, product: MidasRegistryProduct, block_number: int, decimals: int) -> ProductRead:
     """Fetch one Midas product historical sample.
 
@@ -206,13 +268,11 @@ def fetch_product_read(web3: Web3, product: MidasRegistryProduct, block_number: 
         timestamp = datetime.datetime.fromtimestamp(block["timestamp"], tz=datetime.UTC).replace(tzinfo=None)
 
         token = web3.eth.contract(address=Web3.to_checksum_address(product.token), abi=ERC20_ABI)
-        data_feed = web3.eth.contract(address=Web3.to_checksum_address(product.data_feed), abi=DATA_FEED_ABI)
 
         raw_supply = token.functions.totalSupply().call(block_identifier=block_number)
-        raw_share_price = data_feed.functions.getDataInBase18().call(block_identifier=block_number)
 
         total_supply = Decimal(raw_supply) / Decimal(10**decimals)
-        share_price = Decimal(raw_share_price) / Decimal(10**18)
+        share_price = fetch_share_price(web3, product, block_number)
         tvl = total_supply * share_price
 
         return ProductRead(
@@ -224,7 +284,7 @@ def fetch_product_read(web3: Web3, product: MidasRegistryProduct, block_number: 
             tvl=tvl,
             error=None,
         )
-    except (BadFunctionCallOutput, ContractLogicError, ValueError) as e:
+    except (BadFunctionCallOutput, ContractLogicError, ValueError, Web3Exception) as e:
         return ProductRead(
             product=product,
             block_number=block_number,
@@ -343,6 +403,7 @@ def main() -> None:
     setup_logging()
 
     days = int(os.environ.get("DAYS", "7"))
+    require_all_success = os.environ.get("REQUIRE_ALL_SUCCESS", "").strip().lower() in {"1", "true", "yes", "y", "on"}
     products = list(iter_products())
     logger.info("Scanning %d Midas products for %d days", len(products), days)
 
@@ -380,7 +441,7 @@ def main() -> None:
 
             try:
                 decimals = fetch_token_decimals(web3, product)
-            except (BadFunctionCallOutput, ContractLogicError, ValueError) as e:
+            except (BadFunctionCallOutput, ContractLogicError, ValueError, Web3Exception) as e:
                 logger.warning("Could not read decimals for %s %s: %s", product.network, product.symbol, e)
                 for block_number in sample_blocks:
                     reads.append(
@@ -401,7 +462,13 @@ def main() -> None:
 
     print(tabulate(create_history_rows(reads), headers="keys", tablefmt="simple", disable_numparse=True))
     print()
-    print(tabulate(create_summary_rows(reads), headers="keys", tablefmt="simple", disable_numparse=True))
+    summary_rows = create_summary_rows(reads)
+    print(tabulate(summary_rows, headers="keys", tablefmt="simple", disable_numparse=True))
+
+    failed_products = [row for row in summary_rows if row["errors"]]
+    if require_all_success and failed_products:
+        message = f"{len(failed_products)} Midas products had scan errors"
+        raise RuntimeError(message)
 
 
 if __name__ == "__main__":

--- a/tests/midas/test_midas_vault.py
+++ b/tests/midas/test_midas_vault.py
@@ -21,12 +21,13 @@ from eth_defi.erc_4626.scan import create_vault_scan_record
 from eth_defi.hypersync.hypersync_timestamp import get_block_timestamps_using_hypersync
 from eth_defi.hypersync.server import get_hypersync_server
 from eth_defi.hypersync.session import ThrottledHypersyncClient, create_throttled_hypersync_client
-from eth_defi.midas.constants import MIDAS_MBASIS_ETHEREUM, MIDAS_MTBILL_ETHEREUM
+from eth_defi.midas.constants import MIDAS_MBASIS_ETHEREUM, MIDAS_MTBILL_ETHEREUM, MIDAS_PRODUCTS
 from eth_defi.midas.historical import MidasVaultHistoricalReader
 from eth_defi.midas.registry import (
     MIDAS_ADDRESSES_PER_NETWORK,
     MIDAS_CHAIN_IDS,
     MIDAS_PRODUCT_DEPLOYMENTS,
+    MIDAS_PRODUCT_SCAN_EXCLUSIONS,
     MIDAS_REGISTRY_SOURCE_COMMIT,
     MIDAS_REGISTRY_SOURCE_URL,
     MIDAS_SANCTION_LIST_CONTRACTS,
@@ -61,8 +62,11 @@ MTBILL_EXPECTED_DECIMALS = 18
 MBASIS_EXPECTED_TOTAL_SUPPLY = Decimal("105365.233087777728658011")
 MBASIS_EXPECTED_SHARE_PRICE = Decimal("1.19665044")
 MBASIS_EXPECTED_WITHDRAW_FEE = 0.03
-MIDAS_EXPECTED_HARDCODED_LEAD_COUNT = 2
+JIV_EXPECTED_FALLBACK_SHARE_PRICE = Decimal("1")
 MIDAS_EXPECTED_SCANNED_DEPLOYMENT_COUNT = 91
+MIDAS_EXPECTED_ADAPTER_PRODUCT_COUNT = 90
+MIDAS_MINIMUM_SUPPORTED_PRODUCT_COUNT = 2
+MIDAS_JIV_ETHEREUM = next(product for product in MIDAS_PRODUCTS.values() if product.chain_id == ETHEREUM_CHAIN_ID and product.symbol == "JIV")
 
 MIDAS_MTBILL_HISTORY_BLOCKS = [
     25_474_179,
@@ -140,6 +144,9 @@ def web3(anvil_ethereum_fork: AnvilLaunch) -> Web3:
 def test_midas_hardcoded_leads_are_added_to_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
     """Add Midas mTokens as scanner leads without ERC-4626 flow events."""
 
+    expected_mainnet_products = {product.token: product for product in MIDAS_PRODUCTS.values() if product.chain_id == ETHEREUM_CHAIN_ID}
+    expected_end_block = max(product.first_seen_at_block for product in expected_mainnet_products.values())
+
     def fake_probe_vaults(
         chain: int,
         web3factory: object,
@@ -153,7 +160,7 @@ def test_midas_hardcoded_leads_are_added_to_discovery(monkeypatch: pytest.Monkey
 
         assert chain == 1
         assert web3factory is DummyMidasDiscovery.web3factory
-        assert block_identifier == MIDAS_MBASIS_ETHEREUM.first_seen_at_block
+        assert block_identifier == expected_end_block
         assert max_workers == 1
         assert progress_bar_desc is None
         assert MIDAS_MTBILL_ETHEREUM.token in addresses
@@ -166,23 +173,18 @@ def test_midas_hardcoded_leads_are_added_to_discovery(monkeypatch: pytest.Monkey
             )
 
     monkeypatch.setattr(discovery_base_module, "probe_vaults", fake_probe_vaults)
+    monkeypatch.setattr(discovery_base_module, "ODA_FACT_HARDCODED_LEADS", ())
 
     discover = DummyMidasDiscovery(max_workers=1)
     report = discover.scan_vaults(
         start_block=0,
-        end_block=MIDAS_MBASIS_ETHEREUM.first_seen_at_block,
+        end_block=expected_end_block,
         display_progress=False,
     )
 
-    assert report.new_leads == MIDAS_EXPECTED_HARDCODED_LEAD_COUNT
-    assert set(report.leads) == {
-        MIDAS_MTBILL_ETHEREUM.token,
-        MIDAS_MBASIS_ETHEREUM.token,
-    }
-    assert set(report.detections) == {
-        MIDAS_MTBILL_ETHEREUM.token,
-        MIDAS_MBASIS_ETHEREUM.token,
-    }
+    assert report.new_leads == len(expected_mainnet_products)
+    assert set(report.leads) == set(expected_mainnet_products)
+    assert set(report.detections) == set(expected_mainnet_products)
     assert report.detections[MIDAS_MTBILL_ETHEREUM.token].features == {ERC4626Feature.midas_like}
     assert report.detections[MIDAS_MBASIS_ETHEREUM.token].features == {ERC4626Feature.midas_like}
 
@@ -206,11 +208,19 @@ def test_midas_hardcoded_classification_is_chain_aware() -> None:
         chain_id=ETHEREUM_CHAIN_ID,
     ) == {ERC4626Feature.midas_like}
 
-    unsupported_chain_features = identify_vault_features(
+    base_chain_features = identify_vault_features(
         MIDAS_MTBILL_ETHEREUM.token,
         calls,
         debug_text="midas base",
         chain_id=8453,
+    )
+    assert base_chain_features == {ERC4626Feature.midas_like}
+
+    unsupported_chain_features = identify_vault_features(
+        MIDAS_MTBILL_ETHEREUM.token,
+        calls,
+        debug_text="midas unsupported",
+        chain_id=31337,
     )
     assert ERC4626Feature.midas_like not in unsupported_chain_features
 
@@ -246,10 +256,15 @@ def test_midas_registry_iterates_scannable_products() -> None:
     """Build a scanner-friendly view of Midas products with token/datafeed pairs."""
 
     products = list(iter_midas_registry_products(require_historical_contracts=True))
+    adapter_products = list(iter_midas_registry_products(require_historical_contracts=True, require_adapter_data=True))
 
-    assert len(products) > MIDAS_EXPECTED_HARDCODED_LEAD_COUNT
+    assert len(products) > MIDAS_MINIMUM_SUPPORTED_PRODUCT_COUNT
+    assert len(MIDAS_PRODUCTS) == MIDAS_EXPECTED_ADAPTER_PRODUCT_COUNT
+    assert len(adapter_products) == len(MIDAS_PRODUCTS)
     assert len(MIDAS_PRODUCT_DEPLOYMENTS) == MIDAS_EXPECTED_SCANNED_DEPLOYMENT_COUNT
+    assert MIDAS_PRODUCT_SCAN_EXCLUSIONS["base", "mRE7"].startswith("dataFeed is deprecated")
     assert all(product.has_required_historical_contracts for product in products)
+    assert all(product.has_required_adapter_data for product in adapter_products)
     assert all(product.symbol != "paymentTokens" for product in products)
 
     by_key = {(product.network, product.symbol): product for product in products}
@@ -377,6 +392,26 @@ def test_midas_live_mbasis_uses_product_metadata(web3: Web3) -> None:
     assert vault.fetch_share_price(MIDAS_TEST_BLOCK) == MBASIS_EXPECTED_SHARE_PRICE
     assert vault.fetch_total_supply(MIDAS_TEST_BLOCK) == MBASIS_EXPECTED_TOTAL_SUPPLY
     assert vault.get_fee_data().withdraw == MBASIS_EXPECTED_WITHDRAW_FEE
+
+
+@flaky.flaky
+def test_midas_anvil_forked_jiv_uses_custom_feed_fallback(web3: Web3) -> None:
+    """Fall back to ``customFeed`` when a Midas datafeed is unhealthy."""
+
+    vault = MidasVault(
+        web3,
+        VaultSpec(
+            chain_id=ETHEREUM_CHAIN_ID,
+            vault_address=MIDAS_JIV_ETHEREUM.token,
+        ),
+        default_block_identifier=MIDAS_TEST_BLOCK,
+    )
+
+    assert vault.custom_feed_contract is not None
+    with pytest.raises(ValueError):
+        vault.data_feed_contract.functions.getDataInBase18().call(block_identifier=MIDAS_TEST_BLOCK)
+
+    assert vault.fetch_share_price(MIDAS_TEST_BLOCK) == JIV_EXPECTED_FALLBACK_SHARE_PRICE
 
 
 @flaky.flaky


### PR DESCRIPTION
## Why

The first Midas integration only backfilled the two Ethereum products exposed through the initial hand-written allow-list. Midas' public registry now has many deployed mToken products across supported chains, and the scanner should derive its Midas allow-list from that registry instead of a static two-product list.

## Lessons learnt

Some Midas `dataFeed` contracts revert as unhealthy or deprecated while their Chainlink-style `customFeed` contracts still expose NAV/share. The scanner needs to prefer `getDataInBase18()`, then fall back to positive `latestRoundData()` answers. One registry product, `base/mRE7`, currently has no usable NAV source, so it is kept in the raw registry but explicitly excluded from adapter promotion.

## Summary

- Generate `MIDAS_PRODUCTS` directly from `registry.py` using token, datafeed, deployment metadata, and explicit scan exclusions.
- Add custom-feed fallback reads for Midas share price in the vault adapter and manual scan script.
- Expand Midas discovery/classification tests from the original two products to the registry-derived product set, including an Anvil fork test for fallback pricing.
- Verified a strict 4-day manual scan across 90 selected products with zero scan errors.
- Dry-ran the Midas backfill plan and confirmed it now covers 90 products across 10 chains.

## Related issues and PRs

Continues #1237.

## Unrelated CI and test fixes

None.
