### PR TITLE
feat: publish four-hour Hypercore cleaned prices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- feat: Publish Hypercore cleaned economic share prices from retained observations at up to four-hour granularity (2026-07-16)
 - feat: Add Kiln OmniVault protocol metadata, documentation, feed registration and regression coverage (2026-07-15)
 - feat: Add Maseer One wstGBP vault support with hardcoded Ethereum discovery, NAV/share TVL history and Anvil-fork integration tests (2026-07-14)
 - feat: Add Accountable vault synchronous deposits, self-controlled asynchronous redemption claims and historical settlement event scanning (2026-07-14)

--- a/docs/claude-plans/2026-07-15-hypercore-economic-performance-index.md
+++ b/docs/claude-plans/2026-07-15-hypercore-economic-performance-index.md
@@ -2,6 +2,14 @@
 
 **Date:** 2026-07-15
 
+> **Cadence update, 16 July 2026:** This plan introduced the PnL/NAV economic
+> index with one checkpoint per UTC date. The follow-up four-hour publication
+> work supersedes only that cadence: the same economic method now selects at
+> most one observation per occupied four-hour UTC bucket, leaves missing and
+> older coarse buckets absent, and retains original API timestamps. References
+> to daily checkpoint selection below describe the initial implementation, not
+> the current cleaned-output contract.
+
 ## Goal
 
 Make the cleaned share-price history of Hypercore vaults reflect the best

--- a/docs/claude-plans/2026-07-16-hypercore-four-hour-cleaned-prices.md
+++ b/docs/claude-plans/2026-07-16-hypercore-four-hour-cleaned-prices.md
@@ -1,0 +1,335 @@
+# Publish four-hour Hypercore cleaned prices
+
+## Goal
+
+Publish the finest defensible Hypercore economic share-price history from the
+observations already retained by the high-frequency scanner. When usable HF
+data exists, the cleaned curve should change at most once per fixed four-hour
+UTC bucket instead of once per UTC date. Older history must remain naturally
+daily or weekly when Hyperliquid has already downsampled it; the cleaner must
+not manufacture observations or interpolate economic returns.
+
+The output remains an approximate PnL/NAV performance index, not
+Hyperliquid's unavailable historical unit price. Existing recapitalisation,
+terminal-loss, delayed-NAV, clipping and outlier protections must continue to
+apply.
+
+## Current problem
+
+The HF scanner is working as designed. It polls every four hours and stores the
+raw timestamps returned by `vaultDetails`: approximately 20-minute points for
+the latest day, approximately three-hour points for the latest week, and
+coarser points for older periods. Both daily and HF databases are merged into
+raw `vault-prices-1h.parquet`.
+
+The resolution is lost later in
+`approximate_hypercore_share_prices_from_pnl_nav()`. It normalises every
+timestamp to a UTC date, selects one checkpoint per vault per date and carries
+the same clean price through every other HF row. Thus the cleaned Parquet
+contains sub-daily timestamps but does not publish sub-daily economic price
+changes.
+
+The 15 July 2026 production snapshot demonstrates that this is a material loss
+of usable information. Over its latest seven days it contains:
+
+- 75,961 raw Hypercore rows across 461 active vaults;
+- 19,470 usable four-hour buckets, compared with 3,684 daily buckets;
+- sub-daily coverage for all 461 active vaults, averaging 5.28 four-hour
+  buckets per day;
+- 11,059 four-hour checkpoints with a cumulative-PnL change; and
+- 12,372 four-hour checkpoints with a NAV change.
+
+The current cleaned result publishes only 2,400 non-zero price changes in the
+same period, at most one per vault-day. A read-only naive four-hour calculation
+over the recent 19,009 checkpoint intervals produced no gains above 100%, one
+loss at or below -100%, and two absolute moves above 50%. Existing safety rules
+already cover these exceptional cases.
+
+Across the complete retained raw history, four-hour selection yields about
+317,042 checkpoints instead of 85,891 daily checkpoints. Historical outliers
+remain present and must still pass the existing conservative repair rules.
+These figures are indicative acceptance baselines and must be recalculated
+from the final implementation rather than frozen as unit-test constants.
+
+## Output contract
+
+The cleaned output must follow these rules:
+
+1. A fixed UTC bucket is `[00:00, 04:00)`, `[04:00, 08:00)`, and so on.
+2. At most one usable PnL/NAV checkpoint may add performance in each four-hour
+   bucket for a vault and capital epoch.
+3. The selected row keeps its original API timestamp. Do not floor the
+   published timestamp to the bucket boundary.
+4. Other raw rows remain in cleaned Parquet and carry the previous clean price.
+5. Do not create a four-hour row when no raw observation exists. Consumers may
+   resample and forward-fill separately when they need a regular grid.
+6. Daily and weekly source observations remain publishable as-is. They simply
+   occupy their corresponding four-hour bucket, so old history stays coarse.
+7. The raw scanner price remains in `raw_share_price`; it never becomes the
+   authoritative cleaned price.
+8. `returns_1h` remains a compatibility column calculated between consecutive
+   output rows. Its documentation must say that Hypercore performance changes
+   occur at one selected observation per occupied four-hour bucket rather than
+   at true hourly intervals. Gaps can be longer where the source is missing or
+   already coarse.
+9. No Parquet schema change, DuckDB rewrite or new persisted column is needed.
+
+## Implementation
+
+### Four-hour checkpoint selection
+
+Update `approximate_hypercore_share_prices_from_pnl_nav()` in
+`eth_defi/research/wrangle_vault_prices.py`.
+
+Introduce a module-level four-hour checkpoint interval constant. Replace the
+normalised `day_ns` grouping key with a four-hour UTC bucket derived from the
+naive UTC timestamp. Keep the existing deterministic precedence inside a
+bucket:
+
+1. newest finite `written_at` batch;
+2. latest economic timestamp;
+3. HF source as the final exact-tie preference.
+
+Do not add a generic resampling framework or a configurable public API. A
+single Hypercore-specific constant keeps this repair explicit and small. Use
+the same NumPy/Pandas vectorised selection already present in the function.
+
+Rename local variables, docstrings, logging and status descriptions from
+"daily checkpoint" to "four-hour checkpoint" or the bucket-neutral
+"economic checkpoint" where appropriate. Existing status values can remain
+unchanged:
+
+- `approximated_pnl_nav` for a selected ordinary checkpoint;
+- `approximated_pnl_nav_carried` for an unselected row;
+- the existing clipped, wipe-out, delayed and lag-repaired variants for their
+  current meanings.
+
+Changing a label is unnecessary and would create avoidable consumer work.
+
+### Economic return calculation
+
+Keep the current calculation for consecutive selected checkpoints:
+
+```text
+pnl_change = account_pnl_now - account_pnl_previous
+capital_base = max(total_assets_previous, total_assets_now, 1.0)
+period_return = pnl_change / capital_base
+clean_price_now = clean_price_previous * (1 + applied_period_return)
+```
+
+Keep all existing rules after checkpoint selection:
+
+- positive-return cap;
+- funded absorbing-loss deferral;
+- NAV-corroborated terminal wipe-out;
+- absorbing zero price after a terminal wipe-out;
+- recapitalisation epoch separation;
+- synthetic `total_supply = total_assets / clean_share_price`; and
+- EVM/native-protocol isolation.
+
+Apply clipping and deferral to each selected four-hour economic checkpoint,
+not to a subsequently aggregated daily return. Consequently, compounding the
+four-hour results over a UTC date need not reproduce the old daily result when
+the old single daily interval was clipped or deferred. This is intentional:
+the four-hour observations are the new repair decisions, and their compounded
+window return is the quantity that must be validated against economic
+evidence.
+
+The change must not reintroduce scanner share units, daily/HF batch stitching
+or flow-derived synthetic supply.
+
+### Delayed NAV confirmation
+
+The Fish Market repair currently recognises three consecutive *daily*
+checkpoints. Four-hour selection must not break its historical repair or miss
+the same API behaviour at sub-daily cadence.
+
+Make the lag rule bucket-independent. Add one private confirmation-delay
+constant of 26 hours, allowing ordinary API timestamp jitter while excluding
+weekly all-time observations:
+
+- the middle checkpoint has a positive PnL change while NAV is unchanged
+  within the existing tolerance;
+- the previous-to-middle elapsed time is positive and no greater than 26
+  hours;
+- scan forward from the middle checkpoint for at most 26 elapsed hours,
+  skipping selected checkpoints whose PnL and NAV are both unchanged within
+  tolerance;
+- the first non-flat checkpoint must have unchanged PnL and a NAV change
+  matching the earlier PnL move; any intervening economic change disqualifies
+  the repair; and
+- all existing positive-only and numerical-tolerance conditions remain.
+
+Carry the premature PnL checkpoint and apply the gain once at the confirming
+checkpoint using the larger opening or confirmed NAV. Fish Market's actual
+HF timestamps are 16 March 23:12, 17 March 23:32 and 18 March 22:32 UTC, while
+the merged daily source supplies the confirming NAV at 18 March 00:00. The
+predecessor gap is 24 hours 20 minutes, so a strict 24-hour cut-off would
+regress the repair. The bounded 26-hour window admits this ordinary jitter and
+recent four-hour confirmations but rejects weekly all-time points. Do not
+require an exact number of four-hour buckets because missing scanner
+observations, flat intermediate observations and API resolution changes are
+legitimate.
+Missing observations are tolerated by ordinary checkpoint selection, but a
+gap longer than 26 hours deliberately disqualifies this specific lag repair.
+This conservative asymmetry avoids joining unrelated points from the weekly
+all-time series.
+
+Document that a confirming observation may revise the previous checkpoint's
+provisional return. An identical rerun remains idempotent; append stability has
+this already-known evidence-driven exception.
+
+### Processing and publishing
+
+Do not change pipeline ordering. The relevant sequence remains:
+
+1. merge daily and HF raw Hypercore rows into raw Parquet;
+2. discard superseded pre-recapitalisation history from the cleaned view;
+3. build the four-hour PnL/NAV index;
+4. calculate compatibility returns and TVL masks; and
+5. publish `cleaned-vault-prices-1h.parquet`.
+
+Deployment requires regenerating cleaned Parquet from unchanged raw Parquet.
+This deterministically repairs historical rows where HF observations were
+preserved and automatically leaves older downsampled periods coarse. No raw
+Parquet or DuckDB backup/migration is required because neither source is
+modified by wrangling.
+
+## Tests
+
+Extend `tests/research/test_clean_prices.py` with focused function tests:
+
+1. **Multiple checkpoints per day:** observations spanning at least three
+   four-hour buckets produce three economic price changes when PnL changes.
+2. **One checkpoint per bucket:** multiple daily/HF rows in the same bucket
+   select exactly one row using `written_at`, timestamp and HF tie precedence;
+   other rows carry the price.
+3. **No manufactured rows:** a missing four-hour bucket does not add a row or
+   an interpolated return.
+4. **Adaptive coarse history:** daily and weekly observations remain daily and
+   weekly; they are not rejected merely because adjacent buckets are absent.
+5. **Fish Market:** the 17–18 March PnL-first/NAV-confirming sequence remains a
+   single approximately +54.48% gain at the confirming observation.
+6. **Sub-daily NAV lag:** the same stagger across four-hour observations is
+   repaired when one or more flat selected checkpoints appear before the NAV
+   confirmation.
+7. **Lag boundary:** use Fish Market-shaped timestamps to prove that a 24-hour
+   20-minute predecessor gap is accepted. A confirmation more than 26 hours
+   later and a predecessor more than 26 hours earlier are each rejected. An
+   intervening economic change, a negative PnL move or a NAV mismatch is also
+   not joined.
+8. **Per-bucket protections:** multiple clipped or deferred observations in
+   different four-hour buckets of the same UTC date are handled independently;
+   their compounded result intentionally differs from the old single daily
+   decision.
+9. **Existing protections:** terminal wipe-out, recapitalisation, idempotence
+   and non-Hypercore isolation continue to pass.
+10. **Fresh append:** appending an ordinary new bucket preserves old prices;
+   appending a matching NAV confirmation may revise only the provisional
+   PnL-only checkpoint and later compounded prices.
+
+The append test must cover the recent publication tail explicitly: write a
+cleaned prefix ending at the provisional PnL-only checkpoint, append its NAV
+confirmation, rerun the cleaner, and assert that no earlier unrelated epoch or
+vault changes. This is the sole intended evidence-driven revision of already
+published recent Hypercore prices.
+
+Keep the existing production-shaped fixture values. Do not create a separate
+address-specific Fish Market branch in production code.
+
+## Production validation
+
+Run the final wrangle read-only over a copy of the production raw Parquet and
+compare daily and four-hour outputs by vault.
+
+Required checks:
+
+- raw and cleaned source files are not modified in place during validation;
+- retained row count and schema are unchanged apart from existing
+  recapitalisation filtering;
+- recent active vaults publish more than one economic checkpoint per day when
+  HF data exists;
+- no vault publishes more than one selected checkpoint in a four-hour bucket;
+- every selected checkpoint corresponds to a finite raw NAV/PnL observation;
+- all share prices and returns are finite, share prices are non-negative and
+  returns stay within the existing -100%/+100% applied bounds;
+- synthetic total supply maintains the NAV identity wherever NAV and price are
+  finite and price is positive;
+- EVM and other native-protocol rows are byte-equivalent to the current
+  cleaner;
+- report the number of checkpoints, changing checkpoints, carried rows,
+  clipped gains, deferred losses, terminal wipe-outs and delayed-NAV repairs;
+  and
+- report the maximum positive and negative compounded return per vault and UTC
+  date, in addition to enforcing the existing per-checkpoint bounds, so stacked
+  near-cap observations are visible.
+
+Also compare compounded four-hour returns over the old daily windows. Report
+windows where per-checkpoint clipping or deferral changes the aggregate result,
+and reconcile the largest differences against PnL and NAV evidence rather
+than assuming equality with the superseded daily approximation. In particular,
+validate IKAGI's June window this way.
+
+Inspect the largest positive and negative four-hour returns and rapid
+opposite-direction pairs. The purpose is to detect a systematic PnL/NAV timing
+or source-baseline failure, not to reject a genuine return solely because it is
+large.
+
+## Vault regression checks
+
+The earlier repaired vaults must remain economically coherent:
+
+- Crypto Plaza Relative Momentum Edge must not regain its February unit
+  jump/reversal;
+- HODL My Perps must retain only its post-recapitalisation epoch and must not
+  regain the May synthetic unit jump;
+- Magixbox and C.A.T must not mix daily and HF scanner share units;
+- Order Block Hunter, HyperBotPro and Titan Vault must retain PnL/NAV-based
+  direction and magnitude rather than partial-repair prices;
+- Fish Market must retain the approximately +54.48% delayed-NAV repair and the
+  economically reconciled December loss; and
+- Magixbox and Satori's October gains must remain economically supported.
+
+IKAGI's June gain has retained sub-daily raw data. It should be split across
+the selected four-hour checkpoints instead of forced into the previous single
++62.41% daily observation. Report its compounded return over the same original
+window and reconcile the direction against NAV, PnL, ledger and fills; do not
+force each new sub-period to reproduce the old daily percentage.
+
+## Documentation
+
+Update:
+
+- `approximate_hypercore_share_prices_from_pnl_nav()` and
+  `CleanedVaultPriceRow` docstrings;
+- `eth_defi/hyperliquid/problem-vaults.md` with the final four-hour census and
+  residual limitations;
+- `scripts/hyperliquid/README-hyperliquid-vaults-high-frequency.md` to separate
+  the four-hour scan trigger, approximately 20-minute raw API resolution and
+  four-hour cleaned publication cadence; and
+- the prior economic-performance plan where it claims cleaned Hypercore
+  performance is daily-only.
+
+The public cleaner docstring and high-frequency README must tell consumers
+that a later NAV confirmation can revise the recent provisional PnL-only
+checkpoint and its subsequently compounded prices. Add a dated
+`CHANGELOG.md` entry when the implementation is opened as a feature PR.
+
+State explicitly that finer granularity improves timing but does not make the
+approximate index an exact investor share price. Historical resolution is
+limited by what the scanner retained before Hyperliquid downsampled the API
+windows.
+
+## Completion criteria
+
+The work is complete when:
+
+- production-shaped tests and the focused cleaner suite pass;
+- a read-only production run demonstrates sub-daily clean price changes for
+  recent HF-covered vaults;
+- earlier repaired vaults remain repaired;
+- Fish Market remains repaired under the bucket-independent lag rule;
+- documentation no longer claims that cleaned Hypercore performance is
+  daily-only; and
+- regenerated cleaned Parquet can be published without modifying raw Parquet
+  or either Hyperliquid DuckDB database.

--- a/eth_defi/hyperliquid/problem-vaults.md
+++ b/eth_defi/hyperliquid/problem-vaults.md
@@ -25,9 +25,12 @@ authoritative performance series. The wrangle step preserves it as
 
 ## Cleaned economic-performance index
 
-For each vault and UTC date, wrangling selects one finite NAV/PnL checkpoint.
-It prefers the newest `written_at` batch, then the latest economic timestamp,
-with HF as the final tie-break. Other rows carry the previous clean price.
+For each vault and fixed four-hour UTC bucket, wrangling selects one finite
+NAV/PnL checkpoint. It prefers the newest `written_at` batch, then the latest
+economic timestamp, with HF as the final tie-break. The selected row keeps its
+original API timestamp. Other rows carry the previous clean price, and no row
+is manufactured for an empty bucket. Older history therefore remains daily or
+weekly where Hyperliquid has already downsampled it.
 
 For consecutive checkpoints:
 
@@ -38,10 +41,12 @@ period_return = pnl_change / capital_base
 clean_price_now = clean_price_previous * (1 + period_return)
 ```
 
-Positive period returns are capped at 100%. A return at or below -100% is
-accepted only when NAV is also zero and does not recover in the retained epoch.
-Otherwise the price is carried so that a possible cumulative-PnL baseline
-correction cannot permanently zero a funded vault.
+Positive period returns are capped at 100% per selected checkpoint. A return
+at or below -100% is accepted only when NAV is also zero and does not recover
+in the retained epoch. Otherwise the price is carried so that a possible
+cumulative-PnL baseline correction cannot permanently zero a funded vault.
+Several valid checkpoints can compound to more than 100% in one day; the cap
+is not a daily performance cap.
 
 The index starts at `1.0` for each retained capital epoch. This denominator is
 deliberately conservative when capital-flow timing is unknown: deposits and
@@ -51,11 +56,11 @@ presented as Hyperliquid's exact share price.
 
 `hypercore_repair_status` records the evidence used:
 
-- `approximated_pnl_nav`: ordinary daily economic checkpoint;
+- `approximated_pnl_nav`: ordinary four-hour economic checkpoint;
 - `approximated_pnl_nav_clipped`: positive checkpoint capped at 100%;
 - `approximated_pnl_nav_lag_repaired`: the matching NAV for a PnL gain
-  arrived at the following daily checkpoint, so the conservative return was
-  applied only once the NAV denominator was available;
+  arrived within the bounded 26-hour confirmation window, so the conservative
+  return was applied only once the NAV denominator was available;
 - `approximated_pnl_nav_wipe_out`: terminal NAV-corroborated complete loss;
 - `approximated_pnl_nav_carried`: a non-checkpoint duplicate or a row after a
   terminal loss that adds no further performance;
@@ -65,11 +70,19 @@ presented as Hyperliquid's exact share price.
 Clean Hypercore `total_supply` is recalculated as
 `total_assets / share_price`. It is a synthetic index-unit quantity, not an
 actual share count. `returns_1h` remains a compatibility name: Hypercore
-performance occurs at daily checkpoints, while carried rows have zero change.
-Price level, cumulative profit and drawdown use the clean curve. Cadence-sensitive
-statistics such as volatility and Sharpe must select checkpoint rows. Low NAV
-still sets `tvl_filtering_mask`, but does not rewrite the Hypercore return away
-from its price; suitability consumers use the mask to exclude such rows.
+performance occurs at one selected observation per occupied four-hour bucket,
+while carried rows have zero change. Gaps can be longer where observations are
+missing or already coarse. Price level, cumulative profit and drawdown use the
+clean curve. Cadence-sensitive statistics such as volatility and Sharpe must
+select checkpoint rows. Low NAV still sets `tvl_filtering_mask`, but does not
+rewrite the Hypercore return away from its price; suitability consumers use
+the mask to exclude such rows.
+
+The delayed-NAV rule may revise a recent provisional PnL-only checkpoint once
+the matching NAV arrives, together with prices compounded after it. It skips
+flat intermediate checkpoints but rejects other intervening economic changes
+and observations more than 26 hours away. This is the only intended
+evidence-driven revision of recently published Hypercore prices.
 
 ## Verified affected vaults
 
@@ -80,14 +93,14 @@ retained history; the one-period returns demonstrate the repaired economics.
 | Vault | Address | Affected period or row | Previous/raw symptom | New clean result |
 | --- | --- | --- | ---: | ---: |
 | Crypto Plaza Relative Momentum Edge | `0xdc9955a83218b71713a83ee072055591bd4c7304` | 2–15 February 2026 | Daily prices `3.54`/`3.49` mixed with HF near `1` | Largest inspected move about `+15.8%`; no multi-unit jump/reversal |
-| HODL My Perps | `0x13b43faa22d854bf43b4e7581c1b3dfcd416f8c3` | post-recapitalisation May 2026 | 21 May raw unit jump about `54.7x` | `+2.44%` from PnL/NAV |
+| HODL My Perps | `0x13b43faa22d854bf43b4e7581c1b3dfcd416f8c3` | post-recapitalisation May 2026 | 21 May raw unit jump about `54.7x` | `+2.44%` compounded from six PnL/NAV checkpoints on 21 May |
 | Magixbox | `0x1764dd740aba4195643bbb6a44648e0306b00cfa` | 30 January–7 February 2026 | Raw prices `1.28`, `1.77`, `4.61`, `12.90`, `26.04` | `+4.45%`, `+27.94%`, `-1.20%`, `+7.49%`, `-7.25%`, `+2.43%` at successive checkpoints |
 | Magixbox | same | 15 October 2025 | `+528.3%` synthetic price move | `+84.08%` conservative economic return |
 | C.A.T | `0xdfb729b4b789de6d13d6ad7ac8e2750909360af9` | 21 January–12 February 2026 | Price rose from about `1.9` to `36` while NAV stayed near `$5,000` | PnL/NAV index stays around `1.16`–`1.23` over the peak raw-price dates |
 | Scared Money | `0x5290ab34acb59cfe1371baa5782eba14433d308f` | 13 August 2025 | `+204.5%` after a stale deferred row | `+44.59%` over the observed PnL interval |
 | Order Block Hunter | `0x0a8499b5e925d95badc893ec7f0b1613e08f6d7c` | 2 February 2026 | Partial repair created `+275.4%` | `-4.87%`, matching PnL direction |
 | HyperBotPro | `0x12e358f38741c07c1e04a8102a3170d40a600f05` | 18 March 2026 | `+285.0%` synthetic move around a withdrawal | `+12.72%` from PnL/NAV |
-| Titan Vault | `0x4b0eab9444a75a03f1ef340c8beac737afa5ab09` | 7 April 2026 | `+82.9%` and `deferred_hf_nav` | `+27.94%` from the freshest daily checkpoint |
+| Titan Vault | `0x4b0eab9444a75a03f1ef340c8beac737afa5ab09` | 7 April 2026 | `+82.9%` and `deferred_hf_nav` | `+45.15%` when the matching PnL appears in the 04:00–08:00 UTC bucket |
 | Fish Market | `0x61549534dec101179983169644d7929a3d706c97` | 17–18 March 2026 | PnL moved one day before the matching NAV, producing a clipped `+100%` | `+54.48%` on 18 March using the confirmed larger NAV |
 
 These replacements do not assert that every retained PnL observation is exact
@@ -132,25 +145,34 @@ The raw production snapshot contains 874,878 Hypercore rows across 569 vaults.
 After removing 369 superseded recapitalisation rows, the economic-index run
 produces:
 
-- 85,891 daily PnL/NAV checkpoints;
-- 788,695 carried non-performance rows: duplicate daily/HF rows, 43 premature
-  PnL checkpoints, and rows after a terminal wipe-out;
-- 43 delayed NAV confirmations repaired across 29 vaults;
-- 57 uncorroborated absorbing losses carried for review;
-- 6 positive returns capped at 100%; and
+- 316,695 four-hour PnL/NAV checkpoints;
+- 558,116 carried non-performance rows, including duplicate daily/HF rows,
+  268 premature PnL checkpoints, and rows after a terminal wipe-out;
+- 268 delayed NAV confirmations repaired;
+- 54 uncorroborated absorbing losses carried for review;
+- 5 positive returns capped at 100%; and
 - 1 terminal NAV-corroborated wipe-out. Later rows in that epoch remain at zero
   and are carried rather than recording repeated losses or gains.
 
 All finite one-step clean returns are between -100% and +100%. There are no
 `deferred_hf_*` raw prices in the published clean curve because the index is
 applied to every Hypercore vault rather than only suspicious candidates.
+Every selected checkpoint occupies a unique vault/four-hour bucket, all clean
+prices are finite and non-negative, and synthetic supply reproduces NAV to
+floating-point precision.
+
+The latest seven days contain 75,961 retained rows across 461 active vaults
+and 10,880 non-zero clean price changes. There are 317 active vaults with more
+than one clean change on at least one UTC date, confirming that the published
+curve is no longer daily-only when retained HF evidence exists.
 
 This is structural cleaning, not proof that every source PnL change is genuine.
-The same retained production data still contains 225 funded, unmasked daily
-checkpoints over 50% across 100 vaults and 18 rapid opposite-direction moves
-over 50% across 14 vaults. These observations follow the documented PnL/NAV
-approximation and are internally consistent, but they need explicit quality
-filtering or review before return-based backtesting.
+The largest compounded vault-day is TIDAL AFFAIRS at `+247.27%`: three separate
+PnL increases reconcile with the rising NAV, so it is not a synthetic share-unit
+jump, although its low opening NAV makes it unsuitable for an unfiltered
+backtest. Large observations that follow the documented PnL/NAV approximation
+still need the existing TVL mask and explicit quality review before
+return-based backtesting.
 
 Historical repair requires no DuckDB or raw-Parquet rewrite. Regenerating
 `cleaned-vault-prices-1h.parquet` from the unchanged raw Parquet applies the

--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -45,13 +45,19 @@ from eth_defi.version_info import stamp_parquet_schema_metadata
 #: NAV at or below this value counts as a complete Hypercore wipe-out.
 HYPERCORE_ZERO_NAV_EPSILON = 0.000001
 
-#: Maximum absolute mismatch when recognising a one-day PnL/NAV API lag.
+#: Fixed UTC interval used to select publishable Hypercore economic checkpoints.
+HYPERCORE_ECONOMIC_CHECKPOINT_INTERVAL = pd.Timedelta(hours=4)
+
+#: Maximum elapsed time accepted around a delayed Hypercore NAV confirmation.
+MAX_HYPERCORE_PNL_NAV_CONFIRMATION_DELAY = pd.Timedelta(hours=26)
+
+#: Maximum absolute mismatch when recognising a delayed PnL/NAV API update.
 HYPERCORE_PNL_NAV_LAG_ABSOLUTE_TOLERANCE = 1.0
 
-#: Maximum relative mismatch when recognising a one-day PnL/NAV API lag.
+#: Maximum relative mismatch when recognising a delayed PnL/NAV API update.
 HYPERCORE_PNL_NAV_LAG_RELATIVE_TOLERANCE = 0.001
 
-#: PnL-first, NAV-confirming API lag needs three consecutive checkpoints.
+#: PnL-first, NAV-confirming API lag needs a baseline and two later checkpoints.
 MIN_HYPERCORE_PNL_NAV_LAG_CHECKPOINTS = 3
 
 #: New capital must reach this NAV before a recapitalised vault is tracked again.
@@ -336,14 +342,17 @@ class CleanedVaultPriceRow(TypedDict, total=False):
 
     #: Provenance of the cleaned Hypercore PnL/NAV approximation.
     #:
-    #: ``approximated_pnl_nav`` marks a daily economic checkpoint,
+    #: ``approximated_pnl_nav`` marks a four-hour economic checkpoint,
     #: ``approximated_pnl_nav_clipped`` a positive checkpoint capped at 100%,
     #: ``approximated_pnl_nav_lag_repaired`` a gain whose NAV confirmation
-    #: arrived at the following daily checkpoint,
+    #: arrived within the bounded confirmation window,
     #: ``approximated_pnl_nav_wipe_out`` a terminal NAV-corroborated loss, and
     #: ``approximated_pnl_nav_carried`` a row that adds no performance, either
-    #: because it is not the daily checkpoint or because the epoch is already
-    #: at zero after a terminal loss.
+    #: because it is not the selected checkpoint for its four-hour UTC bucket,
+    #: because its PnL awaits NAV confirmation, or because the epoch is already
+    #: at zero after a terminal loss. A later NAV confirmation can revise the
+    #: recent provisional PnL-only checkpoint and subsequently compounded
+    #: prices.
     #: ``deferred_pnl_nav`` means inputs were missing and
     #: ``deferred_pnl_nav_outlier`` means an uncorroborated negative PnL step
     #: was not allowed to zero a funded vault.
@@ -999,6 +1008,86 @@ def remove_inactive_lead_time(
     return filtered_df
 
 
+def _repair_hypercore_delayed_nav_returns(
+    checkpoint_timestamp_ns: np.ndarray,
+    checkpoint_nav: np.ndarray,
+    checkpoint_pnl: np.ndarray,
+    raw_returns: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Move a positive PnL return to its delayed NAV confirmation.
+
+    Hyperliquid's
+    `vaultDetails API <https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint#retrieve-information-about-a-vault>`__
+    can update cumulative PnL before the matching NAV. Fish Market's PnL-only
+    checkpoint arrived 24 hours 20 minutes after its preceding HF observation;
+    the merged daily source supplied the matching NAV 28 minutes later, and a
+    later HF observation repeated it. Applying the provisional observation
+    produced an economically impossible clipped gain. A 26-hour evidence
+    window on both sides admits normal timestamp jitter while avoiding joins
+    across the API's weekly all-time observations. Flat intermediate
+    checkpoints are skipped, but any other economic change disqualifies the
+    repair.
+
+    A later confirming observation can therefore revise the recent
+    provisional checkpoint and prices compounded after it. Confirmations more
+    than 26 hours away are deliberately ignored even when a scanner gap may be
+    responsible, because joining unrelated coarse observations would be less
+    defensible.
+
+    :param checkpoint_timestamp_ns:
+        Ascending checkpoint timestamps as integer nanoseconds.
+    :param checkpoint_nav:
+        Finite NAV values as a float array aligned with the timestamps.
+    :param checkpoint_pnl:
+        Finite cumulative-PnL values as a float array aligned with the
+        timestamps.
+    :param raw_returns:
+        PnL/NAV returns as a float array aligned with the timestamps.
+    :return:
+        Repaired returns, a boolean mask of provisional PnL checkpoints that
+        were carried, and a boolean mask of their NAV confirmations.
+    """
+    repaired_returns = raw_returns.copy()
+    lagged_pnl_checkpoint = np.zeros(len(raw_returns), dtype=bool)
+    lag_confirmed_checkpoint = np.zeros(len(raw_returns), dtype=bool)
+    if len(raw_returns) < MIN_HYPERCORE_PNL_NAV_LAG_CHECKPOINTS:
+        return repaired_returns, lagged_pnl_checkpoint, lag_confirmed_checkpoint
+
+    pnl_changes = np.diff(checkpoint_pnl)
+    nav_changes = np.diff(checkpoint_nav)
+    elapsed_ns = np.diff(checkpoint_timestamp_ns)
+    tolerances = np.maximum(
+        HYPERCORE_PNL_NAV_LAG_ABSOLUTE_TOLERANCE,
+        np.abs(pnl_changes) * HYPERCORE_PNL_NAV_LAG_RELATIVE_TOLERANCE,
+    )
+    maximum_delay_ns = MAX_HYPERCORE_PNL_NAV_CONFIRMATION_DELAY.value
+    pnl_first_candidate = (pnl_changes > HYPERCORE_PNL_NAV_LAG_ABSOLUTE_TOLERANCE) & (np.abs(nav_changes) <= tolerances) & (elapsed_ns > 0) & (elapsed_ns <= maximum_delay_ns)
+    candidate_middle_numbers = np.flatnonzero(pnl_first_candidate) + 1
+
+    for middle_number in candidate_middle_numbers:
+        pnl_move = pnl_changes[middle_number - 1]
+        tolerance = tolerances[middle_number - 1]
+        for confirmation_number in range(middle_number + 1, len(raw_returns)):
+            confirmation_delay_ns = checkpoint_timestamp_ns[confirmation_number] - checkpoint_timestamp_ns[middle_number]
+            if confirmation_delay_ns > maximum_delay_ns:
+                break
+
+            confirmation_pnl_change = checkpoint_pnl[confirmation_number] - checkpoint_pnl[middle_number]
+            confirmation_nav_change = checkpoint_nav[confirmation_number] - checkpoint_nav[middle_number]
+            if abs(confirmation_pnl_change) <= tolerance and abs(confirmation_nav_change) <= tolerance:
+                continue
+
+            if abs(confirmation_pnl_change) <= tolerance and abs(confirmation_nav_change - pnl_move) <= tolerance:
+                lagged_pnl_checkpoint[middle_number] = True
+                lag_confirmed_checkpoint[confirmation_number] = True
+                repaired_returns[middle_number] = 0.0
+                confirmed_capital_base = max(checkpoint_nav[middle_number - 1], checkpoint_nav[confirmation_number], 1.0)
+                repaired_returns[confirmation_number] = pnl_move / confirmed_capital_base
+            break
+
+    return repaired_returns, lagged_pnl_checkpoint, lag_confirmed_checkpoint
+
+
 def approximate_hypercore_share_prices_from_pnl_nav(  # noqa: PLR0914
     prices_df: pd.DataFrame,
     logger: Callable[[str], None] = print,
@@ -1019,15 +1108,18 @@ def approximate_hypercore_share_prices_from_pnl_nav(  # noqa: PLR0914
     time-weighted investor returns.
 
     The cleaned Hypercore price is consequently a conservative performance
-    index. One freshest usable checkpoint is selected per UTC date. Between
-    checkpoints, cumulative account-PnL change is divided by the larger of
-    opening NAV, closing NAV, and one dollar; the resulting returns are
-    compounded from ``1.0`` within each recapitalisation epoch. This denominator
-    prevents unknown capital-flow timing and small NAV from manufacturing
-    performance. Positive returns are capped at ``max_positive_return``. A
-    return at or below ``-100%`` is accepted only when NAV is zero and does not
-    recover in the same epoch; otherwise the price is carried because applying
-    one questionable negative PnL baseline would permanently zero the index.
+    index. One freshest usable checkpoint is selected per fixed four-hour UTC
+    bucket while retaining its original API timestamp. Missing buckets are not
+    manufactured, and older history remains daily or weekly where Hyperliquid
+    has already downsampled it. Between checkpoints, cumulative account-PnL
+    change is divided by the larger of opening NAV, closing NAV, and one dollar;
+    the resulting returns are compounded from ``1.0`` within each
+    recapitalisation epoch. This denominator prevents unknown capital-flow
+    timing and small NAV from manufacturing performance. Positive returns are
+    capped at ``max_positive_return`` per selected checkpoint. A return at or
+    below ``-100%`` is accepted only when NAV is zero and does not recover in
+    the same epoch; otherwise the price is carried because applying one
+    questionable negative PnL baseline would permanently zero the index.
     Non-checkpoint rows are also carried, avoiding duplicate daily/HF returns
     without interpolating future information backwards.
 
@@ -1036,13 +1128,16 @@ def approximate_hypercore_share_prices_from_pnl_nav(  # noqa: PLR0914
     unchanged; the same ``$2,169.43`` appeared in NAV on 18 March with no
     additional PnL or capital flow. Treating the first half of this staggered
     API update as a complete checkpoint produced a clipped ``+100%`` return.
-    When three consecutive daily checkpoints exhibit this exact PnL-then-NAV
-    pattern, within a small numerical tolerance, this function carries the
-    premature checkpoint and applies the return at the confirming checkpoint
-    using the larger opening/confirmed NAV. This gives approximately ``+54.5%``
-    for Fish Market. The narrow consecutive-day and value-matching conditions
-    avoid suppressing large but reconciled gains in Magixbox, IKAGI and Satori
-    Quantum HF Vault.
+    When a checkpoint within 26 hours exhibits this exact PnL-then-NAV pattern,
+    within a small numerical tolerance, this function carries the premature
+    checkpoint and applies the return at the confirming checkpoint using the
+    larger opening/confirmed NAV. Flat intermediate checkpoints may occur; any
+    other economic change disqualifies the repair. This gives approximately
+    ``+54.5%`` for Fish Market. The bounded, positive-only and value-matching
+    conditions avoid suppressing large but reconciled gains in Magixbox, IKAGI
+    and Satori Quantum HF Vault. Because confirmation arrives later, the most
+    recent provisional checkpoint and prices compounded after it may be revised
+    on the next cleaning run.
 
     Input uses a timestamp index and requires ``id`` (string), ``chain``
     (integer), ``share_price`` (float), ``total_assets`` (float), and cumulative
@@ -1062,8 +1157,8 @@ def approximate_hypercore_share_prices_from_pnl_nav(  # noqa: PLR0914
     :param logger:
         Notebook, console, or structured-log adapter accepting one message.
     :param max_positive_return:
-        Maximum approximate return applied at one daily checkpoint. The default
-        is ``1.0`` (100%).
+        Maximum approximate return applied at one four-hour checkpoint. The
+        default is ``1.0`` (100%).
     :return:
         A copy with every Hypercore row expressed on its PnL/NAV performance
         index; all non-Hypercore rows are unchanged.
@@ -1112,7 +1207,7 @@ def approximate_hypercore_share_prices_from_pnl_nav(  # noqa: PLR0914
         positions = hypercore_positions[np.asarray(relative_positions, dtype=int)]
         timestamps = all_timestamps[positions]
         timestamp_ns = timestamps.to_numpy(dtype="datetime64[ns]").astype("int64")
-        day_ns = timestamps.normalize().to_numpy(dtype="datetime64[ns]").astype("int64")
+        bucket_ns = timestamps.floor(HYPERCORE_ECONOMIC_CHECKPOINT_INTERVAL).to_numpy(dtype="datetime64[ns]").astype("int64")
         nav = all_nav[positions]
         pnl = all_pnl[positions]
         source = all_source[positions]
@@ -1126,7 +1221,7 @@ def approximate_hypercore_share_prices_from_pnl_nav(  # noqa: PLR0914
 
         for epoch in np.unique(epoch_number):
             epoch_positions = np.flatnonzero(epoch_number == epoch)
-            epoch_days = day_ns[epoch_positions]
+            epoch_buckets = bucket_ns[epoch_positions]
             usable = np.isfinite(nav[epoch_positions]) & np.isfinite(pnl[epoch_positions])
             usable_positions = epoch_positions[usable]
 
@@ -1136,20 +1231,20 @@ def approximate_hypercore_share_prices_from_pnl_nav(  # noqa: PLR0914
                         hf_priority[usable_positions].astype(np.int8),
                         timestamp_ns[usable_positions],
                         written_at[usable_positions],
-                        day_ns[usable_positions],
+                        bucket_ns[usable_positions],
                     )
                 )
                 ordered_positions = usable_positions[checkpoint_order]
-                ordered_days = day_ns[ordered_positions]
-                latest_per_day = np.r_[ordered_days[1:] != ordered_days[:-1], True]
-                checkpoints = ordered_positions[latest_per_day]
+                ordered_buckets = bucket_ns[ordered_positions]
+                latest_per_bucket = np.r_[ordered_buckets[1:] != ordered_buckets[:-1], True]
+                checkpoints = ordered_positions[latest_per_bucket]
             else:
                 checkpoints = np.asarray([], dtype=int)
-            checkpoint_days = day_ns[checkpoints] if len(checkpoints) else np.asarray([], dtype=np.int64)
-            day_has_checkpoint = np.isin(epoch_days, checkpoint_days)
-            repair_status[epoch_positions[day_has_checkpoint]] = "approximated_pnl_nav_carried"
-            repair_status[epoch_positions[~day_has_checkpoint]] = "deferred_pnl_nav"
-            missing_count += int((~day_has_checkpoint).sum())
+            checkpoint_buckets = bucket_ns[checkpoints] if len(checkpoints) else np.asarray([], dtype=np.int64)
+            bucket_has_checkpoint = np.isin(epoch_buckets, checkpoint_buckets)
+            repair_status[epoch_positions[bucket_has_checkpoint]] = "approximated_pnl_nav_carried"
+            repair_status[epoch_positions[~bucket_has_checkpoint]] = "deferred_pnl_nav"
+            missing_count += int((~bucket_has_checkpoint).sum())
 
             if len(checkpoints) == 0:
                 clean_price[epoch_positions] = 1.0
@@ -1168,40 +1263,12 @@ def approximate_hypercore_share_prices_from_pnl_nav(  # noqa: PLR0914
                 )
                 raw_returns[1:] = np.diff(checkpoint_pnl) / capital_base
 
-            # Hyperliquid can publish cumulative PnL one daily checkpoint
-            # before the matching NAV. Recognise only an exact three-day
-            # stagger: NAV is initially unchanged, PnL is then unchanged, and
-            # the delayed NAV move matches the earlier PnL move.
-            lagged_pnl_checkpoint = np.zeros(len(checkpoints), dtype=bool)
-            lag_confirmed_checkpoint = np.zeros(len(checkpoints), dtype=bool)
-            if len(checkpoints) >= MIN_HYPERCORE_PNL_NAV_LAG_CHECKPOINTS:
-                pnl_changes = np.diff(checkpoint_pnl)
-                nav_changes = np.diff(checkpoint_nav)
-                pnl_move = pnl_changes[:-1]
-                tolerance = np.maximum(
-                    HYPERCORE_PNL_NAV_LAG_ABSOLUTE_TOLERANCE,
-                    np.abs(pnl_move) * HYPERCORE_PNL_NAV_LAG_RELATIVE_TOLERANCE,
-                )
-                one_day_ns = pd.Timedelta(days=1).value
-                consecutive_days = np.diff(checkpoint_days) == one_day_ns
-                lag_pattern = consecutive_days[:-1] & consecutive_days[1:]
-                lag_pattern &= pnl_move > HYPERCORE_PNL_NAV_LAG_ABSOLUTE_TOLERANCE
-                lag_pattern &= np.abs(nav_changes[:-1]) <= tolerance
-                lag_pattern &= np.abs(pnl_changes[1:]) <= tolerance
-                lag_pattern &= np.abs(nav_changes[1:] - pnl_move) <= tolerance
-                lagged_numbers = np.flatnonzero(lag_pattern) + 1
-                confirmed_numbers = lagged_numbers + 1
-                lagged_pnl_checkpoint[lagged_numbers] = True
-                lag_confirmed_checkpoint[confirmed_numbers] = True
-                raw_returns[lagged_numbers] = 0.0
-                confirmed_capital_base = np.maximum.reduce(
-                    [
-                        checkpoint_nav[lagged_numbers - 1],
-                        checkpoint_nav[confirmed_numbers],
-                        np.ones(len(confirmed_numbers), dtype=float),
-                    ]
-                )
-                raw_returns[confirmed_numbers] = pnl_changes[lagged_numbers - 1] / confirmed_capital_base
+            raw_returns, lagged_pnl_checkpoint, lag_confirmed_checkpoint = _repair_hypercore_delayed_nav_returns(
+                checkpoint_timestamp_ns=timestamp_ns[checkpoints],
+                checkpoint_nav=checkpoint_nav,
+                checkpoint_pnl=checkpoint_pnl,
+                raw_returns=raw_returns,
+            )
 
             applied_returns = raw_returns.copy()
             positive_clipped = raw_returns > max_positive_return
@@ -1250,7 +1317,7 @@ def approximate_hypercore_share_prices_from_pnl_nav(  # noqa: PLR0914
             clean_price[epoch_positions] = epoch_prices
 
             checkpoint_count += len(checkpoints)
-            carried_count += int(day_has_checkpoint.sum()) - len(checkpoints) + int(post_wipe_out.sum())
+            carried_count += int(bucket_has_checkpoint.sum()) - len(checkpoints) + int(post_wipe_out.sum())
             carried_count += int(lagged_pnl_checkpoint.sum())
             clipped_count += int(positive_clipped.sum())
             lag_repaired_count += int(lag_confirmed_checkpoint.sum())
@@ -1273,7 +1340,7 @@ def approximate_hypercore_share_prices_from_pnl_nav(  # noqa: PLR0914
     if synthetic_supplies is not None:
         prices_df["total_supply"] = synthetic_supplies
 
-    logger(f"Approximated Hypercore economic share prices for {affected_vaults:,} vaults using {checkpoint_count:,} daily PnL/NAV checkpoints; carried {carried_count:,} non-performance rows, repaired {lag_repaired_count:,} delayed NAV confirmations, deferred {missing_count:,} missing-input rows and {deferred_outlier_count:,} uncorroborated losses, capped {clipped_count:,} gains and recorded {wipe_out_count:,} terminal wipe-outs")
+    logger(f"Approximated Hypercore economic share prices for {affected_vaults:,} vaults using {checkpoint_count:,} four-hour PnL/NAV checkpoints; carried {carried_count:,} non-performance rows, repaired {lag_repaired_count:,} delayed NAV confirmations, deferred {missing_count:,} missing-input rows and {deferred_outlier_count:,} uncorroborated losses, capped {clipped_count:,} gains and recorded {wipe_out_count:,} terminal wipe-outs")
     return prices_df
 
 

--- a/scripts/hyperliquid/README-hyperliquid-vaults-high-frequency.md
+++ b/scripts/hyperliquid/README-hyperliquid-vaults-high-frequency.md
@@ -209,15 +209,18 @@ timestamp for the same vault, the HF row is kept (more recent/granular data).
 ### Raw timestamps, no resampling
 
 HF data is written with the original API timestamps (irregular spacing). The
-downstream cleaning pipeline first replaces raw scanner units with one PnL/NAV
-economic checkpoint per UTC date. Non-checkpoint HF rows carry the last clean
-price. It then computes `returns_1h` via `pct_change()` on consecutive rows.
-When consumers need a regular 1h grid, they call `forward_fill_vault()` which
-does `.resample("h").last().ffill()`.
+downstream cleaning pipeline first replaces raw scanner units with at most one
+PnL/NAV economic checkpoint per fixed four-hour UTC bucket. The selected row
+keeps its original API timestamp. Non-checkpoint HF rows carry the last clean
+price, and missing buckets do not create interpolated rows. Daily and weekly
+source history remains naturally coarse. The pipeline then computes
+`returns_1h` via `pct_change()` on consecutive rows. When consumers need a
+regular 1h grid, they call `forward_fill_vault()` which does
+`.resample("h").last().ffill()`.
 
-Note: `returns_1h` is a misnomer — see the comment at
-`wrangle_vault_prices.py:260`.  It is `pct_change()` between consecutive rows
-regardless of actual time delta.
+Note: `returns_1h` is a compatibility name — see
+`calculate_vault_returns()` in `wrangle_vault_prices.py`. It is `pct_change()`
+between consecutive rows regardless of actual time delta.
 
 ### Column name mapping
 
@@ -291,12 +294,20 @@ Both DuckDB paths are always available:
 
 The cleaning pipeline computes `returns_1h = pct_change()` on consecutive rows
 regardless of actual time delta. Hypercore economic returns occur only at the
-selected daily checkpoints; intervening raw rows carry the price and have zero
-change. Price level, cumulative profit and drawdown use this clean curve.
-Volatility, Sharpe and other cadence-sensitive statistics must select
-`hypercore_repair_status` checkpoint rows instead of treating carried rows as
-independent hourly observations. Consumers that need a uniform 1h price grid
-can use `forward_fill_vault()`.
+selected observations in occupied four-hour UTC buckets; intervening raw rows
+carry the price and have zero change. Gaps can be longer where source history
+is missing or already coarse. Price level, cumulative profit and drawdown use
+this clean curve. Volatility, Sharpe and other cadence-sensitive statistics
+must select `hypercore_repair_status` checkpoint rows instead of treating
+carried rows as independent hourly observations. Consumers that need a uniform
+1h price grid can use `forward_fill_vault()`.
+
+A later NAV observation can confirm a recent PnL-only update. In this bounded
+case, the cleaner carries the provisional checkpoint and applies performance
+at the confirmation, revising subsequently compounded recent prices. The
+confirmation window is 26 hours, may skip flat intermediate observations and
+rejects any intervening economic change. This evidence-driven update is the
+only intended exception to append stability for cleaned Hypercore prices.
 
 **2. Flow metrics are attached to one row per calendar date only**
 

--- a/tests/research/test_clean_prices.py
+++ b/tests/research/test_clean_prices.py
@@ -275,21 +275,21 @@ def test_approximate_hypercore_share_prices_from_pnl_nav() -> None:
     assert result["raw_share_price"].tolist() == prices_df["share_price"].tolist()
     assert (result["share_price"] * result["total_supply"]).tolist() == pytest.approx(result["total_assets"].tolist())
     assert result["hypercore_repair_status"].tolist() == ["approximated_pnl_nav"] * 4
-    assert messages == ["Approximated Hypercore economic share prices for 1 vaults using 4 daily PnL/NAV checkpoints; carried 0 non-performance rows, repaired 0 delayed NAV confirmations, deferred 0 missing-input rows and 0 uncorroborated losses, capped 0 gains and recorded 0 terminal wipe-outs"]
+    assert messages == ["Approximated Hypercore economic share prices for 1 vaults using 4 four-hour PnL/NAV checkpoints; carried 0 non-performance rows, repaired 0 delayed NAV confirmations, deferred 0 missing-input rows and 0 uncorroborated losses, capped 0 gains and recorded 0 terminal wipe-outs"]
 
 
 def test_approximate_hypercore_repairs_delayed_nav_confirmation() -> None:
-    """Fish Market's provisional PnL return moves to its confirmed NAV."""
+    """Fish Market's jittered PnL return moves to its merged daily NAV."""
     prices_df = pd.DataFrame(
         {
-            "chain": [9999] * 4,
-            "id": ["9999-0xfish-market"] * 4,
-            "share_price": [0.180973] * 4,
-            "total_assets": [1812.411674, 1812.411674, 3981.846633, 5171.054434],
-            "total_supply": [10_000.0] * 4,
-            "account_pnl": [-11486.308326, -9316.873367, -9316.873367, -8127.665566],
+            "chain": [9999] * 5,
+            "id": ["9999-0xfish-market"] * 5,
+            "share_price": [0.180973] * 5,
+            "total_assets": [1812.411674, 1812.411674, 3981.846633, 3981.846633, 5171.054434],
+            "total_supply": [10_000.0] * 5,
+            "account_pnl": [-11486.308326, -9316.873367, -9316.873367, -9316.873367, -8127.665566],
         },
-        index=pd.to_datetime(["2026-03-16", "2026-03-17", "2026-03-18", "2026-03-19"]),
+        index=pd.to_datetime(["2026-03-16 23:12:00.091", "2026-03-17 23:32:00.042", "2026-03-18 00:00:00.000", "2026-03-18 22:32:00.010", "2026-03-19 00:00:00.000"]),
     )
 
     provisional = approximate_hypercore_share_prices_from_pnl_nav(prices_df.iloc[:2], logger=lambda _message: None)
@@ -301,14 +301,41 @@ def test_approximate_hypercore_repairs_delayed_nav_confirmation() -> None:
 
     confirmed_return = 2169.434959 / 3981.846633
     following_return = 1189.207801 / 5171.054434
-    assert result["share_price"].tolist() == pytest.approx([1.0, 1.0, 1.0 + confirmed_return, (1.0 + confirmed_return) * (1.0 + following_return)])
+    assert result["share_price"].tolist() == pytest.approx([1.0, 1.0, 1.0 + confirmed_return, 1.0 + confirmed_return, (1.0 + confirmed_return) * (1.0 + following_return)])
     assert result["hypercore_repair_status"].tolist() == [
         "approximated_pnl_nav",
         "approximated_pnl_nav_carried",
         "approximated_pnl_nav_lag_repaired",
         "approximated_pnl_nav",
+        "approximated_pnl_nav",
     ]
-    assert messages == ["Approximated Hypercore economic share prices for 1 vaults using 4 daily PnL/NAV checkpoints; carried 1 non-performance rows, repaired 1 delayed NAV confirmations, deferred 0 missing-input rows and 0 uncorroborated losses, capped 0 gains and recorded 0 terminal wipe-outs"]
+    assert messages == ["Approximated Hypercore economic share prices for 1 vaults using 5 four-hour PnL/NAV checkpoints; carried 1 non-performance rows, repaired 1 delayed NAV confirmations, deferred 0 missing-input rows and 0 uncorroborated losses, capped 0 gains and recorded 0 terminal wipe-outs"]
+
+
+def test_approximate_hypercore_skips_flat_delayed_nav_checkpoints() -> None:
+    """Flat four-hour observations do not block a matching NAV confirmation."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 5,
+            "id": ["9999-0xflat-delay"] * 5,
+            "share_price": [1.0] * 5,
+            "total_assets": [100.0, 100.0, 100.0, 100.0, 200.0],
+            "total_supply": [100.0] * 5,
+            "account_pnl": [0.0, 100.0, 100.0, 100.0, 100.0],
+        },
+        index=pd.to_datetime(["2026-01-01 00:00", "2026-01-01 04:00", "2026-01-01 08:00", "2026-01-01 12:00", "2026-01-01 16:00"]),
+    )
+
+    result = approximate_hypercore_share_prices_from_pnl_nav(prices_df, logger=lambda _message: None)
+
+    assert result["share_price"].tolist() == [1.0, 1.0, 1.0, 1.0, 1.5]
+    assert result["hypercore_repair_status"].tolist() == [
+        "approximated_pnl_nav",
+        "approximated_pnl_nav_carried",
+        "approximated_pnl_nav",
+        "approximated_pnl_nav",
+        "approximated_pnl_nav_lag_repaired",
+    ]
 
 
 def test_approximate_hypercore_does_not_join_weekly_checkpoints() -> None:
@@ -371,8 +398,8 @@ def test_approximate_hypercore_rejects_delayed_nav_mismatch() -> None:
     assert result["hypercore_repair_status"].tolist() == ["approximated_pnl_nav"] * 3
 
 
-def test_approximate_hypercore_uses_freshest_daily_checkpoint() -> None:
-    """A fresher daily row wins over a stale HF row on the same UTC date."""
+def test_approximate_hypercore_uses_freshest_four_hour_checkpoint() -> None:
+    """A fresher daily row wins over a stale HF row in the same UTC bucket."""
     prices_df = pd.DataFrame(
         {
             "chain": [9999] * 3,
@@ -384,7 +411,7 @@ def test_approximate_hypercore_uses_freshest_daily_checkpoint() -> None:
             "hypercore_source": ["daily", "daily", "hf"],
             "written_at": pd.to_datetime(["2026-01-01", "2026-01-04", "2026-01-03"]),
         },
-        index=pd.to_datetime(["2026-01-01", "2026-01-02", "2026-01-02 12:00"], format="mixed"),
+        index=pd.to_datetime(["2026-01-01", "2026-01-02 01:00", "2026-01-02 02:00"], format="mixed"),
     )
 
     result = approximate_hypercore_share_prices_from_pnl_nav(prices_df, logger=lambda _message: None)
@@ -392,6 +419,125 @@ def test_approximate_hypercore_uses_freshest_daily_checkpoint() -> None:
     expected_price = 1 + 10.0 / 110.0
     assert result["share_price"].tolist() == pytest.approx([1.0, expected_price, expected_price])
     assert result["hypercore_repair_status"].tolist() == ["approximated_pnl_nav", "approximated_pnl_nav", "approximated_pnl_nav_carried"]
+
+
+def test_approximate_hypercore_publishes_multiple_four_hour_checkpoints() -> None:
+    """Each occupied four-hour bucket can add one economic price observation."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 5,
+            "id": ["9999-0xfour-hour"] * 5,
+            "share_price": [1.0] * 5,
+            "total_assets": [100.0, 999.0, 110.0, 120.0, 130.0],
+            "total_supply": [100.0] * 5,
+            "account_pnl": [0.0, 999.0, 10.0, 20.0, 30.0],
+            "hypercore_source": ["daily", "hf", "hf", "hf", "hf"],
+            "written_at": pd.to_datetime(["2026-01-02", "2026-01-01", "2026-01-02", "2026-01-02", "2026-01-02"]),
+        },
+        index=pd.to_datetime(["2026-01-01 00:30", "2026-01-01 01:30", "2026-01-01 04:30", "2026-01-01 08:30", "2026-01-01 16:30"]),
+    )
+
+    result = approximate_hypercore_share_prices_from_pnl_nav(prices_df, logger=lambda _message: None)
+
+    first_return = 10.0 / 110.0
+    second_return = 10.0 / 120.0
+    third_return = 10.0 / 130.0
+    expected_prices = [1.0, 1.0, 1.0 + first_return, (1.0 + first_return) * (1.0 + second_return), (1.0 + first_return) * (1.0 + second_return) * (1.0 + third_return)]
+    assert result.index.tolist() == prices_df.index.tolist()
+    assert result["share_price"].tolist() == pytest.approx(expected_prices)
+    assert result["hypercore_repair_status"].tolist() == [
+        "approximated_pnl_nav",
+        "approximated_pnl_nav_carried",
+        "approximated_pnl_nav",
+        "approximated_pnl_nav",
+        "approximated_pnl_nav",
+    ]
+
+
+@pytest.mark.parametrize(
+    "timestamps",
+    [
+        ["2026-01-01 00:00", "2026-01-02 03:00", "2026-01-02 07:00"],
+        ["2026-01-01 00:00", "2026-01-02 00:00", "2026-01-03 03:00"],
+    ],
+)
+def test_approximate_hypercore_bounds_delayed_nav_confirmation(timestamps: list[str]) -> None:
+    """Neither side of a delayed NAV repair may exceed the 26-hour window."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 3,
+            "id": ["9999-0xdelay-boundary"] * 3,
+            "share_price": [1.0] * 3,
+            "total_assets": [100.0, 100.0, 200.0],
+            "total_supply": [100.0] * 3,
+            "account_pnl": [0.0, 100.0, 100.0],
+        },
+        index=pd.to_datetime(timestamps),
+    )
+
+    result = approximate_hypercore_share_prices_from_pnl_nav(prices_df, logger=lambda _message: None)
+
+    assert result["share_price"].tolist() == [1.0, 2.0, 2.0]
+    assert result["hypercore_repair_status"].tolist() == ["approximated_pnl_nav"] * 3
+
+
+def test_approximate_hypercore_does_not_skip_economic_change_for_nav_confirmation() -> None:
+    """An intervening economic change disqualifies a later matching NAV."""
+    prices_df = pd.DataFrame(
+        {
+            "chain": [9999] * 4,
+            "id": ["9999-0xintervening-change"] * 4,
+            "share_price": [1.0] * 4,
+            "total_assets": [100.0, 100.0, 110.0, 200.0],
+            "total_supply": [100.0] * 4,
+            "account_pnl": [0.0, 100.0, 100.0, 100.0],
+        },
+        index=pd.to_datetime(["2026-01-01 00:00", "2026-01-02 00:00", "2026-01-02 04:00", "2026-01-02 08:00"]),
+    )
+
+    result = approximate_hypercore_share_prices_from_pnl_nav(prices_df, logger=lambda _message: None)
+
+    assert result["share_price"].tolist() == [1.0, 2.0, 2.0, 2.0]
+    assert "approximated_pnl_nav_lag_repaired" not in result["hypercore_repair_status"].tolist()
+
+
+def test_approximate_hypercore_applies_protections_per_four_hour_bucket() -> None:
+    """Clips and funded-loss deferrals apply independently within one UTC date."""
+    prices_df = pd.concat(
+        [
+            pd.DataFrame(
+                {
+                    "chain": [9999] * 3,
+                    "id": ["9999-0xstacked-gains"] * 3,
+                    "share_price": [1.0] * 3,
+                    "total_assets": [100.0] * 3,
+                    "total_supply": [100.0] * 3,
+                    "account_pnl": [0.0, 200.0, 400.0],
+                },
+                index=pd.to_datetime(["2026-01-01 00:30", "2026-01-01 04:30", "2026-01-01 08:30"]),
+            ),
+            pd.DataFrame(
+                {
+                    "chain": [9999] * 3,
+                    "id": ["9999-0xstacked-losses"] * 3,
+                    "share_price": [1.0] * 3,
+                    "total_assets": [100.0] * 3,
+                    "total_supply": [100.0] * 3,
+                    "account_pnl": [0.0, -150.0, -300.0],
+                },
+                index=pd.to_datetime(["2026-01-01 00:30", "2026-01-01 04:30", "2026-01-01 08:30"]),
+            ),
+        ]
+    ).sort_values(["id"], kind="stable")
+
+    result = approximate_hypercore_share_prices_from_pnl_nav(prices_df, logger=lambda _message: None)
+    gains = result[result["id"] == "9999-0xstacked-gains"]
+    losses = result[result["id"] == "9999-0xstacked-losses"]
+
+    assert gains["share_price"].tolist() == [1.0, 2.0, 4.0]
+    assert gains["hypercore_repair_status"].tolist() == ["approximated_pnl_nav", "approximated_pnl_nav_clipped", "approximated_pnl_nav_clipped"]
+    assert losses["share_price"].tolist() == [1.0, 1.0, 1.0]
+    assert losses["hypercore_repair_status"].tolist() == ["approximated_pnl_nav", "deferred_pnl_nav_outlier", "deferred_pnl_nav_outlier"]
 
 
 def test_approximate_hypercore_defers_missing_and_absorbing_losses() -> None:


### PR DESCRIPTION
## Why

Hypercore high-frequency scans retain usable sub-daily NAV and cumulative-PnL observations, but the cleaner selected only one economic checkpoint per UTC date. The published Parquet therefore contained sub-daily rows while its cleaned share price changed only daily. This change publishes the finest defensible retained economic evidence without inventing observations or treating Hyperliquid's synthetic scanner units as an investor share price.

## Lessons learnt

Hyperliquid does not expose exact historical vault supply or an investable unit price, so cumulative PnL divided by the larger opening or closing NAV remains the defensible approximation. Fixed four-hour buckets recover recent timing while naturally leaving older downsampled history coarse. Fish Market also showed that a strict 24-hour lag boundary is unsafe: its PnL-only observation was 24 hours 20 minutes after the preceding HF point, while the merged daily source confirmed NAV shortly afterwards.

A read-only run over the 15 July production snapshot selected 316,695 four-hour checkpoints from 874,878 raw Hypercore rows. In the latest seven days, 317 active vaults gained more than one clean price change on at least one day. Earlier repairs remain intact, including HODL's recapitalisation boundary, Magixbox and C.A.T unit cleaning, and Fish Market's +54.48% NAV-confirmed gain.

## Summary

- Select at most one finite PnL/NAV observation per occupied four-hour UTC bucket, retaining the original API timestamp and creating no interpolated rows.
- Generalise delayed NAV confirmation to a bounded 26-hour matcher that skips flat observations but rejects intervening economic changes.
- Preserve the existing per-checkpoint clipping, funded-loss deferral, terminal wipe-out, recapitalisation and synthetic NAV identity rules.
- Add focused four-hour, source-precedence, lag-boundary, append-stability and per-bucket protection coverage.
- Update the Hypercore problem-vault record, high-frequency pipeline documentation, earlier cadence plan and changelog with the production findings and residual approximation limits.

## Related issues and PRs

- Continues #1285, which introduced the PnL/NAV economic index.
- Preserves and generalises the delayed NAV repair from #1286.
- Replaces the daily-only cleaned publication cadence while retaining the raw continuity work from #1271.

## Unrelated CI and test fixes

None.
