### PR TITLE
fix: track combined Frankencoin savings TVL

### DIFF
--- a/docs/source/vaults/frankencoin/index.rst
+++ b/docs/source/vaults/frankencoin/index.rst
@@ -12,6 +12,11 @@ value follows savings module yield. The official `token page
 <https://frankencoin.com/token/>`__ lists savings vault deployments on Ethereum,
 Base and Gnosis.
 
+Trading Strategy reports Frankencoin savings TVL from the whole savings product,
+not only from the ERC-4626 wrapper account. The custom Frankencoin reader sums
+ZCHF held by the underlying savings module and the svZCHF wrapper contract,
+while keeping the ERC-4626 wrapper exchange rate for share-price history.
+
 Fee model
 ~~~~~~~~~
 

--- a/eth_defi/erc_4626/vault_protocol/frankencoin/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/frankencoin/vault.py
@@ -17,12 +17,24 @@ deducted from earned interest and paid to the configured referrer.
 
 import datetime
 import logging
+from collections.abc import Iterable
+from decimal import Decimal
+from functools import cached_property
 
-from eth_typing import BlockIdentifier
+from eth_typing import BlockIdentifier, HexAddress
+from web3.contract import Contract
 
-from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
+from eth_defi.event_reader.conversion import convert_int256_bytes_to_int
+from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
+from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
 
 logger = logging.getLogger(__name__)
+
+#: Minimal ABI for the svZCHF wrapper contract.
+FRANKENCOIN_SAVINGS_VAULT_ABI = [
+    {"inputs": [], "name": "savings", "outputs": [{"type": "address"}], "stateMutability": "view", "type": "function"},
+]
 
 #: Frankencoin Savings Vault on Ethereum.
 #:
@@ -53,6 +65,178 @@ FRANKENCOIN_SAVINGS_VAULTS = frozenset(
 #: Source: ``AbstractSavings.setReferrer()`` rejects values above 250,000 ppm.
 MAX_REFERRAL_FEE = 0.25
 
+#: Number of ZCHF balance calls needed for Frankencoin savings TVL.
+FRANKENCOIN_SAVINGS_BALANCE_CALL_COUNT = 2
+
+
+class FrankencoinHistoricalReader(ERC4626HistoricalReader):
+    """Read Frankencoin savings TVL across the wrapper and savings module.
+
+    Frankencoin's ERC-4626 ``totalAssets()`` only reports assets attributed to
+    the svZCHF wrapper inside the savings module. Most savings deposits sit
+    directly in the underlying savings module, outside the ERC-4626 wrapper.
+
+    For Trading Strategy vault TVL we treat the savings product as a whole and
+    write ``ZCHF.balanceOf(savings_module) + ZCHF.balanceOf(svZCHF_wrapper)`` to
+    ``total_assets``. The share price and total supply still come from the
+    ERC-4626 wrapper, so performance calculations keep using the wrapper's own
+    exchange rate.
+    """
+
+    def get_warmup_calls(self) -> Iterable[tuple[str, callable, object]]:
+        """Yield warmup calls for Frankencoin vaults.
+
+        Includes the standard ERC-4626 calls plus the ZCHF balances that define
+        the savings product TVL.
+
+        :return:
+            Tuples consumed by the vault warmup scanner.
+        """
+        yield from super().get_warmup_calls()
+
+        denomination_token = self.vault.denomination_token
+        if denomination_token is None:
+            return
+
+        wrapper_balance_call = denomination_token.contract.functions.balanceOf(self.vault.address)
+        yield ("wrapper_balance", wrapper_balance_call.call, wrapper_balance_call)
+
+        savings_balance_call = denomination_token.contract.functions.balanceOf(self.vault.savings_module_address)
+        yield ("savings_module_balance", savings_balance_call.call, savings_balance_call)
+
+    def construct_multicalls(self) -> Iterable[EncodedCall]:
+        """Create calls for Frankencoin historical reads.
+
+        :return:
+            Encoded calls for ERC-4626 state and Frankencoin savings TVL.
+        """
+        yield from self.construct_core_erc_4626_multicall()
+        yield from self.construct_savings_balance_multicalls()
+
+    def construct_savings_balance_multicalls(self) -> Iterable[EncodedCall]:
+        """Create ZCHF balance calls used to calculate savings product TVL.
+
+        :return:
+            Encoded ZCHF ``balanceOf`` calls for the savings module and wrapper.
+        """
+        denomination_token = self.vault.denomination_token
+        if denomination_token is None:
+            return
+
+        wrapper_balance_call = EncodedCall.from_contract_call(
+            denomination_token.contract.functions.balanceOf(self.vault.address),
+            extra_data={
+                "function": "wrapper_balance",
+                "vault": self.vault.address,
+            },
+            first_block_number=self.first_block,
+        )
+        yield wrapper_balance_call
+
+        savings_balance_call = EncodedCall.from_contract_call(
+            denomination_token.contract.functions.balanceOf(self.vault.savings_module_address),
+            extra_data={
+                "function": "savings_module_balance",
+                "vault": self.vault.address,
+                "savings_module": self.vault.savings_module_address,
+            },
+            first_block_number=self.first_block,
+        )
+        yield savings_balance_call
+
+    def process_savings_tvl_result(self, call_by_name: dict[str, EncodedCallResult]) -> tuple[Decimal | None, list[str]]:
+        """Decode Frankencoin savings TVL calls.
+
+        :param call_by_name:
+            Multicall results keyed by ``extra_data["function"]``.
+
+        :return:
+            ``(total_assets, errors)`` where ``total_assets`` is denominated in
+            ZCHF.
+        """
+        errors = []
+        denomination_token = self.vault.denomination_token
+        if denomination_token is None:
+            return None, ["denomination token missing"]
+
+        balances = []
+        for function_name in ("savings_module_balance", "wrapper_balance"):
+            result = call_by_name.get(function_name)
+            if result is None:
+                errors.append(f"{function_name} call missing")
+                continue
+            if not result.success:
+                errors.append(f"{function_name} call failed")
+                continue
+
+            raw_balance = convert_int256_bytes_to_int(result.result)
+            balances.append(denomination_token.convert_to_decimals(raw_balance))
+
+        if len(balances) != FRANKENCOIN_SAVINGS_BALANCE_CALL_COUNT:
+            return None, errors
+
+        return sum(balances, Decimal(0)), errors
+
+    def process_result(
+        self,
+        block_number: int,
+        timestamp: datetime.datetime,
+        call_results: list[EncodedCallResult],
+    ) -> VaultHistoricalRead:
+        """Process a Frankencoin historical read result.
+
+        :param block_number:
+            Block number used for the read.
+        :param timestamp:
+            Naive UTC block timestamp.
+        :param call_results:
+            Multicall results for this vault.
+
+        :return:
+            Historical row with Frankencoin savings product TVL.
+        """
+        call_by_name = self.dictify_multicall_results(block_number, call_results)
+
+        # The generic ERC-4626 decoder updates adaptive reader state from
+        # totalAssets(); Frankencoin needs the state update to use combined TVL.
+        total_assets_result = call_by_name.get("total_assets")
+        original_total_assets_state = total_assets_result.state if total_assets_result is not None else None
+        if total_assets_result is not None:
+            total_assets_result.state = None
+        try:
+            share_price, total_supply, erc4626_total_assets, errors, max_deposit = self.process_core_erc_4626_result(call_by_name)
+        finally:
+            if total_assets_result is not None:
+                total_assets_result.state = original_total_assets_state
+
+        savings_total_assets, savings_errors = self.process_savings_tvl_result(call_by_name)
+        if savings_errors:
+            errors = list(errors or [])
+            errors.extend(savings_errors)
+
+        total_assets = savings_total_assets if savings_total_assets is not None else erc4626_total_assets
+
+        convert_to_assets_result = call_by_name.get("convertToAssets")
+        if convert_to_assets_result is not None and convert_to_assets_result.state is not None:
+            convert_to_assets_result.state.on_called(
+                convert_to_assets_result,
+                total_assets=total_assets,
+                share_price=share_price,
+            )
+
+        return VaultHistoricalRead(
+            vault=self.vault,
+            block_number=block_number,
+            timestamp=timestamp,
+            share_price=share_price,
+            total_assets=total_assets,
+            total_supply=total_supply,
+            performance_fee=None,
+            management_fee=None,
+            errors=errors or None,
+            max_deposit=max_deposit,
+        )
+
 
 class FrankencoinVault(ERC4626Vault):
     """Frankencoin ERC-4626 savings vault support.
@@ -61,6 +245,88 @@ class FrankencoinVault(ERC4626Vault):
     module. The underlying contract source documents an interest delay of up to
     three days before deposits start earning yield.
     """
+
+    @cached_property
+    def frankencoin_vault_contract(self) -> Contract:
+        """Return the svZCHF wrapper contract with Frankencoin-specific ABI.
+
+        :return:
+            Web3 contract instance exposing the ``savings()`` accessor.
+        """
+        return self.web3.eth.contract(
+            address=self.address,
+            abi=FRANKENCOIN_SAVINGS_VAULT_ABI,
+        )
+
+    @cached_property
+    def savings_module_address(self) -> HexAddress:
+        """Return the underlying Frankencoin savings module address.
+
+        :return:
+            Savings module address used by this svZCHF wrapper.
+        """
+        return self.frankencoin_vault_contract.functions.savings().call()
+
+    def fetch_total_assets(self, block_identifier: BlockIdentifier) -> Decimal | None:
+        """Return Frankencoin savings product TVL.
+
+        Frankencoin's ERC-4626 wrapper only reports assets attributed to wrapper
+        shareholders. The public savings product also includes direct deposits
+        in the savings module. For vault discovery TVL, report the ZCHF held by
+        both the module and the wrapper contract.
+
+        :param block_identifier:
+            Block number to read.
+
+        :return:
+            Total ZCHF held by the Frankencoin savings module and wrapper.
+        """
+        denomination_token = self.denomination_token
+        if denomination_token is None:
+            return None
+
+        savings_balance = denomination_token.contract.functions.balanceOf(self.savings_module_address).call(block_identifier=block_identifier)
+        wrapper_balance = denomination_token.contract.functions.balanceOf(self.address).call(block_identifier=block_identifier)
+        return denomination_token.convert_to_decimals(savings_balance + wrapper_balance)
+
+    def fetch_nav(self, block_identifier: BlockIdentifier | None = None) -> Decimal | None:
+        """Fetch the Frankencoin savings product NAV.
+
+        :param block_identifier:
+            Block number to read.
+
+        :return:
+            Same value as :py:meth:`fetch_total_assets`.
+        """
+        return self.fetch_total_assets(block_identifier or "latest")
+
+    def fetch_share_price(self, block_identifier: BlockIdentifier) -> Decimal:
+        """Get the svZCHF wrapper share price.
+
+        The Frankencoin TVL override represents the whole savings product, not
+        only svZCHF shareholders. Therefore share price must still come from
+        ``convertToAssets(1 share)`` instead of ``total_assets / total_supply``.
+
+        :param block_identifier:
+            Block number to read.
+
+        :return:
+            svZCHF share price in ZCHF.
+        """
+        one_share = self.share_token.convert_to_raw(Decimal(1))
+        raw_amount = self.vault_contract.functions.convertToAssets(one_share).call(block_identifier=block_identifier)
+        return self.denomination_token.convert_to_decimals(raw_amount)
+
+    def get_historical_reader(self, stateful: bool) -> VaultHistoricalReader:  # noqa: FBT001
+        """Return the Frankencoin historical reader.
+
+        :param stateful:
+            Whether the reader maintains adaptive polling state.
+
+        :return:
+            Frankencoin-specific historical reader.
+        """
+        return FrankencoinHistoricalReader(self, stateful=stateful)
 
     def has_custom_fees(self) -> bool:
         """Frankencoin has an optional per-account referral fee.

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -221,6 +221,45 @@ The script reads RPC URLs using normal `JSON_RPC_<CHAIN_NAME>` variables where
 the chain is known by `eth_defi.chain`. T3tris currently returns Arbitrum vaults,
 so set `JSON_RPC_ARBITRUM` in `.local-test.env`.
 
+### fix-frankencoin-tvl.py
+
+Manual repair script for Frankencoin savings vault TVL in the uncleaned price
+parquet. Before the Frankencoin-specific historical reader was added, generic
+ERC-4626 reads wrote only `svZCHF.totalAssets()` to `total_assets`. This
+underreported Frankencoin product TVL because most ZCHF is held directly by the
+underlying savings module.
+
+The script updates only hardcoded Frankencoin savings vault rows and preserves
+all other vault rows and columns. It keeps the existing share-price samples and
+replaces `total_assets` with:
+
+```text
+ZCHF.balanceOf(savings_module) + ZCHF.balanceOf(svZCHF_wrapper)
+```
+
+```shell
+source .local-test.env && poetry run python scripts/erc-4626/fix-frankencoin-tvl.py
+```
+
+| Variable | Description |
+|----------|-------------|
+| `DRY_RUN` | Optional. Show selected rows without writing. Default: false. |
+| `UNCLEANED_PRICE_DATABASE` | Optional. Path to the uncleaned price parquet. Default: production uncleaned price DB. |
+| `START_BLOCK` | Optional. Inclusive lower block bound for a scoped repair. |
+| `END_BLOCK` | Optional. Inclusive upper block bound for a scoped repair. |
+| `MAX_WORKERS` | Optional. Per-chain parallel RPC workers. Default: 8. |
+| `JSON_RPC_ETHEREUM` | Required if Ethereum Frankencoin rows are present. |
+| `JSON_RPC_BASE` | Required if Base Frankencoin rows are present. |
+| `JSON_RPC_GNOSIS` | Required if Gnosis Frankencoin rows are present. |
+
+After repair, rerun post-processing and data export so cleaned parquet and JSON
+outputs pick up the corrected TVL:
+
+```shell
+poetry run python scripts/erc-4626/post-process-prices.py
+poetry run python scripts/erc-4626/export-data-files.py
+```
+
 ### fix-upshift-vaults.py
 
 Targeted repair script for all EVM Upshift vaults returned by the official

--- a/scripts/erc-4626/fix-frankencoin-tvl.py
+++ b/scripts/erc-4626/fix-frankencoin-tvl.py
@@ -1,0 +1,458 @@
+"""Correct historical Frankencoin savings TVL in the uncleaned price parquet.
+
+Before :class:`eth_defi.erc_4626.vault_protocol.frankencoin.vault.FrankencoinHistoricalReader`
+was added, the generic ERC-4626 reader wrote ``svZCHF.totalAssets()`` to
+``total_assets``. For Frankencoin this underreports product TVL because most
+ZCHF is held directly by the underlying savings module.
+
+This script updates only Frankencoin rows in ``vault-prices-1h.parquet``. It
+keeps existing share-price samples and replaces ``total_assets`` with:
+
+``ZCHF.balanceOf(savings_module) + ZCHF.balanceOf(svZCHF_wrapper)``
+
+Usage:
+
+.. code-block:: shell
+
+    source .local-test.env && poetry run python scripts/erc-4626/fix-frankencoin-tvl.py
+
+Environment variables:
+
+- ``UNCLEANED_PRICE_DATABASE``: Path to the uncleaned price parquet. Defaults to
+  ``~/.tradingstrategy/vaults/vault-prices-1h.parquet``.
+- ``DRY_RUN``: Set to ``true`` to only report without modifying files.
+- ``START_BLOCK``: Optional inclusive block-number lower bound.
+- ``END_BLOCK``: Optional inclusive block-number upper bound.
+- ``MAX_WORKERS``: Optional per-chain parallel RPC workers. Default: 8.
+- ``JSON_RPC_<CHAIN_NAME>``: Archive RPC URLs for affected chains, e.g.
+  ``JSON_RPC_ETHEREUM``, ``JSON_RPC_BASE`` and ``JSON_RPC_GNOSIS``.
+
+After running this script, rerun price post-processing and data export so
+cleaned parquet and JSON outputs pick up the corrected TVL.
+"""
+
+import logging
+import os
+import shutil
+from collections.abc import Callable
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+
+import pandas as pd
+from joblib import Parallel, delayed
+from web3 import Web3
+
+from eth_defi.chain import get_chain_name
+from eth_defi.erc_4626.vault_protocol.frankencoin.vault import (
+    FRANKENCOIN_BASE_SAVINGS_VAULT,
+    FRANKENCOIN_ETHEREUM_SAVINGS_VAULT,
+    FRANKENCOIN_GNOSIS_SAVINGS_VAULT,
+    FRANKENCOIN_SAVINGS_VAULT_ABI,
+)
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.base import VaultHistoricalRead, VaultSpec
+from eth_defi.vault.vaultdb import DEFAULT_UNCLEANED_PRICE_DATABASE
+
+logger = logging.getLogger(__name__)
+
+
+#: Minimal ERC-20 ABI needed for historical ZCHF balances.
+ERC20_BALANCE_ABI = [
+    {"inputs": [{"name": "account", "type": "address"}], "name": "balanceOf", "outputs": [{"name": "", "type": "uint256"}], "stateMutability": "view", "type": "function"},
+]
+
+#: Minimal ERC-4626 ABI needed to find the underlying ZCHF address.
+ERC4626_ASSET_ABI = [
+    {"inputs": [], "name": "asset", "outputs": [{"name": "", "type": "address"}], "stateMutability": "view", "type": "function"},
+]
+
+#: Official Frankencoin Savings Vault addresses supported by this repository.
+FRANKENCOIN_VAULT_SPECS = frozenset(
+    {
+        VaultSpec(1, FRANKENCOIN_ETHEREUM_SAVINGS_VAULT),
+        VaultSpec(8453, FRANKENCOIN_BASE_SAVINGS_VAULT),
+        VaultSpec(100, FRANKENCOIN_GNOSIS_SAVINGS_VAULT),
+    }
+)
+
+
+@dataclass(slots=True, frozen=True)
+class FrankencoinVaultContracts:
+    """On-chain contracts needed to repair one Frankencoin vault.
+
+    :param chain_id:
+        EVM chain id.
+    :param vault_address:
+        svZCHF wrapper address.
+    :param savings_module_address:
+        Underlying Frankencoin savings module address.
+    :param zchf:
+        ZCHF ERC-20 contract.
+    """
+
+    chain_id: int
+    vault_address: str
+    savings_module_address: str
+    zchf: object
+
+
+@dataclass(slots=True, frozen=True)
+class FrankencoinTvlRepairResult:
+    """Result of repairing Frankencoin TVL rows.
+
+    :param matched_rows:
+        Rows selected for Frankencoin repair after block filters.
+    :param updated_rows:
+        Rows whose ``total_assets`` value changed.
+    :param skipped_rows:
+        Frankencoin rows not repaired because an RPC read failed.
+    """
+
+    matched_rows: int
+    updated_rows: int
+    skipped_rows: int
+
+
+def parse_bool_env(name: str, *, default: bool = False) -> bool:
+    """Parse a boolean environment variable.
+
+    :param name:
+        Environment variable name.
+    :param default:
+        Default value when unset.
+
+    :return:
+        Parsed boolean value.
+    """
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "y"}
+
+
+def read_optional_int_env(name: str) -> int | None:
+    """Read an optional integer environment variable.
+
+    :param name:
+        Environment variable name.
+
+    :return:
+        Parsed integer, or ``None``.
+    """
+    value = os.environ.get(name)
+    if not value:
+        return None
+    return int(value)
+
+
+def get_chain_rpc_env_name(chain_id: int) -> str:
+    """Return the JSON-RPC environment variable for a chain.
+
+    :param chain_id:
+        EVM chain id.
+
+    :return:
+        Environment variable name.
+    """
+    chain_name = get_chain_name(chain_id).upper().replace(" ", "_")
+    return f"JSON_RPC_{chain_name}"
+
+
+def create_backup_path(parquet_path: Path) -> Path:
+    """Create a non-conflicting backup path for the parquet file.
+
+    :param parquet_path:
+        Original parquet path.
+
+    :return:
+        Backup path with ``.bak-frankencoin-tvl`` suffix.
+    """
+    base_backup_path = parquet_path.with_suffix(".parquet.bak-frankencoin-tvl")
+    if not base_backup_path.exists():
+        return base_backup_path
+
+    index = 1
+    while True:
+        backup_path = parquet_path.with_suffix(f".parquet.bak-frankencoin-tvl.{index}")
+        if not backup_path.exists():
+            return backup_path
+        index += 1
+
+
+def build_frankencoin_mask(
+    df: pd.DataFrame,
+    *,
+    start_block: int | None = None,
+    end_block: int | None = None,
+) -> pd.Series:
+    """Build a boolean mask for Frankencoin rows to repair.
+
+    :param df:
+        Uncleaned price DataFrame.
+    :param start_block:
+        Optional inclusive lower block bound.
+    :param end_block:
+        Optional inclusive upper block bound.
+
+    :return:
+        Boolean row mask.
+    """
+    spec_pairs = {(spec.chain_id, spec.vault_address.lower()) for spec in FRANKENCOIN_VAULT_SPECS}
+    mask = pd.Series(
+        [(int(chain), str(address).lower()) in spec_pairs for chain, address in zip(df["chain"], df["address"])],
+        index=df.index,
+    )
+    if start_block is not None:
+        mask &= df["block_number"] >= start_block
+    if end_block is not None:
+        mask &= df["block_number"] <= end_block
+    return mask
+
+
+def fetch_frankencoin_vault_contracts(web3: Web3, spec: VaultSpec) -> FrankencoinVaultContracts:
+    """Fetch contracts needed to correct one Frankencoin vault.
+
+    :param web3:
+        Web3 instance for ``spec.chain_id``.
+    :param spec:
+        Frankencoin vault spec.
+
+    :return:
+        Contract bundle for historical TVL reads.
+    """
+    vault_address = Web3.to_checksum_address(spec.vault_address)
+    vault_contract = web3.eth.contract(address=vault_address, abi=FRANKENCOIN_SAVINGS_VAULT_ABI + ERC4626_ASSET_ABI)
+    savings_module_address = Web3.to_checksum_address(vault_contract.functions.savings().call())
+    asset_address = Web3.to_checksum_address(vault_contract.functions.asset().call())
+    zchf = web3.eth.contract(address=asset_address, abi=ERC20_BALANCE_ABI)
+    return FrankencoinVaultContracts(
+        chain_id=spec.chain_id,
+        vault_address=vault_address,
+        savings_module_address=savings_module_address,
+        zchf=zchf,
+    )
+
+
+def fetch_frankencoin_total_assets_raw(contracts: FrankencoinVaultContracts, block_number: int) -> int:
+    """Fetch raw Frankencoin savings product TVL at a historical block.
+
+    :param contracts:
+        Contract bundle for the vault.
+    :param block_number:
+        Historical block number.
+
+    :return:
+        Raw 18-decimal ZCHF amount.
+    """
+    savings_balance = contracts.zchf.functions.balanceOf(contracts.savings_module_address).call(block_identifier=block_number)
+    wrapper_balance = contracts.zchf.functions.balanceOf(contracts.vault_address).call(block_identifier=block_number)
+    return int(savings_balance) + int(wrapper_balance)
+
+
+def decimalise_zchf_raw(raw_amount: int) -> float:
+    """Convert a raw ZCHF amount to decimal units.
+
+    :param raw_amount:
+        Raw 18-decimal ZCHF amount.
+
+    :return:
+        Decimalised ZCHF amount as a float suitable for parquet storage.
+    """
+    return float(Decimal(raw_amount) / Decimal(10**18))
+
+
+def repair_frankencoin_rows(
+    df: pd.DataFrame,
+    *,
+    fetch_total_assets: Callable[[int, int, str], float],
+    start_block: int | None = None,
+    end_block: int | None = None,
+    max_workers: int = 8,
+) -> tuple[pd.DataFrame, FrankencoinTvlRepairResult]:
+    """Repair Frankencoin rows in a price DataFrame.
+
+    :param df:
+        Uncleaned price DataFrame.
+    :param fetch_total_assets:
+        Callback ``(chain_id, block_number, vault_address) -> total_assets``.
+    :param start_block:
+        Optional inclusive lower block bound.
+    :param end_block:
+        Optional inclusive upper block bound.
+    :param max_workers:
+        Number of parallel workers.
+
+    :return:
+        Updated DataFrame and repair summary.
+    """
+    mask = build_frankencoin_mask(df, start_block=start_block, end_block=end_block)
+    matched_df = df[mask]
+    if matched_df.empty:
+        return df.copy(), FrankencoinTvlRepairResult(matched_rows=0, updated_rows=0, skipped_rows=0)
+
+    rows = [(index, int(row.chain), int(row.block_number), str(row.address).lower(), float(row.total_assets)) for index, row in matched_df[["chain", "block_number", "address", "total_assets"]].iterrows()]
+
+    def repair_one(index: int, chain_id: int, block_number: int, address: str, old_total_assets: float) -> tuple[int, float | None, bool]:
+        try:
+            new_total_assets = fetch_total_assets(chain_id, block_number, address)
+        except Exception:
+            logger.exception("Could not fetch Frankencoin TVL for chain=%d address=%s block=%d", chain_id, address, block_number)
+            return index, None, False
+        return index, new_total_assets, new_total_assets != old_total_assets
+
+    repaired = Parallel(n_jobs=max_workers, backend="threading")(delayed(repair_one)(index, chain_id, block_number, address, old_total_assets) for index, chain_id, block_number, address, old_total_assets in rows)
+
+    updated_df = df.copy()
+    updated_rows = 0
+    skipped_rows = 0
+    for index, new_total_assets, changed in repaired:
+        if new_total_assets is None:
+            skipped_rows += 1
+            continue
+        updated_df.at[index, "total_assets"] = new_total_assets
+        if changed:
+            updated_rows += 1
+
+    return updated_df, FrankencoinTvlRepairResult(
+        matched_rows=len(rows),
+        updated_rows=updated_rows,
+        skipped_rows=skipped_rows,
+    )
+
+
+def repair_frankencoin_tvl_parquet(
+    parquet_path: Path,
+    *,
+    dry_run: bool,
+    start_block: int | None,
+    end_block: int | None,
+    max_workers: int,
+) -> FrankencoinTvlRepairResult:
+    """Repair Frankencoin rows in an uncleaned price parquet file.
+
+    :param parquet_path:
+        Path to the uncleaned price parquet.
+    :param dry_run:
+        If ``True``, do not write any files.
+    :param start_block:
+        Optional inclusive lower block bound.
+    :param end_block:
+        Optional inclusive upper block bound.
+    :param max_workers:
+        Number of per-chain parallel RPC workers.
+
+    :return:
+        Repair summary.
+    """
+    if not parquet_path.exists():
+        raise FileNotFoundError(f"Parquet file not found: {parquet_path}")
+
+    logger.info("Reading uncleaned price parquet from %s", parquet_path)
+    df = pd.read_parquet(parquet_path)
+    mask = build_frankencoin_mask(df, start_block=start_block, end_block=end_block)
+    affected_df = df[mask]
+    if affected_df.empty:
+        logger.info("No Frankencoin rows found in %s", parquet_path)
+        return FrankencoinTvlRepairResult(matched_rows=0, updated_rows=0, skipped_rows=0)
+
+    per_vault = affected_df.groupby(["chain", "address"]).agg(
+        rows=("address", "count"),
+        first_block=("block_number", "min"),
+        last_block=("block_number", "max"),
+        first_timestamp=("timestamp", "min"),
+        last_timestamp=("timestamp", "max"),
+    )
+    logger.info("Frankencoin rows selected for repair:")
+    for (chain_id, address), row in per_vault.iterrows():
+        logger.info(
+            "  chain=%d address=%s rows=%d blocks=%d-%d timestamps=%s-%s",
+            chain_id,
+            address,
+            row["rows"],
+            row["first_block"],
+            row["last_block"],
+            row["first_timestamp"],
+            row["last_timestamp"],
+        )
+
+    web3_by_chain: dict[int, Web3] = {}
+    contracts_by_pair: dict[tuple[int, str], FrankencoinVaultContracts] = {}
+
+    for chain_id, address in affected_df[["chain", "address"]].drop_duplicates().itertuples(index=False):
+        chain_id = int(chain_id)
+        rpc_env_name = get_chain_rpc_env_name(chain_id)
+        rpc_url = os.environ.get(rpc_env_name)
+        if not rpc_url:
+            raise RuntimeError(f"Set {rpc_env_name} to repair Frankencoin TVL for chain {chain_id}")
+        web3 = web3_by_chain.setdefault(chain_id, create_multi_provider_web3(rpc_url))
+        spec = VaultSpec(chain_id, str(address).lower())
+        contracts_by_pair[chain_id, str(address).lower()] = fetch_frankencoin_vault_contracts(web3, spec)
+
+    def fetch_total_assets(chain_id: int, block_number: int, vault_address: str) -> float:
+        contracts = contracts_by_pair[chain_id, vault_address.lower()]
+        raw_total_assets = fetch_frankencoin_total_assets_raw(contracts, block_number)
+        return decimalise_zchf_raw(raw_total_assets)
+
+    updated_df, result = repair_frankencoin_rows(
+        df,
+        fetch_total_assets=fetch_total_assets,
+        start_block=start_block,
+        end_block=end_block,
+        max_workers=max_workers,
+    )
+
+    if dry_run:
+        logger.info("DRY RUN: would update %d of %d matched Frankencoin rows", result.updated_rows, result.matched_rows)
+        return result
+
+    if result.skipped_rows:
+        raise RuntimeError(f"Refusing to write {parquet_path}: {result.skipped_rows} Frankencoin rows failed RPC repair")
+
+    if result.updated_rows == 0:
+        logger.info("No Frankencoin total_assets values changed")
+        return result
+
+    backup_path = create_backup_path(parquet_path)
+    logger.info("Creating backup at %s", backup_path)
+    shutil.copy2(parquet_path, backup_path)
+    logger.info("Writing repaired parquet to %s", parquet_path)
+    VaultHistoricalRead.write_uncleaned_parquet(updated_df, parquet_path)
+    return result
+
+
+def main() -> None:
+    """Run the Frankencoin TVL repair script."""
+    setup_console_logging(default_log_level=os.environ.get("LOG_LEVEL", "info"))
+
+    parquet_path = Path(os.environ.get("UNCLEANED_PRICE_DATABASE", str(DEFAULT_UNCLEANED_PRICE_DATABASE))).expanduser()
+    dry_run = parse_bool_env("DRY_RUN", default=False)
+    start_block = read_optional_int_env("START_BLOCK")
+    end_block = read_optional_int_env("END_BLOCK")
+    max_workers = int(os.environ.get("MAX_WORKERS", "8"))
+
+    if dry_run:
+        logger.info("DRY RUN MODE - no files will be modified")
+
+    result = repair_frankencoin_tvl_parquet(
+        parquet_path,
+        dry_run=dry_run,
+        start_block=start_block,
+        end_block=end_block,
+        max_workers=max_workers,
+    )
+    action = "would be " if dry_run else ""
+    logger.info("Frankencoin rows matched: %d", result.matched_rows)
+    logger.info("Frankencoin rows %supdated: %d", action, result.updated_rows)
+    logger.info("Frankencoin rows skipped: %d", result.skipped_rows)
+
+    if result.updated_rows:
+        logger.info("")
+        logger.info("Next steps:")
+        logger.info("  poetry run python scripts/erc-4626/post-process-prices.py")
+        logger.info("  poetry run python scripts/erc-4626/export-data-files.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/erc_4626/test_fix_frankencoin_tvl_script.py
+++ b/tests/erc_4626/test_fix_frankencoin_tvl_script.py
@@ -1,0 +1,141 @@
+"""Tests for the Frankencoin TVL repair script."""
+
+import datetime
+import importlib.util
+from pathlib import Path
+
+import pandas as pd
+
+from eth_defi.erc_4626.vault_protocol.frankencoin.vault import FRANKENCOIN_ETHEREUM_SAVINGS_VAULT
+from eth_defi.vault.base import VaultHistoricalRead
+
+FRANKENCOIN_CORRECTED_TVL = 11_666_191.0
+FRANKENCOIN_OLD_TVL = 3.4
+FRANKENCOIN_SHARE_PRICE = 1.01
+UNRELATED_TVL = 100.0
+
+
+def load_fix_module():
+    """Load the Frankencoin TVL repair script as a module.
+
+    The script filename contains dashes, so it cannot be imported through the
+    normal package path.
+
+    :return:
+        Loaded repair script module.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "erc-4626" / "fix-frankencoin-tvl.py"
+    spec = importlib.util.spec_from_file_location("fix_frankencoin_tvl", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def create_price_rows() -> pd.DataFrame:
+    """Create a minimal canonical price DataFrame for repair tests.
+
+    :return:
+        Price rows containing one Frankencoin row and one unrelated row.
+    """
+    timestamp = datetime.datetime(2026, 7, 10, 12, 0, tzinfo=datetime.UTC).replace(tzinfo=None)
+    return pd.DataFrame(
+        [
+            {
+                "chain": 1,
+                "address": FRANKENCOIN_ETHEREUM_SAVINGS_VAULT,
+                "block_number": 25_000_000,
+                "timestamp": timestamp,
+                "share_price": FRANKENCOIN_SHARE_PRICE,
+                "total_assets": FRANKENCOIN_OLD_TVL,
+                "total_supply": 3.3,
+                "performance_fee": None,
+                "management_fee": None,
+                "errors": "",
+                "vault_poll_frequency": "large_tvl",
+                "max_deposit": None,
+                "max_redeem": None,
+                "deposits_open": "",
+                "redemption_open": "",
+                "trading": "",
+                "available_liquidity": None,
+                "utilisation": None,
+                "written_at": None,
+            },
+            {
+                "chain": 1,
+                "address": "0x0000000000000000000000000000000000000001",
+                "block_number": 25_000_000,
+                "timestamp": timestamp,
+                "share_price": 1.0,
+                "total_assets": UNRELATED_TVL,
+                "total_supply": 100.0,
+                "performance_fee": None,
+                "management_fee": None,
+                "errors": "",
+                "vault_poll_frequency": "small_tvl",
+                "max_deposit": None,
+                "max_redeem": None,
+                "deposits_open": "",
+                "redemption_open": "",
+                "trading": "",
+                "available_liquidity": None,
+                "utilisation": None,
+                "written_at": None,
+            },
+        ]
+    )
+
+
+def test_repair_frankencoin_rows_updates_only_frankencoin() -> None:
+    """Pure row repair updates only hardcoded Frankencoin vault rows."""
+    module = load_fix_module()
+    df = create_price_rows()
+
+    def fetch_total_assets(_chain_id: int, _block_number: int, _address: str) -> float:
+        """Return deterministic corrected TVL for tests."""
+        return FRANKENCOIN_CORRECTED_TVL
+
+    updated_df, result = module.repair_frankencoin_rows(
+        df,
+        fetch_total_assets=fetch_total_assets,
+        max_workers=1,
+    )
+
+    assert result.matched_rows == 1
+    assert result.updated_rows == 1
+    assert result.skipped_rows == 0
+    assert updated_df.loc[0, "total_assets"] == FRANKENCOIN_CORRECTED_TVL
+    assert updated_df.loc[0, "share_price"] == FRANKENCOIN_SHARE_PRICE
+    assert updated_df.loc[1, "total_assets"] == UNRELATED_TVL
+
+
+def test_repair_frankencoin_tvl_parquet_writes_backup(monkeypatch, tmp_path: Path) -> None:
+    """Parquet repair writes a backup and preserves unrelated rows."""
+    module = load_fix_module()
+    parquet_path = tmp_path / "vault-prices-1h.parquet"
+    VaultHistoricalRead.write_uncleaned_parquet(create_price_rows(), parquet_path)
+
+    monkeypatch.setenv("JSON_RPC_ETHEREUM", "https://example.invalid")
+    monkeypatch.setattr(module, "create_multi_provider_web3", lambda _rpc_url: object())
+    monkeypatch.setattr(module, "fetch_frankencoin_vault_contracts", lambda _web3, spec: spec)
+    monkeypatch.setattr(module, "fetch_frankencoin_total_assets_raw", lambda _contracts, _block_number: int(FRANKENCOIN_CORRECTED_TVL * 10**18))
+
+    result = module.repair_frankencoin_tvl_parquet(
+        parquet_path,
+        dry_run=False,
+        start_block=None,
+        end_block=None,
+        max_workers=1,
+    )
+
+    repaired_df = pd.read_parquet(parquet_path)
+
+    assert result.matched_rows == 1
+    assert result.updated_rows == 1
+    assert result.skipped_rows == 0
+    assert (tmp_path / "vault-prices-1h.parquet.bak-frankencoin-tvl").exists()
+    assert repaired_df.loc[0, "total_assets"] == FRANKENCOIN_CORRECTED_TVL
+    assert repaired_df.loc[1, "total_assets"] == UNRELATED_TVL

--- a/tests/erc_4626/vault_protocol/test_frankencoin.py
+++ b/tests/erc_4626/vault_protocol/test_frankencoin.py
@@ -1,20 +1,124 @@
 """Test Frankencoin vault metadata."""
 
 import datetime
+import os
+from decimal import Decimal
 
+import pytest
 from web3 import Web3
 
 from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS, create_vault_instance
 from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name
+from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.frankencoin.vault import (
     FRANKENCOIN_BASE_SAVINGS_VAULT,
     FRANKENCOIN_ETHEREUM_SAVINGS_VAULT,
     FRANKENCOIN_GNOSIS_SAVINGS_VAULT,
     FRANKENCOIN_SAVINGS_VAULTS,
+    FrankencoinHistoricalReader,
     FrankencoinVault,
 )
+from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
+from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.vault.base import VaultSpec, VaultTechnicalRisk
 from eth_defi.vault.fee import VaultFeeMode
+
+JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
+
+
+class _SyntheticToken:
+    """Minimal token wrapper for Frankencoin historical reader unit tests.
+
+    :return:
+        Token-like object that converts raw 18-decimal balances.
+    """
+
+    decimals = 18
+    name = "Synthetic ZCHF"
+    symbol = "ZCHF"
+
+    @staticmethod
+    def convert_to_decimals(raw_amount: int) -> Decimal:
+        """Convert a raw 18-decimal token amount.
+
+        :param raw_amount:
+            Raw token amount.
+
+        :return:
+            Decimal token amount.
+        """
+        return Decimal(raw_amount) / Decimal(10**18)
+
+
+class _SyntheticReaderState:
+    """Capture state updates from the Frankencoin historical reader.
+
+    :return:
+        Synthetic reader state with captured ``on_called`` inputs.
+    """
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    def on_called(
+        self,
+        result: EncodedCallResult,
+        total_assets: Decimal | None = None,
+        share_price: Decimal | None = None,
+    ) -> None:
+        """Record a state update.
+
+        :param result:
+            Multicall result passed to the state update.
+        :param total_assets:
+            TVL value passed to the state update.
+        :param share_price:
+            Share price value passed to the state update.
+        """
+        self.calls.append((result.call.extra_data["function"], total_assets, share_price))
+
+
+def _make_frankencoin_call_result(
+    function_name: str,
+    value: int,
+    *,
+    block_number: int,
+    timestamp: datetime.datetime,
+    state: _SyntheticReaderState | None = None,
+) -> EncodedCallResult:
+    """Create a synthetic Frankencoin multicall result.
+
+    :param function_name:
+        Function key used by the historical reader.
+    :param value:
+        Raw uint256 value to encode.
+    :param block_number:
+        Block number for the synthetic read.
+    :param timestamp:
+        Timestamp for the synthetic read.
+    :param state:
+        Optional reader state attached to the call result.
+
+    :return:
+        Encoded call result.
+    """
+    call = EncodedCall(
+        func_name=function_name,
+        address=FRANKENCOIN_ETHEREUM_SAVINGS_VAULT,
+        data=b"",
+        extra_data={
+            "function": function_name,
+            "vault": FRANKENCOIN_ETHEREUM_SAVINGS_VAULT,
+        },
+    )
+    return EncodedCallResult(
+        call=call,
+        success=True,
+        result=value.to_bytes(32, "big"),
+        block_identifier=block_number,
+        timestamp=timestamp,
+        state=state,
+    )
 
 
 def test_frankencoin_hardcoded_protocols() -> None:
@@ -63,3 +167,82 @@ def test_frankencoin_addresses() -> None:
     assert FRANKENCOIN_ETHEREUM_SAVINGS_VAULT == "0xe5f130253ff137f9917c0107659a4c5262abf6b0"
     assert FRANKENCOIN_BASE_SAVINGS_VAULT == "0xa09ebdf8a01b9ef04149319d64f83b9c01a5b585"
     assert FRANKENCOIN_GNOSIS_SAVINGS_VAULT == "0x6165946250dd04740ab1409217e95a4f38374fe9"
+
+
+def test_frankencoin_reader_updates_state_once_with_combined_tvl() -> None:
+    """Frankencoin reader state sees the combined savings product TVL.
+
+    The generic ERC-4626 core decoder updates reader state using
+    ``totalAssets()``. Frankencoin overrides TVL after that decode, so the
+    stateful reader must avoid the generic update and update state exactly once
+    with ``savings_module_balance + wrapper_balance``.
+    """
+    vault = FrankencoinVault(
+        Web3(),
+        VaultSpec(1, FRANKENCOIN_ETHEREUM_SAVINGS_VAULT),
+        features={ERC4626Feature.frankencoin_like},
+    )
+    synthetic_token = _SyntheticToken()
+    vault.__dict__["denomination_token"] = synthetic_token
+    vault.__dict__["share_token"] = synthetic_token
+
+    reader = FrankencoinHistoricalReader(vault, stateful=False)
+    state = _SyntheticReaderState()
+    block_number = 123
+    timestamp = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC).replace(tzinfo=None)
+    raw_unit = 10**18
+
+    historical_read = reader.process_result(
+        block_number,
+        timestamp,
+        [
+            _make_frankencoin_call_result("total_assets", 3 * raw_unit, block_number=block_number, timestamp=timestamp, state=state),
+            _make_frankencoin_call_result("total_supply", 10 * raw_unit, block_number=block_number, timestamp=timestamp, state=state),
+            _make_frankencoin_call_result("convertToAssets", raw_unit + raw_unit // 100, block_number=block_number, timestamp=timestamp, state=state),
+            _make_frankencoin_call_result("savings_module_balance", 11 * raw_unit, block_number=block_number, timestamp=timestamp, state=state),
+            _make_frankencoin_call_result("wrapper_balance", 4 * raw_unit, block_number=block_number, timestamp=timestamp, state=state),
+        ],
+    )
+
+    assert historical_read.total_assets == Decimal(15)
+    assert historical_read.share_price == Decimal("1.01")
+    assert state.calls == [("convertToAssets", Decimal(15), Decimal("1.01"))]
+
+
+@pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run this test")
+@pytest.mark.timeout(180)
+def test_frankencoin_ethereum_combined_savings_tvl_latest() -> None:
+    """Ethereum svZCHF TVL includes the underlying savings module.
+
+    The ERC-4626 wrapper's own ``totalAssets()`` currently only reports assets
+    attributed to the wrapper's savings-module account. The Frankencoin savings
+    product TVL is much larger because most ZCHF is deposited directly into the
+    underlying savings module.
+    """
+    web3 = create_multi_provider_web3(JSON_RPC_ETHEREUM)
+    vault = create_vault_instance(
+        web3,
+        FRANKENCOIN_ETHEREUM_SAVINGS_VAULT,
+        features={ERC4626Feature.frankencoin_like},
+    )
+
+    assert isinstance(vault, FrankencoinVault)
+    reader = vault.get_historical_reader(stateful=False)
+    assert isinstance(reader, FrankencoinHistoricalReader)
+
+    block_number = web3.eth.block_number
+    block = web3.eth.get_block(block_number)
+    timestamp = datetime.datetime.fromtimestamp(block["timestamp"], datetime.UTC).replace(tzinfo=None)
+    erc4626_assets = ERC4626Vault.fetch_total_assets(vault, block_number)
+    savings_product_assets = vault.fetch_total_assets(block_number)
+    share_price = vault.fetch_share_price(block_number)
+    call_results = [call.call_as_result(web3, block_number) for call in reader.construct_multicalls()]
+    historical_read = reader.process_result(block_number, timestamp, call_results)
+
+    assert erc4626_assets is not None
+    assert savings_product_assets is not None
+    assert erc4626_assets < Decimal("1000")
+    assert savings_product_assets > Decimal("1000000")
+    assert historical_read.total_assets == pytest.approx(savings_product_assets)
+    assert historical_read.share_price == pytest.approx(share_price)
+    assert share_price == pytest.approx(Decimal("1.017"), rel=Decimal("0.01"))

--- a/tests/lighter/test_scan_loop_integration.py
+++ b/tests/lighter/test_scan_loop_integration.py
@@ -52,7 +52,8 @@ def test_scan_loop_lighter_single_cycle(tmp_path: Path, monkeypatch: pytest.Monk
     state_file = tmp_path / "scan-cycle-state.json"
     assert state_file.exists(), "Cycle state file not created"
     state = json.loads(state_file.read_text())
-    assert "Lighter" in state, f"Lighter not in cycle state: {state}"
+    cycle_items = state.get("items", state)
+    assert "Lighter" in cycle_items, f"Lighter not in cycle state: {state}"
 
     # 2. Verify Lighter DuckDB has pools
     duckdb_path = tmp_path / "lighter-pools.duckdb"


### PR DESCRIPTION
## Why

Frankencoin svZCHF reports wrapper-only `totalAssets()`, while the savings product TVL also includes ZCHF held directly in the underlying savings module. This caused historical and live vault TVL to be materially underreported.

## Lessons learnt

Frankencoin savings TVL needs protocol-specific handling: share price and supply should stay ERC-4626 wrapper based, but `total_assets` must include both the savings module balance and wrapper balance. Stateful historical readers also need a single adaptive-state update using the corrected TVL.

## Summary

- Added a Frankencoin historical reader that records combined savings module and wrapper ZCHF balances as TVL.
- Preserved wrapper-based share price reads while overriding `fetch_total_assets()` and NAV for product-level TVL.
- Added a manual `fix-frankencoin-tvl.py` repair script for existing uncleaned parquet history.
- Documented the repair workflow and product-level TVL behaviour.
- Added focused unit/live coverage, including a regression test for the stateful reader double-update issue found during review.

## Related issues and PRs

Continues the Frankencoin vault onboarding and svZCHF TVL correction work.

## Unrelated CI and test fixes

- Fixed the Lighter slow integration test to accept both flat and `items`-wrapped scan cycle state JSON shapes.
