### PR TITLE
fix: refresh T3tris vault curator metadata

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/t3tris/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/t3tris/offchain_metadata.py
@@ -87,9 +87,10 @@ def _parse_vault_detail(raw: dict) -> T3trisVaultMetadata:
     """Parse vault metadata from the T3tris page endpoint.
 
     :param raw:
-        Raw JSON dict from ``/api/v1/pages/vault/{chainId}/{vaultAddress}``.
+        Raw JSON dict from ``/api/v1/pages/vault/{chainId}/{vaultAddress}``
+        or a single vault row from ``/api/v1/vaults``.
     """
-    vault = raw.get("vault") or {}
+    vault = raw.get("vault") or raw
     name = _normalise_optional_string(vault.get("displayName")) or _normalise_optional_string(vault.get("name")) or _normalise_optional_string(vault.get("onchainName")) or ""
     symbol = _normalise_optional_string(vault.get("displaySymbol")) or _normalise_optional_string(vault.get("symbol")) or _normalise_optional_string(vault.get("onchainSymbol"))
     attributes = vault.get("attributes")
@@ -110,6 +111,50 @@ def _parse_vault_detail(raw: dict) -> T3trisVaultMetadata:
         visibility=_normalise_optional_string(vault.get("visibility")),
         ipfs_hash=_normalise_optional_string(vault.get("ipfsHash")),
     )
+
+
+def _fetch_vaults_list_entry(
+    chain_id: int,
+    address: str,
+    api_base_url: str = DEFAULT_API_BASE_URL,
+) -> dict | None:
+    """Fetch a single vault row from T3tris' vault list endpoint.
+
+    :param chain_id:
+        EVM chain id.
+
+    :param address:
+        Vault contract address.
+
+    :param api_base_url:
+        T3tris API base URL.
+
+    :return:
+        Raw vault row, or ``None`` if the vault was not listed.
+    """
+    url = f"{api_base_url}/vaults"
+    address_lower = address.lower()
+    logger.debug("Fetching T3tris vault list from %s", url)
+    try:
+        resp = requests.get(url, timeout=30, headers={"Accept": "application/json"})
+        resp.raise_for_status()
+        payload = resp.json()
+    except (requests.RequestException, JSONDecodeError) as e:
+        logger.warning("Failed to fetch T3tris vault list for %s on chain %d: %s", address, chain_id, e)
+        return None
+
+    vaults = payload.get("vaults") if isinstance(payload, dict) else None
+    if not isinstance(vaults, list):
+        logger.warning("Unexpected T3tris vault list response shape: %s", type(payload))
+        return None
+
+    for item in vaults:
+        if not isinstance(item, dict):
+            continue
+        if item.get("chainId") == chain_id and str(item.get("address", "")).lower() == address_lower:
+            return item
+
+    return None
 
 
 def _fetch_vault_detail(
@@ -138,8 +183,8 @@ def _fetch_vault_detail(
         resp.raise_for_status()
         return resp.json()
     except (requests.RequestException, JSONDecodeError) as e:
-        logger.warning("Failed to fetch T3tris vault detail for %s on chain %d: %s", address, chain_id, e)
-        return None
+        logger.warning("Failed to fetch T3tris vault detail for %s on chain %d: %s; falling back to vault list", address, chain_id, e)
+        return _fetch_vaults_list_entry(chain_id, address, api_base_url=api_base_url)
 
 
 def fetch_t3tris_vault_metadata(

--- a/scripts/erc-4626/fix-t3tris-vaults.py
+++ b/scripts/erc-4626/fix-t3tris-vaults.py
@@ -143,6 +143,15 @@ T3TRIS_VAULT_SNAPSHOT_JSON = """
       "createdAtTs": 1781468480,
       "curatorName": "First Capital",
       "verified": true
+    },
+    {
+      "chainId": 42161,
+      "address": "0xc84cc66300e70acd19500f639bcad7d7a8d34ba9",
+      "name": "Ellen Capital BTC",
+      "createdAtBlock": "481469145",
+      "createdAtTs": 1783458649,
+      "curatorName": null,
+      "verified": true
     }
   ]
 }
@@ -480,7 +489,16 @@ def should_refresh_metadata(vault_db: VaultDatabase, ref: T3trisVaultReference) 
     if row is None:
         return True
 
-    return is_broken_metadata_row(row)
+    if is_broken_metadata_row(row):
+        return True
+
+    expected_curator_name = (ref.curator_name or "").strip()
+    if expected_curator_name:
+        current_manager_name = (row.get("_manager_name") or "").strip()
+        if current_manager_name.casefold() != expected_curator_name.casefold():
+            return True
+
+    return False
 
 
 def upsert_metadata_row(web3: Web3, vault_db: VaultDatabase, token_cache: TokenDiskCache, ref: T3trisVaultReference, updated_at: datetime.datetime) -> bool:

--- a/scripts/erc-4626/update-vault-curators.py
+++ b/scripts/erc-4626/update-vault-curators.py
@@ -1,0 +1,358 @@
+"""Refresh native vault manager names for one protocol in the vault metadata pickle.
+
+This helper rewrites ``VaultRow["_manager_name"]`` values using each
+protocol-specific vault Python class as the source of truth. It is intended for
+fixing persisted metadata rows after a protocol integration starts exposing
+curator or manager metadata without doing a full chain rescan.
+
+Usage:
+
+.. code-block:: shell
+
+    source .local-test.env && PROTOCOL_ID=t3tris poetry run python scripts/erc-4626/update-vault-curators.py
+
+To update only selected vaults:
+
+.. code-block:: shell
+
+    source .local-test.env && PROTOCOL_ID=t3tris VAULT_ID=42161-0x98e43a491a464f0886bc5e57207c340bbed0d01f poetry run python scripts/erc-4626/update-vault-curators.py
+
+Optional environment variables:
+
+- ``VAULT_ID``: comma-separated ``chain-address`` vault ids to update
+- ``VAULT_DB``: metadata pickle path, defaults to ``~/.tradingstrategy/vaults/vault-metadata-db.pickle``
+- ``DRY_RUN``: set to ``true`` to report changes without writing
+- ``LOG_LEVEL``: console log level, defaults to ``info``
+
+The script reads chain RPC URLs from ``JSON_RPC_{CHAIN}`` environment variables,
+for example ``JSON_RPC_ARBITRUM`` for T3tris vaults on Arbitrum.
+"""
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from web3 import Web3
+
+from eth_defi.erc_4626.classification import create_vault_instance
+from eth_defi.erc_4626.core import ERC4262VaultDetection
+from eth_defi.provider.env import get_json_rpc_env, read_json_rpc_url
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.research.vault_metrics import slugify_protocol
+from eth_defi.token import TokenDiskCache
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.base import VaultBase, VaultSpec
+from eth_defi.vault.vaultdb import DEFAULT_VAULT_DATABASE, VaultDatabase, VaultRow
+
+logger = logging.getLogger(__name__)
+
+
+VaultFactory = Callable[[Web3, ERC4262VaultDetection, TokenDiskCache], VaultBase | None]
+
+
+@dataclass(slots=True)
+class VaultCuratorUpdate:
+    """Describe a single vault manager name refresh.
+
+    :param spec:
+        Vault chain/address key in the metadata database.
+
+    :param protocol_id:
+        Normalised protocol id matched from the vault row.
+
+    :param vault_class:
+        Python vault class used to regenerate the manager name.
+
+    :param old_manager_name:
+        Manager name currently stored in the pickle.
+
+    :param new_manager_name:
+        Manager name returned by the vault class.
+    """
+
+    spec: VaultSpec
+    protocol_id: str
+    vault_class: str
+    old_manager_name: str | None
+    new_manager_name: str | None
+
+    @property
+    def changed(self) -> bool:
+        """Whether this refresh changes the stored manager name value.
+
+        :return:
+            ``True`` when ``old_manager_name`` and ``new_manager_name`` differ.
+        """
+        return self.old_manager_name != self.new_manager_name
+
+
+def _get_row_protocol_id(row: VaultRow) -> str:
+    """Resolve a protocol id from a vault metadata row.
+
+    Older pickles may not have ``protocol_slug`` stored, so this falls back to
+    slugifying the human-readable ``Protocol`` field.
+
+    :param row:
+        Vault metadata row.
+
+    :return:
+        Normalised protocol id.
+    """
+    existing_slug = row.get("protocol_slug")
+    if existing_slug:
+        return existing_slug
+
+    protocol_name = row.get("Protocol")
+    if not protocol_name:
+        raise ValueError(f"Vault row is missing Protocol field: {row}")
+
+    return slugify_protocol(protocol_name)
+
+
+def _parse_vault_ids(raw_value: str | None) -> set[VaultSpec] | None:
+    """Parse the optional ``VAULT_ID`` allowlist from the environment.
+
+    :param raw_value:
+        Comma-separated vault ids in ``chain-address`` or ``chain,address`` format.
+
+    :return:
+        Set of vault specs, or ``None`` when no allowlist was supplied.
+    """
+    if not raw_value:
+        return None
+
+    specs = {VaultSpec.parse_string(item.strip()) for item in raw_value.split(",") if item.strip()}
+    if not specs:
+        msg = "VAULT_ID was set but did not contain any vault ids"
+        raise ValueError(msg)
+
+    return specs
+
+
+def _create_vault_from_detection(
+    web3: Web3,
+    detection: ERC4262VaultDetection,
+    token_cache: TokenDiskCache,
+) -> VaultBase | None:
+    """Create a vault instance for a detection row.
+
+    :param web3:
+        Web3 connection for the detection chain.
+
+    :param detection:
+        Persisted vault detection metadata.
+
+    :param token_cache:
+        Token metadata cache shared across refreshes.
+
+    :return:
+        Protocol-specific vault instance, or ``None`` if the detection is not supported.
+    """
+    return create_vault_instance(
+        web3,
+        detection.address,
+        detection.features,
+        token_cache=token_cache,
+    )
+
+
+def _select_matching_specs(
+    vault_db: VaultDatabase,
+    protocol_id: str,
+    vault_ids: set[VaultSpec] | None,
+) -> list[VaultSpec]:
+    """Select vault rows matching a protocol and optional vault id allowlist.
+
+    :param vault_db:
+        Vault metadata database loaded from pickle.
+
+    :param protocol_id:
+        Protocol id to refresh, e.g. ``"t3tris"``.
+
+    :param vault_ids:
+        Optional allowlist of vault ids to refresh.
+
+    :return:
+        Matching vault specs.
+    """
+    matching_specs = []
+    for spec, row in vault_db.rows.items():
+        if vault_ids is not None and spec not in vault_ids:
+            continue
+
+        row_protocol_id = _get_row_protocol_id(row)
+        if row_protocol_id != protocol_id:
+            continue
+
+        matching_specs.append(spec)
+
+    if vault_ids is not None:
+        missing_specs = sorted(vault_ids - set(matching_specs), key=lambda item: item.as_string_id())
+        if missing_specs:
+            missing = ", ".join(spec.as_string_id() for spec in missing_specs)
+            raise ValueError(f"Requested VAULT_ID entries were not found for protocol {protocol_id}: {missing}")
+
+    if not matching_specs:
+        raise ValueError(f"No vault rows found for protocol id {protocol_id}")
+
+    return matching_specs
+
+
+def refresh_vault_curators_for_protocol(
+    vault_db: VaultDatabase,
+    protocol_id: str,
+    web3_by_chain: dict[int, Web3],
+    token_cache: TokenDiskCache,
+    *,
+    vault_ids: set[VaultSpec] | None = None,
+    vault_factory: VaultFactory = _create_vault_from_detection,
+) -> list[VaultCuratorUpdate]:
+    """Refresh native manager names for all matching vault rows.
+
+    The function first reconstructs every matching vault instance and computes
+    every new manager name. Only after all rows have succeeded are the rows
+    mutated. This keeps the caller from writing a partially refreshed pickle if
+    one vault fails.
+
+    :param vault_db:
+        Vault metadata database loaded from pickle.
+
+    :param protocol_id:
+        Protocol id to refresh, e.g. ``"t3tris"``.
+
+    :param web3_by_chain:
+        Web3 connections keyed by chain id. Must contain every chain used by
+        matching rows.
+
+    :param token_cache:
+        Token metadata cache passed to reconstructed vault instances.
+
+    :param vault_ids:
+        Optional allowlist of vault ids to refresh.
+
+    :param vault_factory:
+        Factory for constructing vault instances. Defaults to
+        :py:func:`eth_defi.erc_4626.classification.create_vault_instance` via
+        ``_create_vault_from_detection``.
+
+    :return:
+        List of applied updates.
+    """
+    protocol_id = slugify_protocol(protocol_id)
+    matching_specs = _select_matching_specs(vault_db, protocol_id, vault_ids)
+    pending_updates: list[tuple[VaultRow, VaultCuratorUpdate]] = []
+
+    for spec in matching_specs:
+        row = vault_db.rows[spec]
+        detection = row.get("_detection_data")
+        if not isinstance(detection, ERC4262VaultDetection):
+            raise ValueError(f"Vault row {spec} is missing ERC4262VaultDetection: {detection}")
+
+        web3 = web3_by_chain.get(spec.chain_id)
+        if web3 is None:
+            env_var = get_json_rpc_env(spec.chain_id)
+            raise ValueError(f"Missing Web3 connection for chain {spec.chain_id}. Set {env_var} and retry.")
+
+        vault = vault_factory(web3, detection, token_cache)
+        if vault is None:
+            raise ValueError(f"Could not resolve vault class for {spec}, features: {detection.features}")
+
+        pending_updates.append(
+            (
+                row,
+                VaultCuratorUpdate(
+                    spec=spec,
+                    protocol_id=protocol_id,
+                    vault_class=vault.__class__.__name__,
+                    old_manager_name=row.get("_manager_name"),
+                    new_manager_name=vault.manager_name,
+                ),
+            )
+        )
+
+    for row, update in pending_updates:
+        row["_manager_name"] = update.new_manager_name
+
+    return [update for _, update in pending_updates]
+
+
+def _create_web3_connections_for_protocol(vault_db: VaultDatabase, protocol_id: str, vault_ids: set[VaultSpec] | None) -> dict[int, Web3]:
+    """Create Web3 connections for all chains used by matching vaults.
+
+    :param vault_db:
+        Vault metadata database loaded from pickle.
+
+    :param protocol_id:
+        Protocol id to refresh, e.g. ``"t3tris"``.
+
+    :param vault_ids:
+        Optional allowlist of vault ids to refresh.
+
+    :return:
+        Web3 connections keyed by chain id.
+    """
+    protocol_id = slugify_protocol(protocol_id)
+    matching_specs = _select_matching_specs(vault_db, protocol_id, vault_ids)
+    chain_ids = sorted({spec.chain_id for spec in matching_specs})
+
+    web3_by_chain: dict[int, Web3] = {}
+    for chain_id in chain_ids:
+        rpc_url = read_json_rpc_url(chain_id)
+        web3 = create_multi_provider_web3(rpc_url)
+        connected_chain_id = web3.eth.chain_id
+        if connected_chain_id != chain_id:
+            env_var = get_json_rpc_env(chain_id)
+            raise ValueError(f"{env_var} points to chain {connected_chain_id}, expected {chain_id}")
+        web3_by_chain[chain_id] = web3
+
+    return web3_by_chain
+
+
+def main() -> None:
+    """Run the vault manager name refresh from environment variables.
+
+    Reads ``PROTOCOL_ID`` and optional ``VAULT_ID`` / ``VAULT_DB`` /
+    ``DRY_RUN`` environment variables, refreshes matching rows, and writes the
+    pickle atomically using :py:meth:`eth_defi.vault.vaultdb.VaultDatabase.write`.
+    """
+    setup_console_logging(default_log_level="info")
+
+    protocol_id = os.environ.get("PROTOCOL_ID")
+    if not protocol_id:
+        msg = "Set PROTOCOL_ID environment variable, e.g. PROTOCOL_ID=t3tris"
+        raise RuntimeError(msg)
+
+    vault_db_path = Path(os.environ.get("VAULT_DB", str(DEFAULT_VAULT_DATABASE))).expanduser()
+    dry_run = os.environ.get("DRY_RUN", "false").lower() in {"1", "true", "yes"}
+    vault_ids = _parse_vault_ids(os.environ.get("VAULT_ID"))
+
+    logger.info("Reading vault metadata from %s", vault_db_path)
+    vault_db = VaultDatabase.read(vault_db_path)
+    web3_by_chain = _create_web3_connections_for_protocol(vault_db, protocol_id, vault_ids)
+    token_cache = TokenDiskCache()
+
+    updates = refresh_vault_curators_for_protocol(
+        vault_db=vault_db,
+        protocol_id=protocol_id,
+        web3_by_chain=web3_by_chain,
+        token_cache=token_cache,
+        vault_ids=vault_ids,
+    )
+
+    changed = [update for update in updates if update.changed]
+    logger.info("Refreshed %d %s vault manager names, %d changed", len(updates), slugify_protocol(protocol_id), len(changed))
+    for update in changed:
+        logger.info("%s %s: %s -> %s", update.vault_class, update.spec.as_string_id(), update.old_manager_name, update.new_manager_name)
+
+    if dry_run:
+        logger.info("DRY_RUN=true, not writing %s", vault_db_path)
+        return
+
+    vault_db.write(vault_db_path)
+    logger.info("Wrote refreshed vault metadata to %s", vault_db_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/erc_4626/vault_protocol/test_t3tris_offchain_metadata.py
+++ b/tests/erc_4626/vault_protocol/test_t3tris_offchain_metadata.py
@@ -1,0 +1,85 @@
+"""Test T3tris offchain metadata parsing."""
+
+import requests
+
+from eth_defi.erc_4626.vault_protocol.t3tris import offchain_metadata
+
+
+class _ResponseStub:
+    """Minimal ``requests`` response stub."""
+
+    def __init__(self, payload: dict | None = None, *, should_fail: bool = False):
+        self.payload = payload or {}
+        self.should_fail = should_fail
+
+    def raise_for_status(self) -> None:
+        """Raise a request error when configured."""
+        if self.should_fail:
+            msg = "404 Client Error"
+            raise requests.HTTPError(msg)
+
+    def json(self) -> dict:
+        """Return the configured JSON payload."""
+        return self.payload
+
+
+def test_t3tris_metadata_parses_vault_list_row() -> None:
+    """T3tris metadata accepts a raw ``/vaults`` list row."""
+    metadata = offchain_metadata._parse_vault_detail(
+        {
+            "name": "First - USDC",
+            "symbol": "1ST-USDC",
+            "description": "First Capital vault",
+            "curatorName": "First Capital",
+            "curatorUrl": "https://example.com",
+            "verified": True,
+            "depositsDisabled": False,
+            "category": "Market neutral",
+            "attributes": ["USDC"],
+            "rating": "Low",
+            "visibility": "public",
+            "ipfsHash": "",
+        }
+    )
+
+    assert metadata["name"] == "First - USDC"
+    assert metadata["curator_name"] == "First Capital"
+    assert metadata["symbol"] == "1ST-USDC"
+
+
+def test_t3tris_metadata_falls_back_to_vault_list(monkeypatch) -> None:
+    """Broken T3tris detail endpoint falls back to the vault list endpoint."""
+    calls: list[str] = []
+
+    def fake_get(url: str, **_kwargs) -> _ResponseStub:
+        calls.append(url)
+        if url.endswith("/pages/vault/42161/0x98e43a491a464f0886bc5e57207c340bbed0d01f"):
+            return _ResponseStub(should_fail=True)
+        if url.endswith("/vaults"):
+            return _ResponseStub(
+                {
+                    "vaults": [
+                        {
+                            "chainId": 42161,
+                            "address": "0x98e43a491a464f0886bc5e57207c340bbed0d01f",
+                            "name": "First - USDC",
+                            "curatorName": "First Capital",
+                        }
+                    ]
+                }
+            )
+        raise AssertionError(f"Unexpected URL {url}")
+
+    monkeypatch.setattr(offchain_metadata.requests, "get", fake_get)
+
+    raw = offchain_metadata._fetch_vault_detail(
+        42161,
+        "0x98e43a491a464f0886bc5e57207c340bbed0d01f",
+    )
+
+    assert raw is not None
+    assert raw["curatorName"] == "First Capital"
+    assert calls == [
+        "https://api.t3tris.finance/api/v1/pages/vault/42161/0x98e43a491a464f0886bc5e57207c340bbed0d01f",
+        "https://api.t3tris.finance/api/v1/vaults",
+    ]

--- a/tests/erc_4626/vault_protocol/test_t3tris_repair_script.py
+++ b/tests/erc_4626/vault_protocol/test_t3tris_repair_script.py
@@ -1,0 +1,82 @@
+"""Test T3tris production repair script helpers."""
+
+import datetime
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+from eth_typing import HexAddress
+
+from eth_defi.vault.vaultdb import VaultDatabase
+
+SCRIPT_PATH = Path(__file__).resolve().parents[3] / "scripts" / "erc-4626" / "fix-t3tris-vaults.py"
+
+
+class _HypersyncConfigStub:
+    """Minimal constructor-compatible Hypersync config stub."""
+
+    def __init__(self, **_kwargs):
+        pass
+
+
+class _HypersyncClientStub:
+    """Minimal Hypersync client stub."""
+
+
+def _load_fix_t3tris_module():
+    """Load the T3tris repair script as a module."""
+    hypersync_stub = types.ModuleType("hypersync")
+    hypersync_stub.ClientConfig = _HypersyncConfigStub
+    hypersync_stub.StreamConfig = _HypersyncConfigStub
+    hypersync_stub.HypersyncClient = _HypersyncClientStub
+    sys.modules.setdefault("hypersync", hypersync_stub)
+
+    spec = importlib.util.spec_from_file_location("fix_t3tris_vaults", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_first_capital_ref(module):
+    """Create a First Capital T3tris vault reference."""
+    return module.T3trisVaultReference(
+        chain_id=42161,
+        address=HexAddress("0x98e43a491a464F0886bC5E57207c340BBed0D01F"),
+        name="First - USDC",
+        first_seen_at_block=473_516_860,
+        first_seen_at=datetime.datetime(2026, 6, 14, 20, 21, 20, tzinfo=datetime.UTC).replace(tzinfo=None),
+        curator_name="First Capital",
+        verified=True,
+    )
+
+
+def test_t3tris_repair_refreshes_existing_row_missing_curator() -> None:
+    """Existing T3tris rows without the API curator name need metadata refresh."""
+    module = _load_fix_t3tris_module()
+    ref = _make_first_capital_ref(module)
+    vault_db = VaultDatabase()
+    vault_db.rows[ref.get_spec()] = {
+        "Name": "First - USDC",
+        "Denomination": "USDC",
+        "_manager_name": None,
+    }
+
+    assert module.should_refresh_metadata(vault_db, ref)
+
+
+def test_t3tris_repair_preserves_existing_row_with_matching_curator() -> None:
+    """Existing T3tris rows with the API curator name do not need refresh."""
+    module = _load_fix_t3tris_module()
+    ref = _make_first_capital_ref(module)
+    vault_db = VaultDatabase()
+    vault_db.rows[ref.get_spec()] = {
+        "Name": "First - USDC",
+        "Denomination": "USDC",
+        "_manager_name": "First Capital",
+    }
+
+    assert not module.should_refresh_metadata(vault_db, ref)

--- a/tests/erc_4626/vault_protocol/test_update_vault_curators_script.py
+++ b/tests/erc_4626/vault_protocol/test_update_vault_curators_script.py
@@ -1,0 +1,122 @@
+"""Test vault curator metadata refresh script helpers."""
+
+import datetime
+import importlib.util
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from eth_typing import HexAddress
+
+from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.vaultdb import VaultDatabase
+
+SCRIPT_PATH = Path(__file__).resolve().parents[3] / "scripts" / "erc-4626" / "update-vault-curators.py"
+
+
+@dataclass(slots=True)
+class _VaultStub:
+    """Minimal vault object exposing a manager name."""
+
+    manager_name: str | None
+
+
+def _load_update_vault_curators_module():
+    """Load the vault curator update script as a module."""
+    spec = importlib.util.spec_from_file_location("update_vault_curators", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_detection(spec: VaultSpec) -> ERC4262VaultDetection:
+    """Create a minimal persisted T3tris detection row."""
+    return ERC4262VaultDetection(
+        chain=spec.chain_id,
+        address=HexAddress(spec.vault_address),
+        first_seen_at_block=1,
+        first_seen_at=datetime.datetime(2026, 6, 14, 20, 21, 20, tzinfo=datetime.UTC).replace(tzinfo=None),
+        features={ERC4626Feature.t3tris_like},
+        updated_at=datetime.datetime(2026, 7, 13, tzinfo=datetime.UTC).replace(tzinfo=None),
+        deposit_count=0,
+        redeem_count=0,
+    )
+
+
+def _make_row(spec: VaultSpec, manager_name: str | None) -> dict:
+    """Create a minimal vault metadata row for script tests."""
+    return {
+        "Name": "First - USDC",
+        "Protocol": "T3tris",
+        "protocol_slug": "t3tris",
+        "_detection_data": _make_detection(spec),
+        "_manager_name": manager_name,
+    }
+
+
+def test_update_vault_curators_refreshes_manager_name() -> None:
+    """Existing metadata rows are updated from the vault manager property."""
+    module = _load_update_vault_curators_module()
+    spec = VaultSpec(42161, "0x98e43a491a464f0886bc5e57207c340bbed0d01f")
+    vault_db = VaultDatabase(rows={spec: _make_row(spec, None)})
+
+    updates = module.refresh_vault_curators_for_protocol(
+        vault_db=vault_db,
+        protocol_id="t3tris",
+        web3_by_chain={42161: object()},
+        token_cache=object(),
+        vault_factory=lambda _web3, _detection, _token_cache: _VaultStub("First Capital"),
+    )
+
+    assert len(updates) == 1
+    assert updates[0].changed
+    assert vault_db.rows[spec]["_manager_name"] == "First Capital"
+
+
+def test_update_vault_curators_respects_vault_id_allowlist() -> None:
+    """Only selected vault ids are refreshed when an allowlist is supplied."""
+    module = _load_update_vault_curators_module()
+    first_spec = VaultSpec(42161, "0x98e43a491a464f0886bc5e57207c340bbed0d01f")
+    gami_spec = VaultSpec(42161, "0x9984ad74c5fb6bec3888e14b4e453707d3be7f8f")
+    vault_db = VaultDatabase(
+        rows={
+            first_spec: _make_row(first_spec, None),
+            gami_spec: _make_row(gami_spec, None),
+        }
+    )
+
+    updates = module.refresh_vault_curators_for_protocol(
+        vault_db=vault_db,
+        protocol_id="t3tris",
+        web3_by_chain={42161: object()},
+        token_cache=object(),
+        vault_ids={first_spec},
+        vault_factory=lambda _web3, _detection, _token_cache: _VaultStub("First Capital"),
+    )
+
+    assert [update.spec for update in updates] == [first_spec]
+    assert vault_db.rows[first_spec]["_manager_name"] == "First Capital"
+    assert vault_db.rows[gami_spec]["_manager_name"] is None
+
+
+def test_update_vault_curators_rejects_missing_vault_id() -> None:
+    """Requested vault ids must exist for the selected protocol."""
+    module = _load_update_vault_curators_module()
+    first_spec = VaultSpec(42161, "0x98e43a491a464f0886bc5e57207c340bbed0d01f")
+    missing_spec = VaultSpec(42161, "0x9984ad74c5fb6bec3888e14b4e453707d3be7f8f")
+    vault_db = VaultDatabase(rows={first_spec: _make_row(first_spec, None)})
+
+    with pytest.raises(ValueError, match="Requested VAULT_ID entries were not found"):
+        module.refresh_vault_curators_for_protocol(
+            vault_db=vault_db,
+            protocol_id="t3tris",
+            web3_by_chain={42161: object()},
+            token_cache=object(),
+            vault_ids={missing_spec},
+            vault_factory=lambda _web3, _detection, _token_cache: _VaultStub("First Capital"),
+        )

--- a/tests/vault/test_curator.py
+++ b/tests/vault/test_curator.py
@@ -244,6 +244,22 @@ def test_identify_lagoon_curator_by_curator_metadata() -> None:
     assert slug == "722-capital"
 
 
+def test_identify_t3tris_curator_by_curator_metadata() -> None:
+    """T3tris manager names resolve by exact ``t3tris-curator`` YAML metadata."""
+
+    slug = identify_curator(
+        chain_id=42161,
+        vault_token_symbol="",
+        vault_name="First - USDC",
+        vault_address="0x98e43a491a464f0886bc5e57207c340bbed0d01f",
+        protocol_slug="t3tris",
+        manager_name="First Capital",
+    )
+
+    assert slug == "first-capital"
+    assert get_curator_name("first-capital") == "First Capital"
+
+
 def test_identify_rockawayx_dashboard_vaults_by_address() -> None:
     """RockawayX Dune dashboard vaults resolve by exact address.
 


### PR DESCRIPTION
## Why

T3tris vault metadata rows can be preserved across repair runs even when the persisted `_manager_name` field is stale or missing. This prevents curator identification for vaults whose display name does not include the curator brand, such as First - USDC needing to resolve to First Capital.

The generic metadata repair tooling also did not have a focused way to refresh manager or curator names for selected existing vault rows.

## Lessons learnt

T3tris' per-vault detail endpoint can return 404 while the `/api/v1/vaults` list endpoint still carries the curator metadata. The vault metadata reader needs the list endpoint fallback so both normal scans and repair scripts can populate `_manager_name`.

A targeted metadata updater should validate requested vault ids so operator typos do not silently skip rows.

## Summary

- Added `scripts/erc-4626/update-vault-curators.py` to refresh `_manager_name` for one protocol, optionally restricted by `VAULT_ID`.
- Made T3tris offchain metadata fall back to `/api/v1/vaults` when the detail endpoint fails.
- Made the T3tris repair script refresh existing metadata rows when the API curator name differs from the persisted `_manager_name`.
- Updated the baked T3tris snapshot with the currently listed Ellen Capital BTC vault.
- Added targeted tests for the curator updater, T3tris metadata fallback, T3tris repair refresh logic, and First Capital curator identification.

## Related issues and PRs

Continues the T3tris historical price and metadata repair investigation from the existing `fix-t3tris-vault-historical-prices` branch.

## Unrelated CI and test fixes

None.
