### PR TITLE
feat: add HKD rates and fix Asseto backfill cleaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- feat: Backfill HKD exchange rates and keep HKD-denominated Asseto histories out of the stablecoin-only cleaned dataset (2026-07-18)
 - feat: Add a protocol-selectable generic HyperSync backfill command for tokenised funds (2026-07-17)
 - feat: Start hardcoded tokenised-fund protocol coverage with an EVM integration roadmap (2026-07-17)
 - feat: Add Ondo USDY and OUSG tokenised-fund support with issuer NAV history and curator attribution (2026-07-17)

--- a/docs/source/api/currency_api/index.rst
+++ b/docs/source/api/currency_api/index.rst
@@ -6,8 +6,8 @@ Historical exchange rate ingestion from the free, no-API-key
 (``@fawazahmed0/currency-api``).
 
 This module incrementally scans daily historical exchange rates for a
-configurable set of named currencies (default: EUR, GBP, JPY, AUD, SGD, TRY,
-CHF, CAD, BTC, ETH against USD) and stores them in DuckDB:
+configurable set of named currencies (default: EUR, GBP, JPY, AUD, SGD, HKD,
+TRY, CHF, CAD, BTC, ETH against USD) and stores them in DuckDB:
 
 - One HTTP request per date returns the base currency against ~200 fiat and
   crypto currencies, with a jsDelivr → Cloudflare Pages host fallback

--- a/eth_defi/currency_api/README-currency-api.md
+++ b/eth_defi/currency_api/README-currency-api.md
@@ -3,7 +3,7 @@
 ## Overview
 
 Incrementally scans daily historical exchange rates for a configurable set of
-named currencies (default: EUR, GBP, JPY, AUD, SGD, TRY, CHF, CAD, BTC, ETH
+named currencies (default: EUR, GBP, JPY, AUD, SGD, HKD, TRY, CHF, CAD, BTC, ETH
 against USD) and stores them in a DuckDB database. The data is sourced from the **fawazahmed0 Exchange API**
 (`@fawazahmed0/currency-api`).
 
@@ -178,7 +178,7 @@ LOG_LEVEL=info START_DATE=2026-06-01 END_DATE=2026-06-05 \
   poetry run scan-currencies
 
 # Add more currencies (no schema change; history backfills automatically)
-QUOTE_CURRENCIES=eur,gbp,jpy,aud,sgd,try,chf,cad,btc,eth,sol \
+QUOTE_CURRENCIES=eur,gbp,jpy,aud,sgd,hkd,try,chf,cad,btc,eth,sol \
   poetry run scan-currencies
 
 # Use a non-USD base
@@ -196,7 +196,7 @@ poetry run python -m eth_defi.currency_api.cli
 | `LOG_LEVEL` | `warning` | Logging level |
 | `DB_PATH` | `~/.tradingstrategy/currency-api/exchange-rates.duckdb` | DuckDB database path |
 | `BASE_CURRENCY` | `usd` | Base currency |
-| `QUOTE_CURRENCIES` | `eur,gbp,jpy,aud,sgd,try,chf,cad,btc,eth` | Comma-separated quote currencies |
+| `QUOTE_CURRENCIES` | `eur,gbp,jpy,aud,sgd,hkd,try,chf,cad,btc,eth` | Comma-separated quote currencies |
 | `START_DATE` | *(resume / earliest)* | `YYYY-MM-DD` lower bound (small-batch testing) |
 | `END_DATE` | *(today, UTC)* | `YYYY-MM-DD` upper bound (small-batch testing) |
 | `MAX_WORKERS` | `8` | Parallel date fetchers (threaded) |

--- a/eth_defi/currency_api/__init__.py
+++ b/eth_defi/currency_api/__init__.py
@@ -1,8 +1,8 @@
 """Historical exchange rate ingestion from the fawazahmed0 Exchange API.
 
 This package incrementally scans daily historical exchange rates for a
-configurable set of named currencies (default: EUR, GBP, JPY, AUD, SGD, TRY,
-CHF, CAD, BTC, ETH against USD) and stores them in a DuckDB database.
+configurable set of named currencies (default: EUR, GBP, JPY, AUD, SGD, HKD,
+TRY, CHF, CAD, BTC, ETH against USD) and stores them in a DuckDB database.
 
 The data is sourced from the free, no-API-key
 `fawazahmed0 Exchange API <https://github.com/fawazahmed0/exchange-api>`__

--- a/eth_defi/currency_api/cli.py
+++ b/eth_defi/currency_api/cli.py
@@ -1,7 +1,7 @@
 """Command-line entry point for the currency_api exchange rate scanner.
 
 Fetches daily exchange rates for a configurable set of named currencies
-(default: EUR, GBP, JPY, AUD, SGD, TRY, CHF, CAD, BTC, ETH against USD) from the free, no-API-key
+(default: EUR, GBP, JPY, AUD, SGD, HKD, TRY, CHF, CAD, BTC, ETH against USD) from the free, no-API-key
 fawazahmed0 Exchange API and stores them in a DuckDB database. Resume is
 completeness-driven, so re-running only fetches missing dates/currencies.
 
@@ -17,7 +17,7 @@ Installed as the ``scan-currencies`` Poetry console script
     LOG_LEVEL=info START_DATE=2026-06-01 END_DATE=2026-06-05 poetry run scan-currencies
 
     # Add more currencies (history backfills automatically)
-    QUOTE_CURRENCIES=eur,gbp,jpy,aud,sgd,try,chf,cad,btc,eth,sol poetry run scan-currencies
+    QUOTE_CURRENCIES=eur,gbp,jpy,aud,sgd,hkd,try,chf,cad,btc,eth,sol poetry run scan-currencies
 
 It can also be run as a module: ``poetry run python -m eth_defi.currency_api.cli``.
 
@@ -26,7 +26,7 @@ Environment variables:
 - ``LOG_LEVEL``: Logging level (debug, info, warning, error). Default: warning
 - ``DB_PATH``: DuckDB database file. Default: ~/.tradingstrategy/currency-api/exchange-rates.duckdb
 - ``BASE_CURRENCY``: Base currency. Default: usd
-- ``QUOTE_CURRENCIES``: Comma-separated quote currencies. Default: eur,gbp,jpy,aud,sgd,try,chf,cad,btc,eth
+- ``QUOTE_CURRENCIES``: Comma-separated quote currencies. Default: eur,gbp,jpy,aud,sgd,hkd,try,chf,cad,btc,eth
 - ``START_DATE``: ``YYYY-MM-DD`` lower bound. Default: resume / earliest available
 - ``END_DATE``: ``YYYY-MM-DD`` upper bound. Default: today (UTC)
 - ``MAX_WORKERS``: Parallel date fetchers. Default: 8

--- a/eth_defi/currency_api/constants.py
+++ b/eth_defi/currency_api/constants.py
@@ -28,7 +28,7 @@ SOURCE_NAME = "fawazahmed0"
 DEFAULT_BASE_CURRENCY = "usd"
 
 #: Default set of named quote currencies to scan.
-DEFAULT_QUOTE_CURRENCIES = ("eur", "gbp", "jpy", "aud", "sgd", "try", "chf", "cad", "btc", "eth")
+DEFAULT_QUOTE_CURRENCIES = ("eur", "gbp", "jpy", "aud", "sgd", "hkd", "try", "chf", "cad", "btc", "eth")
 
 #: Earliest date for which the source publishes data: 2024-03-02.
 #:

--- a/eth_defi/tokenised_fund/asseto/backfill.py
+++ b/eth_defi/tokenised_fund/asseto/backfill.py
@@ -83,7 +83,7 @@ from eth_defi.provider.env import get_json_rpc_env, read_json_rpc_url
 from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
 from eth_defi.provider.named import get_provider_name
 from eth_defi.research.wrangle_vault_prices import replace_cleaned_vault_histories
-from eth_defi.token import TokenDiskCache
+from eth_defi.token import TokenDiskCache, is_stablecoin_like
 from eth_defi.tokenised_fund.asseto.constants import ASSETO_PRODUCTS, AssetoProduct
 from eth_defi.tokenised_fund.asseto.offchain_api import AssetoOffchainProduct, fetch_asseto_products
 from eth_defi.utils import setup_console_logging
@@ -411,6 +411,32 @@ def build_vaults(web3: Web3, products: list[AssetoProduct], token_cache: TokenDi
     return vaults
 
 
+def select_cleanable_vault_ids(products: Iterable[AssetoProduct], rows: dict[VaultSpec, dict]) -> set[str]:
+    """Select Asseto histories supported by the stablecoin-only cleaner.
+
+    Asseto publishes products denominated in currencies such as HKD. Their raw
+    NAV histories are valid, but the shared cleaned-price pipeline deliberately
+    filters out denominations not recognised by :func:`is_stablecoin_like`.
+    Passing those identifiers to the strict replacement helper would make it
+    interpret the expected filtering as accidental data loss.
+
+    :param products:
+        Asseto products whose raw histories were scanned.
+    :param rows:
+        Fresh vault metadata rows keyed by vault specification.
+    :return:
+        Canonical vault identifiers eligible for cleaned-history replacement.
+    """
+
+    cleanable_ids: set[str] = set()
+    for product in products:
+        spec = VaultSpec(product.chain_id, product.token)
+        denomination = rows[spec].get("Denomination")
+        if is_stablecoin_like(denomination):
+            cleanable_ids.add(spec.as_string_id())
+    return cleanable_ids
+
+
 def fetch_contract_deployment_block(web3: Web3, address: HexAddress, end_block: int) -> int:
     """Find the first block containing runtime code for an Asseto token.
 
@@ -603,12 +629,25 @@ def backfill_chain(  # noqa: PLR0914 - explicit production pipeline state keeps 
             write_reader_states(reader_state_database_path, reader_states)
             scan_summary = pformat_scan_result(scan_result)
             if clean_prices:
-                cleaned_rows = replace_cleaned_vault_histories(
-                    {VaultSpec(product.chain_id, product.token).as_string_id() for product in scanned_products},
-                    vault_db_path=vault_db_path,
-                    raw_price_df_path=price_database_path,
-                    cleaned_price_df_path=cleaned_price_database_path,
-                    logger=logger.info,
+                cleanable_ids = select_cleanable_vault_ids(scanned_products, rows)
+                scanned_ids = {VaultSpec(product.chain_id, product.token).as_string_id() for product in scanned_products}
+                skipped_ids = scanned_ids - cleanable_ids
+                if skipped_ids:
+                    logger.warning(
+                        "Keeping raw history but skipping cleaned-history replacement for %d Asseto vaults with unsupported denominations: %s",
+                        len(skipped_ids),
+                        ", ".join(sorted(skipped_ids)),
+                    )
+                cleaned_rows = (
+                    replace_cleaned_vault_histories(
+                        cleanable_ids,
+                        vault_db_path=vault_db_path,
+                        raw_price_df_path=price_database_path,
+                        cleaned_price_df_path=cleaned_price_database_path,
+                        logger=logger.info,
+                    )
+                    if cleanable_ids
+                    else 0
                 )
                 scan_summary = f"{scan_summary}; cleaned_rows={cleaned_rows:,}"
 

--- a/tests/asseto/test_asseto_backfill_history.py
+++ b/tests/asseto/test_asseto_backfill_history.py
@@ -9,6 +9,7 @@ from eth_defi.chain import CHAIN_NAMES
 from eth_defi.tokenised_fund.asseto import backfill
 from eth_defi.tokenised_fund.asseto.constants import ASSETO_AOABT_HASHKEY
 from eth_defi.tokenised_fund.asseto.offchain_api import AssetoOffchainProduct
+from eth_defi.vault.base import VaultSpec
 
 EXPLICIT_START_BLOCK = 123_456
 
@@ -106,6 +107,19 @@ def test_build_vaults_skips_product_without_denomination_address(monkeypatch: py
     monkeypatch.setattr(backfill_history_module, "create_vault_instance", unexpected_vault_creation)
 
     assert backfill_history_module.build_vaults(object(), [product_without_collateral], object()) == []
+
+
+def test_select_cleanable_vault_ids_excludes_hkd_products(backfill_history_module) -> None:
+    """Keep HKD Asseto histories raw without passing them to the USD cleaner."""
+
+    usdc_product = replace(ASSETO_AOABT_HASHKEY, chain_id=1, token="0x4867ad1a74b38b0aeff4fff251ed0dadae4f4630", symbol="CFSRS")
+    hkd_product = replace(ASSETO_AOABT_HASHKEY, chain_id=1, token="0x6dc4674573380aff6c3359e19da5cbb6afceb5c3", symbol="CFSAI")
+    rows = {
+        VaultSpec(usdc_product.chain_id, usdc_product.token): {"Denomination": "USDC"},
+        VaultSpec(hkd_product.chain_id, hkd_product.token): {"Denomination": "HKD"},
+    }
+
+    assert backfill_history_module.select_cleanable_vault_ids([usdc_product, hkd_product], rows) == {VaultSpec(usdc_product.chain_id, usdc_product.token).as_string_id()}
 
 
 def test_resolve_price_scan_start_block_uses_asseto_deployment(

--- a/tests/currency_api/test_currency_api.py
+++ b/tests/currency_api/test_currency_api.py
@@ -50,6 +50,7 @@ RATE_BOUNDS = {
     "jpy": (50.0, 500.0),
     "aud": (1.0, 2.5),
     "sgd": (1.0, 2.0),
+    "hkd": (5.0, 10.0),
     "try": (10.0, 100.0),
     "chf": (0.5, 1.5),
     "cad": (1.0, 2.5),
@@ -68,7 +69,7 @@ def test_limited_end_to_end_scan(db_path: Path):
     """Limited real-network end-to-end scan stores and is idempotent.
 
     1. Run a 3-day scan (2026-06-01..03) for the default currencies into a temp DB.
-    2. Assert every (date, quote) cell is present (3 dates x 10 quotes = 30 rows),
+    2. Assert every (date, quote) cell is present (3 dates x 11 quotes = 33 rows),
        the source column is populated, rates are within loose sanity bounds, and
        there were no transient failures.
     3. Re-run the identical scan and assert the row count is unchanged (idempotent


### PR DESCRIPTION
## Why

The all-protocol tokenised-fund backfill crashed after successfully scanning Asseto because CFSAI and AdDLT are HKD-denominated. Their raw histories are valid, but the shared cleaned-price pipeline intentionally filters to recognised stablecoin denominations and its strict replacement guard correctly refused to remove the selected HKD identifiers. HKD exchange-rate history is also needed in the shared currency database for these products.

## Lessons learnt

Asseto raw history supports more fiat denominations than the stablecoin-only cleaned vault-price dataset. A targeted backfill must align its cleaned replacement scope with that boundary instead of weakening the shared data-loss guard. The currency scanner is completeness-driven, so adding a default quote automatically backfills its full available history into existing DuckDB databases.

## Summary

- Keep HKD-denominated Asseto histories in raw Parquet while excluding them from stablecoin-only cleaned-history replacement.
- Log Asseto identifiers skipped from cleaned replacement and retain the strict shared no-data-loss check.
- Add HKD to the default USD currency API quote set and update CLI/API/operator documentation.
- Extend Asseto and real-network currency API regression coverage for the production failure and USD/HKD history.

## Related issues and PRs

Follow-up to #1313.

## Unrelated CI and test fixes

None.
