### PR TITLE
fix: diagnose vault publications and tolerate nullable sparklines

### DIFF
--- a/eth_defi/research/sparkline.py
+++ b/eth_defi/research/sparkline.py
@@ -8,10 +8,9 @@ import gzip
 import warnings
 from io import BytesIO
 
+import matplotlib
 import numpy as np
 import pandas as pd
-
-import matplotlib
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
@@ -19,6 +18,35 @@ import matplotlib.pyplot as plt
 from eth_defi.cloudflare_r2 import calculate_bytes_digest, create_r2_client, upload_bytes_to_r2
 from eth_defi.research.wrangle_vault_prices import forward_fill_vault
 from eth_defi.vault.base import VaultSpec
+
+
+def _filter_finite_share_prices(vault_prices_df: pd.DataFrame) -> pd.DataFrame:
+    """Return chart data with only finite, float share prices.
+
+    PyArrow-backed parquet data can expose ``share_price`` as a nullable or
+    object-backed pandas series. Matplotlib compares y-axis bounds internally,
+    so passing ``pd.NA`` through causes ``TypeError: boolean value of NA is
+    ambiguous``.
+
+    :param vault_prices_df:
+        Single-vault price data with a ``share_price`` column.
+
+    :return:
+        Copy of the input rows whose share prices are finite Python floats.
+
+    :raise ValueError:
+        If the vault has no finite share-price observations to render.
+    """
+    numeric_prices = pd.to_numeric(vault_prices_df["share_price"], errors="coerce")
+    numeric_values = numeric_prices.to_numpy(dtype=float, na_value=np.nan)
+    finite_mask = np.isfinite(numeric_values)
+    if not finite_mask.any():
+        message = "Cannot render sparkline without finite share prices"
+        raise ValueError(message)
+
+    filtered = vault_prices_df.iloc[finite_mask].copy()
+    filtered["share_price"] = numeric_values[finite_mask]
+    return filtered
 
 
 def extract_vault_price_data(
@@ -118,6 +146,8 @@ def render_sparkline_gradient(
 
     if ffill:
         vault_data = forward_fill_vault(vault_data)
+
+    vault_data = _filter_finite_share_prices(vault_data)
 
     dpi = 100
     fig = plt.figure(figsize=(width / dpi, height / dpi), dpi=dpi)

--- a/eth_defi/vault/post_processing.py
+++ b/eth_defi/vault/post_processing.py
@@ -758,7 +758,7 @@ def export_top_vaults_json(
             output_path = base / "top_vaults_by_chain.json"
 
         logger.info("Generating top vaults JSON at %s", output_path)
-        top_vaults_json.main(
+        output_data = top_vaults_json.main(
             data_dir=base,
             vault_db_path=vault_db_path,
             parquet_path=cleaned_path,
@@ -797,6 +797,14 @@ def export_top_vaults_json(
         )
         if uploads_ok:
             logger.info("Top vaults JSON export complete")
+            metadata = output_data.get("metadata", {}) if output_data else {}
+            version = metadata.get("version", {})
+            logger.info(
+                "VAULT_JSON_PUBLISHED: object=%s generated_at=%s commit_hash=%s",
+                object_key,
+                output_data.get("generated_at") if output_data else None,
+                version.get("commit_hash"),
+            )
         else:
             logger.warning("Top vaults JSON export completed with one or more upload failures")
         return uploads_ok

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -262,13 +262,22 @@ def load_cycle_state(path: Path) -> dict[str, str]:
         Path to the JSON file.
     :return:
         Mapping of item name to ISO-formatted last-completed timestamp.
-        Empty dict if the file does not exist.
+        Supports both the legacy bare mapping and the provenance-stamped
+        envelope written by :py:func:`save_cycle_state`. Empty dict if the
+        file does not exist.
     """
     if not path.exists():
         return {}
     try:
-        return json.loads(path.read_text())
-    except (json.JSONDecodeError, OSError) as e:
+        state = json.loads(path.read_text())
+        if "items" in state:
+            items = state["items"]
+            if not isinstance(items, dict):
+                message = "Cycle state items must be a JSON object"
+                raise ValueError(message)
+            return items
+        return state
+    except (json.JSONDecodeError, OSError, ValueError) as e:
         logger.warning("Could not read cycle state from %s: %s", path, e)
         return {}
 
@@ -280,13 +289,22 @@ def save_cycle_state(state: dict[str, str], path: Path) -> None:
     atomic rename, and directory sync.
 
     :param state:
-        Mapping of item name to ISO-formatted last-completed timestamp.
+        Mapping of item name to ISO-formatted last-completed timestamp. The
+        serialised document wraps this mapping with generation timestamp and
+        Docker image commit provenance.
     :param path:
         Destination JSON file.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
+    document = {
+        "generated_at": native_datetime_utc_now().strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "metadata": {
+            "version": VersionInfo.read_docker_version().as_dict(),
+        },
+        "items": state,
+    }
     with atomic_write(str(path), mode="w", overwrite=True) as f:
-        json.dump(state, f, indent=2, sort_keys=True)
+        json.dump(document, f, indent=2, sort_keys=True)
 
 
 def get_due_items(

--- a/eth_defi/vault/top_vaults_json.py
+++ b/eth_defi/vault/top_vaults_json.py
@@ -357,6 +357,23 @@ def save_sticky_export_state(state: dict, path: Path) -> None:
         json.dump(state, f, indent=2, ensure_ascii=False, allow_nan=False)
 
 
+def build_export_metadata(version_info: VersionInfo | None = None) -> dict:
+    """Build provenance metadata shared by all vault metrics JSON outputs.
+
+    :param version_info:
+        Optional Docker image version stamp. When omitted, read the stamp from
+        the running image.
+
+    :return:
+        JSON-serialisable metadata containing the exporter version information.
+    """
+    if version_info is None:
+        version_info = VersionInfo.read_docker_version()
+    return {
+        "version": version_info.as_dict(),
+    }
+
+
 def find_non_serializable_paths(obj, path=None, results=None):
     """
     Recursively traverses a Python object (dict or list) and collects paths to non-serializable values or invalid keys.
@@ -865,7 +882,7 @@ def main(
     output_path: Path | None = None,
     core3_db_path: Path | None = None,
     feed_db_path: Path | None = None,
-):
+) -> VaultMetricsExport:
     """Main execution function for vault analysis and JSON export.
 
     All four arguments are independently overridable. When a path
@@ -1047,16 +1064,18 @@ def main(
     # 7️⃣ Add metadata and deep sanitize.
     # The git version stamp identifies which exporter build produced the file,
     # so stale-deployment issues are diagnosable from the JSON alone.
-    version_info = VersionInfo.read_docker_version()
+    export_metadata = build_export_metadata()
     output_data: VaultMetricsExport = {
-        "generated_at": datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "metadata": {
-            "version": version_info.as_dict(),
-        },
+        "generated_at": format_state_timestamp(now),
+        "metadata": export_metadata,
         "core3_protocols": core3_protocols,
         "curators": curators_export,
         "vaults": vaults,
     }
+
+    # The state file is published with the other scanner data files. Keep its
+    # timestamp and build provenance available for incident investigation.
+    sticky_result.state["metadata"] = export_metadata
 
     validate_strict_json_serialisable(output_data)
     validate_strict_json_serialisable(sticky_result.state)
@@ -1083,6 +1102,7 @@ def main(
     print(f"Missing curator slugs for sticky rows: {sticky_result.stats.missing_curator_slugs:,}")
 
     print(f"Exported {len(vaults):,} vault rows to {output_path}")
+    return output_data
 
 
 if __name__ == "__main__":

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -142,6 +142,30 @@ SKIP_POST_PROCESSING=true \
 poetry run python scripts/erc-4626/scan-vaults-all-chains.py
 ```
 
+#### Pipeline logs and JSON provenance
+
+The all-chains scanner appends its primary operational log to
+`logs/scan-all-chains.log`. Post-processing helpers also append their detailed
+logs to `logs/export-data-files.log`, `logs/export-protocol-metadata.log`, and
+`logs/export-spark-lines.log`.
+
+The exported `top_vaults_by_chain.json` and `stablecoin-vault-metrics.json`
+contain `generated_at` and `metadata.version.commit_hash`. The Ethereum sample
+JSON carries this metadata unchanged. `vault-export-state.json` records the
+same commit under `metadata.version.commit_hash` with its `updated_at`
+timestamp, while `scan-cycle-state.json` contains `generated_at`,
+`metadata.version.commit_hash`, and an `items` mapping.
+
+After the raw and Brotli top-vault JSON objects have been uploaded to every
+configured bucket, the scanner logs one grep-friendly success record:
+
+```text
+VAULT_JSON_PUBLISHED: object=top_vaults_by_chain.json generated_at=... commit_hash=...
+```
+
+Use `rg 'VAULT_JSON_PUBLISHED' logs/scan-all-chains.log` to find the latest
+fully published vault JSON and the exact scanner build that produced it.
+
 Core3 runs after EVM and native vault scans and before post-processing. This
 keeps the Core3 DuckDB closed before `eth_defi.vault.top_vaults_json` reads it
 and before `export-data-files.py` uploads it to R2.

--- a/scripts/erc-4626/export-sparklines.py
+++ b/scripts/erc-4626/export-sparklines.py
@@ -16,16 +16,13 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import pandas as pd
-
+from joblib import Parallel, delayed
 from tqdm_loggable.auto import tqdm
 
-from joblib import Parallel, delayed
-
+from eth_defi.research.sparkline import export_sparkline_as_png, export_sparkline_as_svg, render_sparkline_gradient
 from eth_defi.token import is_stablecoin_like
-from eth_defi.research.sparkline import export_sparkline_as_svg, render_sparkline_gradient, export_sparkline_as_png
 from eth_defi.utils import setup_console_logging
 from eth_defi.vault.vaultdb import VaultDatabase, get_pipeline_data_dir
-
 
 #: What's the threshold to render the spark line for the vault
 #:
@@ -117,39 +114,42 @@ def main():
     def _render_vault(vault_id: str, vault_prices_df: pd.DataFrame) -> list[RenderData]:
         results = []
 
-        # Small SVG sparkline for listings
-        fig_svg = render_sparkline_gradient(
-            vault_prices_df,
-            width=100,
-            height=25,
-            line_width=1,
-            margin_ratio=4,
-        )
-        svg_bytes = export_sparkline_as_svg(fig_svg)
-        results.append(
-            RenderData(
-                vault_id=vault_id,
-                svg_bytes=svg_bytes,
-                content_type="image/svg+xml",
-                extension="svg",
+        try:
+            # Small SVG sparkline for listings
+            fig_svg = render_sparkline_gradient(
+                vault_prices_df,
+                width=100,
+                height=25,
+                line_width=1,
+                margin_ratio=4,
             )
-        )
+            svg_bytes = export_sparkline_as_svg(fig_svg)
+            results.append(
+                RenderData(
+                    vault_id=vault_id,
+                    svg_bytes=svg_bytes,
+                    content_type="image/svg+xml",
+                    extension="svg",
+                )
+            )
 
-        # Large PNG sparkline for Twitter Summary Cards
-        fig_png = render_sparkline_gradient(
-            vault_prices_df,
-            width=300,
-            height=300,
-        )
-        png_bytes = export_sparkline_as_png(fig_png)
-        results.append(
-            RenderData(
-                vault_id=vault_id,
-                svg_bytes=png_bytes,
-                content_type="image/png",
-                extension="png",
+            # Large PNG sparkline for Twitter Summary Cards
+            fig_png = render_sparkline_gradient(
+                vault_prices_df,
+                width=300,
+                height=300,
             )
-        )
+            png_bytes = export_sparkline_as_png(fig_png)
+            results.append(
+                RenderData(
+                    vault_id=vault_id,
+                    svg_bytes=png_bytes,
+                    content_type="image/png",
+                    extension="png",
+                )
+            )
+        except ValueError as e:
+            logger.warning("Skipping sparkline for vault %s: %s", vault_id, e)
 
         return results
 

--- a/tests/erc_4626/test_post_processing.py
+++ b/tests/erc_4626/test_post_processing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -14,6 +15,7 @@ from eth_defi.vault import post_processing
 def test_export_top_vaults_json_passes_pipeline_data_dir(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Top-vaults export passes the pipeline data directory to its exporter module.
 
@@ -22,10 +24,19 @@ def test_export_top_vaults_json_passes_pipeline_data_dir(
     3. Assert the JSON exporter receives that directory and output path
     """
     # 1. Stub the top-vaults JSON exporter and R2 upload.
+    caplog.set_level(logging.INFO)
     calls: list[dict] = []
 
-    def fake_main(**kwargs: object) -> None:
+    def fake_main(**kwargs: object) -> dict:
         calls.append(kwargs)
+        return {
+            "generated_at": "2026-07-11T12:00:00Z",
+            "metadata": {
+                "version": {
+                    "commit_hash": "4cea3aa3deadbeef",
+                },
+            },
+        }
 
     upload_calls: list[Path] = []
 
@@ -55,6 +66,7 @@ def test_export_top_vaults_json_passes_pipeline_data_dir(
     assert calls[0]["parquet_path"] == tmp_path / "cleaned-vault-prices-1h.parquet"
     assert calls[0]["output_path"] == tmp_path / "top_vaults_by_chain.json"
     assert upload_calls == [tmp_path / "top_vaults_by_chain.json"]
+    assert "VAULT_JSON_PUBLISHED: object=top_vaults_by_chain.json generated_at=2026-07-11T12:00:00Z commit_hash=4cea3aa3deadbeef" in caplog.text
 
 
 def test_upload_top_vaults_json_to_configured_buckets_continues_after_primary_failure(

--- a/tests/erc_4626/test_vault_analysis_sticky_export.py
+++ b/tests/erc_4626/test_vault_analysis_sticky_export.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 
 from eth_defi.vault import top_vaults_json
+from eth_defi.version_info import VersionInfo
 
 
 def get_top_vaults_json_module():
@@ -570,6 +571,21 @@ def test_sticky_export_uses_single_state_file(tmp_path: Path, monkeypatch: pytes
     override = tmp_path / "shared-state.json"
     monkeypatch.setenv("VAULT_EXPORT_STATE_PATH", str(override))
     assert module.resolve_sticky_export_state_path(tmp_path) == override
+
+
+def test_sticky_export_state_accepts_provenance_metadata(tmp_path: Path):
+    """Sticky export state keeps the exporter commit stamp when persisted."""
+    module = get_top_vaults_json_module()
+    state = module.make_empty_sticky_export_state(datetime.datetime(2026, 7, 11, 12, 0, 0))
+    version = VersionInfo(tag="v0.31", commit_message="fix: stamp JSON", commit_hash="4cea3aa3deadbeef")
+    state["metadata"] = module.build_export_metadata(version)
+    path = tmp_path / "vault-export-state.json"
+
+    module.save_sticky_export_state(state, path)
+
+    loaded = module.load_sticky_export_state(path, datetime.datetime(2026, 7, 11, 12, 0, 0))
+    assert loaded["updated_at"] == "2026-07-11T12:00:00Z"
+    assert loaded["metadata"]["version"] == version.as_dict()
 
 
 def test_sticky_export_timestamp_normalisation_uses_utc_before_dropping_timezone():

--- a/tests/research/test_sparkline.py
+++ b/tests/research/test_sparkline.py
@@ -1,0 +1,44 @@
+"""Regression tests for nullable values in vault sparklines."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from eth_defi.research.sparkline import export_sparkline_as_png, render_sparkline_gradient
+
+
+def test_gradient_sparkline_ignores_nullable_share_prices() -> None:
+    """Nullable share prices do not reach Matplotlib's y-axis bounds.
+
+    Production Parquet data may contain ``pd.NA`` before the first valid price.
+    The renderer must retain finite points and generate an image rather than
+    raising the ambiguous-boolean TypeError from Matplotlib.
+    """
+    index = pd.date_range("2026-07-01", periods=3, freq="D")
+    vault_prices_df = pd.DataFrame(
+        {
+            "share_price": pd.Series([pd.NA, 1.0, 1.01], index=index, dtype="object"),
+            "total_assets": [np.nan, 10_000.0, 10_100.0],
+        },
+        index=index,
+    )
+
+    fig = render_sparkline_gradient(vault_prices_df, ffill=False)
+    png = export_sparkline_as_png(fig)
+
+    assert png.startswith(b"\x89PNG")
+
+
+def test_gradient_sparkline_rejects_vault_without_finite_share_prices() -> None:
+    """A completely missing price series has no meaningful sparkline."""
+    index = pd.date_range("2026-07-01", periods=2, freq="D")
+    vault_prices_df = pd.DataFrame(
+        {
+            "share_price": pd.Series([pd.NA, pd.NA], index=index, dtype="object"),
+            "total_assets": [10_000.0, 10_000.0],
+        },
+        index=index,
+    )
+
+    with pytest.raises(ValueError, match="without finite share prices"):
+        render_sparkline_gradient(vault_prices_df, ffill=False)

--- a/tests/vault/test_scan_all_chains_config.py
+++ b/tests/vault/test_scan_all_chains_config.py
@@ -1,7 +1,14 @@
 """Test all-chain vault scanner configuration."""
 
+import json
+from pathlib import Path
+
+import pytest
+
 from eth_defi.chain import POA_MIDDLEWARE_NEEDED_CHAIN_IDS
+from eth_defi.vault import scan_all_chains
 from eth_defi.vault.scan_all_chains import build_chain_configs
+from eth_defi.version_info import VersionInfo
 
 LINEA_CHAIN_ID = 59144
 
@@ -30,3 +37,29 @@ def test_linea_uses_poa_middleware_for_historical_settlement_reads():
     """Linea historical settlement backfills need PoA extra-data handling."""
 
     assert LINEA_CHAIN_ID in POA_MIDDLEWARE_NEEDED_CHAIN_IDS
+
+
+def test_cycle_state_is_provenance_stamped_and_reads_legacy_format(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cycle-state saves include a timestamp and Docker commit hash.
+
+    The loader must continue to accept the mapping-only format written by
+    scanner versions before provenance metadata was added.
+    """
+    path = tmp_path / "scan-cycle-state.json"
+    state = {"Ethereum": "2026-07-11T12:00:00"}
+    version = VersionInfo(tag="v0.31", commit_message="fix: stamp JSON", commit_hash="4cea3aa3deadbeef")
+    monkeypatch.setattr(scan_all_chains.VersionInfo, "read_docker_version", lambda: version)
+
+    scan_all_chains.save_cycle_state(state, path)
+
+    document = json.loads(path.read_text())
+    assert document["generated_at"].endswith("Z")
+    assert document["metadata"]["version"] == version.as_dict()
+    assert document["items"] == state
+    assert scan_all_chains.load_cycle_state(path) == state
+
+    path.write_text(json.dumps(state))
+    assert scan_all_chains.load_cycle_state(path) == state


### PR DESCRIPTION
## Why

The Robinhood Morpho API coverage workaround needs production JSON artefacts that identify the exact scanner build and publication time. A nullable share-price value also caused the sparkline export to fail with an ambiguous pandas NA boolean.

## Lessons learnt

A deployed code fix is not enough when generated vault artefacts and persisted metadata cannot be traced to a build. Batch visual exports must isolate malformed per-vault data so one bad series does not block publication.

## Summary

- Stamp vault JSON outputs and scanner state JSON with generation time and Docker commit hash.
- Emit `VAULT_JSON_PUBLISHED` only after every configured raw and Brotli upload succeeds.
- Document the scanner and post-processing logs.
- Filter nullable and non-finite sparkline prices; skip a vault with no renderable prices.
- Add regression coverage for JSON provenance and nullable sparkline data.

## Related issues and PRs

Continues #1246, which retains Robinhood Morpho vaults during the temporary Morpho API coverage gap.

## Unrelated CI and test fixes

None.