### PR TITLE
Lower noisy scanner logs to debug

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/euler/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/euler/offchain_metadata.py
@@ -253,7 +253,7 @@ def fetch_euler_vaults_file_for_chain(
         else:
             timestamp = datetime.datetime.fromtimestamp(file.stat().st_mtime, tz=None)
             ago = now_ - timestamp
-            logger.info("Using cached Euler products file for chain %d from %s, last fetched %s ago", chain_id, file, ago)
+            logger.debug("Using cached Euler products file for chain %d from %s, last fetched %s ago", chain_id, file, ago)
 
             if file_size == 0:
                 return {}

--- a/eth_defi/provider/multi_provider.py
+++ b/eth_defi/provider/multi_provider.py
@@ -303,7 +303,7 @@ def create_multi_provider_web3(
             session=session,
             exception_retry_configuration=None,
         )
-        logger.info(
+        logger.debug(
             "Created provider %s, timeout %s",
             get_url_domain(url),
             request_kwargs.get("timeout"),
@@ -367,7 +367,7 @@ def create_multi_provider_web3(
     else:
         provider = fallback_provider
 
-    logger.info(
+    logger.debug(
         "Configuring MultiProviderWeb3. Call providers: %s, transact providers %s",
         [get_provider_name(c) for c in call_providers],
         get_provider_name(transact_provider) if transact_provider else "-",

--- a/eth_defi/stablecoin_metadata.py
+++ b/eth_defi/stablecoin_metadata.py
@@ -987,7 +987,10 @@ def process_and_upload_stablecoin_metadata(
             content_type="image/png",
             skip_if_current=True,
         )
-        logger.info("%s light logo for stablecoin: %s", "Uploaded" if logo_uploaded else "Skipped unchanged", slug)
+        if logo_uploaded:
+            logger.info("Uploaded light logo for stablecoin: %s", slug)
+        else:
+            logger.debug("Skipped unchanged light logo for stablecoin: %s", slug)
 
     return metadata
 


### PR DESCRIPTION
## Why

Repeated provider setup, cached Euler metadata, and unchanged stablecoin logo messages are high-volume scanner noise at info level.

## Lessons learnt

Threaded scanner workers can emit many identical setup and cache-hit messages in a short period, so unchanged or routine paths should stay at debug level.

## Summary

- Changed MultiProviderWeb3 provider creation and configuration messages from info to debug.
- Changed cached Euler products file reuse from info to debug.
- Changed unchanged stablecoin light logo upload skips to debug while keeping actual uploads at info.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.