### PR TITLE
fix: bound Midas backfill by timestamp cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,17 @@ No test plan or verification section. Use Markdown formatting, headings.
 - To get the latest block number, use given JSON-RPC URL and Python's Web3.py `web3.eth.block_number` call
 - Never try to figure out RPC URL yourself - always use environment variables from the local environment given by the user. See `eth_defi.chain.CHAIN_NAMES` for aliases like chain id 999 -> JSON_RPC_HYPERLIQUD. Stop and ask user if you cannot figure out.
 
+### Block timestamps
+
+- For all bulk or historical blockchain timestamp operations, use the cache-aware
+  Hypersync API: `fetch_block_timestamps_using_hypersync_cached()` or the
+  `fetch_block_timestamps_multiprocess_auto_backend()` wrapper with a Hypersync
+  client. Do not stream timestamps through `get_block_timestamps_using_hypersync*()`
+  directly unless explicitly repairing known cache gaps.
+- Preserve and reuse the per-chain DuckDB cache at
+  `~/.tradingstrategy/block-timestamp/{chain_id}-timestamps.duckdb`. Do not use
+  the legacy `~/.tradingstrategy/block-timestamps.*` location.
+
 For JSON-RPC URL configuration, environment variables. The variables are in the format `JSON_RPC_{CHAIN}` where `{CHAIN}` is the uppercase chain name:
 
 - `JSON_RPC_ETHEREUM` - Ethereum mainnet

--- a/eth_defi/event_reader/timestamp_cache.py
+++ b/eth_defi/event_reader/timestamp_cache.py
@@ -1,7 +1,9 @@
 """DuckDB-based cache for block number -> timestamp mapping.
 
-By default, we manage a database file at ~/.tradingstrategy/block-timestamps.duckdb` where we have chain -> block -> timestamp mapping.
-Getting block numbers and timestamps is a common expensive operation when scanning historical events.
+Each chain has its own database at
+``~/.tradingstrategy/block-timestamp/{chain_id}-timestamps.duckdb``.
+Getting block numbers and timestamps is a common expensive operation when
+scanning historical events.
 """
 
 import pandas as pd

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -856,6 +856,11 @@ source .local-test.env && poetry run python scripts/erc-4626/heal-broken-vaults.
 ### prepopulate-timestamps.py
 
 Prepopulate the Hypersync block timestamp DuckDB cache for all scanner chains.
+The cache consists of one file per chain at
+`~/.tradingstrategy/block-timestamp/{chain_id}-timestamps.duckdb`; preserve and
+copy this directory between scanner hosts. The legacy
+`~/.tradingstrategy/block-timestamps.*` path is not read by the current
+timestamp reader.
 Use this to recover chains stuck in a 429 rate-limit spiral — when a chain's
 timestamp cache falls behind, each scan cycle needs more blocks, making it more
 likely to hit 429 again. Running this script during a quiet period (with the

--- a/scripts/erc-4626/scan-prices.py
+++ b/scripts/erc-4626/scan-prices.py
@@ -55,7 +55,7 @@ Copy server-side run results back to the local machine:
 .. code-block:: shell
 
     rsync -av --inplace --progress --exclude="tmp*" "vitalik7-tailscale:.tradingstrategy/vaults/*" ~/.tradingstrategy/vaults/
-    rsync -av --inplace --progress "vitalik7-tailscale:.tradingstrategy/block-timestamps.*" ~/.tradingstrategy
+    rsync -av --inplace --progress "vitalik7-tailscale:.tradingstrategy/block-timestamp/" ~/.tradingstrategy/block-timestamp/
 
 Debug scan of a single vault:
 

--- a/scripts/midas/backfill-history.py
+++ b/scripts/midas/backfill-history.py
@@ -78,6 +78,7 @@ from eth_defi.erc_4626.classification import create_vault_instance
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
 from eth_defi.erc_4626.discovery_base import PotentialVaultMatch
 from eth_defi.erc_4626.scan import create_vault_scan_record
+from eth_defi.event_reader.timestamp_cache import DEFAULT_TIMESTAMP_CACHE_FOLDER, BlockTimestampDatabase
 from eth_defi.hypersync.utils import configure_hypersync_from_env
 from eth_defi.midas.constants import MIDAS_PRODUCTS, MidasProduct
 from eth_defi.provider.env import get_json_rpc_env, read_json_rpc_url
@@ -158,26 +159,60 @@ def resolve_frequency() -> Literal["1h", "1d"]:
     return cast(Literal["1h", "1d"], frequency)
 
 
-def resolve_price_scan_start_block(products: list[MidasProduct]) -> int:
+def resolve_price_scan_start_block(
+    products: list[MidasProduct],
+    timestamp_cache_folder: Path = DEFAULT_TIMESTAMP_CACHE_FOLDER,
+) -> int:
     """Resolve the first block to read for one chain's Midas backfill.
 
     A targeted backfill must not inherit the ordinary vault scanner's latest
     reader state for the chain.  Those states normally point close to the
     chain head and would silently turn a deployment-history rewrite into a
-    short incremental scan.  Start at the earliest selected Midas deployment
-    unless the operator explicitly pins a start block.
+    short incremental scan.  Start at the earliest selected Midas deployment,
+    but do not request timestamps before the first block available in the
+    local per-chain cache.  This avoids an unusable sparse cache causing the
+    historical reader to fail before it can begin its scan.
 
     :param products:
         Selected Midas products on one EVM chain.
+    :param timestamp_cache_folder:
+        Directory containing ``{chain_id}-timestamps.duckdb`` cache files.
     :return:
-        Explicit ``START_BLOCK`` value, or the earliest selected deployment block.
+        Explicit ``START_BLOCK`` value, or the earliest selected deployment
+        block supported by the local timestamp cache.
     """
 
     explicit_start_block = parse_optional_int_env("START_BLOCK")
     if explicit_start_block is not None:
         return explicit_start_block
 
-    return min(product.first_seen_at_block for product in products)
+    assert products, "Cannot resolve a scan start block without Midas products"
+    chain_ids = {product.chain_id for product in products}
+    assert len(chain_ids) == 1, f"Expected products from one chain, got {chain_ids}"
+
+    deployment_start_block = min(product.first_seen_at_block for product in products)
+    chain_id = products[0].chain_id
+    cache_file = BlockTimestampDatabase.get_database_file_chain(chain_id, timestamp_cache_folder)
+    if not cache_file.exists():
+        logger.info("No timestamp cache found for chain %d at %s", chain_id, cache_file)
+        return deployment_start_block
+
+    timestamp_cache = BlockTimestampDatabase.load(chain_id, cache_file)
+    try:
+        first_cached_block = timestamp_cache.get_first_block()
+    finally:
+        timestamp_cache.close()
+
+    if first_cached_block <= deployment_start_block:
+        return deployment_start_block
+
+    logger.warning(
+        "Clipping Midas history start on chain %d from deployment block %d to timestamp cache start block %d",
+        chain_id,
+        deployment_start_block,
+        first_cached_block,
+    )
+    return first_cached_block
 
 
 def parse_path_env(name: str, default: Path) -> Path:

--- a/tests/midas/test_midas_backfill_history.py
+++ b/tests/midas/test_midas_backfill_history.py
@@ -3,8 +3,10 @@
 import importlib.util
 from pathlib import Path
 
+import pandas as pd
 import pytest
 
+from eth_defi.event_reader.timestamp_cache import BlockTimestampDatabase
 from eth_defi.midas.constants import MIDAS_MBASIS_ETHEREUM, MIDAS_MTBILL_ETHEREUM
 
 EXPLICIT_START_BLOCK = 123_456
@@ -26,6 +28,7 @@ def backfill_history_module():
 def test_resolve_price_scan_start_block_uses_earliest_midas_deployment(
     monkeypatch: pytest.MonkeyPatch,
     backfill_history_module,
+    tmp_path: Path,
 ) -> None:
     """Start a default Midas rewrite at its earliest selected deployment."""
 
@@ -34,6 +37,7 @@ def test_resolve_price_scan_start_block_uses_earliest_midas_deployment(
     assert (
         backfill_history_module.resolve_price_scan_start_block(
             [MIDAS_MBASIS_ETHEREUM, MIDAS_MTBILL_ETHEREUM],
+            timestamp_cache_folder=tmp_path,
         )
         == MIDAS_MTBILL_ETHEREUM.first_seen_at_block
     )
@@ -42,6 +46,7 @@ def test_resolve_price_scan_start_block_uses_earliest_midas_deployment(
 def test_resolve_price_scan_start_block_honours_explicit_override(
     monkeypatch: pytest.MonkeyPatch,
     backfill_history_module,
+    tmp_path: Path,
 ) -> None:
     """Allow an operator to pin a smaller diagnostic backfill range."""
 
@@ -50,8 +55,41 @@ def test_resolve_price_scan_start_block_honours_explicit_override(
     assert (
         backfill_history_module.resolve_price_scan_start_block(
             [MIDAS_MBASIS_ETHEREUM, MIDAS_MTBILL_ETHEREUM],
+            timestamp_cache_folder=tmp_path,
         )
         == EXPLICIT_START_BLOCK
+    )
+
+
+def test_resolve_price_scan_start_block_uses_first_supported_cache_block(
+    monkeypatch: pytest.MonkeyPatch,
+    backfill_history_module,
+    tmp_path: Path,
+) -> None:
+    """Clip a Midas history rewrite to the first timestamp cache block.
+
+    A sparse cache can be valid for its own existing range but cannot answer a
+    request before its first block.  The backfill must therefore begin at that
+    supported boundary instead of failing while looking up its first timestamp.
+    """
+
+    monkeypatch.delenv("START_BLOCK", raising=False)
+    first_cached_block = MIDAS_MTBILL_ETHEREUM.first_seen_at_block + 1_000
+    cache = BlockTimestampDatabase.create(MIDAS_MTBILL_ETHEREUM.chain_id, tmp_path)
+    try:
+        cache.import_chain_data(
+            MIDAS_MTBILL_ETHEREUM.chain_id,
+            pd.Series(data=[1_700_000_000], index=[first_cached_block]),
+        )
+    finally:
+        cache.close()
+
+    assert (
+        backfill_history_module.resolve_price_scan_start_block(
+            [MIDAS_MBASIS_ETHEREUM, MIDAS_MTBILL_ETHEREUM],
+            timestamp_cache_folder=tmp_path,
+        )
+        == first_cached_block
     )
 
 


### PR DESCRIPTION
## Why

A Katana Midas history backfill requested a timestamp before the first block present in its local cache. The slow timestamp fallback only extended the cache tail, so the reader failed before producing any historical rows.

## Lessons learnt

The timestamp cache is per-chain and may start later than a vault deployment. Targeted backfills must use its first supported block unless an operator explicitly supplies `START_BLOCK`. The current cache directory is `~/.tradingstrategy/block-timestamp/`; the legacy `block-timestamps.*` files are not consumed.

## Summary

- Clip automatic Midas history starts to the first cached block for that chain.
- Retain the deployment start when no cache exists and retain explicit `START_BLOCK` behaviour.
- Add regression coverage and correct timestamp-cache operational guidance.
- Add Claude guidance requiring cache-aware Hypersync timestamp reads.

## Related issues and PRs

Continues #1270, which introduced the targeted Midas historical backfill.