### PR TITLE
feat: track vault scanner JSON-RPC usage

### DIFF
--- a/.claude/plans/vault-json-rpc-call-accounting.md
+++ b/.claude/plans/vault-json-rpc-call-accounting.md
@@ -1,0 +1,376 @@
+# Vault JSON-RPC call accounting plan
+
+## Goal
+
+Track the physical JSON-RPC requests spent by each EVM vault scan, persist the
+counts in DuckDB, and display current-cycle and daily usage. Keep
+`lead_discovery` and `price_scan` separate.
+
+The production entry point is `scripts/erc-4626/scan-vaults-all-chains.py`,
+implemented by `eth_defi/vault/scan_all_chains.py`. Apply the same accounting to
+the standalone `scripts/erc-4626/scan-vaults.py` and
+`scripts/erc-4626/scan-prices.py` commands. Use
+`scripts/erc-4626/README-vault-scripts.md` for scanner configuration and
+operator documentation.
+
+## Counting rules
+
+- Count outbound JSON-RPC attempts made during EVM `lead_discovery` and
+  `price_scan` only.
+- Count by the actual method, such as `eth_call`, `eth_chainId`, and
+  `eth_getBlockByNumber`.
+- Attribute each attempt to the domain of the concrete provider that handled
+  it. Store only the hostname, never its scheme, credentials, path, query
+  string, or API key.
+- Count failed attempts and every `FallbackProvider` retry or provider switch.
+  HTTP retries hidden below `HTTPProvider.make_request()` are not observable
+  and are outside the exactness guarantee.
+- Count a Multicall3 batch as one `eth_call`, not as its encoded inner calls.
+- Exclude Hypersync, archive-node preflight, native-chain APIs, settlement
+  scanning, post-processing, Core3, currency rates, and export traffic.
+- Use naive UTC. `cycle_started` is the date on which the tick or standalone
+  invocation began, even if it crosses midnight.
+- Allocate one persistent `cycle_number` per all-chain tick or standalone
+  invocation. Scanner retries reuse it.
+- For lead discovery, `items_scanned` is the number of unique candidate
+  addresses submitted to feature probing, including rejected candidates.
+- For price scanning, `items_scanned` is the number of filtered, supported
+  vault readers submitted to the historical scan.
+
+## Minimal reusable API
+
+Put generic collection and DuckDB support in `eth_defi/provider/rpcdb.py`. It
+must not import vault, ERC-4626, protocol, or scanner modules.
+
+Expose two classes:
+
+- `RPCRequestStats`, a `dataclass(slots=True)` containing call counters keyed by
+  `(rpc_provider_domain, api_call)` and error counters keyed by
+  `(rpc_provider_domain, error_code, error_message)`.
+- `RPCUsageDatabase`, which owns one DuckDB connection and provides
+  `allocate_cycle()`, `record_scan()`, the report queries, and `close()`.
+
+`RPCRequestStats` provides `record_call()`, `record_error()`, and `merge()`.
+Updates are protected by an internal lock for shared use by worker threads.
+Pickling serialises only the counters and recreates the lock, allowing workers
+to return stats through joblib.
+
+Do not add `RPCUsageSchema`, record/context wrapper classes, configurable table
+names, dynamic SQL identifiers, phase enums, or vault report labels to the
+provider module. `RPCUsageDatabase(path)` always uses the two tables defined
+below. Its free-form `phase` and generic `items_scanned` values make it usable
+by another indexer or scanner despite the historical vault table names required
+here.
+
+The main persistence call is deliberately direct:
+
+```python
+database.record_scan(
+    chain=chain_id,
+    phase="price_scan",
+    cycle_started=cycle_started,
+    cycle_number=cycle_number,
+    stats=stats,
+    items_scanned=len(vaults),
+)
+```
+
+Follow the same default-path pattern as the repository's other DuckDB modules.
+Define the constant and resolver beside `RPCUsageDatabase` in
+`eth_defi.provider.rpcdb`:
+
+```python
+DEFAULT_RPC_TRACKING_DATABASE = Path.home() / ".tradingstrategy" / "rpc-tracking.duckdb"
+
+
+def resolve_rpc_tracking_database_path() -> Path:
+    path = os.environ.get("RPC_TRACKING_DATABASE_PATH")
+    return Path(path).expanduser() if path else DEFAULT_RPC_TRACKING_DATABASE
+```
+
+The all-chain scanner and both standalone scripts call this resolver unless a
+path is passed explicitly for a test. `RPCUsageDatabase` creates the resolved
+path's parent directory before opening DuckDB.
+
+## Fixed DuckDB schema
+
+Create the tables without primary keys or indexes, matching the repository's
+existing DuckDB stability practice.
+
+```sql
+CREATE TABLE IF NOT EXISTS vault_rpc_api_calls (
+    chain INTEGER NOT NULL,
+    phase VARCHAR NOT NULL,
+    api_call VARCHAR NOT NULL,
+    cycle_started DATE NOT NULL,
+    cycle_number INTEGER NOT NULL,
+    rpc_provider_domain VARCHAR NOT NULL,
+    call_count UBIGINT NOT NULL,
+    items_scanned INTEGER NOT NULL
+)
+```
+
+```sql
+CREATE TABLE IF NOT EXISTS vault_rpc_api_errors (
+    chain INTEGER NOT NULL,
+    phase VARCHAR NOT NULL,
+    cycle_started DATE NOT NULL,
+    cycle_number INTEGER NOT NULL,
+    rpc_provider_domain VARCHAR NOT NULL,
+    error_code VARCHAR NOT NULL,
+    error_message VARCHAR NOT NULL,
+    error_count UBIGINT NOT NULL
+)
+```
+
+Allocate a cycle with `coalesce(max(cycle_number), 0) + 1` once per tick or
+standalone invocation. The existing pipeline lock serialises this read and all
+scanner writes; `RPCUsageDatabase` documents that other consumers must provide
+the same external serialisation when sharing a database file.
+
+### Append-only writes
+
+Insert one batch when each scan attempt finishes. Retry attempts use the same
+cycle number and append more rows; do not read, delete, replace, or upsert old
+rows. Queries calculate cycle totals with `sum(call_count)` and the cycle item
+count with `max(items_scanned)`.
+
+For each attempt, insert:
+
+- One call row for each observed `(rpc_provider_domain, api_call)` pair.
+- If the attempt made no JSON-RPC requests, one marker row with
+  `api_call = 'none'`, `rpc_provider_domain = 'none'`, and `call_count = 0` so
+  the completed iteration and its `items_scanned` value remain visible.
+- One error row per observed `(rpc_provider_domain, error_code,
+  error_message)` tuple. Do not create a no-error marker row.
+
+Perform each batch with `BEGIN`, `executemany()`, and `COMMIT`; roll back and
+propagate a write failure. All writes happen in the scanner parent process.
+
+Daily and cycle queries sum the method rows directly; the zero-call marker adds
+zero and needs no special case. For a cycle retried several times, sum its call
+rows and use the maximum item count rather than adding the same population
+repeatedly. This maximum is an intentional approximation if retry filtering
+produces a slightly different item population.
+
+### Error normalisation
+
+Normalise errors once at the provider boundary:
+
+- JSON-RPC response: decimal JSON-RPC code, for example `-32005`.
+- HTTP failure: `http_<status>`, for example `http_429`.
+- Transport failure: concrete exception class, for example `ReadTimeout`.
+- Otherwise: `unknown`.
+
+Sanitise the message by removing endpoint credentials, URL paths and query
+strings, excluding request parameters, collapsing whitespace, and truncating
+to a documented limit. This prevents secret leakage and bounds cardinality.
+
+## Provider instrumentation
+
+Extend `FallbackProvider` without changing the existing successful-call
+counter behaviour:
+
+1. Accept an optional `RPCRequestStats` accumulator.
+2. Provide `set_rpc_request_stats(stats_or_none)` for a cached subprocess Web3
+   to attach one task's accumulator and detach it afterwards. Replacing the
+   accumulator does not reset the existing successful-call counters.
+3. Resolve each configured provider's safe domain once during initialisation.
+4. Immediately before every concrete `provider.make_request(method, params)`,
+   call `record_call(domain, method)`.
+5. In the error path, call `record_error()` once for the same provider before
+   retry classification or switching. An attempt that later succeeds still
+   contributes one call and one error.
+6. Count the direct `eth_chainId` requests used to verify or switch providers
+   when they occur inside the scan phase.
+
+Pass the optional accumulator through `create_multi_provider_web3()` and
+`MultiProviderWeb3Factory`. Do not use only
+`install_api_call_counter_middleware()`, because middleware cannot see physical
+fallback attempts.
+
+The dependency direction remains one way: providers and factories may import
+`RPCRequestStats`, while `rpcdb.py` does not import provider implementations.
+
+## Thread and subprocess propagation
+
+Use one accumulator per phase and avoid a registry of created Web3 instances.
+
+### Parent and threaded work
+
+Create the phase accumulator after archive-node preflight, then construct the
+phase's parent Web3 and thread-created Web3 instances with that accumulator.
+Do not attach it to the preflight Web3 or reuse these phase-owned Web3 instances
+for excluded work. Because all phase providers record directly into the shared,
+locked accumulator, the parent/thread path needs no factory registry, stage
+snapshot, detach step, or cached-Web3 re-registration.
+
+Ensure the accumulator is used only by one phase. Lead discovery and price
+scanning create separate accumulators, so their traffic cannot overlap.
+
+### Subprocess work
+
+A process cannot update the parent's in-memory accumulator. Existing workers
+cache Web3 per process, so for each joblib `loky` task:
+
+1. Create a task-local `RPCRequestStats`.
+2. Create the worker Web3 with that accumulator on the cache miss, or use
+   `set_rpc_request_stats()` to attach it to the cached provider.
+3. Run the task and detach the accumulator in `finally`, preventing the next
+   task in that process from recording into an already-returned object.
+4. Return the task stats with a successful normal result and merge them once
+   in the parent.
+
+Update the two existing subprocess result paths:
+
+- `eth_defi/event_reader/multicall_batcher.py` returns task stats with each
+  completed Multicall task. Attach them to the batch result, never every inner
+  encoded call.
+- `eth_defi/event_reader/multicall_timestamp.py` returns task stats with each
+  timestamp result. The Hypersync path contributes nothing.
+
+If a subprocess task raises, propagate its normal exception without wrapping it
+solely to recover counters. Calls made by failed or abruptly terminated tasks
+may therefore be missing; subprocess accounting is explicitly a lower bound on
+failed scans. Successful tasks, including tasks where `FallbackProvider`
+recovers from an intermediate provider error, return complete counters.
+
+Enable this return-and-merge path only for a process backend. When a reader uses
+the threading backend, its Web3 instances already write to the shared phase
+accumulator; returning and merging the same task counters would double-count.
+
+## Scanner integration
+
+Update `eth_defi/vault/scan_all_chains.py`:
+
+1. Resolve the database with `resolve_rpc_tracking_database_path()` and include
+   the file in `bkp_files`. Let the tick's existing pre-scan backup finish
+   before opening the connection.
+2. Open `RPCUsageDatabase` and allocate one cycle at the start of
+   `run_scan_tick()` while the existing pipeline lock is held.
+3. Pass `cycle_started`, `cycle_number`, and the database through the EVM scan
+   calls. Retry passes reuse them.
+4. After preflight, create a `lead_discovery` accumulator in `scan_chain()` and
+   pass it through `scan_vaults_for_chain()`. Return only the chain id and item
+   count in the existing metrics dictionary; the caller already owns the
+   accumulator.
+5. Do the same with a separate `price_scan` accumulator passed through
+   `scan_prices_for_chain()`. Its item count is `len(vaults)` after filtering.
+6. In `scan_chain()`, call `record_scan()` after each attempt and before
+   returning its status. Log an accounting write failure prominently but do not
+   fail and retry an otherwise successful vault scan, which would spend more
+   RPC calls merely because observability storage failed.
+7. Close the database before backup or post-processing reads it.
+8. Do not create usage rows for native protocols or excluded phases.
+
+The current all-chain loop is sequential and the scanner parent performs every
+DuckDB call, so `RPCUsageDatabase` does not need an internal concurrency lock.
+Other consumers must serialise calls if they share a connection across threads.
+
+Do not add RPC stats to `LeadScanReport` or `ParquetScanResult`. The optional
+accumulator is an input to the relevant functions, while the scanner's existing
+metrics dictionary carries the small amount of phase accounting needed by its
+caller. Add only an `items_scanned` integer to `LeadScanReport` if the prepared
+feature-probe candidate count is not otherwise available at the wrapper.
+
+Update the standalone lead and price scripts to open the same database,
+allocate one cycle under `wait_other_writers()`, record their respective phase,
+display the reports, and close the database.
+
+## Reports
+
+After each EVM chain finishes, display with `tabulate()` and log:
+
+1. Current-cycle calls grouped by phase, provider domain, and API method, with
+   a phase total and `items_scanned`.
+2. Daily-to-date totals for that chain grouped separately by phase and provider
+   domain.
+3. A compact current-cycle error table when errors exist, grouped by phase,
+   provider domain, error code, and normalised message.
+
+Daily totals sum method rows directly. First group append-only attempts to one
+cycle:
+
+```text
+cycle_calls = sum(call_count across method rows)
+cycle_items = max(items_scanned across method or zero-marker rows)
+daily_calls = sum(cycle_calls)
+daily_items = sum(cycle_items)
+```
+
+Do not add calls-per-item ratios, configurable report labels, a second daily
+error report, or an all-chain end-of-tick report in the first implementation.
+They are not required to answer how many calls each phase and chain spent.
+
+## Focused tests
+
+Add offline pytest coverage for:
+
+- Every physical fallback attempt increments the correct provider-domain and
+  method counter; errors are recorded once and existing success counters are
+  unchanged.
+- JSON-RPC, HTTP, transport, and unknown error codes are normalised, and
+  messages do not expose endpoint secrets or request parameters.
+- A shared accumulator records threaded calls exactly once.
+- Several `loky` tasks return and merge the exact sum of their calls and
+  errors; one Multicall batch remains one `eth_call`.
+- Timestamp RPC fallback is counted and the Hypersync path is not.
+- DuckDB schema creation, restart-safe cycle allocation, append-only retry
+  inserts, rollback, zero-call markers, and explicit close.
+- Cycle and daily queries sum method rows and use `max(items_scanned)` across
+  retry and fallback-provider rows.
+- Lead and price scans use separate phases and counters, while excluded phases
+  produce no rows.
+- Default and `RPC_TRACKING_DATABASE_PATH` override resolution, including
+  `~` expansion and parent-directory creation.
+- Standalone scripts use the shared resolver.
+
+Use focused test files and the repository-required invocation form:
+
+```shell
+source .local-test.env && poetry run pytest \
+  tests/rpc/test_multi_provider.py \
+  tests/provider/test_rpcdb.py \
+  tests/vault/test_scan_all_chains_rpc_usage.py
+```
+
+Use the exact final paths selected during implementation and a three-minute
+timeout. Do not run the full suite.
+
+## Documentation
+
+Update `scripts/erc-4626/README-vault-scripts.md` with:
+
+- `RPC_TRACKING_DATABASE_PATH` and the default
+  `~/.tradingstrategy/rpc-tracking.duckdb` location.
+- The two phases and their `items_scanned` definitions.
+- Provider-domain attribution, physical-attempt and Multicall semantics.
+- Error sanitisation and the transport-retry limitation.
+- Excluded traffic and examples of both reports.
+- A simple DuckDB daily-total query.
+
+Add the required API stub for `eth_defi.provider.rpcdb` under
+`docs/source/api/provider/` and link it from the provider API index. Show one
+non-vault example that uses `RPCRequestStats` and `RPCUsageDatabase` with a
+different phase and item meaning. Do not export this operational database to
+public R2 storage.
+
+## Acceptance criteria
+
+- Every completed EVM lead-discovery and price-scan attempt records method rows
+  or a zero-call marker.
+- Calls and errors include failed fallback attempts and the concrete provider
+  domain, without storing credentials or URL paths.
+- Lead discovery and price scanning are independently queryable and displayed
+  per chain for the current cycle and UTC day.
+- Retry attempts append to the same cycle without multiplying
+  `items_scanned` in aggregate queries.
+- Successful thread and subprocess calls are merged exactly once; failed or
+  terminated subprocess tasks are documented as a possible lower bound.
+- Collection and persistence live in `eth_defi.provider.rpcdb` and work without
+  importing vault modules or configuring a schema object.
+- All scanners default to `~/.tradingstrategy/rpc-tracking.duckdb` through the
+  shared provider-level resolver.
+- Native protocols, Hypersync, preflight, settlement, and post-processing do
+  not contribute rows.
+- Focused provider, worker, DuckDB, and scanner tests pass.

--- a/.claude/plans/vault-json-rpc-call-accounting.md
+++ b/.claude/plans/vault-json-rpc-call-accounting.md
@@ -20,8 +20,8 @@ operator documentation.
 - Count by the actual method, such as `eth_call`, `eth_chainId`, and
   `eth_getBlockByNumber`.
 - Attribute each attempt to the domain of the concrete provider that handled
-  it. Store only the hostname, never its scheme, credentials, path, query
-  string, or API key.
+  it. In `rpc_provider_domain`, store only the hostname, never its scheme,
+  credentials, path, query string, or API key.
 - Count failed attempts and every `FallbackProvider` retry or provider switch.
   HTTP retries hidden below `HTTPProvider.make_request()` are not observable
   and are outside the exactness guarantee.
@@ -37,9 +37,9 @@ operator documentation.
 - For price scanning, `items_scanned` is the number of filtered, supported
   vault readers submitted to the historical scan.
 
-## Minimal reusable API
+## Provider API
 
-Put generic collection and DuckDB support in `eth_defi/provider/rpcdb.py`. It
+Put collection and DuckDB support in `eth_defi/provider/rpcdb.py`. It
 must not import vault, ERC-4626, protocol, or scanner modules.
 
 Expose two classes:
@@ -58,11 +58,10 @@ to return stats through joblib.
 Do not add `RPCUsageSchema`, record/context wrapper classes, configurable table
 names, dynamic SQL identifiers, phase enums, or vault report labels to the
 provider module. `RPCUsageDatabase(path)` always uses the two tables defined
-below. Its free-form `phase` and generic `items_scanned` values make it usable
-by another indexer or scanner despite the historical vault table names required
-here.
+below. `phase` and `items_scanned` are caller-defined, and the module does not
+import scanner or vault code.
 
-The main persistence call is deliberately direct:
+The main persistence call is:
 
 ```python
 database.record_scan(
@@ -288,7 +287,7 @@ After each EVM chain finishes, display with `tabulate()` and log:
 2. Daily-to-date totals for that chain grouped separately by phase and provider
    domain.
 3. A compact current-cycle error table when errors exist, grouped by phase,
-   provider domain, error code, and normalised message.
+   provider domain, error code, and message.
 
 Daily totals sum method rows directly. First group append-only attempts to one
 cycle:
@@ -299,10 +298,6 @@ cycle_items = max(items_scanned across method or zero-marker rows)
 daily_calls = sum(cycle_calls)
 daily_items = sum(cycle_items)
 ```
-
-Do not add calls-per-item ratios, configurable report labels, a second daily
-error report, or an all-chain end-of-tick report in the first implementation.
-They are not required to answer how many calls each phase and chain spent.
 
 ## Focused tests
 
@@ -336,8 +331,7 @@ source .local-test.env && poetry run pytest \
   tests/vault/test_scan_all_chains_rpc_usage.py
 ```
 
-Use the exact final paths selected during implementation and a three-minute
-timeout. Do not run the full suite.
+Use a three-minute timeout. Do not run the full suite.
 
 ## Documentation
 
@@ -352,17 +346,15 @@ Update `scripts/erc-4626/README-vault-scripts.md` with:
 - A simple DuckDB daily-total query.
 
 Add the required API stub for `eth_defi.provider.rpcdb` under
-`docs/source/api/provider/` and link it from the provider API index. Show one
-non-vault example that uses `RPCRequestStats` and `RPCUsageDatabase` with a
-different phase and item meaning. Do not export this operational database to
-public R2 storage.
+`docs/source/api/provider/` and link it from the provider API index. Do not
+export this operational database to public R2 storage.
 
 ## Acceptance criteria
 
 - Every completed EVM lead-discovery and price-scan attempt records method rows
   or a zero-call marker.
 - Calls and errors include failed fallback attempts and the concrete provider
-  domain, without storing credentials or URL paths.
+  domain. Provider-domain values do not store credentials or URL paths.
 - Lead discovery and price scanning are independently queryable and displayed
   per chain for the current cycle and UTC day.
 - Retry attempts append to the same cycle without multiplying

--- a/.claude/plans/vault-json-rpc-call-accounting.md
+++ b/.claude/plans/vault-json-rpc-call-accounting.md
@@ -162,9 +162,11 @@ Normalise errors once at the provider boundary:
 - Transport failure: concrete exception class, for example `ReadTimeout`.
 - Otherwise: `unknown`.
 
-Sanitise the message by removing endpoint credentials, URL paths and query
-strings, excluding request parameters, collapsing whitespace, and truncating
-to a documented limit. This prevents secret leakage and bounds cardinality.
+Store the provider error message as received so the database retains its full
+diagnostic context. Raw messages may contain endpoint credentials and
+request-specific values, producing sensitive data and high-cardinality rows.
+Treat the database and reports as sensitive operational data and monitor their
+size during sustained provider failures.
 
 ## Provider instrumentation
 
@@ -309,8 +311,8 @@ Add offline pytest coverage for:
 - Every physical fallback attempt increments the correct provider-domain and
   method counter; errors are recorded once and existing success counters are
   unchanged.
-- JSON-RPC, HTTP, transport, and unknown error codes are normalised, and
-  messages do not expose endpoint secrets or request parameters.
+- JSON-RPC, HTTP, transport, and unknown error codes are normalised, while
+  messages retain the provider's diagnostic text.
 - A shared accumulator records threaded calls exactly once.
 - Several `loky` tasks return and merge the exact sum of their calls and
   errors; one Multicall batch remains one `eth_call`.
@@ -345,7 +347,7 @@ Update `scripts/erc-4626/README-vault-scripts.md` with:
   `~/.tradingstrategy/rpc-tracking.duckdb` location.
 - The two phases and their `items_scanned` definitions.
 - Provider-domain attribution, physical-attempt and Multicall semantics.
-- Error sanitisation and the transport-retry limitation.
+- Error normalisation and the transport-retry limitation.
 - Excluded traffic and examples of both reports.
 - A simple DuckDB daily-total query.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- feat: Track per-chain vault scanner JSON-RPC calls and errors in DuckDB (2026-07-20)
 - feat: Add Hypersync-backed Chainlink bundle aggregator history and FILQ NAV support (2026-07-20)
 - feat: Backfill OpenEden TBILL oracle price history while preserving supply-only FDIT and CASHx metadata (2026-07-20)
 - feat: Complete Asseto live-feed discovery, standardise tokenised-fund vault flags and add verified curator logo coverage (2026-07-20)

--- a/docs/source/api/provider/index.rst
+++ b/docs/source/api/provider/index.rst
@@ -31,4 +31,5 @@ This submodule offers functionality to connect and enhance robustness of various
    eth_defi.provider.quicknode
    eth_defi.provider.rpc_proxy
    eth_defi.provider.rpc_monitoring_adapter
+   eth_defi.provider.rpcdb
    eth_defi.provider.tenderly

--- a/docs/source/api/provider/rpcdb.rst
+++ b/docs/source/api/provider/rpcdb.rst
@@ -1,0 +1,37 @@
+JSON-RPC request accounting
+---------------------------
+
+The :py:mod:`eth_defi.provider.rpcdb` module provides reusable physical
+JSON-RPC request counters and append-only DuckDB persistence. Its ``phase`` and
+``items_scanned`` values are caller-defined, so the same API can account for a
+vault scan, block index, transaction batch, or diagnostic job.
+
+For example, a block indexer can use the same fixed `DuckDB database
+<https://duckdb.org/docs/stable/clients/python/overview>`__ with its own phase
+and item meaning:
+
+.. code-block:: python
+
+   from eth_defi.compat import native_datetime_utc_now
+   from eth_defi.provider.rpcdb import (
+       RPCRequestStats,
+       RPCUsageDatabase,
+       resolve_rpc_tracking_database_path,
+   )
+
+   stats = RPCRequestStats()
+   stats.record_call("rpc.example.com", "eth_getBlockByNumber", count=100)
+
+   with RPCUsageDatabase(resolve_rpc_tracking_database_path()) as database:
+       database.record_scan(
+           chain=1,
+           phase="block_index",
+           cycle_started=native_datetime_utc_now().date(),
+           cycle_number=database.allocate_cycle(),
+           stats=stats,
+           items_scanned=100,  # Blocks indexed, not vaults
+       )
+
+.. automodule:: eth_defi.provider.rpcdb
+   :members:
+   :undoc-members:

--- a/docs/source/api/provider/rpcdb.rst
+++ b/docs/source/api/provider/rpcdb.rst
@@ -1,36 +1,9 @@
 JSON-RPC request accounting
 ---------------------------
 
-The :py:mod:`eth_defi.provider.rpcdb` module provides reusable physical
-JSON-RPC request counters and append-only DuckDB persistence. Its ``phase`` and
-``items_scanned`` values are caller-defined, so the same API can account for a
-vault scan, block index, transaction batch, or diagnostic job.
-
-For example, a block indexer can use the same fixed `DuckDB database
-<https://duckdb.org/docs/stable/clients/python/overview>`__ with its own phase
-and item meaning:
-
-.. code-block:: python
-
-   from eth_defi.compat import native_datetime_utc_now
-   from eth_defi.provider.rpcdb import (
-       RPCRequestStats,
-       RPCUsageDatabase,
-       resolve_rpc_tracking_database_path,
-   )
-
-   stats = RPCRequestStats()
-   stats.record_call("rpc.example.com", "eth_getBlockByNumber", count=100)
-
-   with RPCUsageDatabase(resolve_rpc_tracking_database_path()) as database:
-       database.record_scan(
-           chain=1,
-           phase="block_index",
-           cycle_started=native_datetime_utc_now().date(),
-           cycle_number=database.allocate_cycle(),
-           stats=stats,
-           items_scanned=100,  # Blocks indexed, not vaults
-       )
+The :py:mod:`eth_defi.provider.rpcdb` module provides physical JSON-RPC request
+counters and append-only `DuckDB persistence
+<https://duckdb.org/docs/stable/clients/python/overview>`__.
 
 .. automodule:: eth_defi.provider.rpcdb
    :members:

--- a/eth_defi/erc_4626/discovery_base.py
+++ b/eth_defi/erc_4626/discovery_base.py
@@ -527,6 +527,8 @@ class LeadScanReport:
     start_block: int = 0
     #: Accounting / diagnostics
     end_block: int = 0
+    #: Unique candidate addresses submitted to on-chain feature probing
+    items_scanned: int = 0
 
 
 def _prepare_probe_leads(leads: dict[HexAddress, PotentialVaultMatch]) -> tuple[list[HexAddress], dict[str, PotentialVaultMatch], int]:
@@ -706,6 +708,7 @@ class VaultDiscoveryBase(abc.ABC):
                 logger.info("Added hardcoded Asseto vault lead %s", address)
 
         addresses, leads_by_address, mellow_lead_count = _prepare_probe_leads(leads)
+        report.items_scanned = len(addresses)
         logger.info("Found %d vault leads, of which %d are Mellow factory leads", len(leads), mellow_lead_count)
         good_vaults = broken_vaults = 0
 

--- a/eth_defi/erc_4626/lead_scan_core.py
+++ b/eth_defi/erc_4626/lead_scan_core.py
@@ -13,6 +13,7 @@ from typing import Literal
 import pandas as pd
 from joblib import Parallel, delayed
 from tqdm_loggable.auto import tqdm
+from web3 import Web3
 
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.discovery_base import LeadScanReport
@@ -22,6 +23,7 @@ from eth_defi.hypersync.hypersync_timestamp import get_hypersync_block_height
 from eth_defi.hypersync.utils import configure_hypersync_from_env
 from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
 from eth_defi.provider.named import get_provider_name
+from eth_defi.provider.rpcdb import RPCRequestStats
 from eth_defi.vault.vaultdb import VaultDatabase
 
 logger = logging.getLogger(__name__)
@@ -105,6 +107,8 @@ def scan_leads(
     hypersync_api_key: str | None = None,
     hypersync_concurrency: int | None = None,
     max_display_entries: int | None = None,
+    rpc_request_stats: RPCRequestStats | None = None,
+    web3: Web3 | None = None,
 ) -> LeadScanReport:
     """Core loop to discover new vaults on a chain.
 
@@ -118,13 +122,18 @@ def scan_leads(
     :param max_display_entries:
         Maximum number of vaults included in the diagnostic results table.
         ``None`` displays all matching vaults.
+    :param rpc_request_stats:
+        Optional phase accumulator for physical JSON-RPC request accounting.
+    :param web3:
+        Optional phase-owned Web3 connection. Supplying it lets an outer
+        scanner establish the chain id before entering exception-handled work.
     """
 
     from eth_defi.erc_4626.hypersync_discovery import HypersyncVaultDiscover
 
     assert isinstance(vault_db_file, Path)
 
-    web3 = create_multi_provider_web3(json_rpc_urls)
+    web3 = web3 or create_multi_provider_web3(json_rpc_urls, rpc_request_stats=rpc_request_stats)
     chain_id = web3.eth.chain_id
 
     # The parent process verified provider chain IDs above. Subprocess workers
@@ -132,7 +141,7 @@ def scan_leads(
     # storm the primary provider with eth_chainId probes and trip HTTP 429. Seed
     # the verified chain ID so worker-side provider switchover still rejects an
     # endpoint that mis-routes to the wrong chain.
-    web3factory = MultiProviderWeb3Factory(json_rpc_urls, retries=5, skip_verification=True, expected_chain_id=chain_id)
+    web3factory = MultiProviderWeb3Factory(json_rpc_urls, retries=5, skip_verification=True, expected_chain_id=chain_id, rpc_request_stats=rpc_request_stats)
 
     name = get_chain_name(chain_id)
     rpcs = get_provider_name(web3.provider)
@@ -203,7 +212,7 @@ def scan_leads(
 
     if len(rows) == 0:
         printer(f"No vaults found on chain {chain}, not generating any database updates")
-        return LeadScanReport()
+        return report
 
     df = pd.DataFrame(rows)
     # Parquet cannot export the raw Python objects,

--- a/eth_defi/erc_4626/scan.py
+++ b/eth_defi/erc_4626/scan.py
@@ -446,15 +446,22 @@ def create_vault_scan_record_subprocess(
     if web3 is None:
         web3 = _subprocess_web3_cache.web3 = web3factory()
 
+    rpc_request_stats = getattr(web3factory, "rpc_request_stats", None)
+    set_rpc_request_stats = getattr(web3, "set_rpc_request_stats", None)
+    if callable(set_rpc_request_stats):
+        set_rpc_request_stats(rpc_request_stats)
+
     token_cache = getattr(_subprocess_web3_cache, "token_cache", None)
     if token_cache is None:
         token_cache = _subprocess_web3_cache.token_cache = TokenDiskCache()
 
-    record = create_vault_scan_record(
-        web3,
-        detection,
-        block_number,
-        token_cache=token_cache,
-    )
-
-    return record
+    try:
+        return create_vault_scan_record(
+            web3,
+            detection,
+            block_number,
+            token_cache=token_cache,
+        )
+    finally:
+        if callable(set_rpc_request_stats):
+            set_rpc_request_stats(None)

--- a/eth_defi/event_reader/multicall_batcher.py
+++ b/eth_defi/event_reader/multicall_batcher.py
@@ -1956,6 +1956,10 @@ def read_multicall_chunked(
 
         Either "loky" or "threading".
 
+    :param rpc_request_stats:
+        Optional accumulator receiving physical JSON-RPC calls from either
+        worker backend.
+
     :return:
         Iterable of results.
 
@@ -2009,6 +2013,7 @@ def read_multicall_chunked(
                 chunk,
                 timestamp=ts,
                 collect_rpc_request_stats=backend == "loky" and rpc_request_stats is not None,
+                rpc_request_stats=rpc_request_stats if backend == "threading" else None,
             )
 
     performed_calls = success_calls = failed_calls = 0
@@ -2080,6 +2085,9 @@ class MulticallHistoricalTask:
     #: Return a task-local counter to the parent when running under ``loky``.
     collect_rpc_request_stats: bool = False
 
+    #: Shared parent counter when running under the threading backend.
+    rpc_request_stats: RPCRequestStats | None = None
+
     def __post_init__(self):
         assert callable(self.web3factory)
         assert type(self.block_number) in (int, str), f"Got: {self.block_number}"
@@ -2114,7 +2122,7 @@ def _execute_multicall_subprocess(
     if task.collect_rpc_request_stats:
         task_rpc_request_stats = RPCRequestStats()
     else:
-        task_rpc_request_stats = getattr(task.web3factory, "rpc_request_stats", None)
+        task_rpc_request_stats = task.rpc_request_stats if task.rpc_request_stats is not None else getattr(task.web3factory, "rpc_request_stats", None)
 
     reader = per_chain_readers.get(task.chain_id)
     if reader is None:

--- a/eth_defi/event_reader/multicall_batcher.py
+++ b/eth_defi/event_reader/multicall_batcher.py
@@ -50,7 +50,9 @@ from eth_defi.event_reader.timestamp_cache import DEFAULT_TIMESTAMP_CACHE_FOLDER
 from eth_defi.event_reader.web3factory import Web3Factory
 from eth_defi.middleware import ProbablyNodeHasNoBlock, is_retryable_http_exception
 from eth_defi.provider.fallback import ChainIdMismatch, FallbackProvider
+from eth_defi.provider.multi_provider import MultiProviderWeb3Factory
 from eth_defi.provider.named import get_provider_name
+from eth_defi.provider.rpcdb import RPCRequestStats
 from eth_defi.timestamp import get_block_timestamp
 from eth_defi.vault.risk import BROKEN_VAULT_CONTRACTS
 
@@ -852,6 +854,9 @@ class CombinedEncodedCallResult:
     timestamp: datetime.datetime
     results: list[EncodedCallResult]
 
+    #: Physical JSON-RPC calls made by this subprocess task.
+    rpc_request_stats: RPCRequestStats | None = None
+
 
 #: F**k EVM
 WTF_RETRY_EXCEPTIONS_MESSAGE_CLUES = {
@@ -1026,6 +1031,7 @@ class MultiprocessMulticallReader:
         batch_size=40,
         backswitch_threshold=100,
         too_many_requets_sleep=61.0,
+        rpc_request_stats: RPCRequestStats | None = None,
     ):
         """Create subprocess worker instance.
 
@@ -1041,6 +1047,10 @@ class MultiprocessMulticallReader:
         if isinstance(web3factory, Web3):
             # Directly passed
             self.web3 = web3factory
+        elif isinstance(web3factory, MultiProviderWeb3Factory):
+            # Account for provider verification requests made while the
+            # process-local cached Web3 is first constructed.
+            self.web3 = web3factory(rpc_request_stats=rpc_request_stats)
         else:
             # Construct new RPC connection in every subprocess
             self.web3 = web3factory()
@@ -1484,6 +1494,7 @@ def read_multicall_historical(
     require_multicall_result=False,
     hypersync_client: "HypersyncClient | None" = None,
     timestamp_cache_file: Path = DEFAULT_TIMESTAMP_CACHE_FOLDER,
+    rpc_request_stats: RPCRequestStats | None = None,
 ) -> Iterable[CombinedEncodedCallResult]:
     """Read historical data using multiple threads in parallel for speedup.
 
@@ -1580,6 +1591,7 @@ def read_multicall_historical(
             display_progress=display_progress,
             hypersync_client=hypersync_client,
             cache_path=timestamp_cache_file,
+            rpc_request_stats=rpc_request_stats,
         )
 
         timestamp_end_block = timestamps.get_last_block()
@@ -1597,6 +1609,7 @@ def read_multicall_historical(
                 calls_pickle_friendly,
                 timestamp=timestamps[block_number] if timestamps is not None else None,
                 require_multicall_result=require_multicall_result,
+                collect_rpc_request_stats=rpc_request_stats is not None,
             )
             logger.debug(
                 "Created task for block %d with %d calls",
@@ -1609,6 +1622,8 @@ def read_multicall_historical(
 
     try:
         for completed_task in worker_processor(delayed(_execute_multicall_subprocess)(task) for task in _task_gen()):
+            if rpc_request_stats is not None and completed_task.rpc_request_stats is not None:
+                rpc_request_stats.merge(completed_task.rpc_request_stats)
             completed_task_count += 1
             if progress_bar:
                 progress_bar.update(1)
@@ -1644,6 +1659,7 @@ def read_multicall_historical_stateful(
     chunk_size=48,
     hypersync_client: "HypersyncClient | None" = None,
     timestamp_cache_file: Path = DEFAULT_TIMESTAMP_CACHE_FOLDER,
+    rpc_request_stats: RPCRequestStats | None = None,
 ) -> Iterable[CombinedEncodedCallResult]:
     """Read historical data using multicall with reading state and adaptive frequency filtering.
 
@@ -1711,6 +1727,7 @@ def read_multicall_historical_stateful(
         display_progress=display_progress,
         hypersync_client=hypersync_client,
         cache_path=timestamp_cache_file,
+        rpc_request_stats=rpc_request_stats,
     )
 
     chunk = []
@@ -1723,6 +1740,8 @@ def read_multicall_historical_stateful(
             return
 
         for combined_result in worker_processor(delayed(_execute_multicall_subprocess)(task) for task in chunk):
+            if rpc_request_stats is not None and combined_result.rpc_request_stats is not None:
+                rpc_request_stats.merge(combined_result.rpc_request_stats)
             for r in combined_result.results:
                 # Retrofit states to the result objects
                 assert r.timestamp, f"Got bad result: {r}"
@@ -1784,6 +1803,7 @@ def read_multicall_historical_stateful(
             accepted_calls,
             timestamp=timestamp,
             require_multicall_result=require_multicall_result,
+            collect_rpc_request_stats=rpc_request_stats is not None,
         )
 
         chunk.append(task)
@@ -1837,6 +1857,7 @@ def read_multicall_chunked(
     progress_bar_desc: str | None = None,
     timestamped_results=True,
     backend="loky",
+    rpc_request_stats: RPCRequestStats | None = None,
 ) -> Iterable[EncodedCallResult]:
     """Read current data using multiple processes in parallel for speedup.
 
@@ -1945,6 +1966,9 @@ def read_multicall_chunked(
 
     assert type(chain_id) == int, f"Got: {chain_id}"
 
+    if rpc_request_stats is None:
+        rpc_request_stats = getattr(web3factory, "rpc_request_stats", None)
+
     if max_workers == 1:
         timeout = None  # No timeout for single process
 
@@ -1978,10 +2002,19 @@ def read_multicall_chunked(
             ts = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         for i in range(0, len(calls), chunk_size):
             chunk = calls[i : i + chunk_size]
-            yield MulticallHistoricalTask(chain_id, web3factory, block_identifier, chunk, timestamp=ts)
+            yield MulticallHistoricalTask(
+                chain_id,
+                web3factory,
+                block_identifier,
+                chunk,
+                timestamp=ts,
+                collect_rpc_request_stats=backend == "loky" and rpc_request_stats is not None,
+            )
 
     performed_calls = success_calls = failed_calls = 0
     for completed_task in worker_processor(delayed(_execute_multicall_subprocess)(task) for task in _task_gen()):
+        if backend == "loky" and rpc_request_stats is not None and completed_task.rpc_request_stats is not None:
+            rpc_request_stats.merge(completed_task.rpc_request_stats)
         if progress_bar:
             progress_bar.update(1)
 
@@ -2044,6 +2077,9 @@ class MulticallHistoricalTask:
     #: Running counter for task ids, for serialisation checks
     task_id: int = field(default_factory=_create_task_id)
 
+    #: Return a task-local counter to the parent when running under ``loky``.
+    collect_rpc_request_stats: bool = False
+
     def __post_init__(self):
         assert callable(self.web3factory)
         assert type(self.block_number) in (int, str), f"Got: {self.block_number}"
@@ -2075,29 +2111,46 @@ def _execute_multicall_subprocess(
 
     assert task.chain_id
 
+    if task.collect_rpc_request_stats:
+        task_rpc_request_stats = RPCRequestStats()
+    else:
+        task_rpc_request_stats = getattr(task.web3factory, "rpc_request_stats", None)
+
     reader = per_chain_readers.get(task.chain_id)
     if reader is None:
-        reader = per_chain_readers[task.chain_id] = MultiprocessMulticallReader(task.web3factory)
+        reader = per_chain_readers[task.chain_id] = MultiprocessMulticallReader(
+            task.web3factory,
+            rpc_request_stats=task_rpc_request_stats,
+        )
 
-    # Read block timestan for this batch
-    assert task.chain_id == reader.web3.eth.chain_id, f"chain_id mismatch. Wanted: {task.chain_id}, reader has: {reader.web3.eth.chain_id}"
+    set_rpc_request_stats = getattr(reader.web3, "set_rpc_request_stats", None)
+    if callable(set_rpc_request_stats):
+        set_rpc_request_stats(task_rpc_request_stats)
 
-    if task.timestamp is None:
-        timestamp = reader.get_block_timestamp(task.block_number)
-    else:
-        timestamp = task.timestamp
+    try:
+        # Read block timestamp for this batch
+        assert task.chain_id == reader.web3.eth.chain_id, f"chain_id mismatch. Wanted: {task.chain_id}, reader has: {reader.web3.eth.chain_id}"
 
-    # Perform multicall to read share prices
-    call_results = reader.process_calls(
-        task.block_number,
-        task.calls,
-        require_multicall_result=task.require_multicall_result,
-        timestamp=timestamp,
-    )
+        if task.timestamp is None:
+            timestamp = reader.get_block_timestamp(task.block_number)
+        else:
+            timestamp = task.timestamp
 
-    # Pass results back to the main process
-    return CombinedEncodedCallResult(
-        block_number=task.block_number,
-        timestamp=timestamp,
-        results=[c for c in call_results],
-    )
+        # Perform multicall to read share prices
+        call_results = reader.process_calls(
+            task.block_number,
+            task.calls,
+            require_multicall_result=task.require_multicall_result,
+            timestamp=timestamp,
+        )
+
+        # Pass results back to the main process
+        return CombinedEncodedCallResult(
+            block_number=task.block_number,
+            timestamp=timestamp,
+            results=[c for c in call_results],
+            rpc_request_stats=task_rpc_request_stats if task.collect_rpc_request_stats else None,
+        )
+    finally:
+        if callable(set_rpc_request_stats):
+            set_rpc_request_stats(None)

--- a/eth_defi/event_reader/multicall_timestamp.py
+++ b/eth_defi/event_reader/multicall_timestamp.py
@@ -10,8 +10,10 @@ from joblib import Parallel, delayed
 from tqdm_loggable.auto import tqdm
 
 from eth_defi.chain import get_chain_name
-from eth_defi.event_reader.timestamp_cache import load_timestamp_cache, BlockTimestampDatabase, DEFAULT_TIMESTAMP_CACHE_FOLDER, BlockTimestampSlicer
+from eth_defi.event_reader.timestamp_cache import DEFAULT_TIMESTAMP_CACHE_FOLDER, BlockTimestampDatabase, BlockTimestampSlicer, load_timestamp_cache
 from eth_defi.event_reader.web3factory import Web3Factory
+from eth_defi.provider.multi_provider import MultiProviderWeb3Factory
+from eth_defi.provider.rpcdb import RPCRequestStats
 from eth_defi.timestamp import get_block_timestamp
 
 logger = logging.getLogger(__name__)
@@ -26,20 +28,37 @@ def _read_timestamp_subprocess(
     web3factory: Web3Factory,
     chain_id: int,
     block_number: int,
-) -> tuple[int, datetime.datetime]:
+    collect_rpc_request_stats: bool = False,
+) -> tuple[int, datetime.datetime, RPCRequestStats | None]:
     # Initialise web3 connection when called for the first time.
     # We will recycle the same connection instance and it is kept open
     # until shutdown.
     per_chain_web3 = getattr(_timestamp_instance, "per_chain_web3", None)
     if per_chain_web3 is None:
-        per_chain_web3 = _timestamp_instance.per_chain_readers = {}
+        per_chain_web3 = _timestamp_instance.per_chain_web3 = {}
+
+    task_rpc_request_stats = RPCRequestStats() if collect_rpc_request_stats else None
 
     web3 = per_chain_web3.get(chain_id)
     if web3 is None:
-        web3 = per_chain_web3[chain_id] = web3factory()
+        if isinstance(web3factory, MultiProviderWeb3Factory):
+            # Include provider verification requests made on the worker's
+            # first process-local connection in this task's returned totals.
+            web3 = web3factory(rpc_request_stats=task_rpc_request_stats)
+        else:
+            web3 = web3factory()
+        per_chain_web3[chain_id] = web3
 
-    assert web3.eth.chain_id == chain_id, f"Web3 chain ID mismatch: {web3.eth.chain_id} != {chain_id}"
-    return block_number, get_block_timestamp(web3, block_number, raw=True)
+    set_rpc_request_stats = getattr(web3, "set_rpc_request_stats", None)
+    if callable(set_rpc_request_stats):
+        set_rpc_request_stats(task_rpc_request_stats)
+
+    try:
+        assert web3.eth.chain_id == chain_id, f"Web3 chain ID mismatch: {web3.eth.chain_id} != {chain_id}"
+        return block_number, get_block_timestamp(web3, block_number, raw=True), task_rpc_request_stats
+    finally:
+        if callable(set_rpc_request_stats):
+            set_rpc_request_stats(None)
 
 
 def fetch_block_timestamps_multiprocess(
@@ -53,6 +72,7 @@ def fetch_block_timestamps_multiprocess(
     timeout=120,
     cache_path: Path | None = DEFAULT_TIMESTAMP_CACHE_FOLDER,
     checkpoint_freq: int = 20_000,
+    rpc_request_stats: RPCRequestStats | None = None,
 ) -> BlockTimestampSlicer:
     """Extract timestamps using fast multiprocessing.
 
@@ -74,6 +94,9 @@ def fetch_block_timestamps_multiprocess(
         .
     :param checkpoint_freq:
         Block number frequency how often to save.
+
+    :param rpc_request_stats:
+        Optional parent accumulator receiving successful subprocess task calls.
     """
 
     assert start_block <= end_block, f"Start block {start_block} must be less than or equal to end block {end_block}"
@@ -113,7 +136,7 @@ def fetch_block_timestamps_multiprocess(
         first_block_to_check = max(start_block, timestamp_db.get_last_block())
         for _block_number in range(first_block_to_check, end_block + 1, step):
             if result.get(_block_number) is None:
-                yield web3factory, chain_id, _block_number
+                yield web3factory, chain_id, _block_number, rpc_request_stats is not None
 
     last_save = block_number = 0
 
@@ -139,7 +162,9 @@ def fetch_block_timestamps_multiprocess(
     # Because of asyncrhonoisty issues with new DuckDB cache, we need to buffer all tasks and reads in one go
     tasks = list(_task_gen())
     for completed_task in worker_processor(delayed(_read_timestamp_subprocess)(*args) for args in tasks):
-        block_number, timestamp = completed_task
+        block_number, timestamp, task_rpc_request_stats = completed_task
+        if rpc_request_stats is not None and task_rpc_request_stats is not None:
+            rpc_request_stats.merge(task_rpc_request_stats)
 
         index.append(block_number)
         values.append(timestamp)
@@ -183,6 +208,7 @@ def fetch_block_timestamps_multiprocess_auto_backend(
     cache_path: Path | None = DEFAULT_TIMESTAMP_CACHE_FOLDER,
     checkpoint_freq: int = 20_000,
     hypersync_client: "hypersync.HypersyncClient | None" = None,
+    rpc_request_stats: RPCRequestStats | None = None,
 ) -> BlockTimestampSlicer:
     """Fetch block timestamps, choose backend.
 
@@ -232,4 +258,5 @@ def fetch_block_timestamps_multiprocess_auto_backend(
             timeout=timeout,
             cache_path=cache_path,
             checkpoint_freq=checkpoint_freq,
+            rpc_request_stats=rpc_request_stats,
         )

--- a/eth_defi/provider/fallback.py
+++ b/eth_defi/provider/fallback.py
@@ -163,7 +163,7 @@ class FallbackProvider(BaseNamedProvider):
         #: Optional physical request accounting accumulator.
         self.rpc_request_stats = rpc_request_stats
 
-        #: Safe provider domains cached before any request attempts.
+        #: Provider domains cached before any request attempts.
         #:
         #: Custom Web3 providers are not required to expose ``endpoint_uri``.
         #: Keep them usable when accounting is disabled and attribute any later
@@ -226,7 +226,7 @@ class FallbackProvider(BaseNamedProvider):
         self.rpc_request_stats = stats
 
     def _get_rpc_provider_domain(self, provider: NamedProvider) -> str:
-        """Return the pre-sanitised domain for a concrete provider.
+        """Return the cached domain for a concrete provider.
 
         :param provider:
             Provider handling the physical request.
@@ -244,7 +244,7 @@ class FallbackProvider(BaseNamedProvider):
             self.rpc_request_stats.record_call(self._get_rpc_provider_domain(provider), method)
 
     def _record_rpc_error(self, provider: NamedProvider, error: BaseException | dict[str, Any]) -> None:
-        """Record one normalised physical request failure when enabled."""
+        """Record one physical request failure when enabled."""
 
         if self.rpc_request_stats is not None:
             error_code, error_message = normalise_rpc_error(error)

--- a/eth_defi/provider/fallback.py
+++ b/eth_defi/provider/fallback.py
@@ -18,6 +18,7 @@ from web3.types import RPCEndpoint, RPCResponse
 from eth_defi.event_reader.fast_json_rpc import get_last_headers
 from eth_defi.middleware import DEFAULT_RETRYABLE_EXCEPTIONS, DEFAULT_RETRYABLE_HTTP_STATUS_CODES, DEFAULT_RETRYABLE_RPC_ERROR_CODES, ProbablyNodeHasNoBlock, SomeCrappyRPCProviderException, is_retryable_http_exception
 from eth_defi.provider.named import BaseNamedProvider, NamedProvider, get_provider_name
+from eth_defi.provider.rpcdb import RPCRequestStats, normalise_rpc_error
 from eth_defi.utils import get_url_domain
 
 logger = logging.getLogger(__name__)
@@ -116,6 +117,7 @@ class FallbackProvider(BaseNamedProvider):
         retries: int = 6,
         state_missing_switch_over_delay: float = 12.0,
         switchover_noisiness=logging.WARNING,
+        rpc_request_stats: RPCRequestStats | None = None,
     ):
         """
         :param providers:
@@ -158,6 +160,23 @@ class FallbackProvider(BaseNamedProvider):
 
         self.providers = providers
 
+        #: Optional physical request accounting accumulator.
+        self.rpc_request_stats = rpc_request_stats
+
+        #: Safe provider domains cached before any request attempts.
+        #:
+        #: Custom Web3 providers are not required to expose ``endpoint_uri``.
+        #: Keep them usable when accounting is disabled and attribute any later
+        #: attached accounting to a stable, credential-free fallback label.
+        self.rpc_provider_domains: dict[int, str] = {}
+        for provider in providers:
+            endpoint_uri = getattr(provider, "endpoint_uri", None)
+            try:
+                provider_domain = get_url_domain(str(endpoint_uri)) if endpoint_uri else None
+            except (TypeError, ValueError):
+                provider_domain = None
+            self.rpc_provider_domains[id(provider)] = provider_domain or "unknown"
+
         # Use compatibility function instead of direct assertion
         for provider in providers:
             _check_provider_middlewares_compat(provider)
@@ -191,6 +210,45 @@ class FallbackProvider(BaseNamedProvider):
         #: response.  Used to verify that a provider switch did not land us on
         #: a different chain.
         self.expected_chain_id: int | None = None
+
+    def set_rpc_request_stats(self, stats: RPCRequestStats | None) -> None:
+        """Attach or detach a request accumulator on a cached provider.
+
+        Subprocess readers reuse one Web3 connection for several jobs. They
+        swap a fresh task-local accumulator in before each job and detach it in
+        ``finally`` so a later task cannot mutate an already-returned object.
+
+        :param stats:
+            Task or phase accumulator, or ``None`` to disable accounting.
+        """
+
+        assert stats is None or isinstance(stats, RPCRequestStats), f"Expected RPCRequestStats or None, got {type(stats)}"
+        self.rpc_request_stats = stats
+
+    def _get_rpc_provider_domain(self, provider: NamedProvider) -> str:
+        """Return the pre-sanitised domain for a concrete provider.
+
+        :param provider:
+            Provider handling the physical request.
+
+        :return:
+            Hostname with an optional non-default port.
+        """
+
+        return self.rpc_provider_domains[id(provider)]
+
+    def _record_rpc_call(self, provider: NamedProvider, method: str) -> None:
+        """Record one physical request when accounting is enabled."""
+
+        if self.rpc_request_stats is not None:
+            self.rpc_request_stats.record_call(self._get_rpc_provider_domain(provider), method)
+
+    def _record_rpc_error(self, provider: NamedProvider, error: BaseException | dict[str, Any]) -> None:
+        """Record one normalised physical request failure when enabled."""
+
+        if self.rpc_request_stats is not None:
+            error_code, error_message = normalise_rpc_error(error)
+            self.rpc_request_stats.record_error(self._get_rpc_provider_domain(provider), error_code, error_message)
 
     def __repr__(self):
         names = [get_provider_name(p) for p in self.providers]
@@ -287,12 +345,23 @@ class FallbackProvider(BaseNamedProvider):
         :raises Exception:
             If the RPC call fails or returns an empty result.
         """
-        resp = provider.make_request("eth_chainId", [])
-        result = resp.get("result")
-        if not result:
-            name = get_provider_name(provider)
-            raise ValueError(f"Provider {name} returned empty eth_chainId response: {resp}")
-        return int(result, 16)
+        self._record_rpc_call(provider, "eth_chainId")
+        error_recorded = False
+        try:
+            resp = provider.make_request("eth_chainId", [])
+            error_payload = resp.get("error")
+            if error_payload:
+                self._record_rpc_error(provider, error_payload)
+                error_recorded = True
+            result = resp.get("result")
+            if not result:
+                name = get_provider_name(provider)
+                raise ValueError(f"Provider {name} returned empty eth_chainId response: {resp}")
+            return int(result, 16)
+        except Exception as e:
+            if not error_recorded:
+                self._record_rpc_error(provider, e)
+            raise
 
     def switch_provider(self, log_level: int = None, randomise=False, cause: str = "<not specified>"):
         """Switch to next available provider.
@@ -486,6 +555,8 @@ class FallbackProvider(BaseNamedProvider):
         current_sleep = self.sleep
         for i in range(self.retries + 1):
             provider = self.get_active_provider()
+            self._record_rpc_call(provider, str(method))
+            error_recorded = False
             try:
                 # Call the underlying provider
                 resp_data = provider.make_request(method, params)
@@ -496,6 +567,10 @@ class FallbackProvider(BaseNamedProvider):
                 # we should replace this with a custom exception.
                 # Might be also related to EthereumTester only code paths.
                 error_json_payload = resp_data.get("error")
+
+                if error_json_payload:
+                    self._record_rpc_error(provider, error_json_payload)
+                    error_recorded = True
 
                 if _is_tac_provider_madness(error_json_payload):
                     raise SomeCrappyRPCProviderException(str(error_json_payload))
@@ -523,6 +598,8 @@ class FallbackProvider(BaseNamedProvider):
                 return resp_data
 
             except Exception as e:
+                if not error_recorded:
+                    self._record_rpc_error(provider, e)
                 # dRPC hack, as it is giving out it's custom error messages
                 if isinstance(e, HTTPError):
                     if e.response is not None and e.response.status_code == 400:

--- a/eth_defi/provider/multi_provider.py
+++ b/eth_defi/provider/multi_provider.py
@@ -21,6 +21,7 @@ from eth_defi.provider.broken_provider import set_block_tip_latency
 from eth_defi.provider.fallback import ChainIdMismatch, FallbackProvider
 from eth_defi.provider.mev_blocker import MEVBlockerProvider
 from eth_defi.provider.named import NamedProvider, get_provider_name
+from eth_defi.provider.rpcdb import RPCRequestStats, normalise_rpc_error
 from eth_defi.utils import get_url_domain
 
 logger = logging.getLogger(__name__)
@@ -100,6 +101,15 @@ class MultiProviderWeb3(Web3):
         """
         return self.get_fallback_provider().get_total_api_call_counts()
 
+    def set_rpc_request_stats(self, stats: RPCRequestStats | None) -> None:
+        """Attach request accounting to the fallback call provider.
+
+        :param stats:
+            Phase or subprocess-task accumulator, or ``None`` to detach it.
+        """
+
+        self.get_fallback_provider().set_rpc_request_stats(stats)
+
 
 def _apply_anvil_launch_metadata(provider: HTTPProvider) -> None:
     """Attach Anvil launch metadata to a provider when available.
@@ -136,6 +146,7 @@ def create_multi_provider_web3(
     add_signing_middleware: LocalAccount | None = None,
     skip_verification: bool = False,
     expected_chain_id: int | None = None,
+    rpc_request_stats: RPCRequestStats | None = None,
 ) -> MultiProviderWeb3:
     """Create a Web3 instance with multi-provider support.
 
@@ -322,6 +333,7 @@ def create_multi_provider_web3(
         backoff=fallback_backoff,
         switchover_noisiness=switchover_noisiness,
         retries=retries,
+        rpc_request_stats=rpc_request_stats,
     )
 
     # Verify all call providers report the same chain ID before proceeding.
@@ -346,8 +358,14 @@ def create_multi_provider_web3(
 
         # Verify transact provider is on the same chain as call providers
         if fallback_provider.expected_chain_id is not None:
+            transact_domain = get_url_domain(str(transact_provider.endpoint_uri))
+            if rpc_request_stats is not None:
+                rpc_request_stats.record_call(transact_domain, "eth_chainId")
             try:
                 resp = transact_provider.make_request("eth_chainId", [])
+                if rpc_request_stats is not None and resp.get("error"):
+                    error_code, error_message = normalise_rpc_error(resp["error"])
+                    rpc_request_stats.record_error(transact_domain, error_code, error_message)
                 result = resp.get("result")
                 if result:
                     transact_chain_id = int(result, 16)
@@ -357,6 +375,9 @@ def create_multi_provider_web3(
             except ChainIdMismatch:
                 raise
             except Exception as e:
+                if rpc_request_stats is not None:
+                    error_code, error_message = normalise_rpc_error(e)
+                    rpc_request_stats.record_error(transact_domain, error_code, error_message)
                 transact_name = get_provider_name(transact_provider)
                 raise ChainIdMismatch(f"Could not call eth_chainId on {transact_name} provider. Is it a valid JSON-RPC provider? As this is often the first call, you might be also out of API credits. Hint is {e}") from e
 
@@ -413,7 +434,7 @@ class MultiProviderWeb3Factory:
     - Allows creating web3 connections from a config line in multiprocessing worker pools
     """
 
-    def __init__(self, rpc_url: str, retries=6, hint: str | None = "", skip_verification: bool = False, expected_chain_id: int | None = None):
+    def __init__(self, rpc_url: str, retries=6, hint: str | None = "", skip_verification: bool = False, expected_chain_id: int | None = None, rpc_request_stats: RPCRequestStats | None = None):
         self.rpc_url = rpc_url
         self.retries = retries
         self.hint = hint
@@ -430,8 +451,10 @@ class MultiProviderWeb3Factory:
         #: :py:attr:`skip_verification` is set, preserving the runtime
         #: switchover chain-id safety check.
         self.expected_chain_id = expected_chain_id
+        #: Optional accumulator shared by parent-process worker threads.
+        self.rpc_request_stats = rpc_request_stats
 
-    def __call__(self, context: Optional[Any] = None) -> Web3:
+    def __call__(self, context: Optional[Any] = None, rpc_request_stats: RPCRequestStats | None = None) -> Web3:
         """CAlled by the subprocess.
 
         :param context:
@@ -443,4 +466,5 @@ class MultiProviderWeb3Factory:
             hint=self.hint,
             skip_verification=self.skip_verification,
             expected_chain_id=self.expected_chain_id,
+            rpc_request_stats=rpc_request_stats if rpc_request_stats is not None else self.rpc_request_stats,
         )

--- a/eth_defi/provider/rpcdb.py
+++ b/eth_defi/provider/rpcdb.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import datetime
 import os
-import re
 import threading
 from collections import Counter
 from dataclasses import dataclass, field
@@ -29,25 +28,14 @@ try:
 except ImportError:
     duckdb = None
 
-from eth_defi.utils import get_url_domain
-
 #: Default shared DuckDB path for JSON-RPC request accounting.
 DEFAULT_RPC_TRACKING_DATABASE = Path.home() / ".tradingstrategy" / "rpc-tracking.duckdb"
 
 #: Environment variable overriding :data:`DEFAULT_RPC_TRACKING_DATABASE`.
 RPC_TRACKING_DATABASE_PATH_ENV = "RPC_TRACKING_DATABASE_PATH"
 
-#: Maximum stored error-message length after sanitisation.
-MAX_RPC_ERROR_MESSAGE_LENGTH = 500
-
 #: Marker values used to preserve a completed zero-call scan iteration.
 ZERO_CALL_MARKER = "none"
-
-_URL_RE = re.compile(r"https?://[^\s'\"<>]+", re.IGNORECASE)
-_SECRET_RE = re.compile(r"(?i)\b(api[-_ ]?key|token|authorization|secret)\b\s*[:=]\s*[^\s,;}]+")
-_TRACE_RE = re.compile(r"(?i)\b(trace[-_ ]?id|request[-_ ]?id)\b\s*[:=]\s*['\"]?[^\s,'\";}]+")
-_HEX_DATA_RE = re.compile(r"\b0x[a-fA-F0-9]{64,}\b")
-_WHITESPACE_RE = re.compile(r"\s+")
 
 
 def resolve_rpc_tracking_database_path() -> Path:
@@ -65,43 +53,12 @@ def resolve_rpc_tracking_database_path() -> Path:
     return Path(path).expanduser() if path else DEFAULT_RPC_TRACKING_DATABASE
 
 
-def sanitise_rpc_error_message(message: str) -> str:
-    """Remove secrets and high-cardinality identifiers from an RPC error.
-
-    Endpoint URLs are reduced to their provider domain, common secret fields
-    and request identifiers are redacted, whitespace is collapsed, and the
-    stored value is capped to a stable maximum length.
-
-    :param message:
-        Raw exception or JSON-RPC response message. Request parameters should
-        not be included by callers.
-
-    :return:
-        Safe, compact message suitable for a DuckDB aggregation key.
-    """
-
-    def _replace_url(match: re.Match[str]) -> str:
-        raw_url = match.group(0).rstrip(".,);]}")
-        try:
-            domain = get_url_domain(raw_url)
-        except (TypeError, ValueError):
-            domain = None
-        return f"<rpc:{domain}>" if domain else "<rpc-url>"
-
-    clean = _URL_RE.sub(_replace_url, str(message))
-    clean = _SECRET_RE.sub(lambda match: f"{match.group(1)}=<redacted>", clean)
-    clean = _TRACE_RE.sub(lambda match: f"{match.group(1)}=<redacted>", clean)
-    clean = _HEX_DATA_RE.sub("<hex-data>", clean)
-    clean = _WHITESPACE_RE.sub(" ", clean).strip()
-    return clean[:MAX_RPC_ERROR_MESSAGE_LENGTH] or "unknown"
-
-
 def normalise_rpc_error(error: BaseException | dict[str, Any]) -> tuple[str, str]:
     """Convert heterogeneous provider failures to stable aggregation values.
 
     JSON-RPC response dictionaries use their numeric error code. HTTP failures
     use ``http_<status>``. Other Python failures use the concrete exception
-    class name. The returned message is always sanitised.
+    class name. The provider's original error message is retained.
 
     :param error:
         A JSON-RPC error dictionary or an exception raised by the provider.
@@ -118,7 +75,7 @@ def normalise_rpc_error(error: BaseException | dict[str, Any]) -> tuple[str, str
     if payload is not None:
         code = str(payload.get("code", "unknown"))
         message = str(payload.get("message", payload))
-        return code, sanitise_rpc_error_message(message)
+        return code, message
 
     if isinstance(error, HTTPError) and error.response is not None:
         code = f"http_{error.response.status_code}"
@@ -127,7 +84,7 @@ def normalise_rpc_error(error: BaseException | dict[str, Any]) -> tuple[str, str
     else:
         code = "unknown"
 
-    return code, sanitise_rpc_error_message(str(error))
+    return code, str(error)
 
 
 @dataclass(slots=True)
@@ -173,7 +130,7 @@ class RPCRequestStats:
         :param error_code:
             Stable JSON-RPC, HTTP, or exception-class error code.
         :param error_message:
-            Sanitised error message.
+            Provider error message.
         :param count:
             Positive number of matching failures to add.
         """
@@ -181,9 +138,8 @@ class RPCRequestStats:
         assert rpc_provider_domain, "RPC provider domain must not be empty"
         assert error_code, "RPC error code must not be empty"
         assert count > 0, f"Count must be positive: {count}"
-        safe_message = sanitise_rpc_error_message(error_message)
         with self._lock:
-            self.errors[rpc_provider_domain, str(error_code), safe_message] += count
+            self.errors[rpc_provider_domain, str(error_code), str(error_message)] += count
 
     def merge(self, other: RPCRequestStats) -> None:
         """Merge another worker or phase aggregate exactly once.

--- a/eth_defi/provider/rpcdb.py
+++ b/eth_defi/provider/rpcdb.py
@@ -88,15 +88,15 @@ class RPCRequestStats:
     ``calls`` is keyed by ``(rpc_provider_domain, api_call)`` and ``errors`` by
     ``(rpc_provider_domain, error_code, error_message)``. The lock is excluded
     from pickle state and recreated in subprocesses.
-
-    :param calls:
-        Initial provider-domain and method counts.
-    :param errors:
-        Initial provider-domain and error counts.
     """
 
+    #: Provider-domain and JSON-RPC method counts.
     calls: Counter[tuple[str, str]] = field(default_factory=Counter)
+
+    #: Provider-domain, error-code and error-message counts.
     errors: Counter[tuple[str, str, str]] = field(default_factory=Counter)
+
+    #: Synchronises counter updates between worker threads.
     _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False, compare=False)
 
     def record_call(self, rpc_provider_domain: str, api_call: str, count: int = 1) -> None:

--- a/eth_defi/provider/rpcdb.py
+++ b/eth_defi/provider/rpcdb.py
@@ -1,13 +1,7 @@
-"""Reusable JSON-RPC request accounting and DuckDB persistence.
+"""JSON-RPC request accounting and DuckDB persistence.
 
-The counters in this module sit below any particular scanner. A caller creates
-one :class:`RPCRequestStats` for a logical phase, passes it to Web3 providers,
-and persists the completed aggregate with :class:`RPCUsageDatabase`.
-
-The fixed DuckDB schema retains the historical ``vault_rpc_api_*`` table names,
-but ``phase`` and ``items_scanned`` are intentionally generic. For example, a
-block indexer may use ``phase="block_index"`` and define ``items_scanned`` as
-the number of indexed blocks without importing any vault package.
+A caller creates one :class:`RPCRequestStats` for a phase, passes it to Web3
+providers, and persists the aggregate with :class:`RPCUsageDatabase`.
 """
 
 from __future__ import annotations
@@ -34,7 +28,7 @@ DEFAULT_RPC_TRACKING_DATABASE = Path.home() / ".tradingstrategy" / "rpc-tracking
 #: Environment variable overriding :data:`DEFAULT_RPC_TRACKING_DATABASE`.
 RPC_TRACKING_DATABASE_PATH_ENV = "RPC_TRACKING_DATABASE_PATH"
 
-#: Marker values used to preserve a completed zero-call scan iteration.
+#: Marker value used to preserve a completed zero-call scan iteration.
 ZERO_CALL_MARKER = "none"
 
 
@@ -98,7 +92,7 @@ class RPCRequestStats:
     :param calls:
         Initial provider-domain and method counts.
     :param errors:
-        Initial provider-domain and normalised error counts.
+        Initial provider-domain and error counts.
     """
 
     calls: Counter[tuple[str, str]] = field(default_factory=Counter)
@@ -109,7 +103,7 @@ class RPCRequestStats:
         """Record physical JSON-RPC request attempts.
 
         :param rpc_provider_domain:
-            Safe provider hostname, optionally including a non-default port.
+            Provider hostname, optionally including a non-default port.
         :param api_call:
             JSON-RPC method name such as ``eth_call``.
         :param count:
@@ -123,10 +117,10 @@ class RPCRequestStats:
             self.calls[rpc_provider_domain, str(api_call)] += count
 
     def record_error(self, rpc_provider_domain: str, error_code: str, error_message: str, count: int = 1) -> None:
-        """Record normalised JSON-RPC request failures.
+        """Record JSON-RPC request failures.
 
         :param rpc_provider_domain:
-            Safe provider hostname, optionally including a non-default port.
+            Provider hostname, optionally including a non-default port.
         :param error_code:
             Stable JSON-RPC, HTTP, or exception-class error code.
         :param error_message:
@@ -405,7 +399,7 @@ class RPCUsageDatabase:
         )
 
     def fetch_cycle_errors(self, chain: int, cycle_started: datetime.date, cycle_number: int) -> list[tuple[str, str, str, str, int]]:
-        """Fetch current-cycle normalised error totals for one chain.
+        """Fetch current-cycle error totals for one chain.
 
         :return:
             Rows of ``(phase, provider_domain, error_code, error_message,

--- a/eth_defi/provider/rpcdb.py
+++ b/eth_defi/provider/rpcdb.py
@@ -1,0 +1,557 @@
+"""Reusable JSON-RPC request accounting and DuckDB persistence.
+
+The counters in this module sit below any particular scanner. A caller creates
+one :class:`RPCRequestStats` for a logical phase, passes it to Web3 providers,
+and persists the completed aggregate with :class:`RPCUsageDatabase`.
+
+The fixed DuckDB schema retains the historical ``vault_rpc_api_*`` table names,
+but ``phase`` and ``items_scanned`` are intentionally generic. For example, a
+block indexer may use ``phase="block_index"`` and define ``items_scanned`` as
+the number of indexed blocks without importing any vault package.
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+import re
+import threading
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Self
+
+from requests import HTTPError
+from tabulate import tabulate
+
+try:
+    import duckdb
+except ImportError:
+    duckdb = None
+
+from eth_defi.utils import get_url_domain
+
+#: Default shared DuckDB path for JSON-RPC request accounting.
+DEFAULT_RPC_TRACKING_DATABASE = Path.home() / ".tradingstrategy" / "rpc-tracking.duckdb"
+
+#: Environment variable overriding :data:`DEFAULT_RPC_TRACKING_DATABASE`.
+RPC_TRACKING_DATABASE_PATH_ENV = "RPC_TRACKING_DATABASE_PATH"
+
+#: Maximum stored error-message length after sanitisation.
+MAX_RPC_ERROR_MESSAGE_LENGTH = 500
+
+#: Marker values used to preserve a completed zero-call scan iteration.
+ZERO_CALL_MARKER = "none"
+
+_URL_RE = re.compile(r"https?://[^\s'\"<>]+", re.IGNORECASE)
+_SECRET_RE = re.compile(r"(?i)\b(api[-_ ]?key|token|authorization|secret)\b\s*[:=]\s*[^\s,;}]+")
+_TRACE_RE = re.compile(r"(?i)\b(trace[-_ ]?id|request[-_ ]?id)\b\s*[:=]\s*['\"]?[^\s,'\";}]+")
+_HEX_DATA_RE = re.compile(r"\b0x[a-fA-F0-9]{64,}\b")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def resolve_rpc_tracking_database_path() -> Path:
+    """Resolve the shared JSON-RPC tracking DuckDB path.
+
+    The resolver follows the same convention as other repository DuckDB
+    modules: a module-level default below ``~/.tradingstrategy`` and an
+    environment-variable override with user-home expansion.
+
+    :return:
+        Expanded path from ``RPC_TRACKING_DATABASE_PATH`` or the default path.
+    """
+
+    path = os.environ.get(RPC_TRACKING_DATABASE_PATH_ENV)
+    return Path(path).expanduser() if path else DEFAULT_RPC_TRACKING_DATABASE
+
+
+def sanitise_rpc_error_message(message: str) -> str:
+    """Remove secrets and high-cardinality identifiers from an RPC error.
+
+    Endpoint URLs are reduced to their provider domain, common secret fields
+    and request identifiers are redacted, whitespace is collapsed, and the
+    stored value is capped to a stable maximum length.
+
+    :param message:
+        Raw exception or JSON-RPC response message. Request parameters should
+        not be included by callers.
+
+    :return:
+        Safe, compact message suitable for a DuckDB aggregation key.
+    """
+
+    def _replace_url(match: re.Match[str]) -> str:
+        raw_url = match.group(0).rstrip(".,);]}")
+        try:
+            domain = get_url_domain(raw_url)
+        except (TypeError, ValueError):
+            domain = None
+        return f"<rpc:{domain}>" if domain else "<rpc-url>"
+
+    clean = _URL_RE.sub(_replace_url, str(message))
+    clean = _SECRET_RE.sub(lambda match: f"{match.group(1)}=<redacted>", clean)
+    clean = _TRACE_RE.sub(lambda match: f"{match.group(1)}=<redacted>", clean)
+    clean = _HEX_DATA_RE.sub("<hex-data>", clean)
+    clean = _WHITESPACE_RE.sub(" ", clean).strip()
+    return clean[:MAX_RPC_ERROR_MESSAGE_LENGTH] or "unknown"
+
+
+def normalise_rpc_error(error: BaseException | dict[str, Any]) -> tuple[str, str]:
+    """Convert heterogeneous provider failures to stable aggregation values.
+
+    JSON-RPC response dictionaries use their numeric error code. HTTP failures
+    use ``http_<status>``. Other Python failures use the concrete exception
+    class name. The returned message is always sanitised.
+
+    :param error:
+        A JSON-RPC error dictionary or an exception raised by the provider.
+
+    :return:
+        ``(error_code, error_message)`` suitable for
+        :meth:`RPCRequestStats.record_error`.
+    """
+
+    payload: dict[str, Any] | None = error if isinstance(error, dict) else None
+    if payload is None and isinstance(error, BaseException) and error.args and isinstance(error.args[0], dict):
+        payload = error.args[0]
+
+    if payload is not None:
+        code = str(payload.get("code", "unknown"))
+        message = str(payload.get("message", payload))
+        return code, sanitise_rpc_error_message(message)
+
+    if isinstance(error, HTTPError) and error.response is not None:
+        code = f"http_{error.response.status_code}"
+    elif isinstance(error, BaseException):
+        code = error.__class__.__name__
+    else:
+        code = "unknown"
+
+    return code, sanitise_rpc_error_message(str(error))
+
+
+@dataclass(slots=True)
+class RPCRequestStats:
+    """Thread-safe, pickle-safe physical JSON-RPC request counters.
+
+    ``calls`` is keyed by ``(rpc_provider_domain, api_call)`` and ``errors`` by
+    ``(rpc_provider_domain, error_code, error_message)``. The lock is excluded
+    from pickle state and recreated in subprocesses.
+
+    :param calls:
+        Initial provider-domain and method counts.
+    :param errors:
+        Initial provider-domain and normalised error counts.
+    """
+
+    calls: Counter[tuple[str, str]] = field(default_factory=Counter)
+    errors: Counter[tuple[str, str, str]] = field(default_factory=Counter)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False, compare=False)
+
+    def record_call(self, rpc_provider_domain: str, api_call: str, count: int = 1) -> None:
+        """Record physical JSON-RPC request attempts.
+
+        :param rpc_provider_domain:
+            Safe provider hostname, optionally including a non-default port.
+        :param api_call:
+            JSON-RPC method name such as ``eth_call``.
+        :param count:
+            Positive number of attempts to add.
+        """
+
+        assert rpc_provider_domain, "RPC provider domain must not be empty"
+        assert api_call, "JSON-RPC method must not be empty"
+        assert count > 0, f"Count must be positive: {count}"
+        with self._lock:
+            self.calls[rpc_provider_domain, str(api_call)] += count
+
+    def record_error(self, rpc_provider_domain: str, error_code: str, error_message: str, count: int = 1) -> None:
+        """Record normalised JSON-RPC request failures.
+
+        :param rpc_provider_domain:
+            Safe provider hostname, optionally including a non-default port.
+        :param error_code:
+            Stable JSON-RPC, HTTP, or exception-class error code.
+        :param error_message:
+            Sanitised error message.
+        :param count:
+            Positive number of matching failures to add.
+        """
+
+        assert rpc_provider_domain, "RPC provider domain must not be empty"
+        assert error_code, "RPC error code must not be empty"
+        assert count > 0, f"Count must be positive: {count}"
+        safe_message = sanitise_rpc_error_message(error_message)
+        with self._lock:
+            self.errors[rpc_provider_domain, str(error_code), safe_message] += count
+
+    def merge(self, other: RPCRequestStats) -> None:
+        """Merge another worker or phase aggregate exactly once.
+
+        :param other:
+            Detached task statistics to add to this accumulator.
+        """
+
+        assert isinstance(other, RPCRequestStats), f"Expected RPCRequestStats, got {type(other)}"
+        other_calls, other_errors = other.export()
+        with self._lock:
+            self.calls.update(other_calls)
+            self.errors.update(other_errors)
+
+    def export(self) -> tuple[Counter[tuple[str, str]], Counter[tuple[str, str, str]]]:
+        """Take a detached copy of both counter mappings.
+
+        :return:
+            Copied call and error counters safe to iterate without holding the
+            accumulator lock.
+        """
+
+        with self._lock:
+            return self.calls.copy(), self.errors.copy()
+
+    def __getstate__(self) -> tuple[dict[tuple[str, str], int], dict[tuple[str, str, str], int]]:
+        """Serialise counters without the non-pickleable thread lock."""
+
+        calls, errors = self.export()
+        return dict(calls), dict(errors)
+
+    def __setstate__(self, state: tuple[dict[tuple[str, str], int], dict[tuple[str, str, str], int]]) -> None:
+        """Restore counters and create a process-local thread lock."""
+
+        calls, errors = state
+        self.calls = Counter(calls)
+        self.errors = Counter(errors)
+        self._lock = threading.Lock()
+
+
+class RPCUsageDatabase:
+    """Append-only DuckDB storage for JSON-RPC scan accounting.
+
+    One connection belongs to one externally serialised writer. Callers sharing
+    a database across processes must hold their pipeline lock for the complete
+    connection lifetime.
+    """
+
+    def __init__(self, path: Path) -> None:
+        """Open the tracking database and initialise its fixed schema.
+
+        :param path:
+            DuckDB file path. Parent directories are created automatically.
+        """
+
+        assert isinstance(path, Path), f"Expected Path, got {type(path)}"
+        assert not path.is_dir(), f"Expected database file path, got directory: {path}"
+        if duckdb is None:
+            message = "Install eth-defi with the 'duckdb' extra to use RPCUsageDatabase"
+            raise ImportError(message)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self.path = path
+        self.connection: duckdb.DuckDBPyConnection | None = duckdb.connect(str(path))
+        self._create_schema()
+
+    def _create_schema(self) -> None:
+        """Create the fixed call and error aggregation tables."""
+
+        connection = self._require_connection()
+        connection.execute("""
+            CREATE TABLE IF NOT EXISTS vault_rpc_api_calls (
+                chain INTEGER NOT NULL,
+                phase VARCHAR NOT NULL,
+                api_call VARCHAR NOT NULL,
+                cycle_started DATE NOT NULL,
+                cycle_number INTEGER NOT NULL,
+                rpc_provider_domain VARCHAR NOT NULL,
+                call_count UBIGINT NOT NULL,
+                items_scanned INTEGER NOT NULL
+            )
+        """)
+        connection.execute("""
+            CREATE TABLE IF NOT EXISTS vault_rpc_api_errors (
+                chain INTEGER NOT NULL,
+                phase VARCHAR NOT NULL,
+                cycle_started DATE NOT NULL,
+                cycle_number INTEGER NOT NULL,
+                rpc_provider_domain VARCHAR NOT NULL,
+                error_code VARCHAR NOT NULL,
+                error_message VARCHAR NOT NULL,
+                error_count UBIGINT NOT NULL
+            )
+        """)
+
+    def _require_connection(self) -> duckdb.DuckDBPyConnection:
+        """Return the open connection or fail after explicit close.
+
+        :return:
+            Active DuckDB connection.
+        """
+
+        if self.connection is None:
+            raise RuntimeError(f"RPC usage database is closed: {self.path}")
+        return self.connection
+
+    def allocate_cycle(self) -> int:
+        """Allocate the next persistent cycle number.
+
+        Allocation uses both tables and must be called while the external
+        pipeline-writer lock is held. A crash before the first row is inserted
+        may reuse the unpersisted number on the next invocation.
+
+        :return:
+            Next positive cycle number.
+        """
+
+        row = (
+            self._require_connection()
+            .execute("""
+            SELECT coalesce(max(cycle_number), 0) + 1
+            FROM (
+                SELECT cycle_number FROM vault_rpc_api_calls
+                UNION ALL
+                SELECT cycle_number FROM vault_rpc_api_errors
+            )
+        """)
+            .fetchone()
+        )
+        return int(row[0])
+
+    def record_scan(  # noqa: PLR0917
+        self,
+        chain: int,
+        phase: str,
+        cycle_started: datetime.date,
+        cycle_number: int,
+        stats: RPCRequestStats,
+        items_scanned: int,
+    ) -> None:
+        """Append one completed scan-attempt aggregate atomically.
+
+        Call and error rows are committed in the same transaction. An empty
+        call aggregate writes a zero-count marker so the scan iteration and its
+        item count remain visible. Unknown item counts on early failures should
+        be passed as zero.
+
+        :param chain:
+            EVM chain id.
+        :param phase:
+            Caller-defined scan phase, for example ``lead_discovery``.
+        :param cycle_started:
+            Naive UTC calendar date on which the logical cycle started.
+        :param cycle_number:
+            Persistent cycle identifier shared by scanner retries.
+        :param stats:
+            Physical request and error counters for this attempt only.
+        :param items_scanned:
+            Non-negative number of logical items submitted during the attempt.
+        """
+
+        assert chain > 0, f"Invalid EVM chain id: {chain}"
+        assert phase, "Phase must not be empty"
+        assert isinstance(cycle_started, datetime.date), f"Expected date, got {type(cycle_started)}"
+        assert cycle_number > 0, f"Invalid cycle number: {cycle_number}"
+        assert isinstance(stats, RPCRequestStats), f"Expected RPCRequestStats, got {type(stats)}"
+        assert items_scanned >= 0, f"Items scanned must not be negative: {items_scanned}"
+
+        calls, errors = stats.export()
+        call_rows = [(chain, phase, api_call, cycle_started, cycle_number, provider_domain, count, items_scanned) for (provider_domain, api_call), count in sorted(calls.items())]
+        if not call_rows:
+            call_rows.append((chain, phase, ZERO_CALL_MARKER, cycle_started, cycle_number, ZERO_CALL_MARKER, 0, items_scanned))
+
+        error_rows = [(chain, phase, cycle_started, cycle_number, provider_domain, error_code, error_message, count) for (provider_domain, error_code, error_message), count in sorted(errors.items())]
+
+        connection = self._require_connection()
+        connection.execute("BEGIN TRANSACTION")
+        try:
+            connection.executemany(
+                "INSERT INTO vault_rpc_api_calls VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                call_rows,
+            )
+            if error_rows:
+                connection.executemany(
+                    "INSERT INTO vault_rpc_api_errors VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    error_rows,
+                )
+            connection.execute("COMMIT")
+        except duckdb.Error:
+            connection.execute("ROLLBACK")
+            raise
+
+    def fetch_cycle_calls(self, chain: int, cycle_started: datetime.date, cycle_number: int) -> list[tuple[str, str, str, int, int]]:
+        """Fetch current-cycle method rows for one chain.
+
+        :param chain:
+            EVM chain id.
+        :param cycle_started:
+            UTC cycle date.
+        :param cycle_number:
+            Persistent cycle number.
+
+        :return:
+            Rows of ``(phase, provider_domain, api_call, call_count,
+            items_scanned)`` aggregated across retry attempts.
+        """
+
+        return (
+            self._require_connection()
+            .execute(
+                """
+            SELECT phase, rpc_provider_domain, api_call,
+                   sum(call_count)::UBIGINT AS call_count,
+                   max(items_scanned)::INTEGER AS items_scanned
+            FROM vault_rpc_api_calls
+            WHERE chain = ? AND cycle_started = ? AND cycle_number = ?
+            GROUP BY phase, rpc_provider_domain, api_call
+            ORDER BY phase, rpc_provider_domain, api_call
+            """,
+                [chain, cycle_started, cycle_number],
+            )
+            .fetchall()
+        )
+
+    def fetch_daily_totals(self, chain: int, cycle_started: datetime.date) -> list[tuple[str, str, int, int]]:
+        """Fetch daily provider totals without multiplying retry item counts.
+
+        Each cycle contributes the sum of its method rows and the maximum item
+        count reported by any retry. Provider rows display provider-specific
+        calls with the cycle-level item denominator.
+
+        :return:
+            Rows of ``(phase, provider_domain, call_count, items_scanned)``.
+        """
+
+        return (
+            self._require_connection()
+            .execute(
+                """
+            WITH cycle_items AS (
+                SELECT phase, cycle_number, max(items_scanned) AS items_scanned
+                FROM vault_rpc_api_calls
+                WHERE chain = ? AND cycle_started = ?
+                GROUP BY phase, cycle_number
+            ), provider_cycles AS (
+                SELECT phase, cycle_number, rpc_provider_domain,
+                       sum(call_count) AS call_count
+                FROM vault_rpc_api_calls
+                WHERE chain = ? AND cycle_started = ?
+                GROUP BY phase, cycle_number, rpc_provider_domain
+            )
+            SELECT provider_cycles.phase,
+                   provider_cycles.rpc_provider_domain,
+                   sum(provider_cycles.call_count)::UBIGINT,
+                   sum(cycle_items.items_scanned)::UBIGINT
+            FROM provider_cycles
+            JOIN cycle_items USING (phase, cycle_number)
+            GROUP BY provider_cycles.phase, provider_cycles.rpc_provider_domain
+            ORDER BY provider_cycles.phase, provider_cycles.rpc_provider_domain
+            """,
+                [chain, cycle_started, chain, cycle_started],
+            )
+            .fetchall()
+        )
+
+    def fetch_cycle_errors(self, chain: int, cycle_started: datetime.date, cycle_number: int) -> list[tuple[str, str, str, str, int]]:
+        """Fetch current-cycle normalised error totals for one chain.
+
+        :return:
+            Rows of ``(phase, provider_domain, error_code, error_message,
+            error_count)``.
+        """
+
+        return (
+            self._require_connection()
+            .execute(
+                """
+            SELECT phase, rpc_provider_domain, error_code, error_message,
+                   sum(error_count)::UBIGINT
+            FROM vault_rpc_api_errors
+            WHERE chain = ? AND cycle_started = ? AND cycle_number = ?
+            GROUP BY phase, rpc_provider_domain, error_code, error_message
+            ORDER BY phase, rpc_provider_domain, error_code, error_message
+            """,
+                [chain, cycle_started, cycle_number],
+            )
+            .fetchall()
+        )
+
+    def close(self) -> None:
+        """Checkpoint and close the DuckDB connection explicitly."""
+
+        if self.connection is not None:
+            connection = self.connection
+            self.connection = None
+            try:
+                connection.execute("CHECKPOINT")
+            finally:
+                connection.close()
+
+    def __enter__(self) -> Self:
+        """Return this database for a managed connection lifetime."""
+
+        return self
+
+    def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: Any) -> None:
+        """Close the database when leaving a managed connection lifetime."""
+
+        self.close()
+
+
+def format_rpc_usage_report(database: RPCUsageDatabase, chain: int, cycle_started: datetime.date, cycle_number: int) -> str:
+    """Format current-cycle and daily JSON-RPC usage for one chain.
+
+    The formatter is output-system agnostic: scanners may print the returned
+    text, log it, or embed it in another report. Daily rows keep lead discovery
+    and price scanning separate through their ``phase`` column.
+
+    :param database:
+        Open tracking database.
+    :param chain:
+        EVM chain id to report.
+    :param cycle_started:
+        UTC date of the current logical cycle.
+    :param cycle_number:
+        Current persistent cycle number.
+
+    :return:
+        Multi-table plain-text report.
+    """
+
+    cycle_calls = database.fetch_cycle_calls(chain, cycle_started, cycle_number)
+    phase_totals_by_phase: dict[str, tuple[int, int]] = {}
+    for phase, _provider, _api_call, call_count, items_scanned in cycle_calls:
+        previous_calls, previous_items = phase_totals_by_phase.get(phase, (0, 0))
+        phase_totals_by_phase[phase] = previous_calls + call_count, max(previous_items, items_scanned)
+    phase_totals = [(phase, *totals) for phase, totals in phase_totals_by_phase.items()]
+    daily_totals = database.fetch_daily_totals(chain, cycle_started)
+    cycle_errors = database.fetch_cycle_errors(chain, cycle_started, cycle_number)
+
+    sections = [f"JSON-RPC usage for chain {chain}, cycle {cycle_number} ({cycle_started.isoformat()})"]
+    sections.append(
+        tabulate(
+            cycle_calls,
+            headers=("Phase", "Provider", "API call", "Calls", "Items scanned"),
+            tablefmt="simple",
+        )
+        if cycle_calls
+        else "No current-cycle JSON-RPC usage rows"
+    )
+    if phase_totals:
+        sections.extend(
+            (
+                "Current-cycle phase totals",
+                tabulate(phase_totals, headers=("Phase", "Calls", "Items scanned"), tablefmt="simple"),
+            )
+        )
+    if daily_totals:
+        sections.extend(
+            (
+                "UTC daily-to-date totals",
+                tabulate(daily_totals, headers=("Phase", "Provider", "Calls", "Items scanned"), tablefmt="simple"),
+            )
+        )
+    if cycle_errors:
+        sections.extend(
+            (
+                "Current-cycle RPC errors",
+                tabulate(cycle_errors, headers=("Phase", "Provider", "Code", "Message", "Errors"), tablefmt="simple"),
+            )
+        )
+    return "\n\n".join(sections)

--- a/eth_defi/vault/historical.py
+++ b/eth_defi/vault/historical.py
@@ -37,6 +37,7 @@ from eth_defi.event_reader.multicall_batcher import BatchCallState, EncodedCall,
 from eth_defi.event_reader.timestamp_cache import DEFAULT_TIMESTAMP_CACHE_FOLDER
 from eth_defi.event_reader.web3factory import Web3Factory
 from eth_defi.provider.broken_provider import get_almost_latest_block_number
+from eth_defi.provider.rpcdb import RPCRequestStats
 from eth_defi.token import TokenDetails, TokenDiskCache, fetch_erc20_details
 from eth_defi.utils import chunked
 from eth_defi.vault.base import VaultBase, VaultHistoricalRead, VaultHistoricalReader, VaultSpec, verify_parquet_file
@@ -106,6 +107,7 @@ class VaultHistoricalReadMulticaller:
         require_multicall_result=False,
         hypersync_client: "hypersync.HypersyncClient | None" = None,
         timestamp_cache_file: Path = DEFAULT_TIMESTAMP_CACHE_FOLDER,
+        rpc_request_stats: RPCRequestStats | None = None,
     ):
         """
         :param supported_quote_tokens:
@@ -121,6 +123,7 @@ class VaultHistoricalReadMulticaller:
         self.max_workers = max_workers
         self.hypersync_client = hypersync_client
         self.timestamp_cache_file = timestamp_cache_file
+        self.rpc_request_stats = rpc_request_stats
 
         if token_cache is None:
             token_cache = TokenDiskCache()
@@ -490,6 +493,7 @@ class VaultHistoricalReadMulticaller:
             require_multicall_result=self.require_multicall_result,
             hypersync_client=self.hypersync_client,
             timestamp_cache_file=self.timestamp_cache_file,
+            rpc_request_stats=self.rpc_request_stats,
         ):
             total_combined_results += 1
 
@@ -589,6 +593,7 @@ def scan_historical_prices_to_parquet(
     hypersync_client=None,
     timestamp_cache_file=DEFAULT_TIMESTAMP_CACHE_FOLDER,
     vault_addresses: set[str] | None = None,
+    rpc_request_stats: RPCRequestStats | None = None,
 ) -> ParquetScanResult:
     """Scan all historical vault share prices of vaults and save them in to Parquet file.
 
@@ -649,6 +654,9 @@ def scan_historical_prices_to_parquet(
 
         Addresses must be lowercase. When ``None``, all rows for the chain
         are deleted and rewritten (default behaviour).
+
+    :param rpc_request_stats:
+        Optional phase accumulator for physical JSON-RPC request accounting.
 
     :return:
         Scan report.
@@ -717,6 +725,7 @@ def scan_historical_prices_to_parquet(
         require_multicall_result=require_multicall_result,
         hypersync_client=hypersync_client,
         timestamp_cache_file=timestamp_cache_file,
+        rpc_request_stats=rpc_request_stats,
     )
 
     reader_func = read_multicall_historical_stateful if stateful else read_multicall_historical

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -30,6 +30,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
+import duckdb
 from atomicwrites import atomic_write
 from filelock import Timeout as FileLockTimeout
 
@@ -65,6 +66,7 @@ from eth_defi.lighter.session import create_lighter_session
 from eth_defi.lighter.vault_data_export import merge_into_vault_database as lighter_merge_vault_db
 from eth_defi.provider.broken_provider import verify_archive_node
 from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
+from eth_defi.provider.rpcdb import RPCRequestStats, RPCUsageDatabase, format_rpc_usage_report, resolve_rpc_tracking_database_path
 from eth_defi.token import TokenDiskCache
 from eth_defi.utils import setup_console_logging, wait_other_writers
 from eth_defi.vault.historical import scan_historical_prices_to_parquet
@@ -479,6 +481,7 @@ def scan_vaults_for_chain(
     max_workers: int,
     vault_db_path: Path = DEFAULT_VAULT_DATABASE,
     hypersync_concurrency: int | None = None,
+    rpc_request_stats: RPCRequestStats | None = None,
 ) -> tuple[bool, dict]:
     """Scan vaults for a single chain by calling scan_leads() directly.
 
@@ -488,7 +491,12 @@ def scan_vaults_for_chain(
     :param hypersync_concurrency: Hypersync stream concurrency limit
     :return: Tuple of (success, metrics_dict)
     """
+    stats = rpc_request_stats or RPCRequestStats()
+    chain_id = None
+    items_scanned = 0
     try:
+        web3 = create_multi_provider_web3(rpc_url, rpc_request_stats=stats)
+        chain_id = web3.eth.chain_id
         report = scan_leads(
             json_rpc_urls=rpc_url,
             vault_db_file=vault_db_path,
@@ -498,18 +506,28 @@ def scan_vaults_for_chain(
             printer=lambda msg: None,  # Suppress output to keep logs clean
             hypersync_concurrency=hypersync_concurrency,
             max_display_entries=100,
+            rpc_request_stats=stats,
+            web3=web3,
         )
+        items_scanned = report.items_scanned
 
         return True, {
+            "chain_id": chain_id,
             "start_block": report.start_block,
             "end_block": report.end_block,
             "vault_count": len(report.rows),
             "new_vaults": report.new_leads,
+            "items_scanned": items_scanned,
         }
 
     except Exception as e:
         logger.exception("Vault scan failed")
-        return False, {"error": str(e), "traceback": traceback.format_exc()}
+        return False, {
+            "chain_id": chain_id,
+            "items_scanned": items_scanned,
+            "error": str(e),
+            "traceback": traceback.format_exc(),
+        }
 
 
 def scan_prices_for_chain(
@@ -520,6 +538,7 @@ def scan_prices_for_chain(
     uncleaned_price_path: Path = DEFAULT_UNCLEANED_PRICE_DATABASE,
     reader_state_path: Path = DEFAULT_READER_STATE_DATABASE,
     hypersync_concurrency: int | None = None,
+    rpc_request_stats: RPCRequestStats | None = None,
 ) -> tuple[bool, dict]:
     """Scan historical prices for a single chain.
 
@@ -532,21 +551,27 @@ def scan_prices_for_chain(
     :param hypersync_concurrency: Hypersync stream concurrency limit
     :return: Tuple of (success, metrics_dict)
     """
+    stats = rpc_request_stats or RPCRequestStats()
+    metrics = {
+        "chain_id": None,
+        "items_scanned": 0,
+    }
     try:
         # Setup Web3 connection
-        web3 = create_multi_provider_web3(rpc_url)
+        web3 = create_multi_provider_web3(rpc_url, rpc_request_stats=stats)
         token_cache = TokenDiskCache()
         chain_id = web3.eth.chain_id
+        metrics["chain_id"] = chain_id
         # Subprocess price-reading workers rebuild Web3 from this factory; the
         # parent already verified the chain ID, so skip per-worker re-verification
         # to avoid storming the primary provider with eth_chainId probes (HTTP 429).
         # Seed the verified chain ID so worker switchover still rejects wrong-chain endpoints.
-        web3factory = MultiProviderWeb3Factory(rpc_url, retries=5, skip_verification=True, expected_chain_id=chain_id)
+        web3factory = MultiProviderWeb3Factory(rpc_url, retries=5, skip_verification=True, expected_chain_id=chain_id, rpc_request_stats=stats)
 
         # Load vault database
         if not vault_db_path.exists():
             logger.warning("Vault database does not exist, skipping price scan")
-            return True, {"rows_written": 0}
+            return True, {**metrics, "rows_written": 0}
 
         vault_db = pickle.load(vault_db_path.open("rb"))
 
@@ -560,7 +585,7 @@ def scan_prices_for_chain(
 
         if len(chain_vaults) == 0:
             logger.info("No vaults on chain %d, skipping price scan", chain_id)
-            return True, {"rows_written": 0}
+            return True, {**metrics, "rows_written": 0}
 
         # Create vault instances with filtering
         vaults = []
@@ -583,7 +608,9 @@ def scan_prices_for_chain(
 
         if len(vaults) == 0:
             logger.info("No vaults to scan on chain %d after filtering", chain_id)
-            return True, {"rows_written": 0}
+            return True, {**metrics, "rows_written": 0}
+
+        metrics["items_scanned"] = len(vaults)
 
         # Configure HyperSync (shares throttle with vault lead discovery)
         hypersync_config = configure_hypersync_from_env(web3, concurrency=hypersync_concurrency)
@@ -602,6 +629,7 @@ def scan_prices_for_chain(
             frequency=frequency,
             reader_states=reader_states,
             hypersync_client=hypersync_config.hypersync_client,
+            rpc_request_stats=stats,
         )
 
         # Save reader states atomically to avoid corruption on interruption
@@ -610,7 +638,7 @@ def scan_prices_for_chain(
                 pickle.dump(result["reader_states"], f)
 
         return True, {
-            "chain_id": chain_id,
+            **metrics,
             "rows_written": result["rows_written"],
             "start_block": result["start_block"],
             "end_block": result["end_block"],
@@ -618,7 +646,7 @@ def scan_prices_for_chain(
 
     except Exception as e:
         logger.exception("Price scan failed")
-        return False, {"error": str(e), "traceback": traceback.format_exc()}
+        return False, {**metrics, "error": str(e), "traceback": traceback.format_exc()}
 
 
 def scan_chain(
@@ -631,6 +659,9 @@ def scan_chain(
     uncleaned_price_path: Path = DEFAULT_UNCLEANED_PRICE_DATABASE,
     reader_state_path: Path = DEFAULT_READER_STATE_DATABASE,
     hypersync_concurrency: int | None = None,
+    rpc_usage_database: RPCUsageDatabase | None = None,
+    rpc_cycle_started: datetime.date | None = None,
+    rpc_cycle_number: int | None = None,
 ) -> ChainResult:
     """Scan a single chain (vaults and optionally prices).
 
@@ -646,6 +677,27 @@ def scan_chain(
     :return: Scan result
     """
     result = ChainResult(name=config.name, status="running", retry_attempt=retry_attempt)
+
+    def record_rpc_usage(phase: str, stats: RPCRequestStats, metrics: dict) -> None:
+        """Persist one phase attempt without turning observability into a retry."""
+
+        if rpc_usage_database is None or rpc_cycle_started is None or rpc_cycle_number is None:
+            return
+        chain_id = metrics.get("chain_id")
+        if chain_id is None:
+            logger.warning("Cannot attribute %s RPC usage for %s because chain id is unavailable", phase, config.name)
+            return
+        try:
+            rpc_usage_database.record_scan(
+                chain=chain_id,
+                phase=phase,
+                cycle_started=rpc_cycle_started,
+                cycle_number=rpc_cycle_number,
+                stats=stats,
+                items_scanned=int(metrics.get("items_scanned", 0)),
+            )
+        except (duckdb.Error, RuntimeError, AssertionError, TypeError, ValueError):
+            logger.exception("Could not persist %s RPC usage for %s", phase, config.name)
 
     # Check if RPC URL is configured
     rpc_url = os.environ.get(config.env_var)
@@ -676,8 +728,11 @@ def scan_chain(
 
     # Scan vaults
     if config.scan_vaults:
-        vault_success, vault_metrics = scan_vaults_for_chain(rpc_url, max_workers, vault_db_path=vault_db_path, hypersync_concurrency=hypersync_concurrency)
+        vault_stats = RPCRequestStats()
+        vault_success, vault_metrics = scan_vaults_for_chain(rpc_url, max_workers, vault_db_path=vault_db_path, hypersync_concurrency=hypersync_concurrency, rpc_request_stats=vault_stats)
+        record_rpc_usage("lead_discovery", vault_stats, vault_metrics)
         result.vault_scan_ok = vault_success
+        result.chain_id = vault_metrics.get("chain_id")
 
         if vault_success:
             result.start_block = vault_metrics.get("start_block")
@@ -690,6 +745,7 @@ def scan_chain(
 
     # Scan prices
     if scan_prices:
+        price_stats = RPCRequestStats()
         price_success, price_metrics = scan_prices_for_chain(
             rpc_url,
             max_workers,
@@ -698,11 +754,13 @@ def scan_chain(
             uncleaned_price_path=uncleaned_price_path,
             reader_state_path=reader_state_path,
             hypersync_concurrency=hypersync_concurrency,
+            rpc_request_stats=price_stats,
         )
+        record_rpc_usage("price_scan", price_stats, price_metrics)
         result.price_scan_ok = price_success
+        result.chain_id = price_metrics.get("chain_id") or result.chain_id
 
         if price_success:
-            result.chain_id = price_metrics.get("chain_id")
             result.price_rows = price_metrics.get("rows_written")
             # Update block range if not set by vault scan
             if result.start_block is None:
@@ -1733,6 +1791,7 @@ def run_scan_tick(
     scan_vault_settlements: bool = True,
     settlement_start_block: int | None = None,
     settlement_end_block: int | None = None,
+    rpc_tracking_database_path: Path | None = None,
 ) -> dict[str, ChainResult]:
     """Execute one scan tick: EVM chains + native protocols + post-processing.
 
@@ -1774,9 +1833,38 @@ def run_scan_tick(
 
     :param settlement_end_block:
         Optional inclusive forced end block for settlement backfills.
+
+    :param rpc_tracking_database_path:
+        Shared JSON-RPC accounting DuckDB path. Defaults to
+        :func:`eth_defi.provider.rpcdb.resolve_rpc_tracking_database_path`.
     """
     # Back up critical pipeline files before any scanning
-    backup_pipeline_files(backup_files=bkp_files, backup_dir=bkp_dir)
+    rpc_tracking_database_path = rpc_tracking_database_path or resolve_rpc_tracking_database_path()
+    backup_pipeline_files(backup_files=[*bkp_files, rpc_tracking_database_path], backup_dir=bkp_dir)
+
+    rpc_usage_database: RPCUsageDatabase | None = None
+    rpc_cycle_started = native_datetime_utc_now().date()
+    rpc_cycle_number: int | None = None
+    if chains:
+        try:
+            rpc_usage_database = RPCUsageDatabase(rpc_tracking_database_path)
+            rpc_cycle_number = rpc_usage_database.allocate_cycle()
+            logger.info("Tracking JSON-RPC usage in %s, cycle %d", rpc_tracking_database_path, rpc_cycle_number)
+        except (duckdb.Error, OSError):
+            logger.exception("Could not open JSON-RPC usage database %s; continuing without accounting", rpc_tracking_database_path)
+            rpc_usage_database = None
+
+    def display_rpc_report(result: ChainResult) -> None:
+        """Display accounting without failing an otherwise completed scan."""
+
+        if rpc_usage_database is None or rpc_cycle_number is None or result.chain_id is None:
+            return
+        try:
+            rpc_report = format_rpc_usage_report(rpc_usage_database, result.chain_id, rpc_cycle_started, rpc_cycle_number)
+            print(rpc_report)
+            logger.info("%s", rpc_report)
+        except (duckdb.Error, RuntimeError):
+            logger.exception("Could not display JSON-RPC usage for chain %s", result.chain_id)
 
     results: dict[str, ChainResult] = {}
     _ci = cycle_intervals or {}
@@ -1860,6 +1948,9 @@ def run_scan_tick(
                 uncleaned_price_path=uncleaned_price_path,
                 reader_state_path=reader_state_path,
                 hypersync_concurrency=hypersync_concurrency,
+                rpc_usage_database=rpc_usage_database,
+                rpc_cycle_started=rpc_cycle_started,
+                rpc_cycle_number=rpc_cycle_number,
             )
         except Exception as e:
             logger.exception("Chain %s crashed with unhandled exception", chain.name)
@@ -1892,6 +1983,7 @@ def run_scan_tick(
         elif r.status == "skipped":
             logger.warning("%s: SKIPPED - %s", chain.name, r.error)
             update_chain_settlement_result(chain, skip_reason=f"Skipped because {chain.name} scan was skipped")
+        display_rpc_report(r)
         print_dashboard(results, display_order, uncleaned_price_path=uncleaned_price_path)
 
     # Native protocol scans
@@ -2035,6 +2127,9 @@ def run_scan_tick(
                     uncleaned_price_path=uncleaned_price_path,
                     reader_state_path=reader_state_path,
                     hypersync_concurrency=hypersync_concurrency,
+                    rpc_usage_database=rpc_usage_database,
+                    rpc_cycle_started=rpc_cycle_started,
+                    rpc_cycle_number=rpc_cycle_number,
                 )
             except Exception as e:
                 logger.exception("Chain %s crashed with unhandled exception (retry %d)", chain.name, attempt)
@@ -2049,7 +2144,14 @@ def run_scan_tick(
             else:
                 logger.error("%s (retry %d): FAILED - %s", chain.name, attempt, result.error)
                 update_chain_settlement_result(chain, skip_reason=f"Skipped because {chain.name} retry failed")
+            display_rpc_report(result)
             print_dashboard(results, display_order, uncleaned_price_path=uncleaned_price_path)
+
+    if rpc_usage_database is not None:
+        try:
+            rpc_usage_database.close()
+        except duckdb.Error:
+            logger.exception("Could not close JSON-RPC usage database %s", rpc_tracking_database_path)
 
     # Post-processing
     if skip_post_processing:

--- a/poetry.lock
+++ b/poetry.lock
@@ -9201,10 +9201,9 @@ dev = ["hypothesis (>=6.70.0)", "pytest (>=7.1.0)"]
 name = "tabulate"
 version = "0.10.0"
 description = "Pretty-print tabular data"
-optional = true
+optional = false
 python-versions = ">=3.10"
 groups = ["main"]
-markers = "extra == \"data\""
 files = [
     {file = "tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3"},
     {file = "tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d"},
@@ -10186,4 +10185,4 @@ test = ["pytest-xdist"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "95180fa4f744d547fd7418e810c0adc8908dac2e243229ab36f16f7a7a15e05f"
+content-hash = "160fa81e03c56c38837efac406bafb1fd853a737f3c6a076ed68b8fb06898c71"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,8 @@ gspread = {version = "^6.2.1", optional = true}
 python-slugify = "^8.0.4"
 requests-ratelimiter = "^0.7.0"
 strictyaml = "^1.7.3"
+# Render JSON-RPC usage reports from the core provider accounting module
+tabulate = "^0.10.0"
 
 [tool.poetry.group.dev.dependencies]
 flaky = "^3.7.0"

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -35,6 +35,7 @@ LOG_LEVEL=info JSON_RPC_URL=$JSON_RPC_TEMPO poetry run python scripts/erc-4626/s
 | `HYPERSYNC_API_KEY` | Optional. Required when using `auto` scan backend. |
 | `HYPERSYNC_RPM` | Optional. Hypersync API requests-per-minute limit. Default: 150 (75% of the 200 RPM free-tier limit). Throttling is always on; set this to lower the limit after persistent 429 errors. |
 | `HYPERSYNC_CONCURRENCY` | Optional. Number of Hypersync requests in flight per stream — the main throughput knob. Default: server default (10). Increase for dense workloads, decrease for rate-limited plans. See [Envio StreamConfig tuning](https://docs.envio.dev/docs/HyperSync/stream-config-tuning). |
+| `RPC_TRACKING_DATABASE_PATH` | Optional. Shared JSON-RPC accounting DuckDB. Default: `~/.tradingstrategy/rpc-tracking.duckdb`. |
 
 #### Required protocol-specific lead migrations
 
@@ -180,6 +181,71 @@ poetry run python scripts/erc-4626/scan-vaults-all-chains.py
 | `SKIP_SAMPLES` | Optional. Skip Ethereum-only sample file export. Default: false. |
 | `HYPERSYNC_RPM` | Optional. Hypersync API requests-per-minute limit. Default: 150. Lower after persistent 429 errors. |
 | `HYPERSYNC_CONCURRENCY` | Optional. Hypersync stream concurrency. Default: 1 (sequential) in the all-chains scanner to avoid API pressure when scanning many chains. Set higher for faster throughput. See [Envio StreamConfig tuning](https://docs.envio.dev/docs/HyperSync/stream-config-tuning). |
+| `RPC_TRACKING_DATABASE_PATH` | Optional. Shared JSON-RPC accounting DuckDB used by all EVM vault scanners. Default: `~/.tradingstrategy/rpc-tracking.duckdb`. |
+
+#### JSON-RPC usage accounting
+
+The all-chain scanner, `scan-vaults.py`, and `scan-prices.py` store physical
+EVM JSON-RPC attempts in `~/.tradingstrategy/rpc-tracking.duckdb`. Override the
+path for an isolated run with `RPC_TRACKING_DATABASE_PATH`. The scanners hold
+the normal pipeline writer lock for the complete DuckDB connection lifetime,
+so standalone and daemon scans cannot write concurrently. A standalone command
+exits with an operator-readable error if another scanner still holds the lock
+after 60 seconds; stop the daemon or retry when its tick has finished.
+
+Calls are separated into `lead_discovery` and `price_scan` phases. For lead
+discovery, `items_scanned` is the number of unique candidate addresses sent to
+on-chain feature probing. For price scans it is the number of filtered,
+supported vault readers sent to the historical scan. A retry appends its calls
+to the same cycle; daily aggregation sums calls but takes the maximum item count
+for the cycle so the retried population is not multiplied.
+
+Each physical fallback-provider attempt is counted under its concrete provider
+hostname, including failed attempts and provider-switch `eth_chainId` checks.
+Stored hostnames omit schemes, credentials, URL paths, query strings, and API
+keys. A Multicall3 batch is one `eth_call`; its inner encoded contract calls are
+not counted separately. Transport retries hidden below
+`HTTPProvider.make_request()` cannot be observed. Failed or terminated
+subprocess tasks may also leave a lower-bound count because their in-memory
+counter cannot be returned to the parent.
+
+The separate `vault_rpc_api_errors` table stores a sanitised breakdown by chain,
+phase, cycle, provider domain, error code, and message. JSON-RPC codes use their
+decimal value, HTTP failures use values such as `http_429`, and transport
+failures use the exception class name. Request parameters, endpoint secrets,
+and request identifiers are excluded or redacted.
+
+Hypersync, archive-node preflight, native protocol APIs, settlement scanning,
+post-processing, Core3, currency-rate, and export traffic are excluded. A scan
+crossing midnight remains attributed to the UTC date on which its cycle began.
+After each EVM chain the scanner displays current-cycle method totals, daily
+phase/provider totals, and any current-cycle RPC errors.
+
+Daily calls and item counts can be queried without double-counting methods or
+retries:
+
+```sql
+WITH cycles AS (
+    SELECT
+        chain,
+        phase,
+        cycle_started,
+        cycle_number,
+        SUM(call_count) AS calls,
+        MAX(items_scanned) AS items_scanned
+    FROM vault_rpc_api_calls
+    WHERE cycle_started = CURRENT_DATE
+    GROUP BY chain, phase, cycle_started, cycle_number
+)
+SELECT
+    chain,
+    phase,
+    SUM(calls) AS calls,
+    SUM(items_scanned) AS items_scanned
+FROM cycles
+GROUP BY chain, phase
+ORDER BY chain, phase;
+```
 
 Tempo and Robinhood Chain are scanned when `JSON_RPC_TEMPO` and
 `JSON_RPC_ROBINHOOD` are configured. For a focused Tempo-only dry run:

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -202,9 +202,9 @@ for the cycle so the retried population is not multiplied.
 
 Each physical fallback-provider attempt is counted under its concrete provider
 hostname, including failed attempts and provider-switch `eth_chainId` checks.
-Stored hostnames omit schemes, credentials, URL paths, query strings, and API
-keys. A Multicall3 batch is one `eth_call`; its inner encoded contract calls are
-not counted separately. Transport retries hidden below
+Provider-domain values omit schemes, credentials, URL paths, query strings,
+and API keys. A Multicall3 batch is one `eth_call`; its inner encoded contract
+calls are not counted separately. Transport retries hidden below
 `HTTPProvider.make_request()` cannot be observed. Failed or terminated
 subprocess tasks may also leave a lower-bound count because their in-memory
 counter cannot be returned to the parent.

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -209,11 +209,14 @@ not counted separately. Transport retries hidden below
 subprocess tasks may also leave a lower-bound count because their in-memory
 counter cannot be returned to the parent.
 
-The separate `vault_rpc_api_errors` table stores a sanitised breakdown by chain,
-phase, cycle, provider domain, error code, and message. JSON-RPC codes use their
-decimal value, HTTP failures use values such as `http_429`, and transport
-failures use the exception class name. Request parameters, endpoint secrets,
-and request identifiers are excluded or redacted.
+The separate `vault_rpc_api_errors` table stores the provider error-message
+breakdown by chain, phase, cycle, provider domain, error code, and message.
+JSON-RPC codes use their decimal value, HTTP failures use values such as
+`http_429`, and transport failures use the exception class name. Error messages
+are stored as received from the provider. They may contain endpoint credentials
+or request-specific values, and distinct messages create distinct database
+rows. Treat the tracking database and scanner logs as sensitive operational
+data and monitor their size during sustained provider failures.
 
 Hypersync, archive-node preflight, native protocol APIs, settlement scanning,
 post-processing, Core3, currency-rate, and export traffic are excluded. A scan

--- a/scripts/erc-4626/scan-prices.py
+++ b/scripts/erc-4626/scan-prices.py
@@ -87,8 +87,11 @@ import sys
 from pathlib import Path
 from urllib.parse import urlparse
 
+import duckdb
 from atomicwrites import atomic_write
+from filelock import Timeout as FileLockTimeout
 
+from eth_defi.compat import native_datetime_utc_now
 from eth_defi.hypersync.utils import configure_hypersync_from_env
 from eth_defi.provider.named import get_provider_name
 
@@ -100,12 +103,13 @@ except ImportError as e:
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS, create_vault_instance
 from eth_defi.erc_4626.core import ERC4262VaultDetection, is_activity_filter_exempt
-from eth_defi.provider.multi_provider import create_multi_provider_web3, MultiProviderWeb3Factory
+from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
+from eth_defi.provider.rpcdb import RPCRequestStats, RPCUsageDatabase, format_rpc_usage_report, resolve_rpc_tracking_database_path
 from eth_defi.token import TokenDiskCache
-from eth_defi.utils import setup_console_logging
+from eth_defi.utils import setup_console_logging, wait_other_writers
 from eth_defi.vault.base import VaultSpec
-from eth_defi.vault.historical import scan_historical_prices_to_parquet, pformat_scan_result
-from eth_defi.vault.vaultdb import DEFAULT_VAULT_DATABASE, DEFAULT_UNCLEANED_PRICE_DATABASE, DEFAULT_READER_STATE_DATABASE
+from eth_defi.vault.historical import pformat_scan_result, scan_historical_prices_to_parquet
+from eth_defi.vault.vaultdb import DEFAULT_READER_STATE_DATABASE, DEFAULT_UNCLEANED_PRICE_DATABASE, DEFAULT_VAULT_DATABASE, get_pipeline_data_dir
 
 logger = logging.getLogger(__name__)
 
@@ -118,7 +122,9 @@ if JSON_RPC_URL is None:
         raise ValueError(f"Invalid JSON_RPC URL: {JSON_RPC_URL}") from e
 
 
-def main():
+def _run_scan(stats: RPCRequestStats, metrics: dict) -> None:
+    """Run historical price scanning while updating accounting metadata."""
+
     token_cache = TokenDiskCache()
 
     # How many CPUs / subprocess we use
@@ -126,8 +132,8 @@ def main():
     max_workers = int(max_workers)
     # max_workers = 1  # To debug, set workers to 1
 
-    web3 = create_multi_provider_web3(JSON_RPC_URL)
-    web3factory = MultiProviderWeb3Factory(JSON_RPC_URL, retries=5)
+    web3 = create_multi_provider_web3(JSON_RPC_URL, rpc_request_stats=stats)
+    web3factory = MultiProviderWeb3Factory(JSON_RPC_URL, retries=5, skip_verification=True, expected_chain_id=web3.eth.chain_id, rpc_request_stats=stats)
     name = get_chain_name(web3.eth.chain_id)
 
     default_log_level = os.environ.get("LOG_LEVEL", "info")
@@ -155,6 +161,7 @@ def main():
         end_block = int(end_block)
 
     chain_id = web3.eth.chain_id
+    metrics["chain_id"] = chain_id
 
     output_folder = os.environ.get("OUTPUT_FOLDER")
     if output_folder is None:
@@ -237,6 +244,7 @@ def main():
             pass
 
     print(f"After filtering vaults for non-interesting entries, we have {len(vaults):,} vaults left")
+    metrics["items_scanned"] = len(vaults)
 
     if vault_addresses is not None and reader_states:
         # Fresh scan for selected vaults - remove their saved state
@@ -276,6 +284,7 @@ def main():
             reader_states=reader_states,
             hypersync_client=hypersync_config.hypersync_client,
             vault_addresses=vault_addresses,
+            rpc_request_stats=stats,
         )
     finally:
         if pr:
@@ -303,9 +312,44 @@ def main():
     print("All ok")
 
 
+def main() -> None:
+    """Run price scanning under the shared pipeline and DuckDB writer lock."""
+
+    pipeline_lock_path = get_pipeline_data_dir() / "scan-pipeline"
+    database_path = resolve_rpc_tracking_database_path()
+    with wait_other_writers(pipeline_lock_path, timeout=60):
+        with RPCUsageDatabase(database_path) as database:
+            cycle_started = native_datetime_utc_now().date()
+            cycle_number = database.allocate_cycle()
+            stats = RPCRequestStats()
+            metrics = {"chain_id": None, "items_scanned": 0}
+            try:
+                _run_scan(stats, metrics)
+            finally:
+                chain_id = metrics["chain_id"]
+                if chain_id is not None:
+                    try:
+                        database.record_scan(
+                            chain=chain_id,
+                            phase="price_scan",
+                            cycle_started=cycle_started,
+                            cycle_number=cycle_number,
+                            stats=stats,
+                            items_scanned=metrics["items_scanned"],
+                        )
+                        report = format_rpc_usage_report(database, chain_id, cycle_started, cycle_number)
+                        print(report)
+                        logger.info("%s", report)
+                    except (duckdb.Error, RuntimeError, AssertionError, TypeError, ValueError):
+                        logger.exception("Could not persist price-scan RPC usage")
+
+
 if __name__ == "__main__":
     try:
         main()
+    except FileLockTimeout:
+        logger.error("Vault scan pipeline is locked by another scanner; stop it or retry after it finishes")
+        raise SystemExit(1) from None
     except Exception as e:
         logger.exception("Fatal error: %s", e, exc_info=e)
         raise e

--- a/scripts/erc-4626/scan-vaults.py
+++ b/scripts/erc-4626/scan-vaults.py
@@ -42,9 +42,15 @@ import os
 from pathlib import Path
 from urllib.parse import urlparse
 
+import duckdb
+from filelock import Timeout as FileLockTimeout
+
+from eth_defi.compat import native_datetime_utc_now
 from eth_defi.erc_4626.lead_scan_core import scan_leads
-from eth_defi.utils import setup_console_logging
-from eth_defi.vault.vaultdb import DEFAULT_VAULT_DATABASE
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.provider.rpcdb import RPCRequestStats, RPCUsageDatabase, format_rpc_usage_report, resolve_rpc_tracking_database_path
+from eth_defi.utils import setup_console_logging, wait_other_writers
+from eth_defi.vault.vaultdb import DEFAULT_VAULT_DATABASE, get_pipeline_data_dir
 
 try:
     import hypersync
@@ -67,7 +73,9 @@ if JSON_RPC_URL is None:
         raise ValueError(f"Invalid JSON_RPC URL: {JSON_RPC_URL}") from e
 
 
-def main():
+def _run_scan(stats: RPCRequestStats, metrics: dict) -> None:
+    """Run lead discovery while updating outer accounting metadata."""
+
     # How many CPUs / subprocess we use
     max_workers = int(os.environ.get("MAX_WORKERS", "16"))
     # max_workers = 1  # To debug, set workers to 1
@@ -98,7 +106,9 @@ def main():
         assert hypersync_api_key, f"HYPERSYNC_API_KEY must be set to use auto scan backend"
 
     try:
-        scan_leads(
+        web3 = create_multi_provider_web3(JSON_RPC_URL, rpc_request_stats=stats)
+        metrics["chain_id"] = web3.eth.chain_id
+        report = scan_leads(
             json_rpc_urls=JSON_RPC_URL,
             vault_db_file=vault_db_file,
             max_workers=max_workers,
@@ -108,7 +118,10 @@ def main():
             backend=scan_backend,
             max_getlogs_range=max_getlogs_range,
             hypersync_api_key=hypersync_api_key,
+            rpc_request_stats=stats,
+            web3=web3,
         )
+        metrics["items_scanned"] = report.items_scanned
 
         print("All ok")
     except Exception as e:
@@ -116,9 +129,44 @@ def main():
         raise
 
 
+def main() -> None:
+    """Run lead discovery under the shared pipeline and DuckDB writer lock."""
+
+    pipeline_lock_path = get_pipeline_data_dir() / "scan-pipeline"
+    database_path = resolve_rpc_tracking_database_path()
+    with wait_other_writers(pipeline_lock_path, timeout=60):
+        with RPCUsageDatabase(database_path) as database:
+            cycle_started = native_datetime_utc_now().date()
+            cycle_number = database.allocate_cycle()
+            stats = RPCRequestStats()
+            metrics = {"chain_id": None, "items_scanned": 0}
+            try:
+                _run_scan(stats, metrics)
+            finally:
+                chain_id = metrics["chain_id"]
+                if chain_id is not None:
+                    try:
+                        database.record_scan(
+                            chain=chain_id,
+                            phase="lead_discovery",
+                            cycle_started=cycle_started,
+                            cycle_number=cycle_number,
+                            stats=stats,
+                            items_scanned=metrics["items_scanned"],
+                        )
+                        report = format_rpc_usage_report(database, chain_id, cycle_started, cycle_number)
+                        print(report)
+                        logger.info("%s", report)
+                    except (duckdb.Error, RuntimeError, AssertionError, TypeError, ValueError):
+                        logger.exception("Could not persist lead-discovery RPC usage")
+
+
 if __name__ == "__main__":
     try:
         main()
+    except FileLockTimeout:
+        logger.error("Vault scan pipeline is locked by another scanner; stop it or retry after it finishes")
+        raise SystemExit(1) from None
     except Exception as e:
         logger.exception("Fatal error: %s", e, exc_info=e)
         raise e

--- a/tests/erc_4626/test_scan_rpc_usage.py
+++ b/tests/erc_4626/test_scan_rpc_usage.py
@@ -1,0 +1,74 @@
+"""Tests for vault metadata worker JSON-RPC accounting attachment."""
+
+import datetime
+import threading
+from typing import Any
+
+import pytest
+
+from eth_defi.erc_4626 import scan
+from eth_defi.erc_4626.core import ERC4262VaultDetection
+from eth_defi.provider.rpcdb import RPCRequestStats
+
+
+class FakeWeb3:
+    """Record accumulator swaps made by the cached worker helper."""
+
+    def __init__(self) -> None:
+        self.rpc_request_stats: RPCRequestStats | None = None
+        self.attachments: list[RPCRequestStats | None] = []
+
+    def set_rpc_request_stats(self, stats: RPCRequestStats | None) -> None:
+        """Attach or detach the current task accumulator."""
+
+        self.rpc_request_stats = stats
+        self.attachments.append(stats)
+
+
+class FakeFactory:
+    """Return one cached fake Web3 and expose the phase accumulator."""
+
+    def __init__(self, web3: FakeWeb3, stats: RPCRequestStats) -> None:
+        self.web3 = web3
+        self.rpc_request_stats = stats
+
+    def __call__(self, _context: Any | None = None) -> FakeWeb3:
+        """Return the worker connection."""
+
+        return self.web3
+
+
+def test_vault_metadata_worker_attaches_and_detaches_phase_stats(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A cached metadata worker cannot retain a completed phase accumulator."""
+
+    timestamp = datetime.datetime(2026, 7, 20, tzinfo=datetime.timezone.utc).replace(tzinfo=None)
+    detection = ERC4262VaultDetection(
+        chain=1,
+        address="0x0000000000000000000000000000000000000001",
+        first_seen_at_block=1,
+        first_seen_at=timestamp,
+        features=set(),
+        updated_at=timestamp,
+        deposit_count=0,
+        redeem_count=0,
+    )
+    stats = RPCRequestStats()
+    web3 = FakeWeb3()
+    factory = FakeFactory(web3, stats)
+    monkeypatch.setattr(scan, "_subprocess_web3_cache", threading.local())
+    monkeypatch.setattr(scan, "TokenDiskCache", object)
+
+    def create_record(worker_web3: FakeWeb3, worker_detection: ERC4262VaultDetection, block_number: int, token_cache: object) -> dict:
+        """Verify accounting remains attached for the actual metadata read."""
+
+        assert worker_web3.rpc_request_stats is stats
+        assert worker_detection is detection
+        assert token_cache is not None
+        return {"block_number": block_number}
+
+    monkeypatch.setattr(scan, "create_vault_scan_record", create_record)
+
+    result = scan.create_vault_scan_record_subprocess(factory, detection, 100)
+
+    assert result == {"block_number": 100}
+    assert web3.attachments == [stats, None]

--- a/tests/event_reader/test_multicall_batcher.py
+++ b/tests/event_reader/test_multicall_batcher.py
@@ -149,9 +149,7 @@ def test_chunked_multicall_counts_batch_once_without_double_merge(
     parent_stats = RPCRequestStats()
 
     class FakeFactory:
-        """Carry the shared accumulator expected by the thread path."""
-
-        rpc_request_stats = parent_stats
+        """Provide a worker factory without an attached accumulator."""
 
         def __call__(self) -> None:
             """Satisfy the worker factory protocol; the mocked executor does not call it."""
@@ -169,7 +167,8 @@ def test_chunked_multicall_counts_batch_once_without_double_merge(
     def execute_task(task: multicall_batcher.MulticallHistoricalTask) -> multicall_batcher.CombinedEncodedCallResult:
         """Model the one outbound Multicall3 request made by a task batch."""
 
-        task_stats = RPCRequestStats() if task.collect_rpc_request_stats else parent_stats
+        task_stats = RPCRequestStats() if task.collect_rpc_request_stats else task.rpc_request_stats
+        assert task_stats is not None
         task_stats.record_call("rpc.example", "eth_call")
         return multicall_batcher.CombinedEncodedCallResult(
             block_number=100,

--- a/tests/event_reader/test_multicall_batcher.py
+++ b/tests/event_reader/test_multicall_batcher.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from eth_defi.event_reader import multicall_batcher
-
+from eth_defi.provider.rpcdb import RPCRequestStats
 
 ParallelExecutor = Callable[[Iterable[object]], Iterator[object]]
 
@@ -33,6 +33,16 @@ def make_one_result_parallel(result: object) -> Callable[..., ParallelExecutor]:
         return execute
 
     return create_parallel
+
+
+def make_executing_parallel(*_args: object, **_kwargs: object) -> ParallelExecutor:
+    """Execute joblib delayed tuples synchronously for propagation tests."""
+
+    def execute(tasks: Iterable[object]) -> Iterator[object]:
+        for function, args, kwargs in tasks:
+            yield function(*args, **kwargs)
+
+    return execute
 
 
 def test_historical_multicall_without_hypersync_keeps_inline_timestamps(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -91,3 +101,101 @@ def test_historical_multicall_closes_hypersync_timestamps_on_interruption(monkey
     assert next(reader) is result
     reader.close()
     timestamps.close.assert_called_once_with()
+
+
+def test_historical_multicall_merges_worker_rpc_stats_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Merge a successful process task's physical calls into its phase."""
+
+    timestamp = datetime.datetime(2026, 1, 1)
+    worker_stats = RPCRequestStats()
+    worker_stats.record_call("rpc.example", "eth_call", 2)
+    worker_stats.record_error("rpc.example", "http_429", "rate limited")
+    completed = multicall_batcher.CombinedEncodedCallResult(
+        block_number=100,
+        timestamp=timestamp,
+        results=[],
+        rpc_request_stats=worker_stats,
+    )
+    parent_stats = RPCRequestStats()
+
+    monkeypatch.setattr(multicall_batcher, "Parallel", make_one_result_parallel(completed))
+
+    results = list(
+        multicall_batcher.read_multicall_historical(
+            chain_id=1,
+            web3factory=lambda: None,
+            calls=[],
+            start_block=100,
+            end_block=101,
+            step=1,
+            display_progress=False,
+            rpc_request_stats=parent_stats,
+        )
+    )
+
+    calls, errors = parent_stats.export()
+    assert results == [completed]
+    assert calls == {("rpc.example", "eth_call"): 2}
+    assert errors == {("rpc.example", "http_429", "rate limited"): 1}
+
+
+@pytest.mark.parametrize("backend", ["loky", "threading"])
+def test_chunked_multicall_counts_batch_once_without_double_merge(
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+) -> None:
+    """Five encoded inner calls spend one physical call on either backend."""
+
+    parent_stats = RPCRequestStats()
+
+    class FakeFactory:
+        """Carry the shared accumulator expected by the thread path."""
+
+        rpc_request_stats = parent_stats
+
+        def __call__(self) -> None:
+            """Satisfy the worker factory protocol; the mocked executor does not call it."""
+
+    calls = [
+        multicall_batcher.EncodedCall(
+            func_name="probe",
+            address="0x0000000000000000000000000000000000000001",
+            data=bytes([index]),
+            extra_data=None,
+        )
+        for index in range(5)
+    ]
+
+    def execute_task(task: multicall_batcher.MulticallHistoricalTask) -> multicall_batcher.CombinedEncodedCallResult:
+        """Model the one outbound Multicall3 request made by a task batch."""
+
+        task_stats = RPCRequestStats() if task.collect_rpc_request_stats else parent_stats
+        task_stats.record_call("rpc.example", "eth_call")
+        return multicall_batcher.CombinedEncodedCallResult(
+            block_number=100,
+            timestamp=task.timestamp,
+            results=[],
+            rpc_request_stats=task_stats if task.collect_rpc_request_stats else None,
+        )
+
+    monkeypatch.setattr(multicall_batcher, "Parallel", make_executing_parallel)
+    monkeypatch.setattr(multicall_batcher, "_execute_multicall_subprocess", execute_task)
+
+    results = list(
+        multicall_batcher.read_multicall_chunked(
+            chain_id=1,
+            web3factory=FakeFactory(),
+            calls=calls,
+            block_identifier=100,
+            max_workers=2,
+            chunk_size=5,
+            timestamped_results=False,
+            backend=backend,
+            rpc_request_stats=parent_stats,
+        )
+    )
+
+    physical_calls, errors = parent_stats.export()
+    assert results == []
+    assert physical_calls == {("rpc.example", "eth_call"): 1}
+    assert errors == {}

--- a/tests/event_reader/test_multicall_timestamp_rpc_usage.py
+++ b/tests/event_reader/test_multicall_timestamp_rpc_usage.py
@@ -1,0 +1,145 @@
+"""Offline JSON-RPC accounting tests for block timestamp readers."""
+
+import datetime
+import threading
+from pathlib import Path
+
+import pytest
+from web3 import HTTPProvider
+
+from eth_defi.event_reader import multicall_timestamp
+from eth_defi.provider.anvil import launch_anvil
+from eth_defi.provider.multi_provider import MultiProviderWeb3Factory
+from eth_defi.provider.rpcdb import RPCRequestStats
+from eth_defi.utils import get_url_domain
+
+
+class CountingEth:
+    """Minimal Web3 ``eth`` facade that records its chain-id read."""
+
+    def __init__(self, web3: "CountingWeb3") -> None:
+        self.web3 = web3
+
+    @property
+    def chain_id(self) -> int:
+        """Return the test chain and count the physical request."""
+
+        self.web3.rpc_request_stats.record_call("rpc.example", "eth_chainId")
+        return 1
+
+
+class CountingWeb3:
+    """Minimal cached worker Web3 supporting accumulator attachment."""
+
+    def __init__(self) -> None:
+        self.rpc_request_stats: RPCRequestStats | None = None
+        self.eth = CountingEth(self)
+
+    def set_rpc_request_stats(self, stats: RPCRequestStats | None) -> None:
+        """Attach the current subprocess task's accumulator."""
+
+        self.rpc_request_stats = stats
+
+
+def test_timestamp_worker_returns_and_detaches_rpc_stats(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A successful timestamp task returns calls and detaches cached Web3."""
+
+    tested_block = 100
+    expected_timestamp = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc).replace(tzinfo=None)
+    web3 = CountingWeb3()
+    monkeypatch.setattr(multicall_timestamp, "_timestamp_instance", threading.local())
+
+    def fetch_timestamp(counting_web3: CountingWeb3, _block_number: int, raw: object) -> datetime.datetime:
+        """Stand in for the physical block request."""
+
+        assert raw is True
+        counting_web3.rpc_request_stats.record_call("rpc.example", "eth_getBlockByNumber")
+        return expected_timestamp
+
+    monkeypatch.setattr(multicall_timestamp, "get_block_timestamp", fetch_timestamp)
+
+    block_number, timestamp, stats = multicall_timestamp._read_timestamp_subprocess(
+        web3factory=lambda: web3,
+        chain_id=1,
+        block_number=tested_block,
+        collect_rpc_request_stats=True,
+    )
+
+    calls, errors = stats.export()
+    assert block_number == tested_block
+    assert timestamp == expected_timestamp
+    assert calls == {
+        ("rpc.example", "eth_chainId"): 1,
+        ("rpc.example", "eth_getBlockByNumber"): 1,
+    }
+    assert errors == {}
+    assert web3.rpc_request_stats is None
+
+
+def test_hypersync_timestamp_path_does_not_receive_rpc_stats(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The HyperSync timestamp backend stays outside JSON-RPC accounting."""
+
+    expected = object()
+
+    def fetch_hypersync_timestamps(**kwargs: object) -> object:
+        """Verify the optimised backend receives no RPC accumulator."""
+
+        assert "rpc_request_stats" not in kwargs
+        return expected
+
+    monkeypatch.setattr(
+        "eth_defi.hypersync.hypersync_timestamp.fetch_block_timestamps_using_hypersync_cached",
+        fetch_hypersync_timestamps,
+    )
+
+    result = multicall_timestamp.fetch_block_timestamps_multiprocess_auto_backend(
+        chain_id=1,
+        web3factory=lambda: None,
+        start_block=100,
+        end_block=101,
+        step=1,
+        display_progress=False,
+        hypersync_client=object(),
+        rpc_request_stats=RPCRequestStats(),
+    )
+
+    assert result is expected
+
+
+def test_timestamp_loky_tasks_merge_exact_physical_calls(tmp_path: Path) -> None:
+    """Several real process tasks return one block call each to the parent."""
+
+    expected_block_calls = 3
+    anvil = launch_anvil()
+    timestamps = None
+    try:
+        HTTPProvider(anvil.json_rpc_url).make_request("anvil_mine", ["0x3"])
+        provider_domain = get_url_domain(anvil.json_rpc_url)
+        stats = RPCRequestStats()
+        web3factory = MultiProviderWeb3Factory(
+            anvil.json_rpc_url,
+            retries=0,
+            skip_verification=True,
+            expected_chain_id=31337,
+            rpc_request_stats=stats,
+        )
+
+        timestamps = multicall_timestamp.fetch_block_timestamps_multiprocess(
+            chain_id=31337,
+            web3factory=web3factory,
+            start_block=0,
+            end_block=2,
+            step=1,
+            display_progress=False,
+            max_workers=2,
+            cache_path=tmp_path,
+            rpc_request_stats=stats,
+        )
+
+        calls, errors = stats.export()
+        assert calls[provider_domain, "eth_getBlockByNumber"] == expected_block_calls
+        assert errors == {}
+    finally:
+        if timestamps is not None:
+            timestamps.close()
+        anvil.close()

--- a/tests/provider/test_rpcdb.py
+++ b/tests/provider/test_rpcdb.py
@@ -1,4 +1,4 @@
-"""Tests for reusable JSON-RPC request accounting."""
+"""Tests for JSON-RPC request accounting."""
 
 import datetime
 import pickle

--- a/tests/provider/test_rpcdb.py
+++ b/tests/provider/test_rpcdb.py
@@ -1,0 +1,241 @@
+"""Tests for reusable JSON-RPC request accounting."""
+
+import datetime
+import pickle
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import duckdb
+import pytest
+import requests
+from web3 import HTTPProvider, Web3
+
+from eth_defi.provider.fallback import FallbackProvider
+from eth_defi.provider.rpcdb import (
+    RPCRequestStats,
+    RPCUsageDatabase,
+    format_rpc_usage_report,
+    normalise_rpc_error,
+    resolve_rpc_tracking_database_path,
+    sanitise_rpc_error_message,
+)
+
+
+@pytest.fixture()
+def rpc_usage_database(tmp_path: Path):
+    """Create a tracking database that is always explicitly closed."""
+
+    database = RPCUsageDatabase(tmp_path / "rpc-tracking.duckdb")
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+def test_rpc_request_stats_threaded_and_pickle_safe() -> None:
+    """Thread workers share counters and subprocess transport recreates them."""
+
+    stats = RPCRequestStats()
+
+    def record_batch(_: int) -> None:
+        """Record one deterministic worker batch."""
+
+        stats.record_call("rpc.example.com", "eth_call", 10)
+        stats.record_error("rpc.example.com", "http_429", "rate limited")
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(record_batch, range(100)))
+
+    restored = pickle.loads(pickle.dumps(stats))
+    calls, errors = restored.export()
+    assert calls == {("rpc.example.com", "eth_call"): 1_000}
+    assert errors == {("rpc.example.com", "http_429", "rate limited"): 100}
+
+    restored.record_call("rpc.example.com", "eth_blockNumber")
+    calls, _ = restored.export()
+    assert calls[("rpc.example.com", "eth_blockNumber")] == 1
+
+
+def test_rpc_error_normalisation_and_sanitisation() -> None:
+    """Stored errors retain diagnostics without endpoint secrets."""
+
+    code, message = normalise_rpc_error({"code": -32005, "message": "limit trace_id=abc123"})
+    assert code == "-32005"
+    assert "abc123" not in message
+
+    response = requests.Response()
+    response.status_code = 429
+    http_error = requests.HTTPError("429 from https://user:pass@rpc.example.com/private/api-key?token=secret", response=response)
+    code, message = normalise_rpc_error(http_error)
+    assert code == "http_429"
+    assert "user" not in message
+    assert "pass" not in message
+    assert "private" not in message
+    assert "secret" not in message
+    assert "rpc.example.com" in message
+
+    assert sanitise_rpc_error_message("API_KEY=top-secret") == "API_KEY=<redacted>"
+    assert sanitise_rpc_error_message(f"execution reverted: 0x{'ab' * 64}") == "execution reverted: <hex-data>"
+
+
+def test_rpc_tracking_database_path_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The shared resolver expands a configured home-relative path."""
+
+    monkeypatch.setenv("RPC_TRACKING_DATABASE_PATH", "~/custom-rpc.duckdb")
+    assert resolve_rpc_tracking_database_path() == Path.home() / "custom-rpc.duckdb"
+
+
+def test_fallback_provider_accepts_endpointless_custom_provider() -> None:
+    """Accounting support does not tighten the base provider interface."""
+
+    provider = HTTPProvider("https://rpc.example", exception_retry_configuration=None)
+    del provider.endpoint_uri
+
+    fallback = FallbackProvider([provider])
+
+    assert fallback.rpc_provider_domains[id(provider)] == "unknown"
+
+
+def test_fallback_provider_tracks_physical_attempt_domains(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A recovered fallback records failed and successful physical attempts."""
+
+    primary = HTTPProvider("https://primary.example/private-key", exception_retry_configuration=None)
+    fallback = HTTPProvider("https://fallback.example/another-key", exception_retry_configuration=None)
+
+    def primary_request(method: str, params: list) -> dict:
+        """Fail the requested method but support switchover verification."""
+
+        if method == "eth_chainId":
+            return {"jsonrpc": "2.0", "id": 1, "result": "0x1"}
+        raise requests.ConnectionError("primary unavailable")
+
+    def fallback_request(method: str, params: list) -> dict:
+        """Return deterministic chain and block responses."""
+
+        result = "0x1" if method == "eth_chainId" else "0x10"
+        return {"jsonrpc": "2.0", "id": 1, "result": result}
+
+    monkeypatch.setattr(primary, "make_request", primary_request)
+    monkeypatch.setattr(fallback, "make_request", fallback_request)
+
+    stats = RPCRequestStats()
+    provider = FallbackProvider([primary, fallback], retries=1, sleep=0, rpc_request_stats=stats)
+    web3 = Web3(provider)
+
+    assert web3.eth.block_number == 16
+    calls, errors = stats.export()
+    assert calls[("primary.example", "eth_blockNumber")] == 1
+    assert calls[("primary.example", "eth_chainId")] == 1
+    assert calls[("fallback.example", "eth_chainId")] == 1
+    assert calls[("fallback.example", "eth_blockNumber")] == 1
+    assert errors[("primary.example", "ConnectionError", "primary unavailable")] == 1
+    assert provider.api_call_counts[1]["eth_blockNumber"] == 1
+
+
+def test_fallback_provider_records_json_rpc_error_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A JSON-RPC error keeps its protocol code without duplicate recording."""
+
+    upstream = HTTPProvider("https://rpc.example/private-key", exception_retry_configuration=None)
+    monkeypatch.setattr(
+        upstream,
+        "make_request",
+        lambda method, params: {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {"code": -32005, "message": "rate limited request_id=secret"},
+        },
+    )
+    stats = RPCRequestStats()
+    provider = FallbackProvider([upstream], retries=0, sleep=0, rpc_request_stats=stats)
+
+    with pytest.raises(ValueError):
+        provider.make_request("eth_call", [])
+
+    calls, errors = stats.export()
+    assert calls == {("rpc.example", "eth_call"): 1}
+    assert errors == {("rpc.example", "-32005", "rate limited request_id=<redacted>"): 1}
+
+
+def test_rpc_usage_database_append_only_aggregates(rpc_usage_database: RPCUsageDatabase) -> None:
+    """Retries append while cycle and daily queries avoid item multiplication."""
+
+    cycle_started = datetime.date(2026, 7, 20)
+    assert rpc_usage_database.allocate_cycle() == 1
+
+    first_attempt = RPCRequestStats()
+    first_attempt.record_call("primary.example", "eth_call", 2)
+    first_attempt.record_call("fallback.example", "eth_getBlockByNumber")
+    first_attempt.record_error("fallback.example", "http_429", "rate limited")
+    rpc_usage_database.record_scan(1, "lead_discovery", cycle_started, 1, first_attempt, 10)
+
+    retry_attempt = RPCRequestStats()
+    retry_attempt.record_call("primary.example", "eth_call")
+    rpc_usage_database.record_scan(1, "lead_discovery", cycle_started, 1, retry_attempt, 8)
+
+    price_attempt = RPCRequestStats()
+    price_attempt.record_call("primary.example", "eth_call", 4)
+    rpc_usage_database.record_scan(1, "price_scan", cycle_started, 2, price_attempt, 3)
+
+    assert rpc_usage_database.allocate_cycle() == 3
+    assert rpc_usage_database.fetch_cycle_calls(1, cycle_started, 1) == [
+        ("lead_discovery", "fallback.example", "eth_getBlockByNumber", 1, 10),
+        ("lead_discovery", "primary.example", "eth_call", 3, 10),
+    ]
+    assert rpc_usage_database.fetch_daily_totals(1, cycle_started) == [
+        ("lead_discovery", "fallback.example", 1, 10),
+        ("lead_discovery", "primary.example", 3, 10),
+        ("price_scan", "primary.example", 4, 3),
+    ]
+    assert rpc_usage_database.fetch_cycle_errors(1, cycle_started, 1) == [
+        ("lead_discovery", "fallback.example", "http_429", "rate limited", 1),
+    ]
+
+    report = format_rpc_usage_report(rpc_usage_database, 1, cycle_started, 1)
+    assert "lead_discovery" in report
+    assert "fallback.example" in report
+    assert "UTC daily-to-date totals" in report
+
+
+def test_rpc_usage_database_zero_call_marker(rpc_usage_database: RPCUsageDatabase) -> None:
+    """A completed zero-call phase remains visible with its item count."""
+
+    cycle_started = datetime.date(2026, 7, 20)
+    rpc_usage_database.record_scan(8453, "price_scan", cycle_started, 1, RPCRequestStats(), 0)
+
+    assert rpc_usage_database.fetch_cycle_calls(8453, cycle_started, 1) == [
+        ("price_scan", "none", "none", 0, 0),
+    ]
+    report = format_rpc_usage_report(rpc_usage_database, 8453, cycle_started, 1)
+    assert "price_scan" in report
+
+
+def test_rpc_usage_database_rolls_back_both_tables(rpc_usage_database: RPCUsageDatabase) -> None:
+    """An error-row failure rolls back call rows from the same attempt."""
+
+    cycle_started = datetime.date(2026, 7, 20)
+    stats = RPCRequestStats()
+    stats.record_call("rpc.example", "eth_call")
+    stats.record_error("rpc.example", "http_429", "rate limited")
+    rpc_usage_database.connection.execute("DROP TABLE vault_rpc_api_errors")
+
+    with pytest.raises(duckdb.Error):
+        rpc_usage_database.record_scan(1, "price_scan", cycle_started, 1, stats, 1)
+
+    rpc_usage_database._create_schema()
+    assert rpc_usage_database.fetch_cycle_calls(1, cycle_started, 1) == []
+    assert rpc_usage_database.fetch_cycle_errors(1, cycle_started, 1) == []
+
+
+def test_rpc_usage_database_cycle_survives_restart(rpc_usage_database: RPCUsageDatabase) -> None:
+    """Cycle allocation is persistent and closed connections fail clearly."""
+
+    cycle_started = datetime.date(2026, 7, 20)
+    database_path = rpc_usage_database.path
+    rpc_usage_database.record_scan(1, "lead_discovery", cycle_started, 1, RPCRequestStats(), 0)
+    rpc_usage_database.close()
+
+    with pytest.raises(RuntimeError):
+        rpc_usage_database.fetch_cycle_calls(1, cycle_started, 1)
+
+    with RPCUsageDatabase(database_path) as reopened:
+        assert reopened.allocate_cycle() == 2

--- a/tests/provider/test_rpcdb.py
+++ b/tests/provider/test_rpcdb.py
@@ -17,7 +17,6 @@ from eth_defi.provider.rpcdb import (
     format_rpc_usage_report,
     normalise_rpc_error,
     resolve_rpc_tracking_database_path,
-    sanitise_rpc_error_message,
 )
 
 
@@ -56,26 +55,19 @@ def test_rpc_request_stats_threaded_and_pickle_safe() -> None:
     assert calls[("rpc.example.com", "eth_blockNumber")] == 1
 
 
-def test_rpc_error_normalisation_and_sanitisation() -> None:
-    """Stored errors retain diagnostics without endpoint secrets."""
+def test_rpc_error_normalisation() -> None:
+    """Stored errors retain provider diagnostics and stable error codes."""
 
     code, message = normalise_rpc_error({"code": -32005, "message": "limit trace_id=abc123"})
     assert code == "-32005"
-    assert "abc123" not in message
+    assert message == "limit trace_id=abc123"
 
     response = requests.Response()
     response.status_code = 429
     http_error = requests.HTTPError("429 from https://user:pass@rpc.example.com/private/api-key?token=secret", response=response)
     code, message = normalise_rpc_error(http_error)
     assert code == "http_429"
-    assert "user" not in message
-    assert "pass" not in message
-    assert "private" not in message
-    assert "secret" not in message
-    assert "rpc.example.com" in message
-
-    assert sanitise_rpc_error_message("API_KEY=top-secret") == "API_KEY=<redacted>"
-    assert sanitise_rpc_error_message(f"execution reverted: 0x{'ab' * 64}") == "execution reverted: <hex-data>"
+    assert message == "429 from https://user:pass@rpc.example.com/private/api-key?token=secret"
 
 
 def test_rpc_tracking_database_path_override(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -153,7 +145,7 @@ def test_fallback_provider_records_json_rpc_error_once(monkeypatch: pytest.Monke
 
     calls, errors = stats.export()
     assert calls == {("rpc.example", "eth_call"): 1}
-    assert errors == {("rpc.example", "-32005", "rate limited request_id=<redacted>"): 1}
+    assert errors == {("rpc.example", "-32005", "rate limited request_id=secret"): 1}
 
 
 def test_rpc_usage_database_append_only_aggregates(rpc_usage_database: RPCUsageDatabase) -> None:

--- a/tests/vault/test_scan_all_chains_rpc_usage.py
+++ b/tests/vault/test_scan_all_chains_rpc_usage.py
@@ -1,0 +1,127 @@
+"""Tests for JSON-RPC accounting in the all-chain vault scanner."""
+
+import datetime
+from pathlib import Path
+
+import pytest
+
+from eth_defi.provider.rpcdb import RPCRequestStats, RPCUsageDatabase
+from eth_defi.vault import scan_all_chains
+from eth_defi.vault.scan_all_chains import ChainConfig
+
+
+@pytest.fixture()
+def rpc_usage_database(tmp_path: Path):
+    """Create an explicitly closed scanner accounting database."""
+
+    database = RPCUsageDatabase(tmp_path / "rpc-tracking.duckdb")
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+def test_scan_chain_records_lead_and_price_phases(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rpc_usage_database: RPCUsageDatabase,
+) -> None:
+    """A chain attempt persists lead and price statistics separately."""
+
+    monkeypatch.setenv("JSON_RPC_TEST", "https://rpc.example")
+    monkeypatch.setattr(scan_all_chains, "verify_archive_node", lambda rpc_url, chain_name: (rpc_url, 100))
+
+    def fake_scan_vaults_for_chain(*args, rpc_request_stats: RPCRequestStats, **kwargs) -> tuple[bool, dict]:
+        """Return deterministic lead accounting."""
+
+        rpc_request_stats.record_call("rpc.example", "eth_call", 3)
+        return True, {
+            "chain_id": 1,
+            "start_block": 1,
+            "end_block": 100,
+            "vault_count": 2,
+            "new_vaults": 1,
+            "items_scanned": 5,
+        }
+
+    def fake_scan_prices_for_chain(*args, rpc_request_stats: RPCRequestStats, **kwargs) -> tuple[bool, dict]:
+        """Return deterministic price accounting."""
+
+        rpc_request_stats.record_call("fallback.example", "eth_getBlockByNumber", 4)
+        return True, {
+            "chain_id": 1,
+            "rows_written": 8,
+            "start_block": 1,
+            "end_block": 100,
+            "items_scanned": 2,
+        }
+
+    monkeypatch.setattr(scan_all_chains, "scan_vaults_for_chain", fake_scan_vaults_for_chain)
+    monkeypatch.setattr(scan_all_chains, "scan_prices_for_chain", fake_scan_prices_for_chain)
+
+    cycle_started = datetime.date(2026, 7, 20)
+    result = scan_all_chains.scan_chain(
+        ChainConfig("Test", "JSON_RPC_TEST", True),
+        scan_prices=True,
+        max_workers=1,
+        frequency="1h",
+        retry_attempt=0,
+        vault_db_path=tmp_path / "vaults.pickle",
+        uncleaned_price_path=tmp_path / "prices.parquet",
+        reader_state_path=tmp_path / "reader-state.pickle",
+        rpc_usage_database=rpc_usage_database,
+        rpc_cycle_started=cycle_started,
+        rpc_cycle_number=1,
+    )
+
+    assert result.status == "success"
+    assert result.chain_id == 1
+    assert rpc_usage_database.fetch_cycle_calls(1, cycle_started, 1) == [
+        ("lead_discovery", "rpc.example", "eth_call", 3, 5),
+        ("price_scan", "fallback.example", "eth_getBlockByNumber", 4, 2),
+    ]
+
+
+@pytest.mark.parametrize(
+    "failure_type",
+    [scan_all_chains.duckdb.IOException, RuntimeError, AssertionError],
+)
+def test_scan_chain_keeps_scan_success_when_accounting_write_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    rpc_usage_database: RPCUsageDatabase,
+    failure_type: type[BaseException],
+) -> None:
+    """An observability write failure does not trigger an expensive re-scan."""
+
+    monkeypatch.setenv("JSON_RPC_TEST", "https://rpc.example")
+    monkeypatch.setattr(scan_all_chains, "verify_archive_node", lambda rpc_url, chain_name: (rpc_url, 100))
+
+    def fake_scan_vaults_for_chain(*args, rpc_request_stats: RPCRequestStats, **kwargs) -> tuple[bool, dict]:
+        """Return one successful phase."""
+
+        return True, {
+            "chain_id": 1,
+            "start_block": 1,
+            "end_block": 100,
+            "vault_count": 0,
+            "new_vaults": 0,
+            "items_scanned": 0,
+        }
+
+    monkeypatch.setattr(scan_all_chains, "scan_vaults_for_chain", fake_scan_vaults_for_chain)
+    monkeypatch.setattr(rpc_usage_database, "record_scan", lambda **kwargs: (_ for _ in ()).throw(failure_type("write failed")))
+
+    result = scan_all_chains.scan_chain(
+        ChainConfig("Test", "JSON_RPC_TEST", True),
+        scan_prices=False,
+        max_workers=1,
+        frequency="1h",
+        retry_attempt=0,
+        vault_db_path=tmp_path / "vaults.pickle",
+        rpc_usage_database=rpc_usage_database,
+        rpc_cycle_started=datetime.date(2026, 7, 20),
+        rpc_cycle_number=1,
+    )
+
+    assert result.status == "success"


### PR DESCRIPTION
## Why

Vault scans spend JSON-RPC capacity across fallback providers and workers without a persistent per-chain or per-phase accounting trail. Operators need separate lead-discovery and price-scan totals, attributed to the provider that handled each attempt.

## Lessons learnt

Physical fallback attempts must be counted at the provider boundary because middleware sees logical calls rather than provider retries. Process workers return task-local counters, while thread workers share the phase counter. Provider error messages are stored verbatim, so the database and scanner logs are sensitive operational data and may grow quickly when messages contain request-specific values.

## Summary

- Add provider-level JSON-RPC counters, DuckDB persistence, cycle allocation, daily aggregation, and tabulated reports.
- Track methods, provider domains, failed fallback attempts, raw provider errors, phases, cycles, and `items_scanned`.
- Propagate accounting through multi-provider Web3, Multicall and timestamp workers, and threaded vault reads.
- Integrate `lead_discovery` and `price_scan` accounting into the all-chain and standalone scanners, defaulting to `~/.tradingstrategy/rpc-tracking.duckdb`.
- Serialise scanner writers with the shared pipeline lock.
- Add API and operator documentation plus focused regression coverage.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.