### PR TITLE
fix: repair delayed Hypercore NAV confirmation

### DIFF
--- a/docs/claude-plans/2026-07-15-hypercore-economic-performance-index.md
+++ b/docs/claude-plans/2026-07-15-hypercore-economic-performance-index.md
@@ -186,6 +186,8 @@ The function must:
 - build and forward-fill the compounded index;
 - set `hypercore_repair_status` to `approximated_pnl_nav` at usable economic
   checkpoints, `approximated_pnl_nav_clipped` at positive capped checkpoints,
+  `approximated_pnl_nav_lag_repaired` when the following daily checkpoint
+  supplies the matching delayed NAV for a positive PnL move,
   `approximated_pnl_nav_carried` at ordinary non-checkpoint rows and after a
   terminal loss,
   `deferred_pnl_nav` where checkpoint inputs are missing, and
@@ -281,6 +283,9 @@ new raw observation for the current or a future date may add a checkpoint but
 must not alter earlier checkpoint prices. A newly observed recovery after a
 provisional terminal zero is the exception: it can show that the earlier zero
 was not an absorbing loss and deterministically revise that open lifecycle. A
+following daily NAV observation may also show that the previous day's PnL-only
+move was the first half of a staggered API update. In this case the premature
+return is carried and applied at the confirming observation. A
 genuinely late raw observation for a past date may likewise select a fresher
 checkpoint and rewrite the later compounded index. Preserving a known stale
 classification would be worse, and the raw file remains the audit trail. Test
@@ -304,6 +309,7 @@ error in this table.
 | Order Block Hunter, 2 February | `+275.4%` | approximately `-4.9%` |
 | HyperBotPro, 18 March | `+285.0%` | approximately `+12.7%` |
 | Titan Vault, 7 April | `+82.9%` | approximately `+27.9%`; the checked closing NAV is the larger denominator |
+| Fish Market, 17–18 March | clipped `+100%` on the PnL-only checkpoint | approximately `+54.5%` on the following NAV-confirming checkpoint |
 
 Also verify:
 
@@ -389,6 +395,7 @@ an unchanged rerun is identical.
   is appropriate once exact unit performance is acknowledged as unavailable.
 - Update `CleanedVaultPriceRow` and `hypercore_repair_status` documentation to
   describe `approximated_pnl_nav`, `approximated_pnl_nav_clipped`,
+  `approximated_pnl_nav_lag_repaired`,
   `approximated_pnl_nav_carried`, `deferred_pnl_nav` and
   `deferred_pnl_nav_outlier` rather than only `repaired_*`/`deferred_hf_*`
   statuses. Explicitly document that Hypercore `total_supply` is a synthetic

--- a/eth_defi/hyperliquid/problem-vaults.md
+++ b/eth_defi/hyperliquid/problem-vaults.md
@@ -53,6 +53,9 @@ presented as Hyperliquid's exact share price.
 
 - `approximated_pnl_nav`: ordinary daily economic checkpoint;
 - `approximated_pnl_nav_clipped`: positive checkpoint capped at 100%;
+- `approximated_pnl_nav_lag_repaired`: the matching NAV for a PnL gain
+  arrived at the following daily checkpoint, so the conservative return was
+  applied only once the NAV denominator was available;
 - `approximated_pnl_nav_wipe_out`: terminal NAV-corroborated complete loss;
 - `approximated_pnl_nav_carried`: a non-checkpoint duplicate or a row after a
   terminal loss that adds no further performance;
@@ -85,6 +88,7 @@ retained history; the one-period returns demonstrate the repaired economics.
 | Order Block Hunter | `0x0a8499b5e925d95badc893ec7f0b1613e08f6d7c` | 2 February 2026 | Partial repair created `+275.4%` | `-4.87%`, matching PnL direction |
 | HyperBotPro | `0x12e358f38741c07c1e04a8102a3170d40a600f05` | 18 March 2026 | `+285.0%` synthetic move around a withdrawal | `+12.72%` from PnL/NAV |
 | Titan Vault | `0x4b0eab9444a75a03f1ef340c8beac737afa5ab09` | 7 April 2026 | `+82.9%` and `deferred_hf_nav` | `+27.94%` from the freshest daily checkpoint |
+| Fish Market | `0x61549534dec101179983169644d7929a3d706c97` | 17–18 March 2026 | PnL moved one day before the matching NAV, producing a clipped `+100%` | `+54.48%` on 18 March using the confirmed larger NAV |
 
 These replacements do not assert that every retained PnL observation is exact
 or that every Hypercore curve is suitable for unfiltered backtesting. They
@@ -129,10 +133,11 @@ After removing 369 superseded recapitalisation rows, the economic-index run
 produces:
 
 - 85,891 daily PnL/NAV checkpoints;
-- 788,652 carried non-performance rows, including duplicate daily/HF rows and
-  rows after a terminal wipe-out;
+- 788,695 carried non-performance rows: duplicate daily/HF rows, 43 premature
+  PnL checkpoints, and rows after a terminal wipe-out;
+- 43 delayed NAV confirmations repaired across 29 vaults;
 - 57 uncorroborated absorbing losses carried for review;
-- 7 positive returns capped at 100%; and
+- 6 positive returns capped at 100%; and
 - 1 terminal NAV-corroborated wipe-out. Later rows in that epoch remain at zero
   and are carried rather than recording repeated losses or gains.
 

--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -45,6 +45,15 @@ from eth_defi.version_info import stamp_parquet_schema_metadata
 #: NAV at or below this value counts as a complete Hypercore wipe-out.
 HYPERCORE_ZERO_NAV_EPSILON = 0.000001
 
+#: Maximum absolute mismatch when recognising a one-day PnL/NAV API lag.
+HYPERCORE_PNL_NAV_LAG_ABSOLUTE_TOLERANCE = 1.0
+
+#: Maximum relative mismatch when recognising a one-day PnL/NAV API lag.
+HYPERCORE_PNL_NAV_LAG_RELATIVE_TOLERANCE = 0.001
+
+#: PnL-first, NAV-confirming API lag needs three consecutive checkpoints.
+MIN_HYPERCORE_PNL_NAV_LAG_CHECKPOINTS = 3
+
 #: New capital must reach this NAV before a recapitalised vault is tracked again.
 MIN_HYPERCORE_RECAPITALISATION_ASSETS = 1_000.0
 
@@ -329,6 +338,8 @@ class CleanedVaultPriceRow(TypedDict, total=False):
     #:
     #: ``approximated_pnl_nav`` marks a daily economic checkpoint,
     #: ``approximated_pnl_nav_clipped`` a positive checkpoint capped at 100%,
+    #: ``approximated_pnl_nav_lag_repaired`` a gain whose NAV confirmation
+    #: arrived at the following daily checkpoint,
     #: ``approximated_pnl_nav_wipe_out`` a terminal NAV-corroborated loss, and
     #: ``approximated_pnl_nav_carried`` a row that adds no performance, either
     #: because it is not the daily checkpoint or because the epoch is already
@@ -1020,6 +1031,19 @@ def approximate_hypercore_share_prices_from_pnl_nav(  # noqa: PLR0914
     Non-checkpoint rows are also carried, avoiding duplicate daily/HF returns
     without interpolating future information backwards.
 
+    A July 2026 follow-up found a narrower timestamp problem in Fish Market.
+    Cumulative PnL increased by ``$2,169.43`` on 17 March while NAV remained
+    unchanged; the same ``$2,169.43`` appeared in NAV on 18 March with no
+    additional PnL or capital flow. Treating the first half of this staggered
+    API update as a complete checkpoint produced a clipped ``+100%`` return.
+    When three consecutive daily checkpoints exhibit this exact PnL-then-NAV
+    pattern, within a small numerical tolerance, this function carries the
+    premature checkpoint and applies the return at the confirming checkpoint
+    using the larger opening/confirmed NAV. This gives approximately ``+54.5%``
+    for Fish Market. The narrow consecutive-day and value-matching conditions
+    avoid suppressing large but reconciled gains in Magixbox, IKAGI and Satori
+    Quantum HF Vault.
+
     Input uses a timestamp index and requires ``id`` (string), ``chain``
     (integer), ``share_price`` (float), ``total_assets`` (float), and cumulative
     PnL as either exported ``account_pnl`` (float) or scanner-shaped
@@ -1081,6 +1105,7 @@ def approximate_hypercore_share_prices_from_pnl_nav(  # noqa: PLR0914
     clipped_count = 0
     deferred_outlier_count = 0
     wipe_out_count = 0
+    lag_repaired_count = 0
     affected_vaults = 0
 
     for _vault_id, relative_positions in prices_df.loc[hypercore_mask, ["id"]].groupby("id", sort=False).indices.items():
@@ -1143,6 +1168,41 @@ def approximate_hypercore_share_prices_from_pnl_nav(  # noqa: PLR0914
                 )
                 raw_returns[1:] = np.diff(checkpoint_pnl) / capital_base
 
+            # Hyperliquid can publish cumulative PnL one daily checkpoint
+            # before the matching NAV. Recognise only an exact three-day
+            # stagger: NAV is initially unchanged, PnL is then unchanged, and
+            # the delayed NAV move matches the earlier PnL move.
+            lagged_pnl_checkpoint = np.zeros(len(checkpoints), dtype=bool)
+            lag_confirmed_checkpoint = np.zeros(len(checkpoints), dtype=bool)
+            if len(checkpoints) >= MIN_HYPERCORE_PNL_NAV_LAG_CHECKPOINTS:
+                pnl_changes = np.diff(checkpoint_pnl)
+                nav_changes = np.diff(checkpoint_nav)
+                pnl_move = pnl_changes[:-1]
+                tolerance = np.maximum(
+                    HYPERCORE_PNL_NAV_LAG_ABSOLUTE_TOLERANCE,
+                    np.abs(pnl_move) * HYPERCORE_PNL_NAV_LAG_RELATIVE_TOLERANCE,
+                )
+                one_day_ns = pd.Timedelta(days=1).value
+                consecutive_days = np.diff(checkpoint_days) == one_day_ns
+                lag_pattern = consecutive_days[:-1] & consecutive_days[1:]
+                lag_pattern &= pnl_move > HYPERCORE_PNL_NAV_LAG_ABSOLUTE_TOLERANCE
+                lag_pattern &= np.abs(nav_changes[:-1]) <= tolerance
+                lag_pattern &= np.abs(pnl_changes[1:]) <= tolerance
+                lag_pattern &= np.abs(nav_changes[1:] - pnl_move) <= tolerance
+                lagged_numbers = np.flatnonzero(lag_pattern) + 1
+                confirmed_numbers = lagged_numbers + 1
+                lagged_pnl_checkpoint[lagged_numbers] = True
+                lag_confirmed_checkpoint[confirmed_numbers] = True
+                raw_returns[lagged_numbers] = 0.0
+                confirmed_capital_base = np.maximum.reduce(
+                    [
+                        checkpoint_nav[lagged_numbers - 1],
+                        checkpoint_nav[confirmed_numbers],
+                        np.ones(len(confirmed_numbers), dtype=float),
+                    ]
+                )
+                raw_returns[confirmed_numbers] = pnl_changes[lagged_numbers - 1] / confirmed_capital_base
+
             applied_returns = raw_returns.copy()
             positive_clipped = raw_returns > max_positive_return
             applied_returns[positive_clipped] = max_positive_return
@@ -1175,6 +1235,8 @@ def approximate_hypercore_share_prices_from_pnl_nav(  # noqa: PLR0914
             checkpoint_prices = np.cumprod(1.0 + applied_returns)
 
             checkpoint_status = np.full(len(checkpoints), "approximated_pnl_nav", dtype=object)
+            checkpoint_status[lagged_pnl_checkpoint] = "approximated_pnl_nav_carried"
+            checkpoint_status[lag_confirmed_checkpoint] = "approximated_pnl_nav_lag_repaired"
             checkpoint_status[positive_clipped] = "approximated_pnl_nav_clipped"
             checkpoint_status[deferred_absorbing_loss] = "deferred_pnl_nav_outlier"
             checkpoint_status[corroborated_wipe_out] = "approximated_pnl_nav_wipe_out"
@@ -1189,7 +1251,9 @@ def approximate_hypercore_share_prices_from_pnl_nav(  # noqa: PLR0914
 
             checkpoint_count += len(checkpoints)
             carried_count += int(day_has_checkpoint.sum()) - len(checkpoints) + int(post_wipe_out.sum())
+            carried_count += int(lagged_pnl_checkpoint.sum())
             clipped_count += int(positive_clipped.sum())
+            lag_repaired_count += int(lag_confirmed_checkpoint.sum())
             deferred_outlier_count += int(deferred_absorbing_loss.sum())
             wipe_out_count += int(corroborated_wipe_out.sum())
 
@@ -1209,7 +1273,7 @@ def approximate_hypercore_share_prices_from_pnl_nav(  # noqa: PLR0914
     if synthetic_supplies is not None:
         prices_df["total_supply"] = synthetic_supplies
 
-    logger(f"Approximated Hypercore economic share prices for {affected_vaults:,} vaults using {checkpoint_count:,} daily PnL/NAV checkpoints; carried {carried_count:,} non-performance rows, deferred {missing_count:,} missing-input rows and {deferred_outlier_count:,} uncorroborated losses, capped {clipped_count:,} gains and recorded {wipe_out_count:,} terminal wipe-outs")
+    logger(f"Approximated Hypercore economic share prices for {affected_vaults:,} vaults using {checkpoint_count:,} daily PnL/NAV checkpoints; carried {carried_count:,} non-performance rows, repaired {lag_repaired_count:,} delayed NAV confirmations, deferred {missing_count:,} missing-input rows and {deferred_outlier_count:,} uncorroborated losses, capped {clipped_count:,} gains and recorded {wipe_out_count:,} terminal wipe-outs")
     return prices_df
 
 

--- a/tests/research/test_clean_prices.py
+++ b/tests/research/test_clean_prices.py
@@ -275,7 +275,100 @@ def test_approximate_hypercore_share_prices_from_pnl_nav() -> None:
     assert result["raw_share_price"].tolist() == prices_df["share_price"].tolist()
     assert (result["share_price"] * result["total_supply"]).tolist() == pytest.approx(result["total_assets"].tolist())
     assert result["hypercore_repair_status"].tolist() == ["approximated_pnl_nav"] * 4
-    assert messages == ["Approximated Hypercore economic share prices for 1 vaults using 4 daily PnL/NAV checkpoints; carried 0 non-performance rows, deferred 0 missing-input rows and 0 uncorroborated losses, capped 0 gains and recorded 0 terminal wipe-outs"]
+    assert messages == ["Approximated Hypercore economic share prices for 1 vaults using 4 daily PnL/NAV checkpoints; carried 0 non-performance rows, repaired 0 delayed NAV confirmations, deferred 0 missing-input rows and 0 uncorroborated losses, capped 0 gains and recorded 0 terminal wipe-outs"]
+
+
+def test_approximate_hypercore_repairs_delayed_nav_confirmation() -> None:
+    """Fish Market's provisional PnL return moves to its confirmed NAV."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 4,
+            "id": ["9999-0xfish-market"] * 4,
+            "share_price": [0.180973] * 4,
+            "total_assets": [1812.411674, 1812.411674, 3981.846633, 5171.054434],
+            "total_supply": [10_000.0] * 4,
+            "account_pnl": [-11486.308326, -9316.873367, -9316.873367, -8127.665566],
+        },
+        index=pd.to_datetime(["2026-03-16", "2026-03-17", "2026-03-18", "2026-03-19"]),
+    )
+
+    provisional = approximate_hypercore_share_prices_from_pnl_nav(prices_df.iloc[:2], logger=lambda _message: None)
+    assert provisional["share_price"].tolist() == [1.0, 2.0]
+    assert provisional["hypercore_repair_status"].iloc[-1] == "approximated_pnl_nav_clipped"
+
+    messages: list[str] = []
+    result = approximate_hypercore_share_prices_from_pnl_nav(prices_df, logger=messages.append)
+
+    confirmed_return = 2169.434959 / 3981.846633
+    following_return = 1189.207801 / 5171.054434
+    assert result["share_price"].tolist() == pytest.approx([1.0, 1.0, 1.0 + confirmed_return, (1.0 + confirmed_return) * (1.0 + following_return)])
+    assert result["hypercore_repair_status"].tolist() == [
+        "approximated_pnl_nav",
+        "approximated_pnl_nav_carried",
+        "approximated_pnl_nav_lag_repaired",
+        "approximated_pnl_nav",
+    ]
+    assert messages == ["Approximated Hypercore economic share prices for 1 vaults using 4 daily PnL/NAV checkpoints; carried 1 non-performance rows, repaired 1 delayed NAV confirmations, deferred 0 missing-input rows and 0 uncorroborated losses, capped 0 gains and recorded 0 terminal wipe-outs"]
+
+
+def test_approximate_hypercore_does_not_join_weekly_checkpoints() -> None:
+    """Similar weekly values remain separate because API lag is daily."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 3,
+            "id": ["9999-0xweekly"] * 3,
+            "share_price": [1.0] * 3,
+            "total_assets": [100.0, 100.0, 200.0],
+            "total_supply": [100.0] * 3,
+            "account_pnl": [0.0, 100.0, 100.0],
+        },
+        index=pd.to_datetime(["2026-01-01", "2026-01-08", "2026-01-15"]),
+    )
+
+    result = approximate_hypercore_share_prices_from_pnl_nav(prices_df, logger=lambda _message: None)
+
+    assert result["share_price"].tolist() == [1.0, 2.0, 2.0]
+    assert result["hypercore_repair_status"].tolist() == ["approximated_pnl_nav", "approximated_pnl_nav", "approximated_pnl_nav"]
+
+
+def test_approximate_hypercore_does_not_retime_delayed_loss() -> None:
+    """The Fish Market repair does not change loss recognition timing."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 3,
+            "id": ["9999-0xloss"] * 3,
+            "share_price": [1.0] * 3,
+            "total_assets": [100.0, 100.0, 50.0],
+            "total_supply": [100.0] * 3,
+            "account_pnl": [0.0, -50.0, -50.0],
+        },
+        index=pd.to_datetime(["2026-01-01", "2026-01-02", "2026-01-03"]),
+    )
+
+    result = approximate_hypercore_share_prices_from_pnl_nav(prices_df, logger=lambda _message: None)
+
+    assert result["share_price"].tolist() == [1.0, 0.5, 0.5]
+    assert result["hypercore_repair_status"].tolist() == ["approximated_pnl_nav"] * 3
+
+
+def test_approximate_hypercore_rejects_delayed_nav_mismatch() -> None:
+    """A delayed NAV outside the strict tolerance is not joined to PnL."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 3,
+            "id": ["9999-0xmismatch"] * 3,
+            "share_price": [1.0] * 3,
+            "total_assets": [100.0, 100.0, 198.0],
+            "total_supply": [100.0] * 3,
+            "account_pnl": [0.0, 100.0, 100.0],
+        },
+        index=pd.to_datetime(["2026-01-01", "2026-01-02", "2026-01-03"]),
+    )
+
+    result = approximate_hypercore_share_prices_from_pnl_nav(prices_df, logger=lambda _message: None)
+
+    assert result["share_price"].tolist() == [1.0, 2.0, 2.0]
+    assert result["hypercore_repair_status"].tolist() == ["approximated_pnl_nav"] * 3
 
 
 def test_approximate_hypercore_uses_freshest_daily_checkpoint() -> None:


### PR DESCRIPTION
## Why

Hyperliquid can publish cumulative PnL and the matching NAV change at adjacent daily checkpoints. Fish Market gained $2,169.43 economically, but PnL appeared on 17 March while NAV remained stale until 18 March. Treating the first observation independently produced a clipped +100% clean return instead of the conservative +54.48% return available once NAV confirmed the gain.

## Lessons learnt

A large return is not necessarily false: Magixbox, IKAGI and Satori remain supported by PnL, NAV, ledger and trading evidence. The repair must therefore recognise the precise API timing failure instead of applying a blanket return threshold. A future observation may legitimately revise the previous day's provisional classification when it completes a staggered PnL/NAV update.

The matching rule is intentionally narrow: positive PnL only, three consecutive daily checkpoints, initially unchanged NAV, subsequently unchanged PnL, and delayed NAV equal to the earlier PnL move within a $1 or 0.1% tolerance. The production snapshot contains 43 matches across 29 vaults; none of these positive matches has a recorded capital flow in its three-day window.

## Summary

- Carry a premature positive PnL checkpoint when the following day supplies its matching NAV change.
- Apply the gain once at the confirming checkpoint using the larger opening or confirmed NAV.
- Add `approximated_pnl_nav_lag_repaired` provenance and aggregate logging.
- Repair Fish Market from a clipped +100% on 17 March to +54.48% on 18 March.
- Keep Magixbox +84.08%, IKAGI +62.41%, and Satori Quantum HF Vault +62.22% unchanged.
- Add focused coverage for provisional append revision, weekly checkpoints, delayed losses, and NAV values outside tolerance.
- Update the production census and problem-vault documentation.

## Related issues and PRs

- Continues the Hypercore economic-performance approximation introduced in #1285.

## Unrelated CI and test fixes

None.
