### PR TITLE
fix: restore Lagoon fee-adjusted vault metrics

### DIFF
--- a/eth_defi/vault/fee.py
+++ b/eth_defi/vault/fee.py
@@ -53,6 +53,10 @@ VAULT_PROTOCOL_FEE_MATRIX = {
     "Euler": VaultFeeMode.internalised_skimming,
     "Morpho": VaultFeeMode.internalised_skimming,
     "Enzyme": VaultFeeMode.internalised_skimming,
+    # ``get_vault_protocol_name()`` returns this display name for
+    # ``lagoon_like`` vaults. Keep the historical short matrix key as a
+    # compatibility alias for callers of ``get_vault_fee_mode()``.
+    "Lagoon Finance": VaultFeeMode.externalised,
     "Lagoon": VaultFeeMode.externalised,
     # T3tris fees are represented as fee shares. Entry/exit fees reduce the
     # user's net deposit/redeem, while management and high-water-mark

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -465,6 +465,36 @@ be purged and rescanned.
 | `DRY_RUN` | Optional. Set to `true` to report without modifying the pickle. |
 | `LOG_LEVEL` | Optional. Default: info. |
 
+### migrate-lagoon-fee-mode.py
+
+Repair stale fee-accounting modes on Lagoon metadata rows. Older rows contain
+the correct management and performance percentages but no fee mode because the
+fee matrix previously used the non-canonical protocol name `Lagoon`. The
+migration sets the mode to `externalised`, allowing the export pipeline to
+calculate net investor returns. It only changes the metadata pickle; vault
+prices, reader state, and the stored fee percentages remain unchanged.
+
+Inspect the proposed migration first:
+
+```shell
+source .local-test.env && \
+DRY_RUN=true \
+poetry run python scripts/erc-4626/migrate-lagoon-fee-mode.py
+```
+
+Then persist the repair:
+
+```shell
+source .local-test.env && \
+DRY_RUN=false \
+poetry run python scripts/erc-4626/migrate-lagoon-fee-mode.py
+```
+
+Set `VAULT_DB_PATH` to target a downloaded or test metadata pickle. The script
+defaults to dry-run mode and creates a non-overwriting
+`*.bak-lagoon-fee-mode` backup before writing. Run `export-data-files.py`
+afterwards to publish regenerated fee-adjusted metrics.
+
 ### clean-prices.py
 
 Clean raw scanned vault data. Reads `vault-prices-1h.parquet` and generates `cleaned-vault-prices-1h.parquet`.

--- a/scripts/erc-4626/migrate-lagoon-fee-mode.py
+++ b/scripts/erc-4626/migrate-lagoon-fee-mode.py
@@ -1,0 +1,186 @@
+"""Migrate persisted Lagoon fee modes in the vault metadata database.
+
+Older metadata rows have the correct Lagoon management and performance fee
+percentages, but their :class:`~eth_defi.vault.fee.FeeData` has no fee mode.
+The historical fee matrix used ``"Lagoon"`` while the scanner persists the
+canonical protocol name ``"Lagoon Finance"``.  A missing fee mode prevents
+fee-adjusted net-return metrics from being calculated.
+
+This metadata-only migration sets ``VaultFeeMode.externalised`` on stale
+Lagoon ``_fees`` values. It does not alter fee percentages, price Parquet
+files, reader state, or any vault history rows.
+
+Usage:
+
+.. code-block:: shell
+
+    # Inspect affected rows without changing the database
+    source .local-test.env && DRY_RUN=true \\
+        poetry run python scripts/erc-4626/migrate-lagoon-fee-mode.py
+
+    # Create a backup and persist the repair
+    source .local-test.env && DRY_RUN=false \\
+        poetry run python scripts/erc-4626/migrate-lagoon-fee-mode.py
+
+Environment variables:
+
+- ``VAULT_DB_PATH``: Optional path to ``vault-metadata-db.pickle``. Defaults
+  to the production metadata path.
+- ``DRY_RUN``: Set to ``true`` to report affected rows without writing. The
+  default is ``true``.
+- ``LOG_LEVEL``: Optional log level. Defaults to ``info``.
+"""
+
+import logging
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from tabulate import tabulate
+
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.fee import FeeData, VaultFeeMode
+from eth_defi.vault.vaultdb import DEFAULT_VAULT_DATABASE, VaultDatabase, VaultRow
+
+logger = logging.getLogger(__name__)
+
+#: Canonical scanner protocol name for Lagoon vaults.
+LAGOON_PROTOCOL_NAME = "Lagoon Finance"
+
+#: Limit stdout detail while retaining the full migration count.
+MAX_MIGRATED_ROWS_SHOWN = 50
+
+
+@dataclass(slots=True, frozen=True)
+class LagoonFeeModeMigrationResult:
+    """Summarise a Lagoon fee-mode metadata migration.
+
+    :param inspected_rows:
+        Number of metadata rows inspected.
+    :param migrated_rows:
+        Number of stale Lagoon fee records that were or would be updated.
+    :param missing_fee_data_rows:
+        Number of Lagoon rows without a structured ``_fees`` record.
+    """
+
+    inspected_rows: int
+    migrated_rows: int
+    missing_fee_data_rows: int
+
+
+def create_backup_path(vault_db_path: Path) -> Path:
+    """Choose a non-overwriting backup path for a vault metadata pickle.
+
+    :param vault_db_path:
+        Existing metadata pickle to protect before migration.
+    :return:
+        A sibling path that does not already exist.
+    """
+
+    backup_path = vault_db_path.with_suffix(".pickle.bak-lagoon-fee-mode")
+    if not backup_path.exists():
+        return backup_path
+
+    backup_index = 1
+    while True:
+        indexed_backup_path = Path(f"{backup_path}.{backup_index}")
+        if not indexed_backup_path.exists():
+            return indexed_backup_path
+        backup_index += 1
+
+
+def migrate_lagoon_fee_mode(
+    vault_db_path: Path = DEFAULT_VAULT_DATABASE,
+    *,
+    dry_run: bool,
+) -> LagoonFeeModeMigrationResult:
+    """Set the externalised fee mode on stale Lagoon metadata records.
+
+    The fee values are already persisted in each ``FeeData`` object. Only a
+    missing fee mode is repaired, making this safe to run repeatedly and
+    preventing accidental changes to any fee percentage.
+
+    :param vault_db_path:
+        Path to the metadata pickle to inspect or update.
+    :param dry_run:
+        When ``True``, report candidates without modifying the pickle.
+    :return:
+        Counts for inspected, migrated, and unsupported rows.
+    """
+
+    vault_db = VaultDatabase.read(vault_db_path)
+    migrated_rows: list[tuple[int, str, VaultRow]] = []
+    missing_fee_data_rows = 0
+
+    for spec, row in vault_db.rows.items():
+        if row.get("Protocol") != LAGOON_PROTOCOL_NAME:
+            continue
+
+        fee_data = row.get("_fees")
+        if not isinstance(fee_data, FeeData):
+            missing_fee_data_rows += 1
+            continue
+
+        if fee_data.fee_mode is not None:
+            continue
+
+        migrated_rows.append((spec.chain_id, spec.vault_address, row))
+        if not dry_run:
+            fee_data.fee_mode = VaultFeeMode.externalised
+
+    if migrated_rows:
+        table_rows = [[chain_id, address, row.get("Name", ""), row.get("Mgmt fee"), row.get("Perf fee")] for chain_id, address, row in migrated_rows[:MAX_MIGRATED_ROWS_SHOWN]]
+        print(tabulate(table_rows, headers=["Chain", "Address", "Name", "Mgmt fee", "Perf fee"], tablefmt="simple"))
+        if len(migrated_rows) > MAX_MIGRATED_ROWS_SHOWN:
+            print(f"... {len(migrated_rows) - MAX_MIGRATED_ROWS_SHOWN:,} more migrated rows not shown")
+
+    result = LagoonFeeModeMigrationResult(
+        inspected_rows=len(vault_db.rows),
+        migrated_rows=len(migrated_rows),
+        missing_fee_data_rows=missing_fee_data_rows,
+    )
+    if result.migrated_rows == 0:
+        logger.info("No stale Lagoon fee modes found in %s", vault_db_path)
+        return result
+
+    if dry_run:
+        logger.info("DRY RUN: would migrate %d Lagoon fee modes in %s", result.migrated_rows, vault_db_path)
+        return result
+
+    backup_path = create_backup_path(vault_db_path)
+    logger.info("Creating vault DB backup at %s", backup_path)
+    shutil.copy2(vault_db_path, backup_path)
+    vault_db.write(vault_db_path)
+    logger.info("Migrated %d Lagoon fee modes in %s", result.migrated_rows, vault_db_path)
+    return result
+
+
+def main() -> None:
+    """Run the Lagoon fee-mode metadata migration.
+
+    Environment configuration keeps the production invocation consistent with
+    the other ERC-4626 maintenance scripts.
+
+    :return:
+        ``None``. Raises if the requested metadata database is unavailable.
+    """
+
+    setup_console_logging(
+        default_log_level=os.environ.get("LOG_LEVEL", "info"),
+        log_file=Path("logs/migrate-lagoon-fee-mode.log"),
+    )
+    vault_db_path = Path(os.environ.get("VAULT_DB_PATH", str(DEFAULT_VAULT_DATABASE))).expanduser()
+    dry_run = os.environ.get("DRY_RUN", "true").lower() == "true"
+    assert vault_db_path.exists(), f"Vault database not found: {vault_db_path}"
+
+    result = migrate_lagoon_fee_mode(vault_db_path, dry_run=dry_run)
+    print(f"Inspected {result.inspected_rows:,} rows, migrated {result.migrated_rows:,}, skipped {result.missing_fee_data_rows:,} Lagoon rows without structured fee data.")
+    if dry_run:
+        print("Dry run - no changes written.")
+    elif result.migrated_rows:
+        print(f"Saved migrated vault database to {vault_db_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/erc_4626/test_migrate_lagoon_fee_mode.py
+++ b/tests/erc_4626/test_migrate_lagoon_fee_mode.py
@@ -1,0 +1,152 @@
+"""Tests for the persisted Lagoon fee-mode migration."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.fee import FeeData, VaultFeeMode, get_vault_fee_mode
+from eth_defi.vault.vaultdb import VaultDatabase
+
+#: Representative persisted Lagoon management fee.
+MANAGEMENT_FEE = 0.01
+
+#: Representative persisted Lagoon performance fee.
+PERFORMANCE_FEE = 0.20
+
+#: Number of fixture rows inspected by the migration.
+EXPECTED_INSPECTED_ROWS = 3
+
+
+def load_migration_module():
+    """Load the migration script as a Python module.
+
+    :return:
+        Loaded migration module.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "erc-4626" / "migrate-lagoon-fee-mode.py"
+    spec = importlib.util.spec_from_file_location("migrate_lagoon_fee_mode", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def create_fee_data(fee_mode: VaultFeeMode | None) -> FeeData:
+    """Create representative Lagoon fee data.
+
+    :param fee_mode:
+        Fee-accounting mode to persist.
+    :return:
+        Valid structured fee data.
+    """
+
+    return FeeData(
+        fee_mode=fee_mode,
+        management=MANAGEMENT_FEE,
+        performance=PERFORMANCE_FEE,
+        deposit=0.0,
+        withdraw=0.0,
+    )
+
+
+def test_fee_matrix_uses_canonical_lagoon_protocol_name() -> None:
+    """Canonical and historical Lagoon names resolve externalised fees."""
+
+    fee_mode = get_vault_fee_mode("Lagoon Finance", "0x0000000000000000000000000000000000000001")
+    legacy_fee_mode = get_vault_fee_mode("Lagoon", "0x0000000000000000000000000000000000000001")
+
+    assert fee_mode == VaultFeeMode.externalised
+    assert legacy_fee_mode == VaultFeeMode.externalised
+
+
+def test_migrate_lagoon_fee_mode_updates_only_stale_lagoon_rows(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Migration persists the fee mode without changing fee values or other protocols."""
+
+    migration = load_migration_module()
+    lagoon_spec = VaultSpec(1, "0x0000000000000000000000000000000000000001")
+    current_lagoon_spec = VaultSpec(1, "0x0000000000000000000000000000000000000002")
+    morpho_spec = VaultSpec(1, "0x0000000000000000000000000000000000000003")
+    vault_db = VaultDatabase(
+        rows={
+            lagoon_spec: {
+                "Name": "Stale Lagoon vault",
+                "Protocol": "Lagoon Finance",
+                "Mgmt fee": MANAGEMENT_FEE,
+                "Perf fee": PERFORMANCE_FEE,
+                "_fees": create_fee_data(None),
+            },
+            current_lagoon_spec: {
+                "Name": "Current Lagoon vault",
+                "Protocol": "Lagoon Finance",
+                "_fees": create_fee_data(VaultFeeMode.externalised),
+            },
+            morpho_spec: {
+                "Name": "Morpho vault",
+                "Protocol": "Morpho",
+                "_fees": create_fee_data(None),
+            },
+        }
+    )
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    vault_db.write(vault_db_path)
+
+    result = migration.migrate_lagoon_fee_mode(vault_db_path, dry_run=False)
+    captured = capsys.readouterr()
+
+    assert result.inspected_rows == EXPECTED_INSPECTED_ROWS
+    assert result.migrated_rows == 1
+    assert result.missing_fee_data_rows == 0
+    assert "Stale Lagoon vault" in captured.out
+
+    migrated_db = VaultDatabase.read(vault_db_path)
+    migrated_fees = migrated_db.rows[lagoon_spec]["_fees"]
+    assert migrated_fees.fee_mode == VaultFeeMode.externalised
+    assert migrated_fees.management == MANAGEMENT_FEE
+    assert migrated_fees.performance == PERFORMANCE_FEE
+    assert migrated_db.rows[current_lagoon_spec]["_fees"].fee_mode == VaultFeeMode.externalised
+    assert migrated_db.rows[morpho_spec]["_fees"].fee_mode is None
+    assert (tmp_path / "vault-metadata-db.pickle.bak-lagoon-fee-mode").exists()
+
+
+def test_migrate_lagoon_fee_mode_dry_run_does_not_write(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Dry run reports stale Lagoon fee data without changing the pickle."""
+
+    migration = load_migration_module()
+    lagoon_spec = VaultSpec(1, "0x0000000000000000000000000000000000000001")
+    vault_db = VaultDatabase(
+        rows={
+            lagoon_spec: {
+                "Name": "Stale Lagoon vault",
+                "Protocol": "Lagoon Finance",
+                "_fees": create_fee_data(None),
+            },
+        }
+    )
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    vault_db.write(vault_db_path)
+
+    result = migration.migrate_lagoon_fee_mode(vault_db_path, dry_run=True)
+    captured = capsys.readouterr()
+
+    assert result.migrated_rows == 1
+    assert "Stale Lagoon vault" in captured.out
+    unchanged_db = VaultDatabase.read(vault_db_path)
+    assert unchanged_db.rows[lagoon_spec]["_fees"].fee_mode is None
+    assert not (tmp_path / "vault-metadata-db.pickle.bak-lagoon-fee-mode").exists()
+
+
+def test_create_backup_path_keeps_existing_backup(tmp_path: Path) -> None:
+    """Migration never overwrites an existing metadata backup."""
+
+    migration = load_migration_module()
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    backup_path = tmp_path / "vault-metadata-db.pickle.bak-lagoon-fee-mode"
+    vault_db_path.touch()
+    backup_path.touch()
+
+    assert migration.create_backup_path(vault_db_path) == tmp_path / "vault-metadata-db.pickle.bak-lagoon-fee-mode.1"


### PR DESCRIPTION
## Why

Lagoon fees were read correctly, but the canonical protocol name could not resolve the fee-accounting mode. This withheld fee-adjusted net-return metrics from fresh and persisted Lagoon vault metadata.

## Lessons learnt

Fee matrix keys must match the scanner’s canonical protocol names. When a protocol name changes, persisted metadata may need a safe, explicit migration.

## Summary

- Map `Lagoon Finance` to externalised fees while retaining the legacy `Lagoon` alias.
- Add a dry-run-by-default migrator for stale Lagoon fee metadata, with non-overwriting backups.
- Document the operator flow and add focused coverage.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.