### PR TITLE
fix: hardcode all Frankencoin savings vault addresses

### DIFF
--- a/docs/source/vaults/frankencoin/index.rst
+++ b/docs/source/vaults/frankencoin/index.rst
@@ -37,6 +37,7 @@ Links
 - `Twitter <https://x.com/frankencoinzchf>`__
 - `DeFiLlama <https://defillama.com/protocol/frankencoin>`__
 - `Ethereum savings vault <https://etherscan.io/token/0xE5F130253fF137f9917C0107659A4c5262abf6b0>`__
+- `Ethereum legacy savings vault <https://etherscan.io/token/0x637F00cAb9665cB07d91bfB9c6f3fa8faBFEF8BC>`__
 - `Base savings vault <https://basescan.org/address/0xa09EBdf8A01b9ef04149319D64F83b9C01a5b585>`__
 - `Gnosis savings vault <https://gnosisscan.io/token/0x6165946250dd04740ab1409217e95a4f38374fe9>`__
 

--- a/eth_defi/data/vaults/metadata/frankencoin.yaml
+++ b/eth_defi/data/vaults/metadata/frankencoin.yaml
@@ -31,5 +31,6 @@ links:
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/frankencoin/index.html
 example_smart_contracts:
   - https://etherscan.io/token/0xE5F130253fF137f9917C0107659A4c5262abf6b0
+  - https://etherscan.io/token/0x637F00cAb9665cB07d91bfB9c6f3fa8faBFEF8BC
   - https://basescan.org/address/0xa09EBdf8A01b9ef04149319D64F83b9C01a5b585
   - https://gnosisscan.io/token/0x6165946250dd04740ab1409217e95a4f38374fe9

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -17,6 +17,7 @@ from web3.types import BlockIdentifier
 
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.erc_4626.vault_protocol.frankencoin.vault import FRANKENCOIN_SAVINGS_VAULTS
 from eth_defi.erc_4626.vault_protocol.kiloex.constants import KILOEX_VAULT_ADDRESSES, KILOEX_VAULTS_BY_CHAIN
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult, read_multicall_chunked
 from eth_defi.event_reader.web3factory import Web3Factory
@@ -65,6 +66,9 @@ MIDAS_HARDCODED_PROTOCOLS = {token: {ERC4626Feature.midas_like} for token in MID
 #: KiloEx Hybrid Vaults reuse a Gains-compatible contract surface. Classify
 #: known deployments by address instead of the generic ``maxDiscountP()`` probe.
 KILOEX_HARDCODED_PROTOCOLS = {address: {ERC4626Feature.kiloex_like} for address in KILOEX_VAULT_ADDRESSES}
+
+#: Frankencoin hardcoded classification flags.
+FRANKENCOIN_HARDCODED_PROTOCOLS = {HexAddress(address): {ERC4626Feature.frankencoin_like} for address in FRANKENCOIN_SAVINGS_VAULTS}
 
 
 def _get_hardcoded_protocol_features(address: HexAddress | str, chain_id: int | None = None) -> set[ERC4626Feature] | None:
@@ -1929,6 +1933,7 @@ HARDCODED_PROTOCOLS = {
     **ODA_FACT_HARDCODED_PROTOCOLS,
     **MIDAS_HARDCODED_PROTOCOLS,
     **KILOEX_HARDCODED_PROTOCOLS,
+    **FRANKENCOIN_HARDCODED_PROTOCOLS,
     # 3Jane - USD3 senior tranche credit vault on Ethereum
     # https://etherscan.io/address/0x056B269Eb1f75477a8666ae8C7fE01b64dD55eCc
     "0x056b269eb1f75477a8666ae8c7fe01b64dd55ecc": {ERC4626Feature.threejane_like},
@@ -1978,15 +1983,6 @@ HARDCODED_PROTOCOLS = {
     # Spark - spUSDG (Spark Savings USDG) vault on Robinhood Chain
     # https://robinhoodchain.blockscout.com/address/0xde770c84FE66E063336b31737cFE9790f18c4087
     "0xde770c84fe66e063336b31737cfe9790f18c4087": {ERC4626Feature.spark_like},
-    # Frankencoin - svZCHF Savings Vault on Ethereum
-    # https://etherscan.io/token/0xE5F130253fF137f9917C0107659A4c5262abf6b0
-    "0xe5f130253ff137f9917c0107659a4c5262abf6b0": {ERC4626Feature.frankencoin_like},
-    # Frankencoin - svZCHF Savings Vault on Base
-    # https://basescan.org/address/0xa09EBdf8A01b9ef04149319D64F83b9C01a5b585
-    "0xa09ebdf8a01b9ef04149319d64f83b9c01a5b585": {ERC4626Feature.frankencoin_like},
-    # Frankencoin - svZCHF Savings Vault on Gnosis
-    # https://gnosisscan.io/token/0x6165946250dd04740ab1409217e95a4f38374fe9
-    "0x6165946250dd04740ab1409217e95a4f38374fe9": {ERC4626Feature.frankencoin_like},
     # Deltr - StakeddUSD vault on Ethereum
     # https://etherscan.io/address/0xa7a31e6a81300120b7c4488ec3126bc1ad11f320
     "0xa7a31e6a81300120b7c4488ec3126bc1ad11f320": {ERC4626Feature.deltr_like},

--- a/eth_defi/erc_4626/vault_protocol/frankencoin/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/frankencoin/vault.py
@@ -41,6 +41,14 @@ FRANKENCOIN_SAVINGS_VAULT_ABI = [
 #: https://etherscan.io/token/0xE5F130253fF137f9917C0107659A4c5262abf6b0
 FRANKENCOIN_ETHEREUM_SAVINGS_VAULT = "0xe5f130253ff137f9917c0107659a4c5262abf6b0"
 
+#: Legacy Frankencoin Savings Vault on Ethereum picked up by vault discovery.
+#:
+#: This wrapper points at the same Frankencoin savings module as the official
+#: Ethereum svZCHF wrapper.
+#:
+#: https://etherscan.io/token/0x637F00cAb9665cB07d91bfB9c6f3fa8faBFEF8BC
+FRANKENCOIN_ETHEREUM_LEGACY_SAVINGS_VAULT = "0x637f00cab9665cb07d91bfb9c6f3fa8fabfef8bc"
+
 #: Frankencoin Savings Vault on Base.
 #:
 #: https://basescan.org/address/0xa09EBdf8A01b9ef04149319D64F83b9C01a5b585
@@ -51,14 +59,29 @@ FRANKENCOIN_BASE_SAVINGS_VAULT = "0xa09ebdf8a01b9ef04149319d64f83b9c01a5b585"
 #: https://gnosisscan.io/token/0x6165946250dd04740ab1409217e95a4f38374fe9
 FRANKENCOIN_GNOSIS_SAVINGS_VAULT = "0x6165946250dd04740ab1409217e95a4f38374fe9"
 
-#: Official Frankencoin Savings Vault addresses across supported chains.
-FRANKENCOIN_SAVINGS_VAULTS = frozenset(
-    {
-        FRANKENCOIN_ETHEREUM_SAVINGS_VAULT,
-        FRANKENCOIN_BASE_SAVINGS_VAULT,
-        FRANKENCOIN_GNOSIS_SAVINGS_VAULT,
-    }
-)
+#: ERC-4626 Frankencoin Savings Vault wrappers by chain.
+FRANKENCOIN_SAVINGS_VAULTS_BY_CHAIN = {
+    1: frozenset({FRANKENCOIN_ETHEREUM_SAVINGS_VAULT, FRANKENCOIN_ETHEREUM_LEGACY_SAVINGS_VAULT}),
+    8453: frozenset({FRANKENCOIN_BASE_SAVINGS_VAULT}),
+    100: frozenset({FRANKENCOIN_GNOSIS_SAVINGS_VAULT}),
+}
+
+#: Frankencoin Savings Vault addresses across supported chains.
+FRANKENCOIN_SAVINGS_VAULTS = frozenset(vault_address for vaults in FRANKENCOIN_SAVINGS_VAULTS_BY_CHAIN.values() for vault_address in vaults)
+
+#: Frankencoin wrappers that represent the full savings product TVL.
+#:
+#: Ethereum has two svZCHF wrappers that point at the same savings module. Only
+#: the legacy wrapper is currently discovered in production data, so it is the
+#: canonical row for Ethereum product-level TVL.
+FRANKENCOIN_PRODUCT_TVL_VAULTS_BY_CHAIN = {
+    1: frozenset({FRANKENCOIN_ETHEREUM_LEGACY_SAVINGS_VAULT}),
+    8453: frozenset({FRANKENCOIN_BASE_SAVINGS_VAULT}),
+    100: frozenset({FRANKENCOIN_GNOSIS_SAVINGS_VAULT}),
+}
+
+#: Frankencoin Savings Vault addresses that report full savings product TVL.
+FRANKENCOIN_PRODUCT_TVL_VAULTS = frozenset(vault_address for vaults in FRANKENCOIN_PRODUCT_TVL_VAULTS_BY_CHAIN.values() for vault_address in vaults)
 
 #: Maximum optional referral fee in the Frankencoin savings module.
 #:
@@ -98,6 +121,9 @@ class FrankencoinHistoricalReader(ERC4626HistoricalReader):
         if denomination_token is None:
             return
 
+        if not self.vault.reports_savings_product_tvl:
+            return
+
         wrapper_balance_call = denomination_token.contract.functions.balanceOf(self.vault.address)
         yield ("wrapper_balance", wrapper_balance_call.call, wrapper_balance_call)
 
@@ -111,7 +137,8 @@ class FrankencoinHistoricalReader(ERC4626HistoricalReader):
             Encoded calls for ERC-4626 state and Frankencoin savings TVL.
         """
         yield from self.construct_core_erc_4626_multicall()
-        yield from self.construct_savings_balance_multicalls()
+        if self.vault.reports_savings_product_tvl:
+            yield from self.construct_savings_balance_multicalls()
 
     def construct_savings_balance_multicalls(self) -> Iterable[EncodedCall]:
         """Create ZCHF balance calls used to calculate savings product TVL.
@@ -193,8 +220,12 @@ class FrankencoinHistoricalReader(ERC4626HistoricalReader):
             Multicall results for this vault.
 
         :return:
-            Historical row with Frankencoin savings product TVL.
+            Historical row with Frankencoin savings product TVL for canonical
+            wrappers, or regular ERC-4626 wrapper TVL for duplicate wrappers.
         """
+        if not self.vault.reports_savings_product_tvl:
+            return super().process_result(block_number, timestamp, call_results)
+
         call_by_name = self.dictify_multicall_results(block_number, call_results)
 
         # The generic ERC-4626 decoder updates adaptive reader state from
@@ -267,20 +298,36 @@ class FrankencoinVault(ERC4626Vault):
         """
         return self.frankencoin_vault_contract.functions.savings().call()
 
+    @cached_property
+    def reports_savings_product_tvl(self) -> bool:
+        """Whether this wrapper is the canonical full-product TVL row.
+
+        :return:
+            ``True`` if this wrapper should report savings-module TVL.
+        """
+        return self.address.lower() in FRANKENCOIN_PRODUCT_TVL_VAULTS
+
     def fetch_total_assets(self, block_identifier: BlockIdentifier) -> Decimal | None:
         """Return Frankencoin savings product TVL.
 
         Frankencoin's ERC-4626 wrapper only reports assets attributed to wrapper
         shareholders. The public savings product also includes direct deposits
-        in the savings module. For vault discovery TVL, report the ZCHF held by
-        both the module and the wrapper contract.
+        in the savings module. For canonical vault discovery rows, report the
+        ZCHF held by both the module and the wrapper contract.
+
+        Duplicate wrappers fall back to regular ERC-4626 ``totalAssets()`` so
+        exports do not count the same savings module TVL twice.
 
         :param block_identifier:
             Block number to read.
 
         :return:
-            Total ZCHF held by the Frankencoin savings module and wrapper.
+            Total ZCHF held by the Frankencoin savings module and wrapper, or
+            wrapper-only TVL for duplicate wrappers.
         """
+        if not self.reports_savings_product_tvl:
+            return super().fetch_total_assets(block_identifier)
+
         denomination_token = self.denomination_token
         if denomination_token is None:
             return None

--- a/scripts/erc-4626/fix-frankencoin-tvl.py
+++ b/scripts/erc-4626/fix-frankencoin-tvl.py
@@ -45,9 +45,7 @@ from web3 import Web3
 
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.vault_protocol.frankencoin.vault import (
-    FRANKENCOIN_BASE_SAVINGS_VAULT,
-    FRANKENCOIN_ETHEREUM_SAVINGS_VAULT,
-    FRANKENCOIN_GNOSIS_SAVINGS_VAULT,
+    FRANKENCOIN_PRODUCT_TVL_VAULTS_BY_CHAIN,
     FRANKENCOIN_SAVINGS_VAULT_ABI,
 )
 from eth_defi.provider.multi_provider import create_multi_provider_web3
@@ -68,14 +66,8 @@ ERC4626_ASSET_ABI = [
     {"inputs": [], "name": "asset", "outputs": [{"name": "", "type": "address"}], "stateMutability": "view", "type": "function"},
 ]
 
-#: Official Frankencoin Savings Vault addresses supported by this repository.
-FRANKENCOIN_VAULT_SPECS = frozenset(
-    {
-        VaultSpec(1, FRANKENCOIN_ETHEREUM_SAVINGS_VAULT),
-        VaultSpec(8453, FRANKENCOIN_BASE_SAVINGS_VAULT),
-        VaultSpec(100, FRANKENCOIN_GNOSIS_SAVINGS_VAULT),
-    }
-)
+#: Frankencoin Savings Vault addresses supported by this repository.
+FRANKENCOIN_VAULT_SPECS = frozenset(VaultSpec(chain_id, vault_address) for chain_id, vault_addresses in FRANKENCOIN_PRODUCT_TVL_VAULTS_BY_CHAIN.items() for vault_address in vault_addresses)
 
 
 @dataclass(slots=True, frozen=True)

--- a/tests/erc_4626/test_fix_frankencoin_tvl_script.py
+++ b/tests/erc_4626/test_fix_frankencoin_tvl_script.py
@@ -6,11 +6,12 @@ from pathlib import Path
 
 import pandas as pd
 
-from eth_defi.erc_4626.vault_protocol.frankencoin.vault import FRANKENCOIN_ETHEREUM_SAVINGS_VAULT
+from eth_defi.erc_4626.vault_protocol.frankencoin.vault import FRANKENCOIN_PRODUCT_TVL_VAULTS_BY_CHAIN
 from eth_defi.vault.base import VaultHistoricalRead
 
 FRANKENCOIN_CORRECTED_TVL = 11_666_191.0
 FRANKENCOIN_OLD_TVL = 3.4
+FRANKENCOIN_REPAIRED_ROWS = sum(len(vaults) for vaults in FRANKENCOIN_PRODUCT_TVL_VAULTS_BY_CHAIN.values())
 FRANKENCOIN_SHARE_PRICE = 1.01
 UNRELATED_TVL = 100.0
 
@@ -38,32 +39,37 @@ def create_price_rows() -> pd.DataFrame:
     """Create a minimal canonical price DataFrame for repair tests.
 
     :return:
-        Price rows containing one Frankencoin row and one unrelated row.
+        Price rows containing Frankencoin rows and one unrelated row.
     """
     timestamp = datetime.datetime(2026, 7, 10, 12, 0, tzinfo=datetime.UTC).replace(tzinfo=None)
+    frankencoin_rows = [
+        {
+            "chain": chain_id,
+            "address": vault_address,
+            "block_number": 25_000_000,
+            "timestamp": timestamp,
+            "share_price": FRANKENCOIN_SHARE_PRICE,
+            "total_assets": FRANKENCOIN_OLD_TVL,
+            "total_supply": 3.3,
+            "performance_fee": None,
+            "management_fee": None,
+            "errors": "",
+            "vault_poll_frequency": "large_tvl",
+            "max_deposit": None,
+            "max_redeem": None,
+            "deposits_open": "",
+            "redemption_open": "",
+            "trading": "",
+            "available_liquidity": None,
+            "utilisation": None,
+            "written_at": None,
+        }
+        for chain_id, vault_addresses in FRANKENCOIN_PRODUCT_TVL_VAULTS_BY_CHAIN.items()
+        for vault_address in vault_addresses
+    ]
     return pd.DataFrame(
         [
-            {
-                "chain": 1,
-                "address": FRANKENCOIN_ETHEREUM_SAVINGS_VAULT,
-                "block_number": 25_000_000,
-                "timestamp": timestamp,
-                "share_price": FRANKENCOIN_SHARE_PRICE,
-                "total_assets": FRANKENCOIN_OLD_TVL,
-                "total_supply": 3.3,
-                "performance_fee": None,
-                "management_fee": None,
-                "errors": "",
-                "vault_poll_frequency": "large_tvl",
-                "max_deposit": None,
-                "max_redeem": None,
-                "deposits_open": "",
-                "redemption_open": "",
-                "trading": "",
-                "available_liquidity": None,
-                "utilisation": None,
-                "written_at": None,
-            },
+            *frankencoin_rows,
             {
                 "chain": 1,
                 "address": "0x0000000000000000000000000000000000000001",
@@ -104,12 +110,12 @@ def test_repair_frankencoin_rows_updates_only_frankencoin() -> None:
         max_workers=1,
     )
 
-    assert result.matched_rows == 1
-    assert result.updated_rows == 1
+    assert result.matched_rows == FRANKENCOIN_REPAIRED_ROWS
+    assert result.updated_rows == FRANKENCOIN_REPAIRED_ROWS
     assert result.skipped_rows == 0
-    assert updated_df.loc[0, "total_assets"] == FRANKENCOIN_CORRECTED_TVL
     assert updated_df.loc[0, "share_price"] == FRANKENCOIN_SHARE_PRICE
-    assert updated_df.loc[1, "total_assets"] == UNRELATED_TVL
+    assert all(updated_df.loc[0 : FRANKENCOIN_REPAIRED_ROWS - 1, "total_assets"] == FRANKENCOIN_CORRECTED_TVL)
+    assert updated_df.loc[FRANKENCOIN_REPAIRED_ROWS, "total_assets"] == UNRELATED_TVL
 
 
 def test_repair_frankencoin_tvl_parquet_writes_backup(monkeypatch, tmp_path: Path) -> None:
@@ -119,6 +125,8 @@ def test_repair_frankencoin_tvl_parquet_writes_backup(monkeypatch, tmp_path: Pat
     VaultHistoricalRead.write_uncleaned_parquet(create_price_rows(), parquet_path)
 
     monkeypatch.setenv("JSON_RPC_ETHEREUM", "https://example.invalid")
+    monkeypatch.setenv("JSON_RPC_BASE", "https://example.invalid")
+    monkeypatch.setenv("JSON_RPC_GNOSIS", "https://example.invalid")
     monkeypatch.setattr(module, "create_multi_provider_web3", lambda _rpc_url: object())
     monkeypatch.setattr(module, "fetch_frankencoin_vault_contracts", lambda _web3, spec: spec)
     monkeypatch.setattr(module, "fetch_frankencoin_total_assets_raw", lambda _contracts, _block_number: int(FRANKENCOIN_CORRECTED_TVL * 10**18))
@@ -133,9 +141,9 @@ def test_repair_frankencoin_tvl_parquet_writes_backup(monkeypatch, tmp_path: Pat
 
     repaired_df = pd.read_parquet(parquet_path)
 
-    assert result.matched_rows == 1
-    assert result.updated_rows == 1
+    assert result.matched_rows == FRANKENCOIN_REPAIRED_ROWS
+    assert result.updated_rows == FRANKENCOIN_REPAIRED_ROWS
     assert result.skipped_rows == 0
     assert (tmp_path / "vault-prices-1h.parquet.bak-frankencoin-tvl").exists()
-    assert repaired_df.loc[0, "total_assets"] == FRANKENCOIN_CORRECTED_TVL
-    assert repaired_df.loc[1, "total_assets"] == UNRELATED_TVL
+    assert all(repaired_df.loc[0 : FRANKENCOIN_REPAIRED_ROWS - 1, "total_assets"] == FRANKENCOIN_CORRECTED_TVL)
+    assert repaired_df.loc[FRANKENCOIN_REPAIRED_ROWS, "total_assets"] == UNRELATED_TVL

--- a/tests/erc_4626/vault_protocol/test_frankencoin.py
+++ b/tests/erc_4626/vault_protocol/test_frankencoin.py
@@ -11,9 +11,10 @@ from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS, create_vault_i
 from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.frankencoin.vault import (
-    FRANKENCOIN_BASE_SAVINGS_VAULT,
+    FRANKENCOIN_ETHEREUM_LEGACY_SAVINGS_VAULT,
     FRANKENCOIN_ETHEREUM_SAVINGS_VAULT,
     FRANKENCOIN_GNOSIS_SAVINGS_VAULT,
+    FRANKENCOIN_PRODUCT_TVL_VAULTS,
     FRANKENCOIN_SAVINGS_VAULTS,
     FrankencoinHistoricalReader,
     FrankencoinVault,
@@ -104,11 +105,11 @@ def _make_frankencoin_call_result(
     """
     call = EncodedCall(
         func_name=function_name,
-        address=FRANKENCOIN_ETHEREUM_SAVINGS_VAULT,
+        address=FRANKENCOIN_ETHEREUM_LEGACY_SAVINGS_VAULT,
         data=b"",
         extra_data={
             "function": function_name,
-            "vault": FRANKENCOIN_ETHEREUM_SAVINGS_VAULT,
+            "vault": FRANKENCOIN_ETHEREUM_LEGACY_SAVINGS_VAULT,
         },
     )
     return EncodedCallResult(
@@ -122,12 +123,32 @@ def _make_frankencoin_call_result(
 
 
 def test_frankencoin_hardcoded_protocols() -> None:
-    """Official Frankencoin Savings Vaults are classified by hardcoded address."""
+    """Frankencoin Savings Vaults are classified by hardcoded address."""
+    assert set(FRANKENCOIN_SAVINGS_VAULTS) <= set(HARDCODED_PROTOCOLS)
+
     for vault_address in FRANKENCOIN_SAVINGS_VAULTS:
         features = HARDCODED_PROTOCOLS[vault_address]
 
         assert features == {ERC4626Feature.frankencoin_like}
         assert get_vault_protocol_name(features) == "Frankencoin"
+
+
+def test_frankencoin_ethereum_product_tvl_uses_one_wrapper() -> None:
+    """Only one Ethereum wrapper reports shared product TVL."""
+    official_vault = FrankencoinVault(
+        Web3(),
+        VaultSpec(1, FRANKENCOIN_ETHEREUM_SAVINGS_VAULT),
+        features={ERC4626Feature.frankencoin_like},
+    )
+    legacy_vault = FrankencoinVault(
+        Web3(),
+        VaultSpec(1, FRANKENCOIN_ETHEREUM_LEGACY_SAVINGS_VAULT),
+        features={ERC4626Feature.frankencoin_like},
+    )
+
+    assert official_vault.reports_savings_product_tvl is False
+    assert legacy_vault.reports_savings_product_tvl is True
+    assert FRANKENCOIN_PRODUCT_TVL_VAULTS <= FRANKENCOIN_SAVINGS_VAULTS
 
 
 def test_frankencoin_create_vault_instance() -> None:
@@ -162,13 +183,6 @@ def test_frankencoin_static_fee_metadata() -> None:
     assert vault.get_fee_mode() == VaultFeeMode.internalised_skimming
 
 
-def test_frankencoin_addresses() -> None:
-    """Frankencoin savings vault address constants stay lower-case."""
-    assert FRANKENCOIN_ETHEREUM_SAVINGS_VAULT == "0xe5f130253ff137f9917c0107659a4c5262abf6b0"
-    assert FRANKENCOIN_BASE_SAVINGS_VAULT == "0xa09ebdf8a01b9ef04149319d64f83b9c01a5b585"
-    assert FRANKENCOIN_GNOSIS_SAVINGS_VAULT == "0x6165946250dd04740ab1409217e95a4f38374fe9"
-
-
 def test_frankencoin_reader_updates_state_once_with_combined_tvl() -> None:
     """Frankencoin reader state sees the combined savings product TVL.
 
@@ -179,7 +193,7 @@ def test_frankencoin_reader_updates_state_once_with_combined_tvl() -> None:
     """
     vault = FrankencoinVault(
         Web3(),
-        VaultSpec(1, FRANKENCOIN_ETHEREUM_SAVINGS_VAULT),
+        VaultSpec(1, FRANKENCOIN_ETHEREUM_LEGACY_SAVINGS_VAULT),
         features={ERC4626Feature.frankencoin_like},
     )
     synthetic_token = _SyntheticToken()
@@ -222,7 +236,7 @@ def test_frankencoin_ethereum_combined_savings_tvl_latest() -> None:
     web3 = create_multi_provider_web3(JSON_RPC_ETHEREUM)
     vault = create_vault_instance(
         web3,
-        FRANKENCOIN_ETHEREUM_SAVINGS_VAULT,
+        FRANKENCOIN_ETHEREUM_LEGACY_SAVINGS_VAULT,
         features={ERC4626Feature.frankencoin_like},
     )
 
@@ -245,4 +259,4 @@ def test_frankencoin_ethereum_combined_savings_tvl_latest() -> None:
     assert savings_product_assets > Decimal("1000000")
     assert historical_read.total_assets == pytest.approx(savings_product_assets)
     assert historical_read.share_price == pytest.approx(share_price)
-    assert share_price == pytest.approx(Decimal("1.017"), rel=Decimal("0.01"))
+    assert share_price > Decimal(1)


### PR DESCRIPTION
## Why

Production vault exports were picking up the Ethereum Frankencoin svZCHF wrapper `0x637f00cab9665cb07d91bfb9c6f3fa8fabfef8bc`, but it was not classified as Frankencoin. It was treated as a generic ERC-4626 vault and reported wrapper-only TVL instead of the full Frankencoin savings product TVL.

The hardcoded Frankencoin address set needs to cover every known ERC-4626 svZCHF wrapper that the scanner may encounter, while product-level TVL must be reported through only one canonical wrapper per chain to avoid double-counting.

## Lessons learnt

The Frankencoin savings product has both ERC-4626 svZCHF wrappers and direct savings modules. The side-chain CCIP bridged savings module contracts are related protocol contracts, but they do not expose the ERC-4626 surface and should not be forced through the ERC-4626 adapter.

The Ethereum legacy svZCHF wrapper and the official Ethereum svZCHF wrapper point at the same underlying savings module. Both are classified as Frankencoin, but only the production-discovered legacy wrapper reports shared product-level TVL.

## Summary

- Add a chain-aware Frankencoin savings vault registry covering Ethereum official, Ethereum legacy, Base, and Gnosis svZCHF wrappers.
- Build Frankencoin hardcoded ERC-4626 classification from the shared registry.
- Add a canonical product-TVL registry so Ethereum savings-module TVL is not counted twice if both wrappers appear.
- Use the canonical product-TVL registry in the Frankencoin historical TVL repair script.
- Update Frankencoin docs and metadata to include the Ethereum legacy wrapper.
- Keep tests focused on classification, duplicate-TVL prevention, adapter creation, combined TVL reads, and historical repair behaviour.

## Related issues and PRs

Continues the Frankencoin svZCHF TVL work and the historical TVL repair script work.

## Unrelated CI and test fixes

None.
