### PR TITLE
fix: clean Hypercore vault price histories

### DIFF
--- a/eth_defi/hyperliquid/problem-vaults.md
+++ b/eth_defi/hyperliquid/problem-vaults.md
@@ -51,7 +51,7 @@ daily when their timestamp is midnight UTC and HF otherwise. This is valid for
 the historical Hypercore exports, but new data must always use the explicit
 column.
 
-## Crypto Plaza Relative Momentum Edge
+## Crypto plaza relative momentum edge
 
 - Address: `0xdc9955a83218b71713a83ee072055591bd4c7304`
 - Trading Strategy page:
@@ -183,7 +183,7 @@ Hypercore rows for non-empty `hypercore_repair_status`, then grouping by
 `address` and status. Filtering for `share_price != raw_share_price` returns
 only the applied subset and would omit deliberately deferred candidates.
 
-## HODL My Perps
+## HODL my perps
 
 - Address: `0x13b43faa22d854bf43b4e7581c1b3dfcd416f8c3`
 - Trading Strategy page:

--- a/eth_defi/hyperliquid/problem-vaults.md
+++ b/eth_defi/hyperliquid/problem-vaults.md
@@ -25,19 +25,26 @@ addresses this case:
 
 - The daily and high-frequency exporters label every new row as `daily` or
   `hf` through `hypercore_source`.
-- Positive HF observations are the preferred canonical anchors. A daily point
-  bracketed by them is repaired only if its symmetric price deviation exceeds
-  50%.
+- Positive-price, positive-NAV HF observations are the preferred canonical
+  anchors. A daily point bracketed by them becomes a candidate if its symmetric
+  price deviation exceeds 50%.
 - For legacy daily-only vaults, the newest common `written_at` batch supplies
-  the canonical anchors. The repair additionally requires the row's NAV to
-  stay within 50% of the interpolated anchor NAV. This prevents smoothing a
-  genuine deposit, wipe-out, or recapitalisation boundary.
+  the canonical anchors.
+- Both paths repair a candidate only when NAV stays within 50% of the
+  interpolated anchor NAV, the anchors are at most eight days apart, and their
+  interval contains neither zero NAV nor an `epoch_reset`. These checks prevent
+  smoothing a genuine deposit, missing observation, wipe-out, or
+  recapitalisation boundary.
 - The input value is retained in `raw_share_price` for auditability. The repair
   does not extrapolate outside anchor coverage and does not alter anchor rows.
+  `hypercore_repair_status` records `repaired_*` for applied changes and a
+  `deferred_*` reason when the evidence is insufficient and the raw value is
+  kept.
 - A separate recapitalisation filter discards the old cleaned-history epoch
-  after a durable zero-NAV event. It starts at the first new NAV observation
-  of at least `$1,000`, provided recovery took at least seven days, and marks
-  that row as `epoch_reset`. The raw parquet is never discarded or rewritten.
+  after a durable zero-NAV event. Durability is measured from zero NAV to the
+  first later positive NAV; that recovery must take at least seven days. The
+  new epoch starts at the first subsequent observation of at least `$1,000`
+  and is marked `epoch_reset`. The raw parquet is never discarded or rewritten.
 
 Legacy parquet rows predate explicit source provenance. They are classified as
 daily when their timestamp is midnight UTC and HF otherwise. This is valid for
@@ -67,22 +74,26 @@ return in the late-January to mid-February inspection window falls to about
 - Trading Strategy page: [Magixbox](https://tradingstrategy.ai/trading-view/vaults/magixbox)
 - Affected period: 25 January to 5 February 2026
 
-Magixbox has overlapping daily and HF observations. Six stale daily values
-were replaced from the HF anchor curve:
+Magixbox has six daily/HF price-discrepancy candidates. The conservative
+policy automatically repairs two. Four remain unchanged because their NAV is
+more than 50% away from the interpolated HF-anchor NAV; although their prices
+look suspicious, the stored observations do not prove that interpolation is
+economically safe.
 
-| Date | Raw share price | Repaired share price |
-| --- | ---: | ---: |
-| 2026-01-25 | 0.443179 | 0.668308 |
-| 2026-01-30 | 1.278832 | 0.642874 |
-| 2026-01-31 | 1.774786 | 0.724207 |
-| 2026-02-01 | 4.605958 | 0.815830 |
-| 2026-02-03 | 12.898591 | 1.035319 |
-| 2026-02-05 | 26.035410 | 1.303902 |
+| Date | Raw share price | Anchor estimate | Decision |
+| --- | ---: | ---: | --- |
+| 2026-01-25 | 0.443179 | 0.668308 | Repair |
+| 2026-01-30 | 1.278832 | 0.642874 | Defer: NAV |
+| 2026-01-31 | 1.774786 | 0.724207 | Defer: NAV |
+| 2026-02-01 | 4.605958 | 0.815830 | Defer: NAV |
+| 2026-02-03 | 12.898591 | 1.035319 | Repair |
+| 2026-02-05 | 26.035410 | 1.303902 | Defer: NAV |
 
-The pre-repair maximum one-step price return was about 1,895%; the repaired
-series' maximum is about 528%. The remaining large October 2025 move was
-examined separately and is supported by roughly `$12,742.80` of realised PnL
-on 10 October. It must not be removed as a data artefact.
+The four deferred values retain `share_price == raw_share_price` and carry
+`deferred_hf_nav`; downstream consumers can therefore distinguish unresolved
+data from repaired data. The separate large October 2025 move is supported by
+roughly `$12,742.80` of realised PnL on 10 October and must not be removed as a
+data artefact.
 
 At the 13 July 2026 live API check, Magixbox had no open perpetual positions
 and a perp account value of about `$746.22`.
@@ -111,23 +122,31 @@ a perp account value of about `$2,277.49`.
 
 ## Similar price-history candidates
 
-The repair is also the candidate detector: a Hypercore row is a candidate when
-the wrangle output differs from its preserved `raw_share_price`. This is a
-high-confidence classification of a synthetic-price inconsistency, but the
-raw value must remain available for audit.
+The repair now records its candidate classification directly in
+`hypercore_repair_status`. A value beginning with `repaired_` means the cleaned
+price differs from `raw_share_price`; `deferred_` means the row exceeded the
+price-discrepancy threshold but failed one or more safety rules and remains
+unchanged. A large price discrepancy is a reason to inspect a row, not by
+itself proof that the raw value is wrong.
 
 The read-only production snapshot contained two non-overlapping populations:
 
-| Pattern | Anchor method | Vaults | Repaired rows |
-| --- | --- | ---: | ---: |
-| Magixbox-style | HF observations | 143 | 759 |
-| C.A.T-style | Refreshed daily observations plus NAV consistency | 21 | 164 |
-| Total |  | 164 | 923 |
+| Pattern | Anchor method | Vaults | Candidates | Repaired | Deferred |
+| --- | --- | ---: | ---: | ---: | ---: |
+| Magixbox-style | HF observations | 143 | 759 | 612 | 147 |
+| C.A.T-style | Refreshed daily observations | 38 | 292 | 135 | 157 |
+| Total |  | 181 | 1,051 | 747 | 304 |
 
-Most candidates cluster in January and February 2026: 614 of the 759
-Magixbox-style rows and 148 of the 164 C.A.T-style rows. This timing is
-consistent with an historical rolling-window merge problem, rather than 164
-independent strategy events.
+Of the 181 affected vaults, all candidates are automatically repaired for 97;
+84 have at least one deferred row. The latter group requires better source
+data or manual investigation rather than more aggressive interpolation.
+
+The safeguards defer 260 rows for NAV inconsistency, 60 for an anchor gap over
+eight days, and 34 for crossing zero NAV or `epoch_reset`; these counts overlap.
+For example, all 28 deferred rows for BBQ & Tegelwerken BV span fourteen-day
+anchor gaps. Lifecycle-boundary deferrals include 21M, SMM Foundation, and
+Vela Trading. These are real limitations in the evidence available to the
+repair, not proof of genuine investment returns.
 
 ### Magixbox-style examples
 
@@ -135,33 +154,34 @@ These are the largest per-vault symmetric discrepancies in the HF-anchor
 population. A ratio of 20 means that one of the two prices was twenty times
 the other.
 
-| Vault | Address | Repaired rows | Largest ratio |
-| --- | --- | ---: | ---: |
-| Tao Hedge | `0x3d848183c406deae93c2641c045a541cf1d4a6cb` | 8 | 587.6x |
-| HLP Liquidator 3 | `0x5e177e5e39c0f4e421f5865a6d8beed8d921cb70` | 2 | 164.6x |
-| Hyperland | `0x8e108f7c619ab460885edd0f84e313daf119c779` | 12 | 94.8x |
-| Long LINK Short XRP | `0x73ce82fb75868af2a687e9889fcf058dd1cf8ce9` | 12 | 49.2x |
-| Magixbox | `0x1764dd740aba4195643bbb6a44648e0306b00cfa` | 6 | 20.0x |
-| TAPTRADE | `0x5f42236dfb81cba77bf34698b2242826659d1275` | 45 | 19.3x |
+| Vault | Address | Candidates | Repaired | Deferred | Largest ratio |
+| --- | --- | ---: | ---: | ---: | ---: |
+| Tao Hedge | `0x3d848183c406deae93c2641c045a541cf1d4a6cb` | 8 | 5 | 3 | 587.6x |
+| HLP Liquidator 3 | `0x5e177e5e39c0f4e421f5865a6d8beed8d921cb70` | 2 | 0 | 2 | 164.6x |
+| Hyperland | `0x8e108f7c619ab460885edd0f84e313daf119c779` | 12 | 11 | 1 | 94.8x |
+| Long LINK Short XRP | `0x73ce82fb75868af2a687e9889fcf058dd1cf8ce9` | 12 | 10 | 2 | 49.2x |
+| Magixbox | `0x1764dd740aba4195643bbb6a44648e0306b00cfa` | 6 | 2 | 4 | 20.0x |
+| TAPTRADE | `0x5f42236dfb81cba77bf34698b2242826659d1275` | 45 | 26 | 19 | 19.3x |
 
 ### C.A.T-style examples
 
 These vaults lack sufficient HF history for the affected interval. Their
-latest daily refresh batch and compatible NAV history make repair safe.
+latest daily refresh batch supplies anchors, but each candidate still has to
+pass all three safety checks.
 
-| Vault | Address | Repaired rows | Largest ratio |
-| --- | --- | ---: | ---: |
-| Automated AI trading vault | `0x87fdbcf7c8fc949e2ddb4f1a50337ee75dc8233a` | 6 | 35.5x |
-| PUMP TRADE | `0xafc7b17e3d7b564fcbd1b5220455f16a66857ef0` | 23 | 22.8x |
-| C.A.T | `0xdfb729b4b789de6d13d6ad7ac8e2750909360af9` | 14 | 19.0x |
-| TA trader | `0x6fe9749eab7f66f002d7541d6c1e3bb3df19c701` | 17 | 10.2x |
-| MC Recovery Fund | `0x914434e8a235cb608a94a5f70ab8c40927152a24` | 8 | 6.3x |
-| $100K Target | `0xe528531fc82ab104397fe06c550f0bb00720e0ab` | 6 | 4.9x |
+| Vault | Address | Candidates | Repaired | Deferred | Largest ratio |
+| --- | --- | ---: | ---: | ---: | ---: |
+| Automated AI trading vault | `0x87fdbcf7c8fc949e2ddb4f1a50337ee75dc8233a` | 10 | 6 | 4 | 35.5x |
+| PUMP TRADE | `0xafc7b17e3d7b564fcbd1b5220455f16a66857ef0` | 29 | 23 | 6 | 22.8x |
+| C.A.T | `0xdfb729b4b789de6d13d6ad7ac8e2750909360af9` | 14 | 14 | 0 | 19.0x |
+| TA trader | `0x6fe9749eab7f66f002d7541d6c1e3bb3df19c701` | 22 | 17 | 5 | 10.2x |
+| MC Recovery Fund | `0x914434e8a235cb608a94a5f70ab8c40927152a24` | 8 | 8 | 0 | 6.3x |
+| $100K Target | `0xe528531fc82ab104397fe06c550f0bb00720e0ab` | 14 | 6 | 8 | 4.9x |
 
 For any future scan, obtain the complete inventory by filtering cleaned
-Hypercore rows for `share_price != raw_share_price`, then grouping by
-`address` and `hypercore_source`. This makes the candidate set reproducible
-without maintaining a stale hard-coded address list.
+Hypercore rows for non-empty `hypercore_repair_status`, then grouping by
+`address` and status. Filtering for `share_price != raw_share_price` returns
+only the applied subset and would omit deliberately deferred candidates.
 
 ## HODL My Perps
 
@@ -185,10 +205,11 @@ scanner cannot know the original share base.
 Do **not** repair HODL by interpolation: that would hide the real complete
 loss. The wrangle pipeline applies a separate recapitalisation policy:
 
-1. Detect a prior meaningful NAV, zero NAV, and a first later NAV of at least
-   `$1,000` after a seven-day recovery delay.
-2. Discard all preceding rows from the **cleaned** data and mark the first
-   retained row `epoch_reset`.
+1. Detect a prior NAV of at least `$1,000`, zero NAV, and no later positive NAV
+   for at least seven days.
+2. After that durable recovery, wait until NAV again reaches `$1,000`, discard
+   all preceding rows from the **cleaned** data, and mark the first retained
+   row `epoch_reset`.
 3. Preserve the raw parquet for audit and historical analysis.
 
 This scopes the cleaned chart and metrics to the current capital epoch. It does
@@ -204,20 +225,29 @@ liquidation price of `61.4724294668`.
 
 The raw Hypercore history contains many isolated zero-NAV observations caused
 by scanner or rolling-window artefacts. They must not automatically become
-performance epochs. A durable episode is defined here as meaningful NAV above
-`$10`, followed by NAV at or below `$0.000001`, then later meaningful NAV
-above `$10`, with at least one day before recovery.
+performance epochs. The exploratory census used NAV above `$10`, followed by
+NAV at or below `$0.000001`, then later NAV above `$10`, with at least one day
+before recovery. The implemented automatic rule is deliberately stricter: the
+old and new tracked epochs must reach `$1,000`, and the zero period must last
+at least seven days before *any* positive NAV reappears.
 
 There are four such episodes across 569 tracked Hypercore vaults. All four
 also satisfy a seven-day recovery-delay threshold; HODL My Perps and Rehobot
 LR exceed thirty days.
 
-| Vault | Address | Zero interval | First recapitalised observation |
-| --- | --- | --- | --- |
-| Rehobot LR | `0x81a20870c5c7558f117166b2a598abaa8ce91f50` | 15 Oct 2025 – 15 Apr 2026 | 22 Apr 2026, about `$1,012` |
-| HODL My Perps | `0x13b43faa22d854bf43b4e7581c1b3dfcd416f8c3` | 15 Oct 2025 – 17 Apr 2026 | 17 Apr 2026, about `$100` |
-| Sifu | `0xf967239debef10dbc78e9bbbb2d8a16b72a614eb` | 17 Apr 2024 – 1 May 2024 | 15 May 2024, about `$987,000` |
-| HLP Liquidator | `0x2e3d94f0562703b25c83308a05046ddaf9a8dd14` | 12 Nov 2025 | 19 Nov 2025, about `$1.09M` |
+| Vault | Address | Zero interval | New tracked epoch | Rows discarded |
+| --- | --- | --- | --- | ---: |
+| Rehobot LR | `0x81a20870c5c7558f117166b2a598abaa8ce91f50` | 15 Oct 2025 – 15 Apr 2026 | 22 Apr 2026, about `$1,012` | 44 |
+| HODL My Perps | `0x13b43faa22d854bf43b4e7581c1b3dfcd416f8c3` | 15 Oct 2025 – 17 Apr 2026 | 20 Apr 2026, about `$7,859` | 161 |
+| Sifu | `0xf967239debef10dbc78e9bbbb2d8a16b72a614eb` | 17 Apr 2024 – 1 May 2024 | 15 May 2024, about `$987,001` | 25 |
+| HLP Liquidator | `0x2e3d94f0562703b25c83308a05046ddaf9a8dd14` | 12 Nov 2025 | 19 Nov 2025, about `$1.00M` | 139 |
+
+HODL first regained positive NAV on 17 April with about `$100`; it crossed the
+tracking threshold on 20 April. Measuring the seven-day delay to 20 April
+would be wrong: for example, `$2,000 -> $0 -> $900 next day -> $1,000 after
+seven days` is a prompt recovery, not a seven-day wipe-out. The code therefore
+tests durability at the first positive value and applies the `$1,000` threshold
+only when choosing where the new chart epoch starts.
 
 The naive rule "any zero followed by a positive value" finds 325 episodes
 across 322 vaults. Of those, 319 vaults recover within roughly one hour and
@@ -229,18 +259,18 @@ therefore mandatory for the automated `epoch_reset` policy.
 The source-aware repair was run read-only against the production raw parquet
 snapshot containing 848,333 Hypercore rows:
 
-| Repair path | Rows | Vaults |
-| --- | ---: | ---: |
-| Daily rows repaired from HF anchors | 759 | 143 |
-| Stale daily rows repaired from refreshed daily anchors | 164 | 21 |
-| Total | 923 | 164 |
+| Repair path | Candidates | Repaired | Deferred | Candidate vaults |
+| --- | ---: | ---: | ---: | ---: |
+| Daily rows compared with HF anchors | 759 | 612 | 147 | 143 |
+| Stale daily rows compared with refreshed daily anchors | 292 | 135 | 157 | 38 |
+| Total | 1,051 | 747 | 304 | 181 |
 
 No production parquet was modified during this validation. Focused tests cover
 HF-source provenance, legacy provenance inference, daily-only repair,
-unbracketed rows, lifecycle-boundary preservation, and recapitalisation epoch
-filtering. A read-only production run removes 369 pre-recapitalisation rows
-across HODL My Perps, Rehobot LR, Sifu, and HLP Liquidator; the cleaned history
-starts at the first post-recapitalisation NAV of at least `$1,000` for each.
+unbracketed rows, NAV/gap/lifecycle deferrals, recapitalisation epoch filtering,
+and the distinction between first positive NAV and the later `$1,000` tracking
+threshold. A read-only production run removes 369 pre-recapitalisation rows
+across HODL My Perps, Rehobot LR, Sifu, and HLP Liquidator.
 
 See also `scripts/hyperliquid/README-hyperliquid-vaults.md`, in particular
 the *Healing share price data* section, for the scanner-level healing process.

--- a/eth_defi/hyperliquid/problem-vaults.md
+++ b/eth_defi/hyperliquid/problem-vaults.md
@@ -1,0 +1,246 @@
+# Problem vaults
+
+This document records known Hyperliquid / Hypercore vault price-history
+problems investigated in July 2026. It is an operational reference for the
+native-vault scanners and the downstream wrangle step, not an assessment of a
+vault's investment quality.
+
+## Data model and failure mode
+
+Hyperliquid's `vaultDetails` endpoint exposes rolling `day`, `week`, `month`,
+and `allTime` account-value and cumulative-PnL series. The native scanner
+derives an ERC-4626-like share price from those series so that vault returns
+can be compared with other vault protocols.
+
+The account-value and PnL samples in different rolling windows are not always
+aligned. Combining a fresh account-value sample with a stale or differently
+resolved cumulative-PnL sample makes the inferred net flow wrong. The share
+price reconstruction then invents a share mint or burn, producing a temporary
+price spike which often reverses at the next refreshed observation. This is a
+data artefact, not a realised vault return.
+
+The wrangle repair in
+`eth_defi.research.wrangle_vault_prices.fix_hypercore_source_overlap_share_prices`
+addresses this case:
+
+- The daily and high-frequency exporters label every new row as `daily` or
+  `hf` through `hypercore_source`.
+- Positive HF observations are the preferred canonical anchors. A daily point
+  bracketed by them is repaired only if its symmetric price deviation exceeds
+  50%.
+- For legacy daily-only vaults, the newest common `written_at` batch supplies
+  the canonical anchors. The repair additionally requires the row's NAV to
+  stay within 50% of the interpolated anchor NAV. This prevents smoothing a
+  genuine deposit, wipe-out, or recapitalisation boundary.
+- The input value is retained in `raw_share_price` for auditability. The repair
+  does not extrapolate outside anchor coverage and does not alter anchor rows.
+- A separate recapitalisation filter discards the old cleaned-history epoch
+  after a durable zero-NAV event. It starts at the first new NAV observation
+  of at least `$1,000`, provided recovery took at least seven days, and marks
+  that row as `epoch_reset`. The raw parquet is never discarded or rewritten.
+
+Legacy parquet rows predate explicit source provenance. They are classified as
+daily when their timestamp is midnight UTC and HF otherwise. This is valid for
+the historical Hypercore exports, but new data must always use the explicit
+column.
+
+## Crypto Plaza Relative Momentum Edge
+
+- Address: `0xdc9955a83218b71713a83ee072055591bd4c7304`
+- Trading Strategy page:
+  [Crypto Plaza Relative Momentum Edge](https://tradingstrategy.ai/trading-view/vaults/crypto-plaza-relative-momentum-edge)
+- Affected period: February 2026
+
+This was the original reported example. The large February share-price jump
+and reversal were caused by the rolling-window merge described above, not by
+the vault's positions or a real trading gain/loss. The raw values on 5 and 6
+February were respectively `3.538529` and `3.485236`; the HF-anchor repair
+estimates `1.079443` and `1.029948`.
+
+The repair changes ten historical rows for this vault. Its maximum absolute
+return in the late-January to mid-February inspection window falls to about
+16.5% after repair.
+
+## Magixbox
+
+- Address: `0x1764dd740aba4195643bbb6a44648e0306b00cfa`
+- Trading Strategy page: [Magixbox](https://tradingstrategy.ai/trading-view/vaults/magixbox)
+- Affected period: 25 January to 5 February 2026
+
+Magixbox has overlapping daily and HF observations. Six stale daily values
+were replaced from the HF anchor curve:
+
+| Date | Raw share price | Repaired share price |
+| --- | ---: | ---: |
+| 2026-01-25 | 0.443179 | 0.668308 |
+| 2026-01-30 | 1.278832 | 0.642874 |
+| 2026-01-31 | 1.774786 | 0.724207 |
+| 2026-02-01 | 4.605958 | 0.815830 |
+| 2026-02-03 | 12.898591 | 1.035319 |
+| 2026-02-05 | 26.035410 | 1.303902 |
+
+The pre-repair maximum one-step price return was about 1,895%; the repaired
+series' maximum is about 528%. The remaining large October 2025 move was
+examined separately and is supported by roughly `$12,742.80` of realised PnL
+on 10 October. It must not be removed as a data artefact.
+
+At the 13 July 2026 live API check, Magixbox had no open perpetual positions
+and a perp account value of about `$746.22`.
+
+## C.A.T
+
+- Address: `0xdfb729b4b789de6d13d6ad7ac8e2750909360af9`
+- Trading Strategy page: [C.A.T](https://tradingstrategy.ai/trading-view/vaults/c-a-t)
+- Affected period: 22 January to 6 February 2026
+
+C.A.T has no HF history for the affected period, so this case motivated the
+refreshed-daily-anchor fallback. The canonical weekly observations were about
+`1.019542` on 28 January, `1.893065` on 4 February, and `1.961532` on 11
+February. In contrast, stale daily values rose to `19.672888` on 3 February
+and to `36.320766` on 6 February before reversing near `1.90`.
+
+This cannot be an economic return: NAV remained around `$5,000`, and the
+locally synchronised vault ledger records no deposits from 29 January through
+10 February. The repair changes fourteen rows. It reduces the maximum
+one-step return from about 1,814% to 58.1%; for example, the raw values
+`36.239740` and `36.320766` on 5 and 6 February become `1.902698` and
+`1.912379`.
+
+At the 13 July 2026 live API check, C.A.T had no open perpetual positions and
+a perp account value of about `$2,277.49`.
+
+## Similar price-history candidates
+
+The repair is also the candidate detector: a Hypercore row is a candidate when
+the wrangle output differs from its preserved `raw_share_price`. This is a
+high-confidence classification of a synthetic-price inconsistency, but the
+raw value must remain available for audit.
+
+The read-only production snapshot contained two non-overlapping populations:
+
+| Pattern | Anchor method | Vaults | Repaired rows |
+| --- | --- | ---: | ---: |
+| Magixbox-style | HF observations | 143 | 759 |
+| C.A.T-style | Refreshed daily observations plus NAV consistency | 21 | 164 |
+| Total |  | 164 | 923 |
+
+Most candidates cluster in January and February 2026: 614 of the 759
+Magixbox-style rows and 148 of the 164 C.A.T-style rows. This timing is
+consistent with an historical rolling-window merge problem, rather than 164
+independent strategy events.
+
+### Magixbox-style examples
+
+These are the largest per-vault symmetric discrepancies in the HF-anchor
+population. A ratio of 20 means that one of the two prices was twenty times
+the other.
+
+| Vault | Address | Repaired rows | Largest ratio |
+| --- | --- | ---: | ---: |
+| Tao Hedge | `0x3d848183c406deae93c2641c045a541cf1d4a6cb` | 8 | 587.6x |
+| HLP Liquidator 3 | `0x5e177e5e39c0f4e421f5865a6d8beed8d921cb70` | 2 | 164.6x |
+| Hyperland | `0x8e108f7c619ab460885edd0f84e313daf119c779` | 12 | 94.8x |
+| Long LINK Short XRP | `0x73ce82fb75868af2a687e9889fcf058dd1cf8ce9` | 12 | 49.2x |
+| Magixbox | `0x1764dd740aba4195643bbb6a44648e0306b00cfa` | 6 | 20.0x |
+| TAPTRADE | `0x5f42236dfb81cba77bf34698b2242826659d1275` | 45 | 19.3x |
+
+### C.A.T-style examples
+
+These vaults lack sufficient HF history for the affected interval. Their
+latest daily refresh batch and compatible NAV history make repair safe.
+
+| Vault | Address | Repaired rows | Largest ratio |
+| --- | --- | ---: | ---: |
+| Automated AI trading vault | `0x87fdbcf7c8fc949e2ddb4f1a50337ee75dc8233a` | 6 | 35.5x |
+| PUMP TRADE | `0xafc7b17e3d7b564fcbd1b5220455f16a66857ef0` | 23 | 22.8x |
+| C.A.T | `0xdfb729b4b789de6d13d6ad7ac8e2750909360af9` | 14 | 19.0x |
+| TA trader | `0x6fe9749eab7f66f002d7541d6c1e3bb3df19c701` | 17 | 10.2x |
+| MC Recovery Fund | `0x914434e8a235cb608a94a5f70ab8c40927152a24` | 8 | 6.3x |
+| $100K Target | `0xe528531fc82ab104397fe06c550f0bb00720e0ab` | 6 | 4.9x |
+
+For any future scan, obtain the complete inventory by filtering cleaned
+Hypercore rows for `share_price != raw_share_price`, then grouping by
+`address` and `hypercore_source`. This makes the candidate set reproducible
+without maintaining a stale hard-coded address list.
+
+## HODL My Perps
+
+- Address: `0x13b43faa22d854bf43b4e7581c1b3dfcd416f8c3`
+- Trading Strategy page:
+  [HODL My Perps](https://tradingstrategy.ai/trading-view/vaults/hodl-my-perps)
+- Lifecycle boundary: 15 October 2025 to 17 April 2026
+
+HODL My Perps is not a daily/HF overlap problem. Its all-time API history
+shows a real wipe-out on 15 October 2025: NAV became zero and cumulative PnL
+was `-$326,631.13`. NAV remained zero until recapitalisation began on 17 April
+2026.
+
+The post-recapitalisation synthetic share price is not economically continuous
+with the pre-wipe-out shares. It begins near `6.55e-7` for a roughly `$100`
+deposit and later contains non-economic HF jumps, including a roughly 54.7x
+move on 21 May while NAV was near `$31,700`. These values arise because the
+available rolling PnL history begins after a large historical loss, so the
+scanner cannot know the original share base.
+
+Do **not** repair HODL by interpolation: that would hide the real complete
+loss. The wrangle pipeline applies a separate recapitalisation policy:
+
+1. Detect a prior meaningful NAV, zero NAV, and a first later NAV of at least
+   `$1,000` after a seven-day recovery delay.
+2. Discard all preceding rows from the **cleaned** data and mark the first
+   retained row `epoch_reset`.
+3. Preserve the raw parquet for audit and historical analysis.
+
+This scopes the cleaned chart and metrics to the current capital epoch. It does
+not by itself reconstruct any remaining post-recapitalisation synthetic-price
+anomaly. The preceding -100% outcome remains available in raw data, but it is
+not chain-linked into a fictitious return on recapitalised capital.
+
+At the 13 July 2026 live API check, the vault held a long position of `830.3`
+HYPE, entered at `64.8714`, with unrealised PnL of about `-$945.21` and a
+liquidation price of `61.4724294668`.
+
+## Durable zero-NAV and recapitalisation episodes
+
+The raw Hypercore history contains many isolated zero-NAV observations caused
+by scanner or rolling-window artefacts. They must not automatically become
+performance epochs. A durable episode is defined here as meaningful NAV above
+`$10`, followed by NAV at or below `$0.000001`, then later meaningful NAV
+above `$10`, with at least one day before recovery.
+
+There are four such episodes across 569 tracked Hypercore vaults. All four
+also satisfy a seven-day recovery-delay threshold; HODL My Perps and Rehobot
+LR exceed thirty days.
+
+| Vault | Address | Zero interval | First recapitalised observation |
+| --- | --- | --- | --- |
+| Rehobot LR | `0x81a20870c5c7558f117166b2a598abaa8ce91f50` | 15 Oct 2025 – 15 Apr 2026 | 22 Apr 2026, about `$1,012` |
+| HODL My Perps | `0x13b43faa22d854bf43b4e7581c1b3dfcd416f8c3` | 15 Oct 2025 – 17 Apr 2026 | 17 Apr 2026, about `$100` |
+| Sifu | `0xf967239debef10dbc78e9bbbb2d8a16b72a614eb` | 17 Apr 2024 – 1 May 2024 | 15 May 2024, about `$987,000` |
+| HLP Liquidator | `0x2e3d94f0562703b25c83308a05046ddaf9a8dd14` | 12 Nov 2025 | 19 Nov 2025, about `$1.09M` |
+
+The naive rule "any zero followed by a positive value" finds 325 episodes
+across 322 vaults. Of those, 319 vaults recover within roughly one hour and
+are excluded as transient data artefacts. The duration/recovery threshold is
+therefore mandatory for the automated `epoch_reset` policy.
+
+## Validation and operational status
+
+The source-aware repair was run read-only against the production raw parquet
+snapshot containing 848,333 Hypercore rows:
+
+| Repair path | Rows | Vaults |
+| --- | ---: | ---: |
+| Daily rows repaired from HF anchors | 759 | 143 |
+| Stale daily rows repaired from refreshed daily anchors | 164 | 21 |
+| Total | 923 | 164 |
+
+No production parquet was modified during this validation. Focused tests cover
+HF-source provenance, legacy provenance inference, daily-only repair,
+unbracketed rows, lifecycle-boundary preservation, and recapitalisation epoch
+filtering. A read-only production run removes 369 pre-recapitalisation rows
+across HODL My Perps, Rehobot LR, Sifu, and HLP Liquidator; the cleaned history
+starts at the first post-recapitalisation NAV of at least `$1,000` for each.
+
+See also `scripts/hyperliquid/README-hyperliquid-vaults.md`, in particular
+the *Healing share price data* section, for the scanner-level healing process.

--- a/eth_defi/hyperliquid/vault_data_export.py
+++ b/eth_defi/hyperliquid/vault_data_export.py
@@ -312,6 +312,7 @@ def _prepare_hypercore_export(
     timestamp_values,
     flow_col_map: dict[str, str],
     sort_columns: list[str],
+    hypercore_source: str,
 ) -> pd.DataFrame:
     """Shared helper for building Hypercore export DataFrames.
 
@@ -329,6 +330,10 @@ def _prepare_hypercore_export(
     :param sort_columns:
         Columns to sort by before forward-filling (e.g.
         ``["vault_address", "date"]`` or ``["vault_address", "timestamp"]``).
+    :param hypercore_source:
+        Provenance label for the exported observations: ``"daily"`` or
+        ``"hf"``. This remains in the raw parquet so the wrangle step can
+        reconcile overlapping synthetic share-price histories.
     :return:
         DataFrame matching the uncleaned Parquet schema.
     """
@@ -389,6 +394,7 @@ def _prepare_hypercore_export(
             "daily_withdrawal_count": _col(flow_col_map.get("daily_withdrawal_count", "daily_withdrawal_count")),
             "daily_deposit_usd": _col(flow_col_map.get("daily_deposit_usd", "daily_deposit_usd")),
             "daily_withdrawal_usd": _col(flow_col_map.get("daily_withdrawal_usd", "daily_withdrawal_usd")),
+            "hypercore_source": hypercore_source,
             "epoch_reset": _col("epoch_reset", default=False),
             "written_at": _col("written_at", default=pd.NaT),
         },
@@ -434,12 +440,14 @@ def build_raw_prices_dataframe(db: HyperliquidDailyMetricsDatabase) -> pd.DataFr
 
     prices_df = _attach_relationship_type_from_metadata(prices_df, db.get_all_vault_metadata())
 
-    return _prepare_hypercore_export(
+    result = _prepare_hypercore_export(
         prices_df,
         timestamp_values=pd.to_datetime(prices_df["date"]).values,
         flow_col_map={},  # Daily columns already named daily_*
         sort_columns=["vault_address", "date"],
+        hypercore_source="daily",
     )
+    return result
 
 
 def merge_into_vault_database(
@@ -639,7 +647,7 @@ def build_raw_prices_dataframe_hf(db: HyperliquidHighFreqMetricsDatabase) -> pd.
 
     # Map HF column names (deposit_count etc.) back to daily_* names
     # for downstream compatibility.
-    return _prepare_hypercore_export(
+    result = _prepare_hypercore_export(
         prices_df,
         timestamp_values=prices_df["timestamp"].values,
         flow_col_map={
@@ -649,7 +657,9 @@ def build_raw_prices_dataframe_hf(db: HyperliquidHighFreqMetricsDatabase) -> pd.
             "daily_withdrawal_usd": "withdrawal_usd",
         },
         sort_columns=["vault_address", "timestamp"],
+        hypercore_source="hf",
     )
+    return result
 
 
 def build_hypercore_prices_dataframe(
@@ -679,14 +689,12 @@ def build_hypercore_prices_dataframe(
     if daily_db is not None:
         daily_df = build_raw_prices_dataframe(daily_db)
         if not daily_df.empty:
-            daily_df["_source"] = "daily"
             parts.append(daily_df)
             logger.info("Daily DB contributed %d Hypercore rows", len(daily_df))
 
     if hf_db is not None:
         hf_df = build_raw_prices_dataframe_hf(hf_db)
         if not hf_df.empty:
-            hf_df["_source"] = "hf"
             parts.append(hf_df)
             logger.info("HF DB contributed %d Hypercore rows", len(hf_df))
 
@@ -696,9 +704,9 @@ def build_hypercore_prices_dataframe(
     hl_df = pd.concat(parts, ignore_index=True)
 
     # Sort so "hf" comes after "daily", then drop_duplicates keeps last.
-    hl_df = hl_df.sort_values(["address", "timestamp", "_source"])
+    hl_df = hl_df.sort_values(["address", "timestamp", "hypercore_source"])
     hl_df = hl_df.drop_duplicates(subset=["address", "timestamp"], keep="last")
-    return hl_df.drop(columns=["_source"])
+    return hl_df
 
 
 def merge_hypercore_prices_to_parquet(

--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -28,12 +28,29 @@ from IPython.display import display
 from tqdm_loggable.auto import tqdm
 
 from eth_defi.chain import get_chain_name
+from eth_defi.hyperliquid.constants import HYPERCORE_CHAIN_ID
 from eth_defi.token import is_stablecoin_like
+from eth_defi.types import Percent
 from eth_defi.vault.base import VaultSpec, verify_parquet_file
 from eth_defi.vault.settlement_data import (
     merge_vault_settlements_into_cleaned_prices,
 )
 from eth_defi.vault.vaultdb import DEFAULT_UNCLEANED_PRICE_DATABASE, DEFAULT_VAULT_DATABASE, VaultDatabase, VaultRow
+
+#: At least two canonical observations are needed to bracket a daily price.
+MIN_HYPERCORE_PRICE_ANCHORS = 2
+
+#: Rows emitted by one daily refresh share practically the same write time.
+HYPERCORE_DAILY_REFRESH_TOLERANCE = pd.Timedelta(minutes=1)
+
+#: NAV at or below this value counts as a complete Hypercore wipe-out.
+HYPERCORE_ZERO_NAV_EPSILON = 0.000001
+
+#: New capital must reach this NAV before a recapitalised vault is tracked again.
+MIN_HYPERCORE_RECAPITALISATION_ASSETS = 1_000.0
+
+#: Ignore isolated zero-NAV observations that recover before this delay.
+MIN_HYPERCORE_RECAPITALISATION_RECOVERY_DELAY = pd.Timedelta(days=7)
 
 
 class CleanedVaultPriceRow(TypedDict, total=False):
@@ -296,6 +313,17 @@ class CleanedVaultPriceRow(TypedDict, total=False):
     #: Hypercore only — NaN for all other protocols.
     cumulative_volume: float
 
+    #: Hypercore scanner source: ``"daily"`` or ``"hf"``.
+    #:
+    #: Used during wrangling to reconcile overlapping synthetic share prices.
+    #: Hypercore only — NaN for all other protocols.
+    hypercore_source: str
+
+    #: The row starts a new performance epoch after a complete wipe-out.
+    #:
+    #: Hypercore only — false for ordinary observations.
+    epoch_reset: bool
+
     # -- Native protocol flow columns --
     # Populated for native protocols with daily deposit/withdrawal data
     # (Hypercore, GRVT, Lighter, Hibachi). NaN for ERC-4626 vaults.
@@ -366,6 +394,9 @@ VAULT_STATE_COLUMNS = {
     # When this price row was actually written/fetched (naive UTC).
     # NaT for old data that predates this column.
     "written_at": pd.NaT,
+    # Hypercore epoch marker. Set when wrangling discards a complete prior
+    # wipe-out epoch and begins from recapitalised capital.
+    "epoch_reset": False,
     # Latest asynchronous vault settlement timestamp in the interval ending at
     # this price row. Merged from vault-settlements.duckdb after cleaning.
     "vault_settlement_at": pd.NaT,
@@ -912,8 +943,6 @@ def cap_hypercore_share_prices(
     :return:
         DataFrame with capped share prices.
     """
-    from eth_defi.hyperliquid.constants import HYPERCORE_CHAIN_ID
-
     hypercore_mask = prices_df["chain"] == HYPERCORE_CHAIN_ID
     if not hypercore_mask.any():
         return prices_df
@@ -924,6 +953,287 @@ def cap_hypercore_share_prices(
     if overflow_count > 0:
         logger(f"Capping {overflow_count:,} Hypercore share prices above {max_share_price:,.0f}")
         prices_df.loc[overflow_mask, "share_price"] = max_share_price
+
+    return prices_df
+
+
+def discard_hypercore_pre_recapitalisation_history(
+    prices_df: pd.DataFrame,
+    logger=print,
+    min_recapitalisation_assets: float = MIN_HYPERCORE_RECAPITALISATION_ASSETS,
+    min_recovery_delay: pd.Timedelta = MIN_HYPERCORE_RECAPITALISATION_RECOVERY_DELAY,
+) -> pd.DataFrame:
+    """Start a recapitalised Hypercore vault at its new meaningful capital base.
+
+    A complete wipe-out followed by new deposits cannot be represented by one
+    continuous share-price series. The old investors have a -100% return,
+    while the new investors must not inherit the destroyed share supply. When
+    a vault has meaningful NAV, reaches zero, and does not regain meaningful
+    NAV until after ``min_recovery_delay``, discard its earlier observations
+    from the *cleaned* output. The raw parquet remains unchanged.
+
+    The first retained observation must have at least
+    ``min_recapitalisation_assets`` in NAV and is marked ``epoch_reset``. A
+    short zero blip that recovers before the delay is considered a scanner or
+    rolling-window artefact and is not filtered.
+
+    :param prices_df:
+        Vault price data indexed by timestamp, with ``id``, ``chain``, and
+        ``total_assets`` columns. It must be sorted by vault and timestamp.
+    :param logger:
+        Notebook or console logging function.
+    :param min_recapitalisation_assets:
+        Minimum NAV in USD needed before tracking the new investment epoch.
+    :param min_recovery_delay:
+        Minimum elapsed time between zero NAV and the first meaningful
+        recapitalised observation.
+    :return:
+        Price data without the superseded pre-recapitalisation epochs.
+    """
+    hypercore_mask = prices_df["chain"] == HYPERCORE_CHAIN_ID
+    if not hypercore_mask.any():
+        return prices_df
+
+    if "epoch_reset" not in prices_df.columns:
+        prices_df = prices_df.copy()
+        prices_df["epoch_reset"] = False
+
+    remove_mask = np.zeros(len(prices_df), dtype=bool)
+    epoch_reset_positions: list[int] = []
+    hypercore_positions = np.flatnonzero(hypercore_mask.to_numpy())
+
+    for _vault_id, row_positions in prices_df.loc[hypercore_mask].groupby("id", sort=False).indices.items():
+        positions = hypercore_positions[np.asarray(row_positions, dtype=int)]
+        group = prices_df.iloc[positions]
+        total_assets = group["total_assets"].to_numpy(dtype=float)
+        timestamp = pd.DatetimeIndex(group.index)
+
+        meaningful_assets = np.isfinite(total_assets) & (total_assets >= min_recapitalisation_assets)
+        zero_assets = np.isfinite(total_assets) & (total_assets <= HYPERCORE_ZERO_NAV_EPSILON)
+        zero_starts = np.flatnonzero(zero_assets & np.r_[True, ~zero_assets[:-1]])
+        zero_ends = np.flatnonzero(zero_assets & np.r_[~zero_assets[1:], True])
+        recapitalisation_position: int | None = None
+
+        for zero_start, zero_end in zip(zero_starts, zero_ends):
+            # A zero before a vault's first meaningful deposit is normal
+            # initialisation, not a loss of an existing investment epoch.
+            if not meaningful_assets[:zero_start].any():
+                continue
+
+            post_zero_meaningful = np.flatnonzero(meaningful_assets[zero_end + 1 :])
+            if len(post_zero_meaningful) == 0:
+                continue
+
+            first_recapitalisation = zero_end + 1 + int(post_zero_meaningful[0])
+            if timestamp[first_recapitalisation] - timestamp[zero_start] < min_recovery_delay:
+                continue
+
+            # Keep the latest valid reset if a vault has more than one
+            # complete lifecycle. The output must start at its current epoch.
+            recapitalisation_position = first_recapitalisation
+
+        if recapitalisation_position is not None:
+            remove_mask[positions[:recapitalisation_position]] = True
+            epoch_reset_positions.append(int(positions[recapitalisation_position]))
+
+    if not epoch_reset_positions:
+        return prices_df
+
+    epoch_reset_col = prices_df.columns.get_loc("epoch_reset")
+    prices_df.iloc[epoch_reset_positions, epoch_reset_col] = True
+    filtered_prices_df = prices_df.iloc[~remove_mask].copy()
+    logger(f"Discarded {int(remove_mask.sum()):,} pre-recapitalisation Hypercore price rows across {len(epoch_reset_positions):,} vaults; new epochs start once NAV reaches ${min_recapitalisation_assets:,.0f} after {min_recovery_delay}")
+    return filtered_prices_df
+
+
+def fix_hypercore_source_overlap_share_prices(  # noqa: PLR0914
+    prices_df: pd.DataFrame,
+    logger=print,
+    max_anchor_deviation: Percent = 0.50,
+) -> pd.DataFrame:
+    """Repair corrupted daily Hypercore prices using canonical observations.
+
+    Hypercore daily and high-frequency scanners both derive synthetic share
+    prices from the rolling ``vaultDetails`` portfolio windows. Historical
+    daily rows may have been calculated from a different rolling window than
+    the later HF rows. Mixing the two sources can therefore create temporary
+    multi-day price excursions that are absent from the canonical HF history.
+
+    For periods covered by both sources, use positive HF observations as a
+    time-based anchor curve. Some legacy vaults have daily history only. For
+    these, use the latest batch of refreshed daily rows, identified by their
+    common ``written_at`` value, as the canonical anchors. This handles stale
+    rolling-window rows left between observations refreshed from a later
+    ``allTime`` response.
+
+    A daily observation is replaced only when its symmetric deviation from
+    the log-linearly interpolated anchor price exceeds
+    ``max_anchor_deviation``. For the daily-only fallback, its total assets
+    must also remain within the same deviation of the canonical asset curve.
+    This prevents interpolation across a real wipe-out, deposit, or other
+    vault lifecycle boundary. Canonical anchor rows, rows outside anchor
+    coverage, all HF rows, and all non-Hypercore rows are left unchanged.
+
+    ``raw_share_price`` always preserves the input value for auditability.
+
+    :param prices_df:
+        Vault prices indexed by timestamp. New Hypercore rows carry the
+        ``hypercore_source`` value ``daily`` or ``hf``. For legacy rows the
+        source is inferred from daily midnight normalisation versus the raw HF
+        API timestamp.
+    :param logger:
+        Notebook or console logging function.
+    :param max_anchor_deviation:
+        Maximum symmetric ratio deviation from the interpolated anchor.
+        ``0.50`` means either price may be at most 50% larger than the other.
+    :return:
+        Price data with conflicting daily Hypercore prices repaired.
+    """
+    prices_df = prices_df.copy()
+    if "raw_share_price" not in prices_df.columns:
+        prices_df["raw_share_price"] = prices_df["share_price"]
+
+    hypercore_mask = prices_df["chain"] == HYPERCORE_CHAIN_ID
+    if not hypercore_mask.any():
+        return prices_df
+
+    if "hypercore_source" not in prices_df.columns:
+        prices_df["hypercore_source"] = pd.NA
+
+    missing_source_mask = hypercore_mask & prices_df["hypercore_source"].isna()
+    if missing_source_mask.any():
+        # Backwards compatibility for Parquet files written before explicit
+        # source provenance was exported. Daily rows are normalised to midnight;
+        # HF rows retain the raw API timestamp, normally including milliseconds.
+        missing_timestamps = pd.DatetimeIndex(prices_df.index[missing_source_mask])
+        inferred_sources = np.where(missing_timestamps == missing_timestamps.normalize(), "daily", "hf")
+        prices_df.loc[missing_source_mask, "hypercore_source"] = inferred_sources
+        logger(f"Inferred Hypercore source provenance for {int(missing_source_mask.sum()):,} legacy price rows")
+
+    share_price_col = prices_df.columns.get_loc("share_price")
+    hf_fixed_count = 0
+    hf_affected_vaults = 0
+    daily_fixed_count = 0
+    daily_affected_vaults = 0
+    hypercore_positions = np.flatnonzero(hypercore_mask.to_numpy())
+
+    for _vault_id, row_positions in prices_df.loc[hypercore_mask].groupby("id", sort=False).indices.items():
+        # ``groupby().indices`` above is relative to the filtered frame. Map
+        # these positions back to the original frame before assigning by iloc.
+        positions = hypercore_positions[np.asarray(row_positions, dtype=int)]
+        group = prices_df.iloc[positions]
+
+        source = group["hypercore_source"].astype("string").fillna("").to_numpy(dtype=str)
+        share_price = group["share_price"].to_numpy(dtype=float)
+        timestamp_ns = pd.DatetimeIndex(group.index).asi8.astype(float)
+
+        positive_price_mask = np.isfinite(share_price) & (share_price > 0)
+        hf_mask = (source == "hf") & positive_price_mask
+        daily_mask = source == "daily"
+        if not daily_mask.any():
+            continue
+
+        if hf_mask.sum() >= MIN_HYPERCORE_PRICE_ANCHORS:
+            anchor_mask = hf_mask
+            candidate_mask = daily_mask
+            anchor_source = "hf"
+            anchor_assets = None
+        else:
+            # Some legacy vaults were never covered by the HF scanner. A
+            # later daily scan refreshes the canonical allTime observations
+            # in one batch, while stale rows from older rolling windows retain
+            # older or missing write times. Never modify the refresh batch
+            # itself; it is the best available canonical history.
+            if "written_at" not in group.columns or "total_assets" not in group.columns:
+                continue
+            written_at = pd.to_datetime(group["written_at"], errors="coerce")
+            latest_written_at = written_at.max()
+            if pd.isna(latest_written_at):
+                continue
+            total_assets = group["total_assets"].to_numpy(dtype=float)
+            positive_assets_mask = np.isfinite(total_assets) & (total_assets > 0)
+            refreshed_mask = (written_at >= latest_written_at - HYPERCORE_DAILY_REFRESH_TOLERANCE).to_numpy()
+            anchor_mask = daily_mask & refreshed_mask & positive_price_mask & positive_assets_mask
+            candidate_mask = daily_mask & ~anchor_mask
+            anchor_source = "daily"
+            anchor_assets = total_assets[anchor_mask]
+
+        anchor_timestamps = timestamp_ns[anchor_mask]
+        anchor_prices = share_price[anchor_mask]
+        sort_order = np.argsort(anchor_timestamps)
+        anchor_timestamps = anchor_timestamps[sort_order]
+        anchor_prices = anchor_prices[sort_order]
+        if anchor_assets is not None:
+            anchor_assets = anchor_assets[sort_order]
+
+        # np.interp expects unique x values. Keep the last anchor value for any
+        # duplicate timestamp, matching the export deduplication behaviour.
+        reverse_unique_positions = np.unique(anchor_timestamps[::-1], return_index=True)[1]
+        unique_positions = np.sort(len(anchor_timestamps) - 1 - reverse_unique_positions)
+        anchor_timestamps = anchor_timestamps[unique_positions]
+        anchor_prices = anchor_prices[unique_positions]
+        if anchor_assets is not None:
+            anchor_assets = anchor_assets[unique_positions]
+        if len(anchor_timestamps) < MIN_HYPERCORE_PRICE_ANCHORS:
+            continue
+
+        expected_log_price = np.interp(
+            timestamp_ns,
+            anchor_timestamps,
+            np.log(anchor_prices),
+            left=np.nan,
+            right=np.nan,
+        )
+        expected_price = np.exp(expected_log_price)
+        valid_expected = np.isfinite(expected_price) & (expected_price > 0)
+
+        if anchor_assets is not None:
+            expected_assets = np.exp(
+                np.interp(
+                    timestamp_ns,
+                    anchor_timestamps,
+                    np.log(anchor_assets),
+                    left=np.nan,
+                    right=np.nan,
+                )
+            )
+            with np.errstate(divide="ignore", invalid="ignore"):
+                asset_deviation = (
+                    np.maximum(
+                        total_assets / expected_assets,
+                        expected_assets / total_assets,
+                    )
+                    - 1
+                )
+            # A stale synthetic share price should not be accompanied by the
+            # same-sized NAV move. Large NAV deviations can represent genuine
+            # vault lifecycle changes and must not be smoothed away.
+            candidate_mask &= positive_assets_mask & np.isfinite(expected_assets) & (asset_deviation <= max_anchor_deviation)
+
+        with np.errstate(divide="ignore", invalid="ignore"):
+            symmetric_deviation = (
+                np.maximum(
+                    share_price / expected_price,
+                    expected_price / share_price,
+                )
+                - 1
+            )
+        repair_mask = candidate_mask & valid_expected & positive_price_mask & (symmetric_deviation > max_anchor_deviation)
+
+        if repair_mask.any():
+            repair_positions = positions[repair_mask]
+            prices_df.iloc[repair_positions, share_price_col] = expected_price[repair_mask]
+            if anchor_source == "hf":
+                hf_fixed_count += int(repair_mask.sum())
+                hf_affected_vaults += 1
+            else:
+                daily_fixed_count += int(repair_mask.sum())
+                daily_affected_vaults += 1
+
+    if hf_fixed_count:
+        logger(f"Repaired {hf_fixed_count:,} conflicting daily Hypercore share prices across {hf_affected_vaults:,} vaults using HF anchors")
+    if daily_fixed_count:
+        logger(f"Repaired {daily_fixed_count:,} stale daily Hypercore share prices across {daily_affected_vaults:,} vaults using refreshed daily anchors")
 
     return prices_df
 
@@ -1191,6 +1501,11 @@ def process_raw_vault_scan_data(
 
     prices_df = remove_inactive_lead_time(prices_df, logger)
 
+    # A complete Hypercore wipe-out followed by later deposits is a new
+    # investment epoch, not a recoverable price movement. Begin the cleaned
+    # history from the meaningful recapitalisation point.
+    prices_df = discard_hypercore_pre_recapitalisation_history(prices_df, logger)
+
     if diagnose_vault_id:
         vault_prices_df = prices_df[prices_df["id"] == diagnose_vault_id]
         logger("After remove_inactive_lead_time():")
@@ -1201,20 +1516,21 @@ def process_raw_vault_scan_data(
     # this prevents the smoothing algorithm from being confused by absurd values.
     prices_df = cap_hypercore_share_prices(prices_df, logger)
 
-    # fix_outlier_share_prices() uses row-based shift(look_back=24) designed for
-    # hourly ERC-4626 data (24 rows = 24 hours). For Hypercore vaults with weekly
-    # spacing, 24 rows spans ~6 months, making the comparison meaningless and
-    # incorrectly smoothing legitimate price movements. Hypercore share prices are
-    # synthetic and already cleaned by cap_hypercore_share_prices(), so skip them.
-    from eth_defi.hyperliquid.constants import HYPERCORE_CHAIN_ID
+    # Hypercore scans may overlap or refresh only a sparse subset of historical
+    # rows. Repair stale daily values that conflict sharply with canonical HF
+    # observations or the latest daily refresh batch.
+    prices_df = fix_hypercore_source_overlap_share_prices(prices_df, logger)
+
+    # The generic fixer derives one row offset from each vault's median polling
+    # interval. Hypercore mixes roughly 20-minute, daily, and weekly rows, so one
+    # offset cannot represent a stable time window. The source-aware repair above
+    # handles Hypercore; keep the generic fixer limited to EVM vaults.
 
     hypercore_mask = prices_df["chain"] == HYPERCORE_CHAIN_ID
     has_hypercore = hypercore_mask.any()
     has_evm = (~hypercore_mask).any()
 
     if has_hypercore and has_evm:
-        # Set raw_share_price for Hypercore rows (they skip outlier fixing)
-        prices_df.loc[hypercore_mask, "raw_share_price"] = prices_df.loc[hypercore_mask, "share_price"]
         # Fix outlier share prices only for EVM rows, operating in-place
         evm_df = prices_df.loc[~hypercore_mask]
         fixed_evm = fix_outlier_share_prices(evm_df, logger)
@@ -1222,7 +1538,6 @@ def process_raw_vault_scan_data(
     elif has_evm:
         prices_df = fix_outlier_share_prices(prices_df, logger)
     else:
-        prices_df["raw_share_price"] = prices_df["share_price"]
         logger("Skipping fix_outlier_share_prices() for Hypercore-only dataset")
 
     if diagnose_vault_id:

--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -43,6 +43,9 @@ MIN_HYPERCORE_PRICE_ANCHORS = 2
 #: Rows emitted by one daily refresh share practically the same write time.
 HYPERCORE_DAILY_REFRESH_TOLERANCE = pd.Timedelta(minutes=1)
 
+#: Do not estimate a price across a missing weekly Hypercore anchor.
+HYPERCORE_MAX_PRICE_ANCHOR_GAP = pd.Timedelta(days=8)
+
 #: NAV at or below this value counts as a complete Hypercore wipe-out.
 HYPERCORE_ZERO_NAV_EPSILON = 0.000001
 
@@ -324,6 +327,14 @@ class CleanedVaultPriceRow(TypedDict, total=False):
     #: Hypercore only — false for ordinary observations.
     epoch_reset: bool
 
+    #: Outcome of the conservative Hypercore source-overlap repair.
+    #:
+    #: Values start with ``"repaired_"`` when the cleaned share price was
+    #: changed and ``"deferred_"`` when a candidate was left unchanged because
+    #: it failed the NAV, anchor-gap, or lifecycle-boundary safeguards.
+    #: Hypercore only — empty for ordinary observations and other protocols.
+    hypercore_repair_status: str
+
     # -- Native protocol flow columns --
     # Populated for native protocols with daily deposit/withdrawal data
     # (Hypercore, GRVT, Lighter, Hibachi). NaN for ERC-4626 vaults.
@@ -397,6 +408,8 @@ VAULT_STATE_COLUMNS = {
     # Hypercore epoch marker. Set when wrangling discards a complete prior
     # wipe-out epoch and begins from recapitalised capital.
     "epoch_reset": False,
+    # Source-overlap repair outcome. Empty for ordinary and non-Hypercore rows.
+    "hypercore_repair_status": "",
     # Latest asynchronous vault settlement timestamp in the interval ending at
     # this price row. Merged from vault-settlements.duckdb after cleaning.
     "vault_settlement_at": pd.NaT,
@@ -968,14 +981,26 @@ def discard_hypercore_pre_recapitalisation_history(
     A complete wipe-out followed by new deposits cannot be represented by one
     continuous share-price series. The old investors have a -100% return,
     while the new investors must not inherit the destroyed share supply. When
-    a vault has meaningful NAV, reaches zero, and does not regain meaningful
+    a vault has meaningful NAV, reaches zero, and does not regain *any* positive
     NAV until after ``min_recovery_delay``, discard its earlier observations
     from the *cleaned* output. The raw parquet remains unchanged.
 
-    The first retained observation must have at least
-    ``min_recapitalisation_assets`` in NAV and is marked ``epoch_reset``. A
-    short zero blip that recovers before the delay is considered a scanner or
-    rolling-window artefact and is not filtered.
+    Recovery duration and the new tracking threshold are intentionally separate.
+    The delay is measured to the first value above
+    :py:data:`HYPERCORE_ZERO_NAV_EPSILON`, even when that value is below
+    ``min_recapitalisation_assets``. This prevents a sequence such as
+    ``$2,000 -> $0 -> $900 next day -> $1,000 after seven days`` from erasing
+    valid history merely because the recovery crossed the display threshold
+    later. Once a durable recovery is established, the first retained
+    observation must have at least ``min_recapitalisation_assets`` in NAV and
+    is marked ``epoch_reset``.
+
+    The July 2026 production snapshot contained four qualifying episodes across
+    569 Hypercore vaults. HODL My Perps, HLP Liquidator, Rehobot LR, and Sifu all
+    still qualify when measuring the delay to the first positive NAV, removing
+    369 rows from cleaned output. The stricter definition was chosen because the
+    same snapshot contained hundreds of transient zero observations which must
+    not reset lifetime performance.
 
     :param prices_df:
         Vault price data indexed by timestamp, with ``id``, ``chain``, and
@@ -985,8 +1010,7 @@ def discard_hypercore_pre_recapitalisation_history(
     :param min_recapitalisation_assets:
         Minimum NAV in USD needed before tracking the new investment epoch.
     :param min_recovery_delay:
-        Minimum elapsed time between zero NAV and the first meaningful
-        recapitalised observation.
+        Minimum elapsed time between zero NAV and the first later positive NAV.
     :return:
         Price data without the superseded pre-recapitalisation epochs.
     """
@@ -1020,13 +1044,19 @@ def discard_hypercore_pre_recapitalisation_history(
             if not meaningful_assets[:zero_start].any():
                 continue
 
+            post_zero_positive = np.flatnonzero(np.isfinite(total_assets[zero_end + 1 :]) & (total_assets[zero_end + 1 :] > HYPERCORE_ZERO_NAV_EPSILON))
+            if len(post_zero_positive) == 0:
+                continue
+
+            first_positive = zero_end + 1 + int(post_zero_positive[0])
+            if timestamp[first_positive] - timestamp[zero_start] < min_recovery_delay:
+                continue
+
             post_zero_meaningful = np.flatnonzero(meaningful_assets[zero_end + 1 :])
             if len(post_zero_meaningful) == 0:
                 continue
 
             first_recapitalisation = zero_end + 1 + int(post_zero_meaningful[0])
-            if timestamp[first_recapitalisation] - timestamp[zero_start] < min_recovery_delay:
-                continue
 
             # Keep the latest valid reset if a vault has more than one
             # complete lifecycle. The output must start at its current epoch.
@@ -1050,6 +1080,7 @@ def fix_hypercore_source_overlap_share_prices(  # noqa: PLR0914
     prices_df: pd.DataFrame,
     logger=print,
     max_anchor_deviation: Percent = 0.50,
+    max_anchor_gap: pd.Timedelta = HYPERCORE_MAX_PRICE_ANCHOR_GAP,
 ) -> pd.DataFrame:
     """Repair corrupted daily Hypercore prices using canonical observations.
 
@@ -1066,13 +1097,28 @@ def fix_hypercore_source_overlap_share_prices(  # noqa: PLR0914
     rolling-window rows left between observations refreshed from a later
     ``allTime`` response.
 
-    A daily observation is replaced only when its symmetric deviation from
-    the log-linearly interpolated anchor price exceeds
-    ``max_anchor_deviation``. For the daily-only fallback, its total assets
-    must also remain within the same deviation of the canonical asset curve.
-    This prevents interpolation across a real wipe-out, deposit, or other
-    vault lifecycle boundary. Canonical anchor rows, rows outside anchor
-    coverage, all HF rows, and all non-Hypercore rows are left unchanged.
+    A daily observation becomes a repair candidate when its symmetric deviation
+    from the log-linearly interpolated anchor price exceeds
+    ``max_anchor_deviation``. It is changed only when all three conservative
+    safeguards pass:
+
+    - its NAV is within ``max_anchor_deviation`` of the interpolated anchor NAV;
+    - the bracketing anchor gap is no longer than ``max_anchor_gap``; and
+    - the anchor interval contains neither zero NAV nor ``epoch_reset``.
+
+    A July 2026 audit of 848,333 Hypercore rows found 1,051 candidates across
+    181 vaults. These rules automatically repair 747 rows and defer 304
+    ambiguous rows: 260 failed NAV consistency, 60 used a gap over eight days,
+    and 34 crossed a lifecycle boundary, with overlap between the counts. The
+    NAV rule is deliberately applied to HF anchors too. For example, four of
+    six Magixbox candidates are now deferred despite looking suspicious,
+    because the raw data does not preserve enough intra-week information to
+    prove a safe replacement. Avoiding a fabricated investor return takes
+    priority over maximising the number of smooth chart points.
+
+    Canonical anchors, rows outside anchor coverage, all HF rows, and all
+    non-Hypercore rows are left unchanged. Deferred rows also remain unchanged
+    and receive a reason in ``hypercore_repair_status``.
 
     ``raw_share_price`` always preserves the input value for auditability.
 
@@ -1086,12 +1132,18 @@ def fix_hypercore_source_overlap_share_prices(  # noqa: PLR0914
     :param max_anchor_deviation:
         Maximum symmetric ratio deviation from the interpolated anchor.
         ``0.50`` means either price may be at most 50% larger than the other.
+    :param max_anchor_gap:
+        Maximum elapsed time between the two observations used as anchors.
+        Eight days permits the normal historical weekly HF cadence but rejects
+        a missing weekly observation and longer interpolation.
     :return:
         Price data with conflicting daily Hypercore prices repaired.
     """
     prices_df = prices_df.copy()
     if "raw_share_price" not in prices_df.columns:
         prices_df["raw_share_price"] = prices_df["share_price"]
+    if "hypercore_repair_status" not in prices_df.columns:
+        prices_df["hypercore_repair_status"] = ""
 
     hypercore_mask = prices_df["chain"] == HYPERCORE_CHAIN_ID
     if not hypercore_mask.any():
@@ -1111,10 +1163,16 @@ def fix_hypercore_source_overlap_share_prices(  # noqa: PLR0914
         logger(f"Inferred Hypercore source provenance for {int(missing_source_mask.sum()):,} legacy price rows")
 
     share_price_col = prices_df.columns.get_loc("share_price")
+    repair_status_col = prices_df.columns.get_loc("hypercore_repair_status")
     hf_fixed_count = 0
     hf_affected_vaults = 0
     daily_fixed_count = 0
     daily_affected_vaults = 0
+    deferred_count = 0
+    nav_deferred_count = 0
+    gap_deferred_count = 0
+    boundary_deferred_count = 0
+    deferred_vaults: set[str] = set()
     hypercore_positions = np.flatnonzero(hypercore_mask.to_numpy())
 
     for _vault_id, row_positions in prices_df.loc[hypercore_mask].groupby("id", sort=False).indices.items():
@@ -1125,46 +1183,49 @@ def fix_hypercore_source_overlap_share_prices(  # noqa: PLR0914
 
         source = group["hypercore_source"].astype("string").fillna("").to_numpy(dtype=str)
         share_price = group["share_price"].to_numpy(dtype=float)
-        timestamp_ns = pd.DatetimeIndex(group.index).asi8.astype(float)
+        timestamp_ns = pd.DatetimeIndex(group.index).to_numpy(dtype="datetime64[ns]").astype("int64")
+
+        if "total_assets" not in group.columns:
+            continue
+        total_assets = group["total_assets"].to_numpy(dtype=float)
+        positive_assets_mask = np.isfinite(total_assets) & (total_assets > 0)
 
         positive_price_mask = np.isfinite(share_price) & (share_price > 0)
-        hf_mask = (source == "hf") & positive_price_mask
+        hf_price_mask = (source == "hf") & positive_price_mask
         daily_mask = source == "daily"
         if not daily_mask.any():
             continue
 
-        if hf_mask.sum() >= MIN_HYPERCORE_PRICE_ANCHORS:
-            anchor_mask = hf_mask
+        if hf_price_mask.sum() >= MIN_HYPERCORE_PRICE_ANCHORS:
+            # HF coverage selects the HF repair path even if some observations
+            # have unusable NAV. Never reinterpret such a vault as daily-only.
+            anchor_mask = hf_price_mask & positive_assets_mask
             candidate_mask = daily_mask
             anchor_source = "hf"
-            anchor_assets = None
         else:
             # Some legacy vaults were never covered by the HF scanner. A
             # later daily scan refreshes the canonical allTime observations
             # in one batch, while stale rows from older rolling windows retain
             # older or missing write times. Never modify the refresh batch
             # itself; it is the best available canonical history.
-            if "written_at" not in group.columns or "total_assets" not in group.columns:
+            if "written_at" not in group.columns:
                 continue
             written_at = pd.to_datetime(group["written_at"], errors="coerce")
             latest_written_at = written_at.max()
             if pd.isna(latest_written_at):
                 continue
-            total_assets = group["total_assets"].to_numpy(dtype=float)
-            positive_assets_mask = np.isfinite(total_assets) & (total_assets > 0)
             refreshed_mask = (written_at >= latest_written_at - HYPERCORE_DAILY_REFRESH_TOLERANCE).to_numpy()
             anchor_mask = daily_mask & refreshed_mask & positive_price_mask & positive_assets_mask
             candidate_mask = daily_mask & ~anchor_mask
             anchor_source = "daily"
-            anchor_assets = total_assets[anchor_mask]
 
         anchor_timestamps = timestamp_ns[anchor_mask]
         anchor_prices = share_price[anchor_mask]
+        anchor_assets = total_assets[anchor_mask]
         sort_order = np.argsort(anchor_timestamps)
         anchor_timestamps = anchor_timestamps[sort_order]
         anchor_prices = anchor_prices[sort_order]
-        if anchor_assets is not None:
-            anchor_assets = anchor_assets[sort_order]
+        anchor_assets = anchor_assets[sort_order]
 
         # np.interp expects unique x values. Keep the last anchor value for any
         # duplicate timestamp, matching the export deduplication behaviour.
@@ -1172,8 +1233,7 @@ def fix_hypercore_source_overlap_share_prices(  # noqa: PLR0914
         unique_positions = np.sort(len(anchor_timestamps) - 1 - reverse_unique_positions)
         anchor_timestamps = anchor_timestamps[unique_positions]
         anchor_prices = anchor_prices[unique_positions]
-        if anchor_assets is not None:
-            anchor_assets = anchor_assets[unique_positions]
+        anchor_assets = anchor_assets[unique_positions]
         if len(anchor_timestamps) < MIN_HYPERCORE_PRICE_ANCHORS:
             continue
 
@@ -1187,28 +1247,43 @@ def fix_hypercore_source_overlap_share_prices(  # noqa: PLR0914
         expected_price = np.exp(expected_log_price)
         valid_expected = np.isfinite(expected_price) & (expected_price > 0)
 
-        if anchor_assets is not None:
-            expected_assets = np.exp(
-                np.interp(
-                    timestamp_ns,
-                    anchor_timestamps,
-                    np.log(anchor_assets),
-                    left=np.nan,
-                    right=np.nan,
-                )
+        expected_assets = np.exp(
+            np.interp(
+                timestamp_ns,
+                anchor_timestamps,
+                np.log(anchor_assets),
+                left=np.nan,
+                right=np.nan,
             )
-            with np.errstate(divide="ignore", invalid="ignore"):
-                asset_deviation = (
-                    np.maximum(
-                        total_assets / expected_assets,
-                        expected_assets / total_assets,
-                    )
-                    - 1
+        )
+        with np.errstate(divide="ignore", invalid="ignore"):
+            asset_deviation = (
+                np.maximum(
+                    total_assets / expected_assets,
+                    expected_assets / total_assets,
                 )
-            # A stale synthetic share price should not be accompanied by the
-            # same-sized NAV move. Large NAV deviations can represent genuine
-            # vault lifecycle changes and must not be smoothed away.
-            candidate_mask &= positive_assets_mask & np.isfinite(expected_assets) & (asset_deviation <= max_anchor_deviation)
+                - 1
+            )
+        nav_safe_mask = positive_assets_mask & np.isfinite(expected_assets) & (asset_deviation <= max_anchor_deviation)
+
+        right_anchor = np.searchsorted(anchor_timestamps, timestamp_ns, side="left")
+        bracketed_mask = (right_anchor > 0) & (right_anchor < len(anchor_timestamps))
+        left_anchor = np.maximum(right_anchor - 1, 0)
+        clipped_right_anchor = np.minimum(right_anchor, len(anchor_timestamps) - 1)
+        anchor_gap_ns = anchor_timestamps[clipped_right_anchor] - anchor_timestamps[left_anchor]
+        gap_safe_mask = bracketed_mask & (anchor_gap_ns <= max_anchor_gap.value)
+
+        epoch_reset = group["epoch_reset"].fillna(False).astype(bool).to_numpy() if "epoch_reset" in group.columns else np.zeros(len(group), dtype=bool)
+        boundary_mask = epoch_reset | (np.isfinite(total_assets) & (total_assets <= HYPERCORE_ZERO_NAV_EPSILON))
+        boundary_timestamps = np.sort(timestamp_ns[boundary_mask])
+        crosses_boundary = np.zeros(len(group), dtype=bool)
+        if len(boundary_timestamps):
+            left_timestamps = anchor_timestamps[left_anchor]
+            right_timestamps = anchor_timestamps[clipped_right_anchor]
+            boundary_start = np.searchsorted(boundary_timestamps, left_timestamps, side="left")
+            boundary_end = np.searchsorted(boundary_timestamps, right_timestamps, side="right")
+            crosses_boundary = bracketed_mask & (boundary_end > boundary_start)
+        boundary_safe_mask = ~crosses_boundary
 
         with np.errstate(divide="ignore", invalid="ignore"):
             symmetric_deviation = (
@@ -1218,7 +1293,35 @@ def fix_hypercore_source_overlap_share_prices(  # noqa: PLR0914
                 )
                 - 1
             )
-        repair_mask = candidate_mask & valid_expected & positive_price_mask & (symmetric_deviation > max_anchor_deviation)
+        repair_candidate_mask = candidate_mask & valid_expected & positive_price_mask & (symmetric_deviation > max_anchor_deviation)
+        repair_mask = repair_candidate_mask & nav_safe_mask & gap_safe_mask & boundary_safe_mask
+        deferred_mask = repair_candidate_mask & ~repair_mask
+
+        status_values = np.full(len(group), "", dtype=object)
+        status_values[repair_mask] = f"repaired_{anchor_source}"
+        if deferred_mask.any():
+            failure_reason = np.select(
+                [
+                    ~boundary_safe_mask & ~gap_safe_mask & ~nav_safe_mask,
+                    ~boundary_safe_mask & ~gap_safe_mask,
+                    ~boundary_safe_mask & ~nav_safe_mask,
+                    ~gap_safe_mask & ~nav_safe_mask,
+                    ~boundary_safe_mask,
+                    ~gap_safe_mask,
+                    ~nav_safe_mask,
+                ],
+                ["boundary_gap_nav", "boundary_gap", "boundary_nav", "gap_nav", "boundary", "gap", "nav"],
+                default="unknown",
+            )
+            status_values[deferred_mask] = np.asarray([f"deferred_{anchor_source}_{reason}" for reason in failure_reason[deferred_mask]], dtype=object)
+            deferred_count += int(deferred_mask.sum())
+            nav_deferred_count += int((deferred_mask & ~nav_safe_mask).sum())
+            gap_deferred_count += int((deferred_mask & ~gap_safe_mask).sum())
+            boundary_deferred_count += int((deferred_mask & ~boundary_safe_mask).sum())
+            deferred_vaults.add(str(_vault_id))
+
+        status_mask = repair_mask | deferred_mask
+        prices_df.iloc[positions[status_mask], repair_status_col] = status_values[status_mask]
 
         if repair_mask.any():
             repair_positions = positions[repair_mask]
@@ -1234,6 +1337,8 @@ def fix_hypercore_source_overlap_share_prices(  # noqa: PLR0914
         logger(f"Repaired {hf_fixed_count:,} conflicting daily Hypercore share prices across {hf_affected_vaults:,} vaults using HF anchors")
     if daily_fixed_count:
         logger(f"Repaired {daily_fixed_count:,} stale daily Hypercore share prices across {daily_affected_vaults:,} vaults using refreshed daily anchors")
+    if deferred_count:
+        logger(f"Deferred {deferred_count:,} ambiguous Hypercore share-price repairs across {len(deferred_vaults):,} vaults: {nav_deferred_count:,} failed NAV consistency, {gap_deferred_count:,} exceeded the anchor-gap limit, and {boundary_deferred_count:,} crossed a lifecycle boundary (counts overlap)")
 
     return prices_df
 

--- a/tests/erc_4626/test_native_protocol_batch_merge.py
+++ b/tests/erc_4626/test_native_protocol_batch_merge.py
@@ -145,8 +145,10 @@ def test_build_hypercore_prices_dataframe_prefers_high_frequency_duplicate(
     3. Assert the high-frequency share price is retained.
     """
     daily_df = _prices(HYPERCORE_CHAIN_ID, "hypercore-vault", "2025-01-01")
+    daily_df["hypercore_source"] = "daily"
     hf_df = _prices(HYPERCORE_CHAIN_ID, "hypercore-vault", "2025-01-01")
     hf_df["share_price"] = 1.1
+    hf_df["hypercore_source"] = "hf"
     monkeypatch.setattr(vault_data_export, "build_raw_prices_dataframe", lambda _: daily_df)
     monkeypatch.setattr(vault_data_export, "build_raw_prices_dataframe_hf", lambda _: hf_df)
 

--- a/tests/hyperliquid/test_backfill.py
+++ b/tests/hyperliquid/test_backfill.py
@@ -29,7 +29,6 @@ from eth_defi.hyperliquid.backfill import (
 from eth_defi.hyperliquid.daily_metrics import HyperliquidDailyMetricsDatabase, HyperliquidDailyPriceRow, fetch_and_store_vault
 from eth_defi.hyperliquid.vault import PortfolioHistory, VaultInfo, VaultSummary
 
-
 VAULT_A = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 VAULT_B = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 VAULT_C = "0xcccccccccccccccccccccccccccccccccccccccc"
@@ -1210,6 +1209,7 @@ def test_process_raw_vault_scan_data_preserves_hyperliquid_scalars(tmp_path):
         db.save()
 
         raw_df = build_raw_prices_dataframe(db)
+        assert (raw_df["hypercore_source"] == "daily").all()
         spec, vault_row = create_hyperliquid_vault_row(
             vault_address=VAULT_A,
             name="Test Vault",

--- a/tests/hyperliquid/test_high_freq_export.py
+++ b/tests/hyperliquid/test_high_freq_export.py
@@ -11,10 +11,10 @@ Tests that build_raw_prices_dataframe_hf() produces correct output:
 
 import datetime
 
-import numpy as np
 import pandas as pd
 import pytest
 
+from eth_defi.compat import native_datetime_utc_now
 from eth_defi.hyperliquid.high_freq_metrics import (
     HyperliquidHighFreqMetricsDatabase,
     HyperliquidHighFreqPriceRow,
@@ -22,7 +22,6 @@ from eth_defi.hyperliquid.high_freq_metrics import (
 from eth_defi.hyperliquid.vault_data_export import build_raw_prices_dataframe_hf, create_hyperliquid_vault_row
 from eth_defi.research.vault_metrics import calculate_hourly_returns_for_all_vaults, calculate_lifetime_metrics, export_lifetime_row
 from eth_defi.research.wrangle_vault_prices import process_raw_vault_scan_data
-from eth_defi.compat import native_datetime_utc_now
 
 
 @pytest.mark.timeout(30)
@@ -112,6 +111,7 @@ def test_hf_export_raw_timestamps(tmp_path):
 
         # 3. Export with raw timestamps (no resampling)
         result_df = build_raw_prices_dataframe_hf(db)
+        assert (result_df["hypercore_source"] == "hf").all()
 
         assert len(result_df) > 0, "Export produced empty DataFrame"
 

--- a/tests/research/test_clean_prices.py
+++ b/tests/research/test_clean_prices.py
@@ -196,6 +196,7 @@ def test_fix_hypercore_source_overlap_share_prices() -> None:
             "chain": [9999, 9999, 9999, 9999, 1],
             "id": [hypercore_id, hypercore_id, hypercore_id, hypercore_id, evm_id],
             "share_price": [1.0, 3.5, 1.1, 1.2, 4.0],
+            "total_assets": [100.0, 105.0, 110.0, 120.0, 400.0],
             "hypercore_source": ["hf", "daily", "daily", "hf", pd.NA],
         },
         index=timestamps,
@@ -210,6 +211,7 @@ def test_fix_hypercore_source_overlap_share_prices() -> None:
 
     assert repaired == pytest.approx(expected)
     assert hypercore_rows.loc[pd.Timestamp("2026-02-02"), "raw_share_price"] == pytest.approx(3.5)
+    assert hypercore_rows.loc[pd.Timestamp("2026-02-02"), "hypercore_repair_status"] == "repaired_hf"
     assert hypercore_rows.loc[pd.Timestamp("2026-02-03"), "share_price"] == pytest.approx(1.1)
     assert result[result["id"] == evm_id]["share_price"].iloc[0] == pytest.approx(4.0)
     assert messages == ["Repaired 1 conflicting daily Hypercore share prices across 1 vaults using HF anchors"]
@@ -230,6 +232,7 @@ def test_fix_hypercore_source_overlap_preserves_unbracketed_daily_rows() -> None
             "chain": [9999] * 4,
             "id": ["9999-0xhypercore"] * 4,
             "share_price": [10.0, 1.0, 1.2, 10.0],
+            "total_assets": [100.0, 100.0, 120.0, 120.0],
             "hypercore_source": ["daily", "hf", "hf", "daily"],
         },
         index=timestamps,
@@ -247,6 +250,7 @@ def test_fix_hypercore_source_overlap_infers_legacy_sources() -> None:
             "chain": [9999] * 3,
             "id": ["9999-0xhypercore"] * 3,
             "share_price": [1.0, 3.5, 1.2],
+            "total_assets": [100.0, 110.0, 120.0],
         },
         index=pd.to_datetime(
             [
@@ -263,6 +267,7 @@ def test_fix_hypercore_source_overlap_infers_legacy_sources() -> None:
 
     assert result["hypercore_source"].tolist() == ["hf", "daily", "hf"]
     assert result.loc[pd.Timestamp("2026-02-02"), "share_price"] < 1.2
+    assert result.loc[pd.Timestamp("2026-02-02"), "hypercore_repair_status"] == "repaired_hf"
     assert messages[0] == "Inferred Hypercore source provenance for 3 legacy price rows"
     assert messages[1] == "Repaired 1 conflicting daily Hypercore share prices across 1 vaults using HF anchors"
 
@@ -300,6 +305,7 @@ def test_fix_hypercore_source_overlap_uses_refreshed_daily_anchors() -> None:
 
     assert result.loc[pd.Timestamp("2026-01-25"), "share_price"] < 1.1
     assert result.loc[pd.Timestamp("2026-02-01"), "share_price"] < 1.2
+    assert result.loc[pd.Timestamp("2026-01-25"), "hypercore_repair_status"] == "repaired_daily"
     assert result.loc[pd.Timestamp("2026-01-25"), "raw_share_price"] == pytest.approx(2.5)
     assert result.loc[prices_df["written_at"] == latest_refresh, "share_price"].tolist() == [1.0, 1.1, 1.2]
     assert messages == ["Repaired 2 stale daily Hypercore share prices across 1 vaults using refreshed daily anchors"]
@@ -323,6 +329,67 @@ def test_fix_hypercore_source_overlap_preserves_daily_lifecycle_change() -> None
     result = fix_hypercore_source_overlap_share_prices(prices_df, logger=lambda _message: None)
 
     assert result.loc[pd.Timestamp("2026-01-25"), "share_price"] == pytest.approx(10.0)
+    assert result.loc[pd.Timestamp("2026-01-25"), "hypercore_repair_status"] == "deferred_daily_nav"
+
+
+def test_fix_hypercore_source_overlap_defers_unsafe_hf_repairs() -> None:
+    """HF candidates remain raw when NAV, gap, or boundary evidence is unsafe."""
+    vault_ids = ["9999-0xnav", "9999-0xgap", "9999-0xepoch", "9999-0xzero"]
+    frames = [
+        pd.DataFrame(
+            {
+                "chain": [9999] * 3,
+                "id": [vault_ids[0]] * 3,
+                "share_price": [1.0, 10.0, 1.1],
+                "total_assets": [100.0, 1_000.0, 110.0],
+                "hypercore_source": ["hf", "daily", "hf"],
+                "epoch_reset": [False] * 3,
+            },
+            index=pd.to_datetime(["2026-01-01 12:00", "2026-01-02", "2026-01-03 12:00"], format="mixed"),
+        ),
+        pd.DataFrame(
+            {
+                "chain": [9999] * 4,
+                "id": [vault_ids[3]] * 4,
+                "share_price": [1.0, 10.0, 1.05, 1.1],
+                "total_assets": [100.0, 105.0, 0.0, 110.0],
+                "hypercore_source": ["hf", "daily", "daily", "hf"],
+                "epoch_reset": [False] * 4,
+            },
+            index=pd.to_datetime(["2026-01-01 12:00", "2026-01-02", "2026-01-02 12:00", "2026-01-03 12:00"], format="mixed"),
+        ),
+        pd.DataFrame(
+            {
+                "chain": [9999] * 3,
+                "id": [vault_ids[1]] * 3,
+                "share_price": [1.0, 10.0, 1.1],
+                "total_assets": [100.0, 105.0, 110.0],
+                "hypercore_source": ["hf", "daily", "hf"],
+                "epoch_reset": [False] * 3,
+            },
+            index=pd.to_datetime(["2026-01-01 12:00", "2026-01-08", "2026-01-11 12:00"], format="mixed"),
+        ),
+        pd.DataFrame(
+            {
+                "chain": [9999] * 3,
+                "id": [vault_ids[2]] * 3,
+                "share_price": [1.0, 10.0, 1.1],
+                "total_assets": [100.0, 105.0, 110.0],
+                "hypercore_source": ["hf", "daily", "hf"],
+                "epoch_reset": [False, True, False],
+            },
+            index=pd.to_datetime(["2026-01-01 12:00", "2026-01-02", "2026-01-03 12:00"], format="mixed"),
+        ),
+    ]
+    prices_df = pd.concat(frames).sort_index(kind="stable")
+
+    result = fix_hypercore_source_overlap_share_prices(prices_df, logger=lambda _message: None)
+
+    for vault_id, expected_status in zip(vault_ids, ["deferred_hf_nav", "deferred_hf_gap", "deferred_hf_boundary", "deferred_hf_boundary"]):
+        candidate = result[(result["id"] == vault_id) & (result["hypercore_source"] == "daily")].iloc[0]
+        assert candidate["share_price"] == pytest.approx(10.0)
+        assert candidate["raw_share_price"] == pytest.approx(10.0)
+        assert candidate["hypercore_repair_status"] == expected_status
 
 
 def test_discard_hypercore_pre_recapitalisation_history() -> None:
@@ -365,6 +432,24 @@ def test_discard_hypercore_pre_recapitalisation_history() -> None:
     assert len(result[result["id"] == short_blip_id]) == 3
     assert len(result[result["id"] == evm_id]) == 1
     assert messages == ["Discarded 6 pre-recapitalisation Hypercore price rows across 1 vaults; new epochs start once NAV reaches $1,000 after 7 days 00:00:00"]
+
+
+def test_discard_hypercore_history_measures_delay_to_first_positive_nav() -> None:
+    """A prompt small deposit cannot become a delayed recapitalisation reset."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 4,
+            "id": ["9999-0xprompt-recovery"] * 4,
+            "total_assets": [2_000.0, 0.0, 900.0, 1_000.0],
+            "share_price": [1.0] * 4,
+        },
+        index=pd.to_datetime(["2026-01-01", "2026-01-02", "2026-01-03", "2026-01-09"]),
+    )
+
+    result = discard_hypercore_pre_recapitalisation_history(prices_df, logger=lambda _message: None)
+
+    assert result.index.tolist() == prices_df.index.tolist()
+    assert result["epoch_reset"].tolist() == [False] * 4
 
 
 def test_native_protocol_columns_survive_evm_scan_rewrite(tmp_path: Path):

--- a/tests/research/test_clean_prices.py
+++ b/tests/research/test_clean_prices.py
@@ -10,10 +10,14 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
-
 import zstandard as zstd
 
-from eth_defi.research.wrangle_vault_prices import fix_outlier_share_prices, generate_cleaned_vault_datasets
+from eth_defi.research.wrangle_vault_prices import (
+    discard_hypercore_pre_recapitalisation_history,
+    fix_hypercore_source_overlap_share_prices,
+    fix_outlier_share_prices,
+    generate_cleaned_vault_datasets,
+)
 from eth_defi.vault.base import VaultHistoricalRead
 from eth_defi.vault.settlement_data import VaultSettlement, VaultSettlementDatabase
 
@@ -169,6 +173,200 @@ def test_remove_inactive_lead_time():
     assert len(vault2_rows) == 1  # row at index 3 (200)
 
 
+def test_fix_hypercore_source_overlap_share_prices() -> None:
+    """Daily Hypercore excursions are repaired from overlapping HF anchors.
+
+    The daily source contains one synthetic price spike between two stable HF
+    observations. The wrangle repair must replace only that spike, preserve a
+    plausible daily observation, and leave non-Hypercore data untouched.
+    """
+    hypercore_id = "9999-0xhypercore"
+    evm_id = "1-0xevm"
+    timestamps = pd.to_datetime(
+        [
+            "2026-02-01 12:00:00",
+            "2026-02-02 00:00:00",
+            "2026-02-03 00:00:00",
+            "2026-02-04 12:00:00",
+            "2026-02-02 00:00:00",
+        ]
+    )
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999, 9999, 9999, 9999, 1],
+            "id": [hypercore_id, hypercore_id, hypercore_id, hypercore_id, evm_id],
+            "share_price": [1.0, 3.5, 1.1, 1.2, 4.0],
+            "hypercore_source": ["hf", "daily", "daily", "hf", pd.NA],
+        },
+        index=timestamps,
+    )
+
+    messages: list[str] = []
+    result = fix_hypercore_source_overlap_share_prices(prices_df, logger=messages.append)
+
+    hypercore_rows = result[result["id"] == hypercore_id]
+    repaired = hypercore_rows.loc[pd.Timestamp("2026-02-02"), "share_price"]
+    expected = np.exp(np.interp(pd.Timestamp("2026-02-02").value, [pd.Timestamp("2026-02-01 12:00:00").value, pd.Timestamp("2026-02-04 12:00:00").value], np.log([1.0, 1.2])))
+
+    assert repaired == pytest.approx(expected)
+    assert hypercore_rows.loc[pd.Timestamp("2026-02-02"), "raw_share_price"] == pytest.approx(3.5)
+    assert hypercore_rows.loc[pd.Timestamp("2026-02-03"), "share_price"] == pytest.approx(1.1)
+    assert result[result["id"] == evm_id]["share_price"].iloc[0] == pytest.approx(4.0)
+    assert messages == ["Repaired 1 conflicting daily Hypercore share prices across 1 vaults using HF anchors"]
+
+
+def test_fix_hypercore_source_overlap_preserves_unbracketed_daily_rows() -> None:
+    """Daily observations outside HF coverage cannot be safely repaired."""
+    timestamps = pd.to_datetime(
+        [
+            "2026-01-01 00:00:00",
+            "2026-02-01 12:00:00",
+            "2026-02-04 12:00:00",
+            "2026-03-01 00:00:00",
+        ]
+    )
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 4,
+            "id": ["9999-0xhypercore"] * 4,
+            "share_price": [10.0, 1.0, 1.2, 10.0],
+            "hypercore_source": ["daily", "hf", "hf", "daily"],
+        },
+        index=timestamps,
+    )
+
+    result = fix_hypercore_source_overlap_share_prices(prices_df, logger=lambda _message: None)
+
+    assert result["share_price"].tolist() == prices_df["share_price"].tolist()
+
+
+def test_fix_hypercore_source_overlap_infers_legacy_sources() -> None:
+    """Legacy Parquet rows infer daily/HF provenance from timestamp precision."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 3,
+            "id": ["9999-0xhypercore"] * 3,
+            "share_price": [1.0, 3.5, 1.2],
+        },
+        index=pd.to_datetime(
+            [
+                "2026-02-01 12:01:02.003",
+                "2026-02-02 00:00:00",
+                "2026-02-03 12:01:02.003",
+            ],
+            format="mixed",
+        ),
+    )
+
+    messages: list[str] = []
+    result = fix_hypercore_source_overlap_share_prices(prices_df, logger=messages.append)
+
+    assert result["hypercore_source"].tolist() == ["hf", "daily", "hf"]
+    assert result.loc[pd.Timestamp("2026-02-02"), "share_price"] < 1.2
+    assert messages[0] == "Inferred Hypercore source provenance for 3 legacy price rows"
+    assert messages[1] == "Repaired 1 conflicting daily Hypercore share prices across 1 vaults using HF anchors"
+
+
+def test_fix_hypercore_source_overlap_uses_refreshed_daily_anchors() -> None:
+    """Daily-only legacy vaults use the latest refresh batch as anchors.
+
+    Older rolling-window rows may remain between canonical observations from
+    the latest allTime refresh. The repair must interpolate only those stale
+    rows and preserve every row in the latest refresh batch.
+    """
+    latest_refresh = pd.Timestamp("2026-04-10 17:10:32")
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 5,
+            "id": ["9999-0xdaily-only"] * 5,
+            "share_price": [1.0, 2.5, 1.1, 10.0, 1.2],
+            "total_assets": [100.0, 103.0, 105.0, 108.0, 110.0],
+            "hypercore_source": ["daily"] * 5,
+            "written_at": [latest_refresh, pd.NaT, latest_refresh, pd.Timestamp("2026-02-05"), latest_refresh],
+        },
+        index=pd.to_datetime(
+            [
+                "2026-01-21",
+                "2026-01-25",
+                "2026-01-28",
+                "2026-02-01",
+                "2026-02-04",
+            ]
+        ),
+    )
+
+    messages: list[str] = []
+    result = fix_hypercore_source_overlap_share_prices(prices_df, logger=messages.append)
+
+    assert result.loc[pd.Timestamp("2026-01-25"), "share_price"] < 1.1
+    assert result.loc[pd.Timestamp("2026-02-01"), "share_price"] < 1.2
+    assert result.loc[pd.Timestamp("2026-01-25"), "raw_share_price"] == pytest.approx(2.5)
+    assert result.loc[prices_df["written_at"] == latest_refresh, "share_price"].tolist() == [1.0, 1.1, 1.2]
+    assert messages == ["Repaired 2 stale daily Hypercore share prices across 1 vaults using refreshed daily anchors"]
+
+
+def test_fix_hypercore_source_overlap_preserves_daily_lifecycle_change() -> None:
+    """Daily fallback does not interpolate across a genuine NAV boundary."""
+    latest_refresh = pd.Timestamp("2026-04-10 17:10:32")
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 3,
+            "id": ["9999-0xlifecycle"] * 3,
+            "share_price": [1.0, 10.0, 1.1],
+            "total_assets": [100.0, 1_000.0, 110.0],
+            "hypercore_source": ["daily"] * 3,
+            "written_at": [latest_refresh, pd.NaT, latest_refresh],
+        },
+        index=pd.to_datetime(["2026-01-21", "2026-01-25", "2026-01-28"]),
+    )
+
+    result = fix_hypercore_source_overlap_share_prices(prices_df, logger=lambda _message: None)
+
+    assert result.loc[pd.Timestamp("2026-01-25"), "share_price"] == pytest.approx(10.0)
+
+
+def test_discard_hypercore_pre_recapitalisation_history() -> None:
+    """A durable wipe-out starts a new cleaned Hypercore performance epoch."""
+    recapitalised_id = "9999-0xrecapitalised"
+    short_blip_id = "9999-0xshort-blip"
+    evm_id = "1-0xevm"
+    timestamps = pd.to_datetime(
+        [
+            "2026-01-01",  # Existing capital
+            "2026-01-02",  # Zero-NAV epoch begins
+            "2026-01-03",
+            "2026-01-09",
+            "2026-01-10",  # New capital exists, but below tracking threshold
+            "2026-01-11",
+            "2026-01-12",  # New epoch becomes meaningful
+            "2026-01-13",
+            "2026-01-01",  # Isolated zero blip must remain untouched
+            "2026-01-02",
+            "2026-01-03",
+            "2026-01-01",  # Non-Hypercore data is untouched
+        ]
+    )
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 11 + [1],
+            "id": [recapitalised_id] * 8 + [short_blip_id] * 3 + [evm_id],
+            "total_assets": [2_000.0, 0.0, 0.0, 0.0, 100.0, 999.0, 1_000.0, 1_050.0, 2_000.0, 0.0, 1_500.0, 0.0],
+            "share_price": [1.0] * 12,
+        },
+        index=timestamps,
+    )
+
+    messages: list[str] = []
+    result = discard_hypercore_pre_recapitalisation_history(prices_df, logger=messages.append)
+
+    recapitalised = result[result["id"] == recapitalised_id]
+    assert recapitalised.index.tolist() == [pd.Timestamp("2026-01-12"), pd.Timestamp("2026-01-13")]
+    assert recapitalised["epoch_reset"].tolist() == [True, False]
+    assert len(result[result["id"] == short_blip_id]) == 3
+    assert len(result[result["id"] == evm_id]) == 1
+    assert messages == ["Discarded 6 pre-recapitalisation Hypercore price rows across 1 vaults; new epochs start once NAV reaches $1,000 after 7 days 00:00:00"]
+
+
 def test_native_protocol_columns_survive_evm_scan_rewrite(tmp_path: Path):
     """Native protocol columns must survive the EVM scanner's parquet rewrite.
 
@@ -209,6 +407,7 @@ def test_native_protocol_columns_survive_evm_scan_rewrite(tmp_path: Path):
             "account_pnl": [100.0, 110.0, np.nan, np.nan],
             "leader_fraction": [0.5, 0.5, np.nan, np.nan],
             "deposit_closed_reason": ["", "", "", ""],
+            "hypercore_source": ["daily", "hf", None, None],
         },
     )
 
@@ -223,6 +422,7 @@ def test_native_protocol_columns_survive_evm_scan_rewrite(tmp_path: Path):
     assert "account_pnl" in table.schema.names
     assert "leader_fraction" in table.schema.names
     assert "deposit_closed_reason" in table.schema.names
+    assert "hypercore_source" in table.schema.names
 
     # 3. Simulate an EVM scanner reading the file and migrating
     migrated = VaultHistoricalRead.migrate_parquet_schema(table)
@@ -236,6 +436,7 @@ def test_native_protocol_columns_survive_evm_scan_rewrite(tmp_path: Path):
     assert "account_pnl" in migrated.schema.names
     assert "leader_fraction" in migrated.schema.names
     assert "deposit_closed_reason" in migrated.schema.names
+    assert "hypercore_source" in migrated.schema.names
     assert migrated.num_rows == 4
 
     # Legacy __index_level_0__ is NOT present
@@ -282,11 +483,13 @@ def test_native_protocol_columns_survive_evm_scan_rewrite(tmp_path: Path):
     hl_rows = final.filter(pc.equal(final["chain"], 9999))
     assert hl_rows.column("account_pnl").to_pylist() == [100.0, 110.0]
     assert hl_rows.column("leader_fraction").to_pylist() == [0.5, 0.5]
+    assert hl_rows.column("hypercore_source").to_pylist() == ["daily", "hf"]
 
     # EVM rows have null for native columns
     evm_rows = final.filter(pc.equal(final["chain"], 1))
     assert all(v is None for v in evm_rows.column("account_pnl").to_pylist())
     assert all(v is None for v in evm_rows.column("leader_fraction").to_pylist())
+    assert all(v is None for v in evm_rows.column("hypercore_source").to_pylist())
 
 
 def test_fix_outlier_ipor_tau_yield_bond_spike():


### PR DESCRIPTION
## Why

Hypercore daily and high-frequency rolling API windows can reconstruct incompatible synthetic share prices. A true complete wipe-out followed by recapitalisation also cannot be represented as one continuous investor return series.

## Lessons learnt

Persisting the scanner source makes overlapping histories auditable and repairable. A recapitalised vault needs a new cleaned performance epoch; the raw history remains the record of the previous -100% outcome.

## Summary

- Persist daily/HF provenance and repair conflicting daily prices from canonical anchors while preserving the raw value.
- Begin cleaned Hypercore history after durable zero-NAV recapitalisation, with an explicit epoch marker.
- Document Crypto Plaza, Magixbox, C.A.T., HODL My Perps, comparable candidates, and all durable zero-NAV episodes.
- Add focused provenance, repair, recapitalisation, and parquet-preservation coverage.

## Related issues and PRs

- None.