### PR TITLE
fix: make tokenised fund backfills production-safe

### DIFF
--- a/eth_defi/event_reader/multicall_timestamp.py
+++ b/eth_defi/event_reader/multicall_timestamp.py
@@ -14,9 +14,10 @@ from eth_defi.event_reader.timestamp_cache import load_timestamp_cache, BlockTim
 from eth_defi.event_reader.web3factory import Web3Factory
 from eth_defi.timestamp import get_block_timestamp
 
-
 logger = logging.getLogger(__name__)
 
+#: Use exact sampled Hypersync reads when less than one per 100 blocks is needed.
+HYPERSYNC_SPARSE_TIMESTAMP_MIN_STEP = 100
 
 _timestamp_instance = threading.local()
 
@@ -190,14 +191,26 @@ def fetch_block_timestamps_multiprocess_auto_backend(
     For arguments see :py:func:`fetch_block_timestamps_multiprocess`.
 
     :param step:
-        Hypersync does not respect `step` but gets all blocks.
+        Sampling interval. Wide intervals use a sparse, cache-aware Hypersync
+        path instead of downloading every intervening block header.
 
     :return:
         Pandas series block number (int) -> block timestamp (datetime)
     """
 
     if hypersync_client:
-        from eth_defi.hypersync.hypersync_timestamp import fetch_block_timestamps_using_hypersync_cached
+        from eth_defi.hypersync.hypersync_timestamp import fetch_block_timestamps_using_hypersync_cached, fetch_sparse_block_timestamps_using_hypersync_cached
+
+        if step >= HYPERSYNC_SPARSE_TIMESTAMP_MIN_STEP:
+            return fetch_sparse_block_timestamps_using_hypersync_cached(
+                client=hypersync_client,
+                chain_id=chain_id,
+                start_block=start_block,
+                end_block=end_block,
+                step=step,
+                cache_path=cache_path,
+                display_progress=display_progress,
+            )
 
         return fetch_block_timestamps_using_hypersync_cached(
             client=hypersync_client,

--- a/eth_defi/event_reader/timestamp_cache.py
+++ b/eth_defi/event_reader/timestamp_cache.py
@@ -6,10 +6,12 @@ Getting block numbers and timestamps is a common expensive operation when
 scanning historical events.
 """
 
-import pandas as pd
 import datetime
 import logging
+from collections.abc import Iterable
 from pathlib import Path
+
+import pandas as pd
 
 logger = logging.getLogger(__name__)
 
@@ -264,6 +266,38 @@ class BlockTimestampDatabase:
             SELECT COUNT(*) FROM block_timestamps
             """
         ).fetchone()[0]
+
+    def get_missing_block_numbers(self, block_numbers: Iterable[int]) -> list[int]:
+        """Return requested block numbers absent from this cache.
+
+        The lookup is performed as a DuckDB anti-join so sparse historical
+        scans do not need to materialise a multi-million-row cache in Pandas.
+
+        :param block_numbers:
+            Exact EVM block numbers needed by a caller.
+        :return:
+            Missing block numbers in ascending order.
+        """
+
+        requested = tuple(dict.fromkeys(block_numbers))
+        if not requested:
+            return []
+        requested_df = pd.DataFrame({"block_number": requested})
+        self.con.register("requested_block_numbers", requested_df)
+        try:
+            rows = self.con.execute(
+                """
+                SELECT requested.block_number
+                FROM requested_block_numbers AS requested
+                LEFT JOIN block_timestamps AS cached
+                    ON cached.block_number = requested.block_number
+                WHERE cached.block_number IS NULL
+                ORDER BY requested.block_number
+                """
+            ).fetchall()
+        finally:
+            self.con.unregister("requested_block_numbers")
+        return [int(row[0]) for row in rows]
 
     def find_gaps(self) -> list[tuple[int, int, int]]:
         """Find all gaps in the block timestamp database.

--- a/eth_defi/hypersync/hypersync_timestamp.py
+++ b/eth_defi/hypersync/hypersync_timestamp.py
@@ -635,3 +635,167 @@ def fetch_block_timestamps_using_hypersync_cached(
                 await asyncio.sleep(backoff)
 
     return asyncio.run(_hypersync_asyncio_wrapper())
+
+
+async def fetch_sparse_block_timestamps_using_hypersync_cached_async(
+    client: hypersync.HypersyncClient,
+    chain_id: int,
+    start_block: int,
+    end_block: int,
+    step: int,
+    cache_path=DEFAULT_TIMESTAMP_CACHE_FOLDER,
+    display_progress: bool = True,
+    checkpoint_frequency: int = 25,
+    max_concurrency: int = 5,
+) -> BlockTimestampSlicer:
+    """Fetch only exact sampled timestamps through Hypersync and the shared cache.
+
+    Historical state readers may sample one block per hour or day from chains
+    that produce millions of blocks per month. Fetching every intervening
+    header wastes Hypersync quota and can make the first backfill impossible
+    under a rate-limited API key. This path anti-joins the sampled block
+    numbers against the persistent DuckDB cache, fetches only misses, and
+    checkpoints them incrementally.
+
+    :param client:
+        Hypersync client for the requested chain.
+    :param chain_id:
+        Expected EVM chain id.
+    :param start_block:
+        First sampled block, inclusive.
+    :param end_block:
+        Historical reader end block, exclusive.
+    :param step:
+        Number of blocks between historical samples.
+    :param cache_path:
+        Shared per-chain timestamp cache directory.
+    :param display_progress:
+        Whether to display sampled timestamp progress.
+    :param checkpoint_frequency:
+        Maximum number of new timestamps held before a durable cache write.
+    :param max_concurrency:
+        Maximum one-block streams awaited together. The shared client limiter
+        still governs total request starts across the batch.
+    :return:
+        Cache-backed timestamp slicer containing every requested sample.
+    """
+
+    assert start_block <= end_block
+    assert step > 1
+    assert checkpoint_frequency > 0
+    assert max_concurrency > 0
+
+    timestamp_db = load_timestamp_cache(chain_id, cache_path) if cache_path.exists() else BlockTimestampDatabase.create(chain_id, cache_path)
+    requested_blocks = tuple(range(start_block, end_block, step))
+    required_blocks = requested_blocks
+    missing_blocks = timestamp_db.get_missing_block_numbers(required_blocks)
+    if not missing_blocks:
+        logger.info("Chain %d: timestamp cache contains all %d sampled blocks", chain_id, len(requested_blocks))
+        return timestamp_db.get_slicer()
+
+    if is_hypersync_client(client):
+        await _validate_hypersync_chain_id_async(client, chain_id, reason="sparse-timestamp-cache-validate")
+        hypersync_height = await _fetch_hypersync_block_height_async(client, reason="sparse-timestamp-cache-height")
+        required_blocks = tuple(block_number for block_number in requested_blocks if block_number <= hypersync_height)
+        missing_blocks = [block_number for block_number in missing_blocks if block_number <= hypersync_height]
+
+    logger.info(
+        "Chain %d: fetching %d/%d sampled block timestamps through Hypersync (step %d)",
+        chain_id,
+        len(missing_blocks),
+        len(requested_blocks),
+        step,
+    )
+    progress_bar = tqdm(total=len(missing_blocks), desc=f"Reading sampled timestamps (hypersync) on {chain_id}") if display_progress else None
+    pending_index: list[int] = []
+    pending_values: list[int] = []
+
+    def _checkpoint() -> None:
+        """Persist the current sampled timestamp batch."""
+
+        if pending_index:
+            timestamp_db.import_chain_data(chain_id, pd.Series(data=pending_values, index=pending_index))
+            pending_index.clear()
+            pending_values.clear()
+
+    async def _fetch_sample(sample_idx: int, block_number: int) -> BlockHeader:
+        """Fetch and validate one exact sampled block header."""
+
+        headers = [
+            header
+            async for header in get_block_timestamps_using_hypersync_async(
+                client,
+                chain_id,
+                start_block=block_number,
+                end_block=block_number,
+                display_progress=False,
+                validate_chain_id=False,
+                reason=f"sampled-timestamp {sample_idx}/{len(missing_blocks)}",
+            )
+        ]
+        if len(headers) != 1 or headers[0].block_number != block_number:
+            raise HypersyncFlaky(f"Chain {chain_id}: Hypersync did not return sampled block {block_number:,}")
+        return headers[0]
+
+    try:
+        for batch_start in range(0, len(missing_blocks), max_concurrency):
+            batch = missing_blocks[batch_start : batch_start + max_concurrency]
+            headers = await asyncio.gather(*(_fetch_sample(batch_start + batch_offset + 1, block_number) for batch_offset, block_number in enumerate(batch)))
+            pending_index.extend(batch)
+            pending_values.extend(header.timestamp for header in headers)
+            if len(pending_index) >= checkpoint_frequency:
+                _checkpoint()
+            if progress_bar:
+                progress_bar.update(len(batch))
+                progress_bar.set_postfix({"block": f"{batch[-1]:,}"})
+    finally:
+        _checkpoint()
+        if progress_bar:
+            progress_bar.close()
+
+    remaining = timestamp_db.get_missing_block_numbers(required_blocks)
+    if remaining:
+        raise HypersyncFlaky(f"Chain {chain_id}: timestamp cache still lacks {len(remaining)} sampled blocks")
+    return timestamp_db.get_slicer()
+
+
+def fetch_sparse_block_timestamps_using_hypersync_cached(
+    client: hypersync.HypersyncClient,
+    chain_id: int,
+    start_block: int,
+    end_block: int,
+    step: int,
+    cache_path=DEFAULT_TIMESTAMP_CACHE_FOLDER,
+    display_progress: bool = True,
+    attempts: int = 5,
+) -> BlockTimestampSlicer:
+    """Synchronously fetch sparse sampled timestamps with retry/backoff.
+
+    :param attempts:
+        Maximum Hypersync attempts; completed checkpoints survive retries.
+    :return:
+        Cache-backed timestamp slicer containing every requested sample.
+    """
+
+    async def _hypersync_asyncio_wrapper() -> BlockTimestampSlicer:
+        for attempt in range(attempts):
+            try:
+                return await fetch_sparse_block_timestamps_using_hypersync_cached_async(
+                    client=client,
+                    chain_id=chain_id,
+                    start_block=start_block,
+                    end_block=end_block,
+                    step=step,
+                    cache_path=cache_path,
+                    display_progress=display_progress,
+                )
+            except HypersyncFlaky as error:
+                logger.warning("Chain %d: sparse Hypersync fetch flaky on attempt %d/%d: %s", chain_id, attempt + 1, attempts, error)
+                if attempt + 1 >= attempts:
+                    raise
+                backoff = 30 * (2**attempt)
+                logger.info("Chain %d: backing off %ds before sparse retry %d/%d", chain_id, backoff, attempt + 2, attempts)
+                await asyncio.sleep(backoff)
+        raise RuntimeError("Sparse Hypersync timestamp fetch exhausted without returning or raising")
+
+    return asyncio.run(_hypersync_asyncio_wrapper())

--- a/eth_defi/hypersync/utils.py
+++ b/eth_defi/hypersync/utils.py
@@ -68,10 +68,11 @@ def configure_hypersync_from_env(
     def _make_client(url: str) -> ThrottledHypersyncClient:
         """Create a throttled client, lazily building the limiter on first use."""
         nonlocal limiter
+        requests_per_minute = get_hypersync_rpm_from_env()
         if limiter is None:
-            limiter = _create_limiter(requests_per_minute=get_hypersync_rpm_from_env())
+            limiter = _create_limiter(requests_per_minute=requests_per_minute)
         config = hypersync.ClientConfig(url=url, bearer_token=hypersync_api_key)
-        return create_throttled_hypersync_client(config, limiter=limiter, concurrency=concurrency)
+        return create_throttled_hypersync_client(config, requests_per_minute=requests_per_minute, limiter=limiter, concurrency=concurrency)
 
     match scan_backend:
         case "auto":

--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -1724,6 +1724,9 @@ def process_raw_vault_scan_data(
 
     prices_df = sort_and_index_vault_prices(prices_df, PRIORITY_SORT_IDS)
     prices_df = filter_vaults_by_stablecoin(rows, prices_df, logger)
+    if prices_df.empty:
+        logger("No stablecoin-nominated price rows remain; skipping return and TVL cleaning")
+        return prices_df
     # Disabled as low and does not result to any savings
     # prices_df = filter_unneeded_row(prices_df, logger)
 

--- a/eth_defi/tokenised_fund/backfill.py
+++ b/eth_defi/tokenised_fund/backfill.py
@@ -22,6 +22,7 @@ from eth_defi.tokenised_fund.sygnum.backfill import main as backfill_sygnum
 from eth_defi.tokenised_fund.theo.backfill import main as backfill_theo
 from eth_defi.tokenised_fund.usyc.backfill import main as backfill_usyc
 from eth_defi.tokenised_fund.wisdomtree.backfill import main as backfill_wisdomtree
+from eth_defi.tokenised_fund.wisdomtree.nav import WISDOMTREE_DATASPAN_API_KEY_ENV
 from eth_defi.utils import setup_console_logging
 
 logger = logging.getLogger(__name__)
@@ -87,6 +88,31 @@ def run_protocol_backfills(protocols: Iterable[str]) -> tuple[str, ...]:
     return tuple(completed)
 
 
+def configure_optional_private_backfills(protocols_value: str | None, protocols: tuple[str, ...]) -> None:
+    """Make the default all-protocol run tolerate unavailable private data.
+
+    WisdomTree metadata is public on-chain, but its official NAV history needs
+    a private DataSpan API key. The implicit all-protocol workflow therefore
+    registers its metadata and skips only the private price scan when neither
+    the key nor an explicit price-scan choice is present. Explicit WisdomTree
+    selections continue to fail closed without the credential.
+
+    :param protocols_value: Raw ``PROTOCOLS`` environment value.
+    :param protocols: Validated protocol selection.
+    :return: None.
+    """
+
+    is_implicit_all = not (protocols_value or "").strip()
+    scan_choice_is_explicit = "WISDOMTREE_SCAN_PRICES" in os.environ
+    has_api_key = bool(os.environ.get(WISDOMTREE_DATASPAN_API_KEY_ENV))
+    if is_implicit_all and "wisdomtree" in protocols and not scan_choice_is_explicit and not has_api_key:
+        os.environ["WISDOMTREE_SCAN_PRICES"] = "false"
+        logger.warning(
+            "Skipping WisdomTree private NAV history because %s is not set; public on-chain metadata will still be updated",
+            WISDOMTREE_DATASPAN_API_KEY_ENV,
+        )
+
+
 def main() -> None:
     """Run tokenised-fund backfills selected through environment variables.
 
@@ -100,7 +126,9 @@ def main() -> None:
     setup_console_logging(default_log_level=os.environ.get("LOG_LEVEL", "info"))
     if not os.environ.get("DRY_RUN", "").strip():
         os.environ["DRY_RUN"] = "true"
-    protocols = parse_protocols(os.environ.get("PROTOCOLS"))
+    protocols_value = os.environ.get("PROTOCOLS")
+    protocols = parse_protocols(protocols_value)
+    configure_optional_private_backfills(protocols_value, protocols)
     logger.info("Tokenised-fund backfill plan: protocols=%s dry_run=%s", ",".join(protocols), os.environ["DRY_RUN"])
     completed = run_protocol_backfills(protocols)
     logger.info("Tokenised-fund backfill finished: %s", ",".join(completed))

--- a/eth_defi/tokenised_fund/libeara/historical.py
+++ b/eth_defi/tokenised_fund/libeara/historical.py
@@ -1,16 +1,51 @@
 """Historical reader for reviewed Libeara fund shares."""
 
+# Reader classes intentionally mirror :class:`VaultHistoricalReader` signatures.
+# ruff: noqa: FBT001
+
 import datetime
 from collections.abc import Iterable
 from decimal import Decimal
+from functools import cached_property
+from typing import TYPE_CHECKING
 
+from eth_defi.erc_4626.vault import VaultReaderState
 from eth_defi.event_reader.conversion import convert_int256_bytes_to_int
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
 
+if TYPE_CHECKING:
+    from eth_defi.tokenised_fund.libeara.vault import LibearaVault
+
+
+class LibearaVaultReaderState(VaultReaderState):
+    """Persist Libeara adaptive history state using issuer USD NAV values."""
+
+    @cached_property
+    def exchange_rate(self) -> Decimal:
+        """Return the quote conversion for issuer-maintained USD NAV.
+
+        :return:
+            One because reviewed CMTAT NAV values are denominated in USD.
+        """
+
+        return Decimal(1)
+
 
 class LibearaVaultHistoricalReader(VaultHistoricalReader):
     """Read supply and any reviewed issuer NAV fields at historical blocks."""
+
+    def __init__(self, vault: "LibearaVault", stateful: bool):
+        """Create a Libeara historical reader.
+
+        :param vault:
+            Reviewed Libeara fund-share adapter.
+        :param stateful:
+            Whether to attach adaptive scanner state.
+        """
+
+        super().__init__(vault)
+        self.reader_state = LibearaVaultReaderState(vault) if stateful else None
 
     def construct_multicalls(self) -> Iterable[EncodedCall]:
         """Construct the reviewed value calls for this product.
@@ -26,7 +61,11 @@ class LibearaVaultHistoricalReader(VaultHistoricalReader):
         if self.vault.is_ultra:
             calls = calls[:1]
         for name, call in calls:
-            yield EncodedCall.from_contract_call(call, extra_data={"function": name}, first_block_number=self.first_block)
+            yield EncodedCall.from_contract_call(
+                call,
+                extra_data={"function": name, "vault": self.vault.address},
+                first_block_number=self.first_block,
+            )
 
     def process_result(self, block_number: int, timestamp: datetime.datetime, call_results: list[EncodedCallResult]) -> VaultHistoricalRead:
         """Convert available Libeara values to a scan row.
@@ -38,15 +77,20 @@ class LibearaVaultHistoricalReader(VaultHistoricalReader):
         """
 
         values: dict[str, int] = {}
+        state_result: EncodedCallResult | None = None
         errors: list[str] = ["No verified on-chain ULTRA NAV/share source is configured"] if self.vault.is_ultra else []
         for result in call_results:
             name = result.call.extra_data["function"]
             if result.success:
                 values[name] = convert_int256_bytes_to_int(result.result)
+                if name == "latestNAV":
+                    state_result = result
             else:
                 errors.append(f"Libeara CMTAT {name} call failed")
         supply = self.vault.share_token.convert_to_decimals(values["totalSupply"]) if "totalSupply" in values else None
         scale = values.get("NAVScalingFactor")
         nav = Decimal(values["latestNAV"]) / Decimal(scale) if scale and "latestNAV" in values else None
         total_assets = supply * nav if supply is not None and nav is not None else None
+        if self.reader_state is not None and state_result is not None and total_assets is not None:
+            self.reader_state.on_called(state_result, total_assets=total_assets, share_price=nav)
         return VaultHistoricalRead(vault=self.vault, block_number=block_number, timestamp=timestamp, share_price=nav, total_assets=total_assets, total_supply=supply, performance_fee=None, management_fee=None, errors=errors or None, deposits_open=False, redemption_open=False)

--- a/eth_defi/tokenised_fund/libeara/vault.py
+++ b/eth_defi/tokenised_fund/libeara/vault.py
@@ -264,7 +264,7 @@ class LibearaVault(VaultBase):
         :param stateful: Retained shared-reader API parameter.
         :return: Libeara historical reader.
         """
-        return LibearaVaultHistoricalReader(self)
+        return LibearaVaultHistoricalReader(self, stateful=stateful)
 
     def get_fee_data(self) -> FeeData:
         """Return unavailable product fee data.

--- a/eth_defi/tokenised_fund/ondo/vault.py
+++ b/eth_defi/tokenised_fund/ondo/vault.py
@@ -38,6 +38,27 @@ class OndoVaultInfo(VaultInfo, total=False):
     chain_id: int
     oracle: HexAddress
     nav_source: str
+    synthetic_usd_denomination: bool
+
+
+def export_ondo_usd_denomination(chain_id: int) -> dict[str, object]:
+    """Export Ondo's non-transferable USD accounting denomination.
+
+    :param chain_id:
+        EVM chain id of the fund token.
+    :return:
+        Token-like USD metadata without an ERC-20 address.
+    """
+
+    return {
+        "address": None,
+        "chain": chain_id,
+        "name": "United States Dollar",
+        "symbol": "USD",
+        "decimals": None,
+        "total_supply": None,
+        "extra_data": {"synthetic": True},
+    }
 
 
 class OndoVault(VaultBase):
@@ -179,18 +200,20 @@ class OndoVault(VaultBase):
     def fetch_info(self) -> OndoVaultInfo:
         """Export product and NAV-source metadata."""
 
-        return OndoVaultInfo(token=self.address, chain_id=self.chain_id, oracle=self.product.oracle, nav_source=f"ondo_{self.product.oracle_method}")
+        return OndoVaultInfo(token=self.address, chain_id=self.chain_id, oracle=self.product.oracle, nav_source=f"ondo_{self.product.oracle_method}", synthetic_usd_denomination=True)
 
     def fetch_scan_record_extra_data(self) -> dict[str, object]:
         """Export scanner metadata for permissioning and NAV provenance."""
 
         return {
+            "Denomination": "USD",
+            "_denomination_token": export_ondo_usd_denomination(self.chain_id),
             "_notes": self.get_notes(),
             "_deposit_closed_reason": self.fetch_deposit_closed_reason(),
             "_redemption_closed_reason": self.fetch_redemption_closed_reason(),
             "_nav_source": f"ondo_{self.product.oracle_method}",
             "_nav_estimated": False,
-            "_synthetic_usd_denomination": False,
+            "_synthetic_usd_denomination": True,
         }
 
     def fetch_portfolio(self, universe: TradingUniverse, block_identifier: BlockIdentifier | None = None) -> VaultPortfolio:

--- a/eth_defi/tokenised_fund/spiko/vault.py
+++ b/eth_defi/tokenised_fund/spiko/vault.py
@@ -48,6 +48,27 @@ class SpikoVaultInfo(VaultInfo, total=False):
     chain_id: int
     price_oracle: HexAddress
     nav_source: str
+    synthetic_usd_denomination: bool
+
+
+def export_spiko_usd_denomination(chain_id: int) -> dict[str, object]:
+    """Export USTBL's non-transferable USD accounting denomination.
+
+    :param chain_id:
+        EVM chain id of the USTBL deployment.
+    :return:
+        Token-like USD metadata without an ERC-20 address.
+    """
+
+    return {
+        "address": None,
+        "chain": chain_id,
+        "name": "United States Dollar",
+        "symbol": "USD",
+        "decimals": None,
+        "total_supply": None,
+        "extra_data": {"synthetic": True},
+    }
 
 
 class SpikoVault(VaultBase):
@@ -243,14 +264,21 @@ class SpikoVault(VaultBase):
 
         :return: Token, oracle and price-source identifiers.
         """
-        return SpikoVaultInfo(token=self.address, chain_id=self.chain_id, price_oracle=HexAddress(Web3.to_checksum_address(USTBL_PRICE_ORACLE_ADDRESS)), nav_source=USTBL_NAV_SOURCE)
+        return SpikoVaultInfo(token=self.address, chain_id=self.chain_id, price_oracle=HexAddress(Web3.to_checksum_address(USTBL_PRICE_ORACLE_ADDRESS)), nav_source=USTBL_NAV_SOURCE, synthetic_usd_denomination=True)
 
     def fetch_scan_record_extra_data(self) -> dict[str, object]:
         """Expose valuation and restricted-flow diagnostics.
 
         :return: Data recorded with USTBL scan results.
         """
-        return {"_nav_source": USTBL_NAV_SOURCE, "_nav_estimated": False, "_spiko_price_oracle": HexAddress(Web3.to_checksum_address(USTBL_PRICE_ORACLE_ADDRESS))}
+        return {
+            "Denomination": "USD",
+            "_denomination_token": export_spiko_usd_denomination(self.chain_id),
+            "_nav_source": USTBL_NAV_SOURCE,
+            "_nav_estimated": False,
+            "_spiko_price_oracle": HexAddress(Web3.to_checksum_address(USTBL_PRICE_ORACLE_ADDRESS)),
+            "_synthetic_usd_denomination": True,
+        }
 
     def fetch_portfolio(self, universe: TradingUniverse, block_identifier: BlockIdentifier | None = None) -> VaultPortfolio:
         """Return no directly observable underlying portfolio.

--- a/eth_defi/tokenised_fund/wisdomtree/backfill.py
+++ b/eth_defi/tokenised_fund/wisdomtree/backfill.py
@@ -228,7 +228,7 @@ def run_backfill(
     :param reader_state_path: Reader-state pickle path.
     """
 
-    if not dry_run:
+    if not dry_run and scan_prices:
         require_price_scan_key()
     rpc_url = read_json_rpc_url(WTGXX_ETHEREUM.chain_id)
     web3 = create_multi_provider_web3(rpc_url)
@@ -242,6 +242,8 @@ def run_backfill(
         vault_db_path.parent.mkdir(parents=True, exist_ok=True)
         vault_db.write(vault_db_path)
     if not scan_prices or dry_run:
+        if not dry_run:
+            token_cache.commit()
         return
     vault = create_vault_instance(web3, WTGXX_ETHEREUM.token, features={ERC4626Feature.wisdomtree_like}, token_cache=token_cache)
     if vault is None:

--- a/eth_defi/vault/historical.py
+++ b/eth_defi/vault/historical.py
@@ -78,8 +78,16 @@ class ParquetScanResult(TypedDict):
 
 
 def pformat_scan_result(self) -> str:
-    """Format the result as a string."""
-    return f"ParquetScanResult(chain_id={self['chain_id']}, \nstart_block={self['start_block']:,}, \nend_block={self['end_block']:,}, \nrows_written={self['rows_written']:,}, \nrows_deleted={self['rows_deleted']:,}, \nexisting_row_count={self['existing_row_count']:,}, \nreader_state_count={len(self['reader_states'])}, \noutput_fname={self['output_fname']}, \nfile_size={self['file_size']:,} bytes, \nchunks_done={self['chunks_done']:,})"
+    """Format a stateful or stateless Parquet scan result.
+
+    :param self:
+        Result returned by :func:`scan_historical_prices_to_parquet`.
+    :return:
+        Multi-line operator summary.
+    """
+
+    reader_state_count = len(self["reader_states"] or {})
+    return f"ParquetScanResult(chain_id={self['chain_id']}, \nstart_block={self['start_block']:,}, \nend_block={self['end_block']:,}, \nrows_written={self['rows_written']:,}, \nrows_deleted={self['rows_deleted']:,}, \nexisting_row_count={self['existing_row_count']:,}, \nreader_state_count={reader_state_count}, \noutput_fname={self['output_fname']}, \nfile_size={self['file_size']:,} bytes, \nchunks_done={self['chunks_done']:,})"
 
 
 class VaultReadNotSupported(Exception):

--- a/tests/hypersync/test_hypersync_gap_healing.py
+++ b/tests/hypersync/test_hypersync_gap_healing.py
@@ -14,11 +14,15 @@ import asyncio
 import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pandas as pd
+
 from eth_defi.event_reader.block_header import BlockHeader
+from eth_defi.event_reader.timestamp_cache import BlockTimestampDatabase
 from eth_defi.hypersync.hypersync_timestamp import (
     HypersyncFlaky,
     fetch_block_timestamps_using_hypersync_cached,
     fetch_block_timestamps_using_hypersync_cached_async,
+    fetch_sparse_block_timestamps_using_hypersync_cached_async,
     get_hypersync_block_height_with_retries,
     is_hypersync_next_block_range_error,
     is_hypersync_rate_limit_error,
@@ -201,6 +205,48 @@ def test_hypersync_gap_healing_no_gaps(tmp_path):
     # Only the initial fetch, no healing needed
     assert call_count == 1
 
+    slicer.close()
+
+
+def test_sparse_hypersync_timestamp_fetch_reads_only_sampled_cache_misses(tmp_path):
+    """Wide historical scans fetch only exact missing sample blocks.
+
+    1. Seed one of four requested samples in the shared DuckDB cache.
+    2. Run the sparse Hypersync fetch with a 100-block step.
+    3. Verify only the three cache misses were requested and all samples resolve.
+    """
+
+    chain_id = 1
+    cached_block = 1_100
+    timestamp_db = BlockTimestampDatabase.create(chain_id, tmp_path)
+    timestamp_db.import_chain_data(chain_id, pd.Series([1_700_001_100], index=[cached_block]))
+    timestamp_db.close()
+    fetch_calls: list[tuple[int, int]] = []
+
+    async def mock_get_timestamps(client, chain_id, start_block, end_block, timeout=120.0, display_progress=True, progress_throttle=10_000, validate_chain_id=True, reason=None):
+        fetch_calls.append((start_block, end_block))
+        yield _make_block_header(start_block)
+
+    async def _run():
+        with patch(
+            "eth_defi.hypersync.hypersync_timestamp.get_block_timestamps_using_hypersync_async",
+            side_effect=mock_get_timestamps,
+        ):
+            return await fetch_sparse_block_timestamps_using_hypersync_cached_async(
+                client=MagicMock(),
+                chain_id=chain_id,
+                start_block=1_000,
+                end_block=1_400,
+                step=100,
+                cache_path=tmp_path,
+                display_progress=False,
+                checkpoint_frequency=2,
+            )
+
+    slicer = asyncio.run(_run())
+
+    assert fetch_calls == [(1_000, 1_000), (1_200, 1_200), (1_300, 1_300)]
+    assert all(slicer[block_number] is not None for block_number in (1_000, 1_100, 1_200, 1_300))
     slicer.close()
 
 

--- a/tests/libeara/test_libeara_ultra.py
+++ b/tests/libeara/test_libeara_ultra.py
@@ -81,6 +81,7 @@ def test_libeara_ultra_historical_reader_keeps_supply_without_nav() -> None:
 
     reader = LibearaVaultHistoricalReader.__new__(LibearaVaultHistoricalReader)
     reader.vault = DummyUltraVault()
+    reader.reader_state = None
     call = EncodedCall(func_name="totalSupply", address=DummyUltraVault.address, data=b"", extra_data={"function": "totalSupply"})
     result = EncodedCallResult(call=call, success=True, result=(36_192_127_917_021).to_bytes(32, "big"), block_identifier=123)
     timestamp = datetime.datetime(2025, 7, 18, 7, 9, 32, tzinfo=datetime.UTC).replace(tzinfo=None)

--- a/tests/libeara/test_libeara_vault.py
+++ b/tests/libeara/test_libeara_vault.py
@@ -12,7 +12,7 @@ from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS, create_vault_i
 from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.tokenised_fund.libeara.constants import BELIF_ETHEREUM, CUMIU_ETHEREUM, ETHEREUM_CHAIN_ID
-from eth_defi.tokenised_fund.libeara.historical import LibearaVaultHistoricalReader
+from eth_defi.tokenised_fund.libeara.historical import LibearaVaultHistoricalReader, LibearaVaultReaderState
 from eth_defi.tokenised_fund.libeara.vault import LIBEARA_RESTRICTED_FLOW_REASON, LibearaVault
 from eth_defi.vault.curator import identify_curator
 
@@ -82,3 +82,25 @@ def test_libeara_historical_reader_uses_nav_scale(web3: Web3) -> None:
     assert read.total_supply == EXPECTED[CUMIU_ETHEREUM.token][0]
     assert read.share_price == EXPECTED[CUMIU_ETHEREUM.token][1]
     assert read.total_assets == EXPECTED[CUMIU_ETHEREUM.token][0] * EXPECTED[CUMIU_ETHEREUM.token][1]
+
+
+def test_libeara_stateful_historical_reader_updates_scanner_state(web3: Web3) -> None:
+    """Construct and update the state required by the production multicaller.
+
+    :param web3:
+        Archive-connected Ethereum client.
+    """
+
+    vault = create_vault_instance_autodetect(web3, CUMIU_ETHEREUM.token)
+    reader = vault.get_historical_reader(stateful=True)
+    assert isinstance(reader.reader_state, LibearaVaultReaderState)
+    calls = list(reader.construct_multicalls())
+    assert all(call.extra_data["vault"] == vault.address for call in calls)
+    results = [call.call_as_result(web3, block_identifier=TEST_BLOCK, ignore_error=True) for call in calls]
+    timestamp = datetime.datetime.fromtimestamp(web3.eth.get_block(TEST_BLOCK)["timestamp"], tz=datetime.UTC).replace(tzinfo=None)
+    for result in results:
+        result.timestamp = timestamp
+    read = reader.process_result(TEST_BLOCK, timestamp, results)
+    assert reader.reader_state.last_block == TEST_BLOCK
+    assert reader.reader_state.last_share_price == read.share_price
+    assert reader.reader_state.last_tvl == read.total_assets

--- a/tests/ondo/test_ondo_vault.py
+++ b/tests/ondo/test_ondo_vault.py
@@ -82,6 +82,10 @@ def test_ondo_vault_blocks_generic_transactions() -> None:
     assert vault.get_deposit_manager_capability() is None
     assert isinstance(vault.get_historical_reader(stateful=False), OndoVaultHistoricalReader)
     assert vault.get_flags() == {VaultFlag.tokenised_fund}
+    metadata = vault.fetch_scan_record_extra_data()
+    assert metadata["Denomination"] == "USD"
+    assert metadata["_synthetic_usd_denomination"] is True
+    assert metadata["_denomination_token"]["address"] is None
 
 
 @pytest.fixture(scope="module")

--- a/tests/spiko/test_spiko_vault.py
+++ b/tests/spiko/test_spiko_vault.py
@@ -104,6 +104,9 @@ def test_spiko_scan_record_and_curator(web3: Web3) -> None:
     record = create_vault_scan_record(web3, detection, block_identifier=SPIKO_TEST_BLOCK, token_cache={})
     assert record["Protocol"] == "Spiko"
     assert record["NAV"] == EXPECTED_TOTAL_ASSETS
+    assert record["Denomination"] == "USD"
+    assert record["_synthetic_usd_denomination"] is True
+    assert record["_denomination_token"]["address"] is None
     assert record["_nav_source"] == "spiko_ustbl_oracle_latestRoundData"
     assert record["_deposit_closed_reason"] == SPIKO_PERMISSIONED_FLOW_REASON
     curator = identify_curator(1, "USTBL", "Spiko US T-Bills Money Market Fund", USTBL_TOKEN_ADDRESS, "spiko")

--- a/tests/tokenised_fund/test_backfill.py
+++ b/tests/tokenised_fund/test_backfill.py
@@ -29,6 +29,28 @@ def test_run_protocol_backfills_in_selection_order(monkeypatch: pytest.MonkeyPat
     assert calls == ["spiko", "ondo"]
 
 
+def test_implicit_all_skips_private_wisdomtree_history_without_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the one-command all-protocol workflow usable without private data."""
+
+    monkeypatch.delenv(backfill.WISDOMTREE_DATASPAN_API_KEY_ENV, raising=False)
+    monkeypatch.delenv("WISDOMTREE_SCAN_PRICES", raising=False)
+
+    backfill.configure_optional_private_backfills(None, tuple(backfill.PROTOCOL_BACKFILLS))
+
+    assert backfill.os.environ["WISDOMTREE_SCAN_PRICES"] == "false"
+
+
+def test_explicit_wisdomtree_keeps_price_scan_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Do not silently weaken an explicit WisdomTree history request."""
+
+    monkeypatch.delenv(backfill.WISDOMTREE_DATASPAN_API_KEY_ENV, raising=False)
+    monkeypatch.delenv("WISDOMTREE_SCAN_PRICES", raising=False)
+
+    backfill.configure_optional_private_backfills("wisdomtree", ("wisdomtree",))
+
+    assert "WISDOMTREE_SCAN_PRICES" not in backfill.os.environ
+
+
 def test_main_defaults_blank_dry_run_to_true(monkeypatch: pytest.MonkeyPatch) -> None:
     """Never turn a blank aggregate dry-run setting into permission to write."""
 

--- a/tests/tokenised_fund/test_backfill.py
+++ b/tests/tokenised_fund/test_backfill.py
@@ -33,6 +33,9 @@ def test_implicit_all_skips_private_wisdomtree_history_without_key(monkeypatch: 
     """Keep the one-command all-protocol workflow usable without private data."""
 
     monkeypatch.delenv(backfill.WISDOMTREE_DATASPAN_API_KEY_ENV, raising=False)
+    # Register an original value before deleting it so direct os.environ writes
+    # made by the function under test are removed during monkeypatch teardown.
+    monkeypatch.setenv("WISDOMTREE_SCAN_PRICES", "test-original")
     monkeypatch.delenv("WISDOMTREE_SCAN_PRICES", raising=False)
 
     backfill.configure_optional_private_backfills(None, tuple(backfill.PROTOCOL_BACKFILLS))

--- a/tests/vault/test_historical_format.py
+++ b/tests/vault/test_historical_format.py
@@ -1,0 +1,29 @@
+"""Test historical scan operator summaries."""
+
+from pathlib import Path
+
+from eth_defi.vault.historical import pformat_scan_result
+
+
+def test_pformat_scan_result_supports_stateless_scan() -> None:
+    """A stateless scan reports zero reader states instead of raising."""
+
+    result = {
+        "existing": True,
+        "chain_id": 1,
+        "rows_written": 3,
+        "rows_deleted": 2,
+        "existing_row_count": 10,
+        "output_fname": Path("prices.parquet"),
+        "file_size": 123,
+        "chunks_done": 1,
+        "start_block": 100,
+        "end_block": 200,
+        "rows_written_by_vault": {},
+        "price_rows_written_by_vault": {},
+        "reader_states": None,
+    }
+
+    summary = pformat_scan_result(result)
+
+    assert "reader_state_count=0" in summary

--- a/tests/wisdomtree/test_wisdomtree_vault.py
+++ b/tests/wisdomtree/test_wisdomtree_vault.py
@@ -204,3 +204,25 @@ def test_wisdomtree_missing_api_key_fails_before_metadata_write(monkeypatch: pyt
         backfill_module.run_backfill(dry_run=False, scan_prices=True, clean_prices=True, frequency="1d", vault_db_path=tmp_path / "vaults.pickle", raw_price_path=tmp_path / "raw.parquet", cleaned_price_path=tmp_path / "cleaned.parquet", reader_state_path=tmp_path / "state.pickle")
     assert calls == ["api-key-check"]
     assert not list(tmp_path.iterdir())
+
+
+def test_wisdomtree_metadata_only_does_not_require_api_key(monkeypatch: pytest.MonkeyPatch, backfill_module, tmp_path: Path) -> None:
+    """Write public metadata without requiring private DataSpan access."""
+
+    calls: list[str] = []
+
+    class DummyTokenCache:
+        def commit(self) -> None:
+            calls.append("token-cache-commit")
+
+    monkeypatch.setattr(backfill_module, "require_price_scan_key", lambda: calls.append("api-key-check"))
+    monkeypatch.setattr(backfill_module, "read_json_rpc_url", lambda _chain_id: "http://example.invalid")
+    monkeypatch.setattr(backfill_module, "create_multi_provider_web3", lambda _url: SimpleNamespace(eth=SimpleNamespace(block_number=99)))
+    monkeypatch.setattr(backfill_module, "TokenDiskCache", DummyTokenCache)
+    monkeypatch.setattr(backfill_module, "create_vault_scan_record", lambda *args, **kwargs: {"Name": "WisdomTree WTGXX"})
+
+    backfill_module.run_backfill(dry_run=False, scan_prices=False, clean_prices=True, frequency="1d", vault_db_path=tmp_path / "vaults.pickle", raw_price_path=tmp_path / "raw.parquet", cleaned_price_path=tmp_path / "cleaned.parquet", reader_state_path=tmp_path / "state.pickle")
+
+    assert calls == ["token-cache-commit"]
+    assert (tmp_path / "vaults.pickle").exists()
+    assert not (tmp_path / "raw.parquet").exists()


### PR DESCRIPTION
## Why

The generic tokenised-fund backfill passed dry-run checks but failed when production writes exercised historical reader state, large timestamp ranges, denomination-aware cleaning, and private NAV integrations. Operators need the single non-dry command to complete without risking unrelated Parquet histories.

## Lessons learnt

- Dry runs that return before historical reader construction cannot validate reader-state compatibility.
- Historical daily sampling should fetch only sampled timestamp cache misses through Hypersync; filling every intervening block wastes quota and can restart indefinitely after rate limits.
- Public metadata collection and private issuer NAV history need separate failure policies.
- Targeted history replacement must preserve existing rows when a denomination cannot be cleaned safely.

## Summary

- Add Libeara reader state and stable vault identity for historical multicalls.
- Add synthetic USD denomination metadata for Ondo and Spiko issuer NAV histories.
- Add sparse, cache-aware Hypersync timestamp sampling with bounded concurrency and configured rate-limit reporting.
- Preserve Asseto histories with unsupported denominations and handle empty cleaning results safely.
- Support stateless historical scan summaries.
- Let the default all-protocol workflow update WisdomTree metadata without a private DataSpan key while explicit WisdomTree history scans continue to fail closed.
- Add focused regression coverage and validate the complete 13-protocol non-dry aggregate backfill.

## Related issues and PRs

- Follow-up to #1320.

## Unrelated CI and test fixes

None.