### PR TITLE
feat: Add Securitize off-chain NAV sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- feat: Add off-chain Securitize NAV, share-price and TVL history sources with in-memory scanner enrichment (2026-07-16)
 - feat: Add read-only Asseto vault protocol support, public product, fee and role extraction, curator metadata, and blocked deposit manager (2026-07-16)
 - feat: Add Securitize fund descriptions and curator attribution for selected DSTokens, including BCAP, COSX, SCI2 and PRTS (2026-07-16)
 - feat: Replace whole-chain vault lead resets with generated protocol-specific migrations and add the targeted Securitize DSToken backfill helper (2026-07-16)

--- a/docs/source/api/securitize/index.rst
+++ b/docs/source/api/securitize/index.rst
@@ -13,3 +13,6 @@ maintained separately from the shared DSToken adapter.
    eth_defi.securitize.vault
    eth_defi.securitize.historical
    eth_defi.securitize.description
+   eth_defi.securitize.redstone
+   eth_defi.securitize.chronicle
+   eth_defi.securitize.share_price

--- a/eth_defi/securitize/chronicle.py
+++ b/eth_defi/securitize/chronicle.py
@@ -1,0 +1,179 @@
+"""Normalise signed Chronicle Proof of Asset history for Securitize funds.
+
+Chronicle's public STAC dashboard is a visualisation of signed, off-chain
+Proof of Asset records. Unlike RedStone, it does not currently document a
+stable public history endpoint. This module deliberately accepts an explicit
+operator-provided JSON URL instead of guessing an undocumented route.
+
+The parser supports the dashboard's compact ``timestamp``, ``nav`` and
+``totalValueLocked`` record shape. A configured source can therefore use the
+same in-memory Securitize merger as RedStone without a second Parquet rewrite.
+
+Reference: https://chroniclelabs.org/dashboard/proofofasset/securitize-stac
+"""
+
+import datetime
+from collections.abc import Iterator
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+
+import requests
+from eth_typing import HexAddress
+
+from eth_defi.securitize.description import STAC_ETHEREUM
+
+#: Timeout for a public Chronicle history request in seconds.
+DEFAULT_CHRONICLE_API_TIMEOUT = 20.0
+
+#: Unix seconds above this are interpreted as milliseconds.
+UNIX_MILLISECONDS_THRESHOLD = 10_000_000_000
+
+
+class ChronicleAPIError(RuntimeError):
+    """Raised when a configured Chronicle history source is malformed."""
+
+
+@dataclass(slots=True, frozen=True)
+class ChronicleSecuritizeFeed:
+    """One Securitize product verified by Chronicle Proof of Asset."""
+
+    #: EVM chain hosting the Securitize DSToken.
+    chain_id: int
+
+    #: Lower-case DSToken address.
+    token: HexAddress
+
+    #: Chronicle public dashboard slug.
+    dashboard_slug: str
+
+
+@dataclass(slots=True, frozen=True)
+class ChroniclePricePoint:
+    """One Chronicle-verified NAV and optional total-value observation."""
+
+    #: UTC timestamp of the signed observation.
+    timestamp: datetime.datetime
+
+    #: Verified fund NAV per share in USD.
+    share_price: Decimal
+
+    #: Optional verified total fund value in USD.
+    total_assets: Decimal | None
+
+
+#: Securitize products currently announced as Chronicle Proof of Asset feeds.
+CHRONICLE_SECURITIZE_FEEDS: dict[tuple[int, HexAddress], ChronicleSecuritizeFeed] = {
+    (STAC_ETHEREUM.chain_id, STAC_ETHEREUM.token): ChronicleSecuritizeFeed(STAC_ETHEREUM.chain_id, STAC_ETHEREUM.token, "securitize-stac"),
+}
+
+
+def _as_decimal(value: object, field_name: str) -> Decimal:
+    """Parse a positive Chronicle numeric field.
+
+    :param value:
+        Raw JSON numeric field.
+    :param field_name:
+        Field name used in the diagnostic error.
+    :return:
+        Positive decimal value.
+    :raise ChronicleAPIError:
+        If the value is absent, malformed or non-positive.
+    """
+
+    try:
+        decimal_value = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as error:
+        raise ChronicleAPIError(f"Chronicle record has an invalid {field_name}") from error
+    if decimal_value <= 0:
+        raise ChronicleAPIError(f"Chronicle record has a non-positive {field_name}")
+    return decimal_value
+
+
+def _parse_timestamp(value: object) -> datetime.datetime:
+    """Parse a Chronicle Unix-second or Unix-millisecond timestamp.
+
+    :param value:
+        Raw JSON timestamp.
+    :return:
+        Naive UTC timestamp.
+    :raise ChronicleAPIError:
+        If the value cannot be interpreted as a positive Unix timestamp.
+    """
+
+    try:
+        timestamp = int(value)
+    except (TypeError, ValueError) as error:
+        message = "Chronicle record has an invalid timestamp"
+        raise ChronicleAPIError(message) from error
+    if timestamp <= 0:
+        message = "Chronicle record has a non-positive timestamp"
+        raise ChronicleAPIError(message)
+    if timestamp > UNIX_MILLISECONDS_THRESHOLD:
+        timestamp //= 1000
+    return datetime.datetime.fromtimestamp(timestamp, tz=datetime.UTC).replace(tzinfo=None)
+
+
+def _parse_chronicle_record(raw: object) -> ChroniclePricePoint:
+    """Normalise one Chronicle history record.
+
+    :param raw:
+        Raw JSON record from an operator-configured Chronicle export.
+    :return:
+        Verified NAV and optional TVL observation.
+    :raise ChronicleAPIError:
+        If the record does not match the supported public-dashboard shape.
+    """
+
+    if not isinstance(raw, dict):
+        message = "Chronicle history row must be an object"
+        raise ChronicleAPIError(message)
+    timestamp = _parse_timestamp(raw.get("timestamp"))
+    share_price = _as_decimal(raw.get("nav", raw.get("sharePrice")), "NAV")
+    raw_total_assets = raw.get("totalValueLocked", raw.get("totalAssets"))
+    total_assets = _as_decimal(raw_total_assets, "total value") if raw_total_assets is not None else None
+    return ChroniclePricePoint(timestamp=timestamp, share_price=share_price, total_assets=total_assets)
+
+
+def fetch_chronicle_price_history(
+    feed: ChronicleSecuritizeFeed,
+    history_url: str,
+    *,
+    timeout: float = DEFAULT_CHRONICLE_API_TIMEOUT,
+) -> Iterator[ChroniclePricePoint]:
+    """Fetch Chronicle Proof of Asset NAV history from an explicit JSON URL.
+
+    The caller must supply the source URL because Chronicle has not documented
+    a stable public API endpoint for the STAC dashboard. The response may be a
+    list directly or an envelope containing a ``data`` list.
+
+    :param feed:
+        Reviewed Chronicle product metadata. Retained for audit-friendly call
+        sites and future feed-specific validation.
+    :param history_url:
+        Public JSON history URL exported by Chronicle.
+    :param timeout:
+        HTTP request timeout in seconds.
+    :return:
+        Oldest-to-newest distinct signed observations.
+    :raise ChronicleAPIError:
+        If the source response does not contain a supported history list.
+    """
+
+    del feed
+    response = requests.get(history_url, timeout=timeout)
+    response.raise_for_status()
+    try:
+        payload = response.json()
+    except ValueError as error:
+        message = "Chronicle history source returned invalid JSON"
+        raise ChronicleAPIError(message) from error
+    rows = payload.get("data") if isinstance(payload, dict) else payload
+    if not isinstance(rows, list):
+        message = "Chronicle history source must return a list or a data list"
+        raise ChronicleAPIError(message)
+    price_points = sorted((_parse_chronicle_record(row) for row in rows), key=lambda point: point.timestamp)
+    seen_timestamps: set[datetime.datetime] = set()
+    for price_point in price_points:
+        if price_point.timestamp not in seen_timestamps:
+            seen_timestamps.add(price_point.timestamp)
+            yield price_point

--- a/eth_defi/securitize/description.py
+++ b/eth_defi/securitize/description.py
@@ -122,12 +122,12 @@ ACRED_ETHEREUM = SecuritizeProduct(
 
 - **Curator:** Apollo / Securitize.
 - **Vault strategy:** Tokenised feeder fund investing in Apollo Diversified Credit Fund, a diversified global-credit strategy spanning corporate direct lending, asset-backed lending, and performing, dislocated and structured credit.
-- **NAV reporting:** The fund supports subscriptions and redemptions at daily NAV. Its NAV changes with the underlying credit portfolio, so this integration does not model ACRED at a fixed share price.
+- **NAV reporting:** The fund supports subscriptions and redemptions at daily NAV. Its NAV changes with the underlying credit portfolio; historical NAV is read from RedStone's ACRED fundamental feed rather than modelled as a fixed share price.
 - **Investor access:** The product is available to qualifying investors through Securitize Markets.
 - **Fund page:** [Apollo Diversified Credit Securitize Fund]({ACRED_FUND_PAGE_URL}).
 """,
     estimated_nav_per_share=None,
-    nav_source="unconfigured",
+    nav_source="redstone_acred_fundamental",
     denomination="USD",
 )
 
@@ -147,12 +147,12 @@ VBILL_ETHEREUM = SecuritizeProduct(
 
 - **Curator:** VanEck / Securitize.
 - **Vault strategy:** Tokenised fund investing in short-term U.S. Treasury obligations, repurchase agreements collateralised by U.S. Treasury obligations and cash for redemptions.
-- **NAV reporting:** The fund seeks to maintain a stable USD 1 net asset value and has daily NAV calculations. A canonical historical price source has not yet been integrated, so this adapter does not assume a fixed share price.
+- **NAV reporting:** The fund seeks to maintain a stable USD 1 net asset value and has daily NAV calculations. Historical NAV is read from RedStone's Ethereum VBILL fundamental feed, so the adapter does not assume a fixed share price.
 - **Investor access:** The fund is designed for institutional and qualified investors.
 - **Fund page:** [VanEck Treasury Fund]({VBILL_FUND_PAGE_URL}).
 """,
     estimated_nav_per_share=None,
-    nav_source="unconfigured",
+    nav_source="redstone_vbill_ethereum_fundamental",
     denomination="USD",
 )
 
@@ -173,11 +173,11 @@ STAC_ETHEREUM = SecuritizeProduct(
 - **Curator:** BNY Investments / Securitize.
 - **Vault strategy:** Tokenised fund dedicated to U.S. dollar-denominated collateralised loan obligations with AAA-rated tranches.
 - **Fund oversight:** The fund was developed with BNY, which acts as custodian for the underlying assets; BNY Investments is the fund's sub-adviser.
-- **NAV reporting:** The share value follows the NAV of the CLO portfolio and is not a stable-dollar fund. A canonical historical price source has not yet been integrated.
+- **NAV reporting:** The share value follows the NAV of the CLO portfolio and is not a stable-dollar fund. Historical NAV is read from RedStone's STAC fundamental feed; Chronicle separately verifies the fund's assets and valuation inputs through its Proof of Asset dashboard.
 - **Fund page:** [Securitize Tokenized AAA CLO Fund]({STAC_FUND_PAGE_URL}).
 """,
     estimated_nav_per_share=None,
-    nav_source="unconfigured",
+    nav_source="redstone_stac_fundamental",
     denomination="USD",
 )
 
@@ -247,12 +247,12 @@ HLSCOPE_ETHEREUM = SecuritizeProduct(
 
 - **Curator:** Hamilton Lane / Securitize.
 - **Vault strategy:** Tokenised feeder-fund interests providing access to Hamilton Lane's Senior Credit Opportunities Fund, an evergreen private-credit strategy focused on senior secured loans.
-- **NAV reporting:** The underlying strategy's valuations are determined periodically and the share value can change with its private-credit holdings. This integration does not use a fixed share-price estimate.
+- **NAV reporting:** The underlying strategy's valuations are determined periodically and the share value can change with its private-credit holdings. Historical NAV is read from RedStone's HLSCOPE fundamental feed rather than using a fixed share-price estimate.
 - **Investor access:** The fund is a permissioned Securitize offering for eligible investors; subscription and redemption terms follow the feeder-fund documentation.
 - **Fund page:** [Hamilton Lane Senior Credit Opportunities Fund]({HLSCOPE_FUND_PAGE_URL}).
 """,
     estimated_nav_per_share=None,
-    nav_source="unconfigured",
+    nav_source="redstone_hlscope_fundamental",
     denomination="USD",
 )
 

--- a/eth_defi/securitize/redstone.py
+++ b/eth_defi/securitize/redstone.py
@@ -1,0 +1,213 @@
+"""Read Securitize fund NAV history from RedStone's public price API.
+
+RedStone publishes the Securitize feeds used here as signed fundamental-value
+feeds. The API contains repeated publications of the same daily NAV, so this
+module queries one observation at each requested daily checkpoint rather than
+downloading every relay publication.
+
+The public endpoint is undocumented. Its response is therefore validated
+strictly and only recognised, reviewed Securitize token addresses are exposed.
+
+Reference: https://app.redstone.finance/app/feeds/
+"""
+
+import datetime
+from collections.abc import Iterator
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+
+import requests
+from eth_typing import HexAddress
+
+from eth_defi.securitize.description import ACRED_ETHEREUM, HLSCOPE_ETHEREUM, STAC_ETHEREUM, VBILL_ETHEREUM
+
+#: Public RedStone price endpoint used by its feed dashboard.
+REDSTONE_PRICE_API_URL = "https://api.redstone.finance/prices"
+
+#: Timeout for a public RedStone API request in seconds.
+DEFAULT_REDSTONE_API_TIMEOUT = 20.0
+
+
+class RedstoneAPIError(RuntimeError):
+    """Raised when the RedStone public feed API returns malformed data."""
+
+
+@dataclass(slots=True, frozen=True)
+class RedstoneSecuritizeFeed:
+    """One reviewed Securitize NAV feed available through RedStone."""
+
+    #: EVM chain hosting the Securitize DSToken.
+    chain_id: int
+
+    #: Lower-case DSToken address.
+    token: HexAddress
+
+    #: RedStone fundamental feed identifier.
+    feed_id: str
+
+
+@dataclass(slots=True, frozen=True)
+class RedstonePricePoint:
+    """One signed RedStone fundamental NAV observation."""
+
+    #: UTC timestamp at which RedStone published the value.
+    timestamp: datetime.datetime
+
+    #: Fund NAV per share in USD.
+    share_price: Decimal
+
+
+#: Reviewed Securitize products with RedStone fundamental NAV feeds.
+REDSTONE_SECURITIZE_FEEDS: dict[tuple[int, HexAddress], RedstoneSecuritizeFeed] = {
+    (ACRED_ETHEREUM.chain_id, ACRED_ETHEREUM.token): RedstoneSecuritizeFeed(ACRED_ETHEREUM.chain_id, ACRED_ETHEREUM.token, "ACRED_FUNDAMENTAL"),
+    (HLSCOPE_ETHEREUM.chain_id, HLSCOPE_ETHEREUM.token): RedstoneSecuritizeFeed(HLSCOPE_ETHEREUM.chain_id, HLSCOPE_ETHEREUM.token, "HLScope_FUNDAMENTAL"),
+    (STAC_ETHEREUM.chain_id, STAC_ETHEREUM.token): RedstoneSecuritizeFeed(STAC_ETHEREUM.chain_id, STAC_ETHEREUM.token, "STAC_FUNDAMENTAL"),
+    (VBILL_ETHEREUM.chain_id, VBILL_ETHEREUM.token): RedstoneSecuritizeFeed(VBILL_ETHEREUM.chain_id, VBILL_ETHEREUM.token, "VBILL_ETHEREUM_FUNDAMENTAL"),
+}
+
+
+def _as_naive_utc(value: datetime.datetime) -> datetime.datetime:
+    """Normalise a datetime to a naive UTC value.
+
+    :param value:
+        A naive UTC or timezone-aware datetime.
+    :return:
+        Naive UTC datetime.
+    """
+
+    if value.tzinfo is None:
+        return value
+    return value.astimezone(datetime.UTC).replace(tzinfo=None)
+
+
+def _parse_price_point(raw: object, feed_id: str) -> RedstonePricePoint:
+    """Validate and normalise one RedStone API response row.
+
+    :param raw:
+        Raw JSON row returned by RedStone.
+    :param feed_id:
+        Requested feed identifier, used in diagnostic errors.
+    :return:
+        Parsed NAV observation.
+    :raise RedstoneAPIError:
+        If a required field is missing or malformed.
+    """
+
+    if not isinstance(raw, dict):
+        raise RedstoneAPIError(f"RedStone {feed_id} response row must be an object")
+    try:
+        timestamp_ms = int(raw["timestamp"])
+        share_price = Decimal(str(raw["value"]))
+    except (KeyError, TypeError, ValueError, InvalidOperation) as error:
+        raise RedstoneAPIError(f"RedStone {feed_id} response row is missing a valid timestamp or value") from error
+    if timestamp_ms <= 0 or share_price <= 0:
+        raise RedstoneAPIError(f"RedStone {feed_id} response row has a non-positive timestamp or value")
+    return RedstonePricePoint(
+        timestamp=datetime.datetime.fromtimestamp(timestamp_ms / 1000, tz=datetime.UTC).replace(tzinfo=None),
+        share_price=share_price,
+    )
+
+
+def fetch_redstone_price_at(
+    feed: RedstoneSecuritizeFeed,
+    at: datetime.datetime,
+    *,
+    api_url: str = REDSTONE_PRICE_API_URL,
+    timeout: float = DEFAULT_REDSTONE_API_TIMEOUT,
+) -> RedstonePricePoint | None:
+    """Fetch the latest RedStone NAV observation at or before a timestamp.
+
+    The API's ``toTimestamp`` argument is milliseconds since Unix epoch. A
+    one-row request is intentional: Securitize fundamental feeds publish many
+    relays of the same daily NAV and the historical scanner only needs the
+    latest value available at each valuation checkpoint.
+
+    :param feed:
+        Reviewed Securitize RedStone feed.
+    :param at:
+        UTC valuation checkpoint.
+    :param api_url:
+        Override for the public endpoint, primarily for integration tests.
+    :param timeout:
+        HTTP request timeout in seconds.
+    :return:
+        Latest observation at or before ``at``, or ``None`` when the feed had
+        not yet published a value.
+    :raise RedstoneAPIError:
+        If the provider returns a malformed response.
+    """
+
+    at = _as_naive_utc(at)
+    response = requests.get(
+        api_url,
+        params={
+            "symbol": feed.feed_id,
+            "provider": "redstone",
+            "limit": 1,
+            "toTimestamp": int(at.replace(tzinfo=datetime.UTC).timestamp() * 1000),
+        },
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    try:
+        payload = response.json()
+    except ValueError as error:
+        raise RedstoneAPIError(f"RedStone {feed.feed_id} returned invalid JSON") from error
+    if not isinstance(payload, list):
+        raise RedstoneAPIError(f"RedStone {feed.feed_id} response must be a list")
+    if not payload:
+        return None
+    price_point = _parse_price_point(payload[0], feed.feed_id)
+    if price_point.timestamp > at:
+        raise RedstoneAPIError(f"RedStone {feed.feed_id} returned an observation after its requested timestamp")
+    return price_point
+
+
+def fetch_redstone_price_history(
+    feed: RedstoneSecuritizeFeed,
+    start_at: datetime.datetime,
+    end_at: datetime.datetime,
+    *,
+    api_url: str = REDSTONE_PRICE_API_URL,
+    timeout: float = DEFAULT_REDSTONE_API_TIMEOUT,
+) -> Iterator[RedstonePricePoint]:
+    """Fetch a daily checkpointed history for one Securitize RedStone feed.
+
+    This is used for an initial backfill. It includes an anchor observation at
+    ``start_at`` and then asks the provider for the value at each following UTC
+    midnight. Identical provider publications are emitted once, preserving the
+    actual signed timestamp so callers cannot use a NAV before publication.
+
+    :param feed:
+        Reviewed Securitize RedStone feed.
+    :param start_at:
+        Inclusive UTC history boundary.
+    :param end_at:
+        Inclusive UTC history boundary.
+    :param api_url:
+        Override for the public endpoint, primarily for integration tests.
+    :param timeout:
+        HTTP request timeout in seconds.
+    :return:
+        Oldest-to-newest distinct RedStone observations.
+    :raise ValueError:
+        If the requested time range is invalid.
+    """
+
+    start_at = _as_naive_utc(start_at)
+    end_at = _as_naive_utc(end_at)
+    if end_at < start_at:
+        message = "end_at must not be earlier than start_at"
+        raise ValueError(message)
+
+    seen_timestamps: set[datetime.datetime] = set()
+    checkpoint = start_at
+    while True:
+        price_point = fetch_redstone_price_at(feed, checkpoint, api_url=api_url, timeout=timeout)
+        if price_point is not None and price_point.timestamp not in seen_timestamps:
+            seen_timestamps.add(price_point.timestamp)
+            yield price_point
+        if checkpoint == end_at:
+            break
+        next_midnight = datetime.datetime.combine(checkpoint.date() + datetime.timedelta(days=1), datetime.time.min)
+        checkpoint = min(next_midnight, end_at)

--- a/eth_defi/securitize/share_price.py
+++ b/eth_defi/securitize/share_price.py
@@ -1,0 +1,191 @@
+"""Merge authoritative Securitize off-chain NAV values into historical reads.
+
+DSToken contracts provide the historical share supply but not a standard fund
+NAV method. This module joins reviewed NAV feeds to those on-chain supply reads
+before the generic scanner serialises its raw Parquet table. It deliberately
+does not read or write Parquet files itself.
+"""
+
+import bisect
+import datetime
+import os
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, replace
+from decimal import Decimal
+
+from eth_typing import HexAddress
+from web3 import Web3
+
+from eth_defi.securitize.chronicle import CHRONICLE_SECURITIZE_FEEDS, ChroniclePricePoint, fetch_chronicle_price_history
+from eth_defi.securitize.redstone import REDSTONE_SECURITIZE_FEEDS, RedstonePricePoint, fetch_redstone_price_history
+from eth_defi.securitize.vault import SECURITIZE_NAV_UNAVAILABLE_ERROR_PREFIX
+from eth_defi.vault.base import VaultBase, VaultHistoricalRead
+
+
+@dataclass(slots=True, frozen=True)
+class SecuritizeSharePricePoint:
+    """One normalised external Securitize NAV observation."""
+
+    #: Source publication time as naive UTC.
+    timestamp: datetime.datetime
+
+    #: Fund NAV/share in USD.
+    share_price: Decimal
+
+
+class SecuritizeSharePriceEnricher:
+    """Apply pre-fetched Securitize NAVs to on-chain historical supply reads."""
+
+    def __init__(self, price_points: dict[tuple[int, HexAddress], list[SecuritizeSharePricePoint]]):
+        """Create a read transformer from normalised source observations.
+
+        :param price_points:
+            Source observations keyed by EVM chain and lower-case DSToken
+            address. Each list may be unsorted.
+        """
+
+        self.price_points = {key: sorted(points, key=lambda point: point.timestamp) for key, points in price_points.items()}
+        self._timestamps = {key: [point.timestamp for point in points] for key, points in self.price_points.items()}
+
+    def __call__(self, read: VaultHistoricalRead) -> VaultHistoricalRead:
+        """Fill a read's NAV and TVL with the latest published source value.
+
+        A source observation is never applied before its publication timestamp.
+        TVL is always recomputed from that NAV and the same historical token
+        supply already read from the DSToken contract.
+
+        :param read:
+            Completed on-chain historical supply read.
+        :return:
+            Original read when no source value is applicable, otherwise an
+            enriched copy.
+        """
+
+        key = read.vault.chain_id, HexAddress(read.vault.address.lower())
+        points = self.price_points.get(key)
+        if not points:
+            return read
+        point_index = bisect.bisect_right(self._timestamps[key], read.timestamp) - 1
+        if point_index < 0:
+            return read
+        point = points[point_index]
+        total_assets = read.total_supply * point.share_price if read.total_supply is not None else None
+        errors = [error for error in (read.errors or []) if not error.startswith(SECURITIZE_NAV_UNAVAILABLE_ERROR_PREFIX)]
+        return replace(
+            read,
+            share_price=point.share_price,
+            total_assets=total_assets,
+            errors=errors or None,
+        )
+
+
+def fetch_block_timestamp(web3: Web3, block_number: int) -> datetime.datetime:
+    """Fetch one block timestamp as a naive UTC datetime.
+
+    :param web3:
+        Connected chain client.
+    :param block_number:
+        Historical block number already selected by the scanner.
+    :return:
+        Naive UTC block timestamp.
+    """
+
+    block = web3.eth.get_block(block_number)
+    return datetime.datetime.fromtimestamp(block["timestamp"], tz=datetime.UTC).replace(tzinfo=None)
+
+
+def _to_price_points(points: Iterable[RedstonePricePoint | ChroniclePricePoint]) -> list[SecuritizeSharePricePoint]:
+    """Convert an external NAV history to the common Securitize format.
+
+    :param points:
+        RedStone or Chronicle observations.
+    :return:
+        Normalised observations.
+    """
+
+    return [SecuritizeSharePricePoint(point.timestamp, point.share_price) for point in points]
+
+
+def fetch_securitize_share_price_enricher(
+    vaults: Iterable[VaultBase],
+    web3: Web3,
+    start_block: int,
+    end_block: int,
+) -> SecuritizeSharePriceEnricher | None:
+    """Fetch source observations for the resolved scanner range.
+
+    RedStone is the default public source for all currently priced Securitize
+    products. Chronicle can optionally provide a signed STAC history through
+    ``CHRONICLE_STAC_HISTORY_URL``; when set, it is preferred for STAC because
+    it contains the fund's Proof of Asset verification record.
+
+    :param vaults:
+        Vaults selected for one chain scan.
+    :param web3:
+        Connected chain client used only to resolve the scanner's block range.
+    :param start_block:
+        Inclusive resolved historical scan block.
+    :param end_block:
+        Inclusive resolved historical scan block.
+    :return:
+        A pure historical-read transformer, or ``None`` when no selected vault
+        has a configured external price source.
+    """
+
+    vaults = list(vaults)
+    vault_keys = {(vault.chain_id, HexAddress(vault.address.lower())) for vault in vaults}
+    start_at = fetch_block_timestamp(web3, start_block)
+    end_at = fetch_block_timestamp(web3, end_block)
+    price_points: dict[tuple[int, HexAddress], list[SecuritizeSharePricePoint]] = {}
+    chronicle_history_url = os.environ.get("CHRONICLE_STAC_HISTORY_URL")
+    chronicle_keys = vault_keys.intersection(CHRONICLE_SECURITIZE_FEEDS) if chronicle_history_url else set()
+
+    for vault in vaults:
+        key = vault.chain_id, HexAddress(vault.address.lower())
+        if key in chronicle_keys:
+            continue
+        feed = REDSTONE_SECURITIZE_FEEDS.get(key)
+        if feed is not None:
+            price_points[key] = _to_price_points(fetch_redstone_price_history(feed, start_at, end_at))
+
+    if chronicle_history_url:
+        for key in chronicle_keys:
+            feed = CHRONICLE_SECURITIZE_FEEDS[key]
+            chronicle_history = list(fetch_chronicle_price_history(feed, chronicle_history_url))
+            chronicle_points = [point for point in chronicle_history if start_at <= point.timestamp <= end_at]
+            previous_points = [point for point in chronicle_history if point.timestamp < start_at]
+            if previous_points:
+                chronicle_points.insert(0, previous_points[-1])
+            if chronicle_points:
+                price_points[key] = _to_price_points(chronicle_points)
+
+    price_points = {key: points for key, points in price_points.items() if points}
+    if not price_points:
+        return None
+    return SecuritizeSharePriceEnricher(price_points)
+
+
+def create_securitize_share_price_transformer_factory(
+    vaults: Iterable[VaultBase],
+    web3: Web3,
+) -> Callable[[int, int], SecuritizeSharePriceEnricher | None]:
+    """Create the scanner callback that lazily fetches incremental NAV history.
+
+    The factory deliberately propagates provider failures. The scanner resolves
+    this callback before it starts its Parquet rewrite; failing the scan keeps
+    previously enriched NAV and TVL history intact instead of replacing it with
+    unpriced on-chain supply rows.
+
+    :param vaults:
+        Vaults selected for one chain scan.
+    :param web3:
+        Connected chain client.
+    :return:
+        Factory compatible with ``scan_historical_prices_to_parquet``.
+    """
+
+    vaults = [vault for vault in vaults if (vault.chain_id, HexAddress(vault.address.lower())) in REDSTONE_SECURITIZE_FEEDS or (vault.chain_id, HexAddress(vault.address.lower())) in CHRONICLE_SECURITIZE_FEEDS]
+    if not vaults:
+        return lambda _start_block, _end_block: None
+
+    return lambda start_block, end_block: fetch_securitize_share_price_enricher(vaults, web3, start_block, end_block)

--- a/eth_defi/securitize/vault.py
+++ b/eth_defi/securitize/vault.py
@@ -27,6 +27,7 @@ BUIDL_PRODUCT_NAME = BUIDL_ETHEREUM.product_name
 BUIDL_HOMEPAGE = BUIDL_ETHEREUM.homepage
 SECURITIZE_HOMEPAGE = "https://securitize.io/"
 SECURITIZE_RESTRICTED_FLOW_REASON = "Securitize DSToken subscriptions, redemptions and transfers require approved investors and compliance checks"
+SECURITIZE_NAV_UNAVAILABLE_ERROR_PREFIX = "No on-chain NAV source configured for Securitize DSToken"
 
 
 class SecuritizeVaultInfo(VaultInfo, total=False):
@@ -72,8 +73,8 @@ class SecuritizeVault(VaultBase):
     """Scan-only adapter for Securitize DS Protocol tokenised securities.
 
     The adapter reads share supply from the ERC-20-compatible DSToken. BUIDL
-    has an explicit one-USD NAV estimate; other recognised DSTokens require a
-    product-specific NAV feed before historical price scanning is enabled.
+    has an explicit one-USD NAV estimate; other recognised DSTokens receive
+    product-specific NAV history through the scanner's off-chain enrichment.
     """
 
     def __init__(
@@ -251,12 +252,12 @@ class SecuritizeVault(VaultBase):
         :return:
             Registered product NAV/share estimate.
         :raises NotImplementedError:
-            If a recognised DSToken has no configured product NAV source.
+            If the DSToken has no on-chain or static adapter NAV source.
         """
 
         if self.product and self.product.estimated_nav_per_share is not None:
             return self.product.estimated_nav_per_share
-        raise NotImplementedError(f"No NAV source configured for Securitize DSToken {self.address}")
+        raise NotImplementedError(f"{SECURITIZE_NAV_UNAVAILABLE_ERROR_PREFIX} {self.address}")
 
     def fetch_total_supply(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
         """Fetch outstanding DSToken supply.

--- a/eth_defi/vault/historical.py
+++ b/eth_defi/vault/historical.py
@@ -547,6 +547,8 @@ def scan_historical_prices_to_parquet(
     hypersync_client=None,
     timestamp_cache_file=DEFAULT_TIMESTAMP_CACHE_FOLDER,
     vault_addresses: set[str] | None = None,
+    historical_read_transformer: Callable[[VaultHistoricalRead], VaultHistoricalRead] | None = None,
+    historical_read_transformer_factory: Callable[[int, int], Callable[[VaultHistoricalRead], VaultHistoricalRead] | None] | None = None,
 ) -> ParquetScanResult:
     """Scan all historical vault share prices of vaults and save them in to Parquet file.
 
@@ -608,6 +610,17 @@ def scan_historical_prices_to_parquet(
         Addresses must be lowercase. When ``None``, all rows for the chain
         are deleted and rewritten (default behaviour).
 
+    :param historical_read_transformer:
+        Optional pure transformation applied to each completed historical read
+        before it is exported. This lets protocol adapters enrich a read with
+        authoritative off-chain values while keeping the scanner's existing
+        single Parquet read and atomic write.
+
+    :param historical_read_transformer_factory:
+        Optional factory for ``historical_read_transformer``. It receives the
+        resolved inclusive block range after stateful start-block discovery,
+        allowing an off-chain source to fetch only the incremental time range.
+
     :return:
         Scan report.
     """
@@ -667,6 +680,11 @@ def scan_historical_prices_to_parquet(
     if end_block is None:
         end_block = get_almost_latest_block_number(web3)
 
+    if historical_read_transformer_factory is not None:
+        if historical_read_transformer is not None:
+            raise ValueError("Specify either historical_read_transformer or historical_read_transformer_factory, not both")
+        historical_read_transformer = historical_read_transformer_factory(start_block, end_block)
+
     reader = VaultHistoricalReadMulticaller(
         web3factory,
         supported_quote_tokens=None,
@@ -720,6 +738,8 @@ def scan_historical_prices_to_parquet(
     # Convert VaultHistoricalRead objects to exportable dicts for Parquet
     def converter(entries_iter: Iterable[VaultHistoricalRead]) -> Iterable[dict]:
         for entry in entries_iter:
+            if historical_read_transformer is not None:
+                entry = historical_read_transformer(entry)
             yield entry.export()
 
     converted_iter = converter(entries_iter)

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -65,6 +65,7 @@ from eth_defi.lighter.session import create_lighter_session
 from eth_defi.lighter.vault_data_export import merge_into_vault_database as lighter_merge_vault_db
 from eth_defi.provider.broken_provider import verify_archive_node
 from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
+from eth_defi.securitize.share_price import create_securitize_share_price_transformer_factory
 from eth_defi.token import TokenDiskCache
 from eth_defi.utils import setup_console_logging, wait_other_writers
 from eth_defi.vault.historical import scan_historical_prices_to_parquet
@@ -602,6 +603,7 @@ def scan_prices_for_chain(
             frequency=frequency,
             reader_states=reader_states,
             hypersync_client=hypersync_config.hypersync_client,
+            historical_read_transformer_factory=create_securitize_share_price_transformer_factory(vaults, web3),
         )
 
         # Save reader states atomically to avoid corruption on interruption

--- a/scripts/securitize/backfill-history.py
+++ b/scripts/securitize/backfill-history.py
@@ -17,7 +17,10 @@ Environment variables:
 ``DRY_RUN``
     Show the plan without writing data. Default: ``false``.
 ``SECURITIZE_SCAN_PRICES``
-    Scan BUIDL and any future priced DSTokens. Default: ``true``.
+    Scan DSTokens with a reviewed estimated or external NAV source. Default:
+    ``true``.
+``SECURITIZE_PRODUCTS``
+    Optional comma-separated DSToken addresses to backfill.
 ``SECURITIZE_CLEAN_PRICES``
     Rebuild selected cleaned histories after the raw scan. Default: ``true``.
 ``FREQUENCY``
@@ -59,6 +62,7 @@ from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_mu
 from eth_defi.provider.named import get_provider_name
 from eth_defi.research.wrangle_vault_prices import replace_cleaned_vault_histories
 from eth_defi.securitize.description import SECURITIZE_PRODUCTS, SecuritizeProduct
+from eth_defi.securitize.share_price import create_securitize_share_price_transformer_factory
 from eth_defi.token import TokenDiskCache
 from eth_defi.utils import setup_console_logging
 from eth_defi.vault.base import VaultBase, VaultSpec
@@ -151,8 +155,11 @@ def iter_products() -> Iterable[SecuritizeProduct]:
         Unique registry products.
     """
 
+    selected_addresses = {address.strip().lower() for address in os.environ.get("SECURITIZE_PRODUCTS", "").split(",") if address.strip()}
     seen: set[tuple[int, HexAddress]] = set()
     for product in SECURITIZE_PRODUCTS.values():
+        if selected_addresses and product.token.lower() not in selected_addresses:
+            continue
         key = product.chain_id, product.token
         if key not in seen:
             seen.add(key)
@@ -388,7 +395,7 @@ def build_priced_vaults(web3: Web3, products: Iterable[tuple[SecuritizeProduct, 
     return vaults
 
 
-def backfill_chain(
+def backfill_chain(  # noqa: PLR0914
     chain_id: int,
     products: list[SecuritizeProduct],
     *,
@@ -472,7 +479,7 @@ def backfill_chain(
         )
         vault_db.write(vault_db_path)
 
-    priced_products = [(product, deployment_block) for product, (deployment_block, _) in product_state.items() if product.estimated_nav_per_share is not None]
+    priced_products = [(product, deployment_block) for product, (deployment_block, _) in product_state.items() if product.estimated_nav_per_share is not None or product.nav_source != "unconfigured"]
     scan_summary = "-"
     if scan_prices and priced_products:
         vault_ids = {product.token.lower() for product, _ in priced_products}
@@ -482,13 +489,14 @@ def backfill_chain(
             reader_states = read_reader_states(reader_state_database_path)
             reader_states = {spec: state for spec, state in reader_states.items() if spec.vault_address.lower() not in vault_ids}
             start_block = resolve_price_scan_start_block(chain_id, (deployment_block for _, deployment_block in priced_products))
-            logger.info("Backfilling %d priced Securitize products on %s from block %d", len(priced_products), chain_name, start_block)
+            logger.info("Backfilling %d Securitize products with a NAV source on %s from block %d", len(priced_products), chain_name, start_block)
             hypersync_config = configure_hypersync_from_env(web3)
+            priced_vaults = build_priced_vaults(web3, priced_products, token_cache)
             scan_result = scan_historical_prices_to_parquet(
                 output_fname=price_database_path,
                 web3=web3,
                 web3factory=MultiProviderWeb3Factory(json_rpc_url, retries=5),
-                vaults=build_priced_vaults(web3, priced_products, token_cache),
+                vaults=priced_vaults,
                 start_block=start_block,
                 end_block=end_block,
                 max_workers=int(os.environ.get("MAX_WORKERS", "8")),
@@ -498,6 +506,7 @@ def backfill_chain(
                 reader_states=reader_states,
                 hypersync_client=hypersync_config.hypersync_client,
                 vault_addresses=vault_ids,
+                historical_read_transformer_factory=create_securitize_share_price_transformer_factory(priced_vaults, web3),
             )
             write_reader_states(reader_state_database_path, scan_result["reader_states"])
             scan_summary = pformat_scan_result(scan_result)
@@ -554,7 +563,7 @@ def main() -> None:
             "chain_id": chain_id,
             "rpc": get_json_rpc_env(chain_id),
             "products": len(chain_products),
-            "priced_products": sum(product.estimated_nav_per_share is not None for product in chain_products),
+            "priced_products": sum(product.estimated_nav_per_share is not None or product.nav_source != "unconfigured" for product in chain_products),
         }
         for chain_id, chain_products in sorted(products_by_chain.items())
     ]

--- a/scripts/securitize/backfill-offchain-history.py
+++ b/scripts/securitize/backfill-offchain-history.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Backfill one Securitize fund's off-chain NAV and on-chain supply history.
+
+The script delegates to ``backfill-history.py`` so it preserves unrelated
+leads, reader state and Parquet rows. It selects ACRED for the RedStone path by
+default. Select STAC and provide Chronicle's signed history JSON export for the
+Chronicle path.
+
+Run RedStone ACRED with::
+
+    SECURITIZE_NAV_BACKFILL_SOURCE=redstone \\
+    source .local-test.env && poetry run python scripts/securitize/backfill-offchain-history.py
+
+Run Chronicle STAC with::
+
+    SECURITIZE_NAV_BACKFILL_SOURCE=chronicle \\
+    CHRONICLE_STAC_HISTORY_URL=https://... \\
+    source .local-test.env && poetry run python scripts/securitize/backfill-offchain-history.py
+
+``CHRONICLE_STAC_HISTORY_URL`` must be a signed Chronicle history export. The
+public dashboard does not currently document a stable machine-readable URL.
+"""
+
+import os
+import runpy
+from pathlib import Path
+
+
+def main() -> None:
+    """Select one reviewed off-chain source and invoke the scoped migration.
+
+    :return:
+        None.
+    :raise ValueError:
+        If the requested source is unsupported or lacks its required history
+        export URL.
+    """
+
+    source = os.environ.get("SECURITIZE_NAV_BACKFILL_SOURCE", "redstone").lower()
+    match source:
+        case "redstone":
+            os.environ.setdefault("SECURITIZE_PRODUCTS", "0x17418038ecf73ba4026c4f428547bf099706f27b")
+        case "chronicle":
+            if not os.environ.get("CHRONICLE_STAC_HISTORY_URL"):
+                message = "CHRONICLE_STAC_HISTORY_URL is required for a Chronicle STAC backfill"
+                raise ValueError(message)
+            os.environ.setdefault("SECURITIZE_PRODUCTS", "0x51c2d74017390cbbd30550179a16a1c28f7210fc")
+        case _:
+            message = "SECURITIZE_NAV_BACKFILL_SOURCE must be redstone or chronicle"
+            raise ValueError(message)
+
+    runpy.run_path(str(Path(__file__).with_name("backfill-history.py")), run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/securitize/backfill-offchain-history.py
+++ b/scripts/securitize/backfill-offchain-history.py
@@ -6,6 +6,9 @@ leads, reader state and Parquet rows. It selects ACRED for the RedStone path by
 default. Select STAC and provide Chronicle's signed history JSON export for the
 Chronicle path.
 
+The backfill always uses daily samples because Securitize fundamental NAVs are
+published at daily cadence. This avoids redundant hourly source queries.
+
 Run RedStone ACRED with::
 
     SECURITIZE_NAV_BACKFILL_SOURCE=redstone \\
@@ -37,6 +40,7 @@ def main() -> None:
     """
 
     source = os.environ.get("SECURITIZE_NAV_BACKFILL_SOURCE", "redstone").lower()
+    os.environ["FREQUENCY"] = "1d"
     match source:
         case "redstone":
             os.environ.setdefault("SECURITIZE_PRODUCTS", "0x17418038ecf73ba4026c4f428547bf099706f27b")

--- a/tests/securitize/test_securitize_offchain_prices.py
+++ b/tests/securitize/test_securitize_offchain_prices.py
@@ -1,0 +1,242 @@
+"""Test Securitize off-chain NAV parsing and in-memory historical enrichment."""
+
+import datetime
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from eth_defi.securitize import chronicle, redstone, share_price
+from eth_defi.securitize.description import ACRED_ETHEREUM, HLSCOPE_ETHEREUM, STAC_ETHEREUM, VBILL_ETHEREUM
+from eth_defi.securitize.share_price import SecuritizeSharePriceEnricher, SecuritizeSharePricePoint
+from eth_defi.securitize.vault import SECURITIZE_NAV_UNAVAILABLE_ERROR_PREFIX
+from eth_defi.vault.base import VaultHistoricalRead
+
+
+def utc_datetime(year: int, month: int, day: int, hour: int = 0) -> datetime.datetime:
+    """Create a naive UTC datetime accepted by the vault historical schema.
+
+    :param year:
+        Calendar year.
+    :param month:
+        Calendar month.
+    :param day:
+        Calendar day.
+    :param hour:
+        UTC hour.
+    :return:
+        Naive UTC datetime.
+    """
+
+    return datetime.datetime(year, month, day, hour, tzinfo=datetime.UTC).replace(tzinfo=None)
+
+
+class ResponseStub:
+    """Minimal successful HTTP response for public source-client tests."""
+
+    def __init__(self, payload: object):
+        """Create a response with a JSON payload.
+
+        :param payload:
+            Value returned from :meth:`json`.
+        """
+
+        self.payload = payload
+
+    def raise_for_status(self) -> None:
+        """Accept the response as successful."""
+
+    def json(self) -> object:
+        """Return the configured JSON payload.
+
+        :return:
+            Configured JSON object.
+        """
+
+        return self.payload
+
+
+def test_fetch_redstone_price_at_uses_point_in_time_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Read the latest RedStone observation at an explicit UTC checkpoint."""
+
+    calls: list[dict] = []
+
+    def fake_get(url: str, **kwargs: object) -> ResponseStub:
+        """Capture the request and return one signed feed observation."""
+
+        calls.append({"url": url, **kwargs})
+        return ResponseStub([{"timestamp": 1_735_689_600_000, "value": "1001.25"}])
+
+    monkeypatch.setattr(redstone.requests, "get", fake_get)
+    feed = redstone.REDSTONE_SECURITIZE_FEEDS[ACRED_ETHEREUM.chain_id, ACRED_ETHEREUM.token]
+    at = utc_datetime(2025, 1, 2)
+
+    point = redstone.fetch_redstone_price_at(feed, at, api_url="https://api.example")
+
+    assert point == redstone.RedstonePricePoint(utc_datetime(2025, 1, 1), Decimal("1001.25"))
+    assert calls == [
+        {
+            "url": "https://api.example",
+            "params": {
+                "symbol": "ACRED_FUNDAMENTAL",
+                "provider": "redstone",
+                "limit": 1,
+                "toTimestamp": 1_735_776_000_000,
+            },
+            "timeout": redstone.DEFAULT_REDSTONE_API_TIMEOUT,
+        }
+    ]
+
+
+def test_fetch_redstone_price_history_uses_daily_checkpoints_and_deduplicates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Query the anchor, daily checkpoints and end boundary once each."""
+
+    checkpoints: list[datetime.datetime] = []
+    feed = redstone.REDSTONE_SECURITIZE_FEEDS[ACRED_ETHEREUM.chain_id, ACRED_ETHEREUM.token]
+    first_point = redstone.RedstonePricePoint(utc_datetime(2025, 1, 1, 10), Decimal("1000"))
+    final_point = redstone.RedstonePricePoint(utc_datetime(2025, 1, 3, 9), Decimal("1001"))
+
+    def fake_fetch(_feed: redstone.RedstoneSecuritizeFeed, at: datetime.datetime, **_kwargs: object) -> redstone.RedstonePricePoint:
+        """Return duplicate publications around two source changes."""
+
+        checkpoints.append(at)
+        return first_point if at < utc_datetime(2025, 1, 3) else final_point
+
+    monkeypatch.setattr(redstone, "fetch_redstone_price_at", fake_fetch)
+
+    points = list(redstone.fetch_redstone_price_history(feed, utc_datetime(2025, 1, 1, 12), utc_datetime(2025, 1, 3, 18)))
+
+    assert points == [first_point, final_point]
+    assert checkpoints == [
+        utc_datetime(2025, 1, 1, 12),
+        utc_datetime(2025, 1, 2),
+        utc_datetime(2025, 1, 3),
+        utc_datetime(2025, 1, 3, 18),
+    ]
+
+
+def test_fetch_chronicle_price_history_parses_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Parse Chronicle signed NAV records without coupling to Parquet storage."""
+
+    def fake_get(_url: str, **_kwargs: object) -> ResponseStub:
+        """Return a representative dashboard-history export."""
+
+        return ResponseStub(
+            {
+                "data": [
+                    {"timestamp": 1_735_689_600, "nav": "1002.50", "totalValueLocked": "10025000"},
+                    {"timestamp": 1_735_776_000, "nav": "1003.00"},
+                ]
+            }
+        )
+
+    monkeypatch.setattr(chronicle.requests, "get", fake_get)
+    feed = chronicle.CHRONICLE_SECURITIZE_FEEDS[1, "0x51c2d74017390cbbd30550179a16a1c28f7210fc"]
+
+    points = list(chronicle.fetch_chronicle_price_history(feed, "https://chronicle.example/history"))
+
+    assert points == [
+        chronicle.ChroniclePricePoint(utc_datetime(2025, 1, 1), Decimal("1002.50"), Decimal("10025000")),
+        chronicle.ChroniclePricePoint(utc_datetime(2025, 1, 2), Decimal("1003.00"), None),
+    ]
+
+
+def test_securitize_share_price_enricher_updates_tvl_without_parquet_io() -> None:
+    """Join source NAV to the same historical total supply in memory."""
+
+    vault = SimpleNamespace(chain_id=1, address=ACRED_ETHEREUM.token)
+    read = VaultHistoricalRead(
+        vault=vault,
+        block_number=123,
+        timestamp=utc_datetime(2025, 1, 2, 12),
+        share_price=None,
+        total_assets=None,
+        total_supply=Decimal("200"),
+        performance_fee=None,
+        management_fee=None,
+        errors=["No on-chain NAV source configured for Securitize DSToken 0x17418038ecf73ba4026c4f428547bf099706f27b"],
+    )
+    enricher = SecuritizeSharePriceEnricher(
+        {
+            (1, ACRED_ETHEREUM.token): [
+                SecuritizeSharePricePoint(utc_datetime(2025, 1, 2), Decimal("1001.50")),
+            ]
+        }
+    )
+
+    enriched = enricher(read)
+
+    assert enriched is not read
+    assert enriched.share_price == Decimal("1001.50")
+    assert enriched.total_assets == Decimal("200300.00")
+    assert enriched.total_supply == Decimal("200")
+    assert enriched.errors is None
+
+
+def test_securitize_share_price_enricher_keeps_unavailable_nav_before_publication() -> None:
+    """Do not apply an NAV published after the historical supply read."""
+
+    vault = SimpleNamespace(chain_id=1, address=ACRED_ETHEREUM.token)
+    unavailable_nav_error = f"{SECURITIZE_NAV_UNAVAILABLE_ERROR_PREFIX} {ACRED_ETHEREUM.token}"
+    read = VaultHistoricalRead(
+        vault=vault,
+        block_number=123,
+        timestamp=utc_datetime(2025, 1, 1),
+        share_price=None,
+        total_assets=None,
+        total_supply=Decimal("200"),
+        performance_fee=None,
+        management_fee=None,
+        errors=[unavailable_nav_error],
+    )
+    enricher = SecuritizeSharePriceEnricher({(1, ACRED_ETHEREUM.token): [SecuritizeSharePricePoint(utc_datetime(2025, 1, 2), Decimal("1001.50"))]})
+
+    assert enricher(read) is read
+
+
+def test_configured_chronicle_source_can_enrich_without_redstone(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Support a Chronicle-only product and prefer it when it is configured."""
+
+    vault = SimpleNamespace(chain_id=STAC_ETHEREUM.chain_id, address=STAC_ETHEREUM.token)
+    web3 = SimpleNamespace(eth=SimpleNamespace(get_block=lambda _block: {"timestamp": 1_735_776_000}))
+    chronicle_point = chronicle.ChroniclePricePoint(utc_datetime(2025, 1, 2), Decimal("1002.50"), None)
+    monkeypatch.setenv("CHRONICLE_STAC_HISTORY_URL", "https://chronicle.example/history")
+    monkeypatch.setattr(share_price, "REDSTONE_SECURITIZE_FEEDS", {})
+    monkeypatch.setattr(share_price, "fetch_chronicle_price_history", lambda *_args: iter([chronicle_point]))
+
+    enricher = share_price.fetch_securitize_share_price_enricher([vault], web3, 1, 2)
+
+    assert enricher is not None
+    assert enricher.price_points[STAC_ETHEREUM.chain_id, STAC_ETHEREUM.token] == [SecuritizeSharePricePoint(utc_datetime(2025, 1, 2), Decimal("1002.50"))]
+
+
+def test_reviewed_redstone_products_have_matching_source_configuration() -> None:
+    """Keep product notes, metadata and the executable feed registry aligned."""
+
+    products = (ACRED_ETHEREUM, HLSCOPE_ETHEREUM, STAC_ETHEREUM, VBILL_ETHEREUM)
+
+    assert {product.nav_source for product in products} == {
+        "redstone_acred_fundamental",
+        "redstone_hlscope_fundamental",
+        "redstone_stac_fundamental",
+        "redstone_vbill_ethereum_fundamental",
+    }
+    assert {(product.chain_id, product.token) for product in products} == set(redstone.REDSTONE_SECURITIZE_FEEDS)
+
+
+def test_price_transformer_factory_preserves_parquet_when_provider_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Propagate provider failures before the historical scanner can rewrite data."""
+
+    vault = SimpleNamespace(chain_id=ACRED_ETHEREUM.chain_id, address=ACRED_ETHEREUM.token)
+    factory = share_price.create_securitize_share_price_transformer_factory([vault], SimpleNamespace())
+
+    def raise_provider_error(*_args: object, **_kwargs: object) -> None:
+        """Simulate an unavailable external NAV provider."""
+
+        message = "provider unavailable"
+        raise redstone.RedstoneAPIError(message)
+
+    monkeypatch.setattr(share_price, "fetch_securitize_share_price_enricher", raise_provider_error)
+
+    with pytest.raises(redstone.RedstoneAPIError, match="provider unavailable"):
+        factory(1, 2)

--- a/tests/securitize/test_securitize_vault.py
+++ b/tests/securitize/test_securitize_vault.py
@@ -177,6 +177,6 @@ def test_unpriced_dstoken_historical_reader_returns_error(web3: Web3) -> None:
     assert read.share_price is None
     assert read.total_assets is None
     assert read.total_supply == BUIDL_EXPECTED_TOTAL_SUPPLY
-    assert read.errors == [f"No NAV source configured for Securitize DSToken {vault.address}"]
+    assert read.errors == [f"No on-chain NAV source configured for Securitize DSToken {vault.address}"]
     assert read.deposits_open is False
     assert read.redemption_open is False


### PR DESCRIPTION
## Why

Securitize DSTokens expose historical share supply on-chain but do not provide a standard historical NAV method. This adds reviewed off-chain NAV sources so ACRED, VBILL, HLSCOPE and STAC can produce share-price and TVL histories without extra Parquet reads or writes.

## Lessons learnt

RedStone publishes the deployed Securitize fundamental feeds used here. Chronicle's public STAC Proof of Asset dashboard has no documented machine-readable history endpoint, so Chronicle ingestion requires an explicit signed JSON URL and takes precedence only when configured.

## Summary

- Add RedStone and Chronicle NAV source modules with reviewed DSToken feed registries.
- Integrate with the existing all-chain vault price scan through `scan_prices_for_chain()`: once its stateful block range is resolved, the Securitize transformer fetches only that range and enriches each historical DSToken supply read before the scanner's existing single Parquet write.
- Recompute TVL from the enriched NAV and the on-chain historical token supply; normal non-Securitize vault behaviour is unchanged.
- Preserve existing Parquet history by aborting before rewrite when an enabled provider fails.
- Add scoped daily RedStone and Chronicle backfill entry points, source-aware vault notes, API docs and regression coverage.

## Related issues and PRs

Continues the merged Securitize DSToken protocol and targeted-backfill work.

## Unrelated CI and test fixes

None.