### PR TITLE
feat: add USDU stablecoin support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - feat: Add Midas strategy curator attribution for Fasanara, Apollo Crypto and Edge Capital vault products (2026-07-10)
 - feat: Add Tempo chain metadata, Hypersync lookup, vault scanner scheduling and Docker RPC wiring (2026-07-10)
+- feat: Add USDU Finance stablecoin metadata, Ethereum deployment, feed registration and symbol classification (2026-07-11)
 - feat: Batch ERC-4626 vault settlement event scans by chain, track empty settlement scan watermarks, avoid per-chain raw price parquet rereads, and make settlement scan failures non-fatal for the vault scanner cycle (2026-07-10)
 - feat: Expand Midas vault scanning to all registry-scannable products with custom feed fallback and explicit unscannable feed exclusions (2026-07-10)
 - feat: Add a manual HyperEVM vault call probe and blacklist out-of-gas vaults that poison historical scanner Multicall3 batches (2026-07-10)

--- a/eth_defi/data/feeds/stablecoins/usdu.yaml
+++ b/eth_defi/data/feeds/stablecoins/usdu.yaml
@@ -1,0 +1,5 @@
+feeder-id: usdu
+name: USDU Finance
+role: stablecoin
+website: https://usdu.finance/
+twitter: USDUfinance

--- a/eth_defi/data/stablecoins/usdu.yaml
+++ b/eth_defi/data/stablecoins/usdu.yaml
@@ -1,0 +1,55 @@
+symbol: USDU
+name: USDU Finance
+short_description: USDU is a protocol-issued, non-algorithmic stablecoin on Ethereum. It is backed by assets held through DAO-approved protocol adapters and is designed to be convertible to USDC through on-chain liquidity.
+long_description: |
+  [USDU Finance](https://usdu.finance/) issues USDU as a non-algorithmic stablecoin for
+  on-chain credit and structured finance. The protocol mints USDU only through
+  DAO-approved adapters, rather than user-operated collateralised debt positions.
+
+  ## Mechanism
+
+  USDU is backed by assets held in protocol adapters. Its primary liquidity layer is a
+  USDC/USDU Curve pool, while Morpho and TermMax integrations provide lending and
+  fixed-term funding markets. The protocol's DAO governs the adapter and collateral
+  configuration.
+
+  ## Sources
+
+  - [USDU Finance overview](https://usdu.finance/)
+  - [USDU core contracts and deployment configuration](https://github.com/usdu-finance/usdu-core)
+  - [DeFiLlama - USDU Finance](https://defillama.com/stablecoin/usdu-finance)
+category: stablecoin
+links:
+  homepage: https://usdu.finance/
+  coingecko: ''
+  defillama: https://defillama.com/stablecoin/usdu-finance
+  twitter: https://x.com/USDUfinance
+slug: usdu
+contract_addresses:
+  - chain: ethereum
+    address: '0xdde3eC717f220Fc6A29D6a4Be73F91DA5b718e55'
+source_currency: usd
+source_currency_source: manual
+source_currency_usd_rate: 1.0
+source_currency_usd_rate_date: ''
+source_currency_usd_rate_fetched_at: ''
+source_currency_usd_rate_source: ''
+coingecko_id: ''
+coingecko_link: ''
+coingecko_id_source: ''
+coingecko_id_verified_at: ''
+coingecko_id_verification_failed_at: ''
+coingecko_id_verification_failed_reason: ''
+usd_rate: ''
+usd_rate_fetched_at: ''
+usd_rate_updated_at: ''
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
+checks:
+  twitter_last_post_at: ''
+  domain_up_at: '2026-07-10'
+  marked_dead_at: ''
+  information_found_missing_at: ''

--- a/eth_defi/stablecoin_metadata.py
+++ b/eth_defi/stablecoin_metadata.py
@@ -337,6 +337,7 @@ STABLECOIN_LIKE = set(
         "USDV",
         "USDX",
         "USDXL",
+        "USDU",
         "USDai",
         "USDbC",
         "USDe",

--- a/tests/feed/test_stablecoin_rate.py
+++ b/tests/feed/test_stablecoin_rate.py
@@ -11,10 +11,11 @@ from eth_defi.currency_api.client import DateRates
 from eth_defi.currency_api.database import CurrencyRateDatabase
 from eth_defi.feed import stablecoin_rate
 from eth_defi.feed.stablecoin_rate import StablecoinRateFeeder, build_depegged_stablecoin_lookups, iter_stablecoin_rate_targets, refresh_stablecoin_rates
-from eth_defi.stablecoin_metadata import build_stablecoin_metadata_json
+from eth_defi.stablecoin_metadata import STABLECOINS_DATA_DIR, build_stablecoin_metadata_json, is_stablecoin_like
 
 USDC_ADDRESS = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 USDX_ADDRESS = "0x1111111111111111111111111111111111111111"
+USDU_ADDRESS = "0xdde3eC717f220Fc6A29D6a4Be73F91DA5b718e55"
 
 
 @dataclass(slots=True)
@@ -683,6 +684,24 @@ def test_packaged_chf_stablecoins_have_chf_source_currency() -> None:
 
         assert rate.source_currency == "chf"
         assert rate.coingecko_id == "frankencoin"
+
+
+def test_packaged_usdu_metadata_and_rate_target() -> None:
+    """USDU metadata preserves its verified contract and manual USD denomination.
+
+    USDU does not have a dedicated CoinGecko identifier, so its rate target must
+    retain the curated USD source currency without accidentally using another
+    same-ticker asset.
+    """
+    target = next(target for target in iter_stablecoin_rate_targets() if target.symbol == "USDU")
+    metadata = build_stablecoin_metadata_json(STABLECOINS_DATA_DIR / "usdu.yaml")[0]
+
+    assert is_stablecoin_like("USDU") is True
+    assert target.source_currency == "usd"
+    assert target.source_currency_source == "manual"
+    assert target.coingecko_id is None
+    assert metadata["name"] == "USDU Finance"
+    assert metadata["contract_addresses"] == [{"chain": "ethereum", "address": USDU_ADDRESS}]
 
 
 def test_eur_stablecoin_depegs_against_native_currency_from_duckdb(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Why

Register the deployed USDU Finance stablecoin so stablecoin detection, metadata exports and social feeds recognise its Ethereum token.

## Lessons learnt

CoinGecko currently uses the USDU ticker for a different asset, so this metadata intentionally leaves CoinGecko pricing identifiers unset.

## Summary

- Add USDU to stablecoin symbol classification.
- Add USDU Finance metadata, verified Ethereum address and official links.
- Add the USDU stablecoin feed and changelog entry.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.