### PR TITLE
feat: export Midas payment tokens as vault denominations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.2
 
 - feat: Publish Hypercore cleaned economic share prices from retained observations at up to four-hour granularity (2026-07-16)
+- feat: Export Midas issuance-vault payment tokens as scanner denominations and add a manual payment-token audit script (2026-07-16)
 - feat: Add Kiln OmniVault protocol metadata, documentation, feed registration and regression coverage (2026-07-15)
 - feat: Add Maseer One wstGBP vault support with hardcoded Ethereum discovery, NAV/share TVL history and Anvil-fork integration tests (2026-07-14)
 - feat: Add Accountable vault synchronous deposits, self-controlled asynchronous redemption claims and historical settlement event scanning (2026-07-14)

--- a/eth_defi/midas/vault.py
+++ b/eth_defi/midas/vault.py
@@ -18,6 +18,7 @@ from web3 import Web3
 from web3.contract import Contract
 from web3.exceptions import BadFunctionCallOutput, ContractLogicError, Web3Exception
 
+from eth_defi.abi import ZERO_ADDRESS
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.midas.constants import MIDAS_PRODUCTS
 from eth_defi.midas.historical import MidasVaultHistoricalReader
@@ -72,6 +73,13 @@ MIDAS_AGGREGATOR_V3_ABI = [
 MIDAS_MANAGEABLE_VAULT_ABI = [
     {
         "inputs": [],
+        "name": "getPaymentTokens",
+        "outputs": [{"internalType": "address[]", "name": "", "type": "address[]"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
         "name": "instantFee",
         "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
         "stateMutability": "view",
@@ -101,7 +109,8 @@ class MidasVaultInfo(VaultInfo, total=False):
     #: Midas redemption vault contract.
     redemption_vault: HexAddress | None
 
-    #: Whether NAV uses a synthetic denomination token in scanner output.
+    #: Whether the scanner used the off-chain USD fallback because no payment
+    #: token was available.
     synthetic_usd_denomination: bool
 
     #: NAV source label.
@@ -127,11 +136,11 @@ def convert_midas_fee_to_percent(raw_fee: int) -> Percent:
 
 
 def export_midas_usd_denomination(chain_id: int) -> dict[str, object]:
-    """Export synthetic USD accounting denomination metadata.
+    """Export the off-chain USD fallback denomination metadata.
 
-    Midas USD products publish NAV in USD units but do not expose an ERC-4626
-    ``asset()`` token. The scanner can still label the denomination as USD
-    without pretending that there is a depositable ERC-20 denomination token.
+    This is used only when a Midas issuance vault has no configured ERC-20
+    payment token. It records the product's USD accounting label without
+    inventing an ERC-20 address.
 
     :param chain_id:
         Chain id for the scan row.
@@ -166,11 +175,31 @@ def _checksum_or_none(address: HexAddress | None) -> HexAddress | None:
 
 
 class MidasVault(VaultBase):
-    """Scan-only adapter for Midas mToken products.
+    """Scan-only adapter for Midas ``mToken`` investment products.
 
-    The adapter reads ERC-20 supply from the mToken and NAV/share from the
-    Midas datafeed contract. Active issuance and redemption are intentionally
-    unsupported because Midas does not implement ERC-4626/ERC-7540 flows.
+    Midas product architecture differs materially from ERC-4626. The mToken
+    is the share token, while separate issuance and redemption vault contracts
+    perform deposits and withdrawals. NAV/share is published by Midas'
+    ``IDataFeed`` and is independent of any ERC-20 used to pay for an
+    issuance. Consequently this adapter must not call ERC-4626 ``asset()`` or
+    imply that a payment token controls the mToken's NAV denomination.
+
+    Instead, an issuance vault inherits Midas'
+    `ManageableVault <https://github.com/midas-apps/contracts/blob/main/contracts/abstract/ManageableVault.sol>`__
+    implementation. It maintains a mutable ``_paymentTokens`` set and exposes
+    it through ``getPaymentTokens()``; Midas administrators can add or remove
+    accepted payment tokens. :py:meth:`fetch_payment_tokens` reads this
+    authoritative live list. Since the shared vault schema presently has one
+    ERC-20 denomination field, the adapter exports the first returned payment
+    token as a compatibility choice. That order is not an assertion that Midas
+    regards it as a canonical or preferred settlement currency.
+
+    If an issuance vault is absent, returns no ERC-20 payment tokens, or only
+    returns the zero-address ``MANUAL_FULLFILMENT_TOKEN`` sentinel, the adapter
+    exports synthetic off-chain USD. This preserves the USD accounting label
+    without inventing an ERC-20 address. Active issuance and redemption remain
+    intentionally unsupported because Midas does not implement
+    ERC-4626/ERC-7540 flows.
     """
 
     def __init__(
@@ -340,28 +369,115 @@ class MidasVault(VaultBase):
             cause_diagnostics_message=f"Midas share token for vault {self.address}",
         )
 
-    def fetch_denomination_token_address(self) -> HexAddress | None:
-        """Return the ERC-20 denomination token address.
+    def fetch_payment_tokens(self) -> list[TokenDetails]:
+        """Fetch ERC-20 payment tokens accepted by the Midas issuance vault.
 
-        Midas products use NAV feeds rather than ERC-4626 ``asset()`` tokens.
-        The initial supported products are USD-denominated, represented with a
-        synthetic scanner denomination.
+        Midas products have no ERC-4626 ``asset()`` method. Their separate
+        issuance contracts inherit
+        `ManageableVault <https://github.com/midas-apps/contracts/blob/main/contracts/abstract/ManageableVault.sol>`__,
+        whose ``getPaymentTokens()`` method returns its internal
+        ``_paymentTokens`` set. This is the authoritative on-chain list of
+        ERC-20 tokens accepted to pay for a deposit. The companion
+        `DepositVault implementation <https://github.com/midas-apps/contracts/blob/main/contracts/DepositVault.sol>`__
+        converts the supplied ``tokenIn`` amount to USD before calculating the
+        mToken mint amount. Therefore a returned payment token is a settlement
+        route, not necessarily the currency used by the product's NAV feed.
+
+        The set is mutable: Midas vault administrators may add and remove
+        payment tokens, so this method intentionally performs a live read and
+        does not cache the returned list. The contract uses OpenZeppelin's
+        enumerable set, whose returned order is an implementation order rather
+        than an explicit Midas preference. We preserve it exactly because
+        :py:meth:`fetch_primary_payment_token` must choose one token for the
+        shared single-denomination schema; it selects the first item solely as
+        that compatibility rule.
+
+        Midas also defines ``MANUAL_FULLFILMENT_TOKEN`` as the zero address for
+        an off-chain USD bank-transfer route. Current supported products return
+        ERC-20 addresses, but this method filters a zero-address entry so it
+        cannot be mistaken for a transferable ERC-20. When there is no
+        issuance vault, there are no ERC-20 entries, or the returned list only
+        has the manual-fulfilment sentinel, this method returns an empty list.
+        The scan export then falls back to synthetic off-chain USD instead of
+        inventing a token address.
 
         :return:
-            Always ``None`` for the current Midas adapter.
+            Payment-token details in the contract-returned order, or an empty
+            list when the product has no issuance vault or configured ERC-20
+            payment tokens.
         """
 
-        return None
+        issuance_vault = self.issuance_vault_contract
+        if issuance_vault is None:
+            return []
+
+        block_identifier = self.default_block_identifier or "latest"
+        payment_token_addresses = issuance_vault.functions.getPaymentTokens().call(block_identifier=block_identifier)
+        return [
+            fetch_erc20_details(
+                self.web3,
+                Web3.to_checksum_address(address),
+                chain_id=self.chain_id,
+                raise_on_error=False,
+                cache=self.token_cache,
+                cause_diagnostics_message=f"Midas payment token for vault {self.address}",
+            )
+            for address in payment_token_addresses
+            if address.lower() != ZERO_ADDRESS
+        ]
+
+    def fetch_primary_payment_token(self) -> TokenDetails | None:
+        """Fetch the primary Midas payment token for schema compatibility.
+
+        Midas exposes a set of accepted payment tokens, rather than an
+        ERC-4626 ``asset()`` token. The shared :class:`VaultBase` API has one
+        denomination-token slot, however, so Midas adapters define the first
+        ERC-20 returned by
+        `ManageableVault.getPaymentTokens() <https://github.com/midas-apps/contracts/blob/main/contracts/abstract/ManageableVault.sol>`__
+        as the primary payment token. This is a compatibility convention, not
+        a claim that the token denominates the USD NAV calculated by Midas'
+        `DepositVault <https://github.com/midas-apps/contracts/blob/main/contracts/DepositVault.sol>`__.
+
+        :return:
+            The first non-zero payment token in contract-returned order, or
+            ``None`` when the scanner must use its off-chain USD fallback.
+        """
+
+        payment_tokens = self.fetch_payment_tokens()
+        return payment_tokens[0] if payment_tokens else None
+
+    def fetch_denomination_token_address(self) -> HexAddress | None:
+        """Return the primary Midas payment-token address.
+
+        Midas issuance vaults may accept several payment tokens. The common
+        :class:`VaultBase` schema has one denomination-token field, so this
+        method returns the address of :py:meth:`fetch_primary_payment_token`.
+        If the contract returns no ERC-20 payment tokens, the scan export uses
+        synthetic off-chain USD.
+
+        :return:
+            Primary payment-token address, or ``None`` when no token is
+            configured.
+        """
+
+        denomination_token = self.fetch_denomination_token()
+        return denomination_token.address if denomination_token else None
 
     def fetch_denomination_token(self) -> TokenDetails | None:
-        """Fetch ERC-20 denomination token metadata.
+        """Expose the primary Midas payment token through :class:`VaultBase`.
+
+        This override fulfils the :class:`VaultBase` denomination-token API for
+        a non-ERC-4626 Midas product. It deliberately returns
+        :py:meth:`fetch_primary_payment_token`, allowing the shared scanner to
+        cache and export the primary accepted payment token in
+        :py:attr:`VaultBase.denomination_token`.
 
         :return:
-            Always ``None`` because Midas products do not expose an ERC-4626
-            denomination token.
+            Primary payment token, or ``None`` when the scanner must use the
+            off-chain USD fallback.
         """
 
-        return None
+        return self.fetch_primary_payment_token()
 
     def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
         """Fetch Midas NAV per mToken.
@@ -435,6 +551,7 @@ class MidasVault(VaultBase):
             Token and NAV-source metadata.
         """
 
+        denomination_token = self.denomination_token
         return MidasVaultInfo(
             token=self.address,
             chain_id=self.chain_id,
@@ -442,8 +559,8 @@ class MidasVault(VaultBase):
             oracle=_checksum_or_none(self.product.oracle),
             issuance_vault=_checksum_or_none(self.product.issuance_vault),
             redemption_vault=_checksum_or_none(self.product.redemption_vault),
-            denomination_token=self.fetch_denomination_token_address(),
-            synthetic_usd_denomination=self.product.denomination == "USD",
+            denomination_token=denomination_token.address if denomination_token else None,
+            synthetic_usd_denomination=denomination_token is None,
             nav_source=MIDAS_NAV_SOURCE,
             nav_estimated=False,
         )
@@ -456,15 +573,17 @@ class MidasVault(VaultBase):
             Midas contracts.
         """
 
+        denomination_token = self.denomination_token
+        synthetic_usd_denomination = denomination_token is None
         return {
-            "Denomination": self.product.denomination,
-            "_denomination_token": export_midas_usd_denomination(self.chain_id),
+            "Denomination": denomination_token.symbol if denomination_token else "USD",
+            "_denomination_token": denomination_token.export() if denomination_token else export_midas_usd_denomination(self.chain_id),
             "_notes": self.get_notes(),
             "_deposit_closed_reason": self.fetch_deposit_closed_reason(),
             "_redemption_closed_reason": self.fetch_redemption_closed_reason(),
             "_nav_source": MIDAS_NAV_SOURCE,
             "_nav_estimated": False,
-            "_synthetic_usd_denomination": self.product.denomination == "USD",
+            "_synthetic_usd_denomination": synthetic_usd_denomination,
             "_midas_data_feed": Web3.to_checksum_address(self.product.data_feed),
             "_midas_oracle": _checksum_or_none(self.product.oracle),
             "_midas_issuance_vault": _checksum_or_none(self.product.issuance_vault),

--- a/scripts/midas/list-payment-tokens.py
+++ b/scripts/midas/list-payment-tokens.py
@@ -1,0 +1,225 @@
+"""List Midas issuance-vault payment tokens.
+
+This manual script reads ``getPaymentTokens()`` from every Midas product that
+the shared Midas vault adapter supports and displays the full on-chain list.
+The first payment token is the token exported as the scanner denomination;
+when the list is empty, the adapter falls back to off-chain USD.
+
+Configuration is through environment variables:
+
+``NETWORKS``
+    Optional comma-separated Midas network keys, e.g. ``main,base``.
+
+``PRODUCTS``
+    Optional comma-separated product symbols, e.g. ``mTBILL,mBASIS``.
+
+``MAX_PRODUCTS``
+    Optional cap for debugging.
+
+``REQUIRE_ALL_SUCCESS``
+    If ``true``, exit with an error if any selected payment-token read fails.
+
+``LOG_LEVEL``
+    Python logging level. Defaults to ``info``.
+
+Example:
+
+.. code-block:: shell
+
+    source .local-test.env && poetry run python scripts/midas/list-payment-tokens.py
+    source .local-test.env && NETWORKS=main PRODUCTS=carryTradeUSDTRYLeverage poetry run python scripts/midas/list-payment-tokens.py
+
+The script does not write files.
+"""
+
+import logging
+import os
+import sys
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+from tabulate import tabulate
+from web3 import Web3
+from web3.exceptions import BadFunctionCallOutput, ContractLogicError, Web3Exception
+
+from eth_defi.midas.registry import MidasRegistryProduct, iter_midas_registry_products
+from eth_defi.midas.vault import MidasVault
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.token import TokenDetails
+from eth_defi.vault.base import VaultSpec
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class PaymentTokenRead:
+    """Payment-token read result for one Midas product."""
+
+    #: Midas product registry entry.
+    product: MidasRegistryProduct
+
+    #: Token details in the vault's contract-returned order.
+    payment_tokens: list[TokenDetails]
+
+    #: Error message when the contract read failed.
+    error: str | None
+
+
+def parse_csv_env(name: str) -> set[str] | None:
+    """Parse a comma-separated environment variable.
+
+    :param name:
+        Environment variable name.
+    :return:
+        Lower-case values, or ``None`` if unset.
+    """
+
+    value = os.environ.get(name, "").strip()
+    if not value:
+        return None
+
+    return {part.strip().lower() for part in value.split(",") if part.strip()}
+
+
+def parse_bool_env(name: str) -> bool:
+    """Parse a boolean environment variable.
+
+    :param name:
+        Environment variable name.
+    :return:
+        ``True`` for common truthy values.
+    """
+
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "y"}
+
+
+def setup_logging() -> None:
+    """Configure console logging."""
+
+    logging.basicConfig(
+        level=os.environ.get("LOG_LEVEL", "info").upper(),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        stream=sys.stderr,
+    )
+
+
+def iter_products() -> Iterator[MidasRegistryProduct]:
+    """Iterate requested Midas products with issuance vaults and local RPCs.
+
+    :return:
+        Products filtered by ``NETWORKS``, ``PRODUCTS`` and ``MAX_PRODUCTS``.
+    """
+
+    networks = parse_csv_env("NETWORKS")
+    products = parse_csv_env("PRODUCTS")
+    max_products = int(os.environ.get("MAX_PRODUCTS", "0") or "0")
+    yielded = 0
+
+    for product in iter_midas_registry_products(require_adapter_data=True):
+        if networks and product.network.lower() not in networks:
+            continue
+        if products and product.symbol.lower() not in products:
+            continue
+        if product.deposit_vault is None:
+            logger.info("Skipping %s %s: no issuance vault", product.network, product.symbol)
+            continue
+        if product.rpc_env_var is None:
+            logger.info("Skipping %s %s: no local RPC env mapping", product.network, product.symbol)
+            continue
+        if not os.environ.get(product.rpc_env_var):
+            logger.info("Skipping %s %s: %s not set", product.network, product.symbol, product.rpc_env_var)
+            continue
+
+        yield product
+        yielded += 1
+        if max_products and yielded >= max_products:
+            return
+
+
+def fetch_payment_tokens(web3: Web3, product: MidasRegistryProduct) -> list[TokenDetails]:
+    """Fetch payment tokens through the Midas vault adapter.
+
+    :param web3:
+        Connected Web3 provider for the product network.
+    :param product:
+        Registry product with an issuance vault address.
+    :return:
+        Payment-token details in contract-returned order.
+    """
+
+    assert product.token is not None
+    vault = MidasVault(web3, VaultSpec(chain_id=product.chain_id, vault_address=product.token))
+    return vault.fetch_payment_tokens()
+
+
+def fetch_product_read(web3: Web3, product: MidasRegistryProduct) -> PaymentTokenRead:
+    """Fetch payment tokens for one Midas product without aborting the report.
+
+    :param web3:
+        Connected Web3 provider for the product network.
+    :param product:
+        Registry product to inspect.
+    :return:
+        Successful token read or an error row.
+    """
+
+    try:
+        return PaymentTokenRead(product=product, payment_tokens=fetch_payment_tokens(web3, product), error=None)
+    except (BadFunctionCallOutput, ContractLogicError, ValueError, Web3Exception) as e:
+        return PaymentTokenRead(product=product, payment_tokens=[], error=str(e).splitlines()[0])
+
+
+def create_rows(reads: list[PaymentTokenRead]) -> list[dict[str, object]]:
+    """Create printable rows for payment-token reads.
+
+    :param reads:
+        Per-product payment-token reads.
+    :return:
+        Tabulate-friendly row dictionaries.
+    """
+
+    rows: list[dict[str, object]] = []
+    for read in reads:
+        tokens = ", ".join(f"{token.symbol or '<unknown>'} ({token.address})" for token in read.payment_tokens)
+        first_token = read.payment_tokens[0].symbol if read.payment_tokens else "USD (off-chain)"
+        rows.append(
+            {
+                "network": read.product.network,
+                "chain": read.product.chain_id,
+                "product": read.product.symbol,
+                "issuance_vault": read.product.deposit_vault,
+                "denomination": first_token,
+                "payment_tokens": tokens or "-",
+                "status": "ok" if read.error is None else "error",
+                "error": read.error or "",
+            }
+        )
+    return rows
+
+
+def main() -> None:
+    """Read and display payment tokens for all selectable Midas vaults."""
+
+    setup_logging()
+    web3s: dict[str, Web3] = {}
+    reads: list[PaymentTokenRead] = []
+
+    for product in iter_products():
+        assert product.rpc_env_var is not None
+        web3 = web3s.get(product.rpc_env_var)
+        if web3 is None:
+            web3 = create_multi_provider_web3(os.environ[product.rpc_env_var], retries=2, hint="Midas payment-token report")
+            web3s[product.rpc_env_var] = web3
+
+        reads.append(fetch_product_read(web3, product))
+
+    rows = create_rows(reads)
+    print(tabulate(rows, headers="keys", tablefmt="rounded_outline"))
+
+    errors = [read for read in reads if read.error is not None]
+    if errors and parse_bool_env("REQUIRE_ALL_SUCCESS"):
+        raise RuntimeError(f"{len(errors)} Midas payment-token reads failed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/midas/migrate-payment-token-denominations.py
+++ b/scripts/midas/migrate-payment-token-denominations.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""Migrate existing Midas metadata rows to on-chain payment-token denominations.
+
+The Midas adapter historically exported synthetic off-chain USD for every
+product. The adapter now reads the first non-zero entry of the issuance vault's
+``getPaymentTokens()`` list as its primary payment token and exposes it through
+the :class:`eth_defi.vault.base.VaultBase` denomination-token API. Existing
+``vault-metadata-db.pickle`` rows must therefore be refreshed once; normal
+scanner runs will use the new denomination for future metadata scans.
+
+This is metadata-only and deliberately does **not** alter raw or cleaned price
+Parquet files, reader state, leads, or a chain's scanner cursor. Price Parquet
+does not store denomination metadata, and changing a scanner cursor could make
+the main pipeline skip unrelated chain data. The script changes only
+``Denomination``, ``_denomination_token`` and ``_synthetic_usd_denomination``
+on existing Midas rows. It makes a timestamped backup before its atomic
+metadata-database write.
+
+The script starts in dry-run mode. First inspect the proposed changes, then set
+``DRY_RUN=false`` to apply them:
+
+.. code-block:: shell
+
+    source .local-test.env && poetry run python scripts/midas/migrate-payment-token-denominations.py
+    source .local-test.env && DRY_RUN=false poetry run python scripts/midas/migrate-payment-token-denominations.py
+
+Configuration is through environment variables:
+
+``DRY_RUN``
+    Print proposed changes without writing. Defaults to ``true``.
+
+``NETWORKS``
+    Optional comma-separated chain ids or names, e.g. ``1,ethereum,base``.
+
+``PRODUCTS``
+    Optional comma-separated Midas product symbols, e.g. ``mTBILL,mBASIS``.
+
+``MAX_WORKERS``
+    Concurrent RPC reads. Defaults to ``8``.
+
+``VAULT_DB_PATH``
+    Metadata database path. Defaults to the active pipeline data directory.
+
+``BACKUP_PATH``
+    Optional backup pickle path. By default a timestamped sibling of
+    ``VAULT_DB_PATH`` is created before a non-dry-run migration.
+
+``LOG_LEVEL``
+    Python logging level. Defaults to ``info``.
+"""
+
+import logging
+import os
+import shutil
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+from eth_typing import HexAddress
+from joblib import Parallel, delayed
+from tabulate import tabulate
+from web3 import Web3
+
+from eth_defi.chain import CHAIN_NAMES
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.midas.constants import MIDAS_PRODUCTS, MidasProduct
+from eth_defi.midas.vault import MidasVault, export_midas_usd_denomination
+from eth_defi.provider.env import read_json_rpc_url
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.token import TokenDetails
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.vaultdb import VaultDatabase, VaultRow, get_pipeline_data_dir
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class DenominationMigration:
+    """One proposed Midas metadata denomination update."""
+
+    #: Existing vault database key.
+    vault_spec: VaultSpec
+
+    #: Product used to construct the Midas adapter.
+    product: MidasProduct
+
+    #: Existing scanner denomination symbol.
+    old_symbol: str | None
+
+    #: Existing scanner denomination ERC-20 address, if any.
+    old_address: HexAddress | None
+
+    #: Primary Midas payment-token symbol, or off-chain USD.
+    new_symbol: str
+
+    #: Primary Midas payment-token address, or ``None`` for off-chain USD.
+    new_address: HexAddress | None
+
+    #: Export-ready denomination metadata.
+    denomination_token: dict[str, object]
+
+    #: Whether the replacement denomination is synthetic off-chain USD.
+    synthetic_usd_denomination: bool
+
+    @property
+    def changed(self) -> bool:
+        """Return whether the exported denomination identity will change.
+
+        The migration intentionally compares the human-readable symbol and
+        ERC-20 address only. Other token export fields such as total supply are
+        live diagnostics and must not trigger a metadata-only rewrite.
+
+        :return:
+            ``True`` when the existing row needs a denomination update.
+        """
+
+        return self.old_symbol != self.new_symbol or self.old_address != self.new_address
+
+
+def parse_bool_env(name: str, *, default: bool) -> bool:
+    """Parse a boolean environment variable.
+
+    :param name:
+        Environment variable name.
+    :param default:
+        Value to use when the variable is unset.
+    :return:
+        Parsed truth value.
+    """
+
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def parse_csv_env(name: str) -> set[str] | None:
+    """Parse optional comma-separated environment selectors.
+
+    :param name:
+        Environment variable name.
+    :return:
+        Lower-case selectors, or ``None`` when the variable is unset.
+    """
+
+    value = os.environ.get(name, "").strip()
+    if not value:
+        return None
+    return {part.strip().lower() for part in value.split(",") if part.strip()}
+
+
+def get_chain_selectors(chain_id: int) -> set[str]:
+    """Return selectors that identify a chain in ``NETWORKS``.
+
+    :param chain_id:
+        EVM chain id.
+    :return:
+        Decimal chain id and, when known, lower-case chain name.
+    """
+
+    selectors = {str(chain_id)}
+    chain_name = CHAIN_NAMES.get(chain_id)
+    if chain_name:
+        selectors.add(chain_name.lower())
+    return selectors
+
+
+def iter_selected_products() -> Iterator[MidasProduct]:
+    """Iterate unique Midas adapter products selected by the environment.
+
+    The migration uses the same ``MIDAS_PRODUCTS`` registry as the adapter, so
+    it cannot write a denomination for a product unsupported by the scanner.
+
+    :return:
+        Selected products in registry order.
+    """
+
+    networks = parse_csv_env("NETWORKS")
+    products = parse_csv_env("PRODUCTS")
+    seen: set[tuple[int, HexAddress]] = set()
+
+    for product in MIDAS_PRODUCTS.values():
+        key = (product.chain_id, product.token)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        if networks and not (get_chain_selectors(product.chain_id) & networks):
+            continue
+        if products and product.symbol.lower() not in products:
+            continue
+        yield product
+
+
+def resolve_vault_database_path() -> Path:
+    """Resolve the metadata database targeted by the migration.
+
+    :return:
+        Explicit ``VAULT_DB_PATH`` or the active pipeline metadata database.
+    """
+
+    configured_path = os.environ.get("VAULT_DB_PATH")
+    if configured_path:
+        return Path(configured_path).expanduser()
+    return get_pipeline_data_dir() / "vault-metadata-db.pickle"
+
+
+def resolve_backup_path(vault_db_path: Path) -> Path:
+    """Resolve the one-time backup filename for a real migration.
+
+    :param vault_db_path:
+        Metadata database to back up.
+    :return:
+        Explicit ``BACKUP_PATH`` or a timestamped sibling path.
+    """
+
+    configured_path = os.environ.get("BACKUP_PATH")
+    if configured_path:
+        return Path(configured_path).expanduser()
+
+    timestamp = native_datetime_utc_now().strftime("%Y%m%d-%H%M%S")
+    return vault_db_path.with_name(f"{vault_db_path.stem}.before-midas-payment-token-migration-{timestamp}{vault_db_path.suffix}")
+
+
+def fetch_denomination_migration(web3: Web3, product: MidasProduct, existing_row: VaultRow) -> DenominationMigration:
+    """Read a primary payment token and construct one metadata-only update.
+
+    The Midas adapter owns the ``getPaymentTokens()`` ABI call and zero-address
+    manual-fulfilment handling. Delegating to it keeps this one-off migration
+    exactly aligned with future normal scanner behaviour.
+
+    :param web3:
+        JSON-RPC connection for the product chain.
+    :param product:
+        Midas product from the adapter registry.
+    :param existing_row:
+        Current vault metadata row to compare.
+    :return:
+        Proposed denomination update without mutating the database.
+    """
+
+    vault_spec = VaultSpec(chain_id=product.chain_id, vault_address=product.token)
+    vault = MidasVault(web3, vault_spec, token_cache={})
+    token: TokenDetails | None = vault.fetch_denomination_token()
+    existing_token = existing_row.get("_denomination_token") or {}
+
+    if token is None:
+        new_symbol = "USD"
+        new_address = None
+        token_export = export_midas_usd_denomination(product.chain_id)
+    else:
+        if token.symbol is None:
+            message = f"Primary Midas payment token {token.address} for {product.symbol} has no symbol"
+            raise RuntimeError(message)
+        new_symbol = token.symbol
+        new_address = token.address
+        token_export = token.export()
+
+    old_address = existing_token.get("address")
+    if old_address is not None:
+        old_address = HexAddress(old_address)
+
+    return DenominationMigration(
+        vault_spec=vault_spec,
+        product=product,
+        old_symbol=existing_row.get("Denomination"),
+        old_address=old_address,
+        new_symbol=new_symbol,
+        new_address=new_address,
+        denomination_token=token_export,
+        synthetic_usd_denomination=token is None,
+    )
+
+
+def apply_migrations(vault_db: VaultDatabase, migrations: list[DenominationMigration]) -> None:
+    """Apply only denomination fields to in-memory existing metadata rows.
+
+    No rows are created and no scanner state is touched. This deliberately
+    preserves all unrelated metadata collected since the last Midas scan.
+
+    :param vault_db:
+        Metadata database loaded from disk.
+    :param migrations:
+        Changed migration entries to apply.
+    :return:
+        ``None`` after mutating ``vault_db`` in memory.
+    """
+
+    for migration in migrations:
+        row = vault_db.rows[migration.vault_spec].copy()
+        row["Denomination"] = migration.new_symbol
+        row["_denomination_token"] = migration.denomination_token
+        row["_synthetic_usd_denomination"] = migration.synthetic_usd_denomination
+        vault_db.rows[migration.vault_spec] = row
+
+
+def main() -> None:
+    """Run the metadata-only Midas denomination migration.
+
+    Reads all selected records before taking a backup or writing, so an RPC or
+    token-metadata failure leaves the production database unchanged.
+
+    :return:
+        ``None`` after displaying the plan and optionally writing metadata.
+    """
+
+    setup_console_logging(default_log_level=os.environ.get("LOG_LEVEL", "info"))
+    dry_run = parse_bool_env("DRY_RUN", default=True)
+    max_workers = int(os.environ.get("MAX_WORKERS", "8"))
+    if max_workers < 1:
+        message = "MAX_WORKERS must be at least one"
+        raise ValueError(message)
+
+    vault_db_path = resolve_vault_database_path()
+    if not vault_db_path.exists():
+        raise FileNotFoundError(f"Vault metadata database does not exist: {vault_db_path}")
+    vault_db = VaultDatabase.read(vault_db_path)
+
+    selected_products = list(iter_selected_products())
+    existing_products = [product for product in selected_products if VaultSpec(product.chain_id, product.token) in vault_db.rows]
+    missing_products = [product for product in selected_products if VaultSpec(product.chain_id, product.token) not in vault_db.rows]
+    if not existing_products:
+        message = "No selected Midas products have existing metadata rows to migrate"
+        raise RuntimeError(message)
+
+    web3_by_chain = {chain_id: create_multi_provider_web3(read_json_rpc_url(chain_id), retries=2, hint="Midas payment-token denomination migration") for chain_id in {product.chain_id for product in existing_products}}
+    migrations = Parallel(n_jobs=max_workers, backend="threading")(
+        delayed(fetch_denomination_migration)(
+            web3_by_chain[product.chain_id],
+            product,
+            vault_db.rows[VaultSpec(product.chain_id, product.token)],
+        )
+        for product in existing_products
+    )
+    changes = [migration for migration in migrations if migration.changed]
+
+    print(
+        tabulate(
+            [
+                [
+                    migration.product.chain_id,
+                    migration.product.symbol,
+                    migration.old_symbol,
+                    migration.old_address or "-",
+                    migration.new_symbol,
+                    migration.new_address or "-",
+                    "change" if migration.changed else "unchanged",
+                ]
+                for migration in migrations
+            ],
+            headers=["chain", "product", "old symbol", "old token", "new symbol", "new token", "status"],
+            tablefmt="rounded_outline",
+        )
+    )
+    print(f"\nSelected existing Midas rows: {len(existing_products)}")
+    print(f"Rows requiring denomination migration: {len(changes)}")
+    if missing_products:
+        print(f"Registry products without existing rows (not created): {len(missing_products)}")
+
+    if dry_run:
+        print("Dry run: no files written. Re-run with DRY_RUN=false to apply these changes.")
+        return
+    if not changes:
+        print("No migration needed: metadata database already uses current payment-token denominations.")
+        return
+
+    backup_path = resolve_backup_path(vault_db_path)
+    if backup_path.exists():
+        raise FileExistsError(f"Refusing to overwrite existing backup: {backup_path}")
+    backup_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(vault_db_path, backup_path)
+    apply_migrations(vault_db, changes)
+    vault_db.write(vault_db_path)
+    print(f"Migrated {len(changes)} Midas metadata rows in {vault_db_path}")
+    print(f"Backup written to {backup_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/midas/test_midas_vault.py
+++ b/tests/midas/test_midas_vault.py
@@ -6,6 +6,7 @@ import os
 from collections.abc import Iterable
 from decimal import Decimal
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import flaky
 import hypersync
@@ -13,6 +14,7 @@ import pandas as pd
 import pytest
 from web3 import Web3
 
+from eth_defi.abi import ZERO_ADDRESS
 from eth_defi.erc_4626 import discovery_base as discovery_base_module
 from eth_defi.erc_4626.classification import VaultFeatureProbe, create_vault_instance_autodetect, identify_vault_features
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
@@ -38,6 +40,7 @@ from eth_defi.midas.vault import MIDAS_BESPOKE_FLOW_REASON, MIDAS_NAV_SOURCE, Mi
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.research.vault_metrics import calculate_hourly_returns_for_all_vaults, calculate_lifetime_metrics, export_lifetime_row
+from eth_defi.token import TokenDetails
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.top_vaults_json import validate_strict_json_serialisable
 from eth_defi.vault.vaultdb import VaultDatabase
@@ -189,6 +192,48 @@ def test_midas_hardcoded_leads_are_added_to_discovery(monkeypatch: pytest.Monkey
     assert report.detections[MIDAS_MBASIS_ETHEREUM.token].features == {ERC4626Feature.midas_like}
 
 
+def test_midas_manual_fulfilment_token_uses_synthetic_usd(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ignore Midas' zero-address manual-fulfilment sentinel as an ERC-20."""
+
+    vault = MidasVault(
+        MagicMock(),
+        VaultSpec(
+            chain_id=ETHEREUM_CHAIN_ID,
+            vault_address=MIDAS_MTBILL_ETHEREUM.token,
+        ),
+    )
+    issuance_vault = MagicMock()
+    issuance_vault.functions.getPaymentTokens.return_value.call.return_value = [ZERO_ADDRESS]
+    monkeypatch.setattr(MidasVault, "issuance_vault_contract", property(lambda _self: issuance_vault))
+
+    assert vault.fetch_payment_tokens() == []
+    assert vault.fetch_denomination_token() is None
+    assert vault.fetch_info()["denomination_token"] is None
+    assert vault.fetch_info()["synthetic_usd_denomination"] is True
+
+
+def test_midas_primary_payment_token_fulfils_vaultbase_denomination_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Export the first Midas payment token through all VaultBase denomination accessors."""
+
+    vault = MidasVault(
+        MagicMock(),
+        VaultSpec(
+            chain_id=ETHEREUM_CHAIN_ID,
+            vault_address=MIDAS_MTBILL_ETHEREUM.token,
+        ),
+    )
+    primary_payment_token = MagicMock(spec=TokenDetails)
+    primary_payment_token.address = Web3.to_checksum_address("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+    secondary_payment_token = MagicMock(spec=TokenDetails)
+    secondary_payment_token.address = Web3.to_checksum_address("0xdAC17F958D2ee523a2206206994597C13D831ec7")
+    monkeypatch.setattr(vault, "fetch_payment_tokens", lambda: [primary_payment_token, secondary_payment_token])
+
+    assert vault.fetch_primary_payment_token() is primary_payment_token
+    assert vault.fetch_denomination_token() is primary_payment_token
+    assert vault.fetch_denomination_token_address() == primary_payment_token.address
+    assert vault.denomination_token is primary_payment_token
+
+
 def test_midas_hardcoded_classification_is_chain_aware() -> None:
     """Do not classify same-address Midas mTokens on unsupported chains."""
 
@@ -318,7 +363,7 @@ def test_midas_anvil_forked_mtbill_properties(web3: Web3) -> None:
     assert info["oracle"] == Web3.to_checksum_address(MIDAS_MTBILL_ETHEREUM.oracle)
     assert info["issuance_vault"] == Web3.to_checksum_address(MIDAS_MTBILL_ETHEREUM.issuance_vault)
     assert info["redemption_vault"] == Web3.to_checksum_address(MIDAS_MTBILL_ETHEREUM.redemption_vault)
-    assert info["synthetic_usd_denomination"] is True
+    assert info["synthetic_usd_denomination"] is False
     assert info["nav_source"] == MIDAS_NAV_SOURCE
     assert info["nav_estimated"] is False
 
@@ -339,9 +384,9 @@ def test_midas_autodetect_live_mtbill(web3: Web3) -> None:
     assert vault.share_token.name == "Midas US Treasury Bill Token"
     assert vault.share_token.symbol == "mTBILL"
     assert vault.share_token.decimals == MTBILL_EXPECTED_DECIMALS
-    assert vault.fetch_denomination_token_address() is None
-    assert vault.fetch_denomination_token() is None
-    assert vault.denomination_token is None
+    assert vault.fetch_denomination_token_address() == Web3.to_checksum_address("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+    assert vault.fetch_denomination_token().symbol == "USDC"
+    assert vault.denomination_token.symbol == "USDC"
 
 
 @flaky.flaky
@@ -364,10 +409,10 @@ def test_midas_live_supply_nav_and_unsupported_actions(web3: Web3) -> None:
     assert vault.get_fee_data().performance is None
     assert vault.get_fee_data().deposit == 0
     assert vault.get_fee_data().withdraw == MTBILL_EXPECTED_WITHDRAW_FEE
-    assert vault.fetch_info()["denomination_token"] is None
-    assert vault.fetch_scan_record_extra_data()["Denomination"] == "USD"
-    assert vault.fetch_scan_record_extra_data()["_denomination_token"]["symbol"] == "USD"
-    assert vault.fetch_scan_record_extra_data()["_denomination_token"]["address"] is None
+    assert vault.fetch_info()["denomination_token"] == Web3.to_checksum_address("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+    assert vault.fetch_scan_record_extra_data()["Denomination"] == "USDC"
+    assert vault.fetch_scan_record_extra_data()["_denomination_token"]["symbol"] == "USDC"
+    assert vault.fetch_scan_record_extra_data()["_denomination_token"]["address"] == Web3.to_checksum_address("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
     assert vault.fetch_info()["nav_source"] == MIDAS_NAV_SOURCE
     assert vault.fetch_info()["nav_estimated"] is False
 
@@ -518,7 +563,7 @@ def test_midas_scan_record_live_mtbill(web3: Web3) -> None:
     assert record["Symbol"] == "mTBILL"
     assert record["Name"] == "Midas US Treasury Bill Token"
     assert record["Protocol"] == "Midas"
-    assert record["Denomination"] == "USD"
+    assert record["Denomination"] == "USDC"
     assert record["Share token"] == "mTBILL"
     assert record["NAV"] == MTBILL_EXPECTED_TOTAL_ASSETS
     assert record["Mgmt fee"] is None
@@ -528,15 +573,15 @@ def test_midas_scan_record_live_mtbill(web3: Web3) -> None:
     assert record["Shares"] == MTBILL_EXPECTED_TOTAL_SUPPLY
     assert record["Features"] == "midas_like"
     assert record["_detection_data"] == detection
-    assert record["_denomination_token"]["symbol"] == "USD"
-    assert record["_denomination_token"]["address"] is None
+    assert record["_denomination_token"]["symbol"] == "USDC"
+    assert record["_denomination_token"]["address"] == Web3.to_checksum_address("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
     assert record["_share_token"]["symbol"] == "mTBILL"
     assert record["_manager_name"] == "Midas"
     assert record["_deposit_closed_reason"] == MIDAS_BESPOKE_FLOW_REASON
     assert record["_redemption_closed_reason"] == MIDAS_BESPOKE_FLOW_REASON
     assert record["_nav_source"] == MIDAS_NAV_SOURCE
     assert record["_nav_estimated"] is False
-    assert record["_synthetic_usd_denomination"] is True
+    assert record["_synthetic_usd_denomination"] is False
     assert record["_midas_data_feed"] == Web3.to_checksum_address(MIDAS_MTBILL_ETHEREUM.data_feed)
     assert record["_midas_oracle"] == Web3.to_checksum_address(MIDAS_MTBILL_ETHEREUM.oracle)
 
@@ -631,7 +676,7 @@ def test_midas_lead_detection_lifetime_metrics_json_export(monkeypatch: pytest.M
     assert decoded["vaults"][0]["management_fee"] is None
     assert decoded["vaults"][0]["deposit_fee"] == 0
     assert decoded["vaults"][0]["withdraw_fee"] == MTBILL_EXPECTED_WITHDRAW_FEE
-    assert decoded["vaults"][0]["denomination"] == "USD"
+    assert decoded["vaults"][0]["denomination"] == "USDC"
     assert decoded["vaults"][0]["address"] == MIDAS_MTBILL_ETHEREUM.token.lower()
 
 


### PR DESCRIPTION
## Why

Midas issuance vaults publish their accepted ERC-20 payment tokens on-chain. Exporting the first configured token fixes Piku CarryTradeUSDTRYLeverage and makes the same information available for every supported Midas vault.

## Lessons learnt

Midas payment tokens are settlement routes, not necessarily the product NAV currency. The contract-returned order is mutable and is used only because the shared scanner schema has one denomination-token field.

## Summary

- Read `getPaymentTokens()` through `MidasVault.fetch_payment_tokens()`.
- Export the first payment token as the scanner denomination, with synthetic off-chain USD only when no token is configured.
- Add a manual all-vault payment-token report and align Midas fork tests.

## Related issues and PRs

- Continues the Piku metadata work in #1278.