### PR TITLE
fix: reduce unchanged curator metadata log noise

### DIFF
--- a/eth_defi/vault/curator.py
+++ b/eth_defi/vault/curator.py
@@ -1006,7 +1006,10 @@ def process_and_upload_curator_metadata(  # noqa: PLR0917
         content_type="application/json",
         skip_if_current=True,
     )
-    logger.info("%s curator metadata for: %s", "Uploaded" if metadata_uploaded else "Skipped unchanged", slug)
+    if metadata_uploaded:
+        logger.info("Uploaded curator metadata for: %s", slug)
+    else:
+        logger.debug("Skipped unchanged curator metadata for: %s", slug)
 
     logo_dir = FORMATTED_LOGOS_DIR / slug
     for variant in LOGO_VARIANTS:
@@ -1081,11 +1084,10 @@ def upload_protocol_curator_metadata(  # noqa: PLR0917
             content_type="application/json",
             skip_if_current=True,
         )
-        logger.info(
-            "%s protocol-curator metadata for: %s",
-            "Uploaded" if metadata_uploaded else "Skipped unchanged",
-            slug,
-        )
+        if metadata_uploaded:
+            logger.info("Uploaded protocol-curator metadata for: %s", slug)
+        else:
+            logger.debug("Skipped unchanged protocol-curator metadata for: %s", slug)
 
         logo_dir = FORMATTED_LOGOS_DIR / slug
         for variant in LOGO_VARIANTS:


### PR DESCRIPTION
## Why

Vault scanner logs still emitted unchanged curator metadata uploads at INFO level, creating noisy production output during repeated R2 export checks. The previous log-noise PR covered unchanged curator logos but not the metadata JSON upload path.

## Lessons learnt

Curator metadata and curator logo uploads have separate log sites, so both need explicit uploaded-versus-unchanged branches to keep successful writes visible while suppressing no-op uploads.

## Summary

- Keep successful curator metadata uploads at INFO.
- Move unchanged curator metadata uploads to DEBUG.
- Apply the same uploaded-versus-unchanged log split to protocol-curator metadata uploads.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.