### PR TITLE
Fix Frankencoin vault metadata

### DIFF
--- a/eth_defi/data/feeds/curators/frankencoin.yaml
+++ b/eth_defi/data/feeds/curators/frankencoin.yaml
@@ -1,0 +1,38 @@
+# Frankencoin curator - feeds provided by protocols/frankencoin.yaml
+#
+# Alias rationale:
+# - Frankencoin Savings Vaults are protocol-managed; there is no separate
+#   third-party curator for svZCHF vaults.
+# - The organisation's news sources are carried by the source-bearing protocol
+#   feeder protocols/frankencoin.yaml, so this curator aliases that feeder to
+#   avoid scanning the same sources twice.
+# - Official site: https://frankencoin.com/
+#
+# Description sources:
+# - https://frankencoin.com/
+feeder-id: frankencoin
+name: Frankencoin
+role: curator
+canonical-feeder-id: frankencoin
+short_description: Frankencoin is a stablecoin maintaining 1:1 value with the Swiss franc.
+long_description: |
+  Frankencoin is a decentralised Swiss franc stablecoin. Its ZCHF token is designed
+  to keep a 1:1 value with the Swiss franc while remaining transparent, on-chain and
+  usable without relying on a single central issuer.
+
+  The protocol is backed by on-chain collateral that can be liquidated when needed
+  to protect the value of ZCHF.
+
+  Common ways to use Frankencoin include:
+
+  - Pay with digital Swiss francs through DeFi, payment cards, IBAN integrations,
+    and supported merchants.
+  - Borrow ZCHF by depositing crypto assets as collateral.
+  - Earn market-based yield on ZCHF through DeFi applications and the Frankencoin
+    savings module.
+  - Build applications and financial services that need a programmable Swiss franc
+    settlement layer.
+
+  Frankencoin Savings Vaults are protocol-managed ERC-4626 wrappers around the
+  savings module. Because the protocol operates the savings product directly,
+  Frankencoin acts as the curator for svZCHF vaults.

--- a/eth_defi/data/feeds/protocols/frankencoin.yaml
+++ b/eth_defi/data/feeds/protocols/frankencoin.yaml
@@ -6,3 +6,13 @@ twitter: frankencoinzchf
 linkedin: frankencoin
 # rss: not found - the public site exposes documentation and social channels, but no RSS or Atom feed.
 linkedin-rss-hub-disabled-at: 2026-07-10
+short_description: Frankencoin is a stablecoin maintaining 1:1 value with the Swiss franc.
+long_description: |
+  Frankencoin is a decentralised Swiss franc stablecoin. Its ZCHF token is designed
+  to keep a 1:1 value with the Swiss franc while remaining transparent, on-chain and
+  usable without relying on a single central issuer.
+
+  The protocol is backed by on-chain collateral that can be liquidated when needed
+  to protect the value of ZCHF. Frankencoin supports payments, borrowing, DeFi yield
+  through the savings module, and integrations that need a programmable Swiss franc
+  settlement layer.

--- a/eth_defi/data/vaults/metadata/frankencoin.yaml
+++ b/eth_defi/data/vaults/metadata/frankencoin.yaml
@@ -1,15 +1,32 @@
 name: Frankencoin
 slug: frankencoin
+# Logo note: Frankencoin's official coin logo is pixel-art/blocky by design.
+# Do not replace it as a low-resolution asset unless a new official smooth
+# brand source is published.
 short_description: |
-  Oracle-free, over-collateralised Swiss franc stablecoin protocol with ERC-4626 ZCHF savings vaults.
+  Frankencoin is a stablecoin maintaining 1:1 value with the Swiss franc.
 long_description: |
-  Frankencoin is an over-collateralised, oracle-free stablecoin protocol whose ZCHF
-  token tracks the value of the Swiss franc. The protocol is fully on-chain and
-  deployed across multiple EVM networks.
+  Frankencoin is a decentralised Swiss franc stablecoin. Its ZCHF token is designed
+  to keep a 1:1 value with the Swiss franc while remaining transparent, on-chain and
+  usable without relying on a single central issuer.
 
-  The Frankencoin Savings Vaults wrap the Frankencoin savings module as ERC-20
-  and ERC-4626 vault tokens. Users deposit ZCHF and receive svZCHF shares whose
-  value follows the savings module yield.
+  The protocol is backed by on-chain collateral that can be liquidated when needed
+  to protect the value of ZCHF. Frankencoin has been live since 2023 and is deployed
+  across multiple blockchains.
+
+  Common ways to use Frankencoin include:
+
+  - Pay with digital Swiss francs through DeFi, payment cards, IBAN integrations,
+    and supported merchants.
+  - Borrow ZCHF by depositing crypto assets as collateral.
+  - Earn market-based yield on ZCHF through DeFi applications and the Frankencoin
+    savings module.
+  - Build applications and financial services that need a programmable Swiss franc
+    settlement layer.
+
+  The Frankencoin Savings Vaults wrap the savings module as ERC-20 and ERC-4626
+  vault tokens. Users deposit ZCHF and receive svZCHF shares whose value follows
+  the savings module yield.
 fee_description: |
   Frankencoin Savings Vaults do not have protocol-wide management, performance,
   deposit, or withdrawal fees. Yield accrues through the savings module and is

--- a/eth_defi/erc_4626/vault_protocol/frankencoin/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/frankencoin/vault.py
@@ -277,6 +277,15 @@ class FrankencoinVault(ERC4626Vault):
     three days before deposits start earning yield.
     """
 
+    @property
+    def name(self) -> str:
+        """Return a human-readable name for this vault.
+
+        The on-chain share token name is ``SavingsVault ZCHF``. Use the
+        protocol-facing product name in vault listings.
+        """
+        return "Frankencoin Savings Vault"
+
     @cached_property
     def frankencoin_vault_contract(self) -> Contract:
         """Return the svZCHF wrapper contract with Frankencoin-specific ABI.

--- a/tests/erc_4626/vault_protocol/test_frankencoin.py
+++ b/tests/erc_4626/vault_protocol/test_frankencoin.py
@@ -164,6 +164,7 @@ def test_frankencoin_create_vault_instance() -> None:
 
     assert isinstance(vault, FrankencoinVault)
     assert vault.get_protocol_name() == "Frankencoin"
+    assert vault.name == "Frankencoin Savings Vault"
 
 
 def test_frankencoin_static_fee_metadata() -> None:

--- a/tests/research/test_protocol_metadata_export.py
+++ b/tests/research/test_protocol_metadata_export.py
@@ -5,7 +5,19 @@ import os
 import pytest
 import requests
 
-from eth_defi.vault.protocol_metadata import process_and_upload_protocol_metadata
+from eth_defi.vault.protocol_metadata import METADATA_DIR, build_metadata_json, process_and_upload_protocol_metadata
+
+HTTP_OK = 200
+REQUEST_TIMEOUT = 30
+
+
+def test_frankencoin_protocol_metadata_description():
+    """Frankencoin protocol metadata uses the public Swiss franc description."""
+    metadata = build_metadata_json(METADATA_DIR / "frankencoin.yaml", public_url="")
+
+    assert metadata["short_description"] == "Frankencoin is a stablecoin maintaining 1:1 value with the Swiss franc."
+    assert "decentralised Swiss franc stablecoin" in metadata["long_description"]
+    assert "Pay with digital Swiss francs" in metadata["long_description"]
 
 
 @pytest.mark.skipif(os.environ.get("R2_VAULT_METADATA_BUCKET_NAME") is None, reason="R2_VAULT_METADATA_BUCKET_NAME not set")
@@ -50,15 +62,15 @@ def test_upload_euler_protocol_metadata():
         # Download and verify metadata JSON
         # URL format: {public_url}/vault-protocol-metadata/{key_prefix}{slug}/metadata.json
         metadata_url = f"{public_url_normalised}/vault-protocol-metadata/{key_prefix}{slug}/metadata.json"
-        response = requests.get(metadata_url)
-        assert response.status_code == 200, f"Failed to fetch {metadata_url}: {response.status_code}"
+        response = requests.get(metadata_url, timeout=REQUEST_TIMEOUT)
+        assert response.status_code == HTTP_OK, f"Failed to fetch {metadata_url}: {response.status_code}"
         downloaded_metadata = response.json()
         assert downloaded_metadata["name"] == "Euler"
         assert downloaded_metadata["slug"] == "euler"
 
         # Download and verify light logo
         logo_url = f"{public_url_normalised}/vault-protocol-metadata/{key_prefix}{slug}/light.png"
-        response = requests.get(logo_url)
-        assert response.status_code == 200, f"Failed to fetch {logo_url}: {response.status_code}"
+        response = requests.get(logo_url, timeout=REQUEST_TIMEOUT)
+        assert response.status_code == HTTP_OK, f"Failed to fetch {logo_url}: {response.status_code}"
         assert response.headers.get("Content-Type") == "image/png"
         assert len(response.content) > 0

--- a/tests/vault/test_curator_export.py
+++ b/tests/vault/test_curator_export.py
@@ -132,6 +132,21 @@ def test_build_curators_for_export_protocol_curator_alias():
     assert rec["linkedin"] == "https://www.linkedin.com/company/hyperliquid"
 
 
+def test_build_curators_for_export_frankencoin_protocol_curator_alias():
+    """Frankencoin protocol curator uses its curator alias descriptions."""
+    result = build_curators_for_export(["frankencoin"], feed_db=None)
+
+    assert "frankencoin" in result
+    rec = result["frankencoin"]
+    assert rec["protocol_curator"] is True
+    assert rec["canonical_feeder_id"] == "frankencoin"
+    assert rec["short_description"] == "Frankencoin is a stablecoin maintaining 1:1 value with the Swiss franc."
+    assert "savings module" in rec["long_description"]
+    assert rec["website"] == "https://frankencoin.com/"
+    assert rec["twitter"] == "https://x.com/frankencoinzchf"
+    assert rec["linkedin"] == "https://www.linkedin.com/company/frankencoin"
+
+
 def test_build_curators_for_export_canonical_feeder(tmp_path: Path):
     """Alias curators fetch posts from the canonical feeder.
 


### PR DESCRIPTION
## Why

Frankencoin svZCHF vaults were exposed with the raw on-chain token name and sparse protocol/curator metadata. The dashboard should show a cleaner product name and a readable Swiss franc stablecoin description for both protocol and curator metadata.

## Lessons learnt

Frankencoin protocol-curated vaults need a curator alias YAML, like other protocol-managed vaults, so curator export uses the intended descriptions while inheriting the canonical protocol social links. Frankencoin's official coin logo is intentionally pixel-art/blocky, so this PR keeps logo files unchanged and records that note in the metadata YAML.

## Summary

- Map Frankencoin vault names to `Frankencoin Savings Vault` instead of the raw `SavingsVault ZCHF` on-chain name.
- Add Frankencoin curator alias metadata and update protocol/feed descriptions for the Swiss franc stablecoin wording.
- Rewrite the Frankencoin long description for a general audience with pay, borrow, earn, and build use cases from https://frankencoin.com/.
- Add a metadata YAML comment noting that the official Frankencoin coin logo is pixel-art/blocky by design.
- Add focused tests for the vault name, curator export alias, and protocol metadata description.

## Related issues and PRs

Continues the Frankencoin vault integration and production metadata cleanup work.

## Unrelated CI and test fixes

- Added request timeouts and an HTTP status constant in the touched protocol metadata export test so the focused Ruff check passes.