### PR TITLE
fix: classify Spark Savings USDG vault

### DIFF
--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -1961,6 +1961,9 @@ HARDCODED_PROTOCOLS = {
     # Spark - spPYUSD (Spark Savings PYUSD) vault on Ethereum
     # https://etherscan.io/address/0x80128dbb9f07b93dde62a6daeadb69ed14a7d354
     "0x80128dbb9f07b93dde62a6daeadb69ed14a7d354": {ERC4626Feature.spark_like},
+    # Spark - spUSDG (Spark Savings USDG) vault on Robinhood Chain
+    # https://robinhoodchain.blockscout.com/address/0xde770c84FE66E063336b31737cFE9790f18c4087
+    "0xde770c84fe66e063336b31737cfe9790f18c4087": {ERC4626Feature.spark_like},
     # Frankencoin - svZCHF Savings Vault on Ethereum
     # https://etherscan.io/token/0xE5F130253fF137f9917C0107659A4c5262abf6b0
     "0xe5f130253ff137f9917c0107659a4c5262abf6b0": {ERC4626Feature.frankencoin_like},

--- a/tests/erc_4626/vault_protocol/test_spark.py
+++ b/tests/erc_4626/vault_protocol/test_spark.py
@@ -8,16 +8,24 @@ import pytest
 from web3 import Web3
 
 from eth_defi.abi import ZERO_ADDRESS_STR
-from eth_defi.erc_4626.classification import create_vault_instance_autodetect
-from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS, create_vault_instance_autodetect
+from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name
+from eth_defi.erc_4626.vault_protocol.spark.vault import SparkVault
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.erc_4626.vault_protocol.spark.vault import SparkVault
 from eth_defi.vault.base import VaultTechnicalRisk
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 
-pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests")
+
+def test_spark_spusdg_hardcoded_protocol() -> None:
+    """Classify the Robinhood Chain Spark Savings USDG vault by address."""
+    vault_address = "0xde770c84fe66e063336b31737cfe9790f18c4087"
+
+    features = HARDCODED_PROTOCOLS[vault_address]
+
+    assert features == {ERC4626Feature.spark_like}
+    assert get_vault_protocol_name(features) == "Spark"
 
 
 @pytest.fixture(scope="module")
@@ -36,6 +44,7 @@ def web3(anvil_ethereum_fork):
     return web3
 
 
+@pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run this test")
 @flaky.flaky
 def test_spark(
     web3: Web3,
@@ -71,6 +80,7 @@ def test_spark(
     assert vault.can_check_redeem() is False
 
 
+@pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run this test")
 @flaky.flaky
 def test_spark_pyusd(
     web3: Web3,


### PR DESCRIPTION
## Why

Classify Spark Savings USDG (`spUSDG`) on Robinhood Chain as Spark during ERC-4626 discovery.

## Lessons learnt

Spark Savings USDG is deployed on Robinhood Chain (4663) at `0xde770c84fe66e063336b31737cfe9790f18c4087`.

## Summary

- Add the vault to Spark hardcoded protocol addresses.
- Cover address classification with a no-RPC regression test.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.