### PR TITLE
fix: normalise vault fee values

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,9 @@ No test plan or verification section. Use Markdown formatting, headings.
 
 ## Pull requests
 
+- GitHub plugins are not needed for pull-request work. Prefer the local `git`
+  and `gh` command-line tools to create, inspect, update, cancel CI for, and
+  merge pull requests.
 - Only push changes to remote when asked, never update pull requess automatically.
 - Never push directly to a master if not told explicitly
 - If the user ask to open a pull request as feature then start the PR title with "feat:" prefix and also add one line about the feature into `CHANGELOG.md`

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -9,8 +9,9 @@ import logging
 import math
 import warnings
 from dataclasses import asdict, dataclass, is_dataclass
+from decimal import Decimal
 from enum import Enum
-from typing import TYPE_CHECKING, Literal, Optional, TypeAlias, TypedDict
+from typing import TYPE_CHECKING, Literal, TypeAlias, TypedDict
 
 import numpy as np
 import pandas as pd
@@ -57,6 +58,12 @@ logger = logging.getLogger(__name__)
 #:
 #: 0.01 = 1%
 Percent: TypeAlias = float
+
+#: Fee values as received from current and legacy vault metadata.
+#:
+#: The exported metadata normally uses floats, but cached database rows can
+#: contain :class:`decimal.Decimal` values after JSON/YAML deserialisation.
+FeeInput: TypeAlias = Percent | Decimal | Literal["-"] | None
 
 Period: TypeAlias = Literal["1W", "1M", "3M", "6M", "1Y", "lifetime"]
 
@@ -573,15 +580,60 @@ def zero_out_near_zero_prices(s: pd.Series, eps: float = 1e-9, clip_negatives: b
     return s
 
 
+def _normalise_fee_for_calculation(
+    fee: FeeInput,
+    fee_name: str,
+) -> Percent:
+    """Convert a vault fee from metadata to the floating-point metrics representation.
+
+    Vault metadata is persisted independently from the metrics code, so old cache
+    rows can contain :class:`~decimal.Decimal` fees. The return calculations use
+    floating-point share prices and returns, therefore all fee inputs must be
+    converted before arithmetic to avoid mixing ``Decimal`` and ``float``.
+
+    :param fee:
+        Fee as stored in vault metadata. ``None`` and the legacy ``"-"`` value
+        both represent a zero fee.
+    :param fee_name:
+        Human-readable fee name used in validation errors.
+    :return:
+        Fee as a float between zero (inclusive) and one (exclusive).
+    """
+    if fee in {None, "-"}:
+        return 0.0
+
+    normalised_fee = float(fee)
+    assert 0 <= normalised_fee < 1, f"{fee_name} must be between 0 and 1"
+    return normalised_fee
+
+
+def _normalise_fee_for_fee_data(
+    fee: FeeInput,
+    fee_name: str,
+) -> Percent | None:
+    """Normalise a historical fee before constructing ``FeeData``.
+
+    :param fee:
+        Historical scalar fee value.
+    :param fee_name:
+        Human-readable fee name used in validation errors.
+    :return:
+        ``None`` for an unknown fee or a validated floating-point fee.
+    """
+    if fee is None:
+        return None
+    return _normalise_fee_for_calculation(fee, fee_name)
+
+
 def calculate_net_profit(
     start: datetime.datetime,
     end: datetime.datetime,
     share_price_start: float,
     share_price_end: float,
-    management_fee_annual: Percent,
-    performance_fee: Percent,
-    deposit_fee: Percent | None,
-    withdrawal_fee: Percent | None,
+    management_fee_annual: FeeInput,
+    performance_fee: FeeInput,
+    deposit_fee: FeeInput,
+    withdrawal_fee: FeeInput,
     seconds_in_year=365.25 * 86400,
     sample_count: int | None = None,
 ) -> Percent:
@@ -635,20 +687,10 @@ def calculate_net_profit(
         return 0
 
     assert share_price_end >= 0, "End share price must be non-negative"
-    if management_fee_annual in (None, "-"):
-        # - is legacy
-        management_fee_annual = 0.0
-    assert 0 <= management_fee_annual < 1, "Management fee must be between 0 and 1"
-    if performance_fee in (None, "-"):
-        # - is legacy
-        performance_fee = 0.0
-    assert 0 <= performance_fee < 1, "Performance fee must be between 0 and 1"
-    if deposit_fee is None:
-        deposit_fee = 0.0
-    if withdrawal_fee is None:
-        withdrawal_fee = 0.0
-    assert 0 <= deposit_fee < 1, "Deposit fee must be between 0 and 1"
-    assert 0 <= withdrawal_fee < 1, "Withdrawal fee must be between 0 and 1"
+    management_fee_annual = _normalise_fee_for_calculation(management_fee_annual, "Management fee")
+    performance_fee = _normalise_fee_for_calculation(performance_fee, "Performance fee")
+    deposit_fee = _normalise_fee_for_calculation(deposit_fee, "Deposit fee")
+    withdrawal_fee = _normalise_fee_for_calculation(withdrawal_fee, "Withdrawal fee")
 
     delta = end - start
     years = delta.total_seconds() / seconds_in_year
@@ -665,10 +707,10 @@ def calculate_net_profit(
 def calculate_net_returns_from_price(
     name: str,
     share_price: pd.Series,
-    management_fee_annual: Percent | None,
-    performance_fee: Percent | None,
-    deposit_fee: Percent | None,
-    withdrawal_fee: Percent | None,
+    management_fee_annual: FeeInput,
+    performance_fee: FeeInput,
+    deposit_fee: FeeInput,
+    withdrawal_fee: FeeInput,
     seconds_in_year=365.25 * 86400,
     zero_epsilon=0.001,
     freq="h",
@@ -703,24 +745,10 @@ def calculate_net_returns_from_price(
     assert isinstance(share_price, pd.Series), f"share_price must be pandas Series, got {type(share_price)}"
     assert isinstance(share_price.index, pd.DatetimeIndex), "share_price must have DatetimeIndex"
 
-    if management_fee_annual in (None, "-"):
-        management_fee_annual = 0.0
-    assert 0 <= management_fee_annual < 1, "Management fee must be between 0 and 1"
-    if performance_fee in (None, "-"):
-        performance_fee = 0.0
-    assert 0 <= performance_fee < 1, "Performance fee must be between 0 and 1"
-    if deposit_fee is None:
-        deposit_fee = 0.0
-    if withdrawal_fee is None:
-        withdrawal_fee = 0.0
-    assert 0 <= deposit_fee < 1, "Deposit fee must be between 0 and 1"
-    assert 0 <= withdrawal_fee < 1, "Withdrawal fee must be between 0 and 1"
-    if deposit_fee is None:
-        deposit_fee = 0.0
-    if withdrawal_fee is None:
-        withdrawal_fee = 0.0
-    assert 0 <= deposit_fee < 1, "Deposit fee must be between 0 and 1"
-    assert 0 <= withdrawal_fee < 1, "Withdrawal fee must be between 0 and 1"
+    management_fee_annual = _normalise_fee_for_calculation(management_fee_annual, "Management fee")
+    performance_fee = _normalise_fee_for_calculation(performance_fee, "Performance fee")
+    deposit_fee = _normalise_fee_for_calculation(deposit_fee, "Deposit fee")
+    withdrawal_fee = _normalise_fee_for_calculation(withdrawal_fee, "Withdrawal fee")
 
     if len(share_price) == 0:
         return share_price
@@ -781,10 +809,10 @@ def calculate_net_returns_from_price(
 def calculate_net_returns_from_gross(
     name: str,
     cumulative_returns: pd.Series,
-    management_fee_annual: Optional[Percent],
-    performance_fee: Optional[Percent],
-    deposit_fee: Optional[Percent],
-    withdrawal_fee: Optional[Percent],
+    management_fee_annual: FeeInput,
+    performance_fee: FeeInput,
+    deposit_fee: FeeInput,
+    withdrawal_fee: FeeInput,
     seconds_in_year=365.25 * 86400,
 ) -> pd.Series:
     """Convert a cumulative gross return series to a cumulative net return series after fees.
@@ -1561,19 +1589,31 @@ def calculate_vault_record(
     current_nav = prices_df["total_assets"].iloc[-1]
     chain_id = prices_df["chain"].iloc[-1]
 
-    fee_data: FeeData = vault_metadata.get("_fees")
-    gross_fee_data = fee_data
+    fee_data: FeeData | None = vault_metadata.get("_fees")
 
     if fee_data is None:
         # Legacy, unit tests,etc.
         # _fees not in the exported pickle we use for testing
         fee_data = FeeData(
             fee_mode=VaultFeeMode.externalised,
-            management=vault_metadata["Mgmt fee"],
-            performance=vault_metadata["Perf fee"],
-            deposit=vault_metadata.get("Deposit fee", 0),  # Rare: assume 0 if not explicitly set
-            withdraw=vault_metadata.get("Withdrawal fee", 0),  # Rare: assume 0 if not explicitly set
+            management=_normalise_fee_for_fee_data(vault_metadata["Mgmt fee"], "management fee"),
+            performance=_normalise_fee_for_fee_data(vault_metadata["Perf fee"], "performance fee"),
+            deposit=_normalise_fee_for_fee_data(vault_metadata.get("Deposit fee", 0), "deposit fee"),  # Rare: assume 0 if not explicitly set
+            withdraw=_normalise_fee_for_fee_data(vault_metadata.get("Withdrawal fee", 0), "withdrawal fee"),  # Rare: assume 0 if not explicitly set
         )
+    else:
+        # Pickle deserialisation does not call FeeData.__post_init__(). Repair
+        # historical fee values before calculations and JSON export, while new
+        # FeeData construction continues to reject unsupported types.
+        fee_data = FeeData(
+            fee_mode=fee_data.fee_mode,
+            management=_normalise_fee_for_fee_data(fee_data.management, "management fee"),
+            performance=_normalise_fee_for_fee_data(fee_data.performance, "performance fee"),
+            deposit=_normalise_fee_for_fee_data(fee_data.deposit, "deposit fee"),
+            withdraw=_normalise_fee_for_fee_data(fee_data.withdraw, "withdrawal fee"),
+        )
+
+    gross_fee_data = fee_data
 
     vault_address = vault_metadata["Address"]
     protocol = vault_metadata["Protocol"]

--- a/eth_defi/vault/fee.py
+++ b/eth_defi/vault/fee.py
@@ -2,6 +2,7 @@
 
 import enum
 from dataclasses import dataclass
+from numbers import Real
 
 from eth_typing import HexAddress
 
@@ -245,6 +246,25 @@ class FeeData:
     #: Fee for this class
     withdraw: float | None
 
+    def __post_init__(self) -> None:
+        """Validate and normalise fee values at the metadata ingestion boundary.
+
+        Vault return calculations operate on floats. In particular, allowing a
+        :class:`decimal.Decimal` into this dataclass causes a later
+        ``Decimal * float`` failure after the metadata has been persisted in
+        the vault database. Accept real numeric values so existing integer
+        zeroes and NumPy floats remain supported, then retain all known fees
+        as Python floats.
+
+        :raises AssertionError:
+            If a fee is not a real number or ``None``.
+        """
+        for field_name in ("management", "performance", "deposit", "withdraw"):
+            fee = getattr(self, field_name)
+            assert fee is None or (isinstance(fee, Real) and not isinstance(fee, bool)), f"FeeData.{field_name} must be a real number or None, got {type(fee)}"
+            if fee is not None:
+                setattr(self, field_name, float(fee))
+
     @property
     def internalised(self) -> bool | None:
         if self.fee_mode is None:
@@ -260,8 +280,8 @@ class FeeData:
         if self.internalised:
             return FeeData(
                 fee_mode=self.fee_mode,
-                management=0,
-                performance=0,
+                management=0.0,
+                performance=0.0,
                 deposit=self.deposit,
                 withdraw=self.withdraw,
             )

--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -3,6 +3,7 @@
 import json
 import os.path
 import pickle
+from decimal import Decimal
 from pathlib import Path
 
 import pandas as pd
@@ -41,6 +42,97 @@ def test_get_trading_strategy_links_use_canonical_vault_routes():
     assert vault_link == "https://tradingstrategy.ai/trading-view/vaults/texashedge"
     assert vault_metrics._get_trading_strategy_chain_link("Ethereum") == "https://tradingstrategy.ai/trading-view/vaults/chains/ethereum"
     assert vault_metrics._get_trading_strategy_chain_link("Hypercore") == "https://tradingstrategy.ai/trading-view/vaults/chains/hyperliquid"
+
+
+def test_net_return_calculations_accept_decimal_fees() -> None:
+    """Cached Decimal fee metadata is compatible with float price returns."""
+    start = pd.Timestamp("2026-01-01").to_pydatetime()
+    end = pd.Timestamp("2026-01-02").to_pydatetime()
+    expected_return = (1 - 0.01) * (1 + 0.1) * (1 - 0.02) - 1
+
+    net_profit = vault_metrics.calculate_net_profit(
+        start=start,
+        end=end,
+        share_price_start=100.0,
+        share_price_end=110.0,
+        management_fee_annual=Decimal("0"),
+        performance_fee=Decimal("0"),
+        deposit_fee=Decimal("0.01"),
+        withdrawal_fee=Decimal("0.02"),
+    )
+    assert net_profit == pytest.approx(expected_return)
+
+    net_returns = vault_metrics.calculate_net_returns_from_price(
+        name="Decimal fee vault",
+        share_price=pd.Series(
+            [100.0, 110.0],
+            index=pd.date_range("2026-01-01", periods=2, freq="D"),
+        ),
+        management_fee_annual=Decimal("0"),
+        performance_fee=Decimal("0"),
+        deposit_fee=Decimal("0.01"),
+        withdrawal_fee=Decimal("0.02"),
+    )
+    assert net_returns.iloc[-1] == pytest.approx(expected_return)
+
+
+def test_calculate_lifetime_metrics_normalises_pickled_decimal_fees(
+    vault_db: VaultDatabase,
+    price_df: pd.DataFrame,
+) -> None:
+    """Old pickled FeeData with Decimal values exports as floating-point fees."""
+    vault_id = "43111-0x05c2e246156d37b39a825a25dd08d5589e3fd883"
+    vault_spec = VaultSpec.parse_string(vault_id)
+    vault_row = dict(vault_db.rows[vault_spec])
+    legacy_fees = FeeData(
+        fee_mode=VaultFeeMode.externalised,
+        management=0.0,
+        performance=0.0,
+        deposit=0.0,
+        withdraw=0.0,
+    )
+    legacy_fees.management = Decimal("0")
+    legacy_fees.performance = Decimal("0.15")
+    legacy_fees.deposit = Decimal("0.01")
+    legacy_fees.withdraw = Decimal("0.02")
+    vault_row["_fees"] = legacy_fees
+
+    metrics = calculate_lifetime_metrics(
+        price_df.loc[price_df["id"] == vault_id],
+        {vault_spec: vault_row},
+    )
+
+    result = metrics.iloc[0]
+    assert result["mgmt_fee"] == 0.0
+    assert result["perf_fee"] == 0.15
+    assert result["deposit_fee"] == 0.01
+    assert result["withdraw_fee"] == 0.02
+
+
+def test_calculate_lifetime_metrics_normalises_legacy_decimal_fee_columns(
+    vault_db: VaultDatabase,
+    price_df: pd.DataFrame,
+) -> None:
+    """Old metadata columns with Decimal fees can rebuild FeeData safely."""
+    vault_id = "43111-0x05c2e246156d37b39a825a25dd08d5589e3fd883"
+    vault_spec = VaultSpec.parse_string(vault_id)
+    vault_row = dict(vault_db.rows[vault_spec])
+    vault_row["_fees"] = None
+    vault_row["Mgmt fee"] = Decimal("0")
+    vault_row["Perf fee"] = Decimal("0.15")
+    vault_row["Deposit fee"] = Decimal("0.01")
+    vault_row["Withdrawal fee"] = Decimal("0.02")
+
+    metrics = calculate_lifetime_metrics(
+        price_df.loc[price_df["id"] == vault_id],
+        {vault_spec: vault_row},
+    )
+
+    result = metrics.iloc[0]
+    assert result["mgmt_fee"] == 0.0
+    assert result["perf_fee"] == 0.15
+    assert result["deposit_fee"] == 0.01
+    assert result["withdraw_fee"] == 0.02
 
 
 def test_apply_morpho_not_in_api_check_blacklists_vault():

--- a/tests/vault/test_fee.py
+++ b/tests/vault/test_fee.py
@@ -1,0 +1,34 @@
+"""Tests for vault fee metadata."""
+
+from decimal import Decimal
+
+import pytest
+
+from eth_defi.vault.fee import FeeData, VaultFeeMode
+
+
+def test_fee_data_normalises_integer_fees_to_floats() -> None:
+    """Fee metadata stores real-number inputs as floats."""
+    fees = FeeData(
+        fee_mode=VaultFeeMode.externalised,
+        management=0,
+        performance=0,
+        deposit=0,
+        withdraw=0,
+    )
+
+    assert fees.management == 0.0
+    assert fees.performance == 0.0
+    assert fees.deposit == 0.0
+    assert fees.withdraw == 0.0
+    assert all(isinstance(fee, float) for fee in (fees.management, fees.performance, fees.deposit, fees.withdraw))
+
+
+@pytest.mark.parametrize("field_name", ("management", "performance", "deposit", "withdraw"))
+def test_fee_data_rejects_decimal_fees(field_name: str) -> None:
+    """Reject Decimal fee metadata before it can enter the vault pickle."""
+    kwargs = dict.fromkeys(("management", "performance", "deposit", "withdraw"), 0.0)
+    kwargs[field_name] = Decimal("0.01")
+
+    with pytest.raises(AssertionError, match=rf"FeeData\.{field_name} must be a real number or None"):
+        FeeData(fee_mode=VaultFeeMode.externalised, **kwargs)


### PR DESCRIPTION
## Why

Persisted vault fee metadata may contain `Decimal` values, while return calculations use floats. This caused top-vault JSON export to fail with `Decimal * float`.

## Lessons learnt

Validate and normalise persisted numeric metadata at its creation boundary, while repairing historical cache records when they are read.

## Summary

- Normalise historical Decimal fee values before calculations and JSON export.
- Reject unsupported fee types in new `FeeData` instances and persist real values as floats.
- Add regression coverage for direct, pickled, and legacy-column Decimal inputs.
- Document the local `git` and `gh` pull-request workflow.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.