### PR TITLE
fix: audit tokenised fund production metadata

### DIFF
--- a/docs/protocol-research/tokenised-fund-production-audit-2026-07-22.md
+++ b/docs/protocol-research/tokenised-fund-production-audit-2026-07-22.md
@@ -1,0 +1,52 @@
+# Tokenised fund production audit
+
+This audit compares the production vault metadata snapshot dated 2026-07-20 with issuer product pages, fund documents, contract metadata and the current adapters. The snapshot contains 39,531 metadata rows, of which 32 rows are flagged as tokenised funds. Repeated deployments account for five BUIDL chains and two ULTRA chains.
+
+## Findings
+
+- mTBILL was incorrectly exported as USDC-denominated. Midas documents an mTBILL/USD oracle; USDC is an accepted issuance payment token. The adapter and metadata migration now export synthetic USD for mTBILL.
+- OpenEden TBILL correctly retains USDC as its denomination token. OpenEden defines the token price in USDC, assumes USDC/USD at one and uses USDC for subscriptions and redemptions.
+- FDIT and CASHx production rows still contain USD metadata from an older scan. Current supply-only adapters deliberately export no denomination until a machine-readable historical NAV source is integrated. Their legal or share-class currency is nevertheless USD.
+- ULTRA is described by its issuer as USD-denominated, but the adapter deliberately leaves denomination and NAV unavailable until a verified public NAV source is configured.
+- The remaining production rows consistently use USD as their accounting or published NAV currency. Synthetic USD metadata is expected where there is no transferable ERC-20 denomination token.
+- Generic or stale product links were present for MONY, BELIF, CUMIU, mTBILL, BUIDL-I, MI4 and USTBL. Current adapters now resolve individual product sources where a reliable public page exists; a metadata refresh is still required to replace cached production rows.
+
+## Product review
+
+| Product | Production denomination | Reviewed result | Primary evidence |
+|---|---:|---|---|
+| Fidelity FDIT | USD | USD share class; current supply-only adapter intentionally exports no denomination or NAV | [Fidelity product page](https://institutional.fidelity.com/app/funds-and-products/9053/fidelity-treasury-digital-fund-onchain-class-fyoxx.html) |
+| KAIO CASHx | USD | USD feeder/share class; current supply-only adapter intentionally exports no denomination or NAV | [BlackRock underlying fund](https://www.blackrock.com/cash/en-gb/products/229271/blackrock-ics-us-dollar-liquidity-select-acc-fund) |
+| J.P. Morgan MONY | USD | Correct synthetic USD accounting denomination | [MONY launch announcement](https://www.prnewswire.com/news-releases/jp-morgan-asset-management-launches-its-first-tokenized-money-market-fund-302642262.html) |
+| ChinaAMC CUMIU | USD | Correct synthetic USD; issuer page and onchain `currencyNAV()` both identify USD | [ChinaAMC product page](https://www.chinaamc.com.hk/product/chinaamc-usd-digital-money-market-fund-listedclass/) |
+| Bosera BELIF | USD | Correct synthetic USD; onchain `currencyNAV()` identifies USD | [BELIF contract](https://etherscan.io/token/0x237c717df1b60501f8d029d3fe7385fd090df180) |
+| Wellington ULTRA | None | Publicly described as USD-denominated; scanner remains conservative until NAV is configured | [Libeara launch announcement](https://libeara.com/libeara-partners-with-wellington-and-fundbridge-capital-to-launch-a-u-s-treasuries-fund-tokenised-on-public-blockchain/) |
+| Midas mTBILL | USDC | Incorrect; corrected to synthetic USD because the oracle is mTBILL/USD | [Midas contract registry](https://docs.midas.app/protocol-mechanics/smart-contracts) |
+| Ondo OUSG | USD | Correct synthetic USD | [OUSG overview](https://docs.ondo.finance/qualified-access-products/ousg/overview) |
+| Ondo USDY | USD | Correct synthetic USD | [USDY overview](https://docs.ondo.finance/general-access-products/usdy/basics) |
+| OpenEden TBILL | USDC | Correct USDC quote and dealing token | [Token-price methodology](https://docs.openeden.com/tbill/token-price) |
+| BlackRock BUIDL and BUIDL-I | USD | Correct synthetic USD; stable USD 1 share-value model | [BlackRock BUIDL](https://www.blackrock.com/us/individual/products/buidl/) |
+| Apollo ACRED | USD | Correct USD NAV currency | [ACRED fund page](https://securitize.io/primary-market/apollo-diversified-credit-securitize-fund) |
+| VanEck VBILL | USD | Correct USD NAV currency | [VBILL fund page](https://securitize.io/primary-market/vaneck-vbill) |
+| BNY/Securitize STAC | USD | Correct USD NAV currency | [STAC fund page](https://securitize.io/primary-market/Securitize-BNY-CLO-Fund) |
+| Arca RCOIN | USD | Correct USD NAV currency | [Arca fund page](https://www.arcalabs.com/fund-overview) |
+| SPiCE SPICE | USD | Correct USD reporting currency | [SPiCE NAV reports](https://spicevc.com/nav-reports.html) |
+| Hamilton Lane HLSCOPE | USD | Correct USD NAV currency | [SCOPE fund page](https://www.hamiltonlane.com/en-us/strategies/evergreen/global/senior-credit-opportunities-fund) |
+| Blockchain Capital BCAP | USD | Correct USD valuation currency | [Securitize BCAP oracle announcement](https://investors.securitize.io/news/news-details/2025/RedStone-and-Securitize-Catalyze-20Bn-RWA-Market-with-First-Ever-BCAP-Price-Feed-on-ZKsync-05-06-2025/default.aspx) |
+| COSIMO X | USD | Correct USD NAV currency | [COSIMO X fund page](https://www.cosimodigital.com/asset-management/cosimo-x) |
+| Science Blockchain SCI2 | USD | Correct USD reporting currency | [SCI2 investor dashboard](https://science.securitize.io/) |
+| Protos PRTS | USD | Correct USD NAV reporting currency | [PRTS NAV report](https://protosmanagement.com/2024/05/09/protos-asset-management-releases-march-31-2024-prts-token-nav/) |
+| Mantle Index Four MI4 | USD | Correct USD NAV currency; product link updated from the manager homepage | [MI4 fund page](https://securitize.io/primary-market/mantle-index-four-fund) |
+| Spiko USTBL | USD | Correct synthetic USD | [Spiko USD fund page](https://www.spiko.io/spiko-treasury-bills-dollar) |
+| Superstate USTB | USD | Correct synthetic USD | [USTB fund page](https://superstate.com/ustb) |
+| Fidelity/Sygnum FILQ-A and FILQ-D | USD | Correct synthetic USD | [FILQ product page](https://www.sygnum.com/filq/) |
+
+## Price-history coverage
+
+The raw production price file contains history for 20 of the 32 flagged addresses. Twelve rows currently have no raw history: FDIT, CASHx, MONY, both ULTRA deployments, COSX, PRTS, RCOIN, SCI2, SPICE, FILQ-A and FILQ-D. This is expected for supply-only or newly integrated products and for products whose NAV source is intentionally unconfigured; it must not be interpreted as a zero NAV.
+
+Most recorded price-read errors occur before a product's configured oracle or feed boundary, especially for RedStone-backed Securitize funds. They are historical boundary errors rather than evidence that the current feed is failing.
+
+## Operational follow-up
+
+Run the ordinary metadata refresh/backfill after deploying these changes. For an existing production metadata database, the Midas denomination migration can be previewed in dry-run mode before applying it. Production Parquet history does not store denomination metadata and does not need to be discarded or rebuilt.

--- a/eth_defi/data/feeds/curators/blackrock.yaml
+++ b/eth_defi/data/feeds/curators/blackrock.yaml
@@ -16,3 +16,8 @@ other-links:
     url: https://www.blackrock.com/corporate/compliance/scams-and-fraud/resources
   - title: BlackRock BUIDL fund page
     url: https://www.blackrock.com/us/individual/products/buidl/
+  # 2026-07-22 maintain-curators: added the individual CASHx underlying-fund sources.
+  - title: BlackRock ICS US Dollar Liquidity Fund page
+    url: https://www.blackrock.com/cash/en-gb/products/229271/blackrock-ics-us-dollar-liquidity-select-acc-fund
+  - title: BlackRock ICS US Dollar Liquidity Fund factsheet
+    url: https://www.blackrock.com/cash/literature/fact-sheet/blackrock-ics-us-dollar-liquidity-fund-agency-acc-t0-usd-factsheet-ie00bj2kfh24-gb-en-institutional.pdf

--- a/eth_defi/data/feeds/curators/blockchain-capital.yaml
+++ b/eth_defi/data/feeds/curators/blockchain-capital.yaml
@@ -10,3 +10,6 @@ long_description: |
 other-links:
   - title: Blockchain Capital official firm overview and history of BCAP
     url: https://www.blockchaincapital.com/about-us
+  # 2026-07-22 maintain-curators: added Securitize's BCAP-specific oracle and valuation source.
+  - title: Securitize BCAP oracle announcement
+    url: https://investors.securitize.io/news/news-details/2025/RedStone-and-Securitize-Catalyze-20Bn-RWA-Market-with-First-Ever-BCAP-Price-Feed-on-ZKsync-05-06-2025/default.aspx

--- a/eth_defi/data/feeds/curators/bny-investments.yaml
+++ b/eth_defi/data/feeds/curators/bny-investments.yaml
@@ -15,3 +15,6 @@ other-links:
     url: https://www.prnewswire.com/news-releases/securitize-expands-stac-tokenized-aaa-clo-fund-to-solana-302798777.html
   - title: Securitize STAC fund page
     url: https://www.securitize-stac.com/
+  # 2026-07-22 maintain-curators: added Securitize's individual primary-market page for STAC.
+  - title: Securitize BNY CLO Fund primary-market page
+    url: https://securitize.io/primary-market/Securitize-BNY-CLO-Fund

--- a/eth_defi/data/feeds/curators/chinaamc-hong-kong.yaml
+++ b/eth_defi/data/feeds/curators/chinaamc-hong-kong.yaml
@@ -16,5 +16,8 @@ other-links:
     url: https://www.chinaamc.com.hk/
   - title: ChinaAMC USD Digital Money Market Fund - official product page and tokenisation information
     url: https://www.chinaamc.com.hk/product/chinaamc-usd-digital-money-market-fund-listedclass/
+  # 2026-07-22 maintain-curators: added the individual fund factsheet used to verify CUMIU's USD share class.
+  - title: ChinaAMC USD Digital Money Market Fund factsheet
+    url: https://www.chinaamc.com.hk/wp-content/uploads/chinaamc/resources/Factsheet_USDDTMMF_20260430_EN.pdf
   - title: Asseto product application - AMCASH+ public product metadata
     url: https://asseto.finance/product

--- a/eth_defi/data/feeds/curators/fidelity.yaml
+++ b/eth_defi/data/feeds/curators/fidelity.yaml
@@ -13,6 +13,11 @@ other-links:
     url: https://www.fidelity.com/
   - title: Fidelity Treasury Digital Fund OnChain class prospectus
     url: https://www.actionsxchangerepository.fidelity.com/ShowDocument/documentPDF.htm?applicationId=FIIS&clientId=Fidelity&collectionId=1079405&criticalIndicator=N&docFormat=pdf&docName=4.B-CTDLO-SUM.PDF&docType=SUMS&pdfReaderStatus=Y&securityId=09053&securityIdType=SASFN
+  # 2026-07-22 maintain-curators: added product-level pricing and factsheet sources for FDIT.
+  - title: Fidelity Treasury Digital Fund OnChain class product page
+    url: https://institutional.fidelity.com/app/funds-and-products/9053/fidelity-treasury-digital-fund-onchain-class-fyoxx.html
+  - title: Fidelity Treasury Digital Fund OnChain class factsheet
+    url: https://institutional.fidelity.com/app/fund/popup/item/print/FIIS_FS_70615.pdf
   - title: DTCC Digital Assets tokenisation service
     url: https://www.dtcc.com/digital-assets/tokenization
   - title: Fidelity International official company overview

--- a/eth_defi/data/feeds/curators/kaio.yaml
+++ b/eth_defi/data/feeds/curators/kaio.yaml
@@ -1,8 +1,8 @@
 feeder-id: kaio
 name: KAIO
 role: curator
-website: https://www.kaio.xyz/
-linkedin: kaio-digital
+# 2026-07-22 maintain-curators: KAIO is the protocol layer; feed sources moved to protocols/kaio.yaml.
+canonical-feeder-id: kaio
 short_description: KAIO provides permissioned tokenisation infrastructure and operational workflows for institutional fund shares.
 long_description: |
   KAIO operates a regulated digital-asset platform for tokenised alternative and money-market fund products. For CASHx, KAIO provides the tokenisation, investor-registry and settlement infrastructure, while BlackRock is the investment manager of the underlying liquidity fund.
@@ -11,3 +11,7 @@ other-links:
     url: https://docs.kaio.xyz/how-kaio-works/smart-contracts
   - title: KAIO architecture overview
     url: https://docs.kaio.xyz/how-kaio-works/architecture
+  - title: CASHx public product record
+    url: https://app.rwa.xyz/assets/CASHx
+  - title: BlackRock ICS US Dollar Liquidity Fund page
+    url: https://www.blackrock.com/cash/en-gb/products/229271/blackrock-ics-us-dollar-liquidity-select-acc-fund

--- a/eth_defi/data/feeds/curators/mantle-guard.yaml
+++ b/eth_defi/data/feeds/curators/mantle-guard.yaml
@@ -12,3 +12,6 @@ other-links:
     url: https://mantleguard.com/
   - title: Securitize official announcement of the Mantle Index Four fund
     url: https://investors.securitize.io/news/news-details/2025/Securitize-and-Mantle-Launch-Institutional-Crypto-Fund-Mantle-Index-Four-MI4-04-24-2025/default.aspx
+  # 2026-07-22 maintain-curators: added the individual Securitize MI4 fund page.
+  - title: Securitize Mantle Index Four fund page
+    url: https://securitize.io/primary-market/mantle-index-four-fund

--- a/eth_defi/data/feeds/curators/midas.yaml
+++ b/eth_defi/data/feeds/curators/midas.yaml
@@ -2,7 +2,8 @@ feeder-id: midas
 name: Midas
 role: curator
 curatorwatch: https://curatorwatch.com/curator/midas
-website: https://midas.app/
+# 2026-07-22 maintain-curators: Midas is the protocol layer; feed sources moved to protocols/midas.yaml.
+canonical-feeder-id: midas
 short_description: Midas is a platform for composable onchain investment products that turns institutional strategies into tokenised assets for DeFi.
 long_description: |
   Midas provides composable onchain investment products whose mTokens track reference
@@ -11,9 +12,6 @@ long_description: |
   principles, with the Midas Attestation Engine publishing holdings, NAV and performance
   data onchain. The official ecosystem materials position Midas between strategy managers,
   DeFi protocols and investors, providing access to onchain investment products.
-twitter: MidasRWA
-linkedin: midasrwa
-
 # Evidence and background references.
 other-links:
   - title: Midas documentation - About Midas and mToken product model
@@ -22,4 +20,11 @@ other-links:
     url: https://docs.midas.app/resources/official-links
   - title: CuratorWatch - Midas curator profile with AUM, vault count and managed vault evidence
     url: https://curatorwatch.com/curator/midas
-linkedin-rss-hub-disabled-at: 2026-06-26
+  - title: Midas mTBILL product page
+    url: https://midas.app/mtbill
+  - title: Midas mTBILL product documentation
+    url: https://docs.midas.app/tokens/mtbill
+  - title: Midas mTBILL independent reporting
+    url: https://docs.midas.app/tokens/mtbill/independent-reporting
+  - title: Midas smart-contract registry and mTBILL/USD oracle
+    url: https://docs.midas.app/protocol-mechanics/smart-contracts

--- a/eth_defi/data/feeds/curators/openeden.yaml
+++ b/eth_defi/data/feeds/curators/openeden.yaml
@@ -1,13 +1,21 @@
 feeder-id: openeden
 name: OpenEden
 role: curator
-website: https://openeden.com/
-twitter: OpenEden_X
+# 2026-07-22 maintain-curators: OpenEden is the protocol layer; feed sources moved to protocols/openeden.yaml.
+canonical-feeder-id: openeden
 short_description: OpenEden operates a tokenised U.S. Treasury bill fund and its permissioned TBILL Vault.
 long_description: |
   OpenEden provides institutional tokenisation infrastructure for U.S. Treasury bill exposure. Its TBILL Vault issues permissioned TBILL shares, publishes the token price through its documented price oracle and requires investor onboarding for subscriptions and redemptions.
 other-links:
+  - title: OpenEden TBILL product page
+    url: https://openeden.com/tbill
+  - title: OpenEden TBILL transparency page
+    url: https://openeden.com/tbill/transparency
   - title: OpenEden TBILL smart-contract addresses
     url: https://docs.openeden.com/tbill/smart-contract-addresses
   - title: OpenEden TBILL token price documentation
     url: https://docs.openeden.com/tbill/token-price
+  - title: OpenEden TBILL subscription assets
+    url: https://docs.openeden.com/tbill/subscriptions
+  - title: OpenEden TBILL redemption assets
+    url: https://docs.openeden.com/tbill/redemptions

--- a/eth_defi/data/feeds/curators/science-inc.yaml
+++ b/eth_defi/data/feeds/curators/science-inc.yaml
@@ -12,3 +12,6 @@ other-links:
     url: https://www.science-inc.com/entities.html
   - title: Science Inc. official Science Blockchain overview
     url: https://www.science-inc.com/blockchain.html
+  # 2026-07-22 maintain-curators: added the individual SCI2 investor dashboard.
+  - title: Science Blockchain investor dashboard
+    url: https://science.securitize.io/

--- a/eth_defi/data/feeds/curators/spiko-curator.yaml
+++ b/eth_defi/data/feeds/curators/spiko-curator.yaml
@@ -17,3 +17,8 @@ other-links:
     url: https://tech.spiko.io/posts/spiko-smart-contracts/
   - title: Spiko contracts repository - USTBL token and Oracle deployment configuration
     url: https://github.com/spiko-tech/contracts/blob/main/subgraph/config/mainnet.json
+  # 2026-07-22 maintain-curators: added the individual USD fund and official NAV sources.
+  - title: Spiko US T-Bills Money Market Fund product page
+    url: https://www.spiko.io/spiko-treasury-bills-dollar
+  - title: Spiko official product factsheets and NAV data
+    url: https://data.spiko.io/

--- a/eth_defi/data/feeds/curators/superstate.yaml
+++ b/eth_defi/data/feeds/curators/superstate.yaml
@@ -17,3 +17,6 @@ other-links:
     url: https://docs.superstate.com/welcome-to-superstate/smart-contracts
   - title: Superstate USTB fund documentation - product eligibility and operations
     url: https://docs.superstate.com/superstate-funds/ustb
+  # 2026-07-22 maintain-curators: added the individual live USTB fund page.
+  - title: Superstate USTB fund page
+    url: https://superstate.com/ustb

--- a/eth_defi/data/feeds/protocols/fidelity-fdit.yaml
+++ b/eth_defi/data/feeds/protocols/fidelity-fdit.yaml
@@ -1,0 +1,14 @@
+feeder-id: fidelity-fdit
+name: Fidelity FDIT
+role: protocol
+canonical-feeder-id: fidelity
+short_description: Fidelity FDIT is the tokenisation surface for the Fidelity Treasury Digital Fund OnChain share class.
+long_description: |
+  Fidelity FDIT represents permissioned shares in the USD-denominated Fidelity Treasury Digital Fund OnChain class. Public supply is available onchain, while the reviewed adapter does not yet have a machine-readable historical NAV source.
+other-links:
+  - title: Fidelity Treasury Digital Fund OnChain class product page
+    url: https://institutional.fidelity.com/app/funds-and-products/9053/fidelity-treasury-digital-fund-onchain-class-fyoxx.html
+  - title: Fidelity Treasury Digital Fund OnChain class factsheet
+    url: https://institutional.fidelity.com/app/fund/popup/item/print/FIIS_FS_70615.pdf
+  - title: Fidelity Treasury Digital Fund OnChain class prospectus
+    url: https://www.actionsxchangerepository.fidelity.com/ShowDocument/documentPDF.htm?applicationId=FIIS&clientId=Fidelity&collectionId=1079405&criticalIndicator=N&docFormat=pdf&docName=4.B-CTDLO-SUM.PDF&docType=SUMS&pdfReaderStatus=Y&securityId=09053&securityIdType=SASFN

--- a/eth_defi/data/feeds/protocols/kaio.yaml
+++ b/eth_defi/data/feeds/protocols/kaio.yaml
@@ -1,0 +1,17 @@
+feeder-id: kaio
+name: KAIO
+role: protocol
+website: https://www.kaio.xyz/
+linkedin: kaio-digital
+short_description: KAIO provides permissioned tokenisation and investor-registry infrastructure for institutional funds.
+long_description: |
+  KAIO provides the tokenisation, investor-registry and settlement infrastructure for CASHx, a feeder share class of Libre SAF VCC that invests in the BlackRock ICS US Dollar Liquidity Fund.
+other-links:
+  - title: KAIO smart-contract overview
+    url: https://docs.kaio.xyz/how-kaio-works/smart-contracts
+  - title: KAIO architecture overview
+    url: https://docs.kaio.xyz/how-kaio-works/architecture
+  - title: BlackRock ICS US Dollar Liquidity Fund page
+    url: https://www.blackrock.com/cash/en-gb/products/229271/blackrock-ics-us-dollar-liquidity-select-acc-fund
+  - title: CASHx public product record
+    url: https://app.rwa.xyz/assets/CASHx

--- a/eth_defi/data/feeds/protocols/kinexys.yaml
+++ b/eth_defi/data/feeds/protocols/kinexys.yaml
@@ -5,4 +5,14 @@ website: https://www.jpmorgan.com/kinexys/index
 twitter: jpmorgan
 linkedin: jpmorgan
 # rss: not found - Kinexys content hub and J.P. Morgan newsroom pages do not expose RSS/Atom links
+short_description: Kinexys provides J.P. Morgan's blockchain infrastructure for tokenised money-market funds and settlement.
+long_description: |
+  Kinexys Digital Assets provides the tokenisation and settlement infrastructure used by J.P. Morgan's reviewed JLTXX and MONY fund products. J.P. Morgan Asset Management remains the investment manager, while Kinexys supplies the onchain issuance surface.
+other-links:
+  - title: Kinexys tokenised money-market funds product family
+    url: https://www.jpmorgan.com/kinexys/tokenized-money-market-funds
+  - title: J.P. Morgan Asset Management MONY launch announcement
+    url: https://www.prnewswire.com/news-releases/jp-morgan-asset-management-launches-its-first-tokenized-money-market-fund-302642262.html
+  - title: JLTXX official fact sheet
+    url: https://am.jpmorgan.com/content/dam/jpm-am-aem/americas/us/en/literature/fact-sheet/money-market/fs-ocltmm-t.pdf
 linkedin-rss-hub-disabled-at: 2026-07-04

--- a/eth_defi/data/feeds/protocols/libeara.yaml
+++ b/eth_defi/data/feeds/protocols/libeara.yaml
@@ -5,3 +5,17 @@ website: https://libeara.com/
 twitter: libeara_
 linkedin: libeara
 # rss: not found — the public website has no advertised RSS or Atom feed
+short_description: Libeara provides tokenisation and lifecycle infrastructure for regulated fund shares.
+long_description: |
+  Libeara supplies the tokenisation platform for the reviewed CUMIU, BELIF and ULTRA fund-share deployments. The underlying funds retain their own investment managers and accounting currencies.
+other-links:
+  - title: ChinaAMC USD Digital Money Market Fund product page
+    url: https://www.chinaamc.com.hk/product/chinaamc-usd-digital-money-market-fund-listedclass/
+  - title: ChinaAMC USD Digital Money Market Fund factsheet
+    url: https://www.chinaamc.com.hk/wp-content/uploads/chinaamc/resources/Factsheet_USDDTMMF_20260430_EN.pdf
+  - title: BELIF onchain fund record
+    url: https://etherscan.io/token/0x237c717df1b60501f8d029d3fe7385fd090df180
+  - title: ULTRA fund launch and product structure
+    url: https://libeara.com/libeara-partners-with-wellington-and-fundbridge-capital-to-launch-a-u-s-treasuries-fund-tokenised-on-public-blockchain/
+  - title: ULTRA multi-chain expansion
+    url: https://libeara.com/libeara-expands-support-of-fundbridge-issued-ultra-and-mg-999-to-solana-with-theo-to-allocate-on-solana/

--- a/eth_defi/data/feeds/protocols/midas.yaml
+++ b/eth_defi/data/feeds/protocols/midas.yaml
@@ -1,0 +1,21 @@
+feeder-id: midas
+name: Midas
+role: protocol
+website: https://midas.app/
+twitter: MidasRWA
+linkedin: midasrwa
+linkedin-rss-hub-disabled-at: 2026-06-26
+short_description: Midas issues composable onchain investment products with published NAV feeds.
+long_description: |
+  Midas supplies the token, issuance, redemption and oracle infrastructure for mTokens. The reviewed mTBILL tokenised fund publishes an mTBILL/USD oracle and accepts separate settlement assets through its issuance vault.
+other-links:
+  - title: Midas mTBILL product page
+    url: https://midas.app/mtbill
+  - title: Midas mTBILL product documentation
+    url: https://docs.midas.app/tokens/mtbill
+  - title: Midas mTBILL independent reporting
+    url: https://docs.midas.app/tokens/mtbill/independent-reporting
+  - title: Midas smart-contract registry and mTBILL/USD oracle
+    url: https://docs.midas.app/protocol-mechanics/smart-contracts
+  - title: Midas contracts repository
+    url: https://github.com/midas-apps/contracts

--- a/eth_defi/data/feeds/protocols/ondo.yaml
+++ b/eth_defi/data/feeds/protocols/ondo.yaml
@@ -5,3 +5,13 @@ website: https://ondo.finance/
 twitter: OndoFinance
 linkedin: ondo-finance
 # rss: not found — Ondo's official site and documentation do not advertise an RSS or Atom feed.
+short_description: Ondo issues and services permissioned tokenised cash-management products.
+long_description: |
+  Ondo operates the reviewed USDY note and OUSG fund, including investor onboarding, transfer controls and issuer-published onchain redemption or NAV prices.
+other-links:
+  - title: Ondo USDY product overview
+    url: https://docs.ondo.finance/general-access-products/usdy/basics
+  - title: Ondo OUSG fund overview
+    url: https://docs.ondo.finance/qualified-access-products/ousg/overview
+  - title: Ondo official contract registry
+    url: https://docs.ondo.finance/addresses

--- a/eth_defi/data/feeds/protocols/openeden.yaml
+++ b/eth_defi/data/feeds/protocols/openeden.yaml
@@ -1,0 +1,21 @@
+feeder-id: openeden
+name: OpenEden
+role: protocol
+website: https://openeden.com/
+twitter: OpenEden_X
+short_description: OpenEden operates a permissioned tokenised U.S. Treasury bill fund and its onchain price oracle.
+long_description: |
+  OpenEden issues and services the reviewed TBILL fund shares. Its documentation defines TBILL price in USDC, with USDC/USD assumed at one, and uses USDC for subscriptions and redemptions.
+other-links:
+  - title: OpenEden TBILL product page
+    url: https://openeden.com/tbill
+  - title: OpenEden TBILL transparency page
+    url: https://openeden.com/tbill/transparency
+  - title: OpenEden TBILL price and USDC quote methodology
+    url: https://docs.openeden.com/tbill/token-price
+  - title: OpenEden TBILL subscription assets
+    url: https://docs.openeden.com/tbill/subscriptions
+  - title: OpenEden TBILL redemption assets
+    url: https://docs.openeden.com/tbill/redemptions
+  - title: OpenEden TBILL smart-contract addresses
+    url: https://docs.openeden.com/tbill/smart-contract-addresses

--- a/eth_defi/data/feeds/protocols/securitize.yaml
+++ b/eth_defi/data/feeds/protocols/securitize.yaml
@@ -5,3 +5,31 @@ website: https://securitize.io/
 twitter: Securitize
 linkedin: securitize-inc
 # rss: not found - the public Securitize site does not advertise an RSS or Atom feed
+short_description: Securitize provides regulated issuance, transfer-agent and investor infrastructure for tokenised securities and funds.
+long_description: |
+  Securitize supplies the DSToken and investor-services platform used by the reviewed tokenised funds. Each fund keeps its own asset manager, strategy, NAV method and investor terms.
+other-links:
+  - title: BlackRock BUIDL fund page
+    url: https://www.blackrock.com/us/individual/products/buidl/
+  - title: Apollo ACRED fund page
+    url: https://securitize.io/primary-market/apollo-diversified-credit-securitize-fund
+  - title: VanEck VBILL fund page
+    url: https://securitize.io/primary-market/vaneck-vbill
+  - title: Securitize BNY CLO Fund STAC page
+    url: https://securitize.io/primary-market/Securitize-BNY-CLO-Fund
+  - title: Arca U.S. Treasury Fund page
+    url: https://www.arcalabs.com/fund-overview
+  - title: SPiCE VC NAV reports
+    url: https://spicevc.com/nav-reports.html
+  - title: Hamilton Lane Senior Credit Opportunities Fund page
+    url: https://www.hamiltonlane.com/en-us/strategies/evergreen/global/senior-credit-opportunities-fund
+  - title: Securitize BCAP oracle announcement
+    url: https://investors.securitize.io/news/news-details/2025/RedStone-and-Securitize-Catalyze-20Bn-RWA-Market-with-First-Ever-BCAP-Price-Feed-on-ZKsync-05-06-2025/default.aspx
+  - title: COSIMO X fund page
+    url: https://www.cosimodigital.com/asset-management/cosimo-x
+  - title: Science Blockchain investor dashboard
+    url: https://science.securitize.io/
+  - title: Protos PRTS NAV report
+    url: https://protosmanagement.com/2024/05/09/protos-asset-management-releases-march-31-2024-prts-token-nav/
+  - title: Mantle Index Four fund page
+    url: https://securitize.io/primary-market/mantle-index-four-fund

--- a/eth_defi/data/feeds/protocols/spiko.yaml
+++ b/eth_defi/data/feeds/protocols/spiko.yaml
@@ -5,3 +5,13 @@ website: https://www.spiko.io/
 twitter: spiko_finance
 linkedin: spiko-finance
 # rss: not found — Spiko's official website and technology blog expose no RSS or Atom feed.
+short_description: Spiko operates tokenised money-market funds and their onchain share infrastructure.
+long_description: |
+  Spiko issues and services tokenised money-market fund shares. The reviewed USTBL product is the USD-denominated Spiko US T-Bills Money Market Fund.
+other-links:
+  - title: Spiko US T-Bills Money Market Fund product page
+    url: https://www.spiko.io/spiko-treasury-bills-dollar
+  - title: Spiko official product factsheets and NAV data
+    url: https://data.spiko.io/
+  - title: Spiko smart-contract and NAV-oracle architecture
+    url: https://tech.spiko.io/posts/spiko-smart-contracts/

--- a/eth_defi/data/feeds/protocols/superstate.yaml
+++ b/eth_defi/data/feeds/protocols/superstate.yaml
@@ -5,3 +5,13 @@ website: https://superstate.com/
 twitter: superstateinc
 linkedin: superstate
 # rss: not found - the Superstate website does not advertise an RSS or Atom feed
+short_description: Superstate issues and services tokenised investment funds with public onchain ownership and NAV data.
+long_description: |
+  Superstate operates the reviewed USTB tokenised private fund, including its investor lifecycle, token contracts and continuous NAV oracle.
+other-links:
+  - title: Superstate USTB fund page
+    url: https://superstate.com/ustb
+  - title: Superstate USTB product documentation
+    url: https://docs.superstate.com/superstate-funds/ustb
+  - title: Superstate official smart-contract registry
+    url: https://docs.superstate.com/welcome-to-superstate/smart-contracts

--- a/eth_defi/data/feeds/protocols/sygnum.yaml
+++ b/eth_defi/data/feeds/protocols/sygnum.yaml
@@ -5,3 +5,11 @@ website: https://www.sygnum.com/
 twitter: sygnumofficial
 linkedin: sygnum
 # rss: not found - the official Sygnum website does not advertise an RSS or Atom feed
+short_description: Sygnum provides tokenisation, settlement and distribution infrastructure for permissioned investment products.
+long_description: |
+  Sygnum's Desygnate platform provides the tokenisation and servicing infrastructure for the reviewed FILQ accumulating and distributing share classes. Fidelity International manages the underlying USD Digital Liquidity Fund.
+other-links:
+  - title: Sygnum FILQ product page
+    url: https://www.sygnum.com/filq/
+  - title: Sygnum FILQ launch and platform announcement
+    url: https://www.sygnum.com/news/sygnum-powers-fidelity-internationals-first-tokenized-product-launch-with-moodys-aaa-mf-assessment/

--- a/eth_defi/midas/vault.py
+++ b/eth_defi/midas/vault.py
@@ -139,9 +139,9 @@ def convert_midas_fee_to_percent(raw_fee: int) -> Percent:
 def export_midas_usd_denomination(chain_id: int) -> dict[str, object]:
     """Export the off-chain USD fallback denomination metadata.
 
-    This is used only when a Midas issuance vault has no configured ERC-20
-    payment token. It records the product's USD accounting label without
-    inventing an ERC-20 address.
+    This is used for reviewed USD accounting units with no ERC-20 denomination,
+    including mTBILL, and when an issuance vault has no configured ERC-20
+    payment token. It records USD without inventing an ERC-20 address.
 
     :param chain_id:
         Chain id for the scan row.
@@ -191,9 +191,11 @@ class MidasVault(VaultBase):
     it through ``getPaymentTokens()``; Midas administrators can add or remove
     accepted payment tokens. :py:meth:`fetch_payment_tokens` reads this
     authoritative live list. Since the shared vault schema presently has one
-    ERC-20 denomination field, the adapter exports the first returned payment
-    token as a compatibility choice. That order is not an assertion that Midas
-    regards it as a canonical or preferred settlement currency.
+    ERC-20 denomination field, non-fund Midas strategy products export the
+    first returned payment token as a compatibility choice. The regulated
+    mTBILL tokenised fund instead exports its documented USD NAV denomination:
+    USDC is an accepted payment route, not the unit of account of the
+    mTBILL/USD oracle.
 
     If an issuance vault is absent, returns no ERC-20 payment tokens, or only
     returns the zero-address ``MANUAL_FULLFILMENT_TOKEN`` sentinel, the adapter
@@ -463,36 +465,38 @@ class MidasVault(VaultBase):
         return payment_tokens[0] if payment_tokens else None
 
     def fetch_denomination_token_address(self) -> HexAddress | None:
-        """Return the primary Midas payment-token address.
+        """Return the compatible denomination-token address.
 
         Midas issuance vaults may accept several payment tokens. The common
-        :class:`VaultBase` schema has one denomination-token field, so this
-        method returns the address of :py:meth:`fetch_primary_payment_token`.
-        If the contract returns no ERC-20 payment tokens, the scan export uses
-        synthetic off-chain USD.
+        :class:`VaultBase` schema has one denomination-token field. For mTBILL,
+        return ``None`` because the official oracle is mTBILL/USD and USDC is a
+        settlement route. Other Midas strategy products retain the historical
+        first-payment-token compatibility convention.
 
         :return:
-            Primary payment-token address, or ``None`` when no token is
-            configured.
+            Compatible denomination-token address, or ``None`` for synthetic
+            USD.
         """
 
         denomination_token = self.fetch_denomination_token()
         return denomination_token.address if denomination_token else None
 
     def fetch_denomination_token(self) -> TokenDetails | None:
-        """Expose the primary Midas payment token through :class:`VaultBase`.
+        """Expose the reviewed Midas valuation denomination.
 
-        This override fulfils the :class:`VaultBase` denomination-token API for
-        a non-ERC-4626 Midas product. It deliberately returns
-        :py:meth:`fetch_primary_payment_token`, allowing the shared scanner to
-        cache and export the primary accepted payment token in
-        :py:attr:`VaultBase.denomination_token`.
+        mTBILL's official public oracle is denominated in USD. Its issuance
+        vault's payment-token list describes accepted settlement routes and
+        must not relabel NAV as USDC. Other Midas strategy products retain the
+        existing first-payment-token compatibility convention pending a
+        separate product-by-product currency review.
 
         :return:
-            Primary payment token, or ``None`` when the scanner must use the
+            ``None`` for mTBILL, otherwise the primary payment token or the
             off-chain USD fallback.
         """
 
+        if self.product.is_tokenised_fund:
+            return None
         return self.fetch_primary_payment_token()
 
     def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
@@ -772,8 +776,12 @@ class MidasVault(VaultBase):
         :param referral:
             Ignored. Midas product URLs do not use referral parameters here.
         :return:
-            Midas product listing URL.
+            Individual Midas product URL when known, otherwise the listing URL.
         """
 
         metadata = get_handwritten_vault_metadata(self.chain_id, self.address)
-        return metadata.link if metadata else MIDAS_HOMEPAGE
+        if metadata:
+            return metadata.link
+        if self.product.is_tokenised_fund:
+            return "https://midas.app/mtbill"
+        return MIDAS_HOMEPAGE

--- a/eth_defi/tokenised_fund/libeara/constants.py
+++ b/eth_defi/tokenised_fund/libeara/constants.py
@@ -17,6 +17,7 @@ class LibearaProduct:
     :param description: Short public product description.
     :param manager_name: Organisation responsible for portfolio management.
     :param curator_slug: Curator metadata slug used by vault exports.
+    :param homepage: Product-specific public information page.
     :param first_seen_at_block: First block with proxy bytecode.
     :param first_seen_at: Proxy deployment timestamp as naive UTC.
     """
@@ -28,6 +29,7 @@ class LibearaProduct:
     description: str
     manager_name: str
     curator_slug: str
+    homepage: str
     first_seen_at_block: int
     first_seen_at: datetime.datetime
 
@@ -45,6 +47,7 @@ CUMIU_ETHEREUM = LibearaProduct(
     "US-dollar digital money-market strategy.",
     "China Asset Management (Hong Kong)",
     "chinaamc-hong-kong",
+    "https://www.chinaamc.com.hk/product/chinaamc-usd-digital-money-market-fund-listedclass/",
     23_038_326,
     datetime.datetime(2025, 7, 31, 6, 34, 35, tzinfo=datetime.UTC).replace(tzinfo=None),
 )
@@ -59,6 +62,7 @@ BELIF_ETHEREUM = LibearaProduct(
     "Liquidity-income strategy.",
     "Bosera Asset Management (International)",
     "bosera-asset-management-international",
+    "https://app.rwa.xyz/assets/BELIF",
     23_595_754,
     datetime.datetime(2025, 10, 17, 9, 1, 23, tzinfo=datetime.UTC).replace(tzinfo=None),
 )
@@ -72,6 +76,7 @@ LIBEARA_ULTRA_ARBITRUM = LibearaProduct(
     "Ultra-short U.S. Treasury strategy.",
     "Wellington Management",
     "wellington-management",
+    "https://libeara.com/libeara-partners-with-wellington-and-fundbridge-capital-to-launch-a-u-s-treasuries-fund-tokenised-on-public-blockchain/",
     358_954_981,
     datetime.datetime(2025, 7, 18, 7, 9, 32, tzinfo=datetime.UTC).replace(tzinfo=None),
 )
@@ -89,6 +94,7 @@ LIBEARA_ULTRA_ETHEREUM = LibearaProduct(
     "Ultra-short U.S. Treasury strategy.",
     "Wellington Management",
     "wellington-management",
+    "https://libeara.com/libeara-partners-with-wellington-and-fundbridge-capital-to-launch-a-u-s-treasuries-fund-tokenised-on-public-blockchain/",
     21_469_784,
     datetime.datetime(2024, 12, 24, 3, 55, 23, tzinfo=datetime.UTC).replace(tzinfo=None),
 )

--- a/eth_defi/tokenised_fund/libeara/vault.py
+++ b/eth_defi/tokenised_fund/libeara/vault.py
@@ -300,11 +300,9 @@ class LibearaVault(TokenisedFundVault):
         return f"{self.product.product_name} uses a permissioned CMTAT share token. The adapter reads issuer-maintained NAV and does not certify price freshness, investor eligibility or public dealing availability."
 
     def get_link(self, referral: str | None = None) -> str:
-        """Return Libeara's platform URL.
+        """Return the fund's reviewed product-information URL.
 
         :param referral: Ignored.
-        :return: Official platform homepage.
+        :return: Product-specific issuer or public record page.
         """
-        if self.is_ultra:
-            return "https://libeara.com/libeara-partners-with-wellington-and-fundbridge-capital-to-launch-a-u-s-treasuries-fund-tokenised-on-public-blockchain/"
-        return "https://libeara.com/"
+        return self.product.homepage

--- a/eth_defi/tokenised_fund/securitize/description.py
+++ b/eth_defi/tokenised_fund/securitize/description.py
@@ -58,7 +58,7 @@ BLOCKCHAIN_CAPITAL_FUND_PAGE_URL = "https://www.blockchaincapital.com/about-us"
 COSIMO_X_FUND_PAGE_URL = "https://www.cosimodigital.com/asset-management/cosimo-x"
 SCIENCE_BLOCKCHAIN_FUND_PAGE_URL = "https://www.science-inc.com/blockchain.html"
 PROTOS_FUND_PAGE_URL = "https://protosmanagement.com/2024/05/09/protos-asset-management-releases-march-31-2024-prts-token-nav/"
-MI4_FUND_PAGE_URL = "https://mantleguard.com/"
+MI4_FUND_PAGE_URL = "https://securitize.io/primary-market/mantle-index-four-fund"
 
 
 def _create_buidl_product(chain_id: int, token: str, chain_name: str) -> SecuritizeProduct:

--- a/eth_defi/tokenised_fund/spiko/vault.py
+++ b/eth_defi/tokenised_fund/spiko/vault.py
@@ -33,7 +33,7 @@ from eth_defi.vault.lower_case_dict import LowercaseDict
 SPIKO_PERMISSIONED_FLOW_REASON = "Spiko USTBL subscriptions, transfers and redemptions require eligibility checks and issuer-operated daily servicing"
 
 #: USTBL's published annual management fee. The reported NAV is net of this fee.
-#: https://www.spiko.io/use-cases/web3
+#: https://www.spiko.io/spiko-treasury-bills-dollar
 USTBL_MANAGEMENT_FEE: Percent = 0.0025
 
 _ORACLE_ABI = [

--- a/scripts/midas/migrate-payment-token-denominations.py
+++ b/scripts/midas/migrate-payment-token-denominations.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-"""Migrate existing Midas metadata rows to on-chain payment-token denominations.
+"""Migrate existing Midas metadata rows to reviewed denominations.
 
-The Midas adapter historically exported synthetic off-chain USD for every
-product. The adapter now reads the first non-zero entry of the issuance vault's
-``getPaymentTokens()`` list as its primary payment token and exposes it through
-the :class:`eth_defi.vault.base.VaultBase` denomination-token API. Existing
-``vault-metadata-db.pickle`` rows must therefore be refreshed once; normal
-scanner runs will use the new denomination for future metadata scans.
+The Midas adapter uses the first non-zero entry of an issuance vault's
+``getPaymentTokens()`` list as a compatibility denomination for ordinary Midas
+strategy products. Regulated tokenised funds are reviewed separately: mTBILL's
+official oracle is mTBILL/USD, so accepted USDC payments must not relabel its
+NAV denomination. Existing ``vault-metadata-db.pickle`` rows can therefore be
+refreshed with this script; normal scanner runs use the same reviewed logic.
 
 This is metadata-only and deliberately does **not** alter raw or cleaned price
 Parquet files, reader state, leads, or a chain's scanner cursor. Price Parquet
@@ -91,10 +91,10 @@ class DenominationMigration:
     #: Existing scanner denomination ERC-20 address, if any.
     old_address: HexAddress | None
 
-    #: Primary Midas payment-token symbol, or off-chain USD.
+    #: Reviewed denomination symbol.
     new_symbol: str
 
-    #: Primary Midas payment-token address, or ``None`` for off-chain USD.
+    #: Reviewed denomination address, or ``None`` for off-chain USD.
     new_address: HexAddress | None
 
     #: Export-ready denomination metadata.
@@ -224,7 +224,7 @@ def resolve_backup_path(vault_db_path: Path) -> Path:
 
 
 def fetch_denomination_migration(web3: Web3, product: MidasProduct, existing_row: VaultRow) -> DenominationMigration:
-    """Read a primary payment token and construct one metadata-only update.
+    """Resolve the reviewed denomination and construct one metadata-only update.
 
     The Midas adapter owns the ``getPaymentTokens()`` ABI call and zero-address
     manual-fulfilment handling. Delegating to it keeps this one-off migration
@@ -324,7 +324,7 @@ def main() -> None:
         message = "No selected Midas products have existing metadata rows to migrate"
         raise RuntimeError(message)
 
-    web3_by_chain = {chain_id: create_multi_provider_web3(read_json_rpc_url(chain_id), retries=2, hint="Midas payment-token denomination migration") for chain_id in {product.chain_id for product in existing_products}}
+    web3_by_chain = {chain_id: create_multi_provider_web3(read_json_rpc_url(chain_id), retries=2, hint="Midas denomination migration") for chain_id in {product.chain_id for product in existing_products}}
     migrations = Parallel(n_jobs=max_workers, backend="threading")(
         delayed(fetch_denomination_migration)(
             web3_by_chain[product.chain_id],
@@ -362,7 +362,7 @@ def main() -> None:
         print("Dry run: no files written. Re-run with DRY_RUN=false to apply these changes.")
         return
     if not changes:
-        print("No migration needed: metadata database already uses current payment-token denominations.")
+        print("No migration needed: metadata database already uses the reviewed denominations.")
         return
 
     backup_path = resolve_backup_path(vault_db_path)

--- a/tests/libeara/test_libeara_vault.py
+++ b/tests/libeara/test_libeara_vault.py
@@ -58,6 +58,7 @@ def test_libeara_adapter_reads_cmtat_nav(web3: Web3, product) -> None:
     assert isinstance(vault, LibearaVault)
     assert vault.manager_name == product.manager_name
     assert vault.curator_slug == product.curator_slug
+    assert vault.get_link() == product.homepage
     assert vault.fetch_total_supply(TEST_BLOCK) == expected_supply
     assert vault.fetch_share_price(TEST_BLOCK) == expected_price
     assert vault.fetch_total_assets(TEST_BLOCK) == expected_supply * expected_price

--- a/tests/midas/test_midas_vault.py
+++ b/tests/midas/test_midas_vault.py
@@ -212,14 +212,14 @@ def test_midas_manual_fulfilment_token_uses_synthetic_usd(monkeypatch: pytest.Mo
     assert vault.fetch_info()["synthetic_usd_denomination"] is True
 
 
-def test_midas_primary_payment_token_fulfils_vaultbase_denomination_api(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Export the first Midas payment token through all VaultBase denomination accessors."""
+def test_midas_non_fund_primary_payment_token_fulfils_vaultbase_denomination_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Export the first payment token for non-fund Midas strategy products."""
 
     vault = MidasVault(
         MagicMock(),
         VaultSpec(
             chain_id=ETHEREUM_CHAIN_ID,
-            vault_address=MIDAS_MTBILL_ETHEREUM.token,
+            vault_address=MIDAS_MBASIS_ETHEREUM.token,
         ),
     )
     primary_payment_token = MagicMock(spec=TokenDetails)
@@ -351,7 +351,7 @@ def test_midas_anvil_forked_mtbill_properties(web3: Web3) -> None:
     assert vault.symbol == "mTBILL"
     assert vault.description == MIDAS_MTBILL_ETHEREUM.product_name
     assert vault.manager_name == "Midas"
-    assert vault.get_link() == "https://midas.app/products"
+    assert vault.get_link() == "https://midas.app/mtbill"
     assert vault.has_block_range_event_support() is False
     assert vault.has_deposit_distribution_to_all_positions() is False
     assert vault.fetch_portfolio(universe=None).spot_erc20 == {}
@@ -363,7 +363,7 @@ def test_midas_anvil_forked_mtbill_properties(web3: Web3) -> None:
     assert info["oracle"] == Web3.to_checksum_address(MIDAS_MTBILL_ETHEREUM.oracle)
     assert info["issuance_vault"] == Web3.to_checksum_address(MIDAS_MTBILL_ETHEREUM.issuance_vault)
     assert info["redemption_vault"] == Web3.to_checksum_address(MIDAS_MTBILL_ETHEREUM.redemption_vault)
-    assert info["synthetic_usd_denomination"] is False
+    assert info["synthetic_usd_denomination"] is True
     assert info["nav_source"] == MIDAS_NAV_SOURCE
     assert info["nav_estimated"] is False
 
@@ -384,9 +384,9 @@ def test_midas_autodetect_live_mtbill(web3: Web3) -> None:
     assert vault.share_token.name == "Midas US Treasury Bill Token"
     assert vault.share_token.symbol == "mTBILL"
     assert vault.share_token.decimals == MTBILL_EXPECTED_DECIMALS
-    assert vault.fetch_denomination_token_address() == Web3.to_checksum_address("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
-    assert vault.fetch_denomination_token().symbol == "USDC"
-    assert vault.denomination_token.symbol == "USDC"
+    assert vault.fetch_denomination_token_address() is None
+    assert vault.fetch_denomination_token() is None
+    assert vault.denomination_token is None
 
 
 @flaky.flaky
@@ -409,10 +409,10 @@ def test_midas_live_supply_nav_and_unsupported_actions(web3: Web3) -> None:
     assert vault.get_fee_data().performance is None
     assert vault.get_fee_data().deposit == 0
     assert vault.get_fee_data().withdraw == MTBILL_EXPECTED_WITHDRAW_FEE
-    assert vault.fetch_info()["denomination_token"] == Web3.to_checksum_address("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
-    assert vault.fetch_scan_record_extra_data()["Denomination"] == "USDC"
-    assert vault.fetch_scan_record_extra_data()["_denomination_token"]["symbol"] == "USDC"
-    assert vault.fetch_scan_record_extra_data()["_denomination_token"]["address"] == Web3.to_checksum_address("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+    assert vault.fetch_info()["denomination_token"] is None
+    assert vault.fetch_scan_record_extra_data()["Denomination"] == "USD"
+    assert vault.fetch_scan_record_extra_data()["_denomination_token"]["symbol"] == "USD"
+    assert vault.fetch_scan_record_extra_data()["_denomination_token"]["address"] is None
     assert vault.fetch_info()["nav_source"] == MIDAS_NAV_SOURCE
     assert vault.fetch_info()["nav_estimated"] is False
 
@@ -563,7 +563,7 @@ def test_midas_scan_record_live_mtbill(web3: Web3) -> None:
     assert record["Symbol"] == "mTBILL"
     assert record["Name"] == "Midas US Treasury Bill Token"
     assert record["Protocol"] == "Midas"
-    assert record["Denomination"] == "USDC"
+    assert record["Denomination"] == "USD"
     assert record["Share token"] == "mTBILL"
     assert record["NAV"] == MTBILL_EXPECTED_TOTAL_ASSETS
     assert record["Mgmt fee"] is None
@@ -573,15 +573,15 @@ def test_midas_scan_record_live_mtbill(web3: Web3) -> None:
     assert record["Shares"] == MTBILL_EXPECTED_TOTAL_SUPPLY
     assert record["Features"] == "midas_like"
     assert record["_detection_data"] == detection
-    assert record["_denomination_token"]["symbol"] == "USDC"
-    assert record["_denomination_token"]["address"] == Web3.to_checksum_address("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+    assert record["_denomination_token"]["symbol"] == "USD"
+    assert record["_denomination_token"]["address"] is None
     assert record["_share_token"]["symbol"] == "mTBILL"
     assert record["_manager_name"] == "Midas"
     assert record["_deposit_closed_reason"] == MIDAS_BESPOKE_FLOW_REASON
     assert record["_redemption_closed_reason"] == MIDAS_BESPOKE_FLOW_REASON
     assert record["_nav_source"] == MIDAS_NAV_SOURCE
     assert record["_nav_estimated"] is False
-    assert record["_synthetic_usd_denomination"] is False
+    assert record["_synthetic_usd_denomination"] is True
     assert record["_midas_data_feed"] == Web3.to_checksum_address(MIDAS_MTBILL_ETHEREUM.data_feed)
     assert record["_midas_oracle"] == Web3.to_checksum_address(MIDAS_MTBILL_ETHEREUM.oracle)
 
@@ -676,7 +676,7 @@ def test_midas_lead_detection_lifetime_metrics_json_export(monkeypatch: pytest.M
     assert decoded["vaults"][0]["management_fee"] is None
     assert decoded["vaults"][0]["deposit_fee"] == 0
     assert decoded["vaults"][0]["withdraw_fee"] == MTBILL_EXPECTED_WITHDRAW_FEE
-    assert decoded["vaults"][0]["denomination"] == "USDC"
+    assert decoded["vaults"][0]["denomination"] == "USD"
     assert decoded["vaults"][0]["address"] == MIDAS_MTBILL_ETHEREUM.token.lower()
 
 

--- a/tests/securitize/test_securitize_vault.py
+++ b/tests/securitize/test_securitize_vault.py
@@ -67,6 +67,7 @@ def test_securitize_product_registry() -> None:
     products = (BUIDL_ETHEREUM, BUIDL_POLYGON, BUIDL_AVALANCHE, BUIDL_OPTIMISM, BUIDL_ARBITRUM, BUIDL_I_ETHEREUM, ACRED_ETHEREUM, VBILL_ETHEREUM, STAC_ETHEREUM, ARCOIN_ETHEREUM, SPICE_VC_ETHEREUM, HLSCOPE_ETHEREUM, BCAP_ETHEREUM, COSX_ETHEREUM, SCI2_ETHEREUM, PRTS_ETHEREUM, MI4_MANTLE)
     assert {SECURITIZE_PRODUCTS[product.chain_id, product.token] for product in products} == set(products)
     assert all(product.notes.startswith(product.product_name) for product in products)
+    assert MI4_MANTLE.homepage == "https://securitize.io/primary-market/mantle-index-four-fund"
     assert all(identify_curator(product.chain_id, "", product.product_name, product.token) == product.curator_slug for product in products)
 
 


### PR DESCRIPTION
## Why

The production tokenised-fund snapshot mixed NAV accounting currencies with settlement tokens and retained several stale or generic product links. This made mTBILL appear USDC-denominated even though Midas publishes an mTBILL/USD oracle, and made later source review harder than necessary.

## Lessons learnt

A token accepted for subscriptions is not necessarily the currency that denominates fund NAV. Production metadata can also remain stale after adapter behaviour changes, so currency audits need to compare cached rows, current adapter output, oracle semantics and issuer documentation together.

Individual fund pages, factsheets, contract registries and transparency pages are more durable review inputs than organisation homepages.

## Summary

- document the 2026-07-20 production snapshot covering 32 tokenised-fund rows and price-history coverage
- correct mTBILL from the USDC settlement token to synthetic USD accounting metadata
- retain OpenEden TBILL as USDC because its documented price and dealing methodology use USDC
- add product-specific links for Libeara and Securitize funds
- add and expand curator and protocol YAML references, including Fidelity FDIT, KAIO, Midas and OpenEden
- update focused regression coverage and the existing Midas metadata migration

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.