### PR TITLE
feat: add vault deposit manager metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- feat: Export vault deposit-manager capabilities, package Anvil fork probe results and provide a guarded deposit-probe refresh script (2026-07-13)
 - feat: Add KiloEx Hybrid Vault protocol support with hardcoded BNB Chain and Base deployment detection (2026-07-13)
 - feat: Add Piku curator attribution for USP and Morini Capital vaults using hardcoded Ethereum contract addresses (2026-07-13)
 - feat: Add Midas strategy curator attribution for Fasanara, Apollo Crypto and Edge Capital vault products (2026-07-10)

--- a/docs/source/api/erc_4626/index.rst
+++ b/docs/source/api/erc_4626/index.rst
@@ -29,6 +29,7 @@ More info
 
    eth_defi.erc_4626.vault
    eth_defi.erc_4626.deposit_redeem
+   eth_defi.erc_4626.deposit_probe
    eth_defi.erc_4626.flow
    eth_defi.erc_4626.analysis
    eth_defi.erc_4626.hypersync_discovery

--- a/docs/source/vaults/index.rst
+++ b/docs/source/vaults/index.rst
@@ -26,6 +26,22 @@ enabling you to:
 For the core ERC-4626 functionality shared across all vault protocols, see
 :py:mod:`eth_defi.erc_4626`.
 
+Deposit manager capability metadata
+-----------------------------------
+
+Each newly scanned vault record in the public metrics JSON contains a nullable
+``deposit_manager`` object. A non-null value means this library has an explicit
+two-way deposit and redemption manager for that vault shape; its
+``deposit_flow`` and ``redemption_flow`` values are either ``synchronous`` or
+``asynchronous``. Asynchronous flows require callers to persist the returned
+ticket and submit the later claim operation.
+
+This is adapter metadata, not live availability. Before submitting a request,
+consumers must use current chain state and handle a live preflight or
+transaction revert, then handle the declared flow type. The field does not
+assert that an account is permissioned, funded, within a vault cap, or able to
+obtain redemption liquidity.
+
 Vault settlement event scanning
 -------------------------------
 

--- a/eth_defi/data/README.md
+++ b/eth_defi/data/README.md
@@ -10,6 +10,9 @@ No Python files live here — all loading logic is in the source modules listed 
 ```
 eth_defi/data/
 ├── curators.md                          Human-readable curator reference
+├── deposit-status/                      Guarded Anvil vault-deposit evidence
+│   ├── README-deposit-status.md          Manual refresh and review procedure
+│   └── vault-deposit-status.json         Version-controlled probe snapshot
 ├── feeds/                               Feed source YAML files
 │   ├── curators/      (38 YAML)         Curator social/RSS sources
 │   ├── protocols/     (70 YAML)         Vault protocol social/RSS sources

--- a/eth_defi/data/deposit-status/README-deposit-status.md
+++ b/eth_defi/data/deposit-status/README-deposit-status.md
@@ -1,0 +1,59 @@
+# Vault deposit-status artefact
+
+`vault-deposit-status.json` is a version-controlled snapshot of guarded
+Anvil-fork deposit probes. It is package data, like ABI files: consumers can
+read the evidence shipped with a release without depending on an operator's
+home-directory state.
+
+Each row records a vault, its manager capability, the fork block, the outcome,
+and any relevant failure details. It never contains private keys, upstream
+transaction hashes, or transaction hashes from temporary Anvil chains.
+
+## Refreshing the snapshot
+
+Refresh this file deliberately from a repository checkout. The probe defaults
+to this path, so do not set `VAULT_DEPOSIT_STATUS_PATH` for the release refresh.
+
+```shell
+source .local-test.env
+SIMULATE=true \
+VAULT_SELECTION=all_protocols \
+CHAIN_ID=42161 \
+MAX_VAULTS=5 \
+ALLOW_UNCERTIFIED_CANDIDATES=true \
+CONFIRM_ALL=true \
+DEPOSIT_AMOUNT=10 \
+poetry run python scripts/erc-4626/probe-vault-deposits.py
+```
+
+The sweep can take a long time. For an interactive runner, prefer bounded
+protocol batches and resume the same artefact:
+
+```shell
+source .local-test.env
+SIMULATE=true \
+VAULT_SELECTION=protocol \
+PROTOCOL=Morpho \
+CHAIN_ID=8453 \
+MAX_VAULTS=5 \
+CONFIRM_ALL=true \
+DEPOSIT_AMOUNT=10 \
+poetry run python scripts/erc-4626/probe-vault-deposits.py
+```
+
+Review the resulting JSON and its Git diff before committing. `success` means
+the configured `SimpleVaultV0` completed a guarded deposit on the ephemeral
+fork; it is not a live-chain transaction. `funding_error` and `rpc_error` are
+infrastructure findings, not protocol incompatibility. `reverted` means the
+guarded deposit transaction was attempted and did not succeed.
+
+The `max_deposit_guidance` field and the terminal `maxDeposit guidance` column
+are informational only. ERC-4626 permits conservative `maxDeposit` values, and
+Morpho V2 intentionally returns zero. Depositability is decided solely by the
+guarded transaction result. A saved success is historical adapter evidence; a
+production caller must still execute a current-state preflight or handle a
+live transaction revert.
+
+For an experimental run that must not change the package artefact, provide an
+explicit `VAULT_DEPOSIT_STATUS_PATH` outside this directory. Do not copy an
+unreviewed home-directory status file into the package.

--- a/eth_defi/data/deposit-status/README-deposit-status.md
+++ b/eth_defi/data/deposit-status/README-deposit-status.md
@@ -5,9 +5,12 @@ Anvil-fork deposit probes. It is package data, like ABI files: consumers can
 read the evidence shipped with a release without depending on an operator's
 home-directory state.
 
-Each row records a vault, its manager capability, the fork block, the outcome,
-and any relevant failure details. It never contains private keys, upstream
-transaction hashes, or transaction hashes from temporary Anvil chains.
+Each row records a vault, its manager capability, the outcome, and any relevant
+failure details. Every successful current result includes the positive integer
+Anvil fork block used for the attempt. A legacy success without this evidence
+is automatically invalidated on the next refresh. The file never contains
+private keys, upstream transaction hashes, or transaction hashes from
+temporary Anvil chains.
 
 ## Refreshing the snapshot
 
@@ -43,9 +46,17 @@ poetry run python scripts/erc-4626/probe-vault-deposits.py
 
 Review the resulting JSON and its Git diff before committing. `success` means
 the configured `SimpleVaultV0` completed a guarded deposit on the ephemeral
-fork; it is not a live-chain transaction. `funding_error` and `rpc_error` are
-infrastructure findings, not protocol incompatibility. `reverted` means the
-guarded deposit transaction was attempted and did not succeed.
+fork. For a synchronous manager, it also completed a guarded redemption and
+received denomination tokens back. Asynchronous redemption is recorded as not
+exercised because it needs a later protocol settlement. A success is not a
+live-chain transaction. `funding_error` and `rpc_error` are infrastructure
+findings, not protocol incompatibility. `reverted` means a guarded deposit or
+synchronous redemption transaction was attempted and did not succeed.
+
+Before committing a refreshed artefact, verify that no successful current row
+has a missing or non-integer `fork_block_number`. The writer rejects such new
+successes; this separate review also catches hand-edited or externally supplied
+files.
 
 The `max_deposit_guidance` field and the terminal `maxDeposit guidance` column
 are informational only. ERC-4626 permits conservative `maxDeposit` values, and

--- a/eth_defi/data/deposit-status/vault-deposit-status.json
+++ b/eth_defi/data/deposit-status/vault-deposit-status.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "updated_at": "2026-07-13T18:50:54Z",
+  "updated_at": "2026-07-13T20:28:14Z",
   "vaults": {
     "42161-0x0000000f2eb9f69274678c76222b35eec7588a65": {
       "address": "0x0000000f2eb9f69274678c76222b35eec7588a65",
-      "attempt_count": 7,
+      "attempt_count": 9,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -16,7 +16,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483530594,
       "history": [
         {
           "address": "0x0000000f2eb9f69274678c76222b35eec7588a65",
@@ -105,15 +105,73 @@
           "outcome": "success",
           "protocol": "Yo",
           "share_balance_raw": "9473725"
+        },
+        {
+          "address": "0x0000000f2eb9f69274678c76222b35eec7588a65",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:50:54Z",
+          "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+          "message": null,
+          "name": "yoVaultUSD",
+          "outcome": "success",
+          "protocol": "Yo",
+          "share_balance_raw": "9473671"
+        },
+        {
+          "address": "0x0000000f2eb9f69274678c76222b35eec7588a65",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:50:54Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "yoVaultUSD",
+          "outcome": "invalid_evidence",
+          "protocol": "Yo"
+        },
+        {
+          "address": "0x0000000f2eb9f69274678c76222b35eec7588a65",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483529007,
+          "last_attempt_at": "2026-07-13T20:07:30Z",
+          "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+          "message": "Synchronous redemption validation failed: Failed to poke vault: 0x0000000f2eB9f69274678c76222B35eEc7588a65",
+          "minted_share_amount_raw": "9473617",
+          "name": "yoVaultUSD",
+          "outcome": "guard_validation_error",
+          "protocol": "Yo"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:50:54Z",
+      "last_attempt_at": "2026-07-13T20:13:56Z",
       "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
       "message": null,
+      "minted_share_amount_raw": "9473617",
       "name": "yoVaultUSD",
       "outcome": "success",
       "protocol": "Yo",
-      "share_balance_raw": "9473671"
+      "redeemed_asset_amount_raw": "9999899",
+      "redemption_status_detail": "completed"
     },
     "42161-0x018282d5b510f00dcacb8f4a81c3901d2fc9da51": {
       "address": "0x018282d5b510f00dcacb8f4a81c3901d2fc9da51",
@@ -128,7 +186,7 @@
     },
     "42161-0x030cdecbdca6a34e8de3f49d1798d5f70e3a3414": {
       "address": "0x030cdecbdca6a34e8de3f49d1798d5f70e3a3414",
-      "attempt_count": 8,
+      "attempt_count": 10,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -140,7 +198,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483530654,
       "history": [
         {
           "address": "0x030cdecbdca6a34e8de3f49d1798d5f70e3a3414",
@@ -240,19 +298,77 @@
           "outcome": "success",
           "protocol": "Superform",
           "share_balance_raw": "8524069"
+        },
+        {
+          "address": "0x030cdecbdca6a34e8de3f49d1798d5f70e3a3414",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:42:48Z",
+          "max_deposit_guidance": "84933499174727",
+          "message": null,
+          "name": "Static Aave Arbitrum USDC",
+          "outcome": "success",
+          "protocol": "Superform",
+          "share_balance_raw": "8524062"
+        },
+        {
+          "address": "0x030cdecbdca6a34e8de3f49d1798d5f70e3a3414",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:42:48Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Static Aave Arbitrum USDC",
+          "outcome": "invalid_evidence",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0x030cdecbdca6a34e8de3f49d1798d5f70e3a3414",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483529007,
+          "last_attempt_at": "2026-07-13T20:07:40Z",
+          "max_deposit_guidance": "84793570581067",
+          "message": "Synchronous redemption validation failed: Failed to poke vault: 0x030cDeCBDcA6A34e8De3f49d1798d5f70E3a3414",
+          "minted_share_amount_raw": "8524026",
+          "name": "Static Aave Arbitrum USDC",
+          "outcome": "guard_validation_error",
+          "protocol": "Superform"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:42:48Z",
-      "max_deposit_guidance": "84933499174727",
+      "last_attempt_at": "2026-07-13T20:14:13Z",
+      "max_deposit_guidance": "84788924476551",
       "message": null,
+      "minted_share_amount_raw": "8524023",
       "name": "Static Aave Arbitrum USDC",
       "outcome": "success",
       "protocol": "Superform",
-      "share_balance_raw": "8524062"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed"
     },
     "42161-0x0319c82013cf676661f7bde576c6731869a93fc0": {
       "address": "0x0319c82013cf676661f7bde576c6731869a93fc0",
-      "attempt_count": 13,
+      "attempt_count": 15,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -264,71 +380,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483530654,
       "history": [
-        {
-          "address": "0x0319c82013cf676661f7bde576c6731869a93fc0",
-          "attempt_count": 3,
-          "chain_id": 42161,
-          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
-          "deposit_amount": "10",
-          "deposit_manager": {
-            "can_deposit": true,
-            "can_redeem": true,
-            "deposit_flow": "synchronous",
-            "redemption_flow": "synchronous"
-          },
-          "execution_mode": "guard_v0_simple_vault_v0",
-          "fork_block_number": null,
-          "last_attempt_at": "2026-07-13T16:58:11Z",
-          "message": null,
-          "name": "Peapods Interest Bearing USDC - 22",
-          "outcome": "success",
-          "protocol": "Peapods",
-          "share_balance_raw": "8608004"
-        },
-        {
-          "address": "0x0319c82013cf676661f7bde576c6731869a93fc0",
-          "attempt_count": 4,
-          "chain_id": 42161,
-          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
-          "deposit_amount": "10",
-          "deposit_manager": {
-            "can_deposit": true,
-            "can_redeem": true,
-            "deposit_flow": "synchronous",
-            "redemption_flow": "synchronous"
-          },
-          "execution_mode": "guard_v0_simple_vault_v0",
-          "fork_block_number": null,
-          "last_attempt_at": "2026-07-13T17:00:51Z",
-          "message": null,
-          "name": "Peapods Interest Bearing USDC - 22",
-          "outcome": "success",
-          "protocol": "Peapods",
-          "share_balance_raw": "8608003"
-        },
-        {
-          "address": "0x0319c82013cf676661f7bde576c6731869a93fc0",
-          "attempt_count": 5,
-          "chain_id": 42161,
-          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
-          "deposit_amount": "10",
-          "deposit_manager": {
-            "can_deposit": true,
-            "can_redeem": true,
-            "deposit_flow": "synchronous",
-            "redemption_flow": "synchronous"
-          },
-          "execution_mode": "guard_v0_simple_vault_v0",
-          "fork_block_number": null,
-          "last_attempt_at": "2026-07-13T17:03:45Z",
-          "message": null,
-          "name": "Peapods Interest Bearing USDC - 22",
-          "outcome": "success",
-          "protocol": "Peapods",
-          "share_balance_raw": "8608000"
-        },
         {
           "address": "0x0319c82013cf676661f7bde576c6731869a93fc0",
           "attempt_count": 6,
@@ -477,14 +530,72 @@
           "outcome": "success",
           "protocol": "Peapods",
           "share_balance_raw": "8607900"
+        },
+        {
+          "address": "0x0319c82013cf676661f7bde576c6731869a93fc0",
+          "attempt_count": 13,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:36:23Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 22",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "8607883"
+        },
+        {
+          "address": "0x0319c82013cf676661f7bde576c6731869a93fc0",
+          "attempt_count": 13,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:36:23Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Peapods Interest Bearing USDC - 22",
+          "outcome": "invalid_evidence",
+          "protocol": "Peapods"
+        },
+        {
+          "address": "0x0319c82013cf676661f7bde576c6731869a93fc0",
+          "attempt_count": 14,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483529007,
+          "last_attempt_at": "2026-07-13T20:07:49Z",
+          "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007906227386394",
+          "message": "Synchronous redemption validation failed: Failed to poke vault: 0x0319c82013CF676661f7bde576c6731869A93Fc0",
+          "minted_share_amount_raw": "8607770",
+          "name": "Peapods Interest Bearing USDC - 22",
+          "outcome": "guard_validation_error",
+          "protocol": "Peapods"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:36:23Z",
+      "last_attempt_at": "2026-07-13T20:14:15Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007906227378864",
       "message": null,
+      "minted_share_amount_raw": "8607762",
       "name": "Peapods Interest Bearing USDC - 22",
       "outcome": "success",
       "protocol": "Peapods",
-      "share_balance_raw": "8607883"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed"
     },
     "42161-0x034f12a217405d54bf2654b66a96fa74ad715951": {
       "address": "0x034f12a217405d54bf2654b66a96fa74ad715951",
@@ -505,7 +616,7 @@
     },
     "42161-0x037dff1c12805707d7c29f163e0f09fc9102657a": {
       "address": "0x037dff1c12805707d7c29f163e0f09fc9102657a",
-      "attempt_count": 9,
+      "attempt_count": 11,
       "chain_id": 42161,
       "denomination_token_address": "0x7dfF72693f6A4149b17e7C6314655f6A9F7c8B33",
       "deposit_amount": "10",
@@ -517,16 +628,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483530654,
       "history": [
-        {
-          "address": "0x037dff1c12805707d7c29f163e0f09fc9102657a",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "last_attempt_at": "2026-07-13T16:53:57Z",
-          "message": "No configured token holder",
-          "outcome": "skipped"
-        },
         {
           "address": "0x037dff1c12805707d7c29f163e0f09fc9102657a",
           "attempt_count": 2,
@@ -631,14 +734,72 @@
           "outcome": "success",
           "protocol": "Fluid",
           "share_balance_raw": "9689118591397195667"
+        },
+        {
+          "address": "0x037dff1c12805707d7c29f163e0f09fc9102657a",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0x7dfF72693f6A4149b17e7C6314655f6A9F7c8B33",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:22:40Z",
+          "message": null,
+          "name": "Fluid Gho Token",
+          "outcome": "success",
+          "protocol": "Fluid",
+          "share_balance_raw": "9689116295867965021"
+        },
+        {
+          "address": "0x037dff1c12805707d7c29f163e0f09fc9102657a",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:22:40Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Fluid Gho Token",
+          "outcome": "invalid_evidence",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0x037dff1c12805707d7c29f163e0f09fc9102657a",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0x7dfF72693f6A4149b17e7C6314655f6A9F7c8B33",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483529007,
+          "last_attempt_at": "2026-07-13T20:07:59Z",
+          "max_deposit_guidance": "170141183460466476981365330934249644127",
+          "message": "Synchronous redemption validation failed: Failed to poke vault: 0x037dFf1C12805707d7c29F163E0F09fC9102657A",
+          "minted_share_amount_raw": "9688997297862113736",
+          "name": "Fluid Gho Token",
+          "outcome": "guard_validation_error",
+          "protocol": "Fluid"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:22:40Z",
+      "last_attempt_at": "2026-07-13T20:14:17Z",
+      "max_deposit_guidance": "170141183460466476979103939533288966779",
       "message": null,
+      "minted_share_amount_raw": "9688989460218041202",
       "name": "Fluid Gho Token",
       "outcome": "success",
       "protocol": "Fluid",
-      "share_balance_raw": "9689116295867965021"
+      "redeemed_asset_amount_raw": "10000000019969007276",
+      "redemption_status_detail": "completed"
     },
     "42161-0x04419d3509f13054f60d253e0c79491d9e683399": {
       "address": "0x04419d3509f13054f60d253e0c79491d9e683399",
@@ -766,7 +927,7 @@
     },
     "42161-0x05d28a86e057364f6ad1a88944297e58fc6160b3": {
       "address": "0x05d28a86e057364f6ad1a88944297e58fc6160b3",
-      "attempt_count": 2,
+      "attempt_count": 4,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -778,7 +939,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483530654,
       "history": [
         {
           "address": "0x05d28a86e057364f6ad1a88944297e58fc6160b3",
@@ -801,14 +962,72 @@
           "outcome": "success",
           "protocol": "Euler",
           "share_balance_raw": "9729277"
+        },
+        {
+          "address": "0x05d28a86e057364f6ad1a88944297e58fc6160b3",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:23:01Z",
+          "message": null,
+          "name": "Euler Arbitrum Yield",
+          "outcome": "success",
+          "protocol": "Euler",
+          "share_balance_raw": "9729277"
+        },
+        {
+          "address": "0x05d28a86e057364f6ad1a88944297e58fc6160b3",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:23:01Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Euler Arbitrum Yield",
+          "outcome": "invalid_evidence",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0x05d28a86e057364f6ad1a88944297e58fc6160b3",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483529007,
+          "last_attempt_at": "2026-07-13T20:08:10Z",
+          "max_deposit_guidance": "5192296858534827628530348196336111",
+          "message": "Synchronous redemption validation failed: Failed to poke vault: 0x05d28A86E057364F6ad1a88944297E58Fc6160b3",
+          "minted_share_amount_raw": "9729277",
+          "name": "Euler Arbitrum Yield",
+          "outcome": "guard_validation_error",
+          "protocol": "Euler"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:23:01Z",
+      "last_attempt_at": "2026-07-13T20:14:20Z",
+      "max_deposit_guidance": "5192296858534827628530348196336111",
       "message": null,
+      "minted_share_amount_raw": "9729277",
       "name": "Euler Arbitrum Yield",
       "outcome": "success",
       "protocol": "Euler",
-      "share_balance_raw": "9729277"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed"
     },
     "42161-0x0623bd8ec9e040b7bd76dbb8b2fe86d312c28cd8": {
       "address": "0x0623bd8ec9e040b7bd76dbb8b2fe86d312c28cd8",
@@ -846,7 +1065,7 @@
     },
     "42161-0x06b5f3dbf5f0483e533421cd7c48b28ea1cfed34": {
       "address": "0x06b5f3dbf5f0483e533421cd7c48b28ea1cfed34",
-      "attempt_count": 10,
+      "attempt_count": 12,
       "chain_id": 42161,
       "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
       "deposit_amount": "10",
@@ -858,24 +1077,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483530654,
       "history": [
-        {
-          "address": "0x06b5f3dbf5f0483e533421cd7c48b28ea1cfed34",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "last_attempt_at": "2026-07-13T16:53:59Z",
-          "message": "No configured token holder",
-          "outcome": "skipped"
-        },
-        {
-          "address": "0x06b5f3dbf5f0483e533421cd7c48b28ea1cfed34",
-          "attempt_count": 2,
-          "chain_id": 42161,
-          "last_attempt_at": "2026-07-13T16:58:58Z",
-          "message": "No configured token holder",
-          "outcome": "skipped"
-        },
         {
           "address": "0x06b5f3dbf5f0483e533421cd7c48b28ea1cfed34",
           "attempt_count": 3,
@@ -983,14 +1186,72 @@
           "outcome": "success",
           "protocol": "Goat Protocol",
           "share_balance_raw": "160350111538837702"
+        },
+        {
+          "address": "0x06b5f3dbf5f0483e533421cd7c48b28ea1cfed34",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:25:21Z",
+          "message": null,
+          "name": "DAI Multi-Strategy Vault",
+          "outcome": "success",
+          "protocol": "Goat Protocol",
+          "share_balance_raw": "160350111538837702"
+        },
+        {
+          "address": "0x06b5f3dbf5f0483e533421cd7c48b28ea1cfed34",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:25:21Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "DAI Multi-Strategy Vault",
+          "outcome": "invalid_evidence",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x06b5f3dbf5f0483e533421cd7c48b28ea1cfed34",
+          "attempt_count": 11,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483529007,
+          "last_attempt_at": "2026-07-13T20:08:18Z",
+          "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+          "message": "Synchronous redemption validation failed: Failed to poke vault: 0x06B5f3dbf5f0483E533421cD7c48b28EA1CfED34",
+          "minted_share_amount_raw": "160350111538837702",
+          "name": "DAI Multi-Strategy Vault",
+          "outcome": "guard_validation_error",
+          "protocol": "Goat Protocol"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:25:21Z",
+      "last_attempt_at": "2026-07-13T20:14:21Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
       "message": null,
+      "minted_share_amount_raw": "160350111538837702",
       "name": "DAI Multi-Strategy Vault",
       "outcome": "success",
       "protocol": "Goat Protocol",
-      "share_balance_raw": "160350111538837702"
+      "redeemed_asset_amount_raw": "9999999999999999972",
+      "redemption_status_detail": "completed"
     },
     "42161-0x0b1ed8308c9ade48b0bcb0c176b62126ba79886a": {
       "address": "0x0b1ed8308c9ade48b0bcb0c176b62126ba79886a",
@@ -1198,7 +1459,7 @@
     },
     "42161-0x0df2e3a0b5997adc69f8768e495fd98a4d00f134": {
       "address": "0x0df2e3a0b5997adc69f8768e495fd98a4d00f134",
-      "attempt_count": 10,
+      "attempt_count": 12,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -1210,30 +1471,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483530654,
       "history": [
-        {
-          "address": "0x0df2e3a0b5997adc69f8768e495fd98a4d00f134",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "deposit_manager": null,
-          "last_attempt_at": "2026-07-13T16:53:59Z",
-          "message": "Live adapter does not advertise deposits",
-          "name": "Yield Chasing USDC",
-          "outcome": "adapter_error",
-          "protocol": "Goat Protocol"
-        },
-        {
-          "address": "0x0df2e3a0b5997adc69f8768e495fd98a4d00f134",
-          "attempt_count": 2,
-          "chain_id": 42161,
-          "deposit_manager": null,
-          "last_attempt_at": "2026-07-13T16:58:58Z",
-          "message": "Live adapter does not advertise deposits",
-          "name": "Yield Chasing USDC",
-          "outcome": "adapter_error",
-          "protocol": "Goat Protocol"
-        },
         {
           "address": "0x0df2e3a0b5997adc69f8768e495fd98a4d00f134",
           "attempt_count": 3,
@@ -1343,14 +1582,72 @@
           "outcome": "success",
           "protocol": "Goat Protocol",
           "share_balance_raw": "9018893878215402497"
+        },
+        {
+          "address": "0x0df2e3a0b5997adc69f8768e495fd98a4d00f134",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:24:59Z",
+          "message": null,
+          "name": "Yield Chasing USDC",
+          "outcome": "success",
+          "protocol": "Goat Protocol",
+          "share_balance_raw": "9018893878215402497"
+        },
+        {
+          "address": "0x0df2e3a0b5997adc69f8768e495fd98a4d00f134",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:24:59Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Yield Chasing USDC",
+          "outcome": "invalid_evidence",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x0df2e3a0b5997adc69f8768e495fd98a4d00f134",
+          "attempt_count": 11,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483529007,
+          "last_attempt_at": "2026-07-13T20:08:26Z",
+          "max_deposit_guidance": "4996082507458",
+          "message": "Synchronous redemption validation failed: Failed to poke vault: 0x0df2e3a0b5997AdC69f8768E495FD98A4D00F134",
+          "minted_share_amount_raw": "9018893878215402497",
+          "name": "Yield Chasing USDC",
+          "outcome": "guard_validation_error",
+          "protocol": "Goat Protocol"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:24:59Z",
+      "last_attempt_at": "2026-07-13T20:14:22Z",
+      "max_deposit_guidance": "4996082507458",
       "message": null,
+      "minted_share_amount_raw": "9018893878215402497",
       "name": "Yield Chasing USDC",
       "outcome": "success",
       "protocol": "Goat Protocol",
-      "share_balance_raw": "9018893878215402497"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed"
     },
     "42161-0x0e6ad128d7e217439beea90695fe7ec859c7f98c": {
       "address": "0x0e6ad128d7e217439beea90695fe7ec859c7f98c",
@@ -1405,7 +1702,7 @@
     },
     "42161-0x1048918cf09290a625bb75f93443f1159e3ce09d": {
       "address": "0x1048918cf09290a625bb75f93443f1159e3ce09d",
-      "attempt_count": 1,
+      "attempt_count": 6,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -1417,14 +1714,144 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
-      "history": [],
-      "last_attempt_at": "2026-07-13T18:37:01Z",
-      "message": null,
+      "fork_block_number": 483532336,
+      "history": [
+        {
+          "address": "0x1048918cf09290a625bb75f93443f1159e3ce09d",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:37:01Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 15",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "8927700"
+        },
+        {
+          "address": "0x1048918cf09290a625bb75f93443f1159e3ce09d",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:37:01Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Peapods Interest Bearing USDC - 15",
+          "outcome": "invalid_evidence",
+          "protocol": "Peapods"
+        },
+        {
+          "address": "0x1048918cf09290a625bb75f93443f1159e3ce09d",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483529007,
+          "last_attempt_at": "2026-07-13T20:08:37Z",
+          "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007912444643545",
+          "message": "Synchronous redemption validation failed: Failed to poke vault: 0x1048918Cf09290a625BB75f93443f1159e3ce09d",
+          "minted_share_amount_raw": "8927700",
+          "name": "Peapods Interest Bearing USDC - 15",
+          "outcome": "guard_validation_error",
+          "protocol": "Peapods"
+        },
+        {
+          "address": "0x1048918cf09290a625bb75f93443f1159e3ce09d",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483530654,
+          "last_attempt_at": "2026-07-13T20:14:25Z",
+          "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007912444643545",
+          "message": "Synchronous redemption failed: 0xc5bb6dae0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000098967f",
+          "minted_share_amount_raw": "8927700",
+          "name": "Peapods Interest Bearing USDC - 15",
+          "outcome": "reverted",
+          "protocol": "Peapods",
+          "revert_reason": "0xc5bb6dae0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000098967f"
+        },
+        {
+          "address": "0x1048918cf09290a625bb75f93443f1159e3ce09d",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483531578,
+          "last_attempt_at": "2026-07-13T20:18:03Z",
+          "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007912444643545",
+          "message": "Synchronous redemption failed: 0xc5bb6dae0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000098967f",
+          "minted_share_amount_raw": "8927700",
+          "name": "Peapods Interest Bearing USDC - 15",
+          "outcome": "reverted",
+          "protocol": "Peapods",
+          "revert_reason": "0xc5bb6dae0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000098967f"
+        },
+        {
+          "address": "0x1048918cf09290a625bb75f93443f1159e3ce09d",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483531830,
+          "last_attempt_at": "2026-07-13T20:19:13Z",
+          "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007912444643545",
+          "message": "Synchronous redemption failed: 0xc5bb6dae0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000098967f",
+          "minted_share_amount_raw": "8927700",
+          "name": "Peapods Interest Bearing USDC - 15",
+          "outcome": "reverted",
+          "protocol": "Peapods",
+          "revert_reason": "0xc5bb6dae0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000098967f"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T20:21:20Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007912444643545",
+      "message": "Synchronous redemption failed: 0xc5bb6dae0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000098967f",
+      "minted_share_amount_raw": "8927700",
       "name": "Peapods Interest Bearing USDC - 15",
-      "outcome": "success",
+      "outcome": "reverted",
       "protocol": "Peapods",
-      "share_balance_raw": "8927700"
+      "revert_reason": "0xc5bb6dae0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000098967f"
     },
     "42161-0x10c49bf632663f9599b5cacebb2cbe13e7a50970": {
       "address": "0x10c49bf632663f9599b5cacebb2cbe13e7a50970",
@@ -1611,7 +2038,7 @@
     },
     "42161-0x13c798c93e9c6293dd3c40d1f5c9fdcd4f92aa14": {
       "address": "0x13c798c93e9c6293dd3c40d1f5c9fdcd4f92aa14",
-      "attempt_count": 8,
+      "attempt_count": 10,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -1623,7 +2050,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483530654,
       "history": [
         {
           "address": "0x13c798c93e9c6293dd3c40d1f5c9fdcd4f92aa14",
@@ -1723,14 +2150,72 @@
           "outcome": "success",
           "protocol": "Royco",
           "share_balance_raw": "7872576"
+        },
+        {
+          "address": "0x13c798c93e9c6293dd3c40d1f5c9fdcd4f92aa14",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:38:36Z",
+          "message": null,
+          "name": "Lend USDC on Dolomite",
+          "outcome": "success",
+          "protocol": "Royco",
+          "share_balance_raw": "7872566"
+        },
+        {
+          "address": "0x13c798c93e9c6293dd3c40d1f5c9fdcd4f92aa14",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:38:36Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Lend USDC on Dolomite",
+          "outcome": "invalid_evidence",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0x13c798c93e9c6293dd3c40d1f5c9fdcd4f92aa14",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483529007,
+          "last_attempt_at": "2026-07-13T20:08:58Z",
+          "max_deposit_guidance": "495526154020013",
+          "message": "Synchronous redemption validation failed: Failed to poke vault: 0x13c798c93E9C6293dD3c40D1f5c9fdCD4F92AA14",
+          "minted_share_amount_raw": "7872501",
+          "name": "Lend USDC on Dolomite",
+          "outcome": "guard_validation_error",
+          "protocol": "Royco"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:38:36Z",
+      "last_attempt_at": "2026-07-13T20:14:34Z",
+      "max_deposit_guidance": "495526151172951",
       "message": null,
+      "minted_share_amount_raw": "7872496",
       "name": "Lend USDC on Dolomite",
       "outcome": "success",
       "protocol": "Royco",
-      "share_balance_raw": "7872566"
+      "redeemed_asset_amount_raw": "10000000",
+      "redemption_status_detail": "completed"
     },
     "42161-0x149c96643cf21bfd50e715ec4404af68ee333855": {
       "address": "0x149c96643cf21bfd50e715ec4404af68ee333855",
@@ -1977,7 +2462,7 @@
     },
     "42161-0x1a996cb54bb95462040408c06122d45d6cdb6096": {
       "address": "0x1a996cb54bb95462040408c06122d45d6cdb6096",
-      "attempt_count": 9,
+      "attempt_count": 11,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -1989,19 +2474,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483530654,
       "history": [
-        {
-          "address": "0x1a996cb54bb95462040408c06122d45d6cdb6096",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "deposit_manager": null,
-          "last_attempt_at": "2026-07-13T16:53:57Z",
-          "message": "Live adapter does not advertise deposits",
-          "name": "Fluid USD Coin",
-          "outcome": "adapter_error",
-          "protocol": "Fluid"
-        },
         {
           "address": "0x1a996cb54bb95462040408c06122d45d6cdb6096",
           "attempt_count": 2,
@@ -2111,14 +2585,72 @@
           "outcome": "success",
           "protocol": "Fluid",
           "share_balance_raw": "8924992"
+        },
+        {
+          "address": "0x1a996cb54bb95462040408c06122d45d6cdb6096",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:22:32Z",
+          "message": null,
+          "name": "Fluid USD Coin",
+          "outcome": "success",
+          "protocol": "Fluid",
+          "share_balance_raw": "8924990"
+        },
+        {
+          "address": "0x1a996cb54bb95462040408c06122d45d6cdb6096",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:22:32Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Fluid USD Coin",
+          "outcome": "invalid_evidence",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0x1a996cb54bb95462040408c06122d45d6cdb6096",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483529007,
+          "last_attempt_at": "2026-07-13T20:09:10Z",
+          "max_deposit_guidance": "170141183460469231731687255386023177867",
+          "message": "Synchronous redemption validation failed: Failed to poke vault: 0x1A996cb54bb95462040408C06122D45D6Cdb6096",
+          "minted_share_amount_raw": "8924878",
+          "name": "Fluid USD Coin",
+          "outcome": "guard_validation_error",
+          "protocol": "Fluid"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:22:32Z",
+      "last_attempt_at": "2026-07-13T20:14:36Z",
+      "max_deposit_guidance": "170141183460469231731687255363343706646",
       "message": null,
+      "minted_share_amount_raw": "8924871",
       "name": "Fluid USD Coin",
       "outcome": "success",
       "protocol": "Fluid",
-      "share_balance_raw": "8924990"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed"
     },
     "42161-0x1bf5de164620055794eec69f934623c43cc696d4": {
       "address": "0x1bf5de164620055794eec69f934623c43cc696d4",
@@ -2141,7 +2673,7 @@
     },
     "42161-0x1c107c4233ab3056254e717c7a67f9917079b615": {
       "address": "0x1c107c4233ab3056254e717c7a67f9917079b615",
-      "attempt_count": 10,
+      "attempt_count": 12,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -2153,39 +2685,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483530654,
       "history": [
-        {
-          "address": "0x1c107c4233ab3056254e717c7a67f9917079b615",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "last_attempt_at": "2026-07-13T16:54:06Z",
-          "message": "Transaction must include these fields: {'gasPrice'}",
-          "name": "Crypto.com Defi Wallet Compound USDC",
-          "outcome": "rpc_error",
-          "protocol": "Kiln Metavault"
-        },
-        {
-          "address": "0x1c107c4233ab3056254e717c7a67f9917079b615",
-          "attempt_count": 2,
-          "chain_id": 42161,
-          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
-          "deposit_amount": "10",
-          "deposit_manager": {
-            "can_deposit": true,
-            "can_redeem": true,
-            "deposit_flow": "synchronous",
-            "redemption_flow": "synchronous"
-          },
-          "execution_mode": "guard_v0_simple_vault_v0",
-          "fork_block_number": null,
-          "last_attempt_at": "2026-07-13T16:59:38Z",
-          "message": null,
-          "name": "Crypto.com Defi Wallet Compound USDC",
-          "outcome": "success",
-          "protocol": "Kiln Metavault",
-          "share_balance_raw": "9296118"
-        },
         {
           "address": "0x1c107c4233ab3056254e717c7a67f9917079b615",
           "attempt_count": 3,
@@ -2335,14 +2836,72 @@
           "outcome": "success",
           "protocol": "Kiln Metavault",
           "share_balance_raw": "9296083"
+        },
+        {
+          "address": "0x1c107c4233ab3056254e717c7a67f9917079b615",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:29:50Z",
+          "message": null,
+          "name": "Crypto.com Defi Wallet Compound USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9296082"
+        },
+        {
+          "address": "0x1c107c4233ab3056254e717c7a67f9917079b615",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:29:50Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Crypto.com Defi Wallet Compound USDC",
+          "outcome": "invalid_evidence",
+          "protocol": "Kiln Metavault"
+        },
+        {
+          "address": "0x1c107c4233ab3056254e717c7a67f9917079b615",
+          "attempt_count": 11,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483529007,
+          "last_attempt_at": "2026-07-13T20:09:24Z",
+          "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+          "message": "Synchronous redemption validation failed: Failed to poke vault: 0x1C107c4233Ab3056254e717c7a67F9917079b615",
+          "minted_share_amount_raw": "9296043",
+          "name": "Crypto.com Defi Wallet Compound USDC",
+          "outcome": "guard_validation_error",
+          "protocol": "Kiln Metavault"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:29:50Z",
+      "last_attempt_at": "2026-07-13T20:14:40Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
       "message": null,
+      "minted_share_amount_raw": "9296040",
       "name": "Crypto.com Defi Wallet Compound USDC",
       "outcome": "success",
       "protocol": "Kiln Metavault",
-      "share_balance_raw": "9296082"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed"
     },
     "42161-0x1c17a39b156189bf40905425170a3ff62fb650da": {
       "address": "0x1c17a39b156189bf40905425170a3ff62fb650da",
@@ -2637,7 +3196,7 @@
     },
     "42161-0x20d419a8e12c45f88fda7c5760bb6923cee27f98": {
       "address": "0x20d419a8e12c45f88fda7c5760bb6923cee27f98",
-      "attempt_count": 7,
+      "attempt_count": 8,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -2649,7 +3208,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483529007,
       "history": [
         {
           "address": "0x20d419a8e12c45f88fda7c5760bb6923cee27f98",
@@ -2767,18 +3326,52 @@
           "outcome": "success",
           "protocol": "Ostium",
           "status_detail": "deposit_request_submitted"
+        },
+        {
+          "address": "0x20d419a8e12c45f88fda7c5760bb6923cee27f98",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "asynchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:35:34Z",
+          "message": null,
+          "name": "Ostium Liquidity Pool Vault",
+          "outcome": "success",
+          "protocol": "Ostium",
+          "status_detail": "deposit_request_submitted"
+        },
+        {
+          "address": "0x20d419a8e12c45f88fda7c5760bb6923cee27f98",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:35:34Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Ostium Liquidity Pool Vault",
+          "outcome": "invalid_evidence",
+          "protocol": "Ostium"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:35:34Z",
+      "last_attempt_at": "2026-07-13T20:09:39Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
       "message": null,
       "name": "Ostium Liquidity Pool Vault",
       "outcome": "success",
       "protocol": "Ostium",
+      "redemption_status_detail": "not_exercised_asynchronous",
       "status_detail": "deposit_request_submitted"
     },
     "42161-0x22be8d6596595b6e29e3a8a71c551d9a6388c236": {
       "address": "0x22be8d6596595b6e29e3a8a71c551d9a6388c236",
-      "attempt_count": 2,
+      "attempt_count": 7,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -2790,7 +3383,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532336,
       "history": [
         {
           "address": "0x22be8d6596595b6e29e3a8a71c551d9a6388c236",
@@ -2813,14 +3406,144 @@
           "outcome": "success",
           "protocol": "<unknown ERC-7540>",
           "share_balance_raw": "10000000"
+        },
+        {
+          "address": "0x22be8d6596595b6e29e3a8a71c551d9a6388c236",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:18:26Z",
+          "message": null,
+          "name": "Keyrock Vault",
+          "outcome": "success",
+          "protocol": "<unknown ERC-7540>",
+          "share_balance_raw": "10000000"
+        },
+        {
+          "address": "0x22be8d6596595b6e29e3a8a71c551d9a6388c236",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:18:26Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Keyrock Vault",
+          "outcome": "invalid_evidence",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x22be8d6596595b6e29e3a8a71c551d9a6388c236",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483529007,
+          "last_attempt_at": "2026-07-13T20:09:51Z",
+          "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+          "message": "Synchronous redemption failed: execution reverted",
+          "minted_share_amount_raw": "10000000",
+          "name": "Keyrock Vault",
+          "outcome": "reverted",
+          "protocol": "<unknown ERC-7540>",
+          "revert_reason": "execution reverted"
+        },
+        {
+          "address": "0x22be8d6596595b6e29e3a8a71c551d9a6388c236",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483530654,
+          "last_attempt_at": "2026-07-13T20:14:42Z",
+          "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+          "message": "Synchronous redemption failed: execution reverted",
+          "minted_share_amount_raw": "10000000",
+          "name": "Keyrock Vault",
+          "outcome": "reverted",
+          "protocol": "<unknown ERC-7540>",
+          "revert_reason": "execution reverted"
+        },
+        {
+          "address": "0x22be8d6596595b6e29e3a8a71c551d9a6388c236",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483531594,
+          "last_attempt_at": "2026-07-13T20:18:07Z",
+          "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+          "message": "Synchronous redemption failed: execution reverted",
+          "minted_share_amount_raw": "10000000",
+          "name": "Keyrock Vault",
+          "outcome": "reverted",
+          "protocol": "<unknown ERC-7540>",
+          "revert_reason": "execution reverted"
+        },
+        {
+          "address": "0x22be8d6596595b6e29e3a8a71c551d9a6388c236",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483531871,
+          "last_attempt_at": "2026-07-13T20:19:29Z",
+          "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+          "message": "Synchronous redemption failed: execution reverted",
+          "minted_share_amount_raw": "10000000",
+          "name": "Keyrock Vault",
+          "outcome": "reverted",
+          "protocol": "<unknown ERC-7540>",
+          "revert_reason": "execution reverted"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:18:26Z",
-      "message": null,
+      "last_attempt_at": "2026-07-13T20:21:23Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Synchronous redemption failed: execution reverted",
+      "minted_share_amount_raw": "10000000",
       "name": "Keyrock Vault",
-      "outcome": "success",
+      "outcome": "reverted",
       "protocol": "<unknown ERC-7540>",
-      "share_balance_raw": "10000000"
+      "revert_reason": "execution reverted"
     },
     "42161-0x234f6bd082eb325e5b7feb2c627d708f99d4b338": {
       "address": "0x234f6bd082eb325e5b7feb2c627d708f99d4b338",
@@ -2858,7 +3581,7 @@
     },
     "42161-0x2433d6ac11193b4695d9ca73530de93c538ad18a": {
       "address": "0x2433d6ac11193b4695d9ca73530de93c538ad18a",
-      "attempt_count": 8,
+      "attempt_count": 13,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -2870,41 +3593,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532336,
       "history": [
-        {
-          "address": "0x2433d6ac11193b4695d9ca73530de93c538ad18a",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "deposit_manager": null,
-          "last_attempt_at": "2026-07-13T16:54:19Z",
-          "message": "Live adapter does not advertise deposits",
-          "name": "Borrowable USDC Deposit, SiloId: 127",
-          "outcome": "adapter_error",
-          "protocol": "Silo Finance"
-        },
-        {
-          "address": "0x2433d6ac11193b4695d9ca73530de93c538ad18a",
-          "attempt_count": 2,
-          "chain_id": 42161,
-          "deposit_manager": null,
-          "last_attempt_at": "2026-07-13T17:01:01Z",
-          "message": "Live adapter does not advertise deposits",
-          "name": "Borrowable USDC Deposit, SiloId: 127",
-          "outcome": "adapter_error",
-          "protocol": "Silo Finance"
-        },
-        {
-          "address": "0x2433d6ac11193b4695d9ca73530de93c538ad18a",
-          "attempt_count": 3,
-          "chain_id": 42161,
-          "deposit_manager": null,
-          "last_attempt_at": "2026-07-13T17:03:55Z",
-          "message": "Live adapter does not advertise deposits",
-          "name": "Borrowable USDC Deposit, SiloId: 127",
-          "outcome": "adapter_error",
-          "protocol": "Silo Finance"
-        },
         {
           "address": "0x2433d6ac11193b4695d9ca73530de93c538ad18a",
           "attempt_count": 4,
@@ -2970,18 +3660,147 @@
           "outcome": "success",
           "protocol": "Silo Finance",
           "share_balance_raw": "111107595"
+        },
+        {
+          "address": "0x2433d6ac11193b4695d9ca73530de93c538ad18a",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:39:43Z",
+          "message": null,
+          "name": "Borrowable USDC Deposit, SiloId: 127",
+          "outcome": "success",
+          "protocol": "Silo Finance",
+          "share_balance_raw": "111080778"
+        },
+        {
+          "address": "0x2433d6ac11193b4695d9ca73530de93c538ad18a",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:39:43Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Borrowable USDC Deposit, SiloId: 127",
+          "outcome": "invalid_evidence",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0x2433d6ac11193b4695d9ca73530de93c538ad18a",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483529007,
+          "last_attempt_at": "2026-07-13T20:10:03Z",
+          "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+          "message": "Synchronous redemption validation failed: Failed to poke vault: 0x2433D6AC11193b4695D9ca73530de93c538aD18a",
+          "minted_share_amount_raw": "110916240",
+          "name": "Borrowable USDC Deposit, SiloId: 127",
+          "outcome": "guard_validation_error",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0x2433d6ac11193b4695d9ca73530de93c538ad18a",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483530654,
+          "last_attempt_at": "2026-07-13T20:14:46Z",
+          "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+          "message": "Synchronous redemption failed: 0x4323a555",
+          "minted_share_amount_raw": "110903502",
+          "name": "Borrowable USDC Deposit, SiloId: 127",
+          "outcome": "reverted",
+          "protocol": "Silo Finance",
+          "revert_reason": "0x4323a555"
+        },
+        {
+          "address": "0x2433d6ac11193b4695d9ca73530de93c538ad18a",
+          "attempt_count": 11,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483531609,
+          "last_attempt_at": "2026-07-13T20:18:14Z",
+          "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+          "message": "Synchronous redemption failed: 0x4323a555",
+          "minted_share_amount_raw": "110896028",
+          "name": "Borrowable USDC Deposit, SiloId: 127",
+          "outcome": "reverted",
+          "protocol": "Silo Finance",
+          "revert_reason": "0x4323a555"
+        },
+        {
+          "address": "0x2433d6ac11193b4695d9ca73530de93c538ad18a",
+          "attempt_count": 12,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483531938,
+          "last_attempt_at": "2026-07-13T20:19:48Z",
+          "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+          "message": "Synchronous redemption failed: 0x4323a555",
+          "minted_share_amount_raw": "110893381",
+          "name": "Borrowable USDC Deposit, SiloId: 127",
+          "outcome": "reverted",
+          "protocol": "Silo Finance",
+          "revert_reason": "0x4323a555"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:39:43Z",
-      "message": null,
+      "last_attempt_at": "2026-07-13T20:21:27Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Synchronous redemption failed: 0x4323a555",
+      "minted_share_amount_raw": "110890236",
       "name": "Borrowable USDC Deposit, SiloId: 127",
-      "outcome": "success",
+      "outcome": "reverted",
       "protocol": "Silo Finance",
-      "share_balance_raw": "111080778"
+      "revert_reason": "0x4323a555"
     },
     "42161-0x24bb6c093e15658ace2c34bee9ac16f0a6ed2b01": {
       "address": "0x24bb6c093e15658ace2c34bee9ac16f0a6ed2b01",
-      "attempt_count": 2,
+      "attempt_count": 3,
       "chain_id": 42161,
       "denomination_token_address": "0x46850aD61C2B7d64d08c9C754F45254596696984",
       "deposit_amount": "10",
@@ -2993,7 +3812,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483530654,
       "history": [
         {
           "address": "0x24bb6c093e15658ace2c34bee9ac16f0a6ed2b01",
@@ -3016,18 +3835,53 @@
           "outcome": "success",
           "protocol": "Fluid",
           "share_balance_raw": "9926276"
+        },
+        {
+          "address": "0x24bb6c093e15658ace2c34bee9ac16f0a6ed2b01",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0x46850aD61C2B7d64d08c9C754F45254596696984",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:23:04Z",
+          "message": null,
+          "name": "Fluid PayPal USD",
+          "outcome": "success",
+          "protocol": "Fluid",
+          "share_balance_raw": "9926275"
+        },
+        {
+          "address": "0x24bb6c093e15658ace2c34bee9ac16f0a6ed2b01",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:23:04Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Fluid PayPal USD",
+          "outcome": "invalid_evidence",
+          "protocol": "Fluid"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:23:04Z",
+      "last_attempt_at": "2026-07-13T20:14:47Z",
+      "max_deposit_guidance": "170141183460469231731687303715698122418",
       "message": null,
+      "minted_share_amount_raw": "9926228",
       "name": "Fluid PayPal USD",
       "outcome": "success",
       "protocol": "Fluid",
-      "share_balance_raw": "9926275"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed"
     },
     "42161-0x250cf7c82bac7cb6cf899b6052979d4b5ba1f9ca": {
       "address": "0x250cf7c82bac7cb6cf899b6052979d4b5ba1f9ca",
-      "attempt_count": 1,
+      "attempt_count": 3,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -3039,14 +3893,74 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
-      "history": [],
-      "last_attempt_at": "2026-07-13T18:34:39Z",
+      "fork_block_number": 483531638,
+      "history": [
+        {
+          "address": "0x250cf7c82bac7cb6cf899b6052979d4b5ba1f9ca",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:34:39Z",
+          "message": null,
+          "name": "Steakhouse Prime USDC",
+          "outcome": "success",
+          "protocol": "Morpho",
+          "share_balance_raw": "9661478834979530200"
+        },
+        {
+          "address": "0x250cf7c82bac7cb6cf899b6052979d4b5ba1f9ca",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:34:39Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Steakhouse Prime USDC",
+          "outcome": "invalid_evidence",
+          "protocol": "Morpho"
+        },
+        {
+          "address": "0x250cf7c82bac7cb6cf899b6052979d4b5ba1f9ca",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483530654,
+          "last_attempt_at": "2026-07-13T20:14:50Z",
+          "max_deposit_guidance": "999999938700885399",
+          "message": "Synchronous redemption left 966147883498 shares in SimpleVaultV0",
+          "minted_share_amount_raw": "9661478834979530200",
+          "name": "Steakhouse Prime USDC",
+          "outcome": "adapter_error",
+          "protocol": "Morpho"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T20:18:20Z",
+      "max_deposit_guidance": "999999938700885399",
       "message": null,
+      "minted_share_amount_raw": "9661478834979530200",
       "name": "Steakhouse Prime USDC",
       "outcome": "success",
       "protocol": "Morpho",
-      "share_balance_raw": "9661478834979530200"
+      "redeemed_asset_amount_raw": "9999998",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "966147883498"
     },
     "42161-0x253eb67fcdfe60d1751acccd6d5a1a1b62bafc89": {
       "address": "0x253eb67fcdfe60d1751acccd6d5a1a1b62bafc89",
@@ -3333,7 +4247,7 @@
     },
     "42161-0x2ba39e5388ac6c702cb29aea78d52aa66832f1ee": {
       "address": "0x2ba39e5388ac6c702cb29aea78d52aa66832f1ee",
-      "attempt_count": 9,
+      "attempt_count": 12,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -3345,30 +4259,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532386,
       "history": [
-        {
-          "address": "0x2ba39e5388ac6c702cb29aea78d52aa66832f1ee",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "deposit_manager": null,
-          "last_attempt_at": "2026-07-13T16:53:57Z",
-          "message": "Live adapter does not advertise deposits",
-          "name": "Varlamore USDC Growth",
-          "outcome": "adapter_error",
-          "protocol": "Euler"
-        },
-        {
-          "address": "0x2ba39e5388ac6c702cb29aea78d52aa66832f1ee",
-          "attempt_count": 2,
-          "chain_id": 42161,
-          "deposit_manager": null,
-          "last_attempt_at": "2026-07-13T16:58:44Z",
-          "message": "Live adapter does not advertise deposits",
-          "name": "Varlamore USDC Growth",
-          "outcome": "adapter_error",
-          "protocol": "Euler"
-        },
         {
           "address": "0x2ba39e5388ac6c702cb29aea78d52aa66832f1ee",
           "attempt_count": 3,
@@ -3467,18 +4359,100 @@
           "outcome": "success",
           "protocol": "Euler",
           "share_balance_raw": "23010106749233505322635"
+        },
+        {
+          "address": "0x2ba39e5388ac6c702cb29aea78d52aa66832f1ee",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:22:13Z",
+          "message": null,
+          "name": "Varlamore USDC Growth",
+          "outcome": "success",
+          "protocol": "Euler",
+          "share_balance_raw": "23008573517999662706774"
+        },
+        {
+          "address": "0x2ba39e5388ac6c702cb29aea78d52aa66832f1ee",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:22:13Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Varlamore USDC Growth",
+          "outcome": "invalid_evidence",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0x2ba39e5388ac6c702cb29aea78d52aa66832f1ee",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483531664,
+          "last_attempt_at": "2026-07-13T20:18:29Z",
+          "max_deposit_guidance": "24519928653854221733733552434404946937899869954937634749",
+          "message": "Synchronous redemption failed: execution reverted",
+          "minted_share_amount_raw": "22914870101609509697115",
+          "name": "Varlamore USDC Growth",
+          "outcome": "reverted",
+          "protocol": "Euler",
+          "revert_reason": "execution reverted"
+        },
+        {
+          "address": "0x2ba39e5388ac6c702cb29aea78d52aa66832f1ee",
+          "attempt_count": 11,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483532010,
+          "last_attempt_at": "2026-07-13T20:20:16Z",
+          "max_deposit_guidance": "24519928653854221733733552434404946937899869954937634749",
+          "message": "Synchronous redemption failed: execution reverted",
+          "minted_share_amount_raw": "22913623205338414681582",
+          "name": "Varlamore USDC Growth",
+          "outcome": "reverted",
+          "protocol": "Euler",
+          "revert_reason": "execution reverted"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:22:13Z",
-      "message": null,
+      "last_attempt_at": "2026-07-13T20:21:48Z",
+      "max_deposit_guidance": "24519928653854221733733552434404946937899869954937634749",
+      "message": "Synchronous redemption failed: execution reverted",
+      "minted_share_amount_raw": "22912376360218904915251",
       "name": "Varlamore USDC Growth",
-      "outcome": "success",
+      "outcome": "reverted",
       "protocol": "Euler",
-      "share_balance_raw": "23008573517999662706774"
+      "revert_reason": "execution reverted"
     },
     "42161-0x2bdf0ed5dae7c37b314ec1f7dcf401bb52ea967a": {
       "address": "0x2bdf0ed5dae7c37b314ec1f7dcf401bb52ea967a",
-      "attempt_count": 7,
+      "attempt_count": 9,
       "chain_id": 42161,
       "deposit_manager": {
         "can_deposit": true,
@@ -3486,6 +4460,7 @@
         "deposit_flow": "synchronous",
         "redemption_flow": "synchronous"
       },
+      "fork_block_number": 483527056,
       "history": [
         {
           "address": "0x2bdf0ed5dae7c37b314ec1f7dcf401bb52ea967a",
@@ -3554,9 +4529,44 @@
           "name": "Venzo USDT Pro Lending",
           "outcome": "skipped",
           "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x2bdf0ed5dae7c37b314ec1f7dcf401bb52ea967a",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:47:14Z",
+          "max_deposit_guidance": "0",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Venzo USDT Pro Lending",
+          "outcome": "funding_error",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x2bdf0ed5dae7c37b314ec1f7dcf401bb52ea967a",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "fork_block_number": 483526318,
+          "last_attempt_at": "2026-07-13T19:57:14Z",
+          "max_deposit_guidance": "0",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Venzo USDT Pro Lending",
+          "outcome": "funding_error",
+          "protocol": "<unknown ERC-7540>"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:47:14Z",
+      "last_attempt_at": "2026-07-13T20:00:22Z",
       "max_deposit_guidance": "0",
       "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
       "name": "Venzo USDT Pro Lending",
@@ -3659,7 +4669,7 @@
     },
     "42161-0x2c609d9cfc9dda2db5c128b2a665d921ec53579d": {
       "address": "0x2c609d9cfc9dda2db5c128b2a665d921ec53579d",
-      "attempt_count": 1,
+      "attempt_count": 2,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -3671,14 +4681,51 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
-      "history": [],
-      "last_attempt_at": "2026-07-13T18:34:21Z",
+      "fork_block_number": 483531700,
+      "history": [
+        {
+          "address": "0x2c609d9cfc9dda2db5c128b2a665d921ec53579d",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:34:21Z",
+          "message": null,
+          "name": "kpk USDC Yield",
+          "outcome": "success",
+          "protocol": "Morpho",
+          "share_balance_raw": "9655366740747888144"
+        },
+        {
+          "address": "0x2c609d9cfc9dda2db5c128b2a665d921ec53579d",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:34:21Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "kpk USDC Yield",
+          "outcome": "invalid_evidence",
+          "protocol": "Morpho"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T20:18:39Z",
+      "max_deposit_guidance": "999997999992701",
       "message": null,
+      "minted_share_amount_raw": "9655290149356226006",
       "name": "kpk USDC Yield",
       "outcome": "success",
       "protocol": "Morpho",
-      "share_balance_raw": "9655366740747888144"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "965529014935"
     },
     "42161-0x2d55c68e6b9b6b3f70be2e51f289751e627f50ad": {
       "address": "0x2d55c68e6b9b6b3f70be2e51f289751e627f50ad",
@@ -3755,7 +4802,7 @@
     },
     "42161-0x2e7aa06a0f0816de4b1a32a12b0ac4eb584bff2a": {
       "address": "0x2e7aa06a0f0816de4b1a32a12b0ac4eb584bff2a",
-      "attempt_count": 7,
+      "attempt_count": 8,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -3765,9 +4812,9 @@
         "deposit_flow": "synchronous",
         "redemption_flow": "synchronous"
       },
-      "deposit_manager_source": "generic_erc4626",
+      "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483531738,
       "history": [
         {
           "address": "0x2e7aa06a0f0816de4b1a32a12b0ac4eb584bff2a",
@@ -3839,15 +4886,51 @@
           "name": "RizVaultUSDC",
           "outcome": "skipped",
           "protocol": "Yearn"
+        },
+        {
+          "address": "0x2e7aa06a0f0816de4b1a32a12b0ac4eb584bff2a",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:49:53Z",
+          "max_deposit_guidance": "0",
+          "message": null,
+          "name": "RizVaultUSDC",
+          "outcome": "success",
+          "protocol": "Yearn",
+          "share_balance_raw": "6524810"
+        },
+        {
+          "address": "0x2e7aa06a0f0816de4b1a32a12b0ac4eb584bff2a",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:49:53Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "RizVaultUSDC",
+          "outcome": "invalid_evidence",
+          "protocol": "Yearn"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:49:53Z",
+      "last_attempt_at": "2026-07-13T20:18:46Z",
       "max_deposit_guidance": "0",
       "message": null,
+      "minted_share_amount_raw": "6524810",
       "name": "RizVaultUSDC",
       "outcome": "success",
       "protocol": "Yearn",
-      "share_balance_raw": "6524810"
+      "redeemed_asset_amount_raw": "9999997",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "1"
     },
     "42161-0x2ec0160246461f0ce477887dde2c931ee8233de7": {
       "address": "0x2ec0160246461f0ce477887dde2c931ee8233de7",
@@ -3907,7 +4990,7 @@
     },
     "42161-0x2fc47f784f9a4bf754edce4ce29a32b47d7b545e": {
       "address": "0x2fc47f784f9a4bf754edce4ce29a32b47d7b545e",
-      "attempt_count": 9,
+      "attempt_count": 11,
       "chain_id": 42161,
       "deposit_manager": {
         "can_deposit": true,
@@ -3915,6 +4998,7 @@
         "deposit_flow": "synchronous",
         "redemption_flow": "synchronous"
       },
+      "fork_block_number": 483527056,
       "history": [
         {
           "address": "0x2fc47f784f9a4bf754edce4ce29a32b47d7b545e",
@@ -4000,9 +5084,44 @@
           "name": "Delta Netural Water Vault",
           "outcome": "adapter_error",
           "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0x2fc47f784f9a4bf754edce4ce29a32b47d7b545e",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:46:26Z",
+          "max_deposit_guidance": "0",
+          "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "name": "Delta Netural Water Vault",
+          "outcome": "funding_error",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0x2fc47f784f9a4bf754edce4ce29a32b47d7b545e",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "fork_block_number": 483526318,
+          "last_attempt_at": "2026-07-13T19:56:18Z",
+          "max_deposit_guidance": "0",
+          "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "name": "Delta Netural Water Vault",
+          "outcome": "funding_error",
+          "protocol": "<protocol not yet identified>"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:46:26Z",
+      "last_attempt_at": "2026-07-13T19:59:23Z",
       "max_deposit_guidance": "0",
       "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
       "name": "Delta Netural Water Vault",
@@ -4011,7 +5130,7 @@
     },
     "42161-0x3014ed70b39be395e1a5eb8ab4c4b8a5378e6522": {
       "address": "0x3014ed70b39be395e1a5eb8ab4c4b8a5378e6522",
-      "attempt_count": 2,
+      "attempt_count": 3,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -4023,7 +5142,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532126,
       "history": [
         {
           "address": "0x3014ed70b39be395e1a5eb8ab4c4b8a5378e6522",
@@ -4046,14 +5165,50 @@
           "outcome": "success",
           "protocol": "Morpho",
           "share_balance_raw": "117177291453160443"
+        },
+        {
+          "address": "0x3014ed70b39be395e1a5eb8ab4c4b8a5378e6522",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:32:53Z",
+          "message": null,
+          "name": "Not Gauntlet",
+          "outcome": "success",
+          "protocol": "Morpho",
+          "share_balance_raw": "117164890808315763"
+        },
+        {
+          "address": "0x3014ed70b39be395e1a5eb8ab4c4b8a5378e6522",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:32:53Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Not Gauntlet",
+          "outcome": "invalid_evidence",
+          "protocol": "Morpho"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:32:53Z",
+      "last_attempt_at": "2026-07-13T20:20:37Z",
+      "max_deposit_guidance": "4099999934780",
       "message": null,
+      "minted_share_amount_raw": "117058716404675979",
       "name": "Not Gauntlet",
       "outcome": "success",
       "protocol": "Morpho",
-      "share_balance_raw": "117164890808315763"
+      "redeemed_asset_amount_raw": "10000006",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "11705871640"
     },
     "42161-0x307139c61d3f884def18c8dc1676eb88e1ed7839": {
       "address": "0x307139c61d3f884def18c8dc1676eb88e1ed7839",
@@ -4308,7 +5463,7 @@
     },
     "42161-0x34a2b066af16409648ef15d239e656edb8790ca0": {
       "address": "0x34a2b066af16409648ef15d239e656edb8790ca0",
-      "attempt_count": 7,
+      "attempt_count": 8,
       "chain_id": 42161,
       "denomination_token_address": "0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34",
       "deposit_amount": "10",
@@ -4318,9 +5473,9 @@
         "deposit_flow": "synchronous",
         "redemption_flow": "synchronous"
       },
-      "deposit_manager_source": "generic_erc4626",
+      "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532212,
       "history": [
         {
           "address": "0x34a2b066af16409648ef15d239e656edb8790ca0",
@@ -4384,15 +5539,51 @@
           "name": "yPT-USDe (auto-rolling Pendle PT)",
           "outcome": "skipped",
           "protocol": "Yearn"
+        },
+        {
+          "address": "0x34a2b066af16409648ef15d239e656edb8790ca0",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:49:35Z",
+          "max_deposit_guidance": "0",
+          "message": null,
+          "name": "yPT-USDe (auto-rolling Pendle PT)",
+          "outcome": "success",
+          "protocol": "Yearn",
+          "share_balance_raw": "9828515825072468448"
+        },
+        {
+          "address": "0x34a2b066af16409648ef15d239e656edb8790ca0",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:49:35Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "yPT-USDe (auto-rolling Pendle PT)",
+          "outcome": "invalid_evidence",
+          "protocol": "Yearn"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:49:35Z",
+      "last_attempt_at": "2026-07-13T20:20:51Z",
       "max_deposit_guidance": "0",
       "message": null,
+      "minted_share_amount_raw": "9828515825072468448",
       "name": "yPT-USDe (auto-rolling Pendle PT)",
       "outcome": "success",
       "protocol": "Yearn",
-      "share_balance_raw": "9828515825072468448"
+      "redeemed_asset_amount_raw": "9999999999999999998",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "1"
     },
     "42161-0x34e2110f8c9a635477eff75fdbe73251fe02ae4a": {
       "address": "0x34e2110f8c9a635477eff75fdbe73251fe02ae4a",
@@ -4691,7 +5882,7 @@
     },
     "42161-0x37997418ef10f0db0b38a411877de1e17e0b2058": {
       "address": "0x37997418ef10f0db0b38a411877de1e17e0b2058",
-      "attempt_count": 1,
+      "attempt_count": 2,
       "chain_id": 42161,
       "denomination_token_address": "0x940098b108fB7D0a7E374f6eDED7760787464609",
       "deposit_amount": "10",
@@ -4703,14 +5894,51 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
-      "history": [],
-      "last_attempt_at": "2026-07-13T18:34:10Z",
+      "fork_block_number": 483532395,
+      "history": [
+        {
+          "address": "0x37997418ef10f0db0b38a411877de1e17e0b2058",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0x940098b108fB7D0a7E374f6eDED7760787464609",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:34:10Z",
+          "message": null,
+          "name": "MS-sUSDC",
+          "outcome": "success",
+          "protocol": "Morpho",
+          "share_balance_raw": "9999956466711590659"
+        },
+        {
+          "address": "0x37997418ef10f0db0b38a411877de1e17e0b2058",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:34:10Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "MS-sUSDC",
+          "outcome": "invalid_evidence",
+          "protocol": "Morpho"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T20:21:38Z",
+      "max_deposit_guidance": "1327173050315206208215",
       "message": null,
+      "minted_share_amount_raw": "9999956466678531778",
       "name": "MS-sUSDC",
       "outcome": "success",
       "protocol": "Morpho",
-      "share_balance_raw": "9999956466711590659"
+      "redeemed_asset_amount_raw": "10000000000000025328",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "1"
     },
     "42161-0x37c0705a65948ea5e0ae1add13552bcad7711a23": {
       "address": "0x37c0705a65948ea5e0ae1add13552bcad7711a23",
@@ -4732,7 +5960,7 @@
     },
     "42161-0x39e6acc140395862aaac5fda063bb2d11faef137": {
       "address": "0x39e6acc140395862aaac5fda063bb2d11faef137",
-      "attempt_count": 2,
+      "attempt_count": 3,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -4744,7 +5972,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532412,
       "history": [
         {
           "address": "0x39e6acc140395862aaac5fda063bb2d11faef137",
@@ -4767,14 +5995,48 @@
           "outcome": "success",
           "protocol": "<unknown ERC-7540>",
           "share_balance_raw": "9980872"
+        },
+        {
+          "address": "0x39e6acc140395862aaac5fda063bb2d11faef137",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:18:46Z",
+          "message": null,
+          "name": "Oracle Vault",
+          "outcome": "success",
+          "protocol": "<unknown ERC-7540>",
+          "share_balance_raw": "9980872"
+        },
+        {
+          "address": "0x39e6acc140395862aaac5fda063bb2d11faef137",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:18:46Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Oracle Vault",
+          "outcome": "invalid_evidence",
+          "protocol": "<unknown ERC-7540>"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:18:46Z",
-      "message": null,
+      "last_attempt_at": "2026-07-13T20:21:38Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913089563277",
+      "message": "Synchronous redemption failed: execution reverted",
+      "minted_share_amount_raw": "9980872",
       "name": "Oracle Vault",
-      "outcome": "success",
+      "outcome": "reverted",
       "protocol": "<unknown ERC-7540>",
-      "share_balance_raw": "9980872"
+      "revert_reason": "execution reverted"
     },
     "42161-0x3a7d08b8b8e22251efb112868a1640df2fdbcb83": {
       "address": "0x3a7d08b8b8e22251efb112868a1640df2fdbcb83",
@@ -4869,7 +6131,7 @@
     },
     "42161-0x3a87cf9af4d21778dad1ce7d0bf053f4b8f2631f": {
       "address": "0x3a87cf9af4d21778dad1ce7d0bf053f4b8f2631f",
-      "attempt_count": 7,
+      "attempt_count": 8,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -4881,7 +6143,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532494,
       "history": [
         {
           "address": "0x3a87cf9af4d21778dad1ce7d0bf053f4b8f2631f",
@@ -4999,18 +6261,54 @@
           "outcome": "success",
           "protocol": "Peapods",
           "share_balance_raw": "20683402"
+        },
+        {
+          "address": "0x3a87cf9af4d21778dad1ce7d0bf053f4b8f2631f",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:36:02Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 6",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "20683339"
+        },
+        {
+          "address": "0x3a87cf9af4d21778dad1ce7d0bf053f4b8f2631f",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:36:02Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Peapods Interest Bearing USDC - 6",
+          "outcome": "invalid_evidence",
+          "protocol": "Peapods"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:36:02Z",
+      "last_attempt_at": "2026-07-13T20:22:04Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007896300371983",
       "message": null,
+      "minted_share_amount_raw": "20682835",
       "name": "Peapods Interest Bearing USDC - 6",
       "outcome": "success",
       "protocol": "Peapods",
-      "share_balance_raw": "20683339"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0x3dc49d34704386d301c4e407b40b3ecf05225cd5": {
       "address": "0x3dc49d34704386d301c4e407b40b3ecf05225cd5",
-      "attempt_count": 9,
+      "attempt_count": 10,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -5022,7 +6320,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532455,
       "history": [
         {
           "address": "0x3dc49d34704386d301c4e407b40b3ecf05225cd5",
@@ -5133,14 +6431,48 @@
           "outcome": "success",
           "protocol": "Plutus",
           "share_balance_raw": "10000000"
+        },
+        {
+          "address": "0x3dc49d34704386d301c4e407b40b3ecf05225cd5",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:37:40Z",
+          "message": null,
+          "name": "SafeYields Emma AI",
+          "outcome": "success",
+          "protocol": "Plutus",
+          "share_balance_raw": "10000000"
+        },
+        {
+          "address": "0x3dc49d34704386d301c4e407b40b3ecf05225cd5",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:37:40Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "SafeYields Emma AI",
+          "outcome": "invalid_evidence",
+          "protocol": "Plutus"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:37:40Z",
-      "message": null,
+      "last_attempt_at": "2026-07-13T20:21:56Z",
+      "max_deposit_guidance": "997548900000",
+      "message": "Synchronous redemption failed: 0xb94abeec00000000000000000000000065ff0512dcad8fa6f7cdcaea5eba26b26d1db50e00000000000000000000000000000000000000000000000000000000009896800000000000000000000000000000000000000000000000000000000000000000",
+      "minted_share_amount_raw": "10000000",
       "name": "SafeYields Emma AI",
-      "outcome": "success",
+      "outcome": "reverted",
       "protocol": "Plutus",
-      "share_balance_raw": "10000000"
+      "revert_reason": "0xb94abeec00000000000000000000000065ff0512dcad8fa6f7cdcaea5eba26b26d1db50e00000000000000000000000000000000000000000000000000000000009896800000000000000000000000000000000000000000000000000000000000000000"
     },
     "42161-0x3e54d27975cdf0b28a10e04fb53184140757a344": {
       "address": "0x3e54d27975cdf0b28a10e04fb53184140757a344",
@@ -5479,7 +6811,7 @@
     },
     "42161-0x407d3d942d0911a2fea7e22417f81e27c02d6c6f": {
       "address": "0x407d3d942d0911a2fea7e22417f81e27c02d6c6f",
-      "attempt_count": 10,
+      "attempt_count": 11,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -5491,19 +6823,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532455,
       "history": [
-        {
-          "address": "0x407d3d942d0911a2fea7e22417f81e27c02d6c6f",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "deposit_manager": null,
-          "last_attempt_at": "2026-07-13T16:53:59Z",
-          "message": "Live adapter does not advertise deposits",
-          "name": "Autopilot USDC Arbitrum",
-          "outcome": "adapter_error",
-          "protocol": "IPOR Fusion"
-        },
         {
           "address": "0x407d3d942d0911a2fea7e22417f81e27c02d6c6f",
           "attempt_count": 2,
@@ -5624,14 +6945,48 @@
           "outcome": "success",
           "protocol": "IPOR Fusion",
           "share_balance_raw": "2306585863"
+        },
+        {
+          "address": "0x407d3d942d0911a2fea7e22417f81e27c02d6c6f",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:27:48Z",
+          "message": null,
+          "name": "Autopilot USDC Arbitrum",
+          "outcome": "success",
+          "protocol": "IPOR Fusion",
+          "share_balance_raw": "2306585885"
+        },
+        {
+          "address": "0x407d3d942d0911a2fea7e22417f81e27c02d6c6f",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:27:48Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Autopilot USDC Arbitrum",
+          "outcome": "invalid_evidence",
+          "protocol": "IPOR Fusion"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:27:48Z",
-      "message": null,
+      "last_attempt_at": "2026-07-13T20:22:00Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Synchronous redemption failed: 0x1425ea42",
+      "minted_share_amount_raw": "2306587389",
       "name": "Autopilot USDC Arbitrum",
-      "outcome": "success",
+      "outcome": "reverted",
       "protocol": "IPOR Fusion",
-      "share_balance_raw": "2306585885"
+      "revert_reason": "0x1425ea42"
     },
     "42161-0x426e8778bf7f54b0e4fc703dcca6f26a4e5b71de": {
       "address": "0x426e8778bf7f54b0e4fc703dcca6f26a4e5b71de",
@@ -5733,7 +7088,7 @@
     },
     "42161-0x444868b6e8079ac2c55eea115250f92c2b2c4d14": {
       "address": "0x444868b6e8079ac2c55eea115250f92c2b2c4d14",
-      "attempt_count": 8,
+      "attempt_count": 9,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -5745,7 +7100,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532556,
       "history": [
         {
           "address": "0x444868b6e8079ac2c55eea115250f92c2b2c4d14",
@@ -5845,14 +7200,50 @@
           "outcome": "success",
           "protocol": "Dolomite",
           "share_balance_raw": "7872586"
+        },
+        {
+          "address": "0x444868b6e8079ac2c55eea115250f92c2b2c4d14",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:18:41Z",
+          "message": null,
+          "name": "Dolomite: USDC",
+          "outcome": "success",
+          "protocol": "Dolomite",
+          "share_balance_raw": "7872581"
+        },
+        {
+          "address": "0x444868b6e8079ac2c55eea115250f92c2b2c4d14",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:18:41Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Dolomite: USDC",
+          "outcome": "invalid_evidence",
+          "protocol": "Dolomite"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:18:41Z",
+      "last_attempt_at": "2026-07-13T20:22:34Z",
+      "max_deposit_guidance": "495526147882149",
       "message": null,
+      "minted_share_amount_raw": "7872490",
       "name": "Dolomite: USDC",
       "outcome": "success",
       "protocol": "Dolomite",
-      "share_balance_raw": "7872581"
+      "redeemed_asset_amount_raw": "10000000",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0x45df0656f8adf017590009d2f1898eeca4f0a205": {
       "address": "0x45df0656f8adf017590009d2f1898eeca4f0a205",
@@ -6322,7 +7713,7 @@
     },
     "42161-0x4a3f7dd63077cde8d7eff3c958eb69a3dd7d31a9": {
       "address": "0x4a3f7dd63077cde8d7eff3c958eb69a3dd7d31a9",
-      "attempt_count": 7,
+      "attempt_count": 8,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -6334,7 +7725,7 @@
       },
       "deposit_manager_source": "generic_erc4626",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532530,
       "history": [
         {
           "address": "0x4a3f7dd63077cde8d7eff3c958eb69a3dd7d31a9",
@@ -6423,18 +7814,42 @@
           "outcome": "rpc_error",
           "protocol": "Untangle Finance",
           "share_balance_raw": "10411225"
+        },
+        {
+          "address": "0x4a3f7dd63077cde8d7eff3c958eb69a3dd7d31a9",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:48:32Z",
+          "message": "Got <class 'eth_defi.erc_4626.vault_protocol.untangle.vault.UntangleVault'>",
+          "name": "USDn2",
+          "outcome": "rpc_error",
+          "protocol": "Untangle Finance",
+          "share_balance_raw": "10411225"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:48:32Z",
-      "message": "Got <class 'eth_defi.erc_4626.vault_protocol.untangle.vault.UntangleVault'>",
+      "last_attempt_at": "2026-07-13T20:22:10Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Synchronous redemption failed: 0x91ffd347",
+      "minted_share_amount_raw": "10411225",
       "name": "USDn2",
-      "outcome": "rpc_error",
+      "outcome": "reverted",
       "protocol": "Untangle Finance",
-      "share_balance_raw": "10411225"
+      "revert_reason": "0x91ffd347"
     },
     "42161-0x4b6f1c9e5d470b97181786b26da0d0945a7cf027": {
       "address": "0x4b6f1c9e5d470b97181786b26da0d0945a7cf027",
-      "attempt_count": 2,
+      "attempt_count": 3,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -6446,7 +7861,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532546,
       "history": [
         {
           "address": "0x4b6f1c9e5d470b97181786b26da0d0945a7cf027",
@@ -6469,14 +7884,50 @@
           "outcome": "success",
           "protocol": "Morpho",
           "share_balance_raw": "9550058467732998568"
+        },
+        {
+          "address": "0x4b6f1c9e5d470b97181786b26da0d0945a7cf027",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:33:47Z",
+          "message": null,
+          "name": "Hyperithm USDC",
+          "outcome": "success",
+          "protocol": "Morpho",
+          "share_balance_raw": "9550050126193391147"
+        },
+        {
+          "address": "0x4b6f1c9e5d470b97181786b26da0d0945a7cf027",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:33:47Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Hyperithm USDC",
+          "outcome": "invalid_evidence",
+          "protocol": "Morpho"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:33:47Z",
+      "last_attempt_at": "2026-07-13T20:22:22Z",
+      "max_deposit_guidance": "999999999998567353",
       "message": null,
+      "minted_share_amount_raw": "9549977335044010282",
       "name": "Hyperithm USDC",
       "outcome": "success",
       "protocol": "Morpho",
-      "share_balance_raw": "9550050126193391147"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "954997733504"
     },
     "42161-0x4bca8d73561aaeee2d3a584b9f4665310de1dd69": {
       "address": "0x4bca8d73561aaeee2d3a584b9f4665310de1dd69",
@@ -6498,7 +7949,7 @@
     },
     "42161-0x4beef1113f968326905224d2ca272f3032a9a9f4": {
       "address": "0x4beef1113f968326905224d2ca272f3032a9a9f4",
-      "attempt_count": 10,
+      "attempt_count": 11,
       "chain_id": 42161,
       "denomination_token_address": "0x18c11FD286C5EC11c3b683Caa813B77f5163A122",
       "deposit_amount": "10",
@@ -6510,16 +7961,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532675,
       "history": [
-        {
-          "address": "0x4beef1113f968326905224d2ca272f3032a9a9f4",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "last_attempt_at": "2026-07-13T16:53:59Z",
-          "message": "No configured token holder",
-          "outcome": "skipped"
-        },
         {
           "address": "0x4beef1113f968326905224d2ca272f3032a9a9f4",
           "attempt_count": 2,
@@ -6655,14 +8098,47 @@
           "outcome": "success",
           "protocol": "Gains Network",
           "share_balance_raw": "9948289180984316402"
+        },
+        {
+          "address": "0x4beef1113f968326905224d2ca272f3032a9a9f4",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0x18c11FD286C5EC11c3b683Caa813B77f5163A122",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:24:02Z",
+          "message": null,
+          "name": "gTrade (Vault Staked GNS)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "9948289180984316402"
+        },
+        {
+          "address": "0x4beef1113f968326905224d2ca272f3032a9a9f4",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:24:02Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "gTrade (Vault Staked GNS)",
+          "outcome": "invalid_evidence",
+          "protocol": "Gains Network"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:24:02Z",
-      "message": null,
+      "last_attempt_at": "2026-07-13T20:22:49Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Synchronous redemption validation failed: Failed to poke vault: 0x4BeeF1113F968326905224D2Ca272f3032A9a9F4",
+      "minted_share_amount_raw": "9948289180984316402",
       "name": "gTrade (Vault Staked GNS)",
-      "outcome": "success",
-      "protocol": "Gains Network",
-      "share_balance_raw": "9948289180984316402"
+      "outcome": "guard_validation_error",
+      "protocol": "Gains Network"
     },
     "42161-0x4c4f752fa54dafb6d51b4a39018271c90ba1156f": {
       "address": "0x4c4f752fa54dafb6d51b4a39018271c90ba1156f",
@@ -6949,7 +8425,7 @@
     },
     "42161-0x546fa92a0a80058545e750fe2966a2f68a09e827": {
       "address": "0x546fa92a0a80058545e750fe2966a2f68a09e827",
-      "attempt_count": 1,
+      "attempt_count": 2,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -6961,14 +8437,51 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
-      "history": [],
-      "last_attempt_at": "2026-07-13T18:37:13Z",
+      "fork_block_number": 483532583,
+      "history": [
+        {
+          "address": "0x546fa92a0a80058545e750fe2966a2f68a09e827",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:37:13Z",
+          "message": null,
+          "name": "Peapods Metavault for USD Coin",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "9607574"
+        },
+        {
+          "address": "0x546fa92a0a80058545e750fe2966a2f68a09e827",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:37:13Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Peapods Metavault for USD Coin",
+          "outcome": "invalid_evidence",
+          "protocol": "Peapods"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T20:22:31Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
       "message": null,
+      "minted_share_amount_raw": "9607574",
       "name": "Peapods Metavault for USD Coin",
       "outcome": "success",
       "protocol": "Peapods",
-      "share_balance_raw": "9607574"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0x55bfca1b8a4ee0a96ca796d0bc542ec4e604a2e5": {
       "address": "0x55bfca1b8a4ee0a96ca796d0bc542ec4e604a2e5",
@@ -7099,7 +8612,7 @@
     },
     "42161-0x58bfc95a864e18e8f3041d2fcd3418f48393fe6a": {
       "address": "0x58bfc95a864e18e8f3041d2fcd3418f48393fe6a",
-      "attempt_count": 9,
+      "attempt_count": 10,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -7111,7 +8624,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532631,
       "history": [
         {
           "address": "0x58bfc95a864e18e8f3041d2fcd3418f48393fe6a",
@@ -7222,14 +8735,48 @@
           "outcome": "success",
           "protocol": "Plutus",
           "share_balance_raw": "7900731"
+        },
+        {
+          "address": "0x58bfc95a864e18e8f3041d2fcd3418f48393fe6a",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:37:29Z",
+          "message": null,
+          "name": "Plutus Hedge Token",
+          "outcome": "success",
+          "protocol": "Plutus",
+          "share_balance_raw": "7900731"
+        },
+        {
+          "address": "0x58bfc95a864e18e8f3041d2fcd3418f48393fe6a",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:37:29Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Plutus Hedge Token",
+          "outcome": "invalid_evidence",
+          "protocol": "Plutus"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:37:29Z",
-      "message": null,
+      "last_attempt_at": "2026-07-13T20:22:41Z",
+      "max_deposit_guidance": "805422331092",
+      "message": "Synchronous redemption failed: 0x797f246a",
+      "minted_share_amount_raw": "7900731",
       "name": "Plutus Hedge Token",
-      "outcome": "success",
+      "outcome": "reverted",
       "protocol": "Plutus",
-      "share_balance_raw": "7900731"
+      "revert_reason": "0x797f246a"
     },
     "42161-0x5977a9682d7af81d347cfc338c61692163a2784c": {
       "address": "0x5977a9682d7af81d347cfc338c61692163a2784c",
@@ -7267,7 +8814,7 @@
     },
     "42161-0x5c0c306aaa9f877de636f4d5822ca9f2e81563ba": {
       "address": "0x5c0c306aaa9f877de636f4d5822ca9f2e81563ba",
-      "attempt_count": 2,
+      "attempt_count": 3,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -7279,7 +8826,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532735,
       "history": [
         {
           "address": "0x5c0c306aaa9f877de636f4d5822ca9f2e81563ba",
@@ -7302,18 +8849,54 @@
           "outcome": "success",
           "protocol": "Morpho",
           "share_balance_raw": "9655587452696330527"
+        },
+        {
+          "address": "0x5c0c306aaa9f877de636f4d5822ca9f2e81563ba",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:33:18Z",
+          "message": null,
+          "name": "Steakhouse High Yield USDC",
+          "outcome": "success",
+          "protocol": "Morpho",
+          "share_balance_raw": "9655579759141349467"
+        },
+        {
+          "address": "0x5c0c306aaa9f877de636f4d5822ca9f2e81563ba",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:33:18Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Steakhouse High Yield USDC",
+          "outcome": "invalid_evidence",
+          "protocol": "Morpho"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:33:18Z",
+      "last_attempt_at": "2026-07-13T20:23:11Z",
+      "max_deposit_guidance": "1000408031764599389",
       "message": null,
+      "minted_share_amount_raw": "9655504488069405857",
       "name": "Steakhouse High Yield USDC",
       "outcome": "success",
       "protocol": "Morpho",
-      "share_balance_raw": "9655579759141349467"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "965550448807"
     },
     "42161-0x5eb03d0fcfd3860be03b81a1ab3d46db3315202a": {
       "address": "0x5eb03d0fcfd3860be03b81a1ab3d46db3315202a",
-      "attempt_count": 7,
+      "attempt_count": 8,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -7325,7 +8908,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532670,
       "history": [
         {
           "address": "0x5eb03d0fcfd3860be03b81a1ab3d46db3315202a",
@@ -7443,14 +9026,50 @@
           "outcome": "success",
           "protocol": "Peapods",
           "share_balance_raw": "524663"
+        },
+        {
+          "address": "0x5eb03d0fcfd3860be03b81a1ab3d46db3315202a",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:36:13Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 38",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "524555"
+        },
+        {
+          "address": "0x5eb03d0fcfd3860be03b81a1ab3d46db3315202a",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:36:13Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Peapods Interest Bearing USDC - 38",
+          "outcome": "invalid_evidence",
+          "protocol": "Peapods"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:36:13Z",
+      "last_attempt_at": "2026-07-13T20:22:48Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007901386941266",
       "message": null,
+      "minted_share_amount_raw": "523691",
       "name": "Peapods Interest Bearing USDC - 38",
       "outcome": "success",
       "protocol": "Peapods",
-      "share_balance_raw": "524555"
+      "redeemed_asset_amount_raw": "10000033",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0x5f02c1bec4ad5de9b7abf999c1f0854d4836a049": {
       "address": "0x5f02c1bec4ad5de9b7abf999c1f0854d4836a049",
@@ -7642,7 +9261,7 @@
     },
     "42161-0x5ff92b1991504a35d7eaa74998663f402187c9ae": {
       "address": "0x5ff92b1991504a35d7eaa74998663f402187c9ae",
-      "attempt_count": 9,
+      "attempt_count": 11,
       "chain_id": 42161,
       "deposit_manager": {
         "can_deposit": true,
@@ -7650,6 +9269,7 @@
         "deposit_flow": "synchronous",
         "redemption_flow": "synchronous"
       },
+      "fork_block_number": 483527056,
       "history": [
         {
           "address": "0x5ff92b1991504a35d7eaa74998663f402187c9ae",
@@ -7735,9 +9355,44 @@
           "name": "Delta Netural GMX Vault (Senior)",
           "outcome": "adapter_error",
           "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0x5ff92b1991504a35d7eaa74998663f402187c9ae",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:46:35Z",
+          "max_deposit_guidance": "0",
+          "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "funding_error",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0x5ff92b1991504a35d7eaa74998663f402187c9ae",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "fork_block_number": 483526318,
+          "last_attempt_at": "2026-07-13T19:56:31Z",
+          "max_deposit_guidance": "0",
+          "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "funding_error",
+          "protocol": "<protocol not yet identified>"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:46:35Z",
+      "last_attempt_at": "2026-07-13T19:59:35Z",
       "max_deposit_guidance": "0",
       "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
       "name": "Delta Netural GMX Vault (Senior)",
@@ -7763,7 +9418,7 @@
     },
     "42161-0x6263782720a1f77be88038fe371d7bac17fb4652": {
       "address": "0x6263782720a1f77be88038fe371d7bac17fb4652",
-      "attempt_count": 10,
+      "attempt_count": 12,
       "chain_id": 42161,
       "deposit_manager": {
         "can_deposit": true,
@@ -7771,15 +9426,8 @@
         "deposit_flow": "synchronous",
         "redemption_flow": "synchronous"
       },
+      "fork_block_number": 483527056,
       "history": [
-        {
-          "address": "0x6263782720a1f77be88038fe371d7bac17fb4652",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "last_attempt_at": "2026-07-13T16:53:54Z",
-          "message": "No configured token holder",
-          "outcome": "skipped"
-        },
         {
           "address": "0x6263782720a1f77be88038fe371d7bac17fb4652",
           "attempt_count": 2,
@@ -7887,9 +9535,44 @@
           "name": "Foo USD Commit Token",
           "outcome": "funding_error",
           "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x6263782720a1f77be88038fe371d7bac17fb4652",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:47:24Z",
+          "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+          "message": "Could not find balance slot for token 0x972d3Dc804ec7CABEAb6D394b9a9f4E6c313dda7",
+          "name": "Foo USD Commit Token",
+          "outcome": "funding_error",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x6263782720a1f77be88038fe371d7bac17fb4652",
+          "attempt_count": 11,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "fork_block_number": 483526318,
+          "last_attempt_at": "2026-07-13T19:57:26Z",
+          "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+          "message": "Could not find balance slot for token 0x972d3Dc804ec7CABEAb6D394b9a9f4E6c313dda7",
+          "name": "Foo USD Commit Token",
+          "outcome": "funding_error",
+          "protocol": "<unknown ERC-7540>"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:47:24Z",
+      "last_attempt_at": "2026-07-13T20:00:32Z",
       "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
       "message": "Could not find balance slot for token 0x972d3Dc804ec7CABEAb6D394b9a9f4E6c313dda7",
       "name": "Foo USD Commit Token",
@@ -7986,7 +9669,7 @@
     },
     "42161-0x6afb8d3f6d4a34e9cb2f217317f4dc8e05aa673b": {
       "address": "0x6afb8d3f6d4a34e9cb2f217317f4dc8e05aa673b",
-      "attempt_count": 9,
+      "attempt_count": 10,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -7998,7 +9681,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532709,
       "history": [
         {
           "address": "0x6afb8d3f6d4a34e9cb2f217317f4dc8e05aa673b",
@@ -8120,18 +9803,54 @@
           "outcome": "success",
           "protocol": "Euler",
           "share_balance_raw": "9581238"
+        },
+        {
+          "address": "0x6afb8d3f6d4a34e9cb2f217317f4dc8e05aa673b",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:22:42Z",
+          "message": null,
+          "name": "K3 Capital USDai Cluster",
+          "outcome": "success",
+          "protocol": "Euler",
+          "share_balance_raw": "9581237"
+        },
+        {
+          "address": "0x6afb8d3f6d4a34e9cb2f217317f4dc8e05aa673b",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:22:42Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "K3 Capital USDai Cluster",
+          "outcome": "invalid_evidence",
+          "protocol": "Euler"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:22:42Z",
+      "last_attempt_at": "2026-07-13T20:23:01Z",
+      "max_deposit_guidance": "149285254258054",
       "message": null,
+      "minted_share_amount_raw": "9581173",
       "name": "K3 Capital USDai Cluster",
       "outcome": "success",
       "protocol": "Euler",
-      "share_balance_raw": "9581237"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0x6ca200319a0d4127a7a473d6891b86f34e312f42": {
       "address": "0x6ca200319a0d4127a7a473d6891b86f34e312f42",
-      "attempt_count": 7,
+      "attempt_count": 8,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -8143,7 +9862,7 @@
       },
       "deposit_manager_source": "generic_erc4626",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532827,
       "history": [
         {
           "address": "0x6ca200319a0d4127a7a473d6891b86f34e312f42",
@@ -8232,14 +9951,38 @@
           "outcome": "rpc_error",
           "protocol": "NashPoint",
           "share_balance_raw": "9496013"
+        },
+        {
+          "address": "0x6ca200319a0d4127a7a473d6891b86f34e312f42",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:34:52Z",
+          "message": "Got <class 'eth_defi.erc_4626.vault_protocol.nashpoint.vault.NashpointNodeVault'>",
+          "name": "Nashpoint DeFi & RWA Fund",
+          "outcome": "rpc_error",
+          "protocol": "NashPoint",
+          "share_balance_raw": "9496013"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:34:52Z",
-      "message": "Got <class 'eth_defi.erc_4626.vault_protocol.nashpoint.vault.NashpointNodeVault'>",
+      "last_attempt_at": "2026-07-13T20:23:28Z",
+      "max_deposit_guidance": "10000000000000",
+      "message": "Synchronous redemption failed: 0xe11466d6",
+      "minted_share_amount_raw": "9493195",
       "name": "Nashpoint DeFi & RWA Fund",
-      "outcome": "rpc_error",
+      "outcome": "reverted",
       "protocol": "NashPoint",
-      "share_balance_raw": "9496013"
+      "revert_reason": "0xe11466d6"
     },
     "42161-0x6daca1e808c46e18f32e736e0aeb45c3824e073c": {
       "address": "0x6daca1e808c46e18f32e736e0aeb45c3824e073c",
@@ -8254,7 +9997,7 @@
     },
     "42161-0x6db146db8dcf2f96948c3982f0770871246ae810": {
       "address": "0x6db146db8dcf2f96948c3982f0770871246ae810",
-      "attempt_count": 9,
+      "attempt_count": 10,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -8266,7 +10009,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532732,
       "history": [
         {
           "address": "0x6db146db8dcf2f96948c3982f0770871246ae810",
@@ -8388,18 +10131,54 @@
           "outcome": "success",
           "protocol": "Fluid",
           "share_balance_raw": "9749471"
+        },
+        {
+          "address": "0x6db146db8dcf2f96948c3982f0770871246ae810",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:22:50Z",
+          "message": null,
+          "name": "Trust Wallet Fluid USDC",
+          "outcome": "success",
+          "protocol": "Fluid",
+          "share_balance_raw": "9749469"
+        },
+        {
+          "address": "0x6db146db8dcf2f96948c3982f0770871246ae810",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:22:50Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Trust Wallet Fluid USDC",
+          "outcome": "invalid_evidence",
+          "protocol": "Fluid"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:22:50Z",
+      "last_attempt_at": "2026-07-13T20:23:07Z",
+      "max_deposit_guidance": "170141183460469231731687255273644037072",
       "message": null,
+      "minted_share_amount_raw": "9749351",
       "name": "Trust Wallet Fluid USDC",
       "outcome": "success",
       "protocol": "Fluid",
-      "share_balance_raw": "9749469"
+      "redeemed_asset_amount_raw": "10000000",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0x6df0018b0449bb4468bfae8507e13021a7aa0583": {
       "address": "0x6df0018b0449bb4468bfae8507e13021a7aa0583",
-      "attempt_count": 9,
+      "attempt_count": 11,
       "chain_id": 42161,
       "deposit_manager": {
         "can_deposit": true,
@@ -8407,6 +10186,7 @@
         "deposit_flow": "synchronous",
         "redemption_flow": "synchronous"
       },
+      "fork_block_number": 483527056,
       "history": [
         {
           "address": "0x6df0018b0449bb4468bfae8507e13021a7aa0583",
@@ -8492,9 +10272,44 @@
           "name": "Delta Netural Water Vault",
           "outcome": "adapter_error",
           "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0x6df0018b0449bb4468bfae8507e13021a7aa0583",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:46:47Z",
+          "max_deposit_guidance": "0",
+          "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "name": "Delta Netural Water Vault",
+          "outcome": "funding_error",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0x6df0018b0449bb4468bfae8507e13021a7aa0583",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "fork_block_number": 483526318,
+          "last_attempt_at": "2026-07-13T19:56:44Z",
+          "max_deposit_guidance": "0",
+          "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "name": "Delta Netural Water Vault",
+          "outcome": "funding_error",
+          "protocol": "<protocol not yet identified>"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:46:47Z",
+      "last_attempt_at": "2026-07-13T19:59:49Z",
       "max_deposit_guidance": "0",
       "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
       "name": "Delta Netural Water Vault",
@@ -8893,7 +10708,7 @@
     },
     "42161-0x7378292384751b208bd8609ca8d45f027539fa5c": {
       "address": "0x7378292384751b208bd8609ca8d45f027539fa5c",
-      "attempt_count": 10,
+      "attempt_count": 12,
       "chain_id": 42161,
       "deposit_manager": {
         "can_deposit": true,
@@ -8901,15 +10716,8 @@
         "deposit_flow": "synchronous",
         "redemption_flow": "synchronous"
       },
+      "fork_block_number": 483527056,
       "history": [
-        {
-          "address": "0x7378292384751b208bd8609ca8d45f027539fa5c",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "last_attempt_at": "2026-07-13T16:53:54Z",
-          "message": "No configured token holder",
-          "outcome": "skipped"
-        },
         {
           "address": "0x7378292384751b208bd8609ca8d45f027539fa5c",
           "attempt_count": 2,
@@ -9017,9 +10825,44 @@
           "name": "Fractality LR USDT",
           "outcome": "funding_error",
           "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x7378292384751b208bd8609ca8d45f027539fa5c",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:47:23Z",
+          "max_deposit_guidance": "100000000000000",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Fractality LR USDT",
+          "outcome": "funding_error",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x7378292384751b208bd8609ca8d45f027539fa5c",
+          "attempt_count": 11,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "fork_block_number": 483526318,
+          "last_attempt_at": "2026-07-13T19:57:22Z",
+          "max_deposit_guidance": "100000000000000",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Fractality LR USDT",
+          "outcome": "funding_error",
+          "protocol": "<unknown ERC-7540>"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:47:23Z",
+      "last_attempt_at": "2026-07-13T20:00:30Z",
       "max_deposit_guidance": "100000000000000",
       "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
       "name": "Fractality LR USDT",
@@ -9101,7 +10944,7 @@
     },
     "42161-0x7788a3538c5fc7f9c7c8a74eac4c898fc8d87d92": {
       "address": "0x7788a3538c5fc7f9c7c8a74eac4c898fc8d87d92",
-      "attempt_count": 8,
+      "attempt_count": 9,
       "chain_id": 42161,
       "denomination_token_address": "0xf3527ef8dE265eAa3716FB312c12847bFBA66Cef",
       "deposit_amount": "10",
@@ -9113,7 +10956,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532789,
       "history": [
         {
           "address": "0x7788a3538c5fc7f9c7c8a74eac4c898fc8d87d92",
@@ -9205,15 +11048,49 @@
           "outcome": "success",
           "protocol": "USDX Money",
           "share_balance_raw": "8965988382028283477"
+        },
+        {
+          "address": "0x7788a3538c5fc7f9c7c8a74eac4c898fc8d87d92",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xf3527ef8dE265eAa3716FB312c12847bFBA66Cef",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:49:05Z",
+          "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+          "message": null,
+          "name": "Staked USDX",
+          "outcome": "success",
+          "protocol": "USDX Money",
+          "share_balance_raw": "8965988382028283477"
+        },
+        {
+          "address": "0x7788a3538c5fc7f9c7c8a74eac4c898fc8d87d92",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:49:05Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Staked USDX",
+          "outcome": "invalid_evidence",
+          "protocol": "USDX Money"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:49:05Z",
+      "last_attempt_at": "2026-07-13T20:23:16Z",
       "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-      "message": null,
+      "message": "Synchronous redemption failed: execution reverted: 15",
+      "minted_share_amount_raw": "8965988382028283477",
       "name": "Staked USDX",
-      "outcome": "success",
+      "outcome": "reverted",
       "protocol": "USDX Money",
-      "share_balance_raw": "8965988382028283477"
+      "revert_reason": "execution reverted: 15"
     },
     "42161-0x77fca326f749b60b2ab7caebd9ee9d0896643344": {
       "address": "0x77fca326f749b60b2ab7caebd9ee9d0896643344",
@@ -9287,7 +11164,7 @@
     },
     "42161-0x7c574174da4b2be3f705c6244b4bfa0815a8b3ed": {
       "address": "0x7c574174da4b2be3f705c6244b4bfa0815a8b3ed",
-      "attempt_count": 2,
+      "attempt_count": 3,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -9299,7 +11176,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532893,
       "history": [
         {
           "address": "0x7c574174da4b2be3f705c6244b4bfa0815a8b3ed",
@@ -9322,18 +11199,54 @@
           "outcome": "success",
           "protocol": "Morpho",
           "share_balance_raw": "9710214141400362722"
+        },
+        {
+          "address": "0x7c574174da4b2be3f705c6244b4bfa0815a8b3ed",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:33:36Z",
+          "message": null,
+          "name": "Gauntlet USDC Prime",
+          "outcome": "success",
+          "protocol": "Morpho",
+          "share_balance_raw": "9710206128272672391"
+        },
+        {
+          "address": "0x7c574174da4b2be3f705c6244b4bfa0815a8b3ed",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:33:36Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Gauntlet USDC Prime",
+          "outcome": "invalid_evidence",
+          "protocol": "Morpho"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:33:36Z",
+      "last_attempt_at": "2026-07-13T20:23:44Z",
+      "max_deposit_guidance": "1000000014908006966229",
       "message": null,
+      "minted_share_amount_raw": "9710132956403008737",
       "name": "Gauntlet USDC Prime",
       "outcome": "success",
       "protocol": "Morpho",
-      "share_balance_raw": "9710206128272672391"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "971013295641"
     },
     "42161-0x7cfadfd5645b50be87d546f42699d863648251ad": {
       "address": "0x7cfadfd5645b50be87d546f42699d863648251ad",
-      "attempt_count": 8,
+      "attempt_count": 9,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -9345,7 +11258,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532811,
       "history": [
         {
           "address": "0x7cfadfd5645b50be87d546f42699d863648251ad",
@@ -9445,19 +11358,55 @@
           "outcome": "success",
           "protocol": "Superform",
           "share_balance_raw": "8524069"
+        },
+        {
+          "address": "0x7cfadfd5645b50be87d546f42699d863648251ad",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:42:30Z",
+          "max_deposit_guidance": "84933499174727",
+          "message": null,
+          "name": "Static Aave Arbitrum USDCn",
+          "outcome": "success",
+          "protocol": "Superform",
+          "share_balance_raw": "8524062"
+        },
+        {
+          "address": "0x7cfadfd5645b50be87d546f42699d863648251ad",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:42:30Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Static Aave Arbitrum USDCn",
+          "outcome": "invalid_evidence",
+          "protocol": "Superform"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:42:30Z",
-      "max_deposit_guidance": "84933499174727",
+      "last_attempt_at": "2026-07-13T20:23:26Z",
+      "max_deposit_guidance": "84782838444636",
       "message": null,
+      "minted_share_amount_raw": "8524019",
       "name": "Static Aave Arbitrum USDCn",
       "outcome": "success",
       "protocol": "Superform",
-      "share_balance_raw": "8524062"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0x7e97fa6893871a2751b5fe961978dccb2c201e65": {
       "address": "0x7e97fa6893871a2751b5fe961978dccb2c201e65",
-      "attempt_count": 2,
+      "attempt_count": 3,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -9469,7 +11418,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532847,
       "history": [
         {
           "address": "0x7e97fa6893871a2751b5fe961978dccb2c201e65",
@@ -9492,14 +11441,50 @@
           "outcome": "success",
           "protocol": "Morpho",
           "share_balance_raw": "9625624140438479938"
+        },
+        {
+          "address": "0x7e97fa6893871a2751b5fe961978dccb2c201e65",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:33:05Z",
+          "message": null,
+          "name": "Gauntlet USDC Core",
+          "outcome": "success",
+          "protocol": "Morpho",
+          "share_balance_raw": "9625615876197508307"
+        },
+        {
+          "address": "0x7e97fa6893871a2751b5fe961978dccb2c201e65",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:33:05Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Gauntlet USDC Core",
+          "outcome": "invalid_evidence",
+          "protocol": "Morpho"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:33:05Z",
+      "last_attempt_at": "2026-07-13T20:23:33Z",
+      "max_deposit_guidance": "1000000014007438052963",
       "message": null,
+      "minted_share_amount_raw": "9625543427582565240",
       "name": "Gauntlet USDC Core",
       "outcome": "success",
       "protocol": "Morpho",
-      "share_balance_raw": "9625615876197508307"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "962554342758"
     },
     "42161-0x7ea040cae554f92fd6211540722295930028136d": {
       "address": "0x7ea040cae554f92fd6211540722295930028136d",
@@ -9564,7 +11549,7 @@
     },
     "42161-0x7fbfd8cda97c0221b39c581c34afd24c523a3990": {
       "address": "0x7fbfd8cda97c0221b39c581c34afd24c523a3990",
-      "attempt_count": 2,
+      "attempt_count": 3,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -9576,7 +11561,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532955,
       "history": [
         {
           "address": "0x7fbfd8cda97c0221b39c581c34afd24c523a3990",
@@ -9599,14 +11584,50 @@
           "outcome": "success",
           "protocol": "IPOR Fusion",
           "share_balance_raw": "967804564"
+        },
+        {
+          "address": "0x7fbfd8cda97c0221b39c581c34afd24c523a3990",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:28:35Z",
+          "message": null,
+          "name": "Harvest Fusion USDC",
+          "outcome": "success",
+          "protocol": "IPOR Fusion",
+          "share_balance_raw": "967804564"
+        },
+        {
+          "address": "0x7fbfd8cda97c0221b39c581c34afd24c523a3990",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:28:35Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Harvest Fusion USDC",
+          "outcome": "invalid_evidence",
+          "protocol": "IPOR Fusion"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:28:35Z",
+      "last_attempt_at": "2026-07-13T20:24:00Z",
+      "max_deposit_guidance": "1196420126328587459377971626154896759986907634936151266439421543416609894429",
       "message": null,
+      "minted_share_amount_raw": "967805159",
       "name": "Harvest Fusion USDC",
       "outcome": "success",
       "protocol": "IPOR Fusion",
-      "share_balance_raw": "967804564"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0x80761c6bc720756b467ef2ed25cdce1b2551847e": {
       "address": "0x80761c6bc720756b467ef2ed25cdce1b2551847e",
@@ -9764,7 +11785,7 @@
     },
     "42161-0x84ed0f5586ba014a1e7300cd8bf5eb905d9f1b26": {
       "address": "0x84ed0f5586ba014a1e7300cd8bf5eb905d9f1b26",
-      "attempt_count": 1,
+      "attempt_count": 2,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -9776,14 +11797,51 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
-      "history": [],
-      "last_attempt_at": "2026-07-13T18:40:45Z",
+      "fork_block_number": 483532890,
+      "history": [
+        {
+          "address": "0x84ed0f5586ba014a1e7300cd8bf5eb905d9f1b26",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:40:45Z",
+          "message": null,
+          "name": "Borrowable USDC Deposit, SiloId: 152",
+          "outcome": "success",
+          "protocol": "Silo Finance",
+          "share_balance_raw": "9732856123"
+        },
+        {
+          "address": "0x84ed0f5586ba014a1e7300cd8bf5eb905d9f1b26",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:40:45Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Borrowable USDC Deposit, SiloId: 152",
+          "outcome": "invalid_evidence",
+          "protocol": "Silo Finance"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T20:23:49Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
       "message": null,
+      "minted_share_amount_raw": "9732765224",
       "name": "Borrowable USDC Deposit, SiloId: 152",
       "outcome": "success",
       "protocol": "Silo Finance",
-      "share_balance_raw": "9732856123"
+      "redeemed_asset_amount_raw": "10000000",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0x857a6072754532ae77ada617a7d0900b63c1e2a1": {
       "address": "0x857a6072754532ae77ada617a7d0900b63c1e2a1",
@@ -9939,7 +11997,7 @@
     },
     "42161-0x86b1c293e56cbac04d9c15a1af2ef1d2050ff6cd": {
       "address": "0x86b1c293e56cbac04d9c15a1af2ef1d2050ff6cd",
-      "attempt_count": 1,
+      "attempt_count": 2,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -9951,14 +12009,51 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
-      "history": [],
-      "last_attempt_at": "2026-07-13T18:40:33Z",
+      "fork_block_number": 483532934,
+      "history": [
+        {
+          "address": "0x86b1c293e56cbac04d9c15a1af2ef1d2050ff6cd",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:40:33Z",
+          "message": null,
+          "name": "Borrowable USDC Deposit, SiloId: 115",
+          "outcome": "success",
+          "protocol": "Silo Finance",
+          "share_balance_raw": "9206925447"
+        },
+        {
+          "address": "0x86b1c293e56cbac04d9c15a1af2ef1d2050ff6cd",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:40:33Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Borrowable USDC Deposit, SiloId: 115",
+          "outcome": "invalid_evidence",
+          "protocol": "Silo Finance"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T20:24:03Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
       "message": null,
+      "minted_share_amount_raw": "9206839858",
       "name": "Borrowable USDC Deposit, SiloId: 115",
       "outcome": "success",
       "protocol": "Silo Finance",
-      "share_balance_raw": "9206925447"
+      "redeemed_asset_amount_raw": "10000000",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0x88a1999f0e9cacf7e8152b4a5f797c9f0a9c3064": {
       "address": "0x88a1999f0e9cacf7e8152b4a5f797c9f0a9c3064",
@@ -10038,7 +12133,7 @@
     },
     "42161-0x890a69ef363c9c7bdd5e36eb95ceb569f63acbf6": {
       "address": "0x890a69ef363c9c7bdd5e36eb95ceb569f63acbf6",
-      "attempt_count": 10,
+      "attempt_count": 11,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -10050,19 +12145,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533025,
       "history": [
-        {
-          "address": "0x890a69ef363c9c7bdd5e36eb95ceb569f63acbf6",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "deposit_manager": null,
-          "last_attempt_at": "2026-07-13T16:53:59Z",
-          "message": "Live adapter does not advertise deposits",
-          "name": "Main USDC v3",
-          "outcome": "adapter_error",
-          "protocol": "Gearbox"
-        },
         {
           "address": "0x890a69ef363c9c7bdd5e36eb95ceb569f63acbf6",
           "attempt_count": 2,
@@ -10183,14 +12267,50 @@
           "outcome": "success",
           "protocol": "Gearbox",
           "share_balance_raw": "9359761"
+        },
+        {
+          "address": "0x890a69ef363c9c7bdd5e36eb95ceb569f63acbf6",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:24:38Z",
+          "message": null,
+          "name": "Main USDC v3",
+          "outcome": "success",
+          "protocol": "Gearbox",
+          "share_balance_raw": "9359761"
+        },
+        {
+          "address": "0x890a69ef363c9c7bdd5e36eb95ceb569f63acbf6",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:24:38Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Main USDC v3",
+          "outcome": "invalid_evidence",
+          "protocol": "Gearbox"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:24:38Z",
+      "last_attempt_at": "2026-07-13T20:24:17Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
       "message": null,
+      "minted_share_amount_raw": "9359761",
       "name": "Main USDC v3",
       "outcome": "success",
       "protocol": "Gearbox",
-      "share_balance_raw": "9359761"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0x892c83dbd27351fdc72566a509512c8af5f6e66f": {
       "address": "0x892c83dbd27351fdc72566a509512c8af5f6e66f",
@@ -10469,7 +12589,7 @@
     },
     "42161-0x8d08e20be5be6ccceb5b2555f1461e08ae648298": {
       "address": "0x8d08e20be5be6ccceb5b2555f1461e08ae648298",
-      "attempt_count": 10,
+      "attempt_count": 11,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -10481,18 +12601,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483532976,
       "history": [
-        {
-          "address": "0x8d08e20be5be6ccceb5b2555f1461e08ae648298",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "last_attempt_at": "2026-07-13T16:54:03Z",
-          "message": "Transaction must include these fields: {'gasPrice'}",
-          "name": "Trust Wallet Morpho V2 Steakhouse High Yield USDC",
-          "outcome": "rpc_error",
-          "protocol": "Kiln Metavault"
-        },
         {
           "address": "0x8d08e20be5be6ccceb5b2555f1461e08ae648298",
           "attempt_count": 2,
@@ -10663,18 +12773,54 @@
           "outcome": "success",
           "protocol": "Kiln Metavault",
           "share_balance_raw": "9866043"
+        },
+        {
+          "address": "0x8d08e20be5be6ccceb5b2555f1461e08ae648298",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:29:41Z",
+          "message": null,
+          "name": "Trust Wallet Morpho V2 Steakhouse High Yield USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9866042"
+        },
+        {
+          "address": "0x8d08e20be5be6ccceb5b2555f1461e08ae648298",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:29:41Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Trust Wallet Morpho V2 Steakhouse High Yield USDC",
+          "outcome": "invalid_evidence",
+          "protocol": "Kiln Metavault"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:29:41Z",
+      "last_attempt_at": "2026-07-13T20:24:15Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
       "message": null,
+      "minted_share_amount_raw": "9865975",
       "name": "Trust Wallet Morpho V2 Steakhouse High Yield USDC",
       "outcome": "success",
       "protocol": "Kiln Metavault",
-      "share_balance_raw": "9866042"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0x8e3d0ebd80911f9d53b22f876581ab23914e630f": {
       "address": "0x8e3d0ebd80911f9d53b22f876581ab23914e630f",
-      "attempt_count": 1,
+      "attempt_count": 2,
       "chain_id": 42161,
       "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
       "deposit_amount": "10",
@@ -10686,14 +12832,51 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
-      "history": [],
-      "last_attempt_at": "2026-07-13T18:38:58Z",
+      "fork_block_number": 483533033,
+      "history": [
+        {
+          "address": "0x8e3d0ebd80911f9d53b22f876581ab23914e630f",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:38:58Z",
+          "message": null,
+          "name": "Supply DAI into AAVE",
+          "outcome": "success",
+          "protocol": "Royco",
+          "share_balance_raw": "8395125483085495686"
+        },
+        {
+          "address": "0x8e3d0ebd80911f9d53b22f876581ab23914e630f",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:38:58Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Supply DAI into AAVE",
+          "outcome": "invalid_evidence",
+          "protocol": "Royco"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T20:24:20Z",
+      "max_deposit_guidance": "1322957126497328109387280",
       "message": null,
+      "minted_share_amount_raw": "8395091946773581606",
       "name": "Supply DAI into AAVE",
       "outcome": "success",
       "protocol": "Royco",
-      "share_balance_raw": "8395125483085495686"
+      "redeemed_asset_amount_raw": "10000000025092642909",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0x8ecccad4c08f2e225515e6b223b46a723bc5cac3": {
       "address": "0x8ecccad4c08f2e225515e6b223b46a723bc5cac3",
@@ -10882,7 +13065,7 @@
     },
     "42161-0x90788f682463d1ac00bd2230b15a4bd0d32a3e46": {
       "address": "0x90788f682463d1ac00bd2230b15a4bd0d32a3e46",
-      "attempt_count": 10,
+      "attempt_count": 11,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -10894,18 +13077,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533093,
       "history": [
-        {
-          "address": "0x90788f682463d1ac00bd2230b15a4bd0d32a3e46",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "last_attempt_at": "2026-07-13T16:54:02Z",
-          "message": "Transaction must include these fields: {'gasPrice'}",
-          "name": "Trust Wallet AAVE v3 USDC",
-          "outcome": "rpc_error",
-          "protocol": "Kiln Metavault"
-        },
         {
           "address": "0x90788f682463d1ac00bd2230b15a4bd0d32a3e46",
           "attempt_count": 2,
@@ -11076,14 +13249,50 @@
           "outcome": "success",
           "protocol": "Kiln Metavault",
           "share_balance_raw": "9388881"
+        },
+        {
+          "address": "0x90788f682463d1ac00bd2230b15a4bd0d32a3e46",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:29:32Z",
+          "message": null,
+          "name": "Trust Wallet AAVE v3 USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9388880"
+        },
+        {
+          "address": "0x90788f682463d1ac00bd2230b15a4bd0d32a3e46",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:29:32Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Trust Wallet AAVE v3 USDC",
+          "outcome": "invalid_evidence",
+          "protocol": "Kiln Metavault"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:29:32Z",
+      "last_attempt_at": "2026-07-13T20:24:33Z",
+      "max_deposit_guidance": "84782966420667",
       "message": null,
+      "minted_share_amount_raw": "9388834",
       "name": "Trust Wallet AAVE v3 USDC",
       "outcome": "success",
       "protocol": "Kiln Metavault",
-      "share_balance_raw": "9388880"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0x959f3807f0aa7921e18c78b00b2819ba91e52fef": {
       "address": "0x959f3807f0aa7921e18c78b00b2819ba91e52fef",
@@ -11247,7 +13456,7 @@
     },
     "42161-0x96d6c438c704a2de8cdce435803a10d329b72e68": {
       "address": "0x96d6c438c704a2de8cdce435803a10d329b72e68",
-      "attempt_count": 10,
+      "attempt_count": 11,
       "chain_id": 42161,
       "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
       "deposit_amount": "10",
@@ -11259,16 +13468,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533086,
       "history": [
-        {
-          "address": "0x96d6c438c704a2de8cdce435803a10d329b72e68",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "last_attempt_at": "2026-07-13T16:53:59Z",
-          "message": "No configured token holder",
-          "outcome": "skipped"
-        },
         {
           "address": "0x96d6c438c704a2de8cdce435803a10d329b72e68",
           "attempt_count": 2,
@@ -11404,14 +13605,50 @@
           "outcome": "success",
           "protocol": "Kiln Metavault",
           "share_balance_raw": "9400646785104390500"
+        },
+        {
+          "address": "0x96d6c438c704a2de8cdce435803a10d329b72e68",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:29:17Z",
+          "message": null,
+          "name": "Trust Wallet AAVE v3 DAI",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9400646258730814337"
+        },
+        {
+          "address": "0x96d6c438c704a2de8cdce435803a10d329b72e68",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:29:17Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Trust Wallet AAVE v3 DAI",
+          "outcome": "invalid_evidence",
+          "protocol": "Kiln Metavault"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:29:17Z",
+      "last_attempt_at": "2026-07-13T20:24:31Z",
+      "max_deposit_guidance": "1322964114234236088071987",
       "message": null,
+      "minted_share_amount_raw": "9400611608343920688",
       "name": "Trust Wallet AAVE v3 DAI",
       "outcome": "success",
       "protocol": "Kiln Metavault",
-      "share_balance_raw": "9400646258730814337"
+      "redeemed_asset_amount_raw": "10000000015996560023",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0x98c49e13bf99d7cad8069faa2a370933ec9ecf17": {
       "address": "0x98c49e13bf99d7cad8069faa2a370933ec9ecf17",
@@ -11993,7 +14230,7 @@
     },
     "42161-0x9e6de1f581d63129af453fe1ea7253b280b4dca8": {
       "address": "0x9e6de1f581d63129af453fe1ea7253b280b4dca8",
-      "attempt_count": 7,
+      "attempt_count": 9,
       "chain_id": 42161,
       "deposit_manager": {
         "can_deposit": true,
@@ -12001,6 +14238,7 @@
         "deposit_flow": "synchronous",
         "redemption_flow": "synchronous"
       },
+      "fork_block_number": 483527056,
       "history": [
         {
           "address": "0x9e6de1f581d63129af453fe1ea7253b280b4dca8",
@@ -12097,15 +14335,52 @@
           "name": "Volta90 Multi-asset trading strategy",
           "outcome": "skipped",
           "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x9e6de1f581d63129af453fe1ea7253b280b4dca8",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:47:33Z",
+          "max_deposit_guidance": "0",
+          "message": "Anvil transaction reverted",
+          "name": "Volta90 Multi-asset trading strategy",
+          "outcome": "reverted",
+          "protocol": "<unknown ERC-7540>",
+          "revert_reason": "Anvil transaction reverted"
+        },
+        {
+          "address": "0x9e6de1f581d63129af453fe1ea7253b280b4dca8",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "fork_block_number": 483526318,
+          "last_attempt_at": "2026-07-13T19:57:36Z",
+          "max_deposit_guidance": "0",
+          "message": "0x51ee5ed5000000000000000000000000f12974c682a524999558a45200a400fc7862f99f",
+          "name": "Volta90 Multi-asset trading strategy",
+          "outcome": "reverted",
+          "protocol": "<unknown ERC-7540>",
+          "revert_reason": "0x51ee5ed5000000000000000000000000f12974c682a524999558a45200a400fc7862f99f"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:47:33Z",
+      "last_attempt_at": "2026-07-13T20:00:43Z",
       "max_deposit_guidance": "0",
-      "message": "Anvil transaction reverted",
+      "message": "0x51ee5ed500000000000000000000000059fbc37373cf91d56655adb4624fe7b030feb56b",
       "name": "Volta90 Multi-asset trading strategy",
       "outcome": "reverted",
       "protocol": "<unknown ERC-7540>",
-      "revert_reason": "Anvil transaction reverted"
+      "revert_reason": "0x51ee5ed500000000000000000000000059fbc37373cf91d56655adb4624fe7b030feb56b"
     },
     "42161-0x9fa306b1f4a6a83fec98d8ebbabedff78c407f6b": {
       "address": "0x9fa306b1f4a6a83fec98d8ebbabedff78c407f6b",
@@ -12127,7 +14402,7 @@
     },
     "42161-0x9fa578dbf15c86b1ee599aa4507251311fd6fd37": {
       "address": "0x9fa578dbf15c86b1ee599aa4507251311fd6fd37",
-      "attempt_count": 2,
+      "attempt_count": 3,
       "chain_id": 42161,
       "denomination_token_address": "0xC71FAe5853fa2416b37728D73B51E17A32691E45",
       "deposit_amount": "10",
@@ -12139,7 +14414,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533105,
       "history": [
         {
           "address": "0x9fa578dbf15c86b1ee599aa4507251311fd6fd37",
@@ -12162,18 +14437,54 @@
           "outcome": "success",
           "protocol": "ERC-4626",
           "share_balance_raw": "10000012042249106970"
+        },
+        {
+          "address": "0x9fa578dbf15c86b1ee599aa4507251311fd6fd37",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xC71FAe5853fa2416b37728D73B51E17A32691E45",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:21:53Z",
+          "message": null,
+          "name": "Wrapped Ulysses Optimism Stack USDC",
+          "outcome": "success",
+          "protocol": "ERC-4626",
+          "share_balance_raw": "10000012042249106970"
+        },
+        {
+          "address": "0x9fa578dbf15c86b1ee599aa4507251311fd6fd37",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:21:53Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Wrapped Ulysses Optimism Stack USDC",
+          "outcome": "invalid_evidence",
+          "protocol": "ERC-4626"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:21:53Z",
+      "last_attempt_at": "2026-07-13T20:24:31Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
       "message": null,
+      "minted_share_amount_raw": "10000012042249106970",
       "name": "Wrapped Ulysses Optimism Stack USDC",
       "outcome": "success",
       "protocol": "ERC-4626",
-      "share_balance_raw": "10000012042249106970"
+      "redeemed_asset_amount_raw": "10000000000000000000",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0x9fe29a3fec55414f70454e2dbe6522f48ced3e85": {
       "address": "0x9fe29a3fec55414f70454e2dbe6522f48ced3e85",
-      "attempt_count": 10,
+      "attempt_count": 13,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -12185,60 +14496,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533154,
       "history": [
-        {
-          "address": "0x9fe29a3fec55414f70454e2dbe6522f48ced3e85",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "last_attempt_at": "2026-07-13T16:53:57Z",
-          "message": "Transaction must include these fields: {'gasPrice'}",
-          "name": "Noon Symphony Yield Vault",
-          "outcome": "rpc_error",
-          "protocol": "<unknown ERC-7540>"
-        },
-        {
-          "address": "0x9fe29a3fec55414f70454e2dbe6522f48ced3e85",
-          "attempt_count": 2,
-          "chain_id": 42161,
-          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
-          "deposit_amount": "10",
-          "deposit_manager": {
-            "can_deposit": true,
-            "can_redeem": true,
-            "deposit_flow": "synchronous",
-            "redemption_flow": "synchronous"
-          },
-          "execution_mode": "guard_v0_simple_vault_v0",
-          "fork_block_number": null,
-          "last_attempt_at": "2026-07-13T16:58:44Z",
-          "message": null,
-          "name": "Noon Symphony Yield Vault",
-          "outcome": "success",
-          "protocol": "<unknown ERC-7540>",
-          "share_balance_raw": "9910140"
-        },
-        {
-          "address": "0x9fe29a3fec55414f70454e2dbe6522f48ced3e85",
-          "attempt_count": 3,
-          "chain_id": 42161,
-          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
-          "deposit_amount": "10",
-          "deposit_manager": {
-            "can_deposit": true,
-            "can_redeem": true,
-            "deposit_flow": "synchronous",
-            "redemption_flow": "synchronous"
-          },
-          "execution_mode": "guard_v0_simple_vault_v0",
-          "fork_block_number": null,
-          "last_attempt_at": "2026-07-13T17:01:31Z",
-          "message": null,
-          "name": "Noon Symphony Yield Vault",
-          "outcome": "success",
-          "protocol": "<unknown ERC-7540>",
-          "share_balance_raw": "9910138"
-        },
         {
           "address": "0x9fe29a3fec55414f70454e2dbe6522f48ced3e85",
           "attempt_count": 4,
@@ -12368,19 +14627,101 @@
           "outcome": "success",
           "protocol": "<unknown ERC-7540>",
           "share_balance_raw": "9910068"
+        },
+        {
+          "address": "0x9fe29a3fec55414f70454e2dbe6522f48ced3e85",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:47:44Z",
+          "max_deposit_guidance": "19361429872962",
+          "message": null,
+          "name": "Noon Symphony Yield Vault",
+          "outcome": "success",
+          "protocol": "<unknown ERC-7540>",
+          "share_balance_raw": "9910042"
+        },
+        {
+          "address": "0x9fe29a3fec55414f70454e2dbe6522f48ced3e85",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:47:44Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Noon Symphony Yield Vault",
+          "outcome": "invalid_evidence",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x9fe29a3fec55414f70454e2dbe6522f48ced3e85",
+          "attempt_count": 11,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483526318,
+          "last_attempt_at": "2026-07-13T19:57:48Z",
+          "max_deposit_guidance": "19361409872962",
+          "message": "Synchronous redemption failed: 0xe11466d6",
+          "minted_share_amount_raw": "9909978",
+          "name": "Noon Symphony Yield Vault",
+          "outcome": "reverted",
+          "protocol": "<unknown ERC-7540>",
+          "revert_reason": "0xe11466d6"
+        },
+        {
+          "address": "0x9fe29a3fec55414f70454e2dbe6522f48ced3e85",
+          "attempt_count": 12,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483527056,
+          "last_attempt_at": "2026-07-13T20:00:54Z",
+          "max_deposit_guidance": "19361409872962",
+          "message": "Synchronous redemption failed: 0xe11466d6",
+          "minted_share_amount_raw": "9909976",
+          "name": "Noon Symphony Yield Vault",
+          "outcome": "reverted",
+          "protocol": "<unknown ERC-7540>",
+          "revert_reason": "0xe11466d6"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:47:44Z",
-      "max_deposit_guidance": "19361429872962",
-      "message": null,
+      "last_attempt_at": "2026-07-13T20:24:48Z",
+      "max_deposit_guidance": "19361409872962",
+      "message": "Synchronous redemption failed: 0xe11466d6",
+      "minted_share_amount_raw": "9909952",
       "name": "Noon Symphony Yield Vault",
-      "outcome": "success",
+      "outcome": "reverted",
       "protocol": "<unknown ERC-7540>",
-      "share_balance_raw": "9910042"
+      "revert_reason": "0xe11466d6"
     },
     "42161-0xa0675194379ace7139b04a24faca37781d9f3b79": {
       "address": "0xa0675194379ace7139b04a24faca37781d9f3b79",
-      "attempt_count": 9,
+      "attempt_count": 11,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -12392,19 +14733,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533149,
       "history": [
-        {
-          "address": "0xa0675194379ace7139b04a24faca37781d9f3b79",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "deposit_manager": null,
-          "last_attempt_at": "2026-07-13T16:53:57Z",
-          "message": "Live adapter does not advertise deposits",
-          "name": "Tokemak arbUSD",
-          "outcome": "adapter_error",
-          "protocol": "AUTO Finance"
-        },
         {
           "address": "0xa0675194379ace7139b04a24faca37781d9f3b79",
           "attempt_count": 2,
@@ -12514,19 +14844,78 @@
           "outcome": "success",
           "protocol": "AUTO Finance",
           "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xa0675194379ace7139b04a24faca37781d9f3b79",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:48:46Z",
+          "max_deposit_guidance": "5192296858534827528531",
+          "message": null,
+          "name": "Tokemak arbUSD",
+          "outcome": "success",
+          "protocol": "AUTO Finance",
+          "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xa0675194379ace7139b04a24faca37781d9f3b79",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:48:46Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Tokemak arbUSD",
+          "outcome": "invalid_evidence",
+          "protocol": "AUTO Finance"
+        },
+        {
+          "address": "0xa0675194379ace7139b04a24faca37781d9f3b79",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483527056,
+          "last_attempt_at": "2026-07-13T20:01:34Z",
+          "max_deposit_guidance": "5192296858534827528531",
+          "message": "Synchronous redemption validation failed: Failed to poke vault: 0xA0675194379ace7139b04a24fACA37781D9f3b79",
+          "minted_share_amount_raw": "10000000000000000000",
+          "name": "Tokemak arbUSD",
+          "outcome": "guard_validation_error",
+          "protocol": "AUTO Finance"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:48:46Z",
+      "last_attempt_at": "2026-07-13T20:24:53Z",
       "max_deposit_guidance": "5192296858534827528531",
       "message": null,
+      "minted_share_amount_raw": "10000000000000000000",
       "name": "Tokemak arbUSD",
       "outcome": "success",
       "protocol": "AUTO Finance",
-      "share_balance_raw": "10000000000000000000"
+      "redeemed_asset_amount_raw": "10000000",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0xa14283d1ba337352f810ea31eb3159aa27da4981": {
       "address": "0xa14283d1ba337352f810ea31eb3159aa27da4981",
-      "attempt_count": 9,
+      "attempt_count": 11,
       "chain_id": 42161,
       "deposit_manager": {
         "can_deposit": true,
@@ -12534,6 +14923,7 @@
         "deposit_flow": "synchronous",
         "redemption_flow": "synchronous"
       },
+      "fork_block_number": 483527056,
       "history": [
         {
           "address": "0xa14283d1ba337352f810ea31eb3159aa27da4981",
@@ -12619,9 +15009,44 @@
           "name": "Delta Netural GMX Vault (Senior)",
           "outcome": "adapter_error",
           "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0xa14283d1ba337352f810ea31eb3159aa27da4981",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:46:58Z",
+          "max_deposit_guidance": "0",
+          "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "funding_error",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0xa14283d1ba337352f810ea31eb3159aa27da4981",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "fork_block_number": 483526318,
+          "last_attempt_at": "2026-07-13T19:56:58Z",
+          "max_deposit_guidance": "0",
+          "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "funding_error",
+          "protocol": "<protocol not yet identified>"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:46:58Z",
+      "last_attempt_at": "2026-07-13T20:00:02Z",
       "max_deposit_guidance": "0",
       "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
       "name": "Delta Netural GMX Vault (Senior)",
@@ -13090,7 +15515,7 @@
     },
     "42161-0xa9a4bd976dbcfc2b89f554467ac85e2c758e2618": {
       "address": "0xa9a4bd976dbcfc2b89f554467ac85e2c758e2618",
-      "attempt_count": 8,
+      "attempt_count": 9,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -13102,7 +15527,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533146,
       "history": [
         {
           "address": "0xa9a4bd976dbcfc2b89f554467ac85e2c758e2618",
@@ -13202,14 +15627,48 @@
           "outcome": "success",
           "protocol": "Silo Finance",
           "share_balance_raw": "2858840672"
+        },
+        {
+          "address": "0xa9a4bd976dbcfc2b89f554467ac85e2c758e2618",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:40:06Z",
+          "message": null,
+          "name": "Borrowable USDC Deposit, SiloId: 149",
+          "outcome": "success",
+          "protocol": "Silo Finance",
+          "share_balance_raw": "2858140101"
+        },
+        {
+          "address": "0xa9a4bd976dbcfc2b89f554467ac85e2c758e2618",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:40:06Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Borrowable USDC Deposit, SiloId: 149",
+          "outcome": "invalid_evidence",
+          "protocol": "Silo Finance"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:40:06Z",
-      "message": null,
+      "last_attempt_at": "2026-07-13T20:24:50Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Synchronous redemption failed: 0x4323a555",
+      "minted_share_amount_raw": "2853008297",
       "name": "Borrowable USDC Deposit, SiloId: 149",
-      "outcome": "success",
+      "outcome": "reverted",
       "protocol": "Silo Finance",
-      "share_balance_raw": "2858140101"
+      "revert_reason": "0x4323a555"
     },
     "42161-0xab3ac228cac84a8a1c855c3e08f869b65836c962": {
       "address": "0xab3ac228cac84a8a1c855c3e08f869b65836c962",
@@ -13336,7 +15795,7 @@
     },
     "42161-0xac69cfe6bb269cebf8ab4764d7e678c3658b99f2": {
       "address": "0xac69cfe6bb269cebf8ab4764d7e678c3658b99f2",
-      "attempt_count": 9,
+      "attempt_count": 10,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -13348,7 +15807,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533212,
       "history": [
         {
           "address": "0xac69cfe6bb269cebf8ab4764d7e678c3658b99f2",
@@ -13470,18 +15929,52 @@
           "outcome": "success",
           "protocol": "Euler",
           "share_balance_raw": "6070368333"
+        },
+        {
+          "address": "0xac69cfe6bb269cebf8ab4764d7e678c3658b99f2",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:22:28Z",
+          "message": null,
+          "name": "TID Silo Arbitrum USDC",
+          "outcome": "success",
+          "protocol": "Euler",
+          "share_balance_raw": "6069962506"
+        },
+        {
+          "address": "0xac69cfe6bb269cebf8ab4764d7e678c3658b99f2",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:22:28Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "TID Silo Arbitrum USDC",
+          "outcome": "invalid_evidence",
+          "protocol": "Euler"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:22:28Z",
-      "message": null,
+      "last_attempt_at": "2026-07-13T20:25:13Z",
+      "max_deposit_guidance": "24519928653854221733733552434404946937899830954937634815",
+      "message": "Synchronous redemption failed: execution reverted",
+      "minted_share_amount_raw": "6042817881",
       "name": "TID Silo Arbitrum USDC",
-      "outcome": "success",
+      "outcome": "reverted",
       "protocol": "Euler",
-      "share_balance_raw": "6069962506"
+      "revert_reason": "execution reverted"
     },
     "42161-0xacb7432a4bb15402ce2afe0a7c9d5b738604f6f9": {
       "address": "0xacb7432a4bb15402ce2afe0a7c9d5b738604f6f9",
-      "attempt_count": 8,
+      "attempt_count": 9,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -13493,7 +15986,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533233,
       "history": [
         {
           "address": "0xacb7432a4bb15402ce2afe0a7c9d5b738604f6f9",
@@ -13593,14 +16086,48 @@
           "outcome": "success",
           "protocol": "Silo Finance",
           "share_balance_raw": "18677686"
+        },
+        {
+          "address": "0xacb7432a4bb15402ce2afe0a7c9d5b738604f6f9",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:39:29Z",
+          "message": null,
+          "name": "Borrowable USDC Deposit, SiloId: 146",
+          "outcome": "success",
+          "protocol": "Silo Finance",
+          "share_balance_raw": "18667913"
+        },
+        {
+          "address": "0xacb7432a4bb15402ce2afe0a7c9d5b738604f6f9",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:39:29Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Borrowable USDC Deposit, SiloId: 146",
+          "outcome": "invalid_evidence",
+          "protocol": "Silo Finance"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:39:29Z",
-      "message": null,
+      "last_attempt_at": "2026-07-13T20:25:17Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Synchronous redemption failed: 0x4323a555",
+      "minted_share_amount_raw": "18596092",
       "name": "Borrowable USDC Deposit, SiloId: 146",
-      "outcome": "success",
+      "outcome": "reverted",
       "protocol": "Silo Finance",
-      "share_balance_raw": "18667913"
+      "revert_reason": "0x4323a555"
     },
     "42161-0xae30166d195caf189a5c46fabcab5b8271f6301d": {
       "address": "0xae30166d195caf189a5c46fabcab5b8271f6301d",
@@ -14226,7 +16753,7 @@
     },
     "42161-0xbc8dd5dc727edb9929f9f9fe0a288ccc941e4ddb": {
       "address": "0xbc8dd5dc727edb9929f9f9fe0a288ccc941e4ddb",
-      "attempt_count": 1,
+      "attempt_count": 2,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -14238,18 +16765,53 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
-      "history": [],
-      "last_attempt_at": "2026-07-13T18:14:09Z",
-      "message": null,
+      "fork_block_number": 483533223,
+      "history": [
+        {
+          "address": "0xbc8dd5dc727edb9929f9f9fe0a288ccc941e4ddb",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:14:09Z",
+          "message": null,
+          "name": "Systematic Alpha Fund USDC",
+          "outcome": "success",
+          "protocol": "<protocol not yet identified>",
+          "share_balance_raw": "2930983"
+        },
+        {
+          "address": "0xbc8dd5dc727edb9929f9f9fe0a288ccc941e4ddb",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:14:09Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Systematic Alpha Fund USDC",
+          "outcome": "invalid_evidence",
+          "protocol": "<protocol not yet identified>"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T20:25:03Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Synchronous redemption failed: execution reverted: Use requestWithdrawal",
+      "minted_share_amount_raw": "2930983",
       "name": "Systematic Alpha Fund USDC",
-      "outcome": "success",
+      "outcome": "reverted",
       "protocol": "<protocol not yet identified>",
-      "share_balance_raw": "2930983"
+      "revert_reason": "execution reverted: Use requestWithdrawal"
     },
     "42161-0xbc9b0f31634979584e97513cf580f5006497d699": {
       "address": "0xbc9b0f31634979584e97513cf580f5006497d699",
-      "attempt_count": 9,
+      "attempt_count": 11,
       "chain_id": 42161,
       "deposit_manager": {
         "can_deposit": true,
@@ -14257,6 +16819,7 @@
         "deposit_flow": "synchronous",
         "redemption_flow": "synchronous"
       },
+      "fork_block_number": 483527056,
       "history": [
         {
           "address": "0xbc9b0f31634979584e97513cf580f5006497d699",
@@ -14342,9 +16905,44 @@
           "name": "Delta Netural GMX Vault (Senior)",
           "outcome": "adapter_error",
           "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0xbc9b0f31634979584e97513cf580f5006497d699",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:47:11Z",
+          "max_deposit_guidance": "0",
+          "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "funding_error",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0xbc9b0f31634979584e97513cf580f5006497d699",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "fork_block_number": 483526318,
+          "last_attempt_at": "2026-07-13T19:57:11Z",
+          "max_deposit_guidance": "0",
+          "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "funding_error",
+          "protocol": "<protocol not yet identified>"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:47:11Z",
+      "last_attempt_at": "2026-07-13T20:00:19Z",
       "max_deposit_guidance": "0",
       "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
       "name": "Delta Netural GMX Vault (Senior)",
@@ -14462,7 +17060,7 @@
     },
     "42161-0xbe1a0690aa440ccae131b05679aef197f843527a": {
       "address": "0xbe1a0690aa440ccae131b05679aef197f843527a",
-      "attempt_count": 1,
+      "attempt_count": 2,
       "chain_id": 42161,
       "denomination_token_address": "0x211Cc4DD073734dA055fbF44a2b4667d5E5fE5d2",
       "deposit_amount": "10",
@@ -14474,14 +17072,51 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
-      "history": [],
-      "last_attempt_at": "2026-07-13T18:34:31Z",
+      "fork_block_number": 483533312,
+      "history": [
+        {
+          "address": "0xbe1a0690aa440ccae131b05679aef197f843527a",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0x211Cc4DD073734dA055fbF44a2b4667d5E5fE5d2",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:34:31Z",
+          "message": null,
+          "name": "MS-sUSDe",
+          "outcome": "success",
+          "protocol": "Morpho",
+          "share_balance_raw": "9999856329791849717"
+        },
+        {
+          "address": "0xbe1a0690aa440ccae131b05679aef197f843527a",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:34:31Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "MS-sUSDe",
+          "outcome": "invalid_evidence",
+          "protocol": "Morpho"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T20:25:27Z",
+      "max_deposit_guidance": "14485066665821998511425",
       "message": null,
+      "minted_share_amount_raw": "9999856329677042195",
       "name": "MS-sUSDe",
       "outcome": "success",
       "protocol": "Morpho",
-      "share_balance_raw": "9999856329791849717"
+      "redeemed_asset_amount_raw": "10000000000000067955",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "1"
     },
     "42161-0xbe3860fd4c3facdf8ad57aa8c1a36d6dc4390a49": {
       "address": "0xbe3860fd4c3facdf8ad57aa8c1a36d6dc4390a49",
@@ -14598,7 +17233,7 @@
     },
     "42161-0xbe7d1b3cf19eb05ac557be14af24e093fadfd7c6": {
       "address": "0xbe7d1b3cf19eb05ac557be14af24e093fadfd7c6",
-      "attempt_count": 7,
+      "attempt_count": 8,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -14608,9 +17243,9 @@
         "deposit_flow": "synchronous",
         "redemption_flow": "synchronous"
       },
-      "deposit_manager_source": "generic_erc4626",
+      "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533330,
       "history": [
         {
           "address": "0xbe7d1b3cf19eb05ac557be14af24e093fadfd7c6",
@@ -14682,15 +17317,49 @@
           "name": "Teller USDC",
           "outcome": "skipped",
           "protocol": "Yearn"
+        },
+        {
+          "address": "0xbe7d1b3cf19eb05ac557be14af24e093fadfd7c6",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:49:43Z",
+          "max_deposit_guidance": "0",
+          "message": null,
+          "name": "Teller USDC",
+          "outcome": "success",
+          "protocol": "Yearn",
+          "share_balance_raw": "9970265"
+        },
+        {
+          "address": "0xbe7d1b3cf19eb05ac557be14af24e093fadfd7c6",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:49:43Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Teller USDC",
+          "outcome": "invalid_evidence",
+          "protocol": "Yearn"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:49:43Z",
+      "last_attempt_at": "2026-07-13T20:25:38Z",
       "max_deposit_guidance": "0",
-      "message": null,
+      "message": "Synchronous redemption failed: execution reverted: insufficient assets in vault",
+      "minted_share_amount_raw": "9970261",
       "name": "Teller USDC",
-      "outcome": "success",
+      "outcome": "reverted",
       "protocol": "Yearn",
-      "share_balance_raw": "9970265"
+      "revert_reason": "execution reverted: insufficient assets in vault"
     },
     "42161-0xbeeff77ce5c059445714e6a3490e273fe7f2492f": {
       "address": "0xbeeff77ce5c059445714e6a3490e273fe7f2492f",
@@ -14880,7 +17549,7 @@
     },
     "42161-0xc2810eb57526df869049fbf4c541791a3255d24c": {
       "address": "0xc2810eb57526df869049fbf4c541791a3255d24c",
-      "attempt_count": 7,
+      "attempt_count": 8,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -14892,7 +17561,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533273,
       "history": [
         {
           "address": "0xc2810eb57526df869049fbf4c541791a3255d24c",
@@ -15010,14 +17679,50 @@
           "outcome": "success",
           "protocol": "Peapods",
           "share_balance_raw": "32123"
+        },
+        {
+          "address": "0xc2810eb57526df869049fbf4c541791a3255d24c",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:35:50Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 14",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "32122"
+        },
+        {
+          "address": "0xc2810eb57526df869049fbf4c541791a3255d24c",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:35:50Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Peapods Interest Bearing USDC - 14",
+          "outcome": "invalid_evidence",
+          "protocol": "Peapods"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:35:50Z",
+      "last_attempt_at": "2026-07-13T20:25:18Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584001362239591544",
       "message": null,
+      "minted_share_amount_raw": "32116",
       "name": "Peapods Interest Bearing USDC - 14",
       "outcome": "success",
       "protocol": "Peapods",
-      "share_balance_raw": "32122"
+      "redeemed_asset_amount_raw": "9999936",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0xc30db25c7df363fe1ab8c0b4c1522ec2850bc290": {
       "address": "0xc30db25c7df363fe1ab8c0b4c1522ec2850bc290",
@@ -15353,7 +18058,7 @@
     },
     "42161-0xc91c5297d7e161acc74b482aafcc75b85cc0bfed": {
       "address": "0xc91c5297d7e161acc74b482aafcc75b85cc0bfed",
-      "attempt_count": 1,
+      "attempt_count": 2,
       "chain_id": 42161,
       "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
       "deposit_amount": "10",
@@ -15365,15 +18070,52 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
-      "history": [],
-      "last_attempt_at": "2026-07-13T18:43:18Z",
-      "max_deposit_guidance": "1322975429610612769767525",
+      "fork_block_number": 483533372,
+      "history": [
+        {
+          "address": "0xc91c5297d7e161acc74b482aafcc75b85cc0bfed",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:43:18Z",
+          "max_deposit_guidance": "1322975429610612769767525",
+          "message": null,
+          "name": "Static Aave Arbitrum DAI",
+          "outcome": "success",
+          "protocol": "Superform",
+          "share_balance_raw": "8395124113825374072"
+        },
+        {
+          "address": "0xc91c5297d7e161acc74b482aafcc75b85cc0bfed",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:43:18Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Static Aave Arbitrum DAI",
+          "outcome": "invalid_evidence",
+          "protocol": "Superform"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T20:25:44Z",
+      "max_deposit_guidance": "1322956935762227204561732",
       "message": null,
+      "minted_share_amount_raw": "8395091504396855427",
       "name": "Static Aave Arbitrum DAI",
       "outcome": "success",
       "protocol": "Superform",
-      "share_balance_raw": "8395124113825374072"
+      "redeemed_asset_amount_raw": "10000000037638966751",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0xcafc0a559a9bf2fc77a7ecfaf04bd929a7d9c5cf": {
       "address": "0xcafc0a559a9bf2fc77a7ecfaf04bd929a7d9c5cf",
@@ -15461,7 +18203,7 @@
     },
     "42161-0xcc56410e1a136af0eceb7241c6ae394f4d8b581c": {
       "address": "0xcc56410e1a136af0eceb7241c6ae394f4d8b581c",
-      "attempt_count": 9,
+      "attempt_count": 11,
       "chain_id": 42161,
       "deposit_manager": {
         "can_deposit": true,
@@ -15469,6 +18211,7 @@
         "deposit_flow": "synchronous",
         "redemption_flow": "synchronous"
       },
+      "fork_block_number": 483527056,
       "history": [
         {
           "address": "0xcc56410e1a136af0eceb7241c6ae394f4d8b581c",
@@ -15574,19 +18317,56 @@
           "outcome": "reverted",
           "protocol": "Atoma",
           "revert_reason": "Anvil transaction reverted"
+        },
+        {
+          "address": "0xcc56410e1a136af0eceb7241c6ae394f4d8b581c",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:47:52Z",
+          "max_deposit_guidance": "48844849699",
+          "message": "Anvil transaction reverted",
+          "name": "Atoma Vault Share",
+          "outcome": "reverted",
+          "protocol": "Atoma",
+          "revert_reason": "Anvil transaction reverted"
+        },
+        {
+          "address": "0xcc56410e1a136af0eceb7241c6ae394f4d8b581c",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "fork_block_number": 483526318,
+          "last_attempt_at": "2026-07-13T19:57:55Z",
+          "max_deposit_guidance": "48844849699",
+          "message": "0x96ec8e54",
+          "name": "Atoma Vault Share",
+          "outcome": "reverted",
+          "protocol": "Atoma",
+          "revert_reason": "0x96ec8e54"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:47:52Z",
+      "last_attempt_at": "2026-07-13T20:01:02Z",
       "max_deposit_guidance": "48844849699",
-      "message": "Anvil transaction reverted",
+      "message": "0x96ec8e54",
       "name": "Atoma Vault Share",
       "outcome": "reverted",
       "protocol": "Atoma",
-      "revert_reason": "Anvil transaction reverted"
+      "revert_reason": "0x96ec8e54"
     },
     "42161-0xcc6700f5326b2f8930660c483b4d5ce904b815c6": {
       "address": "0xcc6700f5326b2f8930660c483b4d5ce904b815c6",
-      "attempt_count": 9,
+      "attempt_count": 10,
       "chain_id": 42161,
       "denomination_token_address": "0xB459dB106f645d698E74027eeF6019A26a0675Cc",
       "deposit_amount": "10",
@@ -15598,7 +18378,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533413,
       "history": [
         {
           "address": "0xcc6700f5326b2f8930660c483b4d5ce904b815c6",
@@ -15712,14 +18492,50 @@
           "outcome": "success",
           "protocol": "Euler",
           "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xcc6700f5326b2f8930660c483b4d5ce904b815c6",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xB459dB106f645d698E74027eeF6019A26a0675Cc",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:22:50Z",
+          "message": null,
+          "name": "K3 Capital USDai Cluster",
+          "outcome": "success",
+          "protocol": "Euler",
+          "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xcc6700f5326b2f8930660c483b4d5ce904b815c6",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:22:50Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "K3 Capital USDai Cluster",
+          "outcome": "invalid_evidence",
+          "protocol": "Euler"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:22:50Z",
+      "last_attempt_at": "2026-07-13T20:25:52Z",
+      "max_deposit_guidance": "546931269977202956554951",
       "message": null,
+      "minted_share_amount_raw": "10000000000000000000",
       "name": "K3 Capital USDai Cluster",
       "outcome": "success",
       "protocol": "Euler",
-      "share_balance_raw": "10000000000000000000"
+      "redeemed_asset_amount_raw": "10000000000000000000",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0xcc871ae3bbfd0ed24d47855089b1cac30b3e8eef": {
       "address": "0xcc871ae3bbfd0ed24d47855089b1cac30b3e8eef",
@@ -15855,7 +18671,7 @@
     },
     "42161-0xd15a07a4150b0c057912fe883f7ad22b97161591": {
       "address": "0xd15a07a4150b0c057912fe883f7ad22b97161591",
-      "attempt_count": 7,
+      "attempt_count": 8,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -15867,7 +18683,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533332,
       "history": [
         {
           "address": "0xd15a07a4150b0c057912fe883f7ad22b97161591",
@@ -15985,14 +18801,50 @@
           "outcome": "success",
           "protocol": "Peapods",
           "share_balance_raw": "9355537"
+        },
+        {
+          "address": "0xd15a07a4150b0c057912fe883f7ad22b97161591",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:36:33Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 25",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "9355537"
+        },
+        {
+          "address": "0xd15a07a4150b0c057912fe883f7ad22b97161591",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:36:33Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Peapods Interest Bearing USDC - 25",
+          "outcome": "invalid_evidence",
+          "protocol": "Peapods"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:36:33Z",
+      "last_attempt_at": "2026-07-13T20:25:34Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007910181042831",
       "message": null,
+      "minted_share_amount_raw": "9355537",
       "name": "Peapods Interest Bearing USDC - 25",
       "outcome": "success",
       "protocol": "Peapods",
-      "share_balance_raw": "9355537"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0xd1be1f98991cf69355e468ad15b6d0b6429bcfcb": {
       "address": "0xd1be1f98991cf69355e468ad15b6d0b6429bcfcb",
@@ -16085,7 +18937,7 @@
     },
     "42161-0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0": {
       "address": "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0",
-      "attempt_count": 10,
+      "attempt_count": 11,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -16097,18 +18949,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533442,
       "history": [
-        {
-          "address": "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "last_attempt_at": "2026-07-13T16:53:59Z",
-          "message": "Transaction must include these fields: {'gasPrice'}",
-          "name": "gTrade (Gains Network USDC)",
-          "outcome": "rpc_error",
-          "protocol": "Gains Network"
-        },
         {
           "address": "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0",
           "attempt_count": 2,
@@ -16279,14 +19121,47 @@
           "outcome": "success",
           "protocol": "Gains Network",
           "share_balance_raw": "7633388"
+        },
+        {
+          "address": "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:23:50Z",
+          "message": null,
+          "name": "gTrade (Gains Network USDC)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "7633387"
+        },
+        {
+          "address": "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:23:50Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "gTrade (Gains Network USDC)",
+          "outcome": "invalid_evidence",
+          "protocol": "Gains Network"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:23:50Z",
-      "message": null,
+      "last_attempt_at": "2026-07-13T20:26:03Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Synchronous redemption validation failed: Failed to poke vault: 0xd3443ee1e91aF28e5FB858Fbd0D72A63bA8046E0",
+      "minted_share_amount_raw": "7633336",
       "name": "gTrade (Gains Network USDC)",
-      "outcome": "success",
-      "protocol": "Gains Network",
-      "share_balance_raw": "7633387"
+      "outcome": "guard_validation_error",
+      "protocol": "Gains Network"
     },
     "42161-0xd3ca9bec3e681b0f578fd87f20ebcf2b7e0bb739": {
       "address": "0xd3ca9bec3e681b0f578fd87f20ebcf2b7e0bb739",
@@ -16609,7 +19484,7 @@
     },
     "42161-0xd855296f9868ff659f3f359c90b7d005ec049228": {
       "address": "0xd855296f9868ff659f3f359c90b7d005ec049228",
-      "attempt_count": 10,
+      "attempt_count": 11,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -16621,19 +19496,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533468,
       "history": [
-        {
-          "address": "0xd855296f9868ff659f3f359c90b7d005ec049228",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "deposit_manager": null,
-          "last_attempt_at": "2026-07-13T16:53:59Z",
-          "message": "Live adapter does not advertise deposits",
-          "name": "IPOR USDC Prime",
-          "outcome": "adapter_error",
-          "protocol": "IPOR Fusion"
-        },
         {
           "address": "0xd855296f9868ff659f3f359c90b7d005ec049228",
           "attempt_count": 2,
@@ -16754,18 +19618,52 @@
           "outcome": "success",
           "protocol": "IPOR Fusion",
           "share_balance_raw": "987392848"
+        },
+        {
+          "address": "0xd855296f9868ff659f3f359c90b7d005ec049228",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:27:39Z",
+          "message": null,
+          "name": "IPOR USDC Prime",
+          "outcome": "success",
+          "protocol": "IPOR Fusion",
+          "share_balance_raw": "987392864"
+        },
+        {
+          "address": "0xd855296f9868ff659f3f359c90b7d005ec049228",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:27:39Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "IPOR USDC Prime",
+          "outcome": "invalid_evidence",
+          "protocol": "IPOR Fusion"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:27:39Z",
-      "message": null,
+      "last_attempt_at": "2026-07-13T20:26:10Z",
+      "max_deposit_guidance": "769268844425",
+      "message": "Synchronous redemption failed: execution reverted",
+      "minted_share_amount_raw": "987370958",
       "name": "IPOR USDC Prime",
-      "outcome": "success",
+      "outcome": "reverted",
       "protocol": "IPOR Fusion",
-      "share_balance_raw": "987392864"
+      "revert_reason": "execution reverted"
     },
     "42161-0xd85e038593d7a098614721eae955ec2022b9b91b": {
       "address": "0xd85e038593d7a098614721eae955ec2022b9b91b",
-      "attempt_count": 10,
+      "attempt_count": 11,
       "chain_id": 42161,
       "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
       "deposit_amount": "10",
@@ -16777,16 +19675,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533400,
       "history": [
-        {
-          "address": "0xd85e038593d7a098614721eae955ec2022b9b91b",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "last_attempt_at": "2026-07-13T16:53:59Z",
-          "message": "No configured token holder",
-          "outcome": "skipped"
-        },
         {
           "address": "0xd85e038593d7a098614721eae955ec2022b9b91b",
           "attempt_count": 2,
@@ -16922,14 +19812,47 @@
           "outcome": "success",
           "protocol": "Gains Network",
           "share_balance_raw": "7756711420702535167"
+        },
+        {
+          "address": "0xd85e038593d7a098614721eae955ec2022b9b91b",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:24:15Z",
+          "message": null,
+          "name": "gTrade (Gains Network DAI)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "7756711420702535167"
+        },
+        {
+          "address": "0xd85e038593d7a098614721eae955ec2022b9b91b",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:24:15Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "gTrade (Gains Network DAI)",
+          "outcome": "invalid_evidence",
+          "protocol": "Gains Network"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:24:15Z",
-      "message": null,
+      "last_attempt_at": "2026-07-13T20:25:51Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Synchronous redemption validation failed: Failed to poke vault: 0xd85E038593d7A098614721EaE955EC2022B9B91B",
+      "minted_share_amount_raw": "7756711420702535167",
       "name": "gTrade (Gains Network DAI)",
-      "outcome": "success",
-      "protocol": "Gains Network",
-      "share_balance_raw": "7756711420702535167"
+      "outcome": "guard_validation_error",
+      "protocol": "Gains Network"
     },
     "42161-0xd8ea1735593f8c22a53123501266e7bf3596861c": {
       "address": "0xd8ea1735593f8c22a53123501266e7bf3596861c",
@@ -17067,7 +19990,7 @@
     },
     "42161-0xd9fba68d89178e3538e708939332c79efc540179": {
       "address": "0xd9fba68d89178e3538e708939332c79efc540179",
-      "attempt_count": 1,
+      "attempt_count": 2,
       "chain_id": 42161,
       "denomination_token_address": "0x7dfF72693f6A4149b17e7C6314655f6A9F7c8B33",
       "deposit_amount": "10",
@@ -17079,19 +20002,56 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
-      "history": [],
-      "last_attempt_at": "2026-07-13T18:43:03Z",
-      "max_deposit_guidance": "8599640477026176669139055",
+      "fork_block_number": 483533513,
+      "history": [
+        {
+          "address": "0xd9fba68d89178e3538e708939332c79efc540179",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0x7dfF72693f6A4149b17e7C6314655f6A9F7c8B33",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:43:03Z",
+          "max_deposit_guidance": "8599640477026176669139055",
+          "message": null,
+          "name": "Static Aave Arbitrum GHO",
+          "outcome": "success",
+          "protocol": "Superform",
+          "share_balance_raw": "9077848924612385840"
+        },
+        {
+          "address": "0xd9fba68d89178e3538e708939332c79efc540179",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:43:03Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Static Aave Arbitrum GHO",
+          "outcome": "invalid_evidence",
+          "protocol": "Superform"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T20:26:19Z",
+      "max_deposit_guidance": "8607383049674834028201659",
       "message": null,
+      "minted_share_amount_raw": "9077785132290553124",
       "name": "Static Aave Arbitrum GHO",
       "outcome": "success",
       "protocol": "Superform",
-      "share_balance_raw": "9077848924612385840"
+      "redeemed_asset_amount_raw": "10000000043955561974",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0xdc1ab820c92735e7a5e48f10fa3d8424ec47a93e": {
       "address": "0xdc1ab820c92735e7a5e48f10fa3d8424ec47a93e",
-      "attempt_count": 1,
+      "attempt_count": 2,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -17103,14 +20063,51 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
-      "history": [],
-      "last_attempt_at": "2026-07-13T18:40:23Z",
+      "fork_block_number": 483533542,
+      "history": [
+        {
+          "address": "0xdc1ab820c92735e7a5e48f10fa3d8424ec47a93e",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:40:23Z",
+          "message": null,
+          "name": "Borrowable USDC Deposit, SiloId: 145",
+          "outcome": "success",
+          "protocol": "Silo Finance",
+          "share_balance_raw": "9208898067"
+        },
+        {
+          "address": "0xdc1ab820c92735e7a5e48f10fa3d8424ec47a93e",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:40:23Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Borrowable USDC Deposit, SiloId: 145",
+          "outcome": "invalid_evidence",
+          "protocol": "Silo Finance"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T20:26:31Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
       "message": null,
+      "minted_share_amount_raw": "9208824544",
       "name": "Borrowable USDC Deposit, SiloId: 145",
       "outcome": "success",
       "protocol": "Silo Finance",
-      "share_balance_raw": "9208898067"
+      "redeemed_asset_amount_raw": "10000000",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0xded6c304fc97d2408603e393bb37251284e77ee3": {
       "address": "0xded6c304fc97d2408603e393bb37251284e77ee3",
@@ -17279,7 +20276,7 @@
     },
     "42161-0xe15b622502aaef45ee31bcc23c7afa8a0d6f3192": {
       "address": "0xe15b622502aaef45ee31bcc23c7afa8a0d6f3192",
-      "attempt_count": 1,
+      "attempt_count": 2,
       "chain_id": 42161,
       "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
       "deposit_amount": "10",
@@ -17291,18 +20288,55 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
-      "history": [],
-      "last_attempt_at": "2026-07-13T18:38:49Z",
+      "fork_block_number": 483533464,
+      "history": [
+        {
+          "address": "0xe15b622502aaef45ee31bcc23c7afa8a0d6f3192",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:38:49Z",
+          "message": null,
+          "name": "Supply DAI into AAVE",
+          "outcome": "success",
+          "protocol": "Royco",
+          "share_balance_raw": "8395125488351881632"
+        },
+        {
+          "address": "0xe15b622502aaef45ee31bcc23c7afa8a0d6f3192",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:38:49Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Supply DAI into AAVE",
+          "outcome": "invalid_evidence",
+          "protocol": "Royco"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T20:26:09Z",
+      "max_deposit_guidance": "1322956884151552842079525",
       "message": null,
+      "minted_share_amount_raw": "8395091378003513653",
       "name": "Supply DAI into AAVE",
       "outcome": "success",
       "protocol": "Royco",
-      "share_balance_raw": "8395125488351881632"
+      "redeemed_asset_amount_raw": "10000000025092644954",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0xe16722b52fe814f5d551a12f0ec89574a130a0b7": {
       "address": "0xe16722b52fe814f5d551a12f0ec89574a130a0b7",
-      "attempt_count": 8,
+      "attempt_count": 9,
       "chain_id": 42161,
       "deposit_manager": {
         "can_deposit": true,
@@ -17310,6 +20344,7 @@
         "deposit_flow": "synchronous",
         "redemption_flow": "synchronous"
       },
+      "fork_block_number": 483527056,
       "history": [
         {
           "address": "0xe16722b52fe814f5d551a12f0ec89574a130a0b7",
@@ -17397,15 +20432,33 @@
           "name": "L'Investisseur Musulman",
           "outcome": "skipped",
           "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xe16722b52fe814f5d551a12f0ec89574a130a0b7",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:48:52Z",
+          "max_deposit_guidance": "0",
+          "message": "Anvil transaction reverted",
+          "name": "L'Investisseur Musulman",
+          "outcome": "reverted",
+          "protocol": "Centrifuge",
+          "revert_reason": "Anvil transaction reverted"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:48:52Z",
+      "last_attempt_at": "2026-07-13T20:02:03Z",
       "max_deposit_guidance": "0",
-      "message": "Anvil transaction reverted",
+      "message": "0xe4bac01b",
       "name": "L'Investisseur Musulman",
       "outcome": "reverted",
       "protocol": "Centrifuge",
-      "revert_reason": "Anvil transaction reverted"
+      "revert_reason": "0xe4bac01b"
     },
     "42161-0xe1c410eefaebb052e17e0cb6f1c3197f35765aab": {
       "address": "0xe1c410eefaebb052e17e0cb6f1c3197f35765aab",
@@ -17640,7 +20693,7 @@
     },
     "42161-0xe4783824593a50bfe9dc873204cec171ebc62de0": {
       "address": "0xe4783824593a50bfe9dc873204cec171ebc62de0",
-      "attempt_count": 2,
+      "attempt_count": 3,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -17652,7 +20705,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533574,
       "history": [
         {
           "address": "0xe4783824593a50bfe9dc873204cec171ebc62de0",
@@ -17675,14 +20728,50 @@
           "outcome": "success",
           "protocol": "Euler",
           "share_balance_raw": "9670325"
+        },
+        {
+          "address": "0xe4783824593a50bfe9dc873204cec171ebc62de0",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:23:15Z",
+          "message": null,
+          "name": "Euler Earn USDC",
+          "outcome": "success",
+          "protocol": "Euler",
+          "share_balance_raw": "9670325"
+        },
+        {
+          "address": "0xe4783824593a50bfe9dc873204cec171ebc62de0",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:23:15Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Euler Earn USDC",
+          "outcome": "invalid_evidence",
+          "protocol": "Euler"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:23:15Z",
+      "last_attempt_at": "2026-07-13T20:26:41Z",
+      "max_deposit_guidance": "10384593717069655257280810675549086",
       "message": null,
+      "minted_share_amount_raw": "9670325",
       "name": "Euler Earn USDC",
       "outcome": "success",
       "protocol": "Euler",
-      "share_balance_raw": "9670325"
+      "redeemed_asset_amount_raw": "9999998",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "1"
     },
     "42161-0xe5d6eb448ac5a762c1ebe8cd1692b9cd08025176": {
       "address": "0xe5d6eb448ac5a762c1ebe8cd1692b9cd08025176",
@@ -18300,7 +21389,7 @@
     },
     "42161-0xeae33e9f53fc405f834d4678e6c07a2523b2126e": {
       "address": "0xeae33e9f53fc405f834d4678e6c07a2523b2126e",
-      "attempt_count": 7,
+      "attempt_count": 8,
       "chain_id": 42161,
       "deposit_manager": {
         "can_deposit": true,
@@ -18308,6 +21397,7 @@
         "deposit_flow": "synchronous",
         "redemption_flow": "synchronous"
       },
+      "fork_block_number": 483527056,
       "history": [
         {
           "address": "0xeae33e9f53fc405f834d4678e6c07a2523b2126e",
@@ -18379,15 +21469,33 @@
           "name": "Odins Reserve",
           "outcome": "skipped",
           "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xeae33e9f53fc405f834d4678e6c07a2523b2126e",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:48:56Z",
+          "max_deposit_guidance": "0",
+          "message": "Anvil transaction reverted",
+          "name": "Odins Reserve",
+          "outcome": "reverted",
+          "protocol": "Centrifuge",
+          "revert_reason": "Anvil transaction reverted"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:48:56Z",
+      "last_attempt_at": "2026-07-13T20:02:19Z",
       "max_deposit_guidance": "0",
-      "message": "Anvil transaction reverted",
+      "message": "0xe4bac01b",
       "name": "Odins Reserve",
       "outcome": "reverted",
       "protocol": "Centrifuge",
-      "revert_reason": "Anvil transaction reverted"
+      "revert_reason": "0xe4bac01b"
     },
     "42161-0xeb60a64039289a4c07879147073a1ec5aea91553": {
       "address": "0xeb60a64039289a4c07879147073a1ec5aea91553",
@@ -18665,7 +21773,7 @@
     },
     "42161-0xf0543d476e7906374863091034fe679a7be8ee20": {
       "address": "0xf0543d476e7906374863091034fe679a7be8ee20",
-      "attempt_count": 8,
+      "attempt_count": 9,
       "chain_id": 42161,
       "denomination_token_address": "0x6eAf19b2FC24552925dB245F9Ff613157a7dbb4C",
       "deposit_amount": "10",
@@ -18677,7 +21785,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533638,
       "history": [
         {
           "address": "0xf0543d476e7906374863091034fe679a7be8ee20",
@@ -18769,14 +21877,50 @@
           "outcome": "success",
           "protocol": "Silo Finance",
           "share_balance_raw": "9999993720"
+        },
+        {
+          "address": "0xf0543d476e7906374863091034fe679a7be8ee20",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0x6eAf19b2FC24552925dB245F9Ff613157a7dbb4C",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:39:53Z",
+          "message": null,
+          "name": "Borrowable xUSD Deposit, SiloId: 146",
+          "outcome": "success",
+          "protocol": "Silo Finance",
+          "share_balance_raw": "9999993720"
+        },
+        {
+          "address": "0xf0543d476e7906374863091034fe679a7be8ee20",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:39:53Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Borrowable xUSD Deposit, SiloId: 146",
+          "outcome": "invalid_evidence",
+          "protocol": "Silo Finance"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:39:53Z",
+      "last_attempt_at": "2026-07-13T20:26:50Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
       "message": null,
+      "minted_share_amount_raw": "9999993718",
       "name": "Borrowable xUSD Deposit, SiloId: 146",
       "outcome": "success",
       "protocol": "Silo Finance",
-      "share_balance_raw": "9999993720"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0xf18ac7de839d45d0f004a95438c3bce8e27710c2": {
       "address": "0xf18ac7de839d45d0f004a95438c3bce8e27710c2",
@@ -18925,7 +22069,7 @@
     },
     "42161-0xf2ee51a5e7af0f59e27dda070ce79c3c935a2a67": {
       "address": "0xf2ee51a5e7af0f59e27dda070ce79c3c935a2a67",
-      "attempt_count": 2,
+      "attempt_count": 3,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -18937,7 +22081,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533532,
       "history": [
         {
           "address": "0xf2ee51a5e7af0f59e27dda070ce79c3c935a2a67",
@@ -18960,14 +22104,50 @@
           "outcome": "success",
           "protocol": "Plutus",
           "share_balance_raw": "11999780"
+        },
+        {
+          "address": "0xf2ee51a5e7af0f59e27dda070ce79c3c935a2a67",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:37:54Z",
+          "message": null,
+          "name": "Hedge Vault Token",
+          "outcome": "success",
+          "protocol": "Plutus",
+          "share_balance_raw": "11999780"
+        },
+        {
+          "address": "0xf2ee51a5e7af0f59e27dda070ce79c3c935a2a67",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:37:54Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Hedge Vault Token",
+          "outcome": "invalid_evidence",
+          "protocol": "Plutus"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:37:54Z",
+      "last_attempt_at": "2026-07-13T20:26:26Z",
+      "max_deposit_guidance": "999999479950",
       "message": null,
+      "minted_share_amount_raw": "11999780",
       "name": "Hedge Vault Token",
       "outcome": "success",
       "protocol": "Plutus",
-      "share_balance_raw": "11999780"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0xf39a7496440a6cd7bd0708eea0a13324b6b7f16d": {
       "address": "0xf39a7496440a6cd7bd0708eea0a13324b6b7f16d",
@@ -19005,7 +22185,7 @@
     },
     "42161-0xf40808f50b8d858f3ac6d10c441bb61da4564d53": {
       "address": "0xf40808f50b8d858f3ac6d10c441bb61da4564d53",
-      "attempt_count": 10,
+      "attempt_count": 11,
       "chain_id": 42161,
       "denomination_token_address": "0x34e11cFb98b0eb88cFb999b0a5E4235E124BEE34",
       "deposit_amount": "10",
@@ -19017,16 +22197,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533673,
       "history": [
-        {
-          "address": "0xf40808f50b8d858f3ac6d10c441bb61da4564d53",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "last_attempt_at": "2026-07-13T16:53:57Z",
-          "message": "No configured token holder",
-          "outcome": "skipped"
-        },
         {
           "address": "0xf40808f50b8d858f3ac6d10c441bb61da4564d53",
           "attempt_count": 2,
@@ -19162,14 +22334,47 @@
           "outcome": "success",
           "protocol": "Gains Network",
           "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xf40808f50b8d858f3ac6d10c441bb61da4564d53",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0x34e11cFb98b0eb88cFb999b0a5E4235E124BEE34",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:23:26Z",
+          "message": null,
+          "name": "gTrade (Gains Network DAI)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xf40808f50b8d858f3ac6d10c441bb61da4564d53",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:23:26Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "gTrade (Gains Network DAI)",
+          "outcome": "invalid_evidence",
+          "protocol": "Gains Network"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:23:26Z",
-      "message": null,
+      "last_attempt_at": "2026-07-13T20:26:53Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Synchronous redemption validation failed: Failed to poke vault: 0xF40808f50B8d858f3aC6D10C441bB61Da4564D53",
+      "minted_share_amount_raw": "10000000000000000000",
       "name": "gTrade (Gains Network DAI)",
-      "outcome": "success",
-      "protocol": "Gains Network",
-      "share_balance_raw": "10000000000000000000"
+      "outcome": "guard_validation_error",
+      "protocol": "Gains Network"
     },
     "42161-0xf5f77bd63daab15568ace0eb4b5b16d8bb69d534": {
       "address": "0xf5f77bd63daab15568ace0eb4b5b16d8bb69d534",
@@ -19202,7 +22407,7 @@
     },
     "42161-0xf63b7f49b4f5dc5d0e7e583cfd79dc64e646320c": {
       "address": "0xf63b7f49b4f5dc5d0e7e583cfd79dc64e646320c",
-      "attempt_count": 9,
+      "attempt_count": 11,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -19214,19 +22419,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533711,
       "history": [
-        {
-          "address": "0xf63b7f49b4f5dc5d0e7e583cfd79dc64e646320c",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "deposit_manager": null,
-          "last_attempt_at": "2026-07-13T16:53:57Z",
-          "message": "Live adapter does not advertise deposits",
-          "name": "Tokemak arbUSD",
-          "outcome": "adapter_error",
-          "protocol": "AUTO Finance"
-        },
         {
           "address": "0xf63b7f49b4f5dc5d0e7e583cfd79dc64e646320c",
           "attempt_count": 2,
@@ -19336,15 +22530,74 @@
           "outcome": "success",
           "protocol": "AUTO Finance",
           "share_balance_raw": "8916317557292382086"
+        },
+        {
+          "address": "0xf63b7f49b4f5dc5d0e7e583cfd79dc64e646320c",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:48:08Z",
+          "max_deposit_guidance": "5823369891637013142277",
+          "message": null,
+          "name": "Tokemak arbUSD",
+          "outcome": "success",
+          "protocol": "AUTO Finance",
+          "share_balance_raw": "8916309519087630250"
+        },
+        {
+          "address": "0xf63b7f49b4f5dc5d0e7e583cfd79dc64e646320c",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:48:08Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Tokemak arbUSD",
+          "outcome": "invalid_evidence",
+          "protocol": "AUTO Finance"
+        },
+        {
+          "address": "0xf63b7f49b4f5dc5d0e7e583cfd79dc64e646320c",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483527056,
+          "last_attempt_at": "2026-07-13T20:01:19Z",
+          "max_deposit_guidance": "5823382509816447689016",
+          "message": "Synchronous redemption validation failed: Failed to poke vault: 0xf63b7F49B4f5Dc5D0e7e583Cfd79DC64E646320c",
+          "minted_share_amount_raw": "8916290194695447851",
+          "name": "Tokemak arbUSD",
+          "outcome": "guard_validation_error",
+          "protocol": "AUTO Finance"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:48:08Z",
-      "max_deposit_guidance": "5823369891637013142277",
+      "last_attempt_at": "2026-07-13T20:27:07Z",
+      "max_deposit_guidance": "5823387292155376818045",
       "message": null,
+      "minted_share_amount_raw": "8916282867953568497",
       "name": "Tokemak arbUSD",
       "outcome": "success",
       "protocol": "AUTO Finance",
-      "share_balance_raw": "8916309519087630250"
+      "redeemed_asset_amount_raw": "9997982",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0xf84eaa0685626f84fe17bc6c3c9eb2ac8a90d3c1": {
       "address": "0xf84eaa0685626f84fe17bc6c3c9eb2ac8a90d3c1",
@@ -19543,7 +22796,7 @@
     },
     "42161-0xfe3e29b3328026003a15bf0846846b03af86b537": {
       "address": "0xfe3e29b3328026003a15bf0846846b03af86b537",
-      "attempt_count": 10,
+      "attempt_count": 11,
       "chain_id": 42161,
       "denomination_token_address": "0xDCaa75A930a8Fc30433a1375ac76332dB7B240e9",
       "deposit_amount": "10",
@@ -19555,16 +22808,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533616,
       "history": [
-        {
-          "address": "0xfe3e29b3328026003a15bf0846846b03af86b537",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "last_attempt_at": "2026-07-13T16:53:57Z",
-          "message": "No configured token holder",
-          "outcome": "skipped"
-        },
         {
           "address": "0xfe3e29b3328026003a15bf0846846b03af86b537",
           "attempt_count": 2,
@@ -19700,18 +22945,51 @@
           "outcome": "success",
           "protocol": "Gains Network",
           "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xfe3e29b3328026003a15bf0846846b03af86b537",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDCaa75A930a8Fc30433a1375ac76332dB7B240e9",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:23:38Z",
+          "message": null,
+          "name": "gTrade (gDAI)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xfe3e29b3328026003a15bf0846846b03af86b537",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:23:38Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "gTrade (gDAI)",
+          "outcome": "invalid_evidence",
+          "protocol": "Gains Network"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:23:38Z",
-      "message": null,
+      "last_attempt_at": "2026-07-13T20:26:38Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Synchronous redemption validation failed: Failed to poke vault: 0xFe3E29b3328026003a15Bf0846846B03af86b537",
+      "minted_share_amount_raw": "10000000000000000000",
       "name": "gTrade (gDAI)",
-      "outcome": "success",
-      "protocol": "Gains Network",
-      "share_balance_raw": "10000000000000000000"
+      "outcome": "guard_validation_error",
+      "protocol": "Gains Network"
     },
     "42161-0xff05d579bf8333a1ee4f03a87a97986c500f663d": {
       "address": "0xff05d579bf8333a1ee4f03a87a97986c500f663d",
-      "attempt_count": 9,
+      "attempt_count": 11,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -19723,19 +23001,8 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533721,
       "history": [
-        {
-          "address": "0xff05d579bf8333a1ee4f03a87a97986c500f663d",
-          "attempt_count": 1,
-          "chain_id": 42161,
-          "deposit_manager": null,
-          "last_attempt_at": "2026-07-13T16:53:57Z",
-          "message": "Live adapter does not advertise deposits",
-          "name": "Tokemak arbUSD",
-          "outcome": "adapter_error",
-          "protocol": "AUTO Finance"
-        },
         {
           "address": "0xff05d579bf8333a1ee4f03a87a97986c500f663d",
           "attempt_count": 2,
@@ -19845,19 +23112,78 @@
           "outcome": "success",
           "protocol": "AUTO Finance",
           "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xff05d579bf8333a1ee4f03a87a97986c500f663d",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:48:49Z",
+          "max_deposit_guidance": "5192296858534827528531",
+          "message": null,
+          "name": "Tokemak arbUSD",
+          "outcome": "success",
+          "protocol": "AUTO Finance",
+          "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xff05d579bf8333a1ee4f03a87a97986c500f663d",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:48:49Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Tokemak arbUSD",
+          "outcome": "invalid_evidence",
+          "protocol": "AUTO Finance"
+        },
+        {
+          "address": "0xff05d579bf8333a1ee4f03a87a97986c500f663d",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": 483527056,
+          "last_attempt_at": "2026-07-13T20:01:49Z",
+          "max_deposit_guidance": "5192296858534827528531",
+          "message": "Synchronous redemption validation failed: Failed to poke vault: 0xfF05D579Bf8333A1ee4F03A87A97986C500F663d",
+          "minted_share_amount_raw": "10000000000000000000",
+          "name": "Tokemak arbUSD",
+          "outcome": "guard_validation_error",
+          "protocol": "AUTO Finance"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:48:49Z",
+      "last_attempt_at": "2026-07-13T20:27:11Z",
       "max_deposit_guidance": "5192296858534827528531",
       "message": null,
+      "minted_share_amount_raw": "10000000000000000000",
       "name": "Tokemak arbUSD",
       "outcome": "success",
       "protocol": "AUTO Finance",
-      "share_balance_raw": "10000000000000000000"
+      "redeemed_asset_amount_raw": "10000000",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0xff131917e1d6751e4d1b17612751db521b1403c5": {
       "address": "0xff131917e1d6751e4d1b17612751db521b1403c5",
-      "attempt_count": 2,
+      "attempt_count": 3,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -19869,7 +23195,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 483533780,
       "history": [
         {
           "address": "0xff131917e1d6751e4d1b17612751db521b1403c5",
@@ -19892,18 +23218,54 @@
           "outcome": "success",
           "protocol": "Kiln Metavault",
           "share_balance_raw": "9224479"
+        },
+        {
+          "address": "0xff131917e1d6751e4d1b17612751db521b1403c5",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:30:22Z",
+          "message": null,
+          "name": "[STAGING_DO_NOT_USE] Kiln Vault (Aave V3 USDC)",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9224478"
+        },
+        {
+          "address": "0xff131917e1d6751e4d1b17612751db521b1403c5",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:30:22Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "[STAGING_DO_NOT_USE] Kiln Vault (Aave V3 USDC)",
+          "outcome": "invalid_evidence",
+          "protocol": "Kiln Metavault"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:30:22Z",
+      "last_attempt_at": "2026-07-13T20:27:23Z",
+      "max_deposit_guidance": "84783286688768",
       "message": null,
+      "minted_share_amount_raw": "9224435",
       "name": "[STAGING_DO_NOT_USE] Kiln Vault (Aave V3 USDC)",
       "outcome": "success",
       "protocol": "Kiln Metavault",
-      "share_balance_raw": "9224478"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0xff8952c568f342b4be7f49f89c6c846a03993020": {
       "address": "0xff8952c568f342b4be7f49f89c6c846a03993020",
-      "attempt_count": 1,
+      "attempt_count": 2,
       "chain_id": 42161,
       "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
       "deposit_amount": "10",
@@ -19915,14 +23277,51 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
-      "history": [],
-      "last_attempt_at": "2026-07-13T18:41:03Z",
+      "fork_block_number": 483533662,
+      "history": [
+        {
+          "address": "0xff8952c568f342b4be7f49f89c6c846a03993020",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:41:03Z",
+          "message": null,
+          "name": "Borrowable USDC Deposit, SiloId: 154",
+          "outcome": "success",
+          "protocol": "Silo Finance",
+          "share_balance_raw": "9954680126"
+        },
+        {
+          "address": "0xff8952c568f342b4be7f49f89c6c846a03993020",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:41:03Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Borrowable USDC Deposit, SiloId: 154",
+          "outcome": "invalid_evidence",
+          "protocol": "Silo Finance"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T20:26:59Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
       "message": null,
+      "minted_share_amount_raw": "9954680126",
       "name": "Borrowable USDC Deposit, SiloId: 154",
       "outcome": "success",
       "protocol": "Silo Finance",
-      "share_balance_raw": "9954680126"
+      "redeemed_asset_amount_raw": "9999999",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     },
     "42161-0xffa3f282fe588da64351024d7cb825cfcefbee05": {
       "address": "0xffa3f282fe588da64351024d7cb825cfcefbee05",
@@ -19938,7 +23337,7 @@
     },
     "8453-0xbeef0e0834849acc03f0089f01f4f1eeb06873c9": {
       "address": "0xbeef0e0834849acc03f0089f01f4f1eeb06873c9",
-      "attempt_count": 2,
+      "attempt_count": 3,
       "chain_id": 8453,
       "denomination_token_address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
       "deposit_amount": "10",
@@ -19950,7 +23349,7 @@
       },
       "deposit_manager_source": "explicit",
       "execution_mode": "guard_v0_simple_vault_v0",
-      "fork_block_number": null,
+      "fork_block_number": 48592571,
       "history": [
         {
           "address": "0xbeef0e0834849acc03f0089f01f4f1eeb06873c9",
@@ -19974,15 +23373,51 @@
           "outcome": "success",
           "protocol": "Morpho",
           "share_balance_raw": "9681935649456151984"
+        },
+        {
+          "address": "0xbeef0e0834849acc03f0089f01f4f1eeb06873c9",
+          "attempt_count": 2,
+          "chain_id": 8453,
+          "denomination_token_address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:44:34Z",
+          "max_deposit_guidance": "0",
+          "message": null,
+          "name": "Steakhouse Prime Instant",
+          "outcome": "success",
+          "protocol": "Morpho",
+          "share_balance_raw": "9681934680300215192"
+        },
+        {
+          "address": "0xbeef0e0834849acc03f0089f01f4f1eeb06873c9",
+          "attempt_count": 2,
+          "chain_id": 8453,
+          "last_attempt_at": "2026-07-13T18:44:34Z",
+          "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+          "name": "Steakhouse Prime Instant",
+          "outcome": "invalid_evidence",
+          "protocol": "Morpho"
         }
       ],
-      "last_attempt_at": "2026-07-13T18:44:34Z",
+      "last_attempt_at": "2026-07-13T20:28:14Z",
       "max_deposit_guidance": "0",
       "message": null,
+      "minted_share_amount_raw": "9681846274636338780",
       "name": "Steakhouse Prime Instant",
       "outcome": "success",
       "protocol": "Morpho",
-      "share_balance_raw": "9681934680300215192"
+      "redeemed_asset_amount_raw": "10000000",
+      "redemption_status_detail": "completed",
+      "remaining_share_amount_raw": "0"
     }
   }
 }

--- a/eth_defi/data/deposit-status/vault-deposit-status.json
+++ b/eth_defi/data/deposit-status/vault-deposit-status.json
@@ -1,0 +1,19988 @@
+{
+  "schema_version": 1,
+  "updated_at": "2026-07-13T18:50:54Z",
+  "vaults": {
+    "42161-0x0000000f2eb9f69274678c76222b35eec7588a65": {
+      "address": "0x0000000f2eb9f69274678c76222b35eec7588a65",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x0000000f2eb9f69274678c76222b35eec7588a65",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "yoVaultUSD",
+          "outcome": "adapter_error",
+          "protocol": "Yo"
+        },
+        {
+          "address": "0x0000000f2eb9f69274678c76222b35eec7588a65",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "yoVaultUSD",
+          "outcome": "adapter_error",
+          "protocol": "Yo"
+        },
+        {
+          "address": "0x0000000f2eb9f69274678c76222b35eec7588a65",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "yoVaultUSD",
+          "outcome": "adapter_error",
+          "protocol": "Yo"
+        },
+        {
+          "address": "0x0000000f2eb9f69274678c76222b35eec7588a65",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "yoVaultUSD",
+          "outcome": "adapter_error",
+          "protocol": "Yo"
+        },
+        {
+          "address": "0x0000000f2eb9f69274678c76222b35eec7588a65",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:58:52Z",
+          "message": null,
+          "name": "yoVaultUSD",
+          "outcome": "success",
+          "protocol": "Yo",
+          "share_balance_raw": "9473725"
+        },
+        {
+          "address": "0x0000000f2eb9f69274678c76222b35eec7588a65",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:31:19Z",
+          "message": null,
+          "name": "yoVaultUSD",
+          "outcome": "success",
+          "protocol": "Yo",
+          "share_balance_raw": "9473725"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:50:54Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": null,
+      "name": "yoVaultUSD",
+      "outcome": "success",
+      "protocol": "Yo",
+      "share_balance_raw": "9473671"
+    },
+    "42161-0x018282d5b510f00dcacb8f4a81c3901d2fc9da51": {
+      "address": "0x018282d5b510f00dcacb8f4a81c3901d2fc9da51",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:31:20Z",
+      "message": "Unsupported to=0xd7d3eb33A04b9ec11789774dbFE479aF62fF4CA2",
+      "name": "Sandbox",
+      "outcome": "rpc_error",
+      "protocol": "Lagoon Finance"
+    },
+    "42161-0x030cdecbdca6a34e8de3f49d1798d5f70e3a3414": {
+      "address": "0x030cdecbdca6a34e8de3f49d1798d5f70e3a3414",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x030cdecbdca6a34e8de3f49d1798d5f70e3a3414",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Static Aave Arbitrum USDC",
+          "outcome": "adapter_error",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0x030cdecbdca6a34e8de3f49d1798d5f70e3a3414",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Static Aave Arbitrum USDC",
+          "outcome": "adapter_error",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0x030cdecbdca6a34e8de3f49d1798d5f70e3a3414",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Static Aave Arbitrum USDC",
+          "outcome": "adapter_error",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0x030cdecbdca6a34e8de3f49d1798d5f70e3a3414",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Static Aave Arbitrum USDC",
+          "outcome": "adapter_error",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0x030cdecbdca6a34e8de3f49d1798d5f70e3a3414",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:32Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Static Aave Arbitrum USDC",
+          "outcome": "adapter_error",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0x030cdecbdca6a34e8de3f49d1798d5f70e3a3414",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:00:45Z",
+          "message": null,
+          "name": "Static Aave Arbitrum USDC",
+          "outcome": "success",
+          "protocol": "Superform",
+          "share_balance_raw": "8524080"
+        },
+        {
+          "address": "0x030cdecbdca6a34e8de3f49d1798d5f70e3a3414",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:27:22Z",
+          "message": null,
+          "name": "Static Aave Arbitrum USDC",
+          "outcome": "success",
+          "protocol": "Superform",
+          "share_balance_raw": "8524069"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:42:48Z",
+      "max_deposit_guidance": "84933499174727",
+      "message": null,
+      "name": "Static Aave Arbitrum USDC",
+      "outcome": "success",
+      "protocol": "Superform",
+      "share_balance_raw": "8524062"
+    },
+    "42161-0x0319c82013cf676661f7bde576c6731869a93fc0": {
+      "address": "0x0319c82013cf676661f7bde576c6731869a93fc0",
+      "attempt_count": 13,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x0319c82013cf676661f7bde576c6731869a93fc0",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T16:58:11Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 22",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "8608004"
+        },
+        {
+          "address": "0x0319c82013cf676661f7bde576c6731869a93fc0",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:00:51Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 22",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "8608003"
+        },
+        {
+          "address": "0x0319c82013cf676661f7bde576c6731869a93fc0",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:03:45Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 22",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "8608000"
+        },
+        {
+          "address": "0x0319c82013cf676661f7bde576c6731869a93fc0",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:08:12Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 22",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "8607991"
+        },
+        {
+          "address": "0x0319c82013cf676661f7bde576c6731869a93fc0",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:08:55Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 22",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "8607990"
+        },
+        {
+          "address": "0x0319c82013cf676661f7bde576c6731869a93fc0",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:12:37Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 22",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "8607986"
+        },
+        {
+          "address": "0x0319c82013cf676661f7bde576c6731869a93fc0",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:15:41Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 22",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "8607985"
+        },
+        {
+          "address": "0x0319c82013cf676661f7bde576c6731869a93fc0",
+          "attempt_count": 10,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:21:27Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 22",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "8607975"
+        },
+        {
+          "address": "0x0319c82013cf676661f7bde576c6731869a93fc0",
+          "attempt_count": 11,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:57:00Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 22",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "8607932"
+        },
+        {
+          "address": "0x0319c82013cf676661f7bde576c6731869a93fc0",
+          "attempt_count": 12,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:23:00Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 22",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "8607900"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:36:23Z",
+      "message": null,
+      "name": "Peapods Interest Bearing USDC - 22",
+      "outcome": "success",
+      "protocol": "Peapods",
+      "share_balance_raw": "8607883"
+    },
+    "42161-0x034f12a217405d54bf2654b66a96fa74ad715951": {
+      "address": "0x034f12a217405d54bf2654b66a96fa74ad715951",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:30:42Z",
+      "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "name": "Silo Finance Borrowable USDC Deposit in wstETH Silo",
+      "outcome": "funding_error",
+      "protocol": "Yearn"
+    },
+    "42161-0x037dff1c12805707d7c29f163e0f09fc9102657a": {
+      "address": "0x037dff1c12805707d7c29f163e0f09fc9102657a",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "denomination_token_address": "0x7dfF72693f6A4149b17e7C6314655f6A9F7c8B33",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x037dff1c12805707d7c29f163e0f09fc9102657a",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x037dff1c12805707d7c29f163e0f09fc9102657a",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x037dff1c12805707d7c29f163e0f09fc9102657a",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Fluid Gho Token",
+          "outcome": "skipped",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0x037dff1c12805707d7c29f163e0f09fc9102657a",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Fluid Gho Token",
+          "outcome": "skipped",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0x037dff1c12805707d7c29f163e0f09fc9102657a",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:49Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Fluid Gho Token",
+          "outcome": "adapter_error",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0x037dff1c12805707d7c29f163e0f09fc9102657a",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0x7dfF72693f6A4149b17e7C6314655f6A9F7c8B33",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:57:22Z",
+          "message": null,
+          "name": "Fluid Gho Token",
+          "outcome": "success",
+          "protocol": "Fluid",
+          "share_balance_raw": "9689143118329358694"
+        },
+        {
+          "address": "0x037dff1c12805707d7c29f163e0f09fc9102657a",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0x7dfF72693f6A4149b17e7C6314655f6A9F7c8B33",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:13:36Z",
+          "message": null,
+          "name": "Fluid Gho Token",
+          "outcome": "success",
+          "protocol": "Fluid",
+          "share_balance_raw": "9689126025391395249"
+        },
+        {
+          "address": "0x037dff1c12805707d7c29f163e0f09fc9102657a",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0x7dfF72693f6A4149b17e7C6314655f6A9F7c8B33",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:20:39Z",
+          "message": null,
+          "name": "Fluid Gho Token",
+          "outcome": "success",
+          "protocol": "Fluid",
+          "share_balance_raw": "9689118591397195667"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:22:40Z",
+      "message": null,
+      "name": "Fluid Gho Token",
+      "outcome": "success",
+      "protocol": "Fluid",
+      "share_balance_raw": "9689116295867965021"
+    },
+    "42161-0x04419d3509f13054f60d253e0c79491d9e683399": {
+      "address": "0x04419d3509f13054f60d253e0c79491d9e683399",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x04419d3509f13054f60d253e0c79491d9e683399",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x04419d3509f13054f60d253e0c79491d9e683399",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x04419d3509f13054f60d253e0c79491d9e683399",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Main WETH v3",
+          "outcome": "skipped",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0x04419d3509f13054f60d253e0c79491d9e683399",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Main WETH v3",
+          "outcome": "skipped",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0x04419d3509f13054f60d253e0c79491d9e683399",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:24:45Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Main WETH v3",
+          "outcome": "adapter_error",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0x04419d3509f13054f60d253e0c79491d9e683399",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:25:58Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Main WETH v3",
+          "outcome": "adapter_error",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0x04419d3509f13054f60d253e0c79491d9e683399",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:55:41Z",
+          "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "name": "Main WETH v3",
+          "outcome": "funding_error",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0x04419d3509f13054f60d253e0c79491d9e683399",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:15:14Z",
+          "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "name": "Main WETH v3",
+          "outcome": "funding_error",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0x04419d3509f13054f60d253e0c79491d9e683399",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:22:53Z",
+          "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "name": "Main WETH v3",
+          "outcome": "funding_error",
+          "protocol": "Gearbox"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:24:40Z",
+      "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "name": "Main WETH v3",
+      "outcome": "funding_error",
+      "protocol": "Gearbox"
+    },
+    "42161-0x05d28a86e057364f6ad1a88944297e58fc6160b3": {
+      "address": "0x05d28a86e057364f6ad1a88944297e58fc6160b3",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x05d28a86e057364f6ad1a88944297e58fc6160b3",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:21:28Z",
+          "message": null,
+          "name": "Euler Arbitrum Yield",
+          "outcome": "success",
+          "protocol": "Euler",
+          "share_balance_raw": "9729277"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:23:01Z",
+      "message": null,
+      "name": "Euler Arbitrum Yield",
+      "outcome": "success",
+      "protocol": "Euler",
+      "share_balance_raw": "9729277"
+    },
+    "42161-0x0623bd8ec9e040b7bd76dbb8b2fe86d312c28cd8": {
+      "address": "0x0623bd8ec9e040b7bd76dbb8b2fe86d312c28cd8",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x0623bd8ec9e040b7bd76dbb8b2fe86d312c28cd8",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:21:22Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Supply USDT into Fluid",
+          "outcome": "funding_error",
+          "protocol": "Fluid"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:23:10Z",
+      "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "name": "Supply USDT into Fluid",
+      "outcome": "funding_error",
+      "protocol": "Fluid"
+    },
+    "42161-0x06b5f3dbf5f0483e533421cd7c48b28ea1cfed34": {
+      "address": "0x06b5f3dbf5f0483e533421cd7c48b28ea1cfed34",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x06b5f3dbf5f0483e533421cd7c48b28ea1cfed34",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x06b5f3dbf5f0483e533421cd7c48b28ea1cfed34",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x06b5f3dbf5f0483e533421cd7c48b28ea1cfed34",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "DAI Multi-Strategy Vault",
+          "outcome": "skipped",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x06b5f3dbf5f0483e533421cd7c48b28ea1cfed34",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "DAI Multi-Strategy Vault",
+          "outcome": "skipped",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x06b5f3dbf5f0483e533421cd7c48b28ea1cfed34",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:24:46Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "DAI Multi-Strategy Vault",
+          "outcome": "adapter_error",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x06b5f3dbf5f0483e533421cd7c48b28ea1cfed34",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:05Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "DAI Multi-Strategy Vault",
+          "outcome": "adapter_error",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x06b5f3dbf5f0483e533421cd7c48b28ea1cfed34",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:56:13Z",
+          "message": null,
+          "name": "DAI Multi-Strategy Vault",
+          "outcome": "success",
+          "protocol": "Goat Protocol",
+          "share_balance_raw": "160350111538837702"
+        },
+        {
+          "address": "0x06b5f3dbf5f0483e533421cd7c48b28ea1cfed34",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:15:58Z",
+          "message": null,
+          "name": "DAI Multi-Strategy Vault",
+          "outcome": "success",
+          "protocol": "Goat Protocol",
+          "share_balance_raw": "160350111538837702"
+        },
+        {
+          "address": "0x06b5f3dbf5f0483e533421cd7c48b28ea1cfed34",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:23:30Z",
+          "message": null,
+          "name": "DAI Multi-Strategy Vault",
+          "outcome": "success",
+          "protocol": "Goat Protocol",
+          "share_balance_raw": "160350111538837702"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:25:21Z",
+      "message": null,
+      "name": "DAI Multi-Strategy Vault",
+      "outcome": "success",
+      "protocol": "Goat Protocol",
+      "share_balance_raw": "160350111538837702"
+    },
+    "42161-0x0b1ed8308c9ade48b0bcb0c176b62126ba79886a": {
+      "address": "0x0b1ed8308c9ade48b0bcb0c176b62126ba79886a",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "history": [
+        {
+          "address": "0x0b1ed8308c9ade48b0bcb0c176b62126ba79886a",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x0b1ed8308c9ade48b0bcb0c176b62126ba79886a",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x0b1ed8308c9ade48b0bcb0c176b62126ba79886a",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "fija ETH GMXv2 FI",
+          "outcome": "skipped",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0x0b1ed8308c9ade48b0bcb0c176b62126ba79886a",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "fija ETH GMXv2 FI",
+          "outcome": "skipped",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0x0b1ed8308c9ade48b0bcb0c176b62126ba79886a",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:23:31Z",
+          "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+          "name": "fija ETH GMXv2 FI",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0x0b1ed8308c9ade48b0bcb0c176b62126ba79886a",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:55:58Z",
+          "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+          "name": "fija ETH GMXv2 FI",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0x0b1ed8308c9ade48b0bcb0c176b62126ba79886a",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:11:49Z",
+          "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+          "name": "fija ETH GMXv2 FI",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0x0b1ed8308c9ade48b0bcb0c176b62126ba79886a",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:19:15Z",
+          "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+          "name": "fija ETH GMXv2 FI",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:21:08Z",
+      "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+      "name": "fija ETH GMXv2 FI",
+      "outcome": "rpc_error",
+      "protocol": "ERC-4626"
+    },
+    "42161-0x0b2b2b2076d95dda7817e785989fe353fe955ef9": {
+      "address": "0x0b2b2b2076d95dda7817e785989fe353fe955ef9",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x0b2b2b2076d95dda7817e785989fe353fe955ef9",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x0b2b2b2076d95dda7817e785989fe353fe955ef9",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x0b2b2b2076d95dda7817e785989fe353fe955ef9",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Staked USDai",
+          "outcome": "skipped",
+          "protocol": "USDai"
+        },
+        {
+          "address": "0x0b2b2b2076d95dda7817e785989fe353fe955ef9",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Staked USDai",
+          "outcome": "skipped",
+          "protocol": "USDai"
+        },
+        {
+          "address": "0x0b2b2b2076d95dda7817e785989fe353fe955ef9",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:49Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Staked USDai",
+          "outcome": "adapter_error",
+          "protocol": "USDai"
+        },
+        {
+          "address": "0x0b2b2b2076d95dda7817e785989fe353fe955ef9",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:57:38Z",
+          "message": "Could not find balance slot for token 0x0A1a1A107E45b7Ced86833863f482BC5f4ed82EF",
+          "name": "Staked USDai",
+          "outcome": "funding_error",
+          "protocol": "USDai"
+        },
+        {
+          "address": "0x0b2b2b2076d95dda7817e785989fe353fe955ef9",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:29:50Z",
+          "message": "Could not find balance slot for token 0x0A1a1A107E45b7Ced86833863f482BC5f4ed82EF",
+          "name": "Staked USDai",
+          "outcome": "funding_error",
+          "protocol": "USDai"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:48:42Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Could not find balance slot for token 0x0A1a1A107E45b7Ced86833863f482BC5f4ed82EF",
+      "name": "Staked USDai",
+      "outcome": "funding_error",
+      "protocol": "USDai"
+    },
+    "42161-0x0bc9e52051f553e75550ca22c196bf132c52cf0b": {
+      "address": "0x0bc9e52051f553e75550ca22c196bf132c52cf0b",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:43:09Z",
+      "max_deposit_guidance": "552232001625",
+      "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "name": "Static Aave Arbitrum USDC",
+      "outcome": "funding_error",
+      "protocol": "Superform"
+    },
+    "42161-0x0df2e3a0b5997adc69f8768e495fd98a4d00f134": {
+      "address": "0x0df2e3a0b5997adc69f8768e495fd98a4d00f134",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x0df2e3a0b5997adc69f8768e495fd98a4d00f134",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Yield Chasing USDC",
+          "outcome": "adapter_error",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x0df2e3a0b5997adc69f8768e495fd98a4d00f134",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Yield Chasing USDC",
+          "outcome": "adapter_error",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x0df2e3a0b5997adc69f8768e495fd98a4d00f134",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:43Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Yield Chasing USDC",
+          "outcome": "adapter_error",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x0df2e3a0b5997adc69f8768e495fd98a4d00f134",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Yield Chasing USDC",
+          "outcome": "adapter_error",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x0df2e3a0b5997adc69f8768e495fd98a4d00f134",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:24:45Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Yield Chasing USDC",
+          "outcome": "adapter_error",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x0df2e3a0b5997adc69f8768e495fd98a4d00f134",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:05Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Yield Chasing USDC",
+          "outcome": "adapter_error",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x0df2e3a0b5997adc69f8768e495fd98a4d00f134",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:55:58Z",
+          "message": null,
+          "name": "Yield Chasing USDC",
+          "outcome": "success",
+          "protocol": "Goat Protocol",
+          "share_balance_raw": "9018893878215402497"
+        },
+        {
+          "address": "0x0df2e3a0b5997adc69f8768e495fd98a4d00f134",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:15:33Z",
+          "message": null,
+          "name": "Yield Chasing USDC",
+          "outcome": "success",
+          "protocol": "Goat Protocol",
+          "share_balance_raw": "9018893878215402497"
+        },
+        {
+          "address": "0x0df2e3a0b5997adc69f8768e495fd98a4d00f134",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:23:09Z",
+          "message": null,
+          "name": "Yield Chasing USDC",
+          "outcome": "success",
+          "protocol": "Goat Protocol",
+          "share_balance_raw": "9018893878215402497"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:24:59Z",
+      "message": null,
+      "name": "Yield Chasing USDC",
+      "outcome": "success",
+      "protocol": "Goat Protocol",
+      "share_balance_raw": "9018893878215402497"
+    },
+    "42161-0x0e6ad128d7e217439beea90695fe7ec859c7f98c": {
+      "address": "0x0e6ad128d7e217439beea90695fe7ec859c7f98c",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:32:33Z",
+      "message": "Could not find balance slot for token 0x498Bf2B1e120FeD3ad3D42EA2165E9b73f99C1e5",
+      "name": "Llama Lend tBTC / crvUSD",
+      "outcome": "funding_error",
+      "protocol": "Llama Lend"
+    },
+    "42161-0x0f11f7fbdb33347688441400186b210f1f4eebb9": {
+      "address": "0x0f11f7fbdb33347688441400186b210f1f4eebb9",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x0f11f7fbdb33347688441400186b210f1f4eebb9",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:29:02Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "[STAGING_DO_NOT_USE] Kiln Vault (Aave V3 USDT)",
+          "outcome": "funding_error",
+          "protocol": "Kiln Metavault"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:30:29Z",
+      "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "name": "[STAGING_DO_NOT_USE] Kiln Vault (Aave V3 USDT)",
+      "outcome": "funding_error",
+      "protocol": "Kiln Metavault"
+    },
+    "42161-0x1048918cf09290a625bb75f93443f1159e3ce09d": {
+      "address": "0x1048918cf09290a625bb75f93443f1159e3ce09d",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:37:01Z",
+      "message": null,
+      "name": "Peapods Interest Bearing USDC - 15",
+      "outcome": "success",
+      "protocol": "Peapods",
+      "share_balance_raw": "8927700"
+    },
+    "42161-0x10c49bf632663f9599b5cacebb2cbe13e7a50970": {
+      "address": "0x10c49bf632663f9599b5cacebb2cbe13e7a50970",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x10c49bf632663f9599b5cacebb2cbe13e7a50970",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:10Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x10c49bf632663f9599b5cacebb2cbe13e7a50970",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:59:52Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x10c49bf632663f9599b5cacebb2cbe13e7a50970",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "",
+          "outcome": "skipped",
+          "protocol": "Morpho"
+        },
+        {
+          "address": "0x10c49bf632663f9599b5cacebb2cbe13e7a50970",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "",
+          "outcome": "skipped",
+          "protocol": "Morpho"
+        },
+        {
+          "address": "0x10c49bf632663f9599b5cacebb2cbe13e7a50970",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:09Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "",
+          "outcome": "adapter_error",
+          "protocol": "Morpho"
+        },
+        {
+          "address": "0x10c49bf632663f9599b5cacebb2cbe13e7a50970",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:26Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "",
+          "outcome": "adapter_error",
+          "protocol": "Morpho"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T17:59:46Z",
+      "message": "Vault deposits are currently closed",
+      "name": "",
+      "outcome": "skipped",
+      "protocol": "Morpho"
+    },
+    "42161-0x1176c3760af6a1dbaa5bbd0cc6cda8a2ed6b785e": {
+      "address": "0x1176c3760af6a1dbaa5bbd0cc6cda8a2ed6b785e",
+      "attempt_count": 6,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x1176c3760af6a1dbaa5bbd0cc6cda8a2ed6b785e",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "GTxD2",
+          "outcome": "adapter_error",
+          "protocol": "D2 Finance"
+        },
+        {
+          "address": "0x1176c3760af6a1dbaa5bbd0cc6cda8a2ed6b785e",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "GTxD2",
+          "outcome": "adapter_error",
+          "protocol": "D2 Finance"
+        },
+        {
+          "address": "0x1176c3760af6a1dbaa5bbd0cc6cda8a2ed6b785e",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:31Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "GTxD2",
+          "outcome": "adapter_error",
+          "protocol": "D2 Finance"
+        },
+        {
+          "address": "0x1176c3760af6a1dbaa5bbd0cc6cda8a2ed6b785e",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "GTxD2",
+          "outcome": "adapter_error",
+          "protocol": "D2 Finance"
+        },
+        {
+          "address": "0x1176c3760af6a1dbaa5bbd0cc6cda8a2ed6b785e",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:15Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "GTxD2",
+          "outcome": "adapter_error",
+          "protocol": "D2 Finance"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T17:55:23Z",
+      "message": "Vault deposits are currently closed",
+      "name": "GTxD2",
+      "outcome": "skipped",
+      "protocol": "D2 Finance"
+    },
+    "42161-0x1364e70960e60a15ca5a9214c338149f298aacde": {
+      "address": "0x1364e70960e60a15ca5a9214c338149f298aacde",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x1364e70960e60a15ca5a9214c338149f298aacde",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:23:39Z",
+          "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "name": "USDC Multi-Strategy Vault",
+          "outcome": "funding_error",
+          "protocol": "Goat Protocol"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:25:29Z",
+      "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "name": "USDC Multi-Strategy Vault",
+      "outcome": "funding_error",
+      "protocol": "Goat Protocol"
+    },
+    "42161-0x13c798c93e9c6293dd3c40d1f5c9fdcd4f92aa14": {
+      "address": "0x13c798c93e9c6293dd3c40d1f5c9fdcd4f92aa14",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x13c798c93e9c6293dd3c40d1f5c9fdcd4f92aa14",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Lend USDC on Dolomite",
+          "outcome": "adapter_error",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0x13c798c93e9c6293dd3c40d1f5c9fdcd4f92aa14",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Lend USDC on Dolomite",
+          "outcome": "adapter_error",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0x13c798c93e9c6293dd3c40d1f5c9fdcd4f92aa14",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Lend USDC on Dolomite",
+          "outcome": "adapter_error",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0x13c798c93e9c6293dd3c40d1f5c9fdcd4f92aa14",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Lend USDC on Dolomite",
+          "outcome": "adapter_error",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0x13c798c93e9c6293dd3c40d1f5c9fdcd4f92aa14",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:13Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Lend USDC on Dolomite",
+          "outcome": "adapter_error",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0x13c798c93e9c6293dd3c40d1f5c9fdcd4f92aa14",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:58:25Z",
+          "message": null,
+          "name": "Lend USDC on Dolomite",
+          "outcome": "success",
+          "protocol": "Royco",
+          "share_balance_raw": "7872596"
+        },
+        {
+          "address": "0x13c798c93e9c6293dd3c40d1f5c9fdcd4f92aa14",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:24:48Z",
+          "message": null,
+          "name": "Lend USDC on Dolomite",
+          "outcome": "success",
+          "protocol": "Royco",
+          "share_balance_raw": "7872576"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:38:36Z",
+      "message": null,
+      "name": "Lend USDC on Dolomite",
+      "outcome": "success",
+      "protocol": "Royco",
+      "share_balance_raw": "7872566"
+    },
+    "42161-0x149c96643cf21bfd50e715ec4404af68ee333855": {
+      "address": "0x149c96643cf21bfd50e715ec4404af68ee333855",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:38:41Z",
+      "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "name": "Supply USDC into AAVE",
+      "outcome": "funding_error",
+      "protocol": "Royco"
+    },
+    "42161-0x15dcc1978f68c5e0d7a298a65fcc879e2d673d43": {
+      "address": "0x15dcc1978f68c5e0d7a298a65fcc879e2d673d43",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x15dcc1978f68c5e0d7a298a65fcc879e2d673d43",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x15dcc1978f68c5e0d7a298a65fcc879e2d673d43",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x15dcc1978f68c5e0d7a298a65fcc879e2d673d43",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Trust Wallet AAVE v3 USDT",
+          "outcome": "skipped",
+          "protocol": "Kiln Metavault"
+        },
+        {
+          "address": "0x15dcc1978f68c5e0d7a298a65fcc879e2d673d43",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Trust Wallet AAVE v3 USDT",
+          "outcome": "skipped",
+          "protocol": "Kiln Metavault"
+        },
+        {
+          "address": "0x15dcc1978f68c5e0d7a298a65fcc879e2d673d43",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:25:12Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Trust Wallet AAVE v3 USDT",
+          "outcome": "funding_error",
+          "protocol": "Kiln Metavault"
+        },
+        {
+          "address": "0x15dcc1978f68c5e0d7a298a65fcc879e2d673d43",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:25:48Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Trust Wallet AAVE v3 USDT",
+          "outcome": "funding_error",
+          "protocol": "Kiln Metavault"
+        },
+        {
+          "address": "0x15dcc1978f68c5e0d7a298a65fcc879e2d673d43",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:58:01Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Trust Wallet AAVE v3 USDT",
+          "outcome": "funding_error",
+          "protocol": "Kiln Metavault"
+        },
+        {
+          "address": "0x15dcc1978f68c5e0d7a298a65fcc879e2d673d43",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:18:19Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Trust Wallet AAVE v3 USDT",
+          "outcome": "funding_error",
+          "protocol": "Kiln Metavault"
+        },
+        {
+          "address": "0x15dcc1978f68c5e0d7a298a65fcc879e2d673d43",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:27:36Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Trust Wallet AAVE v3 USDT",
+          "outcome": "funding_error",
+          "protocol": "Kiln Metavault"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:29:22Z",
+      "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "name": "Trust Wallet AAVE v3 USDT",
+      "outcome": "funding_error",
+      "protocol": "Kiln Metavault"
+    },
+    "42161-0x1723cb57af58efb35a013870c90fcc3d60174a4e": {
+      "address": "0x1723cb57af58efb35a013870c90fcc3d60174a4e",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "history": [
+        {
+          "address": "0x1723cb57af58efb35a013870c90fcc3d60174a4e",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:09Z",
+          "message": "Transaction must include these fields: {'gasPrice'}",
+          "name": "Angmar Capital",
+          "outcome": "rpc_error",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0x1723cb57af58efb35a013870c90fcc3d60174a4e",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:59:45Z",
+          "message": "Unsupported to=0xaA165ad2591edf884a1c304176afd7E638576EAb",
+          "name": "Angmar Capital",
+          "outcome": "rpc_error",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0x1723cb57af58efb35a013870c90fcc3d60174a4e",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:02:33Z",
+          "message": "Unsupported to=0xf95a4549020dF6992719E47A0b7fB27D7FD5D864",
+          "name": "Angmar Capital",
+          "outcome": "rpc_error",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0x1723cb57af58efb35a013870c90fcc3d60174a4e",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:14:38Z",
+          "message": "Unsupported to=0x65Cce653A4d7A348d5319A86ad2fE8310F877635",
+          "name": "Angmar Capital",
+          "outcome": "rpc_error",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0x1723cb57af58efb35a013870c90fcc3d60174a4e",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:26:10Z",
+          "message": "Unsupported to=0xCb7BD47f8F934718335AA7A38EAb12d3Af6A2057",
+          "name": "Angmar Capital",
+          "outcome": "rpc_error",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0x1723cb57af58efb35a013870c90fcc3d60174a4e",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:26:35Z",
+          "message": "Unsupported to=0x7188a991382e38E3D481527aC12d96963B375b63",
+          "name": "Angmar Capital",
+          "outcome": "rpc_error",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0x1723cb57af58efb35a013870c90fcc3d60174a4e",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:58:47Z",
+          "message": "Unsupported to=0x216dcc2432FD9E604409CbaDD06Fbcd3E1b8acE5",
+          "name": "Angmar Capital",
+          "outcome": "rpc_error",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0x1723cb57af58efb35a013870c90fcc3d60174a4e",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:19:12Z",
+          "message": "Unsupported to=0x976B5D5248c1929e48F9B53FE0e6158428Dd1339",
+          "name": "Angmar Capital",
+          "outcome": "rpc_error",
+          "protocol": "Lagoon Finance"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:30:44Z",
+      "message": "Unsupported to=0xbEc23A3a77009a52B2005886970B51d52daD866e",
+      "name": "Angmar Capital",
+      "outcome": "rpc_error",
+      "protocol": "Lagoon Finance"
+    },
+    "42161-0x1a996cb54bb95462040408c06122d45d6cdb6096": {
+      "address": "0x1a996cb54bb95462040408c06122d45d6cdb6096",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x1a996cb54bb95462040408c06122d45d6cdb6096",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Fluid USD Coin",
+          "outcome": "adapter_error",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0x1a996cb54bb95462040408c06122d45d6cdb6096",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Fluid USD Coin",
+          "outcome": "adapter_error",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0x1a996cb54bb95462040408c06122d45d6cdb6096",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:31Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Fluid USD Coin",
+          "outcome": "adapter_error",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0x1a996cb54bb95462040408c06122d45d6cdb6096",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Fluid USD Coin",
+          "outcome": "adapter_error",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0x1a996cb54bb95462040408c06122d45d6cdb6096",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:49Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Fluid USD Coin",
+          "outcome": "adapter_error",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0x1a996cb54bb95462040408c06122d45d6cdb6096",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:57:12Z",
+          "message": null,
+          "name": "Fluid USD Coin",
+          "outcome": "success",
+          "protocol": "Fluid",
+          "share_balance_raw": "8925016"
+        },
+        {
+          "address": "0x1a996cb54bb95462040408c06122d45d6cdb6096",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:13:25Z",
+          "message": null,
+          "name": "Fluid USD Coin",
+          "outcome": "success",
+          "protocol": "Fluid",
+          "share_balance_raw": "8924999"
+        },
+        {
+          "address": "0x1a996cb54bb95462040408c06122d45d6cdb6096",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:20:31Z",
+          "message": null,
+          "name": "Fluid USD Coin",
+          "outcome": "success",
+          "protocol": "Fluid",
+          "share_balance_raw": "8924992"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:22:32Z",
+      "message": null,
+      "name": "Fluid USD Coin",
+      "outcome": "success",
+      "protocol": "Fluid",
+      "share_balance_raw": "8924990"
+    },
+    "42161-0x1bf5de164620055794eec69f934623c43cc696d4": {
+      "address": "0x1bf5de164620055794eec69f934623c43cc696d4",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:44:39Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Anvil transaction reverted",
+      "name": "USDC-MOON shares",
+      "outcome": "reverted",
+      "protocol": "Teller",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x1c107c4233ab3056254e717c7a67f9917079b615": {
+      "address": "0x1c107c4233ab3056254e717c7a67f9917079b615",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x1c107c4233ab3056254e717c7a67f9917079b615",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:06Z",
+          "message": "Transaction must include these fields: {'gasPrice'}",
+          "name": "Crypto.com Defi Wallet Compound USDC",
+          "outcome": "rpc_error",
+          "protocol": "Kiln Metavault"
+        },
+        {
+          "address": "0x1c107c4233ab3056254e717c7a67f9917079b615",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T16:59:38Z",
+          "message": null,
+          "name": "Crypto.com Defi Wallet Compound USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9296118"
+        },
+        {
+          "address": "0x1c107c4233ab3056254e717c7a67f9917079b615",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:02:25Z",
+          "message": null,
+          "name": "Crypto.com Defi Wallet Compound USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9296117"
+        },
+        {
+          "address": "0x1c107c4233ab3056254e717c7a67f9917079b615",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:14:31Z",
+          "message": null,
+          "name": "Crypto.com Defi Wallet Compound USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9296112"
+        },
+        {
+          "address": "0x1c107c4233ab3056254e717c7a67f9917079b615",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:25:58Z",
+          "message": null,
+          "name": "Crypto.com Defi Wallet Compound USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9296109"
+        },
+        {
+          "address": "0x1c107c4233ab3056254e717c7a67f9917079b615",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:26:19Z",
+          "message": null,
+          "name": "Crypto.com Defi Wallet Compound USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9296108"
+        },
+        {
+          "address": "0x1c107c4233ab3056254e717c7a67f9917079b615",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:58:29Z",
+          "message": null,
+          "name": "Crypto.com Defi Wallet Compound USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9296095"
+        },
+        {
+          "address": "0x1c107c4233ab3056254e717c7a67f9917079b615",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:18:53Z",
+          "message": null,
+          "name": "Crypto.com Defi Wallet Compound USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9296087"
+        },
+        {
+          "address": "0x1c107c4233ab3056254e717c7a67f9917079b615",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:28:12Z",
+          "message": null,
+          "name": "Crypto.com Defi Wallet Compound USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9296083"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:29:50Z",
+      "message": null,
+      "name": "Crypto.com Defi Wallet Compound USDC",
+      "outcome": "success",
+      "protocol": "Kiln Metavault",
+      "share_balance_raw": "9296082"
+    },
+    "42161-0x1c17a39b156189bf40905425170a3ff62fb650da": {
+      "address": "0x1c17a39b156189bf40905425170a3ff62fb650da",
+      "attempt_count": 6,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x1c17a39b156189bf40905425170a3ff62fb650da",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x1c17a39b156189bf40905425170a3ff62fb650da",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x1c17a39b156189bf40905425170a3ff62fb650da",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "xD2",
+          "outcome": "skipped",
+          "protocol": "D2 Finance"
+        },
+        {
+          "address": "0x1c17a39b156189bf40905425170a3ff62fb650da",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "xD2",
+          "outcome": "skipped",
+          "protocol": "D2 Finance"
+        },
+        {
+          "address": "0x1c17a39b156189bf40905425170a3ff62fb650da",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:15Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "xD2",
+          "outcome": "adapter_error",
+          "protocol": "D2 Finance"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T17:55:22Z",
+      "message": "Vault deposits are currently closed",
+      "name": "xD2",
+      "outcome": "skipped",
+      "protocol": "D2 Finance"
+    },
+    "42161-0x1d99daa92608eb3f794ed75eadde1aa4a9d74bd6": {
+      "address": "0x1d99daa92608eb3f794ed75eadde1aa4a9d74bd6",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "history": [
+        {
+          "address": "0x1d99daa92608eb3f794ed75eadde1aa4a9d74bd6",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:19:28Z",
+          "message": "Token 0xC6F780497A95e246EB9449f5e4770916DCd6396A missing symbol on chain 42161: ('execution reverted', '0x')",
+          "name": "Uniswap V3 LP wrapper",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:21:23Z",
+      "message": "Token 0xC6F780497A95e246EB9449f5e4770916DCd6396A missing symbol on chain 42161: ('execution reverted', '0x')",
+      "name": "Uniswap V3 LP wrapper",
+      "outcome": "rpc_error",
+      "protocol": "ERC-4626"
+    },
+    "42161-0x1fe806928cf2dd6b917e10d3a8e7b631b4e4940c": {
+      "address": "0x1fe806928cf2dd6b917e10d3a8e7b631b4e4940c",
+      "attempt_count": 6,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x1fe806928cf2dd6b917e10d3a8e7b631b4e4940c",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Gravity Team LTD",
+          "outcome": "adapter_error",
+          "protocol": "TrueFi"
+        },
+        {
+          "address": "0x1fe806928cf2dd6b917e10d3a8e7b631b4e4940c",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Gravity Team LTD",
+          "outcome": "adapter_error",
+          "protocol": "TrueFi"
+        },
+        {
+          "address": "0x1fe806928cf2dd6b917e10d3a8e7b631b4e4940c",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Gravity Team LTD",
+          "outcome": "adapter_error",
+          "protocol": "TrueFi"
+        },
+        {
+          "address": "0x1fe806928cf2dd6b917e10d3a8e7b631b4e4940c",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Gravity Team LTD",
+          "outcome": "adapter_error",
+          "protocol": "TrueFi"
+        },
+        {
+          "address": "0x1fe806928cf2dd6b917e10d3a8e7b631b4e4940c",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:56:30Z",
+          "message": "Vault deposits are currently closed",
+          "name": "Gravity Team LTD",
+          "outcome": "skipped",
+          "protocol": "TrueFi"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:45:28Z",
+      "max_deposit_guidance": "0",
+      "message": "Anvil transaction reverted",
+      "name": "Gravity Team LTD",
+      "outcome": "reverted",
+      "protocol": "TrueFi",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x20cb8b88989d061a5c73c1ab7eb543a977689849": {
+      "address": "0x20cb8b88989d061a5c73c1ab7eb543a977689849",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x20cb8b88989d061a5c73c1ab7eb543a977689849",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x20cb8b88989d061a5c73c1ab7eb543a977689849",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x20cb8b88989d061a5c73c1ab7eb543a977689849",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Loop Liquidity Pool - WETH",
+          "outcome": "skipped",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0x20cb8b88989d061a5c73c1ab7eb543a977689849",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Loop Liquidity Pool - WETH",
+          "outcome": "skipped",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0x20cb8b88989d061a5c73c1ab7eb543a977689849",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:24:45Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Loop Liquidity Pool - WETH",
+          "outcome": "adapter_error",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0x20cb8b88989d061a5c73c1ab7eb543a977689849",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:25:58Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Loop Liquidity Pool - WETH",
+          "outcome": "adapter_error",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0x20cb8b88989d061a5c73c1ab7eb543a977689849",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:55:44Z",
+          "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "name": "Loop Liquidity Pool - WETH",
+          "outcome": "funding_error",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0x20cb8b88989d061a5c73c1ab7eb543a977689849",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:15:16Z",
+          "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "name": "Loop Liquidity Pool - WETH",
+          "outcome": "funding_error",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0x20cb8b88989d061a5c73c1ab7eb543a977689849",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:22:54Z",
+          "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "name": "Loop Liquidity Pool - WETH",
+          "outcome": "funding_error",
+          "protocol": "Gearbox"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:24:42Z",
+      "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "name": "Loop Liquidity Pool - WETH",
+      "outcome": "funding_error",
+      "protocol": "Gearbox"
+    },
+    "42161-0x20d419a8e12c45f88fda7c5760bb6923cee27f98": {
+      "address": "0x20d419a8e12c45f88fda7c5760bb6923cee27f98",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "asynchronous",
+        "redemption_flow": "asynchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x20d419a8e12c45f88fda7c5760bb6923cee27f98",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:11Z",
+          "message": "Transaction must include these fields: {'gasPrice'}",
+          "name": "Ostium Liquidity Pool Vault",
+          "outcome": "rpc_error",
+          "protocol": "Ostium"
+        },
+        {
+          "address": "0x20d419a8e12c45f88fda7c5760bb6923cee27f98",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "asynchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:00:06Z",
+          "message": null,
+          "name": "Ostium Liquidity Pool Vault",
+          "outcome": "success",
+          "protocol": "Ostium",
+          "status_detail": "deposit_request_submitted"
+        },
+        {
+          "address": "0x20d419a8e12c45f88fda7c5760bb6923cee27f98",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "asynchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:02:59Z",
+          "message": null,
+          "name": "Ostium Liquidity Pool Vault",
+          "outcome": "success",
+          "protocol": "Ostium",
+          "status_detail": "deposit_request_submitted"
+        },
+        {
+          "address": "0x20d419a8e12c45f88fda7c5760bb6923cee27f98",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "asynchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:14:59Z",
+          "message": null,
+          "name": "Ostium Liquidity Pool Vault",
+          "outcome": "success",
+          "protocol": "Ostium",
+          "status_detail": "deposit_request_submitted"
+        },
+        {
+          "address": "0x20d419a8e12c45f88fda7c5760bb6923cee27f98",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "asynchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:56:19Z",
+          "message": null,
+          "name": "Ostium Liquidity Pool Vault",
+          "outcome": "success",
+          "protocol": "Ostium",
+          "status_detail": "deposit_request_submitted"
+        },
+        {
+          "address": "0x20d419a8e12c45f88fda7c5760bb6923cee27f98",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "asynchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:22:12Z",
+          "message": null,
+          "name": "Ostium Liquidity Pool Vault",
+          "outcome": "success",
+          "protocol": "Ostium",
+          "status_detail": "deposit_request_submitted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:35:34Z",
+      "message": null,
+      "name": "Ostium Liquidity Pool Vault",
+      "outcome": "success",
+      "protocol": "Ostium",
+      "status_detail": "deposit_request_submitted"
+    },
+    "42161-0x22be8d6596595b6e29e3a8a71c551d9a6388c236": {
+      "address": "0x22be8d6596595b6e29e3a8a71c551d9a6388c236",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x22be8d6596595b6e29e3a8a71c551d9a6388c236",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:14:49Z",
+          "message": null,
+          "name": "Keyrock Vault",
+          "outcome": "success",
+          "protocol": "<unknown ERC-7540>",
+          "share_balance_raw": "10000000"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:18:26Z",
+      "message": null,
+      "name": "Keyrock Vault",
+      "outcome": "success",
+      "protocol": "<unknown ERC-7540>",
+      "share_balance_raw": "10000000"
+    },
+    "42161-0x234f6bd082eb325e5b7feb2c627d708f99d4b338": {
+      "address": "0x234f6bd082eb325e5b7feb2c627d708f99d4b338",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x234f6bd082eb325e5b7feb2c627d708f99d4b338",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:22:09Z",
+          "message": "Could not find balance slot for token 0x5e021bf2ca47a17887D41f43AF811912D572e4a2",
+          "name": "My eul lite testing vault",
+          "outcome": "funding_error",
+          "protocol": "Euler"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:23:46Z",
+      "message": "Could not find balance slot for token 0x5e021bf2ca47a17887D41f43AF811912D572e4a2",
+      "name": "My eul lite testing vault",
+      "outcome": "funding_error",
+      "protocol": "Euler"
+    },
+    "42161-0x2433d6ac11193b4695d9ca73530de93c538ad18a": {
+      "address": "0x2433d6ac11193b4695d9ca73530de93c538ad18a",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x2433d6ac11193b4695d9ca73530de93c538ad18a",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Borrowable USDC Deposit, SiloId: 127",
+          "outcome": "adapter_error",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0x2433d6ac11193b4695d9ca73530de93c538ad18a",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Borrowable USDC Deposit, SiloId: 127",
+          "outcome": "adapter_error",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0x2433d6ac11193b4695d9ca73530de93c538ad18a",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Borrowable USDC Deposit, SiloId: 127",
+          "outcome": "adapter_error",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0x2433d6ac11193b4695d9ca73530de93c538ad18a",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Borrowable USDC Deposit, SiloId: 127",
+          "outcome": "adapter_error",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0x2433d6ac11193b4695d9ca73530de93c538ad18a",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:18Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Borrowable USDC Deposit, SiloId: 127",
+          "outcome": "adapter_error",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0x2433d6ac11193b4695d9ca73530de93c538ad18a",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:58:55Z",
+          "message": null,
+          "name": "Borrowable USDC Deposit, SiloId: 127",
+          "outcome": "success",
+          "protocol": "Silo Finance",
+          "share_balance_raw": "111156932"
+        },
+        {
+          "address": "0x2433d6ac11193b4695d9ca73530de93c538ad18a",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:25:18Z",
+          "message": null,
+          "name": "Borrowable USDC Deposit, SiloId: 127",
+          "outcome": "success",
+          "protocol": "Silo Finance",
+          "share_balance_raw": "111107595"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:39:43Z",
+      "message": null,
+      "name": "Borrowable USDC Deposit, SiloId: 127",
+      "outcome": "success",
+      "protocol": "Silo Finance",
+      "share_balance_raw": "111080778"
+    },
+    "42161-0x24bb6c093e15658ace2c34bee9ac16f0a6ed2b01": {
+      "address": "0x24bb6c093e15658ace2c34bee9ac16f0a6ed2b01",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "denomination_token_address": "0x46850aD61C2B7d64d08c9C754F45254596696984",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x24bb6c093e15658ace2c34bee9ac16f0a6ed2b01",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0x46850aD61C2B7d64d08c9C754F45254596696984",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:21:16Z",
+          "message": null,
+          "name": "Fluid PayPal USD",
+          "outcome": "success",
+          "protocol": "Fluid",
+          "share_balance_raw": "9926276"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:23:04Z",
+      "message": null,
+      "name": "Fluid PayPal USD",
+      "outcome": "success",
+      "protocol": "Fluid",
+      "share_balance_raw": "9926275"
+    },
+    "42161-0x250cf7c82bac7cb6cf899b6052979d4b5ba1f9ca": {
+      "address": "0x250cf7c82bac7cb6cf899b6052979d4b5ba1f9ca",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:34:39Z",
+      "message": null,
+      "name": "Steakhouse Prime USDC",
+      "outcome": "success",
+      "protocol": "Morpho",
+      "share_balance_raw": "9661478834979530200"
+    },
+    "42161-0x253eb67fcdfe60d1751acccd6d5a1a1b62bafc89": {
+      "address": "0x253eb67fcdfe60d1751acccd6d5a1a1b62bafc89",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x253eb67fcdfe60d1751acccd6d5a1a1b62bafc89",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:23:43Z",
+          "message": "Could not find balance slot for token 0x912CE59144191C1204E64559FE8253a0e49E6548",
+          "name": "ARB Multi-Strategy Vault",
+          "outcome": "funding_error",
+          "protocol": "Goat Protocol"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:25:32Z",
+      "message": "Could not find balance slot for token 0x912CE59144191C1204E64559FE8253a0e49E6548",
+      "name": "ARB Multi-Strategy Vault",
+      "outcome": "funding_error",
+      "protocol": "Goat Protocol"
+    },
+    "42161-0x275310152ae8f11f5ebe39fbe579642fee7cef19": {
+      "address": "0x275310152ae8f11f5ebe39fbe579642fee7cef19",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:44:52Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Anvil transaction reverted",
+      "name": "USDC-DAI shares",
+      "outcome": "reverted",
+      "protocol": "Teller",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x27e569c2ddbc1410649d2b0840b5caf7676e7f84": {
+      "address": "0x27e569c2ddbc1410649d2b0840b5caf7676e7f84",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x27e569c2ddbc1410649d2b0840b5caf7676e7f84",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "USDC-DMT shares",
+          "outcome": "adapter_error",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0x27e569c2ddbc1410649d2b0840b5caf7676e7f84",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "USDC-DMT shares",
+          "outcome": "adapter_error",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0x27e569c2ddbc1410649d2b0840b5caf7676e7f84",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "USDC-DMT shares",
+          "outcome": "adapter_error",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0x27e569c2ddbc1410649d2b0840b5caf7676e7f84",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "USDC-DMT shares",
+          "outcome": "adapter_error",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0x27e569c2ddbc1410649d2b0840b5caf7676e7f84",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "USDC-DMT shares",
+          "outcome": "adapter_error",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0x27e569c2ddbc1410649d2b0840b5caf7676e7f84",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:56:23Z",
+          "message": "Anvil transaction reverted",
+          "name": "USDC-DMT shares",
+          "outcome": "reverted",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0x27e569c2ddbc1410649d2b0840b5caf7676e7f84",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:28:14Z",
+          "message": "Anvil transaction reverted",
+          "name": "USDC-DMT shares",
+          "outcome": "reverted",
+          "protocol": "Teller",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:44:19Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Anvil transaction reverted",
+      "name": "USDC-DMT shares",
+      "outcome": "reverted",
+      "protocol": "Teller",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x2834704003616dad55b5f22d3324e462e92bad93": {
+      "address": "0x2834704003616dad55b5f22d3324e462e92bad93",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x2834704003616dad55b5f22d3324e462e92bad93",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:21:20Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Waltio Fluid USDT",
+          "outcome": "funding_error",
+          "protocol": "Fluid"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:23:08Z",
+      "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "name": "Waltio Fluid USDT",
+      "outcome": "funding_error",
+      "protocol": "Fluid"
+    },
+    "42161-0x2989e49999d60c0a3fe8802f7084832fcf664dc7": {
+      "address": "0x2989e49999d60c0a3fe8802f7084832fcf664dc7",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "history": [
+        {
+          "address": "0x2989e49999d60c0a3fe8802f7084832fcf664dc7",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x2989e49999d60c0a3fe8802f7084832fcf664dc7",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x2989e49999d60c0a3fe8802f7084832fcf664dc7",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "fija ETH GMXv2 FT",
+          "outcome": "skipped",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0x2989e49999d60c0a3fe8802f7084832fcf664dc7",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "fija ETH GMXv2 FT",
+          "outcome": "skipped",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0x2989e49999d60c0a3fe8802f7084832fcf664dc7",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:23:38Z",
+          "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+          "name": "fija ETH GMXv2 FT",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0x2989e49999d60c0a3fe8802f7084832fcf664dc7",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:56:02Z",
+          "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+          "name": "fija ETH GMXv2 FT",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0x2989e49999d60c0a3fe8802f7084832fcf664dc7",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:11:57Z",
+          "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+          "name": "fija ETH GMXv2 FT",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0x2989e49999d60c0a3fe8802f7084832fcf664dc7",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:19:22Z",
+          "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+          "name": "fija ETH GMXv2 FT",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:21:14Z",
+      "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+      "name": "fija ETH GMXv2 FT",
+      "outcome": "rpc_error",
+      "protocol": "ERC-4626"
+    },
+    "42161-0x2ba39e5388ac6c702cb29aea78d52aa66832f1ee": {
+      "address": "0x2ba39e5388ac6c702cb29aea78d52aa66832f1ee",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x2ba39e5388ac6c702cb29aea78d52aa66832f1ee",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Varlamore USDC Growth",
+          "outcome": "adapter_error",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0x2ba39e5388ac6c702cb29aea78d52aa66832f1ee",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Varlamore USDC Growth",
+          "outcome": "adapter_error",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0x2ba39e5388ac6c702cb29aea78d52aa66832f1ee",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:31Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Varlamore USDC Growth",
+          "outcome": "adapter_error",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0x2ba39e5388ac6c702cb29aea78d52aa66832f1ee",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Varlamore USDC Growth",
+          "outcome": "adapter_error",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0x2ba39e5388ac6c702cb29aea78d52aa66832f1ee",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:48Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Varlamore USDC Growth",
+          "outcome": "adapter_error",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0x2ba39e5388ac6c702cb29aea78d52aa66832f1ee",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:56:25Z",
+          "message": null,
+          "name": "Varlamore USDC Growth",
+          "outcome": "success",
+          "protocol": "Euler",
+          "share_balance_raw": "23029399758055992648693"
+        },
+        {
+          "address": "0x2ba39e5388ac6c702cb29aea78d52aa66832f1ee",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:12:24Z",
+          "message": null,
+          "name": "Varlamore USDC Growth",
+          "outcome": "success",
+          "protocol": "Euler",
+          "share_balance_raw": "23016482588640568710293"
+        },
+        {
+          "address": "0x2ba39e5388ac6c702cb29aea78d52aa66832f1ee",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:20:24Z",
+          "message": null,
+          "name": "Varlamore USDC Growth",
+          "outcome": "success",
+          "protocol": "Euler",
+          "share_balance_raw": "23010106749233505322635"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:22:13Z",
+      "message": null,
+      "name": "Varlamore USDC Growth",
+      "outcome": "success",
+      "protocol": "Euler",
+      "share_balance_raw": "23008573517999662706774"
+    },
+    "42161-0x2bdf0ed5dae7c37b314ec1f7dcf401bb52ea967a": {
+      "address": "0x2bdf0ed5dae7c37b314ec1f7dcf401bb52ea967a",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x2bdf0ed5dae7c37b314ec1f7dcf401bb52ea967a",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:54Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x2bdf0ed5dae7c37b314ec1f7dcf401bb52ea967a",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:33Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x2bdf0ed5dae7c37b314ec1f7dcf401bb52ea967a",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Venzo USDT Pro Lending",
+          "outcome": "skipped",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x2bdf0ed5dae7c37b314ec1f7dcf401bb52ea967a",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Venzo USDT Pro Lending",
+          "outcome": "skipped",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x2bdf0ed5dae7c37b314ec1f7dcf401bb52ea967a",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:23:01Z",
+          "message": "Vault deposits are currently closed",
+          "name": "Venzo USDT Pro Lending",
+          "outcome": "skipped",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x2bdf0ed5dae7c37b314ec1f7dcf401bb52ea967a",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:54:02Z",
+          "message": "Vault deposits are currently closed",
+          "name": "Venzo USDT Pro Lending",
+          "outcome": "skipped",
+          "protocol": "<unknown ERC-7540>"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:47:14Z",
+      "max_deposit_guidance": "0",
+      "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "name": "Venzo USDT Pro Lending",
+      "outcome": "funding_error",
+      "protocol": "<unknown ERC-7540>"
+    },
+    "42161-0x2becbb52355a7ddcd8cebe695ed370b765a31e6f": {
+      "address": "0x2becbb52355a7ddcd8cebe695ed370b765a31e6f",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x2becbb52355a7ddcd8cebe695ed370b765a31e6f",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:10Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Nashpoint JAAA CLO Vault",
+          "outcome": "adapter_error",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0x2becbb52355a7ddcd8cebe695ed370b765a31e6f",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:59:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Nashpoint JAAA CLO Vault",
+          "outcome": "adapter_error",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0x2becbb52355a7ddcd8cebe695ed370b765a31e6f",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:02:42Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Nashpoint JAAA CLO Vault",
+          "outcome": "adapter_error",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0x2becbb52355a7ddcd8cebe695ed370b765a31e6f",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:14:46Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Nashpoint JAAA CLO Vault",
+          "outcome": "adapter_error",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0x2becbb52355a7ddcd8cebe695ed370b765a31e6f",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:55:44Z",
+          "message": "Anvil transaction reverted",
+          "name": "Nashpoint JAAA CLO Vault",
+          "outcome": "reverted",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0x2becbb52355a7ddcd8cebe695ed370b765a31e6f",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:21:45Z",
+          "message": "Got <class 'eth_defi.erc_4626.vault_protocol.nashpoint.vault.NashpointNodeVault'>",
+          "name": "Nashpoint JAAA CLO Vault",
+          "outcome": "rpc_error",
+          "protocol": "NashPoint"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:34:56Z",
+      "message": "Got <class 'eth_defi.erc_4626.vault_protocol.nashpoint.vault.NashpointNodeVault'>",
+      "name": "Nashpoint JAAA CLO Vault",
+      "outcome": "rpc_error",
+      "protocol": "NashPoint"
+    },
+    "42161-0x2c609d9cfc9dda2db5c128b2a665d921ec53579d": {
+      "address": "0x2c609d9cfc9dda2db5c128b2a665d921ec53579d",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:34:21Z",
+      "message": null,
+      "name": "kpk USDC Yield",
+      "outcome": "success",
+      "protocol": "Morpho",
+      "share_balance_raw": "9655366740747888144"
+    },
+    "42161-0x2d55c68e6b9b6b3f70be2e51f289751e627f50ad": {
+      "address": "0x2d55c68e6b9b6b3f70be2e51f289751e627f50ad",
+      "attempt_count": 6,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x2d55c68e6b9b6b3f70be2e51f289751e627f50ad",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Summer.fi USDC",
+          "outcome": "adapter_error",
+          "protocol": "Summer.fi"
+        },
+        {
+          "address": "0x2d55c68e6b9b6b3f70be2e51f289751e627f50ad",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Summer.fi USDC",
+          "outcome": "adapter_error",
+          "protocol": "Summer.fi"
+        },
+        {
+          "address": "0x2d55c68e6b9b6b3f70be2e51f289751e627f50ad",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Summer.fi USDC",
+          "outcome": "adapter_error",
+          "protocol": "Summer.fi"
+        },
+        {
+          "address": "0x2d55c68e6b9b6b3f70be2e51f289751e627f50ad",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Summer.fi USDC",
+          "outcome": "adapter_error",
+          "protocol": "Summer.fi"
+        },
+        {
+          "address": "0x2d55c68e6b9b6b3f70be2e51f289751e627f50ad",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:25Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Summer.fi USDC",
+          "outcome": "adapter_error",
+          "protocol": "Summer.fi"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T17:59:56Z",
+      "message": "Vault deposits are currently closed",
+      "name": "Summer.fi USDC",
+      "outcome": "skipped",
+      "protocol": "Summer.fi"
+    },
+    "42161-0x2e7aa06a0f0816de4b1a32a12b0ac4eb584bff2a": {
+      "address": "0x2e7aa06a0f0816de4b1a32a12b0ac4eb584bff2a",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "generic_erc4626",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x2e7aa06a0f0816de4b1a32a12b0ac4eb584bff2a",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "RizVaultUSDC",
+          "outcome": "adapter_error",
+          "protocol": "Yearn"
+        },
+        {
+          "address": "0x2e7aa06a0f0816de4b1a32a12b0ac4eb584bff2a",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "RizVaultUSDC",
+          "outcome": "adapter_error",
+          "protocol": "Yearn"
+        },
+        {
+          "address": "0x2e7aa06a0f0816de4b1a32a12b0ac4eb584bff2a",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "RizVaultUSDC",
+          "outcome": "adapter_error",
+          "protocol": "Yearn"
+        },
+        {
+          "address": "0x2e7aa06a0f0816de4b1a32a12b0ac4eb584bff2a",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "RizVaultUSDC",
+          "outcome": "adapter_error",
+          "protocol": "Yearn"
+        },
+        {
+          "address": "0x2e7aa06a0f0816de4b1a32a12b0ac4eb584bff2a",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:03Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "RizVaultUSDC",
+          "outcome": "adapter_error",
+          "protocol": "Yearn"
+        },
+        {
+          "address": "0x2e7aa06a0f0816de4b1a32a12b0ac4eb584bff2a",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:58:22Z",
+          "message": "Vault deposits are currently closed",
+          "name": "RizVaultUSDC",
+          "outcome": "skipped",
+          "protocol": "Yearn"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:49:53Z",
+      "max_deposit_guidance": "0",
+      "message": null,
+      "name": "RizVaultUSDC",
+      "outcome": "success",
+      "protocol": "Yearn",
+      "share_balance_raw": "6524810"
+    },
+    "42161-0x2ec0160246461f0ce477887dde2c931ee8233de7": {
+      "address": "0x2ec0160246461f0ce477887dde2c931ee8233de7",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x2ec0160246461f0ce477887dde2c931ee8233de7",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:25:30Z",
+          "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "name": "Harvest: USDC Vault (0x2EC0)",
+          "outcome": "funding_error",
+          "protocol": "Harvest Finance"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:27:08Z",
+      "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "name": "Harvest: USDC Vault (0x2EC0)",
+      "outcome": "funding_error",
+      "protocol": "Harvest Finance"
+    },
+    "42161-0x2ece4e4579f573df571849f033fa856fd0d57acd": {
+      "address": "0x2ece4e4579f573df571849f033fa856fd0d57acd",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "history": [
+        {
+          "address": "0x2ece4e4579f573df571849f033fa856fd0d57acd",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:19:51Z",
+          "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+          "name": "fija ETH GMXv2 FC",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:21:44Z",
+      "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+      "name": "fija ETH GMXv2 FC",
+      "outcome": "rpc_error",
+      "protocol": "ERC-4626"
+    },
+    "42161-0x2fc47f784f9a4bf754edce4ce29a32b47d7b545e": {
+      "address": "0x2fc47f784f9a4bf754edce4ce29a32b47d7b545e",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x2fc47f784f9a4bf754edce4ce29a32b47d7b545e",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:54Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x2fc47f784f9a4bf754edce4ce29a32b47d7b545e",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:33Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x2fc47f784f9a4bf754edce4ce29a32b47d7b545e",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Delta Netural Water Vault",
+          "outcome": "skipped",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0x2fc47f784f9a4bf754edce4ce29a32b47d7b545e",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Delta Netural Water Vault",
+          "outcome": "skipped",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0x2fc47f784f9a4bf754edce4ce29a32b47d7b545e",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:22:55Z",
+          "message": "Vault deposits are currently closed",
+          "name": "Delta Netural Water Vault",
+          "outcome": "skipped",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0x2fc47f784f9a4bf754edce4ce29a32b47d7b545e",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:53:50Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Delta Netural Water Vault",
+          "outcome": "adapter_error",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0x2fc47f784f9a4bf754edce4ce29a32b47d7b545e",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T18:08:20Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Delta Netural Water Vault",
+          "outcome": "adapter_error",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0x2fc47f784f9a4bf754edce4ce29a32b47d7b545e",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T18:13:39Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Delta Netural Water Vault",
+          "outcome": "adapter_error",
+          "protocol": "<protocol not yet identified>"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:46:26Z",
+      "max_deposit_guidance": "0",
+      "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "name": "Delta Netural Water Vault",
+      "outcome": "funding_error",
+      "protocol": "<protocol not yet identified>"
+    },
+    "42161-0x3014ed70b39be395e1a5eb8ab4c4b8a5378e6522": {
+      "address": "0x3014ed70b39be395e1a5eb8ab4c4b8a5378e6522",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x3014ed70b39be395e1a5eb8ab4c4b8a5378e6522",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:20:18Z",
+          "message": null,
+          "name": "Not Gauntlet",
+          "outcome": "success",
+          "protocol": "Morpho",
+          "share_balance_raw": "117177291453160443"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:32:53Z",
+      "message": null,
+      "name": "Not Gauntlet",
+      "outcome": "success",
+      "protocol": "Morpho",
+      "share_balance_raw": "117164890808315763"
+    },
+    "42161-0x307139c61d3f884def18c8dc1676eb88e1ed7839": {
+      "address": "0x307139c61d3f884def18c8dc1676eb88e1ed7839",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:31:27Z",
+      "message": "Unsupported to=0xb325D48f618c601adfDEbE1809753e71dBE41635",
+      "name": "USDC Yield ",
+      "outcome": "rpc_error",
+      "protocol": "Lagoon Finance"
+    },
+    "42161-0x32db5cbac1c278696875eb9f27ed4cd7423dd126": {
+      "address": "0x32db5cbac1c278696875eb9f27ed4cd7423dd126",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x32db5cbac1c278696875eb9f27ed4cd7423dd126",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x32db5cbac1c278696875eb9f27ed4cd7423dd126",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x32db5cbac1c278696875eb9f27ed4cd7423dd126",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "FARM_ARB",
+          "outcome": "skipped",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x32db5cbac1c278696875eb9f27ed4cd7423dd126",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "FARM_ARB",
+          "outcome": "skipped",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x32db5cbac1c278696875eb9f27ed4cd7423dd126",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:24:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "FARM_ARB",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x32db5cbac1c278696875eb9f27ed4cd7423dd126",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:27Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "FARM_ARB",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x32db5cbac1c278696875eb9f27ed4cd7423dd126",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:56:32Z",
+          "message": "Could not find balance slot for token 0x912CE59144191C1204E64559FE8253a0e49E6548",
+          "name": "FARM_ARB",
+          "outcome": "funding_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x32db5cbac1c278696875eb9f27ed4cd7423dd126",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:16:21Z",
+          "message": "Could not find balance slot for token 0x912CE59144191C1204E64559FE8253a0e49E6548",
+          "name": "FARM_ARB",
+          "outcome": "funding_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x32db5cbac1c278696875eb9f27ed4cd7423dd126",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:24:19Z",
+          "message": "Could not find balance slot for token 0x912CE59144191C1204E64559FE8253a0e49E6548",
+          "name": "FARM_ARB",
+          "outcome": "funding_error",
+          "protocol": "Harvest Finance"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:26:04Z",
+      "message": "Could not find balance slot for token 0x912CE59144191C1204E64559FE8253a0e49E6548",
+      "name": "FARM_ARB",
+      "outcome": "funding_error",
+      "protocol": "Harvest Finance"
+    },
+    "42161-0x32dcf2f8f5dc4460dc44dd6ea919898a4ca75ea0": {
+      "address": "0x32dcf2f8f5dc4460dc44dd6ea919898a4ca75ea0",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x32dcf2f8f5dc4460dc44dd6ea919898a4ca75ea0",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x32dcf2f8f5dc4460dc44dd6ea919898a4ca75ea0",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x32dcf2f8f5dc4460dc44dd6ea919898a4ca75ea0",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "COMP-USDC shares",
+          "outcome": "skipped",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0x32dcf2f8f5dc4460dc44dd6ea919898a4ca75ea0",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "COMP-USDC shares",
+          "outcome": "skipped",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0x32dcf2f8f5dc4460dc44dd6ea919898a4ca75ea0",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "COMP-USDC shares",
+          "outcome": "adapter_error",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0x32dcf2f8f5dc4460dc44dd6ea919898a4ca75ea0",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:56:14Z",
+          "message": "Could not find balance slot for token 0x354A6dA3fcde098F8389cad84b0182725c6C91dE",
+          "name": "COMP-USDC shares",
+          "outcome": "funding_error",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0x32dcf2f8f5dc4460dc44dd6ea919898a4ca75ea0",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:28:04Z",
+          "message": "Could not find balance slot for token 0x354A6dA3fcde098F8389cad84b0182725c6C91dE",
+          "name": "COMP-USDC shares",
+          "outcome": "funding_error",
+          "protocol": "Teller"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:44:08Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Could not find balance slot for token 0x354A6dA3fcde098F8389cad84b0182725c6C91dE",
+      "name": "COMP-USDC shares",
+      "outcome": "funding_error",
+      "protocol": "Teller"
+    },
+    "42161-0x348fd77c569ff888ab93c03860e7cf5f59760d35": {
+      "address": "0x348fd77c569ff888ab93c03860e7cf5f59760d35",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:48:24Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "name": "Blue",
+      "outcome": "funding_error",
+      "protocol": "Umami"
+    },
+    "42161-0x34a2b066af16409648ef15d239e656edb8790ca0": {
+      "address": "0x34a2b066af16409648ef15d239e656edb8790ca0",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "denomination_token_address": "0x5d3a1Ff2b6BAb83b63cd9AD0787074081a52ef34",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "generic_erc4626",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x34a2b066af16409648ef15d239e656edb8790ca0",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x34a2b066af16409648ef15d239e656edb8790ca0",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x34a2b066af16409648ef15d239e656edb8790ca0",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "yPT-USDe (auto-rolling Pendle PT)",
+          "outcome": "skipped",
+          "protocol": "Yearn"
+        },
+        {
+          "address": "0x34a2b066af16409648ef15d239e656edb8790ca0",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "yPT-USDe (auto-rolling Pendle PT)",
+          "outcome": "skipped",
+          "protocol": "Yearn"
+        },
+        {
+          "address": "0x34a2b066af16409648ef15d239e656edb8790ca0",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:03Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "yPT-USDe (auto-rolling Pendle PT)",
+          "outcome": "adapter_error",
+          "protocol": "Yearn"
+        },
+        {
+          "address": "0x34a2b066af16409648ef15d239e656edb8790ca0",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:58:21Z",
+          "message": "Vault deposits are currently closed",
+          "name": "yPT-USDe (auto-rolling Pendle PT)",
+          "outcome": "skipped",
+          "protocol": "Yearn"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:49:35Z",
+      "max_deposit_guidance": "0",
+      "message": null,
+      "name": "yPT-USDe (auto-rolling Pendle PT)",
+      "outcome": "success",
+      "protocol": "Yearn",
+      "share_balance_raw": "9828515825072468448"
+    },
+    "42161-0x34e2110f8c9a635477eff75fdbe73251fe02ae4a": {
+      "address": "0x34e2110f8c9a635477eff75fdbe73251fe02ae4a",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x34e2110f8c9a635477eff75fdbe73251fe02ae4a",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Harvest: USDC Vault (0x34E2)",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x34e2110f8c9a635477eff75fdbe73251fe02ae4a",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Harvest: USDC Vault (0x34E2)",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x34e2110f8c9a635477eff75fdbe73251fe02ae4a",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:43Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Harvest: USDC Vault (0x34E2)",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x34e2110f8c9a635477eff75fdbe73251fe02ae4a",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Harvest: USDC Vault (0x34E2)",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x34e2110f8c9a635477eff75fdbe73251fe02ae4a",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:24:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Harvest: USDC Vault (0x34E2)",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x34e2110f8c9a635477eff75fdbe73251fe02ae4a",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:27Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Harvest: USDC Vault (0x34E2)",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x34e2110f8c9a635477eff75fdbe73251fe02ae4a",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:56:55Z",
+          "message": "Anvil transaction reverted",
+          "name": "Harvest: USDC Vault (0x34E2)",
+          "outcome": "reverted",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x34e2110f8c9a635477eff75fdbe73251fe02ae4a",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:16:51Z",
+          "message": "Anvil transaction reverted",
+          "name": "Harvest: USDC Vault (0x34E2)",
+          "outcome": "reverted",
+          "protocol": "Harvest Finance",
+          "revert_reason": "Anvil transaction reverted"
+        },
+        {
+          "address": "0x34e2110f8c9a635477eff75fdbe73251fe02ae4a",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:24:48Z",
+          "message": "Anvil transaction reverted",
+          "name": "Harvest: USDC Vault (0x34E2)",
+          "outcome": "reverted",
+          "protocol": "Harvest Finance",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:26:30Z",
+      "message": "Anvil transaction reverted",
+      "name": "Harvest: USDC Vault (0x34E2)",
+      "outcome": "reverted",
+      "protocol": "Harvest Finance",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x36f594e88b1b55f00ca9bfac06539a261d15ef03": {
+      "address": "0x36f594e88b1b55f00ca9bfac06539a261d15ef03",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x36f594e88b1b55f00ca9bfac06539a261d15ef03",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:27:07Z",
+          "message": "Anvil transaction reverted",
+          "name": "IPOR USDC Arbitrum Optimizer Pilot M",
+          "outcome": "reverted",
+          "protocol": "IPOR Fusion",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:28:50Z",
+      "message": "Anvil transaction reverted",
+      "name": "IPOR USDC Arbitrum Optimizer Pilot M",
+      "outcome": "reverted",
+      "protocol": "IPOR Fusion",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x3782ba74e32021dd2e2a7ade5118e83440ee24e4": {
+      "address": "0x3782ba74e32021dd2e2a7ade5118e83440ee24e4",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x3782ba74e32021dd2e2a7ade5118e83440ee24e4",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x3782ba74e32021dd2e2a7ade5118e83440ee24e4",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x3782ba74e32021dd2e2a7ade5118e83440ee24e4",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Yield Chasing USDT",
+          "outcome": "skipped",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x3782ba74e32021dd2e2a7ade5118e83440ee24e4",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Yield Chasing USDT",
+          "outcome": "skipped",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x3782ba74e32021dd2e2a7ade5118e83440ee24e4",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:24:46Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Yield Chasing USDT",
+          "outcome": "adapter_error",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x3782ba74e32021dd2e2a7ade5118e83440ee24e4",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:05Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Yield Chasing USDT",
+          "outcome": "adapter_error",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x3782ba74e32021dd2e2a7ade5118e83440ee24e4",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:56:01Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Yield Chasing USDT",
+          "outcome": "funding_error",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x3782ba74e32021dd2e2a7ade5118e83440ee24e4",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:15:40Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Yield Chasing USDT",
+          "outcome": "funding_error",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x3782ba74e32021dd2e2a7ade5118e83440ee24e4",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:23:13Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Yield Chasing USDT",
+          "outcome": "funding_error",
+          "protocol": "Goat Protocol"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:25:03Z",
+      "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "name": "Yield Chasing USDT",
+      "outcome": "funding_error",
+      "protocol": "Goat Protocol"
+    },
+    "42161-0x37997418ef10f0db0b38a411877de1e17e0b2058": {
+      "address": "0x37997418ef10f0db0b38a411877de1e17e0b2058",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "denomination_token_address": "0x940098b108fB7D0a7E374f6eDED7760787464609",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:34:10Z",
+      "message": null,
+      "name": "MS-sUSDC",
+      "outcome": "success",
+      "protocol": "Morpho",
+      "share_balance_raw": "9999956466711590659"
+    },
+    "42161-0x37c0705a65948ea5e0ae1add13552bcad7711a23": {
+      "address": "0x37c0705a65948ea5e0ae1add13552bcad7711a23",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:47:19Z",
+      "max_deposit_guidance": "6030202489750155986789",
+      "message": "Could not find balance slot for token 0xFa7F8980b0f1E64A2062791cc3b0871572f1F7f0",
+      "name": "glpUNI",
+      "outcome": "funding_error",
+      "protocol": "Umami"
+    },
+    "42161-0x39e6acc140395862aaac5fda063bb2d11faef137": {
+      "address": "0x39e6acc140395862aaac5fda063bb2d11faef137",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x39e6acc140395862aaac5fda063bb2d11faef137",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:15:09Z",
+          "message": null,
+          "name": "Oracle Vault",
+          "outcome": "success",
+          "protocol": "<unknown ERC-7540>",
+          "share_balance_raw": "9980872"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:18:46Z",
+      "message": null,
+      "name": "Oracle Vault",
+      "outcome": "success",
+      "protocol": "<unknown ERC-7540>",
+      "share_balance_raw": "9980872"
+    },
+    "42161-0x3a7d08b8b8e22251efb112868a1640df2fdbcb83": {
+      "address": "0x3a7d08b8b8e22251efb112868a1640df2fdbcb83",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x3a7d08b8b8e22251efb112868a1640df2fdbcb83",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "DeFi Janus Henderson Anemoy Treasury Fund Token",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0x3a7d08b8b8e22251efb112868a1640df2fdbcb83",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "DeFi Janus Henderson Anemoy Treasury Fund Token",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0x3a7d08b8b8e22251efb112868a1640df2fdbcb83",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:31Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "DeFi Janus Henderson Anemoy Treasury Fund Token",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0x3a7d08b8b8e22251efb112868a1640df2fdbcb83",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "DeFi Janus Henderson Anemoy Treasury Fund Token",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0x3a7d08b8b8e22251efb112868a1640df2fdbcb83",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:15Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "DeFi Janus Henderson Anemoy Treasury Fund Token",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0x3a7d08b8b8e22251efb112868a1640df2fdbcb83",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:55:15Z",
+          "message": "Vault deposits are currently closed",
+          "name": "DeFi Janus Henderson Anemoy Treasury Fund Token",
+          "outcome": "skipped",
+          "protocol": "Centrifuge"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:49:06Z",
+      "max_deposit_guidance": "0",
+      "message": "Anvil transaction reverted",
+      "name": "DeFi Janus Henderson Anemoy Treasury Fund Token",
+      "outcome": "reverted",
+      "protocol": "Centrifuge",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x3a87cf9af4d21778dad1ce7d0bf053f4b8f2631f": {
+      "address": "0x3a87cf9af4d21778dad1ce7d0bf053f4b8f2631f",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x3a87cf9af4d21778dad1ce7d0bf053f4b8f2631f",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:14Z",
+          "message": "Transaction must include these fields: {'gasPrice'}",
+          "name": "Peapods Interest Bearing USDC - 6",
+          "outcome": "rpc_error",
+          "protocol": "Peapods"
+        },
+        {
+          "address": "0x3a87cf9af4d21778dad1ce7d0bf053f4b8f2631f",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:00:29Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 6",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "20683799"
+        },
+        {
+          "address": "0x3a87cf9af4d21778dad1ce7d0bf053f4b8f2631f",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:03:25Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 6",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "20683785"
+        },
+        {
+          "address": "0x3a87cf9af4d21778dad1ce7d0bf053f4b8f2631f",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:15:21Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 6",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "20683728"
+        },
+        {
+          "address": "0x3a87cf9af4d21778dad1ce7d0bf053f4b8f2631f",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:56:43Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 6",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "20683525"
+        },
+        {
+          "address": "0x3a87cf9af4d21778dad1ce7d0bf053f4b8f2631f",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:22:40Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 6",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "20683402"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:36:02Z",
+      "message": null,
+      "name": "Peapods Interest Bearing USDC - 6",
+      "outcome": "success",
+      "protocol": "Peapods",
+      "share_balance_raw": "20683339"
+    },
+    "42161-0x3dc49d34704386d301c4e407b40b3ecf05225cd5": {
+      "address": "0x3dc49d34704386d301c4e407b40b3ecf05225cd5",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x3dc49d34704386d301c4e407b40b3ecf05225cd5",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "SafeYields Emma AI",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0x3dc49d34704386d301c4e407b40b3ecf05225cd5",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "SafeYields Emma AI",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0x3dc49d34704386d301c4e407b40b3ecf05225cd5",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "SafeYields Emma AI",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0x3dc49d34704386d301c4e407b40b3ecf05225cd5",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "SafeYields Emma AI",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0x3dc49d34704386d301c4e407b40b3ecf05225cd5",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:17Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "SafeYields Emma AI",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0x3dc49d34704386d301c4e407b40b3ecf05225cd5",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:34Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "SafeYields Emma AI",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0x3dc49d34704386d301c4e407b40b3ecf05225cd5",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:57:37Z",
+          "message": null,
+          "name": "SafeYields Emma AI",
+          "outcome": "success",
+          "protocol": "Plutus",
+          "share_balance_raw": "10000000"
+        },
+        {
+          "address": "0x3dc49d34704386d301c4e407b40b3ecf05225cd5",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:23:38Z",
+          "message": null,
+          "name": "SafeYields Emma AI",
+          "outcome": "success",
+          "protocol": "Plutus",
+          "share_balance_raw": "10000000"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:37:40Z",
+      "message": null,
+      "name": "SafeYields Emma AI",
+      "outcome": "success",
+      "protocol": "Plutus",
+      "share_balance_raw": "10000000"
+    },
+    "42161-0x3e54d27975cdf0b28a10e04fb53184140757a344": {
+      "address": "0x3e54d27975cdf0b28a10e04fb53184140757a344",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x3e54d27975cdf0b28a10e04fb53184140757a344",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:10Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x3e54d27975cdf0b28a10e04fb53184140757a344",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:59:52Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x3e54d27975cdf0b28a10e04fb53184140757a344",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "USDCVault",
+          "outcome": "skipped",
+          "protocol": "Morpho"
+        },
+        {
+          "address": "0x3e54d27975cdf0b28a10e04fb53184140757a344",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "USDCVault",
+          "outcome": "skipped",
+          "protocol": "Morpho"
+        },
+        {
+          "address": "0x3e54d27975cdf0b28a10e04fb53184140757a344",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:09Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "USDCVault",
+          "outcome": "adapter_error",
+          "protocol": "Morpho"
+        },
+        {
+          "address": "0x3e54d27975cdf0b28a10e04fb53184140757a344",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:26Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "USDCVault",
+          "outcome": "adapter_error",
+          "protocol": "Morpho"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T17:59:46Z",
+      "message": "Vault deposits are currently closed",
+      "name": "USDCVault",
+      "outcome": "skipped",
+      "protocol": "Morpho"
+    },
+    "42161-0x3e9d19c8fdee09c7aeb9effeef74ccf5131bcf58": {
+      "address": "0x3e9d19c8fdee09c7aeb9effeef74ccf5131bcf58",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x3e9d19c8fdee09c7aeb9effeef74ccf5131bcf58",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x3e9d19c8fdee09c7aeb9effeef74ccf5131bcf58",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x3e9d19c8fdee09c7aeb9effeef74ccf5131bcf58",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "USDT Multi-Strategy Vault",
+          "outcome": "skipped",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x3e9d19c8fdee09c7aeb9effeef74ccf5131bcf58",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "USDT Multi-Strategy Vault",
+          "outcome": "skipped",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x3e9d19c8fdee09c7aeb9effeef74ccf5131bcf58",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:24:46Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "USDT Multi-Strategy Vault",
+          "outcome": "adapter_error",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x3e9d19c8fdee09c7aeb9effeef74ccf5131bcf58",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:05Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "USDT Multi-Strategy Vault",
+          "outcome": "adapter_error",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x3e9d19c8fdee09c7aeb9effeef74ccf5131bcf58",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:56:06Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "USDT Multi-Strategy Vault",
+          "outcome": "funding_error",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x3e9d19c8fdee09c7aeb9effeef74ccf5131bcf58",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:15:51Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "USDT Multi-Strategy Vault",
+          "outcome": "funding_error",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x3e9d19c8fdee09c7aeb9effeef74ccf5131bcf58",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:23:23Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "USDT Multi-Strategy Vault",
+          "outcome": "funding_error",
+          "protocol": "Goat Protocol"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:25:13Z",
+      "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "name": "USDT Multi-Strategy Vault",
+      "outcome": "funding_error",
+      "protocol": "Goat Protocol"
+    },
+    "42161-0x3f97cea640b8b93472143f87a96d5a86f1f5167f": {
+      "address": "0x3f97cea640b8b93472143f87a96d5a86f1f5167f",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x3f97cea640b8b93472143f87a96d5a86f1f5167f",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "IPOR USDC Arbitrum Optimizer Pilot 2",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0x3f97cea640b8b93472143f87a96d5a86f1f5167f",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "IPOR USDC Arbitrum Optimizer Pilot 2",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0x3f97cea640b8b93472143f87a96d5a86f1f5167f",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:43Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "IPOR USDC Arbitrum Optimizer Pilot 2",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0x3f97cea640b8b93472143f87a96d5a86f1f5167f",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "IPOR USDC Arbitrum Optimizer Pilot 2",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0x3f97cea640b8b93472143f87a96d5a86f1f5167f",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:24:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "IPOR USDC Arbitrum Optimizer Pilot 2",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0x3f97cea640b8b93472143f87a96d5a86f1f5167f",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:33Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "IPOR USDC Arbitrum Optimizer Pilot 2",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0x3f97cea640b8b93472143f87a96d5a86f1f5167f",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:57:36Z",
+          "message": "Anvil transaction reverted",
+          "name": "IPOR USDC Arbitrum Optimizer Pilot 2",
+          "outcome": "reverted",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0x3f97cea640b8b93472143f87a96d5a86f1f5167f",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:17:35Z",
+          "message": "Anvil transaction reverted",
+          "name": "IPOR USDC Arbitrum Optimizer Pilot 2",
+          "outcome": "reverted",
+          "protocol": "IPOR Fusion",
+          "revert_reason": "Anvil transaction reverted"
+        },
+        {
+          "address": "0x3f97cea640b8b93472143f87a96d5a86f1f5167f",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:26:18Z",
+          "message": "Anvil transaction reverted",
+          "name": "IPOR USDC Arbitrum Optimizer Pilot 2",
+          "outcome": "reverted",
+          "protocol": "IPOR Fusion",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:27:56Z",
+      "message": "Anvil transaction reverted",
+      "name": "IPOR USDC Arbitrum Optimizer Pilot 2",
+      "outcome": "reverted",
+      "protocol": "IPOR Fusion",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x407d3d942d0911a2fea7e22417f81e27c02d6c6f": {
+      "address": "0x407d3d942d0911a2fea7e22417f81e27c02d6c6f",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x407d3d942d0911a2fea7e22417f81e27c02d6c6f",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Autopilot USDC Arbitrum",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0x407d3d942d0911a2fea7e22417f81e27c02d6c6f",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Autopilot USDC Arbitrum",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0x407d3d942d0911a2fea7e22417f81e27c02d6c6f",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:43Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Autopilot USDC Arbitrum",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0x407d3d942d0911a2fea7e22417f81e27c02d6c6f",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Autopilot USDC Arbitrum",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0x407d3d942d0911a2fea7e22417f81e27c02d6c6f",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:24:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Autopilot USDC Arbitrum",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0x407d3d942d0911a2fea7e22417f81e27c02d6c6f",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:33Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Autopilot USDC Arbitrum",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0x407d3d942d0911a2fea7e22417f81e27c02d6c6f",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:57:27Z",
+          "message": null,
+          "name": "Autopilot USDC Arbitrum",
+          "outcome": "success",
+          "protocol": "IPOR Fusion",
+          "share_balance_raw": "2306585486"
+        },
+        {
+          "address": "0x407d3d942d0911a2fea7e22417f81e27c02d6c6f",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:17:27Z",
+          "message": null,
+          "name": "Autopilot USDC Arbitrum",
+          "outcome": "success",
+          "protocol": "IPOR Fusion",
+          "share_balance_raw": "2306585748"
+        },
+        {
+          "address": "0x407d3d942d0911a2fea7e22417f81e27c02d6c6f",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:26:08Z",
+          "message": null,
+          "name": "Autopilot USDC Arbitrum",
+          "outcome": "success",
+          "protocol": "IPOR Fusion",
+          "share_balance_raw": "2306585863"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:27:48Z",
+      "message": null,
+      "name": "Autopilot USDC Arbitrum",
+      "outcome": "success",
+      "protocol": "IPOR Fusion",
+      "share_balance_raw": "2306585885"
+    },
+    "42161-0x426e8778bf7f54b0e4fc703dcca6f26a4e5b71de": {
+      "address": "0x426e8778bf7f54b0e4fc703dcca6f26a4e5b71de",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:43:06Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Could not find balance slot for token 0x82E64f49Ed5EC1bC6e43DAD4FC8Af9bb3A2312EE",
+      "name": "Static Aave Arbitrum DAI",
+      "outcome": "funding_error",
+      "protocol": "Superform"
+    },
+    "42161-0x43723a795293dd94f6e22b1233e2a5d44f1619f1": {
+      "address": "0x43723a795293dd94f6e22b1233e2a5d44f1619f1",
+      "attempt_count": 6,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x43723a795293dd94f6e22b1233e2a5d44f1619f1",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Gravity Team",
+          "outcome": "adapter_error",
+          "protocol": "TrueFi"
+        },
+        {
+          "address": "0x43723a795293dd94f6e22b1233e2a5d44f1619f1",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Gravity Team",
+          "outcome": "adapter_error",
+          "protocol": "TrueFi"
+        },
+        {
+          "address": "0x43723a795293dd94f6e22b1233e2a5d44f1619f1",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Gravity Team",
+          "outcome": "adapter_error",
+          "protocol": "TrueFi"
+        },
+        {
+          "address": "0x43723a795293dd94f6e22b1233e2a5d44f1619f1",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Gravity Team",
+          "outcome": "adapter_error",
+          "protocol": "TrueFi"
+        },
+        {
+          "address": "0x43723a795293dd94f6e22b1233e2a5d44f1619f1",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:56:32Z",
+          "message": "Vault deposits are currently closed",
+          "name": "Gravity Team",
+          "outcome": "skipped",
+          "protocol": "TrueFi"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:46:03Z",
+      "max_deposit_guidance": "0",
+      "message": "Anvil transaction reverted",
+      "name": "Gravity Team",
+      "outcome": "reverted",
+      "protocol": "TrueFi",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x444868b6e8079ac2c55eea115250f92c2b2c4d14": {
+      "address": "0x444868b6e8079ac2c55eea115250f92c2b2c4d14",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x444868b6e8079ac2c55eea115250f92c2b2c4d14",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Dolomite: USDC",
+          "outcome": "adapter_error",
+          "protocol": "Dolomite"
+        },
+        {
+          "address": "0x444868b6e8079ac2c55eea115250f92c2b2c4d14",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Dolomite: USDC",
+          "outcome": "adapter_error",
+          "protocol": "Dolomite"
+        },
+        {
+          "address": "0x444868b6e8079ac2c55eea115250f92c2b2c4d14",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:31Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Dolomite: USDC",
+          "outcome": "adapter_error",
+          "protocol": "Dolomite"
+        },
+        {
+          "address": "0x444868b6e8079ac2c55eea115250f92c2b2c4d14",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Dolomite: USDC",
+          "outcome": "adapter_error",
+          "protocol": "Dolomite"
+        },
+        {
+          "address": "0x444868b6e8079ac2c55eea115250f92c2b2c4d14",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:15Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Dolomite: USDC",
+          "outcome": "adapter_error",
+          "protocol": "Dolomite"
+        },
+        {
+          "address": "0x444868b6e8079ac2c55eea115250f92c2b2c4d14",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:55:39Z",
+          "message": null,
+          "name": "Dolomite: USDC",
+          "outcome": "success",
+          "protocol": "Dolomite",
+          "share_balance_raw": "7872597"
+        },
+        {
+          "address": "0x444868b6e8079ac2c55eea115250f92c2b2c4d14",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:11:26Z",
+          "message": null,
+          "name": "Dolomite: USDC",
+          "outcome": "success",
+          "protocol": "Dolomite",
+          "share_balance_raw": "7872586"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:18:41Z",
+      "message": null,
+      "name": "Dolomite: USDC",
+      "outcome": "success",
+      "protocol": "Dolomite",
+      "share_balance_raw": "7872581"
+    },
+    "42161-0x45df0656f8adf017590009d2f1898eeca4f0a205": {
+      "address": "0x45df0656f8adf017590009d2f1898eeca4f0a205",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x45df0656f8adf017590009d2f1898eeca4f0a205",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:21:07Z",
+          "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "name": "Fluid Wrapped Ether",
+          "outcome": "funding_error",
+          "protocol": "Fluid"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:22:56Z",
+      "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "name": "Fluid Wrapped Ether",
+      "outcome": "funding_error",
+      "protocol": "Fluid"
+    },
+    "42161-0x4739e2c293bdcd835829aa7c5d7fbdee93565d1a": {
+      "address": "0x4739e2c293bdcd835829aa7c5d7fbdee93565d1a",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:33:57Z",
+      "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "name": "Steakhouse High Yield USDT0",
+      "outcome": "funding_error",
+      "protocol": "Morpho"
+    },
+    "42161-0x4772d2e014f9fc3a820c444e3313968e9a5c8121": {
+      "address": "0x4772d2e014f9fc3a820c444e3313968e9a5c8121",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x4772d2e014f9fc3a820c444e3313968e9a5c8121",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "YieldFi yUSD",
+          "outcome": "adapter_error",
+          "protocol": "YieldFi"
+        },
+        {
+          "address": "0x4772d2e014f9fc3a820c444e3313968e9a5c8121",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "YieldFi yUSD",
+          "outcome": "adapter_error",
+          "protocol": "YieldFi"
+        },
+        {
+          "address": "0x4772d2e014f9fc3a820c444e3313968e9a5c8121",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "YieldFi yUSD",
+          "outcome": "adapter_error",
+          "protocol": "YieldFi"
+        },
+        {
+          "address": "0x4772d2e014f9fc3a820c444e3313968e9a5c8121",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "YieldFi yUSD",
+          "outcome": "adapter_error",
+          "protocol": "YieldFi"
+        },
+        {
+          "address": "0x4772d2e014f9fc3a820c444e3313968e9a5c8121",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:58:36Z",
+          "message": "Anvil transaction reverted",
+          "name": "YieldFi yUSD",
+          "outcome": "reverted",
+          "protocol": "YieldFi"
+        },
+        {
+          "address": "0x4772d2e014f9fc3a820c444e3313968e9a5c8121",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:31:04Z",
+          "message": "Anvil transaction reverted",
+          "name": "YieldFi yUSD",
+          "outcome": "reverted",
+          "protocol": "YieldFi",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:50:39Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Anvil transaction reverted",
+      "name": "YieldFi yUSD",
+      "outcome": "reverted",
+      "protocol": "YieldFi",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x49014a8eb1585cbee6a7a9a50c3b81017bf6cc4d": {
+      "address": "0x49014a8eb1585cbee6a7a9a50c3b81017bf6cc4d",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x49014a8eb1585cbee6a7a9a50c3b81017bf6cc4d",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:10Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x49014a8eb1585cbee6a7a9a50c3b81017bf6cc4d",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:59:52Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x49014a8eb1585cbee6a7a9a50c3b81017bf6cc4d",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Llama Lend WETH / crvUSD",
+          "outcome": "skipped",
+          "protocol": "Llama Lend"
+        },
+        {
+          "address": "0x49014a8eb1585cbee6a7a9a50c3b81017bf6cc4d",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Llama Lend WETH / crvUSD",
+          "outcome": "skipped",
+          "protocol": "Llama Lend"
+        },
+        {
+          "address": "0x49014a8eb1585cbee6a7a9a50c3b81017bf6cc4d",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:02Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Llama Lend WETH / crvUSD",
+          "outcome": "adapter_error",
+          "protocol": "Llama Lend"
+        },
+        {
+          "address": "0x49014a8eb1585cbee6a7a9a50c3b81017bf6cc4d",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:59:31Z",
+          "message": "Could not find balance slot for token 0x498Bf2B1e120FeD3ad3D42EA2165E9b73f99C1e5",
+          "name": "Llama Lend WETH / crvUSD",
+          "outcome": "funding_error",
+          "protocol": "Llama Lend"
+        },
+        {
+          "address": "0x49014a8eb1585cbee6a7a9a50c3b81017bf6cc4d",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:19:51Z",
+          "message": "Could not find balance slot for token 0x498Bf2B1e120FeD3ad3D42EA2165E9b73f99C1e5",
+          "name": "Llama Lend WETH / crvUSD",
+          "outcome": "funding_error",
+          "protocol": "Llama Lend"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:32:13Z",
+      "message": "Could not find balance slot for token 0x498Bf2B1e120FeD3ad3D42EA2165E9b73f99C1e5",
+      "name": "Llama Lend WETH / crvUSD",
+      "outcome": "funding_error",
+      "protocol": "Llama Lend"
+    },
+    "42161-0x4a03f37e7d3fc243e3f99341d36f4b829bee5e03": {
+      "address": "0x4a03f37e7d3fc243e3f99341d36f4b829bee5e03",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x4a03f37e7d3fc243e3f99341d36f4b829bee5e03",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x4a03f37e7d3fc243e3f99341d36f4b829bee5e03",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x4a03f37e7d3fc243e3f99341d36f4b829bee5e03",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Fluid Tether USD",
+          "outcome": "skipped",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0x4a03f37e7d3fc243e3f99341d36f4b829bee5e03",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Fluid Tether USD",
+          "outcome": "skipped",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0x4a03f37e7d3fc243e3f99341d36f4b829bee5e03",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:49Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Fluid Tether USD",
+          "outcome": "adapter_error",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0x4a03f37e7d3fc243e3f99341d36f4b829bee5e03",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:57:04Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Fluid Tether USD",
+          "outcome": "funding_error",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0x4a03f37e7d3fc243e3f99341d36f4b829bee5e03",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:13:15Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Fluid Tether USD",
+          "outcome": "funding_error",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0x4a03f37e7d3fc243e3f99341d36f4b829bee5e03",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:20:18Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Fluid Tether USD",
+          "outcome": "funding_error",
+          "protocol": "Fluid"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:22:24Z",
+      "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "name": "Fluid Tether USD",
+      "outcome": "funding_error",
+      "protocol": "Fluid"
+    },
+    "42161-0x4a15404235f4a0bc2cbcf5ba7e92763cb8335660": {
+      "address": "0x4a15404235f4a0bc2cbcf5ba7e92763cb8335660",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x4a15404235f4a0bc2cbcf5ba7e92763cb8335660",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x4a15404235f4a0bc2cbcf5ba7e92763cb8335660",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x4a15404235f4a0bc2cbcf5ba7e92763cb8335660",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Plutus Loop vault",
+          "outcome": "skipped",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0x4a15404235f4a0bc2cbcf5ba7e92763cb8335660",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Plutus Loop vault",
+          "outcome": "skipped",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0x4a15404235f4a0bc2cbcf5ba7e92763cb8335660",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:17Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Plutus Loop vault",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0x4a15404235f4a0bc2cbcf5ba7e92763cb8335660",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:34Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Plutus Loop vault",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0x4a15404235f4a0bc2cbcf5ba7e92763cb8335660",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:57:40Z",
+          "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "name": "Plutus Loop vault",
+          "outcome": "funding_error",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0x4a15404235f4a0bc2cbcf5ba7e92763cb8335660",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:23:42Z",
+          "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "name": "Plutus Loop vault",
+          "outcome": "funding_error",
+          "protocol": "Plutus"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:37:43Z",
+      "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "name": "Plutus Loop vault",
+      "outcome": "funding_error",
+      "protocol": "Plutus"
+    },
+    "42161-0x4a3f7dd63077cde8d7eff3c958eb69a3dd7d31a9": {
+      "address": "0x4a3f7dd63077cde8d7eff3c958eb69a3dd7d31a9",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "generic_erc4626",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x4a3f7dd63077cde8d7eff3c958eb69a3dd7d31a9",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "USDn2",
+          "outcome": "adapter_error",
+          "protocol": "Untangle Finance"
+        },
+        {
+          "address": "0x4a3f7dd63077cde8d7eff3c958eb69a3dd7d31a9",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "USDn2",
+          "outcome": "adapter_error",
+          "protocol": "Untangle Finance"
+        },
+        {
+          "address": "0x4a3f7dd63077cde8d7eff3c958eb69a3dd7d31a9",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "USDn2",
+          "outcome": "adapter_error",
+          "protocol": "Untangle Finance"
+        },
+        {
+          "address": "0x4a3f7dd63077cde8d7eff3c958eb69a3dd7d31a9",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "USDn2",
+          "outcome": "adapter_error",
+          "protocol": "Untangle Finance"
+        },
+        {
+          "address": "0x4a3f7dd63077cde8d7eff3c958eb69a3dd7d31a9",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:57:29Z",
+          "message": null,
+          "name": "USDn2",
+          "outcome": "success",
+          "protocol": "Untangle Finance",
+          "share_balance_raw": "10411225"
+        },
+        {
+          "address": "0x4a3f7dd63077cde8d7eff3c958eb69a3dd7d31a9",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:29:43Z",
+          "message": "Got <class 'eth_defi.erc_4626.vault_protocol.untangle.vault.UntangleVault'>",
+          "name": "USDn2",
+          "outcome": "rpc_error",
+          "protocol": "Untangle Finance",
+          "share_balance_raw": "10411225"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:48:32Z",
+      "message": "Got <class 'eth_defi.erc_4626.vault_protocol.untangle.vault.UntangleVault'>",
+      "name": "USDn2",
+      "outcome": "rpc_error",
+      "protocol": "Untangle Finance",
+      "share_balance_raw": "10411225"
+    },
+    "42161-0x4b6f1c9e5d470b97181786b26da0d0945a7cf027": {
+      "address": "0x4b6f1c9e5d470b97181786b26da0d0945a7cf027",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x4b6f1c9e5d470b97181786b26da0d0945a7cf027",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:21:29Z",
+          "message": null,
+          "name": "Hyperithm USDC",
+          "outcome": "success",
+          "protocol": "Morpho",
+          "share_balance_raw": "9550058467732998568"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:33:47Z",
+      "message": null,
+      "name": "Hyperithm USDC",
+      "outcome": "success",
+      "protocol": "Morpho",
+      "share_balance_raw": "9550050126193391147"
+    },
+    "42161-0x4bca8d73561aaeee2d3a584b9f4665310de1dd69": {
+      "address": "0x4bca8d73561aaeee2d3a584b9f4665310de1dd69",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:47:53Z",
+      "max_deposit_guidance": "23381964391377527805",
+      "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "name": "gmWETH",
+      "outcome": "funding_error",
+      "protocol": "Umami"
+    },
+    "42161-0x4beef1113f968326905224d2ca272f3032a9a9f4": {
+      "address": "0x4beef1113f968326905224d2ca272f3032a9a9f4",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "denomination_token_address": "0x18c11FD286C5EC11c3b683Caa813B77f5163A122",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "asynchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x4beef1113f968326905224d2ca272f3032a9a9f4",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x4beef1113f968326905224d2ca272f3032a9a9f4",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x4beef1113f968326905224d2ca272f3032a9a9f4",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "gTrade (Vault Staked GNS)",
+          "outcome": "skipped",
+          "protocol": "Gains Network"
+        },
+        {
+          "address": "0x4beef1113f968326905224d2ca272f3032a9a9f4",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "gTrade (Vault Staked GNS)",
+          "outcome": "skipped",
+          "protocol": "Gains Network"
+        },
+        {
+          "address": "0x4beef1113f968326905224d2ca272f3032a9a9f4",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "denomination_token_address": "0x18c11FD286C5EC11c3b683Caa813B77f5163A122",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:24:33Z",
+          "message": null,
+          "name": "gTrade (Vault Staked GNS)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "9948289180984316402"
+        },
+        {
+          "address": "0x4beef1113f968326905224d2ca272f3032a9a9f4",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0x18c11FD286C5EC11c3b683Caa813B77f5163A122",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:25:39Z",
+          "message": null,
+          "name": "gTrade (Vault Staked GNS)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "9948289180984316402"
+        },
+        {
+          "address": "0x4beef1113f968326905224d2ca272f3032a9a9f4",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0x18c11FD286C5EC11c3b683Caa813B77f5163A122",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:55:12Z",
+          "message": null,
+          "name": "gTrade (Vault Staked GNS)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "9948289180984316402"
+        },
+        {
+          "address": "0x4beef1113f968326905224d2ca272f3032a9a9f4",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0x18c11FD286C5EC11c3b683Caa813B77f5163A122",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:14:45Z",
+          "message": null,
+          "name": "gTrade (Vault Staked GNS)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "9948289180984316402"
+        },
+        {
+          "address": "0x4beef1113f968326905224d2ca272f3032a9a9f4",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0x18c11FD286C5EC11c3b683Caa813B77f5163A122",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:22:14Z",
+          "message": null,
+          "name": "gTrade (Vault Staked GNS)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "9948289180984316402"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:24:02Z",
+      "message": null,
+      "name": "gTrade (Vault Staked GNS)",
+      "outcome": "success",
+      "protocol": "Gains Network",
+      "share_balance_raw": "9948289180984316402"
+    },
+    "42161-0x4c4f752fa54dafb6d51b4a39018271c90ba1156f": {
+      "address": "0x4c4f752fa54dafb6d51b4a39018271c90ba1156f",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x4c4f752fa54dafb6d51b4a39018271c90ba1156f",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x4c4f752fa54dafb6d51b4a39018271c90ba1156f",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x4c4f752fa54dafb6d51b4a39018271c90ba1156f",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Llamarisk crvUSD Vault",
+          "outcome": "skipped",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0x4c4f752fa54dafb6d51b4a39018271c90ba1156f",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Llamarisk crvUSD Vault",
+          "outcome": "skipped",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0x4c4f752fa54dafb6d51b4a39018271c90ba1156f",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:24:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Llamarisk crvUSD Vault",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0x4c4f752fa54dafb6d51b4a39018271c90ba1156f",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:33Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Llamarisk crvUSD Vault",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T17:57:28Z",
+      "message": "Vault deposits are currently closed",
+      "name": "Llamarisk crvUSD Vault",
+      "outcome": "skipped",
+      "protocol": "IPOR Fusion"
+    },
+    "42161-0x4f63cfea7458221cb3a0eee2f31f7424ad34bb58": {
+      "address": "0x4f63cfea7458221cb3a0eee2f31f7424ad34bb58",
+      "attempt_count": 6,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x4f63cfea7458221cb3a0eee2f31f7424ad34bb58",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Summer.fi USDC",
+          "outcome": "adapter_error",
+          "protocol": "Summer.fi"
+        },
+        {
+          "address": "0x4f63cfea7458221cb3a0eee2f31f7424ad34bb58",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Summer.fi USDC",
+          "outcome": "adapter_error",
+          "protocol": "Summer.fi"
+        },
+        {
+          "address": "0x4f63cfea7458221cb3a0eee2f31f7424ad34bb58",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Summer.fi USDC",
+          "outcome": "adapter_error",
+          "protocol": "Summer.fi"
+        },
+        {
+          "address": "0x4f63cfea7458221cb3a0eee2f31f7424ad34bb58",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Summer.fi USDC",
+          "outcome": "adapter_error",
+          "protocol": "Summer.fi"
+        },
+        {
+          "address": "0x4f63cfea7458221cb3a0eee2f31f7424ad34bb58",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:25Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Summer.fi USDC",
+          "outcome": "adapter_error",
+          "protocol": "Summer.fi"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:00:15Z",
+      "message": "Vault deposits are currently closed",
+      "name": "Summer.fi USDC",
+      "outcome": "skipped",
+      "protocol": "Summer.fi"
+    },
+    "42161-0x531c86fb8c6685dc3f136f6143f99ae83dc4847f": {
+      "address": "0x531c86fb8c6685dc3f136f6143f99ae83dc4847f",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "history": [
+        {
+          "address": "0x531c86fb8c6685dc3f136f6143f99ae83dc4847f",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:19:33Z",
+          "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+          "name": "fija ETH GMXv2 FT",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:21:31Z",
+      "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+      "name": "fija ETH GMXv2 FT",
+      "outcome": "rpc_error",
+      "protocol": "ERC-4626"
+    },
+    "42161-0x532b6fe3dee66e5496a565bc939f98965eb35429": {
+      "address": "0x532b6fe3dee66e5496a565bc939f98965eb35429",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x532b6fe3dee66e5496a565bc939f98965eb35429",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:10Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x532b6fe3dee66e5496a565bc939f98965eb35429",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:59:52Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x532b6fe3dee66e5496a565bc939f98965eb35429",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "SMCVault",
+          "outcome": "skipped",
+          "protocol": "Morpho"
+        },
+        {
+          "address": "0x532b6fe3dee66e5496a565bc939f98965eb35429",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "SMCVault",
+          "outcome": "skipped",
+          "protocol": "Morpho"
+        },
+        {
+          "address": "0x532b6fe3dee66e5496a565bc939f98965eb35429",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:09Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "SMCVault",
+          "outcome": "adapter_error",
+          "protocol": "Morpho"
+        },
+        {
+          "address": "0x532b6fe3dee66e5496a565bc939f98965eb35429",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:26Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "SMCVault",
+          "outcome": "adapter_error",
+          "protocol": "Morpho"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T17:59:46Z",
+      "message": "Vault deposits are currently closed",
+      "name": "SMCVault",
+      "outcome": "skipped",
+      "protocol": "Morpho"
+    },
+    "42161-0x5411ef03f2ee209fd7f8941d0ef68981592a804b": {
+      "address": "0x5411ef03f2ee209fd7f8941d0ef68981592a804b",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x5411ef03f2ee209fd7f8941d0ef68981592a804b",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:27:16Z",
+          "message": "Anvil transaction reverted",
+          "name": "Yield FTW",
+          "outcome": "reverted",
+          "protocol": "IPOR Fusion",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:29:00Z",
+      "message": "Anvil transaction reverted",
+      "name": "Yield FTW",
+      "outcome": "reverted",
+      "protocol": "IPOR Fusion",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x546fa92a0a80058545e750fe2966a2f68a09e827": {
+      "address": "0x546fa92a0a80058545e750fe2966a2f68a09e827",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:37:13Z",
+      "message": null,
+      "name": "Peapods Metavault for USD Coin",
+      "outcome": "success",
+      "protocol": "Peapods",
+      "share_balance_raw": "9607574"
+    },
+    "42161-0x55bfca1b8a4ee0a96ca796d0bc542ec4e604a2e5": {
+      "address": "0x55bfca1b8a4ee0a96ca796d0bc542ec4e604a2e5",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:45:14Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Anvil transaction reverted",
+      "name": "USDC-DN-FLAGSHIP shares",
+      "outcome": "reverted",
+      "protocol": "Teller",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x57587aee66d70d99024b02919901cfe552f5a0d4": {
+      "address": "0x57587aee66d70d99024b02919901cfe552f5a0d4",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:31:38Z",
+      "message": "Unsupported to=0xf516830A8b3F45790B01cEfB7dE7626dF96CC5D7",
+      "name": "Dynamic Alpha Sentiment 2X ",
+      "outcome": "rpc_error",
+      "protocol": "Lagoon Finance"
+    },
+    "42161-0x578d5c8e4822b3b1d0a6241cb09d0be6695b1809": {
+      "address": "0x578d5c8e4822b3b1d0a6241cb09d0be6695b1809",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x578d5c8e4822b3b1d0a6241cb09d0be6695b1809",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x578d5c8e4822b3b1d0a6241cb09d0be6695b1809",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x578d5c8e4822b3b1d0a6241cb09d0be6695b1809",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Supply USDT into AAVE",
+          "outcome": "skipped",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0x578d5c8e4822b3b1d0a6241cb09d0be6695b1809",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Supply USDT into AAVE",
+          "outcome": "skipped",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0x578d5c8e4822b3b1d0a6241cb09d0be6695b1809",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:13Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Supply USDT into AAVE",
+          "outcome": "adapter_error",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0x578d5c8e4822b3b1d0a6241cb09d0be6695b1809",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:58:10Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Supply USDT into AAVE",
+          "outcome": "funding_error",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0x578d5c8e4822b3b1d0a6241cb09d0be6695b1809",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:24:31Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Supply USDT into AAVE",
+          "outcome": "funding_error",
+          "protocol": "Royco"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:38:24Z",
+      "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "name": "Supply USDT into AAVE",
+      "outcome": "funding_error",
+      "protocol": "Royco"
+    },
+    "42161-0x58bfc95a864e18e8f3041d2fcd3418f48393fe6a": {
+      "address": "0x58bfc95a864e18e8f3041d2fcd3418f48393fe6a",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x58bfc95a864e18e8f3041d2fcd3418f48393fe6a",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Plutus Hedge Token",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0x58bfc95a864e18e8f3041d2fcd3418f48393fe6a",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Plutus Hedge Token",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0x58bfc95a864e18e8f3041d2fcd3418f48393fe6a",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Plutus Hedge Token",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0x58bfc95a864e18e8f3041d2fcd3418f48393fe6a",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Plutus Hedge Token",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0x58bfc95a864e18e8f3041d2fcd3418f48393fe6a",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:17Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Plutus Hedge Token",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0x58bfc95a864e18e8f3041d2fcd3418f48393fe6a",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:34Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Plutus Hedge Token",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0x58bfc95a864e18e8f3041d2fcd3418f48393fe6a",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:57:25Z",
+          "message": null,
+          "name": "Plutus Hedge Token",
+          "outcome": "success",
+          "protocol": "Plutus",
+          "share_balance_raw": "7900731"
+        },
+        {
+          "address": "0x58bfc95a864e18e8f3041d2fcd3418f48393fe6a",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:23:25Z",
+          "message": null,
+          "name": "Plutus Hedge Token",
+          "outcome": "success",
+          "protocol": "Plutus",
+          "share_balance_raw": "7900731"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:37:29Z",
+      "message": null,
+      "name": "Plutus Hedge Token",
+      "outcome": "success",
+      "protocol": "Plutus",
+      "share_balance_raw": "7900731"
+    },
+    "42161-0x5977a9682d7af81d347cfc338c61692163a2784c": {
+      "address": "0x5977a9682d7af81d347cfc338c61692163a2784c",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "asynchronous"
+      },
+      "history": [
+        {
+          "address": "0x5977a9682d7af81d347cfc338c61692163a2784c",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:22:31Z",
+          "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "name": "gTrade (Gains Network ETH)",
+          "outcome": "funding_error",
+          "protocol": "Gains Network"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:24:21Z",
+      "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "name": "gTrade (Gains Network ETH)",
+      "outcome": "funding_error",
+      "protocol": "Gains Network"
+    },
+    "42161-0x5c0c306aaa9f877de636f4d5822ca9f2e81563ba": {
+      "address": "0x5c0c306aaa9f877de636f4d5822ca9f2e81563ba",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x5c0c306aaa9f877de636f4d5822ca9f2e81563ba",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:20:54Z",
+          "message": null,
+          "name": "Steakhouse High Yield USDC",
+          "outcome": "success",
+          "protocol": "Morpho",
+          "share_balance_raw": "9655587452696330527"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:33:18Z",
+      "message": null,
+      "name": "Steakhouse High Yield USDC",
+      "outcome": "success",
+      "protocol": "Morpho",
+      "share_balance_raw": "9655579759141349467"
+    },
+    "42161-0x5eb03d0fcfd3860be03b81a1ab3d46db3315202a": {
+      "address": "0x5eb03d0fcfd3860be03b81a1ab3d46db3315202a",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x5eb03d0fcfd3860be03b81a1ab3d46db3315202a",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:15Z",
+          "message": "Transaction must include these fields: {'gasPrice'}",
+          "name": "Peapods Interest Bearing USDC - 38",
+          "outcome": "rpc_error",
+          "protocol": "Peapods"
+        },
+        {
+          "address": "0x5eb03d0fcfd3860be03b81a1ab3d46db3315202a",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:00:41Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 38",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "525341"
+        },
+        {
+          "address": "0x5eb03d0fcfd3860be03b81a1ab3d46db3315202a",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:03:35Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 38",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "525319"
+        },
+        {
+          "address": "0x5eb03d0fcfd3860be03b81a1ab3d46db3315202a",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:15:31Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 38",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "525221"
+        },
+        {
+          "address": "0x5eb03d0fcfd3860be03b81a1ab3d46db3315202a",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:56:51Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 38",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "524873"
+        },
+        {
+          "address": "0x5eb03d0fcfd3860be03b81a1ab3d46db3315202a",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:22:49Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 38",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "524663"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:36:13Z",
+      "message": null,
+      "name": "Peapods Interest Bearing USDC - 38",
+      "outcome": "success",
+      "protocol": "Peapods",
+      "share_balance_raw": "524555"
+    },
+    "42161-0x5f02c1bec4ad5de9b7abf999c1f0854d4836a049": {
+      "address": "0x5f02c1bec4ad5de9b7abf999c1f0854d4836a049",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x5f02c1bec4ad5de9b7abf999c1f0854d4836a049",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x5f02c1bec4ad5de9b7abf999c1f0854d4836a049",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x5f02c1bec4ad5de9b7abf999c1f0854d4836a049",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "",
+          "outcome": "skipped",
+          "protocol": "USDai"
+        },
+        {
+          "address": "0x5f02c1bec4ad5de9b7abf999c1f0854d4836a049",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "",
+          "outcome": "skipped",
+          "protocol": "USDai"
+        },
+        {
+          "address": "0x5f02c1bec4ad5de9b7abf999c1f0854d4836a049",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:49Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "",
+          "outcome": "adapter_error",
+          "protocol": "USDai"
+        },
+        {
+          "address": "0x5f02c1bec4ad5de9b7abf999c1f0854d4836a049",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:57:44Z",
+          "message": "Could not find balance slot for token 0x0A1a1A107E45b7Ced86833863f482BC5f4ed82EF",
+          "name": "",
+          "outcome": "funding_error",
+          "protocol": "USDai"
+        },
+        {
+          "address": "0x5f02c1bec4ad5de9b7abf999c1f0854d4836a049",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:29:57Z",
+          "message": "Could not find balance slot for token 0x0A1a1A107E45b7Ced86833863f482BC5f4ed82EF",
+          "name": "",
+          "outcome": "funding_error",
+          "protocol": "USDai"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:48:51Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Could not find balance slot for token 0x0A1a1A107E45b7Ced86833863f482BC5f4ed82EF",
+      "name": "",
+      "outcome": "funding_error",
+      "protocol": "USDai"
+    },
+    "42161-0x5f851f67d24419982ecd7b7765defd64fbb50a97": {
+      "address": "0x5f851f67d24419982ecd7b7765defd64fbb50a97",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": null,
+      "history": [
+        {
+          "address": "0x5f851f67d24419982ecd7b7765defd64fbb50a97",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "gmUSDC",
+          "outcome": "adapter_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0x5f851f67d24419982ecd7b7765defd64fbb50a97",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "gmUSDC",
+          "outcome": "adapter_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0x5f851f67d24419982ecd7b7765defd64fbb50a97",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "gmUSDC",
+          "outcome": "adapter_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0x5f851f67d24419982ecd7b7765defd64fbb50a97",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "gmUSDC",
+          "outcome": "adapter_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0x5f851f67d24419982ecd7b7765defd64fbb50a97",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:43Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "gmUSDC",
+          "outcome": "adapter_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0x5f851f67d24419982ecd7b7765defd64fbb50a97",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:56:51Z",
+          "message": "\nABI Not Found!\nNo element named `deposit` with 2 argument(s).\nProvided argument types: (int,address)\nProvided keyword argument types: {}\n\nTried to find a matching ABI element named `deposit`, but encountered the following problems:\nSignature: deposit(uint256,uint256,address), type: function\nExpected 3 argument(s) but received 2 argument(s).\n",
+          "name": "gmUSDC",
+          "outcome": "rpc_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0x5f851f67d24419982ecd7b7765defd64fbb50a97",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T18:28:59Z",
+          "message": "\nABI Not Found!\nNo element named `deposit` with 2 argument(s).\nProvided argument types: (int,address)\nProvided keyword argument types: {}\n\nTried to find a matching ABI element named `deposit`, but encountered the following problems:\nSignature: deposit(uint256,uint256,address), type: function\nExpected 3 argument(s) but received 2 argument(s).\n",
+          "name": "gmUSDC",
+          "outcome": "rpc_error",
+          "protocol": "Umami"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:46:26Z",
+      "message": "\nABI Not Found!\nNo element named `deposit` with 2 argument(s).\nProvided argument types: (int,address)\nProvided keyword argument types: {}\n\nTried to find a matching ABI element named `deposit`, but encountered the following problems:\nSignature: deposit(uint256,uint256,address), type: function\nExpected 3 argument(s) but received 2 argument(s).\n",
+      "name": "gmUSDC",
+      "outcome": "rpc_error",
+      "protocol": "Umami"
+    },
+    "42161-0x5ff92b1991504a35d7eaa74998663f402187c9ae": {
+      "address": "0x5ff92b1991504a35d7eaa74998663f402187c9ae",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x5ff92b1991504a35d7eaa74998663f402187c9ae",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:54Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x5ff92b1991504a35d7eaa74998663f402187c9ae",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:33Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x5ff92b1991504a35d7eaa74998663f402187c9ae",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "skipped",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0x5ff92b1991504a35d7eaa74998663f402187c9ae",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "skipped",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0x5ff92b1991504a35d7eaa74998663f402187c9ae",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:22:56Z",
+          "message": "Vault deposits are currently closed",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "skipped",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0x5ff92b1991504a35d7eaa74998663f402187c9ae",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:53:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "adapter_error",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0x5ff92b1991504a35d7eaa74998663f402187c9ae",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T18:08:23Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "adapter_error",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0x5ff92b1991504a35d7eaa74998663f402187c9ae",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T18:13:44Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "adapter_error",
+          "protocol": "<protocol not yet identified>"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:46:35Z",
+      "max_deposit_guidance": "0",
+      "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "name": "Delta Netural GMX Vault (Senior)",
+      "outcome": "funding_error",
+      "protocol": "<protocol not yet identified>"
+    },
+    "42161-0x60d38b12d22bf423f28082bf396ff8f28cc506b1": {
+      "address": "0x60d38b12d22bf423f28082bf396ff8f28cc506b1",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:32:26Z",
+      "message": "Could not find balance slot for token 0x498Bf2B1e120FeD3ad3D42EA2165E9b73f99C1e5",
+      "name": "Llama Lend WBTC / crvUSD",
+      "outcome": "funding_error",
+      "protocol": "Llama Lend"
+    },
+    "42161-0x6263782720a1f77be88038fe371d7bac17fb4652": {
+      "address": "0x6263782720a1f77be88038fe371d7bac17fb4652",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x6263782720a1f77be88038fe371d7bac17fb4652",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:54Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x6263782720a1f77be88038fe371d7bac17fb4652",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:33Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x6263782720a1f77be88038fe371d7bac17fb4652",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Foo USD Commit Token",
+          "outcome": "skipped",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x6263782720a1f77be88038fe371d7bac17fb4652",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Foo USD Commit Token",
+          "outcome": "skipped",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x6263782720a1f77be88038fe371d7bac17fb4652",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:23:06Z",
+          "message": "Could not find balance slot for token 0x972d3Dc804ec7CABEAb6D394b9a9f4E6c313dda7",
+          "name": "Foo USD Commit Token",
+          "outcome": "funding_error",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x6263782720a1f77be88038fe371d7bac17fb4652",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:54:06Z",
+          "message": "Could not find balance slot for token 0x972d3Dc804ec7CABEAb6D394b9a9f4E6c313dda7",
+          "name": "Foo USD Commit Token",
+          "outcome": "funding_error",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x6263782720a1f77be88038fe371d7bac17fb4652",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:08:37Z",
+          "message": "Could not find balance slot for token 0x972d3Dc804ec7CABEAb6D394b9a9f4E6c313dda7",
+          "name": "Foo USD Commit Token",
+          "outcome": "funding_error",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x6263782720a1f77be88038fe371d7bac17fb4652",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:14:19Z",
+          "message": "Could not find balance slot for token 0x972d3Dc804ec7CABEAb6D394b9a9f4E6c313dda7",
+          "name": "Foo USD Commit Token",
+          "outcome": "funding_error",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x6263782720a1f77be88038fe371d7bac17fb4652",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:17:52Z",
+          "message": "Could not find balance slot for token 0x972d3Dc804ec7CABEAb6D394b9a9f4E6c313dda7",
+          "name": "Foo USD Commit Token",
+          "outcome": "funding_error",
+          "protocol": "<unknown ERC-7540>"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:47:24Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Could not find balance slot for token 0x972d3Dc804ec7CABEAb6D394b9a9f4E6c313dda7",
+      "name": "Foo USD Commit Token",
+      "outcome": "funding_error",
+      "protocol": "<unknown ERC-7540>"
+    },
+    "42161-0x645c2712fda24a41ed61064054429e00cb4293bb": {
+      "address": "0x645c2712fda24a41ed61064054429e00cb4293bb",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "history": [
+        {
+          "address": "0x645c2712fda24a41ed61064054429e00cb4293bb",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x645c2712fda24a41ed61064054429e00cb4293bb",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x645c2712fda24a41ed61064054429e00cb4293bb",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "fija Strategy ETH GMXv2",
+          "outcome": "skipped",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0x645c2712fda24a41ed61064054429e00cb4293bb",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "fija Strategy ETH GMXv2",
+          "outcome": "skipped",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0x645c2712fda24a41ed61064054429e00cb4293bb",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:23:24Z",
+          "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+          "name": "fija Strategy ETH GMXv2",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0x645c2712fda24a41ed61064054429e00cb4293bb",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:55:53Z",
+          "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+          "name": "fija Strategy ETH GMXv2",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0x645c2712fda24a41ed61064054429e00cb4293bb",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:11:41Z",
+          "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+          "name": "fija Strategy ETH GMXv2",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0x645c2712fda24a41ed61064054429e00cb4293bb",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:19:08Z",
+          "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+          "name": "fija Strategy ETH GMXv2",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:20:59Z",
+      "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+      "name": "fija Strategy ETH GMXv2",
+      "outcome": "rpc_error",
+      "protocol": "ERC-4626"
+    },
+    "42161-0x6afb8d3f6d4a34e9cb2f217317f4dc8e05aa673b": {
+      "address": "0x6afb8d3f6d4a34e9cb2f217317f4dc8e05aa673b",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x6afb8d3f6d4a34e9cb2f217317f4dc8e05aa673b",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "K3 Capital USDai Cluster",
+          "outcome": "adapter_error",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0x6afb8d3f6d4a34e9cb2f217317f4dc8e05aa673b",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "K3 Capital USDai Cluster",
+          "outcome": "adapter_error",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0x6afb8d3f6d4a34e9cb2f217317f4dc8e05aa673b",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:31Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "K3 Capital USDai Cluster",
+          "outcome": "adapter_error",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0x6afb8d3f6d4a34e9cb2f217317f4dc8e05aa673b",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "K3 Capital USDai Cluster",
+          "outcome": "adapter_error",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0x6afb8d3f6d4a34e9cb2f217317f4dc8e05aa673b",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:49Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "K3 Capital USDai Cluster",
+          "outcome": "adapter_error",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0x6afb8d3f6d4a34e9cb2f217317f4dc8e05aa673b",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:56:48Z",
+          "message": null,
+          "name": "K3 Capital USDai Cluster",
+          "outcome": "success",
+          "protocol": "Euler",
+          "share_balance_raw": "9581251"
+        },
+        {
+          "address": "0x6afb8d3f6d4a34e9cb2f217317f4dc8e05aa673b",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:12:58Z",
+          "message": null,
+          "name": "K3 Capital USDai Cluster",
+          "outcome": "success",
+          "protocol": "Euler",
+          "share_balance_raw": "9581243"
+        },
+        {
+          "address": "0x6afb8d3f6d4a34e9cb2f217317f4dc8e05aa673b",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:21:10Z",
+          "message": null,
+          "name": "K3 Capital USDai Cluster",
+          "outcome": "success",
+          "protocol": "Euler",
+          "share_balance_raw": "9581238"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:22:42Z",
+      "message": null,
+      "name": "K3 Capital USDai Cluster",
+      "outcome": "success",
+      "protocol": "Euler",
+      "share_balance_raw": "9581237"
+    },
+    "42161-0x6ca200319a0d4127a7a473d6891b86f34e312f42": {
+      "address": "0x6ca200319a0d4127a7a473d6891b86f34e312f42",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "generic_erc4626",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x6ca200319a0d4127a7a473d6891b86f34e312f42",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:10Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Nashpoint DeFi & RWA Fund",
+          "outcome": "adapter_error",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0x6ca200319a0d4127a7a473d6891b86f34e312f42",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:59:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Nashpoint DeFi & RWA Fund",
+          "outcome": "adapter_error",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0x6ca200319a0d4127a7a473d6891b86f34e312f42",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:02:42Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Nashpoint DeFi & RWA Fund",
+          "outcome": "adapter_error",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0x6ca200319a0d4127a7a473d6891b86f34e312f42",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:14:46Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Nashpoint DeFi & RWA Fund",
+          "outcome": "adapter_error",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0x6ca200319a0d4127a7a473d6891b86f34e312f42",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:55:34Z",
+          "message": null,
+          "name": "Nashpoint DeFi & RWA Fund",
+          "outcome": "success",
+          "protocol": "NashPoint",
+          "share_balance_raw": "9496013"
+        },
+        {
+          "address": "0x6ca200319a0d4127a7a473d6891b86f34e312f42",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:21:41Z",
+          "message": "Got <class 'eth_defi.erc_4626.vault_protocol.nashpoint.vault.NashpointNodeVault'>",
+          "name": "Nashpoint DeFi & RWA Fund",
+          "outcome": "rpc_error",
+          "protocol": "NashPoint",
+          "share_balance_raw": "9496013"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:34:52Z",
+      "message": "Got <class 'eth_defi.erc_4626.vault_protocol.nashpoint.vault.NashpointNodeVault'>",
+      "name": "Nashpoint DeFi & RWA Fund",
+      "outcome": "rpc_error",
+      "protocol": "NashPoint",
+      "share_balance_raw": "9496013"
+    },
+    "42161-0x6daca1e808c46e18f32e736e0aeb45c3824e073c": {
+      "address": "0x6daca1e808c46e18f32e736e0aeb45c3824e073c",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:35:10Z",
+      "message": "Got <class 'eth_defi.erc_4626.vault_protocol.nashpoint.vault.NashpointNodeVault'>",
+      "name": "Inveniam RWA Test Vault",
+      "outcome": "rpc_error",
+      "protocol": "NashPoint"
+    },
+    "42161-0x6db146db8dcf2f96948c3982f0770871246ae810": {
+      "address": "0x6db146db8dcf2f96948c3982f0770871246ae810",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x6db146db8dcf2f96948c3982f0770871246ae810",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Trust Wallet Fluid USDC",
+          "outcome": "adapter_error",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0x6db146db8dcf2f96948c3982f0770871246ae810",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Trust Wallet Fluid USDC",
+          "outcome": "adapter_error",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0x6db146db8dcf2f96948c3982f0770871246ae810",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:31Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Trust Wallet Fluid USDC",
+          "outcome": "adapter_error",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0x6db146db8dcf2f96948c3982f0770871246ae810",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Trust Wallet Fluid USDC",
+          "outcome": "adapter_error",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0x6db146db8dcf2f96948c3982f0770871246ae810",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:49Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Trust Wallet Fluid USDC",
+          "outcome": "adapter_error",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0x6db146db8dcf2f96948c3982f0770871246ae810",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:57:33Z",
+          "message": null,
+          "name": "Trust Wallet Fluid USDC",
+          "outcome": "success",
+          "protocol": "Fluid",
+          "share_balance_raw": "9749494"
+        },
+        {
+          "address": "0x6db146db8dcf2f96948c3982f0770871246ae810",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:13:53Z",
+          "message": null,
+          "name": "Trust Wallet Fluid USDC",
+          "outcome": "success",
+          "protocol": "Fluid",
+          "share_balance_raw": "9749478"
+        },
+        {
+          "address": "0x6db146db8dcf2f96948c3982f0770871246ae810",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:20:59Z",
+          "message": null,
+          "name": "Trust Wallet Fluid USDC",
+          "outcome": "success",
+          "protocol": "Fluid",
+          "share_balance_raw": "9749471"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:22:50Z",
+      "message": null,
+      "name": "Trust Wallet Fluid USDC",
+      "outcome": "success",
+      "protocol": "Fluid",
+      "share_balance_raw": "9749469"
+    },
+    "42161-0x6df0018b0449bb4468bfae8507e13021a7aa0583": {
+      "address": "0x6df0018b0449bb4468bfae8507e13021a7aa0583",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x6df0018b0449bb4468bfae8507e13021a7aa0583",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:54Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x6df0018b0449bb4468bfae8507e13021a7aa0583",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:33Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x6df0018b0449bb4468bfae8507e13021a7aa0583",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Delta Netural Water Vault",
+          "outcome": "skipped",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0x6df0018b0449bb4468bfae8507e13021a7aa0583",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Delta Netural Water Vault",
+          "outcome": "skipped",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0x6df0018b0449bb4468bfae8507e13021a7aa0583",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:22:57Z",
+          "message": "Vault deposits are currently closed",
+          "name": "Delta Netural Water Vault",
+          "outcome": "skipped",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0x6df0018b0449bb4468bfae8507e13021a7aa0583",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:53:53Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Delta Netural Water Vault",
+          "outcome": "adapter_error",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0x6df0018b0449bb4468bfae8507e13021a7aa0583",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T18:08:24Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Delta Netural Water Vault",
+          "outcome": "adapter_error",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0x6df0018b0449bb4468bfae8507e13021a7aa0583",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T18:13:48Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Delta Netural Water Vault",
+          "outcome": "adapter_error",
+          "protocol": "<protocol not yet identified>"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:46:47Z",
+      "max_deposit_guidance": "0",
+      "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "name": "Delta Netural Water Vault",
+      "outcome": "funding_error",
+      "protocol": "<protocol not yet identified>"
+    },
+    "42161-0x6e23cfe8d830488bc824c0add201a1a2e1dfdbeb": {
+      "address": "0x6e23cfe8d830488bc824c0add201a1a2e1dfdbeb",
+      "attempt_count": 6,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x6e23cfe8d830488bc824c0add201a1a2e1dfdbeb",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Summer.fi USDC",
+          "outcome": "adapter_error",
+          "protocol": "Summer.fi"
+        },
+        {
+          "address": "0x6e23cfe8d830488bc824c0add201a1a2e1dfdbeb",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Summer.fi USDC",
+          "outcome": "adapter_error",
+          "protocol": "Summer.fi"
+        },
+        {
+          "address": "0x6e23cfe8d830488bc824c0add201a1a2e1dfdbeb",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Summer.fi USDC",
+          "outcome": "adapter_error",
+          "protocol": "Summer.fi"
+        },
+        {
+          "address": "0x6e23cfe8d830488bc824c0add201a1a2e1dfdbeb",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Summer.fi USDC",
+          "outcome": "adapter_error",
+          "protocol": "Summer.fi"
+        },
+        {
+          "address": "0x6e23cfe8d830488bc824c0add201a1a2e1dfdbeb",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:25Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Summer.fi USDC",
+          "outcome": "adapter_error",
+          "protocol": "Summer.fi"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T17:59:36Z",
+      "message": "Vault deposits are currently closed",
+      "name": "Summer.fi USDC",
+      "outcome": "skipped",
+      "protocol": "Summer.fi"
+    },
+    "42161-0x6faf8b7ffee3306efcfc2ba9fec912b4d49834c1": {
+      "address": "0x6faf8b7ffee3306efcfc2ba9fec912b4d49834c1",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:50:06Z",
+      "max_deposit_guidance": "0",
+      "message": "Anvil transaction reverted",
+      "name": "USDC-A yVault",
+      "outcome": "reverted",
+      "protocol": "Yearn",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x710a1ab6cb8412de9613ad6c7195453ce8b5ca71": {
+      "address": "0x710a1ab6cb8412de9613ad6c7195453ce8b5ca71",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x710a1ab6cb8412de9613ad6c7195453ce8b5ca71",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x710a1ab6cb8412de9613ad6c7195453ce8b5ca71",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x710a1ab6cb8412de9613ad6c7195453ce8b5ca71",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "FARM_LODE",
+          "outcome": "skipped",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x710a1ab6cb8412de9613ad6c7195453ce8b5ca71",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "FARM_LODE",
+          "outcome": "skipped",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x710a1ab6cb8412de9613ad6c7195453ce8b5ca71",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:24:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "FARM_LODE",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x710a1ab6cb8412de9613ad6c7195453ce8b5ca71",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:27Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "FARM_LODE",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x710a1ab6cb8412de9613ad6c7195453ce8b5ca71",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:56:38Z",
+          "message": "Anvil transaction reverted",
+          "name": "FARM_LODE",
+          "outcome": "reverted",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x710a1ab6cb8412de9613ad6c7195453ce8b5ca71",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:16:30Z",
+          "message": "Anvil transaction reverted",
+          "name": "FARM_LODE",
+          "outcome": "reverted",
+          "protocol": "Harvest Finance",
+          "revert_reason": "Anvil transaction reverted"
+        },
+        {
+          "address": "0x710a1ab6cb8412de9613ad6c7195453ce8b5ca71",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:24:27Z",
+          "message": "Anvil transaction reverted",
+          "name": "FARM_LODE",
+          "outcome": "reverted",
+          "protocol": "Harvest Finance",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:26:12Z",
+      "message": "Anvil transaction reverted",
+      "name": "FARM_LODE",
+      "outcome": "reverted",
+      "protocol": "Harvest Finance",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x71d77c39db0eb5d086611a2e950198e3077cf58a": {
+      "address": "0x71d77c39db0eb5d086611a2e950198e3077cf58a",
+      "attempt_count": 6,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x71d77c39db0eb5d086611a2e950198e3077cf58a",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Summer.fi USDC",
+          "outcome": "adapter_error",
+          "protocol": "Summer.fi"
+        },
+        {
+          "address": "0x71d77c39db0eb5d086611a2e950198e3077cf58a",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Summer.fi USDC",
+          "outcome": "adapter_error",
+          "protocol": "Summer.fi"
+        },
+        {
+          "address": "0x71d77c39db0eb5d086611a2e950198e3077cf58a",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Summer.fi USDC",
+          "outcome": "adapter_error",
+          "protocol": "Summer.fi"
+        },
+        {
+          "address": "0x71d77c39db0eb5d086611a2e950198e3077cf58a",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Summer.fi USDC",
+          "outcome": "adapter_error",
+          "protocol": "Summer.fi"
+        },
+        {
+          "address": "0x71d77c39db0eb5d086611a2e950198e3077cf58a",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:25Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Summer.fi USDC",
+          "outcome": "adapter_error",
+          "protocol": "Summer.fi"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T17:59:46Z",
+      "message": "Vault deposits are currently closed",
+      "name": "Summer.fi USDC",
+      "outcome": "skipped",
+      "protocol": "Summer.fi"
+    },
+    "42161-0x727ed4ef04bb2a96ec77e44c1a91dbb01b605e42": {
+      "address": "0x727ed4ef04bb2a96ec77e44c1a91dbb01b605e42",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x727ed4ef04bb2a96ec77e44c1a91dbb01b605e42",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x727ed4ef04bb2a96ec77e44c1a91dbb01b605e42",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x727ed4ef04bb2a96ec77e44c1a91dbb01b605e42",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "glpUSDC",
+          "outcome": "skipped",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0x727ed4ef04bb2a96ec77e44c1a91dbb01b605e42",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "glpUSDC",
+          "outcome": "skipped",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0x727ed4ef04bb2a96ec77e44c1a91dbb01b605e42",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:43Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "glpUSDC",
+          "outcome": "adapter_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0x727ed4ef04bb2a96ec77e44c1a91dbb01b605e42",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:57:02Z",
+          "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "name": "glpUSDC",
+          "outcome": "funding_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0x727ed4ef04bb2a96ec77e44c1a91dbb01b605e42",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:29:21Z",
+          "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "name": "glpUSDC",
+          "outcome": "funding_error",
+          "protocol": "Umami"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:46:41Z",
+      "max_deposit_guidance": "2895955580612",
+      "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "name": "glpUSDC",
+      "outcome": "funding_error",
+      "protocol": "Umami"
+    },
+    "42161-0x7378292384751b208bd8609ca8d45f027539fa5c": {
+      "address": "0x7378292384751b208bd8609ca8d45f027539fa5c",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x7378292384751b208bd8609ca8d45f027539fa5c",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:54Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x7378292384751b208bd8609ca8d45f027539fa5c",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:33Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x7378292384751b208bd8609ca8d45f027539fa5c",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Fractality LR USDT",
+          "outcome": "skipped",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x7378292384751b208bd8609ca8d45f027539fa5c",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Fractality LR USDT",
+          "outcome": "skipped",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x7378292384751b208bd8609ca8d45f027539fa5c",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:23:04Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Fractality LR USDT",
+          "outcome": "funding_error",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x7378292384751b208bd8609ca8d45f027539fa5c",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:54:04Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Fractality LR USDT",
+          "outcome": "funding_error",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x7378292384751b208bd8609ca8d45f027539fa5c",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:08:35Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Fractality LR USDT",
+          "outcome": "funding_error",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x7378292384751b208bd8609ca8d45f027539fa5c",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:14:18Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Fractality LR USDT",
+          "outcome": "funding_error",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x7378292384751b208bd8609ca8d45f027539fa5c",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:17:50Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Fractality LR USDT",
+          "outcome": "funding_error",
+          "protocol": "<unknown ERC-7540>"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:47:23Z",
+      "max_deposit_guidance": "100000000000000",
+      "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "name": "Fractality LR USDT",
+      "outcome": "funding_error",
+      "protocol": "<unknown ERC-7540>"
+    },
+    "42161-0x75288264fdfea8ce68e6d852696ab1ce2f3e5004": {
+      "address": "0x75288264fdfea8ce68e6d852696ab1ce2f3e5004",
+      "attempt_count": 6,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x75288264fdfea8ce68e6d852696ab1ce2f3e5004",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "HYPE++",
+          "outcome": "adapter_error",
+          "protocol": "D2 Finance"
+        },
+        {
+          "address": "0x75288264fdfea8ce68e6d852696ab1ce2f3e5004",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "HYPE++",
+          "outcome": "adapter_error",
+          "protocol": "D2 Finance"
+        },
+        {
+          "address": "0x75288264fdfea8ce68e6d852696ab1ce2f3e5004",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:31Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "HYPE++",
+          "outcome": "adapter_error",
+          "protocol": "D2 Finance"
+        },
+        {
+          "address": "0x75288264fdfea8ce68e6d852696ab1ce2f3e5004",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "HYPE++",
+          "outcome": "adapter_error",
+          "protocol": "D2 Finance"
+        },
+        {
+          "address": "0x75288264fdfea8ce68e6d852696ab1ce2f3e5004",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:15Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "HYPE++",
+          "outcome": "adapter_error",
+          "protocol": "D2 Finance"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T17:55:22Z",
+      "message": "Vault deposits are currently closed",
+      "name": "HYPE++",
+      "outcome": "skipped",
+      "protocol": "D2 Finance"
+    },
+    "42161-0x7788a3538c5fc7f9c7c8a74eac4c898fc8d87d92": {
+      "address": "0x7788a3538c5fc7f9c7c8a74eac4c898fc8d87d92",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "denomination_token_address": "0xf3527ef8dE265eAa3716FB312c12847bFBA66Cef",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x7788a3538c5fc7f9c7c8a74eac4c898fc8d87d92",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x7788a3538c5fc7f9c7c8a74eac4c898fc8d87d92",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x7788a3538c5fc7f9c7c8a74eac4c898fc8d87d92",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Staked USDX",
+          "outcome": "skipped",
+          "protocol": "USDX Money"
+        },
+        {
+          "address": "0x7788a3538c5fc7f9c7c8a74eac4c898fc8d87d92",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Staked USDX",
+          "outcome": "skipped",
+          "protocol": "USDX Money"
+        },
+        {
+          "address": "0x7788a3538c5fc7f9c7c8a74eac4c898fc8d87d92",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:56Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Staked USDX",
+          "outcome": "adapter_error",
+          "protocol": "USDX Money"
+        },
+        {
+          "address": "0x7788a3538c5fc7f9c7c8a74eac4c898fc8d87d92",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xf3527ef8dE265eAa3716FB312c12847bFBA66Cef",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:57:59Z",
+          "message": null,
+          "name": "Staked USDX",
+          "outcome": "success",
+          "protocol": "USDX Money",
+          "share_balance_raw": "8965988382028283477"
+        },
+        {
+          "address": "0x7788a3538c5fc7f9c7c8a74eac4c898fc8d87d92",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xf3527ef8dE265eAa3716FB312c12847bFBA66Cef",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:30:10Z",
+          "message": null,
+          "name": "Staked USDX",
+          "outcome": "success",
+          "protocol": "USDX Money",
+          "share_balance_raw": "8965988382028283477"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:49:05Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": null,
+      "name": "Staked USDX",
+      "outcome": "success",
+      "protocol": "USDX Money",
+      "share_balance_raw": "8965988382028283477"
+    },
+    "42161-0x77fca326f749b60b2ab7caebd9ee9d0896643344": {
+      "address": "0x77fca326f749b60b2ab7caebd9ee9d0896643344",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x77fca326f749b60b2ab7caebd9ee9d0896643344",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:26:45Z",
+          "message": "Anvil transaction reverted",
+          "name": "IPOR USDC Arbitrum Optimizer Pilot K2",
+          "outcome": "reverted",
+          "protocol": "IPOR Fusion",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:28:25Z",
+      "message": "Anvil transaction reverted",
+      "name": "IPOR USDC Arbitrum Optimizer Pilot K2",
+      "outcome": "reverted",
+      "protocol": "IPOR Fusion",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x7c48724b2be85693d7fc087e0d38564aad0b4418": {
+      "address": "0x7c48724b2be85693d7fc087e0d38564aad0b4418",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x7c48724b2be85693d7fc087e0d38564aad0b4418",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:22:16Z",
+          "message": "Could not find balance slot for token 0x5e021bf2ca47a17887D41f43AF811912D572e4a2",
+          "name": "EVK Vault eELIT-2",
+          "outcome": "funding_error",
+          "protocol": "Euler"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:23:58Z",
+      "message": "Could not find balance slot for token 0x5e021bf2ca47a17887D41f43AF811912D572e4a2",
+      "name": "EVK Vault eELIT-2",
+      "outcome": "funding_error",
+      "protocol": "Euler"
+    },
+    "42161-0x7c574174da4b2be3f705c6244b4bfa0815a8b3ed": {
+      "address": "0x7c574174da4b2be3f705c6244b4bfa0815a8b3ed",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x7c574174da4b2be3f705c6244b4bfa0815a8b3ed",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:21:18Z",
+          "message": null,
+          "name": "Gauntlet USDC Prime",
+          "outcome": "success",
+          "protocol": "Morpho",
+          "share_balance_raw": "9710214141400362722"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:33:36Z",
+      "message": null,
+      "name": "Gauntlet USDC Prime",
+      "outcome": "success",
+      "protocol": "Morpho",
+      "share_balance_raw": "9710206128272672391"
+    },
+    "42161-0x7cfadfd5645b50be87d546f42699d863648251ad": {
+      "address": "0x7cfadfd5645b50be87d546f42699d863648251ad",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x7cfadfd5645b50be87d546f42699d863648251ad",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Static Aave Arbitrum USDCn",
+          "outcome": "adapter_error",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0x7cfadfd5645b50be87d546f42699d863648251ad",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Static Aave Arbitrum USDCn",
+          "outcome": "adapter_error",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0x7cfadfd5645b50be87d546f42699d863648251ad",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Static Aave Arbitrum USDCn",
+          "outcome": "adapter_error",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0x7cfadfd5645b50be87d546f42699d863648251ad",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Static Aave Arbitrum USDCn",
+          "outcome": "adapter_error",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0x7cfadfd5645b50be87d546f42699d863648251ad",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:32Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Static Aave Arbitrum USDCn",
+          "outcome": "adapter_error",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0x7cfadfd5645b50be87d546f42699d863648251ad",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:00:31Z",
+          "message": null,
+          "name": "Static Aave Arbitrum USDCn",
+          "outcome": "success",
+          "protocol": "Superform",
+          "share_balance_raw": "8524080"
+        },
+        {
+          "address": "0x7cfadfd5645b50be87d546f42699d863648251ad",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:27:06Z",
+          "message": null,
+          "name": "Static Aave Arbitrum USDCn",
+          "outcome": "success",
+          "protocol": "Superform",
+          "share_balance_raw": "8524069"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:42:30Z",
+      "max_deposit_guidance": "84933499174727",
+      "message": null,
+      "name": "Static Aave Arbitrum USDCn",
+      "outcome": "success",
+      "protocol": "Superform",
+      "share_balance_raw": "8524062"
+    },
+    "42161-0x7e97fa6893871a2751b5fe961978dccb2c201e65": {
+      "address": "0x7e97fa6893871a2751b5fe961978dccb2c201e65",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x7e97fa6893871a2751b5fe961978dccb2c201e65",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:20:35Z",
+          "message": null,
+          "name": "Gauntlet USDC Core",
+          "outcome": "success",
+          "protocol": "Morpho",
+          "share_balance_raw": "9625624140438479938"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:33:05Z",
+      "message": null,
+      "name": "Gauntlet USDC Core",
+      "outcome": "success",
+      "protocol": "Morpho",
+      "share_balance_raw": "9625615876197508307"
+    },
+    "42161-0x7ea040cae554f92fd6211540722295930028136d": {
+      "address": "0x7ea040cae554f92fd6211540722295930028136d",
+      "attempt_count": 3,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x7ea040cae554f92fd6211540722295930028136d",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:08:58Z",
+          "message": "Could not find balance slot for token 0x07C4fA447a96f257b29596ea3ae0791d06D30738",
+          "name": "Curve.fi fooUSD-mockUSDC Commit Token",
+          "outcome": "funding_error",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x7ea040cae554f92fd6211540722295930028136d",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:14:39Z",
+          "message": "Could not find balance slot for token 0x07C4fA447a96f257b29596ea3ae0791d06D30738",
+          "name": "Curve.fi fooUSD-mockUSDC Commit Token",
+          "outcome": "funding_error",
+          "protocol": "<unknown ERC-7540>"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:18:14Z",
+      "message": "Could not find balance slot for token 0x07C4fA447a96f257b29596ea3ae0791d06D30738",
+      "name": "Curve.fi fooUSD-mockUSDC Commit Token",
+      "outcome": "funding_error",
+      "protocol": "<unknown ERC-7540>"
+    },
+    "42161-0x7f14715bc12214f1ff26a6863334e7c8b644f4f7": {
+      "address": "0x7f14715bc12214f1ff26a6863334e7c8b644f4f7",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:31:49Z",
+      "message": "Unsupported to=0xfF5183CEf0382bBFfBD63D2290266Fd7f604937E",
+      "name": "TID Capital Perp Market Maker",
+      "outcome": "rpc_error",
+      "protocol": "Lagoon Finance"
+    },
+    "42161-0x7fbfd8cda97c0221b39c581c34afd24c523a3990": {
+      "address": "0x7fbfd8cda97c0221b39c581c34afd24c523a3990",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x7fbfd8cda97c0221b39c581c34afd24c523a3990",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:26:55Z",
+          "message": null,
+          "name": "Harvest Fusion USDC",
+          "outcome": "success",
+          "protocol": "IPOR Fusion",
+          "share_balance_raw": "967804564"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:28:35Z",
+      "message": null,
+      "name": "Harvest Fusion USDC",
+      "outcome": "success",
+      "protocol": "IPOR Fusion",
+      "share_balance_raw": "967804564"
+    },
+    "42161-0x80761c6bc720756b467ef2ed25cdce1b2551847e": {
+      "address": "0x80761c6bc720756b467ef2ed25cdce1b2551847e",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": null,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:38:50Z",
+      "message": "Live adapter does not advertise deposits",
+      "name": "Deposit USDC in Ostium OLP vault",
+      "outcome": "adapter_error",
+      "protocol": "Royco"
+    },
+    "42161-0x84868a18f0c7602dbe9613d12d544b5f4c3dff95": {
+      "address": "0x84868a18f0c7602dbe9613d12d544b5f4c3dff95",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x84868a18f0c7602dbe9613d12d544b5f4c3dff95",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "USDC-APE shares",
+          "outcome": "adapter_error",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0x84868a18f0c7602dbe9613d12d544b5f4c3dff95",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "USDC-APE shares",
+          "outcome": "adapter_error",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0x84868a18f0c7602dbe9613d12d544b5f4c3dff95",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "USDC-APE shares",
+          "outcome": "adapter_error",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0x84868a18f0c7602dbe9613d12d544b5f4c3dff95",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "USDC-APE shares",
+          "outcome": "adapter_error",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0x84868a18f0c7602dbe9613d12d544b5f4c3dff95",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "USDC-APE shares",
+          "outcome": "adapter_error",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0x84868a18f0c7602dbe9613d12d544b5f4c3dff95",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:56:05Z",
+          "message": "Anvil transaction reverted",
+          "name": "USDC-APE shares",
+          "outcome": "reverted",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0x84868a18f0c7602dbe9613d12d544b5f4c3dff95",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:27:53Z",
+          "message": "Anvil transaction reverted",
+          "name": "USDC-APE shares",
+          "outcome": "reverted",
+          "protocol": "Teller",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:43:57Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Anvil transaction reverted",
+      "name": "USDC-APE shares",
+      "outcome": "reverted",
+      "protocol": "Teller",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x84a1f97fd7585e93aefc97025feb0e3ef3b54f60": {
+      "address": "0x84a1f97fd7585e93aefc97025feb0e3ef3b54f60",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x84a1f97fd7585e93aefc97025feb0e3ef3b54f60",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:23:56Z",
+          "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "name": "WETH Multi-Strategy Vault",
+          "outcome": "funding_error",
+          "protocol": "Goat Protocol"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:25:42Z",
+      "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "name": "WETH Multi-Strategy Vault",
+      "outcome": "funding_error",
+      "protocol": "Goat Protocol"
+    },
+    "42161-0x84ed0f5586ba014a1e7300cd8bf5eb905d9f1b26": {
+      "address": "0x84ed0f5586ba014a1e7300cd8bf5eb905d9f1b26",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:40:45Z",
+      "message": null,
+      "name": "Borrowable USDC Deposit, SiloId: 152",
+      "outcome": "success",
+      "protocol": "Silo Finance",
+      "share_balance_raw": "9732856123"
+    },
+    "42161-0x857a6072754532ae77ada617a7d0900b63c1e2a1": {
+      "address": "0x857a6072754532ae77ada617a7d0900b63c1e2a1",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x857a6072754532ae77ada617a7d0900b63c1e2a1",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Harvest: USDC Vault (0x857a)",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x857a6072754532ae77ada617a7d0900b63c1e2a1",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Harvest: USDC Vault (0x857a)",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x857a6072754532ae77ada617a7d0900b63c1e2a1",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:43Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Harvest: USDC Vault (0x857a)",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x857a6072754532ae77ada617a7d0900b63c1e2a1",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Harvest: USDC Vault (0x857a)",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x857a6072754532ae77ada617a7d0900b63c1e2a1",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:24:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Harvest: USDC Vault (0x857a)",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x857a6072754532ae77ada617a7d0900b63c1e2a1",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:27Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Harvest: USDC Vault (0x857a)",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x857a6072754532ae77ada617a7d0900b63c1e2a1",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:56:45Z",
+          "message": "Anvil transaction reverted",
+          "name": "Harvest: USDC Vault (0x857a)",
+          "outcome": "reverted",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0x857a6072754532ae77ada617a7d0900b63c1e2a1",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:16:40Z",
+          "message": "Anvil transaction reverted",
+          "name": "Harvest: USDC Vault (0x857a)",
+          "outcome": "reverted",
+          "protocol": "Harvest Finance",
+          "revert_reason": "Anvil transaction reverted"
+        },
+        {
+          "address": "0x857a6072754532ae77ada617a7d0900b63c1e2a1",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:24:35Z",
+          "message": "Anvil transaction reverted",
+          "name": "Harvest: USDC Vault (0x857a)",
+          "outcome": "reverted",
+          "protocol": "Harvest Finance",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:26:20Z",
+      "message": "Anvil transaction reverted",
+      "name": "Harvest: USDC Vault (0x857a)",
+      "outcome": "reverted",
+      "protocol": "Harvest Finance",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x8605e3bf88ac794372975781fb50fcdb3fd7fe53": {
+      "address": "0x8605e3bf88ac794372975781fb50fcdb3fd7fe53",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:36:38Z",
+      "message": "Could not find balance slot for token 0x4548c7fAfeFd9e18dBfd583F2b43b67B3B4D4C0A",
+      "name": "Peapods Interest Bearing pPEAS - 30",
+      "outcome": "funding_error",
+      "protocol": "Peapods"
+    },
+    "42161-0x86b1c293e56cbac04d9c15a1af2ef1d2050ff6cd": {
+      "address": "0x86b1c293e56cbac04d9c15a1af2ef1d2050ff6cd",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:40:33Z",
+      "message": null,
+      "name": "Borrowable USDC Deposit, SiloId: 115",
+      "outcome": "success",
+      "protocol": "Silo Finance",
+      "share_balance_raw": "9206925447"
+    },
+    "42161-0x88a1999f0e9cacf7e8152b4a5f797c9f0a9c3064": {
+      "address": "0x88a1999f0e9cacf7e8152b4a5f797c9f0a9c3064",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x88a1999f0e9cacf7e8152b4a5f797c9f0a9c3064",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x88a1999f0e9cacf7e8152b4a5f797c9f0a9c3064",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x88a1999f0e9cacf7e8152b4a5f797c9f0a9c3064",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "PLS pre-migration farming vault",
+          "outcome": "skipped",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0x88a1999f0e9cacf7e8152b4a5f797c9f0a9c3064",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "PLS pre-migration farming vault",
+          "outcome": "skipped",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0x88a1999f0e9cacf7e8152b4a5f797c9f0a9c3064",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:17Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "PLS pre-migration farming vault",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0x88a1999f0e9cacf7e8152b4a5f797c9f0a9c3064",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:34Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "PLS pre-migration farming vault",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T17:57:26Z",
+      "message": "Vault deposits are currently closed",
+      "name": "PLS pre-migration farming vault",
+      "outcome": "skipped",
+      "protocol": "Plutus"
+    },
+    "42161-0x890a69ef363c9c7bdd5e36eb95ceb569f63acbf6": {
+      "address": "0x890a69ef363c9c7bdd5e36eb95ceb569f63acbf6",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x890a69ef363c9c7bdd5e36eb95ceb569f63acbf6",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Main USDC v3",
+          "outcome": "adapter_error",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0x890a69ef363c9c7bdd5e36eb95ceb569f63acbf6",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Main USDC v3",
+          "outcome": "adapter_error",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0x890a69ef363c9c7bdd5e36eb95ceb569f63acbf6",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:43Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Main USDC v3",
+          "outcome": "adapter_error",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0x890a69ef363c9c7bdd5e36eb95ceb569f63acbf6",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Main USDC v3",
+          "outcome": "adapter_error",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0x890a69ef363c9c7bdd5e36eb95ceb569f63acbf6",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:24:45Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Main USDC v3",
+          "outcome": "adapter_error",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0x890a69ef363c9c7bdd5e36eb95ceb569f63acbf6",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:25:58Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Main USDC v3",
+          "outcome": "adapter_error",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0x890a69ef363c9c7bdd5e36eb95ceb569f63acbf6",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:55:40Z",
+          "message": null,
+          "name": "Main USDC v3",
+          "outcome": "success",
+          "protocol": "Gearbox",
+          "share_balance_raw": "9359761"
+        },
+        {
+          "address": "0x890a69ef363c9c7bdd5e36eb95ceb569f63acbf6",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:15:11Z",
+          "message": null,
+          "name": "Main USDC v3",
+          "outcome": "success",
+          "protocol": "Gearbox",
+          "share_balance_raw": "9359761"
+        },
+        {
+          "address": "0x890a69ef363c9c7bdd5e36eb95ceb569f63acbf6",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:22:50Z",
+          "message": null,
+          "name": "Main USDC v3",
+          "outcome": "success",
+          "protocol": "Gearbox",
+          "share_balance_raw": "9359761"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:24:38Z",
+      "message": null,
+      "name": "Main USDC v3",
+      "outcome": "success",
+      "protocol": "Gearbox",
+      "share_balance_raw": "9359761"
+    },
+    "42161-0x892c83dbd27351fdc72566a509512c8af5f6e66f": {
+      "address": "0x892c83dbd27351fdc72566a509512c8af5f6e66f",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x892c83dbd27351fdc72566a509512c8af5f6e66f",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:15:36Z",
+          "message": "Anvil transaction reverted",
+          "name": "ArbSim2",
+          "outcome": "reverted",
+          "protocol": "<unknown ERC-7540>",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:19:15Z",
+      "message": "Anvil transaction reverted",
+      "name": "ArbSim2",
+      "outcome": "reverted",
+      "protocol": "<unknown ERC-7540>",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x8a1ef3066553275829d1c0f64ee8d5871d5ce9d3": {
+      "address": "0x8a1ef3066553275829d1c0f64ee8d5871d5ce9d3",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x8a1ef3066553275829d1c0f64ee8d5871d5ce9d3",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x8a1ef3066553275829d1c0f64ee8d5871d5ce9d3",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x8a1ef3066553275829d1c0f64ee8d5871d5ce9d3",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Yield Chasing Silo USDC",
+          "outcome": "skipped",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x8a1ef3066553275829d1c0f64ee8d5871d5ce9d3",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Yield Chasing Silo USDC",
+          "outcome": "skipped",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x8a1ef3066553275829d1c0f64ee8d5871d5ce9d3",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:24:45Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Yield Chasing Silo USDC",
+          "outcome": "adapter_error",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x8a1ef3066553275829d1c0f64ee8d5871d5ce9d3",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:05Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Yield Chasing Silo USDC",
+          "outcome": "adapter_error",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x8a1ef3066553275829d1c0f64ee8d5871d5ce9d3",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:55:59Z",
+          "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "name": "Yield Chasing Silo USDC",
+          "outcome": "funding_error",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x8a1ef3066553275829d1c0f64ee8d5871d5ce9d3",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:15:37Z",
+          "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "name": "Yield Chasing Silo USDC",
+          "outcome": "funding_error",
+          "protocol": "Goat Protocol"
+        },
+        {
+          "address": "0x8a1ef3066553275829d1c0f64ee8d5871d5ce9d3",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:23:11Z",
+          "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "name": "Yield Chasing Silo USDC",
+          "outcome": "funding_error",
+          "protocol": "Goat Protocol"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:25:01Z",
+      "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "name": "Yield Chasing Silo USDC",
+      "outcome": "funding_error",
+      "protocol": "Goat Protocol"
+    },
+    "42161-0x8b5541b773dd781852940490b0c3dc1a8cdb6a87": {
+      "address": "0x8b5541b773dd781852940490b0c3dc1a8cdb6a87",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x8b5541b773dd781852940490b0c3dc1a8cdb6a87",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x8b5541b773dd781852940490b0c3dc1a8cdb6a87",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x8b5541b773dd781852940490b0c3dc1a8cdb6a87",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Static Aave Arbitrum USDT",
+          "outcome": "skipped",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0x8b5541b773dd781852940490b0c3dc1a8cdb6a87",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Static Aave Arbitrum USDT",
+          "outcome": "skipped",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0x8b5541b773dd781852940490b0c3dc1a8cdb6a87",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:32Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Static Aave Arbitrum USDT",
+          "outcome": "adapter_error",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0x8b5541b773dd781852940490b0c3dc1a8cdb6a87",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:00:48Z",
+          "message": "Could not find balance slot for token 0x6ab707Aca953eDAeFBc4fD23bA73294241490620",
+          "name": "Static Aave Arbitrum USDT",
+          "outcome": "funding_error",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0x8b5541b773dd781852940490b0c3dc1a8cdb6a87",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:27:25Z",
+          "message": "Could not find balance slot for token 0x6ab707Aca953eDAeFBc4fD23bA73294241490620",
+          "name": "Static Aave Arbitrum USDT",
+          "outcome": "funding_error",
+          "protocol": "Superform"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:42:52Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Could not find balance slot for token 0x6ab707Aca953eDAeFBc4fD23bA73294241490620",
+      "name": "Static Aave Arbitrum USDT",
+      "outcome": "funding_error",
+      "protocol": "Superform"
+    },
+    "42161-0x8c20837244c59cd2204d5318e334af16a3c4ab28": {
+      "address": "0x8c20837244c59cd2204d5318e334af16a3c4ab28",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:39:11Z",
+      "message": "Could not find balance slot for token 0x0B2b2B2076d95dda7817e785989fE353fe955ef9",
+      "name": "Royco Senior Tranche sUSDai",
+      "outcome": "funding_error",
+      "protocol": "Royco"
+    },
+    "42161-0x8d08e20be5be6ccceb5b2555f1461e08ae648298": {
+      "address": "0x8d08e20be5be6ccceb5b2555f1461e08ae648298",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x8d08e20be5be6ccceb5b2555f1461e08ae648298",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:03Z",
+          "message": "Transaction must include these fields: {'gasPrice'}",
+          "name": "Trust Wallet Morpho V2 Steakhouse High Yield USDC",
+          "outcome": "rpc_error",
+          "protocol": "Kiln Metavault"
+        },
+        {
+          "address": "0x8d08e20be5be6ccceb5b2555f1461e08ae648298",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T16:59:26Z",
+          "message": null,
+          "name": "Trust Wallet Morpho V2 Steakhouse High Yield USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9866094"
+        },
+        {
+          "address": "0x8d08e20be5be6ccceb5b2555f1461e08ae648298",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:02:10Z",
+          "message": null,
+          "name": "Trust Wallet Morpho V2 Steakhouse High Yield USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9866093"
+        },
+        {
+          "address": "0x8d08e20be5be6ccceb5b2555f1461e08ae648298",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:14:20Z",
+          "message": null,
+          "name": "Trust Wallet Morpho V2 Steakhouse High Yield USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9866085"
+        },
+        {
+          "address": "0x8d08e20be5be6ccceb5b2555f1461e08ae648298",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:25:47Z",
+          "message": null,
+          "name": "Trust Wallet Morpho V2 Steakhouse High Yield USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9866080"
+        },
+        {
+          "address": "0x8d08e20be5be6ccceb5b2555f1461e08ae648298",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:26:08Z",
+          "message": null,
+          "name": "Trust Wallet Morpho V2 Steakhouse High Yield USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9866078"
+        },
+        {
+          "address": "0x8d08e20be5be6ccceb5b2555f1461e08ae648298",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:58:21Z",
+          "message": null,
+          "name": "Trust Wallet Morpho V2 Steakhouse High Yield USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9866059"
+        },
+        {
+          "address": "0x8d08e20be5be6ccceb5b2555f1461e08ae648298",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:18:41Z",
+          "message": null,
+          "name": "Trust Wallet Morpho V2 Steakhouse High Yield USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9866048"
+        },
+        {
+          "address": "0x8d08e20be5be6ccceb5b2555f1461e08ae648298",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:28:01Z",
+          "message": null,
+          "name": "Trust Wallet Morpho V2 Steakhouse High Yield USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9866043"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:29:41Z",
+      "message": null,
+      "name": "Trust Wallet Morpho V2 Steakhouse High Yield USDC",
+      "outcome": "success",
+      "protocol": "Kiln Metavault",
+      "share_balance_raw": "9866042"
+    },
+    "42161-0x8e3d0ebd80911f9d53b22f876581ab23914e630f": {
+      "address": "0x8e3d0ebd80911f9d53b22f876581ab23914e630f",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:38:58Z",
+      "message": null,
+      "name": "Supply DAI into AAVE",
+      "outcome": "success",
+      "protocol": "Royco",
+      "share_balance_raw": "8395125483085495686"
+    },
+    "42161-0x8ecccad4c08f2e225515e6b223b46a723bc5cac3": {
+      "address": "0x8ecccad4c08f2e225515e6b223b46a723bc5cac3",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "history": [
+        {
+          "address": "0x8ecccad4c08f2e225515e6b223b46a723bc5cac3",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:06Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x8ecccad4c08f2e225515e6b223b46a723bc5cac3",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:59:38Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x8ecccad4c08f2e225515e6b223b46a723bc5cac3",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "dev",
+          "outcome": "skipped",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0x8ecccad4c08f2e225515e6b223b46a723bc5cac3",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "dev",
+          "outcome": "skipped",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0x8ecccad4c08f2e225515e6b223b46a723bc5cac3",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:26:03Z",
+          "message": "Unsupported to=0x725F6c0194351663295553F113Ff6cA1936DEe44",
+          "name": "dev",
+          "outcome": "rpc_error",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0x8ecccad4c08f2e225515e6b223b46a723bc5cac3",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:26:30Z",
+          "message": "Unsupported to=0x9b64E77a93C05FEa042824C5A67398570Ab0448C",
+          "name": "dev",
+          "outcome": "rpc_error",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0x8ecccad4c08f2e225515e6b223b46a723bc5cac3",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:58:41Z",
+          "message": "Unsupported to=0x47285Fb8DaeAC5232D95E0E653cF56494cCD8E45",
+          "name": "dev",
+          "outcome": "rpc_error",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0x8ecccad4c08f2e225515e6b223b46a723bc5cac3",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:19:05Z",
+          "message": "Unsupported to=0x5c03d5747fc1aee34d6F933053B25F48F63FbE26",
+          "name": "dev",
+          "outcome": "rpc_error",
+          "protocol": "Lagoon Finance"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:30:39Z",
+      "message": "Unsupported to=0xdF84cCB252A700270064cD1A7E0Dbf0f0dc467b6",
+      "name": "dev",
+      "outcome": "rpc_error",
+      "protocol": "Lagoon Finance"
+    },
+    "42161-0x90465aad4e426948a4ea342ac49a1a38200b7017": {
+      "address": "0x90465aad4e426948a4ea342ac49a1a38200b7017",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x90465aad4e426948a4ea342ac49a1a38200b7017",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x90465aad4e426948a4ea342ac49a1a38200b7017",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x90465aad4e426948a4ea342ac49a1a38200b7017",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Royco Senior Tranche sUSDai",
+          "outcome": "skipped",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0x90465aad4e426948a4ea342ac49a1a38200b7017",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Royco Senior Tranche sUSDai",
+          "outcome": "skipped",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0x90465aad4e426948a4ea342ac49a1a38200b7017",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:13Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Royco Senior Tranche sUSDai",
+          "outcome": "adapter_error",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0x90465aad4e426948a4ea342ac49a1a38200b7017",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:57:54Z",
+          "message": "Could not find balance slot for token 0x0B2b2B2076d95dda7817e785989fE353fe955ef9",
+          "name": "Royco Senior Tranche sUSDai",
+          "outcome": "funding_error",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0x90465aad4e426948a4ea342ac49a1a38200b7017",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:24:15Z",
+          "message": "Could not find balance slot for token 0x0B2b2B2076d95dda7817e785989fE353fe955ef9",
+          "name": "Royco Senior Tranche sUSDai",
+          "outcome": "funding_error",
+          "protocol": "Royco"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:38:09Z",
+      "message": "Could not find balance slot for token 0x0B2b2B2076d95dda7817e785989fE353fe955ef9",
+      "name": "Royco Senior Tranche sUSDai",
+      "outcome": "funding_error",
+      "protocol": "Royco"
+    },
+    "42161-0x90788f682463d1ac00bd2230b15a4bd0d32a3e46": {
+      "address": "0x90788f682463d1ac00bd2230b15a4bd0d32a3e46",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x90788f682463d1ac00bd2230b15a4bd0d32a3e46",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:02Z",
+          "message": "Transaction must include these fields: {'gasPrice'}",
+          "name": "Trust Wallet AAVE v3 USDC",
+          "outcome": "rpc_error",
+          "protocol": "Kiln Metavault"
+        },
+        {
+          "address": "0x90788f682463d1ac00bd2230b15a4bd0d32a3e46",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T16:59:12Z",
+          "message": null,
+          "name": "Trust Wallet AAVE v3 USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9388917"
+        },
+        {
+          "address": "0x90788f682463d1ac00bd2230b15a4bd0d32a3e46",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:01:57Z",
+          "message": null,
+          "name": "Trust Wallet AAVE v3 USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9388916"
+        },
+        {
+          "address": "0x90788f682463d1ac00bd2230b15a4bd0d32a3e46",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:14:06Z",
+          "message": null,
+          "name": "Trust Wallet AAVE v3 USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9388911"
+        },
+        {
+          "address": "0x90788f682463d1ac00bd2230b15a4bd0d32a3e46",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:25:27Z",
+          "message": null,
+          "name": "Trust Wallet AAVE v3 USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9388907"
+        },
+        {
+          "address": "0x90788f682463d1ac00bd2230b15a4bd0d32a3e46",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:25:57Z",
+          "message": null,
+          "name": "Trust Wallet AAVE v3 USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9388906"
+        },
+        {
+          "address": "0x90788f682463d1ac00bd2230b15a4bd0d32a3e46",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:58:12Z",
+          "message": null,
+          "name": "Trust Wallet AAVE v3 USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9388893"
+        },
+        {
+          "address": "0x90788f682463d1ac00bd2230b15a4bd0d32a3e46",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:18:30Z",
+          "message": null,
+          "name": "Trust Wallet AAVE v3 USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9388885"
+        },
+        {
+          "address": "0x90788f682463d1ac00bd2230b15a4bd0d32a3e46",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:27:49Z",
+          "message": null,
+          "name": "Trust Wallet AAVE v3 USDC",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9388881"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:29:32Z",
+      "message": null,
+      "name": "Trust Wallet AAVE v3 USDC",
+      "outcome": "success",
+      "protocol": "Kiln Metavault",
+      "share_balance_raw": "9388880"
+    },
+    "42161-0x959f3807f0aa7921e18c78b00b2819ba91e52fef": {
+      "address": "0x959f3807f0aa7921e18c78b00b2819ba91e52fef",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": null,
+      "history": [
+        {
+          "address": "0x959f3807f0aa7921e18c78b00b2819ba91e52fef",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "gmUSDC",
+          "outcome": "adapter_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0x959f3807f0aa7921e18c78b00b2819ba91e52fef",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "gmUSDC",
+          "outcome": "adapter_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0x959f3807f0aa7921e18c78b00b2819ba91e52fef",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "gmUSDC",
+          "outcome": "adapter_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0x959f3807f0aa7921e18c78b00b2819ba91e52fef",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "gmUSDC",
+          "outcome": "adapter_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0x959f3807f0aa7921e18c78b00b2819ba91e52fef",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:43Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "gmUSDC",
+          "outcome": "adapter_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0x959f3807f0aa7921e18c78b00b2819ba91e52fef",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:56:46Z",
+          "message": "\nABI Not Found!\nNo element named `deposit` with 2 argument(s).\nProvided argument types: (int,address)\nProvided keyword argument types: {}\n\nTried to find a matching ABI element named `deposit`, but encountered the following problems:\nSignature: deposit(uint256,uint256,address), type: function\nExpected 3 argument(s) but received 2 argument(s).\n",
+          "name": "gmUSDC",
+          "outcome": "rpc_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0x959f3807f0aa7921e18c78b00b2819ba91e52fef",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T18:28:50Z",
+          "message": "\nABI Not Found!\nNo element named `deposit` with 2 argument(s).\nProvided argument types: (int,address)\nProvided keyword argument types: {}\n\nTried to find a matching ABI element named `deposit`, but encountered the following problems:\nSignature: deposit(uint256,uint256,address), type: function\nExpected 3 argument(s) but received 2 argument(s).\n",
+          "name": "gmUSDC",
+          "outcome": "rpc_error",
+          "protocol": "Umami"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:46:20Z",
+      "message": "\nABI Not Found!\nNo element named `deposit` with 2 argument(s).\nProvided argument types: (int,address)\nProvided keyword argument types: {}\n\nTried to find a matching ABI element named `deposit`, but encountered the following problems:\nSignature: deposit(uint256,uint256,address), type: function\nExpected 3 argument(s) but received 2 argument(s).\n",
+      "name": "gmUSDC",
+      "outcome": "rpc_error",
+      "protocol": "Umami"
+    },
+    "42161-0x95d99a811823b64c77a1c6cd6b03f6d4dc3d3997": {
+      "address": "0x95d99a811823b64c77a1c6cd6b03f6d4dc3d3997",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x95d99a811823b64c77a1c6cd6b03f6d4dc3d3997",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:28:22Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Trust Wallet Morpho V2 Steakhouse High Yield USDT0",
+          "outcome": "funding_error",
+          "protocol": "Kiln Metavault"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:29:59Z",
+      "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "name": "Trust Wallet Morpho V2 Steakhouse High Yield USDT0",
+      "outcome": "funding_error",
+      "protocol": "Kiln Metavault"
+    },
+    "42161-0x965c05712263f1a81d97ebd7759545ca97a4039f": {
+      "address": "0x965c05712263f1a81d97ebd7759545ca97a4039f",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x965c05712263f1a81d97ebd7759545ca97a4039f",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:15:20Z",
+          "message": "Anvil transaction reverted",
+          "name": "ArbSim3",
+          "outcome": "reverted",
+          "protocol": "<unknown ERC-7540>",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:18:58Z",
+      "message": "Anvil transaction reverted",
+      "name": "ArbSim3",
+      "outcome": "reverted",
+      "protocol": "<unknown ERC-7540>",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x96d6c438c704a2de8cdce435803a10d329b72e68": {
+      "address": "0x96d6c438c704a2de8cdce435803a10d329b72e68",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x96d6c438c704a2de8cdce435803a10d329b72e68",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x96d6c438c704a2de8cdce435803a10d329b72e68",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x96d6c438c704a2de8cdce435803a10d329b72e68",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Trust Wallet AAVE v3 DAI",
+          "outcome": "skipped",
+          "protocol": "Kiln Metavault"
+        },
+        {
+          "address": "0x96d6c438c704a2de8cdce435803a10d329b72e68",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Trust Wallet AAVE v3 DAI",
+          "outcome": "skipped",
+          "protocol": "Kiln Metavault"
+        },
+        {
+          "address": "0x96d6c438c704a2de8cdce435803a10d329b72e68",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:25:07Z",
+          "message": null,
+          "name": "Trust Wallet AAVE v3 DAI",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9400666207735581340"
+        },
+        {
+          "address": "0x96d6c438c704a2de8cdce435803a10d329b72e68",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:25:44Z",
+          "message": null,
+          "name": "Trust Wallet AAVE v3 DAI",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9400665380109045744"
+        },
+        {
+          "address": "0x96d6c438c704a2de8cdce435803a10d329b72e68",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:57:56Z",
+          "message": null,
+          "name": "Trust Wallet AAVE v3 DAI",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9400655694337313119"
+        },
+        {
+          "address": "0x96d6c438c704a2de8cdce435803a10d329b72e68",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:18:14Z",
+          "message": null,
+          "name": "Trust Wallet AAVE v3 DAI",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9400649582404955689"
+        },
+        {
+          "address": "0x96d6c438c704a2de8cdce435803a10d329b72e68",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:27:31Z",
+          "message": null,
+          "name": "Trust Wallet AAVE v3 DAI",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9400646785104390500"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:29:17Z",
+      "message": null,
+      "name": "Trust Wallet AAVE v3 DAI",
+      "outcome": "success",
+      "protocol": "Kiln Metavault",
+      "share_balance_raw": "9400646258730814337"
+    },
+    "42161-0x98c49e13bf99d7cad8069faa2a370933ec9ecf17": {
+      "address": "0x98c49e13bf99d7cad8069faa2a370933ec9ecf17",
+      "attempt_count": 6,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x98c49e13bf99d7cad8069faa2a370933ec9ecf17",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x98c49e13bf99d7cad8069faa2a370933ec9ecf17",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x98c49e13bf99d7cad8069faa2a370933ec9ecf17",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Summer.fi USD\u20ae0",
+          "outcome": "skipped",
+          "protocol": "Summer.fi"
+        },
+        {
+          "address": "0x98c49e13bf99d7cad8069faa2a370933ec9ecf17",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Summer.fi USD\u20ae0",
+          "outcome": "skipped",
+          "protocol": "Summer.fi"
+        },
+        {
+          "address": "0x98c49e13bf99d7cad8069faa2a370933ec9ecf17",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:25Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Summer.fi USD\u20ae0",
+          "outcome": "adapter_error",
+          "protocol": "Summer.fi"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T17:59:40Z",
+      "message": "Vault deposits are currently closed",
+      "name": "Summer.fi USD\u20ae0",
+      "outcome": "skipped",
+      "protocol": "Summer.fi"
+    },
+    "42161-0x98e43a491a464f0886bc5e57207c340bbed0d01f": {
+      "address": "0x98e43a491a464f0886bc5e57207c340bbed0d01f",
+      "attempt_count": 6,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x98e43a491a464f0886bc5e57207c340bbed0d01f",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "First - USDC",
+          "outcome": "adapter_error",
+          "protocol": "T3tris"
+        },
+        {
+          "address": "0x98e43a491a464f0886bc5e57207c340bbed0d01f",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "First - USDC",
+          "outcome": "adapter_error",
+          "protocol": "T3tris"
+        },
+        {
+          "address": "0x98e43a491a464f0886bc5e57207c340bbed0d01f",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "First - USDC",
+          "outcome": "adapter_error",
+          "protocol": "T3tris"
+        },
+        {
+          "address": "0x98e43a491a464f0886bc5e57207c340bbed0d01f",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "First - USDC",
+          "outcome": "adapter_error",
+          "protocol": "T3tris"
+        },
+        {
+          "address": "0x98e43a491a464f0886bc5e57207c340bbed0d01f",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:00:55Z",
+          "message": "Vault deposits are currently closed",
+          "name": "First - USDC",
+          "outcome": "skipped",
+          "protocol": "T3tris"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:43:42Z",
+      "max_deposit_guidance": "0",
+      "message": "Anvil transaction reverted",
+      "name": "First - USDC",
+      "outcome": "reverted",
+      "protocol": "T3tris",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x9984ad74c5fb6bec3888e14b4e453707d3be7f8f": {
+      "address": "0x9984ad74c5fb6bec3888e14b4e453707d3be7f8f",
+      "attempt_count": 6,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x9984ad74c5fb6bec3888e14b4e453707d3be7f8f",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Gami USDC",
+          "outcome": "adapter_error",
+          "protocol": "T3tris"
+        },
+        {
+          "address": "0x9984ad74c5fb6bec3888e14b4e453707d3be7f8f",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Gami USDC",
+          "outcome": "adapter_error",
+          "protocol": "T3tris"
+        },
+        {
+          "address": "0x9984ad74c5fb6bec3888e14b4e453707d3be7f8f",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Gami USDC",
+          "outcome": "adapter_error",
+          "protocol": "T3tris"
+        },
+        {
+          "address": "0x9984ad74c5fb6bec3888e14b4e453707d3be7f8f",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Gami USDC",
+          "outcome": "adapter_error",
+          "protocol": "T3tris"
+        },
+        {
+          "address": "0x9984ad74c5fb6bec3888e14b4e453707d3be7f8f",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:00:55Z",
+          "message": "Vault deposits are currently closed",
+          "name": "Gami USDC",
+          "outcome": "skipped",
+          "protocol": "T3tris"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:43:33Z",
+      "max_deposit_guidance": "0",
+      "message": "Anvil transaction reverted",
+      "name": "Gami USDC",
+      "outcome": "reverted",
+      "protocol": "T3tris",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x999a57ae7694298126a5db2e44f778ca486b14fc": {
+      "address": "0x999a57ae7694298126a5db2e44f778ca486b14fc",
+      "attempt_count": 6,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x999a57ae7694298126a5db2e44f778ca486b14fc",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x999a57ae7694298126a5db2e44f778ca486b14fc",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x999a57ae7694298126a5db2e44f778ca486b14fc",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "xD2e",
+          "outcome": "skipped",
+          "protocol": "D2 Finance"
+        },
+        {
+          "address": "0x999a57ae7694298126a5db2e44f778ca486b14fc",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "xD2e",
+          "outcome": "skipped",
+          "protocol": "D2 Finance"
+        },
+        {
+          "address": "0x999a57ae7694298126a5db2e44f778ca486b14fc",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:15Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "xD2e",
+          "outcome": "adapter_error",
+          "protocol": "D2 Finance"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T17:55:22Z",
+      "message": "Vault deposits are currently closed",
+      "name": "xD2e",
+      "outcome": "skipped",
+      "protocol": "D2 Finance"
+    },
+    "42161-0x9a5eca1b228e47a15bd9fab07716a9fce9eebfb5": {
+      "address": "0x9a5eca1b228e47a15bd9fab07716a9fce9eebfb5",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:30:45Z",
+      "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "name": "Silo Finance Borrowable USDC Deposit in Silo Silo",
+      "outcome": "funding_error",
+      "protocol": "Yearn"
+    },
+    "42161-0x9b5637d7952bc9fa2d693aae51f3103760bf2693": {
+      "address": "0x9b5637d7952bc9fa2d693aae51f3103760bf2693",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x9b5637d7952bc9fa2d693aae51f3103760bf2693",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x9b5637d7952bc9fa2d693aae51f3103760bf2693",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x9b5637d7952bc9fa2d693aae51f3103760bf2693",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Static Aave Arbitrum ARB",
+          "outcome": "skipped",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0x9b5637d7952bc9fa2d693aae51f3103760bf2693",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Static Aave Arbitrum ARB",
+          "outcome": "skipped",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0x9b5637d7952bc9fa2d693aae51f3103760bf2693",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:32Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Static Aave Arbitrum ARB",
+          "outcome": "adapter_error",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0x9b5637d7952bc9fa2d693aae51f3103760bf2693",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:00:37Z",
+          "message": "Could not find balance slot for token 0x912CE59144191C1204E64559FE8253a0e49E6548",
+          "name": "Static Aave Arbitrum ARB",
+          "outcome": "funding_error",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0x9b5637d7952bc9fa2d693aae51f3103760bf2693",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:27:13Z",
+          "message": "Could not find balance slot for token 0x912CE59144191C1204E64559FE8253a0e49E6548",
+          "name": "Static Aave Arbitrum ARB",
+          "outcome": "funding_error",
+          "protocol": "Superform"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:42:37Z",
+      "max_deposit_guidance": "24984355638073228887549897",
+      "message": "Could not find balance slot for token 0x912CE59144191C1204E64559FE8253a0e49E6548",
+      "name": "Static Aave Arbitrum ARB",
+      "outcome": "funding_error",
+      "protocol": "Superform"
+    },
+    "42161-0x9cf01d5da5c382199da0cc029560d5d4f698dd76": {
+      "address": "0x9cf01d5da5c382199da0cc029560d5d4f698dd76",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x9cf01d5da5c382199da0cc029560d5d4f698dd76",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x9cf01d5da5c382199da0cc029560d5d4f698dd76",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x9cf01d5da5c382199da0cc029560d5d4f698dd76",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Borrowable wstUSR Deposit, SiloId: 149",
+          "outcome": "skipped",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0x9cf01d5da5c382199da0cc029560d5d4f698dd76",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Borrowable wstUSR Deposit, SiloId: 149",
+          "outcome": "skipped",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0x9cf01d5da5c382199da0cc029560d5d4f698dd76",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:18Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Borrowable wstUSR Deposit, SiloId: 149",
+          "outcome": "adapter_error",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0x9cf01d5da5c382199da0cc029560d5d4f698dd76",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:59:25Z",
+          "message": "Could not find balance slot for token 0x66CFbD79257dC5217903A36293120282548E2254",
+          "name": "Borrowable wstUSR Deposit, SiloId: 149",
+          "outcome": "funding_error",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0x9cf01d5da5c382199da0cc029560d5d4f698dd76",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:25:42Z",
+          "message": "Could not find balance slot for token 0x66CFbD79257dC5217903A36293120282548E2254",
+          "name": "Borrowable wstUSR Deposit, SiloId: 149",
+          "outcome": "funding_error",
+          "protocol": "Silo Finance"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:40:10Z",
+      "message": "Could not find balance slot for token 0x66CFbD79257dC5217903A36293120282548E2254",
+      "name": "Borrowable wstUSR Deposit, SiloId: 149",
+      "outcome": "funding_error",
+      "protocol": "Silo Finance"
+    },
+    "42161-0x9dd3f844747ab78d616bf76db92756e17a064add": {
+      "address": "0x9dd3f844747ab78d616bf76db92756e17a064add",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x9dd3f844747ab78d616bf76db92756e17a064add",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:10Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x9dd3f844747ab78d616bf76db92756e17a064add",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:59:52Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0x9dd3f844747ab78d616bf76db92756e17a064add",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Test ARGt Prime",
+          "outcome": "skipped",
+          "protocol": "Morpho"
+        },
+        {
+          "address": "0x9dd3f844747ab78d616bf76db92756e17a064add",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Test ARGt Prime",
+          "outcome": "skipped",
+          "protocol": "Morpho"
+        },
+        {
+          "address": "0x9dd3f844747ab78d616bf76db92756e17a064add",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:09Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Test ARGt Prime",
+          "outcome": "adapter_error",
+          "protocol": "Morpho"
+        },
+        {
+          "address": "0x9dd3f844747ab78d616bf76db92756e17a064add",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:26Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Test ARGt Prime",
+          "outcome": "adapter_error",
+          "protocol": "Morpho"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T17:59:47Z",
+      "message": "Vault deposits are currently closed",
+      "name": "Test ARGt Prime",
+      "outcome": "skipped",
+      "protocol": "Morpho"
+    },
+    "42161-0x9e6de1f581d63129af453fe1ea7253b280b4dca8": {
+      "address": "0x9e6de1f581d63129af453fe1ea7253b280b4dca8",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0x9e6de1f581d63129af453fe1ea7253b280b4dca8",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T16:53:55Z",
+          "message": "Vault deposits are currently closed",
+          "name": "Volta90 Multi-asset trading strategy",
+          "outcome": "skipped",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x9e6de1f581d63129af453fe1ea7253b280b4dca8",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T16:58:34Z",
+          "message": "Vault deposits are currently closed",
+          "name": "Volta90 Multi-asset trading strategy",
+          "outcome": "skipped",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x9e6de1f581d63129af453fe1ea7253b280b4dca8",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:01:20Z",
+          "message": "Vault deposits are currently closed",
+          "name": "Volta90 Multi-asset trading strategy",
+          "outcome": "skipped",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x9e6de1f581d63129af453fe1ea7253b280b4dca8",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:13:27Z",
+          "message": "Vault deposits are currently closed",
+          "name": "Volta90 Multi-asset trading strategy",
+          "outcome": "skipped",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x9e6de1f581d63129af453fe1ea7253b280b4dca8",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:23:06Z",
+          "message": "Vault deposits are currently closed",
+          "name": "Volta90 Multi-asset trading strategy",
+          "outcome": "skipped",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x9e6de1f581d63129af453fe1ea7253b280b4dca8",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:54:07Z",
+          "message": "Vault deposits are currently closed",
+          "name": "Volta90 Multi-asset trading strategy",
+          "outcome": "skipped",
+          "protocol": "<unknown ERC-7540>"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:47:33Z",
+      "max_deposit_guidance": "0",
+      "message": "Anvil transaction reverted",
+      "name": "Volta90 Multi-asset trading strategy",
+      "outcome": "reverted",
+      "protocol": "<unknown ERC-7540>",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0x9fa306b1f4a6a83fec98d8ebbabedff78c407f6b": {
+      "address": "0x9fa306b1f4a6a83fec98d8ebbabedff78c407f6b",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:49:56Z",
+      "max_deposit_guidance": "0",
+      "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "name": "USDC-2 yVault",
+      "outcome": "funding_error",
+      "protocol": "Yearn"
+    },
+    "42161-0x9fa578dbf15c86b1ee599aa4507251311fd6fd37": {
+      "address": "0x9fa578dbf15c86b1ee599aa4507251311fd6fd37",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "denomination_token_address": "0xC71FAe5853fa2416b37728D73B51E17A32691E45",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x9fa578dbf15c86b1ee599aa4507251311fd6fd37",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xC71FAe5853fa2416b37728D73B51E17A32691E45",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:19:59Z",
+          "message": null,
+          "name": "Wrapped Ulysses Optimism Stack USDC",
+          "outcome": "success",
+          "protocol": "ERC-4626",
+          "share_balance_raw": "10000012042249106970"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:21:53Z",
+      "message": null,
+      "name": "Wrapped Ulysses Optimism Stack USDC",
+      "outcome": "success",
+      "protocol": "ERC-4626",
+      "share_balance_raw": "10000012042249106970"
+    },
+    "42161-0x9fe29a3fec55414f70454e2dbe6522f48ced3e85": {
+      "address": "0x9fe29a3fec55414f70454e2dbe6522f48ced3e85",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0x9fe29a3fec55414f70454e2dbe6522f48ced3e85",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "Transaction must include these fields: {'gasPrice'}",
+          "name": "Noon Symphony Yield Vault",
+          "outcome": "rpc_error",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0x9fe29a3fec55414f70454e2dbe6522f48ced3e85",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": null,
+          "name": "Noon Symphony Yield Vault",
+          "outcome": "success",
+          "protocol": "<unknown ERC-7540>",
+          "share_balance_raw": "9910140"
+        },
+        {
+          "address": "0x9fe29a3fec55414f70454e2dbe6522f48ced3e85",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:01:31Z",
+          "message": null,
+          "name": "Noon Symphony Yield Vault",
+          "outcome": "success",
+          "protocol": "<unknown ERC-7540>",
+          "share_balance_raw": "9910138"
+        },
+        {
+          "address": "0x9fe29a3fec55414f70454e2dbe6522f48ced3e85",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:13:38Z",
+          "message": null,
+          "name": "Noon Symphony Yield Vault",
+          "outcome": "success",
+          "protocol": "<unknown ERC-7540>",
+          "share_balance_raw": "9910127"
+        },
+        {
+          "address": "0x9fe29a3fec55414f70454e2dbe6522f48ced3e85",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:23:15Z",
+          "message": null,
+          "name": "Noon Symphony Yield Vault",
+          "outcome": "success",
+          "protocol": "<unknown ERC-7540>",
+          "share_balance_raw": "9910118"
+        },
+        {
+          "address": "0x9fe29a3fec55414f70454e2dbe6522f48ced3e85",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:54:14Z",
+          "message": null,
+          "name": "Noon Symphony Yield Vault",
+          "outcome": "success",
+          "protocol": "<unknown ERC-7540>",
+          "share_balance_raw": "9910090"
+        },
+        {
+          "address": "0x9fe29a3fec55414f70454e2dbe6522f48ced3e85",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:08:45Z",
+          "message": null,
+          "name": "Noon Symphony Yield Vault",
+          "outcome": "success",
+          "protocol": "<unknown ERC-7540>",
+          "share_balance_raw": "9910077"
+        },
+        {
+          "address": "0x9fe29a3fec55414f70454e2dbe6522f48ced3e85",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:14:28Z",
+          "message": null,
+          "name": "Noon Symphony Yield Vault",
+          "outcome": "success",
+          "protocol": "<unknown ERC-7540>",
+          "share_balance_raw": "9910071"
+        },
+        {
+          "address": "0x9fe29a3fec55414f70454e2dbe6522f48ced3e85",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:18:04Z",
+          "message": null,
+          "name": "Noon Symphony Yield Vault",
+          "outcome": "success",
+          "protocol": "<unknown ERC-7540>",
+          "share_balance_raw": "9910068"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:47:44Z",
+      "max_deposit_guidance": "19361429872962",
+      "message": null,
+      "name": "Noon Symphony Yield Vault",
+      "outcome": "success",
+      "protocol": "<unknown ERC-7540>",
+      "share_balance_raw": "9910042"
+    },
+    "42161-0xa0675194379ace7139b04a24faca37781d9f3b79": {
+      "address": "0xa0675194379ace7139b04a24faca37781d9f3b79",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0xa0675194379ace7139b04a24faca37781d9f3b79",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Tokemak arbUSD",
+          "outcome": "adapter_error",
+          "protocol": "AUTO Finance"
+        },
+        {
+          "address": "0xa0675194379ace7139b04a24faca37781d9f3b79",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Tokemak arbUSD",
+          "outcome": "adapter_error",
+          "protocol": "AUTO Finance"
+        },
+        {
+          "address": "0xa0675194379ace7139b04a24faca37781d9f3b79",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:31Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Tokemak arbUSD",
+          "outcome": "adapter_error",
+          "protocol": "AUTO Finance"
+        },
+        {
+          "address": "0xa0675194379ace7139b04a24faca37781d9f3b79",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Tokemak arbUSD",
+          "outcome": "adapter_error",
+          "protocol": "AUTO Finance"
+        },
+        {
+          "address": "0xa0675194379ace7139b04a24faca37781d9f3b79",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:15Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Tokemak arbUSD",
+          "outcome": "adapter_error",
+          "protocol": "AUTO Finance"
+        },
+        {
+          "address": "0xa0675194379ace7139b04a24faca37781d9f3b79",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:54:51Z",
+          "message": null,
+          "name": "Tokemak arbUSD",
+          "outcome": "success",
+          "protocol": "AUTO Finance",
+          "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xa0675194379ace7139b04a24faca37781d9f3b79",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:09:36Z",
+          "message": null,
+          "name": "Tokemak arbUSD",
+          "outcome": "success",
+          "protocol": "AUTO Finance",
+          "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xa0675194379ace7139b04a24faca37781d9f3b79",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:16:25Z",
+          "message": null,
+          "name": "Tokemak arbUSD",
+          "outcome": "success",
+          "protocol": "AUTO Finance",
+          "share_balance_raw": "10000000000000000000"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:48:46Z",
+      "max_deposit_guidance": "5192296858534827528531",
+      "message": null,
+      "name": "Tokemak arbUSD",
+      "outcome": "success",
+      "protocol": "AUTO Finance",
+      "share_balance_raw": "10000000000000000000"
+    },
+    "42161-0xa14283d1ba337352f810ea31eb3159aa27da4981": {
+      "address": "0xa14283d1ba337352f810ea31eb3159aa27da4981",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xa14283d1ba337352f810ea31eb3159aa27da4981",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:54Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xa14283d1ba337352f810ea31eb3159aa27da4981",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:33Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xa14283d1ba337352f810ea31eb3159aa27da4981",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "skipped",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0xa14283d1ba337352f810ea31eb3159aa27da4981",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "skipped",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0xa14283d1ba337352f810ea31eb3159aa27da4981",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:22:58Z",
+          "message": "Vault deposits are currently closed",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "skipped",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0xa14283d1ba337352f810ea31eb3159aa27da4981",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:53:54Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "adapter_error",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0xa14283d1ba337352f810ea31eb3159aa27da4981",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T18:08:25Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "adapter_error",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0xa14283d1ba337352f810ea31eb3159aa27da4981",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T18:13:49Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "adapter_error",
+          "protocol": "<protocol not yet identified>"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:46:58Z",
+      "max_deposit_guidance": "0",
+      "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "name": "Delta Netural GMX Vault (Senior)",
+      "outcome": "funding_error",
+      "protocol": "<protocol not yet identified>"
+    },
+    "42161-0xa520272bf782870ce0ab987fc23eb6f883c5e3ec": {
+      "address": "0xa520272bf782870ce0ab987fc23eb6f883c5e3ec",
+      "attempt_count": 6,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xa520272bf782870ce0ab987fc23eb6f883c5e3ec",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xa520272bf782870ce0ab987fc23eb6f883c5e3ec",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xa520272bf782870ce0ab987fc23eb6f883c5e3ec",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "x2D2",
+          "outcome": "skipped",
+          "protocol": "D2 Finance"
+        },
+        {
+          "address": "0xa520272bf782870ce0ab987fc23eb6f883c5e3ec",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "x2D2",
+          "outcome": "skipped",
+          "protocol": "D2 Finance"
+        },
+        {
+          "address": "0xa520272bf782870ce0ab987fc23eb6f883c5e3ec",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:15Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "x2D2",
+          "outcome": "adapter_error",
+          "protocol": "D2 Finance"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T17:55:23Z",
+      "message": "Vault deposits are currently closed",
+      "name": "x2D2",
+      "outcome": "skipped",
+      "protocol": "D2 Finance"
+    },
+    "42161-0xa54eca0bcb77a53643f723b49ddbc28e201a659e": {
+      "address": "0xa54eca0bcb77a53643f723b49ddbc28e201a659e",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xa54eca0bcb77a53643f723b49ddbc28e201a659e",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:10Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Nashpoint iSNR Credit Vault",
+          "outcome": "adapter_error",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0xa54eca0bcb77a53643f723b49ddbc28e201a659e",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:59:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Nashpoint iSNR Credit Vault",
+          "outcome": "adapter_error",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0xa54eca0bcb77a53643f723b49ddbc28e201a659e",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:02:42Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Nashpoint iSNR Credit Vault",
+          "outcome": "adapter_error",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0xa54eca0bcb77a53643f723b49ddbc28e201a659e",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:14:46Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Nashpoint iSNR Credit Vault",
+          "outcome": "adapter_error",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0xa54eca0bcb77a53643f723b49ddbc28e201a659e",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:55:25Z",
+          "message": "Anvil transaction reverted",
+          "name": "Nashpoint iSNR Credit Vault",
+          "outcome": "reverted",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0xa54eca0bcb77a53643f723b49ddbc28e201a659e",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:21:36Z",
+          "message": "Got <class 'eth_defi.erc_4626.vault_protocol.nashpoint.vault.NashpointNodeVault'>",
+          "name": "Nashpoint iSNR Credit Vault",
+          "outcome": "rpc_error",
+          "protocol": "NashPoint"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:34:46Z",
+      "message": "Got <class 'eth_defi.erc_4626.vault_protocol.nashpoint.vault.NashpointNodeVault'>",
+      "name": "Nashpoint iSNR Credit Vault",
+      "outcome": "rpc_error",
+      "protocol": "NashPoint"
+    },
+    "42161-0xa6c2e6a83d594e862cdb349396856f7ffe9a979b": {
+      "address": "0xa6c2e6a83d594e862cdb349396856f7ffe9a979b",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xa6c2e6a83d594e862cdb349396856f7ffe9a979b",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:10Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xa6c2e6a83d594e862cdb349396856f7ffe9a979b",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:59:52Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xa6c2e6a83d594e862cdb349396856f7ffe9a979b",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Llama Lend ARB / crvUSD",
+          "outcome": "skipped",
+          "protocol": "Llama Lend"
+        },
+        {
+          "address": "0xa6c2e6a83d594e862cdb349396856f7ffe9a979b",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Llama Lend ARB / crvUSD",
+          "outcome": "skipped",
+          "protocol": "Llama Lend"
+        },
+        {
+          "address": "0xa6c2e6a83d594e862cdb349396856f7ffe9a979b",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:02Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Llama Lend ARB / crvUSD",
+          "outcome": "adapter_error",
+          "protocol": "Llama Lend"
+        },
+        {
+          "address": "0xa6c2e6a83d594e862cdb349396856f7ffe9a979b",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:59:37Z",
+          "message": "Could not find balance slot for token 0x498Bf2B1e120FeD3ad3D42EA2165E9b73f99C1e5",
+          "name": "Llama Lend ARB / crvUSD",
+          "outcome": "funding_error",
+          "protocol": "Llama Lend"
+        },
+        {
+          "address": "0xa6c2e6a83d594e862cdb349396856f7ffe9a979b",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:19:57Z",
+          "message": "Could not find balance slot for token 0x498Bf2B1e120FeD3ad3D42EA2165E9b73f99C1e5",
+          "name": "Llama Lend ARB / crvUSD",
+          "outcome": "funding_error",
+          "protocol": "Llama Lend"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:32:19Z",
+      "message": "Could not find balance slot for token 0x498Bf2B1e120FeD3ad3D42EA2165E9b73f99C1e5",
+      "name": "Llama Lend ARB / crvUSD",
+      "outcome": "funding_error",
+      "protocol": "Llama Lend"
+    },
+    "42161-0xa76c604145d7394dec36c49af494c144ff327861": {
+      "address": "0xa76c604145d7394dec36c49af494c144ff327861",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xa76c604145d7394dec36c49af494c144ff327861",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xa76c604145d7394dec36c49af494c144ff327861",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xa76c604145d7394dec36c49af494c144ff327861",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Main USDC.e v3",
+          "outcome": "skipped",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0xa76c604145d7394dec36c49af494c144ff327861",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Main USDC.e v3",
+          "outcome": "skipped",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0xa76c604145d7394dec36c49af494c144ff327861",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:24:45Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Main USDC.e v3",
+          "outcome": "adapter_error",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0xa76c604145d7394dec36c49af494c144ff327861",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:25:58Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Main USDC.e v3",
+          "outcome": "adapter_error",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0xa76c604145d7394dec36c49af494c144ff327861",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:55:32Z",
+          "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "name": "Main USDC.e v3",
+          "outcome": "funding_error",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0xa76c604145d7394dec36c49af494c144ff327861",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:15:04Z",
+          "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "name": "Main USDC.e v3",
+          "outcome": "funding_error",
+          "protocol": "Gearbox"
+        },
+        {
+          "address": "0xa76c604145d7394dec36c49af494c144ff327861",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:22:41Z",
+          "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "name": "Main USDC.e v3",
+          "outcome": "funding_error",
+          "protocol": "Gearbox"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:24:29Z",
+      "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "name": "Main USDC.e v3",
+      "outcome": "funding_error",
+      "protocol": "Gearbox"
+    },
+    "42161-0xa909a4aa2a6db0c1a3617a5cf763ae0d780e5c64": {
+      "address": "0xa909a4aa2a6db0c1a3617a5cf763ae0d780e5c64",
+      "attempt_count": 6,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xa909a4aa2a6db0c1a3617a5cf763ae0d780e5c64",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Wincent Investment Fund",
+          "outcome": "adapter_error",
+          "protocol": "TrueFi"
+        },
+        {
+          "address": "0xa909a4aa2a6db0c1a3617a5cf763ae0d780e5c64",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Wincent Investment Fund",
+          "outcome": "adapter_error",
+          "protocol": "TrueFi"
+        },
+        {
+          "address": "0xa909a4aa2a6db0c1a3617a5cf763ae0d780e5c64",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Wincent Investment Fund",
+          "outcome": "adapter_error",
+          "protocol": "TrueFi"
+        },
+        {
+          "address": "0xa909a4aa2a6db0c1a3617a5cf763ae0d780e5c64",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Wincent Investment Fund",
+          "outcome": "adapter_error",
+          "protocol": "TrueFi"
+        },
+        {
+          "address": "0xa909a4aa2a6db0c1a3617a5cf763ae0d780e5c64",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:56:31Z",
+          "message": "Vault deposits are currently closed",
+          "name": "Wincent Investment Fund",
+          "outcome": "skipped",
+          "protocol": "TrueFi"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:45:39Z",
+      "max_deposit_guidance": "0",
+      "message": "Anvil transaction reverted",
+      "name": "Wincent Investment Fund",
+      "outcome": "reverted",
+      "protocol": "TrueFi",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0xa9a4bd976dbcfc2b89f554467ac85e2c758e2618": {
+      "address": "0xa9a4bd976dbcfc2b89f554467ac85e2c758e2618",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0xa9a4bd976dbcfc2b89f554467ac85e2c758e2618",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Borrowable USDC Deposit, SiloId: 149",
+          "outcome": "adapter_error",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0xa9a4bd976dbcfc2b89f554467ac85e2c758e2618",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Borrowable USDC Deposit, SiloId: 149",
+          "outcome": "adapter_error",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0xa9a4bd976dbcfc2b89f554467ac85e2c758e2618",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Borrowable USDC Deposit, SiloId: 149",
+          "outcome": "adapter_error",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0xa9a4bd976dbcfc2b89f554467ac85e2c758e2618",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Borrowable USDC Deposit, SiloId: 149",
+          "outcome": "adapter_error",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0xa9a4bd976dbcfc2b89f554467ac85e2c758e2618",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:18Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Borrowable USDC Deposit, SiloId: 149",
+          "outcome": "adapter_error",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0xa9a4bd976dbcfc2b89f554467ac85e2c758e2618",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:59:18Z",
+          "message": null,
+          "name": "Borrowable USDC Deposit, SiloId: 149",
+          "outcome": "success",
+          "protocol": "Silo Finance",
+          "share_balance_raw": "2860127475"
+        },
+        {
+          "address": "0xa9a4bd976dbcfc2b89f554467ac85e2c758e2618",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:25:39Z",
+          "message": null,
+          "name": "Borrowable USDC Deposit, SiloId: 149",
+          "outcome": "success",
+          "protocol": "Silo Finance",
+          "share_balance_raw": "2858840672"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:40:06Z",
+      "message": null,
+      "name": "Borrowable USDC Deposit, SiloId: 149",
+      "outcome": "success",
+      "protocol": "Silo Finance",
+      "share_balance_raw": "2858140101"
+    },
+    "42161-0xab3ac228cac84a8a1c855c3e08f869b65836c962": {
+      "address": "0xab3ac228cac84a8a1c855c3e08f869b65836c962",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xab3ac228cac84a8a1c855c3e08f869b65836c962",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:28:32Z",
+          "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+          "name": "Crypto.com Defi Wallet Compound USDC.e",
+          "outcome": "funding_error",
+          "protocol": "Kiln Metavault"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:30:08Z",
+      "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "name": "Crypto.com Defi Wallet Compound USDC.e",
+      "outcome": "funding_error",
+      "protocol": "Kiln Metavault"
+    },
+    "42161-0xaba0cb835f40e7af29f8016a1db401e704f855be": {
+      "address": "0xaba0cb835f40e7af29f8016a1db401e704f855be",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xaba0cb835f40e7af29f8016a1db401e704f855be",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:25:18Z",
+          "message": "Anvil transaction reverted",
+          "name": "FARM_ARB_rARB",
+          "outcome": "reverted",
+          "protocol": "Harvest Finance",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:26:59Z",
+      "message": "Anvil transaction reverted",
+      "name": "FARM_ARB_rARB",
+      "outcome": "reverted",
+      "protocol": "Harvest Finance",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0xac62edcda14af2e2547f85d56eb2ce36d11333da": {
+      "address": "0xac62edcda14af2e2547f85d56eb2ce36d11333da",
+      "attempt_count": 3,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xac62edcda14af2e2547f85d56eb2ce36d11333da",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:17:48Z",
+          "message": "Anvil transaction reverted",
+          "name": "IPOR USDC Arbitrum Optimizer Pilot Scheduled 2",
+          "outcome": "reverted",
+          "protocol": "IPOR Fusion",
+          "revert_reason": "Anvil transaction reverted"
+        },
+        {
+          "address": "0xac62edcda14af2e2547f85d56eb2ce36d11333da",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:26:26Z",
+          "message": "Anvil transaction reverted",
+          "name": "IPOR USDC Arbitrum Optimizer Pilot Scheduled 2",
+          "outcome": "reverted",
+          "protocol": "IPOR Fusion",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:28:06Z",
+      "message": "Anvil transaction reverted",
+      "name": "IPOR USDC Arbitrum Optimizer Pilot Scheduled 2",
+      "outcome": "reverted",
+      "protocol": "IPOR Fusion",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0xac69cfe6bb269cebf8ab4764d7e678c3658b99f2": {
+      "address": "0xac69cfe6bb269cebf8ab4764d7e678c3658b99f2",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0xac69cfe6bb269cebf8ab4764d7e678c3658b99f2",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "TID Silo Arbitrum USDC",
+          "outcome": "adapter_error",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0xac69cfe6bb269cebf8ab4764d7e678c3658b99f2",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "TID Silo Arbitrum USDC",
+          "outcome": "adapter_error",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0xac69cfe6bb269cebf8ab4764d7e678c3658b99f2",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:31Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "TID Silo Arbitrum USDC",
+          "outcome": "adapter_error",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0xac69cfe6bb269cebf8ab4764d7e678c3658b99f2",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "TID Silo Arbitrum USDC",
+          "outcome": "adapter_error",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0xac69cfe6bb269cebf8ab4764d7e678c3658b99f2",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:49Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "TID Silo Arbitrum USDC",
+          "outcome": "adapter_error",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0xac69cfe6bb269cebf8ab4764d7e678c3658b99f2",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:56:36Z",
+          "message": null,
+          "name": "TID Silo Arbitrum USDC",
+          "outcome": "success",
+          "protocol": "Euler",
+          "share_balance_raw": "6075682985"
+        },
+        {
+          "address": "0xac69cfe6bb269cebf8ab4764d7e678c3658b99f2",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:12:40Z",
+          "message": null,
+          "name": "TID Silo Arbitrum USDC",
+          "outcome": "success",
+          "protocol": "Euler",
+          "share_balance_raw": "6072135780"
+        },
+        {
+          "address": "0xac69cfe6bb269cebf8ab4764d7e678c3658b99f2",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:20:49Z",
+          "message": null,
+          "name": "TID Silo Arbitrum USDC",
+          "outcome": "success",
+          "protocol": "Euler",
+          "share_balance_raw": "6070368333"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:22:28Z",
+      "message": null,
+      "name": "TID Silo Arbitrum USDC",
+      "outcome": "success",
+      "protocol": "Euler",
+      "share_balance_raw": "6069962506"
+    },
+    "42161-0xacb7432a4bb15402ce2afe0a7c9d5b738604f6f9": {
+      "address": "0xacb7432a4bb15402ce2afe0a7c9d5b738604f6f9",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0xacb7432a4bb15402ce2afe0a7c9d5b738604f6f9",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Borrowable USDC Deposit, SiloId: 146",
+          "outcome": "adapter_error",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0xacb7432a4bb15402ce2afe0a7c9d5b738604f6f9",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Borrowable USDC Deposit, SiloId: 146",
+          "outcome": "adapter_error",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0xacb7432a4bb15402ce2afe0a7c9d5b738604f6f9",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Borrowable USDC Deposit, SiloId: 146",
+          "outcome": "adapter_error",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0xacb7432a4bb15402ce2afe0a7c9d5b738604f6f9",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Borrowable USDC Deposit, SiloId: 146",
+          "outcome": "adapter_error",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0xacb7432a4bb15402ce2afe0a7c9d5b738604f6f9",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:18Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Borrowable USDC Deposit, SiloId: 146",
+          "outcome": "adapter_error",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0xacb7432a4bb15402ce2afe0a7c9d5b738604f6f9",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:58:43Z",
+          "message": null,
+          "name": "Borrowable USDC Deposit, SiloId: 146",
+          "outcome": "success",
+          "protocol": "Silo Finance",
+          "share_balance_raw": "18695675"
+        },
+        {
+          "address": "0xacb7432a4bb15402ce2afe0a7c9d5b738604f6f9",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:25:06Z",
+          "message": null,
+          "name": "Borrowable USDC Deposit, SiloId: 146",
+          "outcome": "success",
+          "protocol": "Silo Finance",
+          "share_balance_raw": "18677686"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:39:29Z",
+      "message": null,
+      "name": "Borrowable USDC Deposit, SiloId: 146",
+      "outcome": "success",
+      "protocol": "Silo Finance",
+      "share_balance_raw": "18667913"
+    },
+    "42161-0xae30166d195caf189a5c46fabcab5b8271f6301d": {
+      "address": "0xae30166d195caf189a5c46fabcab5b8271f6301d",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:36:50Z",
+      "message": "Could not find balance slot for token 0x4548c7fAfeFd9e18dBfd583F2b43b67B3B4D4C0A",
+      "name": "Peapods Metavault for Peapods PEAS LVF Pod",
+      "outcome": "funding_error",
+      "protocol": "Peapods"
+    },
+    "42161-0xae82fdac3397751e099516c9a7220922b651dcbe": {
+      "address": "0xae82fdac3397751e099516c9a7220922b651dcbe",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:31:57Z",
+      "message": "Unsupported to=0x04300408b97df2FbaE293067f446d3459091b7Ef",
+      "name": "BCMUSDC",
+      "outcome": "rpc_error",
+      "protocol": "Lagoon Finance"
+    },
+    "42161-0xaef3c262569e56fb494755110ca6f481f8a2e353": {
+      "address": "0xaef3c262569e56fb494755110ca6f481f8a2e353",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xaef3c262569e56fb494755110ca6f481f8a2e353",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:25:28Z",
+          "message": "Anvil transaction reverted",
+          "name": "FARM_FRAX",
+          "outcome": "reverted",
+          "protocol": "Harvest Finance",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:27:06Z",
+      "message": "Anvil transaction reverted",
+      "name": "FARM_FRAX",
+      "outcome": "reverted",
+      "protocol": "Harvest Finance",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0xb01a958d8e9dba566c6d71f66ef566ccf5fac859": {
+      "address": "0xb01a958d8e9dba566c6d71f66ef566ccf5fac859",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xb01a958d8e9dba566c6d71f66ef566ccf5fac859",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:25:42Z",
+          "message": "Anvil transaction reverted",
+          "name": "Harvest: USDC Vault (0xB01a)",
+          "outcome": "reverted",
+          "protocol": "Harvest Finance",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:27:21Z",
+      "message": "Anvil transaction reverted",
+      "name": "Harvest: USDC Vault (0xB01a)",
+      "outcome": "reverted",
+      "protocol": "Harvest Finance",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0xb165a74407fe1e519d6bcbdec1ed3202b35a4140": {
+      "address": "0xb165a74407fe1e519d6bcbdec1ed3202b35a4140",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xb165a74407fe1e519d6bcbdec1ed3202b35a4140",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xb165a74407fe1e519d6bcbdec1ed3202b35a4140",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xb165a74407fe1e519d6bcbdec1ed3202b35a4140",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Static Aave Arbitrum USDT",
+          "outcome": "skipped",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0xb165a74407fe1e519d6bcbdec1ed3202b35a4140",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Static Aave Arbitrum USDT",
+          "outcome": "skipped",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0xb165a74407fe1e519d6bcbdec1ed3202b35a4140",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:32Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Static Aave Arbitrum USDT",
+          "outcome": "adapter_error",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0xb165a74407fe1e519d6bcbdec1ed3202b35a4140",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:00:34Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Static Aave Arbitrum USDT",
+          "outcome": "funding_error",
+          "protocol": "Superform"
+        },
+        {
+          "address": "0xb165a74407fe1e519d6bcbdec1ed3202b35a4140",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:27:09Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Static Aave Arbitrum USDT",
+          "outcome": "funding_error",
+          "protocol": "Superform"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:42:33Z",
+      "max_deposit_guidance": "65836329031043",
+      "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "name": "Static Aave Arbitrum USDT",
+      "outcome": "funding_error",
+      "protocol": "Superform"
+    },
+    "42161-0xb29613048cb464914a8abdd9e049a1f6662e4740": {
+      "address": "0xb29613048cb464914a8abdd9e049a1f6662e4740",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xb29613048cb464914a8abdd9e049a1f6662e4740",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xb29613048cb464914a8abdd9e049a1f6662e4740",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xb29613048cb464914a8abdd9e049a1f6662e4740",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "gmARB",
+          "outcome": "skipped",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0xb29613048cb464914a8abdd9e049a1f6662e4740",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "gmARB",
+          "outcome": "skipped",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0xb29613048cb464914a8abdd9e049a1f6662e4740",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:43Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "gmARB",
+          "outcome": "adapter_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0xb29613048cb464914a8abdd9e049a1f6662e4740",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:57:15Z",
+          "message": "Could not find balance slot for token 0x912CE59144191C1204E64559FE8253a0e49E6548",
+          "name": "gmARB",
+          "outcome": "funding_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0xb29613048cb464914a8abdd9e049a1f6662e4740",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:29:34Z",
+          "message": "Could not find balance slot for token 0x912CE59144191C1204E64559FE8253a0e49E6548",
+          "name": "gmARB",
+          "outcome": "funding_error",
+          "protocol": "Umami"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:46:57Z",
+      "max_deposit_guidance": "999999999575931716623716001217",
+      "message": "Could not find balance slot for token 0x912CE59144191C1204E64559FE8253a0e49E6548",
+      "name": "gmARB",
+      "outcome": "funding_error",
+      "protocol": "Umami"
+    },
+    "42161-0xb523326c1ced45d0eb3c75c083fed0bcb52ccdce": {
+      "address": "0xb523326c1ced45d0eb3c75c083fed0bcb52ccdce",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xb523326c1ced45d0eb3c75c083fed0bcb52ccdce",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xb523326c1ced45d0eb3c75c083fed0bcb52ccdce",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xb523326c1ced45d0eb3c75c083fed0bcb52ccdce",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "EVK Vault eELIT-1",
+          "outcome": "skipped",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0xb523326c1ced45d0eb3c75c083fed0bcb52ccdce",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "EVK Vault eELIT-1",
+          "outcome": "skipped",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0xb523326c1ced45d0eb3c75c083fed0bcb52ccdce",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:49Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "EVK Vault eELIT-1",
+          "outcome": "adapter_error",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0xb523326c1ced45d0eb3c75c083fed0bcb52ccdce",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:56:38Z",
+          "message": "Could not find balance slot for token 0x5e021bf2ca47a17887D41f43AF811912D572e4a2",
+          "name": "EVK Vault eELIT-1",
+          "outcome": "funding_error",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0xb523326c1ced45d0eb3c75c083fed0bcb52ccdce",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:12:44Z",
+          "message": "Could not find balance slot for token 0x5e021bf2ca47a17887D41f43AF811912D572e4a2",
+          "name": "EVK Vault eELIT-1",
+          "outcome": "funding_error",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0xb523326c1ced45d0eb3c75c083fed0bcb52ccdce",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:20:55Z",
+          "message": "Could not find balance slot for token 0x5e021bf2ca47a17887D41f43AF811912D572e4a2",
+          "name": "EVK Vault eELIT-1",
+          "outcome": "funding_error",
+          "protocol": "Euler"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:22:31Z",
+      "message": "Could not find balance slot for token 0x5e021bf2ca47a17887D41f43AF811912D572e4a2",
+      "name": "EVK Vault eELIT-1",
+      "outcome": "funding_error",
+      "protocol": "Euler"
+    },
+    "42161-0xb739ae19620f7ecb4fb84727f205453aa5bc1ad2": {
+      "address": "0xb739ae19620f7ecb4fb84727f205453aa5bc1ad2",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:50:15Z",
+      "max_deposit_guidance": "0",
+      "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "name": "Silo Finance Borrowable USDC Deposit in ARB Silo",
+      "outcome": "funding_error",
+      "protocol": "Yearn"
+    },
+    "42161-0xb97e63afe33f8907302c37069a044edfaa64a543": {
+      "address": "0xb97e63afe33f8907302c37069a044edfaa64a543",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xb97e63afe33f8907302c37069a044edfaa64a543",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xb97e63afe33f8907302c37069a044edfaa64a543",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xb97e63afe33f8907302c37069a044edfaa64a543",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Supply ARB into AAVE",
+          "outcome": "skipped",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0xb97e63afe33f8907302c37069a044edfaa64a543",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Supply ARB into AAVE",
+          "outcome": "skipped",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0xb97e63afe33f8907302c37069a044edfaa64a543",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:13Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Supply ARB into AAVE",
+          "outcome": "adapter_error",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0xb97e63afe33f8907302c37069a044edfaa64a543",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:58:05Z",
+          "message": "Could not find balance slot for token 0x912CE59144191C1204E64559FE8253a0e49E6548",
+          "name": "Supply ARB into AAVE",
+          "outcome": "funding_error",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0xb97e63afe33f8907302c37069a044edfaa64a543",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:24:28Z",
+          "message": "Could not find balance slot for token 0x912CE59144191C1204E64559FE8253a0e49E6548",
+          "name": "Supply ARB into AAVE",
+          "outcome": "funding_error",
+          "protocol": "Royco"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:38:22Z",
+      "message": "Could not find balance slot for token 0x912CE59144191C1204E64559FE8253a0e49E6548",
+      "name": "Supply ARB into AAVE",
+      "outcome": "funding_error",
+      "protocol": "Royco"
+    },
+    "42161-0xb9e7edb94d62f2182ce532b524037f5cba49736b": {
+      "address": "0xb9e7edb94d62f2182ce532b524037f5cba49736b",
+      "attempt_count": 6,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xb9e7edb94d62f2182ce532b524037f5cba49736b",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Wincent",
+          "outcome": "adapter_error",
+          "protocol": "TrueFi"
+        },
+        {
+          "address": "0xb9e7edb94d62f2182ce532b524037f5cba49736b",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Wincent",
+          "outcome": "adapter_error",
+          "protocol": "TrueFi"
+        },
+        {
+          "address": "0xb9e7edb94d62f2182ce532b524037f5cba49736b",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Wincent",
+          "outcome": "adapter_error",
+          "protocol": "TrueFi"
+        },
+        {
+          "address": "0xb9e7edb94d62f2182ce532b524037f5cba49736b",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Wincent",
+          "outcome": "adapter_error",
+          "protocol": "TrueFi"
+        },
+        {
+          "address": "0xb9e7edb94d62f2182ce532b524037f5cba49736b",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:56:32Z",
+          "message": "Vault deposits are currently closed",
+          "name": "Wincent",
+          "outcome": "skipped",
+          "protocol": "TrueFi"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:45:50Z",
+      "max_deposit_guidance": "0",
+      "message": "Anvil transaction reverted",
+      "name": "Wincent",
+      "outcome": "reverted",
+      "protocol": "TrueFi",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0xbb84d79159d6bbe1de148dc82640caa677e06126": {
+      "address": "0xbb84d79159d6bbe1de148dc82640caa677e06126",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:48:15Z",
+      "max_deposit_guidance": "916305480990418146930",
+      "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "name": "glpWETH",
+      "outcome": "funding_error",
+      "protocol": "Umami"
+    },
+    "42161-0xbc8dd5dc727edb9929f9f9fe0a288ccc941e4ddb": {
+      "address": "0xbc8dd5dc727edb9929f9f9fe0a288ccc941e4ddb",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:14:09Z",
+      "message": null,
+      "name": "Systematic Alpha Fund USDC",
+      "outcome": "success",
+      "protocol": "<protocol not yet identified>",
+      "share_balance_raw": "2930983"
+    },
+    "42161-0xbc9b0f31634979584e97513cf580f5006497d699": {
+      "address": "0xbc9b0f31634979584e97513cf580f5006497d699",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xbc9b0f31634979584e97513cf580f5006497d699",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:54Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xbc9b0f31634979584e97513cf580f5006497d699",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:33Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xbc9b0f31634979584e97513cf580f5006497d699",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "skipped",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0xbc9b0f31634979584e97513cf580f5006497d699",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "skipped",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0xbc9b0f31634979584e97513cf580f5006497d699",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:23:00Z",
+          "message": "Vault deposits are currently closed",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "skipped",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0xbc9b0f31634979584e97513cf580f5006497d699",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:53:56Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "adapter_error",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0xbc9b0f31634979584e97513cf580f5006497d699",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T18:08:27Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "adapter_error",
+          "protocol": "<protocol not yet identified>"
+        },
+        {
+          "address": "0xbc9b0f31634979584e97513cf580f5006497d699",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T18:13:51Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Delta Netural GMX Vault (Senior)",
+          "outcome": "adapter_error",
+          "protocol": "<protocol not yet identified>"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:47:11Z",
+      "max_deposit_guidance": "0",
+      "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "name": "Delta Netural GMX Vault (Senior)",
+      "outcome": "funding_error",
+      "protocol": "<protocol not yet identified>"
+    },
+    "42161-0xbcdef6f4465b5a3e9122946a352d164da7612354": {
+      "address": "0xbcdef6f4465b5a3e9122946a352d164da7612354",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xbcdef6f4465b5a3e9122946a352d164da7612354",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Janus Henderson Anemoy AAA CLO Fund Token",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xbcdef6f4465b5a3e9122946a352d164da7612354",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Janus Henderson Anemoy AAA CLO Fund Token",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xbcdef6f4465b5a3e9122946a352d164da7612354",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:31Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Janus Henderson Anemoy AAA CLO Fund Token",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xbcdef6f4465b5a3e9122946a352d164da7612354",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Janus Henderson Anemoy AAA CLO Fund Token",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xbcdef6f4465b5a3e9122946a352d164da7612354",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:15Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Janus Henderson Anemoy AAA CLO Fund Token",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xbcdef6f4465b5a3e9122946a352d164da7612354",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:55:11Z",
+          "message": "Vault deposits are currently closed",
+          "name": "Janus Henderson Anemoy AAA CLO Fund Token",
+          "outcome": "skipped",
+          "protocol": "Centrifuge"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:48:59Z",
+      "max_deposit_guidance": "0",
+      "message": "Anvil transaction reverted",
+      "name": "Janus Henderson Anemoy AAA CLO Fund Token",
+      "outcome": "reverted",
+      "protocol": "Centrifuge",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0xbde67e089886ec0e615d6f054bc6f746189a3d56": {
+      "address": "0xbde67e089886ec0e615d6f054bc6f746189a3d56",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:42:55Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Could not find balance slot for token 0x724dc807b04555b71ed48a6896b6F41593b8C637",
+      "name": "Static Aave Arbitrum USDCn",
+      "outcome": "funding_error",
+      "protocol": "Superform"
+    },
+    "42161-0xbe1a0690aa440ccae131b05679aef197f843527a": {
+      "address": "0xbe1a0690aa440ccae131b05679aef197f843527a",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "denomination_token_address": "0x211Cc4DD073734dA055fbF44a2b4667d5E5fE5d2",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:34:31Z",
+      "message": null,
+      "name": "MS-sUSDe",
+      "outcome": "success",
+      "protocol": "Morpho",
+      "share_balance_raw": "9999856329791849717"
+    },
+    "42161-0xbe3860fd4c3facdf8ad57aa8c1a36d6dc4390a49": {
+      "address": "0xbe3860fd4c3facdf8ad57aa8c1a36d6dc4390a49",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xbe3860fd4c3facdf8ad57aa8c1a36d6dc4390a49",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xbe3860fd4c3facdf8ad57aa8c1a36d6dc4390a49",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xbe3860fd4c3facdf8ad57aa8c1a36d6dc4390a49",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Fluid Arbitrum",
+          "outcome": "skipped",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0xbe3860fd4c3facdf8ad57aa8c1a36d6dc4390a49",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Fluid Arbitrum",
+          "outcome": "skipped",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0xbe3860fd4c3facdf8ad57aa8c1a36d6dc4390a49",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:49Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Fluid Arbitrum",
+          "outcome": "adapter_error",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0xbe3860fd4c3facdf8ad57aa8c1a36d6dc4390a49",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:57:24Z",
+          "message": "Could not find balance slot for token 0x912CE59144191C1204E64559FE8253a0e49E6548",
+          "name": "Fluid Arbitrum",
+          "outcome": "funding_error",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0xbe3860fd4c3facdf8ad57aa8c1a36d6dc4390a49",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:13:37Z",
+          "message": "Could not find balance slot for token 0x912CE59144191C1204E64559FE8253a0e49E6548",
+          "name": "Fluid Arbitrum",
+          "outcome": "funding_error",
+          "protocol": "Fluid"
+        },
+        {
+          "address": "0xbe3860fd4c3facdf8ad57aa8c1a36d6dc4390a49",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:20:42Z",
+          "message": "Could not find balance slot for token 0x912CE59144191C1204E64559FE8253a0e49E6548",
+          "name": "Fluid Arbitrum",
+          "outcome": "funding_error",
+          "protocol": "Fluid"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:22:42Z",
+      "message": "Could not find balance slot for token 0x912CE59144191C1204E64559FE8253a0e49E6548",
+      "name": "Fluid Arbitrum",
+      "outcome": "funding_error",
+      "protocol": "Fluid"
+    },
+    "42161-0xbe7d1b3cf19eb05ac557be14af24e093fadfd7c6": {
+      "address": "0xbe7d1b3cf19eb05ac557be14af24e093fadfd7c6",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "generic_erc4626",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0xbe7d1b3cf19eb05ac557be14af24e093fadfd7c6",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Teller USDC",
+          "outcome": "adapter_error",
+          "protocol": "Yearn"
+        },
+        {
+          "address": "0xbe7d1b3cf19eb05ac557be14af24e093fadfd7c6",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Teller USDC",
+          "outcome": "adapter_error",
+          "protocol": "Yearn"
+        },
+        {
+          "address": "0xbe7d1b3cf19eb05ac557be14af24e093fadfd7c6",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Teller USDC",
+          "outcome": "adapter_error",
+          "protocol": "Yearn"
+        },
+        {
+          "address": "0xbe7d1b3cf19eb05ac557be14af24e093fadfd7c6",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Teller USDC",
+          "outcome": "adapter_error",
+          "protocol": "Yearn"
+        },
+        {
+          "address": "0xbe7d1b3cf19eb05ac557be14af24e093fadfd7c6",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:03Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Teller USDC",
+          "outcome": "adapter_error",
+          "protocol": "Yearn"
+        },
+        {
+          "address": "0xbe7d1b3cf19eb05ac557be14af24e093fadfd7c6",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:58:21Z",
+          "message": "Vault deposits are currently closed",
+          "name": "Teller USDC",
+          "outcome": "skipped",
+          "protocol": "Yearn"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:49:43Z",
+      "max_deposit_guidance": "0",
+      "message": null,
+      "name": "Teller USDC",
+      "outcome": "success",
+      "protocol": "Yearn",
+      "share_balance_raw": "9970265"
+    },
+    "42161-0xbeeff77ce5c059445714e6a3490e273fe7f2492f": {
+      "address": "0xbeeff77ce5c059445714e6a3490e273fe7f2492f",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xbeeff77ce5c059445714e6a3490e273fe7f2492f",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:10Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xbeeff77ce5c059445714e6a3490e273fe7f2492f",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:59:52Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xbeeff77ce5c059445714e6a3490e273fe7f2492f",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Steakhouse High Yield",
+          "outcome": "skipped",
+          "protocol": "Morpho"
+        },
+        {
+          "address": "0xbeeff77ce5c059445714e6a3490e273fe7f2492f",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Steakhouse High Yield",
+          "outcome": "skipped",
+          "protocol": "Morpho"
+        },
+        {
+          "address": "0xbeeff77ce5c059445714e6a3490e273fe7f2492f",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:09Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Steakhouse High Yield",
+          "outcome": "adapter_error",
+          "protocol": "Morpho"
+        },
+        {
+          "address": "0xbeeff77ce5c059445714e6a3490e273fe7f2492f",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:26Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Steakhouse High Yield",
+          "outcome": "adapter_error",
+          "protocol": "Morpho"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T17:59:47Z",
+      "message": "Vault deposits are currently closed",
+      "name": "Steakhouse High Yield",
+      "outcome": "skipped",
+      "protocol": "Morpho"
+    },
+    "42161-0xc047d64dafe9e6ac76508835c17c6719f9278c1c": {
+      "address": "0xc047d64dafe9e6ac76508835c17c6719f9278c1c",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "history": [
+        {
+          "address": "0xc047d64dafe9e6ac76508835c17c6719f9278c1c",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:10Z",
+          "message": "Transaction must include these fields: {'gasPrice'}",
+          "name": "Dynamic Alpha Fundamental 2X",
+          "outcome": "rpc_error",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0xc047d64dafe9e6ac76508835c17c6719f9278c1c",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:59:52Z",
+          "message": "Unsupported to=0x0786b6c64392713895D4633e21F93F07699ba13B",
+          "name": "Dynamic Alpha Fundamental 2X",
+          "outcome": "rpc_error",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0xc047d64dafe9e6ac76508835c17c6719f9278c1c",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:02:42Z",
+          "message": "Unsupported to=0x7FeB7C767aa8c9FceDAF18Ed5433d40Cf696eefb",
+          "name": "Dynamic Alpha Fundamental 2X",
+          "outcome": "rpc_error",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0xc047d64dafe9e6ac76508835c17c6719f9278c1c",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:14:46Z",
+          "message": "Unsupported to=0xa2A7627A5AEEF7bF2f5be37278b7C1F560b8DD1d",
+          "name": "Dynamic Alpha Fundamental 2X",
+          "outcome": "rpc_error",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0xc047d64dafe9e6ac76508835c17c6719f9278c1c",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:26:18Z",
+          "message": "Unsupported to=0xa5dA88c5f002eC1673faB741750e760BacCF3c97",
+          "name": "Dynamic Alpha Fundamental 2X",
+          "outcome": "rpc_error",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0xc047d64dafe9e6ac76508835c17c6719f9278c1c",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:26:41Z",
+          "message": "Unsupported to=0xAEb430f6d958c88946b4E380994a4424337Fe541",
+          "name": "Dynamic Alpha Fundamental 2X",
+          "outcome": "rpc_error",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0xc047d64dafe9e6ac76508835c17c6719f9278c1c",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:58:55Z",
+          "message": "Unsupported to=0xd27f1999fF943482cBdecB9888c349ffC4aF73Cd",
+          "name": "Dynamic Alpha Fundamental 2X",
+          "outcome": "rpc_error",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0xc047d64dafe9e6ac76508835c17c6719f9278c1c",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:19:19Z",
+          "message": "Unsupported to=0x58C51a169E9e71C732b25AF3d8763EE71D86d296",
+          "name": "Dynamic Alpha Fundamental 2X",
+          "outcome": "rpc_error",
+          "protocol": "Lagoon Finance"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:30:54Z",
+      "message": "Unsupported to=0x4f481AcE0f9323b837Bab4Ee843fbEcaED939Fea",
+      "name": "Dynamic Alpha Fundamental 2X",
+      "outcome": "rpc_error",
+      "protocol": "Lagoon Finance"
+    },
+    "42161-0xc0ba9bfed28ab46da48d2b69316a3838698ef3f5": {
+      "address": "0xc0ba9bfed28ab46da48d2b69316a3838698ef3f5",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:50:08Z",
+      "max_deposit_guidance": "0",
+      "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "name": "USDT-A yVault",
+      "outcome": "funding_error",
+      "protocol": "Yearn"
+    },
+    "42161-0xc2810eb57526df869049fbf4c541791a3255d24c": {
+      "address": "0xc2810eb57526df869049fbf4c541791a3255d24c",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0xc2810eb57526df869049fbf4c541791a3255d24c",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:12Z",
+          "message": "Transaction must include these fields: {'gasPrice'}",
+          "name": "Peapods Interest Bearing USDC - 14",
+          "outcome": "rpc_error",
+          "protocol": "Peapods"
+        },
+        {
+          "address": "0xc2810eb57526df869049fbf4c541791a3255d24c",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:00:18Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 14",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "32128"
+        },
+        {
+          "address": "0xc2810eb57526df869049fbf4c541791a3255d24c",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:03:12Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 14",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "32128"
+        },
+        {
+          "address": "0xc2810eb57526df869049fbf4c541791a3255d24c",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:15:10Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 14",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "32127"
+        },
+        {
+          "address": "0xc2810eb57526df869049fbf4c541791a3255d24c",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:56:34Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 14",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "32125"
+        },
+        {
+          "address": "0xc2810eb57526df869049fbf4c541791a3255d24c",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:22:27Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 14",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "32123"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:35:50Z",
+      "message": null,
+      "name": "Peapods Interest Bearing USDC - 14",
+      "outcome": "success",
+      "protocol": "Peapods",
+      "share_balance_raw": "32122"
+    },
+    "42161-0xc30db25c7df363fe1ab8c0b4c1522ec2850bc290": {
+      "address": "0xc30db25c7df363fe1ab8c0b4c1522ec2850bc290",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xc30db25c7df363fe1ab8c0b4c1522ec2850bc290",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:10Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Nashpoint Institutional USDC Credit Vault",
+          "outcome": "adapter_error",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0xc30db25c7df363fe1ab8c0b4c1522ec2850bc290",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:59:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Nashpoint Institutional USDC Credit Vault",
+          "outcome": "adapter_error",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0xc30db25c7df363fe1ab8c0b4c1522ec2850bc290",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:02:42Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Nashpoint Institutional USDC Credit Vault",
+          "outcome": "adapter_error",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0xc30db25c7df363fe1ab8c0b4c1522ec2850bc290",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:14:46Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Nashpoint Institutional USDC Credit Vault",
+          "outcome": "adapter_error",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0xc30db25c7df363fe1ab8c0b4c1522ec2850bc290",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:55:54Z",
+          "message": "Anvil transaction reverted",
+          "name": "Nashpoint Institutional USDC Credit Vault",
+          "outcome": "reverted",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0xc30db25c7df363fe1ab8c0b4c1522ec2850bc290",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:21:49Z",
+          "message": "Got <class 'eth_defi.erc_4626.vault_protocol.nashpoint.vault.NashpointNodeVault'>",
+          "name": "Nashpoint Institutional USDC Credit Vault",
+          "outcome": "rpc_error",
+          "protocol": "NashPoint"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:35:01Z",
+      "message": "Got <class 'eth_defi.erc_4626.vault_protocol.nashpoint.vault.NashpointNodeVault'>",
+      "name": "Nashpoint Institutional USDC Credit Vault",
+      "outcome": "rpc_error",
+      "protocol": "NashPoint"
+    },
+    "42161-0xc49746617cb9e78e64f93180a17a6e6fc4055039": {
+      "address": "0xc49746617cb9e78e64f93180a17a6e6fc4055039",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:45:03Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Anvil transaction reverted",
+      "name": "USDC-WETH shares",
+      "outcome": "reverted",
+      "protocol": "Teller",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0xc55c9be465a44717062669d9ebef4a7785cfc2a3": {
+      "address": "0xc55c9be465a44717062669d9ebef4a7785cfc2a3",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "asynchronous",
+        "redemption_flow": "asynchronous"
+      },
+      "history": [
+        {
+          "address": "0xc55c9be465a44717062669d9ebef4a7785cfc2a3",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:10Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xc55c9be465a44717062669d9ebef4a7785cfc2a3",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:59:52Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xc55c9be465a44717062669d9ebef4a7785cfc2a3",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "DAMM Stablecoin Fund",
+          "outcome": "skipped",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0xc55c9be465a44717062669d9ebef4a7785cfc2a3",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "DAMM Stablecoin Fund",
+          "outcome": "skipped",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0xc55c9be465a44717062669d9ebef4a7785cfc2a3",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "asynchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:26:55Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "DAMM Stablecoin Fund",
+          "outcome": "funding_error",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0xc55c9be465a44717062669d9ebef4a7785cfc2a3",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "asynchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:59:13Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "DAMM Stablecoin Fund",
+          "outcome": "funding_error",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0xc55c9be465a44717062669d9ebef4a7785cfc2a3",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "asynchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:19:33Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "DAMM Stablecoin Fund",
+          "outcome": "funding_error",
+          "protocol": "Lagoon Finance"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:31:11Z",
+      "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "name": "DAMM Stablecoin Fund",
+      "outcome": "funding_error",
+      "protocol": "Lagoon Finance"
+    },
+    "42161-0xc57adf9f249e687d180d3a24adac636fe881d5c8": {
+      "address": "0xc57adf9f249e687d180d3a24adac636fe881d5c8",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": null,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:13:53Z",
+      "message": "Live adapter does not advertise deposits",
+      "name": "Delta Netural GMX Vault (Senior)",
+      "outcome": "adapter_error",
+      "protocol": "<protocol not yet identified>"
+    },
+    "42161-0xc8248953429d707c6a2815653eca89846ffaa63b": {
+      "address": "0xc8248953429d707c6a2815653eca89846ffaa63b",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:32:29Z",
+      "message": "Could not find balance slot for token 0x498Bf2B1e120FeD3ad3D42EA2165E9b73f99C1e5",
+      "name": "Llama Lend asdCRV / crvUSD",
+      "outcome": "funding_error",
+      "protocol": "Llama Lend"
+    },
+    "42161-0xc8b7753b1e6307caec24938b319b3b03f2804579": {
+      "address": "0xc8b7753b1e6307caec24938b319b3b03f2804579",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "history": [
+        {
+          "address": "0xc8b7753b1e6307caec24938b319b3b03f2804579",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xc8b7753b1e6307caec24938b319b3b03f2804579",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xc8b7753b1e6307caec24938b319b3b03f2804579",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "fija Strategy ETH GMXv2",
+          "outcome": "skipped",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0xc8b7753b1e6307caec24938b319b3b03f2804579",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "fija Strategy ETH GMXv2",
+          "outcome": "skipped",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0xc8b7753b1e6307caec24938b319b3b03f2804579",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:23:48Z",
+          "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+          "name": "fija Strategy ETH GMXv2",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0xc8b7753b1e6307caec24938b319b3b03f2804579",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:56:06Z",
+          "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+          "name": "fija Strategy ETH GMXv2",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0xc8b7753b1e6307caec24938b319b3b03f2804579",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:12:05Z",
+          "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+          "name": "fija Strategy ETH GMXv2",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0xc8b7753b1e6307caec24938b319b3b03f2804579",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:19:28Z",
+          "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+          "name": "fija Strategy ETH GMXv2",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:21:22Z",
+      "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+      "name": "fija Strategy ETH GMXv2",
+      "outcome": "rpc_error",
+      "protocol": "ERC-4626"
+    },
+    "42161-0xc91c5297d7e161acc74b482aafcc75b85cc0bfed": {
+      "address": "0xc91c5297d7e161acc74b482aafcc75b85cc0bfed",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:43:18Z",
+      "max_deposit_guidance": "1322975429610612769767525",
+      "message": null,
+      "name": "Static Aave Arbitrum DAI",
+      "outcome": "success",
+      "protocol": "Superform",
+      "share_balance_raw": "8395124113825374072"
+    },
+    "42161-0xcafc0a559a9bf2fc77a7ecfaf04bd929a7d9c5cf": {
+      "address": "0xcafc0a559a9bf2fc77a7ecfaf04bd929a7d9c5cf",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xcafc0a559a9bf2fc77a7ecfaf04bd929a7d9c5cf",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Singularity Vault",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0xcafc0a559a9bf2fc77a7ecfaf04bd929a7d9c5cf",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Singularity Vault",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0xcafc0a559a9bf2fc77a7ecfaf04bd929a7d9c5cf",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:43Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Singularity Vault",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0xcafc0a559a9bf2fc77a7ecfaf04bd929a7d9c5cf",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Singularity Vault",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0xcafc0a559a9bf2fc77a7ecfaf04bd929a7d9c5cf",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:24:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Singularity Vault",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0xcafc0a559a9bf2fc77a7ecfaf04bd929a7d9c5cf",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:33Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Singularity Vault",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T17:57:37Z",
+      "message": "Vault deposits are currently closed",
+      "name": "Singularity Vault",
+      "outcome": "skipped",
+      "protocol": "IPOR Fusion"
+    },
+    "42161-0xcc56410e1a136af0eceb7241c6ae394f4d8b581c": {
+      "address": "0xcc56410e1a136af0eceb7241c6ae394f4d8b581c",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xcc56410e1a136af0eceb7241c6ae394f4d8b581c",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Atoma Vault Share",
+          "outcome": "adapter_error",
+          "protocol": "Atoma"
+        },
+        {
+          "address": "0xcc56410e1a136af0eceb7241c6ae394f4d8b581c",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Atoma Vault Share",
+          "outcome": "adapter_error",
+          "protocol": "Atoma"
+        },
+        {
+          "address": "0xcc56410e1a136af0eceb7241c6ae394f4d8b581c",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:31Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Atoma Vault Share",
+          "outcome": "adapter_error",
+          "protocol": "Atoma"
+        },
+        {
+          "address": "0xcc56410e1a136af0eceb7241c6ae394f4d8b581c",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Atoma Vault Share",
+          "outcome": "adapter_error",
+          "protocol": "Atoma"
+        },
+        {
+          "address": "0xcc56410e1a136af0eceb7241c6ae394f4d8b581c",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:15Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Atoma Vault Share",
+          "outcome": "adapter_error",
+          "protocol": "Atoma"
+        },
+        {
+          "address": "0xcc56410e1a136af0eceb7241c6ae394f4d8b581c",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:54:26Z",
+          "message": "Anvil transaction reverted",
+          "name": "Atoma Vault Share",
+          "outcome": "reverted",
+          "protocol": "Atoma"
+        },
+        {
+          "address": "0xcc56410e1a136af0eceb7241c6ae394f4d8b581c",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:09:08Z",
+          "message": "Anvil transaction reverted",
+          "name": "Atoma Vault Share",
+          "outcome": "reverted",
+          "protocol": "Atoma",
+          "revert_reason": "Anvil transaction reverted"
+        },
+        {
+          "address": "0xcc56410e1a136af0eceb7241c6ae394f4d8b581c",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:15:53Z",
+          "message": "Anvil transaction reverted",
+          "name": "Atoma Vault Share",
+          "outcome": "reverted",
+          "protocol": "Atoma",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:47:52Z",
+      "max_deposit_guidance": "48844849699",
+      "message": "Anvil transaction reverted",
+      "name": "Atoma Vault Share",
+      "outcome": "reverted",
+      "protocol": "Atoma",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0xcc6700f5326b2f8930660c483b4d5ce904b815c6": {
+      "address": "0xcc6700f5326b2f8930660c483b4d5ce904b815c6",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "denomination_token_address": "0xB459dB106f645d698E74027eeF6019A26a0675Cc",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0xcc6700f5326b2f8930660c483b4d5ce904b815c6",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xcc6700f5326b2f8930660c483b4d5ce904b815c6",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xcc6700f5326b2f8930660c483b4d5ce904b815c6",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "K3 Capital USDai Cluster",
+          "outcome": "skipped",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0xcc6700f5326b2f8930660c483b4d5ce904b815c6",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "K3 Capital USDai Cluster",
+          "outcome": "skipped",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0xcc6700f5326b2f8930660c483b4d5ce904b815c6",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:49Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "K3 Capital USDai Cluster",
+          "outcome": "adapter_error",
+          "protocol": "Euler"
+        },
+        {
+          "address": "0xcc6700f5326b2f8930660c483b4d5ce904b815c6",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xB459dB106f645d698E74027eeF6019A26a0675Cc",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:56:55Z",
+          "message": null,
+          "name": "K3 Capital USDai Cluster",
+          "outcome": "success",
+          "protocol": "Euler",
+          "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xcc6700f5326b2f8930660c483b4d5ce904b815c6",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xB459dB106f645d698E74027eeF6019A26a0675Cc",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:13:06Z",
+          "message": null,
+          "name": "K3 Capital USDai Cluster",
+          "outcome": "success",
+          "protocol": "Euler",
+          "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xcc6700f5326b2f8930660c483b4d5ce904b815c6",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xB459dB106f645d698E74027eeF6019A26a0675Cc",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:21:18Z",
+          "message": null,
+          "name": "K3 Capital USDai Cluster",
+          "outcome": "success",
+          "protocol": "Euler",
+          "share_balance_raw": "10000000000000000000"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:22:50Z",
+      "message": null,
+      "name": "K3 Capital USDai Cluster",
+      "outcome": "success",
+      "protocol": "Euler",
+      "share_balance_raw": "10000000000000000000"
+    },
+    "42161-0xcc871ae3bbfd0ed24d47855089b1cac30b3e8eef": {
+      "address": "0xcc871ae3bbfd0ed24d47855089b1cac30b3e8eef",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xcc871ae3bbfd0ed24d47855089b1cac30b3e8eef",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xcc871ae3bbfd0ed24d47855089b1cac30b3e8eef",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xcc871ae3bbfd0ed24d47855089b1cac30b3e8eef",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "MOON-USDC shares",
+          "outcome": "skipped",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0xcc871ae3bbfd0ed24d47855089b1cac30b3e8eef",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "MOON-USDC shares",
+          "outcome": "skipped",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0xcc871ae3bbfd0ed24d47855089b1cac30b3e8eef",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "MOON-USDC shares",
+          "outcome": "adapter_error",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0xcc871ae3bbfd0ed24d47855089b1cac30b3e8eef",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:55:57Z",
+          "message": "Could not find balance slot for token 0x24404DC041d74cd03cFE28855F555559390C931b",
+          "name": "MOON-USDC shares",
+          "outcome": "funding_error",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0xcc871ae3bbfd0ed24d47855089b1cac30b3e8eef",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:27:43Z",
+          "message": "Could not find balance slot for token 0x24404DC041d74cd03cFE28855F555559390C931b",
+          "name": "MOON-USDC shares",
+          "outcome": "funding_error",
+          "protocol": "Teller"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:43:50Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Could not find balance slot for token 0x24404DC041d74cd03cFE28855F555559390C931b",
+      "name": "MOON-USDC shares",
+      "outcome": "funding_error",
+      "protocol": "Teller"
+    },
+    "42161-0xce4d997a3b404f9eaa796f89deae40747d3647b7": {
+      "address": "0xce4d997a3b404f9eaa796f89deae40747d3647b7",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xce4d997a3b404f9eaa796f89deae40747d3647b7",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:26:58Z",
+          "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "name": "Autopilot WETH Arbitrum",
+          "outcome": "funding_error",
+          "protocol": "IPOR Fusion"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:28:39Z",
+      "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "name": "Autopilot WETH Arbitrum",
+      "outcome": "funding_error",
+      "protocol": "IPOR Fusion"
+    },
+    "42161-0xd15a07a4150b0c057912fe883f7ad22b97161591": {
+      "address": "0xd15a07a4150b0c057912fe883f7ad22b97161591",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0xd15a07a4150b0c057912fe883f7ad22b97161591",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Transaction must include these fields: {'gasPrice'}",
+          "name": "Peapods Interest Bearing USDC - 25",
+          "outcome": "rpc_error",
+          "protocol": "Peapods"
+        },
+        {
+          "address": "0xd15a07a4150b0c057912fe883f7ad22b97161591",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 25",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "9355537"
+        },
+        {
+          "address": "0xd15a07a4150b0c057912fe883f7ad22b97161591",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 25",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "9355537"
+        },
+        {
+          "address": "0xd15a07a4150b0c057912fe883f7ad22b97161591",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 25",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "9355537"
+        },
+        {
+          "address": "0xd15a07a4150b0c057912fe883f7ad22b97161591",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:57:10Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 25",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "9355537"
+        },
+        {
+          "address": "0xd15a07a4150b0c057912fe883f7ad22b97161591",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:23:10Z",
+          "message": null,
+          "name": "Peapods Interest Bearing USDC - 25",
+          "outcome": "success",
+          "protocol": "Peapods",
+          "share_balance_raw": "9355537"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:36:33Z",
+      "message": null,
+      "name": "Peapods Interest Bearing USDC - 25",
+      "outcome": "success",
+      "protocol": "Peapods",
+      "share_balance_raw": "9355537"
+    },
+    "42161-0xd1be1f98991cf69355e468ad15b6d0b6429bcfcb": {
+      "address": "0xd1be1f98991cf69355e468ad15b6d0b6429bcfcb",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xd1be1f98991cf69355e468ad15b6d0b6429bcfcb",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:21:59Z",
+          "message": "Anvil transaction reverted",
+          "name": "Ample Arbitrum USDC",
+          "outcome": "reverted",
+          "protocol": "Euler",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:23:35Z",
+      "message": "Anvil transaction reverted",
+      "name": "Ample Arbitrum USDC",
+      "outcome": "reverted",
+      "protocol": "Euler",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0xd2357ef75b4c88b9cfd981024e15f4f9db8cd087": {
+      "address": "0xd2357ef75b4c88b9cfd981024e15f4f9db8cd087",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xd2357ef75b4c88b9cfd981024e15f4f9db8cd087",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:28:57Z",
+          "message": "Could not find balance slot for token 0x0000206329b97DB379d5E1Bf586BbDB969C63274",
+          "name": "[STAGING_DO_NOT_USE] Kiln Vault (Angle stUSD)",
+          "outcome": "funding_error",
+          "protocol": "Kiln Metavault"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:30:24Z",
+      "message": "Could not find balance slot for token 0x0000206329b97DB379d5E1Bf586BbDB969C63274",
+      "name": "[STAGING_DO_NOT_USE] Kiln Vault (Angle stUSD)",
+      "outcome": "funding_error",
+      "protocol": "Kiln Metavault"
+    },
+    "42161-0xd2ee74cd31cd996fc8f3a7ff7479e86d6dfbb3fa": {
+      "address": "0xd2ee74cd31cd996fc8f3a7ff7479e86d6dfbb3fa",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:44:28Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Anvil transaction reverted",
+      "name": "DMT-USDC shares",
+      "outcome": "reverted",
+      "protocol": "Teller",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0": {
+      "address": "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "asynchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "Transaction must include these fields: {'gasPrice'}",
+          "name": "gTrade (Gains Network USDC)",
+          "outcome": "rpc_error",
+          "protocol": "Gains Network"
+        },
+        {
+          "address": "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": null,
+          "name": "gTrade (Gains Network USDC)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "7633445"
+        },
+        {
+          "address": "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:01:43Z",
+          "message": null,
+          "name": "gTrade (Gains Network USDC)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "7633445"
+        },
+        {
+          "address": "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:13:52Z",
+          "message": null,
+          "name": "gTrade (Gains Network USDC)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "7633443"
+        },
+        {
+          "address": "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:24:23Z",
+          "message": null,
+          "name": "gTrade (Gains Network USDC)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "7633439"
+        },
+        {
+          "address": "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:25:29Z",
+          "message": null,
+          "name": "gTrade (Gains Network USDC)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "7633425"
+        },
+        {
+          "address": "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:55:02Z",
+          "message": null,
+          "name": "gTrade (Gains Network USDC)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "7633413"
+        },
+        {
+          "address": "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:14:32Z",
+          "message": null,
+          "name": "gTrade (Gains Network USDC)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "7633389"
+        },
+        {
+          "address": "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:22:03Z",
+          "message": null,
+          "name": "gTrade (Gains Network USDC)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "7633388"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:23:50Z",
+      "message": null,
+      "name": "gTrade (Gains Network USDC)",
+      "outcome": "success",
+      "protocol": "Gains Network",
+      "share_balance_raw": "7633387"
+    },
+    "42161-0xd3ca9bec3e681b0f578fd87f20ebcf2b7e0bb739": {
+      "address": "0xd3ca9bec3e681b0f578fd87f20ebcf2b7e0bb739",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xd3ca9bec3e681b0f578fd87f20ebcf2b7e0bb739",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:10Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xd3ca9bec3e681b0f578fd87f20ebcf2b7e0bb739",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:59:52Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xd3ca9bec3e681b0f578fd87f20ebcf2b7e0bb739",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Llama Lend WETH / crvUSD",
+          "outcome": "skipped",
+          "protocol": "Llama Lend"
+        },
+        {
+          "address": "0xd3ca9bec3e681b0f578fd87f20ebcf2b7e0bb739",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Llama Lend WETH / crvUSD",
+          "outcome": "skipped",
+          "protocol": "Llama Lend"
+        },
+        {
+          "address": "0xd3ca9bec3e681b0f578fd87f20ebcf2b7e0bb739",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:02Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Llama Lend WETH / crvUSD",
+          "outcome": "adapter_error",
+          "protocol": "Llama Lend"
+        },
+        {
+          "address": "0xd3ca9bec3e681b0f578fd87f20ebcf2b7e0bb739",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:59:27Z",
+          "message": "Could not find balance slot for token 0x498Bf2B1e120FeD3ad3D42EA2165E9b73f99C1e5",
+          "name": "Llama Lend WETH / crvUSD",
+          "outcome": "funding_error",
+          "protocol": "Llama Lend"
+        },
+        {
+          "address": "0xd3ca9bec3e681b0f578fd87f20ebcf2b7e0bb739",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:19:44Z",
+          "message": "Could not find balance slot for token 0x498Bf2B1e120FeD3ad3D42EA2165E9b73f99C1e5",
+          "name": "Llama Lend WETH / crvUSD",
+          "outcome": "funding_error",
+          "protocol": "Llama Lend"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:32:07Z",
+      "message": "Could not find balance slot for token 0x498Bf2B1e120FeD3ad3D42EA2165E9b73f99C1e5",
+      "name": "Llama Lend WETH / crvUSD",
+      "outcome": "funding_error",
+      "protocol": "Llama Lend"
+    },
+    "42161-0xd427c2dae2e10e8b52c2bd54c47217121e8177a8": {
+      "address": "0xd427c2dae2e10e8b52c2bd54c47217121e8177a8",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xd427c2dae2e10e8b52c2bd54c47217121e8177a8",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xd427c2dae2e10e8b52c2bd54c47217121e8177a8",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xd427c2dae2e10e8b52c2bd54c47217121e8177a8",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Aura MOLANDAK Staker Hero",
+          "outcome": "skipped",
+          "protocol": "Yearn"
+        },
+        {
+          "address": "0xd427c2dae2e10e8b52c2bd54c47217121e8177a8",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Aura MOLANDAK Staker Hero",
+          "outcome": "skipped",
+          "protocol": "Yearn"
+        },
+        {
+          "address": "0xd427c2dae2e10e8b52c2bd54c47217121e8177a8",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:03Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Aura MOLANDAK Staker Hero",
+          "outcome": "adapter_error",
+          "protocol": "Yearn"
+        },
+        {
+          "address": "0xd427c2dae2e10e8b52c2bd54c47217121e8177a8",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:58:14Z",
+          "message": "Anvil transaction reverted",
+          "name": "Aura MOLANDAK Staker Hero",
+          "outcome": "reverted",
+          "protocol": "Yearn"
+        },
+        {
+          "address": "0xd427c2dae2e10e8b52c2bd54c47217121e8177a8",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:30:23Z",
+          "message": "Anvil transaction reverted",
+          "name": "Aura MOLANDAK Staker Hero",
+          "outcome": "reverted",
+          "protocol": "Yearn",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:49:18Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Anvil transaction reverted",
+      "name": "Aura MOLANDAK Staker Hero",
+      "outcome": "reverted",
+      "protocol": "Yearn",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0xd531031ea54c7505a9ab2d095cd46e265da7513e": {
+      "address": "0xd531031ea54c7505a9ab2d095cd46e265da7513e",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xd531031ea54c7505a9ab2d095cd46e265da7513e",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xd531031ea54c7505a9ab2d095cd46e265da7513e",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xd531031ea54c7505a9ab2d095cd46e265da7513e",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Aura OOGABOOGA Staker Hero",
+          "outcome": "skipped",
+          "protocol": "Yearn"
+        },
+        {
+          "address": "0xd531031ea54c7505a9ab2d095cd46e265da7513e",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Aura OOGABOOGA Staker Hero",
+          "outcome": "skipped",
+          "protocol": "Yearn"
+        },
+        {
+          "address": "0xd531031ea54c7505a9ab2d095cd46e265da7513e",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:03Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Aura OOGABOOGA Staker Hero",
+          "outcome": "adapter_error",
+          "protocol": "Yearn"
+        },
+        {
+          "address": "0xd531031ea54c7505a9ab2d095cd46e265da7513e",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:58:20Z",
+          "message": "Anvil transaction reverted",
+          "name": "Aura OOGABOOGA Staker Hero",
+          "outcome": "reverted",
+          "protocol": "Yearn"
+        },
+        {
+          "address": "0xd531031ea54c7505a9ab2d095cd46e265da7513e",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:30:31Z",
+          "message": "Anvil transaction reverted",
+          "name": "Aura OOGABOOGA Staker Hero",
+          "outcome": "reverted",
+          "protocol": "Yearn",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:49:26Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Anvil transaction reverted",
+      "name": "Aura OOGABOOGA Staker Hero",
+      "outcome": "reverted",
+      "protocol": "Yearn",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0xd77e220612f92f493172e23654b502d7f1f6b5c6": {
+      "address": "0xd77e220612f92f493172e23654b502d7f1f6b5c6",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "history": [
+        {
+          "address": "0xd77e220612f92f493172e23654b502d7f1f6b5c6",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:19:43Z",
+          "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+          "name": "fija Strategy ETH GMXv2",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:21:37Z",
+      "message": "Token 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE missing symbol on chain 42161: Could not transact with/call contract function, is contract deployed correctly and chain synced?",
+      "name": "fija Strategy ETH GMXv2",
+      "outcome": "rpc_error",
+      "protocol": "ERC-4626"
+    },
+    "42161-0xd855296f9868ff659f3f359c90b7d005ec049228": {
+      "address": "0xd855296f9868ff659f3f359c90b7d005ec049228",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0xd855296f9868ff659f3f359c90b7d005ec049228",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "IPOR USDC Prime",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0xd855296f9868ff659f3f359c90b7d005ec049228",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "IPOR USDC Prime",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0xd855296f9868ff659f3f359c90b7d005ec049228",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:43Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "IPOR USDC Prime",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0xd855296f9868ff659f3f359c90b7d005ec049228",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "IPOR USDC Prime",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0xd855296f9868ff659f3f359c90b7d005ec049228",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:24:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "IPOR USDC Prime",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0xd855296f9868ff659f3f359c90b7d005ec049228",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:33Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "IPOR USDC Prime",
+          "outcome": "adapter_error",
+          "protocol": "IPOR Fusion"
+        },
+        {
+          "address": "0xd855296f9868ff659f3f359c90b7d005ec049228",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:57:17Z",
+          "message": null,
+          "name": "IPOR USDC Prime",
+          "outcome": "success",
+          "protocol": "IPOR Fusion",
+          "share_balance_raw": "987392579"
+        },
+        {
+          "address": "0xd855296f9868ff659f3f359c90b7d005ec049228",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:17:17Z",
+          "message": null,
+          "name": "IPOR USDC Prime",
+          "outcome": "success",
+          "protocol": "IPOR Fusion",
+          "share_balance_raw": "987392767"
+        },
+        {
+          "address": "0xd855296f9868ff659f3f359c90b7d005ec049228",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:25:58Z",
+          "message": null,
+          "name": "IPOR USDC Prime",
+          "outcome": "success",
+          "protocol": "IPOR Fusion",
+          "share_balance_raw": "987392848"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:27:39Z",
+      "message": null,
+      "name": "IPOR USDC Prime",
+      "outcome": "success",
+      "protocol": "IPOR Fusion",
+      "share_balance_raw": "987392864"
+    },
+    "42161-0xd85e038593d7a098614721eae955ec2022b9b91b": {
+      "address": "0xd85e038593d7a098614721eae955ec2022b9b91b",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "asynchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0xd85e038593d7a098614721eae955ec2022b9b91b",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xd85e038593d7a098614721eae955ec2022b9b91b",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xd85e038593d7a098614721eae955ec2022b9b91b",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "gTrade (Gains Network DAI)",
+          "outcome": "skipped",
+          "protocol": "Gains Network"
+        },
+        {
+          "address": "0xd85e038593d7a098614721eae955ec2022b9b91b",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "gTrade (Gains Network DAI)",
+          "outcome": "skipped",
+          "protocol": "Gains Network"
+        },
+        {
+          "address": "0xd85e038593d7a098614721eae955ec2022b9b91b",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:24:45Z",
+          "message": null,
+          "name": "gTrade (Gains Network DAI)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "7756711420702535167"
+        },
+        {
+          "address": "0xd85e038593d7a098614721eae955ec2022b9b91b",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:25:50Z",
+          "message": null,
+          "name": "gTrade (Gains Network DAI)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "7756711420702535167"
+        },
+        {
+          "address": "0xd85e038593d7a098614721eae955ec2022b9b91b",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:55:23Z",
+          "message": null,
+          "name": "gTrade (Gains Network DAI)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "7756711420702535167"
+        },
+        {
+          "address": "0xd85e038593d7a098614721eae955ec2022b9b91b",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:14:55Z",
+          "message": null,
+          "name": "gTrade (Gains Network DAI)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "7756711420702535167"
+        },
+        {
+          "address": "0xd85e038593d7a098614721eae955ec2022b9b91b",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:22:24Z",
+          "message": null,
+          "name": "gTrade (Gains Network DAI)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "7756711420702535167"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:24:15Z",
+      "message": null,
+      "name": "gTrade (Gains Network DAI)",
+      "outcome": "success",
+      "protocol": "Gains Network",
+      "share_balance_raw": "7756711420702535167"
+    },
+    "42161-0xd8ea1735593f8c22a53123501266e7bf3596861c": {
+      "address": "0xd8ea1735593f8c22a53123501266e7bf3596861c",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xd8ea1735593f8c22a53123501266e7bf3596861c",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:21:04Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Trust Wallet Fluid USDT",
+          "outcome": "funding_error",
+          "protocol": "Fluid"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:22:53Z",
+      "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "name": "Trust Wallet Fluid USDT",
+      "outcome": "funding_error",
+      "protocol": "Fluid"
+    },
+    "42161-0xd8f885e2b8fc2cb590c83bd729e24e1b3bf0cfec": {
+      "address": "0xd8f885e2b8fc2cb590c83bd729e24e1b3bf0cfec",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "history": [
+        {
+          "address": "0xd8f885e2b8fc2cb590c83bd729e24e1b3bf0cfec",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xd8f885e2b8fc2cb590c83bd729e24e1b3bf0cfec",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xd8f885e2b8fc2cb590c83bd729e24e1b3bf0cfec",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Uniswap V3 LP wrapper",
+          "outcome": "skipped",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0xd8f885e2b8fc2cb590c83bd729e24e1b3bf0cfec",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Uniswap V3 LP wrapper",
+          "outcome": "skipped",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0xd8f885e2b8fc2cb590c83bd729e24e1b3bf0cfec",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:23:15Z",
+          "message": "Token 0xC6F780497A95e246EB9449f5e4770916DCd6396A missing symbol on chain 42161: ('execution reverted', '0x')",
+          "name": "Uniswap V3 LP wrapper",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0xd8f885e2b8fc2cb590c83bd729e24e1b3bf0cfec",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:55:48Z",
+          "message": "Token 0xC6F780497A95e246EB9449f5e4770916DCd6396A missing symbol on chain 42161: ('execution reverted', '0x')",
+          "name": "Uniswap V3 LP wrapper",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0xd8f885e2b8fc2cb590c83bd729e24e1b3bf0cfec",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:11:36Z",
+          "message": "Token 0xC6F780497A95e246EB9449f5e4770916DCd6396A missing symbol on chain 42161: ('execution reverted', '0x')",
+          "name": "Uniswap V3 LP wrapper",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        },
+        {
+          "address": "0xd8f885e2b8fc2cb590c83bd729e24e1b3bf0cfec",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T18:18:58Z",
+          "message": "Token 0xC6F780497A95e246EB9449f5e4770916DCd6396A missing symbol on chain 42161: ('execution reverted', '0x')",
+          "name": "Uniswap V3 LP wrapper",
+          "outcome": "rpc_error",
+          "protocol": "ERC-4626"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:20:47Z",
+      "message": "Token 0xC6F780497A95e246EB9449f5e4770916DCd6396A missing symbol on chain 42161: ('execution reverted', '0x')",
+      "name": "Uniswap V3 LP wrapper",
+      "outcome": "rpc_error",
+      "protocol": "ERC-4626"
+    },
+    "42161-0xd90701c38a02a6681e987578f63fa9cbba4be2f7": {
+      "address": "0xd90701c38a02a6681e987578f63fa9cbba4be2f7",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": null,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:13:55Z",
+      "message": "Live adapter does not advertise deposits",
+      "name": "Delta Netural GMX Vault (Senior)",
+      "outcome": "adapter_error",
+      "protocol": "<protocol not yet identified>"
+    },
+    "42161-0xd9fba68d89178e3538e708939332c79efc540179": {
+      "address": "0xd9fba68d89178e3538e708939332c79efc540179",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "denomination_token_address": "0x7dfF72693f6A4149b17e7C6314655f6A9F7c8B33",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:43:03Z",
+      "max_deposit_guidance": "8599640477026176669139055",
+      "message": null,
+      "name": "Static Aave Arbitrum GHO",
+      "outcome": "success",
+      "protocol": "Superform",
+      "share_balance_raw": "9077848924612385840"
+    },
+    "42161-0xdc1ab820c92735e7a5e48f10fa3d8424ec47a93e": {
+      "address": "0xdc1ab820c92735e7a5e48f10fa3d8424ec47a93e",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:40:23Z",
+      "message": null,
+      "name": "Borrowable USDC Deposit, SiloId: 145",
+      "outcome": "success",
+      "protocol": "Silo Finance",
+      "share_balance_raw": "9208898067"
+    },
+    "42161-0xded6c304fc97d2408603e393bb37251284e77ee3": {
+      "address": "0xded6c304fc97d2408603e393bb37251284e77ee3",
+      "attempt_count": 3,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xded6c304fc97d2408603e393bb37251284e77ee3",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:08:54Z",
+          "message": "Could not find balance slot for token 0x972d3Dc804ec7CABEAb6D394b9a9f4E6c313dda7",
+          "name": "Foo USD Unlock Token",
+          "outcome": "funding_error",
+          "protocol": "<unknown ERC-7540>"
+        },
+        {
+          "address": "0xded6c304fc97d2408603e393bb37251284e77ee3",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:14:36Z",
+          "message": "Could not find balance slot for token 0x972d3Dc804ec7CABEAb6D394b9a9f4E6c313dda7",
+          "name": "Foo USD Unlock Token",
+          "outcome": "funding_error",
+          "protocol": "<unknown ERC-7540>"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:18:11Z",
+      "message": "Could not find balance slot for token 0x972d3Dc804ec7CABEAb6D394b9a9f4E6c313dda7",
+      "name": "Foo USD Unlock Token",
+      "outcome": "funding_error",
+      "protocol": "<unknown ERC-7540>"
+    },
+    "42161-0xe07f1151887b8fdc6800f737252f6b91b46b5865": {
+      "address": "0xe07f1151887b8fdc6800f737252f6b91b46b5865",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xe07f1151887b8fdc6800f737252f6b91b46b5865",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:10Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xe07f1151887b8fdc6800f737252f6b91b46b5865",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:59:52Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xe07f1151887b8fdc6800f737252f6b91b46b5865",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Llama Lend WBTC / crvUSD",
+          "outcome": "skipped",
+          "protocol": "Llama Lend"
+        },
+        {
+          "address": "0xe07f1151887b8fdc6800f737252f6b91b46b5865",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Llama Lend WBTC / crvUSD",
+          "outcome": "skipped",
+          "protocol": "Llama Lend"
+        },
+        {
+          "address": "0xe07f1151887b8fdc6800f737252f6b91b46b5865",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:02Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Llama Lend WBTC / crvUSD",
+          "outcome": "adapter_error",
+          "protocol": "Llama Lend"
+        },
+        {
+          "address": "0xe07f1151887b8fdc6800f737252f6b91b46b5865",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:59:29Z",
+          "message": "Could not find balance slot for token 0x498Bf2B1e120FeD3ad3D42EA2165E9b73f99C1e5",
+          "name": "Llama Lend WBTC / crvUSD",
+          "outcome": "funding_error",
+          "protocol": "Llama Lend"
+        },
+        {
+          "address": "0xe07f1151887b8fdc6800f737252f6b91b46b5865",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:19:48Z",
+          "message": "Could not find balance slot for token 0x498Bf2B1e120FeD3ad3D42EA2165E9b73f99C1e5",
+          "name": "Llama Lend WBTC / crvUSD",
+          "outcome": "funding_error",
+          "protocol": "Llama Lend"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:32:11Z",
+      "message": "Could not find balance slot for token 0x498Bf2B1e120FeD3ad3D42EA2165E9b73f99C1e5",
+      "name": "Llama Lend WBTC / crvUSD",
+      "outcome": "funding_error",
+      "protocol": "Llama Lend"
+    },
+    "42161-0xe0a21a475f8da0ee7fa5af8c1809d8ac5257607d": {
+      "address": "0xe0a21a475f8da0ee7fa5af8c1809d8ac5257607d",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:47:38Z",
+      "max_deposit_guidance": "5481443365911435438350",
+      "message": "Could not find balance slot for token 0xf97f4df75117a78c1A5a0DBb814Af92458539FB4",
+      "name": "glpLINK",
+      "outcome": "funding_error",
+      "protocol": "Umami"
+    },
+    "42161-0xe15b622502aaef45ee31bcc23c7afa8a0d6f3192": {
+      "address": "0xe15b622502aaef45ee31bcc23c7afa8a0d6f3192",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "denomination_token_address": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:38:49Z",
+      "message": null,
+      "name": "Supply DAI into AAVE",
+      "outcome": "success",
+      "protocol": "Royco",
+      "share_balance_raw": "8395125488351881632"
+    },
+    "42161-0xe16722b52fe814f5d551a12f0ec89574a130a0b7": {
+      "address": "0xe16722b52fe814f5d551a12f0ec89574a130a0b7",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xe16722b52fe814f5d551a12f0ec89574a130a0b7",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "L'Investisseur Musulman",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xe16722b52fe814f5d551a12f0ec89574a130a0b7",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "L'Investisseur Musulman",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xe16722b52fe814f5d551a12f0ec89574a130a0b7",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:31Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "L'Investisseur Musulman",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xe16722b52fe814f5d551a12f0ec89574a130a0b7",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "L'Investisseur Musulman",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xe16722b52fe814f5d551a12f0ec89574a130a0b7",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:15Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "L'Investisseur Musulman",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xe16722b52fe814f5d551a12f0ec89574a130a0b7",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:51:42Z",
+          "message": "Vault deposits are currently closed",
+          "name": "L'Investisseur Musulman",
+          "outcome": "skipped",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xe16722b52fe814f5d551a12f0ec89574a130a0b7",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:55:09Z",
+          "message": "Vault deposits are currently closed",
+          "name": "L'Investisseur Musulman",
+          "outcome": "skipped",
+          "protocol": "Centrifuge"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:48:52Z",
+      "max_deposit_guidance": "0",
+      "message": "Anvil transaction reverted",
+      "name": "L'Investisseur Musulman",
+      "outcome": "reverted",
+      "protocol": "Centrifuge",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0xe1c410eefaebb052e17e0cb6f1c3197f35765aab": {
+      "address": "0xe1c410eefaebb052e17e0cb6f1c3197f35765aab",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xe1c410eefaebb052e17e0cb6f1c3197f35765aab",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:23:45Z",
+          "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+          "name": "Yield Chasing ETH",
+          "outcome": "funding_error",
+          "protocol": "Goat Protocol"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:25:34Z",
+      "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "name": "Yield Chasing ETH",
+      "outcome": "funding_error",
+      "protocol": "Goat Protocol"
+    },
+    "42161-0xe296ee7f83d1d95b3f7827ff1d08fe1e4cf09d8d": {
+      "address": "0xe296ee7f83d1d95b3f7827ff1d08fe1e4cf09d8d",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xe296ee7f83d1d95b3f7827ff1d08fe1e4cf09d8d",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:10Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xe296ee7f83d1d95b3f7827ff1d08fe1e4cf09d8d",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:59:52Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xe296ee7f83d1d95b3f7827ff1d08fe1e4cf09d8d",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Llama Lend IBTC / crvUSD",
+          "outcome": "skipped",
+          "protocol": "Llama Lend"
+        },
+        {
+          "address": "0xe296ee7f83d1d95b3f7827ff1d08fe1e4cf09d8d",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Llama Lend IBTC / crvUSD",
+          "outcome": "skipped",
+          "protocol": "Llama Lend"
+        },
+        {
+          "address": "0xe296ee7f83d1d95b3f7827ff1d08fe1e4cf09d8d",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:02Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Llama Lend IBTC / crvUSD",
+          "outcome": "adapter_error",
+          "protocol": "Llama Lend"
+        },
+        {
+          "address": "0xe296ee7f83d1d95b3f7827ff1d08fe1e4cf09d8d",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:59:35Z",
+          "message": "Could not find balance slot for token 0x498Bf2B1e120FeD3ad3D42EA2165E9b73f99C1e5",
+          "name": "Llama Lend IBTC / crvUSD",
+          "outcome": "funding_error",
+          "protocol": "Llama Lend"
+        },
+        {
+          "address": "0xe296ee7f83d1d95b3f7827ff1d08fe1e4cf09d8d",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:19:53Z",
+          "message": "Could not find balance slot for token 0x498Bf2B1e120FeD3ad3D42EA2165E9b73f99C1e5",
+          "name": "Llama Lend IBTC / crvUSD",
+          "outcome": "funding_error",
+          "protocol": "Llama Lend"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:32:17Z",
+      "message": "Could not find balance slot for token 0x498Bf2B1e120FeD3ad3D42EA2165E9b73f99C1e5",
+      "name": "Llama Lend IBTC / crvUSD",
+      "outcome": "funding_error",
+      "protocol": "Llama Lend"
+    },
+    "42161-0xe3b8175f6d8102d53f519063f942da9ac8637079": {
+      "address": "0xe3b8175f6d8102d53f519063f942da9ac8637079",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xe3b8175f6d8102d53f519063f942da9ac8637079",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xe3b8175f6d8102d53f519063f942da9ac8637079",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xe3b8175f6d8102d53f519063f942da9ac8637079",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "APE-USDC shares",
+          "outcome": "skipped",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0xe3b8175f6d8102d53f519063f942da9ac8637079",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "APE-USDC shares",
+          "outcome": "skipped",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0xe3b8175f6d8102d53f519063f942da9ac8637079",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "APE-USDC shares",
+          "outcome": "adapter_error",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0xe3b8175f6d8102d53f519063f942da9ac8637079",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:56:12Z",
+          "message": "Anvil transaction reverted",
+          "name": "APE-USDC shares",
+          "outcome": "reverted",
+          "protocol": "Teller"
+        },
+        {
+          "address": "0xe3b8175f6d8102d53f519063f942da9ac8637079",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:28:02Z",
+          "message": "Anvil transaction reverted",
+          "name": "APE-USDC shares",
+          "outcome": "reverted",
+          "protocol": "Teller",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:44:04Z",
+      "max_deposit_guidance": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "message": "Anvil transaction reverted",
+      "name": "APE-USDC shares",
+      "outcome": "reverted",
+      "protocol": "Teller",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0xe4783824593a50bfe9dc873204cec171ebc62de0": {
+      "address": "0xe4783824593a50bfe9dc873204cec171ebc62de0",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0xe4783824593a50bfe9dc873204cec171ebc62de0",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:21:43Z",
+          "message": null,
+          "name": "Euler Earn USDC",
+          "outcome": "success",
+          "protocol": "Euler",
+          "share_balance_raw": "9670325"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:23:15Z",
+      "message": null,
+      "name": "Euler Earn USDC",
+      "outcome": "success",
+      "protocol": "Euler",
+      "share_balance_raw": "9670325"
+    },
+    "42161-0xe5d6eb448ac5a762c1ebe8cd1692b9cd08025176": {
+      "address": "0xe5d6eb448ac5a762c1ebe8cd1692b9cd08025176",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "asynchronous",
+        "redemption_flow": "asynchronous"
+      },
+      "history": [
+        {
+          "address": "0xe5d6eb448ac5a762c1ebe8cd1692b9cd08025176",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:10Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xe5d6eb448ac5a762c1ebe8cd1692b9cd08025176",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:59:52Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xe5d6eb448ac5a762c1ebe8cd1692b9cd08025176",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "DAMM Stablecoin Fund",
+          "outcome": "skipped",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0xe5d6eb448ac5a762c1ebe8cd1692b9cd08025176",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "DAMM Stablecoin Fund",
+          "outcome": "skipped",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0xe5d6eb448ac5a762c1ebe8cd1692b9cd08025176",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "asynchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:26:46Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "DAMM Stablecoin Fund",
+          "outcome": "funding_error",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0xe5d6eb448ac5a762c1ebe8cd1692b9cd08025176",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "asynchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:59:00Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "DAMM Stablecoin Fund",
+          "outcome": "funding_error",
+          "protocol": "Lagoon Finance"
+        },
+        {
+          "address": "0xe5d6eb448ac5a762c1ebe8cd1692b9cd08025176",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "asynchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:19:24Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "DAMM Stablecoin Fund",
+          "outcome": "funding_error",
+          "protocol": "Lagoon Finance"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:30:59Z",
+      "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "name": "DAMM Stablecoin Fund",
+      "outcome": "funding_error",
+      "protocol": "Lagoon Finance"
+    },
+    "42161-0xe6e61bf3ec29b4ab1846ea2851fa021c0be886ba": {
+      "address": "0xe6e61bf3ec29b4ab1846ea2851fa021c0be886ba",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xe6e61bf3ec29b4ab1846ea2851fa021c0be886ba",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Harvest: USDC Vault (0xE6e6)",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0xe6e61bf3ec29b4ab1846ea2851fa021c0be886ba",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Harvest: USDC Vault (0xE6e6)",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0xe6e61bf3ec29b4ab1846ea2851fa021c0be886ba",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:43Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Harvest: USDC Vault (0xE6e6)",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0xe6e61bf3ec29b4ab1846ea2851fa021c0be886ba",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Harvest: USDC Vault (0xE6e6)",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0xe6e61bf3ec29b4ab1846ea2851fa021c0be886ba",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:24:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Harvest: USDC Vault (0xE6e6)",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0xe6e61bf3ec29b4ab1846ea2851fa021c0be886ba",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:27Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Harvest: USDC Vault (0xE6e6)",
+          "outcome": "adapter_error",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0xe6e61bf3ec29b4ab1846ea2851fa021c0be886ba",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:57:04Z",
+          "message": "Anvil transaction reverted",
+          "name": "Harvest: USDC Vault (0xE6e6)",
+          "outcome": "reverted",
+          "protocol": "Harvest Finance"
+        },
+        {
+          "address": "0xe6e61bf3ec29b4ab1846ea2851fa021c0be886ba",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:17:01Z",
+          "message": "Anvil transaction reverted",
+          "name": "Harvest: USDC Vault (0xE6e6)",
+          "outcome": "reverted",
+          "protocol": "Harvest Finance",
+          "revert_reason": "Anvil transaction reverted"
+        },
+        {
+          "address": "0xe6e61bf3ec29b4ab1846ea2851fa021c0be886ba",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:25:03Z",
+          "message": "Anvil transaction reverted",
+          "name": "Harvest: USDC Vault (0xE6e6)",
+          "outcome": "reverted",
+          "protocol": "Harvest Finance",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:26:43Z",
+      "message": "Anvil transaction reverted",
+      "name": "Harvest: USDC Vault (0xE6e6)",
+      "outcome": "reverted",
+      "protocol": "Harvest Finance",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0xe82d060687c014b280b65df24acd94a77251c784": {
+      "address": "0xe82d060687c014b280b65df24acd94a77251c784",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:50:25Z",
+      "max_deposit_guidance": "0",
+      "message": "Could not find balance slot for token 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8",
+      "name": "Silo Finance Borrowable USDC Deposit in WBTC Silo",
+      "outcome": "funding_error",
+      "protocol": "Yearn"
+    },
+    "42161-0xe897e7f16e8f4ed568a62955b17744bcb3207d6e": {
+      "address": "0xe897e7f16e8f4ed568a62955b17744bcb3207d6e",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xe897e7f16e8f4ed568a62955b17744bcb3207d6e",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "DeFi Janus Henderson Anemoy AAA CLO Fund Token",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xe897e7f16e8f4ed568a62955b17744bcb3207d6e",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "DeFi Janus Henderson Anemoy AAA CLO Fund Token",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xe897e7f16e8f4ed568a62955b17744bcb3207d6e",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:31Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "DeFi Janus Henderson Anemoy AAA CLO Fund Token",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xe897e7f16e8f4ed568a62955b17744bcb3207d6e",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "DeFi Janus Henderson Anemoy AAA CLO Fund Token",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xe897e7f16e8f4ed568a62955b17744bcb3207d6e",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:15Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "DeFi Janus Henderson Anemoy AAA CLO Fund Token",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xe897e7f16e8f4ed568a62955b17744bcb3207d6e",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:55:13Z",
+          "message": "Vault deposits are currently closed",
+          "name": "DeFi Janus Henderson Anemoy AAA CLO Fund Token",
+          "outcome": "skipped",
+          "protocol": "Centrifuge"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:49:03Z",
+      "max_deposit_guidance": "0",
+      "message": "Anvil transaction reverted",
+      "name": "DeFi Janus Henderson Anemoy AAA CLO Fund Token",
+      "outcome": "reverted",
+      "protocol": "Centrifuge",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0xe9e31e6a598f0476d5eb16a005c50645924ee67e": {
+      "address": "0xe9e31e6a598f0476d5eb16a005c50645924ee67e",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xe9e31e6a598f0476d5eb16a005c50645924ee67e",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xe9e31e6a598f0476d5eb16a005c50645924ee67e",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xe9e31e6a598f0476d5eb16a005c50645924ee67e",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Savings GYD",
+          "outcome": "skipped",
+          "protocol": "Gyroscope"
+        },
+        {
+          "address": "0xe9e31e6a598f0476d5eb16a005c50645924ee67e",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Savings GYD",
+          "outcome": "skipped",
+          "protocol": "Gyroscope"
+        },
+        {
+          "address": "0xe9e31e6a598f0476d5eb16a005c50645924ee67e",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:24:57Z",
+          "message": "Could not find balance slot for token 0x613d4B5fbe5173f91Eee8D619dc38dC909E64E14",
+          "name": "Savings GYD",
+          "outcome": "funding_error",
+          "protocol": "Gyroscope"
+        },
+        {
+          "address": "0xe9e31e6a598f0476d5eb16a005c50645924ee67e",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:26:21Z",
+          "message": "Could not find balance slot for token 0x613d4B5fbe5173f91Eee8D619dc38dC909E64E14",
+          "name": "Savings GYD",
+          "outcome": "funding_error",
+          "protocol": "Gyroscope"
+        },
+        {
+          "address": "0xe9e31e6a598f0476d5eb16a005c50645924ee67e",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:56:23Z",
+          "message": "Could not find balance slot for token 0x613d4B5fbe5173f91Eee8D619dc38dC909E64E14",
+          "name": "Savings GYD",
+          "outcome": "funding_error",
+          "protocol": "Gyroscope"
+        },
+        {
+          "address": "0xe9e31e6a598f0476d5eb16a005c50645924ee67e",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:16:11Z",
+          "message": "Could not find balance slot for token 0x613d4B5fbe5173f91Eee8D619dc38dC909E64E14",
+          "name": "Savings GYD",
+          "outcome": "funding_error",
+          "protocol": "Gyroscope"
+        },
+        {
+          "address": "0xe9e31e6a598f0476d5eb16a005c50645924ee67e",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:24:10Z",
+          "message": "Could not find balance slot for token 0x613d4B5fbe5173f91Eee8D619dc38dC909E64E14",
+          "name": "Savings GYD",
+          "outcome": "funding_error",
+          "protocol": "Gyroscope"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:25:55Z",
+      "message": "Could not find balance slot for token 0x613d4B5fbe5173f91Eee8D619dc38dC909E64E14",
+      "name": "Savings GYD",
+      "outcome": "funding_error",
+      "protocol": "Gyroscope"
+    },
+    "42161-0xea50f402653c41cadbafd1f788341db7b7f37816": {
+      "address": "0xea50f402653c41cadbafd1f788341db7b7f37816",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xea50f402653c41cadbafd1f788341db7b7f37816",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:59Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xea50f402653c41cadbafd1f788341db7b7f37816",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:58Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xea50f402653c41cadbafd1f788341db7b7f37816",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Savings GYD",
+          "outcome": "skipped",
+          "protocol": "Gyroscope"
+        },
+        {
+          "address": "0xea50f402653c41cadbafd1f788341db7b7f37816",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Savings GYD",
+          "outcome": "skipped",
+          "protocol": "Gyroscope"
+        },
+        {
+          "address": "0xea50f402653c41cadbafd1f788341db7b7f37816",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:24:51Z",
+          "message": "Could not find balance slot for token 0xCA5d8F8a8d49439357d3CF46Ca2e720702F132b8",
+          "name": "Savings GYD",
+          "outcome": "funding_error",
+          "protocol": "Gyroscope"
+        },
+        {
+          "address": "0xea50f402653c41cadbafd1f788341db7b7f37816",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:26:16Z",
+          "message": "Could not find balance slot for token 0xCA5d8F8a8d49439357d3CF46Ca2e720702F132b8",
+          "name": "Savings GYD",
+          "outcome": "funding_error",
+          "protocol": "Gyroscope"
+        },
+        {
+          "address": "0xea50f402653c41cadbafd1f788341db7b7f37816",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:56:21Z",
+          "message": "Could not find balance slot for token 0xCA5d8F8a8d49439357d3CF46Ca2e720702F132b8",
+          "name": "Savings GYD",
+          "outcome": "funding_error",
+          "protocol": "Gyroscope"
+        },
+        {
+          "address": "0xea50f402653c41cadbafd1f788341db7b7f37816",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:16:09Z",
+          "message": "Could not find balance slot for token 0xCA5d8F8a8d49439357d3CF46Ca2e720702F132b8",
+          "name": "Savings GYD",
+          "outcome": "funding_error",
+          "protocol": "Gyroscope"
+        },
+        {
+          "address": "0xea50f402653c41cadbafd1f788341db7b7f37816",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:24:06Z",
+          "message": "Could not find balance slot for token 0xCA5d8F8a8d49439357d3CF46Ca2e720702F132b8",
+          "name": "Savings GYD",
+          "outcome": "funding_error",
+          "protocol": "Gyroscope"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:25:52Z",
+      "message": "Could not find balance slot for token 0xCA5d8F8a8d49439357d3CF46Ca2e720702F132b8",
+      "name": "Savings GYD",
+      "outcome": "funding_error",
+      "protocol": "Gyroscope"
+    },
+    "42161-0xeae33e9f53fc405f834d4678e6c07a2523b2126e": {
+      "address": "0xeae33e9f53fc405f834d4678e6c07a2523b2126e",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xeae33e9f53fc405f834d4678e6c07a2523b2126e",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Odins Reserve",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xeae33e9f53fc405f834d4678e6c07a2523b2126e",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Odins Reserve",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xeae33e9f53fc405f834d4678e6c07a2523b2126e",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:31Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Odins Reserve",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xeae33e9f53fc405f834d4678e6c07a2523b2126e",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Odins Reserve",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xeae33e9f53fc405f834d4678e6c07a2523b2126e",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:15Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Odins Reserve",
+          "outcome": "adapter_error",
+          "protocol": "Centrifuge"
+        },
+        {
+          "address": "0xeae33e9f53fc405f834d4678e6c07a2523b2126e",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:55:10Z",
+          "message": "Vault deposits are currently closed",
+          "name": "Odins Reserve",
+          "outcome": "skipped",
+          "protocol": "Centrifuge"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:48:56Z",
+      "max_deposit_guidance": "0",
+      "message": "Anvil transaction reverted",
+      "name": "Odins Reserve",
+      "outcome": "reverted",
+      "protocol": "Centrifuge",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0xeb60a64039289a4c07879147073a1ec5aea91553": {
+      "address": "0xeb60a64039289a4c07879147073a1ec5aea91553",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xeb60a64039289a4c07879147073a1ec5aea91553",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xeb60a64039289a4c07879147073a1ec5aea91553",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xeb60a64039289a4c07879147073a1ec5aea91553",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Royco Junior Tranche sUSDai",
+          "outcome": "skipped",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0xeb60a64039289a4c07879147073a1ec5aea91553",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Royco Junior Tranche sUSDai",
+          "outcome": "skipped",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0xeb60a64039289a4c07879147073a1ec5aea91553",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:13Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Royco Junior Tranche sUSDai",
+          "outcome": "adapter_error",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0xeb60a64039289a4c07879147073a1ec5aea91553",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:58:02Z",
+          "message": "Could not find balance slot for token 0x0B2b2B2076d95dda7817e785989fE353fe955ef9",
+          "name": "Royco Junior Tranche sUSDai",
+          "outcome": "funding_error",
+          "protocol": "Royco"
+        },
+        {
+          "address": "0xeb60a64039289a4c07879147073a1ec5aea91553",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:24:23Z",
+          "message": "Could not find balance slot for token 0x0B2b2B2076d95dda7817e785989fE353fe955ef9",
+          "name": "Royco Junior Tranche sUSDai",
+          "outcome": "funding_error",
+          "protocol": "Royco"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:38:17Z",
+      "message": "Could not find balance slot for token 0x0B2b2B2076d95dda7817e785989fE353fe955ef9",
+      "name": "Royco Junior Tranche sUSDai",
+      "outcome": "funding_error",
+      "protocol": "Royco"
+    },
+    "42161-0xeba51f6472f4ce1c47668c2474ab8f84b32e1ae7": {
+      "address": "0xeba51f6472f4ce1c47668c2474ab8f84b32e1ae7",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:32:23Z",
+      "message": "Could not find balance slot for token 0x498Bf2B1e120FeD3ad3D42EA2165E9b73f99C1e5",
+      "name": "Llama Lend FXN / crvUSD",
+      "outcome": "funding_error",
+      "protocol": "Llama Lend"
+    },
+    "42161-0xebc85f858840c327f4e3b0e9b518efd5c06f3fa7": {
+      "address": "0xebc85f858840c327f4e3b0e9b518efd5c06f3fa7",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": null,
+      "history": [
+        {
+          "address": "0xebc85f858840c327f4e3b0e9b518efd5c06f3fa7",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "gmUSDC",
+          "outcome": "adapter_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0xebc85f858840c327f4e3b0e9b518efd5c06f3fa7",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "gmUSDC",
+          "outcome": "adapter_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0xebc85f858840c327f4e3b0e9b518efd5c06f3fa7",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "gmUSDC",
+          "outcome": "adapter_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0xebc85f858840c327f4e3b0e9b518efd5c06f3fa7",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "gmUSDC",
+          "outcome": "adapter_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0xebc85f858840c327f4e3b0e9b518efd5c06f3fa7",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:43Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "gmUSDC",
+          "outcome": "adapter_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0xebc85f858840c327f4e3b0e9b518efd5c06f3fa7",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:57:07Z",
+          "message": "\nABI Not Found!\nNo element named `deposit` with 2 argument(s).\nProvided argument types: (int,address)\nProvided keyword argument types: {}\n\nTried to find a matching ABI element named `deposit`, but encountered the following problems:\nSignature: deposit(uint256,uint256,address), type: function\nExpected 3 argument(s) but received 2 argument(s).\n",
+          "name": "gmUSDC",
+          "outcome": "rpc_error",
+          "protocol": "Umami"
+        },
+        {
+          "address": "0xebc85f858840c327f4e3b0e9b518efd5c06f3fa7",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T18:29:28Z",
+          "message": "\nABI Not Found!\nNo element named `deposit` with 2 argument(s).\nProvided argument types: (int,address)\nProvided keyword argument types: {}\n\nTried to find a matching ABI element named `deposit`, but encountered the following problems:\nSignature: deposit(uint256,uint256,address), type: function\nExpected 3 argument(s) but received 2 argument(s).\n",
+          "name": "gmUSDC",
+          "outcome": "rpc_error",
+          "protocol": "Umami"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:46:49Z",
+      "message": "\nABI Not Found!\nNo element named `deposit` with 2 argument(s).\nProvided argument types: (int,address)\nProvided keyword argument types: {}\n\nTried to find a matching ABI element named `deposit`, but encountered the following problems:\nSignature: deposit(uint256,uint256,address), type: function\nExpected 3 argument(s) but received 2 argument(s).\n",
+      "name": "gmUSDC",
+      "outcome": "rpc_error",
+      "protocol": "Umami"
+    },
+    "42161-0xee29a26179fe20d5d202dae4a279119e08edc60b": {
+      "address": "0xee29a26179fe20d5d202dae4a279119e08edc60b",
+      "attempt_count": 3,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xee29a26179fe20d5d202dae4a279119e08edc60b",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:17:57Z",
+          "message": "Anvil transaction reverted",
+          "name": "Reactive Yield Optimizer",
+          "outcome": "reverted",
+          "protocol": "IPOR Fusion",
+          "revert_reason": "Anvil transaction reverted"
+        },
+        {
+          "address": "0xee29a26179fe20d5d202dae4a279119e08edc60b",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:26:36Z",
+          "message": "Anvil transaction reverted",
+          "name": "Reactive Yield Optimizer",
+          "outcome": "reverted",
+          "protocol": "IPOR Fusion",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:28:14Z",
+      "message": "Anvil transaction reverted",
+      "name": "Reactive Yield Optimizer",
+      "outcome": "reverted",
+      "protocol": "IPOR Fusion",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0xeeaf2ccb73a01deb38eca2947d963d64cfde6a32": {
+      "address": "0xeeaf2ccb73a01deb38eca2947d963d64cfde6a32",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:32:21Z",
+      "message": "Could not find balance slot for token 0x498Bf2B1e120FeD3ad3D42EA2165E9b73f99C1e5",
+      "name": "Llama Lend CRV / crvUSD",
+      "outcome": "funding_error",
+      "protocol": "Llama Lend"
+    },
+    "42161-0xf0543d476e7906374863091034fe679a7be8ee20": {
+      "address": "0xf0543d476e7906374863091034fe679a7be8ee20",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "denomination_token_address": "0x6eAf19b2FC24552925dB245F9Ff613157a7dbb4C",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0xf0543d476e7906374863091034fe679a7be8ee20",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xf0543d476e7906374863091034fe679a7be8ee20",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xf0543d476e7906374863091034fe679a7be8ee20",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Borrowable xUSD Deposit, SiloId: 146",
+          "outcome": "skipped",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0xf0543d476e7906374863091034fe679a7be8ee20",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Borrowable xUSD Deposit, SiloId: 146",
+          "outcome": "skipped",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0xf0543d476e7906374863091034fe679a7be8ee20",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:26:18Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Borrowable xUSD Deposit, SiloId: 146",
+          "outcome": "adapter_error",
+          "protocol": "Silo Finance"
+        },
+        {
+          "address": "0xf0543d476e7906374863091034fe679a7be8ee20",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0x6eAf19b2FC24552925dB245F9Ff613157a7dbb4C",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:59:03Z",
+          "message": null,
+          "name": "Borrowable xUSD Deposit, SiloId: 146",
+          "outcome": "success",
+          "protocol": "Silo Finance",
+          "share_balance_raw": "9999993720"
+        },
+        {
+          "address": "0xf0543d476e7906374863091034fe679a7be8ee20",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0x6eAf19b2FC24552925dB245F9Ff613157a7dbb4C",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:25:27Z",
+          "message": null,
+          "name": "Borrowable xUSD Deposit, SiloId: 146",
+          "outcome": "success",
+          "protocol": "Silo Finance",
+          "share_balance_raw": "9999993720"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:39:53Z",
+      "message": null,
+      "name": "Borrowable xUSD Deposit, SiloId: 146",
+      "outcome": "success",
+      "protocol": "Silo Finance",
+      "share_balance_raw": "9999993720"
+    },
+    "42161-0xf18ac7de839d45d0f004a95438c3bce8e27710c2": {
+      "address": "0xf18ac7de839d45d0f004a95438c3bce8e27710c2",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": null,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:13:58Z",
+      "message": "Live adapter does not advertise deposits",
+      "name": "Delta Netural GMX Vault (Senior)",
+      "outcome": "adapter_error",
+      "protocol": "<protocol not yet identified>"
+    },
+    "42161-0xf1cb30700f55dab9f5db853715ad96935344b09f": {
+      "address": "0xf1cb30700f55dab9f5db853715ad96935344b09f",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xf1cb30700f55dab9f5db853715ad96935344b09f",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:25:10Z",
+          "message": "Anvil transaction reverted",
+          "name": "FARM_aWETH-ARB",
+          "outcome": "reverted",
+          "protocol": "Harvest Finance",
+          "revert_reason": "Anvil transaction reverted"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:26:50Z",
+      "message": "Anvil transaction reverted",
+      "name": "FARM_aWETH-ARB",
+      "outcome": "reverted",
+      "protocol": "Harvest Finance",
+      "revert_reason": "Anvil transaction reverted"
+    },
+    "42161-0xf2d2d55daf93b0660297eaa10969ebe90ead5ce8": {
+      "address": "0xf2d2d55daf93b0660297eaa10969ebe90ead5ce8",
+      "attempt_count": 8,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xf2d2d55daf93b0660297eaa10969ebe90ead5ce8",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xf2d2d55daf93b0660297eaa10969ebe90ead5ce8",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xf2d2d55daf93b0660297eaa10969ebe90ead5ce8",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "Dolomite: USDT",
+          "outcome": "skipped",
+          "protocol": "Dolomite"
+        },
+        {
+          "address": "0xf2d2d55daf93b0660297eaa10969ebe90ead5ce8",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "Dolomite: USDT",
+          "outcome": "skipped",
+          "protocol": "Dolomite"
+        },
+        {
+          "address": "0xf2d2d55daf93b0660297eaa10969ebe90ead5ce8",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:15Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Dolomite: USDT",
+          "outcome": "adapter_error",
+          "protocol": "Dolomite"
+        },
+        {
+          "address": "0xf2d2d55daf93b0660297eaa10969ebe90ead5ce8",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:55:42Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Dolomite: USDT",
+          "outcome": "funding_error",
+          "protocol": "Dolomite"
+        },
+        {
+          "address": "0xf2d2d55daf93b0660297eaa10969ebe90ead5ce8",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:11:29Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Dolomite: USDT",
+          "outcome": "funding_error",
+          "protocol": "Dolomite"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:18:47Z",
+      "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "name": "Dolomite: USDT",
+      "outcome": "funding_error",
+      "protocol": "Dolomite"
+    },
+    "42161-0xf2ee51a5e7af0f59e27dda070ce79c3c935a2a67": {
+      "address": "0xf2ee51a5e7af0f59e27dda070ce79c3c935a2a67",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0xf2ee51a5e7af0f59e27dda070ce79c3c935a2a67",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:23:58Z",
+          "message": null,
+          "name": "Hedge Vault Token",
+          "outcome": "success",
+          "protocol": "Plutus",
+          "share_balance_raw": "11999780"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:37:54Z",
+      "message": null,
+      "name": "Hedge Vault Token",
+      "outcome": "success",
+      "protocol": "Plutus",
+      "share_balance_raw": "11999780"
+    },
+    "42161-0xf39a7496440a6cd7bd0708eea0a13324b6b7f16d": {
+      "address": "0xf39a7496440a6cd7bd0708eea0a13324b6b7f16d",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xf39a7496440a6cd7bd0708eea0a13324b6b7f16d",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:15:01Z",
+          "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+          "name": "Fractality V2 Vault Test Shares",
+          "outcome": "funding_error",
+          "protocol": "<unknown ERC-7540>"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:18:38Z",
+      "message": "Could not find balance slot for token 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9",
+      "name": "Fractality V2 Vault Test Shares",
+      "outcome": "funding_error",
+      "protocol": "<unknown ERC-7540>"
+    },
+    "42161-0xf40808f50b8d858f3ac6d10c441bb61da4564d53": {
+      "address": "0xf40808f50b8d858f3ac6d10c441bb61da4564d53",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "denomination_token_address": "0x34e11cFb98b0eb88cFb999b0a5E4235E124BEE34",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "asynchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0xf40808f50b8d858f3ac6d10c441bb61da4564d53",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xf40808f50b8d858f3ac6d10c441bb61da4564d53",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xf40808f50b8d858f3ac6d10c441bb61da4564d53",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "gTrade (Gains Network DAI)",
+          "outcome": "skipped",
+          "protocol": "Gains Network"
+        },
+        {
+          "address": "0xf40808f50b8d858f3ac6d10c441bb61da4564d53",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "gTrade (Gains Network DAI)",
+          "outcome": "skipped",
+          "protocol": "Gains Network"
+        },
+        {
+          "address": "0xf40808f50b8d858f3ac6d10c441bb61da4564d53",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "denomination_token_address": "0x34e11cFb98b0eb88cFb999b0a5E4235E124BEE34",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:23:58Z",
+          "message": null,
+          "name": "gTrade (Gains Network DAI)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xf40808f50b8d858f3ac6d10c441bb61da4564d53",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0x34e11cFb98b0eb88cFb999b0a5E4235E124BEE34",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:25:05Z",
+          "message": null,
+          "name": "gTrade (Gains Network DAI)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xf40808f50b8d858f3ac6d10c441bb61da4564d53",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0x34e11cFb98b0eb88cFb999b0a5E4235E124BEE34",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:54:41Z",
+          "message": null,
+          "name": "gTrade (Gains Network DAI)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xf40808f50b8d858f3ac6d10c441bb61da4564d53",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0x34e11cFb98b0eb88cFb999b0a5E4235E124BEE34",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:14:11Z",
+          "message": null,
+          "name": "gTrade (Gains Network DAI)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xf40808f50b8d858f3ac6d10c441bb61da4564d53",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0x34e11cFb98b0eb88cFb999b0a5E4235E124BEE34",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:21:40Z",
+          "message": null,
+          "name": "gTrade (Gains Network DAI)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "10000000000000000000"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:23:26Z",
+      "message": null,
+      "name": "gTrade (Gains Network DAI)",
+      "outcome": "success",
+      "protocol": "Gains Network",
+      "share_balance_raw": "10000000000000000000"
+    },
+    "42161-0xf5f77bd63daab15568ace0eb4b5b16d8bb69d534": {
+      "address": "0xf5f77bd63daab15568ace0eb4b5b16d8bb69d534",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": null,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:14:01Z",
+      "message": "Live adapter does not advertise deposits",
+      "name": "Delta Netural GMX Vault (Senior)",
+      "outcome": "adapter_error",
+      "protocol": "<protocol not yet identified>"
+    },
+    "42161-0xf5ffa3f579120310bdd64fa6f817e3a03b16205d": {
+      "address": "0xf5ffa3f579120310bdd64fa6f817e3a03b16205d",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:36:36Z",
+      "message": "Could not find balance slot for token 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
+      "name": "Peapods Interest Bearing WETH - 18",
+      "outcome": "funding_error",
+      "protocol": "Peapods"
+    },
+    "42161-0xf63b7f49b4f5dc5d0e7e583cfd79dc64e646320c": {
+      "address": "0xf63b7f49b4f5dc5d0e7e583cfd79dc64e646320c",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0xf63b7f49b4f5dc5d0e7e583cfd79dc64e646320c",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Tokemak arbUSD",
+          "outcome": "adapter_error",
+          "protocol": "AUTO Finance"
+        },
+        {
+          "address": "0xf63b7f49b4f5dc5d0e7e583cfd79dc64e646320c",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Tokemak arbUSD",
+          "outcome": "adapter_error",
+          "protocol": "AUTO Finance"
+        },
+        {
+          "address": "0xf63b7f49b4f5dc5d0e7e583cfd79dc64e646320c",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:31Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Tokemak arbUSD",
+          "outcome": "adapter_error",
+          "protocol": "AUTO Finance"
+        },
+        {
+          "address": "0xf63b7f49b4f5dc5d0e7e583cfd79dc64e646320c",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Tokemak arbUSD",
+          "outcome": "adapter_error",
+          "protocol": "AUTO Finance"
+        },
+        {
+          "address": "0xf63b7f49b4f5dc5d0e7e583cfd79dc64e646320c",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:15Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Tokemak arbUSD",
+          "outcome": "adapter_error",
+          "protocol": "AUTO Finance"
+        },
+        {
+          "address": "0xf63b7f49b4f5dc5d0e7e583cfd79dc64e646320c",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:54:41Z",
+          "message": null,
+          "name": "Tokemak arbUSD",
+          "outcome": "success",
+          "protocol": "AUTO Finance",
+          "share_balance_raw": "8916323275509506263"
+        },
+        {
+          "address": "0xf63b7f49b4f5dc5d0e7e583cfd79dc64e646320c",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:09:24Z",
+          "message": null,
+          "name": "Tokemak arbUSD",
+          "outcome": "success",
+          "protocol": "AUTO Finance",
+          "share_balance_raw": "8916319360254195583"
+        },
+        {
+          "address": "0xf63b7f49b4f5dc5d0e7e583cfd79dc64e646320c",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:16:13Z",
+          "message": null,
+          "name": "Tokemak arbUSD",
+          "outcome": "success",
+          "protocol": "AUTO Finance",
+          "share_balance_raw": "8916317557292382086"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:48:08Z",
+      "max_deposit_guidance": "5823369891637013142277",
+      "message": null,
+      "name": "Tokemak arbUSD",
+      "outcome": "success",
+      "protocol": "AUTO Finance",
+      "share_balance_raw": "8916309519087630250"
+    },
+    "42161-0xf84eaa0685626f84fe17bc6c3c9eb2ac8a90d3c1": {
+      "address": "0xf84eaa0685626f84fe17bc6c3c9eb2ac8a90d3c1",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xf84eaa0685626f84fe17bc6c3c9eb2ac8a90d3c1",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:19Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Plutus Dolomite vault",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0xf84eaa0685626f84fe17bc6c3c9eb2ac8a90d3c1",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:01Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Plutus Dolomite vault",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0xf84eaa0685626f84fe17bc6c3c9eb2ac8a90d3c1",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:03:55Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Plutus Dolomite vault",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0xf84eaa0685626f84fe17bc6c3c9eb2ac8a90d3c1",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:15:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Plutus Dolomite vault",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0xf84eaa0685626f84fe17bc6c3c9eb2ac8a90d3c1",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:17Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Plutus Dolomite vault",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        },
+        {
+          "address": "0xf84eaa0685626f84fe17bc6c3c9eb2ac8a90d3c1",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:27:34Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Plutus Dolomite vault",
+          "outcome": "adapter_error",
+          "protocol": "Plutus"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T17:57:41Z",
+      "message": "Vault deposits are currently closed",
+      "name": "Plutus Dolomite vault",
+      "outcome": "skipped",
+      "protocol": "Plutus"
+    },
+    "42161-0xfc1ac64e5afd67465b29d14d0dc1d1d081016394": {
+      "address": "0xfc1ac64e5afd67465b29d14d0dc1d1d081016394",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:40:49Z",
+      "message": "Could not find balance slot for token 0x0c880f6761F1af8d9Aa9C466984b80DAb9a8c9e8",
+      "name": "Borrowable PENDLE Deposit, SiloId: 115",
+      "outcome": "funding_error",
+      "protocol": "Silo Finance"
+    },
+    "42161-0xfe02caf1cb28b81830014ef63be04a1d9a90bd3a": {
+      "address": "0xfe02caf1cb28b81830014ef63be04a1d9a90bd3a",
+      "attempt_count": 7,
+      "chain_id": 42161,
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "history": [
+        {
+          "address": "0xfe02caf1cb28b81830014ef63be04a1d9a90bd3a",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:54:10Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Nashpoint CRDYX Credit Vault",
+          "outcome": "adapter_error",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0xfe02caf1cb28b81830014ef63be04a1d9a90bd3a",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:59:52Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Nashpoint CRDYX Credit Vault",
+          "outcome": "adapter_error",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0xfe02caf1cb28b81830014ef63be04a1d9a90bd3a",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:02:42Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Nashpoint CRDYX Credit Vault",
+          "outcome": "adapter_error",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0xfe02caf1cb28b81830014ef63be04a1d9a90bd3a",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:14:46Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Nashpoint CRDYX Credit Vault",
+          "outcome": "adapter_error",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0xfe02caf1cb28b81830014ef63be04a1d9a90bd3a",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T17:56:04Z",
+          "message": "Anvil transaction reverted",
+          "name": "Nashpoint CRDYX Credit Vault",
+          "outcome": "reverted",
+          "protocol": "NashPoint"
+        },
+        {
+          "address": "0xfe02caf1cb28b81830014ef63be04a1d9a90bd3a",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "last_attempt_at": "2026-07-13T18:21:53Z",
+          "message": "Got <class 'eth_defi.erc_4626.vault_protocol.nashpoint.vault.NashpointNodeVault'>",
+          "name": "Nashpoint CRDYX Credit Vault",
+          "outcome": "rpc_error",
+          "protocol": "NashPoint"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:35:05Z",
+      "message": "Got <class 'eth_defi.erc_4626.vault_protocol.nashpoint.vault.NashpointNodeVault'>",
+      "name": "Nashpoint CRDYX Credit Vault",
+      "outcome": "rpc_error",
+      "protocol": "NashPoint"
+    },
+    "42161-0xfe3e29b3328026003a15bf0846846b03af86b537": {
+      "address": "0xfe3e29b3328026003a15bf0846846b03af86b537",
+      "attempt_count": 10,
+      "chain_id": 42161,
+      "denomination_token_address": "0xDCaa75A930a8Fc30433a1375ac76332dB7B240e9",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "asynchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0xfe3e29b3328026003a15bf0846846b03af86b537",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xfe3e29b3328026003a15bf0846846b03af86b537",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "No configured token holder",
+          "outcome": "skipped"
+        },
+        {
+          "address": "0xfe3e29b3328026003a15bf0846846b03af86b537",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:01:16Z",
+          "message": "No configured token holder",
+          "name": "gTrade (gDAI)",
+          "outcome": "skipped",
+          "protocol": "Gains Network"
+        },
+        {
+          "address": "0xfe3e29b3328026003a15bf0846846b03af86b537",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "last_attempt_at": "2026-07-13T17:13:24Z",
+          "message": "No configured token holder",
+          "name": "gTrade (gDAI)",
+          "outcome": "skipped",
+          "protocol": "Gains Network"
+        },
+        {
+          "address": "0xfe3e29b3328026003a15bf0846846b03af86b537",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDCaa75A930a8Fc30433a1375ac76332dB7B240e9",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:24:10Z",
+          "message": null,
+          "name": "gTrade (gDAI)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xfe3e29b3328026003a15bf0846846b03af86b537",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDCaa75A930a8Fc30433a1375ac76332dB7B240e9",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:25:16Z",
+          "message": null,
+          "name": "gTrade (gDAI)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xfe3e29b3328026003a15bf0846846b03af86b537",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDCaa75A930a8Fc30433a1375ac76332dB7B240e9",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:54:51Z",
+          "message": null,
+          "name": "gTrade (gDAI)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xfe3e29b3328026003a15bf0846846b03af86b537",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDCaa75A930a8Fc30433a1375ac76332dB7B240e9",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:14:20Z",
+          "message": null,
+          "name": "gTrade (gDAI)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xfe3e29b3328026003a15bf0846846b03af86b537",
+          "attempt_count": 9,
+          "chain_id": 42161,
+          "denomination_token_address": "0xDCaa75A930a8Fc30433a1375ac76332dB7B240e9",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "asynchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:21:50Z",
+          "message": null,
+          "name": "gTrade (gDAI)",
+          "outcome": "success",
+          "protocol": "Gains Network",
+          "share_balance_raw": "10000000000000000000"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:23:38Z",
+      "message": null,
+      "name": "gTrade (gDAI)",
+      "outcome": "success",
+      "protocol": "Gains Network",
+      "share_balance_raw": "10000000000000000000"
+    },
+    "42161-0xff05d579bf8333a1ee4f03a87a97986c500f663d": {
+      "address": "0xff05d579bf8333a1ee4f03a87a97986c500f663d",
+      "attempt_count": 9,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0xff05d579bf8333a1ee4f03a87a97986c500f663d",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:53:57Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Tokemak arbUSD",
+          "outcome": "adapter_error",
+          "protocol": "AUTO Finance"
+        },
+        {
+          "address": "0xff05d579bf8333a1ee4f03a87a97986c500f663d",
+          "attempt_count": 2,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T16:58:44Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Tokemak arbUSD",
+          "outcome": "adapter_error",
+          "protocol": "AUTO Finance"
+        },
+        {
+          "address": "0xff05d579bf8333a1ee4f03a87a97986c500f663d",
+          "attempt_count": 3,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:01:31Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Tokemak arbUSD",
+          "outcome": "adapter_error",
+          "protocol": "AUTO Finance"
+        },
+        {
+          "address": "0xff05d579bf8333a1ee4f03a87a97986c500f663d",
+          "attempt_count": 4,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:13:38Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Tokemak arbUSD",
+          "outcome": "adapter_error",
+          "protocol": "AUTO Finance"
+        },
+        {
+          "address": "0xff05d579bf8333a1ee4f03a87a97986c500f663d",
+          "attempt_count": 5,
+          "chain_id": 42161,
+          "deposit_manager": null,
+          "last_attempt_at": "2026-07-13T17:23:15Z",
+          "message": "Live adapter does not advertise deposits",
+          "name": "Tokemak arbUSD",
+          "outcome": "adapter_error",
+          "protocol": "AUTO Finance"
+        },
+        {
+          "address": "0xff05d579bf8333a1ee4f03a87a97986c500f663d",
+          "attempt_count": 6,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T17:55:01Z",
+          "message": null,
+          "name": "Tokemak arbUSD",
+          "outcome": "success",
+          "protocol": "AUTO Finance",
+          "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xff05d579bf8333a1ee4f03a87a97986c500f663d",
+          "attempt_count": 7,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:09:47Z",
+          "message": null,
+          "name": "Tokemak arbUSD",
+          "outcome": "success",
+          "protocol": "AUTO Finance",
+          "share_balance_raw": "10000000000000000000"
+        },
+        {
+          "address": "0xff05d579bf8333a1ee4f03a87a97986c500f663d",
+          "attempt_count": 8,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:16:40Z",
+          "message": null,
+          "name": "Tokemak arbUSD",
+          "outcome": "success",
+          "protocol": "AUTO Finance",
+          "share_balance_raw": "10000000000000000000"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:48:49Z",
+      "max_deposit_guidance": "5192296858534827528531",
+      "message": null,
+      "name": "Tokemak arbUSD",
+      "outcome": "success",
+      "protocol": "AUTO Finance",
+      "share_balance_raw": "10000000000000000000"
+    },
+    "42161-0xff131917e1d6751e4d1b17612751db521b1403c5": {
+      "address": "0xff131917e1d6751e4d1b17612751db521b1403c5",
+      "attempt_count": 2,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0xff131917e1d6751e4d1b17612751db521b1403c5",
+          "attempt_count": 1,
+          "chain_id": 42161,
+          "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "explicit",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:28:53Z",
+          "message": null,
+          "name": "[STAGING_DO_NOT_USE] Kiln Vault (Aave V3 USDC)",
+          "outcome": "success",
+          "protocol": "Kiln Metavault",
+          "share_balance_raw": "9224479"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:30:22Z",
+      "message": null,
+      "name": "[STAGING_DO_NOT_USE] Kiln Vault (Aave V3 USDC)",
+      "outcome": "success",
+      "protocol": "Kiln Metavault",
+      "share_balance_raw": "9224478"
+    },
+    "42161-0xff8952c568f342b4be7f49f89c6c846a03993020": {
+      "address": "0xff8952c568f342b4be7f49f89c6c846a03993020",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "denomination_token_address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:41:03Z",
+      "message": null,
+      "name": "Borrowable USDC Deposit, SiloId: 154",
+      "outcome": "success",
+      "protocol": "Silo Finance",
+      "share_balance_raw": "9954680126"
+    },
+    "42161-0xffa3f282fe588da64351024d7cb825cfcefbee05": {
+      "address": "0xffa3f282fe588da64351024d7cb825cfcefbee05",
+      "attempt_count": 1,
+      "chain_id": 42161,
+      "deposit_manager": null,
+      "history": [],
+      "last_attempt_at": "2026-07-13T18:30:48Z",
+      "message": "Live adapter does not advertise deposits",
+      "name": "Green Goods - Rifai Sicilia DAI Vault",
+      "outcome": "adapter_error",
+      "protocol": "Yearn"
+    },
+    "8453-0xbeef0e0834849acc03f0089f01f4f1eeb06873c9": {
+      "address": "0xbeef0e0834849acc03f0089f01f4f1eeb06873c9",
+      "attempt_count": 2,
+      "chain_id": 8453,
+      "denomination_token_address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "deposit_amount": "10",
+      "deposit_manager": {
+        "can_deposit": true,
+        "can_redeem": true,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous"
+      },
+      "deposit_manager_source": "explicit",
+      "execution_mode": "guard_v0_simple_vault_v0",
+      "fork_block_number": null,
+      "history": [
+        {
+          "address": "0xbeef0e0834849acc03f0089f01f4f1eeb06873c9",
+          "attempt_count": 1,
+          "chain_id": 8453,
+          "denomination_token_address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+          "deposit_amount": "10",
+          "deposit_manager": {
+            "can_deposit": true,
+            "can_redeem": true,
+            "deposit_flow": "synchronous",
+            "redemption_flow": "synchronous"
+          },
+          "deposit_manager_source": "generic_erc4626",
+          "execution_mode": "guard_v0_simple_vault_v0",
+          "fork_block_number": null,
+          "last_attempt_at": "2026-07-13T18:43:28Z",
+          "max_deposit_guidance": "0",
+          "message": null,
+          "name": "Steakhouse Prime Instant",
+          "outcome": "success",
+          "protocol": "Morpho",
+          "share_balance_raw": "9681935649456151984"
+        }
+      ],
+      "last_attempt_at": "2026-07-13T18:44:34Z",
+      "max_deposit_guidance": "0",
+      "message": null,
+      "name": "Steakhouse Prime Instant",
+      "outcome": "success",
+      "protocol": "Morpho",
+      "share_balance_raw": "9681934680300215192"
+    }
+  }
+}

--- a/eth_defi/erc_4626/deposit_probe.py
+++ b/eth_defi/erc_4626/deposit_probe.py
@@ -5,7 +5,7 @@ deposit request from ``SimpleVaultV0`` through its ``GuardV0``.  It never uses a
 private key supplied by an operator and never targets an upstream RPC endpoint.
 
 Large all-protocol runs are intentionally long-lived: each candidate deploys
-and exercises contracts on an isolated Anvil snapshot. Interactive runners
+and exercises contracts on a fresh Anvil fork. Interactive runners
 must run bounded protocol batches and resume from the durable status file,
 rather than imposing one short wall-clock timeout on the complete sweep.
 """
@@ -34,7 +34,7 @@ from eth_defi.erc_4626.classification import create_vault_instance
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.hotwallet import HotWallet
-from eth_defi.provider.anvil import fork_network_anvil, fund_erc20_on_anvil, is_anvil, revert, set_balance, snapshot
+from eth_defi.provider.anvil import fork_network_anvil, fund_erc20_on_anvil, is_anvil, set_balance
 from eth_defi.provider.env import read_json_rpc_url
 from eth_defi.revert_reason import fetch_transaction_revert_reason
 from eth_defi.simple_vault.transact import encode_simple_vault_transaction
@@ -53,6 +53,7 @@ ProbeResult = dict[str, object]
 #: Expected Anvil, RPC, and contract errors from an individual probe attempt.
 PROBE_EXECUTION_EXCEPTIONS = (
     ConnectionError,
+    RuntimeError,
     TimeoutError,
     RequestException,
     ValueError,
@@ -254,11 +255,19 @@ def select_candidates(
         if not vault_ids:
             raise ValueError("vault_ids selection requires VAULT_IDS")  # noqa: EM101
         seen: set[VaultSpec] = set()
+        missing: list[VaultSpec] = []
         for item in vault_ids.split(","):
             spec = VaultSpec.parse_string(item.strip(), separator="-")
-            if spec not in seen and spec in rows:
-                selected.append((spec, rows[spec]))
-                seen.add(spec)
+            if spec in seen:
+                continue
+            seen.add(spec)
+            if spec not in rows:
+                missing.append(spec)
+                continue
+            selected.append((spec, rows[spec]))
+        if missing:
+            missing_ids = ", ".join(spec.as_string_id() for spec in missing)
+            raise ValueError(f"VAULT_IDS entries are missing from the vault database: {missing_ids}")
     else:
         raise ValueError("VAULT_SELECTION must be min_tvl, protocol, all_protocols, or vault_ids")  # noqa: EM101
 
@@ -288,6 +297,45 @@ def select_candidates(
     return candidates
 
 
+def _normalise_legacy_status(state: dict[str, object]) -> dict[str, object]:
+    """Invalidate legacy successes that do not identify their fork block.
+
+    Older probe versions persisted successful outcomes without enough evidence
+    to reproduce the tested chain state. Their complete records remain in the
+    bounded history, while the current outcome fails closed until refreshed.
+
+    :param state:
+        Valid schema-versioned status state.
+    :return:
+        The same state with unverifiable current successes invalidated.
+    :raises ValueError:
+        If an individual vault record is malformed.
+    """
+    vaults = state["vaults"]
+    assert isinstance(vaults, dict)
+    for key, current in tuple(vaults.items()):
+        if not isinstance(current, dict):
+            raise ValueError(f"Malformed vault deposit status record: {key}")
+        fork_block_number = current.get("fork_block_number")
+        valid_fork_block = isinstance(fork_block_number, int) and not isinstance(fork_block_number, bool) and fork_block_number > 0
+        if current.get("outcome") != "success" or valid_fork_block:
+            continue
+        history = list(current.get("history", []))
+        history.append({field: value for field, value in current.items() if field != "history"})
+        identity_fields = ("chain_id", "address", "name", "protocol", "last_attempt_at")
+        invalidated = {field: current[field] for field in identity_fields if field in current}
+        invalidated.update(
+            {
+                "outcome": "invalid_evidence",
+                "message": "Legacy success did not record a valid Anvil fork block; refresh required",
+                "attempt_count": int(current.get("attempt_count", 0)),
+                "history": history[-10:],
+            }
+        )
+        vaults[key] = invalidated
+    return state
+
+
 def _load_status(path: Path) -> dict[str, object]:
     """Load valid local probe state without silently replacing it.
 
@@ -304,14 +352,15 @@ def _load_status(path: Path) -> dict[str, object]:
         state = json.load(f)
     if not isinstance(state, dict) or state.get("schema_version") != STATUS_SCHEMA_VERSION or not isinstance(state.get("vaults"), dict):
         raise ValueError(f"Unsupported or malformed vault deposit status file: {path}")
-    return state
+    return _normalise_legacy_status(state)
 
 
 def update_status(path: Path, key: str, result: ProbeResult) -> None:
-    """Atomically merge one durable, hash-free probe result into local state.
+    """Atomically store one durable, hash-free probe result in local state.
 
-    Re-reading under the lock preserves concurrent writers and unrecognised
-    state fields from later schema versions.
+    Re-reading under the lock preserves concurrent writers. Current-attempt
+    fields are rebuilt from ``result`` so evidence from an older attempt cannot
+    leak into a later failure or success.
 
     :param path:
         Status-file destination.
@@ -319,7 +368,13 @@ def update_status(path: Path, key: str, result: ProbeResult) -> None:
         Canonical vault key.
     :param result:
         Current attempt result without fork-local transaction identifiers.
+    :raises ValueError:
+        If a successful result does not identify a positive integer fork block.
     """
+    if result.get("outcome") == "success":
+        fork_block_number = result.get("fork_block_number")
+        if not isinstance(fork_block_number, int) or isinstance(fork_block_number, bool) or fork_block_number <= 0:
+            raise ValueError("Successful probe result must contain a positive integer fork_block_number")  # noqa: EM101
     path = path.expanduser().absolute()
     with wait_other_writers(path):
         state = _load_status(path)
@@ -327,8 +382,8 @@ def update_status(path: Path, key: str, result: ProbeResult) -> None:
         history = list(existing.get("history", []))
         if existing:
             history.append({k: v for k, v in existing.items() if k != "history"})
-        merged = {**existing, **result, "attempt_count": int(existing.get("attempt_count", 0)) + 1, "history": history[-10:]}
-        state["vaults"][key] = merged
+        current = {**result, "attempt_count": int(existing.get("attempt_count", 0)) + 1, "history": history[-10:]}
+        state["vaults"][key] = current
         state["updated_at"] = _timestamp()
         temporary = path.with_suffix(path.suffix + ".tmp")
         with temporary.open("w", encoding="utf-8") as f:
@@ -546,7 +601,35 @@ def probe_candidate(  # noqa: PLR0914
         shares = vault.vault_contract.functions.balanceOf(simple_vault.address).call()
         if shares <= 0:
             return {**result, "outcome": "adapter_error", "message": "No shares minted to SimpleVaultV0"}
-        result["share_balance_raw"] = str(shares)
+        result["minted_share_amount_raw"] = str(shares)
+        denomination_before_redemption = token.fetch_raw_balance_of(simple_vault.address)
+        try:
+            if isinstance(manager, ERC4626DepositManager):
+                redemption = manager.create_redemption_request(owner=simple_vault.address, raw_shares=shares)
+            else:
+                redemption = manager.create_redemption_request(
+                    owner=simple_vault.address,
+                    shares=vault.share_token.convert_to_decimals(shares),
+                )
+            encoded_redemptions = [encode_simple_vault_transaction(function) for function in redemption.funcs]
+            for target, calldata in encoded_redemptions:
+                guard.functions.validateCall(control.address, target, calldata).call()
+        except (*PROBE_EXECUTION_EXCEPTIONS, AssertionError) as e:
+            return {**result, "outcome": "guard_validation_error", "message": f"Synchronous redemption validation failed: {e}"}
+        try:
+            for target, calldata in encoded_redemptions:
+                _broadcast(control, simple_vault.functions.performCall(target, calldata), web3)
+        except (*PROBE_EXECUTION_EXCEPTIONS, AnvilProbeTransactionError) as e:
+            return {**result, "outcome": "reverted", "message": f"Synchronous redemption failed: {e}", "revert_reason": str(e)}
+        remaining_shares = vault.vault_contract.functions.balanceOf(simple_vault.address).call()
+        denomination_after_redemption = token.fetch_raw_balance_of(simple_vault.address)
+        if remaining_shares >= shares:
+            return {**result, "outcome": "adapter_error", "message": "Synchronous redemption did not reduce the SimpleVaultV0 share balance"}
+        if denomination_after_redemption <= denomination_before_redemption:
+            return {**result, "outcome": "adapter_error", "message": "Synchronous redemption returned no denomination tokens to SimpleVaultV0"}
+        result["redeemed_asset_amount_raw"] = str(denomination_after_redemption - denomination_before_redemption)
+        result["remaining_share_amount_raw"] = str(remaining_shares)
+        result["redemption_status_detail"] = "completed"
     else:
         try:
             ticket = request.parse_deposit_transaction(request_hashes)
@@ -560,6 +643,7 @@ def probe_candidate(  # noqa: PLR0914
         request_id = getattr(ticket, "request_id", getattr(ticket, "settlement_id", None))
         logger.info("Fork-local async request id for %s: %s", candidate.key, request_id)
         result["status_detail"] = "deposit_request_submitted"
+        result["redemption_status_detail"] = "not_exercised_asynchronous"
 
     if token.fetch_raw_balance_of(control.address) != 0 or vault.vault_contract.functions.balanceOf(control.address).call() != 0:
         return {**result, "outcome": "adapter_error", "message": "Control wallet received vault assets or shares"}
@@ -570,11 +654,11 @@ def run_from_environment() -> int:
     """Run the guarded Anvil probe configured through environment variables.
 
     Candidate selection comes from the local vault database. The function
-    launches one isolated fork per chain, reverts every vault attempt, and
-    stores the durable result after each attempt. All-protocol runs can take a
-    long time; interactive callers should invoke bounded protocol batches and
-    resume using the status file instead of terminating the complete sweep
-    early.
+    launches one isolated fork per vault and stores the durable result after
+    each attempt. A fresh process prevents one blocked upstream state read from
+    contaminating later candidates. All-protocol runs can take a long time;
+    interactive callers should invoke bounded protocol batches and resume
+    using the status file instead of terminating the complete sweep early.
 
     :return:
         Process exit status ``0`` after all selected chain batches finish.
@@ -592,7 +676,9 @@ def run_from_environment() -> int:
     chain_id_text = os.environ.get("CHAIN_ID")
     chain_id = int(chain_id_text) if chain_id_text else None
     denomination = os.environ.get("DENOMINATION_TOKEN")
-    denomination_address = Web3.to_checksum_address(denomination) if denomination and Web3.is_address(denomination) else None
+    if denomination and not Web3.is_address(denomination):
+        raise ValueError(f"DENOMINATION_TOKEN is not a valid address: {denomination}")
+    denomination_address = Web3.to_checksum_address(denomination) if denomination else None
     candidates = select_candidates(
         VaultDatabase.read(database_path),
         selection=selection,
@@ -606,48 +692,47 @@ def run_from_environment() -> int:
     )
     if max_vaults > 0 and selection != "all_protocols":
         candidates = candidates[:max_vaults]
+    if not candidates:
+        raise ValueError("Vault selection produced no deposit-capable candidates")  # noqa: EM101
     if len(candidates) > 1 and os.environ.get("CONFIRM_ALL", "").lower() != "true":
         raise RuntimeError("Set CONFIRM_ALL=true to run a multi-vault probe")  # noqa: EM101
     amount = _read_decimal_env("DEPOSIT_AMOUNT")
 
-    grouped: dict[int, list[VaultDepositProbeCandidate]] = defaultdict(list)
-    for candidate in candidates:
-        grouped[candidate.spec.chain_id].append(candidate)
     output_rows: list[VaultDepositProbeOutput] = []
-    for chain_id, chain_candidates in grouped.items():
-        launch = fork_network_anvil(read_json_rpc_url(chain_id))
+    for candidate in candidates:
+        candidate_chain_id = candidate.spec.chain_id
+        launch = None
+        fork_block_number = None
         try:
+            launch = fork_network_anvil(read_json_rpc_url(candidate_chain_id))
             web3 = Web3(HTTPProvider(launch.json_rpc_url))
-            _assert_anvil_target(web3, launch.json_rpc_url, chain_id)
-            if launch.chain_id != chain_id:
-                raise RuntimeError(f"Anvil launch chain id {launch.chain_id} does not match {chain_id}")
-            for candidate in chain_candidates:
-                attempt_snapshot = snapshot(web3)
-                try:
-                    fork_block_number = launch.fork_block_number or web3.eth.block_number
-                    result = probe_candidate(web3, candidate, amount, fork_block_number)
-                except PROBE_EXECUTION_EXCEPTIONS as e:
-                    logger.exception("Probe failed for %s", candidate.key)
-                    result = {"outcome": "rpc_error", "message": str(e)}
-                finally:
-                    if not revert(web3, attempt_snapshot):
-                        raise RuntimeError("Anvil snapshot restoration failed; aborting contaminated chain")  # noqa: EM101
-                result.update({"chain_id": chain_id, "address": candidate.spec.vault_address, "name": candidate.row.get("Name"), "protocol": candidate.row.get("Protocol"), "last_attempt_at": _timestamp()})
-                update_status(status_path, candidate.key, result)
-                output_rows.append(
-                    VaultDepositProbeOutput(
-                        protocol=str(candidate.row.get("Protocol", "<unknown>")),
-                        address=candidate.spec.vault_address,
-                        name=str(candidate.row.get("Name", "")),
-                        denomination_token=candidate.denomination_token_label,
-                        outcome=str(result["outcome"]),
-                        status="Ok (generic ERC-4626)" if result["outcome"] == "success" and result.get("deposit_manager_source") == "generic_erc4626" else "Ok" if result["outcome"] == "success" else str(result["outcome"]),
-                        max_deposit_guidance=str(result.get("max_deposit_guidance", "not available")),
-                        failure_reason=str(result["message"]) if result.get("message") else None,
-                        revert_reason=str(result["revert_reason"]) if result.get("revert_reason") else None,
-                    )
-                )
+            _assert_anvil_target(web3, launch.json_rpc_url, candidate_chain_id)
+            if launch.chain_id != candidate_chain_id:
+                raise RuntimeError(f"Anvil launch chain id {launch.chain_id} does not match {candidate_chain_id}")
+            fork_block_number = launch.fork_block_number or web3.eth.block_number
+            result = probe_candidate(web3, candidate, amount, fork_block_number)
+        except PROBE_EXECUTION_EXCEPTIONS as e:
+            logger.exception("Probe failed for %s", candidate.key)
+            result = {"outcome": "rpc_error", "message": str(e)}
         finally:
-            launch.close()
+            if launch is not None:
+                launch.close()
+        if fork_block_number is not None:
+            result.setdefault("fork_block_number", fork_block_number)
+        result.update({"chain_id": candidate_chain_id, "address": candidate.spec.vault_address, "name": candidate.row.get("Name"), "protocol": candidate.row.get("Protocol"), "last_attempt_at": _timestamp()})
+        update_status(status_path, candidate.key, result)
+        output_rows.append(
+            VaultDepositProbeOutput(
+                protocol=str(candidate.row.get("Protocol", "<unknown>")),
+                address=candidate.spec.vault_address,
+                name=str(candidate.row.get("Name", "")),
+                denomination_token=candidate.denomination_token_label,
+                outcome=str(result["outcome"]),
+                status="Ok (generic ERC-4626)" if result["outcome"] == "success" and result.get("deposit_manager_source") == "generic_erc4626" else "Ok" if result["outcome"] == "success" else str(result["outcome"]),
+                max_deposit_guidance=str(result.get("max_deposit_guidance", "not available")),
+                failure_reason=str(result["message"]) if result.get("message") else None,
+                revert_reason=str(result["revert_reason"]) if result.get("revert_reason") else None,
+            )
+        )
     log_probe_tables(output_rows)
     return 0

--- a/eth_defi/erc_4626/deposit_probe.py
+++ b/eth_defi/erc_4626/deposit_probe.py
@@ -1,0 +1,653 @@
+"""Anvil-only guarded vault-deposit probe.
+
+The probe is intentionally an operator tool: it certifies a manager-generated
+deposit request from ``SimpleVaultV0`` through its ``GuardV0``.  It never uses a
+private key supplied by an operator and never targets an upstream RPC endpoint.
+
+Large all-protocol runs are intentionally long-lived: each candidate deploys
+and exercises contracts on an isolated Anvil snapshot. Interactive runners
+must run bounded protocol batches and resume from the durable status file,
+rather than imposing one short wall-clock timeout on the complete sweep.
+"""
+
+import json
+import logging
+import os
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+
+from eth_account import Account
+from eth_typing import HexAddress
+from requests.exceptions import RequestException
+from tabulate import tabulate
+from web3 import HTTPProvider, Web3
+from web3.contract.contract import ContractFunction
+from web3.exceptions import BadFunctionCallOutput, ContractLogicError, TimeExhausted, TransactionNotFound, Web3Exception
+from web3.types import TxReceipt
+
+from eth_defi.abi import get_deployed_contract
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.deploy import GUARD_LIBRARIES, deploy_contract
+from eth_defi.erc_4626.classification import create_vault_instance
+from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
+from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.hotwallet import HotWallet
+from eth_defi.provider.anvil import fork_network_anvil, fund_erc20_on_anvil, is_anvil, revert, set_balance, snapshot
+from eth_defi.provider.env import read_json_rpc_url
+from eth_defi.revert_reason import fetch_transaction_revert_reason
+from eth_defi.simple_vault.transact import encode_simple_vault_transaction
+from eth_defi.token import fetch_erc20_details
+from eth_defi.utils import wait_other_writers
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.vaultdb import DEFAULT_VAULT_DATABASE, VaultDatabase, VaultRow
+
+logger = logging.getLogger(__name__)
+
+STATUS_SCHEMA_VERSION = 1
+#: Version-controlled package artefact refreshed by the guarded Anvil probe.
+DEFAULT_STATUS_PATH = Path(__file__).parent.parent / "data" / "deposit-status" / "vault-deposit-status.json"
+ProbeResult = dict[str, object]
+
+#: Expected Anvil, RPC, and contract errors from an individual probe attempt.
+PROBE_EXECUTION_EXCEPTIONS = (
+    ConnectionError,
+    TimeoutError,
+    RequestException,
+    ValueError,
+    BadFunctionCallOutput,
+    ContractLogicError,
+    TimeExhausted,
+    TransactionNotFound,
+    Web3Exception,
+)
+
+
+class AnvilProbeTransactionError(RuntimeError):
+    """Anvil mined a probe transaction with a failing status."""
+
+
+@dataclass(frozen=True, slots=True)
+class VaultDepositProbeCandidate:
+    """One database vault selected for a guarded deposit attempt."""
+
+    spec: VaultSpec
+    row: VaultRow
+    denomination_token_address: HexAddress
+
+    @property
+    def key(self) -> str:
+        """Return canonical persistent-state key.
+
+        The key prevents checksum casing differences from creating duplicate
+        status records for the same chain and vault.
+
+        :return:
+            ``<chain_id>-<lowercase_address>`` status key.
+        """
+        return f"{self.spec.chain_id}-{self.spec.vault_address.lower()}"
+
+    @property
+    def denomination_token_label(self) -> str:
+        """Return a compact human-readable denomination-token identifier.
+
+        :return:
+            Scanned denomination symbol followed by its checksummed address.
+        """
+        symbol = self.row.get("Denomination", "<unknown>")
+        return f"{symbol} ({self.denomination_token_address})"
+
+
+@dataclass(frozen=True, slots=True)
+class VaultDepositProbeOutput:
+    """One human-readable result row for a completed or skipped probe."""
+
+    #: Scanner protocol name.
+    protocol: str
+    #: Vault contract address.
+    address: HexAddress | str
+    #: Scanner vault name.
+    name: str
+    #: Symbol and address of the denomination token.
+    denomination_token: str
+    #: Probe outcome used for summary statistics.
+    outcome: str
+    #: Concise result shown in the detailed table.
+    status: str
+    #: Informational ``maxDeposit(address(0))`` response, never a decision input.
+    max_deposit_guidance: str
+    #: Failure detail, absent for successful probes.
+    failure_reason: str | None
+    #: Raw Anvil exception text for reverted execution.
+    revert_reason: str | None
+
+
+def _timestamp() -> str:
+    """Format a naive UTC timestamp at the JSON boundary.
+
+    :return:
+        ISO-8601 UTC timestamp ending in ``Z``.
+    """
+    return native_datetime_utc_now().isoformat(timespec="seconds") + "Z"
+
+
+def require_simulation() -> None:
+    """Require explicit acknowledgement before creating an Anvil fork.
+
+    The flag is an operator-intent gate only; provider identity is separately
+    checked immediately before any transaction is signed.
+
+    :raises AnvilProbeTransactionError:
+        If ``SIMULATE`` is not exactly ``true``.
+    """
+    if os.environ.get("SIMULATE", "").lower() != "true":
+        raise RuntimeError("Set SIMULATE=true: this script only operates against an Anvil fork")  # noqa: EM101
+
+
+def _read_decimal_env(name: str) -> Decimal:
+    """Read one positive human-readable decimal environment value.
+
+    :param name:
+        Name of the required environment variable.
+    :return:
+        Parsed positive decimal without ERC-20 decimal conversion.
+    :raises ValueError:
+        If the setting is absent or not positive.
+    """
+    value = os.environ.get(name)
+    if not value:
+        raise ValueError(f"{name} is required")
+    parsed = Decimal(value)
+    if parsed <= 0:
+        raise ValueError(f"{name} must be positive")
+    return parsed
+
+
+def _row_token_address(row: VaultRow) -> HexAddress | None:
+    """Extract a valid scanned denomination-token address.
+
+    :param row:
+        Scanner metadata row.
+    :return:
+        Checksummed ERC-20 address, or ``None`` for incomplete metadata.
+    """
+    token = row.get("_denomination_token")
+    if not isinstance(token, dict):
+        return None
+    address = token.get("address")
+    if not isinstance(address, str) or not Web3.is_address(address):
+        return None
+    return Web3.to_checksum_address(address)
+
+
+def _has_deposit_capability(row: VaultRow) -> bool:
+    """Check the scanner's fail-closed public deposit capability.
+
+    :param row:
+        Scanner metadata row.
+    :return:
+        ``True`` only for an explicitly advertised deposit manager.
+    """
+    capability = row.get("_deposit_manager")
+    return isinstance(capability, dict) and capability.get("can_deposit") is True
+
+
+def select_candidates(
+    database: VaultDatabase,
+    *,
+    selection: str,
+    min_tvl: Decimal | None = None,
+    denomination_token: HexAddress | None = None,
+    protocol: str | None = None,
+    vault_ids: str | None = None,
+    chain_id: int | None = None,
+    include_uncertified: bool = False,
+    max_per_protocol: int | None = None,
+) -> list[VaultDepositProbeCandidate]:
+    """Select database candidates with deterministic order and fail-closed metadata.
+
+    ``min_tvl`` compares the scanner's USD NAV values. A denomination token
+    may optionally narrow that selection further.
+
+    :param database:
+        Local scanner metadata database.
+    :param selection:
+        One of ``min_tvl``, ``protocol``, ``all_protocols`` or ``vault_ids``.
+    :param min_tvl:
+        Minimum USD NAV for ``min_tvl`` selection.
+    :param denomination_token:
+        Optional denomination-token filter for ``min_tvl`` selection.
+    :param protocol:
+        Case-insensitive protocol name for ``protocol`` selection.
+    :param vault_ids:
+        Comma-separated vault identifiers for explicit selection.
+    :param chain_id:
+        Optional EVM chain filter applied to every selection mode.
+    :param include_uncertified:
+        Include legacy database rows without scanner capability metadata. Their
+        adapter capability is still recomputed and enforced on the Anvil fork.
+    :param max_per_protocol:
+        Optional highest-N NAV limit applied independently in
+        ``all_protocols`` mode.
+    :return:
+        Deterministically ordered, deposit-capable EVM candidates.
+    :raises ValueError:
+        If selection mode requirements are not met.
+    """
+    rows = database.rows
+    selected: list[tuple[VaultSpec, VaultRow]] = []
+    if selection == "min_tvl":
+        if min_tvl is None:
+            raise ValueError("min_tvl selection requires MIN_TVL")  # noqa: EM101
+        wanted_token = denomination_token.lower() if denomination_token is not None else None
+        selected = [(spec, row) for spec, row in rows.items() if isinstance(row.get("NAV"), Decimal) and row["NAV"] >= min_tvl and (wanted_token is None or (_row_token_address(row) is not None and _row_token_address(row).lower() == wanted_token))]
+        selected.sort(key=lambda item: (item[0].chain_id, item[0].vault_address.lower()))
+    elif selection == "protocol":
+        if not protocol:
+            raise ValueError("protocol selection requires PROTOCOL")  # noqa: EM101
+        selected = [(spec, row) for spec, row in rows.items() if str(row.get("Protocol", "")).lower() == protocol.lower()]
+        selected.sort(key=lambda item: (item[0].chain_id, item[0].vault_address.lower()))
+    elif selection == "all_protocols":
+        selected = list(rows.items())
+    elif selection == "vault_ids":
+        if not vault_ids:
+            raise ValueError("vault_ids selection requires VAULT_IDS")  # noqa: EM101
+        seen: set[VaultSpec] = set()
+        for item in vault_ids.split(","):
+            spec = VaultSpec.parse_string(item.strip(), separator="-")
+            if spec not in seen and spec in rows:
+                selected.append((spec, rows[spec]))
+                seen.add(spec)
+    else:
+        raise ValueError("VAULT_SELECTION must be min_tvl, protocol, all_protocols, or vault_ids")  # noqa: EM101
+
+    if chain_id is not None:
+        selected = [(spec, row) for spec, row in selected if spec.chain_id == chain_id]
+
+    candidates: list[VaultDepositProbeCandidate] = []
+    for spec, row in selected:
+        token_address = _row_token_address(row)
+        has_capability = _has_deposit_capability(row)
+        if not Web3.is_address(spec.vault_address) or not (has_capability or include_uncertified):
+            continue
+        if token_address is None or not isinstance(row.get("NAV"), Decimal) or row["NAV"] <= 0:
+            continue
+        candidates.append(VaultDepositProbeCandidate(spec, row, token_address))
+
+    if selection == "protocol":
+        candidates.sort(key=lambda candidate: (-candidate.row["NAV"], candidate.spec.chain_id, candidate.spec.vault_address.lower()))
+    elif selection == "all_protocols":
+        by_protocol: dict[str, list[VaultDepositProbeCandidate]] = defaultdict(list)
+        for candidate in candidates:
+            by_protocol[str(candidate.row.get("Protocol", "<unknown>"))].append(candidate)
+        candidates = []
+        for protocol_name in sorted(by_protocol, key=str.lower):
+            ranked = sorted(by_protocol[protocol_name], key=lambda candidate: (-candidate.row["NAV"], candidate.spec.chain_id, candidate.spec.vault_address.lower()))
+            candidates.extend(ranked[:max_per_protocol] if max_per_protocol else ranked)
+    return candidates
+
+
+def _load_status(path: Path) -> dict[str, object]:
+    """Load valid local probe state without silently replacing it.
+
+    :param path:
+        Absolute or user-expanded local status path.
+    :return:
+        Schema-versioned state object, creating an empty one when absent.
+    :raises ValueError:
+        If existing state is malformed or uses another schema version.
+    """
+    if not path.exists():
+        return {"schema_version": STATUS_SCHEMA_VERSION, "updated_at": _timestamp(), "vaults": {}}
+    with path.open("r", encoding="utf-8") as f:
+        state = json.load(f)
+    if not isinstance(state, dict) or state.get("schema_version") != STATUS_SCHEMA_VERSION or not isinstance(state.get("vaults"), dict):
+        raise ValueError(f"Unsupported or malformed vault deposit status file: {path}")
+    return state
+
+
+def update_status(path: Path, key: str, result: ProbeResult) -> None:
+    """Atomically merge one durable, hash-free probe result into local state.
+
+    Re-reading under the lock preserves concurrent writers and unrecognised
+    state fields from later schema versions.
+
+    :param path:
+        Status-file destination.
+    :param key:
+        Canonical vault key.
+    :param result:
+        Current attempt result without fork-local transaction identifiers.
+    """
+    path = path.expanduser().absolute()
+    with wait_other_writers(path):
+        state = _load_status(path)
+        existing = state["vaults"].get(key, {})
+        history = list(existing.get("history", []))
+        if existing:
+            history.append({k: v for k, v in existing.items() if k != "history"})
+        merged = {**existing, **result, "attempt_count": int(existing.get("attempt_count", 0)) + 1, "history": history[-10:]}
+        state["vaults"][key] = merged
+        state["updated_at"] = _timestamp()
+        temporary = path.with_suffix(path.suffix + ".tmp")
+        with temporary.open("w", encoding="utf-8") as f:
+            json.dump(state, f, indent=2, sort_keys=True, allow_nan=False)
+        temporary.replace(path)
+
+
+def log_probe_tables(rows: list[VaultDepositProbeOutput]) -> None:
+    """Log per-vault outcomes and aggregate outcome counts as tables.
+
+    The detailed table is emitted after results are persisted, allowing an
+    operator to compare terminal output with the durable local status file.
+
+    :param rows:
+        Completed or skipped vault-probe rows.
+    :return:
+        ``None`` after logging both human-readable tables at info level.
+    """
+    logger.info(
+        "Vault deposit probe results\n%s",
+        tabulate(
+            [
+                (
+                    row.protocol,
+                    row.address,
+                    row.name,
+                    row.denomination_token,
+                    row.status,
+                    row.max_deposit_guidance,
+                    "Ok" if row.outcome == "success" else row.failure_reason or row.outcome,
+                    row.revert_reason or "",
+                )
+                for row in sorted(rows, key=lambda row: (row.outcome != "success", row.protocol.lower(), row.address.lower()))
+            ],
+            headers=["Protocol", "Address", "Name", "Denomination token", "Status", "maxDeposit guidance", "Failure reason", "Revert reason"],
+            tablefmt="github",
+        ),
+    )
+    counts = Counter(row.outcome for row in rows)
+    total = len(rows)
+    logger.info(
+        "Vault deposit probe summary\n%s",
+        tabulate(
+            [(outcome, count, f"{count / total:.1%}") for outcome, count in sorted(counts.items())],
+            headers=["Outcome", "Vaults", "Percentage"],
+            tablefmt="github",
+        ),
+    )
+
+
+def _broadcast(wallet: HotWallet, function: ContractFunction, web3: Web3, gas: int = 750_000) -> TxReceipt:
+    """Sign, submit and wait for one control-wallet transaction.
+
+    :param wallet:
+        Fresh gas-only Anvil control wallet.
+    :param function:
+        Bound SimpleVault or Guard contract call.
+    :param web3:
+        Verified Anvil Web3 instance.
+    :param gas:
+        Outer transaction gas limit.
+    :return:
+        Successful mined receipt.
+    :raises AnvilProbeTransactionError:
+        If Anvil reports a reverted receipt, including its replayed reason.
+    """
+    signed = wallet.sign_bound_call_with_new_nonce(function, {"gas": gas}, web3=web3, fill_gas_price=True)
+    tx_hash = web3.eth.send_raw_transaction(signed.rawTransaction)
+    receipt = web3.eth.wait_for_transaction_receipt(tx_hash)
+    if receipt["status"] != 1:
+        raise AnvilProbeTransactionError(fetch_transaction_revert_reason(web3, tx_hash))
+    return receipt
+
+
+def fetch_max_deposit_guidance(vault: ERC4626Vault) -> str:
+    """Read the ERC-4626 ``maxDeposit`` response for operator guidance only.
+
+    ERC-4626 permits conservative underestimates.  In particular, Morpho V2
+    always returns zero because its external gates are address-dependent.  The
+    guarded deposit transaction, rather than this advisory call, decides whether
+    the vault accepts a ``SimpleVaultV0`` deposit.
+
+    :param vault:
+        Constructed ERC-4626 reader whose standard contract accessor is queried.
+    :return:
+        Raw ``maxDeposit(address(0))`` result as text, or a concise unavailable
+        marker when the optional accessor cannot be read.
+    """
+    try:
+        return str(vault.vault_contract.functions.maxDeposit("0x0000000000000000000000000000000000000000").call())
+    except (BadFunctionCallOutput, ContractLogicError, ValueError, Web3Exception) as error:
+        return f"unavailable: {type(error).__name__}"
+
+
+def _assert_anvil_target(web3: Web3, launch_url: str, expected_chain_id: int) -> None:
+    """Reject provider substitution before any transaction is signed.
+
+    :param web3:
+        Candidate transaction provider.
+    :param launch_url:
+        JSON-RPC endpoint produced by the local Anvil launch.
+    :param expected_chain_id:
+        Chain ID selected from vault metadata.
+    :raises RuntimeError:
+        If the endpoint, Anvil identity, or chain ID differs.
+    """
+    endpoint = getattr(web3.provider, "endpoint_uri", None)
+    if endpoint != launch_url or not is_anvil(web3) or web3.eth.chain_id != expected_chain_id:
+        raise RuntimeError("Refusing to mutate a provider that is not the expected Anvil fork")  # noqa: EM101
+
+
+def probe_candidate(  # noqa: PLR0914
+    web3: Web3,
+    candidate: VaultDepositProbeCandidate,
+    amount: Decimal,
+    fork_block_number: int | None,
+) -> ProbeResult:
+    """Run one guarded deposit attempt on an already verified Anvil fork.
+
+    Returned data is safe to persist.  Ephemeral Anvil transaction hashes are
+    deliberately excluded.
+
+    :param web3:
+        Verified Anvil fork provider.
+    :param candidate:
+        Selected local database vault.
+    :param amount:
+        Human-readable denomination-token deposit amount.
+    :param fork_block_number:
+        Upstream block at which the fork started.
+    :return:
+        Hash-free status result for persistent local state.
+    """
+    vault = create_vault_instance(web3, candidate.spec.vault_address, candidate.row["features"])
+    if vault is None:
+        return {"outcome": "adapter_error", "message": "Could not construct vault adapter"}
+    max_deposit_guidance = fetch_max_deposit_guidance(vault) if isinstance(vault, ERC4626Vault) else "not an ERC-4626 vault"
+    capability = vault.get_deposit_manager_capability()
+    manager_source = "explicit"
+    manager = None
+    if capability is None and isinstance(vault, ERC4626Vault) and vault.supports_generic_deposit_manager():
+        capability = vault.get_synchronous_deposit_manager_capability()
+        manager = ERC4626DepositManager(vault)
+        manager_source = "generic_erc4626"
+    capability_data = capability.as_initial_public_schema() if capability else None
+    if capability_data is None or not capability_data["can_deposit"]:
+        return {"outcome": "adapter_error", "message": "Live adapter does not advertise deposits", "deposit_manager": capability_data, "max_deposit_guidance": max_deposit_guidance}
+
+    token = fetch_erc20_details(web3, candidate.denomination_token_address)
+    raw_amount = token.convert_to_raw(amount)
+
+    control = HotWallet(Account.create())
+    set_balance(web3, control.address, Web3.to_wei(10, "ether"))
+    control.sync_nonce(web3)
+    simple_vault = deploy_contract(web3, "guard/SimpleVaultV0.json", control, control.address, libraries=GUARD_LIBRARIES)
+    _broadcast(control, simple_vault.functions.initialiseOwnership(control.address), web3)
+    guard = get_deployed_contract(web3, "guard/GuardV0.json", simple_vault.functions.guard().call())
+    try:
+        _broadcast(control, guard.functions.whitelistERC4626(vault.address, "Vault deposit probe"), web3)
+    except (*PROBE_EXECUTION_EXCEPTIONS, AnvilProbeTransactionError) as e:
+        return {"outcome": "guard_configuration_error", "message": str(e), "deposit_manager": capability_data, "max_deposit_guidance": max_deposit_guidance}
+
+    try:
+        fund_erc20_on_anvil(web3, token.address, simple_vault.address, raw_amount)
+        if token.fetch_raw_balance_of(simple_vault.address) < raw_amount:
+            return {"outcome": "funding_error", "message": "Anvil token deal did not set the required balance", "deposit_manager": capability_data, "max_deposit_guidance": max_deposit_guidance}
+    except RuntimeError as e:
+        return {"outcome": "funding_error", "message": str(e), "deposit_manager": capability_data, "max_deposit_guidance": max_deposit_guidance}
+    if manager is None:
+        manager = vault.get_deposit_manager()
+    try:
+        if isinstance(manager, ERC4626DepositManager):
+            request = manager.create_deposit_request(owner=simple_vault.address, to=simple_vault.address, raw_amount=raw_amount, check_max_deposit=False)
+        else:
+            request = manager.create_deposit_request(owner=simple_vault.address, to=simple_vault.address, raw_amount=raw_amount)
+    except PROBE_EXECUTION_EXCEPTIONS as e:
+        return {"outcome": "adapter_error", "message": str(e), "deposit_manager": capability_data, "max_deposit_guidance": max_deposit_guidance}
+    if request.value:
+        return {"outcome": "guard_value_unsupported", "message": "SimpleVaultV0 cannot forward native value", "deposit_manager": capability_data, "max_deposit_guidance": max_deposit_guidance}
+
+    try:
+        approval_target = manager.get_deposit_approval_target()
+        approve_target, approve_data = encode_simple_vault_transaction(token.approve(approval_target, amount))
+        guard.functions.validateCall(control.address, approve_target, approve_data).call()
+        encoded_requests = [encode_simple_vault_transaction(function) for function in request.funcs]
+        for target, calldata in encoded_requests:
+            guard.functions.validateCall(control.address, target, calldata).call()
+    except PROBE_EXECUTION_EXCEPTIONS as e:
+        return {"outcome": "guard_validation_error", "message": str(e), "deposit_manager": capability_data, "max_deposit_guidance": max_deposit_guidance}
+
+    try:
+        _broadcast(control, simple_vault.functions.performCall(approve_target, approve_data), web3)
+        allowance = token.contract.functions.allowance(simple_vault.address, approval_target).call()
+        if allowance < raw_amount:
+            return {"outcome": "adapter_error", "message": "Guarded approval did not set the requested allowance", "deposit_manager": capability_data, "max_deposit_guidance": max_deposit_guidance}
+        request_hashes = []
+        for target, calldata in encoded_requests:
+            receipt = _broadcast(control, simple_vault.functions.performCall(target, calldata), web3)
+            request_hashes.append(receipt["transactionHash"])
+    except (*PROBE_EXECUTION_EXCEPTIONS, AnvilProbeTransactionError) as e:
+        return {"outcome": "reverted", "message": str(e), "revert_reason": str(e), "deposit_manager": capability_data, "max_deposit_guidance": max_deposit_guidance}
+
+    result = {
+        "outcome": "success",
+        "message": None,
+        "deposit_manager": capability_data,
+        "deposit_amount": str(amount),
+        "fork_block_number": fork_block_number,
+        "execution_mode": "guard_v0_simple_vault_v0",
+        "denomination_token_address": token.address,
+        "deposit_manager_source": manager_source,
+        "max_deposit_guidance": max_deposit_guidance,
+    }
+    if capability_data["deposit_flow"] == "synchronous":
+        shares = vault.vault_contract.functions.balanceOf(simple_vault.address).call()
+        if shares <= 0:
+            return {**result, "outcome": "adapter_error", "message": "No shares minted to SimpleVaultV0"}
+        result["share_balance_raw"] = str(shares)
+    else:
+        try:
+            ticket = request.parse_deposit_transaction(request_hashes)
+        except PROBE_EXECUTION_EXCEPTIONS as e:
+            return {**result, "outcome": "adapter_error", "message": f"Could not parse async deposit ticket: {e}"}
+        if ticket.owner.lower() != simple_vault.address.lower() or ticket.to.lower() != simple_vault.address.lower():
+            return {**result, "outcome": "adapter_error", "message": "Async ticket does not belong to SimpleVaultV0"}
+        # The request id and all deployed addresses are fork-local diagnostics.
+        # Keep them in logs only: persisted state must not look like a real
+        # chain record after the Anvil process has exited.
+        request_id = getattr(ticket, "request_id", getattr(ticket, "settlement_id", None))
+        logger.info("Fork-local async request id for %s: %s", candidate.key, request_id)
+        result["status_detail"] = "deposit_request_submitted"
+
+    if token.fetch_raw_balance_of(control.address) != 0 or vault.vault_contract.functions.balanceOf(control.address).call() != 0:
+        return {**result, "outcome": "adapter_error", "message": "Control wallet received vault assets or shares"}
+    return result
+
+
+def run_from_environment() -> int:
+    """Run the guarded Anvil probe configured through environment variables.
+
+    Candidate selection comes from the local vault database. The function
+    launches one isolated fork per chain, reverts every vault attempt, and
+    stores the durable result after each attempt. All-protocol runs can take a
+    long time; interactive callers should invoke bounded protocol batches and
+    resume using the status file instead of terminating the complete sweep
+    early.
+
+    :return:
+        Process exit status ``0`` after all selected chain batches finish.
+    :raises RuntimeError:
+        If simulation confirmation, provider validation, or snapshot recovery
+        fails.
+    :raises ValueError:
+        If required environment configuration is malformed or absent.
+    """
+    require_simulation()
+    database_path = Path(os.environ.get("VAULT_DATABASE_PATH", str(DEFAULT_VAULT_DATABASE))).expanduser()
+    status_path = Path(os.environ.get("VAULT_DEPOSIT_STATUS_PATH", str(DEFAULT_STATUS_PATH))).expanduser()
+    selection = os.environ.get("VAULT_SELECTION", "")
+    max_vaults = int(os.environ.get("MAX_VAULTS", "0"))
+    chain_id_text = os.environ.get("CHAIN_ID")
+    chain_id = int(chain_id_text) if chain_id_text else None
+    denomination = os.environ.get("DENOMINATION_TOKEN")
+    denomination_address = Web3.to_checksum_address(denomination) if denomination and Web3.is_address(denomination) else None
+    candidates = select_candidates(
+        VaultDatabase.read(database_path),
+        selection=selection,
+        min_tvl=_read_decimal_env("MIN_TVL") if selection == "min_tvl" else None,
+        denomination_token=denomination_address,
+        protocol=os.environ.get("PROTOCOL"),
+        vault_ids=os.environ.get("VAULT_IDS"),
+        chain_id=chain_id,
+        include_uncertified=os.environ.get("ALLOW_UNCERTIFIED_CANDIDATES", "").lower() == "true",
+        max_per_protocol=max_vaults if selection == "all_protocols" and max_vaults > 0 else None,
+    )
+    if max_vaults > 0 and selection != "all_protocols":
+        candidates = candidates[:max_vaults]
+    if len(candidates) > 1 and os.environ.get("CONFIRM_ALL", "").lower() != "true":
+        raise RuntimeError("Set CONFIRM_ALL=true to run a multi-vault probe")  # noqa: EM101
+    amount = _read_decimal_env("DEPOSIT_AMOUNT")
+
+    grouped: dict[int, list[VaultDepositProbeCandidate]] = defaultdict(list)
+    for candidate in candidates:
+        grouped[candidate.spec.chain_id].append(candidate)
+    output_rows: list[VaultDepositProbeOutput] = []
+    for chain_id, chain_candidates in grouped.items():
+        launch = fork_network_anvil(read_json_rpc_url(chain_id))
+        try:
+            web3 = Web3(HTTPProvider(launch.json_rpc_url))
+            _assert_anvil_target(web3, launch.json_rpc_url, chain_id)
+            if launch.chain_id != chain_id:
+                raise RuntimeError(f"Anvil launch chain id {launch.chain_id} does not match {chain_id}")
+            for candidate in chain_candidates:
+                attempt_snapshot = snapshot(web3)
+                try:
+                    fork_block_number = launch.fork_block_number or web3.eth.block_number
+                    result = probe_candidate(web3, candidate, amount, fork_block_number)
+                except PROBE_EXECUTION_EXCEPTIONS as e:
+                    logger.exception("Probe failed for %s", candidate.key)
+                    result = {"outcome": "rpc_error", "message": str(e)}
+                finally:
+                    if not revert(web3, attempt_snapshot):
+                        raise RuntimeError("Anvil snapshot restoration failed; aborting contaminated chain")  # noqa: EM101
+                result.update({"chain_id": chain_id, "address": candidate.spec.vault_address, "name": candidate.row.get("Name"), "protocol": candidate.row.get("Protocol"), "last_attempt_at": _timestamp()})
+                update_status(status_path, candidate.key, result)
+                output_rows.append(
+                    VaultDepositProbeOutput(
+                        protocol=str(candidate.row.get("Protocol", "<unknown>")),
+                        address=candidate.spec.vault_address,
+                        name=str(candidate.row.get("Name", "")),
+                        denomination_token=candidate.denomination_token_label,
+                        outcome=str(result["outcome"]),
+                        status="Ok (generic ERC-4626)" if result["outcome"] == "success" and result.get("deposit_manager_source") == "generic_erc4626" else "Ok" if result["outcome"] == "success" else str(result["outcome"]),
+                        max_deposit_guidance=str(result.get("max_deposit_guidance", "not available")),
+                        failure_reason=str(result["message"]) if result.get("message") else None,
+                        revert_reason=str(result["revert_reason"]) if result.get("revert_reason") else None,
+                    )
+                )
+        finally:
+            launch.close()
+    log_probe_tables(output_rows)
+    return 0

--- a/eth_defi/erc_4626/deposit_redeem.py
+++ b/eth_defi/erc_4626/deposit_redeem.py
@@ -2,6 +2,7 @@
 
 import datetime
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 from eth_typing import BlockIdentifier, HexAddress
 from hexbytes import HexBytes
@@ -13,6 +14,9 @@ from eth_defi.erc_4626.flow import deposit_4626, redeem_4626
 from eth_defi.timestamp import get_block_timestamp
 from eth_defi.trade import TradeFail, TradeSuccess
 from eth_defi.vault.deposit_redeem import DepositRedeemEventAnalysis, DepositRedeemEventFailure, DepositRequest, DepositTicket, RedemptionRequest, RedemptionTicket, VaultDepositManager
+
+if TYPE_CHECKING:
+    from eth_defi.erc_4626.vault import ERC4626Vault
 
 
 class ERC4626DepositTicket(DepositRequest):
@@ -40,7 +44,7 @@ class ERC4626RedemptionRequest(RedemptionRequest):
 class ERC4626DepositManager(VaultDepositManager):
     """Abstraction over different deposit/redeem flows of vaults."""
 
-    def __init__(self, vault: "eth_defi.erc_4626.vault.ERC4626Vault"):
+    def __init__(self, vault: "ERC4626Vault"):
         from eth_defi.erc_4626.vault import ERC4626Vault
 
         assert isinstance(vault, ERC4626Vault), f"Got {type(vault)}"
@@ -84,7 +88,7 @@ class ERC4626DepositManager(VaultDepositManager):
         check_max_deposit=True,
         check_enough_token=True,
     ) -> ERC4626RedemptionRequest:
-        assert not raw_shares, f"Unsupported raw_shares={raw_shares}"
+        assert raw_shares or shares, "Either raw_shares or shares must be supplied"
         assert not to, f"Unsupported to={to}"
 
         if not raw_shares:

--- a/eth_defi/erc_4626/deposit_redeem.py
+++ b/eth_defi/erc_4626/deposit_redeem.py
@@ -175,14 +175,28 @@ class ERC4626DepositManager(VaultDepositManager):
         claim_tx_hash: HexBytes | str,
         deposit_ticket: DepositTicket | None,
     ) -> DepositRedeemEventAnalysis | DepositRedeemEventFailure:
+        """Analyse a mined ERC-4626 deposit or guarded SimpleVault wrapper.
+
+        A ticket identifies an expected SimpleVault wrapper by address. The
+        event analyser still filters events by the underlying vault address.
+
+        :param claim_tx_hash:
+            Mined deposit transaction hash.
+        :param deposit_ticket:
+            Optional ticket whose owner identifies a guarded wrapper.
+        :return:
+            Decoded executed deposit quantities or a revert description.
+        """
         vault = self.vault
         tx = vault.web3.eth.get_transaction(claim_tx_hash)
         receipt = vault.web3.eth.get_transaction_receipt(claim_tx_hash)
+        guarded_call = deposit_ticket is not None and tx["to"].lower() == deposit_ticket.owner.lower()
         analysis = analyse_4626_flow_transaction(
             vault=vault,
             tx_hash=claim_tx_hash,
             tx_receipt=receipt,
             direction="deposit",
+            hot_wallet=not guarded_call,
         )
 
         match analysis:
@@ -190,14 +204,14 @@ class ERC4626DepositManager(VaultDepositManager):
                 return DepositRedeemEventAnalysis(
                     from_=None,  # TODO
                     to=None,  # TODO
-                    tx_hash=tx_hash,
+                    tx_hash=HexBytes(claim_tx_hash),
                     block_number=tx["blockNumber"],
-                    block_timestamp=get_block_timestamp(tx["blockNumber"]),
-                    share_count=vault.share_token.convert_to_decimals(vault.analysis.amount_out),
+                    block_timestamp=get_block_timestamp(vault.web3, tx["blockNumber"]),
+                    share_count=vault.share_token.convert_to_decimals(analysis.amount_out),
                     denomination_amount=vault.denomination_token.convert_to_decimals(analysis.amount_in),
                 )
             case TradeFail():
-                return DepositRedeemEventFailure(tx_hash=claim_tx_hash, revert_reason=analysis.revert_reason)
+                return DepositRedeemEventFailure(tx_hash=HexBytes(claim_tx_hash), revert_reason=analysis.revert_reason)
             case _:
                 raise NotImplementedError(f"Unknown {type(analysis)}")
 
@@ -206,4 +220,42 @@ class ERC4626DepositManager(VaultDepositManager):
         claim_tx_hash: HexBytes | str,
         redemption_ticket: RedemptionTicket | None,
     ) -> DepositRedeemEventAnalysis | DepositRedeemEventFailure:
-        return self.analyse_deposit(claim_tx_hash, redemption_ticket=redemption_ticket)
+        """Analyse a mined ERC-4626 redemption or guarded SimpleVault wrapper.
+
+        A ticket identifies the wrapper only for the transaction-target check;
+        the decoded ``Withdraw`` event must still originate from this vault.
+
+        :param claim_tx_hash:
+            Mined redemption transaction hash.
+        :param redemption_ticket:
+            Optional ticket whose owner identifies a guarded wrapper.
+        :return:
+            Decoded executed redemption quantities or a revert description.
+        """
+        vault = self.vault
+        tx = vault.web3.eth.get_transaction(claim_tx_hash)
+        receipt = vault.web3.eth.get_transaction_receipt(claim_tx_hash)
+        guarded_call = redemption_ticket is not None and tx["to"].lower() == redemption_ticket.owner.lower()
+        analysis = analyse_4626_flow_transaction(
+            vault=vault,
+            tx_hash=claim_tx_hash,
+            tx_receipt=receipt,
+            direction="redeem",
+            hot_wallet=not guarded_call,
+        )
+
+        match analysis:
+            case TradeSuccess():
+                return DepositRedeemEventAnalysis(
+                    from_=None,
+                    to=None,
+                    tx_hash=HexBytes(claim_tx_hash),
+                    block_number=tx["blockNumber"],
+                    block_timestamp=get_block_timestamp(vault.web3, tx["blockNumber"]),
+                    share_count=vault.share_token.convert_to_decimals(analysis.amount_in),
+                    denomination_amount=vault.denomination_token.convert_to_decimals(analysis.amount_out),
+                )
+            case TradeFail():
+                return DepositRedeemEventFailure(tx_hash=HexBytes(claim_tx_hash), revert_reason=analysis.revert_reason)
+            case _:
+                raise NotImplementedError(f"Unknown {type(analysis)}")

--- a/eth_defi/erc_4626/flow.py
+++ b/eth_defi/erc_4626/flow.py
@@ -8,7 +8,6 @@ from web3.contract.contract import ContractFunction
 
 from eth_defi.erc_4626.vault import ERC4626Vault
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -221,7 +220,10 @@ def redeem_4626(
         assert amount > 0
         raw_amount = vault.share_token.convert_to_raw(amount)
 
-    raw_available = vault.share_token.fetch_raw_balance_of(owner)
+    # ERC-4626 shares are the vault's own ERC-20 balance. Reading balanceOf()
+    # directly avoids a separate ERC-7575 share-token classification RPC that
+    # can fail even when the standard redemption call is usable.
+    raw_available = contract.functions.balanceOf(owner).call()
 
     # Apply epsilon correction
     # AssertionError: Max redeem 980060998000964315 is less than 980060999302489527, -1301525212 (-1.301525212e-09)
@@ -233,8 +235,7 @@ def redeem_4626(
             raw_amount = raw_available
 
     if check_enough_token:
-        raw_actual_balance = vault.share_token.fetch_raw_balance_of(owner)
-        assert raw_actual_balance >= raw_amount, f"ERC-4626 redemption: {owner} does not have enough tokens to complete redeem from {vault.address}, has {raw_actual_balance}, wanted to redeem {raw_amount}"
+        assert raw_available >= raw_amount, f"ERC-4626 redemption: {owner} does not have enough tokens to complete redeem from {vault.address}, has {raw_available}, wanted to redeem {raw_amount}"
 
     if check_max_redeem:
         max_redeem = contract.functions.maxRedeem(receiver).call()

--- a/eth_defi/erc_4626/scan.py
+++ b/eth_defi/erc_4626/scan.py
@@ -283,14 +283,6 @@ def create_vault_scan_record(
         Dict for human-readable tables, with internal columns prefixed with å underscore
     """
 
-    vault = create_vault_instance(
-        web3,
-        detection.address,
-        detection.features,
-        token_cache=token_cache,
-        default_block_identifier=block_identifier,
-    )
-
     empty_record = {
         "Symbol": "",
         "Name": "",
@@ -311,7 +303,16 @@ def create_vault_scan_record(
         "_fees": None,
         "_flags": {},
         "_notes": None,
+        "_deposit_manager": None,
     }
+
+    vault = create_vault_instance(
+        web3,
+        detection.address,
+        detection.features,
+        token_cache=token_cache,
+        default_block_identifier=block_identifier,
+    )
 
     if vault is None:
         # Probably not ERC-4626
@@ -352,6 +353,8 @@ def create_vault_scan_record(
         description = vault.description
         short_description = vault.short_description
         notes = _normalise_scan_note(vault.get_notes(), description, short_description)
+        capability_resolver = getattr(vault, "get_deposit_manager_capability", None)
+        deposit_manager_capability = capability_resolver() if capability_resolver is not None else None
 
         data = {
             "Symbol": vault.symbol,
@@ -381,6 +384,7 @@ def create_vault_scan_record(
             "_notes": notes,
             "_manager_name": vault.manager_name,
             "_morpho_offchain_data": vault.morpho_offchain_data if isinstance(vault, (MorphoV1Vault, MorphoV2Vault)) else None,
+            "_deposit_manager": deposit_manager_capability.as_initial_public_schema() if deposit_manager_capability else None,
         }
         data.update(activity_status)
         data.update(lending_stats)

--- a/eth_defi/erc_4626/vault.py
+++ b/eth_defi/erc_4626/vault.py
@@ -4,21 +4,14 @@ import datetime
 import logging
 from decimal import Decimal
 from functools import cached_property
-from typing import Any, Iterable, Literal, TypeAlias
+from typing import TYPE_CHECKING, Any, Iterable, Literal, TypeAlias
 
 import eth_abi
 from eth_typing import HexAddress
 from requests.exceptions import HTTPError
 from web3 import Web3
 from web3.contract import Contract
-
-from eth_defi.middleware import ProbablyNodeHasNoBlock
-from eth_defi.provider.broken_provider import get_safe_cached_latest_block_number
-from eth_defi.provider.fallback import ExtraValueError
-from eth_defi.vault.flag import VaultFlag
-
-from web3.exceptions import BadFunctionCallOutput, BlockNumberOutOfRange
-
+from web3.exceptions import BadFunctionCallOutput, BlockNumberOutOfRange, ContractLogicError, Web3Exception
 from web3.types import BlockIdentifier
 
 from eth_defi.abi import ZERO_ADDRESS_STR
@@ -32,14 +25,50 @@ from eth_defi.erc_4626.vault_token import (
 )
 from eth_defi.event_reader.conversion import BadAddressError, convert_int256_bytes_to_int, convert_uint256_bytes_to_address
 from eth_defi.event_reader.multicall_batcher import BatchCallState, EncodedCall, EncodedCallResult
+from eth_defi.middleware import ProbablyNodeHasNoBlock
+from eth_defi.provider.broken_provider import get_safe_cached_latest_block_number
+from eth_defi.provider.fallback import ExtraValueError
 from eth_defi.token import TokenDetails, TokenDiskCache, fetch_erc20_details, is_stablecoin_like
-from eth_defi.vault.base import DEPOSIT_CLOSED_CAP_REACHED, DEPOSIT_CLOSED_PAUSED, REDEMPTION_CLOSED_INSUFFICIENT_LIQUIDITY, REDEMPTION_CLOSED_PAUSED, TradingUniverse, VaultBase, VaultFlowManager, VaultHistoricalRead, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
+from eth_defi.vault.base import DEPOSIT_CLOSED_CAP_REACHED, REDEMPTION_CLOSED_INSUFFICIENT_LIQUIDITY, TradingUniverse, VaultBase, VaultFlowManager, VaultHistoricalRead, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
+from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
+from eth_defi.vault.flag import VaultFlag
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
 
 
 #: The exchange rate we use for all unknown denomination tokens
 UNKNOWN_EXCHANGE_RATE = Decimal(0.99)
+
+#: Protocol reader classes whose guarded fork probes completed a deposit using
+#: their implemented deposit manager.
+#:
+#: The exact-class rule is intentional: a specialised subclass must be
+#: separately certified instead of inheriting public transaction support.
+CERTIFIED_SYNCHRONOUS_DEPOSIT_MANAGER_CLASSES = frozenset(
+    {
+        "eth_defi.erc_4626.vault_protocol.autopool.vault.AutoPoolVault",
+        "eth_defi.erc_4626.vault_protocol.dolomite.vault.DolomiteVault",
+        "eth_defi.erc_4626.vault_protocol.euler.vault.EulerVault",
+        "eth_defi.erc_4626.vault_protocol.euler.vault.EulerEarnVault",
+        "eth_defi.erc_4626.vault_protocol.fluid.vault.FluidVault",
+        "eth_defi.erc_4626.vault_protocol.gearbox.vault.GearboxVault",
+        "eth_defi.erc_4626.vault_protocol.goat.vault.GoatVault",
+        "eth_defi.erc_4626.vault_protocol.ipor.vault.IPORVault",
+        "eth_defi.erc_4626.vault_protocol.morpho.vault_v1.MorphoV1Vault",
+        "eth_defi.erc_4626.vault_protocol.morpho.vault_v2.MorphoV2Vault",
+        "eth_defi.erc_4626.vault_protocol.plutus.vault.PlutusVault",
+        "eth_defi.erc_4626.vault_protocol.royco.vault.RoycoVault",
+        "eth_defi.erc_4626.vault_protocol.silo.vault.SiloVault",
+        "eth_defi.erc_4626.vault_protocol.summer.vault.SummerVault",
+        "eth_defi.erc_4626.vault_protocol.superform.vault.SuperformVault",
+        "eth_defi.erc_4626.vault_protocol.usdx_money.vault.USDXMoneyVault",
+        "eth_defi.erc_4626.vault_protocol.yearn.vault.YearnV3Vault",
+        "eth_defi.erc_4626.vault_protocol.yo.vault.YoVault",
+    }
+)
 
 #: Known error messages that indicate that share() accessor function
 #: is not accessible and contract is ERC-4626, not ERC-7540.
@@ -830,7 +859,7 @@ class ERC4626Vault(VaultBase):
             :py:exc:`RuntimeError` when the on-chain lookup returns ``None``.
         """
 
-        if type(features) == set:
+        if isinstance(features, set):
             assert len(features) >= 1, "If given, the vault features set should contain at least one feature"
 
         super().__init__(token_cache=token_cache, require_denomination_token=require_denomination_token)
@@ -1128,7 +1157,7 @@ class ERC4626Vault(VaultBase):
             #  {'code': -32603, 'message': 'Failed to call: InvalidTransaction(Revert(RevertError { output: None }))'}
             parsed_error = str(e)
             if not any(msg in parsed_error for msg in KNOWN_SHARE_TOKEN_ERROR_MESSAGES):
-                logger.error(f"fetch_share_token(): Not sure about exception %s", e)
+                logger.error("fetch_share_token(): Not sure about exception %s", e)
                 raise
             # Positively classified: contract is not ERC-7575. Cacheable.
             share_token_address = self.vault_address
@@ -1307,10 +1336,65 @@ class ERC4626Vault(VaultBase):
     def get_flow_manager(self) -> VaultFlowManager:
         return NotImplementedError()
 
-    def get_deposit_manager(self) -> "eth_defi.erc_4626.deposit_redeem.ERC4626DepositManager":
+    def get_deposit_manager(self) -> "ERC4626DepositManager":
         from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
 
         return ERC4626DepositManager(self)
+
+    def get_deposit_manager_capability(self) -> VaultDepositManagerCapability | None:
+        """Declare the exact generic ERC-4626 implementation's two-way flow.
+
+        Subclasses need exact-type inclusion in
+        :data:`CERTIFIED_SYNCHRONOUS_DEPOSIT_MANAGER_CLASSES`. The guarded probe
+        may separately use :meth:`supports_generic_deposit_manager` as a
+        temporary fallback without advertising it as public metadata.
+
+        :return:
+            Synchronous two-way capability for the exact base class, otherwise
+            ``None``.
+        """
+        class_name = f"{type(self).__module__}.{type(self).__qualname__}"
+        if type(self) is not ERC4626Vault and class_name not in CERTIFIED_SYNCHRONOUS_DEPOSIT_MANAGER_CLASSES:
+            return None
+        return self.get_synchronous_deposit_manager_capability()
+
+    def get_synchronous_deposit_manager_capability(self) -> VaultDepositManagerCapability:
+        """Build static metadata for a verified synchronous manager.
+
+        A caller must already have established the reader class' guarded fork
+        evidence. This deliberately performs no RPC reads: the capability is
+        static library metadata, not a live vault availability check.
+
+        :return:
+            Synchronous two-way capability.
+        """
+        return VaultDepositManagerCapability(
+            can_deposit=True,
+            can_redeem=True,
+            deposit_flow="synchronous",
+            redemption_flow="synchronous",
+        )
+
+    def supports_generic_deposit_manager(self) -> bool:
+        """Check whether the live vault exposes the standard ERC-4626 surface.
+
+        This is deliberately an interface check, not a public support claim.
+        Callers must still execute a guarded fork probe before relying on the
+        generic manager for a protocol-specific adapter.
+
+        :return:
+            ``True`` when ``asset`` succeeds with a non-zero asset address.
+            Deposit and redemption availability is established only by a guarded
+            fork transaction, not by ERC-4626 ``max*`` advisory values.
+        """
+        try:
+            asset = self.vault_contract.functions.asset().call()
+        except (BadFunctionCallOutput, ContractLogicError, ValueError, Web3Exception):
+            return False
+
+        if not Web3.is_address(asset) or asset == ZERO_ADDRESS_STR:
+            return False
+        return True
 
     def has_block_range_event_support(self):
         raise NotImplementedError()

--- a/eth_defi/erc_4626/vault_protocol/gains/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/gains/deposit_redeem.py
@@ -208,6 +208,43 @@ class GainsDepositManager(ERC4626DepositManager):
             redemption_ticket.to,
         )
 
+    def serialize_redemption_ticket(self, ticket: GainsRedemptionTicket) -> dict:
+        """Serialise Gains' epoch fields alongside the base ticket data.
+
+        The redemption lifecycle survives a process restart only when both
+        epoch numbers are retained: they determine when ``finish_redemption``
+        becomes available.
+
+        :param ticket:
+            Gains epoch redemption ticket to persist.
+        :return:
+            JSON-compatible base and epoch ticket fields.
+        """
+        assert isinstance(ticket, GainsRedemptionTicket)
+        data = super().serialize_redemption_ticket(ticket)
+        data["vault_current_epoch"] = ticket.current_epoch
+        data["vault_unlock_epoch"] = ticket.unlock_epoch
+        return data
+
+    def reconstruct_redemption_ticket(self, data: dict) -> GainsRedemptionTicket:
+        """Rebuild a Gains redemption ticket from persistent JSON data.
+
+        :param data:
+            JSON-compatible data previously returned by
+            :py:meth:`serialize_redemption_ticket`.
+        :return:
+            Ticket suitable for status checks and later redemption.
+        """
+        return GainsRedemptionTicket(
+            vault_address=data["vault_address"],
+            owner=data["vault_owner"],
+            to=data.get("vault_to", data["vault_owner"]),
+            raw_shares=int(data["vault_raw_amount"]),
+            tx_hash=HexBytes(data["vault_request_tx_hash"]),
+            current_epoch=int(data["vault_current_epoch"]),
+            unlock_epoch=int(data["vault_unlock_epoch"]),
+        )
+
     def has_synchronous_redemption(self) -> bool:
         return False
 

--- a/eth_defi/erc_4626/vault_protocol/gains/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/gains/vault.py
@@ -530,6 +530,22 @@ class GainsVault(ERC4626Vault):
 
         return GainsDepositManager(self)
 
+    def get_deposit_manager_capability(self) -> "VaultDepositManagerCapability | None":
+        """Declare Gains' direct deposit and epoch redemption lifecycle.
+
+        :return:
+            Two-way capability with synchronous deposits and asynchronous
+            redemptions.
+        """
+        from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
+
+        return VaultDepositManagerCapability(
+            can_deposit=True,
+            can_redeem=True,
+            deposit_flow="synchronous",
+            redemption_flow="asynchronous",
+        )
+
     def fetch_deposit_closed_reason(self) -> str | None:
         """Check if deposits are closed.
 
@@ -756,6 +772,27 @@ class OstiumVault(GainsVault):
         from eth_defi.erc_4626.vault_protocol.gains.deposit_redeem import GainsDepositManager
 
         return GainsDepositManager(self)
+
+    def get_deposit_manager_capability(self) -> "VaultDepositManagerCapability | None":
+        """Declare only the current Ostium V1.5 request lifecycle.
+
+        Legacy V1 remains readable through the adapter but is intentionally not
+        advertised as a public transaction integration.
+
+        :return:
+            V1.5 asynchronous two-way capability, or ``None`` for legacy V1.
+        """
+        if self.version != OstiumVersion.v1_5:
+            return None
+
+        from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
+
+        return VaultDepositManagerCapability(
+            can_deposit=True,
+            can_redeem=True,
+            deposit_flow="asynchronous",
+            redemption_flow="asynchronous",
+        )
 
     def get_historical_reader(self, stateful) -> VaultHistoricalReader:
         """Return version-appropriate historical reader."""

--- a/eth_defi/erc_4626/vault_protocol/lagoon/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/vault.py
@@ -887,6 +887,21 @@ class LagoonVault(ERC7540Vault, AutomatedSafe):
 
         return ERC7540DepositManager(self)
 
+    def get_deposit_manager_capability(self) -> "VaultDepositManagerCapability | None":
+        """Declare Lagoon's ERC-7540 request-and-claim lifecycle.
+
+        :return:
+            Two-way asynchronous capability.
+        """
+        from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
+
+        return VaultDepositManagerCapability(
+            can_deposit=True,
+            can_redeem=True,
+            deposit_flow="asynchronous",
+            redemption_flow="asynchronous",
+        )
+
     def can_check_deposit(self) -> bool:
         """Lagoon's maxDeposit does not work correctly for deposit availability checks."""
         return False

--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
@@ -25,7 +25,6 @@ from typing import Iterable
 from eth_typing import BlockIdentifier
 from web3 import Web3
 
-from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.morpho.flag_analytics import analyze_morpho_flags
@@ -38,12 +37,7 @@ from eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata import (
 )
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.types import Percent
-from eth_defi.vault.base import (
-    DEPOSIT_CLOSED_CAP_REACHED,
-    REDEMPTION_CLOSED_INSUFFICIENT_LIQUIDITY,
-    VaultHistoricalRead,
-    VaultHistoricalReader,
-)
+from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
 from eth_defi.vault.flag import NOT_IN_MORPHO_API, VaultFlag
 
 logger = logging.getLogger(__name__)
@@ -413,29 +407,27 @@ class MorphoV2Vault(ERC4626Vault):
         return int.from_bytes(data[0:32], byteorder="big")
 
     def fetch_deposit_closed_reason(self) -> str | None:
-        """Check maxDeposit to determine if deposits are closed.
+        """Return no static deposit-closure decision for Morpho V2.
 
-        Morpho vaults are utilisation-based.
+        Morpho V2 intentionally returns zero for ``maxDeposit`` regardless of
+        the caller. Its external asset and share gates decide whether the
+        actual deposit succeeds, so a guarded transaction is required.
+
+        :return:
+            Always ``None`` because ERC-4626 ``maxDeposit`` is advisory only.
         """
-        try:
-            max_deposit = self.vault_contract.functions.maxDeposit(ZERO_ADDRESS_STR).call()
-            if max_deposit == 0:
-                return f"{DEPOSIT_CLOSED_CAP_REACHED} (maxDeposit=0)"
-        except Exception:
-            pass
         return None
 
     def fetch_redemption_closed_reason(self) -> str | None:
-        """Check maxRedeem to determine if redemptions are closed.
+        """Return no static redemption-closure decision for Morpho V2.
 
-        Morpho vaults are utilisation-based.
+        Morpho V2 intentionally returns zero for ``maxRedeem`` regardless of
+        account state.  Its external gates and the actual redemption determine
+        whether an account can exit.
+
+        :return:
+            Always ``None`` because ERC-4626 ``maxRedeem`` is advisory only.
         """
-        try:
-            max_redeem = self.vault_contract.functions.maxRedeem(ZERO_ADDRESS_STR).call()
-            if max_redeem == 0:
-                return f"{REDEMPTION_CLOSED_INSUFFICIENT_LIQUIDITY} (maxRedeem=0)"
-        except Exception:
-            pass
         return None
 
     def fetch_deposit_next_open(self) -> datetime.datetime | None:
@@ -447,11 +439,12 @@ class MorphoV2Vault(ERC4626Vault):
         return None
 
     def can_check_redeem(self) -> bool:
-        """Morpho V2 supports address(0) checks for redemption availability.
+        """Report that Morpho V2 ``maxRedeem`` cannot determine availability.
 
-        - maxRedeem(address(0)) returns 0 when redemptions are blocked
+        :return:
+            ``False`` because Morpho V2 always conservatively reports zero.
         """
-        return True
+        return False
 
     def get_historical_reader(self, stateful: bool) -> VaultHistoricalReader:
         """Get Morpho V2-specific historical reader with utilisation metrics."""

--- a/eth_defi/erc_4626/vault_protocol/upshift/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/upshift/vault.py
@@ -396,6 +396,28 @@ class UpshiftVault(ERC4626Vault):
 
         return super().get_deposit_manager()
 
+    def get_deposit_manager_capability(self) -> "VaultDepositManagerCapability | None":
+        """Declare only Upshift's normal ERC-4626 vault shape.
+
+        Multi-asset accounting vaults use a separate application flow and must
+        never be represented as generic deposit-manager support.
+
+        :return:
+            Synchronous two-way capability for the normal shape, or ``None``
+            for multi-asset vaults.
+        """
+        if self.multi_asset_like:
+            return None
+
+        from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
+
+        return VaultDepositManagerCapability(
+            can_deposit=True,
+            can_redeem=True,
+            deposit_flow="synchronous",
+            redemption_flow="synchronous",
+        )
+
     def can_check_deposit(self) -> bool:
         """Can the generic ERC-4626 ``maxDeposit(address(0))`` probe be used."""
 

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -2625,6 +2625,7 @@ def format_lifetime_table(
     # Offchain descriptions and protocol extension data are exported via JSON API, not human-readable table
     _del("description")
     _del("short_description")
+    _del("deposit_manager")
     _del("other_data")
     _del("core3")
     _del("denomination_token_rate")

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -271,6 +271,12 @@ class VaultMetricsRecord(TypedDict, total=False):
     #: value must NOT be defaulted to 18 (see ``denomination_token_address``).
     denomination_decimals: int | None
 
+    #: Static support for this library's deposit/redemption manager, or ``None``.
+    #:
+    #: This does not mean the vault is currently open or that an account has
+    #: permission, funds, acceptable slippage, spare cap, or liquidity.
+    deposit_manager: dict | None
+
     #: Share token ERC-20 decimals (the vault's own ERC-4626 token).
     share_token_decimals: int | None
 
@@ -2037,6 +2043,10 @@ def calculate_vault_record(
             "redemption_closed_reason": redemption_closed_reason,
             "deposit_next_open": deposit_next_open,
             "redemption_next_open": redemption_next_open,
+            # Static adapter support, distinct from the live closed-reason
+            # fields immediately above.  Old metadata pickles safely export
+            # null until they have been rescanned.
+            "deposit_manager": vault_metadata.get("_deposit_manager"),
             # Lending protocol statistics
             "available_liquidity": available_liquidity,
             "utilisation": utilisation,

--- a/eth_defi/vault/base.py
+++ b/eth_defi/vault/base.py
@@ -32,7 +32,7 @@ from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResu
 from eth_defi.token import DEFAULT_TOKEN_CACHE, TokenAddress, TokenDetails, fetch_erc20_details
 from eth_defi.types import Percent
 from eth_defi.utils import is_good_multichain_address
-from eth_defi.vault.deposit_redeem import VaultDepositManager
+from eth_defi.vault.deposit_redeem import VaultDepositManager, VaultDepositManagerCapability
 from eth_defi.vault.lower_case_dict import LowercaseDict
 from eth_defi.version_info import stamp_parquet_schema_metadata
 
@@ -1119,6 +1119,20 @@ class VaultBase(ABC):
     def deposit_manager(self) -> VaultDepositManager:
         """Deposit manager assocaited with this vault"""
         return self.get_deposit_manager()
+
+    def get_deposit_manager_capability(self) -> VaultDepositManagerCapability | None:
+        """Return static public transaction-adapter support, if any.
+
+        This method deliberately does not attempt to construct a manager or
+        query live pause, cap, epoch, balance, allow-list, or liquidity state.
+        Adapters opt in only after their complete deposit and redemption
+        lifecycles have focused coverage.  ``None`` is therefore the safe
+        default for unknown and protocol-specific vaults.
+
+        :return:
+            Adapter-specific capability object, or ``None`` when unsupported.
+        """
+        return None
 
     @abstractmethod
     def has_block_range_event_support(self) -> bool:

--- a/eth_defi/vault/deposit_redeem.py
+++ b/eth_defi/vault/deposit_redeem.py
@@ -8,6 +8,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from decimal import Decimal
 from pprint import pformat
+from typing import Literal
 
 from eth_typing import BlockIdentifier, BlockNumber, HexAddress
 from hexbytes import HexBytes
@@ -19,6 +20,76 @@ from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.vault.flow_events import PendingVaultFlow, VaultFlowDirection
 
 logger = logging.getLogger(__name__)
+
+
+VaultDepositFlow = Literal["synchronous", "asynchronous"]
+
+
+@dataclass(frozen=True, slots=True)
+class VaultDepositManagerCapability:
+    """Static public integration capability of a vault deposit manager.
+
+    This describes support implemented by :mod:`eth_defi`, rather than the
+    vault's live cap, pause, allow-list, token balance, or liquidity state.
+    A historical probe cannot establish future acceptance: consumers must make
+    the request against current chain state and handle a current-state revert.
+
+    :param can_deposit:
+        Whether a complete public deposit lifecycle is implemented.
+    :param can_redeem:
+        Whether a complete public redemption lifecycle is implemented.
+    :param deposit_flow:
+        Request lifecycle for deposits when supported.
+    :param redemption_flow:
+        Request lifecycle for redemptions when supported.
+    """
+
+    can_deposit: bool
+    can_redeem: bool
+    deposit_flow: VaultDepositFlow | None = None
+    redemption_flow: VaultDepositFlow | None = None
+
+    def __post_init__(self) -> None:
+        """Validate that supported operations have a lifecycle declaration.
+
+        :raises ValueError:
+            If an operation flag and its flow declaration disagree.
+        """
+        if (self.deposit_flow is not None) != self.can_deposit:
+            raise ValueError("deposit_flow must be present exactly when deposits are supported")
+        if (self.redemption_flow is not None) != self.can_redeem:
+            raise ValueError("redemption_flow must be present exactly when redemptions are supported")
+
+    def as_dict(self) -> dict[str, bool | str]:
+        """Convert the capability to JSON-compatible primitives.
+
+        :return:
+            Directional capability object suitable for internal persistence.
+        """
+        result: dict[str, bool | str] = {
+            "can_deposit": self.can_deposit,
+            "can_redeem": self.can_redeem,
+        }
+        if self.deposit_flow is not None:
+            result["deposit_flow"] = self.deposit_flow
+        if self.redemption_flow is not None:
+            result["redemption_flow"] = self.redemption_flow
+        return result
+
+    def as_initial_public_schema(self) -> dict[str, bool | str] | None:
+        """Return the initial public schema or fail closed for partial support.
+
+        The first export version intentionally advertises only two-way manager
+        support.  Keeping the internal representation directional leaves room
+        for a future schema revision without making a partial manager look
+        depositable today.
+
+        :return:
+            Two-way public capability object, or ``None`` for partial support.
+        """
+        if not (self.can_deposit and self.can_redeem):
+            return None
+        return self.as_dict()
 
 
 class AsyncVaultRequestStatus(enum.Enum):
@@ -465,6 +536,19 @@ class VaultDepositManager(ABC):
         Vault can be full?
         """
         raise NotImplementedError(f"Class {self.__class__.__name__} does not implement can_create_deposit_request()")
+
+    def get_deposit_approval_target(self) -> HexAddress:
+        """Return the ERC-20 spender required for a deposit request.
+
+        Standard ERC-4626 and the currently supported async adapters pull
+        denomination tokens from the vault address itself.  An adapter using a
+        different router or silo must override this method; guarded callers use
+        it to whitelist and validate the exact approval calldata.
+
+        :return:
+            ERC-20 approval spender address.
+        """
+        return self.vault.address
 
     def fetch_vault_flow_events(
         self,

--- a/eth_defi/vault/top_vaults_json.py
+++ b/eth_defi/vault/top_vaults_json.py
@@ -597,6 +597,9 @@ def annotate_fallback_record(record: dict, state_entry: dict, fallback_reason: s
         Annotated copy.
     """
     annotated = copy_export_record(record)
+    # A sticky row is not current adapter certification.  Never replay a
+    # previous positive manager capability when the live scan is unavailable.
+    annotated["deposit_manager"] = None
     annotated["sticky_export"] = True
     annotated["sticky_reason"] = "previously_passed_filter"
     annotated["stale_export"] = True

--- a/eth_defi/vault/vaultdb.py
+++ b/eth_defi/vault/vaultdb.py
@@ -121,6 +121,12 @@ class VaultRow(TypedDict):
     #: TypedDict when populated.
     _morpho_offchain_data: dict | None
 
+    #: Static two-way public vault transaction adapter support, or ``None``.
+    #:
+    #: This private scanner value is copied to ``deposit_manager`` in the JSON
+    #: export.  It is deliberately cleared when a rescan is broken.
+    _deposit_manager: dict | None
+
     #: Protocol-supplied vault manager or curator display name.
     #:
     #: Used by :py:func:`eth_defi.vault.curator.identify_curator` when the
@@ -289,6 +295,9 @@ class VaultDatabase:
                     new_row.get("Name"),
                     existing.get("Name"),
                 )
+                retained = existing.copy()
+                retained["_deposit_manager"] = None
+                self.rows[spec] = retained
                 continue
             self.rows[spec] = new_row
 

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -1279,11 +1279,16 @@ JSON_RPC_URL=$JSON_RPC_BASE poetry run python scripts/erc-4626/erc-4626-deposit-
 ### probe-vault-deposits.py
 
 Probe public vault deposit adapters through a freshly deployed
-``SimpleVaultV0`` and its ``GuardV0`` on an Anvil fork. The control wallet is
-ephemeral and pays only gas. The script uses Anvil's ERC-20 storage deal to
-fund the SimpleVault with the denomination token; resulting shares or async
-requests belong to that SimpleVault. The script never broadcasts to the source
-RPC and refuses to run unless ``SIMULATE=true``. The detailed table records
+``SimpleVaultV0`` and its ``GuardV0`` on an Anvil fork. Synchronous adapters
+must also redeem the minted shares through the same guard before the attempt
+is successful; asynchronous redemption remains a separately documented,
+unexercised lifecycle. The control wallet is ephemeral and pays only gas. The
+script uses Anvil's ERC-20 storage deal to fund the SimpleVault with the
+denomination token; resulting shares or async requests belong to that
+SimpleVault. Each candidate receives a fresh Anvil process so a blocked
+upstream state read cannot contaminate the next attempt. The script never
+broadcasts to the source RPC and refuses to run unless ``SIMULATE=true``. The
+detailed table records
 each ERC-4626 ``maxDeposit(address(0))`` response in its **maxDeposit
 guidance** column, but this advisory value never determines whether a vault is
 tested or marked depositable; only the guarded deposit transaction does. This

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -1275,3 +1275,75 @@ ERC-4626 vault deposit and redeem script. Supports simulation mode on Anvil main
 ```shell
 JSON_RPC_URL=$JSON_RPC_BASE poetry run python scripts/erc-4626/erc-4626-deposit-redeem.py
 ```
+
+### probe-vault-deposits.py
+
+Probe public vault deposit adapters through a freshly deployed
+``SimpleVaultV0`` and its ``GuardV0`` on an Anvil fork. The control wallet is
+ephemeral and pays only gas. The script uses Anvil's ERC-20 storage deal to
+fund the SimpleVault with the denomination token; resulting shares or async
+requests belong to that SimpleVault. The script never broadcasts to the source
+RPC and refuses to run unless ``SIMULATE=true``. The detailed table records
+each ERC-4626 ``maxDeposit(address(0))`` response in its **maxDeposit
+guidance** column, but this advisory value never determines whether a vault is
+tested or marked depositable; only the guarded deposit transaction does. This
+is required for contracts such as Morpho V2 that intentionally always return
+zero. The saved result is historical adapter evidence, not a permission to
+deposit later: production callers must execute their own current-state
+preflight or handle the live transaction revert.
+
+Start with one explicit vault:
+
+```shell
+SIMULATE=true \
+VAULT_SELECTION=vault_ids \
+VAULT_IDS="8453-0xYourVault" \
+DEPOSIT_AMOUNT=10 \
+poetry run python scripts/erc-4626/probe-vault-deposits.py
+```
+
+For a bounded protocol or same-token NAV run, also set ``CONFIRM_ALL=true``
+when more than one vault is selected:
+
+```shell
+SIMULATE=true VAULT_SELECTION=protocol PROTOCOL=Lagoon CHAIN_ID=42161 MAX_VAULTS=5 \
+CONFIRM_ALL=true DEPOSIT_AMOUNT=10 \
+poetry run python scripts/erc-4626/probe-vault-deposits.py
+```
+
+To test the five largest candidates of every Arbitrum protocol in one fork
+batch, use the explicit legacy-row opt-in until the scanner has regenerated
+the metadata pickle:
+
+```shell
+SIMULATE=true VAULT_SELECTION=all_protocols CHAIN_ID=42161 MAX_VAULTS=5 \
+ALLOW_UNCERTIFIED_CANDIDATES=true CONFIRM_ALL=true DEPOSIT_AMOUNT=10 \
+poetry run python scripts/erc-4626/probe-vault-deposits.py
+```
+
+| Variable | Description |
+|----------|-------------|
+| `SIMULATE` | Required. Must be exactly `true`; the script is Anvil-only. |
+| `VAULT_SELECTION` | Exactly one mode: `vault_ids`, `protocol`, `all_protocols`, or `min_tvl`. |
+| `VAULT_IDS` | Comma-separated `chain_id-vault_address` values for `vault_ids`. |
+| `PROTOCOL` | Case-insensitive protocol name for `protocol`. |
+| `CHAIN_ID` | Optional chain filter for every selection mode. |
+| `ALLOW_UNCERTIFIED_CANDIDATES` | Set to `true` only to probe legacy rows lacking scanner metadata; live Anvil capability checks still fail closed. |
+| `MIN_TVL` | Minimum USD NAV for `min_tvl`. |
+| `DENOMINATION_TOKEN` | Optional denomination-token filter for `min_tvl`. |
+| `DEPOSIT_AMOUNT` | Positive, human-readable denomination-token amount. |
+| `VAULT_DATABASE_PATH` | Optional metadata-pickle path. |
+| `VAULT_DEPOSIT_STATUS_PATH` | Optional status-artifact path; default `eth_defi/data/deposit-status/vault-deposit-status.json`. See [`README-deposit-status.md`](../../eth_defi/data/deposit-status/README-deposit-status.md) for the review and refresh procedure. |
+| `MAX_VAULTS` | Optional limit. Protocol mode ranks candidates by descending scanned NAV before truncating; `all_protocols` applies it independently to each protocol. |
+| `CONFIRM_ALL` | Must be `true` when probing more than one selected vault. |
+
+The status file stores durable evidence only: fork block, adapter capability,
+amount, outcome and synchronously minted share amount where applicable. It
+does not store transaction hashes, request IDs, private keys, or addresses of
+the temporary Anvil-deployed contracts.
+
+After every run, the script prints a detailed table with protocol, vault
+address, name, denomination token and failure reason. Successful rows appear
+first with `Ok` as their failure reason. A second table provides outcome counts
+and percentages. For a mined failed call, the separate **Revert reason** column
+contains the reason replayed on the temporary Anvil fork.

--- a/scripts/erc-4626/probe-vault-deposits.py
+++ b/scripts/erc-4626/probe-vault-deposits.py
@@ -1,0 +1,8 @@
+"""Run guarded, Anvil-only vault deposit probes configured through environment variables."""
+
+from eth_defi.erc_4626.deposit_probe import run_from_environment
+from eth_defi.utils import setup_console_logging
+
+if __name__ == "__main__":
+    setup_console_logging(default_log_level="info")
+    raise SystemExit(run_from_environment())

--- a/tests/erc_4626/test_deposit_probe.py
+++ b/tests/erc_4626/test_deposit_probe.py
@@ -7,7 +7,9 @@ from decimal import Decimal
 import pytest
 from hexbytes import HexBytes
 
-from eth_defi.erc_4626.deposit_probe import DEFAULT_STATUS_PATH, VaultDepositProbeCandidate, VaultDepositProbeOutput, fetch_max_deposit_guidance, log_probe_tables, require_simulation, select_candidates, update_status
+import eth_defi.erc_4626.deposit_redeem as erc_4626_deposit_redeem
+from eth_defi.erc_4626.deposit_probe import DEFAULT_STATUS_PATH, VaultDepositProbeCandidate, VaultDepositProbeOutput, fetch_max_deposit_guidance, log_probe_tables, require_simulation, run_from_environment, select_candidates, update_status
+from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
 from eth_defi.erc_4626.vault import CERTIFIED_SYNCHRONOUS_DEPOSIT_MANAGER_CLASSES, ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.gains.deposit_redeem import GainsDepositManager, GainsRedemptionTicket
 from eth_defi.erc_4626.vault_protocol.summer.vault import SummerVault
@@ -94,6 +96,20 @@ def test_max_deposit_guidance_is_reported_without_deciding_generic_support() -> 
     assert vault.supports_generic_deposit_manager() is True
 
 
+def test_generic_redemption_manager_accepts_raw_shares(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The probe can redeem its exact minted share balance without a decimal read."""
+    vault = object.__new__(ERC4626Vault)
+    manager = ERC4626DepositManager(vault)
+    function = object()
+    monkeypatch.setattr(erc_4626_deposit_redeem, "redeem_4626", lambda *args, **kwargs: function)
+    request = manager.create_redemption_request(
+        owner="0x0000000000000000000000000000000000000001",
+        raw_shares=123,
+    )
+    assert request.raw_shares == 123
+    assert request.funcs == [function]
+
+
 def test_probe_requires_explicit_simulation(monkeypatch: pytest.MonkeyPatch) -> None:
     """The script refuses before any provider can be constructed."""
     monkeypatch.delenv("SIMULATE", raising=False)
@@ -140,6 +156,13 @@ def test_select_candidates_deduplicates_explicit_ids_and_requires_capability() -
         vault_ids=f"{first.as_string_id()},{first.as_string_id()},{second.as_string_id()}",
     )
     assert [candidate.spec for candidate in candidates] == [first]
+
+
+def test_select_candidates_rejects_unknown_explicit_ids() -> None:
+    """An explicit typo must not degrade into a partial or empty probe run."""
+    missing = VaultSpec(8453, "0x0000000000000000000000000000000000000001")
+    with pytest.raises(ValueError, match="missing from the vault database"):
+        select_candidates(VaultDatabase(rows={}), selection="vault_ids", vault_ids=missing.as_string_id())
 
 
 def test_protocol_candidates_are_ranked_by_nav_and_chain_filter() -> None:
@@ -218,17 +241,38 @@ def test_all_protocols_limits_each_protocol_by_top_nav() -> None:
 
 
 def test_probe_status_is_atomic_and_never_requires_transaction_hashes(tmp_path) -> None:
-    """Persistent status keeps bounded history without fork transaction data."""
+    """Persistent status keeps bounded history without stale attempt fields."""
     path = tmp_path / "vault-deposit-status.json"
     key = "8453-0x0000000000000000000000000000000000000001"
-    update_status(path, key, {"chain_id": 8453, "address": key.split("-", 1)[1], "outcome": "success"})
-    update_status(path, key, {"chain_id": 8453, "address": key.split("-", 1)[1], "outcome": "reverted"})
+    address = key.split("-", 1)[1]
+    update_status(path, key, {"chain_id": 8453, "address": address, "outcome": "success", "fork_block_number": 123, "execution_mode": "guarded", "minted_share_amount_raw": "10"})
+    update_status(path, key, {"chain_id": 8453, "address": address, "outcome": "reverted", "revert_reason": "paused"})
     data = json.loads(path.read_text())
     assert data["schema_version"] == 1
     assert data["vaults"][key]["outcome"] == "reverted"
+    assert "execution_mode" not in data["vaults"][key]
+    assert "minted_share_amount_raw" not in data["vaults"][key]
     assert data["vaults"][key]["attempt_count"] == len(data["vaults"][key]["history"]) + 1
     assert data["vaults"][key]["history"][0]["outcome"] == "success"
     assert "transaction_hash" not in data["vaults"][key]
+    update_status(path, key, {"chain_id": 8453, "address": address, "outcome": "success", "fork_block_number": 124})
+    data = json.loads(path.read_text())
+    assert data["vaults"][key]["outcome"] == "success"
+    assert "revert_reason" not in data["vaults"][key]
+
+
+def test_successful_probe_status_requires_fork_block(tmp_path) -> None:
+    """A success without reproducible fork evidence fails closed."""
+    with pytest.raises(ValueError, match="fork_block_number"):
+        update_status(tmp_path / "status.json", "8453-0x1", {"outcome": "success", "fork_block_number": None})
+
+
+def test_invalid_denomination_filter_is_rejected_before_database_read(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A malformed token filter cannot silently broaden selection."""
+    monkeypatch.setenv("SIMULATE", "true")
+    monkeypatch.setenv("DENOMINATION_TOKEN", "not-an-address")
+    with pytest.raises(ValueError, match="DENOMINATION_TOKEN is not a valid address"):
+        run_from_environment()
 
 
 def test_probe_logs_detailed_and_summary_tables(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/erc_4626/test_deposit_probe.py
+++ b/tests/erc_4626/test_deposit_probe.py
@@ -1,0 +1,289 @@
+"""Unit tests for guarded vault-deposit probe selection and local state."""
+
+import json
+import logging
+from decimal import Decimal
+
+import pytest
+from hexbytes import HexBytes
+
+from eth_defi.erc_4626.deposit_probe import DEFAULT_STATUS_PATH, VaultDepositProbeCandidate, VaultDepositProbeOutput, fetch_max_deposit_guidance, log_probe_tables, require_simulation, select_candidates, update_status
+from eth_defi.erc_4626.vault import CERTIFIED_SYNCHRONOUS_DEPOSIT_MANAGER_CLASSES, ERC4626Vault
+from eth_defi.erc_4626.vault_protocol.gains.deposit_redeem import GainsDepositManager, GainsRedemptionTicket
+from eth_defi.erc_4626.vault_protocol.summer.vault import SummerVault
+from eth_defi.erc_4626.vault_protocol.yearn.vault import YearnV3Vault
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
+from eth_defi.vault.vaultdb import VaultDatabase
+
+
+def test_vault_deposit_manager_capability_suppresses_partial_public_support() -> None:
+    """The initial JSON schema advertises only complete two-way managers."""
+    complete = VaultDepositManagerCapability(True, True, "synchronous", "asynchronous")
+    assert complete.as_initial_public_schema() == {
+        "can_deposit": True,
+        "can_redeem": True,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "asynchronous",
+    }
+    assert VaultDepositManagerCapability(True, False, "synchronous", None).as_initial_public_schema() is None
+    assert VaultDepositManagerCapability(False, True, None, "asynchronous").as_initial_public_schema() is None
+    with pytest.raises(ValueError, match="deposit_flow"):
+        VaultDepositManagerCapability(True, True, None, "asynchronous")
+
+
+def test_erc4626_subclass_can_use_probe_generic_fallback_after_interface_check() -> None:
+    """A reader subclass exposes generic support without public certification."""
+
+    class ReaderOnlyVault(ERC4626Vault):
+        pass
+
+    class Call:
+        def call(self):
+            return "0x0000000000000000000000000000000000000001"
+
+    class Functions:
+        @staticmethod
+        def asset():
+            return Call()
+
+        @staticmethod
+        def maxDeposit(_owner):
+            return Call()
+
+        @staticmethod
+        def maxRedeem(_owner):
+            return Call()
+
+    subclass = object.__new__(ReaderOnlyVault)
+    subclass.vault_contract = type("Contract", (), {"functions": Functions()})()
+    assert subclass.supports_generic_deposit_manager() is True
+    assert subclass.get_deposit_manager_capability() is None
+
+
+def test_successful_summer_and_yearn_readers_are_synchronous_manager_certified() -> None:
+    """Successful guarded deposit probes enable public manager metadata."""
+    assert "eth_defi.erc_4626.vault_protocol.summer.vault.SummerVault" in CERTIFIED_SYNCHRONOUS_DEPOSIT_MANAGER_CLASSES
+    assert "eth_defi.erc_4626.vault_protocol.yearn.vault.YearnV3Vault" in CERTIFIED_SYNCHRONOUS_DEPOSIT_MANAGER_CLASSES
+    assert object.__new__(SummerVault).get_deposit_manager_capability().as_initial_public_schema() is not None
+    assert object.__new__(YearnV3Vault).get_deposit_manager_capability().as_initial_public_schema() is not None
+
+
+def test_max_deposit_guidance_is_reported_without_deciding_generic_support() -> None:
+    """A zero ERC-4626 response remains guidance, not a closed-vault result."""
+
+    class Call:
+        def __init__(self, value: str | int):
+            self.value = value
+
+        def call(self) -> str | int:
+            return self.value
+
+    class Functions:
+        @staticmethod
+        def asset() -> Call:
+            return Call("0x0000000000000000000000000000000000000001")
+
+        @staticmethod
+        def maxDeposit(_owner: str) -> Call:
+            return Call(0)
+
+    vault = object.__new__(ERC4626Vault)
+    vault.vault_contract = type("Contract", (), {"functions": Functions()})()
+    assert fetch_max_deposit_guidance(vault) == "0"
+    assert vault.supports_generic_deposit_manager() is True
+
+
+def test_probe_requires_explicit_simulation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The script refuses before any provider can be constructed."""
+    monkeypatch.delenv("SIMULATE", raising=False)
+    with pytest.raises(RuntimeError, match="SIMULATE=true"):
+        require_simulation()
+    monkeypatch.setenv("SIMULATE", "false")
+    with pytest.raises(RuntimeError, match="SIMULATE=true"):
+        require_simulation()
+    monkeypatch.setenv("SIMULATE", "true")
+    require_simulation()
+
+
+def test_default_probe_status_is_a_packaged_data_artifact() -> None:
+    """The release snapshot is not sourced from an operator home directory."""
+    assert DEFAULT_STATUS_PATH.name == "vault-deposit-status.json"
+    assert DEFAULT_STATUS_PATH.parent.name == "deposit-status"
+    assert DEFAULT_STATUS_PATH.is_file()
+
+
+def test_select_candidates_deduplicates_explicit_ids_and_requires_capability() -> None:
+    """Explicit candidate order is stable and unsupported rows are excluded."""
+    first = VaultSpec(8453, "0x0000000000000000000000000000000000000001")
+    second = VaultSpec(8453, "0x0000000000000000000000000000000000000002")
+    token = "0x0000000000000000000000000000000000000010"
+    database = VaultDatabase(
+        rows={
+            first: {
+                "NAV": Decimal("100"),
+                "Protocol": "Example",
+                "_denomination_token": {"address": token},
+                "_deposit_manager": {"can_deposit": True, "can_redeem": True},
+            },
+            second: {
+                "NAV": Decimal("100"),
+                "Protocol": "Example",
+                "_denomination_token": {"address": token},
+                "_deposit_manager": None,
+            },
+        },
+    )
+    candidates = select_candidates(
+        database,
+        selection="vault_ids",
+        vault_ids=f"{first.as_string_id()},{first.as_string_id()},{second.as_string_id()}",
+    )
+    assert [candidate.spec for candidate in candidates] == [first]
+
+
+def test_protocol_candidates_are_ranked_by_nav_and_chain_filter() -> None:
+    """Protocol batches choose the largest same-chain vaults before truncation."""
+    token = "0x0000000000000000000000000000000000000010"
+    arbitrum_small = VaultSpec(42161, "0x0000000000000000000000000000000000000001")
+    arbitrum_large = VaultSpec(42161, "0x0000000000000000000000000000000000000002")
+    base_largest = VaultSpec(8453, "0x0000000000000000000000000000000000000003")
+    database = VaultDatabase(
+        rows={
+            arbitrum_small: {"NAV": Decimal("10"), "Protocol": "Example", "_denomination_token": {"address": token}, "_deposit_manager": {"can_deposit": True}},
+            arbitrum_large: {"NAV": Decimal("100"), "Protocol": "Example", "_denomination_token": {"address": token}, "_deposit_manager": {"can_deposit": True}},
+            base_largest: {"NAV": Decimal("1000"), "Protocol": "Example", "_denomination_token": {"address": token}, "_deposit_manager": {"can_deposit": True}},
+        },
+    )
+    candidates = select_candidates(database, selection="protocol", protocol="example", chain_id=42161)
+    assert [candidate.spec for candidate in candidates] == [arbitrum_large, arbitrum_small]
+
+
+def test_min_tvl_uses_usd_nav_without_requiring_one_denomination_token() -> None:
+    """USD NAV selection includes qualifying vaults with different assets."""
+    usdc_vault = VaultSpec(42161, "0x0000000000000000000000000000000000000001")
+    weth_vault = VaultSpec(42161, "0x0000000000000000000000000000000000000002")
+    database = VaultDatabase(
+        rows={
+            usdc_vault: {"NAV": Decimal("100"), "Protocol": "Example", "_denomination_token": {"address": "0x0000000000000000000000000000000000000010"}, "_deposit_manager": {"can_deposit": True}},
+            weth_vault: {"NAV": Decimal("200"), "Protocol": "Example", "_denomination_token": {"address": "0x0000000000000000000000000000000000000020"}, "_deposit_manager": {"can_deposit": True}},
+        },
+    )
+    candidates = select_candidates(database, selection="min_tvl", min_tvl=Decimal("100"))
+    assert {candidate.spec for candidate in candidates} == {usdc_vault, weth_vault}
+
+
+def test_candidate_displays_denomination_symbol_and_address() -> None:
+    """Probe output identifies the denomination token without a holder map."""
+    candidate = VaultDepositProbeCandidate(
+        VaultSpec(42161, "0x0000000000000000000000000000000000000001"),
+        {"Denomination": "USDC"},
+        "0x0000000000000000000000000000000000000010",
+    )
+    assert candidate.denomination_token_label == "USDC (0x0000000000000000000000000000000000000010)"
+
+
+def test_uncertified_legacy_rows_require_explicit_probe_opt_in() -> None:
+    """Old databases can be probed without becoming public capability metadata."""
+    spec = VaultSpec(42161, "0x0000000000000000000000000000000000000001")
+    database = VaultDatabase(
+        rows={
+            spec: {
+                "NAV": Decimal("100"),
+                "Protocol": "Example",
+                "_denomination_token": {"address": "0x0000000000000000000000000000000000000010"},
+                "_deposit_manager": None,
+            },
+        },
+    )
+    assert select_candidates(database, selection="protocol", protocol="example") == []
+    assert len(select_candidates(database, selection="protocol", protocol="example", include_uncertified=True)) == 1
+
+
+def test_all_protocols_limits_each_protocol_by_top_nav() -> None:
+    """All-protocol batches apply their limit independently, not globally."""
+    token = "0x0000000000000000000000000000000000000010"
+    first = VaultSpec(42161, "0x0000000000000000000000000000000000000001")
+    second = VaultSpec(42161, "0x0000000000000000000000000000000000000002")
+    third = VaultSpec(42161, "0x0000000000000000000000000000000000000003")
+    database = VaultDatabase(
+        rows={
+            first: {"NAV": Decimal("1"), "Protocol": "Alpha", "_denomination_token": {"address": token}, "_deposit_manager": {"can_deposit": True}},
+            second: {"NAV": Decimal("2"), "Protocol": "Alpha", "_denomination_token": {"address": token}, "_deposit_manager": {"can_deposit": True}},
+            third: {"NAV": Decimal("3"), "Protocol": "Beta", "_denomination_token": {"address": token}, "_deposit_manager": {"can_deposit": True}},
+        },
+    )
+    candidates = select_candidates(database, selection="all_protocols", max_per_protocol=1)
+    assert [candidate.spec for candidate in candidates] == [second, third]
+
+
+def test_probe_status_is_atomic_and_never_requires_transaction_hashes(tmp_path) -> None:
+    """Persistent status keeps bounded history without fork transaction data."""
+    path = tmp_path / "vault-deposit-status.json"
+    key = "8453-0x0000000000000000000000000000000000000001"
+    update_status(path, key, {"chain_id": 8453, "address": key.split("-", 1)[1], "outcome": "success"})
+    update_status(path, key, {"chain_id": 8453, "address": key.split("-", 1)[1], "outcome": "reverted"})
+    data = json.loads(path.read_text())
+    assert data["schema_version"] == 1
+    assert data["vaults"][key]["outcome"] == "reverted"
+    assert data["vaults"][key]["attempt_count"] == len(data["vaults"][key]["history"]) + 1
+    assert data["vaults"][key]["history"][0]["outcome"] == "success"
+    assert "transaction_hash" not in data["vaults"][key]
+
+
+def test_probe_logs_detailed_and_summary_tables(caplog: pytest.LogCaptureFixture) -> None:
+    """Terminal output shows every vault result and aggregate outcome counts."""
+    caplog.set_level(logging.INFO, logger="eth_defi.erc_4626.deposit_probe")
+    log_probe_tables(
+        [
+            VaultDepositProbeOutput("Example", "0x0000000000000000000000000000000000000002", "Failed vault", "USDC (0x0000000000000000000000000000000000000010)", "reverted", "reverted", "0", "Vault is paused", "execution reverted: paused"),
+            VaultDepositProbeOutput("Example", "0x0000000000000000000000000000000000000001", "Successful vault", "USDC (0x0000000000000000000000000000000000000010)", "success", "Ok (generic ERC-4626)", "0", None, None),
+        ]
+    )
+    output = caplog.text
+    assert "Protocol" in output
+    assert "Name" in output
+    assert "Denomination token" in output
+    assert "maxDeposit guidance" in output
+    assert "Failure reason" in output
+    assert "Revert reason" in output
+    assert "Ok (generic ERC-4626)" in output
+    assert "Vault deposit probe summary" in output
+    assert "Ok" in output
+    assert output.index("Successful vault") < output.index("Failed vault")
+    assert "success" in output
+    assert "reverted" in output
+
+
+def test_broken_rescan_clears_retained_deposit_manager_capability() -> None:
+    """A preserved descriptive row must not retain stale adapter certification."""
+    spec = VaultSpec(8453, "0x0000000000000000000000000000000000000001")
+    database = VaultDatabase(
+        rows={
+            spec: {
+                "Name": "Healthy vault",
+                "Denomination": "USDC",
+                "NAV": Decimal("100"),
+                "_deposit_manager": {"can_deposit": True, "can_redeem": True},
+            },
+        },
+    )
+    database._merge_rows({spec: {"Name": "<broken: TimeoutError>", "Denomination": "", "_deposit_manager": None}})
+    assert database.rows[spec]["Name"] == "Healthy vault"
+    assert database.rows[spec]["_deposit_manager"] is None
+
+
+def test_gains_redemption_ticket_survives_json_round_trip() -> None:
+    """The epoch information required for a later redeem is persistent."""
+    manager = GainsDepositManager.__new__(GainsDepositManager)
+    ticket = GainsRedemptionTicket(
+        vault_address="0x0000000000000000000000000000000000000001",
+        owner="0x0000000000000000000000000000000000000002",
+        to="0x0000000000000000000000000000000000000003",
+        raw_shares=10**30,
+        tx_hash=HexBytes("0x" + "11" * 32),
+        current_epoch=123,
+        unlock_epoch=124,
+    )
+    restored = manager.reconstruct_redemption_ticket(json.loads(json.dumps(manager.serialize_redemption_ticket(ticket))))
+    assert restored == ticket

--- a/tests/erc_4626/test_scan_features.py
+++ b/tests/erc_4626/test_scan_features.py
@@ -113,6 +113,7 @@ def test_create_vault_scan_record_persists_machine_readable_features(monkeypatch
     assert record["features"] is not record["_detection_data"].features
     assert record["_detection_data"].features == features
     assert "erc_7575_like" in record["Features"]
+    assert record["_deposit_manager"] is None
 
 
 def test_vault_database_dataframe_falls_back_to_detection_features() -> None:

--- a/tests/erc_4626/vault_protocol/test_morpho_v2.py
+++ b/tests/erc_4626/vault_protocol/test_morpho_v2.py
@@ -103,15 +103,17 @@ def test_morpho_v2_vault(
     assert deposit_next is None
     assert redemption_next is None
 
-    # Check maxDeposit and maxRedeem with address(0)
-    # Morpho uses these as global availability checks
+    # Read the conservative ERC-4626 guidance values without treating them as
+    # global availability checks.
     max_deposit = vault.vault_contract.functions.maxDeposit(ZERO_ADDRESS_STR).call()
     max_redeem = vault.vault_contract.functions.maxRedeem(ZERO_ADDRESS_STR).call()
     assert max_deposit >= 0
     assert max_redeem >= 0
 
-    # Morpho V2 supports address(0) checks for global deposit/redemption availability
-    assert vault.can_check_redeem() is True
+    # Morpho V2 always reports zero for address(0), so the adapter cannot infer
+    # whether this account can currently redeem.
+    assert vault.can_check_redeem() is False
+    assert redemption_reason is None
 
     # Test lending protocol identification
     assert is_lending_protocol(vault.features) is True


### PR DESCRIPTION
## Why

Downstream vault users need a machine-readable statement of whether this package has a complete deposit and redemption manager for a vault, backed by repeatable guarded fork evidence.

## Lessons learnt

ERC-4626 maxDeposit is advisory across protocols and can be conservatively zero; a successful fork probe is historical adapter evidence, while live callers must still validate current chain state.

## Summary

- Export fail-closed deposit-manager capability metadata in public vault JSON.
- Add a GuardV0 and SimpleVaultV0 Anvil fork probe with persisted, packaged status artefacts and tabulated output.
- Document refresh, long-running operation, current-state caveats and public JSON semantics.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.