### PR TITLE
Blacklist Etherealm USDC V1 vault

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -592,7 +592,9 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0xa9a4bd976dbcfc2b89f554467ac85e2c758e2618": (VaultFlag.illiquid, XUSD_MESSAGE),
     # Borrowable USDC Deposit, SiloId: 20 (Sonic)
     "0x322e1d5384aa4ed66aeca770b95686271de61dc3": (VaultFlag.illiquid, XUSD_MESSAGE),
-    # Etherealm USDC (Morpho on Ethereum)
+    # Etherealm USDC V1 (Morpho on Ethereum)
+    "0x7193794ec82f527efb618ac50c078d348ecba4b6": (VaultFlag.illiquid, ETHEREALM_USDC_ILLIQUID),
+    # Etherealm USDC V2 (Morpho on Ethereum)
     "0xb7305d968ecd8a23a13ec01927e3f9588c7653b5": (VaultFlag.illiquid, ETHEREALM_USDC_ILLIQUID),
     # Borrowable USDC Deposit, SiloId: 178 (Ethereum)
     "0x93c8201c35666f9af8b3b943bad67b42ad0159a1": (VaultFlag.illiquid, XUSD_MESSAGE),

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -61,6 +61,7 @@ def test_summer_fi_protocol_vaults_are_blacklisted() -> None:
         ("0xfa17f7aadbfac2c5d3c8125555404c1ae17df853", "Morpho", VaultFlag.illiquid, "illiquid"),
         ("0xc5e7d3f76a03006540f17668a0267c668ffb5b75", "Liquity", VaultFlag.illiquid, "illiquid"),
         ("0x82c4c641ccc38719ae1f0fbd16a64808d838fdfd", "Morpho", VaultFlag.illiquid, "illiquid"),
+        ("0x7193794ec82f527efb618ac50c078d348ecba4b6", "Morpho", VaultFlag.illiquid, "illiquid"),
         ("0xed9278c5188f37670b33ef3b00729e38260cd5d5", "Euler", VaultFlag.illiquid, "illiquid"),
         ("0xcbc9b61177444a793b85442d3a953b90f6170b7d", "Euler", VaultFlag.illiquid, "illiquid"),
         ("0xd0ee0cf300dfb598270cd7f4d0c6e0d8f6e13f29", "Altura", VaultFlag.controversial, "controversial"),


### PR DESCRIPTION
## Why

The vault scanner surfaced Etherealm USDC V1 on Ethereum. This vault is effectively illiquid and should be hidden from end-user vault reports like the existing Etherealm USDC entry.

## Lessons learnt

Etherscan and on-chain ERC-4626 metadata show `0x7193794ec82f527efb618ac50c078d348ecba4b6` is a modern MetaMorpho Etherealm USDC contract, not an age-old mainnet probe hazard. The right classification is a manual illiquid vault flag, not the broken old-contract deny-list.

## Summary

- Added Etherealm USDC V1 to manual vault flags with the existing illiquid Etherealm note.
- Added focused vault flag test coverage for the V1 address.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.