### PR TITLE
fix: retain Robinhood Morpho vaults during API coverage gap

### DIFF
--- a/docs/source/vaults/morpho/index.rst
+++ b/docs/source/vaults/morpho/index.rst
@@ -19,6 +19,17 @@ across multiple yield sources through smart contract adapters. V2 vaults use
 - Timelocked governance with curator/allocator roles
 - Non-custodial exits via ``forceDeallocate``
 
+Robinhood Chain temporary API workaround
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Robinhood Chain (ID ``4663``) has active Morpho V2 vaults whose public API
+coverage is currently incomplete. Until the API returns every production
+Robinhood vault by address, a missing Morpho API record on that chain does not
+apply the ``not_in_morpho_api`` hard-blacklist flag. The scanner still uses all
+available on-chain metadata, but omits API-provided warning enrichment when no
+record is available. This is intentionally a temporary exception and must be
+removed once Morpho's Robinhood API coverage is complete.
+
 Links
 ~~~~~
 

--- a/eth_defi/erc_4626/vault_protocol/morpho/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/offchain_metadata.py
@@ -93,7 +93,34 @@ MORPHO_API_SUPPORTED_CHAINS = frozenset(
     }
 )
 
+#: Chains where a missing Morpho API record must not blacklist an otherwise
+#: detected Morpho vault.
+#:
+#: Robinhood Chain launched with active Morpho V2 vaults, but its API coverage
+#: is incomplete: some legitimate vaults do not yet resolve by address. Until
+#: Morpho's API provides complete Robinhood coverage, retain on-chain detected
+#: vaults in the universe and omit only unavailable API warning enrichment.
+#:
+#: Remove Robinhood from this set once all production Robinhood Morpho vaults
+#: reliably resolve through the public API.
+MORPHO_API_NOT_FOUND_FLAG_BYPASS_CHAINS = frozenset({4663})  # Robinhood Chain
+
 logger = logging.getLogger(__name__)
+
+
+def is_morpho_api_not_found_flag_bypassed(chain_id: int) -> bool:
+    """Check whether a missing Morpho API record is temporarily non-fatal.
+
+    This narrowly scopes a temporary Robinhood Chain data-quality workaround.
+    It does not suppress RED-level warnings returned by the API, nor does it
+    affect normal missing-vault handling on any other chain.
+
+    :param chain_id:
+        EVM chain ID of the Morpho vault.
+    :return:
+        ``True`` when an API ``NOT_FOUND`` must not add the hard blacklist flag.
+    """
+    return chain_id in MORPHO_API_NOT_FOUND_FLAG_BYPASS_CHAINS
 
 #: GraphQL query to fetch vault-level and market-level warnings for a single vault
 _VAULT_WARNINGS_QUERY = """

--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v1.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v1.py
@@ -25,6 +25,7 @@ from eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata import (
     MorphoVaultAPIStatus,
     MorphoVaultData,
     fetch_morpho_vault_api_result,
+    is_morpho_api_not_found_flag_bypassed,
 )
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.types import Percent
@@ -245,7 +246,7 @@ class MorphoV1Vault(ERC4626Vault):
         note = super().get_notes()
         if note:
             return note
-        if self.morpho_api_result.is_not_found:
+        if self.morpho_api_result.is_not_found and not is_morpho_api_not_found_flag_bypassed(self.chain_id):
             return NOT_IN_MORPHO_API
         data = self.morpho_offchain_data
         if data is not None:
@@ -263,7 +264,7 @@ class MorphoV1Vault(ERC4626Vault):
             Set of :py:class:`~eth_defi.vault.flag.VaultFlag` values.
         """
         flags = super().get_flags()
-        if self.morpho_api_result.is_not_found:
+        if self.morpho_api_result.is_not_found and not is_morpho_api_not_found_flag_bypassed(self.chain_id):
             flags = set(flags)
             flags.add(VaultFlag.not_in_morpho_api)
             return flags

--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
@@ -34,6 +34,7 @@ from eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata import (
     MorphoVaultAPIStatus,
     MorphoVaultData,
     fetch_morpho_vault_api_result,
+    is_morpho_api_not_found_flag_bypassed,
 )
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.types import Percent
@@ -279,7 +280,7 @@ class MorphoV2Vault(ERC4626Vault):
         note = super().get_notes()
         if note:
             return note
-        if self.morpho_api_result.is_not_found:
+        if self.morpho_api_result.is_not_found and not is_morpho_api_not_found_flag_bypassed(self.chain_id):
             return NOT_IN_MORPHO_API
         data = self.morpho_offchain_data
         if data is not None:
@@ -297,7 +298,7 @@ class MorphoV2Vault(ERC4626Vault):
             Set of :py:class:`~eth_defi.vault.flag.VaultFlag` values.
         """
         flags = super().get_flags()
-        if self.morpho_api_result.is_not_found:
+        if self.morpho_api_result.is_not_found and not is_morpho_api_not_found_flag_bypassed(self.chain_id):
             flags = set(flags)
             flags.add(VaultFlag.not_in_morpho_api)
             return flags

--- a/tests/morpho/test_morpho_offchain_metadata.py
+++ b/tests/morpho/test_morpho_offchain_metadata.py
@@ -72,6 +72,7 @@ from eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata import (
     fetch_morpho_vault_data,
 )
 from eth_defi.erc_4626.vault_protocol.morpho.vault_v1 import MorphoV1Vault
+from eth_defi.erc_4626.vault_protocol.morpho.vault_v2 import MorphoV2Vault
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.flag import NOT_IN_MORPHO_API, VaultFlag
@@ -146,11 +147,11 @@ def _patch_morpho_api(monkeypatch: pytest.MonkeyPatch, responses: list[dict]) ->
     return calls
 
 
-def _make_morpho_v1_vault(address: str) -> MorphoV1Vault:
+def _make_morpho_v1_vault(address: str, chain_id: int = 1) -> MorphoV1Vault:
     """Create a Morpho V1 vault with only offchain API dependencies populated."""
     return MorphoV1Vault(
-        web3=_FakeWeb3(),  # type: ignore[arg-type]
-        spec=VaultSpec(chain_id=1, vault_address=address),
+        web3=_FakeWeb3(chain_id),  # type: ignore[arg-type]
+        spec=VaultSpec(chain_id=chain_id, vault_address=address),
         token_cache={},
     )
 
@@ -198,6 +199,35 @@ def test_morpho_not_found_adds_dynamic_flag_and_note(monkeypatch: pytest.MonkeyP
     assert vault.get_flags() == {VaultFlag.not_in_morpho_api}
     assert vault.get_notes() == NOT_IN_MORPHO_API
     assert VaultFlag.morpho_issues not in vault.get_flags()
+
+
+@pytest.mark.parametrize(
+    ("vault_class", "module_path"),
+    [
+        (MorphoV1Vault, "eth_defi.erc_4626.vault_protocol.morpho.vault_v1"),
+        (MorphoV2Vault, "eth_defi.erc_4626.vault_protocol.morpho.vault_v2"),
+    ],
+)
+def test_robinhood_morpho_api_not_found_is_temporarily_not_blacklisted(
+    monkeypatch: pytest.MonkeyPatch,
+    vault_class: type[MorphoV1Vault] | type[MorphoV2Vault],
+    module_path: str,
+):
+    """Robinhood API coverage gaps do not hide on-chain-detected Morpho vaults."""
+    _patch_base_vault_flags(monkeypatch)
+
+    def fake_fetch_morpho_vault_api_result(*_args, **_kwargs) -> MorphoVaultAPIResult:
+        return MorphoVaultAPIResult(MorphoVaultAPIStatus.not_found)
+
+    monkeypatch.setattr(f"{module_path}.fetch_morpho_vault_api_result", fake_fetch_morpho_vault_api_result)
+    vault = vault_class(
+        web3=_FakeWeb3(4663),  # type: ignore[arg-type]
+        spec=VaultSpec(chain_id=4663, vault_address=NOT_FOUND_TEST_VAULT),
+        token_cache={},
+    )
+
+    assert vault.get_flags() == set()
+    assert vault.get_notes() is None
 
 
 def test_morpho_not_found_is_not_cached(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):


### PR DESCRIPTION
## Why

Robinhood Chain has legitimate on-chain-detected Morpho V2 vaults whose Morpho API records are incomplete. The generic missing-record safeguard was blacklisting those vaults and hiding most Robinhood TVL.

## Lessons learnt

Morpho API coverage can be partial for a supported chain. A missing off-chain record must not automatically override verified on-chain vault detection when a narrowly documented temporary exception is required.

## Summary

- Added a Robinhood-only temporary bypass for the Morpho API missing-record blacklist.
- Preserved normal RED-warning handling and missing-record blacklisting on every other chain.
- Documented the removal condition and added V1/V2 regression coverage.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.