### PR TITLE
perf: merge native parquet price partitions in one pass

### DIFF
--- a/.claude/docs/agent-tricks-and-troubleshooting.md
+++ b/.claude/docs/agent-tricks-and-troubleshooting.md
@@ -209,6 +209,42 @@ If these work but the broad review times out, shrink the request: ask Claude to
 inspect `git diff --name-only` first, review one file group at a time, or provide
 a concise summary of the proposed fix instead of embedding a large diff.
 
+### Foreground command-window limits
+
+Some agent runners terminate a foreground command after roughly 30 seconds,
+even when Claude is actively reading files and emitting streaming JSON. This
+can leave a review with only tool calls and no final findings. Do not rely on a
+foreground `claude -p` invocation for a non-trivial worktree review in those
+environments.
+
+Start the review in the background and write the raw JSONL stream to a temporary
+file instead. Restrict tools to read-only operations and redirect stdin so the
+CLI cannot wait for additional prompt input:
+
+```shell
+nohup timeout 120 claude -p "Review the current uncommitted worktree diff for correctness bugs only. Do not edit files or run tests. Return findings first with file:line references." \
+  --permission-mode dontAsk \
+  --allowedTools "Read,Grep,Glob,Bash(git status:*),Bash(git diff:*),Bash(sed:*),Bash(rg:*)" \
+  --output-format stream-json \
+  --verbose \
+  --no-session-persistence \
+  < /dev/null > /tmp/claude-review.jsonl 2>&1 &
+```
+
+Poll the process and inspect the raw file from later commands. Do not pipe the
+Claude process through `head` or `tail`, as that can interfere with streaming:
+
+```shell
+ps -p <pid> -o pid=,stat=,etime=,cmd=
+rg '"type":"result"' /tmp/claude-review.jsonl
+tail -n 40 /tmp/claude-review.jsonl
+```
+
+Only trust the review after the JSONL file contains a successful ``result``
+event with the final findings. If the command reaches its timeout without that
+event, narrow the file scope and repeat the background review rather than trying
+to resume a `--no-session-persistence` session.
+
 ### Reviewing a plan or document with Claude CLI
 
 For Markdown plan reviews, default to a no-tools inline text review after the

--- a/eth_defi/hyperliquid/vault_data_export.py
+++ b/eth_defi/hyperliquid/vault_data_export.py
@@ -26,14 +26,13 @@ Example::
 
 import datetime
 import logging
+from collections.abc import Mapping
 from decimal import Decimal
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 from eth_typing import HexAddress
-
-from collections.abc import Mapping
 
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
@@ -613,6 +612,55 @@ def build_raw_prices_dataframe_hf(db: HyperliquidHighFreqMetricsDatabase) -> pd.
     )
 
 
+def build_hypercore_prices_dataframe(
+    daily_db: HyperliquidDailyMetricsDatabase | None = None,
+    hf_db: HyperliquidHighFreqMetricsDatabase | None = None,
+) -> pd.DataFrame:
+    """Build a deduplicated Hypercore price DataFrame from available databases.
+
+    Daily and high-frequency data are combined without writing a Parquet file.
+    This lets the full post-processing pipeline batch Hypercore with other
+    native-protocol sources in one Parquet rewrite, while standalone callers
+    can still use :py:func:`merge_hypercore_prices_to_parquet`.
+
+    When both databases contain a row for the same ``(address, timestamp)``,
+    the high-frequency row wins because it is the more granular source.
+
+    :param daily_db:
+        Open daily metrics database, if available.
+    :param hf_db:
+        Open high-frequency metrics database, if available.
+    :return:
+        Deduplicated Hypercore raw prices, or an empty DataFrame when neither
+        database has price data.
+    """
+    parts: list[pd.DataFrame] = []
+
+    if daily_db is not None:
+        daily_df = build_raw_prices_dataframe(daily_db)
+        if not daily_df.empty:
+            daily_df["_source"] = "daily"
+            parts.append(daily_df)
+            logger.info("Daily DB contributed %d Hypercore rows", len(daily_df))
+
+    if hf_db is not None:
+        hf_df = build_raw_prices_dataframe_hf(hf_db)
+        if not hf_df.empty:
+            hf_df["_source"] = "hf"
+            parts.append(hf_df)
+            logger.info("HF DB contributed %d Hypercore rows", len(hf_df))
+
+    if not parts:
+        return pd.DataFrame()
+
+    hl_df = pd.concat(parts, ignore_index=True)
+
+    # Sort so "hf" comes after "daily", then drop_duplicates keeps last.
+    hl_df = hl_df.sort_values(["address", "timestamp", "_source"])
+    hl_df = hl_df.drop_duplicates(subset=["address", "timestamp"], keep="last")
+    return hl_df.drop(columns=["_source"])
+
+
 def merge_hypercore_prices_to_parquet(
     parquet_path: Path,
     daily_db: HyperliquidDailyMetricsDatabase | None = None,
@@ -641,36 +689,12 @@ def merge_hypercore_prices_to_parquet(
     :return:
         The combined DataFrame (EVM + Hypercore rows).
     """
-    parts: list[pd.DataFrame] = []
-
-    if daily_db is not None:
-        daily_df = build_raw_prices_dataframe(daily_db)
-        if not daily_df.empty:
-            daily_df["_source"] = "daily"
-            parts.append(daily_df)
-            logger.info("Daily DB contributed %d Hypercore rows", len(daily_df))
-
-    if hf_db is not None:
-        hf_df = build_raw_prices_dataframe_hf(hf_db)
-        if not hf_df.empty:
-            hf_df["_source"] = "hf"
-            parts.append(hf_df)
-            logger.info("HF DB contributed %d Hypercore rows", len(hf_df))
-
-    if not parts:
+    hl_df = build_hypercore_prices_dataframe(daily_db=daily_db, hf_db=hf_db)
+    if hl_df.empty:
         logger.warning("No Hyperliquid data to merge from either database")
         if parquet_path.exists():
             return pd.read_parquet(parquet_path)
         return pd.DataFrame()
-
-    hl_df = pd.concat(parts, ignore_index=True)
-
-    # Deduplicate: when both databases have a row for the same
-    # (address, timestamp), keep the HF row (more granular/recent).
-    # Sort so "hf" comes after "daily", then drop_duplicates keeps last.
-    hl_df = hl_df.sort_values(["address", "timestamp", "_source"])
-    hl_df = hl_df.drop_duplicates(subset=["address", "timestamp"], keep="last")
-    hl_df = hl_df.drop(columns=["_source"])
 
     if parquet_path.exists():
         existing_df = pd.read_parquet(parquet_path)

--- a/eth_defi/vault/base.py
+++ b/eth_defi/vault/base.py
@@ -730,7 +730,7 @@ class VaultHistoricalRead:
         df: "pd.DataFrame",
         path: "pathlib.Path",
         compression: str = "zstd",
-    ):
+    ) -> None:
         """Write a DataFrame to the uncleaned parquet using proper PyArrow types.
 
         Native protocol merge functions (Hyperliquid, GRVT, Lighter) must use
@@ -750,7 +750,6 @@ class VaultHistoricalRead:
             Parquet compression codec.
         """
         import pyarrow as pa
-        import pyarrow.parquet as pq
 
         table = pa.Table.from_pandas(df, preserve_index=False)
 
@@ -767,6 +766,31 @@ class VaultHistoricalRead:
                     table.column(i).cast(target_field.type, safe=False),
                 )
 
+        VaultHistoricalRead.write_uncleaned_arrow_table(table, path, compression=compression)
+
+    @staticmethod
+    def write_uncleaned_arrow_table(
+        table: "pyarrow.Table",
+        path: "pathlib.Path",
+        compression: str = "zstd",
+    ) -> None:
+        """Write a pre-aligned raw-price Arrow table with atomic verification.
+
+        Both the EVM-compatible pandas writer and the direct PyArrow native
+        merge path use this method. The caller is responsible for aligning
+        canonical column types before calling this method; the output is
+        written beside the target, verified, and atomically replaced only on
+        success.
+
+        :param table:
+            Raw price table with its final canonical and native-only schema.
+        :param path:
+            Target uncleaned parquet path.
+        :param compression:
+            Parquet compression codec.
+        """
+        import pyarrow.parquet as pq
+
         # Write to a temp file, verify, then atomically replace the target.
         # If verification fails, the original file is preserved.
         temp_fd, temp_path = tempfile.mkstemp(
@@ -778,7 +802,7 @@ class VaultHistoricalRead:
             pq.write_table(table, temp_path, compression=compression)
             verify_parquet_file(
                 temp_path,
-                expected_rows=len(df),
+                expected_rows=len(table),
                 expected_schema=table.schema,
             )
             os.replace(temp_path, str(path))

--- a/eth_defi/vault/post_processing.py
+++ b/eth_defi/vault/post_processing.py
@@ -14,22 +14,29 @@ import os
 from pathlib import Path
 from typing import Any
 
+import pandas as pd
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.parquet as pq
+
 from eth_defi.cloudflare_r2 import calculate_bytes_digest, copy_r2_object_daily_backup, create_r2_client, upload_bytes_to_r2, upload_file_to_r2
 from eth_defi.grvt.constants import GRVT_CHAIN_ID, GRVT_DAILY_METRICS_DATABASE
 from eth_defi.grvt.daily_metrics import GRVTDailyMetricsDatabase
-from eth_defi.grvt.vault_data_export import merge_into_uncleaned_parquet as grvt_merge_parquet
-from eth_defi.hyperliquid.constants import HYPERCORE_CHAIN_ID
-from eth_defi.hyperliquid.vault_data_export import open_and_merge_hypercore_prices
-from eth_defi.lighter.constants import LIGHTER_CHAIN_ID, LIGHTER_DAILY_METRICS_DATABASE
-from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase
-from eth_defi.lighter.vault_data_export import merge_into_uncleaned_parquet as lighter_merge_parquet
+from eth_defi.grvt.vault_data_export import build_raw_prices_dataframe as build_grvt_prices_dataframe
 from eth_defi.hibachi.constants import HIBACHI_CHAIN_ID, HIBACHI_DAILY_METRICS_DATABASE
 from eth_defi.hibachi.daily_metrics import HibachiDailyMetricsDatabase
-from eth_defi.hibachi.vault_data_export import merge_into_uncleaned_parquet as hibachi_merge_parquet
+from eth_defi.hibachi.vault_data_export import build_raw_prices_dataframe as build_hibachi_prices_dataframe
+from eth_defi.hyperliquid.constants import HYPERCORE_CHAIN_ID, HYPERLIQUID_DAILY_METRICS_DATABASE, HYPERLIQUID_HIGH_FREQ_METRICS_DATABASE
+from eth_defi.hyperliquid.daily_metrics import HyperliquidDailyMetricsDatabase
+from eth_defi.hyperliquid.high_freq_metrics import HyperliquidHighFreqMetricsDatabase
+from eth_defi.hyperliquid.vault_data_export import build_hypercore_prices_dataframe
+from eth_defi.lighter.constants import LIGHTER_CHAIN_ID, LIGHTER_DAILY_METRICS_DATABASE
+from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase
+from eth_defi.lighter.vault_data_export import build_raw_prices_dataframe as build_lighter_prices_dataframe
 from eth_defi.research.wrangle_vault_prices import generate_cleaned_vault_datasets
 from eth_defi.vault import top_vaults_json
+from eth_defi.vault.base import VaultHistoricalRead
 from eth_defi.vault.vaultdb import DEFAULT_UNCLEANED_PRICE_DATABASE, get_pipeline_data_dir
-
 
 #: Required env vars for the top-vaults JSON R2 upload.
 #: See :py:func:`validate_top_vaults_config`.
@@ -248,6 +255,105 @@ def _upload_top_vaults_json_to_configured_buckets(
     return primary_success and alternative_success
 
 
+def _create_native_merge_schema(existing_schema: pa.Schema | None, replacements: dict[int, pd.DataFrame]) -> pa.Schema:
+    """Construct a canonical schema for the native partition replacement.
+
+    Canonical raw-price columns use the exact types required by the EVM
+    scanner. Extra native-protocol fields are retained from the existing
+    parquet and unified with fresh source frames, so a native merge cannot
+    discard fields such as Hypercore account metrics.
+
+    :param existing_schema:
+        Existing raw-price Parquet schema, or ``None`` when creating it.
+    :param replacements:
+        Fresh native price frames keyed by their synthetic chain IDs.
+    :return:
+        Canonical schema followed by compatible native-only fields.
+    """
+    canonical_schema = VaultHistoricalRead.to_pyarrow_schema()
+    canonical_names = set(canonical_schema.names)
+    extra_schemas: list[pa.Schema] = []
+
+    if existing_schema is not None:
+        extra_schemas.append(pa.schema(field for field in existing_schema if field.name not in canonical_names))
+
+    for frame in replacements.values():
+        source_schema = pa.Schema.from_pandas(frame, preserve_index=False)
+        extra_schemas.append(pa.schema(field for field in source_schema if field.name not in canonical_names))
+
+    extras = pa.unify_schemas(extra_schemas, promote_options="permissive") if extra_schemas else pa.schema([])
+    return pa.schema([*canonical_schema, *extras])
+
+
+def _align_native_merge_table(table: pa.Table, schema: pa.Schema) -> pa.Table:
+    """Align an Arrow table to the canonical native merge schema.
+
+    Missing columns are null-filled and incompatible source representations
+    are cast before concatenation. This mirrors the canonical type guarantees
+    of :py:meth:`VaultHistoricalRead.write_uncleaned_parquet` without turning
+    the full raw parquet into a pandas DataFrame.
+
+    :param table:
+        Existing or fresh native Arrow table.
+    :param schema:
+        Required output schema.
+    :return:
+        Table with every required field in schema order.
+    """
+    arrays: list[pa.ChunkedArray] = []
+    for field in schema:
+        column_index = table.schema.get_field_index(field.name)
+        if column_index == -1:
+            arrays.append(pa.chunked_array([pa.nulls(len(table), type=field.type)]))
+            continue
+
+        column = table.column(column_index)
+        arrays.append(column if column.type == field.type else column.cast(field.type, safe=False))
+
+    return pa.Table.from_arrays(arrays, schema=schema)
+
+
+def _write_native_partitions_to_uncleaned_parquet(parquet_path: Path, replacements: dict[int, pd.DataFrame]) -> int:
+    """Replace native chain partitions using PyArrow without full pandas conversion.
+
+    The existing file is read as an Arrow table, only the successful native
+    chains are removed, and fresh source frames are converted and aligned once.
+    The combined table is sorted for compression efficiency, verified in a
+    sibling temporary file, and atomically swapped into place.
+
+    :param parquet_path:
+        Raw vault-price parquet to update.
+    :param replacements:
+        Fresh, non-empty source frames keyed by their synthetic chain IDs.
+    :return:
+        Total row count in the new raw parquet.
+    """
+    assert replacements, "At least one native chain replacement is required"
+
+    existing_table = pq.read_table(parquet_path) if parquet_path.exists() else None
+    schema = _create_native_merge_schema(existing_table.schema if existing_table is not None else None, replacements)
+    replacement_tables = [_align_native_merge_table(pa.Table.from_pandas(frame, preserve_index=False), schema) for frame in replacements.values()]
+    native_table = pa.concat_tables(replacement_tables)
+
+    if existing_table is not None:
+        chain_mask = pc.is_in(existing_table["chain"], value_set=pa.array(list(replacements)))
+        retained_table = _align_native_merge_table(existing_table.filter(pc.invert(chain_mask)), schema)
+        combined_table = pa.concat_tables([retained_table, native_table])
+    else:
+        parquet_path.parent.mkdir(parents=True, exist_ok=True)
+        combined_table = native_table
+
+    sort_indices = pc.sort_indices(
+        combined_table,
+        sort_keys=[("chain", "ascending"), ("address", "ascending"), ("timestamp", "ascending")],
+    )
+    combined_table = combined_table.take(sort_indices)
+
+    VaultHistoricalRead.write_uncleaned_arrow_table(combined_table, parquet_path)
+
+    return len(combined_table)
+
+
 def merge_native_protocols(
     merge_hypercore: bool = False,
     merge_grvt: bool = False,
@@ -260,14 +366,22 @@ def merge_native_protocols(
     lighter_db_path: Path | None = None,
     hibachi_db_path: Path | None = None,
 ) -> dict[str, bool]:
-    """Merge native protocol price data into the uncleaned parquet.
+    """Merge native protocol price data into the uncleaned parquet in one pass.
 
     Must run before cleaning so that native protocol data goes through
     the same cleaning pipeline as EVM vaults.
 
     For Hypercore, both the daily and HF DuckDB databases are always
     merged together so that switching between modes never loses
-    historical data.
+    historical data. All enabled native sources are collected before the
+    existing parquet is read, then their chain partitions are replaced and
+    the result is written once. This avoids repeatedly rewriting the much
+    larger EVM data set.
+
+    An unavailable, empty, or failed source leaves its existing chain
+    partition untouched. This preserves the previous per-source failure
+    semantics and prevents a transient database failure from deleting
+    historical native-protocol prices.
 
     :param merge_hypercore: Merge Hyperliquid native (Hypercore) vault data
     :param merge_grvt: Merge GRVT native vault data
@@ -282,18 +396,37 @@ def merge_native_protocols(
     :return: Dictionary mapping step name to success boolean
     """
     parquet_path = uncleaned_parquet_path or DEFAULT_UNCLEANED_PRICE_DATABASE
-    steps = {}
+    steps: dict[str, bool] = {}
+    replacements: dict[int, pd.DataFrame] = {}
 
     if merge_hypercore:
         try:
             logger.info("Merging Hypercore prices into uncleaned parquet")
-            combined_df = open_and_merge_hypercore_prices(
-                parquet_path,
-                daily_db_path=hyperliquid_db_path,
-                hf_db_path=hyperliquid_hf_db_path,
-            )
-            hl_rows = len(combined_df[combined_df["chain"] == HYPERCORE_CHAIN_ID]) if len(combined_df) > 0 else 0
-            logger.info("Hypercore price merge: %d Hyperliquid price entries in uncleaned parquet", hl_rows)
+            daily_path = hyperliquid_db_path or HYPERLIQUID_DAILY_METRICS_DATABASE
+            hf_path = hyperliquid_hf_db_path or HYPERLIQUID_HIGH_FREQ_METRICS_DATABASE
+            daily_db = None
+            hf_db = None
+            try:
+                if daily_path.exists():
+                    daily_db = HyperliquidDailyMetricsDatabase(daily_path)
+                if hf_path.exists():
+                    hf_db = HyperliquidHighFreqMetricsDatabase(hf_path)
+                if daily_db is None and hf_db is None:
+                    logger.warning("No Hyperliquid DuckDB databases found")
+                    hypercore_df = pd.DataFrame()
+                else:
+                    hypercore_df = build_hypercore_prices_dataframe(daily_db=daily_db, hf_db=hf_db)
+            finally:
+                if daily_db is not None:
+                    daily_db.close()
+                if hf_db is not None:
+                    hf_db.close()
+
+            if hypercore_df.empty:
+                logger.warning("No Hyperliquid data to merge from either database")
+            else:
+                replacements[HYPERCORE_CHAIN_ID] = hypercore_df
+            logger.info("Hypercore price merge: %d fresh Hyperliquid price entries", len(hypercore_df))
             steps["hypercore-price-merge"] = True
         except Exception:
             logger.exception("Hypercore price merge failed")
@@ -305,11 +438,14 @@ def merge_native_protocols(
             g_db_path = grvt_db_path or GRVT_DAILY_METRICS_DATABASE
             db = GRVTDailyMetricsDatabase(g_db_path)
             try:
-                combined_df = grvt_merge_parquet(db, parquet_path)
-                grvt_rows = len(combined_df[combined_df["chain"] == GRVT_CHAIN_ID]) if len(combined_df) > 0 else 0
-                logger.info("GRVT price merge: %d GRVT price entries in uncleaned parquet", grvt_rows)
+                grvt_df = build_grvt_prices_dataframe(db)
             finally:
                 db.close()
+            if grvt_df.empty:
+                logger.warning("No GRVT data to merge")
+            else:
+                replacements[GRVT_CHAIN_ID] = grvt_df
+            logger.info("GRVT price merge: %d fresh GRVT price entries", len(grvt_df))
             steps["grvt-price-merge"] = True
         except Exception:
             logger.exception("GRVT price merge failed")
@@ -321,11 +457,14 @@ def merge_native_protocols(
             l_db_path = lighter_db_path or LIGHTER_DAILY_METRICS_DATABASE
             db = LighterDailyMetricsDatabase(l_db_path)
             try:
-                combined_df = lighter_merge_parquet(db, parquet_path)
-                lighter_rows = len(combined_df[combined_df["chain"] == LIGHTER_CHAIN_ID]) if len(combined_df) > 0 else 0
-                logger.info("Lighter price merge: %d Lighter price entries in uncleaned parquet", lighter_rows)
+                lighter_df = build_lighter_prices_dataframe(db)
             finally:
                 db.close()
+            if lighter_df.empty:
+                logger.warning("No Lighter data to merge")
+            else:
+                replacements[LIGHTER_CHAIN_ID] = lighter_df
+            logger.info("Lighter price merge: %d fresh Lighter price entries", len(lighter_df))
             steps["lighter-price-merge"] = True
         except Exception:
             logger.exception("Lighter price merge failed")
@@ -337,15 +476,41 @@ def merge_native_protocols(
             h_db_path = hibachi_db_path or HIBACHI_DAILY_METRICS_DATABASE
             db = HibachiDailyMetricsDatabase(h_db_path)
             try:
-                combined_df = hibachi_merge_parquet(db, parquet_path)
-                hibachi_rows = len(combined_df[combined_df["chain"] == HIBACHI_CHAIN_ID]) if len(combined_df) > 0 else 0
-                logger.info("Hibachi price merge: %d Hibachi price entries in uncleaned parquet", hibachi_rows)
+                hibachi_df = build_hibachi_prices_dataframe(db)
             finally:
                 db.close()
+            if hibachi_df.empty:
+                logger.warning("No Hibachi data to merge")
+            else:
+                replacements[HIBACHI_CHAIN_ID] = hibachi_df
+            logger.info("Hibachi price merge: %d fresh Hibachi price entries", len(hibachi_df))
             steps["hibachi-price-merge"] = True
         except Exception:
             logger.exception("Hibachi price merge failed")
             steps["hibachi-price-merge"] = False
+
+    if not replacements:
+        return steps
+
+    try:
+        total_rows = _write_native_partitions_to_uncleaned_parquet(parquet_path, replacements)
+        logger.info(
+            "Merged %d native protocol chain partitions (%d fresh rows, %d total rows) into uncleaned %s in one PyArrow parquet write",
+            len(replacements),
+            sum(len(df) for df in replacements.values()),
+            total_rows,
+            parquet_path,
+        )
+    except Exception:
+        logger.exception("Native protocol batch price merge failed")
+        for step_name, chain_id in (
+            ("hypercore-price-merge", HYPERCORE_CHAIN_ID),
+            ("grvt-price-merge", GRVT_CHAIN_ID),
+            ("lighter-price-merge", LIGHTER_CHAIN_ID),
+            ("hibachi-price-merge", HIBACHI_CHAIN_ID),
+        ):
+            if chain_id in replacements:
+                steps[step_name] = False
 
     return steps
 

--- a/scripts/erc-4626/benchmark-native-price-merge.py
+++ b/scripts/erc-4626/benchmark-native-price-merge.py
@@ -1,0 +1,504 @@
+"""Benchmark native-price parquet merge implementations on production-shaped data.
+
+The benchmark never replaces the configured uncleaned price parquet. Each
+candidate writes a temporary sibling file, verifies it, records timing and
+output schema compatibility, and removes the file afterwards.
+
+Experiment results (2026-07-10)
+---------------------------------
+
+The benchmark used the current production-shaped
+``~/.tradingstrategy/vaults/vault-prices-1h.parquet`` with 19,340,511 rows.
+Its four native partitions contained 835,020 rows. Native partitions were
+read from that same parquet for the timing run, which isolates the full-file
+replacement cost from DuckDB export time.
+
+On a warm local filesystem cache, the existing pandas path took 24.19 seconds
+and produced a 258.4 MiB canonical parquet. A direct PyArrow table path took
+14.63 seconds and produced the same canonical schema and size: a 39.5%
+reduction in merge time. DuckDB ``COPY`` took 5.38 seconds, but it rewrote
+``timestamp`` and ``written_at`` as ``timestamp[us]`` rather than
+``timestamp[ms]`` and changed ``deposit_closed_reason`` from ``large_string``
+to ``string``. It is therefore not compatible with the scanner's schema
+contract despite its speed.
+
+Conclusion: use PyArrow for the production native-partition replacement. Keep
+pandas only for the comparatively small protocol source frames. Re-run this
+script after schema or compression changes before considering DuckDB again.
+
+Run with the project's Poetry environment:
+
+.. code-block:: shell
+
+    poetry run python scripts/erc-4626/benchmark-native-price-merge.py
+
+Environment variables:
+
+- ``UNCLEANED_PARQUET_PATH``: Input parquet. Defaults to the vault pipeline.
+- ``PIPELINE_DATA_DIR``: Directory containing native metrics DuckDB files.
+- ``BENCHMARK_RUNS``: Repetitions per implementation (default: 1).
+- ``BENCHMARK_IMPLEMENTATIONS``: Comma-separated subset of ``pandas``,
+  ``pyarrow``, and ``duckdb`` (default: all).
+- ``NATIVE_SOURCE``: ``parquet`` (default) reuses current native partitions;
+  ``duckdb`` rebuilds native frames from their source DuckDB files.
+"""
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from threading import Event, Thread
+
+import duckdb
+import pandas as pd
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.parquet as pq
+from tabulate import tabulate
+
+from eth_defi.grvt.constants import GRVT_CHAIN_ID
+from eth_defi.grvt.daily_metrics import GRVTDailyMetricsDatabase
+from eth_defi.grvt.vault_data_export import build_raw_prices_dataframe as build_grvt_prices_dataframe
+from eth_defi.hibachi.constants import HIBACHI_CHAIN_ID
+from eth_defi.hibachi.daily_metrics import HibachiDailyMetricsDatabase
+from eth_defi.hibachi.vault_data_export import build_raw_prices_dataframe as build_hibachi_prices_dataframe
+from eth_defi.hyperliquid.constants import HYPERCORE_CHAIN_ID
+from eth_defi.hyperliquid.daily_metrics import HyperliquidDailyMetricsDatabase
+from eth_defi.hyperliquid.high_freq_metrics import HyperliquidHighFreqMetricsDatabase
+from eth_defi.hyperliquid.vault_data_export import (
+    build_raw_prices_dataframe as build_hypercore_daily_prices_dataframe,
+)
+from eth_defi.hyperliquid.vault_data_export import (
+    build_raw_prices_dataframe_hf as build_hypercore_hf_prices_dataframe,
+)
+from eth_defi.lighter.constants import LIGHTER_CHAIN_ID
+from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase
+from eth_defi.lighter.vault_data_export import build_raw_prices_dataframe as build_lighter_prices_dataframe
+from eth_defi.vault.base import VaultHistoricalRead, verify_parquet_file
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class BenchmarkResult:
+    """One completed merge implementation measurement.
+
+    :param implementation:
+        Implementation label.
+    :param duration_seconds:
+        Wall-clock duration for read, merge, sort, write, and verification.
+    :param output_rows:
+        Number of rows in the generated parquet.
+    :param output_size_mb:
+        Generated parquet size in MiB.
+    :param schema_matches_canonical_writer:
+        Whether the output schema exactly matches the current writer output.
+    """
+
+    implementation: str
+    duration_seconds: float
+    output_rows: int
+    output_size_mb: float
+    schema_matches_canonical_writer: bool
+
+
+def _resolve_path(name: str, default: Path) -> Path:
+    """Resolve an optional path override from the environment.
+
+    :param name:
+        Environment variable name.
+    :param default:
+        Path used when the environment variable is unset.
+    :return:
+        Expanded configured path.
+    """
+    value = os.environ.get(name)
+    return Path(value).expanduser() if value else default
+
+
+def build_native_price_frames(data_dir: Path) -> dict[int, pd.DataFrame]:
+    """Export all native-source prices from their production DuckDB databases.
+
+    The source frames are built once and reused for each candidate. This keeps
+    the comparison focused on parquet merging rather than API or DuckDB export
+    time, while still using the actual current native data.
+
+    :param data_dir:
+        Directory containing the production DuckDB files.
+    :return:
+        Fresh non-empty native frames keyed by their synthetic chain ID.
+    """
+    frames: dict[int, pd.DataFrame] = {}
+    daily_path = _resolve_path("HYPERLIQUID_DB_PATH", data_dir / "hyperliquid-vaults.duckdb")
+    hf_path = _resolve_path("HYPERLIQUID_HF_DB_PATH", data_dir / "hyperliquid-vaults-hf.duckdb")
+    daily_db = HyperliquidDailyMetricsDatabase(daily_path) if daily_path.exists() else None
+    hf_db = HyperliquidHighFreqMetricsDatabase(hf_path) if hf_path.exists() else None
+    try:
+        hypercore_parts: list[pd.DataFrame] = []
+        if daily_db is not None:
+            daily_df = build_hypercore_daily_prices_dataframe(daily_db)
+            if not daily_df.empty:
+                hypercore_parts.append(daily_df.assign(_source="daily"))
+        if hf_db is not None:
+            hf_df = build_hypercore_hf_prices_dataframe(hf_db)
+            if not hf_df.empty:
+                hypercore_parts.append(hf_df.assign(_source="hf"))
+        if hypercore_parts:
+            hypercore_df = pd.concat(hypercore_parts, ignore_index=True)
+            hypercore_df = hypercore_df.sort_values(["address", "timestamp", "_source"])
+            hypercore_df = hypercore_df.drop_duplicates(subset=["address", "timestamp"], keep="last")
+            frames[HYPERCORE_CHAIN_ID] = hypercore_df.drop(columns=["_source"])
+    finally:
+        if daily_db is not None:
+            daily_db.close()
+        if hf_db is not None:
+            hf_db.close()
+
+    source_specs = (
+        (GRVT_CHAIN_ID, _resolve_path("GRVT_DB_PATH", data_dir / "grvt-vaults.duckdb"), GRVTDailyMetricsDatabase, build_grvt_prices_dataframe),
+        (LIGHTER_CHAIN_ID, _resolve_path("LIGHTER_DB_PATH", data_dir / "lighter-pools.duckdb"), LighterDailyMetricsDatabase, build_lighter_prices_dataframe),
+        (HIBACHI_CHAIN_ID, _resolve_path("HIBACHI_DB_PATH", data_dir / "hibachi-vaults.duckdb"), HibachiDailyMetricsDatabase, build_hibachi_prices_dataframe),
+    )
+    for chain_id, db_path, database_class, builder in source_specs:
+        db = database_class(db_path)
+        try:
+            frame = builder(db)
+        finally:
+            db.close()
+        if not frame.empty:
+            frames[chain_id] = frame
+
+    if not frames:
+        raise RuntimeError(f"No native price frames could be built from {data_dir}")
+
+    logger.info(
+        "Prepared %d native frames containing %d rows",
+        len(frames),
+        sum(len(frame) for frame in frames.values()),
+    )
+    return frames
+
+
+def build_native_price_frames_from_parquet(input_path: Path) -> dict[int, pd.DataFrame]:
+    """Read the current native partitions from the real uncleaned parquet.
+
+    This is the default benchmark source because it measures the expensive
+    replacement operation with production-native data while avoiding repeated
+    DuckDB export work. Use ``NATIVE_SOURCE=duckdb`` to include the source
+    export path instead.
+
+    :param input_path:
+        Current uncleaned price parquet.
+    :return:
+        Non-empty current native frames keyed by synthetic chain ID.
+    """
+    chain_ids = [HYPERCORE_CHAIN_ID, GRVT_CHAIN_ID, LIGHTER_CHAIN_ID, HIBACHI_CHAIN_ID]
+    native_df = pd.read_parquet(input_path, filters=[("chain", "in", chain_ids)])
+    frames = {int(chain_id): frame.copy() for chain_id, frame in native_df.groupby("chain")}
+    assert frames, f"No native rows found in {input_path}"
+    logger.info(
+        "Read %d current native partitions containing %d rows from parquet",
+        len(frames),
+        len(native_df),
+    )
+    return frames
+
+
+class Heartbeat:
+    """Log progress while a long native merge step has no intermediate output.
+
+    :param label:
+        Human-readable operation label.
+    :param interval_seconds:
+        Logging interval.
+    """
+
+    def __init__(self, label: str, interval_seconds: float = 5.0) -> None:
+        self.label = label
+        self.interval_seconds = interval_seconds
+        self._stop_event = Event()
+        self._thread: Thread | None = None
+
+    def __enter__(self) -> None:
+        """Start progress logging in a daemon thread."""
+
+        def report_progress() -> None:
+            while not self._stop_event.wait(self.interval_seconds):
+                logger.info("%s is still running", self.label)
+
+        self._thread = Thread(target=report_progress, daemon=True)
+        self._thread.start()
+
+    def __exit__(self, *_: object) -> None:
+        """Stop progress logging and wait for the thread to exit."""
+        self._stop_event.set()
+        assert self._thread is not None
+        self._thread.join()
+
+
+def _target_schema(existing_schema: pa.Schema, native_frames: dict[int, pd.DataFrame]) -> pa.Schema:
+    """Construct the production writer schema for Arrow candidates.
+
+    Canonical fields use the repository's exact types. Extra native fields are
+    unified across the current parquet and fresh source frames.
+
+    :param existing_schema:
+        Schema of the current uncleaned parquet.
+    :param native_frames:
+        Fresh source data keyed by chain ID.
+    :return:
+        Canonical schema followed by compatible extra native fields.
+    """
+    canonical = VaultHistoricalRead.to_pyarrow_schema()
+    canonical_names = set(canonical.names)
+    extra_schemas = [pa.schema(field for field in existing_schema if field.name not in canonical_names)]
+    for frame in native_frames.values():
+        source_table = pa.Table.from_pandas(frame, preserve_index=False)
+        extra_schemas.append(pa.schema(field for field in source_table.schema if field.name not in canonical_names))
+
+    extras = pa.unify_schemas(extra_schemas, promote_options="permissive")
+    return pa.schema([*canonical, *extras])
+
+
+def _align_table_to_schema(table: pa.Table, schema: pa.Schema) -> pa.Table:
+    """Add missing fields and cast columns to the target schema.
+
+    :param table:
+        Source Arrow table.
+    :param schema:
+        Required result schema.
+    :return:
+        Table with all schema fields in schema order.
+    """
+    arrays: list[pa.ChunkedArray] = []
+    for field in schema:
+        column_index = table.schema.get_field_index(field.name)
+        if column_index == -1:
+            arrays.append(pa.chunked_array([pa.nulls(len(table), type=field.type)]))
+            continue
+        column = table.column(column_index)
+        arrays.append(column if column.type == field.type else column.cast(field.type, safe=False))
+    return pa.Table.from_arrays(arrays, schema=schema)
+
+
+def _arrow_native_table(existing_schema: pa.Schema, native_frames: dict[int, pd.DataFrame]) -> tuple[pa.Table, pa.Schema]:
+    """Create replacement rows aligned to a shared production schema.
+
+    :param existing_schema:
+        Schema of the current uncleaned parquet.
+    :param native_frames:
+        Fresh source data keyed by chain ID.
+    :return:
+        Combined native rows and their exact target schema.
+    """
+    schema = _target_schema(existing_schema, native_frames)
+    tables = [_align_table_to_schema(pa.Table.from_pandas(frame, preserve_index=False), schema) for frame in native_frames.values()]
+    return pa.concat_tables(tables), schema
+
+
+def _temporary_output_path(input_path: Path, implementation: str, run: int) -> Path:
+    """Return a same-filesystem temporary benchmark path.
+
+    :param input_path:
+        Production parquet input path.
+    :param implementation:
+        Candidate implementation label.
+    :param run:
+        One-indexed repetition number.
+    :return:
+        Temporary output path.
+    """
+    return input_path.with_name(f".{input_path.stem}.benchmark-{implementation}-{run}.parquet")
+
+
+def _finish_result(
+    implementation: str,
+    started_at: float,
+    output_path: Path,
+    expected_rows: int,
+    expected_schema: pa.Schema | None,
+) -> BenchmarkResult:
+    """Verify a candidate output and convert it to a benchmark result.
+
+    :param implementation:
+        Candidate label.
+    :param started_at:
+        Timer start from :py:func:`time.perf_counter`.
+    :param output_path:
+        Candidate output file.
+    :param expected_rows:
+        Expected output row count.
+    :param expected_schema:
+        Schema expected for compatibility, or ``None`` for a prototype.
+    :return:
+        Verified benchmark result.
+    """
+    verify_parquet_file(output_path, expected_rows=expected_rows)
+    actual_schema = pq.read_schema(output_path)
+    schema_matches = expected_schema is None or actual_schema == expected_schema
+    if expected_schema is not None and not schema_matches:
+        expected_by_name = {field.name: field.type for field in expected_schema}
+        actual_by_name = {field.name: field.type for field in actual_schema}
+        differences = [f"{name}: expected {expected_type}, got {actual_by_name.get(name, '<missing>')}" for name, expected_type in expected_by_name.items() if actual_by_name.get(name) != expected_type]
+        logger.warning("%s output schema is not production-compatible: %s", implementation, "; ".join(differences))
+    return BenchmarkResult(
+        implementation=implementation,
+        duration_seconds=time.perf_counter() - started_at,
+        output_rows=expected_rows,
+        output_size_mb=output_path.stat().st_size / 1024 / 1024,
+        schema_matches_canonical_writer=schema_matches,
+    )
+
+
+def benchmark_pandas(input_path: Path, native_frames: dict[int, pd.DataFrame], run: int) -> BenchmarkResult:
+    """Measure the current pandas plus canonical-writer implementation.
+
+    :param input_path:
+        Production parquet input path.
+    :param native_frames:
+        Fresh source data keyed by chain ID.
+    :param run:
+        One-indexed repetition number.
+    :return:
+        Benchmark result.
+    """
+    output_path = _temporary_output_path(input_path, "pandas", run)
+    started_at = time.perf_counter()
+    existing_df = pd.read_parquet(input_path)
+    existing_df = existing_df[~existing_df["chain"].isin(native_frames)]
+    combined_df = pd.concat([existing_df, *native_frames.values()], ignore_index=True)
+    combined_df = combined_df.sort_values(["chain", "address", "timestamp"])
+    VaultHistoricalRead.write_uncleaned_parquet(combined_df, output_path)
+    return _finish_result("pandas", started_at, output_path, len(combined_df), pq.read_schema(output_path))
+
+
+def benchmark_pyarrow(input_path: Path, native_frames: dict[int, pd.DataFrame], run: int) -> BenchmarkResult:
+    """Measure an Arrow-table implementation with canonical schema preservation.
+
+    :param input_path:
+        Production parquet input path.
+    :param native_frames:
+        Fresh source data keyed by chain ID.
+    :param run:
+        One-indexed repetition number.
+    :return:
+        Benchmark result.
+    """
+    output_path = _temporary_output_path(input_path, "pyarrow", run)
+    started_at = time.perf_counter()
+    existing_table = pq.read_table(input_path)
+    native_table, schema = _arrow_native_table(existing_table.schema, native_frames)
+    chain_mask = pc.is_in(existing_table["chain"], value_set=pa.array(list(native_frames)))
+    retained_table = _align_table_to_schema(existing_table.filter(pc.invert(chain_mask)), schema)
+    combined_table = pa.concat_tables([retained_table, native_table])
+    sort_indices = pc.sort_indices(combined_table, sort_keys=[("chain", "ascending"), ("address", "ascending"), ("timestamp", "ascending")])
+    combined_table = combined_table.take(sort_indices)
+    pq.write_table(combined_table, output_path, compression="zstd")
+    return _finish_result("pyarrow", started_at, output_path, len(combined_table), schema)
+
+
+def benchmark_duckdb(input_path: Path, native_frames: dict[int, pd.DataFrame], run: int) -> BenchmarkResult:
+    """Measure a DuckDB Parquet SQL merge using the aligned native Arrow table.
+
+    This is a prototype measurement. It deliberately reports whether DuckDB's
+    Parquet writer preserves the exact production Arrow schema; a faster result
+    is not eligible for production use when that flag is false.
+
+    :param input_path:
+        Production parquet input path.
+    :param native_frames:
+        Fresh source data keyed by chain ID.
+    :param run:
+        One-indexed repetition number.
+    :return:
+        Benchmark result.
+    """
+    output_path = _temporary_output_path(input_path, "duckdb", run)
+    started_at = time.perf_counter()
+    existing_schema = pq.read_schema(input_path)
+    native_table, schema = _arrow_native_table(existing_schema, native_frames)
+    parquet_file = pq.ParquetFile(input_path)
+    chain_table = pq.read_table(input_path, columns=["chain"])
+    replaced_rows = pc.sum(pc.is_in(chain_table["chain"], value_set=pa.array(list(native_frames)))).as_py() or 0
+    expected_rows = parquet_file.metadata.num_rows - replaced_rows + len(native_table)
+    chain_ids = ", ".join(str(chain_id) for chain_id in native_frames)
+    escaped_input = str(input_path).replace("'", "''")
+    escaped_output = str(output_path).replace("'", "''")
+    connection = duckdb.connect(":memory:")
+    try:
+        connection.register("native_rows", native_table)
+        query = f"""
+            COPY (
+                SELECT * FROM read_parquet('{escaped_input}') WHERE chain NOT IN ({chain_ids})
+                UNION ALL BY NAME
+                SELECT * FROM native_rows
+                ORDER BY chain, address, timestamp
+            ) TO '{escaped_output}' (FORMAT PARQUET, COMPRESSION ZSTD)
+            """  # noqa: S608 - local paths are escaped before interpolation.
+        connection.execute(query)
+    finally:
+        connection.close()
+    return _finish_result("duckdb", started_at, output_path, expected_rows, schema)
+
+
+def main() -> None:
+    """Run each merge implementation and display comparable results."""
+    logging.basicConfig(level=os.environ.get("LOG_LEVEL", "INFO").upper(), format="%(asctime)s %(levelname)s %(message)s")
+    data_dir = _resolve_path("PIPELINE_DATA_DIR", Path("~/.tradingstrategy/vaults").expanduser())
+    input_path = _resolve_path("UNCLEANED_PARQUET_PATH", data_dir / "vault-prices-1h.parquet")
+    runs = int(os.environ.get("BENCHMARK_RUNS", "1"))
+    assert input_path.exists(), f"Missing input parquet: {input_path}"
+    assert runs > 0, "BENCHMARK_RUNS must be positive"
+
+    source_started_at = time.perf_counter()
+    source_mode = os.environ.get("NATIVE_SOURCE", "parquet").strip().lower()
+    assert source_mode in {"parquet", "duckdb"}, f"Unsupported NATIVE_SOURCE: {source_mode}"
+    with Heartbeat(f"native source preparation ({source_mode})"):
+        native_frames = build_native_price_frames_from_parquet(input_path) if source_mode == "parquet" else build_native_price_frames(data_dir)
+    source_duration = time.perf_counter() - source_started_at
+    logger.info("Native source preparation took %.2f seconds", source_duration)
+
+    results: list[BenchmarkResult] = []
+    candidates_by_name = {
+        "pandas": benchmark_pandas,
+        "pyarrow": benchmark_pyarrow,
+        "duckdb": benchmark_duckdb,
+    }
+    implementation_names = [name.strip().lower() for name in os.environ.get("BENCHMARK_IMPLEMENTATIONS", "pandas,pyarrow,duckdb").split(",") if name.strip()]
+    unknown_names = set(implementation_names) - set(candidates_by_name)
+    assert not unknown_names, f"Unsupported BENCHMARK_IMPLEMENTATIONS values: {sorted(unknown_names)}"
+    candidates = [candidates_by_name[name] for name in implementation_names]
+    try:
+        for run in range(1, runs + 1):
+            for candidate in candidates:
+                logger.info("Running %s benchmark %d/%d", candidate.__name__, run, runs)
+                with Heartbeat(candidate.__name__):
+                    results.append(candidate(input_path, native_frames, run))
+    finally:
+        for result in results:
+            output_path = _temporary_output_path(input_path, result.implementation, 1)
+            if output_path.exists():
+                output_path.unlink()
+        for run in range(1, runs + 1):
+            for implementation in implementation_names:
+                output_path = _temporary_output_path(input_path, implementation, run)
+                if output_path.exists():
+                    output_path.unlink()
+
+    table = [
+        [
+            result.implementation,
+            f"{result.duration_seconds:.2f}",
+            f"{result.output_rows:,}",
+            f"{result.output_size_mb:.1f}",
+            result.schema_matches_canonical_writer,
+        ]
+        for result in results
+    ]
+    print(f"Native source preparation: {source_duration:.2f}s")
+    print(tabulate(table, headers=["implementation", "merge seconds", "rows", "MiB", "canonical schema"], tablefmt="github"))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/erc_4626/test_native_protocol_batch_merge.py
+++ b/tests/erc_4626/test_native_protocol_batch_merge.py
@@ -1,0 +1,187 @@
+"""Tests for batched native-protocol Parquet price merging."""
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from eth_defi.grvt.constants import GRVT_CHAIN_ID
+from eth_defi.hibachi.constants import HIBACHI_CHAIN_ID
+from eth_defi.hyperliquid import vault_data_export
+from eth_defi.hyperliquid.constants import HYPERCORE_CHAIN_ID
+from eth_defi.lighter.constants import LIGHTER_CHAIN_ID
+from eth_defi.vault import base, post_processing
+from eth_defi.vault.base import ParquetVerificationError, VaultHistoricalRead
+
+
+def _prices(chain: int, address: str, timestamp: str) -> pd.DataFrame:
+    """Create a minimal native-protocol price frame for merge tests.
+
+    The canonical Parquet writer fills only the columns present in the source
+    frame, which is sufficient to exercise replacement and atomic-write
+    behaviour without coupling this test to every raw price field.
+
+    :param chain:
+        Chain partition for the test row.
+    :param address:
+        Synthetic vault address.
+    :param timestamp:
+        ISO timestamp for deterministic sorting.
+    :return:
+        One-row raw price DataFrame.
+    """
+    return pd.DataFrame(
+        {
+            "chain": pd.array([chain], dtype="uint32"),
+            "address": [address],
+            "timestamp": pd.to_datetime([timestamp]),
+            "share_price": [1.0],
+        }
+    )
+
+
+def test_merge_native_protocols_rewrites_parquet_once_and_preserves_empty_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Batch successful native sources and retain the prior empty-source partition.
+
+    1. Create raw prices with EVM and stale native-protocol rows.
+    2. Stub Hypercore, GRVT, and Lighter exports with fresh data and Hibachi
+       with no data.
+    3. Merge all four sources and count Parquet writes.
+    4. Assert one write replaced fresh partitions but retained stale Hibachi data.
+    """
+    parquet_path = tmp_path / "vault-prices-1h.parquet"
+    existing_df = pd.concat(
+        [
+            _prices(1, "0xevm", "2025-01-01"),
+            _prices(HYPERCORE_CHAIN_ID, "hypercore-old", "2025-01-01"),
+            _prices(GRVT_CHAIN_ID, "grvt-old", "2025-01-01"),
+            _prices(LIGHTER_CHAIN_ID, "lighter-old", "2025-01-01"),
+            _prices(HIBACHI_CHAIN_ID, "hibachi-old", "2025-01-01"),
+        ],
+        ignore_index=True,
+    )
+    VaultHistoricalRead.write_uncleaned_parquet(existing_df, parquet_path)
+
+    class FakeDatabase:
+        """Provide the close method required by the post-processing pipeline."""
+
+        def __init__(self, _: Path) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    fresh_grvt = _prices(GRVT_CHAIN_ID, "grvt-new", "2025-01-02")
+    fresh_lighter = _prices(LIGHTER_CHAIN_ID, "lighter-new", "2025-01-02")
+    fresh_hypercore = _prices(HYPERCORE_CHAIN_ID, "hypercore-new", "2025-01-02")
+    fresh_hypercore["account_pnl"] = 123.0
+    monkeypatch.setattr(post_processing, "HyperliquidDailyMetricsDatabase", FakeDatabase)
+    monkeypatch.setattr(post_processing, "HyperliquidHighFreqMetricsDatabase", FakeDatabase)
+    monkeypatch.setattr(post_processing, "GRVTDailyMetricsDatabase", FakeDatabase)
+    monkeypatch.setattr(post_processing, "LighterDailyMetricsDatabase", FakeDatabase)
+    monkeypatch.setattr(post_processing, "HibachiDailyMetricsDatabase", FakeDatabase)
+    monkeypatch.setattr(post_processing, "build_grvt_prices_dataframe", lambda _: fresh_grvt)
+    monkeypatch.setattr(post_processing, "build_lighter_prices_dataframe", lambda _: fresh_lighter)
+    monkeypatch.setattr(post_processing, "build_hibachi_prices_dataframe", lambda _: pd.DataFrame())
+    monkeypatch.setattr(post_processing, "build_hypercore_prices_dataframe", lambda **_: fresh_hypercore)
+
+    writes = 0
+    original_write = VaultHistoricalRead.write_uncleaned_arrow_table
+
+    def count_writes(*args: object, **kwargs: object) -> None:
+        """Count batch output writes while retaining production writer behaviour."""
+        nonlocal writes
+        writes += 1
+        original_write(*args, **kwargs)
+
+    monkeypatch.setattr(post_processing.VaultHistoricalRead, "write_uncleaned_arrow_table", count_writes)
+
+    hyperliquid_db_path = tmp_path / "hyperliquid.duckdb"
+    hyperliquid_hf_db_path = tmp_path / "hyperliquid-hf.duckdb"
+    hyperliquid_db_path.touch()
+    hyperliquid_hf_db_path.touch()
+
+    steps = post_processing.merge_native_protocols(
+        merge_hypercore=True,
+        merge_grvt=True,
+        merge_lighter=True,
+        merge_hibachi=True,
+        uncleaned_parquet_path=parquet_path,
+        hyperliquid_db_path=hyperliquid_db_path,
+        hyperliquid_hf_db_path=hyperliquid_hf_db_path,
+        grvt_db_path=tmp_path / "grvt.duckdb",
+        lighter_db_path=tmp_path / "lighter.duckdb",
+        hibachi_db_path=tmp_path / "hibachi.duckdb",
+    )
+
+    result_df = pd.read_parquet(parquet_path)
+    assert writes == 1
+    assert steps == {
+        "hypercore-price-merge": True,
+        "grvt-price-merge": True,
+        "lighter-price-merge": True,
+        "hibachi-price-merge": True,
+    }
+    assert set(result_df["address"]) == {
+        "0xevm",
+        "hypercore-new",
+        "grvt-new",
+        "lighter-new",
+        "hibachi-old",
+    }
+    assert result_df.loc[result_df["address"] == "hypercore-new", "account_pnl"].iloc[0] == pytest.approx(123.0)
+
+
+def test_build_hypercore_prices_dataframe_prefers_high_frequency_duplicate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep the high-frequency row when it overlaps the daily export.
+
+    1. Stub daily and high-frequency exports with the same vault timestamp.
+    2. Build the combined Hypercore frame without writing a parquet file.
+    3. Assert the high-frequency share price is retained.
+    """
+    daily_df = _prices(HYPERCORE_CHAIN_ID, "hypercore-vault", "2025-01-01")
+    hf_df = _prices(HYPERCORE_CHAIN_ID, "hypercore-vault", "2025-01-01")
+    hf_df["share_price"] = 1.1
+    monkeypatch.setattr(vault_data_export, "build_raw_prices_dataframe", lambda _: daily_df)
+    monkeypatch.setattr(vault_data_export, "build_raw_prices_dataframe_hf", lambda _: hf_df)
+
+    result_df = vault_data_export.build_hypercore_prices_dataframe(daily_db=object(), hf_db=object())
+
+    assert len(result_df) == 1
+    assert result_df.iloc[0]["share_price"] == pytest.approx(1.1)
+
+
+def test_native_arrow_merge_preserves_original_parquet_when_verification_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep the original parquet when the new Arrow output cannot be verified.
+
+    1. Write a known-good raw parquet.
+    2. Force the shared atomic writer's verification step to fail.
+    3. Attempt a native partition replacement.
+    4. Assert the original file bytes remain unchanged.
+    """
+    parquet_path = tmp_path / "vault-prices-1h.parquet"
+    original_df = _prices(1, "0xevm", "2025-01-01")
+    VaultHistoricalRead.write_uncleaned_parquet(original_df, parquet_path)
+    original_bytes = parquet_path.read_bytes()
+
+    def fail_verification(*_: object, **__: object) -> None:
+        """Simulate a corrupt temporary parquet output."""
+        raise ParquetVerificationError("simulated verification failure")
+
+    monkeypatch.setattr(base, "verify_parquet_file", fail_verification)
+
+    with pytest.raises(ParquetVerificationError, match="simulated verification failure"):
+        post_processing._write_native_partitions_to_uncleaned_parquet(
+            parquet_path,
+            {HYPERCORE_CHAIN_ID: _prices(HYPERCORE_CHAIN_ID, "hypercore-new", "2025-01-02")},
+        )
+
+    assert parquet_path.read_bytes() == original_bytes


### PR DESCRIPTION
## Why

The scanner rewrote the full raw vault-price parquet once per native protocol. A single replacement pass reduces repeated processing of the 19m-row dataset while retaining source-level failure isolation.

## Lessons learnt

Direct PyArrow table operations preserve the canonical parquet schema and materially reduce merge time. DuckDB COPY is faster but changes timestamp and string types, so it is not suitable without further normalisation.

## Summary

- Batch Hypercore, GRVT, Lighter, and Hibachi price partition replacements into one parquet write.
- Use PyArrow for the full parquet replacement while retaining pandas only for protocol source frames.
- Centralise verified temporary-file atomic replacement for pandas and Arrow writers.
- Add benchmark documentation, regression coverage, and Claude CLI background-review guidance.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.