### PR TITLE
feat: export vault share price sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- feat: Export the source of vault share prices across smart-contract, API, oracle, fixed-price and approximated vault integrations (2026-07-16)
 - feat: Backfill all reviewed Securitize funds with archive-block RedStone NAV reads and official cross-chain BUIDL deployments (2026-07-16)
 - feat: Add off-chain Securitize NAV, share-price and TVL history sources with in-memory scanner enrichment (2026-07-16)
 - feat: Backfill all supported Asseto products from its live registry using daily NAV history and skip chains without configured RPCs (2026-07-16)

--- a/docs/source/api/vault/index.rst
+++ b/docs/source/api/vault/index.rst
@@ -18,6 +18,7 @@ A generic high-level Python framework to integrate different vault providers.
    eth_defi.vault.base
    eth_defi.vault.flow_events
    eth_defi.vault.risk
+   eth_defi.vault.price_source
    eth_defi.vault.fee
    eth_defi.vault.deposit_redeem
    eth_defi.vault.vaultdb

--- a/eth_defi/asseto/vault.py
+++ b/eth_defi/asseto/vault.py
@@ -28,6 +28,7 @@ from eth_defi.types import Percent
 from eth_defi.vault.base import TradingUniverse, VaultBase, VaultDepositManager, VaultFlowManager, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
 from eth_defi.vault.fee import FeeData, VaultFeeMode
 from eth_defi.vault.lower_case_dict import LowercaseDict
+from eth_defi.vault.price_source import PriceSource
 
 logger = logging.getLogger(__name__)
 
@@ -356,6 +357,18 @@ class AssetoVault(VaultBase):
         """
 
         return self.product.pricer is not None
+
+    def get_share_price_source(self) -> PriceSource:
+        """Return the configured Asseto product price source.
+
+        Products with a published ``Pricer`` are read at an archive block.
+        Other reviewed products use Asseto's public daily NAV API.
+
+        :return:
+            Smart-contract state or API source for this product.
+        """
+
+        return PriceSource.smart_contract_state if self.uses_onchain_pricer() else PriceSource.api
 
     def fetch_offchain_price_history(self) -> tuple[AssetoPricePoint, ...]:
         """Fetch and cache Asseto's public daily NAV/share history.

--- a/eth_defi/erc_4626/scan.py
+++ b/eth_defi/erc_4626/scan.py
@@ -304,6 +304,7 @@ def create_vault_scan_record(
         "_flags": {},
         "_notes": None,
         "_deposit_manager": None,
+        "_share_price_source": None,
     }
 
     vault = create_vault_instance(
@@ -383,6 +384,7 @@ def create_vault_scan_record(
             "_short_description": short_description,
             "_notes": notes,
             "_manager_name": vault.manager_name,
+            "_share_price_source": vault.get_share_price_source(),
             "_morpho_offchain_data": vault.morpho_offchain_data if isinstance(vault, (MorphoV1Vault, MorphoV2Vault)) else None,
             "_deposit_manager": deposit_manager_capability.as_initial_public_schema() if deposit_manager_capability else None,
         }

--- a/eth_defi/erc_4626/vault.py
+++ b/eth_defi/erc_4626/vault.py
@@ -32,6 +32,7 @@ from eth_defi.token import TokenDetails, TokenDiskCache, fetch_erc20_details, is
 from eth_defi.vault.base import DEPOSIT_CLOSED_CAP_REACHED, REDEMPTION_CLOSED_INSUFFICIENT_LIQUIDITY, TradingUniverse, VaultBase, VaultFlowManager, VaultHistoricalRead, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
 from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
 from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.price_source import PriceSource
 
 logger = logging.getLogger(__name__)
 
@@ -871,6 +872,19 @@ class ERC4626Vault(VaultBase):
 
     def __repr__(self):
         return f"<{self.__class__.__name__}: {self.spec}>"
+
+    def get_share_price_source(self) -> PriceSource:  # noqa: PLR6301
+        """Return the standard ERC-4626 share-price source.
+
+        ERC-4626 prices are calculated from vault accounting values read at a
+        specific block, including protocol-specific overrides that expose the
+        same state through another contract view.
+
+        :return:
+            Smart-contract state source.
+        """
+
+        return PriceSource.smart_contract_state
 
     def _get_block_identifier(self) -> BlockIdentifier:
         """Resolve which block identifier to use for metadata reads.

--- a/eth_defi/grvt/vault_data_export.py
+++ b/eth_defi/grvt/vault_data_export.py
@@ -38,6 +38,7 @@ from eth_defi.grvt.daily_metrics import GRVTDailyMetricsDatabase
 from eth_defi.vault.base import VaultHistoricalRead, VaultSpec
 from eth_defi.vault.fee import FeeData
 from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.price_source import PriceSource
 from eth_defi.vault.vaultdb import VaultDatabase, VaultRow
 
 logger = logging.getLogger(__name__)
@@ -151,6 +152,7 @@ def create_grvt_vault_row(
         "_deposit_next_open": None,
         "_redemption_closed_reason": None,
         "_redemption_next_open": None,
+        "_share_price_source": PriceSource.api,
     }
 
     spec = VaultSpec(chain_id=chain_id, vault_address=address)

--- a/eth_defi/hibachi/vault_data_export.py
+++ b/eth_defi/hibachi/vault_data_export.py
@@ -38,6 +38,7 @@ from eth_defi.hibachi.daily_metrics import HibachiDailyMetricsDatabase
 from eth_defi.vault.base import VaultHistoricalRead, VaultSpec
 from eth_defi.vault.fee import FeeData
 from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.price_source import PriceSource
 from eth_defi.vault.vaultdb import VaultDatabase, VaultRow
 
 logger = logging.getLogger(__name__)
@@ -157,6 +158,7 @@ def create_hibachi_vault_row(
         "_deposit_next_open": None,
         "_redemption_closed_reason": None,
         "_redemption_next_open": None,
+        "_share_price_source": PriceSource.api,
     }
 
     spec = VaultSpec(chain_id=chain_id, vault_address=address)

--- a/eth_defi/hyperliquid/vault_data_export.py
+++ b/eth_defi/hyperliquid/vault_data_export.py
@@ -43,6 +43,7 @@ from eth_defi.hyperliquid.vault_review_sync import ReviewStatus
 from eth_defi.vault.base import VaultHistoricalRead, VaultSpec
 from eth_defi.vault.fee import FeeData
 from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.price_source import PriceSource
 from eth_defi.vault.risk import VaultTechnicalRisk
 from eth_defi.vault.vaultdb import VaultDatabase, VaultRow
 
@@ -257,6 +258,7 @@ def create_hyperliquid_vault_row(
         "_redemption_next_open": None,
         "_risk": risk,
         "_manual_review_status": manual_review_status,
+        "_share_price_source": PriceSource.approximation,
     }
 
     spec = VaultSpec(chain_id=chain_id, vault_address=address)

--- a/eth_defi/lighter/vault_data_export.py
+++ b/eth_defi/lighter/vault_data_export.py
@@ -38,6 +38,7 @@ from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase
 from eth_defi.vault.base import VaultHistoricalRead, VaultSpec
 from eth_defi.vault.fee import FeeData
 from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.price_source import PriceSource
 from eth_defi.vault.risk import get_vault_risk
 from eth_defi.vault.vaultdb import VaultDatabase, VaultRow
 
@@ -141,6 +142,7 @@ def create_lighter_pool_row(
         "_redemption_closed_reason": None,
         "_redemption_next_open": None,
         "_risk": get_vault_risk("Lighter", address),
+        "_share_price_source": PriceSource.api,
     }
 
     spec = VaultSpec(chain_id=chain_id, vault_address=address)

--- a/eth_defi/maseer_one/vault.py
+++ b/eth_defi/maseer_one/vault.py
@@ -23,6 +23,7 @@ from eth_defi.types import Percent
 from eth_defi.vault.base import TradingUniverse, VaultBase, VaultDepositManager, VaultFlowManager, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
 from eth_defi.vault.fee import FeeData, VaultFeeMode
 from eth_defi.vault.lower_case_dict import LowercaseDict
+from eth_defi.vault.price_source import PriceSource
 
 MASEER_ONE_DOCUMENTATION = "https://docs.wstgbp.com/"
 MASEER_ONE_NAV_SOURCE = "maseer_one_navprice"
@@ -294,6 +295,18 @@ class MaseerOneVault(VaultBase):
             cache=self.token_cache,
             cause_diagnostics_message=f"Maseer One denomination token for vault {self.address}",
         )
+
+    def get_share_price_source(self) -> PriceSource:
+        """Return the Maseer One NAV source classification.
+
+        The adapter reads ``navprice()`` from the product contract at the
+        requested block.
+
+        :return:
+            Smart-contract state source.
+        """
+
+        return PriceSource.smart_contract_state
 
     def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
         """Read Maseer One NAV/share from ``navprice()``.

--- a/eth_defi/mellow/vault.py
+++ b/eth_defi/mellow/vault.py
@@ -136,6 +136,7 @@ from eth_defi.token import TokenDetails, fetch_erc20_details
 from eth_defi.vault.base import TradingUniverse, VaultBase, VaultDepositManager, VaultFlowManager, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
 from eth_defi.vault.fee import BROKEN_FEE_DATA, FeeData
 from eth_defi.vault.lower_case_dict import LowercaseDict
+from eth_defi.vault.price_source import PriceSource
 
 logger = logging.getLogger(__name__)
 
@@ -603,6 +604,18 @@ class MellowVault(VaultBase):
             timestamp=int(timestamp),
             is_suspicious=bool(is_suspicious),
         )
+
+    def get_share_price_source(self) -> PriceSource:
+        """Return the Mellow oracle price-source classification.
+
+        Mellow Core vault reports are read from the vault-coupled oracle
+        contract at the requested block.
+
+        :return:
+            Smart-contract state source.
+        """
+
+        return PriceSource.smart_contract_state
 
     def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal | None:
         """Fetch Mellow share price from the oracle report.

--- a/eth_defi/midas/vault.py
+++ b/eth_defi/midas/vault.py
@@ -28,6 +28,7 @@ from eth_defi.vault.base import TradingUniverse, VaultBase, VaultDepositManager,
 from eth_defi.vault.fee import FeeData, VaultFeeMode
 from eth_defi.vault.handwritten_metadata import get_handwritten_vault_metadata
 from eth_defi.vault.lower_case_dict import LowercaseDict
+from eth_defi.vault.price_source import PriceSource
 
 MIDAS_HOMEPAGE = "https://midas.app/products"
 MIDAS_CONTRACTS_GITHUB = "https://github.com/midas-apps/contracts"
@@ -478,6 +479,18 @@ class MidasVault(VaultBase):
         """
 
         return self.fetch_primary_payment_token()
+
+    def get_share_price_source(self) -> PriceSource:
+        """Return the Midas NAV source classification.
+
+        Midas share prices are read from its deployed data-feed contracts at
+        the requested archive block.
+
+        :return:
+            Smart-contract state source.
+        """
+
+        return PriceSource.smart_contract_state
 
     def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
         """Fetch Midas NAV per mToken.

--- a/eth_defi/oda_fact/vault.py
+++ b/eth_defi/oda_fact/vault.py
@@ -35,6 +35,7 @@ from eth_defi.types import Percent
 from eth_defi.vault.base import TradingUniverse, VaultBase, VaultDepositManager, VaultFlowManager, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
 from eth_defi.vault.fee import BROKEN_FEE_DATA, FeeData, VaultFeeMode
 from eth_defi.vault.lower_case_dict import LowercaseDict
+from eth_defi.vault.price_source import PriceSource
 
 logger = logging.getLogger(__name__)
 
@@ -305,6 +306,18 @@ class OdaFactVault(VaultBase):
         """
 
         return None
+
+    def get_share_price_source(self) -> PriceSource:
+        """Return the JLTXX share-price source classification.
+
+        The current JLTXX integration uses an explicitly labelled USD 1 NAV
+        estimate because no public historical NAV feed is available.
+
+        :return:
+            Fixed-price source.
+        """
+
+        return PriceSource.fixed_price
 
     def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
         """Fetch ODA-FACT share price estimate.

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -46,6 +46,7 @@ from eth_defi.vault.flag import (
     VaultFlag,
     get_notes,
 )
+from eth_defi.vault.price_source import PriceSource
 from eth_defi.vault.risk import VaultTechnicalRisk, get_vault_risk
 from eth_defi.vault.vaultdb import VaultDatabase, VaultRow
 
@@ -260,6 +261,9 @@ class VaultMetricsRecord(TypedDict, total=False):
 
     #: Latest adaptive vault scan cycle, e.g. ``"large_tvl"`` or ``"peaked"``.
     vault_poll_frequency: str | None
+
+    #: Source used to produce the share-price series.
+    share_price_source: str | None
 
     #: Current net asset value in USD
     current_nav: float | None
@@ -1638,6 +1642,13 @@ def calculate_vault_record(
     risk = vault_metadata.get("_risk") or get_vault_risk(protocol, vault_address)
     notes = vault_metadata.get("_notes") or get_notes(vault_address, chain_id=chain_id)
     vault_poll_frequency = get_latest_vault_poll_frequency(prices_df)
+    raw_share_price_source = vault_metadata.get("_share_price_source")
+    if raw_share_price_source is None:
+        share_price_source = None
+    elif isinstance(raw_share_price_source, PriceSource):
+        share_price_source = raw_share_price_source.value
+    else:
+        share_price_source = PriceSource(raw_share_price_source).value
 
     flags = set(vault_metadata.get("_flags") or set())
     risk, notes, flags = apply_bad_flag_check(
@@ -2050,6 +2061,7 @@ def calculate_vault_record(
             "risk": risk,
             "risk_numeric": risk_numeric,
             "vault_poll_frequency": vault_poll_frequency,
+            "share_price_source": share_price_source,
             "id": id_val,
             "start_date": lifetime_start_date,
             "end_date": lifetime_end_date,
@@ -2129,7 +2141,11 @@ def calculate_lifetime_metrics(
 
     Lookback based on the last entry.
 
-    Each output row contains a ``denomination_token_rate`` value produced by
+    Each output row contains a ``share_price_source`` string describing how
+    the adapter obtained its share-price observations, or ``None`` for legacy
+    metadata and adapters without a price source.
+
+    Each output row also contains a ``denomination_token_rate`` value produced by
     :py:meth:`eth_defi.feed.stablecoin_rate.StablecoinRateFeeder.get_denomination_token_rate_section`.
     The value is a :py:class:`eth_defi.feed.stablecoin_rate.DenominationTokenRate`
     carrying both USD rate fields and, for non-USD stablecoins, native source
@@ -2693,6 +2709,7 @@ def format_lifetime_table(
             "protocol": "Protocol",
             "risk": "Risk",
             "vault_poll_frequency": "Scan cycle",
+            "share_price_source": "Share price source",
             # "end_date": "Latest deposit",
             "name": "Name",
             "lockup": "Lock up est. days",
@@ -3361,6 +3378,9 @@ def export_lifetime_row(row: pd.Series) -> dict:
     - Normalises pandas, numpy, datetime, and custom types.
     - Converts finite :class:`~decimal.Decimal` values to JSON number floats.
     - Preserves legacy fee field names.
+
+    The ``share_price_source`` column is retained as a stable
+    :py:class:`eth_defi.vault.price_source.PriceSource` string value.
 
     The ``denomination_token_rate`` dataclass from
     :py:class:`eth_defi.feed.stablecoin_rate.DenominationTokenRate` is converted

--- a/eth_defi/securitize/vault.py
+++ b/eth_defi/securitize/vault.py
@@ -20,6 +20,7 @@ from eth_defi.types import Percent
 from eth_defi.vault.base import TradingUniverse, VaultBase, VaultDepositManager, VaultFlowManager, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
 from eth_defi.vault.fee import BROKEN_FEE_DATA, FeeData
 from eth_defi.vault.lower_case_dict import LowercaseDict
+from eth_defi.vault.price_source import PriceSource
 
 #: Backwards-compatible aliases for the first registered Securitize product.
 BUIDL_ETHEREUM_CHAIN_ID = BUIDL_ETHEREUM.chain_id
@@ -31,6 +32,13 @@ BUIDL_HOMEPAGE = BUIDL_ETHEREUM.homepage
 SECURITIZE_HOMEPAGE = "https://securitize.io/"
 SECURITIZE_RESTRICTED_FLOW_REASON = "Securitize DSToken subscriptions, redemptions and transfers require approved investors and compliance checks"
 SECURITIZE_NAV_UNAVAILABLE_ERROR_PREFIX = "No on-chain NAV source configured for Securitize DSToken"
+
+#: Map executable Securitize NAV-source families to public classifications.
+SECURITIZE_PRICE_SOURCE_PREFIXES: dict[str, PriceSource] = {
+    "redstone_": PriceSource.redstone,
+    "chronicle_": PriceSource.chronicle,
+    "estimated_": PriceSource.fixed_price,
+}
 
 
 class SecuritizeVaultInfo(VaultInfo, total=False):
@@ -111,6 +119,21 @@ class SecuritizeVault(VaultBase):
         self.features = features or {ERC4626Feature.securitize_like}
         self.default_block_identifier = default_block_identifier
         self.product = SECURITIZE_PRODUCTS.get((spec.chain_id, HexAddress(spec.vault_address.lower())))
+
+    def get_share_price_source(self) -> PriceSource | None:
+        """Return the reviewed source configured for this Securitize product.
+
+        Source identifiers are mapped by family so newly reviewed RedStone,
+        Chronicle or estimated products do not require address-specific
+        branches in the adapter.
+
+        :return:
+            Product price source, or ``None`` when NAV is unconfigured.
+        """
+
+        if self.product is None:
+            return None
+        return next((source for prefix, source in SECURITIZE_PRICE_SOURCE_PREFIXES.items() if self.product.nav_source.startswith(prefix)), None)
 
     @property
     def chain_id(self) -> int:

--- a/eth_defi/vault/base.py
+++ b/eth_defi/vault/base.py
@@ -34,6 +34,7 @@ from eth_defi.types import Percent
 from eth_defi.utils import is_good_multichain_address
 from eth_defi.vault.deposit_redeem import VaultDepositManager, VaultDepositManagerCapability
 from eth_defi.vault.lower_case_dict import LowercaseDict
+from eth_defi.vault.price_source import PriceSource
 from eth_defi.version_info import stamp_parquet_schema_metadata
 
 from .fee import FeeData, VaultFeeMode, get_vault_fee_mode
@@ -1093,6 +1094,20 @@ class VaultBase(ABC):
         - Returns None if the protocol does not expose separate manager metadata
         - Override in subclasses that support manager or operator metadata
         """
+        return None
+
+    def get_share_price_source(self) -> PriceSource | None:  # noqa: PLR6301
+        """Return the source used for share-price observations.
+
+        Vault integrations override this method when they expose a share
+        price. Returning ``None`` distinguishes unsupported or unknown pricing
+        from a known source classification.
+
+        :return:
+            Share-price source, or ``None`` when the adapter does not provide
+            one.
+        """
+
         return None
 
     def fetch_scan_record_extra_data(self) -> dict[str, object]:  # noqa: PLR6301

--- a/eth_defi/vault/price_source.py
+++ b/eth_defi/vault/price_source.py
@@ -1,0 +1,30 @@
+"""Classify how a vault share price is obtained."""
+
+import enum
+
+
+class PriceSource(str, enum.Enum):
+    """Machine-readable source of a vault's share-price observations.
+
+    The classification describes the data path used by the vault adapter, not
+    the legal publisher of the underlying fund NAV. Values are stable public
+    export strings consumed by vault-data clients.
+    """
+
+    #: Read directly from historical smart-contract state.
+    smart_contract_state = "smart-contract-state"
+
+    #: Read from a protocol or product API.
+    api = "api"
+
+    #: Reconstructed or estimated because no authoritative price series exists.
+    approximation = "approximation"
+
+    #: Explicitly configured constant share price.
+    fixed_price = "fixed-price"
+
+    #: Read from a RedStone oracle or fundamental-value feed.
+    redstone = "redstone"
+
+    #: Read from a Chronicle oracle or Proof of Asset feed.
+    chronicle = "chronicle"

--- a/eth_defi/vault/vaultdb.py
+++ b/eth_defi/vault/vaultdb.py
@@ -19,6 +19,7 @@ from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature, get_va
 from eth_defi.erc_4626.discovery_base import PotentialVaultMatch
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.price_source import PriceSource
 from eth_defi.vault.risk import VaultTechnicalRisk
 
 logger = logging.getLogger(__name__)
@@ -135,6 +136,9 @@ class VaultRow(TypedDict):
 
     #: Human-readable vault note captured by the vault scanner.
     _notes: str | None
+
+    #: Source used to produce the vault share-price series.
+    _share_price_source: PriceSource | None
 
     __annotations__ = {
         "First seen at": datetime.datetime,

--- a/eth_defi/vault_street/vault.py
+++ b/eth_defi/vault_street/vault.py
@@ -26,6 +26,7 @@ from eth_defi.types import Percent
 from eth_defi.vault.base import TradingUniverse, VaultBase, VaultDepositManager, VaultFlowManager, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
 from eth_defi.vault.fee import FeeData, VaultFeeMode
 from eth_defi.vault.lower_case_dict import LowercaseDict
+from eth_defi.vault.price_source import PriceSource
 from eth_defi.vault_street.constants import (
     PRIME_USD_ADDRESS,
     PRIME_USD_DENOMINATION_TOKEN_ADDRESS,
@@ -284,6 +285,18 @@ class VaultStreetVault(VaultBase):
         """
 
         return Decimal(raw_price) / Decimal(10**PRIME_USD_PRICE_DECIMALS)
+
+    def get_share_price_source(self) -> PriceSource:
+        """Return the primeUSD NAV source classification.
+
+        The adapter reads the deployed ``PriceStorage`` oracle at the requested
+        block.
+
+        :return:
+            Smart-contract state source.
+        """
+
+        return PriceSource.smart_contract_state
 
     def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
         """Fetch primeUSD NAV per token from the PriceStorage oracle.

--- a/tests/erc_4626/test_scan_features.py
+++ b/tests/erc_4626/test_scan_features.py
@@ -7,6 +7,7 @@ import pytest
 import eth_defi.erc_4626.scan as scan_module
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
 from eth_defi.vault.fee import FeeData, VaultFeeMode
+from eth_defi.vault.price_source import PriceSource
 from eth_defi.vault.vaultdb import VaultDatabase
 
 
@@ -74,6 +75,11 @@ class _FakeVault:
         return None
 
     @staticmethod
+    def get_share_price_source() -> PriceSource:
+        """Return the standard contract-state source."""
+        return PriceSource.smart_contract_state
+
+    @staticmethod
     def fetch_scan_record_extra_data() -> dict:
         """Return no protocol-specific scan fields."""
         return {}
@@ -114,6 +120,7 @@ def test_create_vault_scan_record_persists_machine_readable_features(monkeypatch
     assert record["_detection_data"].features == features
     assert "erc_7575_like" in record["Features"]
     assert record["_deposit_manager"] is None
+    assert record["_share_price_source"] is PriceSource.smart_contract_state
 
 
 def test_vault_database_dataframe_falls_back_to_detection_features() -> None:

--- a/tests/oda_fact/test_oda_fact_vault.py
+++ b/tests/oda_fact/test_oda_fact_vault.py
@@ -21,6 +21,7 @@ from eth_defi.oda_fact.vault import KINEXYS_WHITELISTED_FLOW_REASON, OdaFactVaul
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.price_source import PriceSource
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 JLTXX_EXPECTED_MANAGEMENT_FEE = 0.0016
@@ -211,6 +212,7 @@ def test_oda_fact_scan_record_live_jltxx(web3: Web3) -> None:
     assert "JLTXX fact sheet" in record["_notes"]
     assert record["_nav_source"] == "estimated_jltxx_usd_1"
     assert record["_nav_estimated"] is True
+    assert record["_share_price_source"] is PriceSource.fixed_price
     assert record["_synthetic_usd_denomination"] is True
     assert record["_gross_expense_ratio"] == JLTXX_EXPECTED_GROSS_EXPENSE_RATIO
     assert record["_net_expense_ratio"] == JLTXX_EXPECTED_MANAGEMENT_FEE

--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -29,6 +29,7 @@ from eth_defi.research.vault_metrics import (
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.fee import FeeData, VaultFeeMode
 from eth_defi.vault.flag import NOT_IN_MORPHO_API, VaultFlag
+from eth_defi.vault.price_source import PriceSource
 from eth_defi.vault.risk import VaultTechnicalRisk
 from eth_defi.vault.vaultdb import VaultDatabase
 
@@ -783,6 +784,26 @@ def test_export_lifetime_metrics(
     # Verify they serialize to JSON properly (None becomes null)
     assert r["available_liquidity"] is None or isinstance(r["available_liquidity"], (int, float))
     assert r["utilisation"] is None or isinstance(r["utilisation"], (int, float))
+
+
+def test_calculate_lifetime_metrics_exports_share_price_source(
+    vault_db: VaultDatabase,
+    price_df: pd.DataFrame,
+) -> None:
+    """Adapter price-source metadata reaches the DataFrame and JSON export."""
+
+    vault_id = "43111-0x05c2e246156d37b39a825a25dd08d5589e3fd883"
+    spec = VaultSpec.parse_string(vault_id)
+    vault_row = dict(vault_db.rows[spec])
+    vault_row["_share_price_source"] = PriceSource.smart_contract_state
+
+    metrics = calculate_lifetime_metrics(
+        price_df.loc[price_df["id"] == vault_id],
+        {spec: vault_row},
+    )
+
+    assert metrics.iloc[0]["share_price_source"] == "smart-contract-state"
+    assert export_lifetime_row(metrics.iloc[0])["share_price_source"] == "smart-contract-state"
 
 
 def test_export_lifetime_row_nat_serialization():

--- a/tests/vault/test_price_source.py
+++ b/tests/vault/test_price_source.py
@@ -1,0 +1,82 @@
+"""Test vault share-price source classification."""
+
+import datetime
+from dataclasses import replace
+
+from web3 import Web3
+
+from eth_defi.asseto.constants import ASSETO_AOABT_HASHKEY
+from eth_defi.asseto.vault import AssetoVault
+from eth_defi.erc_4626.classification import ODA_FACT_JLTXX_ADDRESS
+from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.grvt.vault_data_export import create_grvt_vault_row
+from eth_defi.hibachi.vault_data_export import create_hibachi_vault_row
+from eth_defi.hyperliquid.vault_data_export import create_hyperliquid_vault_row
+from eth_defi.lighter.vault_data_export import create_lighter_pool_row
+from eth_defi.oda_fact.vault import OdaFactVault
+from eth_defi.securitize.description import ACRED_ETHEREUM, ARCOIN_ETHEREUM, BUIDL_ETHEREUM
+from eth_defi.securitize.vault import SecuritizeVault
+from eth_defi.vault.base import VaultBase, VaultSpec
+from eth_defi.vault.price_source import PriceSource
+
+
+def test_price_source_public_values() -> None:
+    """Price-source enum values are stable public export strings."""
+
+    assert {source.value for source in PriceSource} == {
+        "smart-contract-state",
+        "api",
+        "approximation",
+        "fixed-price",
+        "redstone",
+        "chronicle",
+    }
+
+
+def test_vault_adapter_price_sources() -> None:
+    """Contract, API, oracle and estimated adapters report their real source."""
+
+    web3 = Web3()
+    erc4626 = ERC4626Vault(
+        web3,
+        VaultSpec(chain_id=1, vault_address="0x0000000000000000000000000000000000000001"),
+        features={ERC4626Feature.morpho_like},
+    )
+    assert VaultBase.get_share_price_source(object()) is None
+    assert erc4626.get_share_price_source() is PriceSource.smart_contract_state
+
+    asseto = AssetoVault(web3, VaultSpec(ASSETO_AOABT_HASHKEY.chain_id, ASSETO_AOABT_HASHKEY.token))
+    assert asseto.get_share_price_source() is PriceSource.smart_contract_state
+    asseto.product = replace(ASSETO_AOABT_HASHKEY, pricer=None, offchain_product_id=1)
+    assert asseto.get_share_price_source() is PriceSource.api
+
+    buidl = SecuritizeVault(web3, VaultSpec(BUIDL_ETHEREUM.chain_id, BUIDL_ETHEREUM.token))
+    acred = SecuritizeVault(web3, VaultSpec(ACRED_ETHEREUM.chain_id, ACRED_ETHEREUM.token))
+    arcoin = SecuritizeVault(web3, VaultSpec(ARCOIN_ETHEREUM.chain_id, ARCOIN_ETHEREUM.token))
+    jltxx = OdaFactVault(web3, VaultSpec(chain_id=1, vault_address=ODA_FACT_JLTXX_ADDRESS))
+    assert buidl.get_share_price_source() is PriceSource.fixed_price
+    assert acred.get_share_price_source() is PriceSource.redstone
+    assert arcoin.get_share_price_source() is None
+    assert jltxx.get_share_price_source() is PriceSource.fixed_price
+
+
+def test_native_vault_row_price_sources() -> None:
+    """Native protocol importers persist API and approximation classifications."""
+
+    timestamp = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC).replace(tzinfo=None)
+    _, lighter = create_lighter_pool_row(1, "Lighter", None, 1_000, timestamp)
+    _, grvt = create_grvt_vault_row("VLT:test", 1, "GRVT", None, 1_000)
+    _, hibachi = create_hibachi_vault_row(1, "HIB", "Hibachi", None, 1_000)
+    _, hyperliquid = create_hyperliquid_vault_row(
+        "0x0000000000000000000000000000000000000001",
+        "Hyperliquid",
+        None,
+        1_000,
+        timestamp,
+    )
+
+    assert lighter["_share_price_source"] is PriceSource.api
+    assert grvt["_share_price_source"] is PriceSource.api
+    assert hibachi["_share_price_source"] is PriceSource.api
+    assert hyperliquid["_share_price_source"] is PriceSource.approximation


### PR DESCRIPTION
## Why

Vault consumers need to distinguish prices read from smart-contract state or external APIs and oracles from fixed or reconstructed values. Without this metadata, downstream users cannot assess how a vault equity curve was produced.

## Lessons learnt

The price source describes the adapter data path rather than the legal NAV publisher. A configured constant USD 1 price is materially different from an approximated curve, so JLTXX and BUIDL use `fixed-price` while Hyperliquid remains `approximation`. Securitize source families can be classified from their reviewed NAV source identifiers without address-specific branches.

## Summary

- Add the public `PriceSource` string enum and `VaultBase.get_share_price_source()`.
- Classify ERC-4626 and direct smart-contract vaults, Asseto, Securitize, JLTXX, Lighter, GRVT, Hibachi and Hyperliquid.
- Persist `_share_price_source` in scanner and native vault metadata.
- Export and document `share_price_source` from `calculate_lifetime_metrics()` and JSON serialisation.
- Add focused adapter, scanner, native-vault, live BUIDL/JLTXX and lifetime-export regression coverage.

## Related issues and PRs

This extends the Securitize off-chain NAV and Kinexys JLTXX integrations already on `master`.

## Unrelated CI and test fixes

None.