### PR TITLE
fix: use canonical D2 vault links

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/d2/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/d2/vault.py
@@ -126,6 +126,14 @@ D2_VAULT_ADDRESSES: set[str] = {
     "0xfddd73ecd0d0d75e902a567811a70e167a262fab",
 }
 
+#: D2 Finance strategy page for every known D2 vault.
+#:
+#: Keep native vault links on D2's own website. Trading Strategy page links
+#: are generated separately by the vault metrics reporting layer.
+D2_VAULT_LINK_MATRIX: dict[str, str] = {
+    **{address: D2_STRATEGY_URL_TEMPLATE.format(address=address) for address in D2_VAULT_ADDRESSES},
+}
+
 
 def format_d2_strategy_url(address: HexAddress | str) -> str:
     """Format a D2 Finance strategy page URL.
@@ -333,6 +341,23 @@ class D2Vault(ERC4626Vault):
 
     def get_historical_reader(self, stateful) -> VaultHistoricalReader:
         return D2HistoricalReader(self, stateful)
+
+    def get_link(self, referral: str | None = None) -> str:  # noqa: ARG002
+        """Get the canonical public page for this D2 vault.
+
+        The matrix keeps every native vault link on D2 Finance's strategy
+        pages. Trading Strategy links are exported separately by the vault
+        metrics reporting layer.
+
+        :param referral:
+            Unused because neither supported D2 destination accepts a referral
+            parameter.
+
+        :return:
+            D2 Finance strategy page URL.
+        """
+        address = self.address.lower()
+        return D2_VAULT_LINK_MATRIX.get(address, format_d2_strategy_url(address))
 
     def get_notes(self) -> str | None:
         """Get D2-specific vault notes.

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -455,14 +455,20 @@ def _get_trading_strategy_protocol_link(protocol_slug: str) -> str:
 
 def _get_trading_strategy_vault_link(
     vault_slug: str,
-    vault_address: str,
 ) -> str:
     """Get the tradingstrategy.ai vault URL.
 
-    The vault address is kept in the URL fragment so the canonical page route
-    avoids the legacy redirect and the address does not affect routing.
+    Vault pages have a canonical flat route based on their generated slug.
+    In particular, this keeps D2 vault links pointed at their Trading Strategy
+    vault page instead of an address fragment.
+
+    :param vault_slug:
+        Canonical vault page slug.
+
+    :return:
+        Canonical Trading Strategy vault page URL.
     """
-    return f"https://tradingstrategy.ai/trading-view/vaults/{vault_slug}#{vault_address}"
+    return f"https://tradingstrategy.ai/trading-view/vaults/{vault_slug}"
 
 
 def create_fee_label(
@@ -1630,7 +1636,6 @@ def calculate_vault_record(
 
     trading_strategy_link = _get_trading_strategy_vault_link(
         vault_slug=vault_slug,
-        vault_address=vault_address,
     )
 
     lockup = vault_metadata.get("_lockup", None)

--- a/tests/erc_4626/vault_protocol/test_d2_notes.py
+++ b/tests/erc_4626/vault_protocol/test_d2_notes.py
@@ -5,6 +5,7 @@ from eth_defi.erc_4626.scan import _normalise_scan_note
 from eth_defi.erc_4626.vault_protocol.d2.vault import (
     D2_TEXAS_HEDGE_ADDRESS,
     D2_VAULT_ADDRESSES,
+    D2_VAULT_LINK_MATRIX,
     D2Vault,
 )
 from eth_defi.vault.base import VaultSpec
@@ -47,6 +48,16 @@ def test_d2_vault_note_handles_checksum_address() -> None:
 
     assert note is not None
     assert "[D2 strategy page](https://d2.finance/strategies/0x75288264fdfea8ce68e6d852696ab1ce2f3e5004)" in note
+
+
+def test_d2_vault_link_matrix_covers_every_known_vault() -> None:
+    """D2 vault links resolve to their native D2 Finance strategy page."""
+    assert set(D2_VAULT_LINK_MATRIX) == D2_VAULT_ADDRESSES
+
+    for address, expected_link in D2_VAULT_LINK_MATRIX.items():
+        assert make_d2_vault(address).get_link() == expected_link
+
+    assert make_d2_vault(D2_TEXAS_HEDGE_ADDRESS).get_link() == "https://d2.finance/strategies/0x208f63a7f60c319597c05fa5ec67fde41839bad6"
 
 
 def test_d2_unknown_protocol_vault_gets_generic_note() -> None:

--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -35,11 +35,10 @@ from eth_defi.vault.vaultdb import VaultDatabase
 def test_get_trading_strategy_links_use_canonical_vault_routes():
     """Generated Trading Strategy links use canonical flat vault routes."""
     vault_link = vault_metrics._get_trading_strategy_vault_link(
-        vault_slug="steakhouse-usdc",
-        vault_address="0x6043828A0cE0FccC6D27eC4848673Ff7F54Ebd0C",
+        vault_slug="texashedge",
     )
 
-    assert vault_link == "https://tradingstrategy.ai/trading-view/vaults/steakhouse-usdc#0x6043828A0cE0FccC6D27eC4848673Ff7F54Ebd0C"
+    assert vault_link == "https://tradingstrategy.ai/trading-view/vaults/texashedge"
     assert vault_metrics._get_trading_strategy_chain_link("Ethereum") == "https://tradingstrategy.ai/trading-view/vaults/chains/ethereum"
     assert vault_metrics._get_trading_strategy_chain_link("Hypercore") == "https://tradingstrategy.ai/trading-view/vaults/chains/hyperliquid"
 


### PR DESCRIPTION
## Why

D2 vault records should link to their native D2 Finance strategy pages, while Trading Strategy vault-page URLs remain canonical and fragment-free in report exports.

## Lessons learnt

Native protocol links and Trading Strategy report links have distinct destinations and must be maintained separately.

## Summary

- Add a D2 address-to-strategy-page link matrix and use it from `D2Vault.get_link()`.
- Remove contract-address fragments from canonical Trading Strategy vault-page URLs.
- Add regression tests for matrix coverage and canonical URLs.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.