### PR TITLE
fix: reconcile Hypercore prices using vault ledger flows

### DIFF
--- a/eth_defi/hyperliquid/daily_metrics.py
+++ b/eth_defi/hyperliquid/daily_metrics.py
@@ -615,6 +615,88 @@ class HyperliquidDailyMetricsDatabase(HyperliquidMetricsDatabaseBase):
             .df()
         )
 
+    def update_historical_daily_flows(
+        self,
+        vault_address: HexAddress,
+        daily_flows: dict[datetime.date, tuple[int, int, float, float]],
+        start_date: datetime.date,
+        end_date: datetime.date,
+    ) -> int:
+        """Backfill ledger flows on existing historical price observations.
+
+        A normal scan can only attach flow data to portfolio observations that
+        Hyperliquid still returns. Because the API downsamples old portfolio
+        history, an old daily price row may remain in DuckDB even though a new
+        ``vaultDetails`` response no longer contains that date. This method
+        updates those existing rows directly from separately fetched
+        ``userNonFundingLedgerUpdates`` data. Dates without a ledger event are
+        explicitly stored as zero, which distinguishes a proven zero-flow day
+        from an unknown historical day.
+
+        Existing price, NAV, PnL, and metadata values are never changed. The
+        update is intentionally allowed to replace an old zero withdrawal,
+        because older parser versions read Hyperliquid's zero-valued ``usdc``
+        placeholder instead of ``netWithdrawnUsd``.
+
+        :param vault_address:
+            Lowercase or checksummed Hyperliquid vault address.
+        :param daily_flows:
+            Ledger events aggregated by UTC date as ``(deposit_count,
+            withdrawal_count, deposit_usd, withdrawal_usd)``.
+        :param start_date:
+            First existing daily observation to backfill, inclusive.
+        :param end_date:
+            Last existing daily observation to backfill, inclusive.
+        :return:
+            Number of existing daily price rows updated.
+        """
+        address = vault_address.lower()
+        existing_dates = [
+            row[0]
+            for row in self.con.cursor()
+            .execute(
+                """
+                SELECT date
+                FROM vault_daily_prices
+                WHERE vault_address = ? AND date BETWEEN ? AND ?
+                ORDER BY date
+                """,
+                [address, start_date, end_date],
+            )
+            .fetchall()
+        ]
+        if not existing_dates:
+            return 0
+
+        update_rows = []
+        for date_value in existing_dates:
+            deposit_count, withdrawal_count, deposit_usd, withdrawal_usd = daily_flows.get(date_value, (0, 0, 0.0, 0.0))
+            update_rows.append((deposit_count, withdrawal_count, deposit_usd, withdrawal_usd, address, date_value))
+
+        self.con.cursor().executemany(
+            """
+            UPDATE vault_daily_prices
+            SET daily_deposit_count = ?,
+                daily_withdrawal_count = ?,
+                daily_deposit_usd = ?,
+                daily_withdrawal_usd = ?
+            WHERE vault_address = ? AND date = ?
+            """,
+            update_rows,
+        )
+        self.con.cursor().execute(
+            """
+            UPDATE vault_metadata
+            SET flow_data_earliest_date = LEAST(
+                COALESCE(flow_data_earliest_date, ?),
+                ?
+            )
+            WHERE vault_address = ?
+            """,
+            [start_date, start_date, address],
+        )
+        return len(update_rows)
+
     def get_existing_dates(self, vault_address: HexAddress) -> set[datetime.date]:
         """Get all dates with existing data for a vault.
 

--- a/eth_defi/hyperliquid/deposit.py
+++ b/eth_defi/hyperliquid/deposit.py
@@ -300,18 +300,28 @@ def _parse_vault_event(
         )
 
     elif delta_type == "vaultWithdraw":
+        # Hyperliquid commonly leaves ``usdc`` at zero for a completed vault
+        # withdrawal and reports the realised cash flow in ``netWithdrawnUsd``.
+        # ``usdc`` is the backwards-compatible signed flow field consumed by
+        # daily aggregation, so prefer the net amount whenever the API supplies
+        # it. This is essential for NAV = previous NAV + PnL + net flow
+        # reconciliation; using the zero placeholder turns real withdrawals
+        # into fictitious losses and makes a synthetic share-price spike look
+        # plausible.
+        net_withdrawn_usd = Decimal(str(delta["netWithdrawnUsd"])) if "netWithdrawnUsd" in delta else None
+        withdrawal_usdc = net_withdrawn_usd if net_withdrawn_usd is not None else Decimal(str(delta.get("usdc", "0")))
         return VaultDepositEvent(
             event_type=VaultEventType.vault_withdraw,
             vault_address=delta.get("vault", vault_address),
             user_address=delta.get("user"),
-            usdc=-abs(Decimal(str(delta.get("usdc", "0")))),  # Negative for outflows
+            usdc=-abs(withdrawal_usdc),  # Negative for outflows
             timestamp=update.timestamp,
             hash=update.hash,
             requested_usd=Decimal(str(delta.get("requestedUsd", "0"))) if "requestedUsd" in delta else None,
             commission=Decimal(str(delta.get("commission", "0"))) if "commission" in delta else None,
             closing_cost=Decimal(str(delta.get("closingCost", "0"))) if "closingCost" in delta else None,
             basis=Decimal(str(delta.get("basis", "0"))) if "basis" in delta else None,
-            net_withdrawn_usd=Decimal(str(delta.get("netWithdrawnUsd", "0"))) if "netWithdrawnUsd" in delta else None,
+            net_withdrawn_usd=net_withdrawn_usd,
         )
 
     elif delta_type == "vaultDistribution":

--- a/eth_defi/hyperliquid/vault_metrics_db.py
+++ b/eth_defi/hyperliquid/vault_metrics_db.py
@@ -141,7 +141,11 @@ class HyperliquidMetricsDatabaseBase:
                 tvl = EXCLUDED.tvl,
                 apr = EXCLUDED.apr,
                 last_updated = EXCLUDED.last_updated,
-                flow_data_earliest_date = COALESCE(EXCLUDED.flow_data_earliest_date, vault_metadata.flow_data_earliest_date)
+                flow_data_earliest_date = CASE
+                    WHEN EXCLUDED.flow_data_earliest_date IS NULL THEN vault_metadata.flow_data_earliest_date
+                    WHEN vault_metadata.flow_data_earliest_date IS NULL THEN EXCLUDED.flow_data_earliest_date
+                    ELSE LEAST(EXCLUDED.flow_data_earliest_date, vault_metadata.flow_data_earliest_date)
+                END
             """,
             [
                 vault_address.lower(),

--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -14,6 +14,7 @@ The output is a cleaned DataFrame conforming to
 :py:func:`~eth_defi.research.vault_metrics.calculate_lifetime_metrics`.
 """
 
+import datetime
 import os
 import pickle
 import tempfile
@@ -63,6 +64,15 @@ MIN_HYPERCORE_RECAPITALISATION_RECOVERY_DELAY = pd.Timedelta(days=7)
 
 #: Never infer a scanner-batch price unit across a longer missing-HF interval.
 HYPERCORE_MAX_HF_BATCH_STITCH_GAP = pd.Timedelta(days=2)
+
+#: A flow-reconciled PnL path must end close to its next trusted HF observation.
+HYPERCORE_MAX_PNL_PATH_ENDPOINT_DEVIATION: Percent = 0.10
+
+#: Permit cents and small API rounding differences when checking NAV accounting.
+HYPERCORE_PNL_PATH_ACCOUNTING_ABSOLUTE_TOLERANCE = 1.0
+
+#: Relative NAV accounting tolerance for the flow-reconciled price path.
+HYPERCORE_PNL_PATH_ACCOUNTING_RELATIVE_TOLERANCE: Percent = 0.01
 
 
 class CleanedVaultPriceRow(TypedDict, total=False):
@@ -1228,6 +1238,227 @@ def stitch_hypercore_high_freq_share_price_batches(
     return prices_df
 
 
+def fix_hypercore_flow_reconciled_share_price_paths(  # noqa: PLR0914, PLR0917
+    prices_df: pd.DataFrame,
+    logger=print,
+    max_anchor_deviation: Percent = 0.50,
+    max_anchor_gap: pd.Timedelta = HYPERCORE_MAX_PRICE_ANCHOR_GAP,
+    max_endpoint_deviation: Percent = HYPERCORE_MAX_PNL_PATH_ENDPOINT_DEVIATION,
+    accounting_absolute_tolerance: float = HYPERCORE_PNL_PATH_ACCOUNTING_ABSOLUTE_TOLERANCE,
+    accounting_relative_tolerance: Percent = HYPERCORE_PNL_PATH_ACCOUNTING_RELATIVE_TOLERANCE,
+) -> pd.DataFrame:
+    """Repair a conflicted Hypercore interval from ledger-reconciled PnL.
+
+    Hyperliquid does not expose a native vault share price. Both scanners derive
+    one from rolling portfolio windows, so a daily observation can be in a
+    different arbitrary unit even though its NAV and cumulative PnL are real.
+    In February 2026 Magixbox reported a daily price of ``26.03541`` between HF
+    observations near ``1.30``. Its $7,614.65 of same-day withdrawals and
+    -$1,386.74 PnL exactly reconcile the NAV change to within two cents. The
+    price spike therefore cannot be an investor return: cash flows change the
+    implied supply, while PnL changes the price.
+
+    When persisted daily ledger flows prove that accounting relationship for a
+    conflicted observation, reconstruct its price from the PnL path between
+    adjacent HF anchors using ``1 + pnl_change / previous_nav``. A small
+    log-linear endpoint correction makes the reconstructed path meet the next
+    HF price without discarding the timing and direction of the observed PnL.
+    This is deliberately narrower than generic smoothing: each changed daily
+    row needs known flow values and must reconcile, there may be no wipe-out
+    boundary, and the uncorrected PnL path must already end within
+    ``max_endpoint_deviation`` of the next HF anchor. If old parquet lacks the
+    ledger flow columns, this function leaves it untouched and the older,
+    conservative source-overlap repair remains the fallback.
+
+    :param prices_df:
+        Timestamp-indexed vault price data. Hypercore rows need ``id``,
+        ``chain``, ``share_price``, ``total_assets``, ``account_pnl`` (or
+        scanner-shaped ``cumulative_pnl``), ``daily_deposit_usd``,
+        ``daily_withdrawal_usd``, and ``hypercore_source``. Each repaired
+        calendar date must have a known flow record, on either its daily or HF
+        observation; zero is required when there was no ledger event. Matching
+        daily/HF copies of the same flow are de-duplicated.
+    :param logger:
+        Notebook or console logging function.
+    :param max_anchor_deviation:
+        Minimum symmetric daily/HF price disagreement required before the
+        interval is considered for this specialised repair.
+    :param max_anchor_gap:
+        Largest interval between consecutive HF anchors.
+    :param max_endpoint_deviation:
+        Largest symmetric difference permitted between the uncorrected PnL
+        path and the right HF anchor.
+    :param accounting_absolute_tolerance:
+        Dollar tolerance for API rounding when reconciling one NAV step.
+    :param accounting_relative_tolerance:
+        Relative NAV tolerance for the same reconciliation.
+    :return:
+        A copy with qualifying daily paths marked ``repaired_hf_pnl_flow``;
+        ``raw_share_price`` remains the scanner-derived value.
+    """
+    hypercore_mask = prices_df["chain"] == HYPERCORE_CHAIN_ID
+    pnl_column = "cumulative_pnl" if "cumulative_pnl" in prices_df.columns else "account_pnl"
+    required_columns = {"total_assets", pnl_column, "daily_deposit_usd", "daily_withdrawal_usd"}
+    if not hypercore_mask.any() or not required_columns.issubset(prices_df.columns):
+        return prices_df
+
+    prices_df = prices_df.copy()
+    if "raw_share_price" not in prices_df.columns:
+        prices_df["raw_share_price"] = prices_df["share_price"]
+    if "hypercore_repair_status" not in prices_df.columns:
+        prices_df["hypercore_repair_status"] = ""
+    if "hypercore_source" not in prices_df.columns:
+        prices_df["hypercore_source"] = pd.NA
+
+    missing_source_mask = hypercore_mask & prices_df["hypercore_source"].isna()
+    if missing_source_mask.any():
+        timestamps = pd.DatetimeIndex(prices_df.index[missing_source_mask])
+        prices_df.loc[missing_source_mask, "hypercore_source"] = np.where(timestamps == timestamps.normalize(), "daily", "hf")
+
+    repaired_rows = 0
+    repaired_vaults: set[str] = set()
+    hypercore_positions = np.flatnonzero(hypercore_mask.to_numpy())
+    share_price_col = prices_df.columns.get_loc("share_price")
+    total_supply_col = prices_df.columns.get_loc("total_supply") if "total_supply" in prices_df.columns else None
+    status_col = prices_df.columns.get_loc("hypercore_repair_status")
+
+    for vault_id, row_positions in prices_df.loc[hypercore_mask].groupby("id", sort=False).indices.items():
+        positions = hypercore_positions[np.asarray(row_positions, dtype=int)]
+        group = prices_df.iloc[positions]
+        source = group["hypercore_source"].astype("string").fillna("").to_numpy(dtype=str)
+        status = group["hypercore_repair_status"].astype("string").fillna("").to_numpy(dtype=str)
+        timestamp = pd.DatetimeIndex(group.index)
+        timestamp_ns = timestamp.to_numpy(dtype="datetime64[ns]").astype("int64")
+        share_price = group["share_price"].to_numpy(dtype=float)
+        total_assets = group["total_assets"].to_numpy(dtype=float)
+        account_pnl = group[pnl_column].to_numpy(dtype=float)
+        deposits = group["daily_deposit_usd"].to_numpy(dtype=float)
+        withdrawals = group["daily_withdrawal_usd"].to_numpy(dtype=float)
+        epoch_reset = group["epoch_reset"].fillna(False).astype(bool).to_numpy() if "epoch_reset" in group.columns else np.zeros(len(group), dtype=bool)
+        daily_flow_by_date: dict[datetime.date, tuple[float, float]] = {}
+        known_flow_mask = np.isfinite(deposits) & np.isfinite(withdrawals)
+        calendar_dates = timestamp.date
+        for day in np.unique(calendar_dates):
+            day_positions = np.flatnonzero(calendar_dates == day)
+            known_positions = day_positions[known_flow_mask[day_positions]]
+            if len(known_positions) == 0:
+                continue
+            known_flows = np.column_stack((deposits[known_positions], withdrawals[known_positions]))
+            non_zero_flows = known_flows[np.sum(np.abs(known_flows), axis=1) > 0]
+            candidate_flows = non_zero_flows if len(non_zero_flows) else known_flows
+            if np.allclose(candidate_flows, candidate_flows[0], rtol=0.0, atol=0.01):
+                daily_flow_by_date[day] = tuple(candidate_flows[0])
+
+        hf_positions = np.flatnonzero((source == "hf") & np.isfinite(share_price) & (share_price > 0) & np.isfinite(total_assets) & (total_assets > 0) & np.isfinite(account_pnl))
+        if len(hf_positions) < MIN_HYPERCORE_PRICE_ANCHORS:
+            continue
+
+        for left_position, right_position in zip(hf_positions[:-1], hf_positions[1:]):
+            if timestamp_ns[right_position] - timestamp_ns[left_position] > max_anchor_gap.value:
+                continue
+
+            inner_positions = np.arange(left_position + 1, right_position)
+            if len(inner_positions) == 0 or not np.all(source[inner_positions] == "daily"):
+                continue
+            if np.any(epoch_reset[left_position : right_position + 1]) or np.any(total_assets[left_position : right_position + 1] <= HYPERCORE_ZERO_NAV_EPSILON):
+                continue
+
+            # Do not change a path that had already been handled by a prior
+            # Hypercore repair in this wrangle run.
+            if np.any(status[inner_positions] != ""):
+                continue
+
+            elapsed = (timestamp_ns[inner_positions] - timestamp_ns[left_position]) / (timestamp_ns[right_position] - timestamp_ns[left_position])
+            expected_anchor_prices = np.exp(np.log(share_price[left_position]) + elapsed * (np.log(share_price[right_position]) - np.log(share_price[left_position])))
+            with np.errstate(divide="ignore", invalid="ignore"):
+                anchor_deviation = (
+                    np.maximum(
+                        share_price[inner_positions] / expected_anchor_prices,
+                        expected_anchor_prices / share_price[inner_positions],
+                    )
+                    - 1
+                )
+            candidate_mask = np.isfinite(anchor_deviation) & (anchor_deviation > max_anchor_deviation)
+            candidate_positions = inner_positions[candidate_mask]
+            if len(candidate_positions) == 0:
+                continue
+
+            required_values = np.concatenate(
+                [
+                    total_assets[[left_position, right_position]],
+                    account_pnl[[left_position, right_position]],
+                    total_assets[inner_positions],
+                    account_pnl[inner_positions],
+                ]
+            )
+            if not np.all(np.isfinite(required_values)) or np.any(total_assets[[left_position, *inner_positions]] <= 0):
+                continue
+
+            provisional_prices: list[float] = []
+            previous_assets = total_assets[left_position]
+            previous_pnl = account_pnl[left_position]
+            previous_price = share_price[left_position]
+            pnl_path_valid = True
+            for position in inner_positions:
+                pnl_change = account_pnl[position] - previous_pnl
+                next_price = previous_price * (1 + pnl_change / previous_assets)
+                if not np.isfinite(next_price) or next_price <= 0:
+                    pnl_path_valid = False
+                    break
+                provisional_prices.append(next_price)
+                previous_assets = total_assets[position]
+                previous_pnl = account_pnl[position]
+                previous_price = next_price
+
+            if not pnl_path_valid:
+                continue
+
+            endpoint_price = previous_price * (1 + (account_pnl[right_position] - previous_pnl) / previous_assets)
+            if not np.isfinite(endpoint_price) or endpoint_price <= 0:
+                continue
+            endpoint_deviation = max(endpoint_price / share_price[right_position], share_price[right_position] / endpoint_price) - 1
+            if endpoint_deviation > max_endpoint_deviation:
+                continue
+
+            endpoint_correction = np.log(share_price[right_position] / endpoint_price)
+            repaired_prices = np.asarray(provisional_prices) * np.exp(endpoint_correction * elapsed)
+            repaired_by_position = dict(zip(inner_positions, repaired_prices))
+            repaired_candidate_count = 0
+            for position in candidate_positions:
+                flow_values = daily_flow_by_date.get(timestamp[position].date())
+                if flow_values is None:
+                    continue
+                deposit, withdrawal = flow_values
+                previous_position = position - 1
+                expected_assets = total_assets[previous_position] + (account_pnl[position] - account_pnl[previous_position]) + deposit - withdrawal
+                tolerance = max(
+                    accounting_absolute_tolerance,
+                    accounting_relative_tolerance * max(abs(expected_assets), abs(total_assets[position])),
+                )
+                if not np.isfinite(deposit) or not np.isfinite(withdrawal) or abs(total_assets[position] - expected_assets) > tolerance:
+                    continue
+
+                repaired_price = repaired_by_position[position]
+                original_price = share_price[position]
+                if not np.isfinite(original_price) or original_price <= 0:
+                    continue
+                factor = repaired_price / original_price
+                prices_df.iloc[positions[position], share_price_col] = repaired_price
+                if total_supply_col is not None:
+                    original_supply = prices_df.iloc[positions[position], total_supply_col]
+                    if pd.notna(original_supply) and original_supply > 0:
+                        prices_df.iloc[positions[position], total_supply_col] = original_supply / factor
+                prices_df.iloc[positions[position], status_col] = "repaired_hf_pnl_flow"
+                repaired_rows += 1
+                repaired_candidate_count += 1
+            if repaired_candidate_count:
+                repaired_vaults.add(str(vault_id))
+
+    if repaired_rows:
+        logger(f"Repaired {repaired_rows:,} flow-reconciled Hypercore daily prices across {len(repaired_vaults):,} vaults using PnL paths")
+    return prices_df
+
+
 def fix_hypercore_source_overlap_share_prices(  # noqa: PLR0914
     prices_df: pd.DataFrame,
     logger=print,
@@ -1334,6 +1565,7 @@ def fix_hypercore_source_overlap_share_prices(  # noqa: PLR0914
         group = prices_df.iloc[positions]
 
         source = group["hypercore_source"].astype("string").fillna("").to_numpy(dtype=str)
+        existing_status = group["hypercore_repair_status"].astype("string").fillna("").to_numpy(dtype=str)
         share_price = group["share_price"].to_numpy(dtype=float)
         timestamp_ns = pd.DatetimeIndex(group.index).to_numpy(dtype="datetime64[ns]").astype("int64")
 
@@ -1352,7 +1584,7 @@ def fix_hypercore_source_overlap_share_prices(  # noqa: PLR0914
             # HF coverage selects the HF repair path even if some observations
             # have unusable NAV. Never reinterpret such a vault as daily-only.
             anchor_mask = hf_price_mask & positive_assets_mask
-            candidate_mask = daily_mask
+            candidate_mask = daily_mask & (existing_status == "")
             anchor_source = "hf"
         else:
             # Some legacy vaults were never covered by the HF scanner. A
@@ -1368,7 +1600,7 @@ def fix_hypercore_source_overlap_share_prices(  # noqa: PLR0914
                 continue
             refreshed_mask = (written_at >= latest_written_at - HYPERCORE_DAILY_REFRESH_TOLERANCE).to_numpy()
             anchor_mask = daily_mask & refreshed_mask & positive_price_mask & positive_assets_mask
-            candidate_mask = daily_mask & ~anchor_mask
+            candidate_mask = daily_mask & ~anchor_mask & (existing_status == "")
             anchor_source = "daily"
 
         anchor_timestamps = timestamp_ns[anchor_mask]
@@ -1776,6 +2008,11 @@ def process_raw_vault_scan_data(
     # Hypercore share prices can overflow when total_supply → 0;
     # this prevents the smoothing algorithm from being confused by absurd values.
     prices_df = cap_hypercore_share_prices(prices_df, logger)
+
+    # Some historic daily/HF overlap conflicts are real capital flows paired
+    # with a synthetic daily price unit. Where persisted ledger flows prove the
+    # NAV accounting, retain the observed PnL path rather than interpolating it.
+    prices_df = fix_hypercore_flow_reconciled_share_price_paths(prices_df, logger)
 
     # Hypercore scans may overlap or refresh only a sparse subset of historical
     # rows. Repair stale daily values that conflict sharply with canonical HF

--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -1260,12 +1260,18 @@ def fix_hypercore_flow_reconciled_share_price_paths(  # noqa: PLR0914, PLR0917
 
     When persisted daily ledger flows prove that accounting relationship for a
     conflicted observation, reconstruct its price from the PnL path between
-    adjacent HF anchors using ``1 + pnl_change / previous_nav``. A small
-    log-linear endpoint correction makes the reconstructed path meet the next
-    HF price without discarding the timing and direction of the observed PnL.
-    This is deliberately narrower than generic smoothing: each changed daily
-    row needs known flow values and must reconcile, there may be no wipe-out
-    boundary, and the uncorrected PnL path must already end within
+    adjacent HF anchors using ``1 + pnl_change / previous_nav``. Continue the
+    repair through following daily observations while every NAV step remains
+    ledger-reconciled, then stop at the first unproven step. This ensures the
+    return direction follows profit: for example, Magixbox's positive PnL on 7
+    February must not remain a negative share-price return after repairing its
+    5 February unit change.
+
+    A small log-linear endpoint correction makes the reconstructed path meet
+    the next HF price without discarding the timing and direction of the
+    observed PnL. This is deliberately narrower than generic smoothing: each
+    changed daily row needs known flow values and must reconcile, there may be
+    no wipe-out boundary, and the uncorrected PnL path must already end within
     ``max_endpoint_deviation`` of the next HF anchor. If old parquet lacks the
     ledger flow columns, this function leaves it untouched and the older,
     conservative source-overlap repair remains the fallback.
@@ -1423,25 +1429,30 @@ def fix_hypercore_flow_reconciled_share_price_paths(  # noqa: PLR0914, PLR0917
             endpoint_correction = np.log(share_price[right_position] / endpoint_price)
             repaired_prices = np.asarray(provisional_prices) * np.exp(endpoint_correction * elapsed)
             repaired_by_position = dict(zip(inner_positions, repaired_prices))
-            repaired_candidate_count = 0
-            for position in candidate_positions:
-                flow_values = daily_flow_by_date.get(timestamp[position].date())
-                if flow_values is None:
-                    continue
-                deposit, withdrawal = flow_values
-                previous_position = position - 1
-                expected_assets = total_assets[previous_position] + (account_pnl[position] - account_pnl[previous_position]) + deposit - withdrawal
-                tolerance = max(
-                    accounting_absolute_tolerance,
-                    accounting_relative_tolerance * max(abs(expected_assets), abs(total_assets[position])),
-                )
-                if not np.isfinite(deposit) or not np.isfinite(withdrawal) or abs(total_assets[position] - expected_assets) > tolerance:
-                    continue
+            repair_positions: set[int] = set()
+            for candidate_position in candidate_positions:
+                # The large conflict starts a proven repair segment. Continue
+                # while NAV = previous NAV + PnL + net flow; the first missing
+                # or inconsistent ledger step ends this segment.
+                for position in range(int(candidate_position), int(right_position)):
+                    flow_values = daily_flow_by_date.get(timestamp[position].date())
+                    original_price = share_price[position]
+                    if flow_values is None or not np.isfinite(original_price) or original_price <= 0:
+                        break
+                    deposit, withdrawal = flow_values
+                    previous_position = position - 1
+                    expected_assets = total_assets[previous_position] + (account_pnl[position] - account_pnl[previous_position]) + deposit - withdrawal
+                    tolerance = max(
+                        accounting_absolute_tolerance,
+                        accounting_relative_tolerance * max(abs(expected_assets), abs(total_assets[position])),
+                    )
+                    if not np.isfinite(deposit) or not np.isfinite(withdrawal) or abs(total_assets[position] - expected_assets) > tolerance:
+                        break
+                    repair_positions.add(position)
 
+            for position in sorted(repair_positions):
                 repaired_price = repaired_by_position[position]
                 original_price = share_price[position]
-                if not np.isfinite(original_price) or original_price <= 0:
-                    continue
                 factor = repaired_price / original_price
                 prices_df.iloc[positions[position], share_price_col] = repaired_price
                 if total_supply_col is not None:
@@ -1450,8 +1461,7 @@ def fix_hypercore_flow_reconciled_share_price_paths(  # noqa: PLR0914, PLR0917
                         prices_df.iloc[positions[position], total_supply_col] = original_supply / factor
                 prices_df.iloc[positions[position], status_col] = "repaired_hf_pnl_flow"
                 repaired_rows += 1
-                repaired_candidate_count += 1
-            if repaired_candidate_count:
+            if repair_positions:
                 repaired_vaults.add(str(vault_id))
 
     if repaired_rows:

--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -71,9 +71,6 @@ HYPERCORE_MAX_PNL_PATH_ENDPOINT_DEVIATION: Percent = 0.10
 #: Permit cents and small API rounding differences when checking NAV accounting.
 HYPERCORE_PNL_PATH_ACCOUNTING_ABSOLUTE_TOLERANCE = 1.0
 
-#: Relative NAV accounting tolerance for the flow-reconciled price path.
-HYPERCORE_PNL_PATH_ACCOUNTING_RELATIVE_TOLERANCE: Percent = 0.01
-
 
 class CleanedVaultPriceRow(TypedDict, total=False):
     """Schema for a single row in the cleaned vault price DataFrame.
@@ -1245,7 +1242,6 @@ def fix_hypercore_flow_reconciled_share_price_paths(  # noqa: PLR0914, PLR0917
     max_anchor_gap: pd.Timedelta = HYPERCORE_MAX_PRICE_ANCHOR_GAP,
     max_endpoint_deviation: Percent = HYPERCORE_MAX_PNL_PATH_ENDPOINT_DEVIATION,
     accounting_absolute_tolerance: float = HYPERCORE_PNL_PATH_ACCOUNTING_ABSOLUTE_TOLERANCE,
-    accounting_relative_tolerance: Percent = HYPERCORE_PNL_PATH_ACCOUNTING_RELATIVE_TOLERANCE,
 ) -> pd.DataFrame:
     """Repair a conflicted Hypercore interval from ledger-reconciled PnL.
 
@@ -1267,14 +1263,15 @@ def fix_hypercore_flow_reconciled_share_price_paths(  # noqa: PLR0914, PLR0917
     February must not remain a negative share-price return after repairing its
     5 February unit change.
 
-    A small log-linear endpoint correction makes the reconstructed path meet
-    the next HF price without discarding the timing and direction of the
-    observed PnL. This is deliberately narrower than generic smoothing: each
-    changed daily row needs known flow values and must reconcile, there may be
-    no wipe-out boundary, and the uncorrected PnL path must already end within
-    ``max_endpoint_deviation`` of the next HF anchor. If old parquet lacks the
-    ledger flow columns, this function leaves it untouched and the older,
-    conservative source-overlap repair remains the fallback.
+    The next HF price is only a plausibility guard: the reconstructed path must
+    end within ``max_endpoint_deviation`` of it. The residual difference is not
+    spread over the daily prices, because doing so can reverse the sign of a
+    genuine PnL return. This is deliberately narrower than generic smoothing:
+    each changed daily row needs known flow values and must reconcile to within
+    a fixed dollar tolerance, there may be no wipe-out boundary, and one
+    missing or inconsistent ledger step ends the interval repair. If old
+    parquet lacks the ledger flow columns, this function leaves it untouched
+    and the older, conservative source-overlap repair remains the fallback.
 
     :param prices_df:
         Timestamp-indexed vault price data. Hypercore rows need ``id``,
@@ -1296,8 +1293,6 @@ def fix_hypercore_flow_reconciled_share_price_paths(  # noqa: PLR0914, PLR0917
         path and the right HF anchor.
     :param accounting_absolute_tolerance:
         Dollar tolerance for API rounding when reconciling one NAV step.
-    :param accounting_relative_tolerance:
-        Relative NAV tolerance for the same reconciliation.
     :return:
         A copy with qualifying daily paths marked ``repaired_hf_pnl_flow``;
         ``raw_share_price`` remains the scanner-derived value.
@@ -1426,29 +1421,24 @@ def fix_hypercore_flow_reconciled_share_price_paths(  # noqa: PLR0914, PLR0917
             if endpoint_deviation > max_endpoint_deviation:
                 continue
 
-            endpoint_correction = np.log(share_price[right_position] / endpoint_price)
-            repaired_prices = np.asarray(provisional_prices) * np.exp(endpoint_correction * elapsed)
+            repaired_prices = np.asarray(provisional_prices)
             repaired_by_position = dict(zip(inner_positions, repaired_prices))
             repair_positions: set[int] = set()
-            for candidate_position in candidate_positions:
-                # The large conflict starts a proven repair segment. Continue
-                # while NAV = previous NAV + PnL + net flow; the first missing
-                # or inconsistent ledger step ends this segment.
-                for position in range(int(candidate_position), int(right_position)):
-                    flow_values = daily_flow_by_date.get(timestamp[position].date())
-                    original_price = share_price[position]
-                    if flow_values is None or not np.isfinite(original_price) or original_price <= 0:
-                        break
-                    deposit, withdrawal = flow_values
-                    previous_position = position - 1
-                    expected_assets = total_assets[previous_position] + (account_pnl[position] - account_pnl[previous_position]) + deposit - withdrawal
-                    tolerance = max(
-                        accounting_absolute_tolerance,
-                        accounting_relative_tolerance * max(abs(expected_assets), abs(total_assets[position])),
-                    )
-                    if not np.isfinite(deposit) or not np.isfinite(withdrawal) or abs(total_assets[position] - expected_assets) > tolerance:
-                        break
-                    repair_positions.add(position)
+            candidate_position = int(candidate_positions[0])
+            # The first large conflict starts the only proven repair segment in
+            # this HF interval. Continue while NAV = previous NAV + PnL + net
+            # flow; the first missing or inconsistent ledger step ends it.
+            for position in range(candidate_position, int(right_position)):
+                flow_values = daily_flow_by_date.get(timestamp[position].date())
+                original_price = share_price[position]
+                if flow_values is None or not np.isfinite(original_price) or original_price <= 0:
+                    break
+                deposit, withdrawal = flow_values
+                previous_position = position - 1
+                expected_assets = total_assets[previous_position] + (account_pnl[position] - account_pnl[previous_position]) + deposit - withdrawal
+                if not np.isfinite(deposit) or not np.isfinite(withdrawal) or abs(total_assets[position] - expected_assets) > accounting_absolute_tolerance:
+                    break
+                repair_positions.add(position)
 
             for position in sorted(repair_positions):
                 repaired_price = repaired_by_position[position]

--- a/scripts/hyperliquid/README-hyperliquid-vaults.md
+++ b/scripts/hyperliquid/README-hyperliquid-vaults.md
@@ -240,6 +240,42 @@ so you can backfill as far as the vault has existed.
 After a one-time backfill, set `FLOW_BACKFILL_DAYS` back to 7 (or omit it)
 for regular daily runs to avoid unnecessary API calls.
 
+### Repairing retained historical observations
+
+`FLOW_BACKFILL_DAYS` only attaches flows to portfolio observations still
+returned by the current `vaultDetails` response. Hyperliquid downsamples old
+portfolio history, so an exact historical row retained in our DuckDB may no
+longer appear in a fresh response. This affected Magixbox on 5 February 2026:
+the retained daily price had no withdrawal, while
+`userNonFundingLedgerUpdates` still returned $7,614.65 of withdrawals.
+
+Use the manual historical-flow script for these `deferred_hf_nav` rows. It
+fetches the ledger around each candidate and updates only flow columns on
+existing daily DuckDB observations:
+
+```shell
+# Preview all candidates without writing
+AUTODETECT=true \
+  poetry run python scripts/hyperliquid/backfill-historical-vault-flows.py
+
+# Update Magixbox
+DRY_RUN=false \
+  VAULT_ADDRESSES=0x1764dd740aba4195643bbb6a44648e0306b00cfa \
+  poetry run python scripts/hyperliquid/backfill-historical-vault-flows.py
+```
+
+Set exactly one of `VAULT_ADDRESSES` or `AUTODETECT=true`. Every non-dry-run
+execution first creates the next numbered backup beside the daily DuckDB, such
+as `hyperliquid-vaults.duckdb.bak-0001`. Existing backups are never replaced;
+the DuckDB WAL sidecar is copied as well when present. Stop the scanner while
+the backup and update run.
+
+Afterwards run the normal export and vault-price wrangle. The wrangle repairs a
+large daily/HF unit conflict only when the backfilled ledger flow reconciles
+NAV. It follows the PnL-derived share-price path through subsequent reconciled
+observations and stops at the first missing or inconsistent flow step. Raw
+share prices remain available in `raw_share_price` for auditing.
+
 ## Tombstoning stale vaults
 
 Vaults that drop below the daily TVL processing threshold ($5K) stop receiving

--- a/scripts/hyperliquid/backfill-historical-vault-flows.py
+++ b/scripts/hyperliquid/backfill-historical-vault-flows.py
@@ -1,0 +1,298 @@
+"""Backfill historical Hypercore ledger flows for deferred price repairs.
+
+The normal Hyperliquid scanners fetch only a short rolling flow window. Old
+daily price observations can therefore retain missing or incorrectly parsed
+withdrawals even though ``userNonFundingLedgerUpdates`` still exposes the
+ledger events. This script finds ``deferred_hf_nav`` observations in the
+cleaned Parquet, fetches the surrounding ledger history, and updates the
+existing daily DuckDB rows. It does not change share price, NAV, or PnL.
+
+After the backfill, run the normal Hyperliquid export and vault-price wrangle.
+The flow-reconciled wrangle step will then repair qualifying share-price paths.
+
+Usage:
+
+.. code-block:: shell
+
+    # Preview every currently deferred vault.
+    AUTODETECT=true \
+      poetry run python scripts/hyperliquid/backfill-historical-vault-flows.py
+
+    # Backfill Magixbox in the daily source database.
+    DRY_RUN=false \
+      VAULT_ADDRESSES=0x1764dd740aba4195643bbb6a44648e0306b00cfa \
+      poetry run python scripts/hyperliquid/backfill-historical-vault-flows.py
+
+Environment variables:
+
+- ``DB_PATH``: Daily Hyperliquid DuckDB path.
+- ``CLEANED_PARQUET_PATH``: Cleaned vault-price Parquet used to find candidates.
+- ``VAULT_ADDRESSES``: Comma-separated candidate vaults to repair.
+- ``AUTODETECT``: Select every current ``deferred_hf_nav`` vault. Default: false.
+  Exactly one of ``VAULT_ADDRESSES`` or ``AUTODETECT=true`` is required.
+- ``MAX_WORKERS``: Parallel API readers. Default: 8.
+- ``ANCHOR_PADDING_DAYS``: Days fetched on both sides of candidates. Default: 8.
+- ``REQUESTS_PER_SECOND``: Rate limit for each API session. Default: 1.
+- ``DRY_RUN``: Preview without updating DuckDB. Default: true.
+"""
+
+import datetime
+import logging
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+from eth_typing import HexAddress
+from joblib import Parallel, delayed
+from tabulate import tabulate
+
+from eth_defi.hyperliquid.constants import HYPERCORE_CHAIN_ID, HYPERLIQUID_DAILY_METRICS_DATABASE
+from eth_defi.hyperliquid.daily_metrics import HyperliquidDailyMetricsDatabase
+from eth_defi.hyperliquid.deposit import aggregate_daily_flows, fetch_vault_deposits
+from eth_defi.hyperliquid.session import create_hyperliquid_session
+from eth_defi.utils import setup_console_logging
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CLEANED_PARQUET_PATH = Path.home() / ".tradingstrategy" / "vaults" / "cleaned-vault-prices-1h.parquet"
+
+
+def create_iterated_duckdb_backup(db_path: Path) -> Path:
+    """Create the next numbered backup of a Hyperliquid DuckDB file.
+
+    Backups are written next to the source as ``.bak-0001``, ``.bak-0002``,
+    and so on, and existing backups are never overwritten. If DuckDB has a
+    write-ahead log sidecar, it is copied with the same backup prefix so the
+    pair can be restored together. The caller must ensure no scanner is writing
+    the database while the backup is taken.
+
+    :param db_path:
+        Hyperliquid DuckDB file that will be modified.
+    :return:
+        Path to the newly created main database backup.
+    :raises FileNotFoundError:
+        If the source database does not exist.
+    """
+    if not db_path.is_file():
+        raise FileNotFoundError(db_path)
+
+    backup_number = 1
+    while True:
+        backup_path = db_path.with_name(f"{db_path.name}.bak-{backup_number:04d}")
+        backup_wal_path = Path(f"{backup_path}.wal")
+        if not backup_path.exists() and not backup_wal_path.exists():
+            break
+        backup_number += 1
+
+    shutil.copy2(db_path, backup_path)
+    wal_path = Path(f"{db_path}.wal")
+    if wal_path.is_file():
+        shutil.copy2(wal_path, backup_wal_path)
+    return backup_path
+
+
+def select_historical_flow_candidates(
+    cleaned: pd.DataFrame,
+    requested_addresses: set[HexAddress],
+    *,
+    autodetect: bool,
+) -> pd.DataFrame:
+    """Select deferred Hypercore observations for the manual backfill.
+
+    Explicit address selection and autodetection are mutually exclusive so a
+    missing environment variable cannot accidentally expand a single-vault
+    maintenance operation to every candidate. Autodetection means all rows
+    currently marked ``deferred_hf_nav`` by the production wrangle.
+
+    :param cleaned:
+        Cleaned Hypercore prices with ``address``, ``timestamp``, and
+        ``hypercore_repair_status`` columns.
+    :param requested_addresses:
+        Explicit lowercased Hyperliquid vault addresses.
+    :param autodetect:
+        Whether to select all current ``deferred_hf_nav`` vaults.
+    :return:
+        Matching deferred observations, with lowercased addresses and naive
+        UTC timestamps.
+    :raises RuntimeError:
+        If selection mode is ambiguous or nothing matches.
+    """
+    if bool(requested_addresses) == autodetect:
+        message = "Set exactly one of VAULT_ADDRESSES or AUTODETECT=true"
+        raise RuntimeError(message)
+
+    repair_status = cleaned["hypercore_repair_status"].astype("string").fillna("")
+    candidates = cleaned[repair_status == "deferred_hf_nav"].copy()
+    candidates["address"] = candidates["address"].str.lower()
+    candidates["timestamp"] = pd.to_datetime(candidates["timestamp"])
+    if requested_addresses:
+        candidates = candidates[candidates["address"].isin(requested_addresses)]
+    if candidates.empty:
+        message = "No deferred_hf_nav Hypercore observations matched the requested vaults"
+        raise RuntimeError(message)
+    return candidates
+
+
+@dataclass(slots=True)
+class HistoricalFlowBackfill:
+    """Fetched ledger data for one historical repair window.
+
+    Carries one API result from the parallel read phase into the serial DuckDB
+    update and reporting phase.
+    """
+
+    #: Hyperliquid vault address.
+    vault_address: HexAddress
+    #: Human-readable vault name from cleaned data.
+    name: str
+    #: First daily DuckDB observation to update.
+    start_date: datetime.date
+    #: Last daily DuckDB observation to update.
+    end_date: datetime.date
+    #: Number of ``deferred_hf_nav`` rows selecting this window.
+    candidate_count: int
+    #: Number of ledger events returned by Hyperliquid.
+    event_count: int
+    #: Deposit and withdrawal events aggregated by UTC calendar date.
+    daily_flows: dict[datetime.date, tuple[int, int, float, float]]
+
+
+def fetch_historical_flow_backfill(
+    vault_address: HexAddress,
+    name: str,
+    candidate_timestamps: pd.Series,
+    anchor_padding_days: int,
+    requests_per_second: float,
+) -> HistoricalFlowBackfill:
+    """Fetch the ledger window needed by one vault's deferred repairs.
+
+    The window extends past the deferred observation by the same eight-day
+    limit used for HF price anchors. Hyperliquid's canonical
+    ``userNonFundingLedgerUpdates`` endpoint supplies the underlying deposit
+    and withdrawal events.
+
+    :param vault_address:
+        Hyperliquid vault address.
+    :param name:
+        Human-readable vault name for reporting.
+    :param candidate_timestamps:
+        Naive UTC timestamps of deferred daily observations.
+    :param anchor_padding_days:
+        Number of calendar days included before and after the candidates.
+    :param requests_per_second:
+        Per-session Hyperliquid API request limit.
+    :return:
+        Fetched and daily-aggregated ledger flow data.
+    """
+    padding = datetime.timedelta(days=anchor_padding_days)
+    first_timestamp = candidate_timestamps.min().to_pydatetime()
+    last_timestamp = candidate_timestamps.max().to_pydatetime()
+    start_date = (first_timestamp - padding).date()
+    end_date = (last_timestamp + padding).date()
+    start_time = datetime.datetime.combine(start_date, datetime.time.min)
+    end_time = datetime.datetime.combine(end_date, datetime.time.max)
+
+    session = create_hyperliquid_session(requests_per_second=requests_per_second)
+    events = list(
+        fetch_vault_deposits(
+            session,
+            vault_address,
+            start_time=start_time,
+            end_time=end_time,
+        )
+    )
+    return HistoricalFlowBackfill(
+        vault_address=vault_address,
+        name=name,
+        start_date=start_date,
+        end_date=end_date,
+        candidate_count=len(candidate_timestamps),
+        event_count=len(events),
+        daily_flows=aggregate_daily_flows(events),
+    )
+
+
+def main() -> None:  # noqa: PLR0914
+    """Fetch deferred-vault ledger history and optionally update daily DuckDB.
+
+    Configuration is read from environment variables documented in the module
+    header. The script defaults to a read-only preview. With ``DRY_RUN=false``,
+    only flow columns on already existing daily observations are updated.
+
+    :return:
+        None.
+    """
+    setup_console_logging(default_log_level=os.environ.get("LOG_LEVEL", "info"))
+    db_path = Path(os.environ.get("DB_PATH", str(HYPERLIQUID_DAILY_METRICS_DATABASE))).expanduser()
+    cleaned_path = Path(os.environ.get("CLEANED_PARQUET_PATH", str(DEFAULT_CLEANED_PARQUET_PATH))).expanduser()
+    max_workers = int(os.environ.get("MAX_WORKERS", "8"))
+    anchor_padding_days = int(os.environ.get("ANCHOR_PADDING_DAYS", "8"))
+    requests_per_second = float(os.environ.get("REQUESTS_PER_SECOND", "1"))
+    dry_run = os.environ.get("DRY_RUN", "true").strip().lower() in {"1", "true", "yes"}
+    autodetect = os.environ.get("AUTODETECT", "false").strip().lower() in {"1", "true", "yes"}
+    requested_addresses = {HexAddress(value.strip().lower()) for value in os.environ.get("VAULT_ADDRESSES", "").split(",") if value.strip()}
+
+    cleaned = pd.read_parquet(cleaned_path, filters=[("chain", "==", HYPERCORE_CHAIN_ID)]).reset_index()
+    candidates = select_historical_flow_candidates(cleaned, requested_addresses, autodetect=autodetect)
+
+    fetch_jobs = []
+    for vault_address, group in candidates.groupby("address", sort=False):
+        names = group["name"].dropna() if "name" in group.columns else pd.Series(dtype="string")
+        name = str(names.iloc[-1]) if len(names) else vault_address
+        fetch_jobs.append(
+            delayed(fetch_historical_flow_backfill)(
+                HexAddress(vault_address),
+                name,
+                group["timestamp"],
+                anchor_padding_days,
+                requests_per_second,
+            )
+        )
+
+    backfills = Parallel(n_jobs=max_workers, prefer="threads")(fetch_jobs)
+    updated_rows: dict[HexAddress, int] = {}
+    backup_path: Path | None = None
+    if not dry_run:
+        backup_path = create_iterated_duckdb_backup(db_path)
+        logger.info("Created DuckDB backup %s", backup_path)
+        db = HyperliquidDailyMetricsDatabase(db_path)
+        try:
+            updated_rows = {
+                backfill.vault_address: db.update_historical_daily_flows(
+                    backfill.vault_address,
+                    backfill.daily_flows,
+                    backfill.start_date,
+                    backfill.end_date,
+                )
+                for backfill in backfills
+            }
+            db.save()
+        finally:
+            db.close()
+
+    report = pd.DataFrame(
+        [
+            {
+                "name": backfill.name,
+                "address": backfill.vault_address,
+                "start": backfill.start_date,
+                "end": backfill.end_date,
+                "candidates": backfill.candidate_count,
+                "ledger_events": backfill.event_count,
+                "active_flow_days": len(backfill.daily_flows),
+                "updated_rows": updated_rows.get(backfill.vault_address, 0),
+            }
+            for backfill in backfills
+        ]
+    )
+    print(tabulate(report, headers="keys", tablefmt="simple", showindex=False))
+    mode = "Previewed" if dry_run else "Backfilled"
+    logger.info("%s %d deferred observations across %d Hypercore vaults", mode, int(report["candidates"].sum()), len(report))
+    if backup_path is not None:
+        logger.info("Database backup: %s", backup_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/hyperliquid/test_deposit.py
+++ b/tests/hyperliquid/test_deposit.py
@@ -11,7 +11,7 @@ from datetime import datetime
 import pandas as pd
 import pytest
 
-from eth_defi.hyperliquid.deposit import VaultDepositEvent, VaultEventType, aggregate_daily_flows, create_deposit_dataframe, fetch_vault_deposits, get_deposit_summary
+from eth_defi.hyperliquid.deposit import RawLedgerUpdate, VaultDepositEvent, VaultEventType, _parse_vault_event, aggregate_daily_flows, create_deposit_dataframe, fetch_vault_deposits, get_deposit_summary  # noqa: PLC2701
 
 
 @pytest.fixture(scope="module")
@@ -182,3 +182,25 @@ def test_aggregate_daily_flows_synthetic():
 
     # Distribution event should not create an entry on its own
     assert len(flows) == 2
+
+
+def test_parse_vault_withdraw_uses_net_withdrawn_usd() -> None:
+    """Completed withdrawals use Hyperliquid's realised cash-flow field."""
+    update = RawLedgerUpdate(
+        timestamp_ms=1_770_000_000_000,
+        hash="0xwithdrawal",
+        delta={
+            "type": "vaultWithdraw",
+            "vault": "0xabc",
+            "user": "0xdef",
+            "usdc": "0",
+            "netWithdrawnUsd": "7614.648567",
+        },
+    )
+
+    event = _parse_vault_event(update, "0xabc")
+
+    assert event is not None
+    assert event.event_type == VaultEventType.vault_withdraw
+    assert float(event.usdc) == pytest.approx(-7614.648567)
+    assert float(event.net_withdrawn_usd) == pytest.approx(7614.648567)

--- a/tests/hyperliquid/test_historical_flow_backfill.py
+++ b/tests/hyperliquid/test_historical_flow_backfill.py
@@ -61,6 +61,34 @@ def test_update_historical_daily_flows(tmp_path) -> None:
         db.close()
 
 
+def test_metadata_upsert_preserves_earliest_flow_date(tmp_path) -> None:
+    """A routine metadata refresh cannot forget a deeper flow backfill."""
+    address = "0x1764dd740aba4195643bbb6a44648e0306b00cfa"
+    leader = "0x0000000000000000000000000000000000000001"
+    db = HyperliquidDailyMetricsDatabase(tmp_path / "hyperliquid-vaults.duckdb")
+    try:
+        common_metadata = {
+            "vault_address": address,
+            "name": "Magixbox",
+            "leader": leader,
+            "description": None,
+            "is_closed": False,
+            "relationship_type": "normal",
+            "create_time": None,
+            "commission_rate": None,
+            "follower_count": 1,
+            "tvl": 10_000.0,
+            "apr": 0.0,
+        }
+        db.upsert_vault_metadata(**common_metadata, flow_data_earliest_date=datetime.date(2026, 2, 1))
+        db.upsert_vault_metadata(**common_metadata, flow_data_earliest_date=datetime.date(2026, 7, 1))
+
+        metadata = db.get_all_vault_metadata().set_index("vault_address")
+        assert metadata.loc[address, "flow_data_earliest_date"] == pd.Timestamp("2026-02-01")
+    finally:
+        db.close()
+
+
 def test_historical_flow_candidate_selection() -> None:
     """Explicit addresses and autodetection select deferred observations."""
     select_candidates = runpy.run_path(str(SCRIPT_PATH))["select_historical_flow_candidates"]

--- a/tests/hyperliquid/test_historical_flow_backfill.py
+++ b/tests/hyperliquid/test_historical_flow_backfill.py
@@ -1,0 +1,104 @@
+"""Test manual Hypercore historical ledger-flow backfills."""
+
+import datetime
+import runpy
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from eth_defi.hyperliquid.daily_metrics import HyperliquidDailyMetricsDatabase, HyperliquidDailyPriceRow
+
+SCRIPT_PATH = Path(__file__).parents[2] / "scripts" / "hyperliquid" / "backfill-historical-vault-flows.py"
+
+
+def test_update_historical_daily_flows(tmp_path) -> None:
+    """A deep backfill replaces a legacy zero withdrawal without changing prices.
+
+    Older parser versions stored zero for ``vaultWithdraw.usdc`` even when
+    ``netWithdrawnUsd`` contained the realised cash flow. The manual backfill
+    must replace that zero and make no-event dates explicit.
+    """
+    address = "0x1764dd740aba4195643bbb6a44648e0306b00cfa"
+    db = HyperliquidDailyMetricsDatabase(tmp_path / "hyperliquid-vaults.duckdb")
+    try:
+        db.upsert_daily_prices(
+            [
+                HyperliquidDailyPriceRow(
+                    vault_address=address,
+                    date=datetime.date(2026, 2, day),
+                    share_price=price,
+                    tvl=assets,
+                    cumulative_pnl=pnl,
+                    daily_withdrawal_count=0,
+                    daily_withdrawal_usd=0.0,
+                )
+                for day, price, assets, pnl in [
+                    (4, 1.304877, 19_127.624245, 7_531.634245),
+                    (5, 26.035410, 10_126.256026, 6_144.896026),
+                    (6, 1.20, 10_126.256026, 6_144.896026),
+                ]
+            ]
+        )
+
+        updated = db.update_historical_daily_flows(
+            address,
+            daily_flows={datetime.date(2026, 2, 5): (0, 4, 0.0, 7_614.648567)},
+            start_date=datetime.date(2026, 2, 4),
+            end_date=datetime.date(2026, 2, 6),
+        )
+        prices = db.get_vault_daily_prices(address).set_index("date")
+        expected_updated_rows = 3
+        expected_withdrawal_count = 4
+
+        assert updated == expected_updated_rows
+        assert prices.loc[pd.Timestamp("2026-02-04"), "daily_withdrawal_usd"] == pytest.approx(0.0)
+        assert prices.loc[pd.Timestamp("2026-02-05"), "daily_withdrawal_count"] == expected_withdrawal_count
+        assert prices.loc[pd.Timestamp("2026-02-05"), "daily_withdrawal_usd"] == pytest.approx(7_614.648567)
+        assert prices.loc[pd.Timestamp("2026-02-05"), "share_price"] == pytest.approx(26.035410)
+        assert prices.loc[pd.Timestamp("2026-02-06"), "daily_withdrawal_usd"] == pytest.approx(0.0)
+    finally:
+        db.close()
+
+
+def test_historical_flow_candidate_selection() -> None:
+    """Explicit addresses and autodetection select deferred observations."""
+    select_candidates = runpy.run_path(str(SCRIPT_PATH))["select_historical_flow_candidates"]
+    cleaned = pd.DataFrame(
+        {
+            "address": ["0xaaa", "0xbbb", "0xccc"],
+            "timestamp": pd.to_datetime(["2026-02-01", "2026-02-02", "2026-02-03"]),
+            "hypercore_repair_status": ["deferred_hf_nav", "deferred_hf_nav", "repaired_hf"],
+        }
+    )
+
+    explicit = select_candidates(cleaned, {"0xaaa"}, autodetect=False)
+    autodetected = select_candidates(cleaned, set(), autodetect=True)
+
+    assert explicit["address"].tolist() == ["0xaaa"]
+    assert autodetected["address"].tolist() == ["0xaaa", "0xbbb"]
+    with pytest.raises(RuntimeError, match="exactly one"):
+        select_candidates(cleaned, set(), autodetect=False)
+    with pytest.raises(RuntimeError, match="exactly one"):
+        select_candidates(cleaned, {"0xaaa"}, autodetect=True)
+
+
+def test_create_iterated_duckdb_backup(tmp_path) -> None:
+    """Repeated database updates create numbered main and WAL backups."""
+    create_backup = runpy.run_path(str(SCRIPT_PATH))["create_iterated_duckdb_backup"]
+    db_path = tmp_path / "hyperliquid-vaults.duckdb"
+    wal_path = Path(f"{db_path}.wal")
+    db_path.write_bytes(b"database-v1")
+    wal_path.write_bytes(b"wal-v1")
+
+    first_backup = create_backup(db_path)
+    db_path.write_bytes(b"database-v2")
+    wal_path.write_bytes(b"wal-v2")
+    second_backup = create_backup(db_path)
+
+    assert first_backup.name == "hyperliquid-vaults.duckdb.bak-0001"
+    assert second_backup.name == "hyperliquid-vaults.duckdb.bak-0002"
+    assert first_backup.read_bytes() == b"database-v1"
+    assert Path(f"{first_backup}.wal").read_bytes() == b"wal-v1"
+    assert second_backup.read_bytes() == b"database-v2"
+    assert Path(f"{second_backup}.wal").read_bytes() == b"wal-v2"

--- a/tests/research/test_clean_prices.py
+++ b/tests/research/test_clean_prices.py
@@ -16,6 +16,7 @@ import eth_defi.research.wrangle_vault_prices as vault_price_wrangle
 from eth_defi.research.wrangle_vault_prices import (
     clean_returns,
     discard_hypercore_pre_recapitalisation_history,
+    fix_hypercore_flow_reconciled_share_price_paths,
     fix_hypercore_source_overlap_share_prices,
     fix_outlier_share_prices,
     generate_cleaned_vault_datasets,
@@ -467,6 +468,65 @@ def test_fix_hypercore_source_overlap_defers_unsafe_hf_repairs() -> None:
         assert candidate["share_price"] == pytest.approx(10.0)
         assert candidate["raw_share_price"] == pytest.approx(10.0)
         assert candidate["hypercore_repair_status"] == expected_status
+
+
+def test_fix_hypercore_flow_reconciled_share_price_paths() -> None:
+    """Ledger-proven withdrawals repair a synthetic daily price unit.
+
+    The daily price of 20.0 conflicts with both HF anchors, but its $20
+    withdrawal and -$10 PnL exactly explain the NAV change. The repair must
+    follow PnL, preserve the raw value, and rescale a non-zero derived supply.
+    """
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 4,
+            "id": ["9999-0xflow-reconciled"] * 4,
+            "hypercore_source": ["hf", "daily", "daily", "hf"],
+            "share_price": [1.0, 20.0, 1.3, 1.0],
+            "total_assets": [100.0, 70.0, 80.0, 80.0],
+            "account_pnl": [0.0, -10.0, 0.0, 0.0],
+            "daily_deposit_usd": [np.nan, 0.0, 0.0, np.nan],
+            "daily_withdrawal_usd": [np.nan, 20.0, 0.0, np.nan],
+            "total_supply": [100.0, 5.0, 5.0, 100.0],
+        },
+        index=pd.to_datetime(["2026-01-01 12:00", "2026-01-02", "2026-01-03", "2026-01-04 12:00"], format="mixed"),
+    )
+
+    messages: list[str] = []
+    result = fix_hypercore_flow_reconciled_share_price_paths(prices_df, logger=messages.append)
+
+    first_daily = pd.Timestamp("2026-01-02")
+    second_daily = pd.Timestamp("2026-01-03")
+    endpoint_correction = np.log(1.0 / (0.9 * (1 + 10.0 / 70.0)))
+    assert result.loc[first_daily, "raw_share_price"] == pytest.approx(20.0)
+    assert result.loc[first_daily, "share_price"] == pytest.approx(0.9 * np.exp(endpoint_correction / 6))
+    assert result.loc[second_daily, "share_price"] == pytest.approx(1.3)
+    assert result.loc[first_daily, "hypercore_repair_status"] == "repaired_hf_pnl_flow"
+    assert result.loc[second_daily, "hypercore_repair_status"] == ""
+    assert result.loc[first_daily, "total_supply"] > 100.0
+    assert messages == ["Repaired 1 flow-reconciled Hypercore daily prices across 1 vaults using PnL paths"]
+
+
+def test_fix_hypercore_flow_reconciled_paths_require_hf_endpoint_agreement() -> None:
+    """A PnL path that misses its HF endpoint remains available for fallback."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 3,
+            "id": ["9999-0xendpoint"] * 3,
+            "hypercore_source": ["hf", "daily", "hf"],
+            "share_price": [1.0, 20.0, 2.0],
+            "total_assets": [100.0, 70.0, 70.0],
+            "account_pnl": [0.0, -10.0, -10.0],
+            "daily_deposit_usd": [np.nan, 0.0, np.nan],
+            "daily_withdrawal_usd": [np.nan, 20.0, np.nan],
+        },
+        index=pd.to_datetime(["2026-01-01 12:00", "2026-01-02", "2026-01-03 12:00"], format="mixed"),
+    )
+
+    result = fix_hypercore_flow_reconciled_share_price_paths(prices_df, logger=lambda _message: None)
+
+    assert result.loc[pd.Timestamp("2026-01-02"), "share_price"] == pytest.approx(20.0)
+    assert result.loc[pd.Timestamp("2026-01-02"), "hypercore_repair_status"] == ""
 
 
 def test_discard_hypercore_pre_recapitalisation_history() -> None:

--- a/tests/research/test_clean_prices.py
+++ b/tests/research/test_clean_prices.py
@@ -498,10 +498,9 @@ def test_fix_hypercore_flow_reconciled_share_price_paths() -> None:
 
     first_daily = pd.Timestamp("2026-01-02")
     second_daily = pd.Timestamp("2026-01-03")
-    endpoint_correction = np.log(1.0 / (0.9 * (1 + 10.0 / 70.0)))
     assert result.loc[first_daily, "raw_share_price"] == pytest.approx(20.0)
-    assert result.loc[first_daily, "share_price"] == pytest.approx(0.9 * np.exp(endpoint_correction / 6))
-    assert result.loc[second_daily, "share_price"] == pytest.approx((0.9 * (1 + 10.0 / 70.0)) * np.exp(endpoint_correction / 2))
+    assert result.loc[first_daily, "share_price"] == pytest.approx(0.9)
+    assert result.loc[second_daily, "share_price"] == pytest.approx(0.9 * (1 + 10.0 / 70.0))
     assert result.loc[first_daily, "hypercore_repair_status"] == "repaired_hf_pnl_flow"
     assert result.loc[second_daily, "hypercore_repair_status"] == "repaired_hf_pnl_flow"
     assert result.loc[second_daily, "share_price"] / result.loc[first_daily, "share_price"] - 1 > 0
@@ -531,6 +530,31 @@ def test_fix_hypercore_flow_reconciled_paths_require_hf_endpoint_agreement() -> 
     assert result.loc[pd.Timestamp("2026-01-02"), "hypercore_repair_status"] == ""
 
 
+def test_fix_hypercore_flow_reconciled_path_keeps_pnl_return_direction() -> None:
+    """A nearby lower HF endpoint cannot turn positive PnL into a loss."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 4,
+            "id": ["9999-0xpositive-pnl"] * 4,
+            "hypercore_source": ["hf", "daily", "daily", "hf"],
+            "share_price": [1.0, 20.0, 20.0, 0.93],
+            "total_assets": [100.0, 101.0, 102.0, 102.0],
+            "account_pnl": [0.0, 1.0, 2.0, 2.0],
+            "daily_deposit_usd": [np.nan, 0.0, 0.0, np.nan],
+            "daily_withdrawal_usd": [np.nan, 0.0, 0.0, np.nan],
+        },
+        index=pd.to_datetime(["2026-01-01 12:00", "2026-01-02", "2026-01-03", "2026-01-04 12:00"], format="mixed"),
+    )
+
+    result = fix_hypercore_flow_reconciled_share_price_paths(prices_df, logger=lambda _message: None)
+
+    first_price = result.loc[pd.Timestamp("2026-01-02"), "share_price"]
+    second_price = result.loc[pd.Timestamp("2026-01-03"), "share_price"]
+    assert first_price == pytest.approx(1.01)
+    assert second_price == pytest.approx(1.02)
+    assert second_price / first_price - 1 > 0
+
+
 def test_fix_hypercore_flow_reconciled_path_stops_at_unproven_step() -> None:
     """A repaired PnL segment ends when its next ledger step is missing."""
     prices_df = pd.DataFrame(
@@ -538,11 +562,11 @@ def test_fix_hypercore_flow_reconciled_path_stops_at_unproven_step() -> None:
             "chain": [9999] * 5,
             "id": ["9999-0xpartial-flow"] * 5,
             "hypercore_source": ["hf", "daily", "daily", "daily", "hf"],
-            "share_price": [1.0, 20.0, 1.3, 1.4, 1.1],
+            "share_price": [1.0, 20.0, 1.3, 20.0, 1.1],
             "total_assets": [100.0, 70.0, 80.0, 90.0, 90.0],
             "account_pnl": [0.0, -10.0, 0.0, 10.0, 10.0],
-            "daily_deposit_usd": [np.nan, 0.0, 0.0, np.nan, np.nan],
-            "daily_withdrawal_usd": [np.nan, 20.0, 0.0, np.nan, np.nan],
+            "daily_deposit_usd": [np.nan, 0.0, np.nan, 0.0, np.nan],
+            "daily_withdrawal_usd": [np.nan, 20.0, np.nan, 0.0, np.nan],
         },
         index=pd.to_datetime(["2026-01-01 12:00", "2026-01-02", "2026-01-03", "2026-01-04", "2026-01-05 12:00"], format="mixed"),
     )
@@ -550,9 +574,32 @@ def test_fix_hypercore_flow_reconciled_path_stops_at_unproven_step() -> None:
     result = fix_hypercore_flow_reconciled_share_price_paths(prices_df, logger=lambda _message: None)
 
     assert result.loc[pd.Timestamp("2026-01-02"), "hypercore_repair_status"] == "repaired_hf_pnl_flow"
-    assert result.loc[pd.Timestamp("2026-01-03"), "hypercore_repair_status"] == "repaired_hf_pnl_flow"
-    assert result.loc[pd.Timestamp("2026-01-04"), "share_price"] == pytest.approx(1.4)
+    assert result.loc[pd.Timestamp("2026-01-03"), "hypercore_repair_status"] == ""
+    assert result.loc[pd.Timestamp("2026-01-04"), "share_price"] == pytest.approx(20.0)
     assert result.loc[pd.Timestamp("2026-01-04"), "hypercore_repair_status"] == ""
+
+
+def test_fix_hypercore_flow_reconciled_path_rejects_large_nav_mismatch() -> None:
+    """A percentage-sized NAV mismatch is not accepted for a large vault."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 3,
+            "id": ["9999-0xlarge-nav"] * 3,
+            "hypercore_source": ["hf", "daily", "hf"],
+            "share_price": [1.0, 20.0, 1.0],
+            "total_assets": [100_000_000.0, 100_900_000.0, 100_900_000.0],
+            "account_pnl": [0.0, 0.0, 0.0],
+            "daily_deposit_usd": [np.nan, 0.0, np.nan],
+            "daily_withdrawal_usd": [np.nan, 0.0, np.nan],
+        },
+        index=pd.to_datetime(["2026-01-01 12:00", "2026-01-02", "2026-01-03 12:00"], format="mixed"),
+    )
+
+    result = fix_hypercore_flow_reconciled_share_price_paths(prices_df, logger=lambda _message: None)
+
+    daily = result.loc[pd.Timestamp("2026-01-02")]
+    assert daily["share_price"] == pytest.approx(20.0)
+    assert daily["hypercore_repair_status"] == ""
 
 
 def test_discard_hypercore_pre_recapitalisation_history() -> None:

--- a/tests/research/test_clean_prices.py
+++ b/tests/research/test_clean_prices.py
@@ -474,8 +474,9 @@ def test_fix_hypercore_flow_reconciled_share_price_paths() -> None:
     """Ledger-proven withdrawals repair a synthetic daily price unit.
 
     The daily price of 20.0 conflicts with both HF anchors, but its $20
-    withdrawal and -$10 PnL exactly explain the NAV change. The repair must
-    follow PnL, preserve the raw value, and rescale a non-zero derived supply.
+    withdrawal and -$10 PnL exactly explain the NAV change. The following
+    positive-PnL row also reconciles, so the repair must continue through it,
+    preserve raw values, and rescale a non-zero derived supply.
     """
     prices_df = pd.DataFrame(
         {
@@ -500,11 +501,12 @@ def test_fix_hypercore_flow_reconciled_share_price_paths() -> None:
     endpoint_correction = np.log(1.0 / (0.9 * (1 + 10.0 / 70.0)))
     assert result.loc[first_daily, "raw_share_price"] == pytest.approx(20.0)
     assert result.loc[first_daily, "share_price"] == pytest.approx(0.9 * np.exp(endpoint_correction / 6))
-    assert result.loc[second_daily, "share_price"] == pytest.approx(1.3)
+    assert result.loc[second_daily, "share_price"] == pytest.approx((0.9 * (1 + 10.0 / 70.0)) * np.exp(endpoint_correction / 2))
     assert result.loc[first_daily, "hypercore_repair_status"] == "repaired_hf_pnl_flow"
-    assert result.loc[second_daily, "hypercore_repair_status"] == ""
+    assert result.loc[second_daily, "hypercore_repair_status"] == "repaired_hf_pnl_flow"
+    assert result.loc[second_daily, "share_price"] / result.loc[first_daily, "share_price"] - 1 > 0
     assert result.loc[first_daily, "total_supply"] > 100.0
-    assert messages == ["Repaired 1 flow-reconciled Hypercore daily prices across 1 vaults using PnL paths"]
+    assert messages == ["Repaired 2 flow-reconciled Hypercore daily prices across 1 vaults using PnL paths"]
 
 
 def test_fix_hypercore_flow_reconciled_paths_require_hf_endpoint_agreement() -> None:
@@ -527,6 +529,30 @@ def test_fix_hypercore_flow_reconciled_paths_require_hf_endpoint_agreement() -> 
 
     assert result.loc[pd.Timestamp("2026-01-02"), "share_price"] == pytest.approx(20.0)
     assert result.loc[pd.Timestamp("2026-01-02"), "hypercore_repair_status"] == ""
+
+
+def test_fix_hypercore_flow_reconciled_path_stops_at_unproven_step() -> None:
+    """A repaired PnL segment ends when its next ledger step is missing."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 5,
+            "id": ["9999-0xpartial-flow"] * 5,
+            "hypercore_source": ["hf", "daily", "daily", "daily", "hf"],
+            "share_price": [1.0, 20.0, 1.3, 1.4, 1.1],
+            "total_assets": [100.0, 70.0, 80.0, 90.0, 90.0],
+            "account_pnl": [0.0, -10.0, 0.0, 10.0, 10.0],
+            "daily_deposit_usd": [np.nan, 0.0, 0.0, np.nan, np.nan],
+            "daily_withdrawal_usd": [np.nan, 20.0, 0.0, np.nan, np.nan],
+        },
+        index=pd.to_datetime(["2026-01-01 12:00", "2026-01-02", "2026-01-03", "2026-01-04", "2026-01-05 12:00"], format="mixed"),
+    )
+
+    result = fix_hypercore_flow_reconciled_share_price_paths(prices_df, logger=lambda _message: None)
+
+    assert result.loc[pd.Timestamp("2026-01-02"), "hypercore_repair_status"] == "repaired_hf_pnl_flow"
+    assert result.loc[pd.Timestamp("2026-01-03"), "hypercore_repair_status"] == "repaired_hf_pnl_flow"
+    assert result.loc[pd.Timestamp("2026-01-04"), "share_price"] == pytest.approx(1.4)
+    assert result.loc[pd.Timestamp("2026-01-04"), "hypercore_repair_status"] == ""
 
 
 def test_discard_hypercore_pre_recapitalisation_history() -> None:


### PR DESCRIPTION
## Why

Magixbox’s 5 February 2026 daily price was a synthetic unit change, not a 1,895% investor return. Hyperliquid reports the realised withdrawal in `netWithdrawnUsd`, while our flow aggregation used its frequently-zero `usdc` field. Historical observations also need an explicit ledger backfill because Hyperliquid downsamples old portfolio history and the normal seven-day scan cannot revisit retained daily rows.

## Lessons learnt

Cash flows change implied share supply, while PnL changes price. A repair is justified only where ledger flows reconcile NAV and the PnL path agrees closely with adjacent trusted HF anchors. The HF endpoint must remain a plausibility check rather than a correction target, because spreading its residual across the interval can reverse the direction of genuine PnL returns.

## Summary

- Parse completed vault withdrawals from `netWithdrawnUsd`.
- Repair ledger-reconciled daily/HF conflicts using the unmodified PnL-derived path, with the next HF anchor as a 10% plausibility guard.
- Require NAV accounting to reconcile within a fixed $1 tolerance.
- Continue only through one contiguous proven segment and stop permanently at the first unproven ledger step.
- Add a manual historical-flow backfill with explicit `VAULT_ADDRESSES` and `AUTODETECT=true` modes.
- Create sequential DuckDB and WAL backups before every non-dry-run historical update.
- Preserve the earliest flow-backfill marker across routine metadata refreshes.
- Preserve raw prices and repair status for auditability.
- Add regression coverage for withdrawal parsing, candidate selection, backups, historical flow updates, PnL direction, ledger gaps and large-NAV mismatches.

Copied-production validation changes Magixbox 2026-02-05 from 26.035410 to 1.210274 and 2026-02-07 from 1.176331 to 1.240461, then stops before the unreconciled 8 February observation. Autodetection finds 120 deferred observations across 44 vaults; a copied full backfill enables 184 flow-reconciled rows across 33 vaults.

## Related issues and PRs

Follow-up to #1271, addressing the remaining Magixbox deferred NAV conflict and its historical-data migration path.

## Unrelated CI and test fixes

None.