### PR TITLE
fix: reduce unchanged metadata log level

### DIFF
--- a/eth_defi/vault/protocol_metadata.py
+++ b/eth_defi/vault/protocol_metadata.py
@@ -275,7 +275,10 @@ def process_and_upload_protocol_metadata(
         content_type="application/json",
         skip_if_current=True,
     )
-    logger.info("%s metadata for protocol: %s", "Uploaded" if metadata_uploaded else "Skipped unchanged", slug)
+    if metadata_uploaded:
+        logger.info("Uploaded metadata for protocol: %s", slug)
+    else:
+        logger.debug("Skipped unchanged metadata for protocol: %s", slug)
 
     # Upload available logos
     logo_dir = FORMATTED_LOGOS_DIR / slug


### PR DESCRIPTION
## Why

Repeated unchanged protocol metadata uploads create high-volume INFO logs in the vault scanner loop, even though no data changed. The scanner should keep successful uploads visible while moving no-op metadata skips to DEBUG.

## Lessons learnt

Threaded metadata export can produce a large number of low-value no-op log lines when many protocols are already current.

## Summary

- Keep uploaded protocol metadata messages at INFO.
- Log unchanged protocol metadata skips at DEBUG.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.