### PR TITLE
feat: add vault parquet provenance metadata

### DIFF
--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -23,6 +23,8 @@ from typing import Callable, TypedDict
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 from eth_typing import HexAddress
 from IPython.display import display
 from tqdm_loggable.auto import tqdm
@@ -34,6 +36,7 @@ from eth_defi.vault.settlement_data import (
     merge_vault_settlements_into_cleaned_prices,
 )
 from eth_defi.vault.vaultdb import DEFAULT_UNCLEANED_PRICE_DATABASE, DEFAULT_VAULT_DATABASE, VaultDatabase, VaultRow
+from eth_defi.version_info import stamp_parquet_schema_metadata
 
 
 class CleanedVaultPriceRow(TypedDict, total=False):
@@ -1322,6 +1325,8 @@ def generate_cleaned_vault_datasets(
     - Reads ``vault-prices-1h.parquet`` and generates ``cleaned-vault-prices-1h.parquet``
     - Calculate returns and various performance metrics to be included with prices data
     - Clean returns from abnormalities
+    - Stamp the cleaned Parquet with the current Docker ``metadata.version``
+      provenance, matching vault scanner JSON exports
 
     .. note::
 
@@ -1366,7 +1371,9 @@ def generate_cleaned_vault_datasets(
     )
     try:
         os.close(temp_fd)
-        enhanced_prices_df.to_parquet(temp_path, compression="zstd")
+        table = pa.Table.from_pandas(enhanced_prices_df)
+        table = table.replace_schema_metadata(stamp_parquet_schema_metadata(table.schema).metadata)
+        pq.write_table(table, temp_path, compression="zstd")
         verify_parquet_file(
             temp_path,
             expected_rows=len(enhanced_prices_df),

--- a/eth_defi/vault/base.py
+++ b/eth_defi/vault/base.py
@@ -34,6 +34,7 @@ from eth_defi.types import Percent
 from eth_defi.utils import is_good_multichain_address
 from eth_defi.vault.deposit_redeem import VaultDepositManager
 from eth_defi.vault.lower_case_dict import LowercaseDict
+from eth_defi.version_info import stamp_parquet_schema_metadata
 
 from .fee import FeeData, VaultFeeMode, get_vault_fee_mode
 from .flag import VaultFlag, get_notes, get_vault_special_flags
@@ -779,6 +780,7 @@ class VaultHistoricalRead:
         Both the EVM-compatible pandas writer and the direct PyArrow native
         merge path use this method. The caller is responsible for aligning
         canonical column types before calling this method; the output is
+        stamped with the current Docker ``metadata.version`` provenance,
         written beside the target, verified, and atomically replaced only on
         success.
 
@@ -790,6 +792,8 @@ class VaultHistoricalRead:
             Parquet compression codec.
         """
         import pyarrow.parquet as pq
+
+        table = table.replace_schema_metadata(stamp_parquet_schema_metadata(table.schema).metadata)
 
         # Write to a temp file, verify, then atomically replace the target.
         # If verification fails, the original file is preserved.

--- a/eth_defi/vault/historical.py
+++ b/eth_defi/vault/historical.py
@@ -40,6 +40,7 @@ from eth_defi.token import TokenDetails, TokenDiskCache, fetch_erc20_details
 from eth_defi.utils import chunked
 from eth_defi.vault.base import VaultBase, VaultHistoricalRead, VaultHistoricalReader, VaultSpec, verify_parquet_file
 from eth_defi.vault.risk import BROKEN_VAULT_CONTRACTS
+from eth_defi.version_info import stamp_parquet_schema_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -552,6 +553,8 @@ def scan_historical_prices_to_parquet(
     - Write historical prices to a Parquet file
     - Multiprocess-boosted
     - The same Parquet file can contain data from multiple chains
+    - Stamp the output schema with the current Docker ``metadata.version``
+      provenance, matching vault scanner JSON exports
 
     :param output_fname:
         Path to a destination Parquet file.
@@ -778,6 +781,13 @@ def scan_historical_prices_to_parquet(
             writer_schema = writer_schema.append(field)
     else:
         writer_schema = canonical_schema
+
+    # Store the current scanner build on the file schema. This is done after
+    # combining native-only fields so every rewrite refreshes the provenance.
+    writer_schema = stamp_parquet_schema_metadata(writer_schema)
+
+    if existing_table is not None:
+        existing_table = existing_table.replace_schema_metadata(writer_schema.metadata)
 
     # Perform atomic update of the prices Parquet file.
     #

--- a/eth_defi/vault/sample_export.py
+++ b/eth_defi/vault/sample_export.py
@@ -13,9 +13,12 @@ import os
 from pathlib import Path
 
 import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 
 from eth_defi.cloudflare_r2 import create_r2_client, upload_file_to_r2
 from eth_defi.vault.vaultdb import get_pipeline_data_dir
+from eth_defi.version_info import stamp_parquet_schema_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +30,9 @@ def generate_sample_parquet(cleaned_path: Path, output_path: Path) -> int:
     """Filter the cleaned vault prices parquet to Ethereum only.
 
     Reads the full multi-chain cleaned parquet and writes an
-    Ethereum-only subset for free download.
+    Ethereum-only subset for free download. The output gets the current
+    Docker ``metadata.version`` provenance stamp, matching scanner JSON
+    exports and the full price Parquet files.
 
     :param cleaned_path:
         Path to the full ``cleaned-vault-prices-1h.parquet``.
@@ -53,7 +58,9 @@ def generate_sample_parquet(cleaned_path: Path, output_path: Path) -> int:
     if len(sample_df) == 0:
         raise ValueError(f"No Ethereum (chain_id={ETHEREUM_CHAIN_ID}) rows found in {cleaned_path}")
 
-    sample_df.to_parquet(output_path, compression="zstd")
+    table = pa.Table.from_pandas(sample_df)
+    table = table.replace_schema_metadata(stamp_parquet_schema_metadata(table.schema).metadata)
+    pq.write_table(table, output_path, compression="zstd")
     logger.info(
         "Generated sample parquet: %d Ethereum rows out of %d total -> %s",
         len(sample_df),

--- a/eth_defi/version_info.py
+++ b/eth_defi/version_info.py
@@ -19,10 +19,11 @@ Example::
     print(version.commit_hash)  # None outside Docker
 """
 
+import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,11 @@ VERSION_FILE_ROOT: Path = Path(__file__).parent.parent
 #: ``docker compose build``) stamps this literal string into the files.
 #: :py:meth:`VersionInfo.read_version_file` normalises it to ``None``.
 UNSPECIFIED_SENTINEL = "unspecified"
+
+#: Custom Parquet key containing the same mapping as JSON export
+#: ``metadata.version`` fields.  The value is a UTF-8 JSON object, because
+#: Apache Parquet file metadata is a flat bytes-to-bytes mapping.
+PARQUET_VERSION_METADATA_KEY = b"metadata.version"
 
 
 @dataclass(slots=True, frozen=True)
@@ -121,3 +127,46 @@ class VersionInfo:
             "commit_message": self.commit_message,
             "commit_hash": self.commit_hash,
         }
+
+    def as_parquet_metadata(self) -> dict[bytes, bytes]:
+        """Serialise this version stamp for Parquet file metadata.
+
+        Uses :py:data:`PARQUET_VERSION_METADATA_KEY` with the exact mapping
+        returned by :py:meth:`as_dict`. This is the Parquet equivalent of the
+        ``metadata.version`` object included in vault scanner JSON exports.
+
+        :return:
+            A PyArrow-compatible metadata mapping. The value is UTF-8 JSON so
+            ``None`` fields retain their JSON meaning instead of being
+            conflated with empty strings.
+        """
+        return {
+            PARQUET_VERSION_METADATA_KEY: json.dumps(self.as_dict(), sort_keys=True).encode("utf-8"),
+        }
+
+
+def stamp_parquet_schema_metadata(schema: Any, version_info: VersionInfo | None = None) -> Any:
+    """Add vault-scanner build provenance to a PyArrow schema.
+
+    Preserves existing schema metadata, such as pandas' column-index metadata,
+    while replacing the scanner's version stamp with the version of the code
+    currently writing the file. Use this for every scanner-produced Parquet
+    artefact so raw, cleaned, and sample price data can be traced to the same
+    Docker build as the JSON exports.
+
+    :param schema:
+        PyArrow schema to stamp. ``Any`` avoids imposing a runtime PyArrow
+        dependency on the lightweight version-information module.
+
+    :param version_info:
+        Optional explicit version for tests or specialised callers. When
+        omitted, reads the Docker image stamp of the current process.
+
+    :return:
+        A copy of ``schema`` with ``metadata.version`` provenance metadata.
+    """
+    if version_info is None:
+        version_info = VersionInfo.read_docker_version()
+    metadata = dict(schema.metadata or {})
+    metadata.update(version_info.as_parquet_metadata())
+    return schema.with_metadata(metadata)

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -156,6 +156,21 @@ same commit under `metadata.version.commit_hash` with its `updated_at`
 timestamp, while `scan-cycle-state.json` contains `generated_at`,
 `metadata.version.commit_hash`, and an `items` mapping.
 
+The raw `vault-prices-1h.parquet`, cleaned
+`cleaned-vault-prices-1h.parquet`, and Ethereum sample Parquet carry the same
+Docker version mapping in their file-level `metadata.version` key. The value
+is a UTF-8 JSON object containing `tag`, `commit_message`, and `commit_hash`.
+For example, inspect it with PyArrow:
+
+```python
+import json
+import pyarrow.parquet as pq
+
+metadata = pq.read_metadata("cleaned-vault-prices-1h.parquet").metadata
+version = json.loads(metadata[b"metadata.version"])
+print(version["commit_hash"])
+```
+
 After the raw and Brotli top-vault JSON objects have been uploaded to every
 configured bucket, the scanner logs one grep-friendly success record:
 

--- a/tests/research/test_clean_prices.py
+++ b/tests/research/test_clean_prices.py
@@ -10,12 +10,12 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
-
 import zstandard as zstd
 
 from eth_defi.research.wrangle_vault_prices import fix_outlier_share_prices, generate_cleaned_vault_datasets
 from eth_defi.vault.base import VaultHistoricalRead
 from eth_defi.vault.settlement_data import VaultSettlement, VaultSettlementDatabase
+from eth_defi.version_info import PARQUET_VERSION_METADATA_KEY
 
 
 @pytest.fixture()
@@ -88,6 +88,8 @@ def test_clean_vault_price_data(
     # written_at column should always be present in cleaned output
     # (NaT for old data that predates the column)
     assert "written_at" in df.columns
+
+    assert PARQUET_VERSION_METADATA_KEY in pq.read_metadata(dst).metadata
 
 
 def test_clean_vault_price_data_with_settlement_markers(
@@ -213,6 +215,8 @@ def test_native_protocol_columns_survive_evm_scan_rewrite(tmp_path: Path):
     )
 
     VaultHistoricalRead.write_uncleaned_parquet(native_df, parquet_path)
+
+    assert PARQUET_VERSION_METADATA_KEY in pq.read_metadata(parquet_path).metadata
 
     # 2. Verify the written file has correct canonical types
     table = pq.read_table(parquet_path)

--- a/tests/test_version_info.py
+++ b/tests/test_version_info.py
@@ -1,8 +1,11 @@
 """Test Docker git version stamp reading."""
 
+import json
 from pathlib import Path
 
-from eth_defi.version_info import UNSPECIFIED_SENTINEL, VersionInfo
+import pyarrow as pa
+
+from eth_defi.version_info import PARQUET_VERSION_METADATA_KEY, UNSPECIFIED_SENTINEL, VersionInfo, stamp_parquet_schema_metadata
 
 
 def test_read_docker_version(tmp_path: Path):
@@ -50,3 +53,14 @@ def test_read_docker_version(tmp_path: Path):
     assert version.tag is None
     assert version.commit_message is None
     assert version.commit_hash is None
+
+
+def test_stamp_parquet_schema_metadata() -> None:
+    """Parquet provenance preserves existing metadata and the JSON version shape."""
+    version = VersionInfo(tag="v0.31", commit_message="feat: stamp parquet", commit_hash="4cea3aa3deadbeef")
+    schema = pa.schema([pa.field("chain", pa.uint32())], metadata={b"pandas": b"{}"})
+
+    stamped = stamp_parquet_schema_metadata(schema, version)
+
+    assert stamped.metadata[b"pandas"] == b"{}"
+    assert json.loads(stamped.metadata[PARQUET_VERSION_METADATA_KEY]) == version.as_dict()

--- a/tests/vault/test_sample_export.py
+++ b/tests/vault/test_sample_export.py
@@ -3,7 +3,11 @@
 import json
 from pathlib import Path
 
-from eth_defi.vault.sample_export import generate_sample_json
+import pandas as pd
+import pyarrow.parquet as pq
+
+from eth_defi.vault.sample_export import generate_sample_json, generate_sample_parquet
+from eth_defi.version_info import PARQUET_VERSION_METADATA_KEY
 
 
 def test_sample_json_filters_core3_protocols_and_curators(tmp_path: Path):
@@ -102,3 +106,15 @@ def test_sample_json_filters_core3_protocols_and_curators(tmp_path: Path):
             "commit_hash": "4cea3aa3deadbeef",
         },
     }
+
+
+def test_sample_parquet_has_version_metadata(tmp_path: Path) -> None:
+    """Ethereum sample price exports carry scanner build provenance."""
+    source_path = tmp_path / "cleaned-vault-prices.parquet"
+    output_path = tmp_path / "vault-historical.sample.parquet"
+    pd.DataFrame({"chain": [1, 8453], "share_price": [1.0, 1.01]}).to_parquet(source_path)
+
+    row_count = generate_sample_parquet(source_path, output_path)
+
+    assert row_count == 1
+    assert PARQUET_VERSION_METADATA_KEY in pq.read_metadata(output_path).metadata


### PR DESCRIPTION
## Why

Vault price Parquet artefacts need the same build provenance as the scanner JSON exports, so published data can be traced to the producing commit.

## Lessons learnt

Parquet file metadata is a flat bytes mapping; serialising the JSON-shaped version mapping under `metadata.version` retains nullable fields and a consistent provenance contract.

## Summary

- Stamp raw, cleaned, and Ethereum sample vault Parquet files with Docker version metadata.
- Preserve existing Arrow and pandas schema metadata during stamping.
- Document metadata inspection and add coverage for each output path.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.