### PR TITLE
fix: use structured logging for vault cleaning

### DIFF
--- a/eth_defi/vault/post_processing.py
+++ b/eth_defi/vault/post_processing.py
@@ -549,7 +549,7 @@ def clean_prices(
             kwargs["cleaned_price_df_path"] = cleaned_path
         if settlement_db_path is not None:
             kwargs["settlement_db_path"] = settlement_db_path
-        generate_cleaned_vault_datasets(**kwargs)
+        generate_cleaned_vault_datasets(**kwargs, logger=logger.info)
         logger.info("Price cleaning complete")
         return True
     except OSError:

--- a/tests/erc_4626/test_post_processing.py
+++ b/tests/erc_4626/test_post_processing.py
@@ -12,6 +12,24 @@ brotli = pytest.importorskip("brotli", reason="brotli not installed (cloudflare_
 from eth_defi.vault import post_processing
 
 
+def test_clean_prices_uses_structured_logger(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Wrangler progress is emitted through the post-processing logger."""
+    caplog.set_level(logging.INFO)
+
+    def fake_generate_cleaned_vault_datasets(**kwargs: object) -> None:
+        logger_callback = kwargs["logger"]
+        assert callable(logger_callback)
+        logger_callback("Wrangler progress")
+
+    monkeypatch.setattr(post_processing, "generate_cleaned_vault_datasets", fake_generate_cleaned_vault_datasets)
+
+    assert post_processing.clean_prices()
+    assert any(record.name == post_processing.__name__ and record.message == "Wrangler progress" for record in caplog.records)
+
+
 def test_export_top_vaults_json_passes_pipeline_data_dir(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Why

The post-processing wrapper used structured logging for the start and end of vault-price cleaning, but did not pass a logger callback into the wrangler. The wrangler therefore fell back to Python print(), producing a long block of unprefixed output without timestamps, levels, logger names, or thread information.

## Lessons learnt

Library-style wrangling functions intentionally accept a simple progress callback so notebooks can still use print. Production integration points must explicitly adapt that callback to their module logger.

## Summary

- Pass logger.info from the post-processing wrapper into the vault-price wrangler.
- Add a focused regression proving wrangler progress is emitted by the post-processing logger.

## Related issues and PRs

Follow-up operational logging correction observed after #1280.

## Unrelated CI and test fixes

None.