### PR TITLE
feat: Add Vault Street primeUSD vault support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - feat: Add handwritten Piku/Morini vault strategy descriptions and Piku detail links (2026-07-14)
 - feat: Add Ember synchronous deposit and operator-finalised redemption manager, historical `RequestProcessed` settlement collection, and GuardV0/Lagoon Safe lifecycle support (2026-07-14)
 - feat: Add pathUSD stablecoin classification, Tempo denomination-rate metadata and official packaged logo (2026-07-14)
+- feat: Add Vault Street primeUSD tracking with a direct VaultBase adapter, hardcoded Ethereum discovery and PriceStorage historical NAV reader (2026-07-14)
 - feat: Export vault deposit-manager capabilities, package Anvil fork probe results and provide a guarded deposit-probe refresh script (2026-07-13)
 - feat: Add KiloEx Hybrid Vault protocol support with hardcoded BNB Chain and Base deployment detection (2026-07-13)
 - feat: Add Piku curator attribution for USP and Morini Capital vaults using hardcoded Ethereum contract addresses (2026-07-13)

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -48,6 +48,7 @@ See :ref:`tutorials <tutorials>` for guides and examples on how to use the libra
    maseer_one/index
    midas/index
    oda_fact/index
+   vault_street/index
    royco/index
    velvet/index
    morpho/index

--- a/docs/source/api/vault_street/index.rst
+++ b/docs/source/api/vault_street/index.rst
@@ -1,0 +1,17 @@
+Vault Street API
+================
+
+Vault Street primeUSD support.
+
+The permissioned primeUSD token is read through
+:class:`eth_defi.vault.base.VaultBase`, not ERC-4626. The adapter calculates
+USDC NAV as ERC-20 ``totalSupply()`` multiplied by the Vault Street
+``PriceStorage.getPrice()`` oracle value.
+
+.. autosummary::
+   :toctree: _autosummary_vault_street
+   :recursive:
+
+   eth_defi.vault_street.constants
+   eth_defi.vault_street.vault
+   eth_defi.vault_street.historical

--- a/docs/source/vaults/index.rst
+++ b/docs/source/vaults/index.rst
@@ -122,6 +122,7 @@ Supported protocols
    mellow/index
    maseer-one/index
    midas/index
+   vault_street/index
    morpho/index
    nashpoint/index
    plutus/index

--- a/docs/source/vaults/vault_street/index.rst
+++ b/docs/source/vaults/vault_street/index.rst
@@ -1,0 +1,25 @@
+Vault Street
+============
+
+`Vault Street <https://vaultstreet.com/>`__ is an institutional platform from
+Resolv. Its first product, `primeUSD
+<https://docs.vaultstreet.com/overview/primeusd.md>`__, is a permissioned,
+USDC-denominated yield token backed by a leveraged carry strategy using
+tokenised investment-grade fixed-income collateral.
+
+primeUSD is not an ERC-4626 vault. Its ERC-20 token contract provides supply,
+while a separate Vault Street PriceStorage contract publishes NAV/share through
+``getPrice()``. The adapter therefore directly subclasses ``VaultBase`` and
+calculates TVL as ``totalSupply * getPrice``.
+
+The adapter is read-only. Vault Street applies KYB/KYC allowlisting to deposits,
+transfers and redemptions, so generic transaction support is intentionally not
+provided.
+
+.. autosummary::
+   :toctree: _autosummary_vault_street
+   :recursive:
+
+   eth_defi.vault_street.constants
+   eth_defi.vault_street.vault
+   eth_defi.vault_street.historical

--- a/eth_defi/data/vaults/metadata/vault-street.yaml
+++ b/eth_defi/data/vaults/metadata/vault-street.yaml
@@ -1,32 +1,28 @@
 name: Vault Street
 slug: vault-street
 short_description: |
-  Permissioned institutional USDC yield products with oracle-published NAV.
+  Permissioned institutional USDC yield products.
 long_description: |
   [Vault Street](https://vaultstreet.com/) is Resolv's institutional platform for
   tokenised investment products. Resolv announced the launch of primeUSD in its
   [launch post](https://x.com/ResolvLabs/status/2077020041128935900).
 
   [primeUSD](https://docs.vaultstreet.com/overview/primeusd.md) is a
-  permissioned, USDC-denominated yield token. It is not an ERC-4626 vault: the
-  [primeUSD token](https://etherscan.io/token/0x7ea76108975ec0998b9bc2db04b4eca986400dd7)
-  provides total supply, while the
-  [PriceStorage oracle](https://etherscan.io/address/0x8cda03e2004c35e07963fb792c6b7511dabee369)
-  publishes NAV/share through ``getPrice()``. The
-  [request manager](https://etherscan.io/address/0x8c14b6e8ec9968cd9c69eedea4a1295aec5e5d6e)
-  handles the permissioned deposit and redemption workflow. Vault Street's
-  [smart-contract documentation](https://docs.vaultstreet.com/resources/smart-contracts.md)
-  lists the deployed contracts.
+  permissioned, USDC-denominated yield product for eligible institutional
+  participants. It aims to provide institutional access to the yield from a
+  leveraged carry strategy backed by tokenised investment-grade fixed-income
+  collateral. Participants should review the product documentation for
+  eligibility, terms and current availability.
 fee_description: |
-  Vault Street does not expose a product fee accessor on the primeUSD token or
-  its public PriceStorage oracle. The applicable fee terms are therefore not
-  available through the on-chain adapter.
+  Vault Street does not publish product fee terms in the sources currently
+  available to this integration. Eligible participants should review the
+  product documentation for applicable terms.
 links:
   homepage: https://vaultstreet.com/
   app:
   twitter: https://x.com/ResolvLabs
   github:
-  documentation: https://docs.vaultstreet.com/
+  documentation: https://docs.vaultstreet.com/resources/smart-contracts.md
   fact_sheet: https://docs.vaultstreet.com/overview/primeusd.md
   defillama:
   audits:

--- a/eth_defi/data/vaults/metadata/vault-street.yaml
+++ b/eth_defi/data/vaults/metadata/vault-street.yaml
@@ -1,0 +1,39 @@
+name: Vault Street
+slug: vault-street
+short_description: |
+  Permissioned institutional USDC yield products with oracle-published NAV.
+long_description: |
+  [Vault Street](https://vaultstreet.com/) is Resolv's institutional platform for
+  tokenised investment products. Resolv announced the launch of primeUSD in its
+  [launch post](https://x.com/ResolvLabs/status/2077020041128935900).
+
+  [primeUSD](https://docs.vaultstreet.com/overview/primeusd.md) is a
+  permissioned, USDC-denominated yield token. It is not an ERC-4626 vault: the
+  [primeUSD token](https://etherscan.io/token/0x7ea76108975ec0998b9bc2db04b4eca986400dd7)
+  provides total supply, while the
+  [PriceStorage oracle](https://etherscan.io/address/0x8cda03e2004c35e07963fb792c6b7511dabee369)
+  publishes NAV/share through ``getPrice()``. The
+  [request manager](https://etherscan.io/address/0x8c14b6e8ec9968cd9c69eedea4a1295aec5e5d6e)
+  handles the permissioned deposit and redemption workflow. Vault Street's
+  [smart-contract documentation](https://docs.vaultstreet.com/resources/smart-contracts.md)
+  lists the deployed contracts.
+fee_description: |
+  Vault Street does not expose a product fee accessor on the primeUSD token or
+  its public PriceStorage oracle. The applicable fee terms are therefore not
+  available through the on-chain adapter.
+links:
+  homepage: https://vaultstreet.com/
+  app:
+  twitter: https://x.com/ResolvLabs
+  github:
+  documentation: https://docs.vaultstreet.com/
+  fact_sheet: https://docs.vaultstreet.com/overview/primeusd.md
+  defillama:
+  audits:
+  fees:
+  trading_strategy:
+  integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/vault_street/index.html
+example_smart_contracts:
+  - https://etherscan.io/token/0x7ea76108975ec0998b9bc2db04b4eca986400dd7
+  - https://etherscan.io/address/0x8cda03e2004c35e07963fb792c6b7511dabee369
+  - https://etherscan.io/address/0x8c14b6e8ec9968cd9c69eedea4a1295aec5e5d6e

--- a/eth_defi/data/vaults/metadata/vault-street.yaml
+++ b/eth_defi/data/vaults/metadata/vault-street.yaml
@@ -14,9 +14,9 @@ long_description: |
   collateral. Participants should review the product documentation for
   eligibility, terms and current availability.
 fee_description: |
-  Vault Street does not publish product fee terms in the sources currently
-  available to this integration. Eligible participants should review the
-  product documentation for applicable terms.
+  Vault Street lists a 0.5% protocol fee that accrues daily and is deducted
+  from the vault, with no performance fee. It does not list separate entry or
+  redemption fees.
 links:
   homepage: https://vaultstreet.com/
   app:
@@ -26,7 +26,7 @@ links:
   fact_sheet: https://docs.vaultstreet.com/overview/primeusd.md
   defillama:
   audits:
-  fees:
+  fees: https://app.vaultstreet.com/
   trading_strategy:
   integration_documentation: https://web3-ethereum-defi.readthedocs.io/vaults/vault_street/index.html
 example_smart_contracts:

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -25,6 +25,7 @@ from eth_defi.maseer_one.constants import MASEER_ONE_WSTGBP
 from eth_defi.midas.constants import MIDAS_PRODUCTS, MIDAS_PRODUCTS_BY_TOKEN
 from eth_defi.vault.base import VaultBase, VaultSpec
 from eth_defi.vault.risk import BROKEN_VAULT_CONTRACTS
+from eth_defi.vault_street.constants import PRIME_USD_ADDRESS
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +82,11 @@ KILOEX_HARDCODED_PROTOCOLS = {address: {ERC4626Feature.kiloex_like} for address 
 #: Frankencoin hardcoded classification flags.
 FRANKENCOIN_HARDCODED_PROTOCOLS = {HexAddress(address): {ERC4626Feature.frankencoin_like} for address in FRANKENCOIN_SAVINGS_VAULTS}
 
+#: Vault Street hardcoded classification flags.
+#:
+#: primeUSD is a non-ERC-4626 token whose NAV comes from a separate oracle.
+VAULT_STREET_HARDCODED_PROTOCOLS = {PRIME_USD_ADDRESS: {ERC4626Feature.vault_street_like}}
+
 
 def _get_hardcoded_protocol_features(address: HexAddress | str, chain_id: int | None = None) -> set[ERC4626Feature] | None:
     """Return hardcoded protocol features for a vault address.
@@ -107,6 +113,10 @@ def _get_hardcoded_protocol_features(address: HexAddress | str, chain_id: int | 
         if (chain_id, normalised_address) in MIDAS_PRODUCTS:
             return MIDAS_HARDCODED_PROTOCOLS[normalised_address]
         if normalised_address in MIDAS_HARDCODED_PROTOCOLS:
+            return None
+        if normalised_address == PRIME_USD_ADDRESS:
+            if chain_id == 1:
+                return VAULT_STREET_HARDCODED_PROTOCOLS[normalised_address]
             return None
 
     return HARDCODED_PROTOCOLS.get(normalised_address)
@@ -1514,6 +1524,10 @@ def create_vault_instance(
         from eth_defi.maseer_one.vault import MaseerOneVault
 
         return MaseerOneVault(web3, spec, **kwargs)
+    elif ERC4626Feature.vault_street_like in features:
+        from eth_defi.vault_street.vault import VaultStreetVault
+
+        return VaultStreetVault(web3, spec, **kwargs)
 
     # TODO: Some module deadlock sheningans for Morpho
     elif ERC4626Feature.morpho_like in features:
@@ -1950,6 +1964,7 @@ HARDCODED_PROTOCOLS = {
     **MASEER_ONE_HARDCODED_PROTOCOLS,
     **KILOEX_HARDCODED_PROTOCOLS,
     **FRANKENCOIN_HARDCODED_PROTOCOLS,
+    **VAULT_STREET_HARDCODED_PROTOCOLS,
     # 3Jane - USD3 senior tranche credit vault on Ethereum
     # https://etherscan.io/address/0x056B269Eb1f75477a8666ae8C7fE01b64dD55eCc
     "0x056b269eb1f75477a8666ae8c7fe01b64dd55ecc": {ERC4626Feature.threejane_like},

--- a/eth_defi/erc_4626/core.py
+++ b/eth_defi/erc_4626/core.py
@@ -72,6 +72,12 @@ class ERC4626Feature(enum.Enum):
     #: through a :py:class:`eth_defi.vault.base.VaultBase` adapter.
     maseer_one_like = "maseer_one_like"
 
+    #: Vault Street permissioned tokenised investment products.
+    #:
+    #: Routing marker for non-ERC-4626 products read through a
+    #: :py:class:`eth_defi.vault.base.VaultBase` adapter.
+    vault_street_like = "vault_street_like"
+
     #: Ipor protocol
     #:
     #: https://app.ipor.io/fusion
@@ -817,6 +823,8 @@ def get_vault_protocol_name(features: set[ERC4626Feature]) -> str:
         return "Midas"
     elif ERC4626Feature.maseer_one_like in features:
         return "Maseer One"
+    elif ERC4626Feature.vault_street_like in features:
+        return "Vault Street"
     elif ERC4626Feature.morpho_like in features:
         return "Morpho"
     elif ERC4626Feature.panoptic_like in features:

--- a/eth_defi/erc_4626/discovery_base.py
+++ b/eth_defi/erc_4626/discovery_base.py
@@ -31,6 +31,7 @@ from eth_defi.maseer_one.constants import MASEER_ONE_HARDCODED_LEADS
 from eth_defi.midas.constants import MIDAS_HARDCODED_LEADS
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.risk import BROKEN_VAULT_CONTRACTS
+from eth_defi.vault_street.constants import VAULT_STREET_HARDCODED_LEADS
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +44,7 @@ DEFAULT_HARDCODED_VAULT_LEAD_SOURCES: HardcodedVaultLeadSources = (
     ("ODA-FACT", ODA_FACT_HARDCODED_LEADS),
     ("Midas", MIDAS_HARDCODED_LEADS),
     ("Maseer One", MASEER_ONE_HARDCODED_LEADS),
+    ("Vault Street", VAULT_STREET_HARDCODED_LEADS),
 )
 
 if TYPE_CHECKING:

--- a/eth_defi/vault/fee.py
+++ b/eth_defi/vault/fee.py
@@ -67,6 +67,9 @@ VAULT_PROTOCOL_FEE_MATRIX = {
     # Maseer One applies mint and redemption spreads through mintcost() and
     # burncost(), reducing the user's issued shares or redeemed assets.
     "Maseer One": VaultFeeMode.externalised,
+    # Vault Street does not expose product fee accessors on the primeUSD token
+    # or its public price oracle.
+    "Vault Street": None,
     "Velvet Capital": VaultFeeMode.internalised_skimming,
     "Umami": VaultFeeMode.externalised,
     # Unverified contracts, no open source repo

--- a/eth_defi/vault/fee.py
+++ b/eth_defi/vault/fee.py
@@ -67,9 +67,10 @@ VAULT_PROTOCOL_FEE_MATRIX = {
     # Maseer One applies mint and redemption spreads through mintcost() and
     # burncost(), reducing the user's issued shares or redeemed assets.
     "Maseer One": VaultFeeMode.externalised,
-    # Vault Street does not expose product fee accessors on the primeUSD token
-    # or its public price oracle.
-    "Vault Street": None,
+    # Vault Street's 0.5% protocol fee accrues daily and is deducted from the
+    # primeUSD vault. The product page lists a 0% performance fee.
+    # https://app.vaultstreet.com/
+    "Vault Street": VaultFeeMode.internalised_skimming,
     "Velvet Capital": VaultFeeMode.internalised_skimming,
     "Umami": VaultFeeMode.externalised,
     # Unverified contracts, no open source repo

--- a/eth_defi/vault/risk.py
+++ b/eth_defi/vault/risk.py
@@ -74,6 +74,8 @@ VAULT_PROTOCOL_RISK_MATRIX = {
     # Maseer One is a new compliance-gated RWA tokenisation framework. The
     # contracts are public, but the framework has limited production history.
     "Maseer One": None,
+    # Vault Street primeUSD is a new permissioned institutional product.
+    "Vault Street": None,
     "Velvet Capital": VaultTechnicalRisk.high,
     "Umami": VaultTechnicalRisk.severe,
     # Unverified contracts, no open source repo

--- a/eth_defi/vault/risk.py
+++ b/eth_defi/vault/risk.py
@@ -74,8 +74,8 @@ VAULT_PROTOCOL_RISK_MATRIX = {
     # Maseer One is a new compliance-gated RWA tokenisation framework. The
     # contracts are public, but the framework has limited production history.
     "Maseer One": None,
-    # Vault Street primeUSD is a new permissioned institutional product.
-    "Vault Street": None,
+    # Vault Street primeUSD is a permissioned institutional product.
+    "Vault Street": VaultTechnicalRisk.low,
     "Velvet Capital": VaultTechnicalRisk.high,
     "Umami": VaultTechnicalRisk.severe,
     # Unverified contracts, no open source repo

--- a/eth_defi/vault_street/__init__.py
+++ b/eth_defi/vault_street/__init__.py
@@ -1,0 +1,1 @@
+"""Vault Street tokenised product support."""

--- a/eth_defi/vault_street/constants.py
+++ b/eth_defi/vault_street/constants.py
@@ -1,0 +1,48 @@
+"""Vault Street production contract metadata."""
+
+import datetime
+
+from eth_typing import HexAddress
+
+#: Ethereum mainnet chain id.
+VAULT_STREET_CHAIN_ID = 1
+
+#: Vault Street's permissioned, yield-bearing USD product token.
+#:
+#: https://etherscan.io/token/0x7ea76108975ec0998b9bc2db04b4eca986400dd7
+PRIME_USD_ADDRESS = HexAddress("0x7ea76108975ec0998b9bc2db04b4eca986400dd7")
+
+#: Vault Street ``PriceStorage`` contract exposing ``getPrice()``.
+#:
+#: https://etherscan.io/address/0x8cda03e2004c35e07963fb792c6b7511dabee369
+PRIME_USD_PRICE_ORACLE_ADDRESS = HexAddress("0x8cda03e2004c35e07963fb792c6b7511dabee369")
+
+#: Vault Street request manager for permissioned USDC deposits and redemptions.
+#:
+#: https://etherscan.io/address/0x8c14b6e8ec9968cd9c69eedea4a1295aec5e5d6e
+PRIME_USD_REQUEST_MANAGER_ADDRESS = HexAddress("0x8c14b6e8ec9968cd9c69eedea4a1295aec5e5d6e")
+
+#: Native USDC token on Ethereum mainnet, the primeUSD denomination token.
+PRIME_USD_DENOMINATION_TOKEN_ADDRESS = HexAddress("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48")
+
+#: ``PriceStorage.getPrice()`` fixed-point decimal divisor.
+PRIME_USD_PRICE_DECIMALS = 8
+
+#: Scanner label for the on-chain primeUSD NAV source.
+VAULT_STREET_NAV_SOURCE = "vault_street_price_storage_getPrice"
+
+#: First Ethereum block containing primeUSD bytecode.
+PRIME_USD_FIRST_SEEN_AT_BLOCK = 25_293_536
+
+#: Timestamp of :py:data:`PRIME_USD_FIRST_SEEN_AT_BLOCK`, stored as naive UTC.
+PRIME_USD_FIRST_SEEN_AT = datetime.datetime(2026, 6, 11, 10, 11, 47, tzinfo=datetime.UTC).replace(tzinfo=None)
+
+#: Hardcoded discovery lead for the non-ERC-4626 primeUSD product.
+VAULT_STREET_HARDCODED_LEADS = (
+    (
+        VAULT_STREET_CHAIN_ID,
+        PRIME_USD_ADDRESS,
+        PRIME_USD_FIRST_SEEN_AT_BLOCK,
+        PRIME_USD_FIRST_SEEN_AT,
+    ),
+)

--- a/eth_defi/vault_street/historical.py
+++ b/eth_defi/vault_street/historical.py
@@ -1,0 +1,114 @@
+"""Historical reader for Vault Street primeUSD."""
+
+# Reader classes intentionally mirror :class:`VaultHistoricalReader` signatures.
+# ruff: noqa: FBT001
+
+import datetime
+from collections.abc import Iterable
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from eth_defi.erc_4626.vault import VaultReaderState
+from eth_defi.event_reader.conversion import convert_int256_bytes_to_int
+from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
+from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
+
+if TYPE_CHECKING:
+    from eth_defi.vault_street.vault import VaultStreetVault
+
+
+class VaultStreetHistoricalReader(VaultHistoricalReader):
+    """Read historical primeUSD supply and NAV/share.
+
+    primeUSD is not ERC-4626. Its historical TVL is derived from the ERC-20
+    ``totalSupply()`` and Vault Street's ``PriceStorage.getPrice()`` oracle.
+    """
+
+    def __init__(self, vault: "VaultStreetVault", stateful: bool):
+        """Create a Vault Street historical reader.
+
+        :param vault:
+            Vault Street primeUSD adapter.
+        :param stateful:
+            Whether to attach adaptive reader state for the shared historical
+            scanner.
+        """
+
+        super().__init__(vault)
+        self.reader_state = VaultReaderState(vault) if stateful else None
+
+    def construct_multicalls(self) -> Iterable[EncodedCall]:
+        """Construct supply and NAV/share calls for a historical block.
+
+        :return:
+            Multicall batch reading ``totalSupply()`` and ``getPrice()``.
+        """
+
+        yield EncodedCall.from_contract_call(
+            self.vault.share_token.contract.functions.totalSupply(),
+            extra_data={"function": "totalSupply", "vault": self.vault.address},
+            first_block_number=self.first_block,
+        )
+        yield EncodedCall.from_contract_call(
+            self.vault.price_oracle_contract.functions.getPrice(),
+            extra_data={"function": "getPrice", "vault": self.vault.address},
+            first_block_number=self.first_block,
+        )
+
+    def process_result(
+        self,
+        block_number: int,
+        timestamp: datetime.datetime,
+        call_results: list[EncodedCallResult],
+    ) -> VaultHistoricalRead:
+        """Convert primeUSD multicall results to a vault price row.
+
+        :param block_number:
+            Historical block number.
+        :param timestamp:
+            Naive UTC block timestamp.
+        :param call_results:
+            Results from :py:meth:`construct_multicalls`.
+        :return:
+            Historical primeUSD supply, NAV/share and TVL.
+        """
+
+        total_supply: Decimal | None = None
+        share_price: Decimal | None = None
+        price_result: EncodedCallResult | None = None
+        errors: list[str] = []
+
+        for result in call_results:
+            function = result.call.extra_data["function"]
+            if not result.success:
+                errors.append(f"Vault Street {function} call failed")
+                continue
+
+            raw_value = convert_int256_bytes_to_int(result.result)
+            if function == "totalSupply":
+                total_supply = self.vault.share_token.convert_to_decimals(raw_value)
+            elif function == "getPrice":
+                share_price = self.vault.convert_raw_share_price(raw_value)
+                price_result = result
+
+        total_assets = share_price * total_supply if share_price is not None and total_supply is not None else None
+        if self.reader_state is not None and price_result is not None and total_assets is not None:
+            self.reader_state.on_called(
+                price_result,
+                total_assets=total_assets,
+                share_price=share_price,
+            )
+
+        return VaultHistoricalRead(
+            vault=self.vault,
+            block_number=block_number,
+            timestamp=timestamp,
+            share_price=share_price,
+            total_assets=total_assets,
+            total_supply=total_supply,
+            performance_fee=self.vault.get_performance_fee(block_number),
+            management_fee=self.vault.get_management_fee(block_number),
+            errors=errors or None,
+            deposits_open=False,
+            redemption_open=False,
+        )

--- a/eth_defi/vault_street/vault.py
+++ b/eth_defi/vault_street/vault.py
@@ -1,0 +1,509 @@
+"""Vault Street primeUSD vault adapter.
+
+Vault Street's first product, primeUSD, is a permissioned and yield-bearing
+USDC-denominated token for institutional participants. It is not an ERC-4626
+vault: primeUSD supply is ERC-20 ``totalSupply()``, while NAV/share is published
+by a separate ``PriceStorage.getPrice()`` contract.
+
+- Documentation: https://docs.vaultstreet.com/overview/primeusd.md
+- Contracts: https://docs.vaultstreet.com/resources/smart-contracts.md
+- Token: https://etherscan.io/token/0x7ea76108975ec0998b9bc2db04b4eca986400dd7
+"""
+
+# Adapter classes intentionally mirror :class:`VaultBase` method signatures.
+# ruff: noqa: ARG002, FBT001, FBT002, PLR0904, PLR0917, PLR6301
+
+from decimal import Decimal
+from functools import cached_property
+
+from eth_typing import BlockIdentifier, HexAddress
+from web3 import Web3
+from web3.contract import Contract
+
+from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.token import TokenDetails, fetch_erc20_details
+from eth_defi.types import Percent
+from eth_defi.vault.base import TradingUniverse, VaultBase, VaultDepositManager, VaultFlowManager, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
+from eth_defi.vault.fee import FeeData
+from eth_defi.vault.lower_case_dict import LowercaseDict
+from eth_defi.vault_street.constants import (
+    PRIME_USD_ADDRESS,
+    PRIME_USD_DENOMINATION_TOKEN_ADDRESS,
+    PRIME_USD_FIRST_SEEN_AT_BLOCK,
+    PRIME_USD_PRICE_DECIMALS,
+    PRIME_USD_PRICE_ORACLE_ADDRESS,
+    PRIME_USD_REQUEST_MANAGER_ADDRESS,
+    VAULT_STREET_CHAIN_ID,
+    VAULT_STREET_NAV_SOURCE,
+)
+from eth_defi.vault_street.historical import VaultStreetHistoricalReader
+
+#: Public integration restriction for permissioned primeUSD flows.
+VAULT_STREET_PERMISSIONED_FLOW_REASON = "Vault Street primeUSD deposits, transfers and redemptions require an approved KYB/KYC allowlist"
+
+#: Minimal ABI for the Vault Street ``PriceStorage`` oracle.
+_PRICE_ORACLE_ABI = [
+    {
+        "inputs": [],
+        "name": "getPrice",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+]
+
+
+class VaultStreetVaultInfo(VaultInfo, total=False):
+    """Vault Street primeUSD metadata and compatibility settings."""
+
+    #: ERC-20 primeUSD token address.
+    token: HexAddress
+
+    #: EVM chain id.
+    chain_id: int
+
+    #: USDC denomination token.
+    denomination_token: HexAddress
+
+    #: Contract publishing fixed-point NAV/share.
+    price_oracle: HexAddress
+
+    #: Contract receiving permissioned deposit and redemption requests.
+    request_manager: HexAddress
+
+    #: NAV source label.
+    nav_source: str
+
+
+class VaultStreetVault(VaultBase):
+    """Scan-only adapter for Vault Street's primeUSD token.
+
+    The adapter reads primeUSD ERC-20 supply and combines it with the public
+    price oracle to calculate USDC NAV. Public transaction support is excluded
+    because Vault Street applies institutional allowlisting to its request flow.
+    """
+
+    def __init__(
+        self,
+        web3: Web3,
+        spec: VaultSpec,
+        token_cache: dict | None = None,
+        features: set[ERC4626Feature] | None = None,
+        default_block_identifier: BlockIdentifier | None = None,
+        require_denomination_token: bool = False,
+    ):
+        """Create the primeUSD adapter.
+
+        :param web3:
+            Web3 connection for Ethereum mainnet.
+        :param spec:
+            Chain and primeUSD token address.
+        :param token_cache:
+            Token metadata cache for ERC-20 reads.
+        :param features:
+            Shared pipeline features, expected to include ``vault_street_like``.
+        :param default_block_identifier:
+            Accepted for the shared adapter factory. primeUSD token metadata is
+            immutable, so the adapter has no block-pinned metadata reads.
+        :param require_denomination_token:
+            Whether a missing denomination token must raise.
+        """
+
+        super().__init__(token_cache=token_cache, require_denomination_token=require_denomination_token)
+        if spec.chain_id != VAULT_STREET_CHAIN_ID or spec.vault_address.lower() != PRIME_USD_ADDRESS:
+            raise ValueError(f"Unsupported Vault Street product: chain={spec.chain_id}, token={spec.vault_address}")
+
+        self.web3 = web3
+        self.spec = spec
+        self.features = features or {ERC4626Feature.vault_street_like}
+        _ = default_block_identifier
+        self.first_seen_at_block = PRIME_USD_FIRST_SEEN_AT_BLOCK
+
+    @property
+    def chain_id(self) -> int:
+        """Return Ethereum mainnet chain id.
+
+        :return:
+            ``1`` for the primeUSD deployment.
+        """
+
+        return self.spec.chain_id
+
+    @property
+    def address(self) -> HexAddress:
+        """Return the primeUSD ERC-20 token address.
+
+        :return:
+            Checksummed primeUSD address.
+        """
+
+        return HexAddress(Web3.to_checksum_address(PRIME_USD_ADDRESS))
+
+    @property
+    def vault_address(self) -> HexAddress:
+        """Return the primary vault identifier expected by shared scanner code.
+
+        :return:
+            primeUSD token address.
+        """
+
+        return self.address
+
+    @cached_property
+    def price_oracle_contract(self) -> Contract:
+        """Return the Vault Street NAV/share oracle contract.
+
+        :return:
+            Contract exposing ``getPrice()``.
+        """
+
+        return self.web3.eth.contract(
+            address=Web3.to_checksum_address(PRIME_USD_PRICE_ORACLE_ADDRESS),
+            abi=_PRICE_ORACLE_ABI,
+        )
+
+    @property
+    def name(self) -> str:
+        """Return the primeUSD token name.
+
+        :return:
+            ERC-20 token name.
+        """
+
+        return self.share_token.name
+
+    @property
+    def symbol(self) -> str:
+        """Return the primeUSD token symbol.
+
+        :return:
+            ERC-20 token symbol.
+        """
+
+        return self.share_token.symbol
+
+    @property
+    def description(self) -> str:
+        """Return the product's strategy description.
+
+        :return:
+            Human-readable primeUSD strategy summary.
+        """
+
+        return "Permissioned USDC-denominated leveraged carry strategy using tokenised investment-grade fixed income collateral"
+
+    @property
+    def short_description(self) -> str:
+        """Return a concise product summary.
+
+        :return:
+            Short primeUSD description.
+        """
+
+        return "Permissioned institutional USDC yield product"
+
+    @property
+    def manager_name(self) -> str:
+        """Return the Vault Street platform name.
+
+        :return:
+            Product manager display name.
+        """
+
+        return "Vault Street"
+
+    def fetch_share_token_address(self, block_identifier: BlockIdentifier = "latest") -> HexAddress:
+        """Return the primeUSD ERC-20 address.
+
+        :param block_identifier:
+            Accepted for historical scanner compatibility.
+        :return:
+            primeUSD address.
+        """
+
+        return self.address
+
+    def fetch_share_token(self) -> TokenDetails:
+        """Fetch primeUSD ERC-20 metadata.
+
+        :return:
+            primeUSD token details.
+        """
+
+        return fetch_erc20_details(
+            self.web3,
+            self.address,
+            chain_id=self.chain_id,
+            raise_on_error=False,
+            cache=self.token_cache,
+            cause_diagnostics_message=f"Vault Street share token for vault {self.address}",
+        )
+
+    def fetch_denomination_token_address(self) -> HexAddress:
+        """Return native Ethereum USDC as the primeUSD denomination token.
+
+        :return:
+            USDC ERC-20 address.
+        """
+
+        return HexAddress(Web3.to_checksum_address(PRIME_USD_DENOMINATION_TOKEN_ADDRESS))
+
+    def fetch_denomination_token(self) -> TokenDetails:
+        """Fetch USDC denomination token metadata.
+
+        :return:
+            Ethereum USDC token details.
+        """
+
+        return fetch_erc20_details(
+            self.web3,
+            self.fetch_denomination_token_address(),
+            chain_id=self.chain_id,
+            raise_on_error=False,
+            cache=self.token_cache,
+            cause_diagnostics_message=f"Vault Street denomination token for vault {self.address}",
+        )
+
+    def convert_raw_share_price(self, raw_price: int) -> Decimal:
+        """Convert the PriceStorage fixed-point value to USDC per primeUSD.
+
+        :param raw_price:
+            Raw ``getPrice()`` value with eight decimal places.
+        :return:
+            USDC NAV per one human-readable primeUSD token.
+        """
+
+        return Decimal(raw_price) / Decimal(10**PRIME_USD_PRICE_DECIMALS)
+
+    def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
+        """Fetch primeUSD NAV per token from the PriceStorage oracle.
+
+        :param block_identifier:
+            Historical block number or block tag.
+        :return:
+            USDC NAV per primeUSD.
+        """
+
+        raw_price = self.price_oracle_contract.functions.getPrice().call(block_identifier=block_identifier)
+        return self.convert_raw_share_price(raw_price)
+
+    def fetch_total_supply(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
+        """Fetch total outstanding primeUSD supply.
+
+        :param block_identifier:
+            Historical block number or block tag.
+        :return:
+            Human-readable primeUSD supply.
+        """
+
+        raw_supply = self.share_token.contract.functions.totalSupply().call(block_identifier=block_identifier)
+        return self.share_token.convert_to_decimals(raw_supply)
+
+    def fetch_total_assets(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
+        """Fetch primeUSD TVL from supply multiplied by NAV/share.
+
+        :param block_identifier:
+            Historical block number or block tag.
+        :return:
+            Total USDC NAV.
+        """
+
+        return self.fetch_total_supply(block_identifier) * self.fetch_share_price(block_identifier)
+
+    def fetch_nav(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
+        """Fetch primeUSD total NAV.
+
+        :param block_identifier:
+            Historical block number or block tag.
+        :return:
+            Total USDC NAV.
+        """
+
+        return self.fetch_total_assets(block_identifier)
+
+    def fetch_info(self) -> VaultStreetVaultInfo:
+        """Return Vault Street contract metadata.
+
+        :return:
+            primeUSD token, oracle and request-manager information.
+        """
+
+        return VaultStreetVaultInfo(
+            token=self.address,
+            chain_id=self.chain_id,
+            denomination_token=self.fetch_denomination_token_address(),
+            price_oracle=HexAddress(Web3.to_checksum_address(PRIME_USD_PRICE_ORACLE_ADDRESS)),
+            request_manager=HexAddress(Web3.to_checksum_address(PRIME_USD_REQUEST_MANAGER_ADDRESS)),
+            nav_source=VAULT_STREET_NAV_SOURCE,
+        )
+
+    def fetch_scan_record_extra_data(self) -> dict[str, object]:
+        """Return primeUSD scan diagnostics.
+
+        :return:
+            Price-source and permissioned-flow fields.
+        """
+
+        return {
+            "_nav_source": VAULT_STREET_NAV_SOURCE,
+            "_nav_estimated": False,
+            "_vault_street_price_oracle": HexAddress(Web3.to_checksum_address(PRIME_USD_PRICE_ORACLE_ADDRESS)),
+            "_vault_street_request_manager": HexAddress(Web3.to_checksum_address(PRIME_USD_REQUEST_MANAGER_ADDRESS)),
+        }
+
+    def fetch_portfolio(
+        self,
+        universe: TradingUniverse,
+        block_identifier: BlockIdentifier | None = None,
+    ) -> VaultPortfolio:
+        """Return no directly observable strategy-token balances.
+
+        primeUSD's collateral and deployed positions are not represented as
+        token balances held at the primeUSD ERC-20 address.
+
+        :param universe:
+            Ignored because no on-chain portfolio is exposed by this product.
+        :param block_identifier:
+            Ignored because no on-chain portfolio is exposed by this product.
+        :return:
+            Empty spot portfolio.
+        """
+
+        return VaultPortfolio(spot_erc20=LowercaseDict())
+
+    def has_block_range_event_support(self) -> bool:
+        """Return whether standard flow-event accounting is available.
+
+        :return:
+            ``False`` because primeUSD uses a separate request manager.
+        """
+
+        return False
+
+    def has_deposit_distribution_to_all_positions(self) -> bool:
+        """Return whether deposits are distributed to visible positions.
+
+        :return:
+            ``False`` because positions are not exposed by this adapter.
+        """
+
+        return False
+
+    def get_flow_manager(self) -> VaultFlowManager:
+        """Raise because Vault Street request-flow accounting is unsupported.
+
+        :raises NotImplementedError:
+            Always.
+        """
+
+        message = "Vault Street request-flow accounting is not implemented"
+        raise NotImplementedError(message)
+
+    def get_deposit_manager(self) -> VaultDepositManager:
+        """Raise because permissioned Vault Street transaction support is unavailable.
+
+        :raises NotImplementedError:
+            Always.
+        """
+
+        message = "Vault Street permissioned deposits and redemptions are not implemented"
+        raise NotImplementedError(message)
+
+    def fetch_deposit_closed_reason(self) -> str:
+        """Explain why generic deposits are unavailable.
+
+        :return:
+            Institutional allowlist requirement.
+        """
+
+        return VAULT_STREET_PERMISSIONED_FLOW_REASON
+
+    def fetch_redemption_closed_reason(self) -> str:
+        """Explain why generic redemptions are unavailable.
+
+        :return:
+            Institutional allowlist requirement.
+        """
+
+        return VAULT_STREET_PERMISSIONED_FLOW_REASON
+
+    def get_historical_reader(self, stateful: bool) -> VaultHistoricalReader:
+        """Create a historical primeUSD reader.
+
+        :param stateful:
+            Accepted for shared scanner compatibility.
+        :return:
+            Historical reader using supply and PriceStorage oracle calls.
+        """
+
+        return VaultStreetHistoricalReader(self, stateful=stateful)
+
+    def get_management_fee(self, block_identifier: BlockIdentifier) -> Percent | None:
+        """Return unknown management fee.
+
+        :param block_identifier:
+            Accepted for shared fee API compatibility.
+        :return:
+            ``None`` because no on-chain management-fee accessor is exposed.
+        """
+
+        return None
+
+    def get_performance_fee(self, block_identifier: BlockIdentifier) -> Percent | None:
+        """Return unknown performance fee.
+
+        :param block_identifier:
+            Accepted for shared fee API compatibility.
+        :return:
+            ``None`` because no on-chain performance-fee accessor is exposed.
+        """
+
+        return None
+
+    def get_deposit_fee(self, block_identifier: BlockIdentifier) -> Percent | None:
+        """Return unknown deposit fee.
+
+        :param block_identifier:
+            Accepted for shared fee API compatibility.
+        :return:
+            ``None`` because the permissioned request manager has no public fee accessor.
+        """
+
+        return None
+
+    def get_withdraw_fee(self, block_identifier: BlockIdentifier) -> Percent | None:
+        """Return unknown redemption fee.
+
+        :param block_identifier:
+            Accepted for shared fee API compatibility.
+        :return:
+            ``None`` because the permissioned request manager has no public fee accessor.
+        """
+
+        return None
+
+    def get_fee_data(self) -> FeeData:
+        """Return unavailable fee metadata without making unsupported assumptions.
+
+        :return:
+            Fee data with each fee unset.
+        """
+
+        return FeeData(
+            fee_mode=None,
+            management=None,
+            performance=None,
+            deposit=None,
+            withdraw=None,
+        )
+
+    def get_link(self, referral: str | None = None) -> str:
+        """Return Vault Street's product page.
+
+        :param referral:
+            Ignored because the product URL has no referral parameter.
+        :return:
+            Vault Street primeUSD documentation page.
+        """
+
+        return "https://docs.vaultstreet.com/overview/primeusd.md"

--- a/eth_defi/vault_street/vault.py
+++ b/eth_defi/vault_street/vault.py
@@ -24,7 +24,7 @@ from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.token import TokenDetails, fetch_erc20_details
 from eth_defi.types import Percent
 from eth_defi.vault.base import TradingUniverse, VaultBase, VaultDepositManager, VaultFlowManager, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
-from eth_defi.vault.fee import FeeData
+from eth_defi.vault.fee import FeeData, VaultFeeMode
 from eth_defi.vault.lower_case_dict import LowercaseDict
 from eth_defi.vault_street.constants import (
     PRIME_USD_ADDRESS,
@@ -40,6 +40,16 @@ from eth_defi.vault_street.historical import VaultStreetHistoricalReader
 
 #: Public integration restriction for permissioned primeUSD flows.
 VAULT_STREET_PERMISSIONED_FLOW_REASON = "Vault Street primeUSD deposits, transfers and redemptions require an approved KYB/KYC allowlist"
+
+#: primeUSD protocol fee, accrued daily and deducted from the vault.
+#:
+#: https://app.vaultstreet.com/
+PRIME_USD_PROTOCOL_FEE: Percent = 0.005
+
+#: primeUSD performance fee.
+#:
+#: https://app.vaultstreet.com/
+PRIME_USD_PERFORMANCE_FEE: Percent = 0
 
 #: Minimal ABI for the Vault Street ``PriceStorage`` oracle.
 _PRICE_ORACLE_ABI = [
@@ -439,26 +449,27 @@ class VaultStreetVault(VaultBase):
         return VaultStreetHistoricalReader(self, stateful=stateful)
 
     def get_management_fee(self, block_identifier: BlockIdentifier) -> Percent | None:
-        """Return unknown management fee.
+        """Return the disclosed primeUSD protocol fee.
 
         :param block_identifier:
-            Accepted for shared fee API compatibility.
+            Ignored because the fee is currently static product metadata.
         :return:
-            ``None`` because no on-chain management-fee accessor is exposed.
+            Daily-accrued ``0.5%`` protocol fee represented in the
+            management-like fee field.
         """
 
-        return None
+        return PRIME_USD_PROTOCOL_FEE
 
     def get_performance_fee(self, block_identifier: BlockIdentifier) -> Percent | None:
-        """Return unknown performance fee.
+        """Return the disclosed primeUSD performance fee.
 
         :param block_identifier:
-            Accepted for shared fee API compatibility.
+            Ignored because the fee is currently static product metadata.
         :return:
-            ``None`` because no on-chain performance-fee accessor is exposed.
+            ``0`` because the product page lists no performance fee.
         """
 
-        return None
+        return PRIME_USD_PERFORMANCE_FEE
 
     def get_deposit_fee(self, block_identifier: BlockIdentifier) -> Percent | None:
         """Return unknown deposit fee.
@@ -483,16 +494,20 @@ class VaultStreetVault(VaultBase):
         return None
 
     def get_fee_data(self) -> FeeData:
-        """Return unavailable fee metadata without making unsupported assumptions.
+        """Return disclosed primeUSD fee metadata.
+
+        The product page states that the protocol fee accrues daily and is
+        deducted from the vault. Model it as an internalised management-like
+        fee. It does not disclose explicit entry or redemption fees.
 
         :return:
-            Fee data with each fee unset.
+            Fee data with disclosed protocol and performance fees.
         """
 
         return FeeData(
-            fee_mode=None,
-            management=None,
-            performance=None,
+            fee_mode=VaultFeeMode.internalised_skimming,
+            management=PRIME_USD_PROTOCOL_FEE,
+            performance=PRIME_USD_PERFORMANCE_FEE,
             deposit=None,
             withdraw=None,
         )

--- a/tests/erc_4626/test_classification.py
+++ b/tests/erc_4626/test_classification.py
@@ -6,9 +6,12 @@ Tests for create_probe_calls() chain filtering functionality.
 from eth_defi.erc_4626.classification import (
     CHAIN_RESTRICTED_PROBES,
     ROYCO_CHAIN_IDS,
-    _should_yield_probe,
+    _get_hardcoded_protocol_features,  # noqa: PLC2701
+    _should_yield_probe,  # noqa: PLC2701
     create_probe_calls,
 )
+from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.vault_street.constants import PRIME_USD_ADDRESS
 
 # Chain IDs for reference
 ETHEREUM_MAINNET = 1
@@ -19,6 +22,13 @@ BSC = 56
 MONAD = 143
 MANTLE = 5000
 AVALANCHE = 43114
+
+
+def test_vault_street_hardcoded_protocol_is_ethereum_only() -> None:
+    """Classify the hardcoded primeUSD address only on its deployment chain."""
+
+    assert _get_hardcoded_protocol_features(PRIME_USD_ADDRESS, chain_id=ETHEREUM_MAINNET) == {ERC4626Feature.vault_street_like}
+    assert _get_hardcoded_protocol_features(PRIME_USD_ADDRESS, chain_id=ARBITRUM) is None
 
 
 def test_chain_probe_filtering():

--- a/tests/vault_street/test_vault.py
+++ b/tests/vault_street/test_vault.py
@@ -13,9 +13,10 @@ from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature, get_va
 from eth_defi.erc_4626.scan import create_vault_scan_record
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.vault.fee import VaultFeeMode
 from eth_defi.vault_street.constants import PRIME_USD_ADDRESS, PRIME_USD_FIRST_SEEN_AT, PRIME_USD_FIRST_SEEN_AT_BLOCK
 from eth_defi.vault_street.historical import VaultStreetHistoricalReader
-from eth_defi.vault_street.vault import VAULT_STREET_PERMISSIONED_FLOW_REASON, VaultStreetVault
+from eth_defi.vault_street.vault import PRIME_USD_PERFORMANCE_FEE, PRIME_USD_PROTOCOL_FEE, VAULT_STREET_PERMISSIONED_FLOW_REASON, VaultStreetVault
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 
@@ -74,6 +75,13 @@ def test_vault_street_autodetect_live_prime_usd(web3: Web3) -> None:
     assert vault.fetch_info()["nav_source"] == "vault_street_price_storage_getPrice"
     assert vault.fetch_deposit_closed_reason() == VAULT_STREET_PERMISSIONED_FLOW_REASON
     assert vault.fetch_redemption_closed_reason() == VAULT_STREET_PERMISSIONED_FLOW_REASON
+
+    fee_data = vault.get_fee_data()
+    assert fee_data.fee_mode is VaultFeeMode.internalised_skimming
+    assert fee_data.management == PRIME_USD_PROTOCOL_FEE
+    assert fee_data.performance == PRIME_USD_PERFORMANCE_FEE
+    assert fee_data.deposit is None
+    assert fee_data.withdraw is None
 
     with pytest.raises(NotImplementedError):
         vault.get_deposit_manager()

--- a/tests/vault_street/test_vault.py
+++ b/tests/vault_street/test_vault.py
@@ -1,0 +1,142 @@
+"""Test the Vault Street primeUSD adapter against Ethereum mainnet."""
+
+import datetime
+import os
+from decimal import Decimal
+
+import flaky
+import pytest
+from web3 import Web3
+
+from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS, create_vault_instance_autodetect
+from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature, get_vault_protocol_name
+from eth_defi.erc_4626.scan import create_vault_scan_record
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.vault_street.constants import PRIME_USD_ADDRESS, PRIME_USD_FIRST_SEEN_AT, PRIME_USD_FIRST_SEEN_AT_BLOCK
+from eth_defi.vault_street.historical import VaultStreetHistoricalReader
+from eth_defi.vault_street.vault import VAULT_STREET_PERMISSIONED_FLOW_REASON, VaultStreetVault
+
+JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
+
+pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests")
+
+#: Fixed post-launch block with known supply and published NAV/share.
+PRIME_USD_TEST_BLOCK = 25_532_433
+PRIME_USD_EXPECTED_TOTAL_SUPPLY = Decimal("5237057.988099")
+PRIME_USD_EXPECTED_SHARE_PRICE = Decimal("1.00241049")
+PRIME_USD_EXPECTED_TOTAL_ASSETS = Decimal("5249681.86400873275851")
+
+
+@pytest.fixture(scope="module")
+def anvil_ethereum_fork() -> AnvilLaunch:
+    """Fork Ethereum mainnet at a deterministic primeUSD block."""
+
+    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=PRIME_USD_TEST_BLOCK)
+    try:
+        yield launch
+    finally:
+        launch.close()
+
+
+@pytest.fixture(scope="module")
+def web3(anvil_ethereum_fork: AnvilLaunch) -> Web3:
+    """Create a Web3 connection to the fixed Ethereum fork."""
+
+    return create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url, retries=2)
+
+
+def test_vault_street_hardcoded_protocol() -> None:
+    """Classify primeUSD through its hardcoded non-ERC-4626 address."""
+
+    features = HARDCODED_PROTOCOLS[PRIME_USD_ADDRESS]
+
+    assert features == {ERC4626Feature.vault_street_like}
+    assert get_vault_protocol_name(features) == "Vault Street"
+
+
+@flaky.flaky
+def test_vault_street_autodetect_live_prime_usd(web3: Web3) -> None:
+    """Autodetect primeUSD and read its supply, NAV and access status."""
+
+    vault = create_vault_instance_autodetect(web3, vault_address=PRIME_USD_ADDRESS)
+
+    assert isinstance(vault, VaultStreetVault)
+    assert vault.features == {ERC4626Feature.vault_street_like}
+    assert vault.get_protocol_name() == "Vault Street"
+    assert vault.name == "Vault Street Prime USD"
+    assert vault.symbol == "primeUSD"
+    assert vault.denomination_token.symbol == "USDC"
+    assert vault.fetch_total_supply(PRIME_USD_TEST_BLOCK) == PRIME_USD_EXPECTED_TOTAL_SUPPLY
+    assert vault.fetch_share_price(PRIME_USD_TEST_BLOCK) == PRIME_USD_EXPECTED_SHARE_PRICE
+    assert vault.fetch_total_assets(PRIME_USD_TEST_BLOCK) == PRIME_USD_EXPECTED_TOTAL_ASSETS
+    assert vault.fetch_nav(PRIME_USD_TEST_BLOCK) == PRIME_USD_EXPECTED_TOTAL_ASSETS
+    assert vault.fetch_info()["nav_source"] == "vault_street_price_storage_getPrice"
+    assert vault.fetch_deposit_closed_reason() == VAULT_STREET_PERMISSIONED_FLOW_REASON
+    assert vault.fetch_redemption_closed_reason() == VAULT_STREET_PERMISSIONED_FLOW_REASON
+
+    with pytest.raises(NotImplementedError):
+        vault.get_deposit_manager()
+
+    with pytest.raises(NotImplementedError):
+        vault.get_flow_manager()
+
+
+@flaky.flaky
+def test_vault_street_historical_reader_and_scan_record(web3: Web3) -> None:
+    """Read primeUSD historical data and create a shared scan record."""
+
+    vault = create_vault_instance_autodetect(web3, vault_address=PRIME_USD_ADDRESS)
+    reader = vault.get_historical_reader(stateful=False)
+
+    assert isinstance(reader, VaultStreetHistoricalReader)
+
+    call_results = [call.call_as_result(web3, block_identifier=PRIME_USD_TEST_BLOCK, ignore_error=True) for call in reader.construct_multicalls()]
+    timestamp = datetime.datetime.fromtimestamp(web3.eth.get_block(PRIME_USD_TEST_BLOCK)["timestamp"], tz=datetime.UTC).replace(tzinfo=None)
+    read = reader.process_result(PRIME_USD_TEST_BLOCK, timestamp, call_results)
+
+    assert read.share_price == PRIME_USD_EXPECTED_SHARE_PRICE
+    assert read.total_supply == PRIME_USD_EXPECTED_TOTAL_SUPPLY
+    assert read.total_assets == PRIME_USD_EXPECTED_TOTAL_ASSETS
+    assert read.errors is None
+
+    detection = ERC4262VaultDetection(
+        chain=web3.eth.chain_id,
+        address=PRIME_USD_ADDRESS,
+        first_seen_at_block=PRIME_USD_FIRST_SEEN_AT_BLOCK,
+        first_seen_at=PRIME_USD_FIRST_SEEN_AT,
+        features={ERC4626Feature.vault_street_like},
+        updated_at=PRIME_USD_FIRST_SEEN_AT,
+        deposit_count=0,
+        redeem_count=0,
+    )
+    record = create_vault_scan_record(web3, detection, block_identifier=PRIME_USD_TEST_BLOCK, token_cache={})
+
+    assert record["Protocol"] == "Vault Street"
+    assert record["Denomination"] == "USDC"
+    assert record["NAV"] == PRIME_USD_EXPECTED_TOTAL_ASSETS
+    assert record["Shares"] == PRIME_USD_EXPECTED_TOTAL_SUPPLY
+    assert record["Features"] == "vault_street_like"
+    assert record["_nav_source"] == "vault_street_price_storage_getPrice"
+    assert record["_deposit_closed_reason"] == VAULT_STREET_PERMISSIONED_FLOW_REASON
+
+
+@flaky.flaky
+def test_vault_street_historical_reader_updates_state(web3: Web3) -> None:
+    """Persist primeUSD reader state after a successful historical sample."""
+
+    vault = create_vault_instance_autodetect(web3, vault_address=PRIME_USD_ADDRESS)
+    reader = vault.get_historical_reader(stateful=True)
+
+    timestamp = datetime.datetime.fromtimestamp(web3.eth.get_block(PRIME_USD_TEST_BLOCK)["timestamp"], tz=datetime.UTC).replace(tzinfo=None)
+    call_results = [call.call_as_result(web3, block_identifier=PRIME_USD_TEST_BLOCK, ignore_error=True) for call in reader.construct_multicalls()]
+    for call_result in call_results:
+        call_result.timestamp = timestamp
+        call_result.state = reader.reader_state
+
+    reader.process_result(PRIME_USD_TEST_BLOCK, timestamp, call_results)
+
+    assert reader.reader_state.last_block == PRIME_USD_TEST_BLOCK
+    assert reader.reader_state.entry_count == 1
+    assert reader.reader_state.last_tvl == PRIME_USD_EXPECTED_TOTAL_ASSETS
+    assert reader.reader_state.exchange_rate == 1


### PR DESCRIPTION
## Why

Vault Street primeUSD is a non-ERC-4626, permissioned product that needs supply-and-oracle NAV tracking in the vault pipeline.

## Lessons learnt

primeUSD historical NAV must combine the ERC-20 supply with the PriceStorage `getPrice()` value; generic ERC-4626 accounting and transaction flows do not apply. The official product page states that the 0.5% protocol fee accrues daily and is deducted from the vault.

## Summary

- Add a direct `VaultBase` adapter, hardcoded Ethereum discovery and protocol classification for primeUSD.
- Add stateful historical NAV reading, disclosed fee data, scan metadata, risk classification and documentation.
- Add protocol metadata containing the launch, product, contract, explorer and fee source links.
- Cover fixed-block Ethereum data plus chain-restricted classification.

## Related issues and PRs

- None.

## Unrelated CI and test fixes

- None.