### PR TITLE
notes: mark Morpho Zircuit USDC compounder as subvault

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -691,6 +691,8 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "lighter-pool-281474976710654": (None, LIGHTER_LLP_STAKING),
     # Morpho Yearn Morpho Vault 1 Compounder (Base)
     "0xf115c134c23c7a05fbd489a8be3116ebf54b0d9f": (VaultFlag.subvault, SUBVAULT),
+    # Morpho Zircuit Finance USDC on Base Compounder
+    "0x049e8aab2d3ca187e47d74cf8171ad266f18643e": (VaultFlag.subvault, SUBVAULT),
     # Tulipa Capital USDT0
     "0xaf293898269ac7f366d0e05052b5fdfee8c8052c": (VaultFlag.irregular_reporting, IRREGULAR_REPORTING),
     # Hashfire launch fund.

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -125,6 +125,7 @@ def test_old_mainnet_out_of_gas_contract_is_skipped_by_multicall_blacklist() -> 
         ("0xd0ee0cf300dfb598270cd7f4d0c6e0d8f6e13f29", "Altura", VaultFlag.controversial, "controversial"),
         ("0xda2f1b3cba732d779cff56f0cf9d3bc8aea6cd8d", "Yearn", VaultFlag.subvault, "not intended"),
         ("0x8092c20351cf4048b464df2144dc8a4dd49ce71d", "Morpho", VaultFlag.subvault, "not intended"),
+        ("0x049e8aab2d3ca187e47d74cf8171ad266f18643e", "Yearn", VaultFlag.subvault, "not intended"),
         ("0xc9f01b5c6048b064e6d925d1c2d7206d4feef8a3", "Yearn", VaultFlag.subvault, "not intended"),
         ("0x93fec6639717b6215a48e5a72a162c50dcc40d68", "Yearn", VaultFlag.subvault, "not intended"),
         ("0xad755c6c31515aef8d2f830767d846774f7e9ea9", "Morpho", VaultFlag.malicious, "malicious"),


### PR DESCRIPTION
## Why

The Morpho Zircuit Finance USDC on Base Compounder vault should be hidden from end-user vault listings as a strategy component subvault.

## Lessons learnt

Trading Strategy vault slug `morpho-zircuit-finance-usdc-on-base-compounder` resolves to Base address `0x049e8aab2d3ca187e47d74cf8171ad266f18643e`.

## Summary

- Added the vault to `VAULT_FLAGS_AND_NOTES` with `VaultFlag.subvault` and the shared `SUBVAULT` note.
- Added the address to the focused manual flag regression test.

## Related issues and PRs

None.
