### PR TITLE
fix: serialise Decimal vault metrics JSON

### DIFF
--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -9,6 +9,7 @@ import logging
 import math
 import warnings
 from dataclasses import asdict, dataclass, is_dataclass
+from decimal import Decimal
 from enum import Enum
 from typing import TYPE_CHECKING, Literal, Optional, TypeAlias, TypedDict
 
@@ -3322,6 +3323,7 @@ def export_lifetime_row(row: pd.Series) -> dict:
 
     - Recursively handles nested dicts, lists, tuples, sets, and dataclasses.
     - Normalises pandas, numpy, datetime, and custom types.
+    - Converts finite :class:`~decimal.Decimal` values to JSON number floats.
     - Preserves legacy fee field names.
 
     The ``denomination_token_rate`` dataclass from
@@ -3339,6 +3341,14 @@ def export_lifetime_row(row: pd.Series) -> dict:
         # Numpy scalar
         if isinstance(value, (np.floating, np.integer)):
             return value.item()
+        # Decimal values occur in scanned vault metadata, including fee fields.
+        # JSON has one numeric representation, so retain the public export's
+        # established float convention. JSON cannot represent Decimal NaN or
+        # infinity, which follow the existing float sanitisation rule.
+        if isinstance(value, Decimal):
+            if not value.is_finite():
+                return None
+            return float(value)
         # Pandas timestamp
         if isinstance(value, pd.Timestamp):
             return value.isoformat()

--- a/tests/erc_4626/test_vault_analysis_sticky_export.py
+++ b/tests/erc_4626/test_vault_analysis_sticky_export.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+from decimal import Decimal
 from pathlib import Path
 
 import pandas as pd
@@ -90,6 +91,28 @@ def test_sticky_export_first_qualification_creates_state():
     entry = result.state["vaults"]["1-0xabcd000000000000000000000000000000000001"]
     assert entry["status"] == "active"
     assert entry["last_exported_record"]["address"] == "0xAbCd000000000000000000000000000000000001"
+
+
+def test_sticky_export_converts_decimal_current_row_values() -> None:
+    """Persist current Decimal metrics as JSON-safe sticky state values."""
+    module = get_top_vaults_json_module()
+    now = datetime.datetime(2026, 6, 24, 12, 0, 0)
+    state = module.make_empty_sticky_export_state(now)
+    row = make_metrics_row()
+    row["deposit_fee"] = Decimal("0.015")
+
+    result = module.apply_sticky_export_state(
+        make_lifetime_df(row),
+        state,
+        now=now,
+        threshold_tvl=5_000.0,
+        stale_warning_age_days=14,
+    )
+
+    assert result.vaults[0]["deposit_fee"] == pytest.approx(0.015)
+    assert isinstance(result.vaults[0]["deposit_fee"], float)
+    assert result.state["vaults"]["1-0xabcd000000000000000000000000000000000001"]["last_exported_record"]["deposit_fee"] == pytest.approx(0.015)
+    module.validate_strict_json_serialisable(result.state)
 
 
 def test_sticky_export_missing_current_metrics_use_fallback():

--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -3,6 +3,7 @@
 import json
 import os.path
 import pickle
+from decimal import Decimal
 from pathlib import Path
 
 import pandas as pd
@@ -722,3 +723,28 @@ def test_export_lifetime_row_preserves_flow_fees_without_annual_fees() -> None:
     assert result["performance_fee"] is None
     assert result["deposit_fee"] == 0.01
     assert result["withdraw_fee"] == 0.02
+
+
+def test_export_lifetime_row_converts_nested_decimals_to_strict_json_floats() -> None:
+    """Export Decimal-based vault metadata as strict JSON numeric values."""
+    row = pd.Series(
+        {
+            "deposit_fee": Decimal("0.015"),
+            "withdraw_fee": Decimal("NaN"),
+            "deposit_manager": {
+                "minimum_deposit": Decimal("12.50"),
+                "fee_tiers": [Decimal("0.001"), Decimal("Infinity")],
+            },
+        }
+    )
+
+    result = export_lifetime_row(row)
+
+    assert result["deposit_fee"] == pytest.approx(0.015)
+    assert isinstance(result["deposit_fee"], float)
+    assert result["withdraw_fee"] is None
+    assert result["deposit_manager"] == {
+        "minimum_deposit": 12.5,
+        "fee_tiers": [0.001, None],
+    }
+    json.dumps(result, allow_nan=False)


### PR DESCRIPTION
## Why

A Decimal-valued vault fee caused sticky top-vault JSON export to fail before publication.

## Lessons learnt

Vault scan metadata can carry Decimal values even where metrics normally use floats; public JSON normalisation must handle them recursively.

## Summary

- Convert finite Decimal values in vault metric exports to floats and non-finite values to null.
- Add exporter and sticky-state regression coverage.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.