### PR TITLE
feat: replace lead reset with targeted migrations

### DIFF
--- a/.claude/skills/add-vault-protocol/SKILL.md
+++ b/.claude/skills/add-vault-protocol/SKILL.md
@@ -31,6 +31,8 @@ A new vault protocol integration is not complete unless it includes:
 - Original and post-processed protocol logos
 - Vault documentation and API documentation entries
 - Focused tests for the new protocol
+- A generated protocol-specific historical lead migration script that preserves
+  unrelated vault database, reader-state and Parquet entries
 
 ## Step-by-step implementation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- feat: Replace whole-chain vault lead resets with generated protocol-specific migrations and add the targeted Securitize DSToken backfill helper (2026-07-16)
 - feat: Add Securitize DS Protocol vault support with BUIDL DSToken detection, historical supply scanning and tokenised-fund vault notes (2026-07-16)
 - feat: Publish Hypercore cleaned economic share prices from retained observations at up to four-hour granularity (2026-07-16)
 - feat: Export Midas issuance-vault payment tokens as scanner denominations and add a manual payment-token audit script (2026-07-16)

--- a/eth_defi/erc_4626/README-vault-leads.md
+++ b/eth_defi/erc_4626/README-vault-leads.md
@@ -1,0 +1,24 @@
+# Vault lead migrations
+
+Vault lead discovery is incremental. The normal scanner resumes from each
+chain's recorded cursor and only identifies events emitted after that point.
+
+When an integration adds a discovery event or a non-ERC-4626 vault adapter,
+historical leads for that integration must be recovered through a dedicated,
+generated migration script. These scripts live under
+`scripts/<protocol>/backfill-history.py` and follow the Midas backfill pattern:
+
+- define the reviewed protocol address registry and deployment blocks;
+- upsert only those protocol leads and their metadata rows;
+- reset reader state only for the selected vault IDs;
+- rewrite raw and cleaned price data only for vaults with a supported historical
+  price reader.
+
+The integration workflow generates the migration script together with the
+adapter. It is the required replacement for whole-chain lead rediscovery and
+must be safe to run against an existing production vault database.
+
+`RESET_LEADS` has been removed. Setting it for `scan-vaults.py` is an error.
+The scanner must never restart discovery from block 1, because that can refresh
+unrelated metadata and makes a targeted protocol migration depend on every
+historical discovery adapter.

--- a/eth_defi/erc_4626/lead_scan_core.py
+++ b/eth_defi/erc_4626/lead_scan_core.py
@@ -102,7 +102,6 @@ def scan_leads(
     printer=print,
     backend: Literal["auto", "hypersync", "rpc"] = "auto",
     max_getlogs_range: int | None = None,
-    reset_leads=False,
     hypersync_api_key: str | None = None,
     hypersync_concurrency: int | None = None,
     max_display_entries: int | None = None,
@@ -180,11 +179,7 @@ def scan_leads(
         if not end_block:
             end_block = web3.eth.block_number
 
-    if not reset_leads:
-        vault_discover.seed_existing_leads(existing_db.get_existing_leads_by_chain(chain_id))
-    else:
-        # Rescan all vaults since the beginning of the chat
-        start_block = 1
+    vault_discover.seed_existing_leads(existing_db.get_existing_leads_by_chain(chain_id))
 
     printer(f"Chain: {name}: scan range {start_block:,} - {end_block:,}")
 

--- a/eth_defi/erc_4626/vault_protocol/ipor/README-IPOR-Curators.md
+++ b/eth_defi/erc_4626/vault_protocol/ipor/README-IPOR-Curators.md
@@ -92,9 +92,8 @@ from the atomist field.
 
 IPOR manager-name backfill is a targeted metadata update. There is no read-time
 `VaultDatabase.read()` repair step and no committed `vault_atomists.json`
-overlay. Do not use deprecated `RESET_LEADS=1` for this. Prefer the recommended
-targeted backfill approach in
-[`README-vault-scripts.md`](../../../../scripts/erc-4626/README-vault-scripts.md#recommended-targeted-backfill-for-new-vault-protocols):
+overlay. Use the protocol-specific migration requirements in
+[`README-vault-leads.md`](../../README-vault-leads.md):
 IPOR vaults can exist on multiple chains, and a full historical rediscovery is
 unnecessarily broad for filling one offchain metadata field.
 

--- a/eth_defi/erc_4626/vault_protocol/royco/README-Royco.md
+++ b/eth_defi/erc_4626/vault_protocol/royco/README-Royco.md
@@ -268,23 +268,12 @@ cp ~/.tradingstrategy/vaults/reader-state.pickle \
    ~/.tradingstrategy/vaults/backups/reader-state.before-royco-rescan.pickle
 ```
 
-### 2. Deprecated fallback: rediscover Royco leads
+### 2. Rediscover Royco leads
 
-`RESET_LEADS` is deprecated for protocol backfills. Prefer the recommended
-targeted backfill approach in
-[`README-vault-scripts.md`](../../../../scripts/erc-4626/README-vault-scripts.md#recommended-targeted-backfill-for-new-vault-protocols)
-when the protocol has an API, registry, factory query, or operator-curated
-address list.
-
-```shell
-source .local-test.env && \
-# Deprecated fallback.
-RESET_LEADS=1 \
-SCAN_BACKEND=hypersync \
-LOG_LEVEL=info \
-JSON_RPC_URL="$JSON_RPC_ETHEREUM" \
-poetry run python scripts/erc-4626/scan-vaults.py
-```
+Historical lead recovery requires a generated, Royco-specific migration script
+that upserts only Royco addresses. The incremental scanner never rereads old
+events and no longer supports whole-chain lead resets. See
+[`README-vault-leads.md`](../../README-vault-leads.md).
 
 ### 3. Build Royco API vault ids
 

--- a/eth_defi/mellow/vault.py
+++ b/eth_defi/mellow/vault.py
@@ -13,34 +13,10 @@ production scanner is incremental, so Mellow vaults created before Mellow suppor
 was deployed are not discovered by later incremental scans unless the historical
 lead range is scanned again.
 
-``RESET_LEADS`` is deprecated for protocol backfills. Prefer a targeted protocol
-repair script following
-``scripts/erc-4626/README-vault-scripts.md#recommended-targeted-backfill-for-new-vault-protocols``.
-The legacy fallback for the Ethereum discovery backfill is ``RESET_LEADS=1``.
-This does not truncate the existing vault database and does not wipe existing
-Ethereum or other-chain leads. The scanner builds a fresh in-memory lead set
-from block 1, then merges the new leads and metadata rows into
-``vault-metadata-db.pickle``. Existing unrelated rows remain in the database.
-Take a backup first because matching rows that are rediscovered can be
-refreshed.
-
-.. code-block:: shell
-
-    source .local-test.env
-
-    cp ~/.tradingstrategy/vaults/vault-metadata-db.pickle \
-       ~/.tradingstrategy/vaults/vault-metadata-db.before-mellow-reset-leads.pickle
-
-    # Deprecated fallback. Prefer the recommended targeted backfill approach
-    # in scripts/erc-4626/README-vault-scripts.md.
-    RESET_LEADS=1 \
-    LOG_LEVEL=info \
-    JSON_RPC_URL=$JSON_RPC_ETHEREUM \
-    poetry run python scripts/erc-4626/scan-vaults.py
-
-The backfill cannot currently be limited to only Mellow factory topics. It
-rescans all configured Ethereum vault discovery event topics from block 1 and
-merges the results back into the existing database.
+Historical Mellow lead recovery requires a generated, protocol-specific
+migration script. The incremental scanner does not re-read old factory events,
+and whole-chain lead resets are not supported. See
+``eth_defi/erc_4626/README-vault-leads.md`` for the migration requirements.
 
 After the metadata backfill, rescan prices for the known Lido Mellow Core Vaults
 with a targeted ``VAULT_ID`` run. Targeted price scans clear saved reader state

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -32,65 +32,52 @@ LOG_LEVEL=info JSON_RPC_URL=$JSON_RPC_TEMPO poetry run python scripts/erc-4626/s
 | `MAX_GETLOGS_RANGE` | Optional. Max block range for getLogs. |
 | `SCAN_BACKEND` | Optional. Event reader backend (`auto`, `hypersync`, `rpc`). |
 | `END_BLOCK` | Optional. Stop scanning at this block. |
-| `RESET_LEADS` | Deprecated. Historical whole-chain lead rediscovery from block 1. Existing vault database rows are not deleted before the scan; new results are merged back in and matching rows may be overwritten with freshly detected metadata. Prefer the [recommended targeted backfill approach](#recommended-targeted-backfill-for-new-vault-protocols). Very slow on large chains like Ethereum mainnet (~24M+ blocks). |
 | `HYPERSYNC_API_KEY` | Optional. Required when using `auto` scan backend. |
 | `HYPERSYNC_RPM` | Optional. Hypersync API requests-per-minute limit. Default: 150 (75% of the 200 RPM free-tier limit). Throttling is always on; set this to lower the limit after persistent 429 errors. |
 | `HYPERSYNC_CONCURRENCY` | Optional. Number of Hypersync requests in flight per stream — the main throughput knob. Default: server default (10). Increase for dense workloads, decrease for rate-limited plans. See [Envio StreamConfig tuning](https://docs.envio.dev/docs/HyperSync/stream-config-tuning). |
 
-#### Recommended targeted backfill for new vault protocols
+#### Required protocol-specific lead migrations
 
 The vault scanner is incremental — it only scans new blocks since the last run.
 When support for a new protocol's custom events is added (e.g. Ember's `VaultDeposit`),
 vaults that emitted events before the code change will not be discovered because the scanner
 has already passed those blocks.
 
-For protocols with an authoritative API or registry of vault addresses, prefer a targeted
-protocol repair script. The current pattern is `fix-t3tris-vaults.py` or
-`fix-upshift-vaults.py`: seed the known vault addresses into the lead database,
-refresh only those metadata rows, and run a vault-address-scoped historical
-price scan.
+Each new protocol integration generates a dedicated migration script. The script
+must seed its reviewed addresses into the lead database, refresh only those
+metadata rows, and run vault-address-scoped price history only where a
+historical price reader is supported. Follow the full requirements in
+[`README-vault-leads.md`](../../eth_defi/erc_4626/README-vault-leads.md).
 
-#### Deprecated RESET_LEADS historical rediscovery
+The scanner does not support whole-chain lead resets. `RESET_LEADS` has been
+removed and setting it causes `scan-vaults.py` to fail before it makes any
+database or network changes.
 
-`RESET_LEADS` is deprecated for adding new vault protocols to existing
-production data. Use the [recommended targeted backfill approach](#recommended-targeted-backfill-for-new-vault-protocols)
-above when the protocol has an API, registry, factory query, or operator-curated
-address list.
+### securitize/backfill-history.py
 
-`RESET_LEADS` does **not** truncate the existing vault database before scanning. The scanner
-builds a fresh in-memory lead set from block 1, then merges those leads and metadata rows back
-into the existing pickle. Existing leads that are found again are refreshed; unrelated existing
-rows remain in the database. Because matching rows may be overwritten, take a backup before a
-large production rescan:
-
-```shell
-cp ~/.tradingstrategy/vaults/vault-metadata-db.pickle \
-   ~/.tradingstrategy/vaults/vault-metadata-db.before-reset-leads.pickle
-```
-
-The scanner currently cannot limit discovery to only the newly added custom event topics. A
-historical custom-event backfill, such as TokenGateway/ForgeYields support, still re-queries all
-configured vault discovery events for the block range.
-
-This has several operational problems on mature chains:
-
-- It scans every configured vault discovery topic from block 1, not only the new protocol.
-- It rebuilds metadata for thousands of unrelated historical leads after discovery finishes.
-- A failure in any unrelated protocol adapter can abort the whole run before the new protocol
-  data is written. For example, adding T3tris event signatures on Arbitrum exposed a separate
-  Lagoon `v0.3.0` adapter gap during metadata extraction.
-- It is slow and expensive on chains with large histories, and retrying after an unrelated
-  metadata failure repeats the same full-chain discovery work.
-
-Use deprecated `RESET_LEADS` only when there is no reliable protocol API,
-registry, factory query, or operator-curated address list to seed targeted leads.
+Targeted migration for the reviewed Securitize DSToken registry. The script
+locates each product's deployment block through the archive RPC, upserts only
+those lead and metadata rows, and rewrites historical prices only for BUIDL and
+BUIDL-I, whose adapters have an explicit USD 1 share-price estimate. It leaves
+other Securitize products as metadata leads until a canonical NAV source is
+available.
 
 ```shell
-# Deprecated fallback: re-discover all vaults on Ethereum from block 1
-# Prefer: #recommended-targeted-backfill-for-new-vault-protocols
-# Works with both HyperSync and RPC backends
-RESET_LEADS=1 LOG_LEVEL=info JSON_RPC_URL=$JSON_RPC_ETHEREUM poetry run python scripts/erc-4626/scan-vaults.py
+source .local-test.env && poetry run python scripts/securitize/backfill-history.py
 ```
+
+| Variable | Description |
+|----------|-------------|
+| `DRY_RUN` | Optional. Calculate the migration plan without writing data. Default: false. |
+| `SECURITIZE_SCAN_PRICES` | Optional. Set to `false` to upsert leads and metadata only. Default: true. |
+| `SECURITIZE_CLEAN_PRICES` | Optional. Set to `false` to retain existing cleaned histories. Default: true. |
+| `FREQUENCY` | Optional. Historical price frequency, `1h` or `1d`. Default: `1d`. |
+| `START_BLOCK` / `END_BLOCK` | Optional. Inclusive scoped historical price range. |
+| `MAX_WORKERS` | Optional. Historical multicall worker count. Default: 8. |
+| `VAULT_DB_PATH` | Optional. Metadata database path. Default: production path. |
+| `UNCLEANED_PRICE_DATABASE` | Optional. Raw price parquet path. Default: production path. |
+| `CLEANED_PRICE_DATABASE` | Optional. Cleaned price parquet path. Default: production path. |
+| `READER_STATE_DATABASE` | Optional. Reader-state pickle path. Default: production path. |
 
 ### scan-vaults-all-chains.py
 
@@ -226,10 +213,10 @@ official T3tris API. The script has a baked API snapshot as a fallback, so
 operators can review the current vault address list in the script even if the
 API is temporarily unavailable.
 
-This follows the [recommended targeted backfill approach](#recommended-targeted-backfill-for-new-vault-protocols)
+This follows the [required protocol-specific lead migrations](#required-protocol-specific-lead-migrations)
 for adding T3tris vaults to an existing production database after protocol
-support has been merged. It does not use deprecated `RESET_LEADS` and does not
-wipe whole-chain discovery or price data. It upserts lead rows for the selected
+support has been merged. It does not wipe whole-chain discovery or price data.
+It upserts lead rows for the selected
 T3tris API vaults, repairs missing or broken metadata rows for those same vaults,
 and scans historical prices only for those listed vault addresses. Historical
 prices are scanned at most once per supported chain per run. Caught-up vaults
@@ -307,9 +294,9 @@ Upshift API. The script has a baked API snapshot as a fallback, so operators can
 review the full vault address list in the script even if the API is temporarily
 unavailable.
 
-This follows the [recommended targeted backfill approach](#recommended-targeted-backfill-for-new-vault-protocols).
-It does not use deprecated `RESET_LEADS` and does not wipe whole-chain discovery
-or price data. It upserts lead rows for the selected Upshift API vaults, repairs
+This follows the [required protocol-specific lead migrations](#required-protocol-specific-lead-migrations).
+It does not wipe whole-chain discovery or price data. It upserts lead rows for
+the selected Upshift API vaults, repairs
 missing or broken metadata rows for those same vaults, and scans historical
 prices only for those listed vault addresses. Historical prices are scanned at
 most once per supported chain per run. Caught-up vaults are skipped. For the
@@ -594,28 +581,6 @@ any command you pass is appended as arguments to the all-chains script.
 docker compose --profile oneshot run --rm \
   --entrypoint python \
   -e JSON_RPC_URL="$JSON_RPC_ETHEREUM" \
-  -e LOG_LEVEL=info \
-  vault-scanner \
-  scripts/erc-4626/scan-vaults.py
-```
-
-### Deprecated: scan only Ethereum with lead reset
-
-`RESET_LEADS` is deprecated for adding new vault protocols to existing
-production data. Prefer the [recommended targeted backfill approach](#recommended-targeted-backfill-for-new-vault-protocols).
-This fallback rescans all configured vault discovery event topics from block 1
-and merges the results back into the existing vault database. It does not delete
-the database first, but matching rows may be refreshed with newly detected
-metadata. Back up `~/.tradingstrategy/vaults/vault-metadata-db.pickle` before
-running this against production data.
-
-```shell
-docker compose --profile oneshot run --rm \
-  --entrypoint python \
-  -e JSON_RPC_URL="$JSON_RPC_ETHEREUM" \
-  -e HYPERSYNC_API_KEY="$HYPERSYNC_API_KEY" \
-  -e SCAN_BACKEND=hypersync \
-  -e RESET_LEADS=true \
   -e LOG_LEVEL=info \
   vault-scanner \
   scripts/erc-4626/scan-vaults.py

--- a/scripts/erc-4626/fix-t3tris-vaults.py
+++ b/scripts/erc-4626/fix-t3tris-vaults.py
@@ -3,7 +3,7 @@
 
 This script is a targeted production repair tool for T3tris vaults.
 
-It avoids deprecated ``RESET_LEADS`` and any whole-chain rediscovery. See the
+It avoids whole-chain rediscovery. See the
 recommended targeted backfill approach in
 ``scripts/erc-4626/README-vault-scripts.md#recommended-targeted-backfill-for-new-vault-protocols``.
 Instead it uses the T3tris public vault API and a baked API snapshot to:

--- a/scripts/erc-4626/fix-upshift-vaults.py
+++ b/scripts/erc-4626/fix-upshift-vaults.py
@@ -3,7 +3,7 @@
 
 This script is a targeted production repair tool for Upshift vaults.
 
-It avoids deprecated ``RESET_LEADS`` and any whole-chain rediscovery. See the
+It avoids whole-chain rediscovery. See the
 recommended targeted backfill approach in
 ``scripts/erc-4626/README-vault-scripts.md#recommended-targeted-backfill-for-new-vault-protocols``.
 Instead it uses the Upshift tokenized vault API and a baked API snapshot to:

--- a/scripts/erc-4626/scan-prices.py
+++ b/scripts/erc-4626/scan-prices.py
@@ -32,11 +32,8 @@ Re-run manual test::
     python scripts/erc-4626/scan-vaults.py
     python scripts/erc-4626/scan-prices.py
 
-    # Deprecated RESET_LEADS fallback. Prefer the recommended targeted
-    # backfill approach in:
-    # scripts/erc-4626/README-vault-scripts.md#recommended-targeted-backfill-for-new-vault-protocols
     export JSON_RPC_URL=$JSON_RPC_HEMI
-    RESET_LEADS=true python scripts/erc-4626/scan-vaults.py
+    python scripts/erc-4626/scan-vaults.py
     python scripts/erc-4626/scan-prices.py
 
     export JSON_RPC_URL=$JSON_RPC_ARBITRUM

--- a/scripts/erc-4626/scan-vaults.py
+++ b/scripts/erc-4626/scan-vaults.py
@@ -54,6 +54,10 @@ except ImportError as e:
 
 logger = logging.getLogger(__name__)
 
+RESET_LEADS_REMOVED_MESSAGE = "RESET_LEADS has been removed. Use the generated protocol-specific migration script described in eth_defi/erc_4626/README-vault-leads.md"
+
+assert "RESET_LEADS" not in os.environ, RESET_LEADS_REMOVED_MESSAGE
+
 # Read JSON_RPC_CONFIGURATION from the environment
 JSON_RPC_URL = os.environ.get("JSON_RPC_URL")
 if JSON_RPC_URL is None:
@@ -85,10 +89,6 @@ def main():
     if max_getlogs_range:
         max_getlogs_range = int(max_getlogs_range)
 
-    # Deprecated: prefer the targeted backfill approach documented in
-    # scripts/erc-4626/README-vault-scripts.md#recommended-targeted-backfill-for-new-vault-protocols
-    reset_leads = os.environ.get("RESET_LEADS", None)
-
     # Choose a different scan mode
     scan_backend = os.environ.get("SCAN_BACKEND", "auto")
 
@@ -107,7 +107,6 @@ def main():
             printer=print,
             backend=scan_backend,
             max_getlogs_range=max_getlogs_range,
-            reset_leads=reset_leads,
             hypersync_api_key=hypersync_api_key,
         )
 

--- a/scripts/securitize/backfill-history.py
+++ b/scripts/securitize/backfill-history.py
@@ -1,0 +1,590 @@
+#!/usr/bin/env python3
+"""Backfill Securitize DSToken leads and supported price history.
+
+This migration preserves unrelated vault database rows, reader states and
+Parquet histories. It upserts the reviewed products in
+``SECURITIZE_PRODUCTS`` and rewrites price history only for products with an
+explicit adapter NAV estimate. DSToken contracts do not expose a universal
+fund-NAV method, so unpriced products are registered as leads but excluded from
+the price scan.
+
+Run with::
+
+    source .local-test.env && poetry run python scripts/securitize/backfill-history.py
+
+Environment variables:
+
+``DRY_RUN``
+    Show the plan without writing data. Default: ``false``.
+``SECURITIZE_SCAN_PRICES``
+    Scan BUIDL and any future priced DSTokens. Default: ``true``.
+``SECURITIZE_CLEAN_PRICES``
+    Rebuild selected cleaned histories after the raw scan. Default: ``true``.
+``FREQUENCY``
+    Historical sample interval, ``1h`` or ``1d``. Default: ``1d``.
+``START_BLOCK`` / ``END_BLOCK``
+    Optional inclusive block boundaries for a carefully scoped run.
+``MAX_WORKERS``
+    Historical multicall worker count. Default: ``8``.
+``VAULT_DB_PATH``, ``UNCLEANED_PRICE_DATABASE``, ``CLEANED_PRICE_DATABASE``
+and ``READER_STATE_DATABASE``
+    Optional paths for isolated tests or production-data overrides.
+
+The script reads archive-capable RPC URLs from ``JSON_RPC_<CHAIN_NAME>``.
+"""
+
+import datetime
+import logging
+import os
+import pickle  # noqa: S403 - trusted local production reader-state pickle.
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Literal, cast
+
+from atomicwrites import atomic_write
+from eth_typing import HexAddress
+from tabulate import tabulate
+from web3 import Web3
+
+from eth_defi.chain import get_chain_name
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.erc_4626.classification import create_vault_instance
+from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
+from eth_defi.erc_4626.discovery_base import PotentialVaultMatch
+from eth_defi.erc_4626.scan import create_vault_scan_record
+from eth_defi.event_reader.timestamp_cache import DEFAULT_TIMESTAMP_CACHE_FOLDER, BlockTimestampDatabase
+from eth_defi.hypersync.utils import configure_hypersync_from_env
+from eth_defi.provider.env import get_json_rpc_env, read_json_rpc_url
+from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
+from eth_defi.provider.named import get_provider_name
+from eth_defi.research.wrangle_vault_prices import replace_cleaned_vault_histories
+from eth_defi.securitize.description import SECURITIZE_PRODUCTS, SecuritizeProduct
+from eth_defi.token import TokenDiskCache
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.base import VaultBase, VaultSpec
+from eth_defi.vault.historical import pformat_scan_result, scan_historical_prices_to_parquet
+from eth_defi.vault.vaultdb import DEFAULT_RAW_PRICE_DATABASE, DEFAULT_READER_STATE_DATABASE, DEFAULT_UNCLEANED_PRICE_DATABASE, DEFAULT_VAULT_DATABASE, VaultDatabase
+
+logger = logging.getLogger(__name__)
+
+
+def parse_bool_env(name: str, *, default: bool = False) -> bool:
+    """Parse a conventional boolean environment setting.
+
+    The migration is operated through environment variables so it can run from
+    the same production wrapper as other vault scripts without another command
+    line parser.
+
+    :param name:
+        Environment variable to parse.
+    :param default:
+        Value used when the variable is absent.
+    :return:
+        Parsed boolean value.
+    """
+
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def parse_optional_int_env(name: str) -> int | None:
+    """Read an optional integer block boundary from the environment.
+
+    Operators can use this only to narrow a controlled rerun. The normal path
+    discovers the first contract-code block automatically.
+
+    :param name:
+        Environment variable to parse.
+    :return:
+        Parsed integer, or ``None`` when it is unset.
+    """
+
+    value = os.environ.get(name)
+    return int(value) if value else None
+
+
+def parse_path_env(name: str, default: Path) -> Path:
+    """Read a filesystem override while retaining production defaults.
+
+    Isolated test runs use this to keep state files out of the normal vault
+    pipeline directory.
+
+    :param name:
+        Environment variable holding a path.
+    :param default:
+        Default production path.
+    :return:
+        Expanded configured path.
+    """
+
+    value = os.environ.get(name)
+    return Path(value).expanduser() if value else default.expanduser()
+
+
+def resolve_frequency() -> Literal["1h", "1d"]:
+    """Resolve the requested historical sampling frequency.
+
+    The execution plan and the price scanner use the same validated value so a
+    displayed daily run cannot silently perform hourly work.
+
+    :return:
+        One-hour or one-day scan interval.
+    :raises ValueError:
+        If the requested interval is unsupported.
+    """
+
+    frequency = os.environ.get("FREQUENCY", "1d")
+    if frequency not in {"1h", "1d"}:
+        raise ValueError(f"Unsupported FREQUENCY: {frequency}")
+    return cast(Literal["1h", "1d"], frequency)
+
+
+def iter_products() -> Iterable[SecuritizeProduct]:
+    """Iterate every reviewed Securitize product exactly once.
+
+    The registry is keyed for direct chain-and-address lookup, so guard against
+    an accidental duplicate product when future aliases are added.
+
+    :return:
+        Unique registry products.
+    """
+
+    seen: set[tuple[int, HexAddress]] = set()
+    for product in SECURITIZE_PRODUCTS.values():
+        key = product.chain_id, product.token
+        if key not in seen:
+            seen.add(key)
+            yield product
+
+
+def fetch_contract_deployment_block(web3: Web3, address: HexAddress, end_block: int) -> int:
+    """Find the first block where an address has deployed contract code.
+
+    The reviewed DSToken registry does not duplicate a manually maintained
+    creation-block list. An archive-node binary search yields the first code
+    block in logarithmic RPC calls and remains correct when a new product is
+    added to the registry.
+
+    :param web3:
+        Archive-capable connection for the product chain.
+    :param address:
+        DSToken proxy address.
+    :param end_block:
+        Highest block that may be inspected.
+    :return:
+        First block with non-empty runtime code.
+    :raises ValueError:
+        If the address has no contract code at ``end_block``.
+    """
+
+    address = Web3.to_checksum_address(address)
+    if not web3.eth.get_code(address, block_identifier=end_block):
+        raise ValueError(f"No contract code for Securitize product {address} at block {end_block}")
+
+    low = 0
+    high = end_block
+    while low < high:
+        middle = (low + high) // 2
+        if web3.eth.get_code(address, block_identifier=middle):
+            high = middle
+        else:
+            low = middle + 1
+    return low
+
+
+def fetch_product_first_seen_at(web3: Web3, deployment_block: int) -> datetime.datetime:
+    """Read the naive UTC timestamp for a product deployment block.
+
+    Shared lead records carry both the discovery block and its timestamp. The
+    timestamp comes from the same archive endpoint used to locate deployment.
+
+    :param web3:
+        Archive-capable connection for the product chain.
+    :param deployment_block:
+        First block with the product's runtime code.
+    :return:
+        Naive UTC deployment timestamp.
+    """
+
+    timestamp = web3.eth.get_block(deployment_block)["timestamp"]
+    return datetime.datetime.fromtimestamp(timestamp, tz=datetime.UTC).replace(tzinfo=None)
+
+
+def create_detection(product: SecuritizeProduct, deployment_block: int, first_seen_at: datetime.datetime) -> ERC4262VaultDetection:
+    """Create a scanner-compatible detection for a reviewed DSToken.
+
+    A migration uses the product registry as its authoritative lead source,
+    rather than reprocessing unrelated discovery events from the chain.
+
+    :param product:
+        Reviewed Securitize product.
+    :param deployment_block:
+        First block containing the DSToken proxy code.
+    :param first_seen_at:
+        Deployment timestamp in naive UTC.
+    :return:
+        Detection record accepted by metadata extraction.
+    """
+
+    return ERC4262VaultDetection(
+        chain=product.chain_id,
+        address=product.token,
+        first_seen_at_block=deployment_block,
+        first_seen_at=first_seen_at,
+        features={ERC4626Feature.securitize_like},
+        updated_at=native_datetime_utc_now(),
+        deposit_count=0,
+        redeem_count=0,
+    )
+
+
+def create_lead(product: SecuritizeProduct, deployment_block: int, first_seen_at: datetime.datetime) -> PotentialVaultMatch:
+    """Create a lead row without discovering the whole chain again.
+
+    The lead carries the same initial position as its synthetic detection so
+    downstream metadata and history readers retain the expected ordering.
+
+    :param product:
+        Reviewed Securitize product.
+    :param deployment_block:
+        First block containing the DSToken proxy code.
+    :param first_seen_at:
+        Deployment timestamp in naive UTC.
+    :return:
+        Lead record for the shared vault database.
+    """
+
+    return PotentialVaultMatch(
+        chain=product.chain_id,
+        address=product.token,
+        first_seen_at_block=deployment_block,
+        first_seen_at=first_seen_at,
+        deposit_count=0,
+        withdrawal_count=0,
+    )
+
+
+def read_vault_database(path: Path) -> VaultDatabase:
+    """Load an existing metadata database without replacing its entries.
+
+    A missing path starts an empty database for isolated use. Existing files
+    are read intact and later updated only for selected Securitize rows.
+
+    :param path:
+        Metadata database pickle path.
+    :return:
+        Existing or empty vault database.
+    """
+
+    return VaultDatabase.read(path) if path.exists() else VaultDatabase()
+
+
+def read_reader_states(path: Path) -> dict[VaultSpec, dict]:
+    """Load saved price-reader states from a trusted local pickle.
+
+    Only selected Securitize states are removed before their histories are
+    rewritten; all unrelated states are retained.
+
+    :param path:
+        Reader-state pickle path.
+    :return:
+        Existing states, or an empty mapping when the file is absent.
+    """
+
+    if not path.exists():
+        return {}
+    with path.open("rb") as inp:
+        return pickle.load(inp)  # noqa: S301 - trusted local production reader-state pickle.
+
+
+def write_reader_states(path: Path, states: dict[VaultSpec, dict]) -> None:
+    """Persist reader state atomically after the scoped history scan.
+
+    Atomic replacement ensures that an interrupted process cannot leave a
+    partially serialised reader-state file.
+
+    :param path:
+        Reader-state pickle path.
+    :param states:
+        Complete state mapping returned by the historical scanner.
+    :return:
+        None.
+    """
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with atomic_write(str(path), mode="wb", overwrite=True) as out:
+        pickle.dump(states, out)
+
+
+def resolve_price_scan_start_block(
+    chain_id: int,
+    deployment_blocks: Iterable[int],
+    timestamp_cache_folder: Path = DEFAULT_TIMESTAMP_CACHE_FOLDER,
+) -> int:
+    """Choose a timestamp-cache-compatible start block for selected products.
+
+    A targeted rewrite must begin at deployment, not at the ordinary scanner's
+    latest cursor. If the local timestamp cache begins later, clip to its first
+    supported block instead of issuing an impossible timestamp lookup.
+
+    :param chain_id:
+        EVM chain containing the selected products.
+    :param deployment_blocks:
+        Deployment blocks for products with a configured price source.
+    :param timestamp_cache_folder:
+        Directory containing the per-chain timestamp cache.
+    :return:
+        Explicit override, or the earliest timestamp-cache-compatible block.
+    """
+
+    explicit_start_block = parse_optional_int_env("START_BLOCK")
+    if explicit_start_block is not None:
+        return explicit_start_block
+
+    deployment_start_block = min(deployment_blocks)
+    cache_file = BlockTimestampDatabase.get_database_file_chain(chain_id, timestamp_cache_folder)
+    if not cache_file.exists():
+        return deployment_start_block
+
+    timestamp_cache = BlockTimestampDatabase.load(chain_id, cache_file)
+    try:
+        first_cached_block = timestamp_cache.get_first_block()
+    finally:
+        timestamp_cache.close()
+    return max(deployment_start_block, first_cached_block)
+
+
+def build_priced_vaults(web3: Web3, products: Iterable[tuple[SecuritizeProduct, int]], token_cache: TokenDiskCache) -> list[VaultBase]:
+    """Build adapters only for DSTokens with a configured historical NAV.
+
+    Unpriced DSTokens must remain leads and metadata rows, but their history
+    cannot be inferred from supply alone and therefore must not rewrite price
+    parquet rows.
+
+    :param web3:
+        Connection for one product chain.
+    :param products:
+        Product and deployment-block pairs with a price estimate.
+    :param token_cache:
+        Shared ERC-20 metadata cache.
+    :return:
+        Vault adapters with their individual history start blocks.
+    """
+
+    vaults: list[VaultBase] = []
+    for product, deployment_block in products:
+        vault = create_vault_instance(
+            web3,
+            product.token,
+            features={ERC4626Feature.securitize_like},
+            token_cache=token_cache,
+        )
+        if vault is None:
+            raise RuntimeError(f"Could not create Securitize vault adapter for {product.token}")
+        vault.first_seen_at_block = deployment_block
+        vaults.append(vault)
+    return vaults
+
+
+def backfill_chain(
+    chain_id: int,
+    products: list[SecuritizeProduct],
+    *,
+    dry_run: bool,
+    scan_prices: bool,
+    clean_prices: bool,
+    frequency: Literal["1h", "1d"],
+    vault_db: VaultDatabase,
+    vault_db_path: Path,
+    price_database_path: Path,
+    cleaned_price_database_path: Path,
+    reader_state_database_path: Path,
+    token_cache: TokenDiskCache,
+) -> dict[str, object]:
+    """Upsert one chain's DSToken leads and rewrite only priced histories.
+
+    Product deployments are derived independently for the selected addresses.
+    The shared metadata database receives only their rows, and the historical
+    scanner receives only priced address filters.
+
+    :param chain_id:
+        EVM chain being migrated.
+    :param products:
+        Reviewed Securitize products on that chain.
+    :param dry_run:
+        Whether writes to state and Parquet files are disabled.
+    :param scan_prices:
+        Whether to rebuild supported price histories.
+    :param clean_prices:
+        Whether to rebuild corresponding cleaned histories.
+    :param frequency:
+        Historical sampling interval.
+    :param vault_db:
+        Existing shared metadata database.
+    :param vault_db_path:
+        Metadata database destination.
+    :param price_database_path:
+        Uncleaned price Parquet destination.
+    :param cleaned_price_database_path:
+        Cleaned price Parquet destination.
+    :param reader_state_database_path:
+        Shared reader-state pickle destination.
+    :param token_cache:
+        Shared ERC-20 metadata cache.
+    :return:
+        Tabular migration summary for the chain.
+    """
+
+    json_rpc_url = read_json_rpc_url(chain_id)
+    web3 = create_multi_provider_web3(json_rpc_url)
+    chain_name = get_chain_name(chain_id)
+    end_block = parse_optional_int_env("END_BLOCK") or web3.eth.block_number
+    logger.info("Backfilling %d Securitize products on %s using %s", len(products), chain_name, get_provider_name(web3.provider))
+
+    product_state = {
+        product: (
+            fetch_contract_deployment_block(web3, product.token, end_block),
+            None,
+        )
+        for product in products
+    }
+    product_state = {product: (deployment_block, fetch_product_first_seen_at(web3, deployment_block)) for product, (deployment_block, _) in product_state.items()}
+    leads = {product.token: create_lead(product, deployment_block, first_seen_at) for product, (deployment_block, first_seen_at) in product_state.items()}
+    rows = {
+        VaultSpec(product.chain_id, product.token): create_vault_scan_record(
+            web3,
+            detection=create_detection(product, deployment_block, first_seen_at),
+            block_identifier=end_block,
+            token_cache=token_cache,
+        )
+        for product, (deployment_block, first_seen_at) in product_state.items()
+    }
+
+    if not dry_run:
+        vault_db_path.parent.mkdir(parents=True, exist_ok=True)
+        vault_db.update_leads_and_rows(
+            chain_id=chain_id,
+            last_scanned_block=end_block,
+            leads=leads,
+            rows=rows,
+        )
+        vault_db.write(vault_db_path)
+
+    priced_products = [(product, deployment_block) for product, (deployment_block, _) in product_state.items() if product.estimated_nav_per_share is not None]
+    scan_summary = "-"
+    if scan_prices and priced_products:
+        vault_ids = {product.token.lower() for product, _ in priced_products}
+        if dry_run:
+            scan_summary = "dry-run"
+        else:
+            reader_states = read_reader_states(reader_state_database_path)
+            reader_states = {spec: state for spec, state in reader_states.items() if spec.vault_address.lower() not in vault_ids}
+            start_block = resolve_price_scan_start_block(chain_id, (deployment_block for _, deployment_block in priced_products))
+            logger.info("Backfilling %d priced Securitize products on %s from block %d", len(priced_products), chain_name, start_block)
+            hypersync_config = configure_hypersync_from_env(web3)
+            scan_result = scan_historical_prices_to_parquet(
+                output_fname=price_database_path,
+                web3=web3,
+                web3factory=MultiProviderWeb3Factory(json_rpc_url, retries=5),
+                vaults=build_priced_vaults(web3, priced_products, token_cache),
+                start_block=start_block,
+                end_block=end_block,
+                max_workers=int(os.environ.get("MAX_WORKERS", "8")),
+                chunk_size=32,
+                token_cache=token_cache,
+                frequency=frequency,
+                reader_states=reader_states,
+                hypersync_client=hypersync_config.hypersync_client,
+                vault_addresses=vault_ids,
+            )
+            write_reader_states(reader_state_database_path, scan_result["reader_states"])
+            scan_summary = pformat_scan_result(scan_result)
+            if clean_prices:
+                cleaned_rows = replace_cleaned_vault_histories(
+                    {VaultSpec(product.chain_id, product.token).as_string_id() for product, _ in priced_products},
+                    vault_db_path=vault_db_path,
+                    raw_price_df_path=price_database_path,
+                    cleaned_price_df_path=cleaned_price_database_path,
+                    logger=logger.info,
+                )
+                scan_summary = f"{scan_summary}; cleaned_rows={cleaned_rows:,}"
+
+    return {
+        "chain": chain_name,
+        "chain_id": chain_id,
+        "rpc": get_json_rpc_env(chain_id),
+        "products": len(products),
+        "priced_products": len(priced_products),
+        "metadata_rows": len(rows),
+        "scan": scan_summary,
+    }
+
+
+def main() -> None:
+    """Run the targeted Securitize lead and price-history migration.
+
+    The full registry is grouped by chain so future Securitize deployments can
+    be added without expanding this operational entry point.
+
+    :return:
+        None.
+    """
+
+    setup_console_logging(default_log_level=os.environ.get("LOG_LEVEL", "info"), log_file=Path("logs/securitize-backfill-history.log"))
+    dry_run = parse_bool_env("DRY_RUN")
+    scan_prices = parse_bool_env("SECURITIZE_SCAN_PRICES", default=True)
+    clean_prices = parse_bool_env("SECURITIZE_CLEAN_PRICES", default=True)
+    frequency = resolve_frequency()
+    products_by_chain: dict[int, list[SecuritizeProduct]] = {}
+    for product in iter_products():
+        products_by_chain.setdefault(product.chain_id, []).append(product)
+    if not products_by_chain:
+        message = "No Securitize products are registered"
+        raise RuntimeError(message)
+
+    vault_db_path = parse_path_env("VAULT_DB_PATH", DEFAULT_VAULT_DATABASE)
+    price_database_path = parse_path_env("UNCLEANED_PRICE_DATABASE", DEFAULT_UNCLEANED_PRICE_DATABASE)
+    cleaned_price_database_path = parse_path_env("CLEANED_PRICE_DATABASE", DEFAULT_RAW_PRICE_DATABASE)
+    reader_state_database_path = parse_path_env("READER_STATE_DATABASE", DEFAULT_READER_STATE_DATABASE)
+    plan = [
+        {
+            "chain": get_chain_name(chain_id),
+            "chain_id": chain_id,
+            "rpc": get_json_rpc_env(chain_id),
+            "products": len(chain_products),
+            "priced_products": sum(product.estimated_nav_per_share is not None for product in chain_products),
+        }
+        for chain_id, chain_products in sorted(products_by_chain.items())
+    ]
+    print("Securitize backfill plan")
+    print(tabulate(plan, headers="keys", tablefmt="github"))
+
+    vault_db = read_vault_database(vault_db_path)
+    token_cache = TokenDiskCache()
+    summaries = [
+        backfill_chain(
+            chain_id,
+            chain_products,
+            dry_run=dry_run,
+            scan_prices=scan_prices,
+            clean_prices=clean_prices,
+            frequency=frequency,
+            vault_db=vault_db,
+            vault_db_path=vault_db_path,
+            price_database_path=price_database_path,
+            cleaned_price_database_path=cleaned_price_database_path,
+            reader_state_database_path=reader_state_database_path,
+            token_cache=token_cache,
+        )
+        for chain_id, chain_products in sorted(products_by_chain.items())
+    ]
+    if not dry_run:
+        token_cache.commit()
+    print("Securitize backfill summary")
+    print(tabulate(summaries, headers="keys", tablefmt="github"))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/erc_4626/test_scan_vaults_cli.py
+++ b/tests/erc_4626/test_scan_vaults_cli.py
@@ -1,0 +1,27 @@
+"""Regression tests for the vault lead scanner command script."""
+
+# ruff: noqa: S404
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_scan_vaults_rejects_removed_reset_leads_option() -> None:
+    """Fail before scanner initialisation when a removed reset option is set."""
+
+    repository_root = Path(__file__).parents[2]
+    script = repository_root / "scripts" / "erc-4626" / "scan-vaults.py"
+    environment = os.environ | {"RESET_LEADS": "1"}
+    result = subprocess.run(  # noqa: S603 - invokes the current test interpreter and a fixed repository script.
+        [sys.executable, str(script)],
+        cwd=repository_root,
+        env=environment,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "RESET_LEADS has been removed" in result.stderr

--- a/tests/securitize/test_securitize_backfill.py
+++ b/tests/securitize/test_securitize_backfill.py
@@ -1,0 +1,81 @@
+"""Regression tests for the targeted Securitize backfill helper."""
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from eth_defi.event_reader.timestamp_cache import BlockTimestampDatabase
+
+DEPLOYMENT_BLOCK = 100
+FIRST_CACHED_BLOCK = 150
+EXPLICIT_START_BLOCK = 75
+
+
+@pytest.fixture
+def backfill_history_module():
+    """Load the hyphenated Securitize backfill script as a Python module."""
+
+    script_path = Path(__file__).parents[2] / "scripts" / "securitize" / "backfill-history.py"
+    spec = importlib.util.spec_from_file_location("securitize_backfill_history", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_fetch_contract_deployment_block_uses_binary_search(backfill_history_module) -> None:
+    """Locate the first block with runtime code without scanning all blocks."""
+
+    deployment_block = 83
+    web3 = SimpleNamespace(
+        eth=SimpleNamespace(
+            get_code=lambda _address, block_identifier: b"code" if block_identifier >= deployment_block else b"",
+        )
+    )
+
+    assert backfill_history_module.fetch_contract_deployment_block(web3, "0x0000000000000000000000000000000000000001", 100) == deployment_block
+
+
+def test_fetch_contract_deployment_block_rejects_non_contract(backfill_history_module) -> None:
+    """Reject an address that does not contain runtime code at the scan end."""
+
+    web3 = SimpleNamespace(eth=SimpleNamespace(get_code=lambda *_args, **_kwargs: b""))
+
+    with pytest.raises(ValueError, match="No contract code"):
+        backfill_history_module.fetch_contract_deployment_block(web3, "0x0000000000000000000000000000000000000001", 100)
+
+
+def test_resolve_price_scan_start_block_uses_deployment_without_cache(
+    monkeypatch: pytest.MonkeyPatch,
+    backfill_history_module,
+    tmp_path: Path,
+) -> None:
+    """Start a targeted rewrite at the earliest selected deployment by default."""
+
+    monkeypatch.delenv("START_BLOCK", raising=False)
+
+    assert backfill_history_module.resolve_price_scan_start_block(1, [200, DEPLOYMENT_BLOCK], timestamp_cache_folder=tmp_path) == DEPLOYMENT_BLOCK
+
+
+def test_resolve_price_scan_start_block_honours_cache_and_override(
+    monkeypatch: pytest.MonkeyPatch,
+    backfill_history_module,
+    tmp_path: Path,
+) -> None:
+    """Respect a usable cache boundary unless the operator specifies a block."""
+
+    cache = BlockTimestampDatabase.create(1, tmp_path)
+    try:
+        cache.import_chain_data(1, pd.Series(data=[1_700_000_000], index=[FIRST_CACHED_BLOCK]))
+    finally:
+        cache.close()
+
+    monkeypatch.delenv("START_BLOCK", raising=False)
+    assert backfill_history_module.resolve_price_scan_start_block(1, [DEPLOYMENT_BLOCK], timestamp_cache_folder=tmp_path) == FIRST_CACHED_BLOCK
+
+    monkeypatch.setenv("START_BLOCK", str(EXPLICIT_START_BLOCK))
+    assert backfill_history_module.resolve_price_scan_start_block(1, [DEPLOYMENT_BLOCK], timestamp_cache_folder=tmp_path) == EXPLICIT_START_BLOCK


### PR DESCRIPTION
## Why

Whole-chain `RESET_LEADS` rediscovery refreshes unrelated historical vault metadata and can fail before the intended protocol entries are written. New protocol integrations need deterministic, address-scoped migrations that preserve existing production state.

## Lessons learnt

A protocol migration needs to reset reader state and rewrite Parquet only for its selected vault IDs. Securitize products can be discovered from the reviewed product registry; an archive-node binary search finds each DSToken deployment block without maintaining another manually curated block registry.

## Summary

- Remove the `RESET_LEADS` command option and shared scanner reset branch; `scan-vaults.py` now fails immediately if the removed environment variable is present.
- Add `README-vault-leads.md` and update vault-script guidance so generated protocol-specific migration scripts are the required backfill path.
- Add `scripts/securitize/backfill-history.py`, which upserts only reviewed DSToken leads and metadata, preserves unrelated reader state and price rows, and scans BUIDL/BUIDL-I history only where an explicit NAV estimate is available.
- Update related migration documentation and the vault-protocol integration skill, plus add a changelog entry and regression coverage.

## Related issues and PRs

Follow-up to #1292.

## Unrelated CI and test fixes

None.
