### PR TITLE
fix: preserve legacy wstGBP feature pickles

### DIFF
--- a/eth_defi/erc_4626/core.py
+++ b/eth_defi/erc_4626/core.py
@@ -84,6 +84,26 @@ class ERC4626Feature(enum.Enum):
     #: through a :py:class:`eth_defi.vault.base.VaultBase` adapter.
     wstgbp_like = "wstgbp_like"
 
+    @classmethod
+    def _missing_(cls, value: object) -> "ERC4626Feature | None":
+        """Map retired feature values retained in persisted vault databases.
+
+        Vault discovery state is pickled, and enum unpickling resolves members
+        by their value. ``maseer_one_like`` was renamed to ``wstgbp_like``;
+        retain this value-level migration so existing scan databases remain
+        readable without reclassification or data loss.
+
+        :param value:
+            Serialised enum value.
+        :return:
+            Canonical enum member for a retired value, or ``None`` when the
+            value is unknown.
+        """
+
+        if value == "maseer_one_like":
+            return cls.wstgbp_like
+        return None
+
     #: Vault Street permissioned tokenised investment products.
     #:
     #: Routing marker for non-ERC-4626 products read through a

--- a/tests/erc_4626/test_wstgbp_feature_compatibility.py
+++ b/tests/erc_4626/test_wstgbp_feature_compatibility.py
@@ -1,0 +1,27 @@
+"""Compatibility tests for the wstGBP vault feature migration."""
+
+import pickle
+
+from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name
+
+
+class LegacyMaseerFeature:
+    """Represent the legacy enum payload stored in vault database pickles."""
+
+    def __reduce__(self) -> tuple[object, tuple[str]]:
+        """Recreate the old enum-value deserialisation call.
+
+        :return:
+            Enum constructor and the persisted legacy value.
+        """
+
+        return ERC4626Feature, ("maseer_one_like",)
+
+
+def test_unpickle_legacy_maseer_feature_as_wstgbp() -> None:
+    """Load legacy Maseer feature values from an existing vault database."""
+
+    restored_feature = pickle.loads(pickle.dumps(LegacyMaseerFeature()))
+
+    assert restored_feature is ERC4626Feature.wstgbp_like
+    assert get_vault_protocol_name({restored_feature}) == "wstGBP"


### PR DESCRIPTION
## Why

Existing vault-database pickles contain the retired `maseer_one_like` enum value, which otherwise prevents both lead and price scans from loading.

## Lessons learnt

Persisted enum values are part of the scanner database compatibility surface and need value-level migrations when protocols are renamed.

## Summary

- Map the retired `maseer_one_like` pickle value to canonical `wstgbp_like`.
- Add a regression test that unpickles the legacy enum payload and resolves it as wstGBP.

## Related issues and PRs

Follow-up to #1315.

## Unrelated CI and test fixes

None.