### PR TITLE
docs: update wstGBP wording and onchain convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ Skill discovery rules:
 
 - Use UK/British English instead of US English
 - Say things like `visualise` instead of `visualize`
+- Always spell `onchain` without a hyphen; correct `on-chain` to `onchain`
 - For headings, only capitalise the first letter of heading, do not use title case
 
 ## Installing dependencies

--- a/eth_defi/data/vaults/metadata/wstgbp.yaml
+++ b/eth_defi/data/vaults/metadata/wstgbp.yaml
@@ -3,7 +3,7 @@ slug: wstgbp
 short_description: |
   Non-custodial tokenised sterling with onchain NAV and permissionless minting and redemption.
 long_description: |
-  wstGBP (Wren Staked tGBP) is a non-custodial, non-rebasing ERC-20 wrapper around tGBP, a pound sterling stablecoin issued by BCP Technologies, an FCA-registered cryptoasset firm, backed 1:1 by sterling reserves. Users mint and redeem permissionlessly on Ethereum at the on-chain exchange rate. Balances stay fixed and rewards, when applied, are reflected in the wstGBP to tGBP exchange rate through periodic NAV updates. Minting is free and instant redemption carries a 25 bps fee, with no cooldown.
+  wstGBP (Wren Staked tGBP) is a non-custodial, non-rebasing ERC-20 wrapper around tGBP, a pound sterling stablecoin issued by BCP Technologies, an FCA-registered cryptoasset firm, backed 1:1 by sterling reserves. Users mint and redeem permissionlessly on Ethereum at the onchain exchange rate. Balances stay fixed and rewards, when applied, are reflected in the wstGBP to tGBP exchange rate through periodic NAV updates. Minting is free and instant redemption carries a 25 bps fee, with no cooldown.
 fee_description: |
   Minting is free and instant redemption carries a 25 bps fee, with no cooldown.
 links:

--- a/eth_defi/data/vaults/metadata/wstgbp.yaml
+++ b/eth_defi/data/vaults/metadata/wstgbp.yaml
@@ -3,8 +3,7 @@ slug: wstgbp
 short_description: |
   Non-custodial tokenised sterling with onchain NAV and permissionless minting and redemption.
 long_description: |
-  wstGBP is a non-custodial smart-contract wrapper for tokenised sterling with
-  onchain NAV and permissionless minting and redemption.
+  wstGBP (Wren Staked tGBP) is a non-custodial, non-rebasing ERC-20 wrapper around tGBP, a pound sterling stablecoin issued by BCP Technologies, an FCA-registered cryptoasset firm, backed 1:1 by sterling reserves. Users mint and redeem permissionlessly on Ethereum at the on-chain exchange rate. Balances stay fixed and rewards, when applied, are reflected in the wstGBP to tGBP exchange rate through periodic NAV updates. Minting is free and instant redemption carries a 25 bps fee, with no cooldown.
 fee_description: |
   Minting is free and instant redemption carries a 25 bps fee, with no cooldown.
 links:


### PR DESCRIPTION
## Why

Keep wstGBP metadata aligned with the supplied product description and make the preferred onchain spelling explicit for future edits.

## Lessons learnt

Protocol metadata is consumed independently of vault adapter notes, so its wording must be updated directly.

## Summary

- Update the wstGBP long description with the requested product information.
- Document that `onchain` is always spelled without a hyphen.

## Related issues and PRs

Follow-up to #1315.

## Unrelated CI and test fixes

None.