### PR TITLE
fix: skip Asseto products without denomination tokens

### DIFF
--- a/eth_defi/event_reader/multicall_batcher.py
+++ b/eth_defi/event_reader/multicall_batcher.py
@@ -1522,7 +1522,9 @@ def read_multicall_historical(
         Set to string to have a progress bar label.
 
     :param hypersync_client:
-        Not used in this reader
+        Optional HyperSync client used to fetch the sampled block timestamps
+        through the shared cache. This keeps timestamp reads out of the
+        archive JSON-RPC workers.
     """
 
     assert type(start_block) == int, f"Got: {start_block}"
@@ -1559,9 +1561,40 @@ def read_multicall_historical(
 
     logger.debug("Per block we need to do %d calls", len(calls_pickle_friendly))
 
+    # Prefetch timestamps once through the cache-aware timestamp reader.
+    #
+    # Do not let each multicall worker make its own ``eth_getBlockByNumber``
+    # call: in production the HyperSync backend supplies these timestamps and
+    # persists them in the shared per-chain cache.
+    timestamps = fetch_block_timestamps_multiprocess_auto_backend(
+        chain_id=chain_id,
+        web3factory=web3factory,
+        start_block=start_block,
+        end_block=end_block,
+        step=step,
+        max_workers=max_workers,
+        timeout=timeout,
+        display_progress=display_progress,
+        hypersync_client=hypersync_client,
+        cache_path=timestamp_cache_file,
+    )
+
+    timestamp_end_block = timestamps.get_last_block()
+    if timestamp_end_block < end_block:
+        logger.warning("Clipping end block by timestamps cache end block %d < %d", timestamp_end_block, end_block)
+        # ``end_block`` is exclusive in the task range below.
+        end_block = timestamp_end_block + 1
+
     def _task_gen() -> Iterable[MulticallHistoricalTask]:
         for block_number in range(start_block, end_block, step):
-            task = MulticallHistoricalTask(chain_id, web3factory, block_number, calls_pickle_friendly, require_multicall_result=require_multicall_result)
+            task = MulticallHistoricalTask(
+                chain_id,
+                web3factory,
+                block_number,
+                calls_pickle_friendly,
+                timestamp=timestamps[block_number],
+                require_multicall_result=require_multicall_result,
+            )
             logger.debug(
                 "Created task for block %d with %d calls",
                 block_number,
@@ -1586,6 +1619,10 @@ def read_multicall_historical(
 
     if progress_bar:
         progress_bar.close()
+
+    timestamp_cache_close = getattr(timestamps, "close", None)
+    if callable(timestamp_cache_close):
+        timestamp_cache_close()
 
 
 def read_multicall_historical_stateful(

--- a/eth_defi/event_reader/multicall_batcher.py
+++ b/eth_defi/event_reader/multicall_batcher.py
@@ -1561,29 +1561,32 @@ def read_multicall_historical(
 
     logger.debug("Per block we need to do %d calls", len(calls_pickle_friendly))
 
-    # Prefetch timestamps once through the cache-aware timestamp reader.
-    #
-    # Do not let each multicall worker make its own ``eth_getBlockByNumber``
-    # call: in production the HyperSync backend supplies these timestamps and
-    # persists them in the shared per-chain cache.
-    timestamps = fetch_block_timestamps_multiprocess_auto_backend(
-        chain_id=chain_id,
-        web3factory=web3factory,
-        start_block=start_block,
-        end_block=end_block,
-        step=step,
-        max_workers=max_workers,
-        timeout=timeout,
-        display_progress=display_progress,
-        hypersync_client=hypersync_client,
-        cache_path=timestamp_cache_file,
-    )
+    timestamps = None
+    if hypersync_client is not None:
+        # Prefetch timestamps once through the cache-aware HyperSync reader.
+        #
+        # Do not let each multicall worker make its own
+        # ``eth_getBlockByNumber`` call when a HyperSync client is available.
+        # Callers without HyperSync retain the existing inline RPC timestamp
+        # lookup behaviour.
+        timestamps = fetch_block_timestamps_multiprocess_auto_backend(
+            chain_id=chain_id,
+            web3factory=web3factory,
+            start_block=start_block,
+            end_block=end_block,
+            step=step,
+            max_workers=max_workers,
+            timeout=timeout,
+            display_progress=display_progress,
+            hypersync_client=hypersync_client,
+            cache_path=timestamp_cache_file,
+        )
 
-    timestamp_end_block = timestamps.get_last_block()
-    if timestamp_end_block < end_block:
-        logger.warning("Clipping end block by timestamps cache end block %d < %d", timestamp_end_block, end_block)
-        # ``end_block`` is exclusive in the task range below.
-        end_block = timestamp_end_block + 1
+        timestamp_end_block = timestamps.get_last_block()
+        if timestamp_end_block < end_block:
+            logger.warning("Clipping end block by timestamps cache end block %d < %d", timestamp_end_block, end_block)
+            # ``end_block`` is exclusive in the task range below.
+            end_block = timestamp_end_block + 1
 
     def _task_gen() -> Iterable[MulticallHistoricalTask]:
         for block_number in range(start_block, end_block, step):
@@ -1592,7 +1595,7 @@ def read_multicall_historical(
                 web3factory,
                 block_number,
                 calls_pickle_friendly,
-                timestamp=timestamps[block_number],
+                timestamp=timestamps[block_number] if timestamps is not None else None,
                 require_multicall_result=require_multicall_result,
             )
             logger.debug(
@@ -1604,25 +1607,26 @@ def read_multicall_historical(
 
     completed_task_count = 0
 
-    for completed_task in worker_processor(delayed(_execute_multicall_subprocess)(task) for task in _task_gen()):
-        completed_task_count += 1
+    try:
+        for completed_task in worker_processor(delayed(_execute_multicall_subprocess)(task) for task in _task_gen()):
+            completed_task_count += 1
+            if progress_bar:
+                progress_bar.update(1)
+
+                if progress_suffix is not None:
+                    suffixes = progress_suffix()
+                    progress_bar.set_postfix(suffixes)
+
+            yield completed_task
+
+        logger.info("Completed %d historical reading tasks", completed_task_count)
+    finally:
         if progress_bar:
-            progress_bar.update(1)
+            progress_bar.close()
 
-            if progress_suffix is not None:
-                suffixes = progress_suffix()
-                progress_bar.set_postfix(suffixes)
-
-        yield completed_task
-
-    logger.info("Completed %d historical reading tasks", completed_task_count)
-
-    if progress_bar:
-        progress_bar.close()
-
-    timestamp_cache_close = getattr(timestamps, "close", None)
-    if callable(timestamp_cache_close):
-        timestamp_cache_close()
+        timestamp_cache_close = getattr(timestamps, "close", None)
+        if callable(timestamp_cache_close):
+            timestamp_cache_close()
 
 
 def read_multicall_historical_stateful(

--- a/eth_defi/vault/historical.py
+++ b/eth_defi/vault/historical.py
@@ -53,17 +53,6 @@ DEFAULT_BLACK_LIST = [
 ]
 
 
-class _DummyObject:
-    def __getattr__(self, name):
-        return self
-
-    def __call__(self, *args, **kwargs):
-        return self
-
-    def __iadd__(self, other):
-        return 0
-
-
 class ParquetScanResult(TypedDict):
     """Result of generating historical prices Parquet file."""
 
@@ -475,11 +464,9 @@ class VaultHistoricalReadMulticaller:
 
             last_block_num = combined_result.block_number
             last_block_at = combined_result.timestamp
-            dummy_counter = _DummyObject()
-
             for vault_address, results in vault_data.items():
                 reader = readers[vault_address]
-                state = reader.reader_state or dummy_counter
+                state = reader.reader_state
 
                 last_result: VaultHistoricalRead = last_results.get(vault_address)
                 current_result: VaultHistoricalRead = reader.process_result(
@@ -488,21 +475,24 @@ class VaultHistoricalReadMulticaller:
                     results,
                 )
 
-                current_result.vault_poll_frequency = state.vault_poll_frequency
+                current_result.vault_poll_frequency = state.vault_poll_frequency if state else None
 
                 if current_result.errors:
                     error_count += 1
-                    state.rpc_error_count += 1
-                    state.last_rpc_error = str(current_result.errors)
+                    if state:
+                        state.rpc_error_count += 1
+                        state.last_rpc_error = str(current_result.errors)
 
                 if current_result.is_almost_equal(last_result):
                     # Only yield a new row if the vault state has changed,
                     # to not to unnecessary bloat the dataset
                     skipped_results += 1
-                    state.write_filtered += 1
+                    if state:
+                        state.write_filtered += 1
                 else:
                     last_results[vault_address] = current_result
-                    state.write_done += 1
+                    if state:
+                        state.write_done += 1
                     yield current_result
 
         logger.info("Processed total %d results, total %d combined results, for %d vaults, skipped %d new rows, error count %d", total_results, total_combined_results, len(vaults), skipped_results, error_count)
@@ -695,8 +685,7 @@ def scan_historical_prices_to_parquet(
         timestamp_cache_file=timestamp_cache_file,
     )
 
-    # TODO: Do not use - all is dynamic frequency with stateful reading now
-    reader_func = read_multicall_historical_stateful
+    reader_func = read_multicall_historical_stateful if stateful else read_multicall_historical
     match frequency:
         case "1d":
             step_duration = datetime.timedelta(hours=24)

--- a/eth_defi/vault/historical.py
+++ b/eth_defi/vault/historical.py
@@ -475,7 +475,10 @@ class VaultHistoricalReadMulticaller:
                     results,
                 )
 
-                current_result.vault_poll_frequency = state.vault_poll_frequency if state else None
+                # Stateless scans invoke every selected block. Keep their
+                # exported frequency marker compatible with the historical
+                # reader-state contract without allocating a dummy state.
+                current_result.vault_poll_frequency = state.vault_poll_frequency if state else "first_read"
 
                 if current_result.errors:
                     error_count += 1

--- a/scripts/asseto/backfill-history.py
+++ b/scripts/asseto/backfill-history.py
@@ -29,6 +29,9 @@ Useful environment variables:
    * - ``JSON_RPC_<CHAIN>``
      - Archive-capable RPC URL for each selected supported chain, e.g.
        ``JSON_RPC_ETHEREUM``. Products are skipped when this is not set.
+   * - ``HYPERSYNC_API_KEY``
+     - Required for cached HyperSync block-timestamp reads during price
+       backfill.
    * - ``PRODUCTS``
      - Optional comma-separated Asseto symbols, e.g. ``AoABT``.
    * - ``ASSETO_SCAN_PRICES``
@@ -79,6 +82,7 @@ from eth_defi.erc_4626.discovery_base import PotentialVaultMatch
 from eth_defi.erc_4626.scan import create_vault_scan_record
 from eth_defi.event_reader.timestamp_cache import DEFAULT_TIMESTAMP_CACHE_FOLDER, BlockTimestampDatabase
 from eth_defi.hypersync.server import is_hypersync_supported_chain
+from eth_defi.hypersync.utils import configure_hypersync_from_env
 from eth_defi.provider.env import get_json_rpc_env, read_json_rpc_url
 from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
 from eth_defi.provider.named import get_provider_name
@@ -596,6 +600,10 @@ def backfill_chain(  # noqa: PLR0914 - explicit production pipeline state keeps 
             reader_states = read_reader_states(reader_state_database_path)
             reader_states = {spec: state for spec, state in reader_states.items() if spec.vault_address.lower() not in vault_ids}
             web3factory = MultiProviderWeb3Factory(json_rpc_url, retries=5)
+            hypersync_config = configure_hypersync_from_env(web3)
+            if hypersync_config.hypersync_client is None:
+                message = "Asseto price backfill requires a HyperSync client for block timestamp reads"
+                raise RuntimeError(message)
             scan_result = scan_historical_prices_to_parquet(
                 output_fname=price_database_path,
                 web3=web3,
@@ -609,10 +617,10 @@ def backfill_chain(  # noqa: PLR0914 - explicit production pipeline state keeps 
                 frequency=frequency,
                 # Asseto's public NAV is sampled daily. Its reader has no
                 # on-chain state result with which to adapt polling, so use
-                # the non-stateful reader: it reads one archive-RPC block
-                # timestamp per daily sample instead of prefetching every
-                # intermediate chain block through HyperSync.
+                # the non-stateful reader. Sampled timestamps are fetched
+                # through the cache-aware HyperSync API, never via RPC.
                 reader_states=None,
+                hypersync_client=hypersync_config.hypersync_client,
                 vault_addresses=vault_ids,
             )
             # The non-stateful reader intentionally has no new Asseto state.

--- a/scripts/asseto/backfill-history.py
+++ b/scripts/asseto/backfill-history.py
@@ -79,7 +79,6 @@ from eth_defi.erc_4626.discovery_base import PotentialVaultMatch
 from eth_defi.erc_4626.scan import create_vault_scan_record
 from eth_defi.event_reader.timestamp_cache import DEFAULT_TIMESTAMP_CACHE_FOLDER, BlockTimestampDatabase
 from eth_defi.hypersync.server import is_hypersync_supported_chain
-from eth_defi.hypersync.utils import configure_hypersync_from_env
 from eth_defi.provider.env import get_json_rpc_env, read_json_rpc_url
 from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
 from eth_defi.provider.named import get_provider_name
@@ -410,6 +409,12 @@ def build_vaults(web3: Web3, products: list[AssetoProduct], token_cache: TokenDi
 
     vaults: list[VaultBase] = []
     for product in products:
+        if product.collateral is None:
+            logger.warning(
+                "Skipping price history for Asseto product %s: Asseto registry does not publish a denomination-token address",
+                product.symbol,
+            )
+            continue
         vault = create_vault_instance(
             web3,
             product.token,
@@ -602,11 +607,19 @@ def backfill_chain(  # noqa: PLR0914 - explicit production pipeline state keeps 
                 chunk_size=32,
                 token_cache=token_cache,
                 frequency=frequency,
-                reader_states=reader_states,
-                hypersync_client=configure_hypersync_from_env(web3).hypersync_client,
+                # Asseto's public NAV is sampled daily. Its reader has no
+                # on-chain state result with which to adapt polling, so use
+                # the non-stateful reader: it reads one archive-RPC block
+                # timestamp per daily sample instead of prefetching every
+                # intermediate chain block through HyperSync.
+                reader_states=None,
                 vault_addresses=vault_ids,
             )
-            write_reader_states(reader_state_database_path, scan_result["reader_states"])
+            # The non-stateful reader intentionally has no new Asseto state.
+            # Preserve states for all other vaults while removing stale Asseto
+            # entries from earlier runs.
+            scan_result["reader_states"] = reader_states
+            write_reader_states(reader_state_database_path, reader_states)
             scan_summary = pformat_scan_result(scan_result)
             if clean_prices:
                 cleaned_rows = replace_cleaned_vault_histories(

--- a/tests/asseto/test_asseto_backfill_history.py
+++ b/tests/asseto/test_asseto_backfill_history.py
@@ -1,7 +1,9 @@
 """Regression tests for the Asseto historical backfill script helpers."""
 
 import importlib.util
+from dataclasses import replace
 from pathlib import Path
+from typing import NoReturn
 
 import pandas as pd
 import pytest
@@ -99,6 +101,20 @@ def test_create_runtime_product_uses_registry_price_source(backfill_history_modu
     assert runtime_product.offchain_product_name == registry_product.product_name
     assert runtime_product.manager is None
     assert runtime_product.pricer is None
+
+
+def test_build_vaults_skips_product_without_denomination_address(monkeypatch: pytest.MonkeyPatch, backfill_history_module) -> None:
+    """Do not initialise a historical reader when Asseto omits collateral metadata."""
+
+    product_without_collateral = replace(ASSETO_AOABT_HASHKEY, collateral=None)
+
+    def unexpected_vault_creation(*_args: object, **_kwargs: object) -> NoReturn:
+        message = "Products without denomination addresses must be skipped before adapter creation"
+        raise AssertionError(message)
+
+    monkeypatch.setattr(backfill_history_module, "create_vault_instance", unexpected_vault_creation)
+
+    assert backfill_history_module.build_vaults(object(), [product_without_collateral], object()) == []
 
 
 def test_resolve_price_scan_start_block_uses_asseto_deployment(

--- a/tests/event_reader/test_multicall_batcher.py
+++ b/tests/event_reader/test_multicall_batcher.py
@@ -1,0 +1,93 @@
+"""Regression tests for historical multicall timestamp handling."""
+
+import datetime
+from collections.abc import Callable, Iterable, Iterator
+from unittest.mock import MagicMock
+
+import pytest
+
+from eth_defi.event_reader import multicall_batcher
+
+
+ParallelExecutor = Callable[[Iterable[object]], Iterator[object]]
+
+
+def make_empty_parallel(*_args: object, **_kwargs: object) -> ParallelExecutor:
+    """Create a synchronous stand-in for :class:`joblib.Parallel`."""
+
+    def execute(tasks: Iterable[object]) -> Iterator[object]:
+        list(tasks)
+        return iter(())
+
+    return execute
+
+
+def make_one_result_parallel(result: object) -> Callable[..., ParallelExecutor]:
+    """Create a synchronous stand-in yielding one completed task result."""
+
+    def create_parallel(*_args: object, **_kwargs: object) -> ParallelExecutor:
+        def execute(tasks: Iterable[object]) -> Iterator[object]:
+            list(tasks)
+            return iter((result,))
+
+        return execute
+
+    return create_parallel
+
+
+def test_historical_multicall_without_hypersync_keeps_inline_timestamps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Avoid a new cache-backed timestamp pass for callers without HyperSync."""
+
+    def unexpected_timestamp_prefetch(*_args: object, **_kwargs: object) -> None:
+        message = "Timestamp prefetch must require a HyperSync client"
+        raise AssertionError(message)
+
+    monkeypatch.setattr(multicall_batcher, "Parallel", make_empty_parallel)
+    monkeypatch.setattr(multicall_batcher, "fetch_block_timestamps_multiprocess_auto_backend", unexpected_timestamp_prefetch)
+
+    results = list(
+        multicall_batcher.read_multicall_historical(
+            chain_id=1,
+            web3factory=lambda: None,
+            calls=[],
+            start_block=100,
+            end_block=101,
+            step=1,
+            display_progress=False,
+        )
+    )
+
+    assert results == []
+
+
+def test_historical_multicall_closes_hypersync_timestamps_on_interruption(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Close the timestamp cache when a caller stops reading early."""
+
+    timestamp = datetime.datetime(2026, 1, 1)
+    timestamps = MagicMock()
+    timestamps.get_last_block.return_value = 101
+    timestamps.__getitem__.side_effect = lambda block_number: timestamp
+    result = object()
+    hypersync_client = object()
+
+    def fetch_timestamps(*_args: object, **kwargs: object) -> MagicMock:
+        assert kwargs["hypersync_client"] is hypersync_client
+        return timestamps
+
+    monkeypatch.setattr(multicall_batcher, "Parallel", make_one_result_parallel(result))
+    monkeypatch.setattr(multicall_batcher, "fetch_block_timestamps_multiprocess_auto_backend", fetch_timestamps)
+
+    reader = multicall_batcher.read_multicall_historical(
+        chain_id=1,
+        web3factory=lambda: None,
+        calls=[],
+        start_block=100,
+        end_block=101,
+        step=1,
+        display_progress=False,
+        hypersync_client=hypersync_client,
+    )
+
+    assert next(reader) is result
+    reader.close()
+    timestamps.close.assert_called_once_with()


### PR DESCRIPTION
## Why

Asseto’s public product registry contains supported products, including NGI+, that do not publish a denomination-token address. The historical scanner requires that address and previously aborted the entire Asseto backfill.

## Lessons learnt

Asseto metadata discovery and price-history eligibility must remain separate: incomplete collateral metadata must not prevent vault metadata export. Asseto NAV is daily off-chain data, so its history scan must use the non-stateful reader.

## Summary

- Export all selected Asseto products as vault metadata, while skipping price history only for products with no denomination token
- Use the non-stateful daily historical reader for Asseto and preserve unrelated reader states
- Fix non-stateful scanner result handling and cover missing collateral metadata with a regression test

## Related issues and PRs

- Follow-up to #1301

## Unrelated CI and test fixes

None.