### PR TITLE
fix: null unknown vault net period returns

### DIFF
--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -1105,26 +1105,31 @@ def calculate_period_metrics(
     else:
         returns_gross = (share_price_end / share_price_start) - 1
 
-    # Calculate net returns using calculate_net_profit()
-    returns_net = calculate_net_profit(
-        start=samples_start_at,
-        end=samples_end_at,
-        share_price_start=share_price_start,
-        share_price_end=share_price_end,
-        management_fee_annual=net_fee_data.management,
-        performance_fee=net_fee_data.performance,
-        deposit_fee=net_fee_data.deposit,
-        withdrawal_fee=net_fee_data.withdraw,
-        sample_count=raw_samples,
-    )
+    # Do not turn unknown fees into zero fees. ``calculate_net_profit()``
+    # deliberately accepts ``None`` for legacy callers, but an exported net
+    # return is only meaningful when the investor-facing fee model is known.
+    net_performance_known = gross_fee_data.fee_mode is not None and net_fee_data.can_calculate_investor_net_performance()
+    returns_net = None
+    if net_performance_known:
+        returns_net = calculate_net_profit(
+            start=samples_start_at,
+            end=samples_end_at,
+            share_price_start=share_price_start,
+            share_price_end=share_price_end,
+            management_fee_annual=net_fee_data.management,
+            performance_fee=net_fee_data.performance,
+            deposit_fee=net_fee_data.deposit,
+            withdrawal_fee=net_fee_data.withdraw,
+            sample_count=raw_samples,
+        )
 
     # Calculate CAGR (gross and net)
     # CAGR formula: (1 + return) ^ (1/years) - 1
     years = sample_duration.days / 365.25
     base_gross = 1 + returns_gross
-    base_net = 1 + returns_net
+    base_net = 1 + returns_net if returns_net is not None else None
 
-    if base_gross < 0 or base_net < 0:
+    if base_gross < 0 or (base_net is not None and base_net < 0):
         return PeriodMetrics(
             period=period,
             raw_samples=raw_samples,
@@ -1162,13 +1167,16 @@ def calculate_period_metrics(
     except OverflowError:
         cagr_gross = max_cagr
 
-    try:
-        cagr_net = base_net ** (1 / years) - 1
-    except OverflowError:
-        cagr_net = max_cagr
+    cagr_net = None
+    if base_net is not None:
+        try:
+            cagr_net = base_net ** (1 / years) - 1
+        except OverflowError:
+            cagr_net = max_cagr
 
     cagr_gross = min(cagr_gross, max_cagr)
-    cagr_net = min(cagr_net, max_cagr)
+    if cagr_net is not None:
+        cagr_net = min(cagr_net, max_cagr)
 
     # Calculate daily returns for volatility.
     # Drop NaN prices first so pct_change works across sparse data
@@ -1833,8 +1841,10 @@ def calculate_vault_record(
         symbol=normalised_denomination,
     )
 
-    # Do we know fees for this vault
-    known_fee = mgmt_fee is not None and perf_fee is not None
+    # Do we know enough to calculate an investor-facing net return?
+    # This uses the fee-mode-adjusted fees, because internalised management
+    # and performance fees are already reflected in the share price.
+    known_fee = net_fee_data.can_calculate_investor_net_performance()
 
     # Ensure prices_df index is monotonic and clean
     prices_df = prices_df.loc[~prices_df.index.isna()].sort_index(kind="stable")

--- a/eth_defi/vault/fee.py
+++ b/eth_defi/vault/fee.py
@@ -268,6 +268,26 @@ class FeeData:
         else:
             return self
 
+    def can_calculate_investor_net_performance(self) -> bool:
+        """Check whether fee data is sufficient for investor net-return calculations.
+
+        Net return calculations require a known fee mode and every fee that can
+        affect an investor's deposit-to-redemption return.  In particular,
+        unknown values must not be treated as zero fees.
+
+        :return:
+            ``True`` when the fee mode and all investor-facing fees are known.
+        """
+        return self.fee_mode is not None and all(
+            fee is not None
+            for fee in (
+                self.management,
+                self.performance,
+                self.deposit,
+                self.withdraw,
+            )
+        )
+
 
 #: Could not read fee data from the smart contract / unsupported protocol
 BROKEN_FEE_DATA = FeeData(

--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -312,6 +312,54 @@ def test_calculate_lifetime_metrics_blacklists_scanned_bad_flags(
     assert row["notes"] == expected_note
 
 
+def test_calculate_lifetime_metrics_nullifies_period_net_returns_when_fee_mode_unknown(
+    vault_db: VaultDatabase,
+    price_df: pd.DataFrame,
+) -> None:
+    """Unknown Securitize fee data never produces implied zero-fee net returns."""
+    source_vault_id = "43111-0x05c2e246156d37b39a825a25dd08d5589e3fd883"
+    vault_address = "0x671642Ac281C760e34251d51bC9eEF27026F3B7a"
+    vault_spec = VaultSpec(5000, vault_address)
+    vault_row = dict(vault_db.rows[VaultSpec.parse_string(source_vault_id)])
+    vault_row.update(
+        {
+            "Name": "Mantle Index Four",
+            "Address": vault_address,
+            "Protocol": "Securitize",
+            "_fees": FeeData(
+                fee_mode=None,
+                management=None,
+                performance=None,
+                deposit=None,
+                withdraw=None,
+            ),
+        }
+    )
+    vault_prices = price_df.loc[price_df["id"] == source_vault_id].copy()
+    vault_prices["id"] = vault_spec.as_string_id()
+    vault_prices["chain"] = 5000
+
+    metrics = calculate_lifetime_metrics(vault_prices, {vault_spec: vault_row})
+    row = metrics.iloc[0]
+
+    assert row["fee_mode"] is None
+    assert row["cagr_net"] is None
+    assert row["lifetime_return_net"] is None
+    assert row["one_month_returns_net"] is None
+    assert row["three_months_returns_net"] is None
+
+    period_results = row["period_results"]
+    assert all(period.returns_net is None for period in period_results)
+    assert all(period.cagr_net is None for period in period_results)
+    assert any(period.returns_gross is not None for period in period_results)
+    assert any(period.cagr_gross is not None for period in period_results)
+
+    exported = export_lifetime_row(row)
+    json.dumps(exported)
+    assert all(period["returns_net"] is None for period in exported["period_results"])
+    assert all(period["cagr_net"] is None for period in exported["period_results"])
+
+
 def test_calculate_lifetime_metrics_uses_scanned_d2_notes(
     vault_db: VaultDatabase,
     price_df: pd.DataFrame,


### PR DESCRIPTION
## Why

Vault exports reported period-level net returns even though Mantle Index Four has no known fee mode or investor fee data.

## Lessons learnt

Unknown fees must not be treated as zero fees in investor-performance exports.

## Summary

- Gate period-level net returns and CAGR on complete investor-facing fee data.
- Add a Mantle Index Four-shaped regression test for JSON export consistency.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.