### PR TITLE
fix: repair Hypercore synthetic share price continuity

### DIFF
--- a/docs/claude-plans/2026-07-14-hypercore-share-price-continuity.md
+++ b/docs/claude-plans/2026-07-14-hypercore-share-price-continuity.md
@@ -1,0 +1,202 @@
+# Hypercore share price continuity repair plan
+
+**Date:** 2026-07-14
+
+## Goal
+
+Produce a stable, actionable Hypercore share price with the smallest practical
+change to the existing pipeline:
+
+1. New daily and high-frequency scans must continue on the same price scale.
+2. Existing batch-scale jumps in the historical Parquet must be repaired during
+   wrangling.
+
+Hyperliquid does not expose a native share price or share supply. The value we
+publish is a synthetic time-weighted return index derived from portfolio NAV and
+PnL. This plan keeps that existing model instead of adding a second
+fill-by-fill, candle-based accounting system.
+
+## Root cause
+
+There are two related defects.
+
+- `_merge_portfolio_periods()` overlays high-resolution NAV from the `month`,
+  `week`, and `day` windows, but replaces their matching PnL with the nearest
+  sparse `allTime` PnL. Trading changes are then mistaken for capital flows by
+  `netflow_update = NAV change - PnL change`, corrupting synthetic share supply.
+- Each API read recalculates the complete synthetic curve from rolling windows.
+  The HF scanner appends the newly calculated rows without aligning their price
+  scale with the rows already stored. A `written_at` batch boundary can
+  therefore create a large price-level jump even when NAV and PnL barely move.
+
+HODL My Perps demonstrates both problems after its April 2026 recapitalisation:
+its May price changes of roughly 2x, 56x, and 3.6x coincide with scanner batch
+changes rather than economic returns.
+
+## Part 1: Fix new data going forward
+
+### 1. Preserve each period's NAV/PnL pairs
+
+Update `eth_defi/hyperliquid/daily_metrics.py::_merge_portfolio_periods()`.
+
+- Pair `account_value_history` and `pnl_history` by timestamp within each API
+  period.
+- Treat `allTime` PnL as the common cumulative scale.
+- For each shorter period, find its latest timestamp that is also present in
+  `allTime`, then add the PnL difference at that shared timestamp to every PnL
+  value in the shorter period. If there is no shared timestamp, do not overlay
+  that period.
+- Overlay the aligned `(timestamp, NAV, PnL)` rows together. Do not perform a
+  nearest-neighbour lookup against sparse `allTime` PnL.
+
+This retains the high-resolution trading PnL that the current merge discards,
+while leaving `portfolio_to_combined_dataframe()` and `_calculate_share_price()`
+unchanged.
+
+### 2. Chain a recalculated curve to stored history
+
+Add one small shared helper for the daily and HF scanners. Given a newly
+calculated curve and the latest stored positive share price:
+
+1. Locate that stored timestamp in the new curve, using exact overlap for daily
+   rows and time interpolation for HF rows.
+2. Calculate one multiplicative scale factor so that the new curve equals the
+   stored share price at the overlap.
+3. Multiply new `share_price` values by the factor and divide `total_supply` by
+   the same factor. NAV and PnL are not changed.
+4. Recalculate the first appended return against the actual last stored share
+   price.
+
+Both scanner databases persist their return column independently, so the last
+step is required even though the wrangle pipeline later derives returns again.
+Use one lower-level scaling primitive for this helper, historical batch
+stitching, and recapitalisation normalisation: multiply `share_price` for a row
+slice by a factor and divide `total_supply` by the same factor.
+
+For a brand-new vault with no stored price, use the newly calculated curve as
+is; the existing synthetic-supply calculation anchors its first funded row at
+`1.0`. A missing stored anchor is therefore a valid bootstrap, whereas an
+existing stored anchor outside the new API curve is an error.
+
+For an existing daily vault, only update the overlapping boundary date and
+append later dates; do not refresh its complete historical curve on every scan.
+The HF scanner keeps its existing append-only behaviour after applying the same
+alignment.
+
+If the latest stored timestamp is outside the new API curve, skip that vault for
+the scan and log the reason. Guessing a scale without any overlap would recreate
+the original problem.
+
+### 3. Keep Hypercore returns derived from the repaired price
+
+After the price calculation is corrected, do not replace positive Hypercore
+returns above 50% with zero in `clean_returns()`. That changes the return but
+leaves the price level untouched and hides future calculation defects. Keep the
+existing generic return cleaning for other protocols.
+
+No new Parquet columns or pricing database are needed.
+
+## Part 2: Fix historical data
+
+Historical high-resolution period PnL was discarded by the old merge and can no
+longer be fetched for expired rolling windows. Repair the scale discontinuities
+that are still observable in the raw Parquet instead of attempting a more
+precise reconstruction than the retained data supports.
+
+### 1. Normalise recapitalised epochs
+
+Extend `discard_hypercore_pre_recapitalisation_history()` so that, after it
+selects the first retained row of a recapitalised epoch, it normalises that row
+to share price `1.0` and applies the same factor to all later rows in the epoch.
+Adjust `total_supply` inversely so that `total_assets / total_supply` remains
+consistent.
+
+The old epoch remains in the raw Parquet and retains its real -100% result. For
+HODL, the cleaned epoch continues to start at the existing 20 April 2026 `$1,000`
+tracking threshold.
+
+Initialise `raw_share_price` before this step so the original input value remains
+available after normalisation and later repairs.
+
+### 2. Stitch legacy HF scanner batches
+
+Add one wrangle function before
+`fix_hypercore_source_overlap_share_prices()` and before returns are calculated.
+For each Hypercore vault and recapitalisation epoch:
+
+- Inspect consecutive HF rows where `written_at` changes.
+- Estimate the economic boundary return from the change in `cumulative_pnl`
+  divided by the preceding NAV.
+- When the observed share-price boundary differs from that estimate by more
+  than 50%, multiply the current and all later rows by one correction factor.
+- Only use short, consecutive boundaries with finite positive NAV and PnL. If
+  those inputs are unavailable, leave the rows unchanged.
+- Record an applied repair using the existing `hypercore_repair_status` column,
+  for example `repaired_hf_batch_scale`.
+- Log the vault, timestamp, and factor for every repair; highlight factors over
+  2x so large historical corrections are visible in the wrangle summary.
+
+The correction factor is cumulative across later batches. This repairs HODL's
+post-recapitalisation May jumps and the same `written_at`-aligned failure in
+other vaults without vault-name allowlists or hand-authored dates.
+
+After HF batches are on one scale, run the existing daily/HF source-overlap
+repair so daily rows use the corrected HF curve as their anchor.
+
+### 3. Regenerate the cleaned production Parquet
+
+- Run the wrangle pipeline from the unchanged raw production Parquet.
+- Write the result through the existing temporary-file/atomic replacement path.
+- Do not rewrite or delete the raw Parquet.
+- Compare HODL, Magixbox, C.A.T, and the previously identified batch-jump census
+  before replacing the cleaned production file.
+
+## Focused tests
+
+Add small synthetic tests only:
+
+1. A shorter portfolio period whose PnL starts at zero is aligned to `allTime`
+   while retaining its intra-period PnL changes.
+2. Re-reading the same vault with shifted rolling timestamps produces an HF
+   append on the existing price scale.
+3. A daily refresh updates only the overlap date and new dates.
+4. A `written_at` boundary with stable PnL is stitched, while a matching genuine
+   PnL return is left unchanged.
+5. A recapitalised epoch starts at `1.0`; its old cleaned rows are removed and
+   its raw share prices remain preserved.
+6. Hypercore returns are not silently zeroed solely because they exceed 50%.
+
+Run the relevant tests with:
+
+```shell
+source .local-test.env && poetry run pytest \
+  tests/hyperliquid/test_share_price_continuity.py \
+  tests/research/test_clean_prices.py -k 'hypercore or recapitalisation' -q
+```
+
+Run the completed wrangle step read-only against a copy of the current
+production Parquet and confirm:
+
+- HODL's new epoch starts at `1.0` and no longer has the May batch-scale jumps.
+- No repair crosses a zero-NAV/recapitalisation boundary.
+- Re-running the wrangle step produces identical prices.
+
+## Documentation updates during implementation
+
+- Update `eth_defi/hyperliquid/problem-vaults.md` with the final HODL result and
+  the number of other historical batches repaired.
+- Update the share-price and healing sections of
+  `scripts/hyperliquid/README-hyperliquid-vaults.md` to describe PnL alignment,
+  scanner scale chaining, and historical batch stitching.
+- Correct the `compute_event_share_prices()` documentation: it currently uses
+  realised PnL only and is not the continuous mark-to-market method selected by
+  this plan.
+
+## Out of scope
+
+- A new event-history database or candle-based equity reconstruction.
+- New quality/status schemas beyond the existing `raw_share_price` and
+  `hypercore_repair_status` columns.
+- Interpolating missing C.A.T history where neither HF observations nor a safe
+  scanner-batch boundary exists.
+- Rewriting the raw production Parquet.

--- a/eth_defi/hyperliquid/combined_analysis.py
+++ b/eth_defi/hyperliquid/combined_analysis.py
@@ -52,6 +52,10 @@ Example::
     print(f"Total supply: {combined_df['total_supply'].iloc[-1]:,.2f}")
 """
 
+import datetime
+import math
+from collections.abc import Sequence
+
 import pandas as pd
 
 #: When the computed share price exceeds this threshold, the epoch
@@ -66,6 +70,109 @@ SHARE_PRICE_RESET_THRESHOLD: float = 10_000.0
 #: as zero) to avoid creating phantom shares from negligible dust that
 #: can then produce negative share prices on subsequent losses.
 EPOCH_RESET_MIN_ASSETS: float = 10.0
+
+
+def rescale_share_price_rows(
+    prices_df: pd.DataFrame,
+    factor: float,
+    row_positions: Sequence[int] | None = None,
+) -> pd.DataFrame:
+    """Rescale synthetic share prices without changing the represented NAV.
+
+    Hyperliquid does not publish an investable vault share price or share
+    supply.  The scanners derive both values from rolling portfolio windows,
+    so an otherwise equivalent re-read can use a different arbitrary unit.
+    Multiplying ``share_price`` and dividing ``total_supply`` by the same
+    factor preserves the invariant ``total_assets == share_price *
+    total_supply`` while choosing a consistent unit.
+
+    :param prices_df:
+        DataFrame containing a finite positive ``share_price`` column and,
+        optionally, a ``total_supply`` column. Rows are modified in place.
+    :param factor:
+        Finite positive multiplier applied to ``share_price``.
+    :param row_positions:
+        Optional positional rows to rescale. When omitted every row is
+        rescaled.
+    :return:
+        The same DataFrame instance after the unit rescaling.
+    """
+    if not math.isfinite(factor) or factor <= 0:
+        raise ValueError(f"Share-price scale factor must be finite and positive, got {factor!r}")
+
+    if row_positions is None:
+        prices_df.loc[:, "share_price"] *= factor
+        if "total_supply" in prices_df.columns:
+            prices_df.loc[:, "total_supply"] /= factor
+        return prices_df
+
+    positions = list(row_positions)
+    if not positions:
+        return prices_df
+
+    share_price_column = prices_df.columns.get_loc("share_price")
+    prices_df.iloc[positions, share_price_column] *= factor
+    if "total_supply" in prices_df.columns:
+        total_supply_column = prices_df.columns.get_loc("total_supply")
+        prices_df.iloc[positions, total_supply_column] /= factor
+
+    return prices_df
+
+
+def align_share_price_curve_to_anchor(
+    prices_df: pd.DataFrame,
+    anchor_timestamp: datetime.datetime | pd.Timestamp,
+    anchor_share_price: float,
+) -> pd.DataFrame | None:
+    """Align a newly reconstructed share-price curve to one persisted price.
+
+    The exact timestamp is used when present. For the high-frequency scanner,
+    which may revisit a rolling window with shifted timestamps, the anchor is
+    interpolated in log-price space between bracketing observations. The
+    resulting constant factor is applied with
+    :py:func:`rescale_share_price_rows`, preserving NAV and supply.
+
+    :param prices_df:
+        Chronologically sorted DataFrame with a ``DatetimeIndex`` and finite
+        positive ``share_price`` values.
+    :param anchor_timestamp:
+        Timestamp of the already persisted price.
+    :param anchor_share_price:
+        Finite positive persisted share price to retain.
+    :return:
+        Rescaled DataFrame, or ``None`` when the curve cannot be anchored
+        because the timestamp lies outside it or cannot be interpolated.
+    """
+    if not math.isfinite(anchor_share_price) or anchor_share_price <= 0:
+        raise ValueError(f"Anchor share price must be finite and positive, got {anchor_share_price!r}")
+
+    curve = prices_df.copy()
+    timestamps = pd.DatetimeIndex(curve.index)
+    anchor_timestamp = pd.Timestamp(anchor_timestamp)
+    if len(curve) == 0 or anchor_timestamp < timestamps[0] or anchor_timestamp > timestamps[-1]:
+        return None
+
+    exact_match = timestamps == anchor_timestamp
+    if exact_match.any():
+        curve_price = float(curve.loc[exact_match, "share_price"].iloc[-1])
+    else:
+        right_position = int(timestamps.searchsorted(anchor_timestamp))
+        if right_position == 0 or right_position == len(curve):
+            return None
+        left_position = right_position - 1
+        left_price = float(curve["share_price"].iloc[left_position])
+        right_price = float(curve["share_price"].iloc[right_position])
+        if not all(math.isfinite(price) and price > 0 for price in (left_price, right_price)):
+            return None
+        elapsed = (anchor_timestamp - timestamps[left_position]).total_seconds()
+        span = (timestamps[right_position] - timestamps[left_position]).total_seconds()
+        if span <= 0:
+            return None
+        curve_price = math.exp(math.log(left_price) + (math.log(right_price) - math.log(left_price)) * elapsed / span)
+
+    if not math.isfinite(curve_price) or curve_price <= 0:
+        return None
+    return rescale_share_price_rows(curve, anchor_share_price / curve_price)
 
 
 def analyse_positions_and_deposits(

--- a/eth_defi/hyperliquid/daily_metrics.py
+++ b/eth_defi/hyperliquid/daily_metrics.py
@@ -38,7 +38,7 @@ from joblib import Parallel, delayed
 from tqdm_loggable.auto import tqdm
 
 from eth_defi.compat import native_datetime_utc_now
-from eth_defi.hyperliquid.combined_analysis import _calculate_share_price
+from eth_defi.hyperliquid.combined_analysis import _calculate_share_price, align_share_price_curve_to_anchor
 from eth_defi.hyperliquid.constants import HYPERCORE_CHAIN_ID, HYPERLIQUID_DAILY_METRICS_DATABASE
 from eth_defi.hyperliquid.vault_metrics_db import HyperliquidMetricsDatabaseBase
 from eth_defi.hyperliquid.deposit import aggregate_daily_flows, fetch_vault_deposits
@@ -149,21 +149,16 @@ def _merge_portfolio_periods(
         Merged :py:class:`~eth_defi.hyperliquid.vault.PortfolioHistory`
         with ``period="merged"``.
     """
-    import bisect
-
     all_time = portfolio.get("allTime")
     if all_time is None:
         raise ValueError("allTime period is required for merge")
 
-    # Start with allTime as the base
-    base_avh = list(all_time.account_value_history)
-    base_pnl = list(all_time.pnl_history)
-    base_avh.sort(key=lambda x: x[0])
-    base_pnl.sort(key=lambda x: x[0])
-
-    # Build the authoritative PnL lookup from allTime (for later reconstruction)
-    alltime_pnl_times = [ts for ts, _ in base_pnl]
-    alltime_pnl_values = [float(val) for _, val in base_pnl]
+    # Keep NAV and PnL as one record throughout the merge.  The consumer
+    # intentionally pairs the two streams by position, so independent merges
+    # would silently turn a PnL change into an apparent capital flow.
+    alltime_pnl_by_timestamp = dict(all_time.pnl_history)
+    base_records = [(ts, av, alltime_pnl_by_timestamp[ts]) for ts, av in all_time.account_value_history if ts in alltime_pnl_by_timestamp]
+    base_records.sort(key=lambda record: record[0])
 
     dedup_seconds = dedup_window_hours * 3600
 
@@ -174,45 +169,42 @@ def _merge_portfolio_periods(
             continue
 
         overlay_avh = sorted(period.account_value_history, key=lambda x: x[0])
-        overlay_timestamps = [ts for ts, _ in overlay_avh]
+        overlay_pnl = sorted(period.pnl_history, key=lambda x: x[0])
+        overlay_pnl_by_timestamp = dict(overlay_pnl)
+
+        # Portfolio PnL is cumulative but each rolling period has its own
+        # origin. Rebase it only at an exact shared timestamp, keeping NAV and
+        # PnL observations paired. Nearest-neighbour allTime PnL made ordinary
+        # trading changes look like deposits and corrupted synthetic prices.
+        shared_timestamps = set(overlay_pnl_by_timestamp).intersection(alltime_pnl_by_timestamp)
+        if not shared_timestamps:
+            continue
+        shared_timestamp = max(shared_timestamps)
+        pnl_offset = alltime_pnl_by_timestamp[shared_timestamp] - overlay_pnl_by_timestamp[shared_timestamp]
+        overlay_pairs = [(ts, av, pnl + pnl_offset) for ts, av in overlay_avh if ts in overlay_pnl_by_timestamp for pnl in (overlay_pnl_by_timestamp[ts],)]
+        if len(overlay_pairs) < 2:
+            continue
+        overlay_timestamps = [ts for ts, _av, _pnl in overlay_pairs]
 
         # Remove base points too close to any overlay point
         filtered_base = []
-        for ts, av in base_avh:
+        for ts, av, pnl in base_records:
             too_close = False
             for ots in overlay_timestamps:
                 if abs((ts - ots).total_seconds()) < dedup_seconds:
                     too_close = True
                     break
             if not too_close:
-                filtered_base.append((ts, av))
+                filtered_base.append((ts, av, pnl))
 
-        base_avh = filtered_base
-        base_avh.extend(overlay_avh)
-        base_avh.sort(key=lambda x: x[0])
-
-    def _nearest_pnl(ts: datetime.datetime) -> float:
-        """Look up the nearest allTime PnL value for a given timestamp."""
-        if not alltime_pnl_times:
-            return 0.0
-        pos = bisect.bisect_left(alltime_pnl_times, ts)
-        if pos == 0:
-            return alltime_pnl_values[0]
-        if pos >= len(alltime_pnl_times):
-            return alltime_pnl_values[-1]
-        before = alltime_pnl_times[pos - 1]
-        after = alltime_pnl_times[pos]
-        if abs((ts - before).total_seconds()) <= abs((ts - after).total_seconds()):
-            return alltime_pnl_values[pos - 1]
-        return alltime_pnl_values[pos]
-
-    # Rebuild pnl_history using nearest allTime PnL values
-    merged_pnl = [(ts, _nearest_pnl(ts)) for ts, _ in base_avh]
+        base_records = filtered_base
+        base_records.extend(overlay_pairs)
+        base_records.sort(key=lambda record: record[0])
 
     return PortfolioHistory(
         period="merged",
-        account_value_history=base_avh,
-        pnl_history=merged_pnl,
+        account_value_history=[(ts, av) for ts, av, _pnl in base_records],
+        pnl_history=[(ts, pnl) for ts, _av, pnl in base_records],
         volume=all_time.volume,
     )
 
@@ -1113,6 +1105,31 @@ def fetch_and_store_vault(
         flow_data_earliest_date=flow_data_earliest_date,
     )
 
+    # Keep one latest portfolio observation per UTC day. This preserves the
+    # daily table's public contract while allowing the curve to be aligned to
+    # its existing daily unit before the overlap date is refreshed.
+    combined_df = combined_df.copy()
+    combined_df["date"] = pd.DatetimeIndex(combined_df.index).date
+    combined_df = combined_df.groupby("date", sort=False).tail(1).copy()
+    combined_df.index = pd.to_datetime(combined_df["date"])
+    combined_df.drop(columns="date", inplace=True)
+
+    existing_prices = db.get_vault_daily_prices(vault_address)
+    last_stored_date = db.get_vault_last_date(vault_address)
+    if last_stored_date is not None:
+        stored_anchor = existing_prices.iloc[-1]
+        anchor_timestamp = datetime.datetime.combine(last_stored_date, datetime.time())
+        combined_df = align_share_price_curve_to_anchor(combined_df, anchor_timestamp, float(stored_anchor["share_price"]))
+        if combined_df is None:
+            logger.warning(
+                "Skipping daily price update for %s (%s): current curve does not overlap stored date %s",
+                info.name,
+                vault_address,
+                last_stored_date,
+            )
+            return False
+        combined_df = combined_df[combined_df.index.date >= last_stored_date]
+
     # Build daily price rows.
     # Only the latest row gets the current API snapshot fields;
     # historical rows get None so we track how these values evolve over time.
@@ -1124,6 +1141,11 @@ def fetch_and_store_vault(
     last_idx = len(combined_df) - 1
     rows: list[HyperliquidDailyPriceRow] = []
     prev_share_price = None
+    if last_stored_date is not None and not existing_prices.empty:
+        first_date = combined_df.index[0].date()
+        prior_prices = existing_prices[pd.to_datetime(existing_prices["date"]).dt.date < first_date]
+        if not prior_prices.empty:
+            prev_share_price = float(prior_prices.iloc[-1]["share_price"])
     for i, (ts, row_data) in enumerate(zip(combined_df.index, combined_df.itertuples())):
         date_val = ts.date() if hasattr(ts, "date") else ts
 

--- a/eth_defi/hyperliquid/high_freq_metrics.py
+++ b/eth_defi/hyperliquid/high_freq_metrics.py
@@ -38,15 +38,15 @@ from eth_typing import HexAddress
 from joblib import Parallel, delayed
 from tqdm_loggable.auto import tqdm
 
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.hyperliquid.combined_analysis import align_share_price_curve_to_anchor
 from eth_defi.hyperliquid.constants import (
     HYPERLIQUID_HIGH_FREQ_DEFAULT_INTERVAL,
     HYPERLIQUID_HIGH_FREQ_METRICS_DATABASE,
 )
-from eth_defi.hyperliquid.vault_metrics_db import HyperliquidMetricsDatabaseBase
 from eth_defi.hyperliquid.daily_metrics import (
     portfolio_to_combined_dataframe,
 )
-from eth_defi.hyperliquid.combined_analysis import align_share_price_curve_to_anchor
 from eth_defi.hyperliquid.deposit import (
     aggregate_daily_flows,
     fetch_vault_deposits,
@@ -58,7 +58,7 @@ from eth_defi.hyperliquid.vault import (
     VaultSummary,
     fetch_all_vaults,
 )
-from eth_defi.compat import native_datetime_utc_now
+from eth_defi.hyperliquid.vault_metrics_db import HyperliquidMetricsDatabaseBase
 
 logger = logging.getLogger(__name__)
 
@@ -510,11 +510,12 @@ def fetch_and_store_vault_high_freq(
     now = native_datetime_utc_now()
     prev_share_price = None
     if last_stored_ts is not None and not existing_prices.empty:
-        previous_prices = existing_prices[pd.to_datetime(existing_prices["timestamp"]) < pd.Timestamp(last_stored_ts)]
-        if not previous_prices.empty:
-            prev_share_price = float(previous_prices.iloc[-1]["share_price"])
-        else:
-            prev_share_price = float(existing_prices.iloc[-1]["share_price"])
+        # The reconstructed window can have shifted API timestamps and may
+        # therefore not contain an exact copy of the persisted anchor. The
+        # first appended row is still immediately after that anchor, so its
+        # return must be measured from the latest stored price, not from the
+        # preceding stored observation.
+        prev_share_price = float(existing_prices.iloc[-1]["share_price"])
 
     for i, (ts, row_data) in enumerate(zip(combined_df.index, combined_df.itertuples())):
         raw_ts = ts.to_pydatetime() if hasattr(ts, "to_pydatetime") else ts

--- a/eth_defi/hyperliquid/high_freq_metrics.py
+++ b/eth_defi/hyperliquid/high_freq_metrics.py
@@ -46,6 +46,7 @@ from eth_defi.hyperliquid.vault_metrics_db import HyperliquidMetricsDatabaseBase
 from eth_defi.hyperliquid.daily_metrics import (
     portfolio_to_combined_dataframe,
 )
+from eth_defi.hyperliquid.combined_analysis import align_share_price_curve_to_anchor
 from eth_defi.hyperliquid.deposit import (
     aggregate_daily_flows,
     fetch_vault_deposits,
@@ -483,6 +484,18 @@ def fetch_and_store_vault_high_freq(
     # The merged portfolio history already has the highest available
     # resolution from _merge_portfolio_periods().
     last_stored_ts = db.get_vault_last_timestamp(vault_address)
+    existing_prices = db.get_vault_high_freq_prices(vault_address)
+    if last_stored_ts is not None:
+        stored_anchor = existing_prices.iloc[-1]
+        combined_df = align_share_price_curve_to_anchor(combined_df, last_stored_ts, float(stored_anchor["share_price"]))
+        if combined_df is None:
+            logger.warning(
+                "Skipping HF price update for %s (%s): current curve does not overlap stored timestamp %s",
+                info.name,
+                vault_address,
+                last_stored_ts,
+            )
+            return False
 
     # Precompute the last row index per calendar date so that flow
     # data is only attached once per day (avoiding duplication when
@@ -496,14 +509,18 @@ def fetch_and_store_vault_high_freq(
     rows: list[HyperliquidHighFreqPriceRow] = []
     now = native_datetime_utc_now()
     prev_share_price = None
+    if last_stored_ts is not None and not existing_prices.empty:
+        previous_prices = existing_prices[pd.to_datetime(existing_prices["timestamp"]) < pd.Timestamp(last_stored_ts)]
+        if not previous_prices.empty:
+            prev_share_price = float(previous_prices.iloc[-1]["share_price"])
+        else:
+            prev_share_price = float(existing_prices.iloc[-1]["share_price"])
 
     for i, (ts, row_data) in enumerate(zip(combined_df.index, combined_df.itertuples())):
         raw_ts = ts.to_pydatetime() if hasattr(ts, "to_pydatetime") else ts
 
         # Resumable: only store rows >= last stored timestamp
         if last_stored_ts is not None and raw_ts < last_stored_ts:
-            # Still track prev_share_price for return calc
-            prev_share_price = row_data.share_price
             continue
 
         # Cutoff filtering

--- a/eth_defi/hyperliquid/problem-vaults.md
+++ b/eth_defi/hyperliquid/problem-vaults.md
@@ -19,12 +19,20 @@ price reconstruction then invents a share mint or burn, producing a temporary
 price spike which often reverses at the next refreshed observation. This is a
 data artefact, not a realised vault return.
 
-The wrangle repair in
+The scanner and wrangle repairs in
 `eth_defi.research.wrangle_vault_prices.fix_hypercore_source_overlap_share_prices`
-addresses this case:
+and its surrounding continuity steps address these cases:
 
 - The daily and high-frequency exporters label every new row as `daily` or
   `hf` through `hypercore_source`.
+- Before writing an overlapping scan, each exporter scales its reconstructed
+  curve to the last persisted positive price. Daily scans use the shared date;
+  HF scans use log-price interpolation when rolling-window timestamps shift.
+  This preserves `NAV = share_price × total_supply` and never rewrites older
+  stored rows.
+- The period merge only overlays NAV/PnL pairs after rebasing a child PnL
+  series at an exact shared `allTime` timestamp. A period without such a
+  timestamp is skipped rather than nearest-neighbour matching unrelated PnL.
 - Positive-price, positive-NAV HF observations are the preferred canonical
   anchors. A daily point bracketed by them becomes a candidate if its symmetric
   price deviation exceeds 50%.
@@ -44,7 +52,14 @@ addresses this case:
   after a durable zero-NAV event. Durability is measured from zero NAV to the
   first later positive NAV; that recovery must take at least seven days. The
   new epoch starts at the first subsequent observation of at least `$1,000`
-  and is marked `epoch_reset`. The raw parquet is never discarded or rewritten.
+  and is marked `epoch_reset`. Its first retained synthetic price is normalised
+  to `1.0`; `raw_share_price` retains the scanner value. The raw parquet is
+  never discarded or rewritten.
+- A historical HF batch stitch compares consecutive `hf` rows whose
+  `written_at` changes. If their observed share-price change disagrees by more
+  than 50% with the PnL-supported return over a gap of at most two days, it
+  rescales the later batch and records `repaired_hf_batch_scale`. This is the
+  narrow repair path for HODL's post-recapitalisation unit changes.
 
 Legacy parquet rows predate explicit source provenance. They are classified as
 daily when their timestamp is midnight UTC and HF otherwise. This is valid for
@@ -212,10 +227,12 @@ loss. The wrangle pipeline applies a separate recapitalisation policy:
    row `epoch_reset`.
 3. Preserve the raw parquet for audit and historical analysis.
 
-This scopes the cleaned chart and metrics to the current capital epoch. It does
-not by itself reconstruct any remaining post-recapitalisation synthetic-price
-anomaly. The preceding -100% outcome remains available in raw data, but it is
-not chain-linked into a fictitious return on recapitalised capital.
+This scopes the cleaned chart and metrics to the current capital epoch and
+normalises its first retained price to `1.0`. The subsequent HF-batch stitch
+repairs short-gap arbitrary-unit jumps only when the cumulative-PnL change
+contradicts the observed price return; genuine PnL-supported moves remain.
+The preceding -100% outcome remains available in raw data, but it is not
+chain-linked into a fictitious return on recapitalised capital.
 
 At the 13 July 2026 live API check, the vault held a long position of `830.3`
 HYPE, entered at `64.8714`, with unrealised PnL of about `-$945.21` and a
@@ -271,6 +288,12 @@ unbracketed rows, NAV/gap/lifecycle deferrals, recapitalisation epoch filtering,
 and the distinction between first positive NAV and the later `$1,000` tracking
 threshold. A read-only production run removes 369 pre-recapitalisation rows
 across HODL My Perps, Rehobot LR, Sifu, and HLP Liquidator.
+
+The 14 July 2026 production HODL subset was also run through the new paths
+without writing parquet. It discards 161 pre-epoch rows, starts the retained
+epoch at `1.0`, and stitches three May HF batch boundaries. Its largest
+remaining one-step return is 7.68%, rather than the earlier non-economic 54.7x
+unit jump.
 
 See also `scripts/hyperliquid/README-hyperliquid-vaults.md`, in particular
 the *Healing share price data* section, for the scanner-level healing process.

--- a/eth_defi/hyperliquid/trade_history.py
+++ b/eth_defi/hyperliquid/trade_history.py
@@ -712,7 +712,7 @@ def compute_event_share_prices(
     ledger_events: list,
     initial_total_assets: float = 0.0,
 ) -> list[SharePriceEvent]:
-    """Compute event-accurate share prices from actual ledger events.
+    """Compute an event-driven indicative share-price series from available events.
 
     Unlike the portfolio-history-derived share prices (which suffer from
     resolution artefacts — see ``README-hyperliquid-vault-limitations.md``),
@@ -723,8 +723,11 @@ def compute_event_share_prices(
     - **Trading PnL**: Realised PnL from individual fills (``closed_pnl``)
     - **Funding payments**: USD amounts from ``userFunding``
 
-    This eliminates the resolution-dependent netflow derivation that causes
-    share price spikes in the current pipeline.
+    This avoids the resolution-dependent netflow derivation that causes share
+    price spikes in the portfolio-history pipeline. It is still indicative:
+    API retention limits and incomplete historical event coverage can omit
+    older fills or ledger events, so the result is not an authoritative vault
+    share price.
 
     The share price model follows ERC-4626 mechanics:
 

--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -32,6 +32,7 @@ from IPython.display import display
 from tqdm_loggable.auto import tqdm
 
 from eth_defi.chain import get_chain_name
+from eth_defi.hyperliquid.combined_analysis import rescale_share_price_rows
 from eth_defi.hyperliquid.constants import HYPERCORE_CHAIN_ID
 from eth_defi.token import is_stablecoin_like
 from eth_defi.types import Percent
@@ -59,6 +60,9 @@ MIN_HYPERCORE_RECAPITALISATION_ASSETS = 1_000.0
 
 #: Ignore isolated zero-NAV observations that recover before this delay.
 MIN_HYPERCORE_RECAPITALISATION_RECOVERY_DELAY = pd.Timedelta(days=7)
+
+#: Never infer a scanner-batch price unit across a longer missing-HF interval.
+HYPERCORE_MAX_HF_BATCH_STITCH_GAP = pd.Timedelta(days=2)
 
 
 class CleanedVaultPriceRow(TypedDict, total=False):
@@ -644,7 +648,13 @@ def clean_returns(
 
     returns_df = prices_df
 
+    # Hypercore prices are synthetic. Its source-aware continuity repairs run
+    # before this generic cleaner, and a genuine post-epoch trading return may
+    # exceed the ERC-4626-oriented threshold. Retain it for the downstream
+    # return-based suitability checks instead of replacing it with a false zero.
     high_returns_mask = returns_df[returns_col] > outlier_threshold
+    if "chain" in returns_df.columns:
+        high_returns_mask &= returns_df["chain"] != HYPERCORE_CHAIN_ID
     outlier_returns = returns_df[high_returns_mask]
 
     # Sort by return value (highest first)
@@ -659,7 +669,7 @@ def clean_returns(
         logger(f"Found 0 outlier returns > {outlier_threshold:%}")
 
     # Clean up obv too high returns
-    returns_df.loc[returns_df[returns_col] > outlier_threshold, returns_col] = 0
+    returns_df.loc[high_returns_mask, returns_col] = 0
 
     return returns_df
 
@@ -1023,9 +1033,11 @@ def discard_hypercore_pre_recapitalisation_history(
     if not hypercore_mask.any():
         return prices_df
 
+    prices_df = prices_df.copy()
     if "epoch_reset" not in prices_df.columns:
-        prices_df = prices_df.copy()
         prices_df["epoch_reset"] = False
+    if "raw_share_price" not in prices_df.columns:
+        prices_df["raw_share_price"] = prices_df["share_price"]
 
     remove_mask = np.zeros(len(prices_df), dtype=bool)
     epoch_reset_positions: list[int] = []
@@ -1076,9 +1088,144 @@ def discard_hypercore_pre_recapitalisation_history(
 
     epoch_reset_col = prices_df.columns.get_loc("epoch_reset")
     prices_df.iloc[epoch_reset_positions, epoch_reset_col] = True
+
+    # A new investor epoch must start from a readable unit price. Preserve the
+    # scanner value in raw_share_price, then rescale this vault's retained rows
+    # so the first meaningful recapitalisation observation is exactly 1.0.
+    for epoch_reset_position in epoch_reset_positions:
+        vault_id = prices_df.iloc[epoch_reset_position]["id"]
+        vault_positions = np.flatnonzero((prices_df["id"] == vault_id).to_numpy())
+        retained_positions = vault_positions[vault_positions >= epoch_reset_position]
+        recapitalisation_price = float(prices_df.iloc[epoch_reset_position]["share_price"])
+        if np.isfinite(recapitalisation_price) and recapitalisation_price > 0:
+            rescale_share_price_rows(prices_df, 1.0 / recapitalisation_price, retained_positions)
+
     filtered_prices_df = prices_df.iloc[~remove_mask].copy()
     logger(f"Discarded {int(remove_mask.sum()):,} pre-recapitalisation Hypercore price rows across {len(epoch_reset_positions):,} vaults; new epochs start once NAV reaches ${min_recapitalisation_assets:,.0f} after {min_recovery_delay}")
     return filtered_prices_df
+
+
+def stitch_hypercore_high_freq_share_price_batches(
+    prices_df: pd.DataFrame,
+    logger=print,
+    max_timestamp_gap: pd.Timedelta = HYPERCORE_MAX_HF_BATCH_STITCH_GAP,
+    max_return_deviation: Percent = 0.50,
+) -> pd.DataFrame:
+    """Stitch incompatible Hypercore high-frequency scanner batches.
+
+    The API supplies rolling account-value and cumulative-PnL windows, rather
+    than a share price or supply. A new scan batch can therefore reconstruct
+    the same vault in a different arbitrary unit. At a ``written_at`` batch
+    boundary, the economically expected price change is
+    ``(pnl_now - pnl_before) / nav_before``. When the observed share-price
+    return differs by more than ``max_return_deviation``, rescale the boundary
+    and all later rows. This retains legitimate large trading gains when PnL
+    supports them, while repairing the unit changes seen in HODL My Perps.
+
+    The narrow two-day and consecutive-HF requirements deliberately avoid
+    inferring a price across sparse allTime history, lifecycle resets, or
+    ordinary daily observations. More elaborate capital-flow reconstruction is
+    not justified by the information Hyperliquid currently exposes.
+
+    :param prices_df:
+        Timestamp-indexed vault prices with ``id``, ``chain``,
+        ``share_price``, ``total_assets``, and ``written_at`` columns. The
+        cumulative PnL column is named ``account_pnl`` in exported parquet and
+        ``cumulative_pnl`` in scanner-shaped DataFrames. ``hypercore_source``
+        is used when available; legacy sources are inferred from midnight
+        timestamps.
+    :param logger:
+        Notebook or console logging function.
+    :param max_timestamp_gap:
+        Largest permitted gap between consecutive HF observations.
+    :param max_return_deviation:
+        Symmetric deviation threshold used to distinguish a scale change from
+        an economically supported price movement.
+    :return:
+        A copy with repaired price units and audit columns populated.
+    """
+    hypercore_mask = prices_df["chain"] == HYPERCORE_CHAIN_ID
+    pnl_column = "cumulative_pnl" if "cumulative_pnl" in prices_df.columns else "account_pnl"
+    required_columns = {"total_assets", pnl_column, "written_at"}
+    if not hypercore_mask.any() or not required_columns.issubset(prices_df.columns):
+        return prices_df
+
+    prices_df = prices_df.copy()
+    if "raw_share_price" not in prices_df.columns:
+        prices_df["raw_share_price"] = prices_df["share_price"]
+    if "hypercore_repair_status" not in prices_df.columns:
+        prices_df["hypercore_repair_status"] = ""
+    if "hypercore_source" not in prices_df.columns:
+        prices_df["hypercore_source"] = pd.NA
+
+    missing_source_mask = hypercore_mask & prices_df["hypercore_source"].isna()
+    if missing_source_mask.any():
+        timestamps = pd.DatetimeIndex(prices_df.index[missing_source_mask])
+        prices_df.loc[missing_source_mask, "hypercore_source"] = np.where(timestamps == timestamps.normalize(), "daily", "hf")
+
+    repair_count = 0
+    hypercore_positions = np.flatnonzero(hypercore_mask.to_numpy())
+    status_column = prices_df.columns.get_loc("hypercore_repair_status")
+    for vault_id, row_positions in prices_df.loc[hypercore_mask].groupby("id", sort=False).indices.items():
+        positions = hypercore_positions[np.asarray(row_positions, dtype=int)]
+        group = prices_df.iloc[positions]
+        hf_source_mask = group["hypercore_source"].astype("string").fillna("").to_numpy(dtype=str) == "hf"
+        hf_positions = np.flatnonzero(hf_source_mask)
+        if len(hf_positions) < 2:
+            continue
+
+        hf_written_at = pd.to_datetime(
+            group["written_at"].iloc[hf_positions],
+            errors="coerce",
+        ).to_numpy(dtype="datetime64[ns]")
+        hf_timestamp_ns = (
+            pd.DatetimeIndex(group.index[hf_positions])
+            .to_numpy(
+                dtype="datetime64[ns]",
+            )
+            .astype("int64")
+        )
+        timestamp_gaps = np.diff(hf_timestamp_ns)
+        batch_boundary_mask = np.zeros(len(hf_positions), dtype=bool)
+        has_written_at = ~pd.isna(hf_written_at[:-1]) & ~pd.isna(hf_written_at[1:])
+        changed_batch = hf_written_at[1:] != hf_written_at[:-1]
+        short_forward_gap = (timestamp_gaps > 0) & (timestamp_gaps <= max_timestamp_gap.value)
+        batch_boundary_mask[1:] = has_written_at & changed_batch & short_forward_gap
+        for boundary_position in np.flatnonzero(batch_boundary_mask):
+            previous_position = int(hf_positions[boundary_position - 1])
+            current_position = int(hf_positions[boundary_position])
+            previous_row = prices_df.iloc[positions[previous_position]]
+            current_row = prices_df.iloc[positions[current_position]]
+            previous_epoch_reset = previous_row.get("epoch_reset", False)
+            current_epoch_reset = current_row.get("epoch_reset", False)
+            crosses_epoch_boundary = (pd.notna(previous_epoch_reset) and bool(previous_epoch_reset)) or (pd.notna(current_epoch_reset) and bool(current_epoch_reset))
+            if crosses_epoch_boundary:
+                continue
+
+            previous_nav = float(previous_row["total_assets"])
+            previous_pnl = float(previous_row[pnl_column])
+            current_pnl = float(current_row[pnl_column])
+            previous_price = float(previous_row["share_price"])
+            current_price = float(current_row["share_price"])
+            finite_values = (previous_nav, previous_pnl, current_pnl, previous_price, current_price)
+            if not all(np.isfinite(value) for value in finite_values) or previous_nav <= 0 or previous_price <= 0 or current_price <= 0:
+                continue
+
+            expected_price = previous_price * (1 + (current_pnl - previous_pnl) / previous_nav)
+            if not np.isfinite(expected_price) or expected_price <= 0:
+                continue
+            deviation = max(current_price / expected_price, expected_price / current_price) - 1
+            if deviation > max_return_deviation:
+                factor = expected_price / current_price
+                rescale_share_price_rows(prices_df, factor, positions[current_position:])
+                prices_df.iloc[positions[current_position], status_column] = "repaired_hf_batch_scale"
+                description = "large " if factor > 2 or factor < 0.5 else ""
+                logger(f"Stitched {description}Hypercore HF batch scale for {vault_id} at {current_row.name}: factor {factor:.6f}")
+                repair_count += 1
+
+    if repair_count:
+        logger(f"Stitched {repair_count:,} incompatible Hypercore HF scanner batch boundaries")
+    return prices_df
 
 
 def fix_hypercore_source_overlap_share_prices(  # noqa: PLR0914
@@ -1620,6 +1767,10 @@ def process_raw_vault_scan_data(
         vault_prices_df = prices_df[prices_df["id"] == diagnose_vault_id]
         logger("After remove_inactive_lead_time():")
         display(vault_prices_df)
+
+    # Correct scanner-batch unit changes before using HF observations as
+    # canonical anchors for the daily/HF source-overlap repair.
+    prices_df = stitch_hypercore_high_freq_share_price_batches(prices_df, logger)
 
     # Cap Hypercore share prices before the standard outlier smoothing.
     # Hypercore share prices can overflow when total_supply → 0;

--- a/scripts/hyperliquid/README-hyperliquid-vaults.md
+++ b/scripts/hyperliquid/README-hyperliquid-vaults.md
@@ -159,8 +159,10 @@ the account Profit and Loss (PnL) on Hyperliquid website".
 
 ### Share price computation
 
-Portfolio history from `vaultDetails` gives `account_value_history` and
-`pnl_history` as daily `(datetime, Decimal)` tuples. We derive:
+Portfolio history from `vaultDetails` gives rolling `account_value_history`
+and `pnl_history` `(datetime, Decimal)` tuples. The merge keeps NAV/PnL pairs
+together and rebases a child PnL window only at an exact shared `allTime`
+timestamp; an unanchored window is skipped. We derive:
 
 ```
 pnl_update[i]     = pnl_history[i] - pnl_history[i-1]
@@ -170,6 +172,14 @@ netflow_update[i] = (account_value[i] - account_value[i-1]) - pnl_update[i]
 These feed into `_calculate_share_price()` from `combined_analysis.py`,
 which uses the proven mint/burn share price logic without needing the
 slow per-fill/per-deposit API calls.
+
+Hyperliquid does not publish a vault share price or share supply. Each API
+read reconstructs an arbitrary but internally consistent unit, so the daily
+and HF scanners align their new curve to the latest stored price before writing
+their one-row overlap. The HF path log-linearly interpolates an anchor when
+the rolling-window timestamps shift. The matching inverse supply scaling keeps
+`total_assets == share_price * total_supply`; if no stored anchor lies within
+the current curve, the scan is skipped rather than creating a discontinuity.
 
 ### Hypercore-specific columns in price data
 
@@ -752,8 +762,8 @@ for v in data['vaults'][:5]:
 ## Trade history reconstruction
 
 Separate from the daily metrics pipeline, we can reconstruct per-account
-trade history (fills, funding payments, ledger events) and compute
-event-accurate share prices.
+trade history (fills, funding payments, ledger events) and compute an
+event-driven indicative share-price series.
 
 This uses the `userFillsByTime`, `userFunding`, `userNonFundingLedgerUpdates`,
 and `clearinghouseState` API endpoints directly.
@@ -809,8 +819,8 @@ The `vault-trade-history.py` script reconstructs and displays:
 3. Open round-trip trades with funding costs
 4. Closed round-trip trades with PnL breakdown
 5. Summary totals (realised, funding, fees, net, unrealised)
-6. Event-accurate share price history (using actual deposit/withdrawal
-   events instead of resolution-dependent portfolio history)
+6. Event-driven indicative share-price history (using available
+   deposit/withdrawal events instead of resolution-dependent portfolio history)
 
 ```shell
 # Basic usage
@@ -891,5 +901,5 @@ source .local-test.env && poetry run pytest \
 | `eth_defi/hyperliquid/combined_analysis.py` | `_calculate_share_price()` -- time-weighted return logic |
 | `eth_defi/hyperliquid/vault.py` | API client (`fetch_all_vaults`, `HyperliquidVault`, `VaultInfo`) |
 | `eth_defi/hyperliquid/session.py` | Rate-limited HTTP session (`create_hyperliquid_session`) |
-| `eth_defi/hyperliquid/trade_history.py` | Trade history reconstruction, round-trip trades, event-accurate share prices |
+| `eth_defi/hyperliquid/trade_history.py` | Trade history reconstruction, round-trip trades, event-driven indicative share prices |
 | `eth_defi/hyperliquid/trade_history_db.py` | DuckDB persistence for fills, funding, ledger with incremental sync |

--- a/tests/hyperliquid/test_high_freq_metrics.py
+++ b/tests/hyperliquid/test_high_freq_metrics.py
@@ -14,11 +14,15 @@ concurrency regression test is offline and uses synthetic rows only.
 """
 
 import datetime
+from decimal import Decimal
+from types import SimpleNamespace
 from unittest.mock import patch
 
+import pandas as pd
 import pytest
 from joblib import Parallel, delayed
 
+from eth_defi.compat import native_datetime_utc_now
 from eth_defi.hyperliquid.deposit import fetch_vault_deposits
 from eth_defi.hyperliquid.high_freq_metrics import (
     HyperliquidHighFreqMetricsDatabase,
@@ -26,8 +30,7 @@ from eth_defi.hyperliquid.high_freq_metrics import (
     fetch_and_store_vault_high_freq,
 )
 from eth_defi.hyperliquid.session import create_hyperliquid_session
-from eth_defi.hyperliquid.vault import HyperliquidVault, fetch_all_vaults
-from eth_defi.compat import native_datetime_utc_now
+from eth_defi.hyperliquid.vault import HyperliquidVault, PortfolioHistory, VaultSummary, fetch_all_vaults
 
 
 @pytest.mark.timeout(180)
@@ -173,6 +176,81 @@ def test_high_freq_lifecycle(tmp_path):
         assert tombstone.iloc[0]["tvl"] == pytest.approx(0.0)
         assert tombstone.iloc[0]["cumulative_pnl"] == pytest.approx(5000.0)
 
+    finally:
+        db.close()
+
+
+def test_high_freq_resume_uses_persisted_anchor_for_shifted_timestamps(tmp_path) -> None:
+    """HF return uses the persisted anchor when the API window timestamps shift.
+
+    The reconstructed curve has observations either side of the last persisted
+    timestamp, but none exactly at it. Its scale is interpolated to the anchor;
+    the first appended row must calculate its return from that anchor rather
+    than the older stored observation.
+    """
+    vault_address = "0x0000000000000000000000000000000000000001"
+    anchor_timestamp = datetime.datetime(2026, 1, 1, 11)
+    db = HyperliquidHighFreqMetricsDatabase(tmp_path / "hf-resume.duckdb")
+    db.upsert_high_freq_prices(
+        [
+            HyperliquidHighFreqPriceRow(vault_address, anchor_timestamp - datetime.timedelta(hours=1), 1.0, 100.0, 0.0),
+            HyperliquidHighFreqPriceRow(vault_address, anchor_timestamp, 1.1, 110.0, 10.0),
+        ]
+    )
+
+    summary = VaultSummary(
+        name="Test vault",
+        vault_address=vault_address,
+        leader="0x0000000000000000000000000000000000000002",
+        tvl=Decimal("120"),
+        is_closed=False,
+        relationship_type="normal",
+    )
+    all_time = PortfolioHistory(
+        period="allTime",
+        account_value_history=[(anchor_timestamp - datetime.timedelta(hours=1), Decimal("100")), (anchor_timestamp, Decimal("110"))],
+        pnl_history=[(anchor_timestamp - datetime.timedelta(hours=1), Decimal("0")), (anchor_timestamp, Decimal("10"))],
+        volume=Decimal("0"),
+    )
+    info = SimpleNamespace(
+        name=summary.name,
+        leader=summary.leader,
+        description="",
+        followers=[],
+        portfolio={"allTime": all_time},
+        commission_rate=None,
+        leader_fraction=None,
+        leader_commission=None,
+        is_closed=False,
+        allow_deposits=True,
+        relationship_type="normal",
+    )
+    reconstructed_curve = pd.DataFrame(
+        {
+            "share_price": [1.0, 1.2],
+            "total_assets": [100.0, 120.0],
+            "cumulative_pnl": [0.0, 20.0],
+            "pnl_update": [0.0, 20.0],
+            "epoch_reset": [False, False],
+        },
+        index=pd.to_datetime([anchor_timestamp - datetime.timedelta(hours=1), anchor_timestamp + datetime.timedelta(hours=1)]),
+    )
+
+    try:
+        with (
+            patch.object(HyperliquidVault, "fetch_metadata", return_value=info),
+            patch(
+                "eth_defi.hyperliquid.high_freq_metrics.portfolio_to_combined_dataframe",
+                return_value=reconstructed_curve,
+            ),
+        ):
+            assert fetch_and_store_vault_high_freq(object(), db, summary, flow_backfill_days=0)
+
+        prices = db.get_vault_high_freq_prices(vault_address)
+        appended = prices.iloc[-1]
+        expected_share_price = 1.2 * 1.1 / (1.0 * 1.2) ** 0.5
+        assert appended["share_price"] == pytest.approx(expected_share_price)
+        assert appended["daily_return"] == pytest.approx((expected_share_price - 1.1) / 1.1)
     finally:
         db.close()
 

--- a/tests/hyperliquid/test_share_price_continuity.py
+++ b/tests/hyperliquid/test_share_price_continuity.py
@@ -1,0 +1,61 @@
+"""Regression tests for Hyperliquid synthetic share-price continuity."""
+
+import datetime
+from decimal import Decimal
+
+import pandas as pd
+import pytest
+
+from eth_defi.hyperliquid.combined_analysis import align_share_price_curve_to_anchor
+from eth_defi.hyperliquid.daily_metrics import _merge_portfolio_periods
+from eth_defi.hyperliquid.vault import PortfolioHistory
+
+
+def _portfolio_history(
+    period: str,
+    rows: list[tuple[datetime.datetime, int, int]],
+) -> PortfolioHistory:
+    """Build a compact portfolio fixture from timestamp, NAV, and PnL rows."""
+    return PortfolioHistory(
+        period=period,
+        account_value_history=[(timestamp, Decimal(nav)) for timestamp, nav, _pnl in rows],
+        pnl_history=[(timestamp, Decimal(pnl)) for timestamp, _nav, pnl in rows],
+        volume=Decimal(0),
+    )
+
+
+def test_merge_portfolio_periods_rebases_child_pnl_at_shared_timestamp() -> None:
+    """A rolling PnL window must retain its trading movement after the merge."""
+    start = datetime.datetime(2026, 1, 1)
+    first_child_timestamp = start + datetime.timedelta(days=1)
+    shared_timestamp = start + datetime.timedelta(days=2)
+    portfolio = {
+        "allTime": _portfolio_history("allTime", [(start, 1_000, 0), (shared_timestamp, 1_100, 100)]),
+        "week": _portfolio_history("week", [(first_child_timestamp, 1_050, 5), (shared_timestamp, 1_100, 25)]),
+    }
+
+    result = _merge_portfolio_periods(portfolio, dedup_window_hours=1)
+
+    assert dict(result.pnl_history)[first_child_timestamp] == Decimal(80)
+    assert dict(result.pnl_history)[shared_timestamp] == Decimal(100)
+    assert [timestamp for timestamp, _pnl in result.pnl_history] == [timestamp for timestamp, _nav in result.account_value_history]
+
+
+def test_align_share_price_curve_interpolates_shifted_high_frequency_anchor() -> None:
+    """A shifted HF re-read anchors in log-price space and preserves NAV."""
+    index = pd.to_datetime(["2026-01-01 00:00", "2026-01-01 02:00"])
+    curve = pd.DataFrame(
+        {
+            "share_price": [1.0, 1.2],
+            "total_supply": [100.0, 100.0],
+            "total_assets": [100.0, 120.0],
+        },
+        index=index,
+    )
+
+    aligned = align_share_price_curve_to_anchor(curve, pd.Timestamp("2026-01-01 01:00"), 1.1)
+
+    assert aligned is not None
+    midpoint = (aligned["share_price"].iloc[0] * aligned["share_price"].iloc[1]) ** 0.5
+    assert midpoint == pytest.approx(1.1)
+    assert (aligned["share_price"] * aligned["total_supply"]).to_numpy() == pytest.approx(aligned["total_assets"].to_numpy())

--- a/tests/research/test_clean_prices.py
+++ b/tests/research/test_clean_prices.py
@@ -14,11 +14,13 @@ import zstandard as zstd
 
 import eth_defi.research.wrangle_vault_prices as vault_price_wrangle
 from eth_defi.research.wrangle_vault_prices import (
+    clean_returns,
     discard_hypercore_pre_recapitalisation_history,
     fix_hypercore_source_overlap_share_prices,
     fix_outlier_share_prices,
     generate_cleaned_vault_datasets,
     replace_cleaned_vault_histories,
+    stitch_hypercore_high_freq_share_price_batches,
 )
 from eth_defi.vault.base import VaultHistoricalRead
 from eth_defi.vault.settlement_data import VaultSettlement, VaultSettlementDatabase
@@ -493,7 +495,7 @@ def test_discard_hypercore_pre_recapitalisation_history() -> None:
             "chain": [9999] * 11 + [1],
             "id": [recapitalised_id] * 8 + [short_blip_id] * 3 + [evm_id],
             "total_assets": [2_000.0, 0.0, 0.0, 0.0, 100.0, 999.0, 1_000.0, 1_050.0, 2_000.0, 0.0, 1_500.0, 0.0],
-            "share_price": [1.0] * 12,
+            "share_price": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 10.0, 10.5, 1.0, 1.0, 1.0, 1.0],
         },
         index=timestamps,
     )
@@ -504,6 +506,9 @@ def test_discard_hypercore_pre_recapitalisation_history() -> None:
     recapitalised = result[result["id"] == recapitalised_id]
     assert recapitalised.index.tolist() == [pd.Timestamp("2026-01-12"), pd.Timestamp("2026-01-13")]
     assert recapitalised["epoch_reset"].tolist() == [True, False]
+    assert recapitalised["raw_share_price"].tolist() == [10.0, 10.5]
+    assert recapitalised["share_price"].iloc[0] == pytest.approx(1.0)
+    assert recapitalised["share_price"].iloc[1] == pytest.approx(1.05)
     assert len(result[result["id"] == short_blip_id]) == 3
     assert len(result[result["id"] == evm_id]) == 1
     assert messages == ["Discarded 6 pre-recapitalisation Hypercore price rows across 1 vaults; new epochs start once NAV reaches $1,000 after 7 days 00:00:00"]
@@ -525,6 +530,66 @@ def test_discard_hypercore_history_measures_delay_to_first_positive_nav() -> Non
 
     assert result.index.tolist() == prices_df.index.tolist()
     assert result["epoch_reset"].tolist() == [False] * 4
+
+
+def test_stitch_hypercore_high_freq_share_price_batches() -> None:
+    """A scanner batch unit jump follows PnL, not a 50x investor return."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 3,
+            "id": ["9999-0xstitch"] * 3,
+            "hypercore_source": ["hf"] * 3,
+            "written_at": pd.to_datetime(["2026-01-01", "2026-01-02", "2026-01-02"]),
+            "total_assets": [100.0, 101.0, 102.01],
+            # Exported Hypercore parquet calls this cumulative metric account_pnl.
+            "account_pnl": [0.0, 1.0, 2.01],
+            "share_price": [1.0, 50.0, 50.5],
+            "total_supply": [100.0, 2.02, 2.02],
+        },
+        index=pd.to_datetime(["2026-01-01 12:00", "2026-01-01 13:00", "2026-01-01 14:00"]),
+    )
+
+    result = stitch_hypercore_high_freq_share_price_batches(prices_df, logger=lambda _message: None)
+
+    assert result["share_price"].tolist() == pytest.approx([1.0, 1.01, 1.0201])
+    assert result["total_supply"].tolist() == pytest.approx([100.0, 100.0, 100.0])
+    assert result["hypercore_repair_status"].tolist() == ["", "repaired_hf_batch_scale", ""]
+
+
+def test_stitch_hypercore_batch_keeps_pnl_supported_return() -> None:
+    """A genuine 50 percent PnL gain must not be mistaken for a unit jump."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999, 9999],
+            "id": ["9999-0xreal-gain"] * 2,
+            "hypercore_source": ["hf", "hf"],
+            "written_at": pd.to_datetime(["2026-01-01", "2026-01-02"]),
+            "total_assets": [100.0, 150.0],
+            "cumulative_pnl": [0.0, 50.0],
+            "share_price": [1.0, 1.5],
+        },
+        index=pd.to_datetime(["2026-01-01 12:00", "2026-01-01 13:00"]),
+    )
+
+    result = stitch_hypercore_high_freq_share_price_batches(prices_df, logger=lambda _message: None)
+
+    assert result["share_price"].tolist() == [1.0, 1.5]
+    assert result["hypercore_repair_status"].tolist() == ["", ""]
+
+
+def test_clean_returns_keeps_large_hypercore_return() -> None:
+    """Hypercore continuity repairs own synthetic prices before generic cleaning."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999, 1],
+            "name": ["Hypercore", "EVM"],
+            "returns_1h": [1.0, 1.0],
+        }
+    )
+
+    result = clean_returns({}, prices_df, logger=lambda _message: None)
+
+    assert result["returns_1h"].tolist() == [1.0, 0.0]
 
 
 def test_native_protocol_columns_survive_evm_scan_rewrite(tmp_path: Path):


### PR DESCRIPTION
## Why

Hyperliquid publishes rolling NAV and PnL windows, not a canonical share price or share supply. Re-reading those windows could change the synthetic unit, producing false returns, especially after recapitalisation.

## Lessons learnt

A synthetic price must retain its existing unit at scanner overlap boundaries. Rolling NAV and PnL must be merged as timestamp-paired observations; nearest PnL values turn ordinary PnL into fictitious flows.

## Summary

- Align daily and HF scanner curves to their stored overlap price while preserving NAV and supply.
- Rebase rolling PnL windows only at an exact shared allTime timestamp.
- Start durable recapitalisation epochs at price 1.0 and stitch short-gap HF batch unit changes supported by PnL.
- Retain large Hypercore returns after source-specific repair, document the behaviour, and add regression coverage.

## Related issues and PRs

Builds on the merged Hypercore source-overlap and recapitalisation repairs in commits 3845a5971 and 733f1f2b0.

## Unrelated CI and test fixes

None.