### PR TITLE
fix: correct Hyperliquid vault performance fee semantics

### DIFF
--- a/eth_defi/hyperliquid/constants.py
+++ b/eth_defi/hyperliquid/constants.py
@@ -48,15 +48,14 @@ HYPERLIQUID_VAULT_PERFORMANCE_FEE: float = 0.10
 #: Fee mode for Hyperliquid native vaults.
 #:
 #: The leader's 10% profit share is deducted from depositor profits at withdrawal time.
-#: The PnL history returned by the ``vaultDetails`` API already reflects the
-#: depositor's net returns (after the leader's cut), so the share price we compute
-#: from portfolio history is a net-of-fees price. This matches
-#: :py:attr:`~eth_defi.vault.fee.VaultFeeMode.internalised_skimming` —
-#: gross and net returns are identical from the pipeline's perspective.
+#: The vault account value and PnL history therefore represent the return before
+#: this investor-facing withdrawal fee. This matches
+#: :py:attr:`~eth_defi.vault.fee.VaultFeeMode.externalised`, allowing the
+#: analytics pipeline to calculate the investor's net return from the 10% share.
 #:
 #: Source: https://hyperliquid.gitbook.io/hyperliquid-docs/hypercore/vaults
-#: Source: https://hyperliquid.gitbook.io/hyperliquid-docs/hypercore/vaults/for-vault-leaders
-HYPERLIQUID_VAULT_FEE_MODE: VaultFeeMode = VaultFeeMode.internalised_skimming
+#: Source: https://hyperliquid.gitbook.io/hyperliquid-docs/hypercore/vaults/for-vault-depositors-legacy
+HYPERLIQUID_VAULT_FEE_MODE: VaultFeeMode = VaultFeeMode.externalised
 
 #: Lockup period for user-created Hyperliquid vaults.
 #:

--- a/eth_defi/hyperliquid/vault_data_export.py
+++ b/eth_defi/hyperliquid/vault_data_export.py
@@ -371,6 +371,19 @@ def _prepare_hypercore_export(
     def _col(name: str, default=np.nan):
         return prices_df[name].values if name in prices_df.columns else default
 
+    # Normal Hyperliquid vaults charge the fixed 10% leader profit share.
+    # HLP and its child vaults are protocol-operated and do not charge it.
+    relationship_type = prices_df.get(
+        "relationship_type",
+        pd.Series(index=prices_df.index, dtype=object),
+    )
+    is_protocol_vault = relationship_type.isin(("parent", "child"))
+    performance_fee = np.where(
+        is_protocol_vault,
+        0.0,
+        HYPERLIQUID_VAULT_PERFORMANCE_FEE,
+    )
+
     result = pd.DataFrame(
         {
             "chain": chain_id,
@@ -383,7 +396,7 @@ def _prepare_hypercore_export(
             "follower_count": _col("follower_count"),
             "cumulative_volume": _col("cumulative_volume"),
             "total_supply": 0.0,
-            "performance_fee": 0.0,
+            "performance_fee": performance_fee,
             "management_fee": 0.0,
             "errors": "",
             "deposits_open": deposits_open.values,

--- a/scripts/hyperliquid/migrate-vault-fee-mode.py
+++ b/scripts/hyperliquid/migrate-vault-fee-mode.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Migrate cached Hyperliquid vault metadata to withdrawal-time fee semantics.
+
+Hyperliquid legacy vaults deduct the leader's 10% profit share when a depositor
+withdraws. Older ``vault-metadata-db.pickle`` files incorrectly label this fee
+as internalised, which makes calculated gross and net returns identical. This
+metadata-only migration changes Hypercore ``FeeData.fee_mode`` to
+``externalised`` and preserves all recorded fee percentages.
+
+The script starts in dry-run mode. Inspect the proposed changes, then apply it:
+
+.. code-block:: shell
+
+    source .local-test.env && poetry run python scripts/hyperliquid/migrate-vault-fee-mode.py
+    source .local-test.env && DRY_RUN=false poetry run python scripts/hyperliquid/migrate-vault-fee-mode.py
+
+After applying it, run the normal Hyperliquid scanner and price post-processing
+pipeline to republish the corrected gross and net metrics. Configuration is
+through environment variables:
+
+``DRY_RUN``
+    Print proposed changes without writing. Defaults to ``true``.
+
+``VAULT_DB_PATH``
+    Metadata pickle to migrate. Defaults to the active pipeline data directory.
+
+``BACKUP_PATH``
+    Optional backup pickle path. Defaults to a non-overwriting sibling path.
+
+``LOG_LEVEL``
+    Python logging level. Defaults to ``info``.
+"""
+
+import logging
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from tabulate import tabulate
+
+from eth_defi.hyperliquid.constants import HYPERCORE_CHAIN_ID
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.fee import FeeData, VaultFeeMode
+from eth_defi.vault.vaultdb import VaultDatabase, VaultRow, get_pipeline_data_dir
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class HyperliquidFeeModeMigration:
+    """One cached Hyperliquid metadata row requiring a fee-mode update."""
+
+    #: Existing metadata database key.
+    vault_spec: VaultSpec
+
+    #: Human-readable vault name for the operator output.
+    name: str
+
+    #: Fee mode persisted before this migration.
+    old_fee_mode: VaultFeeMode | None
+
+    #: Updated fee details to persist.
+    new_fee_data: FeeData
+
+
+@dataclass(slots=True)
+class HyperliquidFeeModeMigrationResult:
+    """Summary of a Hyperliquid metadata fee-mode migration."""
+
+    #: Number of Hyperliquid metadata rows inspected.
+    inspected_rows: int
+
+    #: Number of rows requiring the fee-mode update.
+    migrated_rows: int
+
+    #: Backup written before the atomic metadata update, if any.
+    backup_path: Path | None
+
+
+def parse_bool_env(name: str, *, default: bool) -> bool:
+    """Parse a boolean environment variable.
+
+    :param name:
+        Environment variable name.
+    :param default:
+        Value to use when the variable is unset.
+    :return:
+        Parsed boolean value.
+    """
+
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def resolve_vault_database_path() -> Path:
+    """Resolve the cached vault metadata database to migrate.
+
+    :return:
+        Explicit ``VAULT_DB_PATH`` or the active pipeline metadata database.
+    """
+
+    configured_path = os.environ.get("VAULT_DB_PATH")
+    if configured_path:
+        return Path(configured_path).expanduser()
+    return get_pipeline_data_dir() / "vault-metadata-db.pickle"
+
+
+def create_backup_path(vault_db_path: Path) -> Path:
+    """Create a non-overwriting sibling backup path.
+
+    :param vault_db_path:
+        Metadata database to back up.
+    :return:
+        Unused backup path next to the metadata database.
+    """
+
+    configured_path = os.environ.get("BACKUP_PATH")
+    if configured_path:
+        backup_path = Path(configured_path).expanduser()
+        if backup_path.exists():
+            raise FileExistsError(f"Refusing to overwrite existing backup: {backup_path}")
+        return backup_path
+
+    base_path = vault_db_path.with_name(f"{vault_db_path.name}.before-hyperliquid-fee-mode-migration")
+    backup_path = base_path
+    suffix = 1
+    while backup_path.exists():
+        backup_path = base_path.with_name(f"{base_path.name}.{suffix}")
+        suffix += 1
+    return backup_path
+
+
+def _create_externalised_fee_data(row: VaultRow) -> FeeData:
+    """Create externalised fee metadata while preserving stored fee percentages.
+
+    :param row:
+        Existing Hyperliquid vault metadata row.
+    :return:
+        Fee data with the withdrawal-time fee model.
+    """
+
+    existing_fees: FeeData | None = row.get("_fees")
+    if existing_fees is None:
+        return FeeData(
+            fee_mode=VaultFeeMode.externalised,
+            management=row.get("Mgmt fee"),
+            performance=row.get("Perf fee"),
+            deposit=row.get("Deposit fee", 0.0),
+            withdraw=row.get("Withdraw fee", 0.0),
+        )
+
+    return FeeData(
+        fee_mode=VaultFeeMode.externalised,
+        management=existing_fees.management,
+        performance=existing_fees.performance,
+        deposit=existing_fees.deposit,
+        withdraw=existing_fees.withdraw,
+    )
+
+
+def build_hyperliquid_fee_mode_migrations(
+    vault_db: VaultDatabase,
+) -> tuple[int, list[HyperliquidFeeModeMigration]]:
+    """Find Hypercore metadata rows still using internalised fee semantics.
+
+    :param vault_db:
+        In-memory metadata database to inspect without mutating it.
+    :return:
+        Number of inspected Hyperliquid rows and required migrations.
+    """
+
+    inspected_rows = 0
+    migrations: list[HyperliquidFeeModeMigration] = []
+
+    for vault_spec, row in vault_db.rows.items():
+        if vault_spec.chain_id != HYPERCORE_CHAIN_ID or row.get("Protocol") != "Hyperliquid":
+            continue
+
+        inspected_rows += 1
+        existing_fees: FeeData | None = row.get("_fees")
+        old_fee_mode = existing_fees.fee_mode if existing_fees else None
+        if old_fee_mode == VaultFeeMode.externalised:
+            continue
+
+        migrations.append(
+            HyperliquidFeeModeMigration(
+                vault_spec=vault_spec,
+                name=row.get("Name", "<unnamed>"),
+                old_fee_mode=old_fee_mode,
+                new_fee_data=_create_externalised_fee_data(row),
+            )
+        )
+
+    return inspected_rows, migrations
+
+
+def apply_hyperliquid_fee_mode_migrations(
+    vault_db: VaultDatabase,
+    migrations: list[HyperliquidFeeModeMigration],
+) -> None:
+    """Apply fee-mode updates without altering unrelated metadata or state.
+
+    :param vault_db:
+        In-memory metadata database to update.
+    :param migrations:
+        Fee-mode changes selected by :func:`build_hyperliquid_fee_mode_migrations`.
+    :return:
+        ``None`` after updating the in-memory rows.
+    """
+
+    for migration in migrations:
+        row = vault_db.rows[migration.vault_spec].copy()
+        row["_fees"] = migration.new_fee_data
+        vault_db.rows[migration.vault_spec] = row
+
+
+def migrate_hyperliquid_fee_mode(
+    vault_db_path: Path,
+    *,
+    dry_run: bool,
+) -> HyperliquidFeeModeMigrationResult:
+    """Migrate a metadata pickle with a backup before any real write.
+
+    :param vault_db_path:
+        Existing metadata pickle to inspect and optionally update.
+    :param dry_run:
+        If ``True``, report required changes without writing any files.
+    :return:
+        Migration summary including the backup path when one was written.
+    """
+
+    if not vault_db_path.exists():
+        raise FileNotFoundError(f"Vault metadata database does not exist: {vault_db_path}")
+
+    vault_db = VaultDatabase.read(vault_db_path)
+    inspected_rows, migrations = build_hyperliquid_fee_mode_migrations(vault_db)
+    logger.info(
+        "Inspected %d Hyperliquid metadata rows; %d require migration",
+        inspected_rows,
+        len(migrations),
+    )
+
+    if dry_run or not migrations:
+        return HyperliquidFeeModeMigrationResult(
+            inspected_rows=inspected_rows,
+            migrated_rows=len(migrations),
+            backup_path=None,
+        )
+
+    backup_path = create_backup_path(vault_db_path)
+    backup_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(vault_db_path, backup_path)
+    apply_hyperliquid_fee_mode_migrations(vault_db, migrations)
+    vault_db.write(vault_db_path)
+
+    return HyperliquidFeeModeMigrationResult(
+        inspected_rows=inspected_rows,
+        migrated_rows=len(migrations),
+        backup_path=backup_path,
+    )
+
+
+def main() -> None:
+    """Run the Hyperliquid metadata migration configured through environment variables.
+
+    :return:
+        ``None`` after printing the migration result.
+    """
+
+    setup_console_logging(default_log_level=os.environ.get("LOG_LEVEL", "info"))
+    dry_run = parse_bool_env("DRY_RUN", default=True)
+    vault_db_path = resolve_vault_database_path()
+    result = migrate_hyperliquid_fee_mode(vault_db_path, dry_run=dry_run)
+
+    print(
+        tabulate(
+            [
+                [
+                    vault_db_path,
+                    result.inspected_rows,
+                    result.migrated_rows,
+                    "yes" if dry_run else "no",
+                    result.backup_path or "-",
+                ]
+            ],
+            headers=[
+                "vault database",
+                "Hyperliquid rows",
+                "migrated rows",
+                "dry run",
+                "backup",
+            ],
+            tablefmt="rounded_outline",
+        )
+    )
+    if dry_run:
+        print("Dry run: no files written. Re-run with DRY_RUN=false to apply the migration.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/hyperliquid/test_backfill.py
+++ b/tests/hyperliquid/test_backfill.py
@@ -1021,6 +1021,7 @@ def test_build_raw_prices_deposits_open_healthy(tmp_path):
         latest = result.iloc[-1]
         assert latest["deposit_closed_reason"] is None
         assert latest["deposits_open"] == "true"
+        assert result["performance_fee"].tolist() == pytest.approx([0.1] * len(result))
 
     finally:
         db.close()
@@ -1101,6 +1102,7 @@ def test_build_raw_prices_hlp_parent_ignores_leader_fraction(tmp_path):
 
         assert row["deposit_closed_reason"] is None
         assert row["deposits_open"] == "true"
+        assert row["performance_fee"] == pytest.approx(0.0)
 
     finally:
         db.close()

--- a/tests/hyperliquid/test_fee_semantics.py
+++ b/tests/hyperliquid/test_fee_semantics.py
@@ -1,0 +1,95 @@
+"""Regression tests for Hyperliquid legacy vault withdrawal-time fees."""
+
+import datetime
+
+import pytest
+
+from eth_defi.hyperliquid.constants import (
+    HYPERLIQUID_VAULT_FEE_MODE,
+    HYPERLIQUID_VAULT_PERFORMANCE_FEE,
+)
+from eth_defi.hyperliquid.vault_data_export import create_hyperliquid_vault_row
+from eth_defi.research.vault_metrics import calculate_net_profit
+from eth_defi.vault.fee import VaultFeeMode
+
+
+def test_normal_hyperliquid_vault_uses_externalised_performance_fee() -> None:
+    """Normal Hyperliquid vaults apply the 10% leader share to investor returns."""
+    _, vault_row = create_hyperliquid_vault_row(
+        vault_address="0x1111111111111111111111111111111111111111",
+        name="Normal vault",
+        description=None,
+        tvl=1_000.0,
+        create_time=datetime.datetime(2024, 1, 1),
+    )
+
+    assert HYPERLIQUID_VAULT_FEE_MODE == VaultFeeMode.externalised
+    assert vault_row["_fees"].fee_mode == VaultFeeMode.externalised
+    assert vault_row["_fees"].performance == HYPERLIQUID_VAULT_PERFORMANCE_FEE
+    assert vault_row["_fees"].get_net_fees().performance == HYPERLIQUID_VAULT_PERFORMANCE_FEE
+
+
+def test_hyperliquid_performance_fee_reduces_investor_return() -> None:
+    """A 20% vault profit leaves 18% after the 10% leader profit share."""
+    _, vault_row = create_hyperliquid_vault_row(
+        vault_address="0x1111111111111111111111111111111111111111",
+        name="Normal vault",
+        description=None,
+        tvl=1_000.0,
+        create_time=datetime.datetime(2024, 1, 1),
+    )
+    net_fees = vault_row["_fees"].get_net_fees()
+
+    net_return = calculate_net_profit(
+        start=datetime.datetime(2024, 1, 1),
+        end=datetime.datetime(2024, 2, 1),
+        share_price_start=1.0,
+        share_price_end=1.2,
+        management_fee_annual=net_fees.management,
+        performance_fee=net_fees.performance,
+        deposit_fee=net_fees.deposit,
+        withdrawal_fee=net_fees.withdraw,
+    )
+
+    assert net_return == pytest.approx(0.18)
+
+
+def test_hyperliquid_performance_fee_does_not_charge_losses() -> None:
+    """A negative return remains unchanged because no leader profit share is due."""
+    _, vault_row = create_hyperliquid_vault_row(
+        vault_address="0x1111111111111111111111111111111111111111",
+        name="Normal vault",
+        description=None,
+        tvl=1_000.0,
+        create_time=datetime.datetime(2024, 1, 1),
+    )
+    net_fees = vault_row["_fees"].get_net_fees()
+
+    net_return = calculate_net_profit(
+        start=datetime.datetime(2024, 1, 1),
+        end=datetime.datetime(2024, 2, 1),
+        share_price_start=1.0,
+        share_price_end=0.8,
+        management_fee_annual=net_fees.management,
+        performance_fee=net_fees.performance,
+        deposit_fee=net_fees.deposit,
+        withdrawal_fee=net_fees.withdraw,
+    )
+
+    assert net_return == pytest.approx(-0.2)
+
+
+def test_hyperliquid_protocol_vault_keeps_zero_performance_fee() -> None:
+    """HLP protocol vaults remain the no-performance-fee exception."""
+    _, vault_row = create_hyperliquid_vault_row(
+        vault_address="0xdfc24b077bc1425ad1dea75bcb6f8158e10df303",
+        name="HLP",
+        description=None,
+        tvl=1_000.0,
+        create_time=datetime.datetime(2024, 1, 1),
+        relationship_type="parent",
+    )
+
+    assert vault_row["_fees"].fee_mode == VaultFeeMode.externalised
+    assert vault_row["_fees"].performance == 0.0
+    assert vault_row["_fees"].get_net_fees().performance == 0.0

--- a/tests/hyperliquid/test_high_freq_export.py
+++ b/tests/hyperliquid/test_high_freq_export.py
@@ -128,6 +128,7 @@ def test_hf_export_raw_timestamps(tmp_path):
         assert sorted_df.loc[0, "share_price"] == pytest.approx(1.000)
         assert sorted_df.loc[1, "share_price"] == pytest.approx(1.010)
         assert sorted_df.loc[2, "share_price"] == pytest.approx(1.020)
+        assert sorted_df["performance_fee"].tolist() == pytest.approx([0.1, 0.1, 0.1])
 
         # 6. Verify flow columns use daily_* naming
         assert "daily_deposit_count" in result_df.columns
@@ -271,6 +272,7 @@ def test_hf_export_hlp_parent_ignores_leader_fraction(tmp_path):
 
         assert result_row["deposit_closed_reason"] is None
         assert result_row["deposits_open"] == "true"
+        assert result_row["performance_fee"] == pytest.approx(0.0)
 
     finally:
         db.close()

--- a/tests/hyperliquid/test_migrate_vault_fee_mode.py
+++ b/tests/hyperliquid/test_migrate_vault_fee_mode.py
@@ -1,0 +1,136 @@
+"""Regression tests for the Hyperliquid cached fee-mode migration helper."""
+
+import importlib.util
+from pathlib import Path
+
+from eth_defi.hyperliquid.constants import (
+    HYPERCORE_CHAIN_ID,
+    HYPERLIQUID_VAULT_PERFORMANCE_FEE,
+)
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.fee import FeeData, VaultFeeMode
+from eth_defi.vault.vaultdb import VaultDatabase
+
+
+def load_migration_module():
+    """Load the hyphenated migration script as a Python module.
+
+    :return:
+        Loaded migration module.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "hyperliquid" / "migrate-vault-fee-mode.py"
+    spec = importlib.util.spec_from_file_location(
+        "migrate_hyperliquid_vault_fee_mode",
+        script_path,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def create_row(protocol: str, fee_mode: VaultFeeMode) -> dict:
+    """Create minimal metadata with a configurable fee mode.
+
+    :param protocol:
+        Protocol name persisted in the metadata row.
+    :param fee_mode:
+        Existing fee mode to migrate or preserve.
+    :return:
+        Minimal vault metadata row.
+    """
+
+    return {
+        "Name": "Test vault",
+        "Protocol": protocol,
+        "Mgmt fee": 0.0,
+        "Perf fee": 0.1,
+        "Deposit fee": 0.0,
+        "Withdraw fee": 0.0,
+        "_fees": FeeData(
+            fee_mode=fee_mode,
+            management=0.0,
+            performance=0.1,
+            deposit=0.0,
+            withdraw=0.0,
+        ),
+    }
+
+
+def test_migrate_hyperliquid_fee_mode_updates_only_hypercore_metadata(
+    tmp_path: Path,
+) -> None:
+    """Migrate Hypercore rows while preserving all unrelated vault metadata."""
+    migration = load_migration_module()
+    hyperliquid_spec = VaultSpec(
+        HYPERCORE_CHAIN_ID,
+        "0x1111111111111111111111111111111111111111",
+    )
+    evm_spec = VaultSpec(1, "0x2222222222222222222222222222222222222222")
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    VaultDatabase(
+        rows={
+            hyperliquid_spec: create_row(
+                "Hyperliquid",
+                VaultFeeMode.internalised_skimming,
+            ),
+            evm_spec: create_row("Yearn", VaultFeeMode.internalised_skimming),
+        }
+    ).write(vault_db_path)
+
+    dry_run = migration.migrate_hyperliquid_fee_mode(vault_db_path, dry_run=True)
+    assert dry_run.inspected_rows == 1
+    assert dry_run.migrated_rows == 1
+    assert dry_run.backup_path is None
+    dry_run_db = VaultDatabase.read(vault_db_path)
+    assert dry_run_db.rows[hyperliquid_spec]["_fees"].fee_mode == VaultFeeMode.internalised_skimming
+
+    result = migration.migrate_hyperliquid_fee_mode(vault_db_path, dry_run=False)
+    assert result.inspected_rows == 1
+    assert result.migrated_rows == 1
+    assert result.backup_path is not None
+    assert result.backup_path.exists()
+
+    migrated_db = VaultDatabase.read(vault_db_path)
+    assert migrated_db.rows[hyperliquid_spec]["_fees"].fee_mode == VaultFeeMode.externalised
+    assert migrated_db.rows[hyperliquid_spec]["_fees"].performance == HYPERLIQUID_VAULT_PERFORMANCE_FEE
+    assert migrated_db.rows[evm_spec]["_fees"].fee_mode == VaultFeeMode.internalised_skimming
+
+
+def test_hyperliquid_fee_mode_migration_is_idempotent(tmp_path: Path) -> None:
+    """Already migrated metadata does not create a backup or rewrite the pickle."""
+    migration = load_migration_module()
+    hyperliquid_spec = VaultSpec(
+        HYPERCORE_CHAIN_ID,
+        "0x1111111111111111111111111111111111111111",
+    )
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    vault_db = VaultDatabase(
+        rows={
+            hyperliquid_spec: create_row(
+                "Hyperliquid",
+                VaultFeeMode.externalised,
+            )
+        }
+    )
+    vault_db.write(vault_db_path)
+
+    result = migration.migrate_hyperliquid_fee_mode(vault_db_path, dry_run=False)
+
+    assert result.inspected_rows == 1
+    assert result.migrated_rows == 0
+    assert result.backup_path is None
+
+
+def test_create_backup_path_never_overwrites_existing_backup(tmp_path: Path) -> None:
+    """Increment the backup suffix when a previous migration backup exists."""
+    migration = load_migration_module()
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    first_backup_path = tmp_path / "vault-metadata-db.pickle.before-hyperliquid-fee-mode-migration"
+    first_backup_path.touch()
+
+    expected_backup_path = tmp_path / "vault-metadata-db.pickle.before-hyperliquid-fee-mode-migration.1"
+    assert migration.create_backup_path(vault_db_path) == expected_backup_path


### PR DESCRIPTION
## Why

Hyperliquid legacy vaults deduct the leader's 10% profit share at withdrawal. We previously labelled this external investor fee as internalised, making calculated gross and net returns identical.

## Lessons learnt

Hyperliquid vault account equity is pre-withdrawal-commission. Investor net returns are a period-level estimate: individual depositor entry prices and high-water marks are not available in the vault-level series.

## Summary

- Mark Hyperliquid vault fees as externalised and export the 10% fee for normal vaults; preserve HLP parent/child as fee-free.
- Add a dry-run-by-default, backed-up, idempotent metadata migration helper.
- Cover positive and negative returns, raw exports, and migration behaviour.

## Related issues and PRs

- Continues the Hyperliquid vault fee semantics investigation.

## Unrelated CI and test fixes

- `test_fetch_and_store_vault_preserves_historical_apr_on_resume` and `test_deposit_closed_reason_in_cleaned_data` currently fail unchanged on the main checkout; this PR does not modify them.