### PR TITLE
notes: mark Morpho AUSD compounders as subvaults

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -618,6 +618,10 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0xda2f1b3cba732d779cff56f0cf9d3bc8aea6cd8d": (VaultFlag.subvault, SUBVAULT),
     # Morpho Gauntlet USDT Prime Compounder
     "0x6d2981ff9b8d7edbb7604de7a65bac8694ac849f": (VaultFlag.subvault, SUBVAULT),
+    # Morpho Gauntlet AUSD Vault Compounder
+    "0xf7ede5332c6b4a235be4aa3c019222cfe72e984f": (VaultFlag.subvault, SUBVAULT),
+    # Morpho Steakhouse Prime AUSD Compounder
+    "0xc1ec6d26902949bf6cbb0c9859dbead1e87fb243": (VaultFlag.subvault, SUBVAULT),
     # Hyperliquidity Trader (HLT) - irregular share price action due to epoch resets
     "0x5a733b25a17dc0f26b862ca9e32b439801b1a8c7": (VaultFlag.abnormal_share_price, HLT_IRREGULAR_SHARE_PRICE),
     # Secured Finance JPYC Lender


### PR DESCRIPTION
## Why

Two Yearn Morpho AUSD compounder vaults should be hidden from direct end-user exposure because they are subvaults used as part of other strategies.

## Lessons learnt

The vault exports already contain the resolved Trading Strategy vault slugs and lowercase addresses, which makes adding manual vault flags straightforward.

## Summary

- Marked Morpho Gauntlet AUSD Vault Compounder as a subvault.
- Marked Morpho Steakhouse Prime AUSD Compounder as a subvault.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.