### PR TITLE
Fix Hyperliquid HLP deposit marker

### DIFF
--- a/eth_defi/hyperliquid/vault_data_export.py
+++ b/eth_defi/hyperliquid/vault_data_export.py
@@ -26,14 +26,13 @@ Example::
 
 import datetime
 import logging
+from collections.abc import Mapping
 from decimal import Decimal
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 from eth_typing import HexAddress
-
-from collections.abc import Mapping
 
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
@@ -94,6 +93,40 @@ def _get_deposit_closed_reason(
     if leader_fraction is not None and leader_fraction < LEADER_FRACTION_WARNING_THRESHOLD:
         return "Leader share of the vault capital near allowed Hyperliquid minimum and new capital may not be accepted"
     return None
+
+
+def _attach_relationship_type_from_metadata(
+    prices_df: pd.DataFrame,
+    metadata_df: pd.DataFrame,
+) -> pd.DataFrame:
+    """Attach vault relationship type to price rows.
+
+    Hyperliquid stores ``relationship_type`` as vault metadata, while
+    deposit-open markers are computed from price rows.  HLP protocol vaults
+    must carry this metadata into the per-row calculation so their small
+    ``leader_fraction`` is not treated as the legacy leader 5% constraint.
+
+    :param prices_df:
+        Price rows from daily or high-frequency DuckDB tables.
+    :param metadata_df:
+        Vault metadata rows from ``vault_metadata``.
+    :return:
+        Copy of ``prices_df`` with a ``relationship_type`` column when metadata
+        is available.
+    """
+    if prices_df.empty or metadata_df.empty or "relationship_type" not in metadata_df.columns:
+        return prices_df
+
+    relationship_df = metadata_df[["vault_address", "relationship_type"]].copy()
+    relationship_df["vault_address"] = relationship_df["vault_address"].str.lower()
+
+    prices_df = prices_df.copy()
+    prices_df["vault_address"] = prices_df["vault_address"].str.lower()
+
+    if "relationship_type" in prices_df.columns:
+        prices_df = prices_df.drop(columns=["relationship_type"])
+
+    return prices_df.merge(relationship_df, on="vault_address", how="left")
 
 
 def create_hyperliquid_vault_row(
@@ -261,11 +294,13 @@ def _compute_deposit_closed_reason_column(prices_df: pd.DataFrame) -> pd.Series:
             continue
 
         lf = row.get("leader_fraction")
+        relationship_type = row.get("relationship_type", "normal")
         reasons.append(
             _get_deposit_closed_reason(
                 is_closed=bool(is_closed),
                 allow_deposits=bool(allow_deposits),
                 leader_fraction=float(lf) if pd.notna(lf) else None,
+                relationship_type=str(relationship_type) if pd.notna(relationship_type) else "normal",
             )
         )
 
@@ -396,6 +431,8 @@ def build_raw_prices_dataframe(db: HyperliquidDailyMetricsDatabase) -> pd.DataFr
     prices_df = db.get_all_daily_prices()
     if prices_df.empty:
         return pd.DataFrame()
+
+    prices_df = _attach_relationship_type_from_metadata(prices_df, db.get_all_vault_metadata())
 
     return _prepare_hypercore_export(
         prices_df,
@@ -597,6 +634,8 @@ def build_raw_prices_dataframe_hf(db: HyperliquidHighFreqMetricsDatabase) -> pd.
     prices_df = db.get_all_high_freq_prices()
     if prices_df.empty:
         return pd.DataFrame()
+
+    prices_df = _attach_relationship_type_from_metadata(prices_df, db.get_all_vault_metadata())
 
     # Map HF column names (deposit_count etc.) back to daily_* names
     # for downstream compatibility.

--- a/scripts/hyperliquid/fix-hlp-deposit-open-marker.py
+++ b/scripts/hyperliquid/fix-hlp-deposit-open-marker.py
@@ -1,0 +1,229 @@
+"""Fix stale HLP deposit-open markers in cached parquet data.
+
+The Hyperliquidity Provider (HLP) is a Hyperliquid protocol vault
+(``relationship_type="parent"``), not a legacy user-created leader vault.
+Older exports could still apply the legacy 5% leader-fraction warning to HLP
+history rows and mark deposits as closed.
+
+This script repairs already-written parquet files without re-scanning:
+
+.. code-block:: shell
+
+    # Fix default raw and cleaned pipeline parquet files
+    poetry run python scripts/hyperliquid/fix-hlp-deposit-open-marker.py
+
+    # Dry run
+    DRY_RUN=true poetry run python scripts/hyperliquid/fix-hlp-deposit-open-marker.py
+
+    # Fix specific files
+    PARQUET_PATHS=/tmp/vault-prices-1h.parquet,/tmp/cleaned-vault-prices-1h.parquet \\
+      poetry run python scripts/hyperliquid/fix-hlp-deposit-open-marker.py
+
+Environment variables:
+
+- ``PARQUET_PATHS``: Comma-separated parquet files to repair.
+  Default: ``~/.tradingstrategy/vaults/vault-prices-1h.parquet`` and
+  ``~/.tradingstrategy/vaults/cleaned-vault-prices-1h.parquet`` when present.
+- ``VAULT_ADDRESS``: Vault address to repair.
+  Default: HLP mainnet address.
+- ``DRY_RUN``: If ``true``, report rows that would change. Default: ``false``.
+- ``BACKUP``: If ``true``, write ``.bak-YYYYmmdd-HHMMSS`` backups before
+  modifying files. Default: ``true``.
+- ``LOG_LEVEL``: Logging level. Default: ``info``.
+"""
+
+import logging
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+from tabulate import tabulate
+
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.hyperliquid.constants import HLP_VAULT_ADDRESS_MAINNET, HYPERCORE_CHAIN_ID
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.base import VaultHistoricalRead, verify_parquet_file
+from eth_defi.vault.vaultdb import DEFAULT_RAW_PRICE_DATABASE, DEFAULT_UNCLEANED_PRICE_DATABASE
+
+logger = logging.getLogger(__name__)
+
+
+LEADER_FRACTION_REASON = "Leader share of the vault capital near allowed Hyperliquid minimum and new capital may not be accepted"
+
+
+def _env_bool(name: str, *, default: bool) -> bool:
+    """Read a boolean environment variable."""
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "y"}
+
+
+def _get_default_parquet_paths() -> list[Path]:
+    """Return default parquet paths that exist on disc."""
+    return [
+        path
+        for path in (
+            DEFAULT_UNCLEANED_PRICE_DATABASE,
+            DEFAULT_RAW_PRICE_DATABASE,
+        )
+        if path.exists()
+    ]
+
+
+def _get_parquet_paths() -> list[Path]:
+    """Read target parquet paths from environment or defaults."""
+    paths_str = os.environ.get("PARQUET_PATHS", "").strip()
+    if paths_str:
+        return [Path(part.strip()).expanduser() for part in paths_str.split(",") if part.strip()]
+    return _get_default_parquet_paths()
+
+
+def _write_parquet(df: pd.DataFrame, path: Path) -> None:
+    """Write a parquet file using the correct writer for raw or cleaned data."""
+    if path.name == DEFAULT_UNCLEANED_PRICE_DATABASE.name:
+        VaultHistoricalRead.write_uncleaned_parquet(df, path)
+        return
+
+    temp_fd, temp_path = tempfile.mkstemp(
+        suffix=".parquet",
+        dir=str(path.parent),
+    )
+    try:
+        os.close(temp_fd)
+        df.to_parquet(temp_path, compression="zstd")
+        verify_parquet_file(
+            temp_path,
+            expected_rows=len(df),
+            required_columns=["deposits_open", "deposit_closed_reason"],
+        )
+        os.replace(temp_path, str(path))
+    except BaseException:
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+        raise
+
+
+def fix_hlp_deposit_open_marker(
+    path: Path,
+    vault_address: str,
+    *,
+    dry_run: bool,
+    backup: bool,
+) -> dict[str, object]:
+    """Fix HLP deposit-open markers in one parquet file.
+
+    :param path:
+        Parquet file to repair.
+    :param vault_address:
+        Lowercased vault address to repair.
+    :param dry_run:
+        Whether to only report candidate rows.
+    :param backup:
+        Whether to create a timestamped backup before writing.
+    :return:
+        Summary dictionary for tabular output.
+    """
+    if not path.exists():
+        return {
+            "path": str(path),
+            "exists": False,
+            "hlp_rows": 0,
+            "changed_rows": 0,
+            "backup": "",
+        }
+
+    df = pd.read_parquet(path)
+
+    required = {"chain", "address", "deposits_open", "deposit_closed_reason"}
+    missing = required - set(df.columns)
+    if missing:
+        message = f"{path} missing required columns: {sorted(missing)}"
+        raise RuntimeError(message)
+
+    address_series = df["address"].astype(str).str.lower()
+    hlp_mask = (df["chain"].astype("int64") == HYPERCORE_CHAIN_ID) & (address_series == vault_address)
+    reason_series = df["deposit_closed_reason"].astype(object).fillna("").astype(str)
+    deposits_series = df["deposits_open"].astype(object).fillna("").astype(str)
+
+    stale_reason_mask = reason_series == LEADER_FRACTION_REASON
+    closed_mask = deposits_series == "false"
+    fix_mask = hlp_mask & (stale_reason_mask | closed_mask)
+
+    changed_rows = int(fix_mask.sum())
+    backup_path = ""
+
+    if changed_rows and not dry_run:
+        if backup:
+            timestamp = native_datetime_utc_now().strftime("%Y%m%d-%H%M%S")
+            backup_file = path.with_name(f"{path.name}.bak-{timestamp}")
+            shutil.copy2(path, backup_file)
+            backup_path = str(backup_file)
+
+        df["deposits_open"] = df["deposits_open"].astype(object)
+        df["deposit_closed_reason"] = df["deposit_closed_reason"].astype(object)
+        df.loc[hlp_mask, "deposits_open"] = "true"
+        df.loc[hlp_mask, "deposit_closed_reason"] = ""
+
+        _write_parquet(df, path)
+
+    return {
+        "path": str(path),
+        "exists": True,
+        "hlp_rows": int(hlp_mask.sum()),
+        "changed_rows": changed_rows,
+        "backup": backup_path,
+    }
+
+
+def main() -> None:
+    """Run the manual HLP marker repair."""
+    setup_console_logging(
+        default_log_level=os.environ.get("LOG_LEVEL", "info"),
+        log_file=Path("logs/fix-hlp-deposit-open-marker.log"),
+    )
+
+    paths = _get_parquet_paths()
+    if not paths:
+        message = "No parquet files found. Set PARQUET_PATHS to repair explicit files."
+        raise RuntimeError(message)
+
+    vault_address = os.environ.get("VAULT_ADDRESS", str(HLP_VAULT_ADDRESS_MAINNET)).strip().lower()
+    dry_run = _env_bool("DRY_RUN", default=False)
+    backup = _env_bool("BACKUP", default=True)
+
+    logger.info("Repairing HLP deposit markers for %s", vault_address)
+    logger.info("Dry run: %s", dry_run)
+
+    summaries = [
+        fix_hlp_deposit_open_marker(
+            path=path,
+            vault_address=vault_address,
+            dry_run=dry_run,
+            backup=backup,
+        )
+        for path in paths
+    ]
+
+    print(
+        tabulate(
+            summaries,
+            headers={
+                "path": "Path",
+                "exists": "Exists",
+                "hlp_rows": "HLP rows",
+                "changed_rows": "Changed rows",
+                "backup": "Backup",
+            },
+            tablefmt="simple",
+        )
+    )
+
+    if dry_run:
+        print("DRY_RUN=true - no changes made")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/hyperliquid/test_backfill.py
+++ b/tests/hyperliquid/test_backfill.py
@@ -54,7 +54,7 @@ def _make_vault_row(address: str, account_value: float, cum_ledger: float, cum_v
     return f"2026-01-01T00:00:00,{address},{str(is_vault).lower()},{account_value},{cum_vlm},{cum_ledger}"
 
 
-def _setup_metrics_db_with_metadata(db, vault_address):
+def _setup_metrics_db_with_metadata(db, vault_address, relationship_type: str = "normal"):
     """Insert minimal vault metadata so upsert_daily_prices works."""
     db.upsert_vault_metadata(
         vault_address=vault_address,
@@ -62,7 +62,7 @@ def _setup_metrics_db_with_metadata(db, vault_address):
         leader="0x0000000000000000000000000000000000000001",
         description=None,
         is_closed=False,
-        relationship_type="normal",
+        relationship_type=relationship_type,
         create_time=datetime.datetime(2024, 1, 1),
         commission_rate=0.1,
         follower_count=5,
@@ -1077,6 +1077,31 @@ def test_build_raw_prices_deposit_closed_leader_fraction(tmp_path):
         assert row["deposit_closed_reason"] is not None
         assert "Leader share" in row["deposit_closed_reason"]
         assert row["deposits_open"] == "false"
+
+    finally:
+        db.close()
+
+
+def test_build_raw_prices_hlp_parent_ignores_leader_fraction(tmp_path):
+    """HLP parent vault rows stay deposit-open even with tiny leader_fraction."""
+    from eth_defi.hyperliquid.vault_data_export import build_raw_prices_dataframe
+
+    metrics_db_path = tmp_path / "metrics.duckdb"
+    db = HyperliquidDailyMetricsDatabase(metrics_db_path)
+    try:
+        _setup_metrics_db_with_metadata(db, VAULT_A, relationship_type="parent")
+
+        rows = [
+            _make_daily_price_row(VAULT_A, datetime.date(2024, 1, 1), is_closed=False, allow_deposits=True, leader_fraction=0.001),
+        ]
+        db.upsert_daily_prices(rows)
+        db.save()
+
+        result = build_raw_prices_dataframe(db)
+        row = result.iloc[0]
+
+        assert row["deposit_closed_reason"] is None
+        assert row["deposits_open"] == "true"
 
     finally:
         db.close()

--- a/tests/hyperliquid/test_high_freq_export.py
+++ b/tests/hyperliquid/test_high_freq_export.py
@@ -230,6 +230,53 @@ def test_hf_export_forward_fills_sparse_metadata_snapshots(tmp_path):
 
 
 @pytest.mark.timeout(30)
+def test_hf_export_hlp_parent_ignores_leader_fraction(tmp_path):
+    """HLP parent HF rows stay deposit-open even with tiny leader_fraction."""
+    duckdb_path = tmp_path / "hf-hlp-parent.duckdb"
+    db = HyperliquidHighFreqMetricsDatabase(duckdb_path)
+
+    try:
+        vault_addr = "0xdfc24b077bc1425ad1dea75bcb6f8158e10df303"
+        db.upsert_vault_metadata(
+            vault_address=vault_addr,
+            name="Hyperliquidity Provider (HLP)",
+            leader="0x677d831aef5328190852e24f13c46cac05f984e7",
+            description=None,
+            is_closed=False,
+            relationship_type="parent",
+            create_time=None,
+            commission_rate=0.0,
+            follower_count=1000,
+            tvl=1000000.0,
+            apr=0.10,
+        )
+
+        row = HyperliquidHighFreqPriceRow(
+            vault_address=vault_addr,
+            timestamp=datetime.datetime(2026, 3, 9, 0, 0, 0),
+            share_price=1.0,
+            tvl=1000000.0,
+            cumulative_pnl=0.0,
+            is_closed=False,
+            allow_deposits=True,
+            leader_fraction=0.001,
+            leader_commission=0.0,
+            written_at=native_datetime_utc_now(),
+        )
+        db.upsert_high_freq_prices([row])
+        db.save()
+
+        result_df = build_raw_prices_dataframe_hf(db)
+        result_row = result_df.iloc[0]
+
+        assert result_row["deposit_closed_reason"] is None
+        assert result_row["deposits_open"] == "true"
+
+    finally:
+        db.close()
+
+
+@pytest.mark.timeout(30)
 def test_hf_forward_filled_metadata_reaches_cleaned_and_lifetime_outputs(tmp_path):
     """HF metadata forward-fill should reach cleaned data and lifetime exports."""
     duckdb_path = tmp_path / "hf-cleaned-forward-fill.duckdb"


### PR DESCRIPTION
## Why

HLP was marked deposit-closed in cached Hypercore vault history because the raw export applied the legacy vault leader 5% capital warning to protocol vault rows. HLP is a Hyperliquid protocol vault, so a small leader fraction should not suppress deposits.

## Lessons learnt

Hyperliquid protocol vault metadata must flow into per-row export decisions. The vault database path already handled `relationship_type="parent"`, but the raw price export path recomputed deposit markers without that metadata.

## Summary

- Attach Hyperliquid `relationship_type` metadata before computing raw daily and high-frequency deposit markers.
- Keep HLP parent rows deposit-open even when `leader_fraction` is below the legacy user-vault threshold.
- Add a manual parquet repair script for stale HLP deposit markers in existing cached data.
- Add daily and high-frequency regression coverage for parent vault marker handling.

## Related issues and PRs

- Fixes HLP allocation being blocked by stale Hypercore deposit-closed markers.

## Unrelated CI and test fixes

None.