### PR TITLE
fix: initialise tokenised fund reader states

### DIFF
--- a/eth_defi/erc_4626/vault.py
+++ b/eth_defi/erc_4626/vault.py
@@ -514,6 +514,36 @@ class VaultReaderState(BatchCallState):
         # Diagnostics counter
         self.entry_count += 1
 
+    def on_unpriced_call(self, result: "EncodedCallResult") -> None:
+        """Update adaptive scan state for a successful supply-only read.
+
+        Some tokenised funds expose their share supply but no reviewed scalar
+        NAV or TVL. They still need persistent reader state so the stateful
+        scanner can cache token metadata, advance its last-read block and
+        throttle historical calls. Zero values are internal scheduling
+        sentinels only; the exported historical row must continue to expose
+        ``None`` for its share price and total assets.
+
+        :param result:
+            Successful supply call carrying a block number and timestamp.
+        """
+
+        assert result.success, f"Cannot update unpriced reader state from failed call: {result}"
+        assert result.timestamp, f"EncodedCallResult {result} has no timestamp, cannot update state"
+
+        timestamp = result.timestamp
+        if self.first_read_at is None:
+            self.first_read_at = timestamp
+        if self.first_block is None:
+            self.first_block = result.block_identifier
+
+        # Scheduling sentinels only: unpriced rows still export NAV and TVL as None.
+        self.last_tvl = Decimal(0)
+        self.last_share_price = Decimal(0)
+        self.last_call_at = timestamp
+        self.last_block = result.block_identifier
+        self.entry_count += 1
+
     def pformat(self) -> str:
         """Pretty print the current state."""
         lines = []

--- a/eth_defi/tokenised_fund/centrifuge/historical.py
+++ b/eth_defi/tokenised_fund/centrifuge/historical.py
@@ -1,13 +1,14 @@
 """Historical reads for Centrifuge permissioned tranche tokens."""
 
 # Reader classes intentionally mirror :class:`VaultHistoricalReader` signatures.
-# ruff: noqa: ARG002, FBT001
+# ruff: noqa: FBT001
 
 import datetime
 from collections.abc import Iterable
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
+from eth_defi.erc_4626.vault import VaultReaderState
 from eth_defi.event_reader.conversion import convert_int256_bytes_to_int
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
@@ -35,7 +36,7 @@ class CentrifugeTrancheHistoricalReader(VaultHistoricalReader):
         """
 
         super().__init__(vault)
-        self.reader_state = None
+        self.reader_state = VaultReaderState(vault) if stateful else None
 
     def construct_multicalls(self) -> Iterable[EncodedCall]:
         """Construct the ERC-20 supply read.
@@ -69,12 +70,17 @@ class CentrifugeTrancheHistoricalReader(VaultHistoricalReader):
         """
 
         total_supply: Decimal | None = None
+        state_result: EncodedCallResult | None = None
         errors = ["Centrifuge Tranche token has no on-chain NAV/share source; linked vault valuation is not configured"]
         for result in call_results:
             if result.call.extra_data.get("function") == "totalSupply" and result.success:
                 total_supply = self.vault.share_token.convert_to_decimals(convert_int256_bytes_to_int(result.result))
+                state_result = result
             elif result.call.extra_data.get("function") == "totalSupply":
                 errors.append("Centrifuge Tranche totalSupply call failed")
+
+        if self.reader_state is not None and state_result is not None:
+            self.reader_state.on_unpriced_call(state_result)
 
         return VaultHistoricalRead(
             vault=self.vault,

--- a/eth_defi/tokenised_fund/sygnum/historical.py
+++ b/eth_defi/tokenised_fund/sygnum/historical.py
@@ -1,12 +1,13 @@
 """Historical reader for Sygnum FILQ shares."""
 
-# ruff: noqa: ARG002, FBT001
+# ruff: noqa: FBT001
 
 import datetime
 from collections.abc import Iterable
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
+from eth_defi.erc_4626.vault import VaultReaderState
 from eth_defi.event_reader.conversion import convert_int256_bytes_to_int
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
@@ -32,6 +33,7 @@ class SygnumVaultHistoricalReader(VaultHistoricalReader):
         """
 
         super().__init__(vault)
+        self.reader_state = VaultReaderState(vault) if stateful else None
 
     def construct_multicalls(self) -> Iterable[EncodedCall]:
         """Construct the ERC-20 total-supply call.
@@ -55,13 +57,17 @@ class SygnumVaultHistoricalReader(VaultHistoricalReader):
         """
 
         total_supply: Decimal | None = None
+        state_result: EncodedCallResult | None = None
         errors = [self.vault.nav_unavailable_reason]
         for result in call_results:
             if result.call.extra_data.get("function") == "totalSupply":
                 if result.success:
                     total_supply = self.vault.share_token.convert_to_decimals(convert_int256_bytes_to_int(result.result))
+                    state_result = result
                 else:
                     errors.append("Sygnum FILQ totalSupply call failed")
+        if self.reader_state is not None and state_result is not None:
+            self.reader_state.on_unpriced_call(state_result)
         return VaultHistoricalRead(
             vault=self.vault,
             block_number=block_number,

--- a/eth_defi/tokenised_fund/theo/historical.py
+++ b/eth_defi/tokenised_fund/theo/historical.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
+from eth_defi.erc_4626.vault import VaultReaderState
 from eth_defi.event_reader.conversion import convert_int256_bytes_to_int
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
@@ -27,12 +28,11 @@ class TheoITokenHistoricalReader(VaultHistoricalReader):
         """Create a supply-only iToken reader.
 
         :param vault: Theo iToken adapter.
-        :param stateful: Ignored as no scalar price call can update reader state.
+        :param stateful: Whether to retain supply-only adaptive reader state.
         """
 
         super().__init__(vault)
-        _ = stateful
-        self.reader_state = None
+        self.reader_state = VaultReaderState(vault) if stateful else None
 
     def construct_multicalls(self) -> Iterable[EncodedCall]:
         """Construct the ERC-20 supply read.
@@ -56,14 +56,19 @@ class TheoITokenHistoricalReader(VaultHistoricalReader):
         """
 
         total_supply: Decimal | None = None
+        state_result: EncodedCallResult | None = None
         errors = ["Theo thBILL iToken has no reviewed scalar NAV/share source; basket valuation is not configured"]
         for result in call_results:
             if result.call.extra_data.get("function") != "totalSupply":
                 continue
             if result.success:
                 total_supply = self.vault.share_token.convert_to_decimals(convert_int256_bytes_to_int(result.result))
+                state_result = result
             else:
                 errors.append("Theo thBILL totalSupply call failed")
+
+        if self.reader_state is not None and state_result is not None:
+            self.reader_state.on_unpriced_call(state_result)
 
         return VaultHistoricalRead(
             vault=self.vault,

--- a/eth_defi/vault/base.py
+++ b/eth_defi/vault/base.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Iterable, Tuple, TypedDict
 from eth_typing import BlockIdentifier, BlockNumber, HexAddress
 from web3 import Web3
 
-from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
+from eth_defi.event_reader.multicall_batcher import BatchCallState, EncodedCall, EncodedCallResult
 from eth_defi.token import DEFAULT_TOKEN_CACHE, TokenAddress, TokenDetails, fetch_erc20_details
 from eth_defi.types import Percent
 from eth_defi.utils import is_good_multichain_address
@@ -838,6 +838,7 @@ class VaultHistoricalReader(ABC):
     def __init__(self, vault: "VaultBase"):
         assert isinstance(vault, VaultBase)
         self.vault = vault
+        self.reader_state: BatchCallState | None = None
 
     @property
     def first_block(self) -> int | None:

--- a/eth_defi/vault/historical.py
+++ b/eth_defi/vault/historical.py
@@ -148,8 +148,31 @@ class VaultHistoricalReadMulticaller:
                     raise VaultReadNotSupported(f"Vault {vault} has denomination token {denomination_token} which is not supported denomination token set: {self.supported_quote_tokens}")
 
     def _prepare_reader(self, vault: VaultBase, stateful=False) -> VaultHistoricalReader:
-        """Run in subprocess"""
-        return vault.get_historical_reader(stateful=stateful)
+        """Create a historical reader and validate its state contract.
+
+        Stateful multicall filtering requires every call to have a
+        :class:`~eth_defi.event_reader.multicall_batcher.BatchCallState`.
+        Validate this at construction so a new protocol reader cannot fail
+        later in token preparation or inside a joblib worker with an obscure
+        missing-attribute error.
+
+        :param vault:
+            Vault adapter creating the protocol-specific reader.
+        :param stateful:
+            Whether persistent adaptive scan state is required.
+        :return:
+            Validated protocol-specific historical reader.
+        :raise TypeError:
+            If a stateful reader does not initialise ``reader_state``.
+        """
+
+        reader = vault.get_historical_reader(stateful=stateful)
+        vault_id = f"{vault.__class__.__name__} at {vault.address}"
+        if not isinstance(reader, VaultHistoricalReader):
+            raise TypeError(f"{vault_id} returned invalid historical reader {reader!r}")
+        if stateful and not isinstance(reader.reader_state, BatchCallState):
+            raise TypeError(f"{reader.__class__.__name__} did not initialise a BatchCallState reader_state for a stateful scan of {vault_id}")
+        return reader
 
     def _prepare_denomination_token(self, reader: "eth_defi.erc_4626.vault.ERC4626HistoricalReader") -> HexAddress:
         """Run in subprocess"""

--- a/tests/centrifuge/test_centrifuge_tranche.py
+++ b/tests/centrifuge/test_centrifuge_tranche.py
@@ -14,6 +14,7 @@ from web3 import Web3
 from eth_defi.erc_4626.classification import create_vault_instance, create_vault_instance_autodetect, identify_vault_features
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature, get_vault_protocol_name
 from eth_defi.erc_4626.scan import create_vault_scan_record
+from eth_defi.erc_4626.vault import VaultReaderState
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.token import TokenDiskCache
@@ -104,6 +105,8 @@ def test_jtrsy_adapter_blocks_public_flows() -> None:
 
     with pytest.raises(NotImplementedError, match="not the subscription/redemption vault"):
         vault.get_deposit_manager()
+    reader = vault.get_historical_reader(stateful=True)
+    assert isinstance(reader.reader_state, VaultReaderState)
 
 
 def test_jtrsy_history_never_invents_price_or_tvl() -> None:
@@ -111,6 +114,7 @@ def test_jtrsy_history_never_invents_price_or_tvl() -> None:
 
     reader = CentrifugeTrancheHistoricalReader.__new__(CentrifugeTrancheHistoricalReader)
     reader.vault = DummyTrancheVault()
+    reader.reader_state = None
     call = EncodedCall(
         func_name="totalSupply",
         address=JTRSY_ETHEREUM.token,

--- a/tests/sygnum/test_sygnum_vault.py
+++ b/tests/sygnum/test_sygnum_vault.py
@@ -13,11 +13,14 @@ from eth_defi.erc_4626 import discovery_base as discovery_base_module
 from eth_defi.erc_4626.classification import VaultFeatureProbe, create_vault_instance, identify_vault_features
 from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name
 from eth_defi.erc_4626.discovery_base import LeadScanReport, VaultDiscoveryBase
+from eth_defi.erc_4626.vault import VaultReaderState
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.tokenised_fund.sygnum.constants import FILQ_A_ETHEREUM_ADDRESS, FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK, SYGNUM_ETHEREUM_CHAIN_ID, SYGNUM_HARDCODED_LEADS
 from eth_defi.tokenised_fund.sygnum.historical import SygnumVaultHistoricalReader
 from eth_defi.tokenised_fund.sygnum.vault import SYGNUM_NAV_UNAVAILABLE_REASON, SYGNUM_RESTRICTED_FLOW_REASON, SygnumVault
+from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.curator import get_curator_name, identify_curator, is_protocol_curator
+from eth_defi.vault.historical import VaultHistoricalReadMulticaller
 
 
 class DummySygnumDiscovery(VaultDiscoveryBase):
@@ -53,7 +56,11 @@ class DummyVault:
     """Minimal historical-reader adapter."""
 
     address = FILQ_A_ETHEREUM_ADDRESS
+    vault_address = FILQ_A_ETHEREUM_ADDRESS
+    spec = VaultSpec(SYGNUM_ETHEREUM_CHAIN_ID, FILQ_A_ETHEREUM_ADDRESS)
+    first_seen_at_block = FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK
     share_token = DummyToken()
+    denomination_token = None
     nav_unavailable_reason = SYGNUM_NAV_UNAVAILABLE_REASON
 
 
@@ -78,6 +85,8 @@ def test_sygnum_vault_blocks_public_flows_and_unpriced_nav() -> None:
         vault.get_deposit_manager()
     with pytest.raises(RuntimeError, match="no public historical NAV"):
         vault.fetch_share_price()
+    reader = vault.get_historical_reader(stateful=True)
+    assert isinstance(reader.reader_state, VaultReaderState)
 
 
 def test_sygnum_historical_reader_keeps_supply_without_price() -> None:
@@ -85,13 +94,34 @@ def test_sygnum_historical_reader_keeps_supply_without_price() -> None:
 
     reader = SygnumVaultHistoricalReader.__new__(SygnumVaultHistoricalReader)
     reader.vault = DummyVault()
+    reader.reader_state = VaultReaderState(reader.vault)
     call = EncodedCall(func_name="totalSupply", address=FILQ_A_ETHEREUM_ADDRESS, data=b"", extra_data={"function": "totalSupply", "vault": FILQ_A_ETHEREUM_ADDRESS})
-    result = EncodedCallResult(call=call, success=True, result=(44_826_428).to_bytes(32, "big"), block_identifier=FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK)
-    row = reader.process_result(FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK, datetime.datetime(2026, 4, 27, 2, 19, 35, tzinfo=datetime.UTC).replace(tzinfo=None), [result])
+    timestamp = datetime.datetime(2026, 4, 27, 2, 19, 35, tzinfo=datetime.UTC).replace(tzinfo=None)
+    result = EncodedCallResult(call=call, success=True, result=(44_826_428).to_bytes(32, "big"), block_identifier=FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK, timestamp=timestamp)
+    row = reader.process_result(FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK, timestamp, [result])
     assert row.total_supply == Decimal("448264.28")
     assert row.share_price is None
     assert row.total_assets is None
     assert row.errors == [SYGNUM_NAV_UNAVAILABLE_REASON]
+    assert reader.reader_state.last_block == FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK
+    assert reader.reader_state.last_call_at == timestamp
+    assert reader.reader_state.last_tvl == Decimal(0)
+    assert reader.reader_state.last_share_price == Decimal(0)
+
+
+def test_stateful_scanner_rejects_reader_without_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reject malformed protocol readers before threaded token preparation."""
+
+    vault = create_vault_instance(SimpleNamespace(eth=SimpleNamespace(chain_id=1)), FILQ_A_ETHEREUM_ADDRESS, features={ERC4626Feature.sygnum_like})
+    multicaller = object.__new__(VaultHistoricalReadMulticaller)
+    prepared_reader = multicaller._prepare_reader(vault, stateful=True)
+    assert isinstance(prepared_reader.reader_state, VaultReaderState)
+    assert multicaller._prepare_denomination_token(prepared_reader) is None
+
+    stateless_reader = vault.get_historical_reader(stateful=False)
+    monkeypatch.setattr(vault, "get_historical_reader", lambda stateful: stateless_reader)
+    with pytest.raises(TypeError, match="did not initialise a BatchCallState reader_state"):
+        multicaller._prepare_reader(vault, stateful=True)
 
 
 def test_sygnum_hardcoded_lead_is_discovered(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/theo/test_theo.py
+++ b/tests/theo/test_theo.py
@@ -12,6 +12,7 @@ import pytest
 from eth_defi.erc_4626.classification import create_vault_instance, create_vault_instance_autodetect, identify_vault_features
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature, get_vault_protocol_name
 from eth_defi.erc_4626.scan import create_vault_scan_record
+from eth_defi.erc_4626.vault import VaultReaderState
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.token import TokenDiskCache
@@ -49,6 +50,8 @@ def test_thbill_adapter_blocks_unreviewed_public_flows() -> None:
     assert vault.get_deposit_manager_capability() is None
     with pytest.raises(NotImplementedError, match="KYC approval"):
         vault.get_deposit_manager()
+    reader = vault.get_historical_reader(stateful=True)
+    assert isinstance(reader.reader_state, VaultReaderState)
 
 
 def test_thbill_history_never_invents_price_or_tvl() -> None:
@@ -56,6 +59,7 @@ def test_thbill_history_never_invents_price_or_tvl() -> None:
 
     reader = TheoITokenHistoricalReader.__new__(TheoITokenHistoricalReader)
     reader.vault = SimpleNamespace(address=THBILL_ETHEREUM.token, share_token=SimpleNamespace(convert_to_decimals=lambda raw_amount: Decimal(raw_amount) / Decimal(10**6)))
+    reader.reader_state = None
     call = EncodedCall(func_name="totalSupply", address=THBILL_ETHEREUM.token, data=b"", extra_data={"function": "totalSupply", "vault": THBILL_ETHEREUM.token})
     read = reader.process_result(123, datetime.datetime(2026, 7, 17, tzinfo=datetime.UTC).replace(tzinfo=None), [EncodedCallResult(call=call, success=True, result=(123_456_789).to_bytes(32, "big"), block_identifier=123)])
     assert read.total_supply == Decimal("123.456789")


### PR DESCRIPTION
## Why

The looped vault scanner crashed while preparing Sygnum with `AttributeError: 'SygnumVaultHistoricalReader' object has no attribute 'reader_state'`. The shared stateful multicall scanner requires every historical reader to provide a `BatchCallState`, including supply-only tokenised funds without public NAV data.

The same audit found Centrifuge and Theo explicitly discarded state when `stateful=True`, which would fail later in the same scan pipeline after Sygnum was corrected.

## Lessons learnt

Supply-only readers still need persistent state for token metadata caching, last-read progress and adaptive polling. Their scheduling state must be updated separately from economic state because they intentionally have no denomination token, NAV or TVL. Error-path diagnostics must also avoid vault string formatting because `VaultBase.__repr__` can trigger RPC metadata reads and mask the original failure.

## Summary

- Initialise stateful reader state for Sygnum, Centrifuge and Theo.
- Add bookkeeping-only state updates for successful unpriced supply reads without exporting synthetic NAV or TVL.
- Define the `reader_state` interface on the historical reader base class.
- Validate reader and `BatchCallState` construction before threaded token preparation.
- Keep validation diagnostics network-free.
- Add regression coverage for the exact Sygnum denomination-token preparation path and the two similar supply-only readers.
- Cover shared historical state and warmup behaviour; 26 focused tests pass.

## Related issues and PRs

Continues the tokenised-fund production hardening from #1321.

## Unrelated CI and test fixes

None.
