### PR TITLE
fix: add missing vault fee adapter functionality

### DIFF
--- a/.claude/skills/add-vault-protocol/SKILL.md
+++ b/.claude/skills/add-vault-protocol/SKILL.md
@@ -141,6 +141,14 @@ elif ERC4626Feature.{protocol_slug}_like in features:
 
 Edit `eth_defi/erc_4626/classification.py`:
 
+**Probe budget:** Classification runs every probe against every candidate
+vault. Prefer one no-argument, protocol-specific view accessor per protocol.
+Use a second probe only when independently necessary contract variants cannot
+be safely identified by the first one, and document why both are required. Do
+not add fee, version, or other adapter data accessors merely to corroborate a
+classification; read those only after the adapter has been selected. Never add
+more than two protocol probes without explicit maintainer approval.
+
 1. In `create_probe_calls()`, add a probe call that uniquely identifies this protocol:
    - Analyse the ABI and the vault implementation smart contract source code to find a function unique to this protocol
    - Look for functions like `getProtocolSpecificData()`, custom role constants, etc. and compare them to what is already implemented in `create_probe_calls()`

--- a/docs/source/vaults/yearn/index.rst
+++ b/docs/source/vaults/yearn/index.rst
@@ -29,4 +29,5 @@ Links
    :recursive:
 
    eth_defi.erc_4626.vault_protocol.yearn.vault
+   eth_defi.erc_4626.vault_protocol.yearn.compounder
    eth_defi.erc_4626.vault_protocol.yearn.morpho_compounder

--- a/eth_defi/abi/upshift/MultiAssetVault.json
+++ b/eth_defi/abi/upshift/MultiAssetVault.json
@@ -79,12 +79,38 @@
   },
   {
     "inputs": [],
+    "name": "managementFeePercent",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "lpTokenAddress",
     "outputs": [
       {
         "internalType": "address",
         "name": "",
         "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "performanceFeeRate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -839,6 +839,33 @@ def create_probe_calls(
             extra_data=None,
         )
 
+        # Yearn TokenizedStrategy compounders (Solidity).
+        # ``tokenizedStrategyAddress()`` identifies modern proxy instances,
+        # while the older v2 implementation exposes ``apiVersion()`` and the
+        # same basis-point ``performanceFee()`` accessor.
+        # https://etherscan.io/address/0xD377919FA87120584B21279a491F82D5265A139c#code
+        yield EncodedCall.from_keccak_signature(
+            address=address,
+            signature=Web3.keccak(text="tokenizedStrategyAddress()")[0:4],
+            function="tokenizedStrategyAddress",
+            data=b"",
+            extra_data=None,
+        )
+        yield EncodedCall.from_keccak_signature(
+            address=address,
+            signature=Web3.keccak(text="apiVersion()")[0:4],
+            function="apiVersion",
+            data=b"",
+            extra_data=None,
+        )
+        yield EncodedCall.from_keccak_signature(
+            address=address,
+            signature=Web3.keccak(text="performanceFee()")[0:4],
+            function="performanceFee",
+            data=b"",
+            extra_data=None,
+        )
+
         # Yearn V3 (Vyper)
         # https://polygonscan.com/address/0xa013fbd4b711f9ded6fb09c1c0d358e2fbc2eaa0#readContract
         yield EncodedCall.from_keccak_signature(
@@ -1391,7 +1418,7 @@ def identify_vault_features(
     if calls["getGrossTVL"].success:
         features.add(ERC4626Feature.t3tris_like)
 
-    if calls["GOV"].success:
+    if calls["GOV"].success or calls["tokenizedStrategyAddress"].success or (calls["apiVersion"].success and calls["performanceFee"].success):
         features.add(ERC4626Feature.yearn_compounder_like)
 
     if calls["get_default_queue"].success:
@@ -2054,6 +2081,10 @@ def create_vault_instance(
         from eth_defi.erc_4626.vault_protocol.yearn.morpho_compounder import YearnMorphoCompounderStrategy
 
         return YearnMorphoCompounderStrategy(web3, spec, **kwargs)
+    elif ERC4626Feature.yearn_compounder_like in features:
+        from eth_defi.erc_4626.vault_protocol.yearn.compounder import YearnCompounderVault
+
+        return YearnCompounderVault(web3, spec, **kwargs)
     elif ERC4626Feature.yearn_v3_like in features or ERC4626Feature.yearn_tokenised_strategy in features:
         # Both of these have fees internatilised
         from eth_defi.erc_4626.vault_protocol.yearn.vault import YearnV3Vault

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -840,28 +840,12 @@ def create_probe_calls(
         )
 
         # Yearn TokenizedStrategy compounders (Solidity).
-        # ``tokenizedStrategyAddress()`` identifies modern proxy instances,
-        # while the older v2 implementation exposes ``apiVersion()`` and the
-        # same basis-point ``performanceFee()`` accessor.
+        # Both legacy and modern strategy instances expose this version marker.
         # https://etherscan.io/address/0xD377919FA87120584B21279a491F82D5265A139c#code
-        yield EncodedCall.from_keccak_signature(
-            address=address,
-            signature=Web3.keccak(text="tokenizedStrategyAddress()")[0:4],
-            function="tokenizedStrategyAddress",
-            data=b"",
-            extra_data=None,
-        )
         yield EncodedCall.from_keccak_signature(
             address=address,
             signature=Web3.keccak(text="apiVersion()")[0:4],
             function="apiVersion",
-            data=b"",
-            extra_data=None,
-        )
-        yield EncodedCall.from_keccak_signature(
-            address=address,
-            signature=Web3.keccak(text="performanceFee()")[0:4],
-            function="performanceFee",
             data=b"",
             extra_data=None,
         )
@@ -1418,7 +1402,7 @@ def identify_vault_features(
     if calls["getGrossTVL"].success:
         features.add(ERC4626Feature.t3tris_like)
 
-    if calls["GOV"].success or calls["tokenizedStrategyAddress"].success or (calls["apiVersion"].success and calls["performanceFee"].success):
+    if calls["GOV"].success or calls["apiVersion"].success:
         features.add(ERC4626Feature.yearn_compounder_like)
 
     if calls["get_default_queue"].success:

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -2060,20 +2060,24 @@ def create_vault_instance(
         from eth_defi.erc_4626.vault_protocol.frankencoin.vault import FrankencoinVault
 
         return FrankencoinVault(web3, spec, **kwargs)
+    elif ERC4626Feature.term_finance_like in features:
+        from eth_defi.erc_4626.vault_protocol.term_finance.vault import TermFinanceVault
+
+        return TermFinanceVault(web3, spec, **kwargs)
     elif ERC4626Feature.yearn_morpho_compounder_like in features:
         # Yearn V3 vault with Morpho Compounder strategy
         from eth_defi.erc_4626.vault_protocol.yearn.morpho_compounder import YearnMorphoCompounderStrategy
 
         return YearnMorphoCompounderStrategy(web3, spec, **kwargs)
-    elif ERC4626Feature.yearn_compounder_like in features:
-        from eth_defi.erc_4626.vault_protocol.yearn.compounder import YearnCompounderVault
-
-        return YearnCompounderVault(web3, spec, **kwargs)
     elif ERC4626Feature.yearn_v3_like in features or ERC4626Feature.yearn_tokenised_strategy in features:
         # Both of these have fees internatilised
         from eth_defi.erc_4626.vault_protocol.yearn.vault import YearnV3Vault
 
         return YearnV3Vault(web3, spec, **kwargs)
+    elif ERC4626Feature.yearn_compounder_like in features:
+        from eth_defi.erc_4626.vault_protocol.yearn.compounder import YearnCompounderVault
+
+        return YearnCompounderVault(web3, spec, **kwargs)
     elif ERC4626Feature.goat_like in features:
         # Both of these have fees internatilised
         from eth_defi.erc_4626.vault_protocol.goat.vault import GoatVault
@@ -2173,11 +2177,6 @@ def create_vault_instance(
         from eth_defi.erc_4626.vault_protocol.usdd.vault import USSDVault
 
         return USSDVault(web3, spec, **kwargs)
-
-    elif ERC4626Feature.term_finance_like in features:
-        from eth_defi.erc_4626.vault_protocol.term_finance.vault import TermFinanceVault
-
-        return TermFinanceVault(web3, spec, **kwargs)
 
     elif ERC4626Feature.zerolend_like in features:
         from eth_defi.erc_4626.vault_protocol.zerolend.vault import ZeroLendVault

--- a/eth_defi/erc_4626/vault_protocol/upshift/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/upshift/vault.py
@@ -17,11 +17,17 @@ from eth_defi.event_reader.conversion import convert_int256_bytes_to_int
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.token import TokenDetails
 from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
+from eth_defi.vault.fee import VaultFeeMode
 
 logger = logging.getLogger(__name__)
 
-#: Upshift fee values are stored as basis points, where 10_000 is 100%.
-UPSHIFT_FEE_DENOMINATOR = 10_000
+#: Upshift management, withdrawal and instant-redemption fees use basis points.
+UPSHIFT_BASIS_POINTS_DENOMINATOR = 10_000
+
+#: Upshift performance fees use parts per million. The verified implementation
+#: calculates ``totalAssetsIncrease * performanceFeeRate / 1e6``.
+#: https://etherscan.io/address/0xEB5f80aCEa6060764E91c185bE93752Ab40F01c2#code
+UPSHIFT_PERFORMANCE_FEE_DENOMINATOR = 1_000_000
 
 
 class UpshiftMultiAssetHistoricalReader(VaultHistoricalReader):
@@ -301,6 +307,22 @@ class UpshiftVault(ERC4626Vault):
         """Upshift has withdrawal and instant redemption fees."""
         return True
 
+    def get_fee_mode(self) -> VaultFeeMode | None:
+        """Return the fee-accounting model when the vault exposes it.
+
+        Multi-asset vaults accrue management and performance fees against vault
+        assets, making the share price net of those fees.  TokenizedAccount
+        vaults do not expose those configuration values, so their overall fee
+        mode remains unknown.
+
+        :return:
+            ``internalised_skimming`` for multi-asset vaults, otherwise
+            ``None``.
+        """
+        if self.multi_asset_like:
+            return VaultFeeMode.internalised_skimming
+        return None
+
     def get_management_fee(self, block_identifier: BlockIdentifier) -> float | None:
         """Get management fee.
 
@@ -318,12 +340,13 @@ class UpshiftVault(ERC4626Vault):
             return None
 
         raw_bps = self.upshift_contract.functions.managementFeePercent().call(block_identifier=block_identifier)
-        return raw_bps / UPSHIFT_FEE_DENOMINATOR
+        return raw_bps / UPSHIFT_BASIS_POINTS_DENOMINATOR
 
     def get_performance_fee(self, block_identifier: BlockIdentifier) -> float | None:
         """Get performance fee.
 
-        Multi-asset vaults expose ``performanceFeeRate()`` in basis points.
+        Multi-asset vaults expose ``performanceFeeRate()`` in parts per
+        million.
         TokenizedAccount contracts do not expose an equivalent fee getter, so
         their performance fee remains unknown rather than being treated as zero.
 
@@ -336,8 +359,8 @@ class UpshiftVault(ERC4626Vault):
         if not self.multi_asset_like:
             return None
 
-        raw_bps = self.upshift_contract.functions.performanceFeeRate().call(block_identifier=block_identifier)
-        return raw_bps / UPSHIFT_FEE_DENOMINATOR
+        raw_ppm = self.upshift_contract.functions.performanceFeeRate().call(block_identifier=block_identifier)
+        return raw_ppm / UPSHIFT_PERFORMANCE_FEE_DENOMINATOR
 
     def get_withdraw_fee(self, block_identifier: BlockIdentifier) -> float:
         """Read the standard queued-redemption fee.
@@ -353,7 +376,7 @@ class UpshiftVault(ERC4626Vault):
             Decimal withdrawal-fee fraction, e.g. ``0.002`` for 20 bps.
         """
         raw_bps = self.upshift_contract.functions.withdrawalFee().call(block_identifier=block_identifier)
-        return raw_bps / UPSHIFT_FEE_DENOMINATOR
+        return raw_bps / UPSHIFT_BASIS_POINTS_DENOMINATOR
 
     def fetch_instant_redemption_fee(self, block_identifier: BlockIdentifier) -> float:
         """Read the extra instant-redemption fee outside the shared fee schema.
@@ -369,7 +392,7 @@ class UpshiftVault(ERC4626Vault):
             Decimal instant-redemption fee fraction, e.g. ``0.002`` for 20 bps.
         """
         raw_bps = self.upshift_contract.functions.instantRedemptionFee().call(block_identifier=block_identifier)
-        return raw_bps / UPSHIFT_FEE_DENOMINATOR
+        return raw_bps / UPSHIFT_BASIS_POINTS_DENOMINATOR
 
     def fetch_total_assets(self, block_identifier: BlockIdentifier) -> Decimal | None:
         """Fetch vault NAV in denomination token units.

--- a/eth_defi/erc_4626/vault_protocol/upshift/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/upshift/vault.py
@@ -11,7 +11,7 @@ from web3 import Web3
 from web3.contract import Contract
 
 from eth_defi.abi import get_deployed_contract
-from eth_defi.erc_4626.core import ERC4626Feature, get_deployed_erc_4626_contract
+from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault import ERC4626Vault, VaultReaderState
 from eth_defi.event_reader.conversion import convert_int256_bytes_to_int
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
@@ -19,6 +19,9 @@ from eth_defi.token import TokenDetails
 from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
 
 logger = logging.getLogger(__name__)
+
+#: Upshift fee values are stored as basis points, where 10_000 is 100%.
+UPSHIFT_FEE_DENOMINATOR = 10_000
 
 
 class UpshiftMultiAssetHistoricalReader(VaultHistoricalReader):
@@ -246,8 +249,9 @@ class UpshiftVault(ERC4626Vault):
                 self.spec.vault_address,
             )
 
-        return get_deployed_erc_4626_contract(
+        return get_deployed_contract(
             self.web3,
+            "upshift/TokenizedAccount.json",
             self.spec.vault_address,
         )
 
@@ -300,30 +304,72 @@ class UpshiftVault(ERC4626Vault):
     def get_management_fee(self, block_identifier: BlockIdentifier) -> float | None:
         """Get management fee.
 
-        The supported Upshift ABIs expose fee charging hooks, but not a single
-        protocol-wide management-fee convention that maps cleanly to the shared
-        historical schema.
+        Multi-asset vaults expose ``managementFeePercent()`` in basis points.
+        TokenizedAccount contracts do not expose an equivalent fee getter, so
+        their management fee remains unknown rather than being treated as zero.
 
         :param block_identifier:
             Block number or ``"latest"``.
 
         :return:
-            ``None`` because fee extraction is not yet implemented.
+            Decimal management-fee fraction, or ``None`` when unavailable.
         """
+        if not self.multi_asset_like:
+            return None
 
-        return None
+        raw_bps = self.upshift_contract.functions.managementFeePercent().call(block_identifier=block_identifier)
+        return raw_bps / UPSHIFT_FEE_DENOMINATOR
 
     def get_performance_fee(self, block_identifier: BlockIdentifier) -> float | None:
         """Get performance fee.
 
+        Multi-asset vaults expose ``performanceFeeRate()`` in basis points.
+        TokenizedAccount contracts do not expose an equivalent fee getter, so
+        their performance fee remains unknown rather than being treated as zero.
+
         :param block_identifier:
             Block number or ``"latest"``.
 
         :return:
-            ``None`` because fee extraction is not yet implemented.
+            Decimal performance-fee fraction, or ``None`` when unavailable.
         """
+        if not self.multi_asset_like:
+            return None
 
-        return None
+        raw_bps = self.upshift_contract.functions.performanceFeeRate().call(block_identifier=block_identifier)
+        return raw_bps / UPSHIFT_FEE_DENOMINATOR
+
+    def get_withdraw_fee(self, block_identifier: BlockIdentifier) -> float:
+        """Read the standard queued-redemption fee.
+
+        ``withdrawalFee()`` excludes the separate fee for the optional instant
+        redemption path.  That additional fee remains represented by
+        :py:meth:`has_custom_fees`.
+
+        :param block_identifier:
+            Block number or ``"latest"`` at which to read the configuration.
+
+        :return:
+            Decimal withdrawal-fee fraction, e.g. ``0.002`` for 20 bps.
+        """
+        raw_bps = self.upshift_contract.functions.withdrawalFee().call(block_identifier=block_identifier)
+        return raw_bps / UPSHIFT_FEE_DENOMINATOR
+
+    def fetch_instant_redemption_fee(self, block_identifier: BlockIdentifier) -> float:
+        """Read the extra instant-redemption fee outside the shared fee schema.
+
+        Upshift supports a queued redemption flow and an optional immediate
+        redemption.  The latter fee cannot be substituted for the standard
+        withdrawal fee because it applies only when a user chooses that path.
+
+        :param block_identifier:
+            Block number or ``"latest"`` at which to read the configuration.
+
+        :return:
+            Decimal instant-redemption fee fraction, e.g. ``0.002`` for 20 bps.
+        """
+        raw_bps = self.upshift_contract.functions.instantRedemptionFee().call(block_identifier=block_identifier)
+        return raw_bps / UPSHIFT_FEE_DENOMINATOR
 
     def fetch_total_assets(self, block_identifier: BlockIdentifier) -> Decimal | None:
         """Fetch vault NAV in denomination token units.

--- a/eth_defi/erc_4626/vault_protocol/yearn/compounder.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/compounder.py
@@ -1,0 +1,94 @@
+"""Yearn TokenizedStrategy compounder vault support.
+
+Yearn compounders are Solidity ERC-4626 vaults that delegate their strategy
+logic to a Yearn ``TokenizedStrategy`` implementation.  Their performance fee
+is configured per vault in basis points and charged when a strategy report is
+processed, diluting the share price rather than charging an investor directly.
+
+- `Yearn TokenizedStrategy source <https://github.com/yearn/tokenized-strategy>`__
+- `Verified TokenizedStrategy implementation <https://etherscan.io/address/0xD377919FA87120584B21279a491F82D5265A139c#code>`__
+"""
+
+import datetime
+
+from eth_typing import BlockIdentifier
+
+from eth_defi.erc_4626.vault import ERC4626Vault
+
+#: Yearn TokenizedStrategy fee precision: 10_000 basis points is 100%.
+PERFORMANCE_FEE_DENOMINATOR = 10_000
+
+#: Minimal ABI for the Yearn TokenizedStrategy fee accessor.
+_PERFORMANCE_FEE_ABI = [
+    {
+        "inputs": [],
+        "name": "performanceFee",
+        "outputs": [{"internalType": "uint16", "name": "", "type": "uint16"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+]
+
+
+class YearnCompounderVault(ERC4626Vault):
+    """Read fee data from Yearn TokenizedStrategy compounder vaults.
+
+    These vaults expose a performance-fee percentage but no annual management,
+    deposit, or standard-withdrawal fee.  The performance fee is accrued during
+    strategy reporting and therefore is already reflected in the share price.
+    """
+
+    def get_management_fee(self, block_identifier: BlockIdentifier) -> float:  # noqa: PLR6301
+        """Return the absent Yearn compounder management fee.
+
+        Yearn's TokenizedStrategy interface has no management-fee accessor and
+        the supported compounder implementations charge only the configured
+        performance fee.
+
+        :param block_identifier:
+            Block number or ``"latest"``. Ignored because the fee is absent.
+
+        :return:
+            Always ``0.0``.
+        """
+        del block_identifier
+        return 0.0
+
+    def get_performance_fee(self, block_identifier: BlockIdentifier) -> float:
+        """Read the strategy-report performance fee as a fraction.
+
+        ``performanceFee()`` returns a ``uint16`` basis-point value.  The fee
+        is internalised when Yearn processes a strategy report.
+
+        :param block_identifier:
+            Block number or ``"latest"`` at which to read the configuration.
+
+        :return:
+            Decimal performance-fee fraction, e.g. ``0.2`` for 20%.
+        """
+        contract = self.web3.eth.contract(address=self.vault_address, abi=_PERFORMANCE_FEE_ABI)
+        raw_bps = contract.functions.performanceFee().call(block_identifier=block_identifier)
+        return raw_bps / PERFORMANCE_FEE_DENOMINATOR
+
+    def get_estimated_lock_up(self) -> datetime.timedelta:  # noqa: PLR6301
+        """Return the immediate-redemption availability of compounder vaults.
+
+        The supported Yearn compounder contracts use synchronous ERC-4626
+        redemption and do not publish a lock-up period.
+
+        :return:
+            A zero-length lock-up.
+        """
+        return datetime.timedelta(0)
+
+    def get_link(self, referral: str | None = None) -> str:
+        """Return the direct Yearn vault page.
+
+        :param referral:
+            Optional referral identifier, unsupported by Yearn.
+
+        :return:
+            Yearn vault URL for this chain and vault address.
+        """
+        del referral
+        return f"https://yearn.fi/v3/{self.chain_id}/{self.vault_address}"

--- a/eth_defi/vault/fee.py
+++ b/eth_defi/vault/fee.py
@@ -120,6 +120,9 @@ VAULT_PROTOCOL_FEE_MATRIX = {
     "D2 Finance": VaultFeeMode.internalised_skimming,
     "Untangle Finance": VaultFeeMode.externalised,
     "Yearn": VaultFeeMode.internalised_skimming,
+    # Upshift multi-asset vaults accrue management/performance fees against
+    # vault assets, so the reported share price is already net of those fees.
+    "Upshift": VaultFeeMode.internalised_skimming,
     "Goat Protocol": VaultFeeMode.internalised_skimming,
     "USDai": VaultFeeMode.internalised_skimming,
     "AUTO Finance": VaultFeeMode.internalised_minting,

--- a/eth_defi/vault/fee.py
+++ b/eth_defi/vault/fee.py
@@ -120,9 +120,6 @@ VAULT_PROTOCOL_FEE_MATRIX = {
     "D2 Finance": VaultFeeMode.internalised_skimming,
     "Untangle Finance": VaultFeeMode.externalised,
     "Yearn": VaultFeeMode.internalised_skimming,
-    # Upshift multi-asset vaults accrue management/performance fees against
-    # vault assets, so the reported share price is already net of those fees.
-    "Upshift": VaultFeeMode.internalised_skimming,
     "Goat Protocol": VaultFeeMode.internalised_skimming,
     "USDai": VaultFeeMode.internalised_skimming,
     "AUTO Finance": VaultFeeMode.internalised_minting,

--- a/tests/erc_4626/vault_protocol/test_upshift.py
+++ b/tests/erc_4626/vault_protocol/test_upshift.py
@@ -28,6 +28,9 @@ UPSHIFT_TORI_VAULT = "0xcd69123b3FBBfC666E1f6a501da27B564C00De54"
 UPSHIFT_CTUSD_VAULT = "0xc87DBBB8C67e4F19fCD2E297c05937567b2572Ce"
 UPSHIFT_SENTORA_USD_EARN_VAULT = "0x74ad2f789ed583dbd141bbdafc673fe1f033718b"
 UPSHIFT_SENTORA_INSTANT_REDEMPTION_FEE = 0.002
+UPSHIFT_GAMMA_BTC_VAULT = "0x3e4ef6ccc7e4a045c9d3f48b08813d59df14e256"
+UPSHIFT_GAMMA_BTC_MANAGEMENT_FEE = 0.005
+UPSHIFT_GAMMA_BTC_PERFORMANCE_FEE = 0.1
 UPSHIFT_TORI_HISTORY_START_BLOCK = 25_355_071
 UPSHIFT_TORI_HISTORY_STEP_BLOCKS = 7_200
 UPSHIFT_TORI_HISTORY_SAMPLE_COUNT = 8
@@ -77,6 +80,7 @@ def test_upshift(
     assert vault.has_custom_fees() is True
     assert vault.get_management_fee("latest") is None
     assert vault.get_performance_fee("latest") is None
+    assert vault.get_fee_mode() is None
 
     # Upshift uses a daily claim processing system
     assert vault.get_estimated_lock_up().days == 1
@@ -180,6 +184,24 @@ def test_upshift_multi_asset_fee_data(web3: Web3) -> None:
     assert fee_data.performance == 0.0
     assert fee_data.deposit == 0.0
     assert fee_data.withdraw == 0.0
+
+
+@flaky.flaky
+def test_upshift_multi_asset_fee_units(web3: Web3) -> None:
+    """Read non-zero Upshift multi-asset fees with their protocol-specific units.
+
+    Management fees use basis points, while performance fees use parts per
+    million in the verified ``TokenizedVault`` implementation.
+
+    :param web3:
+        Web3 client connected to the deterministic Ethereum fork.
+    """
+    vault = create_vault_instance_autodetect(web3, vault_address=UPSHIFT_GAMMA_BTC_VAULT)
+
+    assert isinstance(vault, UpshiftVault)
+    fee_data = vault.get_fee_data()
+    assert fee_data.management == UPSHIFT_GAMMA_BTC_MANAGEMENT_FEE
+    assert fee_data.performance == UPSHIFT_GAMMA_BTC_PERFORMANCE_FEE
 
 
 @flaky.flaky

--- a/tests/erc_4626/vault_protocol/test_upshift.py
+++ b/tests/erc_4626/vault_protocol/test_upshift.py
@@ -16,6 +16,7 @@ from eth_defi.event_reader.multicall_batcher import read_multicall_historical
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
 from eth_defi.token import TokenDiskCache
+from eth_defi.vault.fee import VaultFeeMode
 from eth_defi.vault.risk import VaultTechnicalRisk
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
@@ -25,6 +26,8 @@ pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHE
 UPSHIFT_MULTI_ASSET_FORK_BLOCK = 25_405_251
 UPSHIFT_TORI_VAULT = "0xcd69123b3FBBfC666E1f6a501da27B564C00De54"
 UPSHIFT_CTUSD_VAULT = "0xc87DBBB8C67e4F19fCD2E297c05937567b2572Ce"
+UPSHIFT_SENTORA_USD_EARN_VAULT = "0x74ad2f789ed583dbd141bbdafc673fe1f033718b"
+UPSHIFT_SENTORA_INSTANT_REDEMPTION_FEE = 0.002
 UPSHIFT_TORI_HISTORY_START_BLOCK = 25_355_071
 UPSHIFT_TORI_HISTORY_STEP_BLOCKS = 7_200
 UPSHIFT_TORI_HISTORY_SAMPLE_COUNT = 8
@@ -151,6 +154,32 @@ def test_upshift_multi_asset_vault_metadata(
     link = vault.get_link()
     assert "app.upshift.finance" in link
     assert Web3.to_checksum_address(vault_address) in link
+
+
+@flaky.flaky
+def test_upshift_multi_asset_fee_data(web3: Web3) -> None:
+    """Read the complete shared fee model from Sentora USD Earn.
+
+    Sentora USD Earn is an Upshift multi-asset vault with a separate 20-basis-
+    point instant-redemption fee.  That fee is intentionally exposed through a
+    protocol-specific accessor, not the standard queued-withdrawal field.
+
+    :param web3:
+        Web3 client connected to the deterministic Ethereum fork.
+    """
+    vault = create_vault_instance_autodetect(web3, vault_address=UPSHIFT_SENTORA_USD_EARN_VAULT)
+
+    assert isinstance(vault, UpshiftVault)
+    assert vault.multi_asset_like is True
+    assert vault.has_custom_fees() is True
+    assert vault.fetch_instant_redemption_fee("latest") == UPSHIFT_SENTORA_INSTANT_REDEMPTION_FEE
+
+    fee_data = vault.get_fee_data()
+    assert fee_data.fee_mode == VaultFeeMode.internalised_skimming
+    assert fee_data.management == 0.0
+    assert fee_data.performance == 0.0
+    assert fee_data.deposit == 0.0
+    assert fee_data.withdraw == 0.0
 
 
 @flaky.flaky

--- a/tests/erc_4626/vault_protocol/test_yearn_compounder.py
+++ b/tests/erc_4626/vault_protocol/test_yearn_compounder.py
@@ -14,12 +14,16 @@ from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.vault.fee import VaultFeeMode
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
+JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
 
 pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests")
 
 HYPERITHM_VAULT = "0xba8704c18b55f60f5d84b53c3f39a0189a0965b3"
 HYPERITHM_FORK_BLOCK = 24_140_000
 HYPERITHM_PERFORMANCE_FEE = 0.2
+MOONWELL_WETH_BORROWER_VAULT = "0xfdb431e661372fa1146efb70bf120ecded944a78"
+MOONWELL_FORK_BLOCK = 48_900_000
+MOONWELL_PERFORMANCE_FEE = 0.1
 
 
 @pytest.fixture(scope="module")
@@ -72,3 +76,23 @@ def test_yearn_legacy_compounder_fee_data(web3: Web3) -> None:
     assert fee_data.performance == HYPERITHM_PERFORMANCE_FEE
     assert fee_data.deposit == 0.0
     assert fee_data.withdraw == 0.0
+
+
+@flaky.flaky
+@pytest.mark.skipif(JSON_RPC_BASE is None, reason="JSON_RPC_BASE needed to run this test")
+def test_yearn_modern_compounder_fee_data() -> None:
+    """Read Yearn modern compounder fees from Moonwell USDC Lender WETH Borrower.
+
+    The modern proxy exposes ``tokenizedStrategyAddress()`` and must therefore
+    be detected independently of the legacy ``apiVersion()`` path.
+    """
+    launch = fork_network_anvil(JSON_RPC_BASE, fork_block_number=MOONWELL_FORK_BLOCK)
+    try:
+        base_web3 = create_multi_provider_web3(launch.json_rpc_url)
+        vault = create_vault_instance_autodetect(base_web3, vault_address=MOONWELL_WETH_BORROWER_VAULT)
+
+        assert isinstance(vault, YearnCompounderVault)
+        assert vault.features == {ERC4626Feature.yearn_compounder_like}
+        assert vault.get_fee_data().performance == MOONWELL_PERFORMANCE_FEE
+    finally:
+        launch.close()

--- a/tests/erc_4626/vault_protocol/test_yearn_compounder.py
+++ b/tests/erc_4626/vault_protocol/test_yearn_compounder.py
@@ -1,0 +1,74 @@
+"""Test Yearn TokenizedStrategy compounder fee metadata."""
+
+import os
+
+import flaky
+import pytest
+from web3 import Web3
+
+from eth_defi.erc_4626.classification import create_vault_instance_autodetect
+from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.erc_4626.vault_protocol.yearn.compounder import YearnCompounderVault
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.vault.fee import VaultFeeMode
+
+JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
+
+pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests")
+
+HYPERITHM_VAULT = "0xba8704c18b55f60f5d84b53c3f39a0189a0965b3"
+HYPERITHM_FORK_BLOCK = 24_140_000
+HYPERITHM_PERFORMANCE_FEE = 0.2
+
+
+@pytest.fixture(scope="module")
+def anvil_ethereum_fork() -> AnvilLaunch:
+    """Fork Ethereum after the Hyperithm compounder deployment.
+
+    :return:
+        Anvil process connected to the deterministic fork block.
+    """
+    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=HYPERITHM_FORK_BLOCK)
+    try:
+        yield launch
+    finally:
+        launch.close()
+
+
+@pytest.fixture(scope="module")
+def web3(anvil_ethereum_fork: AnvilLaunch) -> Web3:
+    """Create a Web3 client for the local Ethereum fork.
+
+    :param anvil_ethereum_fork:
+        Running Ethereum mainnet fork.
+
+    :return:
+        Web3 client connected to Anvil.
+    """
+    return create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url)
+
+
+@flaky.flaky
+def test_yearn_legacy_compounder_fee_data(web3: Web3) -> None:
+    """Read Yearn legacy compounder fees from the Hyperithm USDC strategy.
+
+    The vault implements the older Yearn TokenizedStrategy surface: it does
+    not expose ``GOV()`` or ``tokenizedStrategyAddress()``, so classification
+    must recognise the joint ``apiVersion()`` and ``performanceFee()`` probe.
+
+    :param web3:
+        Web3 client connected to the deterministic Ethereum fork.
+    """
+    vault = create_vault_instance_autodetect(web3, vault_address=HYPERITHM_VAULT)
+
+    assert isinstance(vault, YearnCompounderVault)
+    assert vault.features == {ERC4626Feature.yearn_compounder_like}
+    assert vault.get_protocol_name() == "Yearn"
+
+    fee_data = vault.get_fee_data()
+    assert fee_data.fee_mode == VaultFeeMode.internalised_skimming
+    assert fee_data.management == 0.0
+    assert fee_data.performance == HYPERITHM_PERFORMANCE_FEE
+    assert fee_data.deposit == 0.0
+    assert fee_data.withdraw == 0.0

--- a/tests/erc_4626/vault_protocol/test_yearn_compounder.py
+++ b/tests/erc_4626/vault_protocol/test_yearn_compounder.py
@@ -57,9 +57,9 @@ def web3(anvil_ethereum_fork: AnvilLaunch) -> Web3:
 def test_yearn_legacy_compounder_fee_data(web3: Web3) -> None:
     """Read Yearn legacy compounder fees from the Hyperithm USDC strategy.
 
-    The vault implements the older Yearn TokenizedStrategy surface: it does
-    not expose ``GOV()`` or ``tokenizedStrategyAddress()``, so classification
-    must recognise the joint ``apiVersion()`` and ``performanceFee()`` probe.
+    The vault implements the older Yearn TokenizedStrategy surface and does
+    not expose ``GOV()``. Classification therefore uses the single shared
+    ``apiVersion()`` marker.
 
     :param web3:
         Web3 client connected to the deterministic Ethereum fork.
@@ -83,8 +83,8 @@ def test_yearn_legacy_compounder_fee_data(web3: Web3) -> None:
 def test_yearn_modern_compounder_fee_data() -> None:
     """Read Yearn modern compounder fees from Moonwell USDC Lender WETH Borrower.
 
-    The modern proxy exposes ``tokenizedStrategyAddress()`` and must therefore
-    be detected independently of the legacy ``apiVersion()`` path.
+    The modern proxy also exposes the same ``apiVersion()`` marker as the
+    legacy strategy, so one protocol probe covers both contract variants.
     """
     launch = fork_network_anvil(JSON_RPC_BASE, fork_block_number=MOONWELL_FORK_BLOCK)
     try:


### PR DESCRIPTION
## Why

The reported Yearn TokenizedStrategy and Upshift multi-asset vaults expose fee data onchain, but classification did not select an adapter that could read it.

This change provides the missing adapter functionality. Existing production metadata still needs a targeted backfill because regular lead scans do not revisit already-recorded vaults.

## Lessons learnt

Yearn compounders expose a shared version marker across legacy and modern strategy variants, so a single protocol probe is sufficient. Its broad marker can overlap other integrations, so specialised adapter routing must take precedence. Upshift management, withdrawal, and instant-redemption fees use basis points, while its performance fee uses parts per million; the two units must not share a denominator.

## Summary

- Add Yearn compounder detection through one shared version-marker probe, adapter routing, and onchain performance-fee reading.
- Preserve specialised Term Finance, Yearn V3, and Yearn Morpho routing when their features overlap that marker.
- Complete Upshift multi-asset management, performance, withdrawal, and instant-redemption fee accessors with their respective onchain units.
- Scope Upshift fee mode to the multi-asset implementation that exposes its management and performance configuration.
- Document the one-probe preference and two-probe maximum in the `add-vault-protocol` skill.
- Add ABI coverage, documentation, and fork tests for legacy and modern Yearn detection plus zero and non-zero Upshift fee data.

## Related issues and PRs

- A separate, targeted production metadata migration is required after deployment to refresh the ten existing vault records; it is not part of this adapter PR.

## Unrelated CI and test fixes

- None.
