### PR TITLE
feat: add Noon sUSN stablecoin support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- feat: Add Noon sUSN yield-bearing stablecoin metadata and feed coverage (2026-07-21)
 - feat: Track per-chain vault scanner JSON-RPC calls and errors in DuckDB (2026-07-20)
 - feat: Add Hypersync-backed Chainlink bundle aggregator history and FILQ NAV support (2026-07-20)
 - feat: Backfill OpenEden TBILL oracle price history while preserving supply-only FDIT and CASHx metadata (2026-07-20)

--- a/eth_defi/data/feeds/stablecoins/susn.yaml
+++ b/eth_defi/data/feeds/stablecoins/susn.yaml
@@ -1,0 +1,5 @@
+feeder-id: susn
+name: Noon Staked USN
+role: stablecoin
+website: https://noon.capital/
+twitter: noon_capital

--- a/eth_defi/data/stablecoins/susn.yaml
+++ b/eth_defi/data/stablecoins/susn.yaml
@@ -1,0 +1,49 @@
+symbol: sUSN
+name: Noon Staked USN
+slug: susn
+category: yield_bearing
+short_description: |
+  sUSN is Noon's yield-bearing staking token for the USN dollar stablecoin. It represents staked USN and appreciates as Noon allocates protocol returns to the staking pool.
+long_description: |
+  [sUSN](https://noon.capital/) is the staked form of Noon's USN stablecoin. Users stake USN through the Noon application or acquire sUSN in decentralised-exchange pools. Each sUSN represents a pro-rata share of the USN held by the staking pool, so its value can rise above one dollar as returns accrue.
+
+  Noon states that USN is backed one-to-one by USDT, USDC or short-term U.S. Treasury bills. It directs 80% of daily protocol returns to the USN staking pool by minting USN, which increases the USN backing per sUSN; unstaking is subject to a cooldown period.
+
+  ## Sources
+
+  - [Noon documentation — USN and sUSN](https://docs.noon.capital/built-for-high-yields/our-stablecoin-usn-and-susn)
+  - [Noon documentation — contracts and addresses](https://docs.noon.capital/additional-resources/contracts-and-addresses)
+  - [CoinGecko — Staked USN](https://www.coingecko.com/en/coins/staked-usn)
+links:
+  homepage: https://noon.capital/
+  coingecko: https://www.coingecko.com/en/coins/staked-usn
+  defillama: https://defillama.com/protocol/noon
+  twitter: https://x.com/noon_capital
+contract_addresses:
+  - chain: ethereum
+    address: "0xE24a3DC889621612422A64E6388927901608B91D"
+source_currency: ''
+source_currency_source: ''
+source_currency_usd_rate: ''
+source_currency_usd_rate_date: ''
+source_currency_usd_rate_fetched_at: ''
+source_currency_usd_rate_source: ''
+coingecko_id: staked-usn
+coingecko_link: https://www.coingecko.com/en/coins/staked-usn
+coingecko_id_source: url
+coingecko_id_verified_at: '2026-07-21T00:00:00'
+coingecko_id_verification_failed_at: ''
+coingecko_id_verification_failed_reason: ''
+usd_rate: ''
+usd_rate_fetched_at: ''
+usd_rate_updated_at: ''
+peg_rate: ''
+peg_rate_currency: ''
+rate_fetch_failed_at: ''
+rate_fetch_failed_reason: ''
+depegged_at: ''
+checks:
+  twitter_last_post_at: ''
+  domain_up_at: '2026-07-21'
+  marked_dead_at: ''
+  information_found_missing_at: ''

--- a/eth_defi/stablecoin_metadata.py
+++ b/eth_defi/stablecoin_metadata.py
@@ -410,7 +410,7 @@ STABLECOIN_LIKE = set(
 
 #: Stablecoins which can be used as collateral, but which also have built-in yield bearing function
 #: with rebasing.
-YIELD_BEARING_STABLES = {"sfrxUSD", "sUSDe", "sUSDai", "sBOLD", "sAUSD", "sUSG", "ynUSDx", "sNUSD", "savUSD", "syrupUSDC", "stcUSD", "apyUSD", "sUSD3"}
+YIELD_BEARING_STABLES = {"sfrxUSD", "sUSDe", "sUSDai", "sBOLD", "sAUSD", "sUSG", "sUSN", "ynUSDx", "sNUSD", "savUSD", "syrupUSDC", "stcUSD", "apyUSD", "sUSD3"}
 
 #: Stablecoins plus their interest wrapped counterparts on Compound and Aave.
 #: Also contains other derivates.

--- a/tests/feed/test_stablecoin_rate.py
+++ b/tests/feed/test_stablecoin_rate.py
@@ -18,6 +18,7 @@ USDX_ADDRESS = "0x1111111111111111111111111111111111111111"
 USDU_ADDRESS = "0xdde3eC717f220Fc6A29D6a4Be73F91DA5b718e55"
 NARAUSD_ADDRESS = "0x5C6263904CCFD3Bcf1aAa6e7063dDd29743b3Bb7"
 PATHUSD_ADDRESS = "0x20C0000000000000000000000000000000000000"
+SUSN_ADDRESS = "0xE24a3DC889621612422A64E6388927901608B91D"
 
 
 @dataclass(slots=True)
@@ -723,6 +724,17 @@ def test_packaged_narausd_metadata_and_rate_target() -> None:
     assert metadata["contract_addresses"] == [{"chain": "ethereum", "address": NARAUSD_ADDRESS}]
     assert get_stablecoin_available_logos("narausd") == {"light": True}
     assert metadata["logos"] == {"light": "https://pub.example/stablecoin-metadata/narausd/light.png"}
+
+
+def test_packaged_susn_metadata() -> None:
+    """sUSN classification and metadata identify Noon's Ethereum staking token."""
+
+    metadata = build_stablecoin_metadata_json(STABLECOINS_DATA_DIR / "susn.yaml")[0]
+
+    assert is_stablecoin_like("sUSN") is True
+    assert metadata["name"] == "Noon Staked USN"
+    assert metadata["category"] == "yield_bearing"
+    assert metadata["contract_addresses"] == [{"chain": "ethereum", "address": SUSN_ADDRESS}]
 
 
 def test_packaged_pathusd_metadata_and_rate_target() -> None:


### PR DESCRIPTION
## Why

Noon sUSN is a yield-bearing staking receipt for USN that needs stablecoin-like classification, structured product metadata and a post-feed identity.

## Lessons learnt

Yield-bearing staking receipts should describe their accrual mechanism rather than imply a fixed one-dollar redemption value.

## Summary

- classify sUSN as a yield-bearing stablecoin-like asset
- add verified Ethereum contract, product metadata and CoinGecko reference
- add Noon’s stablecoin feed identity and regression coverage

## Related issues and PRs

- Follows the tokenised-fund metadata improvements in #1336.