### PR TITLE
fix: resume Hypercore scans after zero share price

### DIFF
--- a/docs/claude-plans/2026-07-14-hypercore-share-price-continuity.md
+++ b/docs/claude-plans/2026-07-14-hypercore-share-price-continuity.md
@@ -78,11 +78,12 @@ is; the existing synthetic-supply calculation anchors its first funded row at
 `1.0`. A missing stored anchor is therefore a valid bootstrap, whereas an
 existing stored anchor outside the new API curve is an error.
 
-A zero stored price records a complete NAV wipe-out and cannot be used as a
-scale factor. Resume the reconstructed curve unchanged at this boundary; the
-wrangle pipeline applies the stricter duration and NAV thresholds that decide
-whether a later recapitalisation becomes a retained performance epoch. Keep
-negative and non-finite stored prices as hard errors.
+A zero stored price may record a complete NAV wipe-out and cannot be used as a
+scale factor. The scanner cannot classify it as durable or transient at resume
+time, so resume the reconstructed curve unchanged. The wrangle pipeline applies
+the stricter duration and NAV thresholds that decide whether a later
+recapitalisation becomes a retained performance epoch. Keep negative and
+non-finite stored prices as hard errors.
 
 For an existing daily vault, only update the overlapping boundary date and
 append later dates; do not refresh its complete historical curve on every scan.

--- a/docs/claude-plans/2026-07-14-hypercore-share-price-continuity.md
+++ b/docs/claude-plans/2026-07-14-hypercore-share-price-continuity.md
@@ -56,7 +56,7 @@ unchanged.
 ### 2. Chain a recalculated curve to stored history
 
 Add one small shared helper for the daily and HF scanners. Given a newly
-calculated curve and the latest stored positive share price:
+calculated curve and the latest stored share price:
 
 1. Locate that stored timestamp in the new curve, using exact overlap for daily
    rows and time interpolation for HF rows.
@@ -77,6 +77,12 @@ For a brand-new vault with no stored price, use the newly calculated curve as
 is; the existing synthetic-supply calculation anchors its first funded row at
 `1.0`. A missing stored anchor is therefore a valid bootstrap, whereas an
 existing stored anchor outside the new API curve is an error.
+
+A zero stored price records a complete NAV wipe-out and cannot be used as a
+scale factor. Resume the reconstructed curve unchanged at this boundary; the
+wrangle pipeline applies the stricter duration and NAV thresholds that decide
+whether a later recapitalisation becomes a retained performance epoch. Keep
+negative and non-finite stored prices as hard errors.
 
 For an existing daily vault, only update the overlapping boundary date and
 append later dates; do not refresh its complete historical curve on every scan.

--- a/docs/claude-plans/2026-07-14-hypercore-share-price-continuity.md
+++ b/docs/claude-plans/2026-07-14-hypercore-share-price-continuity.md
@@ -90,9 +90,10 @@ append later dates; do not refresh its complete historical curve on every scan.
 The HF scanner keeps its existing append-only behaviour after applying the same
 alignment.
 
-If the latest stored timestamp is outside the new API curve, skip that vault for
-the scan and log the reason. Guessing a scale without any overlap would recreate
-the original problem.
+If a positive latest stored price has a timestamp outside the new API curve,
+skip that vault for the scan and log the reason. Guessing a scale without any
+overlap would recreate the original problem. A zero price remains the explicit
+unscaled-resume exception described above.
 
 ### 3. Keep Hypercore returns derived from the repaired price
 

--- a/eth_defi/hyperliquid/combined_analysis.py
+++ b/eth_defi/hyperliquid/combined_analysis.py
@@ -131,13 +131,14 @@ def align_share_price_curve_to_anchor(
     high-frequency scanner. The resulting constant factor is applied with
     :py:func:`rescale_share_price_rows`, preserving NAV and supply.
 
-    A persisted zero is a valid observation for Hyperliquid vaults whose NAV
-    was completely wiped out while synthetic supply remained. Zero cannot be
-    used as a scale factor, so the reconstructed curve is returned unchanged.
-    This avoids linking its scale to destroyed shares; any later
-    recapitalisation epoch is selected and normalised by the wrangle pipeline.
-    Negative and non-finite persisted prices indicate invalid stored data and
-    raise :py:class:`ValueError`.
+    A persisted zero may be a valid observation for a Hyperliquid vault whose
+    NAV was completely wiped out while synthetic supply remained. The scanner
+    cannot classify the zero as durable or transient at resume time, but zero
+    cannot be used as a scale factor in either case. The reconstructed curve
+    is therefore returned unchanged. Any later recapitalisation epoch is
+    selected and normalised by the wrangle pipeline. Negative and non-finite
+    persisted prices indicate invalid stored data and raise
+    :py:class:`ValueError`.
 
     :param prices_df:
         Chronologically sorted DataFrame with a ``DatetimeIndex`` and

--- a/eth_defi/hyperliquid/combined_analysis.py
+++ b/eth_defi/hyperliquid/combined_analysis.py
@@ -124,29 +124,40 @@ def align_share_price_curve_to_anchor(
     anchor_timestamp: datetime.datetime | pd.Timestamp,
     anchor_share_price: float,
 ) -> pd.DataFrame | None:
-    """Align a newly reconstructed share-price curve to one persisted price.
+    """Resume a reconstructed share-price curve from one persisted price.
 
-    The exact timestamp is used when present. For the high-frequency scanner,
-    which may revisit a rolling window with shifted timestamps, the anchor is
-    interpolated in log-price space between bracketing observations. The
-    resulting constant factor is applied with
+    A positive persisted price is aligned at its exact timestamp, or
+    interpolated in log-price space between bracketing observations for the
+    high-frequency scanner. The resulting constant factor is applied with
     :py:func:`rescale_share_price_rows`, preserving NAV and supply.
 
+    A persisted zero is a valid observation for Hyperliquid vaults whose NAV
+    was completely wiped out while synthetic supply remained. Zero cannot be
+    used as a scale factor, so the reconstructed curve is returned unchanged.
+    This avoids linking its scale to destroyed shares; any later
+    recapitalisation epoch is selected and normalised by the wrangle pipeline.
+    Negative and non-finite persisted prices indicate invalid stored data and
+    raise :py:class:`ValueError`.
+
     :param prices_df:
-        Chronologically sorted DataFrame with a ``DatetimeIndex`` and finite
-        positive ``share_price`` values.
+        Chronologically sorted DataFrame with a ``DatetimeIndex`` and
+        ``share_price``, ``total_supply`` and ``total_assets`` columns.
     :param anchor_timestamp:
         Timestamp of the already persisted price.
     :param anchor_share_price:
-        Finite positive persisted share price to retain.
+        Finite non-negative persisted share price. Zero denotes a lifecycle
+        boundary that cannot anchor the reconstructed scale.
     :return:
-        Rescaled DataFrame, or ``None`` when the curve cannot be anchored
-        because the timestamp lies outside it or cannot be interpolated.
+        Rescaled or unchanged DataFrame, or ``None`` when a positive anchor
+        lies outside the curve or cannot be interpolated.
     """
-    if not math.isfinite(anchor_share_price) or anchor_share_price <= 0:
-        raise ValueError(f"Anchor share price must be finite and positive, got {anchor_share_price!r}")
+    if not math.isfinite(anchor_share_price) or anchor_share_price < 0:
+        raise ValueError(f"Anchor share price must be finite and non-negative, got {anchor_share_price!r}")
 
     curve = prices_df.copy()
+    if anchor_share_price == 0:
+        return curve
+
     timestamps = pd.DatetimeIndex(curve.index)
     anchor_timestamp = pd.Timestamp(anchor_timestamp)
     if len(curve) == 0 or anchor_timestamp < timestamps[0] or anchor_timestamp > timestamps[-1]:

--- a/eth_defi/hyperliquid/daily_metrics.py
+++ b/eth_defi/hyperliquid/daily_metrics.py
@@ -1198,8 +1198,11 @@ def fetch_and_store_vault(
 
     existing_prices = db.get_vault_daily_prices(vault_address)
     last_stored_date = db.get_vault_last_date(vault_address)
+    stored_overlap_return: float | None = None
     if last_stored_date is not None:
         stored_anchor = existing_prices.iloc[-1]
+        raw_stored_return = stored_anchor["daily_return"]
+        stored_overlap_return = float(raw_stored_return) if pd.notna(raw_stored_return) else None
         anchor_timestamp = datetime.datetime.combine(last_stored_date, datetime.time())
         combined_df = align_share_price_curve_to_anchor(combined_df, anchor_timestamp, float(stored_anchor["share_price"]))
         if combined_df is None:
@@ -1237,7 +1240,12 @@ def fetch_and_store_vault(
         daily_pnl = row_data.pnl_update
         epoch_reset_val = bool(row_data.epoch_reset) if hasattr(row_data, "epoch_reset") else False
 
-        if prev_share_price is not None and prev_share_price > 0:
+        if last_stored_date is not None and date_val == last_stored_date and stored_overlap_return is not None:
+            # Preserve the return already derived for the idempotent overlap
+            # row. Recomputing it can erase a real -100% wipe-out when no
+            # preceding stored day is available.
+            daily_return = stored_overlap_return
+        elif prev_share_price is not None and prev_share_price > 0:
             daily_return = (share_price - prev_share_price) / prev_share_price
         else:
             daily_return = 0.0

--- a/eth_defi/hyperliquid/high_freq_metrics.py
+++ b/eth_defi/hyperliquid/high_freq_metrics.py
@@ -509,6 +509,7 @@ def fetch_and_store_vault_high_freq(
     rows: list[HyperliquidHighFreqPriceRow] = []
     now = native_datetime_utc_now()
     prev_share_price = None
+    stored_overlap_return: float | None = None
     if last_stored_ts is not None and not existing_prices.empty:
         # The reconstructed window can have shifted API timestamps and may
         # therefore not contain an exact copy of the persisted anchor. The
@@ -516,6 +517,8 @@ def fetch_and_store_vault_high_freq(
         # return must be measured from the latest stored price, not from the
         # preceding stored observation.
         prev_share_price = float(existing_prices.iloc[-1]["share_price"])
+        raw_stored_return = existing_prices.iloc[-1]["daily_return"]
+        stored_overlap_return = float(raw_stored_return) if pd.notna(raw_stored_return) else None
 
     for i, (ts, row_data) in enumerate(zip(combined_df.index, combined_df.itertuples())):
         raw_ts = ts.to_pydatetime() if hasattr(ts, "to_pydatetime") else ts
@@ -534,7 +537,12 @@ def fetch_and_store_vault_high_freq(
         daily_pnl = row_data.pnl_update
         epoch_reset_val = bool(row_data.epoch_reset) if hasattr(row_data, "epoch_reset") else False
 
-        if prev_share_price is not None and prev_share_price > 0:
+        if last_stored_ts is not None and raw_ts == last_stored_ts and stored_overlap_return is not None:
+            # Preserve the return already derived for the idempotent overlap
+            # row. Recomputing it against its own stored price would replace
+            # both ordinary returns and a real -100% wipe-out with zero.
+            daily_return = stored_overlap_return
+        elif prev_share_price is not None and prev_share_price > 0:
             daily_return = (share_price - prev_share_price) / prev_share_price
         else:
             daily_return = 0.0

--- a/scripts/hyperliquid/README-hyperliquid-vaults.md
+++ b/scripts/hyperliquid/README-hyperliquid-vaults.md
@@ -180,6 +180,11 @@ their one-row overlap. The HF path log-linearly interpolates an anchor when
 the rolling-window timestamps shift. The matching inverse supply scaling keeps
 `total_assets == share_price * total_supply`; if no stored anchor lies within
 the current curve, the scan is skipped rather than creating a discontinuity.
+An exact zero stored price is a valid complete-wipe-out observation, but it
+cannot scale another curve. The scanners therefore resume that reconstructed
+curve without alignment; the wrangle pipeline separately decides whether a
+later recapitalisation qualifies as a new retained performance epoch. Negative
+or non-finite stored prices remain hard errors.
 
 ### Hypercore-specific columns in price data
 

--- a/scripts/hyperliquid/README-hyperliquid-vaults.md
+++ b/scripts/hyperliquid/README-hyperliquid-vaults.md
@@ -178,8 +178,9 @@ read reconstructs an arbitrary but internally consistent unit, so the daily
 and HF scanners align their new curve to the latest stored price before writing
 their one-row overlap. The HF path log-linearly interpolates an anchor when
 the rolling-window timestamps shift. The matching inverse supply scaling keeps
-`total_assets == share_price * total_supply`; if no stored anchor lies within
-the current curve, the scan is skipped rather than creating a discontinuity.
+`total_assets == share_price * total_supply`; if no positive stored anchor lies
+within the current curve, the scan is skipped rather than creating a
+discontinuity.
 An exact zero stored price may record a complete wipe-out, but it cannot scale
 another curve. Because the scanner cannot classify the zero as durable or
 transient at resume time, it resumes the reconstructed curve without alignment.

--- a/scripts/hyperliquid/README-hyperliquid-vaults.md
+++ b/scripts/hyperliquid/README-hyperliquid-vaults.md
@@ -180,11 +180,12 @@ their one-row overlap. The HF path log-linearly interpolates an anchor when
 the rolling-window timestamps shift. The matching inverse supply scaling keeps
 `total_assets == share_price * total_supply`; if no stored anchor lies within
 the current curve, the scan is skipped rather than creating a discontinuity.
-An exact zero stored price is a valid complete-wipe-out observation, but it
-cannot scale another curve. The scanners therefore resume that reconstructed
-curve without alignment; the wrangle pipeline separately decides whether a
-later recapitalisation qualifies as a new retained performance epoch. Negative
-or non-finite stored prices remain hard errors.
+An exact zero stored price may record a complete wipe-out, but it cannot scale
+another curve. Because the scanner cannot classify the zero as durable or
+transient at resume time, it resumes the reconstructed curve without alignment.
+The wrangle pipeline separately decides whether a later recapitalisation
+qualifies as a new retained performance epoch. Negative or non-finite stored
+prices remain hard errors.
 
 ### Hypercore-specific columns in price data
 

--- a/tests/hyperliquid/test_high_freq_metrics.py
+++ b/tests/hyperliquid/test_high_freq_metrics.py
@@ -255,6 +255,69 @@ def test_high_freq_resume_uses_persisted_anchor_for_shifted_timestamps(tmp_path)
         db.close()
 
 
+def test_high_freq_resume_after_zero_price_lifecycle_boundary(tmp_path) -> None:
+    """A terminal zero price must not abort a later HF scan."""
+    vault_address = "0x0000000000000000000000000000000000000001"
+    anchor_timestamp = datetime.datetime(2026, 1, 1, 11)
+    db = HyperliquidHighFreqMetricsDatabase(tmp_path / "hf-zero-anchor.duckdb")
+    db.upsert_high_freq_prices([HyperliquidHighFreqPriceRow(vault_address, anchor_timestamp, 0.0, 0.0, -100.0)])
+
+    summary = VaultSummary(
+        name="Recapitalised test vault",
+        vault_address=vault_address,
+        leader="0x0000000000000000000000000000000000000002",
+        tvl=Decimal("100"),
+        is_closed=False,
+        relationship_type="normal",
+    )
+    all_time = PortfolioHistory(
+        period="allTime",
+        account_value_history=[(anchor_timestamp, Decimal("0")), (anchor_timestamp + datetime.timedelta(hours=1), Decimal("100"))],
+        pnl_history=[(anchor_timestamp, Decimal("-100")), (anchor_timestamp + datetime.timedelta(hours=1), Decimal("-100"))],
+        volume=Decimal("0"),
+    )
+    info = SimpleNamespace(
+        name=summary.name,
+        leader=summary.leader,
+        description="",
+        followers=[],
+        portfolio={"allTime": all_time},
+        commission_rate=None,
+        leader_fraction=None,
+        leader_commission=None,
+        is_closed=False,
+        allow_deposits=True,
+        relationship_type="normal",
+    )
+    reconstructed_curve = pd.DataFrame(
+        {
+            "share_price": [0.0, 1.0],
+            "total_assets": [0.0, 100.0],
+            "cumulative_pnl": [-100.0, -100.0],
+            "pnl_update": [0.0, 0.0],
+            "epoch_reset": [False, True],
+        },
+        index=pd.to_datetime([anchor_timestamp, anchor_timestamp + datetime.timedelta(hours=1)]),
+    )
+
+    try:
+        with (
+            patch.object(HyperliquidVault, "fetch_metadata", return_value=info),
+            patch(
+                "eth_defi.hyperliquid.high_freq_metrics.portfolio_to_combined_dataframe",
+                return_value=reconstructed_curve,
+            ),
+        ):
+            assert fetch_and_store_vault_high_freq(object(), db, summary, flow_backfill_days=0)
+
+        prices = db.get_vault_high_freq_prices(vault_address)
+        assert prices["share_price"].tolist() == pytest.approx([0.0, 1.0])
+        assert prices.iloc[-1]["daily_return"] == pytest.approx(0.0)
+        assert bool(prices.iloc[-1]["epoch_reset"])
+    finally:
+        db.close()
+
+
 @pytest.mark.timeout(30)
 def test_post_info_proxy_fix():
     """Verify _make_request() and fetch_vault_deposits() route through post_info().

--- a/tests/hyperliquid/test_high_freq_metrics.py
+++ b/tests/hyperliquid/test_high_freq_metrics.py
@@ -260,7 +260,7 @@ def test_high_freq_resume_after_zero_price_lifecycle_boundary(tmp_path) -> None:
     vault_address = "0x0000000000000000000000000000000000000001"
     anchor_timestamp = datetime.datetime(2026, 1, 1, 11)
     db = HyperliquidHighFreqMetricsDatabase(tmp_path / "hf-zero-anchor.duckdb")
-    db.upsert_high_freq_prices([HyperliquidHighFreqPriceRow(vault_address, anchor_timestamp, 0.0, 0.0, -100.0)])
+    db.upsert_high_freq_prices([HyperliquidHighFreqPriceRow(vault_address, anchor_timestamp, 0.0, 0.0, -100.0, daily_return=-1.0)])
 
     summary = VaultSummary(
         name="Recapitalised test vault",
@@ -312,6 +312,7 @@ def test_high_freq_resume_after_zero_price_lifecycle_boundary(tmp_path) -> None:
 
         prices = db.get_vault_high_freq_prices(vault_address)
         assert prices["share_price"].tolist() == pytest.approx([0.0, 1.0])
+        assert prices.iloc[0]["daily_return"] == pytest.approx(-1.0)
         assert prices.iloc[-1]["daily_return"] == pytest.approx(0.0)
         assert bool(prices.iloc[-1]["epoch_reset"])
     finally:

--- a/tests/hyperliquid/test_share_price_continuity.py
+++ b/tests/hyperliquid/test_share_price_continuity.py
@@ -2,13 +2,15 @@
 
 import datetime
 from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pandas as pd
 import pytest
 
 from eth_defi.hyperliquid.combined_analysis import align_share_price_curve_to_anchor
-from eth_defi.hyperliquid.daily_metrics import _merge_portfolio_periods
-from eth_defi.hyperliquid.vault import PortfolioHistory
+from eth_defi.hyperliquid.daily_metrics import HyperliquidDailyMetricsDatabase, HyperliquidDailyPriceRow, _merge_portfolio_periods, fetch_and_store_vault
+from eth_defi.hyperliquid.vault import HyperliquidVault, PortfolioHistory, VaultSummary
 
 
 def _portfolio_history(
@@ -77,3 +79,79 @@ def test_align_share_price_curve_treats_zero_anchor_as_lifecycle_boundary() -> N
 
     assert resumed is not curve
     pd.testing.assert_frame_equal(resumed, curve)
+
+
+def test_daily_resume_preserves_zero_price_overlap_return(tmp_path) -> None:
+    """A daily zero-anchor resume must retain its stored wipe-out return."""
+    vault_address = "0x0000000000000000000000000000000000000001"
+    anchor_timestamp = datetime.datetime(2026, 1, 1)
+    db = HyperliquidDailyMetricsDatabase(tmp_path / "daily-zero-anchor.duckdb")
+    db.upsert_daily_prices(
+        [
+            HyperliquidDailyPriceRow(
+                vault_address,
+                anchor_timestamp.date(),
+                0.0,
+                0.0,
+                -100.0,
+                daily_return=-1.0,
+            )
+        ]
+    )
+
+    summary = VaultSummary(
+        name="Recapitalised test vault",
+        vault_address=vault_address,
+        leader="0x0000000000000000000000000000000000000002",
+        tvl=Decimal("100"),
+        is_closed=False,
+        relationship_type="normal",
+    )
+    all_time = _portfolio_history(
+        "allTime",
+        [
+            (anchor_timestamp, 0, -100),
+            (anchor_timestamp + datetime.timedelta(days=1), 100, -100),
+        ],
+    )
+    info = SimpleNamespace(
+        name=summary.name,
+        leader=summary.leader,
+        description="",
+        followers=[],
+        portfolio={"allTime": all_time},
+        commission_rate=None,
+        leader_fraction=None,
+        leader_commission=None,
+        is_closed=False,
+        allow_deposits=True,
+        relationship_type="normal",
+    )
+    reconstructed_curve = pd.DataFrame(
+        {
+            "share_price": [0.0, 1.0],
+            "total_assets": [0.0, 100.0],
+            "cumulative_pnl": [-100.0, -100.0],
+            "pnl_update": [0.0, 0.0],
+            "epoch_reset": [False, True],
+        },
+        index=pd.to_datetime([anchor_timestamp, anchor_timestamp + datetime.timedelta(days=1)]),
+    )
+
+    try:
+        with (
+            patch.object(HyperliquidVault, "fetch_metadata", return_value=info),
+            patch(
+                "eth_defi.hyperliquid.daily_metrics.portfolio_to_combined_dataframe",
+                return_value=reconstructed_curve,
+            ),
+        ):
+            assert fetch_and_store_vault(object(), db, summary, flow_backfill_days=0)
+
+        prices = db.get_vault_daily_prices(vault_address)
+        assert prices["share_price"].tolist() == pytest.approx([0.0, 1.0])
+        assert prices.iloc[0]["daily_return"] == pytest.approx(-1.0)
+        assert prices.iloc[-1]["daily_return"] == pytest.approx(0.0)
+        assert bool(prices.iloc[-1]["epoch_reset"])
+    finally:
+        db.close()

--- a/tests/hyperliquid/test_share_price_continuity.py
+++ b/tests/hyperliquid/test_share_price_continuity.py
@@ -59,3 +59,21 @@ def test_align_share_price_curve_interpolates_shifted_high_frequency_anchor() ->
     midpoint = (aligned["share_price"].iloc[0] * aligned["share_price"].iloc[1]) ** 0.5
     assert midpoint == pytest.approx(1.1)
     assert (aligned["share_price"] * aligned["total_supply"]).to_numpy() == pytest.approx(aligned["total_assets"].to_numpy())
+
+
+def test_align_share_price_curve_treats_zero_anchor_as_lifecycle_boundary() -> None:
+    """A wiped-out epoch must not be used to scale a recapitalised curve."""
+    index = pd.to_datetime(["2026-01-01", "2026-01-02"])
+    curve = pd.DataFrame(
+        {
+            "share_price": [0.0, 1.0],
+            "total_supply": [100.0, 100.0],
+            "total_assets": [0.0, 100.0],
+        },
+        index=index,
+    )
+
+    resumed = align_share_price_curve_to_anchor(curve, index[0], 0.0)
+
+    assert resumed is not curve
+    pd.testing.assert_frame_equal(resumed, curve)


### PR DESCRIPTION
## Why

Hypercore daily and high-frequency scans began failing after the continuity repair in #1271 because the latest persisted share price can legitimately be zero after a complete vault wipe-out. Zero cannot be used as a multiplicative continuity anchor, and rejecting it caused one closed vault worker to abort the entire parallel scan.

## Lessons learnt

A zero synthetic share price is both economically meaningful and mathematically unusable as a scaling anchor. Scanner continuity and recapitalisation policy are separate concerns: the scanner must resume without scaling at zero, while the wrangle pipeline decides whether a later recovery qualifies as a retained performance epoch.

## Summary

- Treat an exact zero persisted Hypercore share price as a lifecycle boundary and return the reconstructed curve unchanged.
- Continue rejecting negative and non-finite stored prices.
- Add unit and scanner regression coverage for zero-anchor resume.
- Correct the scanner README and continuity plan to document the boundary between scanner resume and wrangle epoch selection.
- Verify the real resume path against a disposable copy of production DuckDB and live Hyperliquid data for Crypto Long Short, Wino, and Singapore Savings Bonds.

## Related issues and PRs

Continues the Hypercore share-price continuity work from #1271 and the ledger-flow repair from #1276.

## Unrelated CI and test fixes

None.