### PR TITLE
fix: use current T3tris vault detail endpoint

### DIFF
--- a/eth_defi/data/feeds/curators/first-capital.yaml
+++ b/eth_defi/data/feeds/curators/first-capital.yaml
@@ -12,4 +12,4 @@ other-links:
   - title: T3tris app - First - USDC vault curated by First Capital
     url: https://app.t3tris.finance/vaults?chainId=42161&address=0x98e43a491a464f0886bc5e57207c340bbed0d01f
   - title: T3tris API - First - USDC vault metadata on Arbitrum
-    url: https://api.t3tris.finance/api/v1/pages/vault/42161/0x98e43a491a464f0886bc5e57207c340bbed0d01f
+    url: https://api.t3tris.finance/api/v1/vaults/42161/0x98e43a491a464f0886bc5e57207c340bbed0d01f

--- a/eth_defi/erc_4626/vault_protocol/t3tris/README-t3tris.md
+++ b/eth_defi/erc_4626/vault_protocol/t3tris/README-t3tris.md
@@ -234,14 +234,14 @@ The vault detail page uses a separate REST endpoint for the offchain metadata
 shown in the application:
 
 ```text
-GET https://api.t3tris.finance/api/v1/pages/vault/{chainId}/{vaultAddress}
+GET https://api.t3tris.finance/api/v1/vaults/{chainId}/{vaultAddress}
 ```
 
 For example:
 
 ```shell
 curl -sS \
-  "https://api.t3tris.finance/api/v1/pages/vault/42161/0x9984ad74c5fb6bec3888e14b4e453707d3be7f8f" \
+  "https://api.t3tris.finance/api/v1/vaults/42161/0x9984ad74c5fb6bec3888e14b4e453707d3be7f8f" \
   | jq ".vault | {description, curatorName, curatorUrl, verified, depositsDisabled, showComposition, displayName, displaySymbol, category, attributes, rating, ipfsHash, visibility, visibilityLocked}"
 ```
 
@@ -284,7 +284,7 @@ Important REST metadata fields:
 Adding an account query parameter can include account-specific page data:
 
 ```text
-GET https://api.t3tris.finance/api/v1/pages/vault/{chainId}/{vaultAddress}?account={address}
+GET https://api.t3tris.finance/api/v1/vaults/{chainId}/{vaultAddress}?account={address}
 ```
 
 The vault list endpoint also includes the same offchain metadata for discovery:

--- a/eth_defi/erc_4626/vault_protocol/t3tris/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/t3tris/offchain_metadata.py
@@ -1,7 +1,7 @@
 """T3tris vault offchain metadata.
 
 - T3tris stores vault page descriptions in their backend, not on-chain
-- The detail endpoint ``/api/v1/pages/vault/{chainId}/{vaultAddress}``
+- The detail endpoint ``/api/v1/vaults/{chainId}/{vaultAddress}``
   returns the same page view model shown in the T3tris app
 - We fetch and cache this data locally to avoid repeated API calls
 - Two-level caching: disk (2-day TTL) + in-process dictionary
@@ -35,7 +35,7 @@ class T3trisVaultMetadata(TypedDict):
     """Metadata about a T3tris vault from offchain source.
 
     Fetched from the T3tris REST API endpoint:
-    ``GET /api/v1/pages/vault/{chainId}/{vaultAddress}``.
+    ``GET /api/v1/vaults/{chainId}/{vaultAddress}``.
     """
 
     #: Vault name shown in the app.
@@ -87,7 +87,7 @@ def _parse_vault_detail(raw: dict) -> T3trisVaultMetadata:
     """Parse vault metadata from the T3tris page endpoint.
 
     :param raw:
-        Raw JSON dict from ``/api/v1/pages/vault/{chainId}/{vaultAddress}``
+        Raw JSON dict from ``/api/v1/vaults/{chainId}/{vaultAddress}``
         or a single vault row from ``/api/v1/vaults``.
     """
     vault = raw.get("vault") or raw
@@ -176,7 +176,7 @@ def _fetch_vault_detail(
     :return:
         Raw JSON response dict, or ``None`` if the request fails.
     """
-    url = f"{api_base_url}/pages/vault/{chain_id}/{address}"
+    url = f"{api_base_url}/vaults/{chain_id}/{address}"
     logger.debug("Fetching T3tris vault detail from %s", url)
     try:
         resp = requests.get(url, timeout=30, headers={"Accept": "application/json"})

--- a/eth_defi/erc_4626/vault_protocol/t3tris/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/t3tris/vault.py
@@ -491,7 +491,7 @@ class T3trisVault(ERC4626Vault):
     def t3tris_metadata(self) -> T3trisVaultMetadata | None:
         """Offchain metadata from T3tris' web app API.
 
-        Fetched from ``api.t3tris.finance/api/v1/pages/vault`` and cached on
+        Fetched from ``api.t3tris.finance/api/v1/vaults`` and cached on
         disk and in-process to avoid repeated API calls.
         """
         return fetch_t3tris_vault_metadata(self.web3, self.spec.vault_address)

--- a/scripts/erc-4626/fix-t3tris-vaults.py
+++ b/scripts/erc-4626/fix-t3tris-vaults.py
@@ -20,7 +20,7 @@ remains scoped to those selected T3tris addresses.
 API documentation:
 
 - https://api.t3tris.finance/api/v1/vaults
-- https://api.t3tris.finance/api/v1/pages/vault/{chainId}/{vaultAddress}
+- https://api.t3tris.finance/api/v1/vaults/{chainId}/{vaultAddress}
 
 Usage:
 

--- a/tests/erc_4626/vault_protocol/test_t3tris_offchain_metadata.py
+++ b/tests/erc_4626/vault_protocol/test_t3tris_offchain_metadata.py
@@ -47,13 +47,44 @@ def test_t3tris_metadata_parses_vault_list_row() -> None:
     assert metadata["symbol"] == "1ST-USDC"
 
 
-def test_t3tris_metadata_falls_back_to_vault_list(monkeypatch) -> None:
-    """Broken T3tris detail endpoint falls back to the vault list endpoint."""
+def test_t3tris_metadata_fetches_current_detail_endpoint(monkeypatch) -> None:
+    """T3tris metadata uses the detail endpoint used by the live web application."""
     calls: list[str] = []
 
     def fake_get(url: str, **_kwargs) -> _ResponseStub:
         calls.append(url)
-        if url.endswith("/pages/vault/42161/0x98e43a491a464f0886bc5e57207c340bbed0d01f"):
+        if url.endswith("/vaults/42161/0x98e43a491a464f0886bc5e57207c340bbed0d01f"):
+            return _ResponseStub(
+                {
+                    "vault": {
+                        "name": "First - USDC",
+                        "curatorName": "First Capital",
+                    }
+                }
+            )
+        raise AssertionError(f"Unexpected URL {url}")
+
+    monkeypatch.setattr(offchain_metadata.requests, "get", fake_get)
+
+    raw = offchain_metadata._fetch_vault_detail(
+        42161,
+        "0x98e43a491a464f0886bc5e57207c340bbed0d01f",
+    )
+
+    assert raw is not None
+    assert raw["vault"]["curatorName"] == "First Capital"
+    assert calls == [
+        "https://api.t3tris.finance/api/v1/vaults/42161/0x98e43a491a464f0886bc5e57207c340bbed0d01f",
+    ]
+
+
+def test_t3tris_metadata_falls_back_to_vault_list(monkeypatch) -> None:
+    """A broken T3tris detail endpoint falls back to the vault list endpoint."""
+    calls: list[str] = []
+
+    def fake_get(url: str, **_kwargs) -> _ResponseStub:
+        calls.append(url)
+        if url.endswith("/vaults/42161/0x98e43a491a464f0886bc5e57207c340bbed0d01f"):
             return _ResponseStub(should_fail=True)
         if url.endswith("/vaults"):
             return _ResponseStub(
@@ -80,6 +111,6 @@ def test_t3tris_metadata_falls_back_to_vault_list(monkeypatch) -> None:
     assert raw is not None
     assert raw["curatorName"] == "First Capital"
     assert calls == [
-        "https://api.t3tris.finance/api/v1/pages/vault/42161/0x98e43a491a464f0886bc5e57207c340bbed0d01f",
+        "https://api.t3tris.finance/api/v1/vaults/42161/0x98e43a491a464f0886bc5e57207c340bbed0d01f",
         "https://api.t3tris.finance/api/v1/vaults",
     ]


### PR DESCRIPTION
## Why

T3tris removed `/api/v1/pages/vault/{chainId}/{vaultAddress}`. The current web application uses `/api/v1/vaults/{chainId}/{vaultAddress}` instead. The retired route produced warnings during curator metadata refreshes and the list fallback omits private vaults.

## Lessons learnt

T3tris REST routes are application-internal. Keep the integration aligned with the deployed client bundle and retain the list endpoint only as an outage fallback.

## Summary

- Fetch T3tris vault details from the live `/api/v1/vaults/{chainId}/{vaultAddress}` route.
- Add direct-detail and fallback regression coverage.
- Update T3tris documentation and the First Capital metadata source URL.

## Related issues and PRs

- Follow-up to #1266, which added the curator metadata refresh script.

## Unrelated CI and test fixes

None.