### PR TITLE
fix: preserve descriptions for delisted Accountable vaults

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/accountable/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/offchain_metadata.py
@@ -9,6 +9,9 @@
 - We fetch and cache this data locally to avoid repeated API calls
 - Two-level caching: disk (2-day TTL) + in-process dictionary
 - Single cache file for all chains (Accountable has ~7 vaults total)
+- Accountable may remove a vault from its API after it has been discovered. The
+  durable vault database must retain its latest available metadata copy; an API
+  omission must not erase previously stored descriptions.
 """
 
 import datetime

--- a/eth_defi/erc_4626/vault_protocol/accountable/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/offchain_metadata.py
@@ -143,7 +143,7 @@ def _fetch_vault_detail(
         return None
 
 
-def _extract_first_sentence(text: str | None) -> str | None:
+def extract_first_sentence(text: str | None) -> str | None:
     """Extract a listing-friendly first sentence from a vault strategy.
 
     Accountable's API provides only a full ``vault_strategy`` field. Its
@@ -186,7 +186,7 @@ def _parse_vault_metadata(listing_item: dict, detail: dict | None) -> Accountabl
     return AccountableVaultMetadata(
         name=listing_item.get("loan_name", ""),
         description=vault_strategy,
-        short_description=_extract_first_sentence(vault_strategy),
+        short_description=extract_first_sentence(vault_strategy),
         company_name=loan.get("company_name") or listing_item.get("company_name"),
         company_url=loan.get("company_url"),
         net_apy=listing_item.get("net_apy"),

--- a/scripts/erc-4626/fix-accountable-descriptions.py
+++ b/scripts/erc-4626/fix-accountable-descriptions.py
@@ -26,7 +26,11 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
-from eth_defi.erc_4626.vault_protocol.accountable.offchain_metadata import AccountableVaultMetadata, fetch_accountable_vaults
+from eth_defi.erc_4626.vault_protocol.accountable.offchain_metadata import (
+    AccountableVaultMetadata,
+    extract_first_sentence,
+    fetch_accountable_vaults,
+)
 from eth_defi.utils import setup_console_logging
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.handwritten_metadata import get_handwritten_vault_metadata
@@ -91,9 +95,9 @@ def refresh_accountable_descriptions(
 ) -> list[AccountableDescriptionUpdate]:
     """Update all persisted Accountable vault descriptions from fresh API metadata.
 
-    All new values are validated before the database is mutated. This prevents
-    a partial metadata update if Accountable no longer returns one of the vaults
-    stored in the production database.
+    All new values are validated before the database is mutated. When
+    Accountable has delisted a vault, its existing full strategy description is
+    retained and used to regenerate the short description instead.
 
     :param vault_db:
         Vault metadata database loaded from pickle.
@@ -118,10 +122,22 @@ def refresh_accountable_descriptions(
         else:
             metadata = normalised_metadata.get(spec.vault_address.lower())
             if metadata is None:
-                raise ValueError(f"Accountable API metadata is missing vault {spec.as_string_id()}")
-
-            description = metadata.get("description")
-            short_description = metadata.get("short_description")
+                description = row.get("_description")
+                short_description = extract_first_sentence(description)
+                if description and short_description:
+                    logger.warning(
+                        "Accountable API metadata is missing vault %s; using its stored strategy description",
+                        spec.as_string_id(),
+                    )
+                else:
+                    logger.warning(
+                        "Skipping Accountable vault %s because neither API nor stored strategy metadata is available",
+                        spec.as_string_id(),
+                    )
+                    continue
+            else:
+                description = metadata.get("description")
+                short_description = metadata.get("short_description")
         if not description or not short_description:
             raise ValueError(f"Accountable API metadata has no strategy description for {spec.as_string_id()}")
 
@@ -139,8 +155,8 @@ def refresh_accountable_descriptions(
         )
 
     if not pending_updates:
-        msg = "No Accountable vault rows found in the metadata database"
-        raise ValueError(msg)
+        logger.warning("No Accountable vault rows have a usable strategy description")
+        return []
 
     for row, update in pending_updates:
         row["_description"] = update.new_description
@@ -169,6 +185,10 @@ def main() -> None:
     logger.info("Fetching fresh Accountable vault strategy metadata")
     metadata_by_address = fetch_accountable_vaults(max_cache_duration=datetime.timedelta(0))
     updates = refresh_accountable_descriptions(vault_db, metadata_by_address)
+
+    if not updates:
+        logger.info("No Accountable vault descriptions available to refresh")
+        return
 
     changed = [update for update in updates if update.changed]
     logger.info("Refreshed descriptions for %d Accountable vaults, %d changed", len(updates), len(changed))

--- a/tests/erc_4626/test_fix_accountable_descriptions.py
+++ b/tests/erc_4626/test_fix_accountable_descriptions.py
@@ -3,8 +3,6 @@
 import importlib.util
 from pathlib import Path
 
-import pytest
-
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.vaultdb import VaultDatabase
 
@@ -75,37 +73,56 @@ def test_refresh_accountable_descriptions_updates_only_accountable_rows() -> Non
     assert vault_db.rows[other_spec]["_short_description"] == "Unchanged summary."
 
 
-def test_refresh_accountable_descriptions_does_not_partially_update() -> None:
-    """Reject incomplete API metadata before mutating persisted rows.
+def test_refresh_accountable_descriptions_uses_stored_strategy_for_delisted_vault() -> None:
+    """Repair the short summary if the Accountable API has delisted a vault.
 
     :return:
-        None. Assertions validate atomic in-memory update preparation.
+        None. Assertions validate the stored-strategy fallback.
     """
     module = _load_fix_accountable_descriptions_module()
-    first_spec = VaultSpec(chain_id=143, vault_address="0x23b148d8f389c5821739381f1ff87bb7e1162566")
-    second_spec = VaultSpec(chain_id=143, vault_address="0x3a2c4aaae6776dc1c31316de559598f2f952e2cb")
+    spec = VaultSpec(chain_id=143, vault_address="0x4c0d041889281531ff060290d71091401caa786d")
     vault_db = VaultDatabase(
         rows={
-            first_spec: {
+            spec: {
                 "Protocol": "Accountable",
-                "Address": first_spec.vault_address,
-                "_description": "First old description.",
-                "_short_description": "First old summary.",
-            },
-            second_spec: {
-                "Protocol": "Accountable",
-                "Address": second_spec.vault_address,
-                "_description": "Second old description.",
-                "_short_description": "Second old summary.",
+                "Address": spec.vault_address,
+                "_description": "Asia Credit Yield Vault lends to regional borrowers. It has a second sentence.",
+                "_short_description": "Outdated manager description.",
             },
         }
     )
 
-    with pytest.raises(ValueError, match="missing vault"):
-        module.refresh_accountable_descriptions(vault_db, {})
+    updates = module.refresh_accountable_descriptions(vault_db, {})
 
-    assert vault_db.rows[first_spec]["_description"] == "First old description."
-    assert vault_db.rows[second_spec]["_short_description"] == "Second old summary."
+    assert len(updates) == 1
+    assert vault_db.rows[spec]["_description"] == "Asia Credit Yield Vault lends to regional borrowers. It has a second sentence."
+    assert vault_db.rows[spec]["_short_description"] == "Asia Credit Yield Vault lends to regional borrowers."
+
+
+def test_refresh_accountable_descriptions_skips_delisted_vault_without_strategy() -> None:
+    """Leave a delisted vault untouched when no strategy text is available.
+
+    :return:
+        None. Assertions validate that stale historical rows do not block the backfill.
+    """
+    module = _load_fix_accountable_descriptions_module()
+    spec = VaultSpec(chain_id=143, vault_address="0x4c0d041889281531ff060290d71091401caa786d")
+    vault_db = VaultDatabase(
+        rows={
+            spec: {
+                "Protocol": "Accountable",
+                "Address": spec.vault_address,
+                "_description": None,
+                "_short_description": "Outdated manager description.",
+            },
+        }
+    )
+
+    updates = module.refresh_accountable_descriptions(vault_db, {})
+
+    assert updates == []
+    assert vault_db.rows[spec]["_description"] is None
+    assert vault_db.rows[spec]["_short_description"] == "Outdated manager description."
 
 
 def test_refresh_accountable_descriptions_preserves_handwritten_metadata() -> None:


### PR DESCRIPTION
## Why

Accountable can delist vaults from its API while their historical database records remain. The migration must not fail or delete the latest known strategy metadata in this situation.

## Lessons learnt

Accountable’s API is a current-listing source, not a historical archive. Persisted metadata is the durable copy for delisted vaults.

## Summary

- Retain a stored full strategy and regenerate its first-sentence summary when a vault is no longer returned by Accountable.
- Skip historical records without either live or stored strategy metadata.
- Document the retention rule in the Accountable off-chain metadata module.

## Related issues and PRs

Follow-up to #1334, which introduced the Accountable description migration.