### PR TITLE
fix: use wstGBP homepage for vault link

### DIFF
--- a/eth_defi/wstgbp/vault.py
+++ b/eth_defi/wstgbp/vault.py
@@ -24,7 +24,7 @@ from eth_defi.vault.fee import FeeData, VaultFeeMode
 from eth_defi.vault.lower_case_dict import LowercaseDict
 from eth_defi.wstgbp.historical import WSTGBPVaultHistoricalReader
 
-WSTGBP_DOCUMENTATION = "https://docs.wstgbp.com/"
+WSTGBP_HOMEPAGE = "https://wstgbp.com"
 WSTGBP_NAV_SOURCE = "wstgbp_navprice"
 WSTGBP_NOTE = "wstGBP (Wren Staked tGBP) is a non-custodial, non-rebasing ERC-20 wrapper around tGBP, a pound sterling stablecoin issued by BCP Technologies, an FCA-registered cryptoasset firm, backed 1:1 by sterling reserves. Users mint and redeem permissionlessly on Ethereum at the onchain exchange rate. Balances stay fixed and rewards, when applied, are reflected in the wstGBP to tGBP exchange rate through periodic NAV updates. Minting is free and instant redemption carries a 25 bps fee, with no cooldown."
 WAD = Decimal(10**18)
@@ -493,12 +493,12 @@ class WSTGBPVault(VaultBase):
         return float(Decimal(raw_nav - raw_burn_cost) / Decimal(raw_nav))
 
     def get_link(self, referral: str | None = None) -> str:
-        """Return the Wren Staked tGBP product documentation link.
+        """Return the Wren Staked tGBP homepage.
 
         :param referral:
             Ignored because Wren Staked tGBP links do not use referral parameters.
         :return:
-            Public wstGBP documentation URL.
+            Public wstGBP homepage URL.
         """
 
-        return WSTGBP_DOCUMENTATION
+        return WSTGBP_HOMEPAGE

--- a/tests/wstgbp/test_wstgbp_vault.py
+++ b/tests/wstgbp/test_wstgbp_vault.py
@@ -73,7 +73,7 @@ def test_wstgbp_metadata_and_fees(web3: Web3) -> None:
     assert vault.share_token.decimals == WSTGBP_EXPECTED_DECIMALS
     assert vault.fetch_denomination_token_address() == Web3.to_checksum_address(WSTGBP_EXPECTED_GEM)
     assert vault.denomination_token.symbol == "tGBP"
-    assert vault.get_link() == "https://docs.wstgbp.com/"
+    assert vault.get_link() == "https://wstgbp.com"
 
     info = vault.fetch_info()
     assert info["denomination_token"] == Web3.to_checksum_address(WSTGBP_EXPECTED_GEM)


### PR DESCRIPTION
## Why

The vault link should direct users to the wstGBP homepage rather than the documentation subdomain.

## Lessons learnt

Vault adapter links are user-facing product links and should use the canonical homepage when one is supplied.

## Summary

- Return `https://wstgbp.com` from the wstGBP vault adapter.
- Update the focused integration assertion.

## Related issues and PRs

Follow-up to #1315.

## Unrelated CI and test fixes

None.