### PR TITLE
feat: backfill OpenEden and FILQ oracle price history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- feat: Add Hypersync-backed Chainlink bundle aggregator history and FILQ NAV support (2026-07-20)
 - feat: Backfill OpenEden TBILL oracle price history while preserving supply-only FDIT and CASHx metadata (2026-07-20)
 - feat: Complete Asseto live-feed discovery, standardise tokenised-fund vault flags and add verified curator logo coverage (2026-07-20)
 - feat: Fill supported-chain tokenised-fund discovery gaps for mTBILL, FDIT, CASHx, TBILL, FILQ-D and Ethereum ULTRA (2026-07-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- feat: Backfill OpenEden TBILL oracle price history while preserving supply-only FDIT and CASHx metadata (2026-07-20)
 - feat: Complete Asseto live-feed discovery, standardise tokenised-fund vault flags and add verified curator logo coverage (2026-07-20)
 - feat: Fill supported-chain tokenised-fund discovery gaps for mTBILL, FDIT, CASHx, TBILL, FILQ-D and Ethereum ULTRA (2026-07-20)
 - feat: Backfill HKD exchange rates and keep HKD-denominated Asseto histories out of the stablecoin-only cleaned dataset (2026-07-18)

--- a/docs/source/api/chainlink/index.rst
+++ b/docs/source/api/chainlink/index.rst
@@ -15,4 +15,5 @@ and creating your own.
    :recursive:
 
    eth_defi.chainlink.round_data
+   eth_defi.chainlink.bundle_aggregator
    eth_defi.chainlink.token_price

--- a/eth_defi/chainlink/bundle_aggregator.py
+++ b/eth_defi/chainlink/bundle_aggregator.py
@@ -1,0 +1,422 @@
+"""Read Chainlink Data Feeds bundle aggregators and their report history.
+
+Chainlink bundle feeds publish multiple values in a single opaque ``bytes``
+payload.  The proxy exposes the current bundle through ``latestBundle()``,
+while the underlying ``DataFeedsCache`` emits every accepted update as a
+``BundleReportUpdated`` event.  Historical event discovery is performed with
+Hypersync, avoiding JSON-RPC log-range limitations.
+
+The bundle schema is feed-specific.  Callers must know the word index and
+decimal scale for the value they consume; this module deliberately does not
+guess field meanings.  See the verified `DataFeedsCache contract
+<https://etherscan.io/address/0x16b53825c8ceaea593507274d4c1aaec9e261433#code>`__
+and an example `BundleReportUpdated transaction
+<https://etherscan.io/tx/0x162d17b2e8e340f0c7396059a524d411ed91a28948bbd5b3123ababe74f734de#eventlog>`__.
+"""
+
+import asyncio
+import datetime
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from decimal import Decimal
+
+import eth_abi
+from eth_typing import BlockIdentifier, HexAddress
+from web3 import Web3
+from web3.contract import Contract
+
+from eth_defi.compat import native_datetime_utc_fromtimestamp
+from eth_defi.utils import from_unix_timestamp
+
+try:
+    import hypersync
+    from hypersync import BlockField, LogField
+
+    from eth_defi.hypersync.session import open_hypersync_stream
+except ImportError:
+    hypersync = None
+
+
+#: Solidity signature emitted by Chainlink's DataFeedsCache for bundle updates.
+BUNDLE_REPORT_UPDATED_EVENT_SIGNATURE = "BundleReportUpdated(bytes16,uint256,bytes)"
+
+#: Topic zero for :data:`BUNDLE_REPORT_UPDATED_EVENT_SIGNATURE`.
+BUNDLE_REPORT_UPDATED_TOPIC0 = "0x" + Web3.keccak(text=BUNDLE_REPORT_UPDATED_EVENT_SIGNATURE).hex()
+
+#: Minimal Chainlink bundle proxy ABI used for current and historical state reads.
+BUNDLE_AGGREGATOR_PROXY_ABI = [
+    {"inputs": [], "name": "aggregator", "outputs": [{"type": "address"}], "stateMutability": "view", "type": "function"},
+    {"inputs": [], "name": "bundleDecimals", "outputs": [{"type": "uint8[]"}], "stateMutability": "view", "type": "function"},
+    {"inputs": [], "name": "description", "outputs": [{"type": "string"}], "stateMutability": "view", "type": "function"},
+    {"inputs": [], "name": "latestBundle", "outputs": [{"type": "bytes"}], "stateMutability": "view", "type": "function"},
+    {"inputs": [], "name": "latestBundleTimestamp", "outputs": [{"type": "uint256"}], "stateMutability": "view", "type": "function"},
+]
+
+#: Number of bytes in a Chainlink bundle data identifier.
+BUNDLE_DATA_ID_SIZE = 16
+
+#: Number of bytes in an EVM event topic.
+EVENT_TOPIC_SIZE = 32
+
+#: Topic count for ``BundleReportUpdated``.
+BUNDLE_REPORT_UPDATED_TOPIC_COUNT = 3
+
+
+def _decode_hypersync_int(value: int | str) -> int:
+    """Decode a Hypersync integer field.
+
+    :param value: Integer or hexadecimal integer returned by Hypersync.
+    :return: Decoded Python integer.
+    """
+
+    if isinstance(value, int):
+        return value
+    return int(value, 16) if value.startswith("0x") else int(value)
+
+
+def _event_data_to_bytes(value: bytes | str) -> bytes:
+    """Normalise event data to bytes.
+
+    :param value: Raw bytes or a ``0x``-prefixed hexadecimal string.
+    :return: Decoded event data.
+    """
+
+    if isinstance(value, bytes):
+        return value
+    return bytes.fromhex(value[2:] if value.startswith("0x") else value)
+
+
+def encode_bundle_data_id_topic(data_id: bytes) -> str:
+    """Encode an indexed ``bytes16`` feed identifier as an event topic.
+
+    Solidity right-pads indexed fixed-size byte arrays to a 32-byte topic.
+
+    :param data_id: Chainlink bundle feed identifier.
+    :return: ``0x``-prefixed 32-byte event topic.
+    :raise ValueError: If ``data_id`` is not exactly 16 bytes.
+    """
+
+    if len(data_id) != BUNDLE_DATA_ID_SIZE:
+        raise ValueError(f"Chainlink bundle data id must be 16 bytes, got {len(data_id)}")
+    return "0x" + data_id.hex() + "0" * 32
+
+
+def decode_bundle_data_id_topic(topic: str) -> bytes:
+    """Decode an indexed ``bytes16`` feed identifier.
+
+    :param topic: ``0x``-prefixed 32-byte event topic.
+    :return: The first 16 bytes containing the feed identifier.
+    :raise ValueError: If the topic is not 32 bytes.
+    """
+
+    raw = _event_data_to_bytes(topic)
+    if len(raw) != EVENT_TOPIC_SIZE:
+        raise ValueError(f"Chainlink event topic must be 32 bytes, got {len(raw)}")
+    return raw[:BUNDLE_DATA_ID_SIZE]
+
+
+def decode_bundle_decimal(bundle: bytes, index: int, decimals: int, *, signed: bool = False) -> Decimal:
+    """Decode one fixed-width numeric field from a Chainlink bundle.
+
+    Bundle schemas may mix numeric and dynamic fields.  The caller is
+    responsible for selecting a numeric word and supplying the corresponding
+    scale from ``bundleDecimals()``.
+
+    :param bundle: Raw bundle returned by ``latestBundle()`` or its update event.
+    :param index: Zero-based 32-byte word index.
+    :param decimals: Decimal scale for this field.
+    :param signed: Decode the word as a signed two's-complement integer.
+    :return: Human-readable decimal value.
+    :raise ValueError: If the index, decimal scale, or payload length is invalid.
+    """
+
+    if index < 0:
+        raise ValueError(f"Chainlink bundle index cannot be negative: {index}")
+    if decimals < 0:
+        raise ValueError(f"Chainlink bundle decimal scale cannot be negative: {decimals}")
+    start = index * 32
+    end = start + 32
+    if len(bundle) < end:
+        raise ValueError(f"Chainlink bundle has {len(bundle)} bytes, cannot decode word {index}")
+    raw_value = int.from_bytes(bundle[start:end], byteorder="big", signed=signed)
+    return Decimal(raw_value) / Decimal(10**decimals)
+
+
+@dataclass(slots=True, frozen=True)
+class ChainlinkLatestBundleData:
+    """Current state returned by a Chainlink bundle aggregator proxy."""
+
+    #: Bundle proxy contract.
+    proxy: Contract
+
+    #: Feed-specific opaque bundle payload.
+    bundle: bytes
+
+    #: Chainlink report timestamp as Unix seconds.
+    updated_at: int
+
+    #: Decimal metadata for feed fields.
+    decimals: tuple[int, ...]
+
+    #: Human-readable feed description.
+    description: str
+
+    #: Underlying DataFeedsCache contract emitting report events.
+    aggregator_address: HexAddress
+
+    @property
+    def update_time(self) -> datetime.datetime:
+        """Return the report timestamp as a naive UTC datetime."""
+
+        return native_datetime_utc_fromtimestamp(self.updated_at)
+
+    def decode_decimal(self, index: int, *, signed: bool = False) -> Decimal:
+        """Decode a numeric field using the proxy-provided decimal scale.
+
+        :param index: Zero-based bundle field index.
+        :param signed: Decode a signed integer field.
+        :return: Human-readable decimal value.
+        :raise IndexError: If the proxy has no decimal metadata for ``index``.
+        """
+
+        try:
+            decimals = self.decimals[index]
+        except IndexError as exc:
+            raise IndexError(f"Chainlink bundle has {len(self.decimals)} decimal entries, cannot decode index {index}") from exc
+        return decode_bundle_decimal(self.bundle, index, decimals, signed=signed)
+
+
+@dataclass(slots=True, frozen=True)
+class ChainlinkBundleReport:
+    """A historical Chainlink ``BundleReportUpdated`` event."""
+
+    #: DataFeedsCache contract that emitted the event.
+    aggregator_address: HexAddress
+
+    #: Feed-specific Chainlink data identifier.
+    data_id: bytes
+
+    #: Chainlink report timestamp as Unix seconds.
+    updated_at: int
+
+    #: Feed-specific opaque bundle payload.
+    bundle: bytes
+
+    #: Block containing the accepted report.
+    block_number: int
+
+    #: Naive UTC timestamp of the containing block, when returned by Hypersync.
+    block_timestamp: datetime.datetime | None
+
+    #: Transaction hash containing the report.
+    transaction_hash: str
+
+    #: Event position in the transaction receipt.
+    log_index: int
+
+    @property
+    def update_time(self) -> datetime.datetime:
+        """Return the report timestamp as a naive UTC datetime."""
+
+        return native_datetime_utc_fromtimestamp(self.updated_at)
+
+    def decode_decimal(self, index: int, decimals: int, *, signed: bool = False) -> Decimal:
+        """Decode a feed-specific numeric bundle field.
+
+        :param index: Zero-based bundle field index.
+        :param decimals: Feed-specific decimal scale for this field.
+        :param signed: Decode a signed integer field.
+        :return: Human-readable decimal value.
+        """
+
+        return decode_bundle_decimal(self.bundle, index, decimals, signed=signed)
+
+
+def create_bundle_aggregator_proxy(web3: Web3, proxy_address: HexAddress | str) -> Contract:
+    """Create a minimal Chainlink bundle proxy contract instance.
+
+    :param web3: Web3 connection for the proxy's chain.
+    :param proxy_address: Chainlink bundle aggregator proxy address.
+    :return: Web3 contract instance.
+    """
+
+    return web3.eth.contract(address=Web3.to_checksum_address(proxy_address), abi=BUNDLE_AGGREGATOR_PROXY_ABI)
+
+
+def fetch_chainlink_latest_bundle(
+    web3: Web3,
+    proxy_address: HexAddress | str,
+    block_identifier: BlockIdentifier = "latest",
+) -> ChainlinkLatestBundleData:
+    """Fetch a Chainlink bundle from its proxy at a specific block.
+
+    :param web3: Web3 connection for the proxy's chain.
+    :param proxy_address: Chainlink bundle aggregator proxy address.
+    :param block_identifier: Current or historical block identifier.
+    :return: Bundle, report timestamp, decimal metadata, description and cache address.
+    :raise ValueError: If the proxy returns an empty or untimestamped bundle.
+    """
+
+    proxy = create_bundle_aggregator_proxy(web3, proxy_address)
+    bundle = bytes(proxy.functions.latestBundle().call(block_identifier=block_identifier))
+    updated_at = proxy.functions.latestBundleTimestamp().call(block_identifier=block_identifier)
+    if not bundle or updated_at <= 0:
+        raise ValueError(f"Chainlink bundle proxy {proxy.address} returned an empty observation at block {block_identifier}")
+    decimals = tuple(proxy.functions.bundleDecimals().call(block_identifier=block_identifier))
+    description = proxy.functions.description().call(block_identifier=block_identifier)
+    aggregator_address = HexAddress(proxy.functions.aggregator().call(block_identifier=block_identifier))
+    return ChainlinkLatestBundleData(
+        proxy=proxy,
+        bundle=bundle,
+        updated_at=updated_at,
+        decimals=decimals,
+        description=description,
+        aggregator_address=aggregator_address,
+    )
+
+
+def decode_bundle_report_event(
+    *,
+    aggregator_address: HexAddress | str,
+    topics: list[str | None],
+    data: bytes | str,
+    block_number: int,
+    block_timestamp: datetime.datetime | None,
+    transaction_hash: str,
+    log_index: int,
+) -> ChainlinkBundleReport:
+    """Decode one ``BundleReportUpdated`` event.
+
+    :param aggregator_address: DataFeedsCache contract emitting the event.
+    :param topics: Event topics containing signature, data id and report timestamp.
+    :param data: ABI-encoded non-indexed ``bytes bundle`` value.
+    :param block_number: Block containing the event.
+    :param block_timestamp: Naive UTC timestamp of the containing block.
+    :param transaction_hash: Transaction containing the event.
+    :param log_index: Event position within the receipt.
+    :return: Decoded bundle report.
+    :raise ValueError: If the topics do not match the expected event.
+    """
+
+    populated_topics = [topic for topic in topics if topic is not None]
+    if len(populated_topics) != BUNDLE_REPORT_UPDATED_TOPIC_COUNT:
+        raise ValueError(f"BundleReportUpdated must have three populated topics, got {len(populated_topics)}")
+    if populated_topics[0].lower() != BUNDLE_REPORT_UPDATED_TOPIC0.lower():
+        raise ValueError(f"Unexpected Chainlink bundle event topic: {populated_topics[0]}")
+    data_id = decode_bundle_data_id_topic(populated_topics[1])
+    updated_at = _decode_hypersync_int(populated_topics[2])
+    (bundle,) = eth_abi.decode(["bytes"], _event_data_to_bytes(data))
+    return ChainlinkBundleReport(
+        aggregator_address=HexAddress(Web3.to_checksum_address(aggregator_address)),
+        data_id=data_id,
+        updated_at=updated_at,
+        bundle=bytes(bundle),
+        block_number=block_number,
+        block_timestamp=block_timestamp,
+        transaction_hash=transaction_hash,
+        log_index=log_index,
+    )
+
+
+async def fetch_chainlink_bundle_reports_hypersync_async(
+    hypersync_client,
+    *,
+    aggregator_address: HexAddress | str,
+    start_block: int,
+    end_block: int,
+    data_ids: set[bytes] | None = None,
+    recv_timeout: float = 90.0,
+) -> list[ChainlinkBundleReport]:
+    """Fetch Chainlink bundle reports through Hypersync.
+
+    The query targets the underlying DataFeedsCache address, not the bundle
+    proxy: the cache emits reports while the proxy only forwards state reads.
+
+    :param hypersync_client: Configured native or throttled Hypersync client.
+    :param aggregator_address: DataFeedsCache contract emitting report events.
+    :param start_block: Inclusive first block.
+    :param end_block: Inclusive final block.
+    :param data_ids: Optional set of 16-byte feed identifiers to include.
+    :param recv_timeout: Maximum wait for each streamed response.
+    :return: Reports sorted by block and log index.
+    """
+
+    if hypersync is None:
+        message = "The hypersync package is required for Chainlink bundle history"
+        raise ImportError(message)
+    if start_block > end_block:
+        raise ValueError(f"Bad Chainlink bundle block range: {start_block} - {end_block}")
+    if data_ids is not None and not data_ids:
+        return []
+
+    topics: list[list[str]] = [[BUNDLE_REPORT_UPDATED_TOPIC0]]
+    if data_ids is not None:
+        topics.append([encode_bundle_data_id_topic(data_id) for data_id in sorted(data_ids)])
+    query = hypersync.Query(
+        from_block=start_block,
+        to_block=end_block + 1,
+        logs=[hypersync.LogSelection(address=[str(aggregator_address).lower()], topics=topics)],
+        field_selection=hypersync.FieldSelection(
+            block=[BlockField.NUMBER, BlockField.TIMESTAMP],
+            log=[LogField.BLOCK_NUMBER, LogField.LOG_INDEX, LogField.ADDRESS, LogField.TRANSACTION_HASH, LogField.TOPIC0, LogField.TOPIC1, LogField.TOPIC2, LogField.DATA],
+        ),
+    )
+
+    receiver = await open_hypersync_stream(hypersync_client, query)
+    reports: list[ChainlinkBundleReport] = []
+    while True:
+        response = await asyncio.wait_for(receiver.recv(), timeout=recv_timeout)
+        if response is None:
+            break
+        block_timestamps = {_decode_hypersync_int(block.number): from_unix_timestamp(_decode_hypersync_int(block.timestamp)) for block in response.data.blocks or [] if block.number is not None and block.timestamp is not None}
+        for log in response.data.logs or []:
+            block_number = _decode_hypersync_int(log.block_number)
+            reports.append(
+                decode_bundle_report_event(
+                    aggregator_address=log.address,
+                    topics=log.topics,
+                    data=log.data or "0x",
+                    block_number=block_number,
+                    block_timestamp=block_timestamps.get(block_number),
+                    transaction_hash=log.transaction_hash,
+                    log_index=_decode_hypersync_int(log.log_index),
+                )
+            )
+    reports.sort(key=lambda report: (report.block_number, report.log_index))
+    return reports
+
+
+def fetch_chainlink_bundle_reports_hypersync(
+    hypersync_client,
+    *,
+    aggregator_address: HexAddress | str,
+    start_block: int,
+    end_block: int,
+    data_ids: set[bytes] | None = None,
+    recv_timeout: float = 90.0,
+) -> list[ChainlinkBundleReport]:
+    """Synchronously fetch Chainlink bundle reports through Hypersync.
+
+    :param hypersync_client: Configured native or throttled Hypersync client.
+    :param aggregator_address: DataFeedsCache contract emitting report events.
+    :param start_block: Inclusive first block.
+    :param end_block: Inclusive final block.
+    :param data_ids: Optional set of 16-byte feed identifiers to include.
+    :param recv_timeout: Maximum wait for each streamed response.
+    :return: Reports sorted by block and log index.
+    """
+
+    coroutine = fetch_chainlink_bundle_reports_hypersync_async(
+        hypersync_client=hypersync_client,
+        aggregator_address=aggregator_address,
+        start_block=start_block,
+        end_block=end_block,
+        data_ids=data_ids,
+        recv_timeout=recv_timeout,
+    )
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coroutine)
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(asyncio.run, coroutine).result()

--- a/eth_defi/tokenised_fund/docs/tokenised-fund-contracts-compiled.md
+++ b/eth_defi/tokenised_fund/docs/tokenised-fund-contracts-compiled.md
@@ -774,9 +774,17 @@ not locate a public issuer repository containing this implementation.
 
 At 2026-07-17, `totalSupply()` returned **448,264.28 FILQ-A** and
 **300,377.53 FILQ-D** on Ethereum (both 2 decimals). The `SygToken` ABI exposes
-`getPrice()` and configured Chainlink/bundle-feed accessors, so a price route is
-available on-chain; validate the selected class's oracle address and feed
-decimals before consumption.
+configured Chainlink bundle-feed accessors. FILQ-A uses proxy
+`0x0c6c...ac5c` and data id `02000001220700030000000000000000`; FILQ-D uses
+proxy `0x7484...866a` and data id `02000001230700030000000000000000`.
+Both proxies resolve to DataFeedsCache `0x16b5...1433`, which emits
+`BundleReportUpdated(bytes16,uint256,bytes)` for every accepted daily report.
+
+`getPrice()` is the single-value AggregatorV3 route and reverts for these
+bundle feeds. In both reviewed schemas NAV/share is the second 32-byte bundle
+word. `bundleDecimals()` scales it by four decimals for FILQ-A and two for
+FILQ-D. Current and fixed-block reads use `latestBundle()`; historical report
+discovery uses the cache event through Hypersync.
 
 ## Integration implications
 
@@ -795,14 +803,16 @@ decimals before consumption.
   settlement behaviour and potential out-of-hours queueing or fees.
 - Resolve proxy implementations at integration time and monitor timelocked
   upgrades, the external permission-manager address, role membership, pause
-  state, and each class's configured oracle. `totalSupply` alone neither
-  establishes NAV nor independent redeemability.
+  state, each class's configured oracle, data id, bundle decimals and cache
+  aggregator. Chainlink NAV establishes valuation but does not establish
+  independent redeemability.
 
 ## Primary sources
 
 - [Sourcify exact-match FILQ-A `UUPSProxy`](https://sourcify.dev/server/v2/contract/1/0x54a4fc78431f9201824643e99bec891bb7462a1d?fields=all)
 - [Sourcify exact-match FILQ-D `UUPSProxy`](https://sourcify.dev/server/v2/contract/1/0xf0db6f529581e7f6ebac7a7f6882923c00fc3a66?fields=all)
 - [Sourcify exact-match `SygToken` implementation](https://sourcify.dev/server/v2/contract/1/0x7030fe438be6ed196b8886616bbf5a245c267339?fields=all)
+- [Verified Chainlink DataFeedsCache](https://etherscan.io/address/0x16b53825c8ceaea593507274d4c1aaec9e261433#code)
 - [Sygnum FILQ page](https://www.sygnum.com/filq/)
 - [Sygnum's FILQ launch and Desygnate architecture](https://www.sygnum.com/news/sygnum-powers-fidelity-internationals-first-tokenized-product-launch-with-moodys-aaa-mf-assessment/)
 - [Fidelity International Strategies Funds SPC prospectus](https://www.fidelityinternational.com/legal/documents/FISGF/en/pr.fisgf.en.xx.pdf)

--- a/eth_defi/tokenised_fund/docs/tokenised-fund-contracts/filq.md
+++ b/eth_defi/tokenised_fund/docs/tokenised-fund-contracts/filq.md
@@ -82,9 +82,17 @@ not locate a public issuer repository containing this implementation.
 
 At 2026-07-17, `totalSupply()` returned **448,264.28 FILQ-A** and
 **300,377.53 FILQ-D** on Ethereum (both 2 decimals). The `SygToken` ABI exposes
-`getPrice()` and configured Chainlink/bundle-feed accessors, so a price route is
-available on-chain; validate the selected class's oracle address and feed
-decimals before consumption.
+configured Chainlink bundle-feed accessors. FILQ-A uses proxy
+`0x0c6c...ac5c` and data id `02000001220700030000000000000000`; FILQ-D uses
+proxy `0x7484...866a` and data id `02000001230700030000000000000000`.
+Both proxies resolve to DataFeedsCache `0x16b5...1433`, which emits
+`BundleReportUpdated(bytes16,uint256,bytes)` for every accepted daily report.
+
+`getPrice()` is the single-value AggregatorV3 route and reverts for these
+bundle feeds. In both reviewed schemas NAV/share is the second 32-byte bundle
+word. `bundleDecimals()` scales it by four decimals for FILQ-A and two for
+FILQ-D. Current and fixed-block reads use `latestBundle()`; historical report
+discovery uses the cache event through Hypersync.
 
 ## Integration implications
 
@@ -103,14 +111,16 @@ decimals before consumption.
   settlement behaviour and potential out-of-hours queueing or fees.
 - Resolve proxy implementations at integration time and monitor timelocked
   upgrades, the external permission-manager address, role membership, pause
-  state, and each class's configured oracle. `totalSupply` alone neither
-  establishes NAV nor independent redeemability.
+  state, each class's configured oracle, data id, bundle decimals and cache
+  aggregator. Chainlink NAV establishes valuation but does not establish
+  independent redeemability.
 
 ## Primary sources
 
 - [Sourcify exact-match FILQ-A `UUPSProxy`](https://sourcify.dev/server/v2/contract/1/0x54a4fc78431f9201824643e99bec891bb7462a1d?fields=all)
 - [Sourcify exact-match FILQ-D `UUPSProxy`](https://sourcify.dev/server/v2/contract/1/0xf0db6f529581e7f6ebac7a7f6882923c00fc3a66?fields=all)
 - [Sourcify exact-match `SygToken` implementation](https://sourcify.dev/server/v2/contract/1/0x7030fe438be6ed196b8886616bbf5a245c267339?fields=all)
+- [Verified Chainlink DataFeedsCache](https://etherscan.io/address/0x16b53825c8ceaea593507274d4c1aaec9e261433#code)
 - [Sygnum FILQ page](https://www.sygnum.com/filq/)
 - [Sygnum's FILQ launch and Desygnate architecture](https://www.sygnum.com/news/sygnum-powers-fidelity-internationals-first-tokenized-product-launch-with-moodys-aaa-mf-assessment/)
 - [Fidelity International Strategies Funds SPC prospectus](https://www.fidelityinternational.com/legal/documents/FISGF/en/pr.fisgf.en.xx.pdf)

--- a/eth_defi/tokenised_fund/fdit/vault.py
+++ b/eth_defi/tokenised_fund/fdit/vault.py
@@ -14,4 +14,8 @@ class FditVault(SupplyOnlyTokenisedFundVault):
     curator = "fidelity-investments"
     homepage = "https://institutional.fidelity.com/app/funds-and-products/9053/fidelity-treasury-digital-fund-onchain-class-fyoxx.html"
     restricted_flow_reason = "FDIT transfers, issuance and redemption are controlled by Fidelity and DTCC compliance workflows"
+    # TODO: Fidelity's public FDIT token contract exposes ERC-20 supply but no
+    # verified NAV/share accessor or issuer historical-NAV API. Add price rows
+    # only after Fidelity documents a machine-readable, independently verifiable
+    # NAV data source and its historical retention policy.
     nav_unavailable_reason = "FDIT has no verified public on-chain or historical NAV/share interface"

--- a/eth_defi/tokenised_fund/kaio/vault.py
+++ b/eth_defi/tokenised_fund/kaio/vault.py
@@ -14,4 +14,7 @@ class KaioVault(SupplyOnlyTokenisedFundVault):
     curator = "kaio"
     homepage = "https://www.kaio.xyz/"
     restricted_flow_reason = "CASHx transfers, issuance and redemption require KAIO-approved investors and book-controlled settlement"
+    # TODO: CASHx exposes ERC-20 supply, but KAIO has not published a verified
+    # on-chain NAV oracle or historical issuer NAV endpoint for this share class.
+    # Do not infer one-dollar NAV or TVL from the token supply.
     nav_unavailable_reason = "CASHx has no verified public on-chain or historical NAV/share interface"

--- a/eth_defi/tokenised_fund/openeden/backfill.py
+++ b/eth_defi/tokenised_fund/openeden/backfill.py
@@ -1,26 +1,116 @@
-"""Register the reviewed OpenEden TBILL lead and current metadata."""
+"""Backfill OpenEden TBILL metadata and oracle-backed price history.
 
-from dataclasses import dataclass
+TBILL uses an issuer-operated Chainlink-compatible NAV oracle.  The historical
+reader calls that oracle at sampled blocks; HyperSync supplies cache-aware block
+timestamps to the common scanner, so this migration never performs JSON-RPC log
+discovery.  It replaces only TBILL rows in the shared price files.
+"""
 
-from eth_defi.erc_4626.core import ERC4626Feature
-from eth_defi.tokenised_fund.openeden.constants import OPENEDEN_CHAIN_ID, OPENEDEN_TBILL_ADDRESS, OPENEDEN_TBILL_FIRST_SEEN_AT, OPENEDEN_TBILL_FIRST_SEEN_AT_BLOCK
-from eth_defi.tokenised_fund.supply_only_backfill import backfill_supply_only_product
+import os
+from pathlib import Path
+
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.erc_4626.classification import create_vault_instance
+from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
+from eth_defi.erc_4626.discovery_base import PotentialVaultMatch
+from eth_defi.erc_4626.scan import create_vault_scan_record
+from eth_defi.hypersync.utils import configure_hypersync_from_env
+from eth_defi.provider.env import read_json_rpc_url
+from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
+from eth_defi.research.wrangle_vault_prices import replace_cleaned_vault_histories
+from eth_defi.token import TokenDiskCache
+from eth_defi.tokenised_fund.openeden.constants import OPENEDEN_CHAIN_ID, OPENEDEN_TBILL_ADDRESS, OPENEDEN_TBILL_FIRST_SEEN_AT, OPENEDEN_TBILL_FIRST_SEEN_AT_BLOCK, OPENEDEN_TBILL_ORACLE_FIRST_SEEN_AT_BLOCK
+from eth_defi.tokenised_fund.usyc.backfill import parse_bool_env, parse_path_env, read_reader_states, write_reader_states
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.historical import scan_historical_prices_to_parquet
+from eth_defi.vault.vaultdb import DEFAULT_RAW_PRICE_DATABASE, DEFAULT_READER_STATE_DATABASE, DEFAULT_UNCLEANED_PRICE_DATABASE, DEFAULT_VAULT_DATABASE, VaultDatabase
 
 
-@dataclass(slots=True, frozen=True)
-class OpenEdenBackfillProduct:
-    """Static record accepted by the conservative metadata migration."""
+def create_openeden_detection() -> ERC4262VaultDetection:
+    """Create the address-scoped TBILL detection record.
 
-    chain_id: int = OPENEDEN_CHAIN_ID
-    token: str = OPENEDEN_TBILL_ADDRESS
-    first_seen_at_block: int = OPENEDEN_TBILL_FIRST_SEEN_AT_BLOCK
-    first_seen_at: object = OPENEDEN_TBILL_FIRST_SEEN_AT
+    :return: Reviewed OpenEden TBILL detection.
+    """
+
+    return ERC4262VaultDetection(
+        chain=OPENEDEN_CHAIN_ID,
+        address=OPENEDEN_TBILL_ADDRESS,
+        first_seen_at_block=OPENEDEN_TBILL_FIRST_SEEN_AT_BLOCK,
+        first_seen_at=OPENEDEN_TBILL_FIRST_SEEN_AT,
+        features={ERC4626Feature.openeden_like},
+        updated_at=native_datetime_utc_now(),
+        deposit_count=0,
+        redeem_count=0,
+    )
 
 
 def main() -> None:
-    """Upsert TBILL metadata while preserving all existing price histories.
+    """Backfill OpenEden TBILL without disturbing unrelated vault data.
 
     :return: ``None``.
     """
 
-    backfill_supply_only_product(OpenEdenBackfillProduct(), ERC4626Feature.openeden_like, "OpenEden TBILL")
+    setup_console_logging(default_log_level=os.environ.get("LOG_LEVEL", "info"))
+    dry_run = parse_bool_env("DRY_RUN")
+    frequency = os.environ.get("FREQUENCY", "1d")
+    if frequency != "1d":
+        raise ValueError(f"OpenEden TBILL backfill supports only FREQUENCY=1d, got: {frequency}")
+    start_block = int(os.environ.get("START_BLOCK", OPENEDEN_TBILL_ORACLE_FIRST_SEEN_AT_BLOCK))
+    web3_url = read_json_rpc_url(OPENEDEN_CHAIN_ID)
+    web3 = create_multi_provider_web3(web3_url)
+    end_block = int(os.environ.get("END_BLOCK", web3.eth.block_number))
+    if end_block < start_block:
+        raise ValueError(f"END_BLOCK {end_block} is before OpenEden oracle deployment {start_block}")
+
+    vault_db_path = parse_path_env("VAULT_DB_PATH", DEFAULT_VAULT_DATABASE)
+    raw_path = parse_path_env("UNCLEANED_PRICE_DATABASE", DEFAULT_UNCLEANED_PRICE_DATABASE)
+    cleaned_path = parse_path_env("CLEANED_PRICE_DATABASE", DEFAULT_RAW_PRICE_DATABASE)
+    state_path = parse_path_env("READER_STATE_DATABASE", DEFAULT_READER_STATE_DATABASE)
+    detection = create_openeden_detection()
+    token_cache = TokenDiskCache()
+    vault = create_vault_instance(web3, OPENEDEN_TBILL_ADDRESS, features=detection.features, token_cache=token_cache)
+    if vault is None:
+        raise RuntimeError("Could not create OpenEden TBILL adapter")
+    vault.first_seen_at_block = start_block
+    if dry_run:
+        return
+
+    vault_db = VaultDatabase.read(vault_db_path) if vault_db_path.exists() else VaultDatabase()
+    previous_cursor = vault_db.last_scanned_block.get(OPENEDEN_CHAIN_ID)
+    spec = VaultSpec(OPENEDEN_CHAIN_ID, OPENEDEN_TBILL_ADDRESS)
+    vault_db.update_leads_and_rows(
+        chain_id=OPENEDEN_CHAIN_ID,
+        last_scanned_block=end_block,
+        leads={OPENEDEN_TBILL_ADDRESS: PotentialVaultMatch(OPENEDEN_CHAIN_ID, OPENEDEN_TBILL_ADDRESS, OPENEDEN_TBILL_FIRST_SEEN_AT_BLOCK, OPENEDEN_TBILL_FIRST_SEEN_AT)},
+        rows={spec: create_vault_scan_record(web3, detection, block_identifier=end_block, token_cache=token_cache)},
+    )
+    if previous_cursor is None:
+        vault_db.last_scanned_block.pop(OPENEDEN_CHAIN_ID, None)
+    else:
+        vault_db.last_scanned_block[OPENEDEN_CHAIN_ID] = previous_cursor
+    vault_db.write(vault_db_path)
+
+    hypersync_client = configure_hypersync_from_env(web3).hypersync_client
+    if hypersync_client is None:
+        raise RuntimeError("OpenEden TBILL price backfill requires HyperSync for block timestamps")
+    prior_states = read_reader_states(state_path)
+    retained_states = {existing_spec: state for existing_spec, state in prior_states.items() if existing_spec != spec}
+    scan_historical_prices_to_parquet(
+        output_fname=raw_path,
+        web3=web3,
+        web3factory=MultiProviderWeb3Factory(web3_url, retries=5),
+        vaults=[vault],
+        start_block=start_block,
+        end_block=end_block,
+        max_workers=int(os.environ.get("MAX_WORKERS", "8")),
+        chunk_size=32,
+        token_cache=token_cache,
+        frequency="1d",
+        reader_states=None,
+        hypersync_client=hypersync_client,
+        vault_addresses={OPENEDEN_TBILL_ADDRESS},
+    )
+    write_reader_states(state_path, retained_states)
+    replace_cleaned_vault_histories({spec.as_string_id()}, vault_db_path=vault_db_path, raw_price_df_path=raw_path, cleaned_price_df_path=cleaned_path)
+    token_cache.commit()

--- a/eth_defi/tokenised_fund/supply_only.py
+++ b/eth_defi/tokenised_fund/supply_only.py
@@ -152,29 +152,29 @@ class SupplyOnlyTokenisedFundVault(TokenisedFundVault):
     def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
         """Reject unverified NAV reads.
 
-        :param block_identifier: Requested block identifier.
-        :raise RuntimeError: Always, until a public NAV source is configured.
+            :param block_identifier: Requested block identifier.
+        :raise NotImplementedError: Always, until a public NAV source is configured.
         """
 
-        raise RuntimeError(self.nav_unavailable_reason)
+        raise NotImplementedError(self.nav_unavailable_reason)
 
     def fetch_total_assets(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
         """Reject TVL calculation without a verified NAV.
 
-        :param block_identifier: Requested block identifier.
-        :raise RuntimeError: Always.
+            :param block_identifier: Requested block identifier.
+        :raise NotImplementedError: Always.
         """
 
-        raise RuntimeError(self.nav_unavailable_reason)
+        raise NotImplementedError(self.nav_unavailable_reason)
 
     def fetch_nav(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
         """Reject NAV calculation without a verified price source.
 
-        :param block_identifier: Requested block identifier.
-        :raise RuntimeError: Always.
+            :param block_identifier: Requested block identifier.
+        :raise NotImplementedError: Always.
         """
 
-        raise RuntimeError(self.nav_unavailable_reason)
+        raise NotImplementedError(self.nav_unavailable_reason)
 
     def fetch_info(self) -> VaultInfo:
         """Export conservative token and NAV-availability metadata.

--- a/eth_defi/tokenised_fund/sygnum/backfill.py
+++ b/eth_defi/tokenised_fund/sygnum/backfill.py
@@ -1,33 +1,48 @@
-"""Add reviewed Sygnum FILQ share-class leads without touching unrelated histories.
+"""Backfill reviewed Sygnum FILQ metadata and Chainlink bundle NAV history.
 
-FILQ currently has no public, verified NAV-history route. This generated
-migration therefore writes only hardcoded metadata leads. It explicitly
-does not reset reader state or alter raw/cleaned Parquet files: creating price
-rows without NAV would be misleading, and retaining those files prevents an
-accidental full-chain rescan.
+The shared Chainlink DataFeedsCache emits every accepted FILQ bundle as a
+``BundleReportUpdated`` event. Hypersync reads these reports without JSON-RPC
+log-range queries; archive RPC state supplies the FILQ token supply at each
+report block. Only the two reviewed FILQ identifiers are replaced in shared
+raw and cleaned price files.
 
 Run with ``source .local-test.env && PROTOCOLS=sygnum poetry run python scripts/backfill-tokenised-funds.py``.
 Set ``DRY_RUN=true`` to inspect the address-scoped plan without writing.
-``VAULT_DB_PATH`` and ``END_BLOCK`` may be overridden for controlled runs.
+``VAULT_DB_PATH``, price database paths, ``START_BLOCK``, ``END_BLOCK`` and
+``MAX_WORKERS`` may be overridden for controlled runs.
 """
+
+# The CLI entry point needs all configured paths, both products and scan state.
+# ruff: noqa: PLR0914
 
 import logging
 import os
 from pathlib import Path
 
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.parquet as pq
+from joblib import Parallel, delayed
 from tabulate import tabulate
 
+from eth_defi.chainlink.bundle_aggregator import ChainlinkBundleReport, fetch_chainlink_bundle_reports_hypersync
 from eth_defi.compat import native_datetime_utc_now
+from eth_defi.erc_4626.classification import create_vault_instance
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
 from eth_defi.erc_4626.discovery_base import PotentialVaultMatch
 from eth_defi.erc_4626.scan import create_vault_scan_record
+from eth_defi.hypersync.hypersync_timestamp import get_hypersync_block_height
+from eth_defi.hypersync.utils import configure_hypersync_from_env
 from eth_defi.provider.env import read_json_rpc_url
 from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.research.wrangle_vault_prices import generate_cleaned_vault_datasets, replace_cleaned_vault_histories
 from eth_defi.token import TokenDiskCache
-from eth_defi.tokenised_fund.sygnum.constants import FILQ_A_ETHEREUM_ADDRESS, FILQ_A_ETHEREUM_FIRST_SEEN_AT, FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK, FILQ_D_ETHEREUM_ADDRESS, FILQ_D_ETHEREUM_FIRST_SEEN_AT, FILQ_D_ETHEREUM_FIRST_SEEN_AT_BLOCK, SYGNUM_ETHEREUM_CHAIN_ID
+from eth_defi.tokenised_fund.sygnum.constants import FILQ_A_BUNDLE_DATA_ID, FILQ_A_BUNDLE_FIRST_SEEN_AT_BLOCK, FILQ_A_ETHEREUM_ADDRESS, FILQ_A_ETHEREUM_FIRST_SEEN_AT, FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK, FILQ_BUNDLE_AGGREGATOR_ADDRESS, FILQ_D_BUNDLE_DATA_ID, FILQ_D_BUNDLE_FIRST_SEEN_AT_BLOCK, FILQ_D_ETHEREUM_ADDRESS, FILQ_D_ETHEREUM_FIRST_SEEN_AT, FILQ_D_ETHEREUM_FIRST_SEEN_AT_BLOCK, SYGNUM_ETHEREUM_CHAIN_ID
+from eth_defi.tokenised_fund.sygnum.vault import SygnumVault
+from eth_defi.tokenised_fund.usyc.backfill import parse_path_env, read_reader_states, write_reader_states
 from eth_defi.utils import setup_console_logging
-from eth_defi.vault.base import VaultSpec
-from eth_defi.vault.vaultdb import DEFAULT_VAULT_DATABASE, VaultDatabase
+from eth_defi.vault.base import VaultHistoricalRead, VaultSpec
+from eth_defi.vault.vaultdb import DEFAULT_RAW_PRICE_DATABASE, DEFAULT_READER_STATE_DATABASE, DEFAULT_UNCLEANED_PRICE_DATABASE, DEFAULT_VAULT_DATABASE, VaultDatabase
 
 logger = logging.getLogger(__name__)
 
@@ -90,42 +105,214 @@ def upsert_filq_metadata(vault_db: VaultDatabase, rows: dict, end_block: int) ->
         vault_db.last_scanned_block.pop(SYGNUM_ETHEREUM_CHAIN_ID, None)
 
 
+def fetch_filq_historical_read(report: ChainlinkBundleReport, vault: SygnumVault) -> VaultHistoricalRead:
+    """Fetch token supply for one Chainlink report and construct a price row.
+
+    :param report: Hypersync-discovered FILQ bundle report.
+    :param vault: FILQ share class matching ``report.data_id``.
+    :return: Priced FILQ history row at the report block.
+    """
+
+    bundle_decimals = vault.fetch_validated_bundle_decimals(report.block_number)
+    share_price = vault.decode_bundle_nav(report.bundle, bundle_decimals)
+    if share_price <= 0:
+        raise ValueError(f"FILQ report at block {report.block_number} returned invalid NAV {share_price}")
+    total_supply = vault.fetch_total_supply(report.block_number)
+    row = VaultHistoricalRead(
+        vault=vault,
+        block_number=report.block_number,
+        timestamp=report.block_timestamp or report.update_time,
+        share_price=share_price,
+        total_assets=share_price * total_supply,
+        total_supply=total_supply,
+        performance_fee=None,
+        management_fee=None,
+        errors=None,
+        deposits_open=False,
+        redemption_open=False,
+    )
+    row.vault_poll_frequency = "chainlink_bundle_event"
+    return row
+
+
+def fetch_filq_historical_reads(
+    reports: list[ChainlinkBundleReport],
+    vaults_by_data_id: dict[bytes, SygnumVault],
+    max_workers: int,
+) -> list[VaultHistoricalRead]:
+    """Fetch FILQ supplies for Chainlink reports in parallel.
+
+    :param reports: Hypersync-discovered reports for the reviewed data ids.
+    :param vaults_by_data_id: FILQ adapter keyed by Chainlink data id.
+    :param max_workers: Maximum archive-RPC worker threads.
+    :return: Historical rows ordered by block and log index.
+    :raise ValueError: If Hypersync returned an unexpected feed identifier.
+    """
+
+    unknown_data_ids = {report.data_id for report in reports} - set(vaults_by_data_id)
+    if unknown_data_ids:
+        raise ValueError(f"Unexpected FILQ Chainlink data ids: {[data_id.hex() for data_id in sorted(unknown_data_ids)]}")
+    return Parallel(n_jobs=max_workers, backend="threading")(delayed(fetch_filq_historical_read)(report, vaults_by_data_id[report.data_id]) for report in reports)
+
+
+def write_filq_historical_reads(
+    path: Path,
+    reads: list[VaultHistoricalRead],
+    start_block: int,
+) -> tuple[int, int]:
+    """Atomically replace FILQ rows in the shared raw price Parquet.
+
+    Existing unrelated chains, vaults, rows before ``start_block`` and native
+    protocol columns are retained. Schema migration failures propagate so a
+    corrupt production Parquet can never be silently discarded.
+
+    :param path: Shared uncleaned vault-price Parquet path.
+    :param reads: Fresh FILQ event-derived rows.
+    :param start_block: Inclusive replacement boundary.
+    :return: Tuple of deleted and inserted row counts.
+    """
+
+    if not reads:
+        message = "Cannot replace FILQ price history with an empty report set"
+        raise ValueError(message)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    canonical_schema = VaultHistoricalRead.to_pyarrow_schema()
+    selected_addresses = pa.array([FILQ_A_ETHEREUM_ADDRESS, FILQ_D_ETHEREUM_ADDRESS])
+    if path.exists():
+        existing_table = VaultHistoricalRead.migrate_parquet_schema(pq.read_table(path))
+        mask = pc.and_(
+            pc.and_(pc.equal(existing_table["chain"], SYGNUM_ETHEREUM_CHAIN_ID), pc.is_in(existing_table["address"], selected_addresses)),
+            pc.greater_equal(existing_table["block_number"], start_block),
+        )
+        deleted_rows = pc.sum(mask).as_py() or 0
+        existing_table = existing_table.filter(pc.invert(mask))
+    else:
+        existing_table = None
+        deleted_rows = 0
+
+    written_at = native_datetime_utc_now()
+    new_table = pa.Table.from_pylist([read.export() for read in reads], schema=canonical_schema)
+    new_table = new_table.set_column(
+        new_table.schema.get_field_index("written_at"),
+        "written_at",
+        pa.array([written_at] * len(new_table), type=pa.timestamp("ms")),
+    )
+    if existing_table is not None:
+        for field in existing_table.schema:
+            if field.name not in new_table.schema.names:
+                new_table = new_table.append_column(field, pa.nulls(len(new_table), type=field.type))
+        new_table = new_table.select(existing_table.schema.names)
+        combined = pa.concat_tables([existing_table.replace_schema_metadata(None), new_table.replace_schema_metadata(None)])
+    else:
+        combined = new_table
+    order = pc.sort_indices(combined, sort_keys=[("chain", "ascending"), ("address", "ascending"), ("block_number", "ascending")])
+    combined = combined.take(order)
+    VaultHistoricalRead.write_uncleaned_arrow_table(combined, path)
+    return deleted_rows, len(new_table)
+
+
 def main() -> None:
-    """Run the FILQ metadata-only migration.
+    """Run the FILQ metadata and Chainlink bundle history migration.
 
     :return: ``None``.
     """
 
     setup_console_logging(default_log_level=os.environ.get("LOG_LEVEL", "info"))
     dry_run = parse_bool_env("DRY_RUN", default=False)
-    vault_db_path = Path(os.environ.get("VAULT_DB_PATH", str(DEFAULT_VAULT_DATABASE))).expanduser()
-    web3 = create_multi_provider_web3(read_json_rpc_url(SYGNUM_ETHEREUM_CHAIN_ID))
+    frequency = os.environ.get("FREQUENCY", "1d")
+    if frequency != "1d":
+        raise ValueError(f"Sygnum FILQ backfill supports only FREQUENCY=1d, got: {frequency}")
+    vault_db_path = parse_path_env("VAULT_DB_PATH", DEFAULT_VAULT_DATABASE)
+    raw_path = parse_path_env("UNCLEANED_PRICE_DATABASE", DEFAULT_UNCLEANED_PRICE_DATABASE)
+    cleaned_path = parse_path_env("CLEANED_PRICE_DATABASE", DEFAULT_RAW_PRICE_DATABASE)
+    reader_state_path = parse_path_env("READER_STATE_DATABASE", DEFAULT_READER_STATE_DATABASE)
+    start_block = int(os.environ.get("START_BLOCK", FILQ_A_BUNDLE_FIRST_SEEN_AT_BLOCK))
+    json_rpc_url = read_json_rpc_url(SYGNUM_ETHEREUM_CHAIN_ID)
+    web3 = create_multi_provider_web3(json_rpc_url)
     end_block = int(os.environ.get("END_BLOCK", web3.eth.block_number))
-    if end_block < FILQ_D_ETHEREUM_FIRST_SEEN_AT_BLOCK:
-        raise ValueError(f"END_BLOCK must be at least {FILQ_D_ETHEREUM_FIRST_SEEN_AT_BLOCK}")
+    if end_block < FILQ_D_BUNDLE_FIRST_SEEN_AT_BLOCK:
+        raise ValueError(f"END_BLOCK must be at least the first FILQ-D bundle report {FILQ_D_BUNDLE_FIRST_SEEN_AT_BLOCK}")
+    if start_block > end_block:
+        raise ValueError(f"START_BLOCK {start_block} is after END_BLOCK {end_block}")
     plan = tabulate(
         [
-            {"chain": "Ethereum", "address": FILQ_A_ETHEREUM_ADDRESS, "end_block": end_block, "write_prices": False, "dry_run": dry_run},
-            {"chain": "Ethereum", "address": FILQ_D_ETHEREUM_ADDRESS, "end_block": end_block, "write_prices": False, "dry_run": dry_run},
+            {"chain": "Ethereum", "address": FILQ_A_ETHEREUM_ADDRESS, "start_block": start_block, "end_block": end_block, "write_prices": True, "dry_run": dry_run},
+            {"chain": "Ethereum", "address": FILQ_D_ETHEREUM_ADDRESS, "start_block": start_block, "end_block": end_block, "write_prices": True, "dry_run": dry_run},
         ],
         headers="keys",
         tablefmt="github",
     )
     logger.info("Sygnum FILQ migration plan:\n%s", plan)
     if dry_run:
-        logger.info("DRY RUN: would upsert FILQ metadata only; reader state and Parquet files remain untouched")
+        logger.info("DRY RUN: would read FILQ bundle reports through Hypersync and replace only FILQ price rows")
         return
+
+    hypersync_client = configure_hypersync_from_env(web3).hypersync_client
+    if hypersync_client is None:
+        message = "Sygnum FILQ price backfill requires Hypersync"
+        raise RuntimeError(message)
+    hypersync_height = get_hypersync_block_height(hypersync_client)
+    scan_end_block = min(end_block, hypersync_height)
+    if scan_end_block < end_block:
+        logger.warning("Clamping FILQ end block from %d to Hypersync indexed height %d", end_block, scan_end_block)
+
+    token_cache = TokenDiskCache()
+    vaults: list[SygnumVault] = []
+    for address in (FILQ_A_ETHEREUM_ADDRESS, FILQ_D_ETHEREUM_ADDRESS):
+        vault = create_vault_instance(web3, address, features={ERC4626Feature.sygnum_like}, token_cache=token_cache)
+        if not isinstance(vault, SygnumVault):
+            raise RuntimeError(f"Could not create Sygnum FILQ adapter for {address}")
+        _ = vault.share_token
+        vaults.append(vault)
+    vaults_by_data_id = {vault.bundle_data_id: vault for vault in vaults}
+    reports = fetch_chainlink_bundle_reports_hypersync(
+        hypersync_client,
+        aggregator_address=FILQ_BUNDLE_AGGREGATOR_ADDRESS,
+        start_block=start_block,
+        end_block=scan_end_block,
+        data_ids={FILQ_A_BUNDLE_DATA_ID, FILQ_D_BUNDLE_DATA_ID},
+    )
+    seen_data_ids = {report.data_id for report in reports}
+    missing_data_ids = set(vaults_by_data_id) - seen_data_ids
+    if missing_data_ids:
+        raise RuntimeError(f"Hypersync returned no FILQ reports for data ids: {[data_id.hex() for data_id in sorted(missing_data_ids)]}")
+    historical_reads = fetch_filq_historical_reads(reports, vaults_by_data_id, max_workers=int(os.environ.get("MAX_WORKERS", "8")))
+    deleted_rows, inserted_rows = write_filq_historical_reads(raw_path, historical_reads, start_block)
+    logger.info("Replaced %d FILQ raw rows with %d Chainlink bundle reports", deleted_rows, inserted_rows)
+
     vault_db = VaultDatabase.read(vault_db_path) if vault_db_path.exists() else VaultDatabase()
     rows = {
-        VaultSpec(SYGNUM_ETHEREUM_CHAIN_ID, address): create_vault_scan_record(web3, detection=create_detection(address, first_seen_at_block, first_seen_at), block_identifier=end_block, token_cache=TokenDiskCache())
+        VaultSpec(SYGNUM_ETHEREUM_CHAIN_ID, address): create_vault_scan_record(web3, detection=create_detection(address, first_seen_at_block, first_seen_at), block_identifier=scan_end_block, token_cache=token_cache)
         for address, first_seen_at_block, first_seen_at in (
             (FILQ_A_ETHEREUM_ADDRESS, FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK, FILQ_A_ETHEREUM_FIRST_SEEN_AT),
             (FILQ_D_ETHEREUM_ADDRESS, FILQ_D_ETHEREUM_FIRST_SEEN_AT_BLOCK, FILQ_D_ETHEREUM_FIRST_SEEN_AT),
         )
     }
     vault_db_path.parent.mkdir(parents=True, exist_ok=True)
-    upsert_filq_metadata(vault_db, rows, end_block)
+    upsert_filq_metadata(vault_db, rows, scan_end_block)
     vault_db.write(vault_db_path)
+
+    selected_specs = {
+        VaultSpec(SYGNUM_ETHEREUM_CHAIN_ID, FILQ_A_ETHEREUM_ADDRESS),
+        VaultSpec(SYGNUM_ETHEREUM_CHAIN_ID, FILQ_D_ETHEREUM_ADDRESS),
+    }
+    retained_states = {spec: state for spec, state in read_reader_states(reader_state_path).items() if spec not in selected_specs}
+    write_reader_states(reader_state_path, retained_states)
+    if cleaned_path.exists():
+        replace_cleaned_vault_histories(
+            {spec.as_string_id() for spec in selected_specs},
+            vault_db_path=vault_db_path,
+            raw_price_df_path=raw_path,
+            cleaned_price_df_path=cleaned_path,
+        )
+    else:
+        generate_cleaned_vault_datasets(
+            vault_db_path=vault_db_path,
+            price_df_path=raw_path,
+            cleaned_price_df_path=cleaned_path,
+            display=False,
+        )
+    token_cache.commit()
 
 
 if __name__ == "__main__":

--- a/eth_defi/tokenised_fund/sygnum/constants.py
+++ b/eth_defi/tokenised_fund/sygnum/constants.py
@@ -32,6 +32,62 @@ FILQ_D_ETHEREUM_FIRST_SEEN_AT = datetime.datetime(2026, 4, 27, 15, 10, 59, tzinf
 #: https://sourcify.dev/server/v2/contract/1/0x7030fe438be6ed196b8886616bbf5a245c267339?fields=all
 FILQ_SYGTOKEN_IMPLEMENTATION = HexAddress("0x7030fe438be6ed196b8886616bbf5a245c267339")
 
+#: Chainlink bundle proxy configured for FILQ-A.
+FILQ_A_BUNDLE_PROXY_ADDRESS = HexAddress("0x0c6c789a375cc4ee9ce6008715c915a91da5ac5c")
+
+#: Chainlink bundle proxy configured for FILQ-D.
+FILQ_D_BUNDLE_PROXY_ADDRESS = HexAddress("0x7484379d1af1b718dccc6bb5e58aadbcb6e4866a")
+
+#: Shared Chainlink DataFeedsCache that stores and emits both FILQ feeds.
+#:
+#: https://etherscan.io/address/0x16b53825c8ceaea593507274d4c1aaec9e261433#code
+FILQ_BUNDLE_AGGREGATOR_ADDRESS = HexAddress("0x16b53825c8ceaea593507274d4c1aaec9e261433")
+
+#: FILQ-A Chainlink bundle data identifier.
+FILQ_A_BUNDLE_DATA_ID = bytes.fromhex("02000001220700030000000000000000")
+
+#: FILQ-D Chainlink bundle data identifier.
+FILQ_D_BUNDLE_DATA_ID = bytes.fromhex("02000001230700030000000000000000")
+
+#: First accepted FILQ-A ``BundleReportUpdated`` event.
+FILQ_A_BUNDLE_FIRST_SEEN_AT_BLOCK = 25_038_639
+
+#: First accepted FILQ-D ``BundleReportUpdated`` event.
+FILQ_D_BUNDLE_FIRST_SEEN_AT_BLOCK = 25_139_026
+
+#: FILQ's NAV/share is the second numeric word in both reviewed bundle schemas.
+FILQ_NAV_BUNDLE_INDEX = 1
+
+#: Reviewed current bundle decimal metadata keyed by FILQ token address.
+FILQ_BUNDLE_DECIMALS_BY_TOKEN: dict[HexAddress, tuple[int, ...]] = {
+    FILQ_A_ETHEREUM_ADDRESS: (0, 4, 9, 9, 0, 0),
+    FILQ_D_ETHEREUM_ADDRESS: (0, 2, 9, 9, 0, 0),
+}
+
+#: Bundle proxy keyed by reviewed FILQ token address.
+FILQ_BUNDLE_PROXY_BY_TOKEN: dict[HexAddress, HexAddress] = {
+    FILQ_A_ETHEREUM_ADDRESS: FILQ_A_BUNDLE_PROXY_ADDRESS,
+    FILQ_D_ETHEREUM_ADDRESS: FILQ_D_BUNDLE_PROXY_ADDRESS,
+}
+
+#: Bundle data identifier keyed by reviewed FILQ token address.
+FILQ_BUNDLE_DATA_ID_BY_TOKEN: dict[HexAddress, bytes] = {
+    FILQ_A_ETHEREUM_ADDRESS: FILQ_A_BUNDLE_DATA_ID,
+    FILQ_D_ETHEREUM_ADDRESS: FILQ_D_BUNDLE_DATA_ID,
+}
+
+#: First bundle report block keyed by reviewed FILQ token address.
+FILQ_BUNDLE_FIRST_SEEN_AT_BLOCK_BY_TOKEN: dict[HexAddress, int] = {
+    FILQ_A_ETHEREUM_ADDRESS: FILQ_A_BUNDLE_FIRST_SEEN_AT_BLOCK,
+    FILQ_D_ETHEREUM_ADDRESS: FILQ_D_BUNDLE_FIRST_SEEN_AT_BLOCK,
+}
+
+#: FILQ token deployment block keyed by reviewed token address.
+FILQ_FIRST_SEEN_AT_BLOCK_BY_TOKEN: dict[HexAddress, int] = {
+    FILQ_A_ETHEREUM_ADDRESS: FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK,
+    FILQ_D_ETHEREUM_ADDRESS: FILQ_D_ETHEREUM_FIRST_SEEN_AT_BLOCK,
+}
+
 #: Reviewed FILQ token addresses keyed by EVM chain.
 SYGNUM_PRODUCTS_BY_CHAIN: dict[int, frozenset[HexAddress]] = {
     SYGNUM_ETHEREUM_CHAIN_ID: frozenset({FILQ_A_ETHEREUM_ADDRESS, FILQ_D_ETHEREUM_ADDRESS}),

--- a/eth_defi/tokenised_fund/sygnum/historical.py
+++ b/eth_defi/tokenised_fund/sygnum/historical.py
@@ -1,44 +1,59 @@
-"""Historical reader for Sygnum FILQ shares."""
+"""Historical state reader for Sygnum FILQ shares."""
 
 # ruff: noqa: FBT001
 
 import datetime
 from collections.abc import Iterable
 from decimal import Decimal
+from functools import cached_property
 from typing import TYPE_CHECKING
+
+from eth_abi import decode
+from web3 import Web3
 
 from eth_defi.erc_4626.vault import VaultReaderState
 from eth_defi.event_reader.conversion import convert_int256_bytes_to_int
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
+from eth_defi.tokenised_fund.sygnum.constants import FILQ_BUNDLE_AGGREGATOR_ADDRESS
 from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
 
 if TYPE_CHECKING:
     from eth_defi.tokenised_fund.sygnum.vault import SygnumVault
 
 
-class SygnumVaultHistoricalReader(VaultHistoricalReader):
-    """Read FILQ token supply without fabricating unavailable NAV history.
+class SygnumVaultReaderState(VaultReaderState):
+    """Adaptive reader state for FILQ's synthetic USD denomination."""
 
-    Sygnum configures a class-specific price-feed address, but the reviewed
-    contract does not expose a public generic Chainlink ``latestRoundData`` or
-    ``decimals`` response.  This reader therefore emits supply-only rows with
-    a diagnostic error rather than inventing a one-dollar price.
+    @cached_property
+    def exchange_rate(self) -> Decimal:
+        """Return one because FILQ NAV and TVL are already denominated in USD."""
+
+        return Decimal(1)
+
+
+class SygnumVaultHistoricalReader(VaultHistoricalReader):
+    """Read FILQ supply and its official Chainlink bundle NAV.
+
+    FILQ's price feed is a Chainlink bundle proxy rather than an AggregatorV3
+    feed.  Historical state reads use ``latestBundle()`` at the sampled block;
+    the targeted Sygnum backfill separately reads every accepted report event
+    through :mod:`eth_defi.chainlink.bundle_aggregator` and Hypersync.
     """
 
     def __init__(self, vault: "SygnumVault", stateful: bool):
-        """Create the supply-only reader.
+        """Create the FILQ state reader.
 
         :param vault: FILQ adapter.
         :param stateful: Retained for shared reader compatibility.
         """
 
         super().__init__(vault)
-        self.reader_state = VaultReaderState(vault) if stateful else None
+        self.reader_state = SygnumVaultReaderState(vault) if stateful else None
 
     def construct_multicalls(self) -> Iterable[EncodedCall]:
-        """Construct the ERC-20 total-supply call.
+        """Construct FILQ supply and Chainlink bundle calls.
 
-        :return: Supply call for the reviewed FILQ proxy.
+        :return: Supply, bundle, report-timestamp and schema-validation calls.
         """
 
         yield EncodedCall.from_contract_call(
@@ -46,38 +61,103 @@ class SygnumVaultHistoricalReader(VaultHistoricalReader):
             extra_data={"function": "totalSupply", "vault": self.vault.address},
             first_block_number=self.first_block,
         )
+        yield EncodedCall.from_contract_call(
+            self.vault.price_feed_contract.functions.latestBundle(),
+            extra_data={"function": "latestBundle", "vault": self.vault.address},
+            first_block_number=self.vault.oracle_first_seen_at_block,
+        )
+        yield EncodedCall.from_contract_call(
+            self.vault.price_feed_contract.functions.latestBundleTimestamp(),
+            extra_data={"function": "latestBundleTimestamp", "vault": self.vault.address},
+            first_block_number=self.vault.oracle_first_seen_at_block,
+        )
+        yield EncodedCall.from_contract_call(
+            self.vault.price_feed_contract.functions.bundleDecimals(),
+            extra_data={"function": "bundleDecimals", "vault": self.vault.address},
+            first_block_number=self.vault.oracle_first_seen_at_block,
+        )
+        yield EncodedCall.from_contract_call(
+            self.vault.price_feed_contract.functions.aggregator(),
+            extra_data={"function": "aggregator", "vault": self.vault.address},
+            first_block_number=self.vault.oracle_first_seen_at_block,
+        )
 
     def process_result(self, block_number: int, timestamp: datetime.datetime, call_results: list[EncodedCallResult]) -> VaultHistoricalRead:
-        """Convert a supply result to an explicitly unpriced history row.
+        """Convert supply and bundle results to a priced history row.
 
         :param block_number: Historical block number.
         :param timestamp: Naive UTC block timestamp.
         :param call_results: Multicall results from :meth:`construct_multicalls`.
-        :return: Supply-only FILQ history row.
+        :return: FILQ supply, NAV/share and total NAV history row.
         """
 
         total_supply: Decimal | None = None
-        state_result: EncodedCallResult | None = None
-        errors = [self.vault.nav_unavailable_reason]
+        bundle: bytes | None = None
+        bundle_updated_at: int | None = None
+        bundle_decimals: tuple[int, ...] | None = None
+        aggregator_address: str | None = None
+        supply_result: EncodedCallResult | None = None
+        price_result: EncodedCallResult | None = None
+        errors: list[str] = []
         for result in call_results:
-            if result.call.extra_data.get("function") == "totalSupply":
-                if result.success:
-                    total_supply = self.vault.share_token.convert_to_decimals(convert_int256_bytes_to_int(result.result))
-                    state_result = result
-                else:
-                    errors.append("Sygnum FILQ totalSupply call failed")
-        if self.reader_state is not None and state_result is not None:
-            self.reader_state.on_unpriced_call(state_result)
+            function = result.call.extra_data.get("function")
+            if not result.success:
+                errors.append(f"Sygnum FILQ {function} call failed")
+                continue
+            if function == "totalSupply":
+                total_supply = self.vault.share_token.convert_to_decimals(convert_int256_bytes_to_int(result.result))
+                supply_result = result
+            elif function == "latestBundle":
+                (bundle,) = decode(["bytes"], bytes(result.result))
+                bundle = bytes(bundle)
+                price_result = result
+            elif function == "latestBundleTimestamp":
+                bundle_updated_at = convert_int256_bytes_to_int(result.result)
+            elif function == "bundleDecimals":
+                (decoded_decimals,) = decode(["uint8[]"], bytes(result.result))
+                bundle_decimals = tuple(decoded_decimals)
+            elif function == "aggregator":
+                (decoded_address,) = decode(["address"], bytes(result.result))
+                aggregator_address = Web3.to_checksum_address(decoded_address)
+
+        share_price: Decimal | None = None
+        schema_valid = True
+        if bundle_decimals is not None and bundle_decimals != self.vault.bundle_decimals:
+            errors.append(f"Sygnum FILQ bundle decimals changed to {bundle_decimals}")
+            schema_valid = False
+        if aggregator_address is not None and aggregator_address.lower() != FILQ_BUNDLE_AGGREGATOR_ADDRESS:
+            errors.append(f"Sygnum FILQ bundle aggregator changed to {aggregator_address}")
+            schema_valid = False
+        if bundle_decimals is None:
+            errors.append("Sygnum FILQ bundle decimals unavailable")
+            schema_valid = False
+        if aggregator_address is None:
+            errors.append("Sygnum FILQ bundle aggregator unavailable")
+            schema_valid = False
+        if bundle is not None and bundle_updated_at is not None and bundle_updated_at > 0 and schema_valid:
+            share_price = self.vault.decode_bundle_nav(bundle, bundle_decimals)
+            if share_price <= 0:
+                errors.append("Sygnum FILQ bundle returned an invalid NAV")
+                share_price = None
+        elif bundle is not None and (bundle_updated_at is None or bundle_updated_at <= 0):
+            errors.append("Sygnum FILQ bundle returned an invalid report timestamp")
+
+        total_assets = share_price * total_supply if share_price is not None and total_supply is not None else None
+        if self.reader_state is not None:
+            if price_result is not None and total_assets is not None and share_price is not None:
+                self.reader_state.on_called(price_result, total_assets=total_assets, share_price=share_price)
+            elif supply_result is not None:
+                self.reader_state.on_unpriced_call(supply_result)
         return VaultHistoricalRead(
             vault=self.vault,
             block_number=block_number,
             timestamp=timestamp,
-            share_price=None,
-            total_assets=None,
+            share_price=share_price,
+            total_assets=total_assets,
             total_supply=total_supply,
             performance_fee=None,
             management_fee=None,
-            errors=errors,
+            errors=errors or None,
             deposits_open=False,
             redemption_open=False,
         )

--- a/eth_defi/tokenised_fund/sygnum/vault.py
+++ b/eth_defi/tokenised_fund/sygnum/vault.py
@@ -3,18 +3,25 @@
 FILQ is a permissioned SygToken ERC-20, not an ERC-4626 vault.  Authoritative
 sources: https://www.sygnum.com/filq/ and the exact verified implementation
 https://sourcify.dev/server/v2/contract/1/0x7030fe438be6ed196b8886616bbf5a245c267339?fields=all.
+
+NAV/share is published by Chainlink bundle feeds.  Their accepted reports are
+available as ``BundleReportUpdated`` events from the shared DataFeedsCache.
 """
 
 # ruff: noqa: ARG002, FBT001, FBT002, PLR0904, PLR0917, PLR6301
 
 import datetime
 from decimal import Decimal
+from functools import cached_property
 
 from eth_typing import BlockIdentifier, HexAddress
 from web3 import Web3
+from web3.contract import Contract
 
+from eth_defi.chainlink.bundle_aggregator import create_bundle_aggregator_proxy, decode_bundle_decimal, fetch_chainlink_latest_bundle
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.token import TokenDetails, fetch_erc20_details
+from eth_defi.tokenised_fund.sygnum.constants import FILQ_BUNDLE_AGGREGATOR_ADDRESS, FILQ_BUNDLE_DATA_ID_BY_TOKEN, FILQ_BUNDLE_DECIMALS_BY_TOKEN, FILQ_BUNDLE_FIRST_SEEN_AT_BLOCK_BY_TOKEN, FILQ_BUNDLE_PROXY_BY_TOKEN, FILQ_FIRST_SEEN_AT_BLOCK_BY_TOKEN, FILQ_NAV_BUNDLE_INDEX, SYGNUM_ETHEREUM_CHAIN_ID
 from eth_defi.tokenised_fund.sygnum.historical import SygnumVaultHistoricalReader
 from eth_defi.tokenised_fund.vault import TokenisedFundVault
 from eth_defi.types import Percent
@@ -23,7 +30,6 @@ from eth_defi.vault.fee import BROKEN_FEE_DATA, FeeData
 from eth_defi.vault.lower_case_dict import LowercaseDict
 
 SYGNUM_RESTRICTED_FLOW_REASON = "FILQ subscriptions, transfers and redemptions require Sygnum-approved wallets and issuer-controlled settlement"
-SYGNUM_NAV_UNAVAILABLE_REASON = "FILQ has a configured Sygnum price-feed contract, but no public historical NAV interface has been verified"
 
 
 class SygnumVaultInfo(VaultInfo, total=False):
@@ -47,15 +53,12 @@ def export_sygnum_usd_denomination(chain_id: int) -> dict[str, object]:
 
 
 class SygnumVault(TokenisedFundVault):
-    """Scan-only adapter for reviewed Sygnum FILQ share classes.
+    """Read-only adapter for reviewed Sygnum FILQ share classes.
 
-    The public token surface provides ERC-20 supply and price-feed metadata,
-    but not a publicly readable, verified historical NAV.  Public dealing
-    flows are deliberately unavailable because every transfer and settlement
-    is subject to the Sygnum permission manager.
+    ERC-20 supply is combined with the reviewed FILQ Chainlink bundle NAV.
+    Public dealing flows remain unavailable because every transfer and
+    settlement is subject to the Sygnum permission manager.
     """
-
-    nav_unavailable_reason = SYGNUM_NAV_UNAVAILABLE_REASON
 
     def __init__(self, web3: Web3, spec: VaultSpec, token_cache: dict | None = None, features: set[ERC4626Feature] | None = None, default_block_identifier: BlockIdentifier | None = None, require_denomination_token: bool = False):
         """Create a FILQ adapter.
@@ -69,8 +72,13 @@ class SygnumVault(TokenisedFundVault):
         """
 
         super().__init__(token_cache=token_cache, require_denomination_token=require_denomination_token)
+        token_address = HexAddress(spec.vault_address.lower())
+        if spec.chain_id != SYGNUM_ETHEREUM_CHAIN_ID or token_address not in FILQ_BUNDLE_PROXY_BY_TOKEN:
+            raise ValueError(f"Unsupported Sygnum FILQ product: chain={spec.chain_id}, token={spec.vault_address}")
         self.web3, self.spec, self.features = web3, spec, features or {ERC4626Feature.sygnum_like}
         self.default_block_identifier = default_block_identifier
+        self.first_seen_at_block = FILQ_FIRST_SEEN_AT_BLOCK_BY_TOKEN[token_address]
+        self.oracle_first_seen_at_block = FILQ_BUNDLE_FIRST_SEEN_AT_BLOCK_BY_TOKEN[token_address]
 
     @property
     def chain_id(self) -> int:
@@ -86,6 +94,30 @@ class SygnumVault(TokenisedFundVault):
     def vault_address(self) -> HexAddress:
         """Return the scanner-compatible share-token address."""
         return self.address
+
+    @property
+    def price_feed_address(self) -> HexAddress:
+        """Return the reviewed FILQ Chainlink bundle proxy address."""
+
+        return HexAddress(Web3.to_checksum_address(FILQ_BUNDLE_PROXY_BY_TOKEN[HexAddress(self.spec.vault_address.lower())]))
+
+    @cached_property
+    def price_feed_contract(self) -> Contract:
+        """Return the FILQ Chainlink bundle proxy contract."""
+
+        return create_bundle_aggregator_proxy(self.web3, self.price_feed_address)
+
+    @property
+    def bundle_data_id(self) -> bytes:
+        """Return the reviewed Chainlink data identifier for this share class."""
+
+        return FILQ_BUNDLE_DATA_ID_BY_TOKEN[HexAddress(self.spec.vault_address.lower())]
+
+    @property
+    def bundle_decimals(self) -> tuple[int, ...]:
+        """Return the reviewed FILQ bundle decimal metadata."""
+
+        return FILQ_BUNDLE_DECIMALS_BY_TOKEN[HexAddress(self.spec.vault_address.lower())]
 
     @property
     def name(self) -> str:
@@ -149,43 +181,103 @@ class SygnumVault(TokenisedFundVault):
         """
         return self.share_token.convert_to_decimals(self.share_token.contract.functions.totalSupply().call(block_identifier=block_identifier))
 
-    def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
-        """Reject unavailable NAV reads rather than returning a synthetic price.
+    def decode_bundle_nav(self, bundle: bytes, bundle_decimals: tuple[int, ...] | None = None) -> Decimal:
+        """Decode FILQ NAV/share from its reviewed bundle schema.
 
-            :param block_identifier: Requested block identifier.
-        :raise NotImplementedError: Always, until a public, verified NAV route exists.
+        Both FILQ feeds place NAV in the second fixed-width word. FILQ-A uses
+        four decimals and FILQ-D two decimals, as returned by their respective
+        ``bundleDecimals()`` methods.
+
+        :param bundle: Raw Chainlink bundle payload.
+        :param bundle_decimals: Decimal layout read from the proxy at the
+            bundle block. Defaults to the reviewed layout for callers that
+            already validated the proxy schema.
+        :return: USD NAV per FILQ share.
         """
-        raise NotImplementedError(self.nav_unavailable_reason)
+
+        decimals = bundle_decimals or self.bundle_decimals
+        return decode_bundle_decimal(bundle, FILQ_NAV_BUNDLE_INDEX, decimals[FILQ_NAV_BUNDLE_INDEX])
+
+    def fetch_validated_bundle_decimals(self, block_identifier: BlockIdentifier = "latest") -> tuple[int, ...]:
+        """Fetch and validate the FILQ bundle schema at a block.
+
+        Historical callers use the schema from the same block as the bundle
+        instead of assuming that the proxy's current layout applies to all
+        earlier reports.
+
+        :param block_identifier: Current or historical Ethereum block.
+        :return: Reviewed decimal layout at ``block_identifier``.
+        :raise ValueError: If the proxy implementation or decimals do not
+            match the reviewed FILQ feed.
+        """
+
+        aggregator_address = self.price_feed_contract.functions.aggregator().call(block_identifier=block_identifier)
+        if aggregator_address.lower() != FILQ_BUNDLE_AGGREGATOR_ADDRESS:
+            raise ValueError(f"Unexpected FILQ bundle aggregator at block {block_identifier}: {aggregator_address}")
+        bundle_decimals = tuple(self.price_feed_contract.functions.bundleDecimals().call(block_identifier=block_identifier))
+        if bundle_decimals != self.bundle_decimals:
+            raise ValueError(f"Unexpected FILQ bundle decimals at block {block_identifier}: {bundle_decimals}")
+        return bundle_decimals
+
+    def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
+        """Fetch FILQ NAV/share from the official Chainlink bundle feed.
+
+        :param block_identifier: Current or historical Ethereum block.
+        :return: USD NAV per FILQ share.
+        :raise ValueError: If the configured feed no longer matches the reviewed schema.
+        """
+
+        observation = fetch_chainlink_latest_bundle(self.web3, self.price_feed_address, block_identifier)
+        if observation.aggregator_address.lower() != FILQ_BUNDLE_AGGREGATOR_ADDRESS:
+            raise ValueError(f"Unexpected FILQ bundle aggregator: {observation.aggregator_address}")
+        if observation.decimals != self.bundle_decimals:
+            raise ValueError(f"Unexpected FILQ bundle decimals: {observation.decimals}")
+        nav = observation.decode_decimal(FILQ_NAV_BUNDLE_INDEX)
+        if nav <= 0:
+            raise ValueError(f"FILQ bundle returned an invalid NAV: {nav}")
+        return nav
 
     def fetch_total_assets(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
-        """Reject TVL calculation without a verified NAV.
+        """Fetch FILQ TVL as outstanding supply multiplied by NAV/share.
 
-            :param block_identifier: Requested block identifier.
-        :raise NotImplementedError: Always, because NAV is unavailable.
+        :param block_identifier: Current or historical Ethereum block.
+        :return: Total USD NAV.
         """
-        raise NotImplementedError(self.nav_unavailable_reason)
+
+        return self.fetch_total_supply(block_identifier) * self.fetch_share_price(block_identifier)
 
     def fetch_nav(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
-        """Reject NAV calculation without a verified price source.
+        """Fetch total FILQ NAV.
 
-            :param block_identifier: Requested block identifier.
-        :raise NotImplementedError: Always, because NAV is unavailable.
+        :param block_identifier: Current or historical Ethereum block.
+        :return: Total USD NAV.
         """
-        raise NotImplementedError(self.nav_unavailable_reason)
+
+        return self.fetch_total_assets(block_identifier)
 
     def fetch_info(self) -> SygnumVaultInfo:
         """Return conservative FILQ scan metadata.
 
         :return: Token, chain and NAV-availability metadata.
         """
-        return SygnumVaultInfo(token=self.address, chain_id=self.chain_id, denomination_token=None, synthetic_usd_denomination=True, nav_source="sygnum_price_feed_unavailable", nav_available=False)
+        return SygnumVaultInfo(token=self.address, chain_id=self.chain_id, denomination_token=None, synthetic_usd_denomination=True, nav_source="chainlink_bundle_aggregator", nav_available=True)
 
     def fetch_scan_record_extra_data(self) -> dict[str, object]:
         """Export explicit restrictions and price-data diagnostics.
 
         :return: Private scan columns.
         """
-        return {"Denomination": "USD", "_denomination_token": export_sygnum_usd_denomination(self.chain_id), "_deposit_closed_reason": SYGNUM_RESTRICTED_FLOW_REASON, "_redemption_closed_reason": SYGNUM_RESTRICTED_FLOW_REASON, "_nav_source": "sygnum_price_feed_unavailable", "_nav_available": False}
+        return {
+            "Denomination": "USD",
+            "_denomination_token": export_sygnum_usd_denomination(self.chain_id),
+            "_deposit_closed_reason": SYGNUM_RESTRICTED_FLOW_REASON,
+            "_redemption_closed_reason": SYGNUM_RESTRICTED_FLOW_REASON,
+            "_nav_source": "chainlink_bundle_aggregator",
+            "_nav_available": True,
+            "_chainlink_bundle_proxy": self.price_feed_address,
+            "_chainlink_bundle_aggregator": FILQ_BUNDLE_AGGREGATOR_ADDRESS,
+            "_chainlink_bundle_data_id": "0x" + self.bundle_data_id.hex(),
+        }
 
     def fetch_portfolio(self, universe: TradingUniverse, block_identifier: BlockIdentifier | None = None) -> VaultPortfolio:
         """Return no on-chain asset portfolio for the off-chain fund.
@@ -227,10 +319,10 @@ class SygnumVault(TokenisedFundVault):
         return SYGNUM_RESTRICTED_FLOW_REASON
 
     def get_historical_reader(self, stateful: bool) -> VaultHistoricalReader:
-        """Create a supply-only historical reader.
+        """Create a bundle-priced historical reader.
 
         :param stateful: Retained for reader compatibility.
-        :return: FILQ supply-only reader.
+        :return: FILQ supply and Chainlink bundle NAV reader.
         """
         return SygnumVaultHistoricalReader(self, stateful)
 

--- a/eth_defi/tokenised_fund/sygnum/vault.py
+++ b/eth_defi/tokenised_fund/sygnum/vault.py
@@ -152,26 +152,26 @@ class SygnumVault(TokenisedFundVault):
     def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
         """Reject unavailable NAV reads rather than returning a synthetic price.
 
-        :param block_identifier: Requested block identifier.
-        :raise RuntimeError: Always, until a public, verified NAV route exists.
+            :param block_identifier: Requested block identifier.
+        :raise NotImplementedError: Always, until a public, verified NAV route exists.
         """
-        raise RuntimeError(self.nav_unavailable_reason)
+        raise NotImplementedError(self.nav_unavailable_reason)
 
     def fetch_total_assets(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
         """Reject TVL calculation without a verified NAV.
 
-        :param block_identifier: Requested block identifier.
-        :raise RuntimeError: Always, because NAV is unavailable.
+            :param block_identifier: Requested block identifier.
+        :raise NotImplementedError: Always, because NAV is unavailable.
         """
-        raise RuntimeError(self.nav_unavailable_reason)
+        raise NotImplementedError(self.nav_unavailable_reason)
 
     def fetch_nav(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
         """Reject NAV calculation without a verified price source.
 
-        :param block_identifier: Requested block identifier.
-        :raise RuntimeError: Always, because NAV is unavailable.
+            :param block_identifier: Requested block identifier.
+        :raise NotImplementedError: Always, because NAV is unavailable.
         """
-        raise RuntimeError(self.nav_unavailable_reason)
+        raise NotImplementedError(self.nav_unavailable_reason)
 
     def fetch_info(self) -> SygnumVaultInfo:
         """Return conservative FILQ scan metadata.

--- a/scripts/backfill-tokenised-funds.py
+++ b/scripts/backfill-tokenised-funds.py
@@ -5,6 +5,11 @@
 Set ``PROTOCOLS`` to a comma-separated list of protocol slugs. It defaults to
 all integrations. The aggregate command defaults to ``DRY_RUN=true``; set
 ``DRY_RUN=false`` explicitly to write metadata, reader state or Parquet data.
+
+To backfill FILQ-A and FILQ-D using Chainlink bundle reports from Hypersync::
+
+    source .local-test.env
+    DRY_RUN=false PROTOCOLS=sygnum FREQUENCY=1d poetry run python scripts/backfill-tokenised-funds.py
 """
 
 from eth_defi.tokenised_fund.backfill import main

--- a/tests/chainlink/test_bundle_aggregator.py
+++ b/tests/chainlink/test_bundle_aggregator.py
@@ -1,0 +1,105 @@
+"""Chainlink bundle aggregator decoding and Hypersync query tests."""
+
+import asyncio
+import datetime
+from decimal import Decimal
+from types import SimpleNamespace
+
+from eth_abi import encode
+
+from eth_defi.chainlink import bundle_aggregator
+from eth_defi.chainlink.bundle_aggregator import BUNDLE_REPORT_UPDATED_TOPIC0, decode_bundle_decimal, decode_bundle_report_event, encode_bundle_data_id_topic, fetch_chainlink_bundle_reports_hypersync_async
+
+FILQ_D_DATA_ID = bytes.fromhex("02000001230700030000000000000000")
+FILQ_CACHE_ADDRESS = "0x16B53825C8ceAEA593507274D4C1AAEC9E261433"
+FILQ_REPORT_BLOCK = 25_425_952
+FILQ_REPORT_TIMESTAMP = 1_782_767_700
+
+
+def create_filq_d_bundle() -> bytes:
+    """Create the reviewed FILQ-D event payload structure.
+
+    :return: 320-byte bundle with a one-dollar NAV in its second word.
+    """
+
+    numeric_words = (192, 100, 91_303, 3_330_000_000, 1, 1)
+    tail = (15).to_bytes(32, "big") + b"Class SP Dist 1".ljust(32, b"\x00") + (12).to_bytes(32, "big") + b"KYG5R61G1161".ljust(32, b"\x00")
+    return b"".join(value.to_bytes(32, "big") for value in numeric_words) + tail
+
+
+def test_decode_bundle_report_event() -> None:
+    """Decode FILQ-D's real Chainlink event shape and NAV scale."""
+
+    bundle = create_filq_d_bundle()
+    report = decode_bundle_report_event(
+        aggregator_address=FILQ_CACHE_ADDRESS,
+        topics=[BUNDLE_REPORT_UPDATED_TOPIC0, encode_bundle_data_id_topic(FILQ_D_DATA_ID), hex(FILQ_REPORT_TIMESTAMP)],
+        data=encode(["bytes"], [bundle]),
+        block_number=FILQ_REPORT_BLOCK,
+        block_timestamp=datetime.datetime(2026, 6, 29, 21, 16, 23, tzinfo=datetime.UTC).replace(tzinfo=None),
+        transaction_hash="0x162d17b2e8e340f0c7396059a524d411ed91a28948bbd5b3123ababe74f734de",
+        log_index=202,
+    )
+
+    assert report.data_id == FILQ_D_DATA_ID
+    assert report.bundle == bundle
+    assert report.update_time == datetime.datetime(2026, 6, 29, 21, 15, tzinfo=datetime.UTC).replace(tzinfo=None)
+    assert report.decode_decimal(1, 2) == 1
+    assert decode_bundle_decimal(bundle, 3, 9) == Decimal("3.33")
+
+
+def test_fetch_bundle_reports_builds_targeted_hypersync_query(monkeypatch) -> None:
+    """Filter bundle history by cache address, event signature and data id."""
+
+    bundle = create_filq_d_bundle()
+    block = SimpleNamespace(number=FILQ_REPORT_BLOCK, timestamp=FILQ_REPORT_TIMESTAMP + 83)
+    log = SimpleNamespace(
+        block_number=FILQ_REPORT_BLOCK,
+        log_index=202,
+        address=FILQ_CACHE_ADDRESS,
+        transaction_hash="0x162d17b2e8e340f0c7396059a524d411ed91a28948bbd5b3123ababe74f734de",
+        topics=[BUNDLE_REPORT_UPDATED_TOPIC0, encode_bundle_data_id_topic(FILQ_D_DATA_ID), hex(FILQ_REPORT_TIMESTAMP)],
+        data="0x" + encode(["bytes"], [bundle]).hex(),
+    )
+    response = SimpleNamespace(data=SimpleNamespace(blocks=[block], logs=[log]))
+
+    class FakeReceiver:
+        """Yield one Hypersync response and finish."""
+
+        def __init__(self) -> None:
+            self.responses = iter((response, None))
+
+        async def recv(self):
+            """Return the next fake response."""
+
+            return next(self.responses)
+
+    captured = {}
+
+    async def fake_open_hypersync_stream(client, query):
+        """Capture the generated query and return a fake stream."""
+
+        await asyncio.sleep(0)
+        captured["client"] = client
+        captured["query"] = query
+        return FakeReceiver()
+
+    monkeypatch.setattr(bundle_aggregator, "open_hypersync_stream", fake_open_hypersync_stream)
+    client = object()
+    reports = asyncio.run(
+        fetch_chainlink_bundle_reports_hypersync_async(
+            client,
+            aggregator_address=FILQ_CACHE_ADDRESS,
+            start_block=FILQ_REPORT_BLOCK,
+            end_block=FILQ_REPORT_BLOCK,
+            data_ids={FILQ_D_DATA_ID},
+        )
+    )
+
+    assert len(reports) == 1
+    assert reports[0].decode_decimal(1, 2) == 1
+    query = captured["query"]
+    assert query.from_block == FILQ_REPORT_BLOCK
+    assert query.to_block == FILQ_REPORT_BLOCK + 1
+    assert query.logs[0].address == [FILQ_CACHE_ADDRESS.lower()]
+    assert query.logs[0].topics == [[BUNDLE_REPORT_UPDATED_TOPIC0], [encode_bundle_data_id_topic(FILQ_D_DATA_ID)]]

--- a/tests/sygnum/test_sygnum_backfill.py
+++ b/tests/sygnum/test_sygnum_backfill.py
@@ -1,7 +1,15 @@
 """Regression tests for the address-scoped Sygnum migration helper."""
 
+import datetime
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
 from eth_defi.tokenised_fund.sygnum import backfill
 from eth_defi.tokenised_fund.sygnum.constants import FILQ_A_ETHEREUM_ADDRESS, FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK, FILQ_D_ETHEREUM_ADDRESS, FILQ_D_ETHEREUM_FIRST_SEEN_AT_BLOCK
+from eth_defi.vault.base import VaultHistoricalRead
 
 
 def test_sygnum_backfill_defaults_to_filq_a_and_accepts_filq_d() -> None:
@@ -18,3 +26,56 @@ def test_sygnum_backfill_defaults_to_filq_a_and_accepts_filq_d() -> None:
     distributing_detection = backfill.create_detection(FILQ_D_ETHEREUM_ADDRESS, FILQ_D_ETHEREUM_FIRST_SEEN_AT_BLOCK)
     assert distributing_lead.address == FILQ_D_ETHEREUM_ADDRESS
     assert distributing_detection.address == FILQ_D_ETHEREUM_ADDRESS
+
+
+def create_history_read(address: str, block_number: int, share_price: Decimal) -> VaultHistoricalRead:
+    """Create a minimal raw price row for Parquet replacement tests.
+
+    :param address: Vault identifier.
+    :param block_number: Row block number.
+    :param share_price: Row NAV/share.
+    :return: Scanner-compatible historical read.
+    """
+
+    vault = SimpleNamespace(chain_id=1, address=address, vault_address=address)
+    return VaultHistoricalRead(
+        vault=vault,
+        block_number=block_number,
+        timestamp=datetime.datetime(2026, 5, 6, tzinfo=datetime.UTC).replace(tzinfo=None),
+        share_price=share_price,
+        total_assets=share_price * Decimal(100),
+        total_supply=Decimal(100),
+        performance_fee=None,
+        management_fee=None,
+        errors=None,
+    )
+
+
+def test_write_filq_historical_reads_preserves_unrelated_rows(tmp_path) -> None:
+    """Replace only FILQ rows at and after the selected report boundary."""
+
+    expected_inserted = 2
+    expected_total_rows = 3
+    expected_filq_a_nav = 100.0085
+    path = tmp_path / "vault-prices.parquet"
+    unrelated_address = "0x0000000000000000000000000000000000000001"
+    old_rows = [
+        create_history_read(unrelated_address, 25_000_000, Decimal(2)),
+        create_history_read(FILQ_A_ETHEREUM_ADDRESS, 25_038_639, Decimal(99)),
+    ]
+    old_table = pa.Table.from_pylist([row.export() for row in old_rows], schema=VaultHistoricalRead.to_pyarrow_schema())
+    VaultHistoricalRead.write_uncleaned_arrow_table(old_table, path)
+
+    new_rows = [
+        create_history_read(FILQ_A_ETHEREUM_ADDRESS, 25_038_639, Decimal("100.0085")),
+        create_history_read(FILQ_D_ETHEREUM_ADDRESS, 25_139_026, Decimal(1)),
+    ]
+    deleted, inserted = backfill.write_filq_historical_reads(path, new_rows, start_block=25_038_639)
+
+    assert deleted == 1
+    assert inserted == expected_inserted
+    result = pq.read_table(path).to_pandas()
+    assert len(result) == expected_total_rows
+    assert set(result["address"]) == {unrelated_address, FILQ_A_ETHEREUM_ADDRESS, FILQ_D_ETHEREUM_ADDRESS}
+    filq_a = result[result["address"] == FILQ_A_ETHEREUM_ADDRESS].iloc[0]
+    assert filq_a["share_price"] == expected_filq_a_nav

--- a/tests/sygnum/test_sygnum_backfill.py
+++ b/tests/sygnum/test_sygnum_backfill.py
@@ -1,11 +1,11 @@
 """Regression tests for the address-scoped Sygnum migration helper."""
 
 from eth_defi.tokenised_fund.sygnum import backfill
-from eth_defi.tokenised_fund.sygnum.constants import FILQ_A_ETHEREUM_ADDRESS, FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK
+from eth_defi.tokenised_fund.sygnum.constants import FILQ_A_ETHEREUM_ADDRESS, FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK, FILQ_D_ETHEREUM_ADDRESS, FILQ_D_ETHEREUM_FIRST_SEEN_AT_BLOCK
 
 
-def test_sygnum_backfill_is_filq_a_only() -> None:
-    """Keep the migration lead scoped to the independently verified class."""
+def test_sygnum_backfill_defaults_to_filq_a_and_accepts_filq_d() -> None:
+    """Keep both independently verified FILQ share classes address-scoped."""
 
     lead = backfill.create_lead()
     detection = backfill.create_detection()
@@ -13,3 +13,8 @@ def test_sygnum_backfill_is_filq_a_only() -> None:
     assert lead.first_seen_at_block == FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK
     assert detection.address == FILQ_A_ETHEREUM_ADDRESS
     assert detection.first_seen_at_block == FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK
+
+    distributing_lead = backfill.create_lead(FILQ_D_ETHEREUM_ADDRESS, FILQ_D_ETHEREUM_FIRST_SEEN_AT_BLOCK)
+    distributing_detection = backfill.create_detection(FILQ_D_ETHEREUM_ADDRESS, FILQ_D_ETHEREUM_FIRST_SEEN_AT_BLOCK)
+    assert distributing_lead.address == FILQ_D_ETHEREUM_ADDRESS
+    assert distributing_detection.address == FILQ_D_ETHEREUM_ADDRESS

--- a/tests/sygnum/test_sygnum_bundle_integration.py
+++ b/tests/sygnum/test_sygnum_bundle_integration.py
@@ -1,0 +1,37 @@
+"""Ethereum archive-node regression tests for FILQ bundle schemas."""
+
+import os
+from decimal import Decimal
+
+import pytest
+
+from eth_defi.chainlink.bundle_aggregator import fetch_chainlink_latest_bundle
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.tokenised_fund.sygnum.constants import FILQ_A_BUNDLE_FIRST_SEEN_AT_BLOCK, FILQ_A_BUNDLE_PROXY_ADDRESS, FILQ_BUNDLE_AGGREGATOR_ADDRESS, FILQ_D_BUNDLE_FIRST_SEEN_AT_BLOCK, FILQ_D_BUNDLE_PROXY_ADDRESS
+
+JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
+
+pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run FILQ bundle integration tests")
+
+
+@pytest.mark.parametrize(
+    ("proxy_address", "block_number", "expected_decimals", "expected_nav"),
+    (
+        (FILQ_A_BUNDLE_PROXY_ADDRESS, FILQ_A_BUNDLE_FIRST_SEEN_AT_BLOCK, (0, 4, 9, 9, 0, 0), Decimal("100.0085")),
+        (FILQ_D_BUNDLE_PROXY_ADDRESS, FILQ_D_BUNDLE_FIRST_SEEN_AT_BLOCK, (0, 2, 9, 9, 0, 0), Decimal(1)),
+    ),
+)
+def test_filq_bundle_schema_at_first_report(proxy_address: str, block_number: int, expected_decimals: tuple[int, ...], expected_nav: Decimal) -> None:
+    """Decode a known live FILQ report using its fixed-block proxy schema.
+
+    :param proxy_address: FILQ Chainlink bundle proxy.
+    :param block_number: First accepted report block for the share class.
+    :param expected_decimals: Reviewed per-word decimal layout.
+    :param expected_nav: Known NAV/share in the second bundle word.
+    """
+
+    web3 = create_multi_provider_web3(JSON_RPC_ETHEREUM)
+    observation = fetch_chainlink_latest_bundle(web3, proxy_address, block_number)
+    assert observation.aggregator_address.lower() == FILQ_BUNDLE_AGGREGATOR_ADDRESS
+    assert observation.decimals == expected_decimals
+    assert observation.decode_decimal(1) == expected_nav

--- a/tests/sygnum/test_sygnum_vault.py
+++ b/tests/sygnum/test_sygnum_vault.py
@@ -8,16 +8,18 @@ from decimal import Decimal
 from types import SimpleNamespace
 
 import pytest
+from eth_abi import encode
 
+from eth_defi.chainlink.bundle_aggregator import decode_bundle_decimal
 from eth_defi.erc_4626 import discovery_base as discovery_base_module
 from eth_defi.erc_4626.classification import VaultFeatureProbe, create_vault_instance, identify_vault_features
 from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name
 from eth_defi.erc_4626.discovery_base import LeadScanReport, VaultDiscoveryBase
 from eth_defi.erc_4626.vault import VaultReaderState
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
-from eth_defi.tokenised_fund.sygnum.constants import FILQ_A_ETHEREUM_ADDRESS, FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK, SYGNUM_ETHEREUM_CHAIN_ID, SYGNUM_HARDCODED_LEADS
-from eth_defi.tokenised_fund.sygnum.historical import SygnumVaultHistoricalReader
-from eth_defi.tokenised_fund.sygnum.vault import SYGNUM_NAV_UNAVAILABLE_REASON, SYGNUM_RESTRICTED_FLOW_REASON, SygnumVault
+from eth_defi.tokenised_fund.sygnum.constants import FILQ_A_BUNDLE_FIRST_SEEN_AT_BLOCK, FILQ_A_ETHEREUM_ADDRESS, FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK, FILQ_BUNDLE_AGGREGATOR_ADDRESS, SYGNUM_ETHEREUM_CHAIN_ID, SYGNUM_HARDCODED_LEADS
+from eth_defi.tokenised_fund.sygnum.historical import SygnumVaultHistoricalReader, SygnumVaultReaderState
+from eth_defi.tokenised_fund.sygnum.vault import SYGNUM_RESTRICTED_FLOW_REASON, SygnumVault
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.curator import get_curator_name, identify_curator, is_protocol_curator
 from eth_defi.vault.historical import VaultHistoricalReadMulticaller
@@ -59,9 +61,21 @@ class DummyVault:
     vault_address = FILQ_A_ETHEREUM_ADDRESS
     spec = VaultSpec(SYGNUM_ETHEREUM_CHAIN_ID, FILQ_A_ETHEREUM_ADDRESS)
     first_seen_at_block = FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK
+    oracle_first_seen_at_block = FILQ_A_BUNDLE_FIRST_SEEN_AT_BLOCK
     share_token = DummyToken()
     denomination_token = None
-    nav_unavailable_reason = SYGNUM_NAV_UNAVAILABLE_REASON
+    bundle_decimals = (0, 4, 9, 9, 0, 0)
+
+    def decode_bundle_nav(self, bundle: bytes, bundle_decimals: tuple[int, ...] | None = None) -> Decimal:
+        """Decode the accumulating-class NAV word.
+
+        :param bundle: Test bundle payload.
+        :param bundle_decimals: Schema decoded at the sampled block.
+        :return: Four-decimal NAV/share.
+        """
+
+        decimals = bundle_decimals or self.bundle_decimals
+        return decode_bundle_decimal(bundle, 1, decimals[1])
 
 
 def test_sygnum_hardcoded_classification_is_chain_aware() -> None:
@@ -73,8 +87,8 @@ def test_sygnum_hardcoded_classification_is_chain_aware() -> None:
     assert get_vault_protocol_name({ERC4626Feature.sygnum_like}) == "Sygnum"
 
 
-def test_sygnum_vault_blocks_public_flows_and_unpriced_nav() -> None:
-    """Keep permissioned FILQ flows and unavailable NAV explicit."""
+def test_sygnum_vault_blocks_public_flows_and_decodes_bundle_nav() -> None:
+    """Keep permissioned FILQ flows explicit while exposing reviewed NAV."""
 
     vault = create_vault_instance(SimpleNamespace(eth=SimpleNamespace(chain_id=1)), FILQ_A_ETHEREUM_ADDRESS, features={ERC4626Feature.sygnum_like})
     assert isinstance(vault, SygnumVault)
@@ -83,30 +97,64 @@ def test_sygnum_vault_blocks_public_flows_and_unpriced_nav() -> None:
     assert vault.get_deposit_manager_capability() is None
     with pytest.raises(NotImplementedError, match="Sygnum-approved"):
         vault.get_deposit_manager()
-    with pytest.raises(RuntimeError, match="no public historical NAV"):
-        vault.fetch_share_price()
+    bundle = (192).to_bytes(32, "big") + (1_006_781).to_bytes(32, "big")
+    assert vault.decode_bundle_nav(bundle) == Decimal("100.6781")
+    info = vault.fetch_info()
+    assert info["nav_available"] is True
+    assert info["nav_source"] == "chainlink_bundle_aggregator"
     reader = vault.get_historical_reader(stateful=True)
     assert isinstance(reader.reader_state, VaultReaderState)
 
 
-def test_sygnum_historical_reader_keeps_supply_without_price() -> None:
-    """Avoid synthetic FILQ NAV or TVL in historical rows."""
+def test_sygnum_historical_reader_prices_supply_from_bundle() -> None:
+    """Decode FILQ NAV and TVL from supply and bundle state calls."""
 
     reader = SygnumVaultHistoricalReader.__new__(SygnumVaultHistoricalReader)
     reader.vault = DummyVault()
-    reader.reader_state = VaultReaderState(reader.vault)
-    call = EncodedCall(func_name="totalSupply", address=FILQ_A_ETHEREUM_ADDRESS, data=b"", extra_data={"function": "totalSupply", "vault": FILQ_A_ETHEREUM_ADDRESS})
+    reader.reader_state = SygnumVaultReaderState(reader.vault)
+    supply_call = EncodedCall(func_name="totalSupply", address=FILQ_A_ETHEREUM_ADDRESS, data=b"", extra_data={"function": "totalSupply", "vault": FILQ_A_ETHEREUM_ADDRESS})
+    bundle_call = EncodedCall(func_name="latestBundle", address=FILQ_A_ETHEREUM_ADDRESS, data=b"", extra_data={"function": "latestBundle", "vault": FILQ_A_ETHEREUM_ADDRESS})
+    timestamp_call = EncodedCall(func_name="latestBundleTimestamp", address=FILQ_A_ETHEREUM_ADDRESS, data=b"", extra_data={"function": "latestBundleTimestamp", "vault": FILQ_A_ETHEREUM_ADDRESS})
+    decimals_call = EncodedCall(func_name="bundleDecimals", address=FILQ_A_ETHEREUM_ADDRESS, data=b"", extra_data={"function": "bundleDecimals", "vault": FILQ_A_ETHEREUM_ADDRESS})
+    aggregator_call = EncodedCall(func_name="aggregator", address=FILQ_A_ETHEREUM_ADDRESS, data=b"", extra_data={"function": "aggregator", "vault": FILQ_A_ETHEREUM_ADDRESS})
     timestamp = datetime.datetime(2026, 4, 27, 2, 19, 35, tzinfo=datetime.UTC).replace(tzinfo=None)
-    result = EncodedCallResult(call=call, success=True, result=(44_826_428).to_bytes(32, "big"), block_identifier=FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK, timestamp=timestamp)
-    row = reader.process_result(FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK, timestamp, [result])
+    bundle = (192).to_bytes(32, "big") + (1_006_781).to_bytes(32, "big")
+    results = [
+        EncodedCallResult(call=supply_call, success=True, result=(44_826_428).to_bytes(32, "big"), block_identifier=FILQ_A_BUNDLE_FIRST_SEEN_AT_BLOCK, timestamp=timestamp),
+        EncodedCallResult(call=bundle_call, success=True, result=encode(["bytes"], [bundle]), block_identifier=FILQ_A_BUNDLE_FIRST_SEEN_AT_BLOCK, timestamp=timestamp),
+        EncodedCallResult(call=timestamp_call, success=True, result=(1_784_322_900).to_bytes(32, "big"), block_identifier=FILQ_A_BUNDLE_FIRST_SEEN_AT_BLOCK, timestamp=timestamp),
+        EncodedCallResult(call=decimals_call, success=True, result=encode(["uint8[]"], [[0, 4, 9, 9, 0, 0]]), block_identifier=FILQ_A_BUNDLE_FIRST_SEEN_AT_BLOCK, timestamp=timestamp),
+        EncodedCallResult(call=aggregator_call, success=True, result=encode(["address"], [FILQ_BUNDLE_AGGREGATOR_ADDRESS]), block_identifier=FILQ_A_BUNDLE_FIRST_SEEN_AT_BLOCK, timestamp=timestamp),
+    ]
+    row = reader.process_result(FILQ_A_BUNDLE_FIRST_SEEN_AT_BLOCK, timestamp, results)
     assert row.total_supply == Decimal("448264.28")
+    assert row.share_price == Decimal("100.6781")
+    assert row.total_assets == Decimal("45130396.008268")
+    assert row.errors is None
+    assert reader.reader_state.last_block == FILQ_A_BUNDLE_FIRST_SEEN_AT_BLOCK
+    assert reader.reader_state.last_call_at == timestamp
+    assert reader.reader_state.last_tvl == Decimal("45130396.008268")
+    assert reader.reader_state.last_share_price == Decimal("100.6781")
+
+
+def test_sygnum_historical_reader_advances_state_before_first_bundle() -> None:
+    """Throttle pre-oracle supply reads even though they cannot be priced."""
+
+    reader = SygnumVaultHistoricalReader.__new__(SygnumVaultHistoricalReader)
+    reader.vault = DummyVault()
+    reader.reader_state = SygnumVaultReaderState(reader.vault)
+    block_number = FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK
+    timestamp = datetime.datetime(2026, 4, 27, 2, 19, 35, tzinfo=datetime.UTC).replace(tzinfo=None)
+    supply_call = EncodedCall(func_name="totalSupply", address=FILQ_A_ETHEREUM_ADDRESS, data=b"", extra_data={"function": "totalSupply", "vault": FILQ_A_ETHEREUM_ADDRESS})
+    results = [EncodedCallResult(call=supply_call, success=True, result=(10_000_000).to_bytes(32, "big"), block_identifier=block_number, timestamp=timestamp)]
+
+    row = reader.process_result(block_number, timestamp, results)
+
+    assert row.total_supply == Decimal("100000")
     assert row.share_price is None
     assert row.total_assets is None
-    assert row.errors == [SYGNUM_NAV_UNAVAILABLE_REASON]
-    assert reader.reader_state.last_block == FILQ_A_ETHEREUM_FIRST_SEEN_AT_BLOCK
+    assert reader.reader_state.last_block == block_number
     assert reader.reader_state.last_call_at == timestamp
-    assert reader.reader_state.last_tvl == Decimal(0)
-    assert reader.reader_state.last_share_price == Decimal(0)
 
 
 def test_stateful_scanner_rejects_reader_without_state(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -119,7 +167,14 @@ def test_stateful_scanner_rejects_reader_without_state(monkeypatch: pytest.Monke
     assert multicaller._prepare_denomination_token(prepared_reader) is None
 
     stateless_reader = vault.get_historical_reader(stateful=False)
-    monkeypatch.setattr(vault, "get_historical_reader", lambda stateful: stateless_reader)
+
+    def return_stateless_reader(*, stateful: bool):
+        """Return the intentionally malformed stateless reader."""
+
+        _ = stateful
+        return stateless_reader
+
+    monkeypatch.setattr(vault, "get_historical_reader", return_stateless_reader)
     with pytest.raises(TypeError, match="did not initialise a BatchCallState reader_state"):
         multicaller._prepare_reader(vault, stateful=True)
 

--- a/tests/tokenised_fund/test_supported_chain_gaps.py
+++ b/tests/tokenised_fund/test_supported_chain_gaps.py
@@ -5,8 +5,8 @@ from types import SimpleNamespace
 import pytest
 
 from eth_defi.erc_4626.classification import create_vault_instance, identify_vault_features
-from eth_defi.erc_4626.scan import OPTIONAL_READ_EXCEPTIONS
 from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name
+from eth_defi.erc_4626.scan import OPTIONAL_READ_EXCEPTIONS
 from eth_defi.midas.constants import MIDAS_MBASIS_ETHEREUM, MIDAS_MTBILL_ETHEREUM
 from eth_defi.midas.vault import MidasVault
 from eth_defi.tokenised_fund.fdit.constants import FDIT_ETHEREUM, FDIT_HARDCODED_LEADS
@@ -60,16 +60,19 @@ def test_new_chain_scoped_leads_keep_separate_share_classes() -> None:
 
 
 def test_supply_only_funds_expose_unavailable_nav_as_optional() -> None:
-    """Keep supply-only metadata rows valid when NAV is intentionally unavailable."""
+    """Keep FDIT metadata valid while FILQ exposes its reviewed NAV source."""
 
     web3 = SimpleNamespace(eth=SimpleNamespace(chain_id=1))
     fdit = create_vault_instance(web3, FDIT_ETHEREUM.token, features={ERC4626Feature.fdit_like})
     filq = create_vault_instance(web3, FILQ_D_ETHEREUM_ADDRESS, features={ERC4626Feature.sygnum_like})
 
-    for vault in (fdit, filq):
-        with pytest.raises(NotImplementedError):
-            vault.fetch_nav()
-        with pytest.raises(NotImplementedError):
-            vault.fetch_total_assets()
+    with pytest.raises(NotImplementedError):
+        fdit.fetch_nav()
+    with pytest.raises(NotImplementedError):
+        fdit.fetch_total_assets()
+
+    filq_info = filq.fetch_info()
+    assert filq_info["nav_available"] is True
+    assert filq_info["nav_source"] == "chainlink_bundle_aggregator"
 
     assert NotImplementedError in OPTIONAL_READ_EXCEPTIONS

--- a/tests/tokenised_fund/test_supported_chain_gaps.py
+++ b/tests/tokenised_fund/test_supported_chain_gaps.py
@@ -2,7 +2,10 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 from eth_defi.erc_4626.classification import create_vault_instance, identify_vault_features
+from eth_defi.erc_4626.scan import OPTIONAL_READ_EXCEPTIONS
 from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name
 from eth_defi.midas.constants import MIDAS_MBASIS_ETHEREUM, MIDAS_MTBILL_ETHEREUM
 from eth_defi.midas.vault import MidasVault
@@ -54,3 +57,19 @@ def test_new_chain_scoped_leads_keep_separate_share_classes() -> None:
     assert LIBEARA_ULTRA_ETHEREUM.token != LIBEARA_ULTRA_ARBITRUM.token
     assert FDIT_HARDCODED_LEADS[0][1] == FDIT_ETHEREUM.token
     assert KAIO_HARDCODED_LEADS[0][1] == CASHX_ETHEREUM.token
+
+
+def test_supply_only_funds_expose_unavailable_nav_as_optional() -> None:
+    """Keep supply-only metadata rows valid when NAV is intentionally unavailable."""
+
+    web3 = SimpleNamespace(eth=SimpleNamespace(chain_id=1))
+    fdit = create_vault_instance(web3, FDIT_ETHEREUM.token, features={ERC4626Feature.fdit_like})
+    filq = create_vault_instance(web3, FILQ_D_ETHEREUM_ADDRESS, features={ERC4626Feature.sygnum_like})
+
+    for vault in (fdit, filq):
+        with pytest.raises(NotImplementedError):
+            vault.fetch_nav()
+        with pytest.raises(NotImplementedError):
+            vault.fetch_total_assets()
+
+    assert NotImplementedError in OPTIONAL_READ_EXCEPTIONS


### PR DESCRIPTION
## Why

The supported-chain tokenised-fund migration registered OpenEden TBILL and Sygnum FILQ without writing all verified historical NAV data. Supply-only products were also incorrectly treated as broken when NAV was intentionally unavailable.

## Lessons learnt

Chainlink-labelled feeds must be integrated against their deployed interfaces. OpenEden exposes an AggregatorV3-compatible oracle, while FILQ uses Chainlink bundle proxies backed by a shared DataFeedsCache. Historical event discovery must use Hypersync, and bundle field meaning and decimal scaling must be independently verified before calculating NAV or TVL.

## Summary

- Preserve valid supply-only metadata for FDIT and KAIO CASHx. Their total supply is tracked, while NAV, share price and TVL remain unset until a verified pricing source is available.
- Backfill OpenEden TBILL daily oracle-backed history while preserving unrelated vault data.
- Add a generic Chainlink bundle-aggregator reader with Hypersync `BundleReportUpdated` event support.
- Add FILQ-A and FILQ-D NAV and TVL support using reviewed bundle data identifiers, per-class decimal layouts and archive-RPC supply reads.
- Validate the FILQ proxy aggregator and decimal schema at each historical report block.
- Add address-scoped, atomic and idempotent raw and cleaned Parquet replacement.
- Add aggregate backfill support for `PROTOCOLS=fdit,kaio,openeden,sygnum`.

### Known data-source gaps

- FDIT: no verified issuer or on-chain NAV source is available, so only total supply is tracked.
- CASHx: no verified issuer or on-chain NAV source is available, so only total supply is tracked.
- FILQ flow events remain unavailable because subscriptions, transfers and redemptions use permissioned issuer-controlled settlement. NAV and TVL are supported independently through Chainlink bundle reports.

## Related issues and PRs

- Follow-up to #1325.

## Unrelated CI and test fixes

None.