### PR TITLE
notes: mark AUSD yVault as subvault

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -622,6 +622,8 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0xf7ede5332c6b4a235be4aa3c019222cfe72e984f": (VaultFlag.subvault, SUBVAULT),
     # Morpho Steakhouse Prime AUSD Compounder
     "0xc1ec6d26902949bf6cbb0c9859dbead1e87fb243": (VaultFlag.subvault, SUBVAULT),
+    # AUSD yVault (Yearn on Katana)
+    "0x93fec6639717b6215a48e5a72a162c50dcc40d68": (VaultFlag.subvault, SUBVAULT),
     # Hyperliquidity Trader (HLT) - irregular share price action due to epoch resets
     "0x5a733b25a17dc0f26b862ca9e32b439801b1a8c7": (VaultFlag.abnormal_share_price, HLT_IRREGULAR_SHARE_PRICE),
     # Secured Finance JPYC Lender

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -93,6 +93,7 @@ def test_hyperevm_out_of_gas_vault_is_blacklisted() -> None:
         ("0xda2f1b3cba732d779cff56f0cf9d3bc8aea6cd8d", "Yearn", VaultFlag.subvault, "not intended"),
         ("0x8092c20351cf4048b464df2144dc8a4dd49ce71d", "Morpho", VaultFlag.subvault, "not intended"),
         ("0xc9f01b5c6048b064e6d925d1c2d7206d4feef8a3", "Yearn", VaultFlag.subvault, "not intended"),
+        ("0x93fec6639717b6215a48e5a72a162c50dcc40d68", "Yearn", VaultFlag.subvault, "not intended"),
         ("0xad755c6c31515aef8d2f830767d846774f7e9ea9", "Morpho", VaultFlag.malicious, "malicious"),
     ],
 )


### PR DESCRIPTION
## Why

AUSD yVault should be treated as a subvault so it is not directly exposed in end-user vault listings.

## Lessons learnt

The exported Trading Strategy vault record resolves `ausd-yvault` to Katana address `0x93fec6639717b6215a48e5a72a162c50dcc40d68`.

## Summary

- Added AUSD yVault to the manual vault flags as `VaultFlag.subvault`.
- Added regression coverage for the manual subvault flag.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.