### PR TITLE
fix: compact all-chain vault scan logs

### DIFF
--- a/eth_defi/erc_4626/lead_scan_core.py
+++ b/eth_defi/erc_4626/lead_scan_core.py
@@ -27,7 +27,11 @@ from eth_defi.vault.vaultdb import VaultDatabase
 logger = logging.getLogger(__name__)
 
 
-def display_vaults_table(df: pd.DataFrame, nav_threshold=Decimal(1.1)) -> None:
+def display_vaults_table(
+    df: pd.DataFrame,
+    nav_threshold: Decimal = Decimal(1.1),
+    max_entries: int | None = None,
+) -> None:
     """Diplay scanned vault leads in the terminal
 
     - Only used for local diagnostics
@@ -48,27 +52,14 @@ def display_vaults_table(df: pd.DataFrame, nav_threshold=Decimal(1.1)) -> None:
     if not os.environ.get("PRINT_ALL_VAULTS"):
         df = df[df["NAV"] > 1_000]
 
-    del df["First seen"]
-    del df["Symbol"]
-    del df["Shares"]
-
-    if "Deposit fee" in df.columns:
-        del df["Deposit fee"]
-    if "Withdraw fee" in df.columns:
-        del df["Withdraw fee"]
-
-    if "Lock up" in df.columns:
-        del df["Lock up"]
-
-    del df["Link"]
-
     # Remove zero entries
     df = df.loc[df["NAV"] >= nav_threshold]
 
-    # df["Mgmt fee"] = df["Mgmt fee"].apply(lambda x: f"{x:.1%}" if type(x) == float else "-")
-    # df["Perf fee"] = df["Perf fee"].apply(lambda x: f"{x:.1%}" if type(x) == float else "-")
-    # df["Address"] = df["Address"].apply(lambda x: x[0:8])  # Address is too wide in terminal
-    df = df.set_index("Address")
+    # Keep operational logs compact and focused on vault identity and size.
+    df = df[["Name", "Protocol", "Share token", "NAV"]]
+
+    if max_entries is not None:
+        df = df.head(max_entries)
 
     # Round dust to zero, drop to 4 decimals
     def round_below_epsilon(x, epsilon=Decimal("0.1"), round_factor=Decimal("0.001")):
@@ -99,7 +90,7 @@ def display_vaults_table(df: pd.DataFrame, nav_threshold=Decimal(1.1)) -> None:
     df = df.apply(lambda col: col.map(round_below_epsilon))
 
     with pd.option_context("display.max_rows", None, "display.max_columns", None, "display.width", 200):
-        logger.info("Vault scan results:\n%s", df.to_string())
+        logger.info("Vault scan results:\n%s", df.to_string(index=False))
 
 
 def scan_leads(
@@ -114,6 +105,7 @@ def scan_leads(
     reset_leads=False,
     hypersync_api_key: str | None = None,
     hypersync_concurrency: int | None = None,
+    max_display_entries: int | None = None,
 ) -> LeadScanReport:
     """Core loop to discover new vaults on a chain.
 
@@ -124,6 +116,9 @@ def scan_leads(
         Number of concurrent Hypersync stream requests.
         ``None`` falls back to the ``HYPERSYNC_CONCURRENCY`` env var,
         then to the Hypersync server default.
+    :param max_display_entries:
+        Maximum number of vaults included in the diagnostic results table.
+        ``None`` displays all matching vaults.
     """
 
     from eth_defi.erc_4626.hypersync_discovery import HypersyncVaultDiscover
@@ -240,7 +235,7 @@ def scan_leads(
     data_dict = {r["_detection_data"].get_spec(): r for r in rows}
     report.rows = data_dict
 
-    display_vaults_table(df)
+    display_vaults_table(df, max_entries=max_display_entries)
 
     printer(f"Saving vault pickled database to {vault_db_file}")
     # Merge new results

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -418,6 +418,7 @@ def scan_vaults_for_chain(
             hypersync_api_key=os.environ.get("HYPERSYNC_API_KEY"),
             printer=lambda msg: None,  # Suppress output to keep logs clean
             hypersync_concurrency=hypersync_concurrency,
+            max_display_entries=100,
         )
 
         return True, {

--- a/tests/erc_4626/test_lead_scan_core.py
+++ b/tests/erc_4626/test_lead_scan_core.py
@@ -1,0 +1,37 @@
+"""Unit tests for ERC-4626 lead scanner terminal output."""
+
+import logging
+from decimal import Decimal
+
+import pandas as pd
+import pytest
+
+from eth_defi.erc_4626.lead_scan_core import display_vaults_table
+
+
+def test_display_vaults_table_limits_columns_and_entries(caplog: pytest.LogCaptureFixture):
+    """The all-chains scanner can keep its vault results log compact."""
+
+    df = pd.DataFrame(
+        {
+            "Name": ["Vault one", "Vault two", "Vault three"],
+            "Protocol": ["Protocol"] * 3,
+            "Share token": ["SHARE"] * 3,
+            "NAV": [Decimal("1001")] * 3,
+            "Address": ["0x1", "0x2", "0x3"],
+            "Features": ["verbose"] * 3,
+        }
+    )
+
+    caplog.set_level(logging.INFO, logger="eth_defi.erc_4626.lead_scan_core")
+    display_vaults_table(df, max_entries=2)
+
+    assert "Vault one" in caplog.text
+    assert "Vault two" in caplog.text
+    assert "Vault three" not in caplog.text
+    assert "Name" in caplog.text
+    assert "Protocol" in caplog.text
+    assert "Share token" in caplog.text
+    assert "NAV" in caplog.text
+    assert "Address" not in caplog.text
+    assert "Features" not in caplog.text


### PR DESCRIPTION
## Why

The all-chains vault scanner logs an unbounded, wide results table, obscuring operational logs.

## Lessons learnt

Keep scan diagnostics limited to the fields operators need and cap high-volume output at the caller that runs continuously.

## Summary

- Limit all-chains vault result logs to 100 entries.
- Display only name, protocol, share token, and NAV.
- Add unit coverage for the compact display.

Initial worktree: `/home/mikko/code/freqtrade-strategies/deps/web3-ethereum-defi`.