### PR TITLE
fix: combine settlement scan errors into chain dashboard rows

### DIFF
--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from atomicwrites import atomic_write
 from filelock import Timeout as FileLockTimeout
 
+from eth_defi.chain import get_chain_name
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.core3.constants import resolve_core3_database_path
 from eth_defi.core3.scanner import scan_projects as core3_scan_projects
@@ -1458,8 +1459,6 @@ def _load_last_timestamps(uncleaned_price_path: Path | None = None) -> dict[str,
     :return:
         Mapping of chain name to formatted date string (YYYY-MM-DD HH:MM).
     """
-    from eth_defi.chain import get_chain_name
-
     path = uncleaned_price_path or DEFAULT_UNCLEANED_PRICE_DATABASE
     if not path.exists():
         return {}
@@ -1485,6 +1484,32 @@ def _load_last_timestamps(uncleaned_price_path: Path | None = None) -> dict[str,
     except Exception as e:
         logger.warning("Could not read last timestamps from parquet: %s", e)
         return {}
+
+
+def _append_result_error(result: ChainResult, error: str, traceback_str: str | None = None) -> None:
+    """Append an error message to a dashboard result.
+
+    Settlement scanning is a secondary per-chain scan. It should not get
+    its own dashboard row, so failures are attached to the nearest normal
+    scan result and shown in the existing error column.
+
+    :param result:
+        Existing dashboard result to update.
+    :param error:
+        Error message to append.
+    :param traceback_str:
+        Optional traceback to append to the result traceback.
+    """
+    if result.error:
+        result.error = f"{result.error}; {error}"
+    else:
+        result.error = error
+
+    if traceback_str:
+        if result.traceback_str:
+            result.traceback_str = f"{result.traceback_str}\n\n{traceback_str}"
+        else:
+            result.traceback_str = traceback_str
 
 
 def print_dashboard(results: dict[str, ChainResult], display_order: list[str] | None = None, uncleaned_price_path: Path | None = None) -> None:
@@ -1532,7 +1557,7 @@ def print_dashboard(results: dict[str, ChainResult], display_order: list[str] | 
         line = f"{result.name:<15} {status:<10} {cycle:<8} {vaults:<8} {new:<6} {blocks:<22} {duration:<10} {retry:<5} {last_data:<18}"
         if result.status == "not due" and result.next_due_in_hours is not None:
             line += f"  due in {result.next_due_in_hours:.1f}h"
-        elif result.status == "failed" and result.error:
+        if result.error:
             # Truncate long error messages to fit the dashboard
             error_msg = result.error[:40]
             line += f"  {error_msg}"
@@ -1562,9 +1587,12 @@ def print_dashboard(results: dict[str, ChainResult], display_order: list[str] | 
     logger.info(dashboard)
 
     # Print full error messages below the dashboard
-    failed_results = [r for r in ordered_results if r.status == "failed" and r.error]
-    for r in failed_results:
-        logger.error("%s: %s", r.name, r.error)
+    error_results = [r for r in ordered_results if r.error]
+    for r in error_results:
+        if r.status == "failed":
+            logger.error("%s: %s", r.name, r.error)
+        else:
+            logger.warning("%s: %s", r.name, r.error)
 
 
 def backup_pipeline_files(backup_files: list[Path] | None = None, backup_dir: Path | None = None):
@@ -1737,29 +1765,22 @@ def run_scan_tick(
         chain_result: ChainResult | None = None,
         skip_reason: str | None = None,
     ) -> None:
-        """Update the dashboard result for one chain's settlement scan."""
+        """Attach one chain's settlement scan outcome to its dashboard row."""
         nonlocal settlement_vault_db
 
         if not scan_vault_settlements or skip_post_processing:
             return
 
-        result_name = f"{chain.name} settlements"
+        dashboard_result = results[chain.name]
         if skip_reason is not None:
-            results[result_name] = ChainResult(
-                name=result_name,
-                status="skipped",
-                error=skip_reason,
-                cycle_interval=_ci.get(chain.name),
-            )
+            logger.info("%s: settlement scan skipped: %s", chain.name, skip_reason)
             return
 
         assert chain_result is not None, "Settlement scan needs a successful chain result"
         if chain_result.chain_id is None or chain_result.rpc_url is None or chain_result.end_block is None:
-            results[result_name] = ChainResult(
-                name=result_name,
-                status="skipped",
-                error=f"Skipped because {chain.name} scan did not report chain id, RPC URL or end block",
-                cycle_interval=_ci.get(chain.name),
+            _append_result_error(
+                dashboard_result,
+                f"Settlement scan skipped because {chain.name} scan did not report chain id, RPC URL or end block",
             )
             return
 
@@ -1768,7 +1789,7 @@ def run_scan_tick(
         if settlement_vault_db is None:
             settlement_vault_db = VaultDatabase.read(vault_db_path)
 
-        results[result_name] = scan_chain_vault_settlements(
+        settlement_result = scan_chain_vault_settlements(
             chain=chain,
             vault_db=settlement_vault_db,
             chain_id=chain_result.chain_id,
@@ -1778,12 +1799,16 @@ def run_scan_tick(
             settlement_start_block=settlement_start_block,
             settlement_end_block=settlement_end_block,
         )
+        if settlement_result.error:
+            _append_result_error(
+                dashboard_result,
+                f"Settlement scan failed: {settlement_result.error}",
+                settlement_result.traceback_str,
+            )
 
     # Initialise results for all items in this tick
     for c in chains:
         results[c.name] = ChainResult(name=c.name, status="pending", retry_attempt=0, cycle_interval=_ci.get(c.name))
-        if scan_vault_settlements and not skip_post_processing:
-            results[f"{c.name} settlements"] = ChainResult(name=f"{c.name} settlements", status="pending", retry_attempt=0, cycle_interval=_ci.get(c.name))
     for proto in active_protocols:
         results[proto] = ChainResult(name=proto, status="pending", cycle_interval=_ci.get(proto))
 
@@ -1795,13 +1820,7 @@ def run_scan_tick(
     for name in excluded_chains or []:
         results[name] = ChainResult(name=name, status="disabled", cycle_interval=_ci.get(name))
 
-    chain_display_order = []
-    for c in chains:
-        chain_display_order.append(c.name)
-        if scan_vault_settlements and not skip_post_processing:
-            chain_display_order.append(f"{c.name} settlements")
-
-    display_order = chain_display_order + active_protocols + list((not_due_items or {}).keys()) + (excluded_chains or [])
+    display_order = [c.name for c in chains] + active_protocols + list((not_due_items or {}).keys()) + (excluded_chains or [])
     print_dashboard(results, display_order, uncleaned_price_path=uncleaned_price_path)
 
     # First pass - scan EVM chains
@@ -2061,13 +2080,13 @@ def run_scan_tick(
                 logger.warning("  - %s: %s", name, r.error)
     logger.info("Scan complete at %s", native_datetime_utc_now().isoformat())
 
-    # Print full tracebacks for failed chains
-    failed_results = [r for r in results.values() if r.status == "failed" and r.traceback_str]
-    if failed_results:
+    # Print full tracebacks for failed scans and attached settlement errors
+    traceback_results = [r for r in results.values() if r.traceback_str and (r.status == "failed" or (r.error is not None and "Settlement scan failed" in r.error))]
+    if traceback_results:
         print("\n" + "=" * 100)
-        print(" " * 30 + "Full tracebacks for failed chains")
+        print(" " * 25 + "Full tracebacks for failed scans")
         print("=" * 100)
-        for r in failed_results:
+        for r in traceback_results:
             print(f"\n--- {r.name} (retry {r.retry_attempt}) ---")
             print(r.traceback_str)
         print("=" * 100)

--- a/tests/mellow/test_mellow_hypersync_integration.py
+++ b/tests/mellow/test_mellow_hypersync_integration.py
@@ -33,7 +33,6 @@ PRICE_START_BLOCK = 24_999_754
 PRICE_SECOND_BLOCK = 24_999_755
 PRICE_EXCLUSIVE_END_BLOCK = 24_999_756
 PRICE_STEP_BLOCKS = 1
-EXPECTED_MAX_DETECTIONS = 10
 EXPECTED_PRICE_ROWS = 2
 EXPECTED_START_SHARE_PRICE = 1.0080417560461396
 EXPECTED_END_SHARE_PRICE = 1.008280253418576
@@ -94,7 +93,6 @@ def test_mellow_hypersync_discovery_and_historical_reader_price_row(tmp_path: Pa
         display_progress=False,
     )
 
-    assert len(report.detections) <= EXPECTED_MAX_DETECTIONS
     detection = report.detections[LIDO_EARN_USD_VAULT_LOWER]
     assert detection.address == LIDO_EARN_USD_VAULT_LOWER
     assert detection.first_seen_at_block == LIDO_EARN_USD_CREATED_BLOCK

--- a/tests/vault/test_scan_all_chains_core3.py
+++ b/tests/vault/test_scan_all_chains_core3.py
@@ -448,7 +448,11 @@ def test_run_scan_tick_ignores_currency_rate_failure(tmp_path: Path, monkeypatch
     assert saved_items == [scan_all_chains.CURRENCY_RATES_PROTOCOL_NAME]
 
 
-def test_run_scan_tick_continues_when_vault_settlement_scan_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+def test_run_scan_tick_continues_when_vault_settlement_scan_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+):
     """Vault settlement failures are reported without blocking exports.
 
     Steps:
@@ -456,11 +460,11 @@ def test_run_scan_tick_continues_when_vault_settlement_scan_fails(tmp_path: Path
     1. Mock one EVM chain scan to succeed.
     2. Mock its per-chain settlement scanner to reproduce the Linea historical
        ``extraData`` failure.
-    3. Assert the chain settlement row is shown as failed and post-processing
-       still runs.
+    3. Assert no settlement dashboard row is shown, the normal chain row
+       carries the error, and post-processing still runs.
     """
     post_processing_calls: list[dict[str, object]] = []
-    dashboard_snapshots: list[tuple[list[str], dict[str, str]]] = []
+    dashboard_snapshots: list[tuple[list[str], dict[str, tuple[str, str | None]]]] = []
     error_message = "Linea historical extraData is 97 bytes"
     settlement_result_name = "Linea settlements"
 
@@ -491,7 +495,7 @@ def test_run_scan_tick_continues_when_vault_settlement_scan_fails(tmp_path: Path
         dashboard_snapshots.append(
             (
                 list(display_order or []),
-                {name: result.status for name, result in results.items()},
+                {name: (result.status, result.error) for name, result in results.items()},
             )
         )
 
@@ -500,7 +504,6 @@ def test_run_scan_tick_continues_when_vault_settlement_scan_fails(tmp_path: Path
     monkeypatch.setattr(scan_all_chains.VaultDatabase, "read", staticmethod(lambda _path: object()))
     monkeypatch.setattr(scan_all_chains, "run_post_processing", fake_run_post_processing)
     monkeypatch.setattr(scan_all_chains, "print_dashboard", fake_print_dashboard)
-    monkeypatch.setattr("builtins.print", lambda *_, **__: None)
 
     results = scan_all_chains.run_scan_tick(
         chains=[
@@ -545,12 +548,17 @@ def test_run_scan_tick_continues_when_vault_settlement_scan_fails(tmp_path: Path
         scan_vault_settlements=True,
     )
 
-    settlement_result = results[settlement_result_name]
-    assert settlement_result.status == "failed"
-    assert "Linea historical extraData" in settlement_result.error
-    assert f"RuntimeError: {error_message}" in settlement_result.traceback_str
+    assert settlement_result_name not in results
+    linea_result = results["Linea"]
+    assert linea_result.status == "success"
+    assert "Settlement scan failed" in linea_result.error
+    assert "Linea historical extraData" in linea_result.error
+    assert f"RuntimeError: {error_message}" in linea_result.traceback_str
     assert post_processing_calls
     assert post_processing_calls[0]["settlement_db_path"] == tmp_path / "vault-settlements.duckdb"
 
-    assert any(settlement_result_name in display_order and statuses[settlement_result_name] == "pending" for display_order, statuses in dashboard_snapshots)
-    assert any(settlement_result_name in display_order and statuses[settlement_result_name] == "failed" for display_order, statuses in dashboard_snapshots)
+    assert all(settlement_result_name not in display_order for display_order, _ in dashboard_snapshots)
+    assert any(statuses["Linea"][0] == "success" and statuses["Linea"][1] and "Linea historical extraData" in statuses["Linea"][1] for _, statuses in dashboard_snapshots)
+    captured = capsys.readouterr()
+    assert "Full tracebacks for failed scans" in captured.out
+    assert f"RuntimeError: {error_message}" in captured.out


### PR DESCRIPTION
## Why

Settlement scans run alongside each EVM chain scan, but showing a separate `<chain> settlements` row doubles the dashboard noise and makes related failures harder to read with the main chain status. Settlement failures should be visible in the same chain row and logged with the other row errors.

## Lessons learnt

The settlement scanner had moved to a per-chain flow on current `master`, so the fix needed to preserve that scan timing while changing only how the dashboard result is represented. Claude review also caught that the attached settlement traceback filter needed to match the new error text.

## Summary

- Stop creating per-chain settlement dashboard rows.
- Attach settlement scan skip/failure messages and tracebacks to the parent chain result.
- Show and log errors for successful rows when they have attached secondary scan errors.
- Update the regression test to verify settlement rows are absent and full tracebacks still print.

## Related issues and PRs

None.

## Unrelated CI and test fixes

- Remove a stale live Mellow Hypersync discovery count ceiling that started failing after the scan range returned more unrelated vault detections.