### PR TITLE
fix: use Accountable vault strategy descriptions

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/accountable/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/offchain_metadata.py
@@ -14,19 +14,18 @@
 import datetime
 import json
 import logging
+import re
 from json import JSONDecodeError
 from pathlib import Path
 from typing import TypedDict
 
 import requests
-
 from eth_typing import HexAddress
 from web3 import Web3
 
-from eth_defi.compat import native_datetime_utc_now, native_datetime_utc_fromtimestamp
+from eth_defi.compat import native_datetime_utc_fromtimestamp, native_datetime_utc_now
 from eth_defi.disk_cache import DEFAULT_CACHE_ROOT
 from eth_defi.utils import wait_other_writers
-
 
 #: Where we cache fetched Accountable metadata files
 DEFAULT_CACHE_PATH = DEFAULT_CACHE_ROOT / "accountable"
@@ -56,7 +55,7 @@ class AccountableVaultMetadata(TypedDict):
     #: Full vault strategy description (may contain markdown formatting)
     description: str | None
 
-    #: Company/manager description used as a short summary
+    #: First sentence of the full vault strategy description
     short_description: str | None
 
     #: Company/manager name, e.g. ``Aegis``
@@ -144,6 +143,30 @@ def _fetch_vault_detail(
         return None
 
 
+def _extract_first_sentence(text: str | None) -> str | None:
+    """Extract a listing-friendly first sentence from a vault strategy.
+
+    Accountable's API provides only a full ``vault_strategy`` field. Its
+    ``company_info`` field describes the manager, rather than the individual
+    vault, so it must not be used for the vault listing summary.
+
+    :param text:
+        Full strategy description supplied by Accountable, or ``None``.
+
+    :return:
+        The first sentence when a sentence boundary exists, otherwise the
+        stripped complete text.
+    """
+    if not text:
+        return None
+
+    stripped = text.strip()
+    boundary = re.search(r"(?<=[.!?])\s+", stripped)
+    if boundary:
+        return stripped[: boundary.start()]
+    return stripped
+
+
 def _parse_vault_metadata(listing_item: dict, detail: dict | None) -> AccountableVaultMetadata:
     """Parse vault metadata from listing and detail API responses.
 
@@ -154,6 +177,7 @@ def _parse_vault_metadata(listing_item: dict, detail: dict | None) -> Accountabl
         Raw dict from the detail endpoint ``/api/loan/{id}``, or None if fetch failed
     """
     loan = detail.get("loan", {}) if detail else {}
+    vault_strategy = loan.get("vault_strategy")
 
     # Performance fee from listing is in basis points (e.g. 200000 = 20%)
     raw_fee = listing_item.get("performance_fee")
@@ -161,8 +185,8 @@ def _parse_vault_metadata(listing_item: dict, detail: dict | None) -> Accountabl
 
     return AccountableVaultMetadata(
         name=listing_item.get("loan_name", ""),
-        description=loan.get("vault_strategy"),
-        short_description=loan.get("company_info"),
+        description=vault_strategy,
+        short_description=_extract_first_sentence(vault_strategy),
         company_name=loan.get("company_name") or listing_item.get("company_name"),
         company_url=loan.get("company_url"),
         net_apy=listing_item.get("net_apy"),

--- a/eth_defi/erc_4626/vault_protocol/accountable/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/vault.py
@@ -286,7 +286,7 @@ class AccountableVault(ERC4626Vault):
 
     @property
     def short_description(self) -> str | None:
-        """Company/manager description from Accountable's offchain metadata."""
+        """First sentence of the vault strategy from Accountable's offchain metadata."""
 
         metadata = get_handwritten_vault_metadata(self.chain_id, self.address)
         if metadata:

--- a/scripts/erc-4626/fix-accountable-descriptions.py
+++ b/scripts/erc-4626/fix-accountable-descriptions.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Backfill Accountable vault descriptions in the production metadata pickle.
+
+Accountable's API exposes a full ``vault_strategy`` per vault. This script
+updates persisted Accountable metadata after the vault adapter changed its
+description mapping, without rescanning historical chain events or touching
+price data. Address-scoped handwritten strategy overrides remain authoritative.
+
+Usage:
+
+.. code-block:: shell
+
+    source .local-test.env && poetry run python scripts/erc-4626/fix-accountable-descriptions.py
+
+Optional environment variables:
+
+- ``VAULT_DB``: metadata pickle path, defaults to
+  ``~/.tradingstrategy/vaults/vault-metadata-db.pickle``
+- ``DRY_RUN``: set to ``true`` to report changes without writing
+- ``LOG_LEVEL``: console log level, defaults to ``info``
+"""
+
+import datetime
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from eth_defi.erc_4626.vault_protocol.accountable.offchain_metadata import AccountableVaultMetadata, fetch_accountable_vaults
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.handwritten_metadata import get_handwritten_vault_metadata
+from eth_defi.vault.vaultdb import DEFAULT_VAULT_DATABASE, VaultDatabase, VaultRow
+
+logger = logging.getLogger(__name__)
+
+ACCOUNTABLE_PROTOCOL_NAME = "Accountable"
+
+
+@dataclass(slots=True, frozen=True)
+class AccountableDescriptionUpdate:
+    """Describe a persisted Accountable vault description update.
+
+    :param spec:
+        Vault chain/address key in the metadata database.
+
+    :param old_description:
+        Existing full description in the pickle.
+
+    :param new_description:
+        Full ``vault_strategy`` from Accountable's API.
+
+    :param old_short_description:
+        Existing listing description in the pickle.
+
+    :param new_short_description:
+        First sentence of ``vault_strategy`` from Accountable's API.
+    """
+
+    spec: VaultSpec
+    old_description: str | None
+    new_description: str
+    old_short_description: str | None
+    new_short_description: str
+
+    @property
+    def changed(self) -> bool:
+        """Check whether either persisted description changes.
+
+        :return:
+            ``True`` when the full or short description differs.
+        """
+        return (self.old_description, self.old_short_description) != (self.new_description, self.new_short_description)
+
+
+def _normalise_metadata_by_address(metadata_by_address: dict[str, AccountableVaultMetadata]) -> dict[str, AccountableVaultMetadata]:
+    """Normalise Accountable metadata keys for case-insensitive vault matching.
+
+    :param metadata_by_address:
+        Accountable metadata keyed by ERC-4626 share-token address.
+
+    :return:
+        Metadata keyed by lower-case share-token address.
+    """
+    return {address.lower(): metadata for address, metadata in metadata_by_address.items()}
+
+
+def refresh_accountable_descriptions(
+    vault_db: VaultDatabase,
+    metadata_by_address: dict[str, AccountableVaultMetadata],
+) -> list[AccountableDescriptionUpdate]:
+    """Update all persisted Accountable vault descriptions from fresh API metadata.
+
+    All new values are validated before the database is mutated. This prevents
+    a partial metadata update if Accountable no longer returns one of the vaults
+    stored in the production database.
+
+    :param vault_db:
+        Vault metadata database loaded from pickle.
+
+    :param metadata_by_address:
+        Fresh Accountable API metadata keyed by ERC-4626 share-token address.
+
+    :return:
+        Applied description updates for all Accountable vaults.
+    """
+    normalised_metadata = _normalise_metadata_by_address(metadata_by_address)
+    pending_updates: list[tuple[VaultRow, AccountableDescriptionUpdate]] = []
+
+    for spec, row in vault_db.rows.items():
+        if row.get("Protocol") != ACCOUNTABLE_PROTOCOL_NAME:
+            continue
+
+        handwritten_metadata = get_handwritten_vault_metadata(spec.chain_id, spec.vault_address)
+        if handwritten_metadata:
+            description = handwritten_metadata.description
+            short_description = handwritten_metadata.short_description
+        else:
+            metadata = normalised_metadata.get(spec.vault_address.lower())
+            if metadata is None:
+                raise ValueError(f"Accountable API metadata is missing vault {spec.as_string_id()}")
+
+            description = metadata.get("description")
+            short_description = metadata.get("short_description")
+        if not description or not short_description:
+            raise ValueError(f"Accountable API metadata has no strategy description for {spec.as_string_id()}")
+
+        pending_updates.append(
+            (
+                row,
+                AccountableDescriptionUpdate(
+                    spec=spec,
+                    old_description=row.get("_description"),
+                    new_description=description,
+                    old_short_description=row.get("_short_description"),
+                    new_short_description=short_description,
+                ),
+            )
+        )
+
+    if not pending_updates:
+        msg = "No Accountable vault rows found in the metadata database"
+        raise ValueError(msg)
+
+    for row, update in pending_updates:
+        row["_description"] = update.new_description
+        row["_short_description"] = update.new_short_description
+
+    return [update for _, update in pending_updates]
+
+
+def main() -> None:
+    """Run the Accountable description backfill from environment variables.
+
+    The Accountable cache is deliberately bypassed so that prior cached manager
+    descriptions cannot be copied back into the production metadata pickle.
+    The output pickle is written atomically by :class:`VaultDatabase`.
+
+    :return:
+        None. The function reports updates and writes unless ``DRY_RUN`` is set.
+    """
+    setup_console_logging(default_log_level=os.environ.get("LOG_LEVEL", "info"))
+
+    vault_db_path = Path(os.environ.get("VAULT_DB", str(DEFAULT_VAULT_DATABASE))).expanduser()
+    dry_run = os.environ.get("DRY_RUN", "false").lower() in {"1", "true", "yes"}
+
+    logger.info("Reading vault metadata from %s", vault_db_path)
+    vault_db = VaultDatabase.read(vault_db_path)
+    logger.info("Fetching fresh Accountable vault strategy metadata")
+    metadata_by_address = fetch_accountable_vaults(max_cache_duration=datetime.timedelta(0))
+    updates = refresh_accountable_descriptions(vault_db, metadata_by_address)
+
+    changed = [update for update in updates if update.changed]
+    logger.info("Refreshed descriptions for %d Accountable vaults, %d changed", len(updates), len(changed))
+    for update in changed:
+        logger.info(
+            "%s: short description %r -> %r",
+            update.spec.as_string_id(),
+            update.old_short_description,
+            update.new_short_description,
+        )
+
+    if dry_run:
+        logger.info("DRY_RUN=true, not writing %s", vault_db_path)
+        return
+
+    vault_db.write(vault_db_path)
+    logger.info("Wrote refreshed Accountable descriptions to %s", vault_db_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/erc_4626/test_fix_accountable_descriptions.py
+++ b/tests/erc_4626/test_fix_accountable_descriptions.py
@@ -1,0 +1,133 @@
+"""Test the Accountable description metadata backfill script."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.vaultdb import VaultDatabase
+
+
+def _load_fix_accountable_descriptions_module():
+    """Load the Accountable description backfill script as a Python module.
+
+    :return:
+        Loaded script module.
+    """
+    repo_root = Path(__file__).parents[2]
+    script_path = repo_root / "scripts" / "erc-4626" / "fix-accountable-descriptions.py"
+    spec = importlib.util.spec_from_file_location("fix_accountable_descriptions", script_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_refresh_accountable_descriptions_updates_only_accountable_rows() -> None:
+    """Use strategy metadata for the full and short persisted vault descriptions.
+
+    :return:
+        None. Assertions validate the targeted database mutation.
+    """
+    module = _load_fix_accountable_descriptions_module()
+    accountable_spec = VaultSpec(chain_id=143, vault_address="0x23b148d8f389c5821739381f1ff87bb7e1162566")
+    other_spec = VaultSpec(chain_id=1, vault_address="0x0000000000000000000000000000000000000001")
+    vault_db = VaultDatabase(
+        rows={
+            accountable_spec: {
+                "Protocol": "Accountable",
+                "Address": accountable_spec.vault_address,
+                "_description": "Old manager profile.",
+                "_short_description": "Old manager profile.",
+            },
+            other_spec: {
+                "Protocol": "Morpho",
+                "Address": other_spec.vault_address,
+                "_description": "Unchanged description.",
+                "_short_description": "Unchanged summary.",
+            },
+        }
+    )
+    strategy = "This is an auto-looping vault for aHYPER. It uses a lending market."
+    updates = module.refresh_accountable_descriptions(
+        vault_db,
+        {
+            accountable_spec.vault_address.upper(): {
+                "name": "aHYPER Looping Vault",
+                "description": strategy,
+                "short_description": "This is an auto-looping vault for aHYPER.",
+                "company_name": "Hyperithm",
+                "company_url": "https://www.hyperithm.com/",
+                "net_apy": None,
+                "performance_fee": None,
+                "yield_source": None,
+                "loan_address": "0xE19b272b2fe4a54103A41F9B1c65dB3D2F6d886D",
+            },
+        },
+    )
+
+    assert len(updates) == 1
+    assert updates[0].changed is True
+    assert vault_db.rows[accountable_spec]["_description"] == strategy
+    assert vault_db.rows[accountable_spec]["_short_description"] == "This is an auto-looping vault for aHYPER."
+    assert vault_db.rows[other_spec]["_description"] == "Unchanged description."
+    assert vault_db.rows[other_spec]["_short_description"] == "Unchanged summary."
+
+
+def test_refresh_accountable_descriptions_does_not_partially_update() -> None:
+    """Reject incomplete API metadata before mutating persisted rows.
+
+    :return:
+        None. Assertions validate atomic in-memory update preparation.
+    """
+    module = _load_fix_accountable_descriptions_module()
+    first_spec = VaultSpec(chain_id=143, vault_address="0x23b148d8f389c5821739381f1ff87bb7e1162566")
+    second_spec = VaultSpec(chain_id=143, vault_address="0x3a2c4aaae6776dc1c31316de559598f2f952e2cb")
+    vault_db = VaultDatabase(
+        rows={
+            first_spec: {
+                "Protocol": "Accountable",
+                "Address": first_spec.vault_address,
+                "_description": "First old description.",
+                "_short_description": "First old summary.",
+            },
+            second_spec: {
+                "Protocol": "Accountable",
+                "Address": second_spec.vault_address,
+                "_description": "Second old description.",
+                "_short_description": "Second old summary.",
+            },
+        }
+    )
+
+    with pytest.raises(ValueError, match="missing vault"):
+        module.refresh_accountable_descriptions(vault_db, {})
+
+    assert vault_db.rows[first_spec]["_description"] == "First old description."
+    assert vault_db.rows[second_spec]["_short_description"] == "Second old summary."
+
+
+def test_refresh_accountable_descriptions_preserves_handwritten_metadata() -> None:
+    """Prefer the address-scoped manager strategy over Accountable API metadata.
+
+    :return:
+        None. Assertions validate precedence of handwritten vault metadata.
+    """
+    module = _load_fix_accountable_descriptions_module()
+    spec = VaultSpec(chain_id=1, vault_address="0x99351baed3d8ab544ccb08af96a105910fda71e7")
+    vault_db = VaultDatabase(
+        rows={
+            spec: {
+                "Protocol": "Accountable",
+                "Address": spec.vault_address,
+                "_description": "Old description.",
+                "_short_description": "Old summary.",
+            },
+        }
+    )
+
+    module.refresh_accountable_descriptions(vault_db, {})
+
+    assert vault_db.rows[spec]["_description"] == "Morini Capital's strategy arbitrages spreads between USD/TRY rates on Turkish crypto exchanges and fiat rails. Its TRY positions are continuously hedged."
+    assert vault_db.rows[spec]["_short_description"] == "Delta-neutral USD/TRY foreign-exchange arbitrage strategy."

--- a/tests/erc_4626/vault_protocol/test_accountable_offchain_metadata.py
+++ b/tests/erc_4626/vault_protocol/test_accountable_offchain_metadata.py
@@ -1,0 +1,34 @@
+"""Unit tests for Accountable's offchain vault metadata parsing."""
+
+from eth_defi.erc_4626.vault_protocol.accountable.offchain_metadata import _parse_vault_metadata  # noqa: PLC2701
+
+
+def test_accountable_strategy_metadata_uses_first_sentence_as_short_description() -> None:
+    """Keep the listing summary specific to the vault rather than its manager.
+
+    Accountable separates a manager biography in ``company_info`` from the
+    vault's strategy. The strategy is the appropriate source for both the
+    full vault description and the listing summary.
+
+    :return:
+        None. Assertions validate parsed Accountable API metadata.
+    """
+    strategy = "This is the vault strategy.\nIt has a separate second sentence."
+    metadata = _parse_vault_metadata(
+        {
+            "loan_name": "Example vault",
+            "performance_fee": 200_000,
+            "loan_address": "0x0000000000000000000000000000000000000001",
+        },
+        {
+            "loan": {
+                "vault_strategy": strategy,
+                "company_info": "Example Manager is an institutional asset manager.",
+                "company_name": "Example Manager",
+            },
+        },
+    )
+
+    assert metadata["description"] == strategy
+    assert metadata["short_description"] == "This is the vault strategy."
+    assert metadata["short_description"] != "Example Manager is an institutional asset manager."


### PR DESCRIPTION
## Why

Accountable’s `company_info` is the manager biography, but it was being displayed as each vault’s short description. Existing persisted vault metadata also needs a targeted backfill because incremental discovery does not revisit old vault rows.

## Lessons learnt

Accountable exposes the vault strategy separately as `vault_strategy`; address-scoped handwritten metadata must remain higher priority than API metadata.

## Summary

- Derive Accountable short descriptions from the first sentence of `vault_strategy`.
- Preserve the full `vault_strategy` as the long vault description.
- Add an atomic Accountable metadata backfill script and regression coverage, including handwritten overrides.

## Related issues and PRs

- Fixes the incorrect curator description shown for aHYPER Looping Vault and other Accountable vaults.