### PR TITLE
fix: repair Midas historical backfills

### DIFF
--- a/.claude/docs/agent-tricks-and-troubleshooting.md
+++ b/.claude/docs/agent-tricks-and-troubleshooting.md
@@ -451,15 +451,16 @@ git status --short --branch
 git rev-parse --show-toplevel
 ```
 
-For this repository's worktrees, run commands from the worktree directory and
-use the parent repository Poetry environment unless changing package
-dependencies. Follow the test command rules from `CLAUDE.md` and always verify
-the working directory and branch before trusting review output:
+For this repository's worktrees, run commands from the target worktree, use the
+parent repository Poetry environment unless changing package dependencies, and
+force imports from the target worktree. Follow the test command rules from
+`AGENTS.md` and always verify the working directory and branch before trusting
+review output:
 
 ```shell
 pwd
 git status --short --branch
-source .local-test.env && poetry run pytest tests/path/to/test.py
+source .local-test.env && PYTHONPATH="$(pwd):$PYTHONPATH" poetry run pytest tests/path/to/test.py
 ```
 
 ### The agent misses repository instructions

--- a/.claude/docs/agent-tricks-and-troubleshooting.md
+++ b/.claude/docs/agent-tricks-and-troubleshooting.md
@@ -221,8 +221,13 @@ Start the review in the background and write the raw JSONL stream to a temporary
 file instead. Restrict tools to read-only operations and redirect stdin so the
 CLI cannot wait for additional prompt input:
 
+Use a 15-minute wall-clock deadline for an external-agent process, including
+Claude CLI and Codex CLI. This gives a legitimate review enough time to inspect
+the worktree; it does not override the separate one-minute no-output rule for a
+grounded Claude review.
+
 ```shell
-nohup timeout 120 claude -p "Review the current uncommitted worktree diff for correctness bugs only. Do not edit files or run tests. Return findings first with file:line references." \
+nohup timeout 900 claude -p "Review the current uncommitted worktree diff for correctness bugs only. Do not edit files or run tests. Return findings first with file:line references." \
   --permission-mode dontAsk \
   --allowedTools "Read,Grep,Glob,Bash(git status:*),Bash(git diff:*),Bash(sed:*),Bash(rg:*)" \
   --output-format stream-json \

--- a/eth_defi/midas/historical.py
+++ b/eth_defi/midas/historical.py
@@ -6,6 +6,7 @@
 import datetime
 from collections.abc import Iterable
 from decimal import Decimal
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 from eth_defi.erc_4626.vault import VaultReaderState
@@ -15,6 +16,26 @@ from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
 
 if TYPE_CHECKING:
     from eth_defi.midas.vault import MidasVault
+
+
+class MidasVaultReaderState(VaultReaderState):
+    """Persist adaptive Midas history scan state.
+
+    Midas datafeeds publish share prices in USD and the historical reader
+    already calculates TVL in USD.  Unlike ERC-4626 vaults, an mToken does not
+    expose an ERC-20 denomination token, so the generic exchange-rate lookup
+    cannot be used here.
+    """
+
+    @cached_property
+    def exchange_rate(self) -> Decimal:
+        """Return the USD exchange rate for Midas' USD-denominated NAV.
+
+        :return:
+            One, because Midas reader ``total_assets`` is already in USD.
+        """
+
+        return Decimal(1)
 
 
 class MidasVaultHistoricalReader(VaultHistoricalReader):
@@ -38,7 +59,7 @@ class MidasVaultHistoricalReader(VaultHistoricalReader):
 
         super().__init__(vault)
         if stateful:
-            self.reader_state = VaultReaderState(vault)
+            self.reader_state = MidasVaultReaderState(vault)
         else:
             self.reader_state = None
 
@@ -88,6 +109,7 @@ class MidasVaultHistoricalReader(VaultHistoricalReader):
 
         total_supply: Decimal | None = None
         share_price: Decimal | None = None
+        state_result: EncodedCallResult | None = None
         errors: list[str] = []
 
         for result in call_results:
@@ -104,10 +126,18 @@ class MidasVaultHistoricalReader(VaultHistoricalReader):
                 if result.success:
                     raw_share_price = convert_int256_bytes_to_int(result.result)
                     share_price = Decimal(raw_share_price) / Decimal(10**18)
+                    state_result = result
                 else:
                     errors.append("Midas getDataInBase18 call failed")
 
         total_assets = share_price * total_supply if share_price is not None and total_supply is not None else None
+
+        if self.reader_state is not None and state_result is not None and total_assets is not None:
+            self.reader_state.on_called(
+                state_result,
+                total_assets=total_assets,
+                share_price=share_price,
+            )
 
         return VaultHistoricalRead(
             vault=self.vault,

--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -18,6 +18,7 @@ import os
 import pickle
 import tempfile
 import warnings
+from bisect import bisect_right
 from pathlib import Path
 from typing import Callable, TypedDict
 
@@ -1827,7 +1828,8 @@ def replace_cleaned_vault_histories(  # noqa: PLR0914
     transformation is independent between vault ids.  Recompute the complete
     raw history for the selected ids, then stream-copy all other cleaned row
     groups into a replacement Parquet.  This avoids expensive pandas cleaning
-    for unrelated vaults while preserving their existing cleaned rows.
+    for unrelated vaults while preserving their existing cleaned rows and
+    physical ``id, timestamp`` order.
 
     The destination remains a single Parquet file, so its bytes must still be
     rewritten before the atomic replace.  The function does not silently drop
@@ -1894,6 +1896,17 @@ def replace_cleaned_vault_histories(  # noqa: PLR0914
     vault_db = VaultDatabase.read(vault_db_path)
     cleaned_selected_df = process_raw_vault_scan_data(vault_db.rows, raw_prices_df, logger=logger)
     cleaned_selected_df = merge_vault_settlements_into_cleaned_prices(cleaned_selected_df, settlement_db_path=settlement_db_path)
+    if "timestamp" not in cleaned_selected_df.columns and cleaned_selected_df.index.name == "timestamp":
+        cleaned_selected_df = cleaned_selected_df.reset_index()
+
+    missing_cleaned_columns = {"id", "timestamp"} - set(cleaned_selected_df.columns)
+    if missing_cleaned_columns:
+        raise ValueError(f"Selected cleaned histories are missing required columns: {sorted(missing_cleaned_columns)}")
+
+    cleaned_ids = set(cleaned_selected_df["id"].astype(str).str.lower())
+    missing_cleaned_ids = set(canonical_ids) - cleaned_ids
+    if missing_cleaned_ids:
+        raise ValueError(f"Cleaning removed all rows for selected vault ids; refusing to replace existing histories: {', '.join(sorted(missing_cleaned_ids))}")
     cleaned_selected_df.sort_values(by=["id", "timestamp"], inplace=True)
 
     existing_reader = pq.ParquetFile(cleaned_price_df_path)
@@ -1913,20 +1926,33 @@ def replace_cleaned_vault_histories(  # noqa: PLR0914
             column = pa.nulls(len(selected_table), type=field.type)
         selected_columns.append(column)
     selected_table = pa.Table.from_arrays(selected_columns, schema=output_schema)
+    selected_sort_keys = list(zip(selected_table["id"].to_pylist(), selected_table["timestamp"].to_pylist(), strict=True))
 
     value_set = pa.array(canonical_ids, type=pa.string())
     temp_fd, temp_path = tempfile.mkstemp(suffix=".parquet", dir=str(cleaned_price_df_path.parent))
     os.close(temp_fd)
     retained_rows = 0
+    selected_row_offset = 0
     try:
         with pq.ParquetWriter(temp_path, output_schema, compression="zstd") as writer:
             for batch in existing_reader.iter_batches(batch_size=100_000):
                 table = pa.Table.from_batches([batch]).replace_schema_metadata(output_schema.metadata)
                 retained = table.filter(pc.invert(pc.is_in(table["id"], value_set=value_set)))
                 if retained.num_rows:
+                    retained_row_count = retained.num_rows
+                    last_sort_key = (retained["id"][-1].as_py(), retained["timestamp"][-1].as_py())
+                    selected_end = bisect_right(selected_sort_keys, last_sort_key, lo=selected_row_offset)
+                    if selected_end > selected_row_offset:
+                        combined = pa.concat_tables(
+                            [retained, selected_table.slice(selected_row_offset, selected_end - selected_row_offset)],
+                        )
+                        sort_indices = pc.sort_indices(combined, sort_keys=[("id", "ascending"), ("timestamp", "ascending")])
+                        retained = combined.take(sort_indices)
+                        selected_row_offset = selected_end
                     writer.write_table(retained)
-                    retained_rows += retained.num_rows
-            writer.write_table(selected_table)
+                    retained_rows += retained_row_count
+            if selected_row_offset < selected_table.num_rows:
+                writer.write_table(selected_table.slice(selected_row_offset))
 
         expected_rows = retained_rows + selected_table.num_rows
         verify_parquet_file(

--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -24,6 +24,7 @@ from typing import Callable, TypedDict
 import numpy as np
 import pandas as pd
 import pyarrow as pa
+import pyarrow.compute as pc
 import pyarrow.parquet as pq
 from eth_typing import HexAddress
 from IPython.display import display
@@ -37,7 +38,7 @@ from eth_defi.vault.base import VaultSpec, verify_parquet_file
 from eth_defi.vault.settlement_data import (
     merge_vault_settlements_into_cleaned_prices,
 )
-from eth_defi.vault.vaultdb import DEFAULT_UNCLEANED_PRICE_DATABASE, DEFAULT_VAULT_DATABASE, VaultDatabase, VaultRow
+from eth_defi.vault.vaultdb import DEFAULT_RAW_PRICE_DATABASE, DEFAULT_UNCLEANED_PRICE_DATABASE, DEFAULT_VAULT_DATABASE, VaultDatabase, VaultRow
 from eth_defi.version_info import stamp_parquet_schema_metadata
 
 #: At least two canonical observations are needed to bracket a daily price.
@@ -1807,6 +1808,140 @@ def generate_cleaned_vault_datasets(
 
     fsize = cleaned_price_df_path.stat().st_size
     logger(f"Saved cleaned vault prices to {cleaned_price_df_path}, total {len(enhanced_prices_df):,} rows, file size is {fsize / 1024 / 1024:.2f} MB")
+
+
+def replace_cleaned_vault_histories(  # noqa: PLR0914
+    vault_ids: set[str],
+    *,
+    vault_db_path: Path = DEFAULT_VAULT_DATABASE,
+    raw_price_df_path: Path = DEFAULT_UNCLEANED_PRICE_DATABASE,
+    cleaned_price_df_path: Path = DEFAULT_RAW_PRICE_DATABASE,
+    settlement_db_path: Path | None = None,
+    logger: Callable[[str], None] = print,
+) -> int:
+    """Rebuild and atomically replace cleaned histories for selected vaults.
+
+    The normal cleaner is deliberately whole-dataset: it reads every raw row,
+    applies its transformations, and emits a new Parquet file.  A historical
+    repair only changes a small number of vaults, however, and each cleaner
+    transformation is independent between vault ids.  Recompute the complete
+    raw history for the selected ids, then stream-copy all other cleaned row
+    groups into a replacement Parquet.  This avoids expensive pandas cleaning
+    for unrelated vaults while preserving their existing cleaned rows.
+
+    The destination remains a single Parquet file, so its bytes must still be
+    rewritten before the atomic replace.  The function does not silently drop
+    columns: a selected vault whose cleaned columns do not match the existing
+    output raises an error before replacing the original file.
+
+    :param vault_ids:
+        Canonical lower-case ``chain_id-address`` ids to replace.
+    :param vault_db_path:
+        Metadata database used for denormalisation and stablecoin filtering.
+    :param raw_price_df_path:
+        Raw scanner Parquet containing the replacement histories.
+    :param cleaned_price_df_path:
+        Existing cleaned Parquet to update atomically.
+    :param settlement_db_path:
+        Optional settlement database applied to the selected cleaned rows.
+    :param logger:
+        Progress callback.
+    :return:
+        Number of cleaned rows written for the selected vaults.
+    """
+
+    canonical_ids = sorted(vault_id.lower() for vault_id in vault_ids)
+    if not canonical_ids:
+        message = "vault_ids must not be empty"
+        raise ValueError(message)
+
+    assert vault_db_path.exists(), f"Vault metadata database does not exist: {vault_db_path}"
+    assert raw_price_df_path.exists(), f"Raw price database does not exist: {raw_price_df_path}"
+    assert cleaned_price_df_path.exists(), f"Cleaned price database does not exist: {cleaned_price_df_path}"
+
+    vault_specs = [VaultSpec.parse_string(vault_id) for vault_id in canonical_ids]
+    logger(f"Loading raw histories for {len(canonical_ids):,} selected vaults from {raw_price_df_path}")
+    raw_reader = pq.ParquetFile(raw_price_df_path)
+    required_raw_columns = {"chain", "address"}
+    missing_raw_columns = required_raw_columns - set(raw_reader.schema_arrow.names)
+    if missing_raw_columns:
+        raise ValueError(f"Raw price database is missing required columns: {sorted(missing_raw_columns)}")
+
+    selected_raw_batches: list[pa.Table] = []
+    for batch in raw_reader.iter_batches(batch_size=100_000):
+        raw_table = pa.Table.from_batches([batch])
+        pair_mask = pc.and_(
+            pc.equal(raw_table["chain"], vault_specs[0].chain_id),
+            pc.equal(raw_table["address"], vault_specs[0].vault_address),
+        )
+        for spec in vault_specs[1:]:
+            pair_mask = pc.or_(
+                pair_mask,
+                pc.and_(
+                    pc.equal(raw_table["chain"], spec.chain_id),
+                    pc.equal(raw_table["address"], spec.vault_address),
+                ),
+            )
+        selected_raw = raw_table.filter(pair_mask)
+        if selected_raw.num_rows:
+            selected_raw_batches.append(selected_raw)
+
+    raw_prices_df = pa.concat_tables(selected_raw_batches).to_pandas(types_mapper=pd.ArrowDtype) if selected_raw_batches else pd.DataFrame()
+    if raw_prices_df.empty:
+        raise ValueError(f"No raw price rows found for selected vault ids: {', '.join(canonical_ids)}")
+
+    logger(f"Loading vault metadata from {vault_db_path}")
+    vault_db = VaultDatabase.read(vault_db_path)
+    cleaned_selected_df = process_raw_vault_scan_data(vault_db.rows, raw_prices_df, logger=logger)
+    cleaned_selected_df = merge_vault_settlements_into_cleaned_prices(cleaned_selected_df, settlement_db_path=settlement_db_path)
+    cleaned_selected_df.sort_values(by=["id", "timestamp"], inplace=True)
+
+    existing_reader = pq.ParquetFile(cleaned_price_df_path)
+    output_schema = existing_reader.schema_arrow
+    selected_table = pa.Table.from_pandas(cleaned_selected_df)
+    unexpected_columns = set(selected_table.schema.names) - set(output_schema.names)
+    if unexpected_columns:
+        raise ValueError(f"Selected cleaned histories contain columns missing from {cleaned_price_df_path}: {sorted(unexpected_columns)}")
+
+    selected_columns = []
+    for field in output_schema:
+        if field.name in selected_table.schema.names:
+            column = selected_table[field.name]
+            if column.type != field.type:
+                column = column.cast(field.type)
+        else:
+            column = pa.nulls(len(selected_table), type=field.type)
+        selected_columns.append(column)
+    selected_table = pa.Table.from_arrays(selected_columns, schema=output_schema)
+
+    value_set = pa.array(canonical_ids, type=pa.string())
+    temp_fd, temp_path = tempfile.mkstemp(suffix=".parquet", dir=str(cleaned_price_df_path.parent))
+    os.close(temp_fd)
+    retained_rows = 0
+    try:
+        with pq.ParquetWriter(temp_path, output_schema, compression="zstd") as writer:
+            for batch in existing_reader.iter_batches(batch_size=100_000):
+                table = pa.Table.from_batches([batch]).replace_schema_metadata(output_schema.metadata)
+                retained = table.filter(pc.invert(pc.is_in(table["id"], value_set=value_set)))
+                if retained.num_rows:
+                    writer.write_table(retained)
+                    retained_rows += retained.num_rows
+            writer.write_table(selected_table)
+
+        expected_rows = retained_rows + selected_table.num_rows
+        verify_parquet_file(
+            temp_path,
+            expected_rows=expected_rows,
+            expected_schema=output_schema,
+        )
+        os.replace(temp_path, cleaned_price_df_path)
+    except BaseException:
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+        raise
+
+    logger(f"Replaced {selected_table.num_rows:,} cleaned price rows for {len(canonical_ids):,} vaults; preserved {retained_rows:,} unrelated rows")
+    return selected_table.num_rows
 
 
 def forward_fill_vault(

--- a/scripts/midas/backfill-history.py
+++ b/scripts/midas/backfill-history.py
@@ -66,6 +66,7 @@ import pickle  # noqa: S403 - trusted local production reader-state pickle.
 import sys
 from collections.abc import Iterable
 from pathlib import Path
+from typing import Literal, cast
 
 from atomicwrites import atomic_write
 from eth_typing import HexAddress
@@ -137,6 +138,24 @@ def parse_optional_int_env(name: str) -> int | None:
     if not value:
         return None
     return int(value)
+
+
+def resolve_frequency() -> Literal["1h", "1d"]:
+    """Read and validate the historical backfill sampling frequency.
+
+    Both the printed execution plan and the scanner must use this one resolved
+    value.  Reading the environment independently inside the chain loop would
+    let their defaults diverge.
+
+    :return:
+        Requested sampling frequency, defaulting to one daily sample.
+    """
+
+    frequency = os.environ.get("FREQUENCY", "1d")
+    if frequency not in {"1h", "1d"}:
+        message = f"Unsupported FREQUENCY: {frequency}"
+        raise ValueError(message)
+    return cast(Literal["1h", "1d"], frequency)
 
 
 def resolve_price_scan_start_block(products: list[MidasProduct]) -> int:
@@ -346,6 +365,7 @@ def backfill_chain(  # noqa: PLR0914
     dry_run: bool,
     scan_prices: bool,
     clean_prices: bool,
+    frequency: Literal["1h", "1d"],
     vault_db: VaultDatabase,
     vault_db_path: Path,
     price_database_path: Path,
@@ -365,6 +385,8 @@ def backfill_chain(  # noqa: PLR0914
         Whether to scan historical prices.
     :param clean_prices:
         Whether to replace selected histories in the cleaned price database.
+    :param frequency:
+        Historical sampling frequency shared with the displayed execution plan.
     :param vault_db:
         Vault metadata database.
     :param vault_db_path:
@@ -444,7 +466,7 @@ def backfill_chain(  # noqa: PLR0914
                 max_workers=int(os.environ.get("MAX_WORKERS", "8")),
                 chunk_size=32,
                 token_cache=token_cache,
-                frequency=os.environ.get("FREQUENCY", "1h"),
+                frequency=frequency,
                 reader_states=reader_states,
                 hypersync_client=hypersync_config.hypersync_client,
                 vault_addresses=vault_ids,
@@ -480,10 +502,7 @@ def main() -> None:
     dry_run = parse_bool_env("DRY_RUN")
     scan_prices = parse_bool_env("MIDAS_SCAN_PRICES", default=True)
     clean_prices = parse_bool_env("MIDAS_CLEAN_PRICES", default=True)
-    frequency = os.environ.get("FREQUENCY", "1d")
-    if frequency not in {"1h", "1d"}:
-        message = f"Unsupported FREQUENCY: {frequency}"
-        raise ValueError(message)
+    frequency = resolve_frequency()
 
     products = list(iter_selected_products())
     if not products:
@@ -532,6 +551,7 @@ def main() -> None:
                 dry_run=dry_run,
                 scan_prices=scan_prices,
                 clean_prices=clean_prices,
+                frequency=frequency,
                 vault_db=vault_db,
                 vault_db_path=vault_db_path,
                 price_database_path=price_database_path,

--- a/scripts/midas/backfill-history.py
+++ b/scripts/midas/backfill-history.py
@@ -36,9 +36,9 @@ Useful environment variables:
      - Optional comma-separated Midas product symbols, e.g. ``mTBILL,mBASIS``.
    * - ``MIDAS_SCAN_PRICES``
      - If ``false``, update only leads and metadata. Default: ``true``.
-   * - ``MIDAS_REWRITE_TARGETED``
-     - If ``true``, clear reader states for selected Midas vaults so history is
-       rewritten from their first deployment block. Default: ``true``.
+   * - ``MIDAS_CLEAN_PRICES``
+     - If ``true``, rebuild and replace only the selected vault histories in
+       the cleaned price Parquet. Default: ``true``.
    * - ``MAX_WORKERS``
      - Historical multicall worker count. Default: ``8``.
    * - ``FREQUENCY``
@@ -51,6 +51,8 @@ Useful environment variables:
      - Optional metadata DB path. Default: production vault metadata DB.
    * - ``UNCLEANED_PRICE_DATABASE``
      - Optional uncleaned price parquet path. Default: production price DB.
+   * - ``CLEANED_PRICE_DATABASE``
+     - Optional cleaned price parquet path. Default: production cleaned price DB.
    * - ``READER_STATE_DATABASE``
      - Optional reader-state pickle path. Default: production reader state DB.
 
@@ -80,11 +82,12 @@ from eth_defi.midas.constants import MIDAS_PRODUCTS, MidasProduct
 from eth_defi.provider.env import get_json_rpc_env, read_json_rpc_url
 from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
 from eth_defi.provider.named import get_provider_name
+from eth_defi.research.wrangle_vault_prices import replace_cleaned_vault_histories
 from eth_defi.token import TokenDiskCache
 from eth_defi.utils import setup_console_logging
 from eth_defi.vault.base import VaultBase, VaultSpec
 from eth_defi.vault.historical import pformat_scan_result, scan_historical_prices_to_parquet
-from eth_defi.vault.vaultdb import DEFAULT_READER_STATE_DATABASE, DEFAULT_UNCLEANED_PRICE_DATABASE, DEFAULT_VAULT_DATABASE, VaultDatabase
+from eth_defi.vault.vaultdb import DEFAULT_RAW_PRICE_DATABASE, DEFAULT_READER_STATE_DATABASE, DEFAULT_UNCLEANED_PRICE_DATABASE, DEFAULT_VAULT_DATABASE, VaultDatabase
 
 logger = logging.getLogger(__name__)
 
@@ -134,6 +137,28 @@ def parse_optional_int_env(name: str) -> int | None:
     if not value:
         return None
     return int(value)
+
+
+def resolve_price_scan_start_block(products: list[MidasProduct]) -> int:
+    """Resolve the first block to read for one chain's Midas backfill.
+
+    A targeted backfill must not inherit the ordinary vault scanner's latest
+    reader state for the chain.  Those states normally point close to the
+    chain head and would silently turn a deployment-history rewrite into a
+    short incremental scan.  Start at the earliest selected Midas deployment
+    unless the operator explicitly pins a start block.
+
+    :param products:
+        Selected Midas products on one EVM chain.
+    :return:
+        Explicit ``START_BLOCK`` value, or the earliest selected deployment block.
+    """
+
+    explicit_start_block = parse_optional_int_env("START_BLOCK")
+    if explicit_start_block is not None:
+        return explicit_start_block
+
+    return min(product.first_seen_at_block for product in products)
 
 
 def parse_path_env(name: str, default: Path) -> Path:
@@ -320,10 +345,11 @@ def backfill_chain(  # noqa: PLR0914
     *,
     dry_run: bool,
     scan_prices: bool,
-    rewrite_targeted: bool,
+    clean_prices: bool,
     vault_db: VaultDatabase,
     vault_db_path: Path,
     price_database_path: Path,
+    cleaned_price_database_path: Path,
     reader_state_database_path: Path,
     token_cache: TokenDiskCache,
 ) -> dict[str, object]:
@@ -337,14 +363,16 @@ def backfill_chain(  # noqa: PLR0914
         Whether writes are disabled.
     :param scan_prices:
         Whether to scan historical prices.
-    :param rewrite_targeted:
-        Whether to clear selected vault reader states before scanning.
+    :param clean_prices:
+        Whether to replace selected histories in the cleaned price database.
     :param vault_db:
         Vault metadata database.
     :param vault_db_path:
         Vault metadata database path.
     :param price_database_path:
         Historical price parquet path.
+    :param cleaned_price_database_path:
+        Cleaned historical price parquet path.
     :param reader_state_database_path:
         Reader-state pickle path.
     :param token_cache:
@@ -391,18 +419,27 @@ def backfill_chain(  # noqa: PLR0914
             scan_summary = "dry-run"
         else:
             reader_states = read_reader_states(reader_state_database_path)
-            if rewrite_targeted:
-                reader_states = {spec: state for spec, state in reader_states.items() if spec.vault_address.lower() not in vault_ids}
+            # Targeted history scans replace rows from the Midas deployment
+            # block onwards. Retaining a later state would make the adaptive
+            # reader skip those deleted rows instead of restoring them.
+            reader_states = {spec: state for spec, state in reader_states.items() if spec.vault_address.lower() not in vault_ids}
 
             web3factory = MultiProviderWeb3Factory(json_rpc_url, retries=5)
             hypersync_config = configure_hypersync_from_env(web3)
             vaults = build_vaults(web3, products, token_cache)
+            start_block = resolve_price_scan_start_block(products)
+            logger.info(
+                "Backfill price history for %d Midas products on %s from block %d",
+                len(products),
+                chain_name,
+                start_block,
+            )
             scan_result = scan_historical_prices_to_parquet(
                 output_fname=price_database_path,
                 web3=web3,
                 web3factory=web3factory,
                 vaults=vaults,
-                start_block=parse_optional_int_env("START_BLOCK"),
+                start_block=start_block,
                 end_block=end_block,
                 max_workers=int(os.environ.get("MAX_WORKERS", "8")),
                 chunk_size=32,
@@ -414,6 +451,16 @@ def backfill_chain(  # noqa: PLR0914
             )
             write_reader_states(reader_state_database_path, scan_result["reader_states"])
             scan_summary = pformat_scan_result(scan_result)
+
+            if clean_prices:
+                cleaned_rows = replace_cleaned_vault_histories(
+                    {VaultSpec(product.chain_id, product.token).as_string_id() for product in products},
+                    vault_db_path=vault_db_path,
+                    raw_price_df_path=price_database_path,
+                    cleaned_price_df_path=cleaned_price_database_path,
+                    logger=logger.info,
+                )
+                scan_summary = f"{scan_summary}; cleaned_rows={cleaned_rows:,}"
 
     return {
         "chain": chain_name,
@@ -432,7 +479,7 @@ def main() -> None:
 
     dry_run = parse_bool_env("DRY_RUN")
     scan_prices = parse_bool_env("MIDAS_SCAN_PRICES", default=True)
-    rewrite_targeted = parse_bool_env("MIDAS_REWRITE_TARGETED", default=True)
+    clean_prices = parse_bool_env("MIDAS_CLEAN_PRICES", default=True)
     frequency = os.environ.get("FREQUENCY", "1h")
     if frequency not in {"1h", "1d"}:
         message = f"Unsupported FREQUENCY: {frequency}"
@@ -445,6 +492,7 @@ def main() -> None:
 
     vault_db_path = parse_path_env("VAULT_DB_PATH", DEFAULT_VAULT_DATABASE)
     price_database_path = parse_path_env("UNCLEANED_PRICE_DATABASE", DEFAULT_UNCLEANED_PRICE_DATABASE)
+    cleaned_price_database_path = parse_path_env("CLEANED_PRICE_DATABASE", DEFAULT_RAW_PRICE_DATABASE)
     reader_state_database_path = parse_path_env("READER_STATE_DATABASE", DEFAULT_READER_STATE_DATABASE)
 
     products_by_chain: dict[int, list[MidasProduct]] = {}
@@ -466,9 +514,11 @@ def main() -> None:
     print(tabulate(plan, headers="keys", tablefmt="github"))
     print(f"Vault DB: {vault_db_path}")
     print(f"Price DB: {price_database_path}")
+    print(f"Cleaned price DB: {cleaned_price_database_path}")
     print(f"Reader states: {reader_state_database_path}")
     print(f"Frequency: {frequency}")
     print(f"Dry run: {dry_run}")
+    print(f"Update cleaned prices: {clean_prices}")
 
     vault_db = read_vault_database(vault_db_path)
     token_cache = TokenDiskCache()
@@ -481,10 +531,11 @@ def main() -> None:
                 chain_products,
                 dry_run=dry_run,
                 scan_prices=scan_prices,
-                rewrite_targeted=rewrite_targeted,
+                clean_prices=clean_prices,
                 vault_db=vault_db,
                 vault_db_path=vault_db_path,
                 price_database_path=price_database_path,
+                cleaned_price_database_path=cleaned_price_database_path,
                 reader_state_database_path=reader_state_database_path,
                 token_cache=token_cache,
             )

--- a/scripts/midas/backfill-history.py
+++ b/scripts/midas/backfill-history.py
@@ -42,7 +42,7 @@ Useful environment variables:
    * - ``MAX_WORKERS``
      - Historical multicall worker count. Default: ``8``.
    * - ``FREQUENCY``
-     - Historical price frequency, ``1h`` or ``1d``. Default: ``1h``.
+     - Historical price frequency, ``1h`` or ``1d``. Default: ``1d``.
    * - ``START_BLOCK``
      - Optional global minimum start block override.
    * - ``END_BLOCK``
@@ -480,7 +480,7 @@ def main() -> None:
     dry_run = parse_bool_env("DRY_RUN")
     scan_prices = parse_bool_env("MIDAS_SCAN_PRICES", default=True)
     clean_prices = parse_bool_env("MIDAS_CLEAN_PRICES", default=True)
-    frequency = os.environ.get("FREQUENCY", "1h")
+    frequency = os.environ.get("FREQUENCY", "1d")
     if frequency not in {"1h", "1d"}:
         message = f"Unsupported FREQUENCY: {frequency}"
         raise ValueError(message)

--- a/tests/midas/test_midas_backfill_history.py
+++ b/tests/midas/test_midas_backfill_history.py
@@ -1,0 +1,55 @@
+"""Regression tests for the Midas historical backfill helpers."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from eth_defi.midas.constants import MIDAS_MBASIS_ETHEREUM, MIDAS_MTBILL_ETHEREUM
+
+EXPLICIT_START_BLOCK = 123_456
+
+
+@pytest.fixture
+def backfill_history_module():
+    """Load the hyphenated Midas backfill script as a Python module."""
+
+    script_path = Path(__file__).parents[2] / "scripts" / "midas" / "backfill-history.py"
+    spec = importlib.util.spec_from_file_location("midas_backfill_history", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_resolve_price_scan_start_block_uses_earliest_midas_deployment(
+    monkeypatch: pytest.MonkeyPatch,
+    backfill_history_module,
+) -> None:
+    """Start a default Midas rewrite at its earliest selected deployment."""
+
+    monkeypatch.delenv("START_BLOCK", raising=False)
+
+    assert (
+        backfill_history_module.resolve_price_scan_start_block(
+            [MIDAS_MBASIS_ETHEREUM, MIDAS_MTBILL_ETHEREUM],
+        )
+        == MIDAS_MTBILL_ETHEREUM.first_seen_at_block
+    )
+
+
+def test_resolve_price_scan_start_block_honours_explicit_override(
+    monkeypatch: pytest.MonkeyPatch,
+    backfill_history_module,
+) -> None:
+    """Allow an operator to pin a smaller diagnostic backfill range."""
+
+    monkeypatch.setenv("START_BLOCK", str(EXPLICIT_START_BLOCK))
+
+    assert (
+        backfill_history_module.resolve_price_scan_start_block(
+            [MIDAS_MBASIS_ETHEREUM, MIDAS_MTBILL_ETHEREUM],
+        )
+        == EXPLICIT_START_BLOCK
+    )

--- a/tests/midas/test_midas_backfill_history.py
+++ b/tests/midas/test_midas_backfill_history.py
@@ -53,3 +53,35 @@ def test_resolve_price_scan_start_block_honours_explicit_override(
         )
         == EXPLICIT_START_BLOCK
     )
+
+
+def test_resolve_frequency_defaults_to_daily(monkeypatch: pytest.MonkeyPatch, backfill_history_module) -> None:
+    """Use daily historical samples unless an operator explicitly overrides them.
+
+    1. Clear the optional operator override.
+    2. Resolve the script frequency.
+    3. Assert that the documented daily default is used.
+    """
+
+    # 1. Clear the optional operator override.
+    monkeypatch.delenv("FREQUENCY", raising=False)
+
+    # 2. Resolve the script frequency.
+    # 3. Assert that the documented daily default is used.
+    assert backfill_history_module.resolve_frequency() == "1d"
+
+
+def test_resolve_frequency_honours_hourly_override(monkeypatch: pytest.MonkeyPatch, backfill_history_module) -> None:
+    """Allow an operator to opt into an hourly Midas historical backfill.
+
+    1. Set the explicit hourly operator override.
+    2. Resolve the script frequency.
+    3. Assert that the requested frequency is retained.
+    """
+
+    # 1. Set the explicit hourly operator override.
+    monkeypatch.setenv("FREQUENCY", "1h")
+
+    # 2. Resolve the script frequency.
+    # 3. Assert that the requested frequency is retained.
+    assert backfill_history_module.resolve_frequency() == "1h"

--- a/tests/midas/test_midas_vault.py
+++ b/tests/midas/test_midas_vault.py
@@ -22,7 +22,7 @@ from eth_defi.hypersync.hypersync_timestamp import get_block_timestamps_using_hy
 from eth_defi.hypersync.server import get_hypersync_server
 from eth_defi.hypersync.session import ThrottledHypersyncClient, create_throttled_hypersync_client
 from eth_defi.midas.constants import MIDAS_MBASIS_ETHEREUM, MIDAS_MTBILL_ETHEREUM, MIDAS_PRODUCTS
-from eth_defi.midas.historical import MidasVaultHistoricalReader
+from eth_defi.midas.historical import MidasVaultHistoricalReader, MidasVaultReaderState
 from eth_defi.midas.registry import (
     MIDAS_ADDRESSES_PER_NETWORK,
     MIDAS_CHAIN_IDS,
@@ -451,6 +451,46 @@ def test_midas_historical_reader_live_mtbill(web3: Web3) -> None:
     assert read.performance_fee is None
     assert read.management_fee is None
     assert read.errors is None
+
+
+@flaky.flaky
+def test_midas_historical_reader_updates_state(web3: Web3) -> None:
+    """Persist Midas reader state after a successful historical sample."""
+
+    vault = create_vault_instance_autodetect(
+        web3,
+        vault_address=MIDAS_MTBILL_ETHEREUM.token,
+    )
+    reader = vault.get_historical_reader(stateful=True)
+    assert isinstance(reader, MidasVaultHistoricalReader)
+    assert isinstance(reader.reader_state, MidasVaultReaderState)
+
+    timestamp = datetime.datetime.fromtimestamp(
+        web3.eth.get_block(MIDAS_TEST_BLOCK)["timestamp"],
+        tz=datetime.UTC,
+    ).replace(tzinfo=None)
+    call_results = [
+        call.call_as_result(
+            web3,
+            block_identifier=MIDAS_TEST_BLOCK,
+            ignore_error=True,
+        )
+        for call in reader.construct_multicalls()
+    ]
+    for call_result in call_results:
+        call_result.timestamp = timestamp
+        call_result.state = reader.reader_state
+
+    reader.process_result(
+        block_number=MIDAS_TEST_BLOCK,
+        timestamp=timestamp,
+        call_results=call_results,
+    )
+
+    assert reader.reader_state.last_block == MIDAS_TEST_BLOCK
+    assert reader.reader_state.entry_count == 1
+    assert reader.reader_state.last_tvl == MTBILL_EXPECTED_TOTAL_ASSETS
+    assert reader.reader_state.exchange_rate == 1
 
 
 @flaky.flaky

--- a/tests/research/test_clean_prices.py
+++ b/tests/research/test_clean_prices.py
@@ -12,6 +12,7 @@ import pyarrow.parquet as pq
 import pytest
 import zstandard as zstd
 
+import eth_defi.research.wrangle_vault_prices as vault_price_wrangle
 from eth_defi.research.wrangle_vault_prices import (
     discard_hypercore_pre_recapitalisation_history,
     fix_hypercore_source_overlap_share_prices,
@@ -165,8 +166,8 @@ def test_replace_cleaned_vault_histories_preserves_unrelated_vaults(
         price_df_path=raw_price_df,
         cleaned_price_df_path=cleaned_path,
     )
-    before = pd.read_parquet(cleaned_path).sort_values(["id", "timestamp"]).reset_index(drop=True)
-    target_id = str(before["id"].iloc[0])
+    before = pd.read_parquet(cleaned_path).reset_index(drop=True)
+    target_id = str(before["id"].drop_duplicates().iloc[1])
 
     replaced_rows = replace_cleaned_vault_histories(
         {target_id},
@@ -174,9 +175,52 @@ def test_replace_cleaned_vault_histories_preserves_unrelated_vaults(
         raw_price_df_path=raw_price_df,
         cleaned_price_df_path=cleaned_path,
     )
-    after = pd.read_parquet(cleaned_path).sort_values(["id", "timestamp"]).reset_index(drop=True)
+    after = pd.read_parquet(cleaned_path).reset_index(drop=True)
 
     assert replaced_rows == len(before[before["id"] == target_id])
+    pd.testing.assert_frame_equal(after, before)
+
+
+def test_replace_cleaned_vault_histories_rejects_vault_removed_by_cleaning(
+    vault_db: Path,
+    raw_price_df: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep existing history when cleaning would remove a selected vault.
+
+    1. Create a normal cleaned price database and retain its contents.
+    2. Mock the selected-vault cleaner to return no rows.
+    3. Assert that replacement fails and the original Parquet remains intact.
+    """
+
+    # 1. Create a normal cleaned price database and retain its contents.
+    cleaned_path = tmp_path / "cleaned-vault-prices.parquet"
+    generate_cleaned_vault_datasets(
+        vault_db_path=vault_db,
+        price_df_path=raw_price_df,
+        cleaned_price_df_path=cleaned_path,
+    )
+    before = pd.read_parquet(cleaned_path).reset_index(drop=True)
+    target_id = str(before["id"].iloc[0])
+    empty_cleaned_rows = pd.read_parquet(cleaned_path).iloc[0:0].copy()
+
+    # 2. Mock the selected-vault cleaner to return no rows.
+    monkeypatch.setattr(
+        vault_price_wrangle,
+        "process_raw_vault_scan_data",
+        lambda *args, **kwargs: empty_cleaned_rows,
+    )
+
+    # 3. Assert that replacement fails and the original Parquet remains intact.
+    with pytest.raises(ValueError, match="Cleaning removed all rows"):
+        replace_cleaned_vault_histories(
+            {target_id},
+            vault_db_path=vault_db,
+            raw_price_df_path=raw_price_df,
+            cleaned_price_df_path=cleaned_path,
+        )
+    after = pd.read_parquet(cleaned_path).reset_index(drop=True)
     pd.testing.assert_frame_equal(after, before)
 
 

--- a/tests/research/test_clean_prices.py
+++ b/tests/research/test_clean_prices.py
@@ -17,6 +17,7 @@ from eth_defi.research.wrangle_vault_prices import (
     fix_hypercore_source_overlap_share_prices,
     fix_outlier_share_prices,
     generate_cleaned_vault_datasets,
+    replace_cleaned_vault_histories,
 )
 from eth_defi.vault.base import VaultHistoricalRead
 from eth_defi.vault.settlement_data import VaultSettlement, VaultSettlementDatabase
@@ -150,6 +151,33 @@ def test_clean_vault_price_data_with_settlement_markers(
     assert "timestamp" in df.columns or df.index.name == "timestamp"
     assert "vault_settlement_at" in df.columns
     assert df["vault_settlement_at"].notna().any()
+
+
+def test_replace_cleaned_vault_histories_preserves_unrelated_vaults(
+    vault_db: Path,
+    raw_price_df: Path,
+    tmp_path: Path,
+) -> None:
+    """A targeted history repair does not re-clean or remove other vault ids."""
+    cleaned_path = tmp_path / "cleaned-vault-prices.parquet"
+    generate_cleaned_vault_datasets(
+        vault_db_path=vault_db,
+        price_df_path=raw_price_df,
+        cleaned_price_df_path=cleaned_path,
+    )
+    before = pd.read_parquet(cleaned_path).sort_values(["id", "timestamp"]).reset_index(drop=True)
+    target_id = str(before["id"].iloc[0])
+
+    replaced_rows = replace_cleaned_vault_histories(
+        {target_id},
+        vault_db_path=vault_db,
+        raw_price_df_path=raw_price_df,
+        cleaned_price_df_path=cleaned_path,
+    )
+    after = pd.read_parquet(cleaned_path).sort_values(["id", "timestamp"]).reset_index(drop=True)
+
+    assert replaced_rows == len(before[before["id"] == target_id])
+    pd.testing.assert_frame_equal(after, before)
 
 
 def test_remove_inactive_lead_time():


### PR DESCRIPTION
## Why

Midas history rewrites incorrectly inherited the latest reader state from unrelated Ethereum vaults, so they started near the chain head and omitted deployment-era data. Midas readers also did not persist successful samples, preventing adaptive scheduling.

## Lessons learnt

A targeted historical rewrite must derive its start block and reader state solely from its selected vaults. A one-file Parquet dataset still needs an atomic file rewrite to replace rows, but only selected vault histories need recalculation.

## Summary

- Start Midas backfills at the earliest selected deployment block.
- Persist USD-denominated Midas reader state after successful samples.
- Rebuild only selected cleaned vault histories while preserving all other rows.
- Remove the unsafe partial-rewrite switch and add regression coverage.

## Related issues and PRs

Continues Midas integration PRs #1237 and #1240.