### PR TITLE
fix: export D2 Finance protocol curator

### DIFF
--- a/eth_defi/vault/curator.py
+++ b/eth_defi/vault/curator.py
@@ -159,6 +159,7 @@ CURATORS_DATA_DIR: Path = Path(__file__).parent.parent / "data" / "feeds" / "cur
 #: :py:func:`eth_defi.research.vault_metrics.slugify_protocol` output.
 PROTOCOL_CURATED_SLUGS: set[str] = {
     "atoma",
+    "d2-finance",
     "frankencoin",
     "gains-network",
     "ostium",
@@ -191,6 +192,7 @@ ALL_PROTOCOL_CURATOR_SLUGS: set[str] = PROTOCOL_CURATED_SLUGS | {
 #: slug matches a protocol rather than a third-party curator YAML file.
 PROTOCOL_CURATOR_NAMES: dict[str, str] = {
     "atoma": "Atoma",
+    "d2-finance": "D2 Finance",
     "frankencoin": "Frankencoin",
     "gains-network": "Gains Network",
     "ostium": "Ostium",

--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -515,6 +515,7 @@ def test_calculate_lifetime_metrics_uses_scanned_d2_notes(
     spec = VaultSpec.parse_string(vault_id)
     vault_row = dict(vault_db.rows[spec])
     vault_row["Protocol"] = D2_PROTOCOL_NAME
+    vault_row["protocol_slug"] = "d2-finance"
     vault_row["Address"] = address
     vault_row["_risk"] = VaultTechnicalRisk.negligible
     vault_row["_flags"] = set()
@@ -526,10 +527,22 @@ def test_calculate_lifetime_metrics_uses_scanned_d2_notes(
         {spec: vault_row},
     )
 
-    note = metrics.iloc[0]["notes"]
+    lifetime_row = metrics.iloc[0]
+    note = lifetime_row["notes"]
     assert "D2 Finance strategy vault" in note
     assert "**Summary:**" in note
     assert f"[D2 strategy page](https://d2.finance/strategies/{address})" in note
+
+    assert lifetime_row["curator_slug"] == "d2-finance"
+    assert lifetime_row["curator_name"] == "D2 Finance"
+    assert bool(lifetime_row["protocol_curator"]) is True
+
+    exported = json.loads(json.dumps(export_lifetime_row(lifetime_row)))
+    assert exported["protocol"] == "D2 Finance"
+    assert exported["protocol_slug"] == "d2-finance"
+    assert exported["curator_slug"] == "d2-finance"
+    assert exported["curator_name"] == "D2 Finance"
+    assert exported["protocol_curator"] is True
 
 
 def test_calculate_lifetime_metrics_does_not_apply_non_d2_protocol_notes(

--- a/tests/vault/test_curator.py
+++ b/tests/vault/test_curator.py
@@ -605,6 +605,27 @@ def test_identify_gains_network_protocol_curator() -> None:
     assert get_curator_name("gains-network") == "Gains Network"
 
 
+def test_identify_d2_finance_protocol_curator() -> None:
+    """D2 HYPE++ resolves to the D2 Finance protocol curator.
+
+    D2 Finance's documented strategy vault architecture has the D2 trading
+    team execute each vault's strategy through the protocol's trader/OMS
+    infrastructure, so D2 protocol vaults are not inferred from their names.
+    """
+
+    slug = identify_curator(
+        chain_id=42161,
+        vault_token_symbol="HYPE++",
+        vault_name="HYPE++",
+        vault_address="0x75288264fdfea8ce68e6d852696ab1ce2f3e5004",
+        protocol_slug="d2-finance",
+    )
+
+    assert slug == "d2-finance"
+    assert get_curator_name(slug) == "D2 Finance"
+    assert is_protocol_curator(slug)
+
+
 def test_identify_3jane_protocol_curator() -> None:
     """3Jane protocol vaults (USD3/sUSD3) resolve to the protocol-managed slug."""
 

--- a/tests/vault/test_curator_export.py
+++ b/tests/vault/test_curator_export.py
@@ -147,6 +147,29 @@ def test_build_curators_for_export_frankencoin_protocol_curator_alias():
     assert rec["linkedin"] == "https://www.linkedin.com/company/frankencoin"
 
 
+def test_build_curators_for_export_d2_finance_protocol_curator():
+    """D2 Finance protocol curator metadata uses its protocol feeder and logos."""
+
+    result = build_curators_for_export(
+        ["d2-finance"],
+        feed_db=None,
+        public_url="https://example.com",
+    )
+
+    rec = result["d2-finance"]
+    assert rec["name"] == "D2 Finance"
+    assert rec["website"] == "https://d2.finance/"
+    assert rec["twitter"] == "https://x.com/D2_Finance"
+    assert rec["linkedin"] == "https://www.linkedin.com/company/d2finance"
+    assert rec["protocol_curator"] is True
+    assert rec["canonical_feeder_id"] is None
+    assert rec["logos"] == {
+        "generic": "https://example.com/curator-metadata/d2-finance/generic.png",
+        "dark": "https://example.com/curator-metadata/d2-finance/dark.png",
+        "light": "https://example.com/curator-metadata/d2-finance/light.png",
+    }
+
+
 def test_build_curators_for_export_canonical_feeder(tmp_path: Path):
     """Alias curators fetch posts from the canonical feeder.
 


### PR DESCRIPTION
## Why

D2 Finance vault records lacked protocol-curator metadata, preventing consumers from reliably associating D2 HYPE++ with its curator.

## Lessons learnt

Protocol-operated vaults must be classified from their protocol slug, rather than inferred from display names.

## Summary

- Classify D2 Finance vaults as protocol curated.
- Export D2 curator metadata using the protocol feeder and existing logos.
- Cover curator detection and vault JSON fields with regressions.

## Related issues and PRs

- None.

## Unrelated CI and test fixes

- None.