### PR TITLE
feat: backfill all supported Asseto products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- feat: Backfill all supported Asseto products from its live registry using daily NAV history and skip chains without configured RPCs (2026-07-16)
 - feat: Add read-only Asseto vault protocol support, public product, fee and role extraction, curator metadata, and blocked deposit manager (2026-07-16)
 - feat: Add Securitize fund descriptions and curator attribution for selected DSTokens, including BCAP, COSX, SCI2 and PRTS (2026-07-16)
 - feat: Replace whole-chain vault lead resets with generated protocol-specific migrations and add the targeted Securitize DSToken backfill helper (2026-07-16)

--- a/eth_defi/asseto/constants.py
+++ b/eth_defi/asseto/constants.py
@@ -23,11 +23,13 @@ class AssetoProduct:
     :param token:
         ERC-20 tokenised fund share address.
     :param manager:
-        Asseto ``AoABTManager`` request/claim contract.
+        Asseto ``AoABTManager`` request/claim contract, when published.
     :param pricer:
-        Asseto ``Pricer`` contract that publishes NAV/share in base-18 USD.
+        Asseto ``Pricer`` contract that publishes NAV/share in base-18 USD,
+        when published.
     :param collateral:
-        Stablecoin used by the manager for subscriptions and redemptions.
+        Stablecoin used by the manager for subscriptions and redemptions, when
+        the product publishes it.
     :param first_seen_at_block:
         Token proxy deployment block.
     :param first_seen_at:
@@ -45,14 +47,20 @@ class AssetoProduct:
     token: HexAddress
     symbol: str
     product_name: str
-    manager: HexAddress
-    pricer: HexAddress
-    collateral: HexAddress
+    manager: HexAddress | None
+    pricer: HexAddress | None
+    collateral: HexAddress | None
     first_seen_at_block: int
     first_seen_at: datetime.datetime
     management_fee: Percent | None = None
     performance_fee: Percent | None = None
     has_custom_fees: bool = False
+    #: Asseto public product-registry identifier for its display NAV history.
+    offchain_product_id: int | None = None
+    #: Product key required by Asseto's off-chain product endpoints.
+    offchain_product_name: str | None = None
+    #: Informational public product description.
+    description: str | None = None
 
 
 #: HashKey Chain EVM chain id.

--- a/eth_defi/asseto/historical.py
+++ b/eth_defi/asseto/historical.py
@@ -49,11 +49,12 @@ class AssetoVaultHistoricalReader(VaultHistoricalReader):
             extra_data={"function": "totalSupply", "vault": self.vault.address},
             first_block_number=self.first_block,
         )
-        yield EncodedCall.from_contract_call(
-            self.vault.pricer_contract.functions.getLatestPrice(),
-            extra_data={"function": "getLatestPrice", "vault": self.vault.address},
-            first_block_number=self.first_block,
-        )
+        if self.vault.uses_onchain_pricer():
+            yield EncodedCall.from_contract_call(
+                self.vault.pricer_contract.functions.getLatestPrice(),
+                extra_data={"function": "getLatestPrice", "vault": self.vault.address},
+                first_block_number=self.first_block,
+            )
 
     def process_result(
         self,
@@ -89,6 +90,11 @@ class AssetoVaultHistoricalReader(VaultHistoricalReader):
             elif function == "getLatestPrice":
                 share_price = Decimal(convert_int256_bytes_to_int(result.result)) / Decimal(10**18)
                 state_result = result
+
+        if share_price is None and not self.vault.uses_onchain_pricer():
+            share_price = self.vault.fetch_offchain_share_price(timestamp)
+            if share_price is None:
+                errors.append("Asseto off-chain price history is not available for this timestamp")
 
         total_assets = share_price * total_supply if share_price is not None and total_supply is not None else None
         if self.reader_state is not None and state_result is not None and total_assets is not None:

--- a/eth_defi/asseto/vault.py
+++ b/eth_defi/asseto/vault.py
@@ -8,7 +8,9 @@ not ERC-4626 or ERC-7540, but can be read through :class:`VaultBase`.
 #: Adapter classes intentionally mirror :class:`VaultBase` method signatures.
 # ruff: noqa: ARG002, FBT001, FBT002, PLR0904, PLR0917, PLR6301
 
+import datetime
 import logging
+from bisect import bisect_right
 from collections.abc import Iterator
 from decimal import Decimal
 
@@ -19,7 +21,7 @@ from web3.contract import Contract
 
 from eth_defi.asseto.constants import ASSETO_PRODUCTS, AssetoProduct
 from eth_defi.asseto.historical import AssetoVaultHistoricalReader
-from eth_defi.asseto.offchain_api import AssetoAPIError, AssetoRoleInfo, fetch_asseto_product_roles
+from eth_defi.asseto.offchain_api import AssetoAPIError, AssetoPricePoint, AssetoRoleInfo, fetch_asseto_price_history, fetch_asseto_product_roles
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.token import TokenDetails, fetch_erc20_details
 from eth_defi.types import Percent
@@ -108,13 +110,13 @@ class AssetoVaultInfo(VaultInfo, total=False):
     chain_id: int
 
     #: Asseto request/claim manager contract.
-    manager: HexAddress
+    manager: HexAddress | None
 
     #: Asseto NAV/share price contract.
-    pricer: HexAddress
+    pricer: HexAddress | None
 
     #: Subscription and redemption collateral token.
-    collateral: HexAddress
+    collateral: HexAddress | None
 
     #: NAV source label.
     nav_source: str
@@ -166,6 +168,8 @@ class AssetoVault(VaultBase):
             self.product: AssetoProduct = ASSETO_PRODUCTS[key]
         except KeyError as error:
             raise RuntimeError(f"Unsupported Asseto product: chain={spec.chain_id}, token={spec.vault_address}") from error
+        self._offchain_price_history: tuple[AssetoPricePoint, ...] | None = None
+        self._offchain_price_timestamps: tuple[int, ...] | None = None
 
     @property
     def chain_id(self) -> int:
@@ -189,12 +193,16 @@ class AssetoVault(VaultBase):
     def pricer_contract(self) -> Contract:
         """Return the Asseto NAV/share pricer contract."""
 
+        if self.product.pricer is None:
+            raise RuntimeError(f"Asseto product {self.product.symbol} has no published on-chain pricer")
         return self.web3.eth.contract(address=Web3.to_checksum_address(self.product.pricer), abi=ASSETO_PRICER_ABI)
 
     @property
     def manager_contract(self) -> Contract:
         """Return the Asseto request/claim manager fee contract."""
 
+        if self.product.manager is None:
+            raise RuntimeError(f"Asseto product {self.product.symbol} has no published manager contract")
         return self.web3.eth.contract(address=Web3.to_checksum_address(self.product.manager), abi=ASSETO_MANAGER_FEE_ABI)
 
     @property
@@ -213,13 +221,13 @@ class AssetoVault(VaultBase):
     def description(self) -> str | None:
         """Return a short Asseto product description."""
 
-        return "Tokenised fund share backed by Asseto Orient Arbitrage strategy exposure"
+        return self.product.description or "Tokenised fund share published through Asseto"
 
     @property
     def short_description(self) -> str | None:
         """Return the concise product description used in vault listings."""
 
-        return "KYC-gated tokenised fund share with on-chain NAV pricing"
+        return "KYC-gated tokenised fund share with Asseto-published NAV"
 
     @property
     def manager_name(self) -> str | None:
@@ -231,6 +239,12 @@ class AssetoVault(VaultBase):
         and optional API failures yield ``None`` rather than attributing the
         Asseto technology provider as the strategy curator.
         """
+
+        if self.product.offchain_product_id is not None:
+            # The registry endpoint already exposes these products, but its
+            # detail endpoint does not consistently accept the registry key.
+            # Do not turn metadata scans into noisy failed role requests.
+            return None
 
         try:
             return self.fetch_curator_name()
@@ -254,7 +268,7 @@ class AssetoVault(VaultBase):
             If the public application request fails.
         """
 
-        yield from fetch_asseto_product_roles(self.product.symbol)
+        yield from fetch_asseto_product_roles(self.product.offchain_product_name or self.product.symbol)
 
     def fetch_curator_name(self) -> str | None:
         """Resolve the strategy curator from Asseto's priority partner roles.
@@ -311,14 +325,19 @@ class AssetoVault(VaultBase):
             USDT collateral address for the registered Asseto product.
         """
 
+        if self.product.collateral is None:
+            raise NotImplementedError(f"Asseto product {self.product.symbol} does not publish a collateral token")
         return HexAddress(Web3.to_checksum_address(self.product.collateral))
 
-    def fetch_denomination_token(self) -> TokenDetails:
+    def fetch_denomination_token(self) -> TokenDetails | None:
         """Fetch Asseto's collateral token metadata.
 
         :return:
             Product collateral token details.
         """
+
+        if self.product.collateral is None:
+            return None
 
         return fetch_erc20_details(
             self.web3,
@@ -329,17 +348,72 @@ class AssetoVault(VaultBase):
             cause_diagnostics_message=f"Asseto collateral token for vault {self.address}",
         )
 
-    def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
+    def uses_onchain_pricer(self) -> bool:
+        """Return whether the product has a verified on-chain NAV contract.
+
+        :return:
+            ``True`` for products with an Asseto ``Pricer`` contract.
+        """
+
+        return self.product.pricer is not None
+
+    def fetch_offchain_price_history(self) -> tuple[AssetoPricePoint, ...]:
+        """Fetch and cache Asseto's public daily NAV/share history.
+
+        Registry products without a published on-chain ``Pricer`` use this
+        informational source for their historical backfill. The cache avoids
+        making a network request for every historical scanner row.
+
+        :return:
+            Chronologically ordered Asseto display-price observations.
+        :raise RuntimeError:
+            If this product has no public Asseto registry identifier.
+        """
+
+        if self.product.offchain_product_id is None:
+            raise RuntimeError(f"Asseto product {self.product.symbol} has no off-chain price source")
+        if self._offchain_price_history is None:
+            self._offchain_price_history = tuple(sorted(fetch_asseto_price_history(self.product.offchain_product_id), key=lambda point: point.timestamp))
+            self._offchain_price_timestamps = tuple(point.timestamp for point in self._offchain_price_history)
+        return self._offchain_price_history
+
+    def fetch_offchain_share_price(self, timestamp: datetime.datetime) -> Decimal | None:
+        """Look up the latest published display NAV at a historical timestamp.
+
+        Asseto publishes daily observations, while the shared scanner samples
+        at approximate chain blocks. Use the most recent observation at or
+        before the sample timestamp and return ``None`` before history starts.
+
+        :param timestamp:
+            Naive UTC scanner timestamp.
+        :return:
+            Asseto display NAV/share, or ``None`` when unavailable.
+        """
+
+        history = self.fetch_offchain_price_history()
+        assert self._offchain_price_timestamps is not None
+        target = int(timestamp.replace(tzinfo=datetime.UTC).timestamp())
+        index = bisect_right(self._offchain_price_timestamps, target) - 1
+        return history[index].value if index >= 0 else None
+
+    def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal | None:
         """Fetch the latest Asseto NAV/share in collateral denomination.
 
         :param block_identifier:
             Historical or latest block identifier.
         :return:
-            NAV for one human-readable AoABT token.
+            NAV for one human-readable token, or ``None`` when Asseto has not
+            published a display-price observation.
         """
 
-        raw_price = self.pricer_contract.functions.getLatestPrice().call(block_identifier=block_identifier)
-        return Decimal(raw_price) / Decimal(10**18)
+        if self.uses_onchain_pricer():
+            raw_price = self.pricer_contract.functions.getLatestPrice().call(block_identifier=block_identifier)
+            return Decimal(raw_price) / Decimal(10**18)
+
+        history = self.fetch_offchain_price_history()
+        if not history:
+            return None
+        return history[-1].value
 
     def fetch_total_supply(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
         """Fetch the outstanding AoABT share supply.
@@ -353,7 +427,7 @@ class AssetoVault(VaultBase):
         raw_supply = self.share_token.contract.functions.totalSupply().call(block_identifier=block_identifier)
         return self.share_token.convert_to_decimals(raw_supply)
 
-    def fetch_total_assets(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
+    def fetch_total_assets(self, block_identifier: BlockIdentifier = "latest") -> Decimal | None:
         """Calculate TVL from AoABT supply and the administrator-published NAV.
 
         :param block_identifier:
@@ -362,9 +436,10 @@ class AssetoVault(VaultBase):
             Total assets in collateral denomination.
         """
 
-        return self.fetch_total_supply(block_identifier) * self.fetch_share_price(block_identifier)
+        share_price = self.fetch_share_price(block_identifier)
+        return self.fetch_total_supply(block_identifier) * share_price if share_price is not None else None
 
-    def fetch_nav(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
+    def fetch_nav(self, block_identifier: BlockIdentifier = "latest") -> Decimal | None:
         """Fetch Asseto product NAV.
 
         :param block_identifier:
@@ -385,10 +460,10 @@ class AssetoVault(VaultBase):
         return AssetoVaultInfo(
             token=self.address,
             chain_id=self.chain_id,
-            manager=Web3.to_checksum_address(self.product.manager),
-            pricer=Web3.to_checksum_address(self.product.pricer),
-            collateral=self.fetch_denomination_token_address(),
-            nav_source=ASSETO_NAV_SOURCE,
+            manager=Web3.to_checksum_address(self.product.manager) if self.product.manager else None,
+            pricer=Web3.to_checksum_address(self.product.pricer) if self.product.pricer else None,
+            collateral=self.fetch_denomination_token_address() if self.product.collateral else None,
+            nav_source=ASSETO_NAV_SOURCE if self.uses_onchain_pricer() else "asseto_offchain_price_history",
         )
 
     def fetch_scan_record_extra_data(self) -> dict[str, object]:
@@ -399,15 +474,15 @@ class AssetoVault(VaultBase):
         """
 
         return {
-            "Denomination": self.denomination_token.symbol,
+            "Denomination": self.denomination_token.symbol if self.denomination_token else None,
             "_notes": self.get_notes(),
             "_deposit_closed_reason": self.fetch_deposit_closed_reason(),
             "_redemption_closed_reason": self.fetch_redemption_closed_reason(),
-            "_nav_source": ASSETO_NAV_SOURCE,
-            "_nav_estimated": False,
-            "_asseto_manager": Web3.to_checksum_address(self.product.manager),
-            "_asseto_pricer": Web3.to_checksum_address(self.product.pricer),
-            "_asseto_collateral": self.fetch_denomination_token_address(),
+            "_nav_source": ASSETO_NAV_SOURCE if self.uses_onchain_pricer() else "asseto_offchain_price_history",
+            "_nav_estimated": not self.uses_onchain_pricer(),
+            "_asseto_manager": Web3.to_checksum_address(self.product.manager) if self.product.manager else None,
+            "_asseto_pricer": Web3.to_checksum_address(self.product.pricer) if self.product.pricer else None,
+            "_asseto_collateral": self.fetch_denomination_token_address() if self.product.collateral else None,
         }
 
     def fetch_portfolio(
@@ -546,7 +621,7 @@ class AssetoVault(VaultBase):
 
         return self.product.performance_fee
 
-    def get_deposit_fee(self, block_identifier: BlockIdentifier) -> Percent:
+    def get_deposit_fee(self, block_identifier: BlockIdentifier) -> Percent | None:
         """Read the current entry fee from the manager's ``mintFee``.
 
         ``AoABTManager`` deducts this fee from subscribed collateral before the
@@ -558,12 +633,14 @@ class AssetoVault(VaultBase):
             Entry/deposit fee as a fraction.
         """
 
+        if self.product.manager is None:
+            return None
         manager = self.manager_contract.functions
         raw_fee = manager.mintFee().call(block_identifier=block_identifier)
         denominator = manager.BPS_DENOMINATOR().call(block_identifier=block_identifier)
         return convert_asseto_basis_points_to_percent(raw_fee, denominator)
 
-    def get_withdraw_fee(self, block_identifier: BlockIdentifier) -> Percent:
+    def get_withdraw_fee(self, block_identifier: BlockIdentifier) -> Percent | None:
         """Read the current exit fee from the manager's ``redemptionFee``.
 
         ``AoABTManager`` deducts this fee from collateral after calculating the
@@ -575,6 +652,8 @@ class AssetoVault(VaultBase):
             Exit/withdraw fee as a fraction.
         """
 
+        if self.product.manager is None:
+            return None
         manager = self.manager_contract.functions
         raw_fee = manager.redemptionFee().call(block_identifier=block_identifier)
         denominator = manager.BPS_DENOMINATOR().call(block_identifier=block_identifier)

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -1162,7 +1162,7 @@ def identify_vault_features(
     # Securitize DSTokens deliberately extend ERC-20, but do not implement
     # ERC-4626's convertToShares(). Detect them before the generic ERC-4626
     # failure branch below.
-    if calls["COMPLIANCE_SERVICE"].success:
+    if (compliance_service := calls.get("COMPLIANCE_SERVICE")) and compliance_service.success:
         return {ERC4626Feature.securitize_like}
 
     if calls["assetsWhitelistAddress"].success:

--- a/eth_defi/maseer_one/vault.py
+++ b/eth_defi/maseer_one/vault.py
@@ -548,7 +548,7 @@ class MaseerOneVault(VaultBase):
         if raw_nav == 0:
             return None
         raw_mint_cost = self.maseer_contract.functions.mintcost().call(block_identifier=block_identifier)
-        return Decimal(raw_mint_cost - raw_nav) / Decimal(raw_nav)
+        return float(Decimal(raw_mint_cost - raw_nav) / Decimal(raw_nav))
 
     def get_withdraw_fee(self, block_identifier: BlockIdentifier) -> Percent | None:
         """Calculate the redemption spread below NAV/share.
@@ -563,7 +563,7 @@ class MaseerOneVault(VaultBase):
         if raw_nav == 0:
             return None
         raw_burn_cost = self.maseer_contract.functions.burncost().call(block_identifier=block_identifier)
-        return Decimal(raw_nav - raw_burn_cost) / Decimal(raw_nav)
+        return float(Decimal(raw_nav - raw_burn_cost) / Decimal(raw_nav))
 
     def get_link(self, referral: str | None = None) -> str:
         """Return the Maseer One product documentation link.

--- a/scripts/asseto/backfill-history.py
+++ b/scripts/asseto/backfill-history.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Backfill historical Asseto vault data into the shared vault pipeline.
 
-This is a targeted production tool for Asseto products registered in
-:data:`eth_defi.asseto.constants.ASSETO_PRODUCTS`. It does not rediscover the
-whole HashKey Chain and updates only the selected Asseto vault identifiers.
-The historical scan reads ERC-20 supply and Asseto's ``Pricer`` NAV/share,
-then calculates TVL as ``totalSupply * getLatestPrice``.
+This is a targeted production tool for the EVM products currently published by
+Asseto's public product registry. It does not rediscover whole chains and
+updates only the selected Asseto vault identifiers. Historical rows combine
+on-chain ERC-20 supply with Asseto's verified ``Pricer`` NAV/share where
+available, or its public daily display-NAV history for other products.
 
 Usage:
 
@@ -39,7 +39,7 @@ Useful environment variables:
    * - ``MAX_WORKERS``
      - Historical multicall worker count. Default: ``8``.
    * - ``FREQUENCY``
-     - Historical price frequency, ``1h`` or ``1d``. Default: ``1d``.
+     - Historical price frequency. Asseto supports daily ``1d`` samples only.
    * - ``START_BLOCK`` / ``END_BLOCK``
      - Optional global scan range overrides.
    * - ``VAULT_DB_PATH`` / ``UNCLEANED_PRICE_DATABASE``
@@ -55,6 +55,7 @@ HyperSync are included. Asseto products on unsupported chains, such as HashKey
 or Pharos until they are added to the project, are reported and skipped.
 """
 
+import datetime
 import logging
 import os
 import pickle  # noqa: S403 - trusted local production reader-state pickle.
@@ -66,8 +67,10 @@ from typing import Literal, cast
 from atomicwrites import atomic_write
 from eth_typing import HexAddress
 from tabulate import tabulate
+from web3 import Web3
 
 from eth_defi.asseto.constants import ASSETO_PRODUCTS, AssetoProduct
+from eth_defi.asseto.offchain_api import AssetoOffchainProduct, fetch_asseto_products
 from eth_defi.chain import CHAIN_NAMES, get_chain_name
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.erc_4626.classification import create_vault_instance
@@ -146,18 +149,22 @@ def parse_path_env(name: str, default: Path) -> Path:
 
 
 def resolve_frequency() -> Literal["1h", "1d"]:
-    """Resolve the historical sampling frequency once for plan and scanner.
+    """Resolve the daily historical sampling frequency for Asseto.
+
+    Asseto's public NAV history contains daily observations. The scanner must
+    therefore not generate artificial hourly rows by carrying a daily value
+    forward between price publications.
 
     :return:
-        Daily sampling by default, or the explicit supported override.
+        The required daily sampling interval.
     :raise ValueError:
-        If ``FREQUENCY`` is not supported by the historical reader.
+        If an hourly or other unsupported frequency is requested.
     """
 
     frequency = os.environ.get("FREQUENCY", "1d")
-    if frequency not in {"1h", "1d"}:
-        raise ValueError(f"Unsupported FREQUENCY: {frequency}")
-    return cast(Literal["1h", "1d"], frequency)
+    if frequency != "1d":
+        raise ValueError(f"Asseto backfill supports only daily FREQUENCY=1d, got: {frequency}")
+    return cast(Literal["1h", "1d"], "1d")
 
 
 def get_chain_selector_names(chain_id: int) -> set[str]:
@@ -212,37 +219,36 @@ def read_asseto_json_rpc_url(chain_id: int) -> str:
     return read_json_rpc_url(chain_id)
 
 
-def iter_selected_products() -> Iterable[AssetoProduct]:
-    """Iterate adapter-supported Asseto products filtered by environment.
+def iter_selected_products() -> Iterable[AssetoOffchainProduct]:
+    """Iterate current eligible Asseto registry products filtered by environment.
 
     :return:
-        Unique product metadata records selected by ``NETWORKS`` and
-        ``PRODUCTS``.
+        Unique registry products on supported chains with configured RPC URLs.
     """
 
     networks = parse_csv_env("NETWORKS")
     products = parse_csv_env("PRODUCTS")
     seen: set[tuple[int, HexAddress]] = set()
-    for product in ASSETO_PRODUCTS.values():
-        key = (product.chain_id, product.token)
+    for product in fetch_asseto_products():
+        key = (product.chain_id, product.contract_address)
         if key in seen:
             continue
         seen.add(key)
         if networks and not (get_chain_selector_names(product.chain_id) & networks):
             continue
-        if products and product.symbol.lower() not in products:
+        if products and (product.symbol or product.product_name).lower() not in products:
             continue
         if product.chain_id not in CHAIN_NAMES:
             logger.warning(
                 "Skipping Asseto product %s on unsupported chain %d: chain is not configured in eth_defi.chain",
-                product.symbol,
+                product.symbol or product.product_name,
                 product.chain_id,
             )
             continue
         if not is_hypersync_supported_chain(product.chain_id):
             logger.warning(
                 "Skipping Asseto product %s on chain %d: HyperSync is not supported",
-                product.symbol,
+                product.symbol or product.product_name,
                 product.chain_id,
             )
             continue
@@ -250,7 +256,7 @@ def iter_selected_products() -> Iterable[AssetoProduct]:
         if not os.environ.get(rpc_env_var):
             logger.warning(
                 "Skipping Asseto product %s on chain %d: %s is not set",
-                product.symbol,
+                product.symbol or product.product_name,
                 product.chain_id,
                 rpc_env_var,
             )
@@ -389,7 +395,7 @@ def write_reader_states(path: Path, states: dict[VaultSpec, dict]) -> None:
         pickle.dump(states, out)
 
 
-def build_vaults(web3, products: list[AssetoProduct], token_cache: TokenDiskCache) -> list[VaultBase]:
+def build_vaults(web3: Web3, products: list[AssetoProduct], token_cache: TokenDiskCache) -> list[VaultBase]:
     """Build Asseto vault adapters and attach deployment block hints.
 
     :param web3:
@@ -412,14 +418,85 @@ def build_vaults(web3, products: list[AssetoProduct], token_cache: TokenDiskCach
         )
         if vault is None:
             raise RuntimeError(f"Could not create Asseto vault adapter for {product.symbol} {product.token}")
+        if not vault.uses_onchain_pricer() and not vault.fetch_offchain_price_history():
+            logger.warning("Skipping price history for Asseto product %s: Asseto API returned no prices", product.symbol)
+            continue
         vault.first_seen_at_block = product.first_seen_at_block
         vaults.append(vault)
     return vaults
 
 
-def backfill_chain(
+def fetch_contract_deployment_block(web3: Web3, address: HexAddress, end_block: int) -> int:
+    """Find the first block containing runtime code for an Asseto token.
+
+    :param web3:
+        Archive-capable connection for the product chain.
+    :param address:
+        Asseto ERC-20 token address.
+    :param end_block:
+        Highest block that may be checked.
+    :return:
+        First block containing contract code.
+    :raise ValueError:
+        If the public registry address has no contract code on this chain.
+    """
+
+    address = Web3.to_checksum_address(address)
+    if not web3.eth.get_code(address, block_identifier=end_block):
+        raise ValueError(f"No contract code for Asseto product {address} at block {end_block}")
+
+    low = 0
+    high = end_block
+    while low < high:
+        middle = (low + high) // 2
+        if web3.eth.get_code(address, block_identifier=middle):
+            high = middle
+        else:
+            low = middle + 1
+    return low
+
+
+def create_runtime_product(
+    product: AssetoOffchainProduct,
+    deployment_block: int,
+    first_seen_at: datetime.datetime,
+) -> AssetoProduct:
+    """Convert one public registry entry to a temporary scanner product.
+
+    Public registry products do not all expose Asseto's request/claim manager
+    and ``Pricer`` contracts. The generic adapter therefore uses their
+    published daily NAV history, while preserving the exact token identity and
+    deployment information read from the configured archive RPC.
+
+    :param product:
+        Asseto public EVM product entry.
+    :param deployment_block:
+        First token-code block found on-chain.
+    :param first_seen_at:
+        Naive UTC deployment timestamp.
+    :return:
+        Runtime Asseto adapter product metadata.
+    """
+
+    return AssetoProduct(
+        chain_id=product.chain_id,
+        token=product.contract_address,
+        symbol=product.symbol or product.product_name,
+        product_name=product.full_name or product.product_name,
+        manager=None,
+        pricer=None,
+        collateral=product.denomination_address,
+        first_seen_at_block=deployment_block,
+        first_seen_at=first_seen_at,
+        offchain_product_id=product.product_id,
+        offchain_product_name=product.product_name,
+        description=product.introduction,
+    )
+
+
+def backfill_chain(  # noqa: PLR0914 - explicit production pipeline state keeps the write path auditable.
     chain_id: int,
-    products: list[AssetoProduct],
+    products: list[AssetoOffchainProduct],
     *,
     dry_run: bool,
     scan_prices: bool,
@@ -473,7 +550,16 @@ def backfill_chain(
     logger.info("Backfilling %d Asseto products on %s using %s", len(products), chain_name, get_provider_name(web3.provider))
 
     end_block = parse_optional_int_env("END_BLOCK") or web3.eth.block_number
-    leads = {product.token: create_asseto_lead(product) for product in products}
+    runtime_products: list[AssetoProduct] = []
+    for product in products:
+        deployment_block = fetch_contract_deployment_block(web3, product.contract_address, end_block)
+        timestamp = web3.eth.get_block(deployment_block)["timestamp"]
+        first_seen_at = datetime.datetime.fromtimestamp(timestamp, tz=datetime.UTC).replace(tzinfo=None)
+        runtime_product = create_runtime_product(product, deployment_block, first_seen_at)
+        ASSETO_PRODUCTS[runtime_product.chain_id, runtime_product.token] = runtime_product
+        runtime_products.append(runtime_product)
+
+    leads = {product.token: create_asseto_lead(product) for product in runtime_products}
     rows = {
         VaultSpec(product.chain_id, product.token): create_vault_scan_record(
             web3,
@@ -481,7 +567,7 @@ def backfill_chain(
             block_identifier=end_block,
             token_cache=token_cache,
         )
-        for product in products
+        for product in runtime_products
     }
 
     if not dry_run:
@@ -496,10 +582,12 @@ def backfill_chain(
 
     scan_summary = "-"
     if scan_prices:
-        vault_ids = {product.token.lower() for product in products}
+        vaults = build_vaults(web3, runtime_products, token_cache)
+        vault_ids = {vault.address.lower() for vault in vaults}
+        scanned_products = [product for product in runtime_products if product.token.lower() in vault_ids]
         if dry_run:
-            scan_summary = "dry-run"
-        else:
+            scan_summary = f"dry-run ({len(scanned_products)} products with price history)"
+        elif vaults:
             reader_states = read_reader_states(reader_state_database_path)
             reader_states = {spec: state for spec, state in reader_states.items() if spec.vault_address.lower() not in vault_ids}
             web3factory = MultiProviderWeb3Factory(json_rpc_url, retries=5)
@@ -507,8 +595,8 @@ def backfill_chain(
                 output_fname=price_database_path,
                 web3=web3,
                 web3factory=web3factory,
-                vaults=build_vaults(web3, products, token_cache),
-                start_block=resolve_price_scan_start_block(products),
+                vaults=vaults,
+                start_block=resolve_price_scan_start_block(scanned_products),
                 end_block=end_block,
                 max_workers=int(os.environ.get("MAX_WORKERS", "8")),
                 chunk_size=32,
@@ -522,7 +610,7 @@ def backfill_chain(
             scan_summary = pformat_scan_result(scan_result)
             if clean_prices:
                 cleaned_rows = replace_cleaned_vault_histories(
-                    {VaultSpec(product.chain_id, product.token).as_string_id() for product in products},
+                    {VaultSpec(product.chain_id, product.token).as_string_id() for product in scanned_products},
                     vault_db_path=vault_db_path,
                     raw_price_df_path=price_database_path,
                     cleaned_price_df_path=cleaned_price_database_path,
@@ -534,7 +622,7 @@ def backfill_chain(
         "chain": chain_name,
         "chain_id": chain_id,
         "rpc": rpc_env_var,
-        "products": ", ".join(product.symbol for product in products),
+        "products": ", ".join(product.symbol or product.product_name for product in products),
         "metadata_rows": len(rows),
         "scan": scan_summary,
     }
@@ -560,7 +648,7 @@ def main() -> None:
     price_database_path = parse_path_env("UNCLEANED_PRICE_DATABASE", DEFAULT_UNCLEANED_PRICE_DATABASE)
     cleaned_price_database_path = parse_path_env("CLEANED_PRICE_DATABASE", DEFAULT_RAW_PRICE_DATABASE)
     reader_state_database_path = parse_path_env("READER_STATE_DATABASE", DEFAULT_READER_STATE_DATABASE)
-    products_by_chain: dict[int, list[AssetoProduct]] = {}
+    products_by_chain: dict[int, list[AssetoOffchainProduct]] = {}
     for product in products:
         products_by_chain.setdefault(product.chain_id, []).append(product)
 
@@ -569,8 +657,7 @@ def main() -> None:
             "chain": get_chain_name(chain_id),
             "chain_id": chain_id,
             "rpc": get_asseto_rpc_env(chain_id),
-            "products": ", ".join(product.symbol for product in chain_products),
-            "first_block": min(product.first_seen_at_block for product in chain_products),
+            "products": ", ".join(product.symbol or product.product_name for product in chain_products),
         }
         for chain_id, chain_products in sorted(products_by_chain.items())
     ]

--- a/tests/asseto/test_asseto_backfill_history.py
+++ b/tests/asseto/test_asseto_backfill_history.py
@@ -1,17 +1,46 @@
 """Regression tests for the Asseto historical backfill script helpers."""
 
 import importlib.util
-from dataclasses import replace
 from pathlib import Path
 
 import pandas as pd
 import pytest
 
 from eth_defi.asseto.constants import ASSETO_AOABT_HASHKEY
+from eth_defi.asseto.offchain_api import AssetoOffchainProduct
 from eth_defi.chain import CHAIN_NAMES
 from eth_defi.event_reader.timestamp_cache import BlockTimestampDatabase
 
 EXPLICIT_START_BLOCK = 123_456
+
+
+def make_registry_product(chain_id: int, *, symbol: str = "AoABT") -> AssetoOffchainProduct:
+    """Create one representative public Asseto registry product.
+
+    :param chain_id:
+        EVM chain containing the mocked token.
+    :param symbol:
+        Product symbol used by filtering tests.
+    :return:
+        Public registry product fixture.
+    """
+
+    return AssetoOffchainProduct(
+        product_id=2,
+        product_name="AoABT",
+        full_name="Asseto test product",
+        symbol=symbol,
+        product_type="uda",
+        chain_id=chain_id,
+        chain_name="Ethereum" if chain_id == 1 else "HashKey Chain",
+        contract_address=ASSETO_AOABT_HASHKEY.token,
+        denomination_symbol="USDT",
+        denomination_address=ASSETO_AOABT_HASHKEY.collateral,
+        tvl=None,
+        apy=None,
+        introduction="Test Asseto product",
+        protocol=None,
+    )
 
 
 @pytest.fixture
@@ -27,19 +56,20 @@ def backfill_history_module():
     return module
 
 
-def test_unsupported_asseto_chain_is_excluded_from_backfill(backfill_history_module) -> None:
+def test_unsupported_asseto_chain_is_excluded_from_backfill(monkeypatch: pytest.MonkeyPatch, backfill_history_module) -> None:
     """Exclude HashKey until it is supported by project and HyperSync mappings."""
 
     assert ASSETO_AOABT_HASHKEY.chain_id not in CHAIN_NAMES
     assert not backfill_history_module.is_supported_asseto_chain(ASSETO_AOABT_HASHKEY.chain_id)
+    monkeypatch.setattr(backfill_history_module, "fetch_asseto_products", lambda: iter([make_registry_product(177)]))
     assert list(backfill_history_module.iter_selected_products()) == []
 
 
 def test_supported_asseto_chain_uses_standard_rpc_configuration(monkeypatch: pytest.MonkeyPatch, backfill_history_module) -> None:
     """Select a registered HyperSync chain with its normal RPC environment variable."""
 
-    ethereum_product = replace(ASSETO_AOABT_HASHKEY, chain_id=1)
-    monkeypatch.setattr(backfill_history_module, "ASSETO_PRODUCTS", {(1, ethereum_product.token): ethereum_product})
+    ethereum_product = make_registry_product(1)
+    monkeypatch.setattr(backfill_history_module, "fetch_asseto_products", lambda: iter([ethereum_product]))
     monkeypatch.setenv("JSON_RPC_ETHEREUM", "https://ethereum-rpc.example")
 
     assert backfill_history_module.get_asseto_rpc_env(ethereum_product.chain_id) == "JSON_RPC_ETHEREUM"
@@ -49,11 +79,26 @@ def test_supported_asseto_chain_uses_standard_rpc_configuration(monkeypatch: pyt
 def test_missing_rpc_excludes_supported_asseto_chain(monkeypatch: pytest.MonkeyPatch, backfill_history_module) -> None:
     """Avoid partial backfills when the normal RPC variable is unset."""
 
-    ethereum_product = replace(ASSETO_AOABT_HASHKEY, chain_id=1)
-    monkeypatch.setattr(backfill_history_module, "ASSETO_PRODUCTS", {(1, ethereum_product.token): ethereum_product})
+    ethereum_product = make_registry_product(1)
+    monkeypatch.setattr(backfill_history_module, "fetch_asseto_products", lambda: iter([ethereum_product]))
     monkeypatch.delenv("JSON_RPC_ETHEREUM", raising=False)
 
     assert list(backfill_history_module.iter_selected_products()) == []
+
+
+def test_create_runtime_product_uses_registry_price_source(backfill_history_module) -> None:
+    """Keep the registry id that drives non-pricer historical NAV reads."""
+
+    registry_product = make_registry_product(1)
+    first_seen_at = ASSETO_AOABT_HASHKEY.first_seen_at
+
+    runtime_product = backfill_history_module.create_runtime_product(registry_product, EXPLICIT_START_BLOCK, first_seen_at)
+
+    assert runtime_product.token == registry_product.contract_address
+    assert runtime_product.offchain_product_id == registry_product.product_id
+    assert runtime_product.offchain_product_name == registry_product.product_name
+    assert runtime_product.manager is None
+    assert runtime_product.pricer is None
 
 
 def test_resolve_price_scan_start_block_uses_asseto_deployment(
@@ -104,8 +149,8 @@ def test_resolve_price_scan_start_block_honours_explicit_override(
 def test_iter_selected_products_honours_symbol_filter(monkeypatch: pytest.MonkeyPatch, backfill_history_module) -> None:
     """Select a requested product when its chain meets all backfill requirements."""
 
-    ethereum_product = replace(ASSETO_AOABT_HASHKEY, chain_id=1)
-    monkeypatch.setattr(backfill_history_module, "ASSETO_PRODUCTS", {(1, ethereum_product.token): ethereum_product})
+    ethereum_product = make_registry_product(1)
+    monkeypatch.setattr(backfill_history_module, "fetch_asseto_products", lambda: iter([ethereum_product]))
     monkeypatch.setenv("PRODUCTS", "aoabt")
     monkeypatch.setenv("NETWORKS", "ethereum")
     monkeypatch.setenv("JSON_RPC_ETHEREUM", "https://ethereum-rpc.example")
@@ -119,3 +164,12 @@ def test_resolve_frequency_defaults_to_daily(monkeypatch: pytest.MonkeyPatch, ba
     monkeypatch.delenv("FREQUENCY", raising=False)
 
     assert backfill_history_module.resolve_frequency() == "1d"
+
+
+def test_resolve_frequency_rejects_hourly_sampling(monkeypatch: pytest.MonkeyPatch, backfill_history_module) -> None:
+    """Prevent hourly rows from being manufactured from daily Asseto NAV data."""
+
+    monkeypatch.setenv("FREQUENCY", "1h")
+
+    with pytest.raises(ValueError, match="only daily"):
+        backfill_history_module.resolve_frequency()

--- a/tests/asseto/test_asseto_vault.py
+++ b/tests/asseto/test_asseto_vault.py
@@ -68,6 +68,20 @@ class DummyAssetoVault:
         return 0.01
 
 
+class DummyOffchainAssetoVault(DummyAssetoVault):
+    """Synthetic registry product with an Asseto display-price history."""
+
+    def uses_onchain_pricer(self) -> bool:
+        """Disable the HashKey-specific pricer call."""
+
+        return False
+
+    def fetch_offchain_share_price(self, _timestamp: datetime.datetime) -> Decimal:
+        """Return a cached daily NAV/share point."""
+
+        return Decimal("1.25")
+
+
 class DummyAssetoReaderState:
     """Record state updates issued by the Asseto historical reader."""
 
@@ -290,6 +304,24 @@ def test_asseto_historical_reader_calculates_tvl_and_updates_state() -> None:
             "share_price": Decimal("1.0123456789"),
         }
     ]
+
+
+def test_asseto_historical_reader_uses_offchain_nav_without_pricer() -> None:
+    """Combine historical ERC-20 supply with a registry product's display NAV."""
+
+    reader, _state = make_asseto_historical_reader(stateful=False)
+    reader.vault = DummyOffchainAssetoVault()
+
+    read = reader.process_result(
+        123,
+        SYNTHETIC_TIMESTAMP,
+        [make_asseto_call_result("totalSupply", 2_500_000)],
+    )
+
+    assert read.total_supply == Decimal("2.5")
+    assert read.share_price == Decimal("1.25")
+    assert read.total_assets == Decimal("3.125")
+    assert read.errors is None
 
 
 def test_asseto_historical_reader_records_partial_call_failure() -> None:

--- a/tests/maseer_one/test_maseer_one_vault.py
+++ b/tests/maseer_one/test_maseer_one_vault.py
@@ -132,7 +132,7 @@ def test_maseer_one_wstgbp_metadata_and_fees(web3: Web3) -> None:
     assert vault.get_fee_data().management is None
     assert vault.get_fee_data().performance is None
     assert vault.get_fee_data().deposit == 0
-    assert vault.get_fee_data().withdraw == WSTGBP_EXPECTED_WITHDRAW_FEE
+    assert vault.get_fee_data().withdraw == pytest.approx(float(WSTGBP_EXPECTED_WITHDRAW_FEE))
     assert vault.fetch_deposit_closed_reason() == MASEER_ONE_BESPOKE_FLOW_REASON
     assert vault.fetch_redemption_closed_reason() == MASEER_ONE_BESPOKE_FLOW_REASON
 
@@ -251,7 +251,7 @@ def test_maseer_one_wstgbp_scan_record(web3: Web3) -> None:
     assert record["Mgmt fee"] is None
     assert record["Perf fee"] is None
     assert record["Deposit fee"] == 0
-    assert record["Withdraw fee"] == WSTGBP_EXPECTED_WITHDRAW_FEE
+    assert record["Withdraw fee"] == pytest.approx(float(WSTGBP_EXPECTED_WITHDRAW_FEE))
     assert record["Features"] == "maseer_one_like"
     assert record["_denomination_token"]["address"] == Web3.to_checksum_address(WSTGBP_EXPECTED_GEM)
     assert record["_denomination_token"]["symbol"] == "tGBP"


### PR DESCRIPTION
## Why

Asseto publishes products on Ethereum, BNB Chain and Avalanche, but the original targeted backfill only processed one HashKey product and therefore performed no work on the supported chains.

## Lessons learnt

Asseto product contract metadata is published dynamically. Backfill selection must read that registry and use the product-level daily NAV history where a verified on-chain pricer is not available.

## Summary

- Discover all current Asseto EVM products from the public registry.
- Backfill supported chains with configured standard JSON-RPC endpoints, skipping unavailable chains cleanly.
- Combine ERC-20 supply with Asseto daily NAV history and enforce daily sampling.

## Related issues and PRs

Follow-up to #1297 and #1298.

## Unrelated CI and test fixes

- Normalise Maseer One fee ratios to native floats before placing them in persisted fee metadata.
- Treat the Securitize probe as optional when classifying a manually supplied minimal probe-result map.