### PR TITLE
fix: approximate Hypercore economic share prices

### DIFF
--- a/docs/claude-plans/2026-07-14-hypercore-share-price-continuity.md
+++ b/docs/claude-plans/2026-07-14-hypercore-share-price-continuity.md
@@ -2,6 +2,12 @@
 
 **Date:** 2026-07-14
 
+> **Superseded for cleaned-price construction:** the scanner continuity work
+> remains useful for raw-data quality, but cleaned Hypercore performance now
+> follows the PnL/NAV economic-index plan in
+> `2026-07-15-hypercore-economic-performance-index.md`. HF anchors and
+> flow-reconciled synthetic units are not authoritative cleaned prices.
+
 ## Goal
 
 Produce a stable, actionable Hypercore share price with the smallest practical

--- a/docs/claude-plans/2026-07-15-hypercore-economic-performance-index.md
+++ b/docs/claude-plans/2026-07-15-hypercore-economic-performance-index.md
@@ -139,7 +139,9 @@ units. Build one deterministic economic checkpoint per vault and UTC date:
    last known clean index value through non-checkpoint rows, so no return is
    fabricated from duplicate or stale observations. Mark these rows
    `approximated_pnl_nav_carried` so cadence-sensitive consumers can select
-   only actual checkpoints.
+   only actual performance checkpoints. Rows after a terminal loss use the
+   same carried status because the index is already zero and cannot record
+   further performance within that epoch.
 5. If a date has no usable NAV/PnL pair, carry the last clean price and record
    `deferred_pnl_nav` in `hypercore_repair_status`. Use
    `deferred_pnl_nav_outlier` for an uncorroborated return at or below `-100%`.
@@ -184,7 +186,8 @@ The function must:
 - build and forward-fill the compounded index;
 - set `hypercore_repair_status` to `approximated_pnl_nav` at usable economic
   checkpoints, `approximated_pnl_nav_clipped` at positive capped checkpoints,
-  `approximated_pnl_nav_carried` at ordinary non-checkpoint rows,
+  `approximated_pnl_nav_carried` at ordinary non-checkpoint rows and after a
+  terminal loss,
   `deferred_pnl_nav` where checkpoint inputs are missing, and
   `deferred_pnl_nav_outlier` for an uncorroborated absorbing loss;
 - recompute the synthetic `total_supply` as `total_assets / share_price` for
@@ -273,12 +276,15 @@ This separation is intentional:
 - investigators can still compare the index with `raw_share_price`, NAV, PnL,
   source and write batch.
 
-Re-running wrangle on unchanged input must be idempotent. Appending a new raw
-observation for the current or a future date may add a checkpoint but must not
-alter earlier checkpoint prices. A genuinely late raw observation for a past
-date is allowed to select a fresher checkpoint and deterministically rewrite
-the later compounded index: preserving a known stale point would be worse, and
-the raw file remains the audit trail. Test and document both cases.
+Re-running wrangle on unchanged input must be idempotent. Appending an ordinary
+new raw observation for the current or a future date may add a checkpoint but
+must not alter earlier checkpoint prices. A newly observed recovery after a
+provisional terminal zero is the exception: it can show that the earlier zero
+was not an absorbing loss and deterministically revise that open lifecycle. A
+genuinely late raw observation for a past date may likewise select a fresher
+checkpoint and rewrite the later compounded index. Preserving a known stale
+classification would be worse, and the raw file remains the audit trail. Test
+and document these cases.
 
 ## Vault-level acceptance checks
 
@@ -340,9 +346,10 @@ Replace the specialised anchor/stitch tests in
 9. A production-shaped Order Block Hunter fixture cannot create a spike by
    mixing one repaired row with one deferred raw row.
 10. A second run on the same input produces the same clean prices and statuses.
-11. Appending a future checkpoint leaves all earlier checkpoints byte-for-byte
-    unchanged; adding a fresher past-date row deterministically revises the
-    later index.
+11. Appending an ordinary future checkpoint leaves earlier checkpoints
+    byte-for-byte unchanged. A future recovery may revise a provisional
+    terminal wipe-out, while a fresher past-date row deterministically revises
+    the later index.
 
 Run the focused tests with the repository Poetry environment and
 `.local-test.env`, then run the full `tests/research/test_clean_prices.py` file

--- a/docs/claude-plans/2026-07-15-hypercore-economic-performance-index.md
+++ b/docs/claude-plans/2026-07-15-hypercore-economic-performance-index.md
@@ -1,0 +1,410 @@
+# Hypercore economic performance index plan
+
+**Date:** 2026-07-15
+
+## Goal
+
+Make the cleaned share-price history of Hypercore vaults reflect the best
+available estimate of real economic performance. In particular, the cleaned
+curves for Crypto Plaza Relative Momentum Edge, HODL My Perps, Magixbox,
+C.A.T, Scared Money, Order Block Hunter, HyperBotPro and Titan Vault must no
+longer contain changes caused by scanner units, missing flows, incompatible
+rolling windows or a partially repaired daily/HF path.
+
+The output is an approximate performance index, not a reconstructed
+Hyperliquid share price. It must be suitable for charts and return calculations
+without suggesting precision that the source data cannot support.
+
+## Why an exact share price is impossible
+
+Hyperliquid does not publish a historical vault share price or historical share
+supply. Its `vaultDetails` response contains rolling account-value and
+cumulative-PnL windows, but those windows:
+
+- have different resolutions and retention periods;
+- can refresh at different timestamps;
+- do not provide the exact timing and unit price of every capital flow; and
+- can be reconstructed on a different arbitrary synthetic share-price scale by
+  separate daily and high-frequency scanner runs.
+
+The current scanner infers net flows from changes in NAV and PnL, then invents
+an ERC-4626-like supply. A stale or differently aligned PnL observation is
+therefore interpreted as a deposit or withdrawal and permanently changes that
+synthetic supply. Later scans can reconstruct the same economic history in a
+different unit. The raw result is internally useful for diagnosis, but it is
+not an authoritative investor share price.
+
+The vault ledger helps in some intervals, but it does not make exact historical
+time-weighted returns recoverable. Old events can be absent, observations can
+fall between price timestamps, and the order of a flow and trading PnL inside a
+period is unknown. Position and fill reconstruction is also insufficient: it
+cannot recover historical mark-to-market equity, funding and all vault-level
+cash movements at every price timestamp.
+
+Consequently, no more elaborate stitching rule can make the raw synthetic
+share price exact. The defensible output is a clearly labelled performance
+index whose direction and magnitude come from observed account PnL relative to
+observed capital.
+
+## Confirmed failure modes
+
+The production data checked on 15 July 2026 shows four distinct ways in which
+the current repair stack can leave or create an implausible clean return:
+
+1. A stale daily row is retained as `deferred_hf_gap`, so the next valid row is
+   compared with the wrong starting level. Scared Money's apparent 13 August
+   `+204.5%` move is this case.
+2. A raw synthetic curve can be exactly consistent with the scanner's assumed
+   flow ordering but not with a knowable investor return. Magixbox's October
+   `+528.3%` and HyperBotPro's March `+285.0%` moves are examples.
+3. Hyperliquid cannot provide enough evidence for the conservative anchor
+   repair, leaving `deferred_hf_nav` prices in the published clean curve. This
+   affects Magixbox, Order Block Hunter and Titan Vault.
+4. Repairing only one side of an incompatible price interval mixes two units
+   and creates a new return. Order Block Hunter's raw 1–2 February movement is
+   about `-4.6%`, but repairing 1 February and deferring 2 February turns it
+   into `+275.4%`.
+
+There are 265 `deferred_*` rows across 68 Hypercore vaults in the checked clean
+Parquet. Forty-one of those rows across 29 vaults directly produce a move over
+50%. A separate 390 unflagged moves over 50% occur across 148 vaults. These are
+not all false trading returns, but the raw synthetic price alone cannot prove
+which are genuine.
+
+## Chosen approximation
+
+Replace the published Hypercore synthetic price during wrangling with a
+conservative PnL/NAV performance index. Do this for every Hypercore vault, not
+only a list of known addresses and not only rows exceeding an outlier
+threshold.
+
+For consecutive usable economic observations in the same performance epoch:
+
+```text
+pnl_change = account_pnl_now - account_pnl_previous
+capital_base = max(total_assets_previous, total_assets_now, 1.0)
+raw_period_return = pnl_change / capital_base
+if raw_period_return <= -1.0 and wipe_out_is_corroborated:
+    period_return = -1.0
+elif raw_period_return <= -1.0:
+    carry previous price and mark deferred_pnl_nav_outlier
+else:
+    period_return = min(raw_period_return, 1.0)
+clean_price_now = clean_price_previous * (1.0 + period_return)
+```
+
+Use the difference in cumulative `account_pnl`, not the exported `daily_pnl`.
+The latter is calculated inside individual scanner windows and has been shown
+to be inconsistent when daily and HF histories are merged. The maximum of
+opening and closing NAV is deliberately conservative when the intra-period
+timing of deposits and withdrawals is unknown: capital flows cannot generate a
+return, and uncertain small denominators cannot turn PnL into a multi-hundred
+percent price jump. The positive 100% return bound prevents one questionable
+period from dominating the complete history; it is a data-quality bound, not a
+claim that a leveraged vault cannot economically gain more.
+
+A negative return at or below `-100%` needs different handling because zero is
+an absorbing compounded-price state. Accept `-100%` only when NAV is also at
+the zero threshold and remains zero until the end of the data or a qualifying
+`epoch_reset`. That is independent evidence of a wipe-out. If NAV remains
+funded, carry the previous price and mark `deferred_pnl_nav_outlier` instead of
+turning one possible cumulative-PnL baseline correction into a false permanent
+loss. Returns strictly between `-100%` and zero are applied without clipping.
+
+Start each retained vault or recapitalisation epoch at `1.0`. A `-100%` result
+ends that epoch. A later funded history must satisfy the existing durable-zero
+and `$1,000` recapitalisation rule before it starts a new index at `1.0`; it
+must never be compounded from zero or joined to the wiped-out capital.
+Clear raw scanner `epoch_reset` flags before applying that rule: production
+validation showed that they also mark arbitrary synthetic-supply resets in
+funded vaults and would create false clean restarts.
+
+This approximation cannot assign the PnL to an exact trade or flow timestamp.
+It intentionally reports the return at the next usable economic observation.
+Do not interpolate backwards across an observation gap, because that would
+introduce future information into backtests.
+
+## Canonical observations
+
+Daily and HF rows can describe the same calendar period with different scanner
+units. Build one deterministic economic checkpoint per vault and UTC date:
+
+1. Consider rows with finite `total_assets` and `account_pnl`.
+2. Prefer the row from the newest finite `written_at` batch on that UTC date,
+   then the latest economic timestamp. At an otherwise identical timestamp,
+   prefer an explicit `hf` row. For legacy rows without `written_at`, fall back
+   to latest timestamp and the same source tie-break.
+3. Calculate the PnL/NAV index only between these selected checkpoints.
+4. Preserve the existing row set for metadata compatibility. Forward-fill the
+   last known clean index value through non-checkpoint rows, so no return is
+   fabricated from duplicate or stale observations. Mark these rows
+   `approximated_pnl_nav_carried` so cadence-sensitive consumers can select
+   only actual checkpoints.
+5. If a date has no usable NAV/PnL pair, carry the last clean price and record
+   `deferred_pnl_nav` in `hypercore_repair_status`. Use
+   `deferred_pnl_nav_outlier` for an uncorroborated return at or below `-100%`.
+   The row remains visible but its zero price movement must not be described as
+   observed performance.
+
+This produces a daily-resolution economic curve even when the raw file
+contains irregular HF timestamps. `returns_1h` remains the existing
+compatibility name, but it continues to mean the percentage change between
+consecutive rows rather than a guaranteed one-hour return. The documentation
+must state this explicitly. Price level, cumulative profit and drawdown are the
+supported outputs of this approximation. Volatility, Sharpe and other
+cadence-sensitive statistics must use the selected daily checkpoints rather
+than treating every carried raw row as an independent hourly return; audit
+those downstream call sites during implementation.
+
+Newest `written_at` is the best available freshness signal, not proof that an
+API value is economically correct. Cumulative PnL can legitimately rise or
+fall, so a monotonicity check would reject real losses. Retain the residual
+source-baseline risk in the documentation, expose clipped/deferred statuses and
+inspect the largest resulting returns in production validation.
+
+## Wrangle implementation
+
+Add one focused function in
+`eth_defi/research/wrangle_vault_prices.py`, provisionally named
+`approximate_hypercore_share_prices_from_pnl_nav()`.
+
+The function must:
+
+- operate only on
+  `eth_defi.hyperliquid.constants.HYPERCORE_CHAIN_ID` (`9999`, the project's
+  synthetic namespace for native Hyperliquid vaults, distinct from HyperEVM
+  chain id `999`) and leave all peers unchanged;
+- require timestamp-sorted vault groups and keep epoch boundaries separate;
+- use only duration/NAV-qualified epoch boundaries rebuilt by
+  `discard_hypercore_pre_recapitalisation_history()`, never raw scanner reset
+  flags;
+- initialise `raw_share_price` from the untouched scanner value before any
+  clean price is changed;
+- select daily checkpoints deterministically as described above;
+- build and forward-fill the compounded index;
+- set `hypercore_repair_status` to `approximated_pnl_nav` at usable economic
+  checkpoints, `approximated_pnl_nav_clipped` at positive capped checkpoints,
+  `approximated_pnl_nav_carried` at ordinary non-checkpoint rows,
+  `deferred_pnl_nav` where checkpoint inputs are missing, and
+  `deferred_pnl_nav_outlier` for an uncorroborated absorbing loss;
+- recompute the synthetic `total_supply` as `total_assets / share_price` for
+  finite positive values, so the exported NAV identity is not left internally
+  contradictory; and
+- log aggregate vault, checkpoint, carried-row and clipped/deferred-return
+  counts rather than one line for every repaired price; and
+- fail the production validation if the raw input contains Hypercore metadata
+  but the function selects zero `HYPERCORE_CHAIN_ID` rows. This catches a
+  namespace or input-filter mistake that synthetic fixtures alone would miss.
+
+Its docstring must record the production findings behind the policy: exact
+Hyperliquid unit-price history is unavailable, partial daily/HF repairs created
+Order Block Hunter's clean spike, and known ledger flows still do not establish
+intra-period time-weighted returns. The docstring must explain why cumulative
+PnL, the conservative NAV denominator, daily checkpoints, the asymmetric
+positive cap/negative wipe-out rule and carry-forward were selected, and
+document all expected DataFrame columns and types.
+
+Call the function immediately after
+`discard_hypercore_pre_recapitalisation_history()` and before
+`calculate_vault_returns()`. Once the index is authoritative for cleaned
+Hypercore rows, remove the Hypercore calls to:
+
+- `stitch_hypercore_high_freq_share_price_batches()`;
+- `cap_hypercore_share_prices()`;
+- `fix_hypercore_flow_reconciled_share_price_paths()`; and
+- `fix_hypercore_source_overlap_share_prices()`.
+
+Delete the now-unused repair implementations, constants and narrowly coupled
+tests after a repository-wide reference check. Do not layer the new index on
+top of those repairs: that would retain unnecessary code and make
+`raw_share_price` mean "partly repaired input" rather than the scanner value.
+Keep the generic EVM share-price repair unchanged and continue excluding
+Hypercore from it.
+
+`calculate_vault_returns()` must run after the approximation so
+`returns_1h`, compounded profit and chart performance all derive from the same
+clean `share_price`. Do not repair only `returns_1h`; a return series that
+disagrees with its price level is not actionable.
+
+The generic TVL cleaner must keep `tvl_filtering_mask` for low-capital
+Hypercore rows but must not zero their return after it was derived from the
+index. Consumers can exclude masked rows for suitability analysis without
+making published profit disagree with price.
+
+## Historical data
+
+Historical repair needs no raw-data migration and no destructive DuckDB edit.
+The ordinary production wrangle already rebuilds the cleaned Parquet from the
+raw Parquet, so the same function repairs all retained history on the next
+cleaning run.
+
+The historical procedure is:
+
+1. Make a copy of the current raw and cleaned production Parquets.
+2. Run the updated wrangle against the raw copy.
+3. Compare all named vaults and the full Hypercore anomaly census.
+4. Publish the regenerated cleaned Parquet through the existing temporary-file
+   and atomic-replacement path.
+5. Leave the raw Parquet and both scanner DuckDB files untouched.
+
+`raw_share_price` preserves the old synthetic series for audit and incident
+analysis. The old epoch of a recapitalised vault remains available in raw data,
+including HODL's genuine `-100%` outcome, while the cleaned chart represents
+only the current investable epoch.
+
+The manual historical-flow backfill is no longer required to obtain the clean
+price. Retain it only if it remains useful for raw accounting diagnosis;
+otherwise remove it. In either case, remove instructions claiming that
+backfilled flows are necessary to resolve `deferred_hf_nav` rows.
+
+## Data going forward
+
+Keep the daily and HF scanners and their raw synthetic calculations unchanged
+unless an independent scanner bug needs fixing. New observations continue to
+append to the raw stores, preserving source evidence. Every production wrangle
+then deterministically rebuilds the PnL/NAV index using both old and new raw
+rows.
+
+This separation is intentional:
+
+- scanners collect and preserve what Hyperliquid returned;
+- wrangling decides the best comparable economic-performance approximation;
+- consumers read only the cleaned index for charts and returns; and
+- investigators can still compare the index with `raw_share_price`, NAV, PnL,
+  source and write batch.
+
+Re-running wrangle on unchanged input must be idempotent. Appending a new raw
+observation for the current or a future date may add a checkpoint but must not
+alter earlier checkpoint prices. A genuinely late raw observation for a past
+date is allowed to select a fresher checkpoint and deterministically rewrite
+the later compounded index: preserving a known stale point would be worse, and
+the raw file remains the audit trail. Test and document both cases.
+
+## Vault-level acceptance checks
+
+Use production-shaped fixtures for the failure mechanics and a read-only run
+over the production raw Parquet for exact vault validation. The indicative
+returns below come from the 15 July investigation. Recalculate them directly
+from the copied raw checkpoints with the final denominator before freezing
+fixture expectations; do not make an implementation conform to a transcription
+error in this table.
+
+| Vault and event | Current clean symptom | Expected economic-index result |
+| --- | ---: | ---: |
+| Scared Money, 13 August | `+204.5%` | approximately `+44.6%` |
+| Magixbox, 15 October | `+528.3%` | approximately `+84.1%` |
+| Magixbox, 30 January | `+94.8%` | approximately `+4.5%` |
+| Magixbox, 1 February | `+159.5%` | approximately `-1.2%` |
+| Order Block Hunter, 2 February | `+275.4%` | approximately `-4.9%` |
+| HyperBotPro, 18 March | `+285.0%` | approximately `+12.7%` |
+| Titan Vault, 7 April | `+82.9%` | approximately `+27.9%`; the checked closing NAV is the larger denominator |
+
+Also verify:
+
+- Crypto Plaza Relative Momentum Edge no longer has its February synthetic
+  jump/reversal;
+- C.A.T no longer rises from about `1.9` to `36` while NAV stays near `$5,000`;
+- Magixbox's January/February values no longer mix prices near `1` with values
+  of `4.6`, `12.9` and `26.0`;
+- HODL starts its post-recapitalisation clean epoch at `1.0`, does not contain
+  the May `54.7x` unit jump or the later `+5,589%` clean move, and does not hide
+  the old epoch's raw complete loss; and
+- the same rules cover Rehobot LR, Sifu, HLP Liquidator and any future durable
+  recapitalisation without address-specific branches.
+
+The purpose of these checks is not to force every large result below an
+arbitrary chart threshold. A large PnL-supported return may remain, up to the
+documented approximation bound. The required invariant is that deposits,
+withdrawals, scanner scale changes and partial repair units cannot themselves
+become clean performance.
+
+## Focused tests
+
+Replace the specialised anchor/stitch tests in
+`tests/research/test_clean_prices.py` with focused tests for the new contract:
+
+1. No-flow PnL changes compound from the previous clean index and have the
+   expected sign and magnitude.
+2. A large deposit or withdrawal with no PnL leaves the clean price flat.
+3. Mixed daily/HF rows on the same date produce one deterministic checkpoint;
+   stale duplicates cannot create a return.
+4. Missing NAV/PnL carries the previous clean price and records
+   `deferred_pnl_nav`.
+5. A positive ratio over 100% is capped and counted. A ratio at or below
+   `-100%` ends a genuinely zero-NAV epoch but is deferred for a funded vault.
+6. A durable recapitalisation discards the previous cleaned epoch and restarts
+   at `1.0`; no return crosses the boundary.
+7. `raw_share_price` remains byte-for-byte equal to the input scanner values,
+   while `total_supply`, `share_price` and `returns_1h` agree after cleaning.
+8. Non-Hypercore rows are unchanged.
+9. A production-shaped Order Block Hunter fixture cannot create a spike by
+   mixing one repaired row with one deferred raw row.
+10. A second run on the same input produces the same clean prices and statuses.
+11. Appending a future checkpoint leaves all earlier checkpoints byte-for-byte
+    unchanged; adding a fresher past-date row deterministically revises the
+    later index.
+
+Run the focused tests with the repository Poetry environment and
+`.local-test.env`, then run the full `tests/research/test_clean_prices.py` file
+because the implementation removes several existing repair paths.
+
+## Production validation
+
+Run the new wrangle read-only against a copy of the current production raw
+Parquet and produce a compact before/after table containing:
+
+- the named vault and timestamp;
+- raw scanner price;
+- old clean price and return;
+- new economic-index price and return;
+- NAV, cumulative PnL and repair status; and
+- whether the return was clipped or carried.
+
+Scan all Hypercore vaults after the change and report:
+
+- maximum and minimum clean period returns;
+- count of clipped checkpoints;
+- count of carried and uncorroborated-negative rows and affected vaults;
+- count of returns over 50% by status; and
+- recapitalised vaults and their first retained timestamp.
+
+Manually inspect the largest positive and negative results rather than adding
+more automatic rules. The implementation is complete when all named failure
+mechanics use the approximation, no `deferred_hf_*` raw price remains in the
+published clean curve, price-derived profits agree with the clean price, and
+an unchanged rerun is identical.
+
+## Documentation changes during implementation
+
+- Rewrite the data-model and affected-vault sections of
+  `eth_defi/hyperliquid/problem-vaults.md`. It currently describes HF anchors
+  as canonical and says Magixbox's October move must remain; neither statement
+  is appropriate once exact unit performance is acknowledged as unavailable.
+- Update `CleanedVaultPriceRow` and `hypercore_repair_status` documentation to
+  describe `approximated_pnl_nav`, `approximated_pnl_nav_clipped`,
+  `approximated_pnl_nav_carried`, `deferred_pnl_nav` and
+  `deferred_pnl_nav_outlier` rather than only `repaired_*`/`deferred_hf_*`
+  statuses. Explicitly document that Hypercore `total_supply` is a synthetic
+  index-unit quantity, not an actual share count, and confirm with a
+  repository-wide consumer audit that nobody treats it as on-chain supply.
+- Update `scripts/hyperliquid/README-hyperliquid-vaults.md` and
+  `scripts/hyperliquid/README-hyperliquid-vaults-high-frequency.md` to separate
+  raw scanner price from the cleaned daily-resolution economic index.
+- Mark
+  `docs/claude-plans/2026-07-14-hypercore-share-price-continuity.md` as
+  superseded for cleaned-price construction. Its scanner continuity work
+  remains useful for raw data quality, but its historical HF-anchor repair is
+  no longer the published performance method.
+- Correct or remove healing-script documentation that promises an exact share
+  price from stored `daily_pnl`, flow backfills or API re-fetches.
+- Include Python files, scripts, notebooks and documentation in the reference
+  audit before deleting the old repair helpers.
+
+## Out of scope
+
+- Claiming an exact historical Hyperliquid investor share price.
+- Reconstructing mark-to-market equity from fills, candles and funding.
+- Rewriting the raw Parquet or either scanner DuckDB.
+- Address-specific repair dates or allowlists.
+- Adding a new database, schema migration or operational service.
+- Renaming the widely consumed `returns_1h` column in this change.

--- a/eth_defi/hyperliquid/problem-vaults.md
+++ b/eth_defi/hyperliquid/problem-vaults.md
@@ -1,299 +1,143 @@
 # Problem vaults
 
-This document records known Hyperliquid / Hypercore vault price-history
-problems investigated in July 2026. It is an operational reference for the
-native-vault scanners and the downstream wrangle step, not an assessment of a
-vault's investment quality.
+This document records known Hyperliquid/Hypercore price-history problems and
+the cleaned economic-performance approximation adopted in July 2026. It is an
+operational data-quality reference, not an assessment of investment quality.
 
-## Data model and failure mode
+## Why the share price is approximate
 
-Hyperliquid's `vaultDetails` endpoint exposes rolling `day`, `week`, `month`,
-and `allTime` account-value and cumulative-PnL series. The native scanner
-derives an ERC-4626-like share price from those series so that vault returns
-can be compared with other vault protocols.
+Hyperliquid's `vaultDetails` API does not expose historical share supply or an
+investable vault unit price. It exposes rolling account-value and cumulative
+PnL windows with different resolutions and retention periods. Daily and
+high-frequency reads can therefore combine observations fetched at different
+times and reconstruct the same vault on different arbitrary synthetic units.
 
-The account-value and PnL samples in different rolling windows are not always
-aligned. Combining a fresh account-value sample with a stale or differently
-resolved cumulative-PnL sample makes the inferred net flow wrong. The share
-price reconstruction then invents a share mint or burn, producing a temporary
-price spike which often reverses at the next refreshed observation. This is a
-data artefact, not a realised vault return.
+The vault ledger does not close this gap. It can explain many NAV changes, but
+historical events may be missing and the order of trading PnL and flows inside
+an observation interval is unknown. Position fills also cannot reconstruct
+complete historical mark-to-market equity and funding at every price time.
+Exact historical time-weighted investor returns are consequently impossible to
+recover from the available API data.
 
-The scanner and wrangle repairs in
-`eth_defi.research.wrangle_vault_prices.fix_hypercore_source_overlap_share_prices`
-and its surrounding continuity steps address these cases:
+Raw Parquet `share_price` remains useful scanner evidence, but it is not an
+authoritative performance series. The wrangle step preserves it as
+`raw_share_price` and publishes a conservative PnL/NAV index instead.
 
-- The daily and high-frequency exporters label every new row as `daily` or
-  `hf` through `hypercore_source`.
-- Before writing an overlapping scan, each exporter scales its reconstructed
-  curve to the last persisted positive price. Daily scans use the shared date;
-  HF scans use log-price interpolation when rolling-window timestamps shift.
-  This preserves `NAV = share_price × total_supply` and never rewrites older
-  stored rows.
-- The period merge only overlays NAV/PnL pairs after rebasing a child PnL
-  series at an exact shared `allTime` timestamp. A period without such a
-  timestamp is skipped rather than nearest-neighbour matching unrelated PnL.
-- Positive-price, positive-NAV HF observations are the preferred canonical
-  anchors. A daily point bracketed by them becomes a candidate if its symmetric
-  price deviation exceeds 50%.
-- For legacy daily-only vaults, the newest common `written_at` batch supplies
-  the canonical anchors.
-- Both paths repair a candidate only when NAV stays within 50% of the
-  interpolated anchor NAV, the anchors are at most eight days apart, and their
-  interval contains neither zero NAV nor an `epoch_reset`. These checks prevent
-  smoothing a genuine deposit, missing observation, wipe-out, or
-  recapitalisation boundary.
-- The input value is retained in `raw_share_price` for auditability. The repair
-  does not extrapolate outside anchor coverage and does not alter anchor rows.
-  `hypercore_repair_status` records `repaired_*` for applied changes and a
-  `deferred_*` reason when the evidence is insufficient and the raw value is
-  kept.
-- A separate recapitalisation filter discards the old cleaned-history epoch
-  after a durable zero-NAV event. Durability is measured from zero NAV to the
-  first later positive NAV; that recovery must take at least seven days. The
-  new epoch starts at the first subsequent observation of at least `$1,000`
-  and is marked `epoch_reset`. Its first retained synthetic price is normalised
-  to `1.0`; `raw_share_price` retains the scanner value. The raw parquet is
-  never discarded or rewritten.
-- A historical HF batch stitch compares consecutive `hf` rows whose
-  `written_at` changes. If their observed share-price change disagrees by more
-  than 50% with the PnL-supported return over a gap of at most two days, it
-  rescales the later batch and records `repaired_hf_batch_scale`. This is the
-  narrow repair path for HODL's post-recapitalisation unit changes.
+## Cleaned economic-performance index
 
-Legacy parquet rows predate explicit source provenance. They are classified as
-daily when their timestamp is midnight UTC and HF otherwise. This is valid for
-the historical Hypercore exports, but new data must always use the explicit
-column.
+For each vault and UTC date, wrangling selects one finite NAV/PnL checkpoint.
+It prefers the newest `written_at` batch, then the latest economic timestamp,
+with HF as the final tie-break. Other rows carry the previous clean price.
 
-## Crypto plaza relative momentum edge
+For consecutive checkpoints:
 
-- Address: `0xdc9955a83218b71713a83ee072055591bd4c7304`
-- Trading Strategy page:
-  [Crypto Plaza Relative Momentum Edge](https://tradingstrategy.ai/trading-view/vaults/crypto-plaza-relative-momentum-edge)
-- Affected period: February 2026
+```text
+pnl_change = account_pnl_now - account_pnl_previous
+capital_base = max(total_assets_previous, total_assets_now, 1.0)
+period_return = pnl_change / capital_base
+clean_price_now = clean_price_previous * (1 + period_return)
+```
 
-This was the original reported example. The large February share-price jump
-and reversal were caused by the rolling-window merge described above, not by
-the vault's positions or a real trading gain/loss. The raw values on 5 and 6
-February were respectively `3.538529` and `3.485236`; the HF-anchor repair
-estimates `1.079443` and `1.029948`.
+Positive period returns are capped at 100%. A return at or below -100% is
+accepted only when NAV is also zero and does not recover in the retained epoch.
+Otherwise the price is carried so that a possible cumulative-PnL baseline
+correction cannot permanently zero a funded vault.
 
-The repair changes ten historical rows for this vault. Its maximum absolute
-return in the late-January to mid-February inspection window falls to about
-16.5% after repair.
+The index starts at `1.0` for each retained capital epoch. This denominator is
+deliberately conservative when capital-flow timing is unknown: deposits and
+withdrawals cannot generate clean performance, and uncertain low NAV cannot
+create an unbounded return. It is still an approximation and must not be
+presented as Hyperliquid's exact share price.
 
-## Magixbox
+`hypercore_repair_status` records the evidence used:
 
-- Address: `0x1764dd740aba4195643bbb6a44648e0306b00cfa`
-- Trading Strategy page: [Magixbox](https://tradingstrategy.ai/trading-view/vaults/magixbox)
-- Affected period: 25 January to 5 February 2026
+- `approximated_pnl_nav`: ordinary daily economic checkpoint;
+- `approximated_pnl_nav_clipped`: positive checkpoint capped at 100%;
+- `approximated_pnl_nav_wipe_out`: terminal NAV-corroborated complete loss;
+- `approximated_pnl_nav_carried`: non-checkpoint daily/HF duplicate;
+- `deferred_pnl_nav`: checkpoint inputs were unavailable; and
+- `deferred_pnl_nav_outlier`: an uncorroborated absorbing loss was carried.
 
-Magixbox has six daily/HF price-discrepancy candidates. The conservative
-policy automatically repairs two. Four remain unchanged because their NAV is
-more than 50% away from the interpolated HF-anchor NAV; although their prices
-look suspicious, the stored observations do not prove that interpolation is
-economically safe.
+Clean Hypercore `total_supply` is recalculated as
+`total_assets / share_price`. It is a synthetic index-unit quantity, not an
+actual share count. `returns_1h` remains a compatibility name: Hypercore
+performance occurs at daily checkpoints, while carried rows have zero change.
+Price level, cumulative profit and drawdown use the clean curve. Cadence-sensitive
+statistics such as volatility and Sharpe must select checkpoint rows. Low NAV
+still sets `tvl_filtering_mask`, but does not rewrite the Hypercore return away
+from its price; suitability consumers use the mask to exclude such rows.
 
-| Date | Raw share price | Anchor estimate | Decision |
-| --- | ---: | ---: | --- |
-| 2026-01-25 | 0.443179 | 0.668308 | Repair |
-| 2026-01-30 | 1.278832 | 0.642874 | Defer: NAV |
-| 2026-01-31 | 1.774786 | 0.724207 | Defer: NAV |
-| 2026-02-01 | 4.605958 | 0.815830 | Defer: NAV |
-| 2026-02-03 | 12.898591 | 1.035319 | Repair |
-| 2026-02-05 | 26.035410 | 1.303902 | Defer: NAV |
+## Verified affected vaults
 
-The four deferred values retain `share_price == raw_share_price` and carry
-`deferred_hf_nav`; downstream consumers can therefore distinguish unresolved
-data from repaired data. The separate large October 2025 move is supported by
-roughly `$12,742.80` of realised PnL on 10 October and must not be removed as a
-data artefact.
+The following results come from a read-only run over the 15 July 2026
+production raw Parquet. Absolute clean index levels depend on the complete
+retained history; the one-period returns demonstrate the repaired economics.
 
-At the 13 July 2026 live API check, Magixbox had no open perpetual positions
-and a perp account value of about `$746.22`.
+| Vault | Address | Affected period or row | Previous/raw symptom | New clean result |
+| --- | --- | --- | ---: | ---: |
+| Crypto Plaza Relative Momentum Edge | `0xdc9955a83218b71713a83ee072055591bd4c7304` | 2–15 February 2026 | Daily prices `3.54`/`3.49` mixed with HF near `1` | Largest inspected move about `+15.8%`; no multi-unit jump/reversal |
+| HODL My Perps | `0x13b43faa22d854bf43b4e7581c1b3dfcd416f8c3` | post-recapitalisation May 2026 | 21 May raw unit jump about `54.7x` | `+2.44%` from PnL/NAV |
+| Magixbox | `0x1764dd740aba4195643bbb6a44648e0306b00cfa` | 30 January–7 February 2026 | Raw prices `1.28`, `1.77`, `4.61`, `12.90`, `26.04` | `+4.45%`, `+27.94%`, `-1.20%`, `+7.49%`, `-7.25%`, `+2.43%` at successive checkpoints |
+| Magixbox | same | 15 October 2025 | `+528.3%` synthetic price move | `+84.08%` conservative economic return |
+| C.A.T | `0xdfb729b4b789de6d13d6ad7ac8e2750909360af9` | 21 January–12 February 2026 | Price rose from about `1.9` to `36` while NAV stayed near `$5,000` | PnL/NAV index stays around `1.16`–`1.23` over the peak raw-price dates |
+| Scared Money | `0x5290ab34acb59cfe1371baa5782eba14433d308f` | 13 August 2025 | `+204.5%` after a stale deferred row | `+44.59%` over the observed PnL interval |
+| Order Block Hunter | `0x0a8499b5e925d95badc893ec7f0b1613e08f6d7c` | 2 February 2026 | Partial repair created `+275.4%` | `-4.87%`, matching PnL direction |
+| HyperBotPro | `0x12e358f38741c07c1e04a8102a3170d40a600f05` | 18 March 2026 | `+285.0%` synthetic move around a withdrawal | `+12.72%` from PnL/NAV |
+| Titan Vault | `0x4b0eab9444a75a03f1ef340c8beac737afa5ab09` | 7 April 2026 | `+82.9%` and `deferred_hf_nav` | `+27.94%` from the freshest daily checkpoint |
 
-## C.A.T
+These replacements do not assert that every retained PnL observation is exact.
+They remove the known mechanism by which share units and flows became
+performance and expose clipping or deferral explicitly for later inspection.
 
-- Address: `0xdfb729b4b789de6d13d6ad7ac8e2750909360af9`
-- Trading Strategy page: [C.A.T](https://tradingstrategy.ai/trading-view/vaults/c-a-t)
-- Affected period: 22 January to 6 February 2026
+## HODL My Perps and recapitalisation
 
-C.A.T has no HF history for the affected period, so this case motivated the
-refreshed-daily-anchor fallback. The canonical weekly observations were about
-`1.019542` on 28 January, `1.893065` on 4 February, and `1.961532` on 11
-February. In contrast, stale daily values rose to `19.672888` on 3 February
-and to `36.320766` on 6 February before reversing near `1.90`.
+HODL is also a real lifecycle boundary. NAV reached zero on 15 October 2025
+with cumulative PnL around `-$326,631` and stayed zero until new capital arrived
+in April 2026. One continuous share price cannot represent both the old
+investors' -100% result and the new investors' performance.
 
-This cannot be an economic return: NAV remained around `$5,000`, and the
-locally synchronised vault ledger records no deposits from 29 January through
-10 February. The repair changes fourteen rows. It reduces the maximum
-one-step return from about 1,814% to 58.1%; for example, the raw values
-`36.239740` and `36.320766` on 5 and 6 February become `1.902698` and
-`1.912379`.
+The cleaned recapitalisation rule requires:
 
-At the 13 July 2026 live API check, C.A.T had no open perpetual positions and
-a perp account value of about `$2,277.49`.
+1. a previous NAV of at least `$1,000`;
+2. zero NAV with no positive recovery for at least seven days; and
+3. a later NAV of at least `$1,000` before tracking restarts.
 
-## Similar price-history candidates
+The old rows remain untouched in raw Parquet. Cleaned history starts the new
+capital epoch at `1.0`, so destroyed old supply is not chain-linked to new
+capital. Raw scanner `epoch_reset` flags are cleared first because they also
+mark arbitrary reconstruction resets in funded vaults.
 
-The repair now records its candidate classification directly in
-`hypercore_repair_status`. A value beginning with `repaired_` means the cleaned
-price differs from `raw_share_price`; `deferred_` means the row exceeded the
-price-discrepancy threshold but failed one or more safety rules and remains
-unchanged. A large price discrepancy is a reason to inspect a row, not by
-itself proof that the raw value is wrong.
+The 15 July production snapshot has four duration/NAV-qualified
+recapitalisations:
 
-The read-only production snapshot contained two non-overlapping populations:
+| Vault | Address | New retained epoch | Rows discarded from clean output |
+| --- | --- | --- | ---: |
+| Rehobot LR | `0x81a20870c5c7558f117166b2a598abaa8ce91f50` | 22 April 2026 | 44 |
+| HODL My Perps | `0x13b43faa22d854bf43b4e7581c1b3dfcd416f8c3` | 20 April 2026 | 161 |
+| Sifu | `0xf967239debef10dbc78e9bbbb2d8a16b72a614eb` | 15 May 2024 | 25 |
+| HLP Liquidator | `0x2e3d94f0562703b25c83308a05046ddaf9a8dd14` | 19 November 2025 | 139 |
 
-| Pattern | Anchor method | Vaults | Candidates | Repaired | Deferred |
-| --- | --- | ---: | ---: | ---: | ---: |
-| Magixbox-style | HF observations | 143 | 759 | 612 | 147 |
-| C.A.T-style | Refreshed daily observations | 38 | 292 | 135 | 157 |
-| Total |  | 181 | 1,051 | 747 | 304 |
+The naive rule "any zero followed by positive NAV" finds hundreds of transient
+scanner zeroes. The duration and capital thresholds are therefore required.
 
-Of the 181 affected vaults, all candidates are automatically repaired for 97;
-84 have at least one deferred row. The latter group requires better source
-data or manual investigation rather than more aggressive interpolation.
+## Production census and validation
 
-The safeguards defer 260 rows for NAV inconsistency, 60 for an anchor gap over
-eight days, and 34 for crossing zero NAV or `epoch_reset`; these counts overlap.
-For example, all 28 deferred rows for BBQ & Tegelwerken BV span fourteen-day
-anchor gaps. Lifecycle-boundary deferrals include 21M, SMM Foundation, and
-Vela Trading. These are real limitations in the evidence available to the
-repair, not proof of genuine investment returns.
+The raw production snapshot contains 874,878 Hypercore rows across 569 vaults.
+After removing 369 superseded recapitalisation rows, the economic-index run
+produces:
 
-### Magixbox-style examples
+- 85,891 daily PnL/NAV checkpoints;
+- 788,618 carried daily/HF duplicate rows;
+- 57 uncorroborated absorbing losses carried for review;
+- 9 positive returns capped at 100%; and
+- 2 terminal NAV-corroborated wipe-outs.
 
-These are the largest per-vault symmetric discrepancies in the HF-anchor
-population. A ratio of 20 means that one of the two prices was twenty times
-the other.
+All resulting one-step clean returns are between -100% and +100%. There are no
+`deferred_hf_*` raw prices in the published clean curve because the index is
+applied to every Hypercore vault rather than only suspicious candidates.
 
-| Vault | Address | Candidates | Repaired | Deferred | Largest ratio |
-| --- | --- | ---: | ---: | ---: | ---: |
-| Tao Hedge | `0x3d848183c406deae93c2641c045a541cf1d4a6cb` | 8 | 5 | 3 | 587.6x |
-| HLP Liquidator 3 | `0x5e177e5e39c0f4e421f5865a6d8beed8d921cb70` | 2 | 0 | 2 | 164.6x |
-| Hyperland | `0x8e108f7c619ab460885edd0f84e313daf119c779` | 12 | 11 | 1 | 94.8x |
-| Long LINK Short XRP | `0x73ce82fb75868af2a687e9889fcf058dd1cf8ce9` | 12 | 10 | 2 | 49.2x |
-| Magixbox | `0x1764dd740aba4195643bbb6a44648e0306b00cfa` | 6 | 2 | 4 | 20.0x |
-| TAPTRADE | `0x5f42236dfb81cba77bf34698b2242826659d1275` | 45 | 26 | 19 | 19.3x |
-
-### C.A.T-style examples
-
-These vaults lack sufficient HF history for the affected interval. Their
-latest daily refresh batch supplies anchors, but each candidate still has to
-pass all three safety checks.
-
-| Vault | Address | Candidates | Repaired | Deferred | Largest ratio |
-| --- | --- | ---: | ---: | ---: | ---: |
-| Automated AI trading vault | `0x87fdbcf7c8fc949e2ddb4f1a50337ee75dc8233a` | 10 | 6 | 4 | 35.5x |
-| PUMP TRADE | `0xafc7b17e3d7b564fcbd1b5220455f16a66857ef0` | 29 | 23 | 6 | 22.8x |
-| C.A.T | `0xdfb729b4b789de6d13d6ad7ac8e2750909360af9` | 14 | 14 | 0 | 19.0x |
-| TA trader | `0x6fe9749eab7f66f002d7541d6c1e3bb3df19c701` | 22 | 17 | 5 | 10.2x |
-| MC Recovery Fund | `0x914434e8a235cb608a94a5f70ab8c40927152a24` | 8 | 8 | 0 | 6.3x |
-| $100K Target | `0xe528531fc82ab104397fe06c550f0bb00720e0ab` | 14 | 6 | 8 | 4.9x |
-
-For any future scan, obtain the complete inventory by filtering cleaned
-Hypercore rows for non-empty `hypercore_repair_status`, then grouping by
-`address` and status. Filtering for `share_price != raw_share_price` returns
-only the applied subset and would omit deliberately deferred candidates.
-
-## HODL my perps
-
-- Address: `0x13b43faa22d854bf43b4e7581c1b3dfcd416f8c3`
-- Trading Strategy page:
-  [HODL My Perps](https://tradingstrategy.ai/trading-view/vaults/hodl-my-perps)
-- Lifecycle boundary: 15 October 2025 to 17 April 2026
-
-HODL My Perps is not a daily/HF overlap problem. Its all-time API history
-shows a real wipe-out on 15 October 2025: NAV became zero and cumulative PnL
-was `-$326,631.13`. NAV remained zero until recapitalisation began on 17 April
-2026.
-
-The post-recapitalisation synthetic share price is not economically continuous
-with the pre-wipe-out shares. It begins near `6.55e-7` for a roughly `$100`
-deposit and later contains non-economic HF jumps, including a roughly 54.7x
-move on 21 May while NAV was near `$31,700`. These values arise because the
-available rolling PnL history begins after a large historical loss, so the
-scanner cannot know the original share base.
-
-Do **not** repair HODL by interpolation: that would hide the real complete
-loss. The wrangle pipeline applies a separate recapitalisation policy:
-
-1. Detect a prior NAV of at least `$1,000`, zero NAV, and no later positive NAV
-   for at least seven days.
-2. After that durable recovery, wait until NAV again reaches `$1,000`, discard
-   all preceding rows from the **cleaned** data, and mark the first retained
-   row `epoch_reset`.
-3. Preserve the raw parquet for audit and historical analysis.
-
-This scopes the cleaned chart and metrics to the current capital epoch and
-normalises its first retained price to `1.0`. The subsequent HF-batch stitch
-repairs short-gap arbitrary-unit jumps only when the cumulative-PnL change
-contradicts the observed price return; genuine PnL-supported moves remain.
-The preceding -100% outcome remains available in raw data, but it is not
-chain-linked into a fictitious return on recapitalised capital.
-
-At the 13 July 2026 live API check, the vault held a long position of `830.3`
-HYPE, entered at `64.8714`, with unrealised PnL of about `-$945.21` and a
-liquidation price of `61.4724294668`.
-
-## Durable zero-NAV and recapitalisation episodes
-
-The raw Hypercore history contains many isolated zero-NAV observations caused
-by scanner or rolling-window artefacts. They must not automatically become
-performance epochs. The exploratory census used NAV above `$10`, followed by
-NAV at or below `$0.000001`, then later NAV above `$10`, with at least one day
-before recovery. The implemented automatic rule is deliberately stricter: the
-old and new tracked epochs must reach `$1,000`, and the zero period must last
-at least seven days before *any* positive NAV reappears.
-
-There are four such episodes across 569 tracked Hypercore vaults. All four
-also satisfy a seven-day recovery-delay threshold; HODL My Perps and Rehobot
-LR exceed thirty days.
-
-| Vault | Address | Zero interval | New tracked epoch | Rows discarded |
-| --- | --- | --- | --- | ---: |
-| Rehobot LR | `0x81a20870c5c7558f117166b2a598abaa8ce91f50` | 15 Oct 2025 – 15 Apr 2026 | 22 Apr 2026, about `$1,012` | 44 |
-| HODL My Perps | `0x13b43faa22d854bf43b4e7581c1b3dfcd416f8c3` | 15 Oct 2025 – 17 Apr 2026 | 20 Apr 2026, about `$7,859` | 161 |
-| Sifu | `0xf967239debef10dbc78e9bbbb2d8a16b72a614eb` | 17 Apr 2024 – 1 May 2024 | 15 May 2024, about `$987,001` | 25 |
-| HLP Liquidator | `0x2e3d94f0562703b25c83308a05046ddaf9a8dd14` | 12 Nov 2025 | 19 Nov 2025, about `$1.00M` | 139 |
-
-HODL first regained positive NAV on 17 April with about `$100`; it crossed the
-tracking threshold on 20 April. Measuring the seven-day delay to 20 April
-would be wrong: for example, `$2,000 -> $0 -> $900 next day -> $1,000 after
-seven days` is a prompt recovery, not a seven-day wipe-out. The code therefore
-tests durability at the first positive value and applies the `$1,000` threshold
-only when choosing where the new chart epoch starts.
-
-The naive rule "any zero followed by a positive value" finds 325 episodes
-across 322 vaults. Of those, 319 vaults recover within roughly one hour and
-are excluded as transient data artefacts. The duration/recovery threshold is
-therefore mandatory for the automated `epoch_reset` policy.
-
-## Validation and operational status
-
-The source-aware repair was run read-only against the production raw parquet
-snapshot containing 848,333 Hypercore rows:
-
-| Repair path | Candidates | Repaired | Deferred | Candidate vaults |
-| --- | ---: | ---: | ---: | ---: |
-| Daily rows compared with HF anchors | 759 | 612 | 147 | 143 |
-| Stale daily rows compared with refreshed daily anchors | 292 | 135 | 157 | 38 |
-| Total | 1,051 | 747 | 304 | 181 |
-
-No production parquet was modified during this validation. Focused tests cover
-HF-source provenance, legacy provenance inference, daily-only repair,
-unbracketed rows, NAV/gap/lifecycle deferrals, recapitalisation epoch filtering,
-and the distinction between first positive NAV and the later `$1,000` tracking
-threshold. A read-only production run removes 369 pre-recapitalisation rows
-across HODL My Perps, Rehobot LR, Sifu, and HLP Liquidator.
-
-The 14 July 2026 production HODL subset was also run through the new paths
-without writing parquet. It discards 161 pre-epoch rows, starts the retained
-epoch at `1.0`, and stitches three May HF batch boundaries. Its largest
-remaining one-step return is 7.68%, rather than the earlier non-economic 54.7x
-unit jump.
-
-See also `scripts/hyperliquid/README-hyperliquid-vaults.md`, in particular
-the *Healing share price data* section, for the scanner-level healing process.
+Historical repair requires no DuckDB or raw-Parquet rewrite. Regenerating
+`cleaned-vault-prices-1h.parquet` from the unchanged raw Parquet applies the
+same deterministic rule to old and future observations. The manual ledger-flow
+backfill remains useful for raw accounting diagnosis but is no longer required
+to obtain a cleaned share price.

--- a/eth_defi/hyperliquid/problem-vaults.md
+++ b/eth_defi/hyperliquid/problem-vaults.md
@@ -54,7 +54,8 @@ presented as Hyperliquid's exact share price.
 - `approximated_pnl_nav`: ordinary daily economic checkpoint;
 - `approximated_pnl_nav_clipped`: positive checkpoint capped at 100%;
 - `approximated_pnl_nav_wipe_out`: terminal NAV-corroborated complete loss;
-- `approximated_pnl_nav_carried`: non-checkpoint daily/HF duplicate;
+- `approximated_pnl_nav_carried`: a non-checkpoint duplicate or a row after a
+  terminal loss that adds no further performance;
 - `deferred_pnl_nav`: checkpoint inputs were unavailable; and
 - `deferred_pnl_nav_outlier`: an uncorroborated absorbing loss was carried.
 
@@ -85,9 +86,10 @@ retained history; the one-period returns demonstrate the repaired economics.
 | HyperBotPro | `0x12e358f38741c07c1e04a8102a3170d40a600f05` | 18 March 2026 | `+285.0%` synthetic move around a withdrawal | `+12.72%` from PnL/NAV |
 | Titan Vault | `0x4b0eab9444a75a03f1ef340c8beac737afa5ab09` | 7 April 2026 | `+82.9%` and `deferred_hf_nav` | `+27.94%` from the freshest daily checkpoint |
 
-These replacements do not assert that every retained PnL observation is exact.
-They remove the known mechanism by which share units and flows became
-performance and expose clipping or deferral explicitly for later inspection.
+These replacements do not assert that every retained PnL observation is exact
+or that every Hypercore curve is suitable for unfiltered backtesting. They
+remove the known mechanism by which share units and flows became performance
+and expose clipping or deferral explicitly for later inspection.
 
 ## HODL My Perps and recapitalisation
 
@@ -127,14 +129,23 @@ After removing 369 superseded recapitalisation rows, the economic-index run
 produces:
 
 - 85,891 daily PnL/NAV checkpoints;
-- 788,618 carried daily/HF duplicate rows;
+- 788,652 carried non-performance rows, including duplicate daily/HF rows and
+  rows after a terminal wipe-out;
 - 57 uncorroborated absorbing losses carried for review;
-- 9 positive returns capped at 100%; and
-- 2 terminal NAV-corroborated wipe-outs.
+- 7 positive returns capped at 100%; and
+- 1 terminal NAV-corroborated wipe-out. Later rows in that epoch remain at zero
+  and are carried rather than recording repeated losses or gains.
 
-All resulting one-step clean returns are between -100% and +100%. There are no
+All finite one-step clean returns are between -100% and +100%. There are no
 `deferred_hf_*` raw prices in the published clean curve because the index is
 applied to every Hypercore vault rather than only suspicious candidates.
+
+This is structural cleaning, not proof that every source PnL change is genuine.
+The same retained production data still contains 225 funded, unmasked daily
+checkpoints over 50% across 100 vaults and 18 rapid opposite-direction moves
+over 50% across 14 vaults. These observations follow the documented PnL/NAV
+approximation and are internally consistent, but they need explicit quality
+filtering or review before return-based backtesting.
 
 Historical repair requires no DuckDB or raw-Parquet rewrite. Regenerating
 `cleaned-vault-prices-1h.parquet` from the unchanged raw Parquet applies the

--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -330,7 +330,9 @@ class CleanedVaultPriceRow(TypedDict, total=False):
     #: ``approximated_pnl_nav`` marks a daily economic checkpoint,
     #: ``approximated_pnl_nav_clipped`` a positive checkpoint capped at 100%,
     #: ``approximated_pnl_nav_wipe_out`` a terminal NAV-corroborated loss, and
-    #: ``approximated_pnl_nav_carried`` an ordinary non-checkpoint row.
+    #: ``approximated_pnl_nav_carried`` a row that adds no performance, either
+    #: because it is not the daily checkpoint or because the epoch is already
+    #: at zero after a terminal loss.
     #: ``deferred_pnl_nav`` means inputs were missing and
     #: ``deferred_pnl_nav_outlier`` means an uncorroborated negative PnL step
     #: was not allowed to zero a funded vault.
@@ -579,11 +581,17 @@ def filter_vaults_by_stablecoin(
     return prices_df
 
 
-def calculate_vault_returns(prices_df: pd.DataFrame, logger=print):
+def calculate_vault_returns(
+    prices_df: pd.DataFrame,
+    logger: Callable[[str], None] = print,
+) -> pd.DataFrame:
     """Calculate returns for each vault.
 
-    - Filter out reads for which we did not get a proper share price
-    - Add ``returns_1h`` columns
+    Filter out reads without a share price and add the compatibility
+    ``returns_1h`` column. Consecutive zero prices after a complete loss carry
+    a zero return: the loss was already recorded by the first transition to
+    zero, and leaving later ``0 / 0`` changes as NaN makes the terminal curve
+    unnecessarily difficult for downstream consumers to use.
 
     Example of input data:
 
@@ -592,6 +600,13 @@ def calculate_vault_returns(prices_df: pd.DataFrame, logger=print):
              chain                                     address  block_number           timestamp  share_price  ...  errors                                                id  name  event_count            protocol
         207  42161  0x487cdc7d21ac8765eff6c0e681aea36ae1594471      13294721 2022-05-30 19:59:22          1.0  ...          42161-0x487cdc7d21ac8765eff6c0e681aea36ae1594471  LDAI           17  <unknown ERC-4626>
 
+    :param prices_df:
+        Price rows containing string ``id`` and numeric ``share_price``
+        columns, ordered by vault and timestamp.
+    :param logger:
+        Notebook, console, or structured-log adapter accepting one message.
+    :return:
+        Price rows with ``returns_1h`` calculated between consecutive rows.
     """
     assert isinstance(prices_df, pd.DataFrame), "prices_df must be a pandas DataFrame"
 
@@ -609,7 +624,10 @@ def calculate_vault_returns(prices_df: pd.DataFrame, logger=print):
     # spaced at daily or irregular intervals — producing ~24h or
     # variable-interval returns labelled "1h".  Renaming would break
     # every downstream consumer so the name is kept for compatibility.
+    previous_share_price = prices_df.groupby("id")["share_price"].shift(1)
     prices_df["returns_1h"] = prices_df.groupby("id")["share_price"].pct_change()
+    repeated_zero_price = (prices_df["share_price"] == 0) & (previous_share_price == 0)
+    prices_df.loc[repeated_zero_price, "returns_1h"] = 0.0
     return prices_df
 
 
@@ -637,7 +655,7 @@ def clean_returns(
     """
 
     # Kept for API compatibility with notebook and script callers.
-    del display
+    del rows, display
 
     returns_df = prices_df
 
@@ -707,6 +725,9 @@ def clean_by_tvl(
         cleaning applied.
     """
 
+    # Kept for API compatibility with notebook and script callers.
+    del rows
+
     returns_df = prices_df
 
     # TVL based cleaning.
@@ -737,7 +758,7 @@ def clean_by_tvl(
     # so that we zero the returns of the following day
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", FutureWarning)
-        mask = mask | mask.groupby(returns_df["id"]).shift(1).fillna(False)
+        mask |= mask.groupby(returns_df["id"]).shift(1).fillna(False)
 
     # Hypercore returns are already bounded and audited by the PnL/NAV index.
     # Keep its price-derived return internally consistent, while retaining the
@@ -972,7 +993,7 @@ def approximate_hypercore_share_prices_from_pnl_nav(  # noqa: PLR0914
     logger: Callable[[str], None] = print,
     max_positive_return: Percent = 1.0,
 ) -> pd.DataFrame:
-    """Build an actionable Hypercore economic-performance index from PnL and NAV.
+    """Build an approximate Hypercore economic-performance index from PnL and NAV.
 
     Hyperliquid does not expose historical vault share supply or an investable
     unit price through its
@@ -1138,12 +1159,26 @@ def approximate_hypercore_share_prices_from_pnl_nav(  # noqa: PLR0914
             deferred_absorbing_loss = funded_absorbing_loss & ~corroborated_wipe_out
             applied_returns[deferred_absorbing_loss] = 0.0
             applied_returns[corroborated_wipe_out] = -1.0
+
+            # A complete loss is absorbing within one capital epoch. Later API
+            # baseline changes cannot create performance or another wipe-out
+            # after the clean index has reached zero.
+            wipe_out_numbers = np.flatnonzero(corroborated_wipe_out)
+            post_wipe_out = np.zeros(len(checkpoints), dtype=bool)
+            if len(wipe_out_numbers):
+                post_wipe_out[int(wipe_out_numbers[0]) + 1 :] = True
+                applied_returns[post_wipe_out] = 0.0
+                positive_clipped[post_wipe_out] = False
+                deferred_absorbing_loss[post_wipe_out] = False
+                corroborated_wipe_out[post_wipe_out] = False
+
             checkpoint_prices = np.cumprod(1.0 + applied_returns)
 
             checkpoint_status = np.full(len(checkpoints), "approximated_pnl_nav", dtype=object)
             checkpoint_status[positive_clipped] = "approximated_pnl_nav_clipped"
             checkpoint_status[deferred_absorbing_loss] = "deferred_pnl_nav_outlier"
             checkpoint_status[corroborated_wipe_out] = "approximated_pnl_nav_wipe_out"
+            checkpoint_status[post_wipe_out] = "approximated_pnl_nav_carried"
             repair_status[checkpoints] = checkpoint_status
 
             checkpoint_lookup = np.searchsorted(checkpoints, epoch_positions, side="right") - 1
@@ -1153,7 +1188,7 @@ def approximate_hypercore_share_prices_from_pnl_nav(  # noqa: PLR0914
             clean_price[epoch_positions] = epoch_prices
 
             checkpoint_count += len(checkpoints)
-            carried_count += int(day_has_checkpoint.sum()) - len(checkpoints)
+            carried_count += int(day_has_checkpoint.sum()) - len(checkpoints) + int(post_wipe_out.sum())
             clipped_count += int(positive_clipped.sum())
             deferred_outlier_count += int(deferred_absorbing_loss.sum())
             wipe_out_count += int(corroborated_wipe_out.sum())
@@ -1174,7 +1209,7 @@ def approximate_hypercore_share_prices_from_pnl_nav(  # noqa: PLR0914
     if synthetic_supplies is not None:
         prices_df["total_supply"] = synthetic_supplies
 
-    logger(f"Approximated Hypercore economic share prices for {affected_vaults:,} vaults using {checkpoint_count:,} daily PnL/NAV checkpoints; carried {carried_count:,} duplicate rows, deferred {missing_count:,} missing-input rows and {deferred_outlier_count:,} uncorroborated losses, capped {clipped_count:,} gains and recorded {wipe_out_count:,} terminal wipe-outs")
+    logger(f"Approximated Hypercore economic share prices for {affected_vaults:,} vaults using {checkpoint_count:,} daily PnL/NAV checkpoints; carried {carried_count:,} non-performance rows, deferred {missing_count:,} missing-input rows and {deferred_outlier_count:,} uncorroborated losses, capped {clipped_count:,} gains and recorded {wipe_out_count:,} terminal wipe-outs")
     return prices_df
 
 
@@ -1570,7 +1605,7 @@ def process_raw_vault_scan_data(
 
     if diagnose_vault_id:
         vault_prices_df = prices_df[prices_df["id"] == diagnose_vault_id]
-        logger("After remove_inactive_lead_time():")
+        logger("After discard_hypercore_pre_recapitalisation_history():")
         display(vault_prices_df)
 
     # Hyperliquid does not expose an authoritative historical unit price or
@@ -1613,7 +1648,7 @@ def process_raw_vault_scan_data(
 
     if diagnose_vault_id:
         vault_prices_df = prices_df[prices_df["id"] == diagnose_vault_id]
-        print("After clean_returns():")
+        logger("After clean_returns():")
         display(vault_prices_df)
 
     prices_df = clean_by_tvl(

--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -14,7 +14,6 @@ The output is a cleaned DataFrame conforming to
 :py:func:`~eth_defi.research.vault_metrics.calculate_lifetime_metrics`.
 """
 
-import datetime
 import os
 import pickle
 import tempfile
@@ -33,7 +32,6 @@ from IPython.display import display
 from tqdm_loggable.auto import tqdm
 
 from eth_defi.chain import get_chain_name
-from eth_defi.hyperliquid.combined_analysis import rescale_share_price_rows
 from eth_defi.hyperliquid.constants import HYPERCORE_CHAIN_ID
 from eth_defi.token import is_stablecoin_like
 from eth_defi.types import Percent
@@ -44,15 +42,6 @@ from eth_defi.vault.settlement_data import (
 from eth_defi.vault.vaultdb import DEFAULT_RAW_PRICE_DATABASE, DEFAULT_UNCLEANED_PRICE_DATABASE, DEFAULT_VAULT_DATABASE, VaultDatabase, VaultRow
 from eth_defi.version_info import stamp_parquet_schema_metadata
 
-#: At least two canonical observations are needed to bracket a daily price.
-MIN_HYPERCORE_PRICE_ANCHORS = 2
-
-#: Rows emitted by one daily refresh share practically the same write time.
-HYPERCORE_DAILY_REFRESH_TOLERANCE = pd.Timedelta(minutes=1)
-
-#: Do not estimate a price across a missing weekly Hypercore anchor.
-HYPERCORE_MAX_PRICE_ANCHOR_GAP = pd.Timedelta(days=8)
-
 #: NAV at or below this value counts as a complete Hypercore wipe-out.
 HYPERCORE_ZERO_NAV_EPSILON = 0.000001
 
@@ -61,15 +50,6 @@ MIN_HYPERCORE_RECAPITALISATION_ASSETS = 1_000.0
 
 #: Ignore isolated zero-NAV observations that recover before this delay.
 MIN_HYPERCORE_RECAPITALISATION_RECOVERY_DELAY = pd.Timedelta(days=7)
-
-#: Never infer a scanner-batch price unit across a longer missing-HF interval.
-HYPERCORE_MAX_HF_BATCH_STITCH_GAP = pd.Timedelta(days=2)
-
-#: A flow-reconciled PnL path must end close to its next trusted HF observation.
-HYPERCORE_MAX_PNL_PATH_ENDPOINT_DEVIATION: Percent = 0.10
-
-#: Permit cents and small API rounding differences when checking NAV accounting.
-HYPERCORE_PNL_PATH_ACCOUNTING_ABSOLUTE_TOLERANCE = 1.0
 
 
 class CleanedVaultPriceRow(TypedDict, total=False):
@@ -152,11 +132,10 @@ class CleanedVaultPriceRow(TypedDict, total=False):
     #: (``convertToAssets(1e decimals)``).
     #: GRVT, Lighter, and Hibachi provide native share prices from their
     #: respective APIs.
-    #: Hypercore (native Hyperliquid vaults) does not expose a share price;
-    #: it is **internally calculated** as ``total_assets / total_supply``
-    #: from reconstructed equity curves and deposit/withdrawal histories.
-    #: See :py:mod:`eth_defi.hyperliquid.combined_analysis` for the
-    #: Hypercore share price derivation.
+    #: Hypercore (native Hyperliquid vaults) does not expose a historical share
+    #: price or supply. Its cleaned value is a PnL/NAV economic-performance
+    #: index starting at ``1.0`` for each retained capital epoch. The scanner's
+    #: synthetic input remains available in ``raw_share_price``.
     #:
     #: General — present for all protocols.
     share_price: float
@@ -167,6 +146,9 @@ class CleanedVaultPriceRow(TypedDict, total=False):
     total_assets: float
 
     #: Total supply of vault share tokens.
+    #: Hypercore has no exposed historical token supply; its value is synthetic
+    #: index units calculated as ``total_assets / share_price`` and must not be
+    #: interpreted as an on-chain share count.
     #:
     #: General — present for all protocols.
     total_supply: float
@@ -343,11 +325,15 @@ class CleanedVaultPriceRow(TypedDict, total=False):
     #: Hypercore only — false for ordinary observations.
     epoch_reset: bool
 
-    #: Outcome of the conservative Hypercore source-overlap repair.
+    #: Provenance of the cleaned Hypercore PnL/NAV approximation.
     #:
-    #: Values start with ``"repaired_"`` when the cleaned share price was
-    #: changed and ``"deferred_"`` when a candidate was left unchanged because
-    #: it failed the NAV, anchor-gap, or lifecycle-boundary safeguards.
+    #: ``approximated_pnl_nav`` marks a daily economic checkpoint,
+    #: ``approximated_pnl_nav_clipped`` a positive checkpoint capped at 100%,
+    #: ``approximated_pnl_nav_wipe_out`` a terminal NAV-corroborated loss, and
+    #: ``approximated_pnl_nav_carried`` an ordinary non-checkpoint row.
+    #: ``deferred_pnl_nav`` means inputs were missing and
+    #: ``deferred_pnl_nav_outlier`` means an uncorroborated negative PnL step
+    #: was not allowed to zero a funded vault.
     #: Hypercore only — empty for ordinary observations and other protocols.
     hypercore_repair_status: str
 
@@ -694,6 +680,32 @@ def clean_by_tvl(
 
     - Clean returns from TVL-manipulation outliers
     - See https://x.com/moo9000/status/1914746350216077544 for manipulation example
+
+    Hypercore keeps its PnL/NAV price-derived return because rewriting the
+    return alone would make profit disagree with the cleaned share price. Its
+    low-TVL observations still receive ``tvl_filtering_mask=True`` so
+    investment-suitability consumers can exclude them. Other protocols retain
+    the existing zero-return behaviour.
+
+    :param rows:
+        Vault metadata keyed by address. Retained for compatibility with the
+        existing cleaner interface.
+    :param prices_df:
+        Timestamp-indexed price rows containing ``id``, ``chain``,
+        ``total_assets``, and the selected return column.
+    :param logger:
+        Notebook, console, or structured-log adapter accepting one message.
+    :param tvl_threshold_min:
+        Absolute minimum NAV in USD.
+    :param tvl_threshold_max:
+        Absolute maximum NAV in USD.
+    :param tvl_threshold_min_dynamic:
+        Minimum NAV as a fraction of the vault's all-time average NAV.
+    :param returns_col:
+        Name of the return column to clean.
+    :return:
+        The input frame with TVL audit columns and protocol-appropriate return
+        cleaning applied.
     """
 
     returns_df = prices_df
@@ -728,8 +740,15 @@ def clean_by_tvl(
         warnings.simplefilter("ignore", FutureWarning)
         mask = mask | mask.groupby(returns_df["id"]).shift(1).fillna(False)
 
-    # Set daily_returns to zero where the mask is True
-    returns_df.loc[mask, returns_col] = 0
+    # Hypercore returns are already bounded and audited by the PnL/NAV index.
+    # Keep its price-derived return internally consistent, while retaining the
+    # TVL mask so investment-suitability consumers can exclude low-capital rows.
+    return_cleaning_mask = mask
+    if "chain" in returns_df.columns:
+        return_cleaning_mask = mask & (returns_df["chain"] != HYPERCORE_CHAIN_ID)
+
+    # Set generic protocol returns to zero where the mask is true.
+    returns_df.loc[return_cleaning_mask, returns_col] = 0
     returns_df["tvl_filtering_mask"] = mask
 
     return returns_df
@@ -772,9 +791,6 @@ def filter_unneeded_row(
 
         if len(group) <= 1:
             return group  # Keep groups with only one row
-
-        # chain-address id for debug
-        id = group.iloc[0]["id"]
 
         keep_mask = pd.Series(True, index=group.index)
         i = 0
@@ -952,47 +968,218 @@ def remove_inactive_lead_time(
     return filtered_df
 
 
-def cap_hypercore_share_prices(
+def approximate_hypercore_share_prices_from_pnl_nav(  # noqa: PLR0914
     prices_df: pd.DataFrame,
-    logger=print,
-    max_share_price: float = 1_000_000.0,
+    logger: Callable[[str], None] = print,
+    max_positive_return: Percent = 1.0,
 ) -> pd.DataFrame:
-    """Cap share prices for Hypercore (Hyperliquid native) vaults.
+    """Build an actionable Hypercore economic-performance index from PnL and NAV.
 
-    Hypercore share prices are derived synthetically from portfolio
-    history in :py:func:`~eth_defi.hyperliquid.combined_analysis._calculate_share_price`.
-    When ``total_supply`` approaches zero while ``total_assets`` remains nonzero
-    (e.g. after most depositors withdrew from a leveraged trading vault),
-    share prices can overflow to absurd values (trillions+).
+    Hyperliquid does not expose historical vault share supply or an investable
+    unit price through its
+    `vaultDetails API <https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint#retrieve-information-about-a-vault>`__.
+    Its rolling NAV and PnL windows can refresh at different timestamps, so the
+    scanner-derived ERC-4626-like supply can change units between daily and HF
+    reads. The July 2026 production investigation found that this left raw
+    multi-hundred-percent moves in cleaned data and that a partial daily/HF
+    repair itself created Order Block Hunter's ``+275.4%`` clean return.
+    Ledger flows prove NAV accounting for some intervals, but their
+    intra-period ordering is unavailable and therefore cannot recover exact
+    time-weighted investor returns.
 
-    This step caps those overflow values before the standard
-    :py:func:`fix_outlier_share_prices` smoothing runs.  Only applies
-    to Hypercore vaults (chain == 9999).
+    The cleaned Hypercore price is consequently a conservative performance
+    index. One freshest usable checkpoint is selected per UTC date. Between
+    checkpoints, cumulative account-PnL change is divided by the larger of
+    opening NAV, closing NAV, and one dollar; the resulting returns are
+    compounded from ``1.0`` within each recapitalisation epoch. This denominator
+    prevents unknown capital-flow timing and small NAV from manufacturing
+    performance. Positive returns are capped at ``max_positive_return``. A
+    return at or below ``-100%`` is accepted only when NAV is zero and does not
+    recover in the same epoch; otherwise the price is carried because applying
+    one questionable negative PnL baseline would permanently zero the index.
+    Non-checkpoint rows are also carried, avoiding duplicate daily/HF returns
+    without interpolating future information backwards.
+
+    Input uses a timestamp index and requires ``id`` (string), ``chain``
+    (integer), ``share_price`` (float), ``total_assets`` (float), and cumulative
+    PnL as either exported ``account_pnl`` (float) or scanner-shaped
+    ``cumulative_pnl`` (float). Optional ``written_at`` timestamps select the
+    freshest scanner batch, ``hypercore_source`` strings break otherwise equal
+    ties in favour of HF, and boolean ``epoch_reset`` values separate
+    performance epochs. The output preserves scanner values in
+    ``raw_share_price``, writes audit values to ``hypercore_repair_status``, and
+    recalculates Hypercore ``total_supply`` as synthetic index units so that
+    ``total_assets == share_price * total_supply`` remains true. Hypercore
+    ``total_supply`` is not an actual token supply.
 
     :param prices_df:
-        Price data with ``chain`` and ``share_price`` columns.
+        Timestamp-indexed cleaned-price input containing the columns described
+        above. Rows must already be ordered by vault and timestamp.
     :param logger:
-        Logging function.
-    :param max_share_price:
-        Maximum allowed share price for Hypercore vaults.
+        Notebook, console, or structured-log adapter accepting one message.
+    :param max_positive_return:
+        Maximum approximate return applied at one daily checkpoint. The default
+        is ``1.0`` (100%).
     :return:
-        DataFrame with capped share prices.
+        A copy with every Hypercore row expressed on its PnL/NAV performance
+        index; all non-Hypercore rows are unchanged.
     """
     hypercore_mask = prices_df["chain"] == HYPERCORE_CHAIN_ID
     if not hypercore_mask.any():
         return prices_df
 
-    overflow_mask = hypercore_mask & (prices_df["share_price"] > max_share_price)
-    overflow_count = overflow_mask.sum()
+    if max_positive_return <= 0:
+        raise ValueError(f"max_positive_return must be positive, got {max_positive_return!r}")
 
-    if overflow_count > 0:
-        logger(f"Capping {overflow_count:,} Hypercore share prices above {max_share_price:,.0f}")
-        prices_df.loc[overflow_mask, "share_price"] = max_share_price
+    pnl_column = "account_pnl" if "account_pnl" in prices_df.columns else "cumulative_pnl"
+    required_columns = {"id", "share_price", "total_assets", pnl_column}
+    missing_columns = required_columns.difference(prices_df.columns)
+    if missing_columns:
+        raise ValueError(f"Cannot approximate Hypercore share prices; missing columns: {sorted(missing_columns)}")
 
+    prices_df = prices_df.copy()
+    if "raw_share_price" not in prices_df.columns:
+        prices_df["raw_share_price"] = prices_df["share_price"]
+    if "hypercore_repair_status" not in prices_df.columns:
+        prices_df["hypercore_repair_status"] = ""
+
+    share_price_col = prices_df.columns.get_loc("share_price")
+    hypercore_positions = np.flatnonzero(hypercore_mask.to_numpy())
+    clean_share_prices = prices_df["share_price"].to_numpy(dtype=float, copy=True)
+    repair_statuses = prices_df["hypercore_repair_status"].astype("string").fillna("").to_numpy(dtype=object, copy=True)
+    synthetic_supplies = prices_df["total_supply"].to_numpy(dtype=float, copy=True) if "total_supply" in prices_df.columns else None
+    all_timestamps = pd.DatetimeIndex(prices_df.index)
+    all_nav = prices_df["total_assets"].to_numpy(dtype=float)
+    all_pnl = prices_df[pnl_column].to_numpy(dtype=float)
+    all_source = prices_df["hypercore_source"].astype("string").fillna("").to_numpy(dtype=str) if "hypercore_source" in prices_df.columns else np.full(len(prices_df), "", dtype=str)
+    all_written_at = pd.to_datetime(prices_df["written_at"], errors="coerce").to_numpy(dtype="datetime64[ns]").astype("int64") if "written_at" in prices_df.columns else np.full(len(prices_df), pd.NaT.value, dtype=np.int64)
+    all_epoch_reset = prices_df["epoch_reset"].fillna(False).to_numpy(dtype=bool) if "epoch_reset" in prices_df.columns else np.zeros(len(prices_df), dtype=bool)
+
+    checkpoint_count = 0
+    carried_count = 0
+    missing_count = 0
+    clipped_count = 0
+    deferred_outlier_count = 0
+    wipe_out_count = 0
+    affected_vaults = 0
+
+    for _vault_id, relative_positions in prices_df.loc[hypercore_mask, ["id"]].groupby("id", sort=False).indices.items():
+        positions = hypercore_positions[np.asarray(relative_positions, dtype=int)]
+        timestamps = all_timestamps[positions]
+        timestamp_ns = timestamps.to_numpy(dtype="datetime64[ns]").astype("int64")
+        day_ns = timestamps.normalize().to_numpy(dtype="datetime64[ns]").astype("int64")
+        nav = all_nav[positions]
+        pnl = all_pnl[positions]
+        source = all_source[positions]
+        hf_priority = source == "hf"
+        written_at = all_written_at[positions]
+        epoch_reset = all_epoch_reset[positions]
+        epoch_number = np.cumsum(epoch_reset)
+
+        clean_price = np.full(len(positions), np.nan, dtype=float)
+        repair_status = np.full(len(positions), "", dtype=object)
+
+        for epoch in np.unique(epoch_number):
+            epoch_positions = np.flatnonzero(epoch_number == epoch)
+            epoch_days = day_ns[epoch_positions]
+            usable = np.isfinite(nav[epoch_positions]) & np.isfinite(pnl[epoch_positions])
+            usable_positions = epoch_positions[usable]
+
+            if len(usable_positions):
+                checkpoint_order = np.lexsort(
+                    (
+                        hf_priority[usable_positions].astype(np.int8),
+                        timestamp_ns[usable_positions],
+                        written_at[usable_positions],
+                        day_ns[usable_positions],
+                    )
+                )
+                ordered_positions = usable_positions[checkpoint_order]
+                ordered_days = day_ns[ordered_positions]
+                latest_per_day = np.r_[ordered_days[1:] != ordered_days[:-1], True]
+                checkpoints = ordered_positions[latest_per_day]
+            else:
+                checkpoints = np.asarray([], dtype=int)
+            checkpoint_days = day_ns[checkpoints] if len(checkpoints) else np.asarray([], dtype=np.int64)
+            day_has_checkpoint = np.isin(epoch_days, checkpoint_days)
+            repair_status[epoch_positions[day_has_checkpoint]] = "approximated_pnl_nav_carried"
+            repair_status[epoch_positions[~day_has_checkpoint]] = "deferred_pnl_nav"
+            missing_count += int((~day_has_checkpoint).sum())
+
+            if len(checkpoints) == 0:
+                clean_price[epoch_positions] = 1.0
+                continue
+
+            checkpoint_nav = nav[checkpoints]
+            checkpoint_pnl = pnl[checkpoints]
+            raw_returns = np.zeros(len(checkpoints), dtype=float)
+            if len(checkpoints) > 1:
+                capital_base = np.maximum.reduce(
+                    [
+                        checkpoint_nav[:-1],
+                        checkpoint_nav[1:],
+                        np.ones(len(checkpoints) - 1, dtype=float),
+                    ]
+                )
+                raw_returns[1:] = np.diff(checkpoint_pnl) / capital_base
+
+            applied_returns = raw_returns.copy()
+            positive_clipped = raw_returns > max_positive_return
+            applied_returns[positive_clipped] = max_positive_return
+
+            funded_absorbing_loss = raw_returns <= -1.0
+            corroborated_wipe_out = np.zeros(len(checkpoints), dtype=bool)
+            positive_nav = np.isfinite(nav[epoch_positions]) & (nav[epoch_positions] > HYPERCORE_ZERO_NAV_EPSILON)
+            later_positive_nav = np.r_[np.maximum.accumulate(positive_nav[::-1])[::-1][1:], False]
+            for checkpoint_number in np.flatnonzero(funded_absorbing_loss):
+                checkpoint_position = checkpoints[checkpoint_number]
+                epoch_position = int(np.searchsorted(epoch_positions, checkpoint_position))
+                corroborated_wipe_out[checkpoint_number] = checkpoint_nav[checkpoint_number] <= HYPERCORE_ZERO_NAV_EPSILON and not later_positive_nav[epoch_position]
+
+            deferred_absorbing_loss = funded_absorbing_loss & ~corroborated_wipe_out
+            applied_returns[deferred_absorbing_loss] = 0.0
+            applied_returns[corroborated_wipe_out] = -1.0
+            checkpoint_prices = np.cumprod(1.0 + applied_returns)
+
+            checkpoint_status = np.full(len(checkpoints), "approximated_pnl_nav", dtype=object)
+            checkpoint_status[positive_clipped] = "approximated_pnl_nav_clipped"
+            checkpoint_status[deferred_absorbing_loss] = "deferred_pnl_nav_outlier"
+            checkpoint_status[corroborated_wipe_out] = "approximated_pnl_nav_wipe_out"
+            repair_status[checkpoints] = checkpoint_status
+
+            checkpoint_lookup = np.searchsorted(checkpoints, epoch_positions, side="right") - 1
+            has_previous_checkpoint = checkpoint_lookup >= 0
+            epoch_prices = np.ones(len(epoch_positions), dtype=float)
+            epoch_prices[has_previous_checkpoint] = checkpoint_prices[checkpoint_lookup[has_previous_checkpoint]]
+            clean_price[epoch_positions] = epoch_prices
+
+            checkpoint_count += len(checkpoints)
+            carried_count += int(day_has_checkpoint.sum()) - len(checkpoints)
+            clipped_count += int(positive_clipped.sum())
+            deferred_outlier_count += int(deferred_absorbing_loss.sum())
+            wipe_out_count += int(corroborated_wipe_out.sum())
+
+        clean_share_prices[positions] = clean_price
+        repair_statuses[positions] = repair_status
+        if synthetic_supplies is not None:
+            valid_supply = np.isfinite(nav) & np.isfinite(clean_price) & (clean_price > 0)
+            synthetic_supply = synthetic_supplies[positions].copy()
+            synthetic_supply[valid_supply] = nav[valid_supply] / clean_price[valid_supply]
+            zero_supply = np.isfinite(nav) & (nav <= HYPERCORE_ZERO_NAV_EPSILON) & (clean_price == 0)
+            synthetic_supply[zero_supply] = 0.0
+            synthetic_supplies[positions] = synthetic_supply
+        affected_vaults += 1
+
+    prices_df.iloc[:, share_price_col] = clean_share_prices
+    prices_df["hypercore_repair_status"] = repair_statuses
+    if synthetic_supplies is not None:
+        prices_df["total_supply"] = synthetic_supplies
+
+    logger(f"Approximated Hypercore economic share prices for {affected_vaults:,} vaults using {checkpoint_count:,} daily PnL/NAV checkpoints; carried {carried_count:,} duplicate rows, deferred {missing_count:,} missing-input rows and {deferred_outlier_count:,} uncorroborated losses, capped {clipped_count:,} gains and recorded {wipe_out_count:,} terminal wipe-outs")
     return prices_df
 
 
-def discard_hypercore_pre_recapitalisation_history(
+def discard_hypercore_pre_recapitalisation_history(  # noqa: PLR0914
     prices_df: pd.DataFrame,
     logger=print,
     min_recapitalisation_assets: float = MIN_HYPERCORE_RECAPITALISATION_ASSETS,
@@ -1016,6 +1203,12 @@ def discard_hypercore_pre_recapitalisation_history(
     later. Once a durable recovery is established, the first retained
     observation must have at least ``min_recapitalisation_assets`` in NAV and
     is marked ``epoch_reset``.
+
+    Raw scanner ``epoch_reset`` values are cleared before applying this rule.
+    They mark arbitrary resets of the reconstructed synthetic supply, including
+    funded vaults, and are not evidence of an economic wipe-out. Only the
+    duration/NAV-qualified marker produced here may split the cleaned
+    performance index.
 
     The July 2026 production snapshot contained four qualifying episodes across
     569 Hypercore vaults. HODL My Perps, HLP Liquidator, Rehobot LR, and Sifu all
@@ -1042,19 +1235,26 @@ def discard_hypercore_pre_recapitalisation_history(
 
     prices_df = prices_df.copy()
     if "epoch_reset" not in prices_df.columns:
-        prices_df["epoch_reset"] = False
+        epoch_reset_values = np.zeros(len(prices_df), dtype=bool)
+    else:
+        # Scanner epoch resets only describe a reconstructed synthetic-supply
+        # boundary. They are not evidence of a durable economic wipe-out.
+        # Rebuild this marker exclusively from the duration/NAV rule below.
+        epoch_reset_values = prices_df["epoch_reset"].fillna(False).to_numpy(dtype=bool, copy=True)
+        epoch_reset_values[hypercore_mask.to_numpy()] = False
     if "raw_share_price" not in prices_df.columns:
         prices_df["raw_share_price"] = prices_df["share_price"]
 
     remove_mask = np.zeros(len(prices_df), dtype=bool)
     epoch_reset_positions: list[int] = []
     hypercore_positions = np.flatnonzero(hypercore_mask.to_numpy())
+    all_total_assets = prices_df["total_assets"].to_numpy(dtype=float)
+    all_timestamps = pd.DatetimeIndex(prices_df.index)
 
-    for _vault_id, row_positions in prices_df.loc[hypercore_mask].groupby("id", sort=False).indices.items():
+    for _vault_id, row_positions in prices_df.loc[hypercore_mask, ["id"]].groupby("id", sort=False).indices.items():
         positions = hypercore_positions[np.asarray(row_positions, dtype=int)]
-        group = prices_df.iloc[positions]
-        total_assets = group["total_assets"].to_numpy(dtype=float)
-        timestamp = pd.DatetimeIndex(group.index)
+        total_assets = all_total_assets[positions]
+        timestamp = all_timestamps[positions]
 
         meaningful_assets = np.isfinite(total_assets) & (total_assets >= min_recapitalisation_assets)
         zero_assets = np.isfinite(total_assets) & (total_assets <= HYPERCORE_ZERO_NAV_EPSILON)
@@ -1091,640 +1291,34 @@ def discard_hypercore_pre_recapitalisation_history(
             epoch_reset_positions.append(int(positions[recapitalisation_position]))
 
     if not epoch_reset_positions:
+        prices_df["epoch_reset"] = epoch_reset_values
         return prices_df
 
-    epoch_reset_col = prices_df.columns.get_loc("epoch_reset")
-    prices_df.iloc[epoch_reset_positions, epoch_reset_col] = True
+    epoch_reset_values[epoch_reset_positions] = True
 
     # A new investor epoch must start from a readable unit price. Preserve the
     # scanner value in raw_share_price, then rescale this vault's retained rows
     # so the first meaningful recapitalisation observation is exactly 1.0.
+    share_prices = prices_df["share_price"].to_numpy(dtype=float, copy=True)
+    total_supplies = prices_df["total_supply"].to_numpy(dtype=float, copy=True) if "total_supply" in prices_df.columns else None
     for epoch_reset_position in epoch_reset_positions:
         vault_id = prices_df.iloc[epoch_reset_position]["id"]
         vault_positions = np.flatnonzero((prices_df["id"] == vault_id).to_numpy())
         retained_positions = vault_positions[vault_positions >= epoch_reset_position]
-        recapitalisation_price = float(prices_df.iloc[epoch_reset_position]["share_price"])
+        recapitalisation_price = share_prices[epoch_reset_position]
         if np.isfinite(recapitalisation_price) and recapitalisation_price > 0:
-            rescale_share_price_rows(prices_df, 1.0 / recapitalisation_price, retained_positions)
+            factor = 1.0 / recapitalisation_price
+            share_prices[retained_positions] *= factor
+            if total_supplies is not None:
+                total_supplies[retained_positions] /= factor
 
+    prices_df["epoch_reset"] = epoch_reset_values
+    prices_df["share_price"] = share_prices
+    if total_supplies is not None:
+        prices_df["total_supply"] = total_supplies
     filtered_prices_df = prices_df.iloc[~remove_mask].copy()
     logger(f"Discarded {int(remove_mask.sum()):,} pre-recapitalisation Hypercore price rows across {len(epoch_reset_positions):,} vaults; new epochs start once NAV reaches ${min_recapitalisation_assets:,.0f} after {min_recovery_delay}")
     return filtered_prices_df
-
-
-def stitch_hypercore_high_freq_share_price_batches(
-    prices_df: pd.DataFrame,
-    logger=print,
-    max_timestamp_gap: pd.Timedelta = HYPERCORE_MAX_HF_BATCH_STITCH_GAP,
-    max_return_deviation: Percent = 0.50,
-) -> pd.DataFrame:
-    """Stitch incompatible Hypercore high-frequency scanner batches.
-
-    The API supplies rolling account-value and cumulative-PnL windows, rather
-    than a share price or supply. A new scan batch can therefore reconstruct
-    the same vault in a different arbitrary unit. At a ``written_at`` batch
-    boundary, the economically expected price change is
-    ``(pnl_now - pnl_before) / nav_before``. When the observed share-price
-    return differs by more than ``max_return_deviation``, rescale the boundary
-    and all later rows. This retains legitimate large trading gains when PnL
-    supports them, while repairing the unit changes seen in HODL My Perps.
-
-    The narrow two-day and consecutive-HF requirements deliberately avoid
-    inferring a price across sparse allTime history, lifecycle resets, or
-    ordinary daily observations. More elaborate capital-flow reconstruction is
-    not justified by the information Hyperliquid currently exposes.
-
-    :param prices_df:
-        Timestamp-indexed vault prices with ``id``, ``chain``,
-        ``share_price``, ``total_assets``, and ``written_at`` columns. The
-        cumulative PnL column is named ``account_pnl`` in exported parquet and
-        ``cumulative_pnl`` in scanner-shaped DataFrames. ``hypercore_source``
-        is used when available; legacy sources are inferred from midnight
-        timestamps.
-    :param logger:
-        Notebook or console logging function.
-    :param max_timestamp_gap:
-        Largest permitted gap between consecutive HF observations.
-    :param max_return_deviation:
-        Symmetric deviation threshold used to distinguish a scale change from
-        an economically supported price movement.
-    :return:
-        A copy with repaired price units and audit columns populated.
-    """
-    hypercore_mask = prices_df["chain"] == HYPERCORE_CHAIN_ID
-    pnl_column = "cumulative_pnl" if "cumulative_pnl" in prices_df.columns else "account_pnl"
-    required_columns = {"total_assets", pnl_column, "written_at"}
-    if not hypercore_mask.any() or not required_columns.issubset(prices_df.columns):
-        return prices_df
-
-    prices_df = prices_df.copy()
-    if "raw_share_price" not in prices_df.columns:
-        prices_df["raw_share_price"] = prices_df["share_price"]
-    if "hypercore_repair_status" not in prices_df.columns:
-        prices_df["hypercore_repair_status"] = ""
-    if "hypercore_source" not in prices_df.columns:
-        prices_df["hypercore_source"] = pd.NA
-
-    missing_source_mask = hypercore_mask & prices_df["hypercore_source"].isna()
-    if missing_source_mask.any():
-        timestamps = pd.DatetimeIndex(prices_df.index[missing_source_mask])
-        prices_df.loc[missing_source_mask, "hypercore_source"] = np.where(timestamps == timestamps.normalize(), "daily", "hf")
-
-    repair_count = 0
-    hypercore_positions = np.flatnonzero(hypercore_mask.to_numpy())
-    status_column = prices_df.columns.get_loc("hypercore_repair_status")
-    for vault_id, row_positions in prices_df.loc[hypercore_mask].groupby("id", sort=False).indices.items():
-        positions = hypercore_positions[np.asarray(row_positions, dtype=int)]
-        group = prices_df.iloc[positions]
-        hf_source_mask = group["hypercore_source"].astype("string").fillna("").to_numpy(dtype=str) == "hf"
-        hf_positions = np.flatnonzero(hf_source_mask)
-        if len(hf_positions) < 2:
-            continue
-
-        hf_written_at = pd.to_datetime(
-            group["written_at"].iloc[hf_positions],
-            errors="coerce",
-        ).to_numpy(dtype="datetime64[ns]")
-        hf_timestamp_ns = (
-            pd.DatetimeIndex(group.index[hf_positions])
-            .to_numpy(
-                dtype="datetime64[ns]",
-            )
-            .astype("int64")
-        )
-        timestamp_gaps = np.diff(hf_timestamp_ns)
-        batch_boundary_mask = np.zeros(len(hf_positions), dtype=bool)
-        has_written_at = ~pd.isna(hf_written_at[:-1]) & ~pd.isna(hf_written_at[1:])
-        changed_batch = hf_written_at[1:] != hf_written_at[:-1]
-        short_forward_gap = (timestamp_gaps > 0) & (timestamp_gaps <= max_timestamp_gap.value)
-        batch_boundary_mask[1:] = has_written_at & changed_batch & short_forward_gap
-        for boundary_position in np.flatnonzero(batch_boundary_mask):
-            previous_position = int(hf_positions[boundary_position - 1])
-            current_position = int(hf_positions[boundary_position])
-            previous_row = prices_df.iloc[positions[previous_position]]
-            current_row = prices_df.iloc[positions[current_position]]
-            previous_epoch_reset = previous_row.get("epoch_reset", False)
-            current_epoch_reset = current_row.get("epoch_reset", False)
-            crosses_epoch_boundary = (pd.notna(previous_epoch_reset) and bool(previous_epoch_reset)) or (pd.notna(current_epoch_reset) and bool(current_epoch_reset))
-            if crosses_epoch_boundary:
-                continue
-
-            previous_nav = float(previous_row["total_assets"])
-            previous_pnl = float(previous_row[pnl_column])
-            current_pnl = float(current_row[pnl_column])
-            previous_price = float(previous_row["share_price"])
-            current_price = float(current_row["share_price"])
-            finite_values = (previous_nav, previous_pnl, current_pnl, previous_price, current_price)
-            if not all(np.isfinite(value) for value in finite_values) or previous_nav <= 0 or previous_price <= 0 or current_price <= 0:
-                continue
-
-            expected_price = previous_price * (1 + (current_pnl - previous_pnl) / previous_nav)
-            if not np.isfinite(expected_price) or expected_price <= 0:
-                continue
-            deviation = max(current_price / expected_price, expected_price / current_price) - 1
-            if deviation > max_return_deviation:
-                factor = expected_price / current_price
-                rescale_share_price_rows(prices_df, factor, positions[current_position:])
-                prices_df.iloc[positions[current_position], status_column] = "repaired_hf_batch_scale"
-                description = "large " if factor > 2 or factor < 0.5 else ""
-                logger(f"Stitched {description}Hypercore HF batch scale for {vault_id} at {current_row.name}: factor {factor:.6f}")
-                repair_count += 1
-
-    if repair_count:
-        logger(f"Stitched {repair_count:,} incompatible Hypercore HF scanner batch boundaries")
-    return prices_df
-
-
-def fix_hypercore_flow_reconciled_share_price_paths(  # noqa: PLR0914, PLR0917
-    prices_df: pd.DataFrame,
-    logger=print,
-    max_anchor_deviation: Percent = 0.50,
-    max_anchor_gap: pd.Timedelta = HYPERCORE_MAX_PRICE_ANCHOR_GAP,
-    max_endpoint_deviation: Percent = HYPERCORE_MAX_PNL_PATH_ENDPOINT_DEVIATION,
-    accounting_absolute_tolerance: float = HYPERCORE_PNL_PATH_ACCOUNTING_ABSOLUTE_TOLERANCE,
-) -> pd.DataFrame:
-    """Repair a conflicted Hypercore interval from ledger-reconciled PnL.
-
-    Hyperliquid does not expose a native vault share price. Both scanners derive
-    one from rolling portfolio windows, so a daily observation can be in a
-    different arbitrary unit even though its NAV and cumulative PnL are real.
-    In February 2026 Magixbox reported a daily price of ``26.03541`` between HF
-    observations near ``1.30``. Its $7,614.65 of same-day withdrawals and
-    -$1,386.74 PnL exactly reconcile the NAV change to within two cents. The
-    price spike therefore cannot be an investor return: cash flows change the
-    implied supply, while PnL changes the price.
-
-    When persisted daily ledger flows prove that accounting relationship for a
-    conflicted observation, reconstruct its price from the PnL path between
-    adjacent HF anchors using ``1 + pnl_change / previous_nav``. Continue the
-    repair through following daily observations while every NAV step remains
-    ledger-reconciled, then stop at the first unproven step. This ensures the
-    return direction follows profit: for example, Magixbox's positive PnL on 7
-    February must not remain a negative share-price return after repairing its
-    5 February unit change.
-
-    The next HF price is only a plausibility guard: the reconstructed path must
-    end within ``max_endpoint_deviation`` of it. The residual difference is not
-    spread over the daily prices, because doing so can reverse the sign of a
-    genuine PnL return. This is deliberately narrower than generic smoothing:
-    each changed daily row needs known flow values and must reconcile to within
-    a fixed dollar tolerance, there may be no wipe-out boundary, and one
-    missing or inconsistent ledger step ends the interval repair. If old
-    parquet lacks the ledger flow columns, this function leaves it untouched
-    and the older, conservative source-overlap repair remains the fallback.
-
-    :param prices_df:
-        Timestamp-indexed vault price data. Hypercore rows need ``id``,
-        ``chain``, ``share_price``, ``total_assets``, ``account_pnl`` (or
-        scanner-shaped ``cumulative_pnl``), ``daily_deposit_usd``,
-        ``daily_withdrawal_usd``, and ``hypercore_source``. Each repaired
-        calendar date must have a known flow record, on either its daily or HF
-        observation; zero is required when there was no ledger event. Matching
-        daily/HF copies of the same flow are de-duplicated.
-    :param logger:
-        Notebook or console logging function.
-    :param max_anchor_deviation:
-        Minimum symmetric daily/HF price disagreement required before the
-        interval is considered for this specialised repair.
-    :param max_anchor_gap:
-        Largest interval between consecutive HF anchors.
-    :param max_endpoint_deviation:
-        Largest symmetric difference permitted between the uncorrected PnL
-        path and the right HF anchor.
-    :param accounting_absolute_tolerance:
-        Dollar tolerance for API rounding when reconciling one NAV step.
-    :return:
-        A copy with qualifying daily paths marked ``repaired_hf_pnl_flow``;
-        ``raw_share_price`` remains the scanner-derived value.
-    """
-    hypercore_mask = prices_df["chain"] == HYPERCORE_CHAIN_ID
-    pnl_column = "cumulative_pnl" if "cumulative_pnl" in prices_df.columns else "account_pnl"
-    required_columns = {"total_assets", pnl_column, "daily_deposit_usd", "daily_withdrawal_usd"}
-    if not hypercore_mask.any() or not required_columns.issubset(prices_df.columns):
-        return prices_df
-
-    prices_df = prices_df.copy()
-    if "raw_share_price" not in prices_df.columns:
-        prices_df["raw_share_price"] = prices_df["share_price"]
-    if "hypercore_repair_status" not in prices_df.columns:
-        prices_df["hypercore_repair_status"] = ""
-    if "hypercore_source" not in prices_df.columns:
-        prices_df["hypercore_source"] = pd.NA
-
-    missing_source_mask = hypercore_mask & prices_df["hypercore_source"].isna()
-    if missing_source_mask.any():
-        timestamps = pd.DatetimeIndex(prices_df.index[missing_source_mask])
-        prices_df.loc[missing_source_mask, "hypercore_source"] = np.where(timestamps == timestamps.normalize(), "daily", "hf")
-
-    repaired_rows = 0
-    repaired_vaults: set[str] = set()
-    hypercore_positions = np.flatnonzero(hypercore_mask.to_numpy())
-    share_price_col = prices_df.columns.get_loc("share_price")
-    total_supply_col = prices_df.columns.get_loc("total_supply") if "total_supply" in prices_df.columns else None
-    status_col = prices_df.columns.get_loc("hypercore_repair_status")
-
-    for vault_id, row_positions in prices_df.loc[hypercore_mask].groupby("id", sort=False).indices.items():
-        positions = hypercore_positions[np.asarray(row_positions, dtype=int)]
-        group = prices_df.iloc[positions]
-        source = group["hypercore_source"].astype("string").fillna("").to_numpy(dtype=str)
-        status = group["hypercore_repair_status"].astype("string").fillna("").to_numpy(dtype=str)
-        timestamp = pd.DatetimeIndex(group.index)
-        timestamp_ns = timestamp.to_numpy(dtype="datetime64[ns]").astype("int64")
-        share_price = group["share_price"].to_numpy(dtype=float)
-        total_assets = group["total_assets"].to_numpy(dtype=float)
-        account_pnl = group[pnl_column].to_numpy(dtype=float)
-        deposits = group["daily_deposit_usd"].to_numpy(dtype=float)
-        withdrawals = group["daily_withdrawal_usd"].to_numpy(dtype=float)
-        epoch_reset = group["epoch_reset"].fillna(False).astype(bool).to_numpy() if "epoch_reset" in group.columns else np.zeros(len(group), dtype=bool)
-        daily_flow_by_date: dict[datetime.date, tuple[float, float]] = {}
-        known_flow_mask = np.isfinite(deposits) & np.isfinite(withdrawals)
-        calendar_dates = timestamp.date
-        for day in np.unique(calendar_dates):
-            day_positions = np.flatnonzero(calendar_dates == day)
-            known_positions = day_positions[known_flow_mask[day_positions]]
-            if len(known_positions) == 0:
-                continue
-            known_flows = np.column_stack((deposits[known_positions], withdrawals[known_positions]))
-            non_zero_flows = known_flows[np.sum(np.abs(known_flows), axis=1) > 0]
-            candidate_flows = non_zero_flows if len(non_zero_flows) else known_flows
-            if np.allclose(candidate_flows, candidate_flows[0], rtol=0.0, atol=0.01):
-                daily_flow_by_date[day] = tuple(candidate_flows[0])
-
-        hf_positions = np.flatnonzero((source == "hf") & np.isfinite(share_price) & (share_price > 0) & np.isfinite(total_assets) & (total_assets > 0) & np.isfinite(account_pnl))
-        if len(hf_positions) < MIN_HYPERCORE_PRICE_ANCHORS:
-            continue
-
-        for left_position, right_position in zip(hf_positions[:-1], hf_positions[1:]):
-            if timestamp_ns[right_position] - timestamp_ns[left_position] > max_anchor_gap.value:
-                continue
-
-            inner_positions = np.arange(left_position + 1, right_position)
-            if len(inner_positions) == 0 or not np.all(source[inner_positions] == "daily"):
-                continue
-            if np.any(epoch_reset[left_position : right_position + 1]) or np.any(total_assets[left_position : right_position + 1] <= HYPERCORE_ZERO_NAV_EPSILON):
-                continue
-
-            # Do not change a path that had already been handled by a prior
-            # Hypercore repair in this wrangle run.
-            if np.any(status[inner_positions] != ""):
-                continue
-
-            elapsed = (timestamp_ns[inner_positions] - timestamp_ns[left_position]) / (timestamp_ns[right_position] - timestamp_ns[left_position])
-            expected_anchor_prices = np.exp(np.log(share_price[left_position]) + elapsed * (np.log(share_price[right_position]) - np.log(share_price[left_position])))
-            with np.errstate(divide="ignore", invalid="ignore"):
-                anchor_deviation = (
-                    np.maximum(
-                        share_price[inner_positions] / expected_anchor_prices,
-                        expected_anchor_prices / share_price[inner_positions],
-                    )
-                    - 1
-                )
-            candidate_mask = np.isfinite(anchor_deviation) & (anchor_deviation > max_anchor_deviation)
-            candidate_positions = inner_positions[candidate_mask]
-            if len(candidate_positions) == 0:
-                continue
-
-            required_values = np.concatenate(
-                [
-                    total_assets[[left_position, right_position]],
-                    account_pnl[[left_position, right_position]],
-                    total_assets[inner_positions],
-                    account_pnl[inner_positions],
-                ]
-            )
-            if not np.all(np.isfinite(required_values)) or np.any(total_assets[[left_position, *inner_positions]] <= 0):
-                continue
-
-            provisional_prices: list[float] = []
-            previous_assets = total_assets[left_position]
-            previous_pnl = account_pnl[left_position]
-            previous_price = share_price[left_position]
-            pnl_path_valid = True
-            for position in inner_positions:
-                pnl_change = account_pnl[position] - previous_pnl
-                next_price = previous_price * (1 + pnl_change / previous_assets)
-                if not np.isfinite(next_price) or next_price <= 0:
-                    pnl_path_valid = False
-                    break
-                provisional_prices.append(next_price)
-                previous_assets = total_assets[position]
-                previous_pnl = account_pnl[position]
-                previous_price = next_price
-
-            if not pnl_path_valid:
-                continue
-
-            endpoint_price = previous_price * (1 + (account_pnl[right_position] - previous_pnl) / previous_assets)
-            if not np.isfinite(endpoint_price) or endpoint_price <= 0:
-                continue
-            endpoint_deviation = max(endpoint_price / share_price[right_position], share_price[right_position] / endpoint_price) - 1
-            if endpoint_deviation > max_endpoint_deviation:
-                continue
-
-            repaired_prices = np.asarray(provisional_prices)
-            repaired_by_position = dict(zip(inner_positions, repaired_prices))
-            repair_positions: set[int] = set()
-            candidate_position = int(candidate_positions[0])
-            # The first large conflict starts the only proven repair segment in
-            # this HF interval. Continue while NAV = previous NAV + PnL + net
-            # flow; the first missing or inconsistent ledger step ends it.
-            for position in range(candidate_position, int(right_position)):
-                flow_values = daily_flow_by_date.get(timestamp[position].date())
-                original_price = share_price[position]
-                if flow_values is None or not np.isfinite(original_price) or original_price <= 0:
-                    break
-                deposit, withdrawal = flow_values
-                previous_position = position - 1
-                expected_assets = total_assets[previous_position] + (account_pnl[position] - account_pnl[previous_position]) + deposit - withdrawal
-                if not np.isfinite(deposit) or not np.isfinite(withdrawal) or abs(total_assets[position] - expected_assets) > accounting_absolute_tolerance:
-                    break
-                repair_positions.add(position)
-
-            for position in sorted(repair_positions):
-                repaired_price = repaired_by_position[position]
-                original_price = share_price[position]
-                factor = repaired_price / original_price
-                prices_df.iloc[positions[position], share_price_col] = repaired_price
-                if total_supply_col is not None:
-                    original_supply = prices_df.iloc[positions[position], total_supply_col]
-                    if pd.notna(original_supply) and original_supply > 0:
-                        prices_df.iloc[positions[position], total_supply_col] = original_supply / factor
-                prices_df.iloc[positions[position], status_col] = "repaired_hf_pnl_flow"
-                repaired_rows += 1
-            if repair_positions:
-                repaired_vaults.add(str(vault_id))
-
-    if repaired_rows:
-        logger(f"Repaired {repaired_rows:,} flow-reconciled Hypercore daily prices across {len(repaired_vaults):,} vaults using PnL paths")
-    return prices_df
-
-
-def fix_hypercore_source_overlap_share_prices(  # noqa: PLR0914
-    prices_df: pd.DataFrame,
-    logger=print,
-    max_anchor_deviation: Percent = 0.50,
-    max_anchor_gap: pd.Timedelta = HYPERCORE_MAX_PRICE_ANCHOR_GAP,
-) -> pd.DataFrame:
-    """Repair corrupted daily Hypercore prices using canonical observations.
-
-    Hypercore daily and high-frequency scanners both derive synthetic share
-    prices from the rolling ``vaultDetails`` portfolio windows. Historical
-    daily rows may have been calculated from a different rolling window than
-    the later HF rows. Mixing the two sources can therefore create temporary
-    multi-day price excursions that are absent from the canonical HF history.
-
-    For periods covered by both sources, use positive HF observations as a
-    time-based anchor curve. Some legacy vaults have daily history only. For
-    these, use the latest batch of refreshed daily rows, identified by their
-    common ``written_at`` value, as the canonical anchors. This handles stale
-    rolling-window rows left between observations refreshed from a later
-    ``allTime`` response.
-
-    A daily observation becomes a repair candidate when its symmetric deviation
-    from the log-linearly interpolated anchor price exceeds
-    ``max_anchor_deviation``. It is changed only when all three conservative
-    safeguards pass:
-
-    - its NAV is within ``max_anchor_deviation`` of the interpolated anchor NAV;
-    - the bracketing anchor gap is no longer than ``max_anchor_gap``; and
-    - the anchor interval contains neither zero NAV nor ``epoch_reset``.
-
-    A July 2026 audit of 848,333 Hypercore rows found 1,051 candidates across
-    181 vaults. These rules automatically repair 747 rows and defer 304
-    ambiguous rows: 260 failed NAV consistency, 60 used a gap over eight days,
-    and 34 crossed a lifecycle boundary, with overlap between the counts. The
-    NAV rule is deliberately applied to HF anchors too. For example, four of
-    six Magixbox candidates are now deferred despite looking suspicious,
-    because the raw data does not preserve enough intra-week information to
-    prove a safe replacement. Avoiding a fabricated investor return takes
-    priority over maximising the number of smooth chart points.
-
-    Canonical anchors, rows outside anchor coverage, all HF rows, and all
-    non-Hypercore rows are left unchanged. Deferred rows also remain unchanged
-    and receive a reason in ``hypercore_repair_status``.
-
-    ``raw_share_price`` always preserves the input value for auditability.
-
-    :param prices_df:
-        Vault prices indexed by timestamp. New Hypercore rows carry the
-        ``hypercore_source`` value ``daily`` or ``hf``. For legacy rows the
-        source is inferred from daily midnight normalisation versus the raw HF
-        API timestamp.
-    :param logger:
-        Notebook or console logging function.
-    :param max_anchor_deviation:
-        Maximum symmetric ratio deviation from the interpolated anchor.
-        ``0.50`` means either price may be at most 50% larger than the other.
-    :param max_anchor_gap:
-        Maximum elapsed time between the two observations used as anchors.
-        Eight days permits the normal historical weekly HF cadence but rejects
-        a missing weekly observation and longer interpolation.
-    :return:
-        Price data with conflicting daily Hypercore prices repaired.
-    """
-    prices_df = prices_df.copy()
-    if "raw_share_price" not in prices_df.columns:
-        prices_df["raw_share_price"] = prices_df["share_price"]
-    if "hypercore_repair_status" not in prices_df.columns:
-        prices_df["hypercore_repair_status"] = ""
-
-    hypercore_mask = prices_df["chain"] == HYPERCORE_CHAIN_ID
-    if not hypercore_mask.any():
-        return prices_df
-
-    if "hypercore_source" not in prices_df.columns:
-        prices_df["hypercore_source"] = pd.NA
-
-    missing_source_mask = hypercore_mask & prices_df["hypercore_source"].isna()
-    if missing_source_mask.any():
-        # Backwards compatibility for Parquet files written before explicit
-        # source provenance was exported. Daily rows are normalised to midnight;
-        # HF rows retain the raw API timestamp, normally including milliseconds.
-        missing_timestamps = pd.DatetimeIndex(prices_df.index[missing_source_mask])
-        inferred_sources = np.where(missing_timestamps == missing_timestamps.normalize(), "daily", "hf")
-        prices_df.loc[missing_source_mask, "hypercore_source"] = inferred_sources
-        logger(f"Inferred Hypercore source provenance for {int(missing_source_mask.sum()):,} legacy price rows")
-
-    share_price_col = prices_df.columns.get_loc("share_price")
-    repair_status_col = prices_df.columns.get_loc("hypercore_repair_status")
-    hf_fixed_count = 0
-    hf_affected_vaults = 0
-    daily_fixed_count = 0
-    daily_affected_vaults = 0
-    deferred_count = 0
-    nav_deferred_count = 0
-    gap_deferred_count = 0
-    boundary_deferred_count = 0
-    deferred_vaults: set[str] = set()
-    hypercore_positions = np.flatnonzero(hypercore_mask.to_numpy())
-
-    for _vault_id, row_positions in prices_df.loc[hypercore_mask].groupby("id", sort=False).indices.items():
-        # ``groupby().indices`` above is relative to the filtered frame. Map
-        # these positions back to the original frame before assigning by iloc.
-        positions = hypercore_positions[np.asarray(row_positions, dtype=int)]
-        group = prices_df.iloc[positions]
-
-        source = group["hypercore_source"].astype("string").fillna("").to_numpy(dtype=str)
-        existing_status = group["hypercore_repair_status"].astype("string").fillna("").to_numpy(dtype=str)
-        share_price = group["share_price"].to_numpy(dtype=float)
-        timestamp_ns = pd.DatetimeIndex(group.index).to_numpy(dtype="datetime64[ns]").astype("int64")
-
-        if "total_assets" not in group.columns:
-            continue
-        total_assets = group["total_assets"].to_numpy(dtype=float)
-        positive_assets_mask = np.isfinite(total_assets) & (total_assets > 0)
-
-        positive_price_mask = np.isfinite(share_price) & (share_price > 0)
-        hf_price_mask = (source == "hf") & positive_price_mask
-        daily_mask = source == "daily"
-        if not daily_mask.any():
-            continue
-
-        if hf_price_mask.sum() >= MIN_HYPERCORE_PRICE_ANCHORS:
-            # HF coverage selects the HF repair path even if some observations
-            # have unusable NAV. Never reinterpret such a vault as daily-only.
-            anchor_mask = hf_price_mask & positive_assets_mask
-            candidate_mask = daily_mask & (existing_status == "")
-            anchor_source = "hf"
-        else:
-            # Some legacy vaults were never covered by the HF scanner. A
-            # later daily scan refreshes the canonical allTime observations
-            # in one batch, while stale rows from older rolling windows retain
-            # older or missing write times. Never modify the refresh batch
-            # itself; it is the best available canonical history.
-            if "written_at" not in group.columns:
-                continue
-            written_at = pd.to_datetime(group["written_at"], errors="coerce")
-            latest_written_at = written_at.max()
-            if pd.isna(latest_written_at):
-                continue
-            refreshed_mask = (written_at >= latest_written_at - HYPERCORE_DAILY_REFRESH_TOLERANCE).to_numpy()
-            anchor_mask = daily_mask & refreshed_mask & positive_price_mask & positive_assets_mask
-            candidate_mask = daily_mask & ~anchor_mask & (existing_status == "")
-            anchor_source = "daily"
-
-        anchor_timestamps = timestamp_ns[anchor_mask]
-        anchor_prices = share_price[anchor_mask]
-        anchor_assets = total_assets[anchor_mask]
-        sort_order = np.argsort(anchor_timestamps)
-        anchor_timestamps = anchor_timestamps[sort_order]
-        anchor_prices = anchor_prices[sort_order]
-        anchor_assets = anchor_assets[sort_order]
-
-        # np.interp expects unique x values. Keep the last anchor value for any
-        # duplicate timestamp, matching the export deduplication behaviour.
-        reverse_unique_positions = np.unique(anchor_timestamps[::-1], return_index=True)[1]
-        unique_positions = np.sort(len(anchor_timestamps) - 1 - reverse_unique_positions)
-        anchor_timestamps = anchor_timestamps[unique_positions]
-        anchor_prices = anchor_prices[unique_positions]
-        anchor_assets = anchor_assets[unique_positions]
-        if len(anchor_timestamps) < MIN_HYPERCORE_PRICE_ANCHORS:
-            continue
-
-        expected_log_price = np.interp(
-            timestamp_ns,
-            anchor_timestamps,
-            np.log(anchor_prices),
-            left=np.nan,
-            right=np.nan,
-        )
-        expected_price = np.exp(expected_log_price)
-        valid_expected = np.isfinite(expected_price) & (expected_price > 0)
-
-        expected_assets = np.exp(
-            np.interp(
-                timestamp_ns,
-                anchor_timestamps,
-                np.log(anchor_assets),
-                left=np.nan,
-                right=np.nan,
-            )
-        )
-        with np.errstate(divide="ignore", invalid="ignore"):
-            asset_deviation = (
-                np.maximum(
-                    total_assets / expected_assets,
-                    expected_assets / total_assets,
-                )
-                - 1
-            )
-        nav_safe_mask = positive_assets_mask & np.isfinite(expected_assets) & (asset_deviation <= max_anchor_deviation)
-
-        right_anchor = np.searchsorted(anchor_timestamps, timestamp_ns, side="left")
-        bracketed_mask = (right_anchor > 0) & (right_anchor < len(anchor_timestamps))
-        left_anchor = np.maximum(right_anchor - 1, 0)
-        clipped_right_anchor = np.minimum(right_anchor, len(anchor_timestamps) - 1)
-        anchor_gap_ns = anchor_timestamps[clipped_right_anchor] - anchor_timestamps[left_anchor]
-        gap_safe_mask = bracketed_mask & (anchor_gap_ns <= max_anchor_gap.value)
-
-        epoch_reset = group["epoch_reset"].fillna(False).astype(bool).to_numpy() if "epoch_reset" in group.columns else np.zeros(len(group), dtype=bool)
-        boundary_mask = epoch_reset | (np.isfinite(total_assets) & (total_assets <= HYPERCORE_ZERO_NAV_EPSILON))
-        boundary_timestamps = np.sort(timestamp_ns[boundary_mask])
-        crosses_boundary = np.zeros(len(group), dtype=bool)
-        if len(boundary_timestamps):
-            left_timestamps = anchor_timestamps[left_anchor]
-            right_timestamps = anchor_timestamps[clipped_right_anchor]
-            boundary_start = np.searchsorted(boundary_timestamps, left_timestamps, side="left")
-            boundary_end = np.searchsorted(boundary_timestamps, right_timestamps, side="right")
-            crosses_boundary = bracketed_mask & (boundary_end > boundary_start)
-        boundary_safe_mask = ~crosses_boundary
-
-        with np.errstate(divide="ignore", invalid="ignore"):
-            symmetric_deviation = (
-                np.maximum(
-                    share_price / expected_price,
-                    expected_price / share_price,
-                )
-                - 1
-            )
-        repair_candidate_mask = candidate_mask & valid_expected & positive_price_mask & (symmetric_deviation > max_anchor_deviation)
-        repair_mask = repair_candidate_mask & nav_safe_mask & gap_safe_mask & boundary_safe_mask
-        deferred_mask = repair_candidate_mask & ~repair_mask
-
-        status_values = np.full(len(group), "", dtype=object)
-        status_values[repair_mask] = f"repaired_{anchor_source}"
-        if deferred_mask.any():
-            failure_reason = np.select(
-                [
-                    ~boundary_safe_mask & ~gap_safe_mask & ~nav_safe_mask,
-                    ~boundary_safe_mask & ~gap_safe_mask,
-                    ~boundary_safe_mask & ~nav_safe_mask,
-                    ~gap_safe_mask & ~nav_safe_mask,
-                    ~boundary_safe_mask,
-                    ~gap_safe_mask,
-                    ~nav_safe_mask,
-                ],
-                ["boundary_gap_nav", "boundary_gap", "boundary_nav", "gap_nav", "boundary", "gap", "nav"],
-                default="unknown",
-            )
-            status_values[deferred_mask] = np.asarray([f"deferred_{anchor_source}_{reason}" for reason in failure_reason[deferred_mask]], dtype=object)
-            deferred_count += int(deferred_mask.sum())
-            nav_deferred_count += int((deferred_mask & ~nav_safe_mask).sum())
-            gap_deferred_count += int((deferred_mask & ~gap_safe_mask).sum())
-            boundary_deferred_count += int((deferred_mask & ~boundary_safe_mask).sum())
-            deferred_vaults.add(str(_vault_id))
-
-        status_mask = repair_mask | deferred_mask
-        prices_df.iloc[positions[status_mask], repair_status_col] = status_values[status_mask]
-
-        if repair_mask.any():
-            repair_positions = positions[repair_mask]
-            prices_df.iloc[repair_positions, share_price_col] = expected_price[repair_mask]
-            if anchor_source == "hf":
-                hf_fixed_count += int(repair_mask.sum())
-                hf_affected_vaults += 1
-            else:
-                daily_fixed_count += int(repair_mask.sum())
-                daily_affected_vaults += 1
-
-    if hf_fixed_count:
-        logger(f"Repaired {hf_fixed_count:,} conflicting daily Hypercore share prices across {hf_affected_vaults:,} vaults using HF anchors")
-    if daily_fixed_count:
-        logger(f"Repaired {daily_fixed_count:,} stale daily Hypercore share prices across {daily_affected_vaults:,} vaults using refreshed daily anchors")
-    if deferred_count:
-        logger(f"Deferred {deferred_count:,} ambiguous Hypercore share-price repairs across {len(deferred_vaults):,} vaults: {nav_deferred_count:,} failed NAV consistency, {gap_deferred_count:,} exceeded the anchor-gap limit, and {boundary_deferred_count:,} crossed a lifecycle boundary (counts overlap)")
-
-    return prices_df
 
 
 def fix_outlier_share_prices(
@@ -2000,28 +1594,14 @@ def process_raw_vault_scan_data(
         logger("After remove_inactive_lead_time():")
         display(vault_prices_df)
 
-    # Correct scanner-batch unit changes before using HF observations as
-    # canonical anchors for the daily/HF source-overlap repair.
-    prices_df = stitch_hypercore_high_freq_share_price_batches(prices_df, logger)
-
-    # Cap Hypercore share prices before the standard outlier smoothing.
-    # Hypercore share prices can overflow when total_supply → 0;
-    # this prevents the smoothing algorithm from being confused by absurd values.
-    prices_df = cap_hypercore_share_prices(prices_df, logger)
-
-    # Some historic daily/HF overlap conflicts are real capital flows paired
-    # with a synthetic daily price unit. Where persisted ledger flows prove the
-    # NAV accounting, retain the observed PnL path rather than interpolating it.
-    prices_df = fix_hypercore_flow_reconciled_share_price_paths(prices_df, logger)
-
-    # Hypercore scans may overlap or refresh only a sparse subset of historical
-    # rows. Repair stale daily values that conflict sharply with canonical HF
-    # observations or the latest daily refresh batch.
-    prices_df = fix_hypercore_source_overlap_share_prices(prices_df, logger)
+    # Hyperliquid does not expose an authoritative historical unit price or
+    # share supply. Replace every raw Hypercore scanner unit with one
+    # conservative PnL/NAV performance index before calculating returns.
+    prices_df = approximate_hypercore_share_prices_from_pnl_nav(prices_df, logger)
 
     # The generic fixer derives one row offset from each vault's median polling
     # interval. Hypercore mixes roughly 20-minute, daily, and weekly rows, so one
-    # offset cannot represent a stable time window. The source-aware repair above
+    # offset cannot represent a stable time window. The economic index above
     # handles Hypercore; keep the generic fixer limited to EVM vaults.
 
     hypercore_mask = prices_df["chain"] == HYPERCORE_CHAIN_ID

--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -641,10 +641,9 @@ def clean_returns(
 
     returns_df = prices_df
 
-    # Hypercore prices are synthetic. Its source-aware continuity repairs run
-    # before this generic cleaner, and a genuine post-epoch trading return may
-    # exceed the ERC-4626-oriented threshold. Retain it for the downstream
-    # return-based suitability checks instead of replacing it with a false zero.
+    # Hypercore's bounded PnL/NAV approximation runs before this generic
+    # cleaner. Retain its audited economic return instead of replacing it with
+    # a value that disagrees with the cleaned performance index.
     high_returns_mask = returns_df[returns_col] > outlier_threshold
     if "chain" in returns_df.columns:
         high_returns_mask &= returns_df["chain"] != HYPERCORE_CHAIN_ID
@@ -1295,27 +1294,7 @@ def discard_hypercore_pre_recapitalisation_history(  # noqa: PLR0914
         return prices_df
 
     epoch_reset_values[epoch_reset_positions] = True
-
-    # A new investor epoch must start from a readable unit price. Preserve the
-    # scanner value in raw_share_price, then rescale this vault's retained rows
-    # so the first meaningful recapitalisation observation is exactly 1.0.
-    share_prices = prices_df["share_price"].to_numpy(dtype=float, copy=True)
-    total_supplies = prices_df["total_supply"].to_numpy(dtype=float, copy=True) if "total_supply" in prices_df.columns else None
-    for epoch_reset_position in epoch_reset_positions:
-        vault_id = prices_df.iloc[epoch_reset_position]["id"]
-        vault_positions = np.flatnonzero((prices_df["id"] == vault_id).to_numpy())
-        retained_positions = vault_positions[vault_positions >= epoch_reset_position]
-        recapitalisation_price = share_prices[epoch_reset_position]
-        if np.isfinite(recapitalisation_price) and recapitalisation_price > 0:
-            factor = 1.0 / recapitalisation_price
-            share_prices[retained_positions] *= factor
-            if total_supplies is not None:
-                total_supplies[retained_positions] /= factor
-
     prices_df["epoch_reset"] = epoch_reset_values
-    prices_df["share_price"] = share_prices
-    if total_supplies is not None:
-        prices_df["total_supply"] = total_supplies
     filtered_prices_df = prices_df.iloc[~remove_mask].copy()
     logger(f"Discarded {int(remove_mask.sum()):,} pre-recapitalisation Hypercore price rows across {len(epoch_reset_positions):,} vaults; new epochs start once NAV reaches ${min_recapitalisation_assets:,.0f} after {min_recovery_delay}")
     return filtered_prices_df

--- a/scripts/hyperliquid/README-hyperliquid-vaults-high-frequency.md
+++ b/scripts/hyperliquid/README-hyperliquid-vaults-high-frequency.md
@@ -208,12 +208,12 @@ timestamp for the same vault, the HF row is kept (more recent/granular data).
 
 ### Raw timestamps, no resampling
 
-HF data is written with the original API timestamps (irregular spacing).  The
-downstream cleaning pipeline computes `returns_1h` via `pct_change()` on
-consecutive rows — this already works for irregular timestamps.  The daily
-pipeline has always produced ~24h returns labelled `returns_1h` for Hypercore,
-so irregular spacing is not a new issue.  When consumers need a regular 1h grid,
-they call `forward_fill_vault()` which does `.resample("h").last().ffill()`.
+HF data is written with the original API timestamps (irregular spacing). The
+downstream cleaning pipeline first replaces raw scanner units with one PnL/NAV
+economic checkpoint per UTC date. Non-checkpoint HF rows carry the last clean
+price. It then computes `returns_1h` via `pct_change()` on consecutive rows.
+When consumers need a regular 1h grid, they call `forward_fill_vault()` which
+does `.resample("h").last().ffill()`.
 
 Note: `returns_1h` is a misnomer — see the comment at
 `wrangle_vault_prices.py:260`.  It is `pct_change()` between consecutive rows
@@ -290,12 +290,13 @@ Both DuckDB paths are always available:
 **1. `returns_1h` is returns between consecutive rows, not true 1h returns**
 
 The cleaning pipeline computes `returns_1h = pct_change()` on consecutive rows
-regardless of actual time delta.  For HF data with raw timestamps, these are
-irregular-interval returns (sometimes minutes apart for `day` period data,
-sometimes a week for `allTime` data).  This is the same as the daily pipeline
-where Hypercore `returns_1h` values are actually ~24h returns.  Downstream
-consumers that need uniform 1h returns should use `forward_fill_vault()` first,
-which resamples to a regular 1h grid.
+regardless of actual time delta. Hypercore economic returns occur only at the
+selected daily checkpoints; intervening raw rows carry the price and have zero
+change. Price level, cumulative profit and drawdown use this clean curve.
+Volatility, Sharpe and other cadence-sensitive statistics must select
+`hypercore_repair_status` checkpoint rows instead of treating carried rows as
+independent hourly observations. Consumers that need a uniform 1h price grid
+can use `forward_fill_vault()`.
 
 **2. Flow metrics are attached to one row per calendar date only**
 

--- a/scripts/hyperliquid/README-hyperliquid-vaults.md
+++ b/scripts/hyperliquid/README-hyperliquid-vaults.md
@@ -2,14 +2,14 @@
 
 ## Overview
 
-Scans Hyperliquid native (non-EVM) vaults, computes time-weighted share prices,
+Scans Hyperliquid native (non-EVM) vaults, records synthetic scanner prices,
 and merges the data into the existing ERC-4626 vault metrics pipeline so that
 `vault-analysis-json.py` produces a single unified JSON with both EVM and
 Hyperliquid vaults.
 
-Hypercore data goes through the same `process_raw_vault_scan_data()` cleaning
-pipeline as EVM vaults (outlier share price smoothing, return cleaning,
-TVL-based filtering, etc.).
+Hypercore data goes through `process_raw_vault_scan_data()`, where its raw
+scanner price is replaced by a conservative PnL/NAV economic-performance index
+before returns and TVL filters are calculated.
 
 ## Architecture
 
@@ -37,8 +37,8 @@ daily-metrics.duckdb  ----merge----->  vault-metadata-db.pickle
   vault_daily_prices table                   |
                                              v
                                       process_raw_vault_scan_data()
-                                        cap_hypercore_share_prices()
-                                        fix_outlier_share_prices()
+                                        discard durable old epochs
+                                        approximate_hypercore_share_prices_from_pnl_nav()
                                         calculate_vault_returns()
                                              |
                                              v
@@ -173,20 +173,30 @@ These feed into `_calculate_share_price()` from `combined_analysis.py`,
 which uses the proven mint/burn share price logic without needing the
 slow per-fill/per-deposit API calls.
 
-Hyperliquid does not publish a vault share price or share supply. Each API
-read reconstructs an arbitrary but internally consistent unit, so the daily
-and HF scanners align their new curve to the latest stored price before writing
-their one-row overlap. The HF path log-linearly interpolates an anchor when
-the rolling-window timestamps shift. The matching inverse supply scaling keeps
-`total_assets == share_price * total_supply`; if no positive stored anchor lies
-within the current curve, the scan is skipped rather than creating a
-discontinuity.
+Hyperliquid does not publish a historical vault share price or share supply.
+Each API read reconstructs an arbitrary but internally consistent scanner unit,
+so the daily and HF scanners align new raw observations to persisted history
+where possible. This improves raw continuity but cannot make rolling NAV/PnL
+windows an exact investor share price.
+
+The wrangle step therefore treats scanner `share_price` as audit evidence only
+and copies it to `raw_share_price`. It selects the freshest finite NAV/PnL
+checkpoint per vault and UTC date, then compounds the change in cumulative PnL
+over the larger of opening and closing NAV. Capital flows do not create clean
+performance, duplicate daily/HF rows carry the last index value, and no future
+observation is interpolated backwards. Clean Hypercore `total_supply` is a
+synthetic index-unit value used to preserve
+`total_assets == share_price * total_supply`; it is not an actual token supply.
+
+Exact historical time-weighted returns remain unobtainable because the API
+does not expose historical share supply or the ordering of PnL and flows inside
+an observation interval. The cleaned curve is the best conservative economic
+approximation and must be labelled as such.
 An exact zero stored price may record a complete wipe-out, but it cannot scale
-another curve. Because the scanner cannot classify the zero as durable or
-transient at resume time, it resumes the reconstructed curve without alignment.
-The wrangle pipeline separately decides whether a later recapitalisation
-qualifies as a new retained performance epoch. Negative or non-finite stored
-prices remain hard errors.
+another raw curve. The wrangle pipeline separately requires a seven-day zero
+period and a new `$1,000` capital base before retaining a recapitalised epoch.
+Raw scanner `epoch_reset` flags are discarded because they also describe
+arbitrary synthetic-supply resets in funded vaults.
 
 ### Hypercore-specific columns in price data
 
@@ -256,12 +266,12 @@ longer appear in a fresh response. This affected Magixbox on 5 February 2026:
 the retained daily price had no withdrawal, while
 `userNonFundingLedgerUpdates` still returned $7,614.65 of withdrawals.
 
-Use the manual historical-flow script for these `deferred_hf_nav` rows. It
-fetches the ledger around each candidate and updates only flow columns on
-existing daily DuckDB observations:
+The manual historical-flow script can still fetch the ledger around selected
+observations and update flow columns in the daily DuckDB for accounting
+diagnostics:
 
 ```shell
-# Preview all candidates without writing
+# Preview candidates from a legacy cleaned file without writing
 AUTODETECT=true \
   poetry run python scripts/hyperliquid/backfill-historical-vault-flows.py
 
@@ -277,11 +287,11 @@ as `hyperliquid-vaults.duckdb.bak-0001`. Existing backups are never replaced;
 the DuckDB WAL sidecar is copied as well when present. Stop the scanner while
 the backup and update run.
 
-Afterwards run the normal export and vault-price wrangle. The wrangle repairs a
-large daily/HF unit conflict only when the backfilled ledger flow reconciles
-NAV. It follows the PnL-derived share-price path through subsequent reconciled
-observations and stops at the first missing or inconsistent flow step. Raw
-share prices remain available in `raw_share_price` for auditing.
+The cleaned economic-performance index does not depend on this backfill. It
+uses cumulative PnL and NAV for all Hypercore vaults, while ledger flows remain
+useful for explaining raw NAV changes. `AUTODETECT=true` only applies to legacy
+cleaned files containing `deferred_hf_nav`; new cleaned files do not emit that
+status.
 
 ## Tombstoning stale vaults
 
@@ -583,9 +593,11 @@ SCAN_HYPERCORE=true HYPERCORE_MODE=high_freq SCAN_CYCLES="Hypercore=4h" \
 
 ## Healing share price data
 
-The share price computation has evolved over time. If the production DuckDB
-contains data computed with older logic, run the combined healer to fix it
-**with minimal destruction of historical rows**.
+These legacy tools improve the scanner's synthetic DuckDB price and are useful
+for raw-data diagnosis. They do not recover an exact Hyperliquid investor share
+price and are not needed to build the cleaned PnL/NAV index. If the production
+DuckDB contains data computed with older scanner logic, run the combined healer
+with minimal destruction of historical rows.
 
 ```shell
 # Dry run: detect issues without modifying data
@@ -617,8 +629,9 @@ The script runs these steps automatically:
    multi-period merge. Only the stuck vaults are re-fetched; all other
    vaults keep their existing data.
 4. **Verify** — re-run detection and report remaining issues.
-5. **Pipeline** (optional, `RUN_PIPELINE=true`) — push healed data
-   through the downstream cleaning pipeline.
+5. **Pipeline** (optional, `RUN_PIPELINE=true`) — push healed raw data through
+   the downstream cleaning pipeline, which independently constructs the
+   PnL/NAV economic index.
 
 ### What each step fixes
 

--- a/scripts/hyperliquid/backfill-historical-vault-flows.py
+++ b/scripts/hyperliquid/backfill-historical-vault-flows.py
@@ -1,20 +1,21 @@
-"""Backfill historical Hypercore ledger flows for deferred price repairs.
+"""Backfill historical Hypercore ledger flows for accounting diagnostics.
 
 The normal Hyperliquid scanners fetch only a short rolling flow window. Old
 daily price observations can therefore retain missing or incorrectly parsed
 withdrawals even though ``userNonFundingLedgerUpdates`` still exposes the
-ledger events. This script finds ``deferred_hf_nav`` observations in the
-cleaned Parquet, fetches the surrounding ledger history, and updates the
+ledger events. This script can find legacy ``deferred_hf_nav`` observations in
+a cleaned Parquet, fetch the surrounding ledger history, and update the
 existing daily DuckDB rows. It does not change share price, NAV, or PnL.
 
-After the backfill, run the normal Hyperliquid export and vault-price wrangle.
-The flow-reconciled wrangle step will then repair qualifying share-price paths.
+The current cleaned PnL/NAV economic-performance index does not need these
+flows. Use the script only to investigate raw NAV accounting or maintain a
+legacy database. New cleaned files do not emit ``deferred_hf_nav``.
 
 Usage:
 
 .. code-block:: shell
 
-    # Preview every currently deferred vault.
+    # Preview every deferred vault in a legacy cleaned Parquet.
     AUTODETECT=true \
       poetry run python scripts/hyperliquid/backfill-historical-vault-flows.py
 
@@ -28,7 +29,7 @@ Environment variables:
 - ``DB_PATH``: Daily Hyperliquid DuckDB path.
 - ``CLEANED_PARQUET_PATH``: Cleaned vault-price Parquet used to find candidates.
 - ``VAULT_ADDRESSES``: Comma-separated candidate vaults to repair.
-- ``AUTODETECT``: Select every current ``deferred_hf_nav`` vault. Default: false.
+- ``AUTODETECT``: Select every legacy ``deferred_hf_nav`` vault. Default: false.
   Exactly one of ``VAULT_ADDRESSES`` or ``AUTODETECT=true`` is required.
 - ``MAX_WORKERS``: Parallel API readers. Default: 8.
 - ``ANCHOR_PADDING_DAYS``: Days fetched on both sides of candidates. Default: 8.
@@ -104,7 +105,8 @@ def select_historical_flow_candidates(
     Explicit address selection and autodetection are mutually exclusive so a
     missing environment variable cannot accidentally expand a single-vault
     maintenance operation to every candidate. Autodetection means all rows
-    currently marked ``deferred_hf_nav`` by the production wrangle.
+    marked ``deferred_hf_nav`` in an older cleaned Parquet; the current
+    production wrangle does not emit this status.
 
     :param cleaned:
         Cleaned Hypercore prices with ``address``, ``timestamp``, and
@@ -112,7 +114,7 @@ def select_historical_flow_candidates(
     :param requested_addresses:
         Explicit lowercased Hyperliquid vault addresses.
     :param autodetect:
-        Whether to select all current ``deferred_hf_nav`` vaults.
+        Whether to select all legacy ``deferred_hf_nav`` vaults.
     :return:
         Matching deferred observations, with lowercased addresses and naive
         UTC timestamps.

--- a/scripts/hyperliquid/heal-all-share-prices.py
+++ b/scripts/hyperliquid/heal-all-share-prices.py
@@ -1,7 +1,9 @@
-"""Heal all Hyperliquid vault share prices in a single run.
+"""Heal all synthetic Hyperliquid scanner share prices in a single run.
 
 Combines offline recomputation and API re-fetch into one script
-that fixes share price data with minimal destruction of historical rows.
+that improves raw scanner data with minimal destruction of historical rows.
+Hyperliquid does not expose an exact historical investor share price; the
+downstream wrangle independently builds its cleaned PnL/NAV economic index.
 
 Steps
 -----

--- a/scripts/hyperliquid/heal-share-prices-offline.py
+++ b/scripts/hyperliquid/heal-share-prices-offline.py
@@ -1,4 +1,4 @@
-"""Heal Hyperliquid vault share prices offline from stored DuckDB data.
+"""Heal synthetic Hyperliquid scanner share prices from stored DuckDB data.
 
 Problem
 -------
@@ -23,6 +23,10 @@ already stored in DuckDB. The stored ``tvl`` (total_assets), ``daily_pnl``
 (pnl_update), and ``cumulative_pnl`` columns contain enough information
 to reconstruct ``netflow_update`` and rerun ``_calculate_share_price()``
 with the fixed chain-linked logic.
+
+This improves raw scanner continuity only. Hyperliquid does not expose an exact
+historical investor share price, and the downstream wrangle constructs its
+cleaned PnL/NAV economic index independently.
 
 Usage
 -----

--- a/tests/research/test_clean_prices.py
+++ b/tests/research/test_clean_prices.py
@@ -14,14 +14,13 @@ import zstandard as zstd
 
 import eth_defi.research.wrangle_vault_prices as vault_price_wrangle
 from eth_defi.research.wrangle_vault_prices import (
+    approximate_hypercore_share_prices_from_pnl_nav,
+    clean_by_tvl,
     clean_returns,
     discard_hypercore_pre_recapitalisation_history,
-    fix_hypercore_flow_reconciled_share_price_paths,
-    fix_hypercore_source_overlap_share_prices,
     fix_outlier_share_prices,
     generate_cleaned_vault_datasets,
     replace_cleaned_vault_histories,
-    stitch_hypercore_high_freq_share_price_batches,
 )
 from eth_defi.vault.base import VaultHistoricalRead
 from eth_defi.vault.settlement_data import VaultSettlement, VaultSettlementDatabase
@@ -251,355 +250,198 @@ def test_remove_inactive_lead_time():
     assert len(vault2_rows) == 1  # row at index 3 (200)
 
 
-def test_fix_hypercore_source_overlap_share_prices() -> None:
-    """Daily Hypercore excursions are repaired from overlapping HF anchors.
+def test_approximate_hypercore_share_prices_from_pnl_nav() -> None:
+    """PnL changes drive the clean index while capital flows leave it flat."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 4,
+            "id": ["9999-0xeconomic"] * 4,
+            "share_price": [1.0, 50.0, 0.01, 500.0],
+            "total_assets": [100.0, 110.0, 200.0, 220.0],
+            "total_supply": [100.0, 2.2, 20_000.0, 0.44],
+            "account_pnl": [0.0, 10.0, 10.0, 30.0],
+            "hypercore_source": ["daily"] * 4,
+            "written_at": pd.to_datetime(["2026-01-05"] * 4),
+        },
+        index=pd.to_datetime(["2026-01-01", "2026-01-02", "2026-01-03", "2026-01-04"]),
+    )
 
-    The daily source contains one synthetic price spike between two stable HF
-    observations. The wrangle repair must replace only that spike, preserve a
-    plausible daily observation, and leave non-Hypercore data untouched.
-    """
-    hypercore_id = "9999-0xhypercore"
-    evm_id = "1-0xevm"
-    timestamps = pd.to_datetime(
+    messages: list[str] = []
+    result = approximate_hypercore_share_prices_from_pnl_nav(prices_df, logger=messages.append)
+
+    expected_prices = [1.0, 1.0 * (1 + 10.0 / 110.0), 1.0 * (1 + 10.0 / 110.0), 1.0 * (1 + 10.0 / 110.0) * (1 + 20.0 / 220.0)]
+    assert result["share_price"].tolist() == pytest.approx(expected_prices)
+    assert result["raw_share_price"].tolist() == prices_df["share_price"].tolist()
+    assert (result["share_price"] * result["total_supply"]).tolist() == pytest.approx(result["total_assets"].tolist())
+    assert result["hypercore_repair_status"].tolist() == ["approximated_pnl_nav"] * 4
+    assert messages == ["Approximated Hypercore economic share prices for 1 vaults using 4 daily PnL/NAV checkpoints; carried 0 duplicate rows, deferred 0 missing-input rows and 0 uncorroborated losses, capped 0 gains and recorded 0 terminal wipe-outs"]
+
+
+def test_approximate_hypercore_uses_freshest_daily_checkpoint() -> None:
+    """A fresher daily row wins over a stale HF row on the same UTC date."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 3,
+            "id": ["9999-0xfresh"] * 3,
+            "share_price": [1.0, 20.0, 30.0],
+            "total_assets": [100.0, 110.0, 200.0],
+            "total_supply": [100.0, 5.5, 200.0 / 30.0],
+            "account_pnl": [0.0, 10.0, 100.0],
+            "hypercore_source": ["daily", "daily", "hf"],
+            "written_at": pd.to_datetime(["2026-01-01", "2026-01-04", "2026-01-03"]),
+        },
+        index=pd.to_datetime(["2026-01-01", "2026-01-02", "2026-01-02 12:00"], format="mixed"),
+    )
+
+    result = approximate_hypercore_share_prices_from_pnl_nav(prices_df, logger=lambda _message: None)
+
+    expected_price = 1 + 10.0 / 110.0
+    assert result["share_price"].tolist() == pytest.approx([1.0, expected_price, expected_price])
+    assert result["hypercore_repair_status"].tolist() == ["approximated_pnl_nav", "approximated_pnl_nav", "approximated_pnl_nav_carried"]
+
+
+def test_approximate_hypercore_defers_missing_and_absorbing_losses() -> None:
+    """Missing inputs and an uncorroborated loss carry a funded vault's price."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 4,
+            "id": ["9999-0xdeferred"] * 4,
+            "share_price": [1.0, 2.0, 3.0, 4.0],
+            "total_assets": [100.0, np.nan, 50.0, 60.0],
+            "total_supply": [100.0, 100.0, 100.0, 100.0],
+            "account_pnl": [0.0, np.nan, -150.0, -150.0],
+        },
+        index=pd.to_datetime(["2026-01-01", "2026-01-02", "2026-01-03", "2026-01-04"]),
+    )
+
+    result = approximate_hypercore_share_prices_from_pnl_nav(prices_df, logger=lambda _message: None)
+
+    assert result["share_price"].tolist() == [1.0] * 4
+    assert result["hypercore_repair_status"].tolist() == ["approximated_pnl_nav", "deferred_pnl_nav", "deferred_pnl_nav_outlier", "approximated_pnl_nav"]
+
+
+def test_approximate_hypercore_caps_gain_and_records_terminal_wipe_out() -> None:
+    """Extreme gains are bounded and a terminal zero NAV can end the index."""
+    prices_df = pd.concat(
         [
-            "2026-02-01 12:00:00",
-            "2026-02-02 00:00:00",
-            "2026-02-03 00:00:00",
-            "2026-02-04 12:00:00",
-            "2026-02-02 00:00:00",
+            pd.DataFrame(
+                {
+                    "chain": [9999, 9999],
+                    "id": ["9999-0xgain"] * 2,
+                    "share_price": [1.0, 50.0],
+                    "total_assets": [100.0, 200.0],
+                    "total_supply": [100.0, 4.0],
+                    "account_pnl": [0.0, 500.0],
+                },
+                index=pd.to_datetime(["2026-01-01", "2026-01-02"]),
+            ),
+            pd.DataFrame(
+                {
+                    "chain": [9999, 9999],
+                    "id": ["9999-0xwipe"] * 2,
+                    "share_price": [1.0, 1.0],
+                    "total_assets": [100.0, 0.0],
+                    "total_supply": [100.0, 100.0],
+                    "account_pnl": [0.0, -100.0],
+                },
+                index=pd.to_datetime(["2026-01-01", "2026-01-02"]),
+            ),
+        ]
+    ).sort_values(["id"], kind="stable")
+
+    result = approximate_hypercore_share_prices_from_pnl_nav(prices_df, logger=lambda _message: None)
+    gain = result[result["id"] == "9999-0xgain"]
+    wipe = result[result["id"] == "9999-0xwipe"]
+
+    assert gain["share_price"].tolist() == [1.0, 2.0]
+    assert gain["hypercore_repair_status"].tolist() == ["approximated_pnl_nav", "approximated_pnl_nav_clipped"]
+    assert wipe["share_price"].tolist() == [1.0, 0.0]
+    assert wipe["total_supply"].tolist() == [100.0, 0.0]
+    assert wipe["hypercore_repair_status"].tolist() == ["approximated_pnl_nav", "approximated_pnl_nav_wipe_out"]
+
+
+def test_approximate_hypercore_prevents_partial_repair_spike() -> None:
+    """One repaired and one raw synthetic unit cannot create a clean return."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999, 9999, 9999],
+            "id": ["9999-0xorder-block-hunter"] * 3,
+            "share_price": [1.0, 0.860920, 3.231962],
+            "total_assets": [100.0, 105.0, 100.0],
+            "total_supply": [100.0, 105.0 / 0.860920, 100.0 / 3.231962],
+            "account_pnl": [0.0, 5.0, 0.0],
+            "hypercore_repair_status": ["", "repaired_hf", "deferred_hf_nav"],
+        },
+        index=pd.to_datetime(["2026-01-31", "2026-02-01", "2026-02-02"]),
+    )
+
+    result = approximate_hypercore_share_prices_from_pnl_nav(prices_df, logger=lambda _message: None)
+
+    assert result["share_price"].tolist() == pytest.approx([1.0, 1 + 5.0 / 105.0, (1 + 5.0 / 105.0) * (1 - 5.0 / 105.0)])
+    assert result["share_price"].pct_change().iloc[-1] == pytest.approx(-5.0 / 105.0)
+    assert result["raw_share_price"].tolist() == prices_df["share_price"].tolist()
+
+
+def test_approximate_hypercore_is_idempotent_and_append_stable() -> None:
+    """An identical rerun and a future append preserve earlier checkpoints."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999, 9999],
+            "id": ["9999-0xstable"] * 2,
+            "share_price": [10.0, 20.0],
+            "total_assets": [100.0, 110.0],
+            "total_supply": [10.0, 5.5],
+            "account_pnl": [0.0, 10.0],
+        },
+        index=pd.to_datetime(["2026-01-01", "2026-01-02"]),
+    )
+
+    first = approximate_hypercore_share_prices_from_pnl_nav(prices_df, logger=lambda _message: None)
+    second = approximate_hypercore_share_prices_from_pnl_nav(first, logger=lambda _message: None)
+    appended_input = pd.concat(
+        [
+            prices_df,
+            pd.DataFrame(
+                {
+                    "chain": [9999],
+                    "id": ["9999-0xstable"],
+                    "share_price": [30.0],
+                    "total_assets": [120.0],
+                    "total_supply": [4.0],
+                    "account_pnl": [20.0],
+                },
+                index=pd.to_datetime(["2026-01-03"]),
+            ),
         ]
     )
+    appended = approximate_hypercore_share_prices_from_pnl_nav(appended_input, logger=lambda _message: None)
+
+    pd.testing.assert_series_equal(first["share_price"], second["share_price"])
+    assert first["raw_share_price"].tolist() == second["raw_share_price"].tolist()
+    assert appended["share_price"].iloc[:2].tolist() == first["share_price"].tolist()
+
+
+def test_approximate_hypercore_leaves_other_protocols_unchanged() -> None:
+    """The Hypercore approximation does not alter another protocol's rows."""
     prices_df = pd.DataFrame(
         {
-            "chain": [9999, 9999, 9999, 9999, 1],
-            "id": [hypercore_id, hypercore_id, hypercore_id, hypercore_id, evm_id],
-            "share_price": [1.0, 3.5, 1.1, 1.2, 4.0],
-            "total_assets": [100.0, 105.0, 110.0, 120.0, 400.0],
-            "hypercore_source": ["hf", "daily", "daily", "hf", pd.NA],
+            "chain": [9999, 1],
+            "id": ["9999-0xhypercore", "1-0xevm"],
+            "share_price": [20.0, 5.0],
+            "total_assets": [100.0, 500.0],
+            "total_supply": [5.0, 100.0],
+            "account_pnl": [0.0, np.nan],
+            "hypercore_repair_status": ["old", "evm-status"],
         },
-        index=timestamps,
+        index=pd.to_datetime(["2026-01-01", "2026-01-01"]),
     )
 
-    messages: list[str] = []
-    result = fix_hypercore_source_overlap_share_prices(prices_df, logger=messages.append)
+    result = approximate_hypercore_share_prices_from_pnl_nav(prices_df, logger=lambda _message: None)
+    evm = result[result["chain"] == 1].iloc[0]
 
-    hypercore_rows = result[result["id"] == hypercore_id]
-    repaired = hypercore_rows.loc[pd.Timestamp("2026-02-02"), "share_price"]
-    expected = np.exp(np.interp(pd.Timestamp("2026-02-02").value, [pd.Timestamp("2026-02-01 12:00:00").value, pd.Timestamp("2026-02-04 12:00:00").value], np.log([1.0, 1.2])))
-
-    assert repaired == pytest.approx(expected)
-    assert hypercore_rows.loc[pd.Timestamp("2026-02-02"), "raw_share_price"] == pytest.approx(3.5)
-    assert hypercore_rows.loc[pd.Timestamp("2026-02-02"), "hypercore_repair_status"] == "repaired_hf"
-    assert hypercore_rows.loc[pd.Timestamp("2026-02-03"), "share_price"] == pytest.approx(1.1)
-    assert result[result["id"] == evm_id]["share_price"].iloc[0] == pytest.approx(4.0)
-    assert messages == ["Repaired 1 conflicting daily Hypercore share prices across 1 vaults using HF anchors"]
-
-
-def test_fix_hypercore_source_overlap_preserves_unbracketed_daily_rows() -> None:
-    """Daily observations outside HF coverage cannot be safely repaired."""
-    timestamps = pd.to_datetime(
-        [
-            "2026-01-01 00:00:00",
-            "2026-02-01 12:00:00",
-            "2026-02-04 12:00:00",
-            "2026-03-01 00:00:00",
-        ]
-    )
-    prices_df = pd.DataFrame(
-        {
-            "chain": [9999] * 4,
-            "id": ["9999-0xhypercore"] * 4,
-            "share_price": [10.0, 1.0, 1.2, 10.0],
-            "total_assets": [100.0, 100.0, 120.0, 120.0],
-            "hypercore_source": ["daily", "hf", "hf", "daily"],
-        },
-        index=timestamps,
-    )
-
-    result = fix_hypercore_source_overlap_share_prices(prices_df, logger=lambda _message: None)
-
-    assert result["share_price"].tolist() == prices_df["share_price"].tolist()
-
-
-def test_fix_hypercore_source_overlap_infers_legacy_sources() -> None:
-    """Legacy Parquet rows infer daily/HF provenance from timestamp precision."""
-    prices_df = pd.DataFrame(
-        {
-            "chain": [9999] * 3,
-            "id": ["9999-0xhypercore"] * 3,
-            "share_price": [1.0, 3.5, 1.2],
-            "total_assets": [100.0, 110.0, 120.0],
-        },
-        index=pd.to_datetime(
-            [
-                "2026-02-01 12:01:02.003",
-                "2026-02-02 00:00:00",
-                "2026-02-03 12:01:02.003",
-            ],
-            format="mixed",
-        ),
-    )
-
-    messages: list[str] = []
-    result = fix_hypercore_source_overlap_share_prices(prices_df, logger=messages.append)
-
-    assert result["hypercore_source"].tolist() == ["hf", "daily", "hf"]
-    assert result.loc[pd.Timestamp("2026-02-02"), "share_price"] < 1.2
-    assert result.loc[pd.Timestamp("2026-02-02"), "hypercore_repair_status"] == "repaired_hf"
-    assert messages[0] == "Inferred Hypercore source provenance for 3 legacy price rows"
-    assert messages[1] == "Repaired 1 conflicting daily Hypercore share prices across 1 vaults using HF anchors"
-
-
-def test_fix_hypercore_source_overlap_uses_refreshed_daily_anchors() -> None:
-    """Daily-only legacy vaults use the latest refresh batch as anchors.
-
-    Older rolling-window rows may remain between canonical observations from
-    the latest allTime refresh. The repair must interpolate only those stale
-    rows and preserve every row in the latest refresh batch.
-    """
-    latest_refresh = pd.Timestamp("2026-04-10 17:10:32")
-    prices_df = pd.DataFrame(
-        {
-            "chain": [9999] * 5,
-            "id": ["9999-0xdaily-only"] * 5,
-            "share_price": [1.0, 2.5, 1.1, 10.0, 1.2],
-            "total_assets": [100.0, 103.0, 105.0, 108.0, 110.0],
-            "hypercore_source": ["daily"] * 5,
-            "written_at": [latest_refresh, pd.NaT, latest_refresh, pd.Timestamp("2026-02-05"), latest_refresh],
-        },
-        index=pd.to_datetime(
-            [
-                "2026-01-21",
-                "2026-01-25",
-                "2026-01-28",
-                "2026-02-01",
-                "2026-02-04",
-            ]
-        ),
-    )
-
-    messages: list[str] = []
-    result = fix_hypercore_source_overlap_share_prices(prices_df, logger=messages.append)
-
-    assert result.loc[pd.Timestamp("2026-01-25"), "share_price"] < 1.1
-    assert result.loc[pd.Timestamp("2026-02-01"), "share_price"] < 1.2
-    assert result.loc[pd.Timestamp("2026-01-25"), "hypercore_repair_status"] == "repaired_daily"
-    assert result.loc[pd.Timestamp("2026-01-25"), "raw_share_price"] == pytest.approx(2.5)
-    assert result.loc[prices_df["written_at"] == latest_refresh, "share_price"].tolist() == [1.0, 1.1, 1.2]
-    assert messages == ["Repaired 2 stale daily Hypercore share prices across 1 vaults using refreshed daily anchors"]
-
-
-def test_fix_hypercore_source_overlap_preserves_daily_lifecycle_change() -> None:
-    """Daily fallback does not interpolate across a genuine NAV boundary."""
-    latest_refresh = pd.Timestamp("2026-04-10 17:10:32")
-    prices_df = pd.DataFrame(
-        {
-            "chain": [9999] * 3,
-            "id": ["9999-0xlifecycle"] * 3,
-            "share_price": [1.0, 10.0, 1.1],
-            "total_assets": [100.0, 1_000.0, 110.0],
-            "hypercore_source": ["daily"] * 3,
-            "written_at": [latest_refresh, pd.NaT, latest_refresh],
-        },
-        index=pd.to_datetime(["2026-01-21", "2026-01-25", "2026-01-28"]),
-    )
-
-    result = fix_hypercore_source_overlap_share_prices(prices_df, logger=lambda _message: None)
-
-    assert result.loc[pd.Timestamp("2026-01-25"), "share_price"] == pytest.approx(10.0)
-    assert result.loc[pd.Timestamp("2026-01-25"), "hypercore_repair_status"] == "deferred_daily_nav"
-
-
-def test_fix_hypercore_source_overlap_defers_unsafe_hf_repairs() -> None:
-    """HF candidates remain raw when NAV, gap, or boundary evidence is unsafe."""
-    vault_ids = ["9999-0xnav", "9999-0xgap", "9999-0xepoch", "9999-0xzero"]
-    frames = [
-        pd.DataFrame(
-            {
-                "chain": [9999] * 3,
-                "id": [vault_ids[0]] * 3,
-                "share_price": [1.0, 10.0, 1.1],
-                "total_assets": [100.0, 1_000.0, 110.0],
-                "hypercore_source": ["hf", "daily", "hf"],
-                "epoch_reset": [False] * 3,
-            },
-            index=pd.to_datetime(["2026-01-01 12:00", "2026-01-02", "2026-01-03 12:00"], format="mixed"),
-        ),
-        pd.DataFrame(
-            {
-                "chain": [9999] * 4,
-                "id": [vault_ids[3]] * 4,
-                "share_price": [1.0, 10.0, 1.05, 1.1],
-                "total_assets": [100.0, 105.0, 0.0, 110.0],
-                "hypercore_source": ["hf", "daily", "daily", "hf"],
-                "epoch_reset": [False] * 4,
-            },
-            index=pd.to_datetime(["2026-01-01 12:00", "2026-01-02", "2026-01-02 12:00", "2026-01-03 12:00"], format="mixed"),
-        ),
-        pd.DataFrame(
-            {
-                "chain": [9999] * 3,
-                "id": [vault_ids[1]] * 3,
-                "share_price": [1.0, 10.0, 1.1],
-                "total_assets": [100.0, 105.0, 110.0],
-                "hypercore_source": ["hf", "daily", "hf"],
-                "epoch_reset": [False] * 3,
-            },
-            index=pd.to_datetime(["2026-01-01 12:00", "2026-01-08", "2026-01-11 12:00"], format="mixed"),
-        ),
-        pd.DataFrame(
-            {
-                "chain": [9999] * 3,
-                "id": [vault_ids[2]] * 3,
-                "share_price": [1.0, 10.0, 1.1],
-                "total_assets": [100.0, 105.0, 110.0],
-                "hypercore_source": ["hf", "daily", "hf"],
-                "epoch_reset": [False, True, False],
-            },
-            index=pd.to_datetime(["2026-01-01 12:00", "2026-01-02", "2026-01-03 12:00"], format="mixed"),
-        ),
-    ]
-    prices_df = pd.concat(frames).sort_index(kind="stable")
-
-    result = fix_hypercore_source_overlap_share_prices(prices_df, logger=lambda _message: None)
-
-    for vault_id, expected_status in zip(vault_ids, ["deferred_hf_nav", "deferred_hf_gap", "deferred_hf_boundary", "deferred_hf_boundary"]):
-        candidate = result[(result["id"] == vault_id) & (result["hypercore_source"] == "daily")].iloc[0]
-        assert candidate["share_price"] == pytest.approx(10.0)
-        assert candidate["raw_share_price"] == pytest.approx(10.0)
-        assert candidate["hypercore_repair_status"] == expected_status
-
-
-def test_fix_hypercore_flow_reconciled_share_price_paths() -> None:
-    """Ledger-proven withdrawals repair a synthetic daily price unit.
-
-    The daily price of 20.0 conflicts with both HF anchors, but its $20
-    withdrawal and -$10 PnL exactly explain the NAV change. The following
-    positive-PnL row also reconciles, so the repair must continue through it,
-    preserve raw values, and rescale a non-zero derived supply.
-    """
-    prices_df = pd.DataFrame(
-        {
-            "chain": [9999] * 4,
-            "id": ["9999-0xflow-reconciled"] * 4,
-            "hypercore_source": ["hf", "daily", "daily", "hf"],
-            "share_price": [1.0, 20.0, 1.3, 1.0],
-            "total_assets": [100.0, 70.0, 80.0, 80.0],
-            "account_pnl": [0.0, -10.0, 0.0, 0.0],
-            "daily_deposit_usd": [np.nan, 0.0, 0.0, np.nan],
-            "daily_withdrawal_usd": [np.nan, 20.0, 0.0, np.nan],
-            "total_supply": [100.0, 5.0, 5.0, 100.0],
-        },
-        index=pd.to_datetime(["2026-01-01 12:00", "2026-01-02", "2026-01-03", "2026-01-04 12:00"], format="mixed"),
-    )
-
-    messages: list[str] = []
-    result = fix_hypercore_flow_reconciled_share_price_paths(prices_df, logger=messages.append)
-
-    first_daily = pd.Timestamp("2026-01-02")
-    second_daily = pd.Timestamp("2026-01-03")
-    assert result.loc[first_daily, "raw_share_price"] == pytest.approx(20.0)
-    assert result.loc[first_daily, "share_price"] == pytest.approx(0.9)
-    assert result.loc[second_daily, "share_price"] == pytest.approx(0.9 * (1 + 10.0 / 70.0))
-    assert result.loc[first_daily, "hypercore_repair_status"] == "repaired_hf_pnl_flow"
-    assert result.loc[second_daily, "hypercore_repair_status"] == "repaired_hf_pnl_flow"
-    assert result.loc[second_daily, "share_price"] / result.loc[first_daily, "share_price"] - 1 > 0
-    assert result.loc[first_daily, "total_supply"] > 100.0
-    assert messages == ["Repaired 2 flow-reconciled Hypercore daily prices across 1 vaults using PnL paths"]
-
-
-def test_fix_hypercore_flow_reconciled_paths_require_hf_endpoint_agreement() -> None:
-    """A PnL path that misses its HF endpoint remains available for fallback."""
-    prices_df = pd.DataFrame(
-        {
-            "chain": [9999] * 3,
-            "id": ["9999-0xendpoint"] * 3,
-            "hypercore_source": ["hf", "daily", "hf"],
-            "share_price": [1.0, 20.0, 2.0],
-            "total_assets": [100.0, 70.0, 70.0],
-            "account_pnl": [0.0, -10.0, -10.0],
-            "daily_deposit_usd": [np.nan, 0.0, np.nan],
-            "daily_withdrawal_usd": [np.nan, 20.0, np.nan],
-        },
-        index=pd.to_datetime(["2026-01-01 12:00", "2026-01-02", "2026-01-03 12:00"], format="mixed"),
-    )
-
-    result = fix_hypercore_flow_reconciled_share_price_paths(prices_df, logger=lambda _message: None)
-
-    assert result.loc[pd.Timestamp("2026-01-02"), "share_price"] == pytest.approx(20.0)
-    assert result.loc[pd.Timestamp("2026-01-02"), "hypercore_repair_status"] == ""
-
-
-def test_fix_hypercore_flow_reconciled_path_keeps_pnl_return_direction() -> None:
-    """A nearby lower HF endpoint cannot turn positive PnL into a loss."""
-    prices_df = pd.DataFrame(
-        {
-            "chain": [9999] * 4,
-            "id": ["9999-0xpositive-pnl"] * 4,
-            "hypercore_source": ["hf", "daily", "daily", "hf"],
-            "share_price": [1.0, 20.0, 20.0, 0.93],
-            "total_assets": [100.0, 101.0, 102.0, 102.0],
-            "account_pnl": [0.0, 1.0, 2.0, 2.0],
-            "daily_deposit_usd": [np.nan, 0.0, 0.0, np.nan],
-            "daily_withdrawal_usd": [np.nan, 0.0, 0.0, np.nan],
-        },
-        index=pd.to_datetime(["2026-01-01 12:00", "2026-01-02", "2026-01-03", "2026-01-04 12:00"], format="mixed"),
-    )
-
-    result = fix_hypercore_flow_reconciled_share_price_paths(prices_df, logger=lambda _message: None)
-
-    first_price = result.loc[pd.Timestamp("2026-01-02"), "share_price"]
-    second_price = result.loc[pd.Timestamp("2026-01-03"), "share_price"]
-    assert first_price == pytest.approx(1.01)
-    assert second_price == pytest.approx(1.02)
-    assert second_price / first_price - 1 > 0
-
-
-def test_fix_hypercore_flow_reconciled_path_stops_at_unproven_step() -> None:
-    """A repaired PnL segment ends when its next ledger step is missing."""
-    prices_df = pd.DataFrame(
-        {
-            "chain": [9999] * 5,
-            "id": ["9999-0xpartial-flow"] * 5,
-            "hypercore_source": ["hf", "daily", "daily", "daily", "hf"],
-            "share_price": [1.0, 20.0, 1.3, 20.0, 1.1],
-            "total_assets": [100.0, 70.0, 80.0, 90.0, 90.0],
-            "account_pnl": [0.0, -10.0, 0.0, 10.0, 10.0],
-            "daily_deposit_usd": [np.nan, 0.0, np.nan, 0.0, np.nan],
-            "daily_withdrawal_usd": [np.nan, 20.0, np.nan, 0.0, np.nan],
-        },
-        index=pd.to_datetime(["2026-01-01 12:00", "2026-01-02", "2026-01-03", "2026-01-04", "2026-01-05 12:00"], format="mixed"),
-    )
-
-    result = fix_hypercore_flow_reconciled_share_price_paths(prices_df, logger=lambda _message: None)
-
-    assert result.loc[pd.Timestamp("2026-01-02"), "hypercore_repair_status"] == "repaired_hf_pnl_flow"
-    assert result.loc[pd.Timestamp("2026-01-03"), "hypercore_repair_status"] == ""
-    assert result.loc[pd.Timestamp("2026-01-04"), "share_price"] == pytest.approx(20.0)
-    assert result.loc[pd.Timestamp("2026-01-04"), "hypercore_repair_status"] == ""
-
-
-def test_fix_hypercore_flow_reconciled_path_rejects_large_nav_mismatch() -> None:
-    """A percentage-sized NAV mismatch is not accepted for a large vault."""
-    prices_df = pd.DataFrame(
-        {
-            "chain": [9999] * 3,
-            "id": ["9999-0xlarge-nav"] * 3,
-            "hypercore_source": ["hf", "daily", "hf"],
-            "share_price": [1.0, 20.0, 1.0],
-            "total_assets": [100_000_000.0, 100_900_000.0, 100_900_000.0],
-            "account_pnl": [0.0, 0.0, 0.0],
-            "daily_deposit_usd": [np.nan, 0.0, np.nan],
-            "daily_withdrawal_usd": [np.nan, 0.0, np.nan],
-        },
-        index=pd.to_datetime(["2026-01-01 12:00", "2026-01-02", "2026-01-03 12:00"], format="mixed"),
-    )
-
-    result = fix_hypercore_flow_reconciled_share_price_paths(prices_df, logger=lambda _message: None)
-
-    daily = result.loc[pd.Timestamp("2026-01-02")]
-    assert daily["share_price"] == pytest.approx(20.0)
-    assert daily["hypercore_repair_status"] == ""
+    assert evm["share_price"] == pytest.approx(5.0)
+    assert evm["total_supply"] == pytest.approx(100.0)
+    assert evm["hypercore_repair_status"] == "evm-status"
 
 
 def test_discard_hypercore_pre_recapitalisation_history() -> None:
@@ -665,49 +507,23 @@ def test_discard_hypercore_history_measures_delay_to_first_positive_nav() -> Non
     assert result["epoch_reset"].tolist() == [False] * 4
 
 
-def test_stitch_hypercore_high_freq_share_price_batches() -> None:
-    """A scanner batch unit jump follows PnL, not a 50x investor return."""
+def test_discard_hypercore_history_rebuilds_scanner_epoch_markers() -> None:
+    """Synthetic scanner resets cannot split the cleaned economic index."""
     prices_df = pd.DataFrame(
         {
-            "chain": [9999] * 3,
-            "id": ["9999-0xstitch"] * 3,
-            "hypercore_source": ["hf"] * 3,
-            "written_at": pd.to_datetime(["2026-01-01", "2026-01-02", "2026-01-02"]),
-            "total_assets": [100.0, 101.0, 102.01],
-            # Exported Hypercore parquet calls this cumulative metric account_pnl.
-            "account_pnl": [0.0, 1.0, 2.01],
-            "share_price": [1.0, 50.0, 50.5],
-            "total_supply": [100.0, 2.02, 2.02],
+            "chain": [9999, 9999, 9999, 1],
+            "id": ["9999-0xfunded"] * 3 + ["1-0xevm"],
+            "total_assets": [1_000.0, 1_100.0, 1_200.0, 100.0],
+            "share_price": [1.0, 1.0, 1.0, 1.0],
+            "epoch_reset": [False, True, False, True],
         },
-        index=pd.to_datetime(["2026-01-01 12:00", "2026-01-01 13:00", "2026-01-01 14:00"]),
+        index=pd.to_datetime(["2026-01-01", "2026-01-02", "2026-01-03", "2026-01-01"]),
     )
 
-    result = stitch_hypercore_high_freq_share_price_batches(prices_df, logger=lambda _message: None)
+    result = discard_hypercore_pre_recapitalisation_history(prices_df, logger=lambda _message: None)
 
-    assert result["share_price"].tolist() == pytest.approx([1.0, 1.01, 1.0201])
-    assert result["total_supply"].tolist() == pytest.approx([100.0, 100.0, 100.0])
-    assert result["hypercore_repair_status"].tolist() == ["", "repaired_hf_batch_scale", ""]
-
-
-def test_stitch_hypercore_batch_keeps_pnl_supported_return() -> None:
-    """A genuine 50 percent PnL gain must not be mistaken for a unit jump."""
-    prices_df = pd.DataFrame(
-        {
-            "chain": [9999, 9999],
-            "id": ["9999-0xreal-gain"] * 2,
-            "hypercore_source": ["hf", "hf"],
-            "written_at": pd.to_datetime(["2026-01-01", "2026-01-02"]),
-            "total_assets": [100.0, 150.0],
-            "cumulative_pnl": [0.0, 50.0],
-            "share_price": [1.0, 1.5],
-        },
-        index=pd.to_datetime(["2026-01-01 12:00", "2026-01-01 13:00"]),
-    )
-
-    result = stitch_hypercore_high_freq_share_price_batches(prices_df, logger=lambda _message: None)
-
-    assert result["share_price"].tolist() == [1.0, 1.5]
-    assert result["hypercore_repair_status"].tolist() == ["", ""]
+    assert result[result["chain"] == 9999]["epoch_reset"].tolist() == [False, False, False]
+    assert result[result["chain"] == 1]["epoch_reset"].tolist() == [True]
 
 
 def test_clean_returns_keeps_large_hypercore_return() -> None:
@@ -723,6 +539,23 @@ def test_clean_returns_keeps_large_hypercore_return() -> None:
     result = clean_returns({}, prices_df, logger=lambda _message: None)
 
     assert result["returns_1h"].tolist() == [1.0, 0.0]
+
+
+def test_clean_by_tvl_keeps_hypercore_price_return_consistent() -> None:
+    """Low NAV flags Hypercore suitability without rewriting its price return."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999, 1],
+            "id": ["9999-0xhypercore", "1-0xevm"],
+            "total_assets": [100.0, 100.0],
+            "returns_1h": [0.25, 0.25],
+        }
+    )
+
+    result = clean_by_tvl({}, prices_df, logger=lambda _message: None)
+
+    assert result["returns_1h"].tolist() == [0.25, 0.0]
+    assert result["tvl_filtering_mask"].tolist() == [True, True]
 
 
 def test_native_protocol_columns_survive_evm_scan_rewrite(tmp_path: Path):

--- a/tests/research/test_clean_prices.py
+++ b/tests/research/test_clean_prices.py
@@ -444,6 +444,26 @@ def test_approximate_hypercore_leaves_other_protocols_unchanged() -> None:
     assert evm["hypercore_repair_status"] == "evm-status"
 
 
+def test_approximate_hypercore_rejects_invalid_configuration() -> None:
+    """Invalid approximation inputs fail explicitly instead of publishing data."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999],
+            "id": ["9999-0xinvalid"],
+            "share_price": [1.0],
+            "total_assets": [100.0],
+            "account_pnl": [0.0],
+        },
+        index=pd.to_datetime(["2026-01-01"]),
+    )
+
+    with pytest.raises(ValueError, match="max_positive_return must be positive"):
+        approximate_hypercore_share_prices_from_pnl_nav(prices_df, max_positive_return=0.0)
+
+    with pytest.raises(ValueError, match="missing columns:.*cumulative_pnl"):
+        approximate_hypercore_share_prices_from_pnl_nav(prices_df.drop(columns="account_pnl"))
+
+
 def test_discard_hypercore_pre_recapitalisation_history() -> None:
     """A durable wipe-out starts a new cleaned Hypercore performance epoch."""
     recapitalised_id = "9999-0xrecapitalised"
@@ -482,8 +502,7 @@ def test_discard_hypercore_pre_recapitalisation_history() -> None:
     assert recapitalised.index.tolist() == [pd.Timestamp("2026-01-12"), pd.Timestamp("2026-01-13")]
     assert recapitalised["epoch_reset"].tolist() == [True, False]
     assert recapitalised["raw_share_price"].tolist() == [10.0, 10.5]
-    assert recapitalised["share_price"].iloc[0] == pytest.approx(1.0)
-    assert recapitalised["share_price"].iloc[1] == pytest.approx(1.05)
+    assert recapitalised["share_price"].tolist() == [10.0, 10.5]
     assert len(result[result["id"] == short_blip_id]) == 3
     assert len(result[result["id"] == evm_id]) == 1
     assert messages == ["Discarded 6 pre-recapitalisation Hypercore price rows across 1 vaults; new epochs start once NAV reaches $1,000 after 7 days 00:00:00"]
@@ -527,7 +546,7 @@ def test_discard_hypercore_history_rebuilds_scanner_epoch_markers() -> None:
 
 
 def test_clean_returns_keeps_large_hypercore_return() -> None:
-    """Hypercore continuity repairs own synthetic prices before generic cleaning."""
+    """The Hypercore economic index owns its bounded return cleaning."""
     prices_df = pd.DataFrame(
         {
             "chain": [9999, 1],

--- a/tests/research/test_clean_prices.py
+++ b/tests/research/test_clean_prices.py
@@ -15,6 +15,7 @@ import zstandard as zstd
 import eth_defi.research.wrangle_vault_prices as vault_price_wrangle
 from eth_defi.research.wrangle_vault_prices import (
     approximate_hypercore_share_prices_from_pnl_nav,
+    calculate_vault_returns,
     clean_by_tvl,
     clean_returns,
     discard_hypercore_pre_recapitalisation_history,
@@ -274,7 +275,7 @@ def test_approximate_hypercore_share_prices_from_pnl_nav() -> None:
     assert result["raw_share_price"].tolist() == prices_df["share_price"].tolist()
     assert (result["share_price"] * result["total_supply"]).tolist() == pytest.approx(result["total_assets"].tolist())
     assert result["hypercore_repair_status"].tolist() == ["approximated_pnl_nav"] * 4
-    assert messages == ["Approximated Hypercore economic share prices for 1 vaults using 4 daily PnL/NAV checkpoints; carried 0 duplicate rows, deferred 0 missing-input rows and 0 uncorroborated losses, capped 0 gains and recorded 0 terminal wipe-outs"]
+    assert messages == ["Approximated Hypercore economic share prices for 1 vaults using 4 daily PnL/NAV checkpoints; carried 0 non-performance rows, deferred 0 missing-input rows and 0 uncorroborated losses, capped 0 gains and recorded 0 terminal wipe-outs"]
 
 
 def test_approximate_hypercore_uses_freshest_daily_checkpoint() -> None:
@@ -360,6 +361,33 @@ def test_approximate_hypercore_caps_gain_and_records_terminal_wipe_out() -> None
     assert wipe["hypercore_repair_status"].tolist() == ["approximated_pnl_nav", "approximated_pnl_nav_wipe_out"]
 
 
+def test_approximate_hypercore_carries_rows_after_terminal_wipe_out() -> None:
+    """Later API baselines cannot add performance after a complete loss."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 4,
+            "id": ["9999-0xterminal"] * 4,
+            "share_price": [1.0] * 4,
+            "total_assets": [100.0, 0.0, 0.0, 0.0],
+            "total_supply": [100.0] * 4,
+            "account_pnl": [0.0, -100.0, 500.0, -200.0],
+        },
+        index=pd.to_datetime(["2026-01-01", "2026-01-02", "2026-01-03", "2026-01-04"]),
+    )
+
+    result = approximate_hypercore_share_prices_from_pnl_nav(prices_df, logger=lambda _message: None)
+    result = calculate_vault_returns(result, logger=lambda _message: None)
+
+    assert result["share_price"].tolist() == [1.0, 0.0, 0.0, 0.0]
+    assert result["returns_1h"].iloc[1:].tolist() == [-1.0, 0.0, 0.0]
+    assert result["hypercore_repair_status"].tolist() == [
+        "approximated_pnl_nav",
+        "approximated_pnl_nav_wipe_out",
+        "approximated_pnl_nav_carried",
+        "approximated_pnl_nav_carried",
+    ]
+
+
 def test_approximate_hypercore_prevents_partial_repair_spike() -> None:
     """One repaired and one raw synthetic unit cannot create a clean return."""
     prices_df = pd.DataFrame(
@@ -421,6 +449,44 @@ def test_approximate_hypercore_is_idempotent_and_append_stable() -> None:
     assert appended["share_price"].iloc[:2].tolist() == first["share_price"].tolist()
 
 
+def test_approximate_hypercore_future_recovery_revises_terminal_loss() -> None:
+    """Later positive NAV can disprove a provisional terminal wipe-out."""
+    initial = pd.DataFrame(
+        {
+            "chain": [9999, 9999],
+            "id": ["9999-0xrecovery"] * 2,
+            "share_price": [1.0, 1.0],
+            "total_assets": [100.0, 0.0],
+            "total_supply": [100.0, 0.0],
+            "account_pnl": [0.0, -100.0],
+        },
+        index=pd.to_datetime(["2026-01-01", "2026-01-02"]),
+    )
+    recovered = pd.concat(
+        [
+            initial,
+            pd.DataFrame(
+                {
+                    "chain": [9999],
+                    "id": ["9999-0xrecovery"],
+                    "share_price": [1.0],
+                    "total_assets": [50.0],
+                    "total_supply": [50.0],
+                    "account_pnl": [-50.0],
+                },
+                index=pd.to_datetime(["2026-01-03"]),
+            ),
+        ]
+    )
+
+    provisional = approximate_hypercore_share_prices_from_pnl_nav(initial, logger=lambda _message: None)
+    revised = approximate_hypercore_share_prices_from_pnl_nav(recovered, logger=lambda _message: None)
+
+    assert provisional["hypercore_repair_status"].iloc[-1] == "approximated_pnl_nav_wipe_out"
+    assert revised["hypercore_repair_status"].iloc[1] == "deferred_pnl_nav_outlier"
+    assert revised["share_price"].iloc[1] == pytest.approx(1.0)
+
+
 def test_approximate_hypercore_leaves_other_protocols_unchanged() -> None:
     """The Hypercore approximation does not alter another protocol's rows."""
     prices_df = pd.DataFrame(
@@ -460,7 +526,7 @@ def test_approximate_hypercore_rejects_invalid_configuration() -> None:
     with pytest.raises(ValueError, match="max_positive_return must be positive"):
         approximate_hypercore_share_prices_from_pnl_nav(prices_df, max_positive_return=0.0)
 
-    with pytest.raises(ValueError, match="missing columns:.*cumulative_pnl"):
+    with pytest.raises(ValueError, match=r"missing columns:.*cumulative_pnl"):
         approximate_hypercore_share_prices_from_pnl_nav(prices_df.drop(columns="account_pnl"))
 
 


### PR DESCRIPTION
## Why

Hyperliquid does not expose authoritative historical vault share supply or an investable unit price. Its rolling NAV and cumulative-PnL windows can refresh independently, so the scanner synthetic supply changes units and produces implausible clean returns. The previous layered repair paths could also repair only one side of an interval and create a new anomaly.

We need a consistent economic-performance approximation even though exact historical time-weighted returns cannot be recovered from the API.

## Lessons learnt

- Raw Hypercore share price is audit evidence, not a stable investor unit.
- Cumulative PnL divided by a conservative observed-capital base gives a deterministic economic approximation without treating deposits or withdrawals as performance.
- Scanner `epoch_reset` flags describe synthetic reconstruction boundaries; only a durable zero-NAV recapitalisation is an economic epoch boundary.
- A terminal zero is absorbing within its capital epoch. Later API baseline changes must be carried, while a newly observed positive-NAV recovery may revise a provisional terminal classification.
- Share price and returns must stay derived from the same curve. Low-TVL suitability should be represented by the existing mask instead of silently rewriting Hypercore returns.
- Structural consistency does not certify every large Hyperliquid PnL observation as suitable for unfiltered backtesting.

## Summary

- Replace the overlapping Hypercore stitching, capping, source-overlap, and flow-reconciliation cleaners with one daily PnL/NAV economic-performance index.
- Preserve scanner prices in `raw_share_price`, publish repair provenance, bound uncertain gains, defer uncorroborated absorbing losses, and retain NAV-corroborated terminal wipe-outs.
- Carry all observations after a terminal loss at zero, and emit zero instead of `NaN` for repeated zero-price returns.
- Keep the existing seven-day/$1,000 recapitalisation rule, while rebuilding epoch markers from economic evidence.
- Recompute synthetic Hypercore supply from NAV and the clean index so price, returns, and accounting remain internally consistent.
- Add focused regressions and document the approximation, residual large-return risk, affected production vaults, repair census, historical regeneration, and legacy diagnostic scripts.

## Related issues and PRs

Continues the Hypercore data-quality work from #1264, #1271, #1276, and #1280. It supersedes their layered cleaned-price repair mechanics; raw scanner continuity and collection fixes remain unchanged.

## Unrelated CI and test fixes

None.
