### PR TITLE
fix: retain Tempo Morpho vaults during API coverage gap

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/morpho/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/offchain_metadata.py
@@ -96,14 +96,15 @@ MORPHO_API_SUPPORTED_CHAINS = frozenset(
 #: Chains where a missing Morpho API record must not blacklist an otherwise
 #: detected Morpho vault.
 #:
-#: Robinhood Chain launched with active Morpho V2 vaults, but its API coverage
-#: is incomplete: some legitimate vaults do not yet resolve by address. Until
-#: Morpho's API provides complete Robinhood coverage, retain on-chain detected
-#: vaults in the universe and omit only unavailable API warning enrichment.
+#: Robinhood Chain and Tempo launched with active Morpho vaults before the
+#: public API had complete coverage. Some legitimate vaults therefore do not
+#: resolve by address. Until Morpho's API provides complete coverage, retain
+#: on-chain detected vaults in the universe and omit only unavailable API
+#: warning enrichment.
 #:
-#: Remove Robinhood from this set once all production Robinhood Morpho vaults
-#: reliably resolve through the public API.
-MORPHO_API_NOT_FOUND_FLAG_BYPASS_CHAINS = frozenset({4663})  # Robinhood Chain
+#: Remove either chain from this set once its production Morpho vaults reliably
+#: resolve through the public API.
+MORPHO_API_NOT_FOUND_FLAG_BYPASS_CHAINS = frozenset({4217, 4663})  # Tempo, Robinhood Chain
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +112,8 @@ logger = logging.getLogger(__name__)
 def is_morpho_api_not_found_flag_bypassed(chain_id: int) -> bool:
     """Check whether a missing Morpho API record is temporarily non-fatal.
 
-    This narrowly scopes a temporary Robinhood Chain data-quality workaround.
+    This narrowly scopes temporary Tempo and Robinhood Chain data-quality
+    workarounds.
     It does not suppress RED-level warnings returned by the API, nor does it
     affect normal missing-vault handling on any other chain.
 

--- a/tests/morpho/test_morpho_offchain_metadata.py
+++ b/tests/morpho/test_morpho_offchain_metadata.py
@@ -202,18 +202,22 @@ def test_morpho_not_found_adds_dynamic_flag_and_note(monkeypatch: pytest.MonkeyP
 
 
 @pytest.mark.parametrize(
-    ("vault_class", "module_path"),
+    ("chain_id", "chain_name", "vault_class", "module_path"),
     [
-        (MorphoV1Vault, "eth_defi.erc_4626.vault_protocol.morpho.vault_v1"),
-        (MorphoV2Vault, "eth_defi.erc_4626.vault_protocol.morpho.vault_v2"),
+        (4217, "Tempo", MorphoV1Vault, "eth_defi.erc_4626.vault_protocol.morpho.vault_v1"),
+        (4217, "Tempo", MorphoV2Vault, "eth_defi.erc_4626.vault_protocol.morpho.vault_v2"),
+        (4663, "Robinhood", MorphoV1Vault, "eth_defi.erc_4626.vault_protocol.morpho.vault_v1"),
+        (4663, "Robinhood", MorphoV2Vault, "eth_defi.erc_4626.vault_protocol.morpho.vault_v2"),
     ],
 )
-def test_robinhood_morpho_api_not_found_is_temporarily_not_blacklisted(
+def test_morpho_api_not_found_bypass_chains_are_temporarily_not_blacklisted(
     monkeypatch: pytest.MonkeyPatch,
+    chain_id: int,
+    chain_name: str,
     vault_class: type[MorphoV1Vault] | type[MorphoV2Vault],
     module_path: str,
 ):
-    """Robinhood API coverage gaps do not hide on-chain-detected Morpho vaults."""
+    """Tempo and Robinhood API coverage gaps do not hide detected Morpho vaults."""
     _patch_base_vault_flags(monkeypatch)
 
     def fake_fetch_morpho_vault_api_result(*_args, **_kwargs) -> MorphoVaultAPIResult:
@@ -221,13 +225,13 @@ def test_robinhood_morpho_api_not_found_is_temporarily_not_blacklisted(
 
     monkeypatch.setattr(f"{module_path}.fetch_morpho_vault_api_result", fake_fetch_morpho_vault_api_result)
     vault = vault_class(
-        web3=_FakeWeb3(4663),  # type: ignore[arg-type]
-        spec=VaultSpec(chain_id=4663, vault_address=NOT_FOUND_TEST_VAULT),
+        web3=_FakeWeb3(chain_id),  # type: ignore[arg-type]
+        spec=VaultSpec(chain_id=chain_id, vault_address=NOT_FOUND_TEST_VAULT),
         token_cache={},
     )
 
-    assert vault.get_flags() == set()
-    assert vault.get_notes() is None
+    assert vault.get_flags() == set(), chain_name
+    assert vault.get_notes() is None, chain_name
 
 
 def test_morpho_not_found_is_not_cached(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):


### PR DESCRIPTION
## Why

Tempo Morpho vaults with pathUSD denominations are legitimate on-chain vaults, but the public Morpho API does not yet cover Tempo. Its definitive missing-record response was incorrectly escalated to a hard blacklist.

## Lessons learnt

A missing Morpho API record on a newly supported chain can reflect incomplete API coverage rather than a vault-level risk signal; the exception must remain scoped to that chain.

## Summary

- Add Tempo (chain 4217) to the temporary Morpho API missing-record bypass.
- Preserve the existing Robinhood bypass.
- Test both Morpho V1 and V2 adapters for both bypass chains.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.