### PR TITLE
feat: add Lighter Robinhood multichain vault scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.2
 
 - feat: Add Bulla Network Factoring vault recognition, native fee reads and safe read-only support (2026-07-21)
+- feat: Add multi-deployment Lighter vault scanning for Ethereum and Robinhood Chain with deployment-aware metrics and automatic legacy data migration (2026-07-22)
 - feat: Track per-chain vault scanner JSON-RPC calls and errors in DuckDB (2026-07-20)
 - feat: Add Hypersync-backed Chainlink bundle aggregator history and FILQ NAV support (2026-07-20)
 - feat: Backfill OpenEden TBILL oracle price history while preserving supply-only FDIT and CASHx metadata (2026-07-20)

--- a/contracts/guard/README.md
+++ b/contracts/guard/README.md
@@ -55,7 +55,7 @@ The guard dispatcher validates calls to the following protocols:
 | **Velora (ParaSwap)** | [VeloraLib](./src/lib/VeloraLib.sol) | Atomic swaps with balance-envelope verification for opaque Augustus calldata |
 | **GMX V2** | [GmxLib](./src/lib/GmxLib.sol) | Perpetuals multicall validation with market/router whitelisting |
 | **Hypercore** | [HypercoreVaultLib](./src/lib/HypercoreVaultLib.sol) | HyperEVM native vault deposits, CoreWriter action validation |
-| **Lighter** | [LighterLib](./src/lib/LighterLib.sol) | zk-rollup perps DEX L1 deposit/withdraw validation with receiver + asset-index checks ([docs](../../eth_defi/lighter/README-lighter-guard.md)) |
+| **Lighter (Ethereum)** | [LighterLib](./src/lib/LighterLib.sol) | Ethereum `ZkLighter` USDC deposit/withdraw validation with receiver + asset-index checks; Robinhood custody is not supported ([docs](../../eth_defi/lighter/README-lighter-guard.md)) |
 | **ERC-20** | Built-in | `approve`, `transfer` to whitelisted addresses only |
 
 Additional built-in support: `multicall` batching, Lagoon vault `settle`/`requestSettle`,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,7 +194,7 @@ services:
     entrypoint: [ "python", "scripts/erc-4626/scan-vaults-all-chains.py" ]
     environment:
       LOOP_INTERVAL_SECONDS: ${LOOP_INTERVAL_SECONDS:-3600}
-      SCAN_CYCLES: ${SCAN_CYCLES:-Ethereum=8h,Base=8h,Arbitrum=8h,Hypercore=4h,GRVT=4h,Lighter=4h,Hibachi=4h,Core3=24h}
+      SCAN_CYCLES: ${SCAN_CYCLES:-Ethereum=8h,Base=8h,Arbitrum=8h,Hypercore=4h,GRVT=4h,Lighter Ethereum=4h,Lighter Robinhood=4h,Hibachi=4h,Core3=24h}
       DEFAULT_CYCLE: ${DEFAULT_CYCLE:-24h}
 
       CHAIN_ORDER: ${CHAIN_ORDER:-}

--- a/eth_defi/lighter/README-lighter-guard.md
+++ b/eth_defi/lighter/README-lighter-guard.md
@@ -9,6 +9,15 @@ This document describes how the on-chain guard whitelisting works. It mirrors
 the GMX (`eth_defi/gmx/README-GMX-Lagoon.md`) and Hypercore
 (`docs/README-Hypercore-guard.md`) guard integrations.
 
+> Deployment scope: this guard integration supports only the original
+> **Ethereum-settled Lighter deployment** and its USDC `ZkLighter` custody
+> contract. The Robinhood work currently covers native-pool discovery,
+> metrics and export only. Do not use `LighterDeployment.create_ethereum()`,
+> the whitelisting helpers or public-key helpers for
+> Robinhood. Robinhood documents USDG deposits into a Lighter Relayer smart
+> contract on Robinhood Chain (chain id 4663), but this repository has not
+> configured or verified that contract's address and ABI for guard use.
+>
 > Guard scope: **deposit / withdraw only** (the on-chain L1 custody flow).
 > Lighter account creation happens when the Safe receives its first credited
 > deposit. On-book trading (`createOrder`) is signed with the Lighter API key,
@@ -147,9 +156,13 @@ Funds are released on-chain directly to the Safe address.
 
 ## Account valuation (off-chain)
 
-Lighter account NAV is read off-chain from the public account API, not through
-the guard. Use `eth_defi.lighter.valuation.fetch_lighter_total_equity()` with
-the Safe's Lighter account index to fetch `LighterEquity`.
+Ethereum Lighter account NAV is read off-chain from the public account API, not
+through the guard. Use
+`eth_defi.lighter.valuation.fetch_lighter_total_equity()` with the Safe's
+Lighter account index and an explicit `LighterSession` to fetch
+`LighterEquity`. This section's Safe and USDC flow uses an Ethereum session;
+reading another deployment through its session does not configure its custody
+contracts or Guard support.
 
 `LighterEquity.get_total()` returns Lighter's canonical `total_asset_value`
 field in USDC. The helper also exposes collateral, unrealised PnL, available
@@ -236,6 +249,10 @@ tests reuse the same function.
 
 ## Limitations (current scope)
 
+- **Ethereum deployment only.** The configured `ZkLighter` proxy, USDC token,
+  Safe whitelisting, API-key rotation and example flows all target Ethereum
+  mainnet. The deployment-aware native-pool metrics pipeline does not make
+  these custody helpers multi-chain.
 - **USDC-only.** A single deposit asset (USDC) is whitelisted; its asset index
   is read from `ZkLighter.USDC_ASSET_INDEX()`. Additional assets are not
   supported yet — `whitelistLighter` takes one `assetIndex` per call (each call
@@ -256,7 +273,8 @@ guard/module at deployment time, exactly like `GmxLib` and `HypercoreVaultLib`
 
 ## Manual test recipe
 
-On an Anvil **Ethereum mainnet fork** (Lighter is L1):
+On an Anvil **Ethereum mainnet fork** (this guard integration targets Lighter's
+Ethereum L1 custody contract):
 
 1. Deploy the guard with `LighterLib` linked; run `setup_lighter_whitelisting`
    (`whitelistLighter(zkLighter, usdc, usdcAssetIndex, notes)` + `allowReceiver(safe)`).
@@ -271,6 +289,7 @@ On an Anvil **Ethereum mainnet fork** (Lighter is L1):
 
 - Lighter deposits and withdrawals: <https://apidocs.lighter.xyz/docs/deposits-transfers-and-withdrawals>
 - Lighter docs: <https://docs.lighter.xyz>
+- Robinhood Wallet perpetual futures: <https://robinhood.com/us/en/support/articles/robinhood-wallet-perpetual-futures/>
 - `ZkLighter` on Etherscan: <https://etherscan.io/address/0x831ef69bab8af8b1037a4961b8d0674b124e7008>
 - Guard core: `contracts/guard/src/GuardV0Base.sol`
 - Lighter library: `contracts/guard/src/lib/LighterLib.sol`

--- a/eth_defi/lighter/__init__.py
+++ b/eth_defi/lighter/__init__.py
@@ -3,8 +3,10 @@
 This module provides tools for interacting with the `Lighter <https://lighter.xyz/>`__
 decentralised perpetuals exchange, including pool data extraction and daily metrics.
 
-Lighter is a ZK-rollup perp DEX on Ethereum with public pools (vaults)
-including the LLP (Lighter Liquidity Pool) and user-created leveraged pools.
+The metrics integration indexes public pools (vaults) from Lighter deployments
+associated with Ethereum and Robinhood Chain, including protocol liquidity
+pools and user-created leveraged pools. Custody and Guard helpers remain
+specific to the original Ethereum deployment.
 
 See :py:mod:`eth_defi.lighter.vault` for pool-related functionality,
 :py:mod:`eth_defi.lighter.daily_metrics` for the daily metrics pipeline and

--- a/eth_defi/lighter/constants.py
+++ b/eth_defi/lighter/constants.py
@@ -20,9 +20,10 @@ from eth_defi.vault.fee import VaultFeeMode
 #: .. warning::
 #:
 #:     This is a synthetic id used by the off-chain pool-metrics pipeline — it
-#:     is **not** an EVM chain. The on-chain Lighter deposit/withdraw contract
-#:     lives on Ethereum mainnet (chain id 1); see
-#:     :py:data:`LIGHTER_L1_CONTRACT` below.
+#:     is **not** an EVM chain. The original deployment's onchain Lighter
+#:     deposit/withdraw contract lives on Ethereum mainnet (chain id 1); see
+#:     :py:data:`LIGHTER_L1_CONTRACT` below. The Robinhood metrics deployment
+#:     is associated with Robinhood Chain (chain id 4663).
 LIGHTER_CHAIN_ID: int = 9998
 
 #: Legacy synthetic chain ID used by the first implementation of Lighter on
@@ -99,12 +100,14 @@ LIGHTER_POOL_FEE_MODE: VaultFeeMode = VaultFeeMode.internalised_skimming
 
 #: Pool denomination currency.
 #:
-#: Lighter uses USDC as the exchange base currency.
+#: The original Ethereum Lighter deployment uses USDC as its collateral
+#: currency. Robinhood deployment configuration overrides this with USDG.
 LIGHTER_DENOMINATION: str = "USDC"
 
 #: Pool cooldown period for withdrawals.
 #:
-#: From ``systemConfig.liquidity_pool_cooldown_period`` (300000ms = 5 minutes).
+#: Ethereum value from ``systemConfig.liquidity_pool_cooldown_period``
+#: (300000ms = 5 minutes). Robinhood deployment configuration overrides it.
 LIGHTER_POOL_LOCKUP: datetime.timedelta = datetime.timedelta(minutes=5)
 
 
@@ -189,6 +192,34 @@ class LighterAPIConfig:
         """
         return f"{self.app_url}/public-pools/{account_index}"
 
+    def matches_pool_address(self, address: str) -> bool:
+        """Check whether a synthetic pool address belongs to this deployment.
+
+        A numeric suffix is required because the backwards-compatible
+        Ethereum prefix ``lighter-pool`` is also the beginning of the
+        Robinhood prefix ``lighter-pool-robinhood``. This exact check lets
+        partial price merges distinguish the two deployments without relying
+        on prefix ordering.
+
+        :param address:
+            Synthetic Lighter vault address.
+        :return:
+            ``True`` when the address has this deployment's prefix and a
+            numeric Lighter account index.
+        """
+        prefix = f"{self.address_prefix}-"
+        address = str(address)
+        return address.startswith(prefix) and address.removeprefix(prefix).isdigit()
+
+    @property
+    def pool_address_pattern(self) -> str:
+        """Return the PyArrow regex for this deployment's pool addresses.
+
+        :return:
+            Anchored regular expression matching synthetic pool addresses.
+        """
+        return f"^{self.address_prefix}-[0-9]+$"
+
 
 #: Ethereum-settled Lighter deployment. The legacy address format and
 #: synthetic chain ID are intentionally retained for dataset compatibility.
@@ -241,23 +272,18 @@ LIGHTER_DEPLOYMENTS_BY_SLUG: dict[str, LighterAPIConfig] = {deployment.slug: dep
 def identify_lighter_pool_deployment(address: str) -> LighterAPIConfig | None:
     """Resolve a synthetic Lighter pool address to its deployment.
 
-    Deployment prefixes are checked longest-first because the backwards-
-    compatible Ethereum prefix ``lighter-pool`` is also the beginning of the
-    Robinhood prefix ``lighter-pool-robinhood``. This helper is used by partial
-    Parquet replacement so an independently completed Ethereum or Robinhood
-    scan cannot remove the other deployment's retained history.
+    This helper is used by partial Parquet replacement so an independently
+    completed Ethereum or Robinhood scan cannot remove the other deployment's
+    retained history. :py:meth:`LighterAPIConfig.matches_pool_address`
+    validates the numeric account-index suffix, preventing the shorter
+    Ethereum prefix from matching Robinhood addresses.
 
     :param address:
         Synthetic Lighter vault address.
     :return:
         Matching deployment, or ``None`` when the address is not recognised.
     """
-    address = str(address)
-    deployments_by_prefix_length = sorted(LIGHTER_DEPLOYMENTS, key=lambda deployment: len(deployment.address_prefix), reverse=True)
-    return next(
-        (deployment for deployment in deployments_by_prefix_length if address.startswith(f"{deployment.address_prefix}-")),
-        None,
-    )
+    return next((deployment for deployment in LIGHTER_DEPLOYMENTS if deployment.matches_pool_address(address)), None)
 
 
 #: Set of Lighter system pool addresses (protocol-curated).
@@ -265,7 +291,7 @@ def identify_lighter_pool_deployment(address: str) -> LighterAPIConfig | None:
 #: The LLP (Lighter Liquidity Pool) is the protocol's own liquidity pool;
 #: the XLP (Experimental Liquidity Provider) is the protocol-run pool for
 #: experimental markets.  Both are community-owned and protocol-operated.
-#: Uses the synthetic address format ``lighter-pool-{account_index}``.
+#: Uses each deployment's synthetic pool-address format.
 #:
 #: These are protocol-operated pools with special properties (no operator fee).
 #: Ethereum system pools are fetched separately via ``systemConfig`` when they

--- a/eth_defi/lighter/constants.py
+++ b/eth_defi/lighter/constants.py
@@ -6,6 +6,7 @@ Shared constants used across the Lighter modules
 """
 
 import datetime
+from dataclasses import dataclass
 from pathlib import Path
 
 from eth_typing import HexAddress
@@ -23,6 +24,40 @@ from eth_defi.vault.fee import VaultFeeMode
 #:     lives on Ethereum mainnet (chain id 1); see
 #:     :py:data:`LIGHTER_L1_CONTRACT` below.
 LIGHTER_CHAIN_ID: int = 9998
+
+#: Legacy synthetic chain ID used by the first implementation of Lighter on
+#: Robinhood support.
+#:
+#: Both deployments now intentionally use :py:data:`LIGHTER_CHAIN_ID` because
+#: they belong to one native Lighter dataset namespace. Keep this old value
+#: only so Parquet and VaultDatabase migrations can remove rows written by the
+#: short-lived split-chain implementation.
+LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID: int = 9996
+
+#: Ethereum mainnet chain ID associated with the original Lighter deployment.
+#:
+#: This is deliberately separate from :py:data:`LIGHTER_CHAIN_ID`. The latter
+#: is the synthetic vault-dataset ID used to partition native Lighter prices,
+#: whereas this value identifies the EVM chain associated with the deployment.
+#: This distinction became necessary when adding Lighter on Robinhood Chain.
+LIGHTER_ETHEREUM_DEPLOYMENT_CHAIN_ID: int = 1
+
+#: Robinhood Chain ID associated with the Robinhood Lighter deployment.
+#:
+#: For now this field exists specifically so lifetime-metrics consumers can
+#: distinguish Lighter on Robinhood Chain from Lighter on Ethereum without
+#: replacing the synthetic IDs used by the vault price pipeline.
+LIGHTER_ROBINHOOD_DEPLOYMENT_CHAIN_ID: int = 4663
+
+#: LLP account index exposed by the Robinhood Lighter public-pools API.
+#:
+#: For now this override exists specifically for Lighter on Robinhood. Its
+#: ``systemConfig.liquidity_pool_index`` currently points at the next,
+#: uninitialised account instead of the live USDG LLP account. Account type 3
+#: cannot be used as a generic fallback because Ethereum currently exposes both
+#: LLP and XLP with that account type. Keeping the workaround in deployment
+#: configuration prevents XLP from being misclassified as the canonical LLP.
+LIGHTER_ROBINHOOD_LLP_ACCOUNT_INDEX: int = 281474976710654
 
 #: Lighter L1 contract (``ZkLighter`` proxy), Ethereum mainnet (chain id 1).
 #:
@@ -43,6 +78,9 @@ LIGHTER_USDC_ETHEREUM: HexAddress = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 
 #: Lighter mainnet API base URL.
 LIGHTER_API_URL: str = "https://mainnet.zklighter.elliot.ai"
+
+#: Lighter API for the deployment settling on Robinhood Chain.
+LIGHTER_ROBINHOOD_API_URL: str = "https://api.rh.lighter.xyz"
 
 #: Default path for Lighter daily metrics DuckDB database.
 LIGHTER_DAILY_METRICS_DATABASE: Path = Path.home() / ".tradingstrategy" / "vaults" / "lighter-pools.duckdb"
@@ -70,6 +108,136 @@ LIGHTER_DENOMINATION: str = "USDC"
 LIGHTER_POOL_LOCKUP: datetime.timedelta = datetime.timedelta(minutes=5)
 
 
+@dataclass(frozen=True, slots=True)
+class LighterAPIConfig:
+    """Configuration for one independently indexed Lighter deployment.
+
+    Lighter account indexes are only unique within a deployment. In
+    particular, account ``281474976710654`` exists on both Ethereum Lighter
+    and Robinhood Lighter, so downstream storage must always pair an account
+    index with :py:attr:`slug`.
+
+    :param slug:
+        Stable storage identifier for the deployment.
+    :param name:
+        Human-readable scanner and scheduling name.
+    :param chain_id:
+        Synthetic vault-dataset chain ID. This remains the primary identity
+        used for price partitions and :class:`~eth_defi.vault.base.VaultSpec`.
+    :param deployment_chain_id:
+        Real EVM chain associated with this Lighter deployment. For now this
+        separate identity is needed to expose whether a Lighter pool belongs
+        to the Ethereum or Robinhood deployment in lifetime-metrics exports.
+    :param api_url:
+        REST API base URL.
+    :param app_url:
+        Web application base URL used for vault links.
+    :param address_prefix:
+        Synthetic vault address prefix. Deployment-specific prefixes prevent
+        address-only metadata rules from leaking between deployments.
+    :param denomination:
+        Pool collateral symbol.
+    :param lockup:
+        Public-pool withdrawal cooldown reported by ``systemConfig``.
+    :param llp_account_index_override:
+        Deployment-specific canonical LLP account override. ``None`` trusts
+        ``systemConfig``. For now Robinhood needs an override because its live
+        system configuration points at an uninitialised account.
+    """
+
+    slug: str
+    name: str
+    chain_id: int
+
+    #: Real EVM chain associated with this deployment.
+    #:
+    #: Do not use this value as the Lighter vault's primary ``chain_id``. The
+    #: synthetic :py:attr:`chain_id` is still required to keep native Lighter
+    #: price rows separate from ordinary ERC-4626 vaults. Both Lighter
+    #: deployments share that synthetic ID and use deployment-specific address
+    #: prefixes for uniqueness. For now this second chain ID supports Lighter
+    #: on Robinhood in downstream lifetime-metrics exports.
+    deployment_chain_id: int
+
+    api_url: str
+    app_url: str
+    address_prefix: str
+    denomination: str
+    lockup: datetime.timedelta
+
+    #: Canonical LLP account override for deployments with unreliable system
+    #: configuration. For now only Lighter on Robinhood uses this field.
+    llp_account_index_override: int | None = None
+
+    def format_pool_address(self, account_index: int) -> str:
+        """Create a globally unique synthetic pool address.
+
+        :param account_index:
+            Deployment-local Lighter account index.
+        :return:
+            Synthetic address accepted by :class:`eth_defi.vault.base.VaultSpec`.
+        """
+        return f"{self.address_prefix}-{account_index}"
+
+    def format_pool_link(self, account_index: int) -> str:
+        """Create the deployment-specific public-pool application link.
+
+        :param account_index:
+            Deployment-local Lighter account index.
+        :return:
+            Public-pool detail URL.
+        """
+        return f"{self.app_url}/public-pools/{account_index}"
+
+
+#: Ethereum-settled Lighter deployment. The legacy address format and
+#: synthetic chain ID are intentionally retained for dataset compatibility.
+LIGHTER_ETHEREUM: LighterAPIConfig = LighterAPIConfig(
+    slug="ethereum",
+    name="Lighter Ethereum",
+    chain_id=LIGHTER_CHAIN_ID,
+    # Associated EVM deployment chain exported alongside synthetic ID 9998.
+    deployment_chain_id=LIGHTER_ETHEREUM_DEPLOYMENT_CHAIN_ID,
+    api_url=LIGHTER_API_URL,
+    app_url="https://app.lighter.xyz",
+    address_prefix="lighter-pool",
+    denomination=LIGHTER_DENOMINATION,
+    lockup=LIGHTER_POOL_LOCKUP,
+)
+
+#: Robinhood Chain-settled Lighter deployment. Its live API reports USDG as
+#: collateral and a zero public-pool cooldown.
+LIGHTER_ROBINHOOD: LighterAPIConfig = LighterAPIConfig(
+    slug="robinhood",
+    name="Lighter Robinhood",
+    # Both Lighter deployments belong to the same synthetic dataset chain.
+    # The Robinhood address prefix below prevents VaultSpec/address collisions.
+    chain_id=LIGHTER_CHAIN_ID,
+    # Associated EVM deployment chain exported specifically so consumers can
+    # identify this pool as Lighter on Robinhood rather than Ethereum.
+    deployment_chain_id=LIGHTER_ROBINHOOD_DEPLOYMENT_CHAIN_ID,
+    api_url=LIGHTER_ROBINHOOD_API_URL,
+    app_url="https://robinhoodchain.lighter.xyz",
+    address_prefix="lighter-pool-robinhood",
+    denomination="USDG",
+    lockup=datetime.timedelta(0),
+    # For now Robinhood's systemConfig points at account 281474976710655,
+    # which is uninitialised, while publicPoolsMetadata exposes the live USDG
+    # LLP at 281474976710654. Do not replace this with ``account_type == 3``:
+    # Ethereum also exposes XLP as account type 3 and it is not the LLP.
+    llp_account_index_override=LIGHTER_ROBINHOOD_LLP_ACCOUNT_INDEX,
+)
+
+#: Production Lighter deployments scanned by the all-chain vault pipeline.
+LIGHTER_DEPLOYMENTS: tuple[LighterAPIConfig, ...] = (
+    LIGHTER_ETHEREUM,
+    LIGHTER_ROBINHOOD,
+)
+
+#: Deployment lookup for DuckDB export and migration code.
+LIGHTER_DEPLOYMENTS_BY_SLUG: dict[str, LighterAPIConfig] = {deployment.slug: deployment for deployment in LIGHTER_DEPLOYMENTS}
+
+
 #: Set of Lighter system pool addresses (protocol-curated).
 #:
 #: The LLP (Lighter Liquidity Pool) is the protocol's own liquidity pool;
@@ -77,10 +245,13 @@ LIGHTER_POOL_LOCKUP: datetime.timedelta = datetime.timedelta(minutes=5)
 #: experimental markets.  Both are community-owned and protocol-operated.
 #: Uses the synthetic address format ``lighter-pool-{account_index}``.
 #:
-#: These are protocol-operated pools with special properties (no operator fee,
-#: not listed in ``publicPoolsMetadata``, fetched separately via ``systemConfig``).
-#: Useful for filtering protocol pools from user-created pools.
+#: These are protocol-operated pools with special properties (no operator fee).
+#: Ethereum system pools are fetched separately via ``systemConfig`` when they
+#: are absent from ``publicPoolsMetadata``; the Robinhood LLP is currently
+#: present in that listing. Useful for filtering protocol pools from
+#: user-created pools.
 LIGHTER_SYSTEM_POOL_ADDRESSES: set[str] = {
     "lighter-pool-281474976710654",  # LLP (Lighter Liquidity Pool)
     "lighter-pool-281474976680784",  # XLP (Experimental Liquidity Provider)
+    "lighter-pool-robinhood-281474976710654",  # Robinhood LLP / insurance pool
 }

--- a/eth_defi/lighter/constants.py
+++ b/eth_defi/lighter/constants.py
@@ -238,6 +238,28 @@ LIGHTER_DEPLOYMENTS: tuple[LighterAPIConfig, ...] = (
 LIGHTER_DEPLOYMENTS_BY_SLUG: dict[str, LighterAPIConfig] = {deployment.slug: deployment for deployment in LIGHTER_DEPLOYMENTS}
 
 
+def identify_lighter_pool_deployment(address: str) -> LighterAPIConfig | None:
+    """Resolve a synthetic Lighter pool address to its deployment.
+
+    Deployment prefixes are checked longest-first because the backwards-
+    compatible Ethereum prefix ``lighter-pool`` is also the beginning of the
+    Robinhood prefix ``lighter-pool-robinhood``. This helper is used by partial
+    Parquet replacement so an independently completed Ethereum or Robinhood
+    scan cannot remove the other deployment's retained history.
+
+    :param address:
+        Synthetic Lighter vault address.
+    :return:
+        Matching deployment, or ``None`` when the address is not recognised.
+    """
+    address = str(address)
+    deployments_by_prefix_length = sorted(LIGHTER_DEPLOYMENTS, key=lambda deployment: len(deployment.address_prefix), reverse=True)
+    return next(
+        (deployment for deployment in deployments_by_prefix_length if address.startswith(f"{deployment.address_prefix}-")),
+        None,
+    )
+
+
 #: Set of Lighter system pool addresses (protocol-curated).
 #:
 #: The LLP (Lighter Liquidity Pool) is the protocol's own liquidity pool;

--- a/eth_defi/lighter/constants.py
+++ b/eth_defi/lighter/constants.py
@@ -111,7 +111,7 @@ LIGHTER_DENOMINATION: str = "USDC"
 LIGHTER_POOL_LOCKUP: datetime.timedelta = datetime.timedelta(minutes=5)
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(slots=True, frozen=True)
 class LighterAPIConfig:
     """Configuration for one independently indexed Lighter deployment.
 
@@ -119,37 +119,18 @@ class LighterAPIConfig:
     particular, account ``281474976710654`` exists on both Ethereum Lighter
     and Robinhood Lighter, so downstream storage must always pair an account
     index with :py:attr:`slug`.
-
-    :param slug:
-        Stable storage identifier for the deployment.
-    :param name:
-        Human-readable scanner and scheduling name.
-    :param chain_id:
-        Synthetic vault-dataset chain ID. This remains the primary identity
-        used for price partitions and :class:`~eth_defi.vault.base.VaultSpec`.
-    :param deployment_chain_id:
-        Real EVM chain associated with this Lighter deployment. For now this
-        separate identity is needed to expose whether a Lighter pool belongs
-        to the Ethereum or Robinhood deployment in lifetime-metrics exports.
-    :param api_url:
-        REST API base URL.
-    :param app_url:
-        Web application base URL used for vault links.
-    :param address_prefix:
-        Synthetic vault address prefix. Deployment-specific prefixes prevent
-        address-only metadata rules from leaking between deployments.
-    :param denomination:
-        Pool collateral symbol.
-    :param lockup:
-        Public-pool withdrawal cooldown reported by ``systemConfig``.
-    :param llp_account_index_override:
-        Deployment-specific canonical LLP account override. ``None`` trusts
-        ``systemConfig``. For now Robinhood needs an override because its live
-        system configuration points at an uninitialised account.
     """
 
+    #: Stable storage identifier for the deployment.
     slug: str
+
+    #: Human-readable scanner and scheduling name.
     name: str
+
+    #: Synthetic vault-dataset chain ID.
+    #:
+    #: This remains the primary identity used for price partitions and
+    #: :class:`~eth_defi.vault.base.VaultSpec` records.
     chain_id: int
 
     #: Real EVM chain associated with this deployment.
@@ -162,14 +143,30 @@ class LighterAPIConfig:
     #: on Robinhood in downstream lifetime-metrics exports.
     deployment_chain_id: int
 
+    #: REST API base URL.
     api_url: str
+
+    #: Web application base URL used for vault links.
     app_url: str
+
+    #: Synthetic vault address prefix.
+    #:
+    #: Deployment-specific prefixes prevent address-only metadata rules from
+    #: leaking between deployments.
     address_prefix: str
+
+    #: Pool collateral symbol.
     denomination: str
+
+    #: Public-pool withdrawal cooldown reported by ``systemConfig``.
     lockup: datetime.timedelta
 
     #: Canonical LLP account override for deployments with unreliable system
-    #: configuration. For now only Lighter on Robinhood uses this field.
+    #: configuration.
+    #:
+    #: ``None`` trusts ``systemConfig``. For now only Lighter on Robinhood uses
+    #: an override because its live system configuration points at an
+    #: uninitialised account.
     llp_account_index_override: int | None = None
 
     def format_pool_address(self, account_index: int) -> str:

--- a/eth_defi/lighter/daily_metrics.py
+++ b/eth_defi/lighter/daily_metrics.py
@@ -32,9 +32,10 @@ from joblib import Parallel, delayed
 from tqdm_loggable.auto import tqdm
 
 from eth_defi.compat import native_datetime_utc_now
-from eth_defi.lighter.constants import LIGHTER_DAILY_METRICS_DATABASE
+from eth_defi.lighter.constants import LIGHTER_DAILY_METRICS_DATABASE, LIGHTER_ETHEREUM
 from eth_defi.lighter.session import LighterSession
 from eth_defi.lighter.vault import (
+    LIGHTER_LLP_DESCRIPTION,
     LighterPoolSummary,
     fetch_all_pools,
     fetch_pool_detail,
@@ -63,11 +64,111 @@ class LighterDailyMetricsDatabase:
         self.con = duckdb.connect(str(path))
         self._init_schema()
 
-    def _init_schema(self):
-        """Create tables if they do not exist."""
-        self.con.execute("""
-            CREATE TABLE IF NOT EXISTS pool_metadata (
-                account_index BIGINT PRIMARY KEY,
+    def _init_schema(self) -> None:
+        """Create or migrate the deployment-aware database schema.
+
+        The original schema keyed both tables only by ``account_index``.
+        Lighter deployments reuse account indexes, so legacy rows are copied
+        transactionally into composite-key tables and labelled ``ethereum``.
+        Any migration failure aborts database opening without discarding the
+        original tables.
+        """
+        if not self._table_exists("pool_metadata"):
+            self._create_pool_metadata_table("pool_metadata")
+        if not self._table_exists("pool_daily_prices"):
+            self._create_pool_daily_prices_table("pool_daily_prices")
+
+        metadata_columns = self._get_table_columns("pool_metadata")
+        if "status" not in metadata_columns:
+            self.con.execute("ALTER TABLE pool_metadata ADD COLUMN status INTEGER DEFAULT 0")
+
+        price_columns = self._get_table_columns("pool_daily_prices")
+        if "written_at" not in price_columns:
+            self.con.execute("ALTER TABLE pool_daily_prices ADD COLUMN written_at TIMESTAMP")
+
+        metadata_needs_migration = "deployment" not in metadata_columns
+        prices_need_migration = "deployment" not in price_columns
+        if not metadata_needs_migration and not prices_need_migration:
+            return
+
+        logger.info("Migrating legacy Lighter DuckDB schema to deployment-aware composite keys")
+        self.con.execute("BEGIN TRANSACTION")
+        try:
+            if metadata_needs_migration:
+                self._create_pool_metadata_table("pool_metadata_v2")
+                self.con.execute(
+                    """
+                    INSERT INTO pool_metadata_v2 (
+                        deployment, account_index, name, description, l1_address,
+                        is_llp, status, operator_fee, total_asset_value,
+                        annual_percentage_yield, sharpe_ratio, created_at, last_updated
+                    )
+                    SELECT ?, account_index, name, description, l1_address,
+                        is_llp, status, operator_fee, total_asset_value,
+                        annual_percentage_yield, sharpe_ratio, created_at, last_updated
+                    FROM pool_metadata
+                    """,
+                    [LIGHTER_ETHEREUM.slug],
+                )
+                self.con.execute("DROP TABLE pool_metadata")
+                self.con.execute("ALTER TABLE pool_metadata_v2 RENAME TO pool_metadata")
+
+            if prices_need_migration:
+                self._create_pool_daily_prices_table("pool_daily_prices_v2")
+                self.con.execute(
+                    """
+                    INSERT INTO pool_daily_prices_v2 (
+                        deployment, account_index, date, share_price, tvl,
+                        daily_return, annual_percentage_yield, written_at
+                    )
+                    SELECT ?, account_index, date, share_price, tvl,
+                        daily_return, annual_percentage_yield, written_at
+                    FROM pool_daily_prices
+                    """,
+                    [LIGHTER_ETHEREUM.slug],
+                )
+                self.con.execute("DROP TABLE pool_daily_prices")
+                self.con.execute("ALTER TABLE pool_daily_prices_v2 RENAME TO pool_daily_prices")
+        except duckdb.Error:
+            self.con.execute("ROLLBACK")
+            raise
+        else:
+            self.con.execute("COMMIT")
+
+    def _table_exists(self, table_name: str) -> bool:
+        """Check whether a DuckDB table exists.
+
+        :param table_name:
+            Unquoted internal table name.
+        :return:
+            ``True`` when the table exists.
+        """
+        row = self.con.execute(
+            "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'main' AND table_name = ?",
+            [table_name],
+        ).fetchone()
+        return bool(row and row[0])
+
+    def _get_table_columns(self, table_name: str) -> set[str]:
+        """Read column names for an internal DuckDB table.
+
+        :param table_name:
+            Unquoted internal table name.
+        :return:
+            Column-name set.
+        """
+        return {row[1] for row in self.con.execute(f"PRAGMA table_info('{table_name}')").fetchall()}
+
+    def _create_pool_metadata_table(self, table_name: str) -> None:
+        """Create a deployment-aware pool metadata table.
+
+        :param table_name:
+            Trusted internal table name used during schema migration.
+        """
+        self.con.execute(f"""
+            CREATE TABLE {table_name} (
+                deployment VARCHAR NOT NULL,
+                account_index BIGINT NOT NULL,
                 name VARCHAR NOT NULL,
                 description VARCHAR,
                 l1_address VARCHAR,
@@ -78,17 +179,20 @@ class LighterDailyMetricsDatabase:
                 annual_percentage_yield DOUBLE,
                 sharpe_ratio DOUBLE,
                 created_at TIMESTAMP,
-                last_updated TIMESTAMP NOT NULL
+                last_updated TIMESTAMP NOT NULL,
+                PRIMARY KEY (deployment, account_index)
             )
         """)
-        # Migrate existing databases that lack the status column
-        try:
-            self.con.execute("ALTER TABLE pool_metadata ADD COLUMN status INTEGER DEFAULT 0")
-        except duckdb.CatalogException:
-            pass  # Column already exists
 
-        self.con.execute("""
-            CREATE TABLE IF NOT EXISTS pool_daily_prices (
+    def _create_pool_daily_prices_table(self, table_name: str) -> None:
+        """Create a deployment-aware daily price table.
+
+        :param table_name:
+            Trusted internal table name used during schema migration.
+        """
+        self.con.execute(f"""
+            CREATE TABLE {table_name} (
+                deployment VARCHAR NOT NULL,
                 account_index BIGINT NOT NULL,
                 date DATE NOT NULL,
                 share_price DOUBLE NOT NULL,
@@ -96,18 +200,13 @@ class LighterDailyMetricsDatabase:
                 daily_return DOUBLE,
                 annual_percentage_yield DOUBLE,
                 written_at TIMESTAMP,
-                PRIMARY KEY (account_index, date)
+                PRIMARY KEY (deployment, account_index, date)
             )
         """)
 
-        # Migration for existing databases: add written_at column for data auditability
-        try:
-            self.con.execute("ALTER TABLE pool_daily_prices ADD COLUMN written_at TIMESTAMP")
-        except duckdb.CatalogException:
-            pass
-
     def upsert_pool_metadata(
         self,
+        deployment: str,
         account_index: int,
         name: str,
         description: str | None = None,
@@ -122,8 +221,10 @@ class LighterDailyMetricsDatabase:
     ):
         """Insert or update pool metadata.
 
+        :param deployment:
+            Stable deployment slug.
         :param account_index:
-            Pool account index (primary key).
+            Pool account index, unique within the deployment.
         :param name:
             Pool display name.
         :param description:
@@ -148,11 +249,11 @@ class LighterDailyMetricsDatabase:
         self.con.execute(
             """
             INSERT INTO pool_metadata (
-                account_index, name, description, l1_address, is_llp,
+                deployment, account_index, name, description, l1_address, is_llp,
                 status, operator_fee, total_asset_value, annual_percentage_yield,
                 sharpe_ratio, created_at, last_updated
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT (account_index) DO UPDATE SET
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (deployment, account_index) DO UPDATE SET
                 name = excluded.name,
                 description = excluded.description,
                 l1_address = excluded.l1_address,
@@ -166,6 +267,7 @@ class LighterDailyMetricsDatabase:
                 last_updated = excluded.last_updated
             """,
             [
+                deployment,
                 account_index,
                 name,
                 description,
@@ -183,11 +285,14 @@ class LighterDailyMetricsDatabase:
 
     def upsert_daily_prices(
         self,
+        deployment: str,
         rows: list[tuple],
         cutoff_date: datetime.date | None = None,
     ):
         """Bulk upsert daily price rows for a pool.
 
+        :param deployment:
+            Stable deployment slug applied to every row.
         :param rows:
             List of tuples: ``(account_index, date, share_price, tvl, daily_return, annual_percentage_yield, written_at)``.
         :param cutoff_date:
@@ -203,94 +308,124 @@ class LighterDailyMetricsDatabase:
         self.con.executemany(
             """
             INSERT INTO pool_daily_prices (
-                account_index, date, share_price, tvl,
+                deployment, account_index, date, share_price, tvl,
                 daily_return, annual_percentage_yield, written_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT (account_index, date) DO UPDATE SET
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (deployment, account_index, date) DO UPDATE SET
                 share_price = excluded.share_price,
                 tvl = excluded.tvl,
                 daily_return = excluded.daily_return,
                 annual_percentage_yield = excluded.annual_percentage_yield,
                 written_at = excluded.written_at
             """,
-            rows,
+            [(deployment, *row) for row in rows],
         )
 
-    def get_all_daily_prices(self) -> pd.DataFrame:
+    def get_all_daily_prices(self, deployment: str | None = None) -> pd.DataFrame:
         """Retrieve all daily price data.
 
+        :param deployment:
+            Optional deployment slug filter.
         :return:
             DataFrame with columns: account_index, date, share_price, tvl,
             daily_return, annual_percentage_yield.
         """
-        return self.con.execute("SELECT * FROM pool_daily_prices ORDER BY account_index, date").fetchdf()
+        if deployment is None:
+            return self.con.execute("SELECT * FROM pool_daily_prices ORDER BY deployment, account_index, date").fetchdf()
+        return self.con.execute(
+            "SELECT * FROM pool_daily_prices WHERE deployment = ? ORDER BY account_index, date",
+            [deployment],
+        ).fetchdf()
 
-    def get_pool_daily_prices(self, account_index: int) -> pd.DataFrame:
+    def get_pool_daily_prices(self, account_index: int, deployment: str = LIGHTER_ETHEREUM.slug) -> pd.DataFrame:
         """Get daily prices for a specific pool.
 
         :param account_index:
             Pool account index.
+        :param deployment:
+            Stable deployment slug. Defaults to Ethereum for compatibility.
         :return:
             DataFrame with daily price data for the pool.
         """
         return self.con.execute(
-            "SELECT * FROM pool_daily_prices WHERE account_index = ? ORDER BY date",
-            [account_index],
+            "SELECT * FROM pool_daily_prices WHERE deployment = ? AND account_index = ? ORDER BY date",
+            [deployment, account_index],
         ).fetchdf()
 
-    def get_all_pool_metadata(self) -> pd.DataFrame:
+    def get_all_pool_metadata(self, deployment: str | None = None) -> pd.DataFrame:
         """Retrieve all pool metadata ordered by TVL.
 
+        :param deployment:
+            Optional deployment slug filter.
         :return:
             DataFrame with pool metadata.
         """
-        return self.con.execute("SELECT * FROM pool_metadata ORDER BY total_asset_value DESC").fetchdf()
+        if deployment is None:
+            return self.con.execute("SELECT * FROM pool_metadata ORDER BY deployment, total_asset_value DESC").fetchdf()
+        return self.con.execute(
+            "SELECT * FROM pool_metadata WHERE deployment = ? ORDER BY total_asset_value DESC",
+            [deployment],
+        ).fetchdf()
 
-    def get_pool_count(self) -> int:
+    def get_pool_count(self, deployment: str | None = None) -> int:
         """Get number of pools with daily price data.
 
+        :param deployment:
+            Optional deployment slug filter.
         :return:
             Count of unique pools.
         """
-        result = self.con.execute("SELECT COUNT(DISTINCT account_index) FROM pool_daily_prices").fetchone()
+        if deployment is None:
+            result = self.con.execute("SELECT COUNT(*) FROM (SELECT DISTINCT deployment, account_index FROM pool_daily_prices)").fetchone()
+        else:
+            result = self.con.execute(
+                "SELECT COUNT(DISTINCT account_index) FROM pool_daily_prices WHERE deployment = ?",
+                [deployment],
+            ).fetchone()
         return result[0] if result else 0
 
-    def get_vault_count(self) -> int:
+    def get_vault_count(self, deployment: str | None = None) -> int:
         """Get number of pools with daily price data.
 
         Alias for :py:meth:`get_pool_count` to unify the interface
         across Hyperliquid, GRVT, and Lighter scanners.
 
+        :param deployment:
+            Optional deployment slug filter.
         :return:
             Count of unique pools.
         """
-        return self.get_pool_count()
+        return self.get_pool_count(deployment=deployment)
 
-    def get_pool_daily_price_count(self, account_index: int) -> int:
+    def get_pool_daily_price_count(self, account_index: int, deployment: str = LIGHTER_ETHEREUM.slug) -> int:
         """Get number of daily price records for a specific pool.
 
         :param account_index:
             Pool account index.
+        :param deployment:
+            Stable deployment slug. Defaults to Ethereum for compatibility.
         :return:
             Count of daily price records.
         """
         result = self.con.execute(
-            "SELECT COUNT(*) FROM pool_daily_prices WHERE account_index = ?",
-            [account_index],
+            "SELECT COUNT(*) FROM pool_daily_prices WHERE deployment = ? AND account_index = ?",
+            [deployment, account_index],
         ).fetchone()
         return result[0] if result else 0
 
-    def get_pool_last_date(self, account_index: int) -> datetime.date | None:
+    def get_pool_last_date(self, account_index: int, deployment: str = LIGHTER_ETHEREUM.slug) -> datetime.date | None:
         """Get the latest date with price data for a pool.
 
         :param account_index:
             Pool account index.
+        :param deployment:
+            Stable deployment slug. Defaults to Ethereum for compatibility.
         :return:
             Latest date or ``None`` if no data.
         """
         result = self.con.execute(
-            "SELECT MAX(date) FROM pool_daily_prices WHERE account_index = ?",
-            [account_index],
+            "SELECT MAX(date) FROM pool_daily_prices WHERE deployment = ? AND account_index = ?",
+            [deployment, account_index],
         ).fetchone()
         if result and result[0] is not None:
             val = result[0]
@@ -371,9 +506,10 @@ def fetch_and_store_pool(
 
     # Store metadata
     db.upsert_pool_metadata(
+        deployment=session.deployment.slug,
         account_index=summary.account_index,
         name=detail.name or summary.name,
-        description=detail.description,
+        description=detail.description or (LIGHTER_LLP_DESCRIPTION if summary.is_llp else ""),
         l1_address=summary.l1_address,
         is_llp=summary.is_llp,
         status=summary.status,
@@ -400,7 +536,11 @@ def fetch_and_store_pool(
             )
         )
 
-    db.upsert_daily_prices(rows, cutoff_date=cutoff_date)
+    db.upsert_daily_prices(
+        deployment=session.deployment.slug,
+        rows=rows,
+        cutoff_date=cutoff_date,
+    )
 
     logger.debug(
         "Stored %d daily prices for pool %s (%d)",
@@ -475,7 +615,7 @@ def run_daily_scan(
             else:
                 raise
 
-    logger.info("Fetched %d pools from Lighter", len(all_pools))
+    logger.info("Fetched %d pools from %s", len(all_pools), session.deployment.name)
 
     # Filter pools
     if pool_indices is not None:
@@ -496,7 +636,7 @@ def run_daily_scan(
     logger.info("Processing %d pools", len(filtered))
 
     # Fetch details and store in parallel
-    desc = "Fetching Lighter pool details"
+    desc = f"Fetching {session.deployment.name} pool details"
     results = Parallel(n_jobs=max_workers, backend="threading")(delayed(_process_pool_worker)(session, db, summary, cutoff_date, timeout) for summary in tqdm(filtered, desc=desc))
 
     success_count = sum(1 for r in results if r)
@@ -505,7 +645,8 @@ def run_daily_scan(
     db.save()
 
     logger.info(
-        "Daily scan complete. Processed %d pools (%d successful, %d failed) into %s",
+        "%s daily scan complete. Processed %d pools (%d successful, %d failed) into %s",
+        session.deployment.name,
         len(filtered),
         success_count,
         fail_count,

--- a/eth_defi/lighter/daily_metrics.py
+++ b/eth_defi/lighter/daily_metrics.py
@@ -230,7 +230,7 @@ class LighterDailyMetricsDatabase:
         :param description:
             Pool description text.
         :param l1_address:
-            L1 Ethereum address.
+            Operator address reported in the API's legacy ``l1_address`` field.
         :param is_llp:
             Whether this is the LLP protocol pool.
         :param status:
@@ -238,7 +238,7 @@ class LighterDailyMetricsDatabase:
         :param operator_fee:
             Operator fee percentage.
         :param total_asset_value:
-            Total value locked in USDC.
+            Total value locked in the deployment's collateral currency.
         :param annual_percentage_yield:
             Current APY.
         :param sharpe_ratio:
@@ -584,7 +584,7 @@ def run_daily_scan(
     :param db_path:
         Path to the DuckDB database file.
     :param min_tvl:
-        Minimum TVL in USDC to include a pool.
+        Minimum TVL in the deployment's collateral currency to include a pool.
         Ignored when ``pool_indices`` is provided.
     :param max_pools:
         Maximum number of pools to process (sorted by TVL descending).

--- a/eth_defi/lighter/session.py
+++ b/eth_defi/lighter/session.py
@@ -17,7 +17,7 @@ from pyrate_limiter import SQLiteBucket
 from requests import Session
 from requests_ratelimiter import LimiterAdapter
 
-from eth_defi.lighter.constants import LIGHTER_API_URL, LIGHTER_DEFAULT_REQUESTS_PER_SECOND
+from eth_defi.lighter.constants import LIGHTER_DEFAULT_REQUESTS_PER_SECOND, LIGHTER_ETHEREUM, LighterAPIConfig
 from eth_defi.logging_retry import LoggingRetry
 
 logger = logging.getLogger(__name__)
@@ -48,21 +48,30 @@ class LighterSession(Session):
     #: Lighter API base URL (e.g. ``https://mainnet.zklighter.elliot.ai``).
     api_url: str
 
-    def __init__(self, api_url: str = LIGHTER_API_URL):
+    #: Deployment whose API and vault namespace this session accesses.
+    deployment: LighterAPIConfig
+
+    def __init__(
+        self,
+        api_url: str | None = None,
+        deployment: LighterAPIConfig = LIGHTER_ETHEREUM,
+    ):
         super().__init__()
-        self.api_url = api_url
+        self.api_url = api_url or deployment.api_url
+        self.deployment = deployment
 
     def __repr__(self) -> str:
-        return f"<LighterSession api_url={self.api_url!r}>"
+        return f"<LighterSession deployment={self.deployment.slug!r} api_url={self.api_url!r}>"
 
 
 def create_lighter_session(
-    api_url: str = LIGHTER_API_URL,
+    api_url: str | None = None,
     retries: int = DEFAULT_RETRIES,
     backoff_factor: float = DEFAULT_BACKOFF_FACTOR,
     requests_per_second: float = LIGHTER_DEFAULT_REQUESTS_PER_SECOND,
     pool_maxsize: int = 32,
     rate_limit_db_path: Path = LIGHTER_RATE_LIMIT_SQLITE_DATABASE,
+    deployment: LighterAPIConfig = LIGHTER_ETHEREUM,
 ) -> LighterSession:
     """Create a :py:class:`LighterSession` configured for Lighter API.
 
@@ -82,8 +91,8 @@ def create_lighter_session(
         session = create_lighter_session()
 
     :param api_url:
-        Lighter API base URL. Defaults to mainnet
-        (:py:data:`~eth_defi.lighter.constants.LIGHTER_API_URL`).
+        Optional Lighter API base URL override. Defaults to the configured
+        deployment URL.
     :param retries:
         Maximum number of retry attempts for failed requests.
     :param backoff_factor:
@@ -96,12 +105,15 @@ def create_lighter_session(
     :param rate_limit_db_path:
         Path to SQLite database for storing rate limit state.
         Using SQLite ensures thread-safe rate limiting across multiple threads.
+    :param deployment:
+        Deployment whose pool namespace this session accesses. Defaults to the
+        backwards-compatible Ethereum deployment.
     :return:
         Configured :py:class:`LighterSession` with rate limiting and retry logic.
     """
     rate_limit_db_path.parent.mkdir(parents=True, exist_ok=True)
 
-    session = LighterSession(api_url=api_url)
+    session = LighterSession(api_url=api_url, deployment=deployment)
 
     retry_policy = LoggingRetry(
         total=retries,

--- a/eth_defi/lighter/valuation.py
+++ b/eth_defi/lighter/valuation.py
@@ -39,22 +39,22 @@ class LighterEquity:
     #: Lighter account index.
     account_index: int
 
-    #: Account collateral in USDC, before unrealised position PnL.
+    #: Account collateral before unrealised position PnL.
     collateral: Decimal
 
-    #: Sum of ``positions[].unrealized_pnl`` in USDC.
+    #: Sum of ``positions[].unrealized_pnl`` in the collateral currency.
     unrealised_pnl: Decimal
 
     #: Canonical account NAV reported by Lighter as ``total_asset_value``.
     total_asset_value: Decimal
 
-    #: Free USDC balance available for new orders or withdrawals.
+    #: Free collateral balance available for new orders or withdrawals.
     available_balance: Decimal
 
-    #: Cross-margin initial margin requirement in USDC.
+    #: Cross-margin initial margin requirement in the collateral currency.
     initial_margin_requirement: Decimal
 
-    #: Cross-margin maintenance margin requirement in USDC.
+    #: Cross-margin maintenance margin requirement in the collateral currency.
     maintenance_margin_requirement: Decimal
 
     #: Number of open position records returned by the Lighter API.
@@ -69,7 +69,7 @@ class LighterEquity:
         check.
 
         :return:
-            Account net asset value in USDC.
+            Account net asset value in the deployment's collateral currency.
         """
         return self.total_asset_value
 
@@ -77,7 +77,7 @@ class LighterEquity:
         """Calculate account NAV from collateral and unrealised PnL.
 
         :return:
-            ``collateral + unrealised_pnl`` in USDC.
+            ``collateral + unrealised_pnl`` in the collateral currency.
         """
         return self.collateral + self.unrealised_pnl
 
@@ -92,7 +92,8 @@ def fetch_lighter_total_equity(
     Uses Lighter's public ``/api/v1/account?by=index&value={account_index}``
     endpoint. No API key is required. The returned
     :py:meth:`LighterEquity.get_total` value is the canonical
-    ``total_asset_value`` reported by Lighter, denominated in USDC.
+    ``total_asset_value`` reported by Lighter, denominated in the deployment's
+    collateral currency.
 
     Authoritative endpoint documentation:
     https://apidocs.lighter.xyz/reference/account
@@ -222,7 +223,7 @@ def _parse_position_unrealised_pnl(position: dict[str, Any]) -> Decimal:
     :param position:
         Raw position dict from ``account["positions"]``.
     :return:
-        Position unrealised PnL in USDC.
+        Position unrealised PnL in the deployment's collateral currency.
     """
     value = position.get("unrealized_pnl", position.get("unrealizedPnl"))
     return _parse_decimal(value, "positions[].unrealized_pnl", default=Decimal(0))

--- a/eth_defi/lighter/vault.py
+++ b/eth_defi/lighter/vault.py
@@ -7,7 +7,7 @@ via public endpoints:
   TVL, APY, Sharpe ratio, and operator fee
 - **Pool details** (share price history, daily returns, positions) via
   ``/api/v1/account`` — per-pool detailed data
-- **System config** via ``/api/v1/systemConfig`` — LLP account index
+- **System config** via ``/api/v1/systemConfig`` — reported LLP account index
 
 No authentication required.
 
@@ -20,7 +20,7 @@ For more information about Lighter:
 import datetime
 import logging
 from dataclasses import dataclass
-from typing import Any, Iterator
+from typing import Any
 
 import pandas as pd
 
@@ -29,7 +29,7 @@ from eth_defi.types import Percent
 
 logger = logging.getLogger(__name__)
 
-#: Display-name fallback for account-type-3 protocol liquidity pools. The
+#: Display-name fallback for the canonical protocol liquidity pool. The
 #: Robinhood deployment currently returns an empty API name for this account.
 LIGHTER_LLP_NAME = "Lighter Liquidity Provider (LLP)"
 
@@ -50,7 +50,7 @@ class LighterPoolSummary:
     #: Pool display name (e.g. "ETH 3x long")
     name: str
 
-    #: L1 (Ethereum) address of the pool operator
+    #: Operator address from the API's legacy ``l1_address`` field
     l1_address: str
 
     #: Annual percentage yield
@@ -131,14 +131,15 @@ def fetch_system_config(
 ) -> dict[str, Any]:
     """Fetch Lighter system configuration.
 
-    Returns system config including the LLP account index.
+    Returns system config including the deployment's reported LLP account
+    index. Deployment configuration may override a stale reported value.
 
     :param session:
         HTTP session.
     :param timeout:
         HTTP request timeout.
     :return:
-        System config dict with key field ``liquidity_pool_index``.
+        System config dict with reported ``liquidity_pool_index`` field.
     """
     url = f"{session.api_url}/api/v1/systemConfig"
     resp = session.get(url, timeout=timeout)
@@ -154,7 +155,8 @@ def fetch_all_pools(
     """Fetch all Lighter public pools.
 
     Uses ``/api/v1/publicPoolsMetadata`` with pagination.
-    Also fetches system config to identify the LLP pool.
+    Also fetches system config and applies any deployment-specific LLP account
+    override to identify the canonical pool exactly.
 
     :param session:
         HTTP session.

--- a/eth_defi/lighter/vault.py
+++ b/eth_defi/lighter/vault.py
@@ -29,6 +29,13 @@ from eth_defi.types import Percent
 
 logger = logging.getLogger(__name__)
 
+#: Display-name fallback for account-type-3 protocol liquidity pools. The
+#: Robinhood deployment currently returns an empty API name for this account.
+LIGHTER_LLP_NAME = "Lighter Liquidity Provider (LLP)"
+
+#: Description fallback for the same protocol-operated insurance pool.
+LIGHTER_LLP_DESCRIPTION = "Protocol-operated liquidity and insurance pool that provides market-making liquidity and handles liquidations on Lighter."
+
 
 @dataclass(slots=True)
 class LighterPoolSummary:
@@ -55,7 +62,7 @@ class LighterPoolSummary:
     #: Operator fee percentage (e.g. 10.0 = 10%)
     operator_fee: Percent
 
-    #: Total asset value (TVL) in USDC
+    #: Total asset value (TVL) in the deployment's collateral currency
     total_asset_value: float
 
     #: Total shares outstanding
@@ -93,7 +100,7 @@ class LighterPoolDetail:
     #: Pool description text
     description: str
 
-    #: Total asset value in USDC
+    #: Total asset value in the deployment's collateral currency
     total_asset_value: float
 
     #: Operator fee percentage (e.g. 10.0 = 10%)
@@ -158,9 +165,14 @@ def fetch_all_pools(
     :return:
         List of :py:class:`LighterPoolSummary` objects.
     """
-    # Get LLP index from system config
+    # Get the canonical LLP index from deployment configuration when the API
+    # cannot currently provide it reliably. For now this override is needed by
+    # Lighter on Robinhood: its systemConfig points at an uninitialised account,
+    # while the live USDG LLP is present in publicPoolsMetadata at the preceding
+    # index. Ethereum continues to trust its systemConfig value.
     config = fetch_system_config(session, timeout=timeout)
-    llp_index = config.get("liquidity_pool_index")
+    reported_llp_index = config.get("liquidity_pool_index")
+    llp_index = session.deployment.llp_account_index_override or reported_llp_index
 
     all_pools = []
 
@@ -181,6 +193,13 @@ def fetch_all_pools(
 
         for p in pools_data:
             account_index = int(p["account_index"])
+            account_type = int(p.get("account_type", 0))
+            # Identify LLP by its canonical deployment-local account index.
+            # Account type 3 is not sufficient: Ethereum currently exposes both
+            # LLP and XLP with that type. This distinction became load-bearing
+            # when adding Lighter on Robinhood because its systemConfig LLP
+            # index needs the deployment override above.
+            is_llp = account_index == llp_index
             created_ts = p.get("created_at")
             created_at = datetime.datetime.fromtimestamp(created_ts) if created_ts else None
 
@@ -190,7 +209,7 @@ def fetch_all_pools(
             all_pools.append(
                 LighterPoolSummary(
                     account_index=account_index,
-                    name=p.get("name", ""),
+                    name=p.get("name") or (LIGHTER_LLP_NAME if is_llp else ""),
                     l1_address=p.get("l1_address", ""),
                     annual_percentage_yield=float(p.get("annual_percentage_yield", 0)),
                     sharpe_ratio=sharpe_val,
@@ -198,10 +217,10 @@ def fetch_all_pools(
                     total_asset_value=float(p.get("total_asset_value", "0")),
                     total_shares=int(p.get("total_shares", 0)),
                     status=int(p.get("status", 0)),
-                    account_type=int(p.get("account_type", 0)),
+                    account_type=account_type,
                     master_account_index=int(p.get("master_account_index", 0)),
                     created_at=created_at,
-                    is_llp=(account_index == llp_index),
+                    is_llp=is_llp,
                 )
             )
 
@@ -214,9 +233,11 @@ def fetch_all_pools(
         if start_index < 0:
             break
 
-    # The LLP (Lighter Liquidity Pool) is a special system pool that
-    # is NOT included in publicPoolsMetadata. Add it explicitly by
-    # fetching its account details.
+    # The LLP can be absent from publicPoolsMetadata on some deployments. Add
+    # the exact canonical account explicitly, without allowing another type-3
+    # protocol pool such as Ethereum XLP to suppress this recovery path. For
+    # now Robinhood reaches the correct canonical identity through its
+    # deployment-specific override above.
     llp_in_listing = any(p.account_index == llp_index for p in all_pools)
     if llp_index and not llp_in_listing:
         try:

--- a/eth_defi/lighter/vault_data_export.py
+++ b/eth_defi/lighter/vault_data_export.py
@@ -39,6 +39,7 @@ from eth_defi.lighter.constants import (
     LIGHTER_ETHEREUM,
     LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID,
     LIGHTER_POOL_FEE_MODE,
+    LIGHTER_ROBINHOOD,
     LighterAPIConfig,
     identify_lighter_pool_deployment,
 )
@@ -52,8 +53,8 @@ from eth_defi.vault.vaultdb import VaultDatabase, VaultRow
 logger = logging.getLogger(__name__)
 
 
-def get_lighter_price_deployments(prices_df: pd.DataFrame) -> set[str]:
-    """Resolve deployment slugs represented by a Lighter raw-price frame.
+def get_lighter_price_deployments(prices_df: pd.DataFrame) -> set[LighterAPIConfig]:
+    """Resolve deployments represented by a Lighter raw-price frame.
 
     The frame must contain synthetic Lighter addresses in its ``address``
     column. Unknown addresses abort the merge because treating an incomplete
@@ -63,14 +64,14 @@ def get_lighter_price_deployments(prices_df: pd.DataFrame) -> set[str]:
     :param prices_df:
         Lighter raw-price DataFrame with string ``address`` values.
     :return:
-        Deployment slugs represented by at least one row.
+        Deployment configurations represented by at least one row.
     """
     assert "address" in prices_df.columns, f"Lighter price frame is missing address column: {prices_df.columns}"
     deployments = prices_df["address"].apply(identify_lighter_pool_deployment)
     unknown_addresses = prices_df.loc[deployments.isna(), "address"].drop_duplicates().tolist()
     if unknown_addresses:
         raise ValueError(f"Cannot identify Lighter deployment for price addresses: {unknown_addresses}")
-    return {deployment.slug for deployment in deployments}
+    return set(deployments)
 
 
 def create_lighter_pool_row(
@@ -388,7 +389,7 @@ def merge_into_uncleaned_parquet(
             return pd.read_parquet(parquet_path)
         return pd.DataFrame()
 
-    fresh_deployment_slugs = get_lighter_price_deployments(lighter_df)
+    fresh_deployments = get_lighter_price_deployments(lighter_df)
 
     if parquet_path.exists():
         existing_df = pd.read_parquet(parquet_path)
@@ -400,12 +401,12 @@ def merge_into_uncleaned_parquet(
         shared_lighter_mask = existing_df["chain"].isin({deployment.chain_id for deployment in LIGHTER_DEPLOYMENTS})
         existing_deployments = existing_df.loc[shared_lighter_mask, "address"].apply(identify_lighter_pool_deployment)
         replace_current_mask = pd.Series(False, index=existing_df.index)
-        replace_current_mask.loc[shared_lighter_mask] = existing_deployments.apply(lambda deployment: deployment is not None and deployment.slug in fresh_deployment_slugs)
+        replace_current_mask.loc[shared_lighter_mask] = existing_deployments.isin(fresh_deployments)
 
         # Remove the short-lived 9996 partition only when fresh Robinhood data
         # is available to replace it. An Ethereum-only standalone scan must
         # leave legacy Robinhood history intact until Robinhood succeeds.
-        replace_legacy_robinhood_mask = existing_df["chain"].eq(LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID) if "robinhood" in fresh_deployment_slugs else pd.Series(False, index=existing_df.index)
+        replace_legacy_robinhood_mask = existing_df["chain"].eq(LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID) if LIGHTER_ROBINHOOD in fresh_deployments else pd.Series(False, index=existing_df.index)
         existing_df = existing_df[~(replace_current_mask | replace_legacy_robinhood_mask)]
 
         combined = pd.concat([existing_df, lighter_df], ignore_index=True)

--- a/eth_defi/lighter/vault_data_export.py
+++ b/eth_defi/lighter/vault_data_export.py
@@ -33,11 +33,18 @@ import pandas as pd
 
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
-from eth_defi.lighter.constants import LIGHTER_CHAIN_ID, LIGHTER_DENOMINATION, LIGHTER_POOL_FEE_MODE, LIGHTER_POOL_LOCKUP
+from eth_defi.lighter.constants import (
+    LIGHTER_DEPLOYMENTS,
+    LIGHTER_DEPLOYMENTS_BY_SLUG,
+    LIGHTER_ETHEREUM,
+    LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID,
+    LIGHTER_POOL_FEE_MODE,
+    LighterAPIConfig,
+)
 from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase
 from eth_defi.vault.base import VaultHistoricalRead, VaultSpec
 from eth_defi.vault.fee import FeeData
-from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.flag import VaultFlag, get_notes
 from eth_defi.vault.risk import get_vault_risk
 from eth_defi.vault.vaultdb import VaultDatabase, VaultRow
 
@@ -53,6 +60,7 @@ def create_lighter_pool_row(
     operator_fee: float = 0.0,
     is_llp: bool = False,
     status: int = 0,
+    deployment: LighterAPIConfig = LIGHTER_ETHEREUM,
 ) -> tuple[VaultSpec, VaultRow]:
     """Create a synthetic VaultRow for a Lighter pool.
 
@@ -71,7 +79,7 @@ def create_lighter_pool_row(
     :param description:
         Pool description text.
     :param tvl:
-        Current TVL in USDC.
+        Current TVL in the deployment's collateral currency.
     :param created_at:
         Pool creation timestamp.
     :param operator_fee:
@@ -80,11 +88,14 @@ def create_lighter_pool_row(
         Whether this is the LLP protocol pool.
     :param status:
         Pool status code from the API (0 = active).
+    :param deployment:
+        Lighter deployment configuration. Defaults to Ethereum for backwards
+        compatibility.
     :return:
         Tuple of (VaultSpec, VaultRow).
     """
-    address = f"lighter-pool-{account_index}"
-    chain_id = LIGHTER_CHAIN_ID
+    address = deployment.format_pool_address(account_index)
+    chain_id = deployment.chain_id
 
     # Convert operator_fee from percentage to decimal fraction
     perf_fee = operator_fee / 100.0 if operator_fee else 0.0
@@ -114,12 +125,12 @@ def create_lighter_pool_row(
         "Symbol": (name or "")[:10],
         "Name": name or "",
         "Address": address,
-        "Denomination": LIGHTER_DENOMINATION,
+        "Denomination": deployment.denomination,
         "Share token": (name or "")[:10],
         "NAV": Decimal(str(tvl)),
         "Shares": Decimal("0"),
         "Protocol": "Lighter",
-        "Link": f"https://app.lighter.xyz/public-pools/{account_index}",
+        "Link": deployment.format_pool_link(account_index),
         "First seen": created_at,
         "Mgmt fee": 0.0,
         "Perf fee": perf_fee,
@@ -127,11 +138,11 @@ def create_lighter_pool_row(
         "Withdraw fee": 0.0,
         "Features": "",
         "_detection_data": detection,
-        "_denomination_token": {"address": "0x0000000000000000000000000000000000000000", "symbol": "USDC", "decimals": 6},
+        "_denomination_token": {"address": "0x0000000000000000000000000000000000000000", "symbol": deployment.denomination, "decimals": 6},
         "_share_token": None,
         "_fees": fee_data,
         "_flags": flags,
-        "_lockup": LIGHTER_POOL_LOCKUP,
+        "_lockup": deployment.lockup,
         "_description": description,
         "_short_description": description.split(".")[0].strip() + "." if description else None,
         "_available_liquidity": None,
@@ -140,7 +151,22 @@ def create_lighter_pool_row(
         "_deposit_next_open": None,
         "_redemption_closed_reason": None,
         "_redemption_next_open": None,
+        # Persist the deployment-specific manual note in VaultDatabase instead
+        # of relying only on lifetime-metrics fallback lookup. For now this is
+        # important for Lighter on Robinhood because its USDG insurance-fund
+        # note must not inherit Ethereum LLP's USDC/LIT staking requirements.
+        "_notes": get_notes(address, chain_id=chain_id, protocol_name="Lighter"),
         "_risk": get_vault_risk("Lighter", address),
+        # Keep the deployment slug in static vault metadata so the generic
+        # lifetime-metrics code does not need to import Lighter configuration.
+        # For now this is exported to distinguish Lighter on Robinhood from
+        # the original Ethereum deployment.
+        "_deployment": deployment.slug,
+        # ``chain_id`` above is intentionally the shared synthetic Lighter ID
+        # (9998) and must remain the VaultSpec and price-partition namespace.
+        # This associated EVM chain ID (1/4663) is additional metadata
+        # introduced specifically for Lighter on Robinhood metrics consumers.
+        "_deployment_chain_id": deployment.deployment_chain_id,
     }
 
     spec = VaultSpec(chain_id=chain_id, vault_address=address)
@@ -169,16 +195,22 @@ def build_raw_prices_dataframe(db: LighterDailyMetricsDatabase) -> pd.DataFrame:
     if prices_df.empty:
         return pd.DataFrame()
 
-    chain_id = LIGHTER_CHAIN_ID
+    unknown_deployments = set(prices_df["deployment"].unique()) - set(LIGHTER_DEPLOYMENTS_BY_SLUG)
+    if unknown_deployments:
+        raise ValueError(f"Unknown Lighter deployments in daily metrics database: {sorted(unknown_deployments)}")
 
-    # Build synthetic address from account_index
-    addresses = prices_df["account_index"].apply(lambda idx: f"lighter-pool-{idx}")
+    deployments = prices_df["deployment"].apply(LIGHTER_DEPLOYMENTS_BY_SLUG.__getitem__)
+    chain_ids = deployments.apply(lambda deployment: deployment.chain_id)
+    addresses = prices_df.apply(
+        lambda row: LIGHTER_DEPLOYMENTS_BY_SLUG[row["deployment"]].format_pool_address(int(row["account_index"])),
+        axis=1,
+    )
 
     # Use .values to strip the DuckDB RangeIndex — otherwise pandas
     # tries to align it with the new index and fills everything with NaN.
     result = pd.DataFrame(
         {
-            "chain": chain_id,
+            "chain": chain_ids.values,
             "address": addresses.values,
             "block_number": 0,
             "timestamp": pd.to_datetime(prices_df["date"]).values,
@@ -226,18 +258,57 @@ def merge_into_vault_database(
 
     metadata_df = db.get_all_pool_metadata()
 
+    # The first Robinhood implementation used synthetic chain 9996. Both
+    # deployments now share Lighter chain 9998 and are kept unique by their
+    # deployment-specific address prefixes. Remove the short-lived legacy
+    # VaultSpec rows automatically once Robinhood metadata is present, so the
+    # normal metadata merge cannot leave duplicate Robinhood vaults behind.
+    has_robinhood_metadata = "robinhood" in set(metadata_df["deployment"]) if not metadata_df.empty else False
+    legacy_specs: list[VaultSpec] = []
+    if has_robinhood_metadata:
+        legacy_specs = [spec for spec in vault_db.rows if spec.chain_id == LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID and str(spec.vault_address).startswith("lighter-pool-robinhood-")]
+        for spec in legacy_specs:
+            del vault_db.rows[spec]
+        if legacy_specs:
+            logger.info(
+                "Removed %d legacy Lighter Robinhood VaultSpec rows from synthetic chain %d",
+                len(legacy_specs),
+                LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID,
+            )
+
     added = 0
     updated = 0
     for _, row in metadata_df.iterrows():
+        deployment_slug = str(row["deployment"])
+        try:
+            deployment = LIGHTER_DEPLOYMENTS_BY_SLUG[deployment_slug]
+        except KeyError as e:
+            raise ValueError(f"Unknown Lighter deployment in pool metadata: {deployment_slug}") from e
+
+        # DuckDB nullable scalar columns arrive through Pandas as NaN/NaT.
+        # Normalise them explicitly because ``NaN or 0`` still returns NaN and
+        # would make FeeData validation fail during an automatic legacy merge.
+        description = row.get("description")
+        description = None if pd.isna(description) else str(description)
+        created_at = row.get("created_at")
+        created_at = None if pd.isna(created_at) else created_at
+        tvl = row.get("total_asset_value")
+        tvl = 0.0 if pd.isna(tvl) else float(tvl)
+        operator_fee = row.get("operator_fee")
+        operator_fee = 0.0 if pd.isna(operator_fee) else float(operator_fee)
+        status = row.get("status")
+        status = 0 if pd.isna(status) else int(status)
+
         spec, vault_row = create_lighter_pool_row(
             account_index=int(row["account_index"]),
             name=row["name"],
-            description=row.get("description"),
-            tvl=row.get("total_asset_value", 0.0) or 0.0,
-            created_at=row.get("created_at"),
-            operator_fee=row.get("operator_fee", 0.0) or 0.0,
+            description=description,
+            tvl=tvl,
+            created_at=created_at,
+            operator_fee=operator_fee,
             is_llp=bool(row.get("is_llp", False)),
-            status=int(row.get("status", 0) or 0),
+            status=status,
+            deployment=deployment,
         )
 
         if spec in vault_db.rows:
@@ -271,8 +342,8 @@ def merge_into_uncleaned_parquet(
     (:py:func:`~eth_defi.research.wrangle_vault_prices.process_raw_vault_scan_data`)
     can process all vaults together.
 
-    Reads the existing Parquet, removes any prior Lighter rows
-    (chain == 9998), appends fresh Lighter daily price rows,
+    Reads the existing Parquet, removes prior rows for every configured
+    Lighter deployment, appends fresh Lighter daily price rows,
     and writes back. Idempotent: running twice produces the same result.
 
     If the Parquet file does not exist, creates a new one.
@@ -296,8 +367,12 @@ def merge_into_uncleaned_parquet(
     if parquet_path.exists():
         existing_df = pd.read_parquet(parquet_path)
 
-        # Remove any existing Lighter rows
-        existing_df = existing_df[existing_df["chain"] != LIGHTER_CHAIN_ID]
+        # Remove the current shared Lighter partition and the short-lived 9996
+        # Robinhood partition. Fresh Ethereum and Robinhood rows are then
+        # written together under chain 9998 with distinct address prefixes.
+        lighter_chain_ids = {deployment.chain_id for deployment in LIGHTER_DEPLOYMENTS}
+        lighter_chain_ids.add(LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID)
+        existing_df = existing_df[~existing_df["chain"].isin(lighter_chain_ids)]
 
         combined = pd.concat([existing_df, lighter_df], ignore_index=True)
     else:

--- a/eth_defi/lighter/vault_data_export.py
+++ b/eth_defi/lighter/vault_data_export.py
@@ -40,6 +40,7 @@ from eth_defi.lighter.constants import (
     LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID,
     LIGHTER_POOL_FEE_MODE,
     LighterAPIConfig,
+    identify_lighter_pool_deployment,
 )
 from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase
 from eth_defi.vault.base import VaultHistoricalRead, VaultSpec
@@ -49,6 +50,27 @@ from eth_defi.vault.risk import get_vault_risk
 from eth_defi.vault.vaultdb import VaultDatabase, VaultRow
 
 logger = logging.getLogger(__name__)
+
+
+def get_lighter_price_deployments(prices_df: pd.DataFrame) -> set[str]:
+    """Resolve deployment slugs represented by a Lighter raw-price frame.
+
+    The frame must contain synthetic Lighter addresses in its ``address``
+    column. Unknown addresses abort the merge because treating an incomplete
+    export as a whole-chain replacement could discard the other deployment's
+    history now that Ethereum and Robinhood share synthetic chain 9998.
+
+    :param prices_df:
+        Lighter raw-price DataFrame with string ``address`` values.
+    :return:
+        Deployment slugs represented by at least one row.
+    """
+    assert "address" in prices_df.columns, f"Lighter price frame is missing address column: {prices_df.columns}"
+    deployments = prices_df["address"].apply(identify_lighter_pool_deployment)
+    unknown_addresses = prices_df.loc[deployments.isna(), "address"].drop_duplicates().tolist()
+    if unknown_addresses:
+        raise ValueError(f"Cannot identify Lighter deployment for price addresses: {unknown_addresses}")
+    return {deployment.slug for deployment in deployments}
 
 
 def create_lighter_pool_row(
@@ -342,9 +364,11 @@ def merge_into_uncleaned_parquet(
     (:py:func:`~eth_defi.research.wrangle_vault_prices.process_raw_vault_scan_data`)
     can process all vaults together.
 
-    Reads the existing Parquet, removes prior rows for every configured
-    Lighter deployment, appends fresh Lighter daily price rows,
-    and writes back. Idempotent: running twice produces the same result.
+    Reads the existing Parquet, removes prior rows only for deployments present
+    in the fresh export, appends fresh Lighter daily price rows, and writes
+    back. Idempotent: running twice produces the same result. This
+    deployment-scoped replacement preserves Robinhood history during an
+    Ethereum-only scan, and vice versa.
 
     If the Parquet file does not exist, creates a new one.
 
@@ -364,15 +388,25 @@ def merge_into_uncleaned_parquet(
             return pd.read_parquet(parquet_path)
         return pd.DataFrame()
 
+    fresh_deployment_slugs = get_lighter_price_deployments(lighter_df)
+
     if parquet_path.exists():
         existing_df = pd.read_parquet(parquet_path)
 
-        # Remove the current shared Lighter partition and the short-lived 9996
-        # Robinhood partition. Fresh Ethereum and Robinhood rows are then
-        # written together under chain 9998 with distinct address prefixes.
-        lighter_chain_ids = {deployment.chain_id for deployment in LIGHTER_DEPLOYMENTS}
-        lighter_chain_ids.add(LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID)
-        existing_df = existing_df[~existing_df["chain"].isin(lighter_chain_ids)]
+        # Ethereum and Robinhood share chain 9998 but scan independently. Only
+        # remove address namespaces represented by this fresh export, otherwise
+        # a successful Ethereum scan followed by a failed Robinhood scan would
+        # silently erase valid Robinhood history (or vice versa).
+        shared_lighter_mask = existing_df["chain"].isin({deployment.chain_id for deployment in LIGHTER_DEPLOYMENTS})
+        existing_deployments = existing_df.loc[shared_lighter_mask, "address"].apply(identify_lighter_pool_deployment)
+        replace_current_mask = pd.Series(False, index=existing_df.index)
+        replace_current_mask.loc[shared_lighter_mask] = existing_deployments.apply(lambda deployment: deployment is not None and deployment.slug in fresh_deployment_slugs)
+
+        # Remove the short-lived 9996 partition only when fresh Robinhood data
+        # is available to replace it. An Ethereum-only standalone scan must
+        # leave legacy Robinhood history intact until Robinhood succeeds.
+        replace_legacy_robinhood_mask = existing_df["chain"].eq(LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID) if "robinhood" in fresh_deployment_slugs else pd.Series(False, index=existing_df.index)
+        existing_df = existing_df[~(replace_current_mask | replace_legacy_robinhood_mask)]
 
         combined = pd.concat([existing_df, lighter_df], ignore_index=True)
     else:

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -225,6 +225,21 @@ class VaultMetricsRecord(TypedDict, total=False):
     #: Chain display name, e.g. ``"Ethereum"``
     chain: str
 
+    #: Native protocol deployment slug, or ``None`` for ordinary EVM vaults.
+    #:
+    #: For now this is populated for Lighter so consumers can distinguish the
+    #: original ``ethereum`` deployment from Lighter on ``robinhood`` while
+    #: retaining Lighter's synthetic vault-dataset chain ID.
+    deployment: str | None
+
+    #: Real EVM chain ID associated with a native protocol deployment.
+    #:
+    #: For now this is populated for Lighter on Ethereum (1) and Lighter on
+    #: Robinhood Chain (4663). Both deployments keep ``chain_id=9998`` because
+    #: they share the native Lighter dataset namespace; their synthetic address
+    #: prefixes and these deployment fields distinguish individual vaults.
+    deployment_chain_id: int | None
+
     #: Protocol display name, e.g. ``"Morpho"``
     protocol: str
 
@@ -1606,6 +1621,13 @@ def calculate_vault_record(
     current_nav = prices_df["total_assets"].iloc[-1]
     chain_id = prices_df["chain"].iloc[-1]
 
+    # Native vault integrations may use a synthetic chain ID as their dataset
+    # identity. For now Lighter uses this optional metadata to expose whether a
+    # pool belongs to its Ethereum or Robinhood deployment without teaching
+    # this generic metrics module about Lighter-specific constants.
+    deployment = vault_metadata.get("_deployment")
+    deployment_chain_id = vault_metadata.get("_deployment_chain_id")
+
     fee_data: FeeData | None = vault_metadata.get("_fees")
 
     if fee_data is None:
@@ -2052,6 +2074,12 @@ def calculate_vault_record(
             "denomination_slug": denomination_slug,
             "share_token": share_token,
             "chain": get_chain_name(chain_id),
+            # These optional fields are currently populated by Lighter. They
+            # were introduced for Lighter on Robinhood so API consumers can see
+            # the associated EVM chain while ``chain_id=9998`` continues to
+            # carry their shared synthetic native-pool dataset identity.
+            "deployment": deployment,
+            "deployment_chain_id": deployment_chain_id,
             "peak_nav": max_nav,
             "current_nav": current_nav,
             "years": age,
@@ -2620,6 +2648,12 @@ def format_lifetime_table(
     _del("peak_nav")
     _del("address")
     _del("chain_id")
+    # Machine-readable deployment identity is exported through the JSON API,
+    # not the human-readable metrics table. For now these fields specifically
+    # support distinguishing Lighter on Robinhood from Lighter on Ethereum;
+    # the table continues to display the synthetic Lighter chain name.
+    _del("deployment")
+    _del("deployment_chain_id")
     _del("end_date")
     _del("risk_numeric")
     _del("stablecoinish")
@@ -2769,7 +2803,7 @@ def display_lifetime_table(df: pd.DataFrame):
     :param df:
         DataFrame returned by :py:func:`format_lifetime_table`.
     """
-    from IPython.display import display, HTML
+    from IPython.display import HTML, display
 
     style = "<style>table.lifetime-table td, table.lifetime-table th { padding: 2px 6px; white-space: nowrap; }</style>"
     table_html = df.to_html(escape=False, classes="lifetime-table")

--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -1720,6 +1720,13 @@ def process_raw_vault_scan_data(
         logger("After add_denormalised_vault_data():")
         display(vault_prices_df)
 
+    # ``read_parquet(dtype_backend="pyarrow")`` may return a
+    # ``timestamp[ms][pyarrow]`` Series. Pandas then creates a generic Index,
+    # even though the values are datetimes, and the chronological processing
+    # below correctly rejects it. Materialise the canonical DatetimeIndex
+    # representation before indexing. This was surfaced by the initial shared
+    # chain scan for Lighter Ethereum and Lighter Robinhood.
+    prices_df["timestamp"] = pd.to_datetime(prices_df["timestamp"])
     prices_df = prices_df.set_index("timestamp")
 
     prices_df = sort_and_index_vault_prices(prices_df, PRIORITY_SORT_IDS)

--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -389,6 +389,14 @@ Depositing into LLP requires staking LIT tokens at a 1:10 ratio (1 LIT staked pe
 
 Withdrawal cooldown is 5 minutes. Operator fee is 0%."""
 
+LIGHTER_ROBINHOOD_LLP_INSURANCE = """Lighter Liquidity Provider (LLP) on Robinhood Chain is the USDG-denominated protocol insurance fund for Robinhood Wallet perpetual futures.
+
+During partial liquidations, the protocol can send a liquidation fee of up to 1% to LLP. During full liquidations, LLP can take over the remaining positions. The pool therefore carries market-making and liquidation risk and is not equivalent to holding USDG directly.
+
+Robinhood's public documentation does not state that the Ethereum LLP's LIT staking access rule applies to this deployment, so the Ethereum USDC/LIT requirements are intentionally not repeated here.
+
+[Robinhood Wallet perpetual futures](https://robinhood.com/us/en/support/articles/robinhood-wallet-perpetual-futures/)."""
+
 GRVT_GLP_DEPOSIT_LIMITS = """GLP deposit limits are tied to your lifetime trading volume on GRVT. Each tier sets a maximum percentage of account equity and an absolute USDT cap:
 
 | Trading volume | % of equity | Max USDT |
@@ -689,6 +697,10 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "vlt:34dtzyg6lhkgm49je5aabi9tebw": (None, GRVT_GLP_DEPOSIT_LIMITS),
     # Lighter Liquidity Provider (LLP) — requires LIT token staking for deposits
     "lighter-pool-281474976710654": (None, LIGHTER_LLP_STAKING),
+    # Lighter LLP on Robinhood Chain. For now this has a separate note because
+    # the deployment uses USDG and Robinhood's documentation does not state
+    # that Ethereum LLP's USDC/LIT staking requirements apply here.
+    "lighter-pool-robinhood-281474976710654": (None, LIGHTER_ROBINHOOD_LLP_INSURANCE),
     # Morpho Yearn Morpho Vault 1 Compounder (Base)
     "0xf115c134c23c7a05fbd489a8be3116ebf54b0d9f": (VaultFlag.subvault, SUBVAULT),
     # Morpho Zircuit Finance USDC on Base Compounder

--- a/eth_defi/vault/post_processing.py
+++ b/eth_defi/vault/post_processing.py
@@ -30,7 +30,7 @@ from eth_defi.hyperliquid.constants import HYPERCORE_CHAIN_ID, HYPERLIQUID_DAILY
 from eth_defi.hyperliquid.daily_metrics import HyperliquidDailyMetricsDatabase
 from eth_defi.hyperliquid.high_freq_metrics import HyperliquidHighFreqMetricsDatabase
 from eth_defi.hyperliquid.vault_data_export import build_hypercore_prices_dataframe
-from eth_defi.lighter.constants import LIGHTER_DAILY_METRICS_DATABASE, LIGHTER_DEPLOYMENTS, LIGHTER_DEPLOYMENTS_BY_SLUG, LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID
+from eth_defi.lighter.constants import LIGHTER_DAILY_METRICS_DATABASE, LIGHTER_DEPLOYMENTS, LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID, LIGHTER_ROBINHOOD
 from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase
 from eth_defi.lighter.vault_data_export import build_raw_prices_dataframe as build_lighter_prices_dataframe
 from eth_defi.lighter.vault_data_export import get_lighter_price_deployments
@@ -504,18 +504,18 @@ def merge_native_protocols(
             if lighter_df.empty:
                 logger.warning("No Lighter data to merge")
             else:
-                fresh_deployment_slugs = get_lighter_price_deployments(lighter_df)
+                fresh_deployments = get_lighter_price_deployments(lighter_df)
                 for chain_id, deployment_df in lighter_df.groupby("chain"):
                     replacements[int(chain_id)] = deployment_df
                     # Both Lighter deployments share chain 9998 but are scanned
                     # independently. Restrict replacement to deployment address
                     # namespaces present in this fresh export, preventing a
                     # partial scan from deleting the other deployment's data.
-                    replacement_address_patterns[int(chain_id)] = {f"^{LIGHTER_DEPLOYMENTS_BY_SLUG[slug].address_prefix}-[0-9]+$" for slug in fresh_deployment_slugs}
+                    replacement_address_patterns[int(chain_id)] = {deployment.pool_address_pattern for deployment in fresh_deployments}
                 # The short-lived 9996 partition contains Robinhood only. Do
                 # not remove it until fresh Robinhood data is available; an
                 # Ethereum-only scan is not a valid replacement for it.
-                if "robinhood" in fresh_deployment_slugs:
+                if LIGHTER_ROBINHOOD in fresh_deployments:
                     remove_chain_ids.add(LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID)
             logger.info("Lighter price merge: %d fresh Lighter price entries", len(lighter_df))
             steps["lighter-price-merge"] = True

--- a/eth_defi/vault/post_processing.py
+++ b/eth_defi/vault/post_processing.py
@@ -30,9 +30,10 @@ from eth_defi.hyperliquid.constants import HYPERCORE_CHAIN_ID, HYPERLIQUID_DAILY
 from eth_defi.hyperliquid.daily_metrics import HyperliquidDailyMetricsDatabase
 from eth_defi.hyperliquid.high_freq_metrics import HyperliquidHighFreqMetricsDatabase
 from eth_defi.hyperliquid.vault_data_export import build_hypercore_prices_dataframe
-from eth_defi.lighter.constants import LIGHTER_DAILY_METRICS_DATABASE, LIGHTER_DEPLOYMENTS, LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID
+from eth_defi.lighter.constants import LIGHTER_DAILY_METRICS_DATABASE, LIGHTER_DEPLOYMENTS, LIGHTER_DEPLOYMENTS_BY_SLUG, LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID
 from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase
 from eth_defi.lighter.vault_data_export import build_raw_prices_dataframe as build_lighter_prices_dataframe
+from eth_defi.lighter.vault_data_export import get_lighter_price_deployments
 from eth_defi.research.wrangle_vault_prices import generate_cleaned_vault_datasets
 from eth_defi.vault import top_vaults_json
 from eth_defi.vault.base import VaultHistoricalRead
@@ -317,6 +318,7 @@ def _write_native_partitions_to_uncleaned_parquet(
     parquet_path: Path,
     replacements: dict[int, pd.DataFrame],
     remove_chain_ids: set[int] | None = None,
+    replacement_address_patterns: dict[int, set[str]] | None = None,
 ) -> int:
     """Replace native chain partitions using PyArrow without full pandas conversion.
 
@@ -333,10 +335,17 @@ def _write_native_partitions_to_uncleaned_parquet(
         Additional obsolete chain partitions to remove without replacing.
         Currently used to clean the legacy Lighter Robinhood synthetic chain
         9996 after both Lighter deployments were consolidated under 9998.
+    :param replacement_address_patterns:
+        Optional regular-expression address namespaces for partial replacement
+        within a shared synthetic chain. Currently used by Lighter so an
+        independently successful Ethereum or Robinhood scan replaces only its
+        own addresses within chain 9998.
     :return:
         Total row count in the new raw parquet.
     """
     assert replacements, "At least one native chain replacement is required"
+    replacement_address_patterns = replacement_address_patterns or {}
+    assert set(replacement_address_patterns).issubset(replacements), "Address-scoped replacement requires a fresh frame for the same chain"
 
     existing_table = pq.read_table(parquet_path) if parquet_path.exists() else None
     schema = _create_native_merge_schema(existing_table.schema if existing_table is not None else None, replacements)
@@ -344,9 +353,29 @@ def _write_native_partitions_to_uncleaned_parquet(
     native_table = pa.concat_tables(replacement_tables)
 
     if existing_table is not None:
-        replaced_chain_ids = set(replacements)
-        replaced_chain_ids.update(remove_chain_ids or set())
-        chain_mask = pc.is_in(existing_table["chain"], value_set=pa.array(list(replaced_chain_ids)))
+        # Most native protocols own a whole synthetic chain partition. Lighter
+        # is different: Ethereum and Robinhood now share chain 9998 and scan
+        # independently, so its replacement mask is narrowed by synthetic
+        # address namespace below.
+        whole_chain_ids = (set(replacements) - set(replacement_address_patterns)) | (remove_chain_ids or set())
+        if whole_chain_ids:
+            chain_mask = pc.is_in(
+                existing_table["chain"],
+                value_set=pa.array(list(whole_chain_ids), type=existing_table["chain"].type),
+            )
+        else:
+            chain_mask = pa.array([False] * len(existing_table))
+
+        for chain_id, address_patterns in replacement_address_patterns.items():
+            address_mask = pa.array([False] * len(existing_table))
+            for pattern in address_patterns:
+                address_mask = pc.or_(address_mask, pc.match_substring_regex(existing_table["address"], pattern=pattern))
+            scoped_chain_mask = pc.and_(
+                pc.equal(existing_table["chain"], pa.scalar(chain_id, type=existing_table["chain"].type)),
+                address_mask,
+            )
+            chain_mask = pc.or_(chain_mask, scoped_chain_mask)
+
         retained_table = _align_native_merge_table(existing_table.filter(pc.invert(chain_mask)), schema)
         combined_table = pa.concat_tables([retained_table, native_table])
     else:
@@ -409,6 +438,7 @@ def merge_native_protocols(
     steps: dict[str, bool] = {}
     replacements: dict[int, pd.DataFrame] = {}
     remove_chain_ids: set[int] = set()
+    replacement_address_patterns: dict[int, set[str]] = {}
 
     if merge_hypercore:
         try:
@@ -474,12 +504,19 @@ def merge_native_protocols(
             if lighter_df.empty:
                 logger.warning("No Lighter data to merge")
             else:
+                fresh_deployment_slugs = get_lighter_price_deployments(lighter_df)
                 for chain_id, deployment_df in lighter_df.groupby("chain"):
                     replacements[int(chain_id)] = deployment_df
-                # A successful fresh Lighter export now contains Ethereum and
-                # Robinhood addresses together under chain 9998. Remove the
-                # obsolete 9996 partition in the same atomic Parquet rewrite.
-                remove_chain_ids.add(LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID)
+                    # Both Lighter deployments share chain 9998 but are scanned
+                    # independently. Restrict replacement to deployment address
+                    # namespaces present in this fresh export, preventing a
+                    # partial scan from deleting the other deployment's data.
+                    replacement_address_patterns[int(chain_id)] = {f"^{LIGHTER_DEPLOYMENTS_BY_SLUG[slug].address_prefix}-[0-9]+$" for slug in fresh_deployment_slugs}
+                # The short-lived 9996 partition contains Robinhood only. Do
+                # not remove it until fresh Robinhood data is available; an
+                # Ethereum-only scan is not a valid replacement for it.
+                if "robinhood" in fresh_deployment_slugs:
+                    remove_chain_ids.add(LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID)
             logger.info("Lighter price merge: %d fresh Lighter price entries", len(lighter_df))
             steps["lighter-price-merge"] = True
         except Exception:
@@ -513,6 +550,7 @@ def merge_native_protocols(
             parquet_path,
             replacements,
             remove_chain_ids=remove_chain_ids,
+            replacement_address_patterns=replacement_address_patterns,
         )
         logger.info(
             "Merged %d native protocol chain partitions (%d fresh rows, %d total rows) into uncleaned %s in one PyArrow parquet write",

--- a/eth_defi/vault/post_processing.py
+++ b/eth_defi/vault/post_processing.py
@@ -334,7 +334,7 @@ def _write_native_partitions_to_uncleaned_parquet(
     :param remove_chain_ids:
         Additional obsolete chain partitions to remove without replacing.
         Currently used to clean the legacy Lighter Robinhood synthetic chain
-        9996 after both Lighter deployments were consolidated under 9998.
+        9996 once Robinhood data is available under the shared chain 9998.
     :param replacement_address_patterns:
         Optional regular-expression address namespaces for partial replacement
         within a shared synthetic chain. Currently used by Lighter so an

--- a/eth_defi/vault/post_processing.py
+++ b/eth_defi/vault/post_processing.py
@@ -30,7 +30,7 @@ from eth_defi.hyperliquid.constants import HYPERCORE_CHAIN_ID, HYPERLIQUID_DAILY
 from eth_defi.hyperliquid.daily_metrics import HyperliquidDailyMetricsDatabase
 from eth_defi.hyperliquid.high_freq_metrics import HyperliquidHighFreqMetricsDatabase
 from eth_defi.hyperliquid.vault_data_export import build_hypercore_prices_dataframe
-from eth_defi.lighter.constants import LIGHTER_CHAIN_ID, LIGHTER_DAILY_METRICS_DATABASE
+from eth_defi.lighter.constants import LIGHTER_DAILY_METRICS_DATABASE, LIGHTER_DEPLOYMENTS, LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID
 from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase
 from eth_defi.lighter.vault_data_export import build_raw_prices_dataframe as build_lighter_prices_dataframe
 from eth_defi.research.wrangle_vault_prices import generate_cleaned_vault_datasets
@@ -313,7 +313,11 @@ def _align_native_merge_table(table: pa.Table, schema: pa.Schema) -> pa.Table:
     return pa.Table.from_arrays(arrays, schema=schema)
 
 
-def _write_native_partitions_to_uncleaned_parquet(parquet_path: Path, replacements: dict[int, pd.DataFrame]) -> int:
+def _write_native_partitions_to_uncleaned_parquet(
+    parquet_path: Path,
+    replacements: dict[int, pd.DataFrame],
+    remove_chain_ids: set[int] | None = None,
+) -> int:
     """Replace native chain partitions using PyArrow without full pandas conversion.
 
     The existing file is read as an Arrow table, only the successful native
@@ -325,6 +329,10 @@ def _write_native_partitions_to_uncleaned_parquet(parquet_path: Path, replacemen
         Raw vault-price parquet to update.
     :param replacements:
         Fresh, non-empty source frames keyed by their synthetic chain IDs.
+    :param remove_chain_ids:
+        Additional obsolete chain partitions to remove without replacing.
+        Currently used to clean the legacy Lighter Robinhood synthetic chain
+        9996 after both Lighter deployments were consolidated under 9998.
     :return:
         Total row count in the new raw parquet.
     """
@@ -336,7 +344,9 @@ def _write_native_partitions_to_uncleaned_parquet(parquet_path: Path, replacemen
     native_table = pa.concat_tables(replacement_tables)
 
     if existing_table is not None:
-        chain_mask = pc.is_in(existing_table["chain"], value_set=pa.array(list(replacements)))
+        replaced_chain_ids = set(replacements)
+        replaced_chain_ids.update(remove_chain_ids or set())
+        chain_mask = pc.is_in(existing_table["chain"], value_set=pa.array(list(replaced_chain_ids)))
         retained_table = _align_native_merge_table(existing_table.filter(pc.invert(chain_mask)), schema)
         combined_table = pa.concat_tables([retained_table, native_table])
     else:
@@ -398,6 +408,7 @@ def merge_native_protocols(
     parquet_path = uncleaned_parquet_path or DEFAULT_UNCLEANED_PRICE_DATABASE
     steps: dict[str, bool] = {}
     replacements: dict[int, pd.DataFrame] = {}
+    remove_chain_ids: set[int] = set()
 
     if merge_hypercore:
         try:
@@ -463,7 +474,12 @@ def merge_native_protocols(
             if lighter_df.empty:
                 logger.warning("No Lighter data to merge")
             else:
-                replacements[LIGHTER_CHAIN_ID] = lighter_df
+                for chain_id, deployment_df in lighter_df.groupby("chain"):
+                    replacements[int(chain_id)] = deployment_df
+                # A successful fresh Lighter export now contains Ethereum and
+                # Robinhood addresses together under chain 9998. Remove the
+                # obsolete 9996 partition in the same atomic Parquet rewrite.
+                remove_chain_ids.add(LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID)
             logger.info("Lighter price merge: %d fresh Lighter price entries", len(lighter_df))
             steps["lighter-price-merge"] = True
         except Exception:
@@ -493,7 +509,11 @@ def merge_native_protocols(
         return steps
 
     try:
-        total_rows = _write_native_partitions_to_uncleaned_parquet(parquet_path, replacements)
+        total_rows = _write_native_partitions_to_uncleaned_parquet(
+            parquet_path,
+            replacements,
+            remove_chain_ids=remove_chain_ids,
+        )
         logger.info(
             "Merged %d native protocol chain partitions (%d fresh rows, %d total rows) into uncleaned %s in one PyArrow parquet write",
             len(replacements),
@@ -506,11 +526,12 @@ def merge_native_protocols(
         for step_name, chain_id in (
             ("hypercore-price-merge", HYPERCORE_CHAIN_ID),
             ("grvt-price-merge", GRVT_CHAIN_ID),
-            ("lighter-price-merge", LIGHTER_CHAIN_ID),
             ("hibachi-price-merge", HIBACHI_CHAIN_ID),
         ):
             if chain_id in replacements:
                 steps[step_name] = False
+        if any(deployment.chain_id in replacements for deployment in LIGHTER_DEPLOYMENTS):
+            steps["lighter-price-merge"] = False
 
     return steps
 

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -61,7 +61,7 @@ from eth_defi.hibachi.vault_data_export import merge_into_vault_database as hiba
 from eth_defi.hyperliquid.daily_metrics import run_daily_scan as hyperliquid_run_daily_scan
 from eth_defi.hyperliquid.session import create_hyperliquid_session
 from eth_defi.hypersync.utils import configure_hypersync_from_env
-from eth_defi.lighter.constants import LIGHTER_DEPLOYMENTS, LIGHTER_ETHEREUM, LighterAPIConfig
+from eth_defi.lighter.constants import LIGHTER_DAILY_METRICS_DATABASE, LIGHTER_DEPLOYMENTS, LIGHTER_ETHEREUM, LighterAPIConfig
 from eth_defi.lighter.daily_metrics import run_daily_scan as lighter_run_daily_scan
 from eth_defi.lighter.session import create_lighter_session
 from eth_defi.lighter.vault_data_export import merge_into_vault_database as lighter_merge_vault_db
@@ -150,7 +150,7 @@ def ensure_default_scan_cycles(cycle_overrides: dict[str, datetime.timedelta]) -
         Copy of the overrides with built-in defaults applied.
     """
     result = dict(cycle_overrides)
-    legacy_lighter_cycle = result.get("Lighter")
+    legacy_lighter_cycle = result.pop("Lighter", None)
     if legacy_lighter_cycle is not None:
         for deployment in LIGHTER_DEPLOYMENTS:
             result.setdefault(deployment.name, legacy_lighter_cycle)
@@ -1231,8 +1231,9 @@ def scan_lighter_fn(
 
     Runs the Lighter daily metrics pipeline: discovers pools from the
     public API, fetches share price history, stores in DuckDB, and
-    merges into the shared ERC-4626 pipeline files (VaultDatabase pickle
-    + cleaned Parquet).
+    merges pool metadata into the shared VaultDatabase pickle. Price rows are
+    merged into the shared uncleaned Parquet later by post-processing, after
+    all independently scheduled Lighter deployments have had a chance to run.
 
     No authentication required.
 
@@ -1247,8 +1248,6 @@ def scan_lighter_fn(
     :return:
         Scan result with vault count and duration.
     """
-    from eth_defi.lighter.constants import LIGHTER_DAILY_METRICS_DATABASE
-
     if db_path is None:
         db_path = LIGHTER_DAILY_METRICS_DATABASE
 

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -377,7 +377,7 @@ def get_due_items(
     return due_chains, due_protocols
 
 
-@dataclass
+@dataclass(slots=True)
 class ChainConfig:
     """Configuration for scanning a single chain"""
 
@@ -391,7 +391,7 @@ class ChainConfig:
     scan_vaults: bool
 
 
-@dataclass
+@dataclass(slots=True)
 class ChainResult:
     """Result of scanning a single chain"""
 

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -61,6 +61,7 @@ from eth_defi.hibachi.vault_data_export import merge_into_vault_database as hiba
 from eth_defi.hyperliquid.daily_metrics import run_daily_scan as hyperliquid_run_daily_scan
 from eth_defi.hyperliquid.session import create_hyperliquid_session
 from eth_defi.hypersync.utils import configure_hypersync_from_env
+from eth_defi.lighter.constants import LIGHTER_DEPLOYMENTS, LIGHTER_ETHEREUM, LighterAPIConfig
 from eth_defi.lighter.daily_metrics import run_daily_scan as lighter_run_daily_scan
 from eth_defi.lighter.session import create_lighter_session
 from eth_defi.lighter.vault_data_export import merge_into_vault_database as lighter_merge_vault_db
@@ -149,6 +150,10 @@ def ensure_default_scan_cycles(cycle_overrides: dict[str, datetime.timedelta]) -
         Copy of the overrides with built-in defaults applied.
     """
     result = dict(cycle_overrides)
+    legacy_lighter_cycle = result.get("Lighter")
+    if legacy_lighter_cycle is not None:
+        for deployment in LIGHTER_DEPLOYMENTS:
+            result.setdefault(deployment.name, legacy_lighter_cycle)
     result.setdefault(CURRENCY_RATES_PROTOCOL_NAME, CURRENCY_RATES_DEFAULT_CYCLE)
     return result
 
@@ -247,7 +252,7 @@ def build_active_protocols(
     if scan_grvt:
         all_protocols.append("GRVT")
     if scan_lighter:
-        all_protocols.append("Lighter")
+        all_protocols.extend(deployment.name for deployment in LIGHTER_DEPLOYMENTS)
     if scan_hibachi:
         all_protocols.append("Hibachi")
     if scan_core3:
@@ -1220,6 +1225,7 @@ def scan_lighter_fn(
     max_workers: int,
     db_path: Path | None = None,
     vault_db_path: Path = DEFAULT_VAULT_DATABASE,
+    deployment: LighterAPIConfig = LIGHTER_ETHEREUM,
 ) -> ChainResult:
     """Scan Lighter native pools via public endpoints.
 
@@ -1236,6 +1242,8 @@ def scan_lighter_fn(
         Path to the Lighter DuckDB file.  ``None`` uses the default.
     :param vault_db_path:
         Path to the vault database pickle.
+    :param deployment:
+        Lighter deployment to scan. Defaults to Ethereum for compatibility.
     :return:
         Scan result with vault count and duration.
     """
@@ -1244,11 +1252,11 @@ def scan_lighter_fn(
     if db_path is None:
         db_path = LIGHTER_DAILY_METRICS_DATABASE
 
-    result = ChainResult(name="Lighter", status="running")
+    result = ChainResult(name=deployment.name, status="running")
     start_time = time.time()
 
     try:
-        session = create_lighter_session()
+        session = create_lighter_session(deployment=deployment)
 
         db = lighter_run_daily_scan(
             session=session,
@@ -1257,7 +1265,7 @@ def scan_lighter_fn(
         )
 
         try:
-            vault_count = db.get_vault_count()
+            vault_count = db.get_vault_count(deployment=deployment.slug)
             result.vault_count = vault_count
             result.vault_scan_ok = True
 
@@ -1269,7 +1277,7 @@ def scan_lighter_fn(
         result.status = "success"
 
     except Exception as e:
-        logger.exception("Lighter scan failed")
+        logger.exception("%s scan failed", deployment.name)
         result.status = "failed"
         result.error = str(e)
         result.traceback_str = traceback.format_exc()
@@ -2029,22 +2037,34 @@ def run_scan_tick(
             logger.error("GRVT: FAILED - %s", r.error)
         print_dashboard(results, display_order, uncleaned_price_path=uncleaned_price_path)
 
-    if scan_lighter and "Lighter" in active_protocols:
-        logger.info("Scanning Lighter (native pools)")
-        try:
-            results["Lighter"] = scan_lighter_fn(max_workers, db_path=lighter_db_path, vault_db_path=vault_db_path)
-        except Exception as e:
-            logger.exception("Lighter scan crashed with unhandled exception")
-            results["Lighter"] = ChainResult(name="Lighter", status="failed", error=str(e), traceback_str=traceback.format_exc())
-        r = results["Lighter"]
-        if r.status == "success":
-            logger.info("Lighter: SUCCESS - %d pools", r.vault_count or 0)
-            # Save cycle state for data fetching progress — not related to post-processing
-            if on_item_success:
-                on_item_success("Lighter")
-        elif r.status == "failed":
-            logger.error("Lighter: FAILED - %s", r.error)
-        print_dashboard(results, display_order, uncleaned_price_path=uncleaned_price_path)
+    if scan_lighter:
+        for deployment in LIGHTER_DEPLOYMENTS:
+            if deployment.name not in active_protocols:
+                continue
+            logger.info("Scanning %s (native pools)", deployment.name)
+            try:
+                results[deployment.name] = scan_lighter_fn(
+                    max_workers,
+                    db_path=lighter_db_path,
+                    vault_db_path=vault_db_path,
+                    deployment=deployment,
+                )
+            except Exception as e:
+                logger.exception("%s scan crashed with unhandled exception", deployment.name)
+                results[deployment.name] = ChainResult(
+                    name=deployment.name,
+                    status="failed",
+                    error=str(e),
+                    traceback_str=traceback.format_exc(),
+                )
+            result = results[deployment.name]
+            if result.status == "success":
+                logger.info("%s: SUCCESS - %d pools", deployment.name, result.vault_count or 0)
+                if on_item_success:
+                    on_item_success(deployment.name)
+            elif result.status == "failed":
+                logger.error("%s: FAILED - %s", deployment.name, result.error)
+            print_dashboard(results, display_order, uncleaned_price_path=uncleaned_price_path)
 
     if scan_hibachi and "Hibachi" in active_protocols:
         logger.info("Scanning Hibachi (native vaults)")

--- a/eth_defi/vault/vaultdb.py
+++ b/eth_defi/vault/vaultdb.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 from io import BufferedIOBase
 from pathlib import Path
-from typing import TypeAlias, TypedDict
+from typing import NotRequired, TypeAlias, TypedDict
 
 import pandas as pd
 from atomicwrites import atomic_write
@@ -135,6 +135,21 @@ class VaultRow(TypedDict):
 
     #: Human-readable vault note captured by the vault scanner.
     _notes: str | None
+
+    #: Protocol deployment slug for native vault integrations.
+    #:
+    #: For now this is populated by Lighter so the metrics export can state
+    #: whether a native Lighter pool belongs to the ``ethereum`` or
+    #: ``robinhood`` deployment. It is optional for existing EVM vault rows.
+    _deployment: NotRequired[str | None]
+
+    #: Real EVM chain associated with a native protocol deployment.
+    #:
+    #: For now this is populated for Lighter on Ethereum (1) and Lighter on
+    #: Robinhood Chain (4663). It must not replace the synthetic chain ID in
+    #: ``_detection_data`` because that ID is the Lighter price-partition and
+    #: :class:`~eth_defi.vault.base.VaultSpec` identity.
+    _deployment_chain_id: NotRequired[int | None]
 
     __annotations__ = {
         "First seen at": datetime.datetime,

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -183,6 +183,14 @@ poetry run python scripts/erc-4626/scan-vaults-all-chains.py
 | `HYPERSYNC_CONCURRENCY` | Optional. Hypersync stream concurrency. Default: 1 (sequential) in the all-chains scanner to avoid API pressure when scanning many chains. Set higher for faster throughput. See [Envio StreamConfig tuning](https://docs.envio.dev/docs/HyperSync/stream-config-tuning). |
 | `RPC_TRACKING_DATABASE_PATH` | Optional. Shared JSON-RPC accounting DuckDB used by all EVM vault scanners. Default: `~/.tradingstrategy/rpc-tracking.duckdb`. |
 
+Both Lighter deployments use synthetic native-pool chain ID `9998`; their
+address prefixes distinguish price series. Lifetime-metrics export the
+additional `deployment_chain_id` (`1` for Ethereum or `4663` for Robinhood)
+and `deployment` slug. The Lighter DuckDB schema migration runs automatically
+when an existing database is opened. See the
+[Lighter native-pool pipeline](../lighter/README-lighter-vaults.md) for the
+storage and partial-scan replacement rules.
+
 #### JSON-RPC usage accounting
 
 The all-chain scanner, `scan-vaults.py`, and `scan-prices.py` store physical

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -162,12 +162,12 @@ poetry run python scripts/erc-4626/scan-vaults-all-chains.py
 | `LOG_LEVEL` | Optional. Default: WARNING. |
 | `PIPELINE_DATA_DIR` | Optional. Directory for all pipeline files (parquet, pickle, DuckDB, state). Default: `~/.tradingstrategy/vaults`. |
 | `LOOP_INTERVAL_SECONDS` | Optional. When >0, enables looped mode — ticks every N seconds. Default: 0 (single run). |
-| `SCAN_CYCLES` | Optional. Per-item cycle intervals, e.g. `Ethereum=8h,Base=8h,Arbitrum=8h,Lighter=4h,GRVT=4h,Hypercore=4h,Hibachi=4h,Core3=24h`. |
+| `SCAN_CYCLES` | Optional. Per-item cycle intervals, e.g. `Ethereum=8h,Base=8h,Arbitrum=8h,Lighter Ethereum=4h,Lighter Robinhood=4h,GRVT=4h,Hypercore=4h,Hibachi=4h,Core3=24h`. Legacy `Lighter=4h` applies to both Lighter deployments. |
 | `DEFAULT_CYCLE` | Optional. Default cycle for items not in `SCAN_CYCLES`. Default: `24h`. |
 | `MAX_CYCLES` | Optional. Exit after N cycles (for testing). Default: 0 (unlimited). |
 | `SCAN_HYPERCORE` | Optional. Enable Hyperliquid native vault scanning. Default: false. |
 | `SCAN_GRVT` | Optional. Enable GRVT native vault scanning. Default: false. |
-| `SCAN_LIGHTER` | Optional. Enable Lighter native pool scanning. Default: false. |
+| `SCAN_LIGHTER` | Optional. Enable native pool scanning for both Lighter Ethereum and Lighter Robinhood. Default: false. |
 | `SCAN_HIBACHI` | Optional. Enable Hibachi native vault scanning. Default: false. |
 | `SCAN_VAULT_SETTLEMENTS` | Optional. Scan Lagoon and D2 settlement events during each successful EVM chain cycle. Default: true. The scan fills `vault-settlements.duckdb` before price cleaning; `vault_settlement_at` is then merged into the cleaned price frame during cleaning. Set to `false` only for debugging runs where new settlement event reads are deliberately skipped. Settlement scan failures are logged and shown in the dashboard without aborting the rest of the scanner cycle. |
 | `VAULT_SETTLEMENT_START_BLOCK` | Optional. Inclusive settlement scan start block for forced backfills. Normally unset so scans continue incrementally from `vault-settlements.duckdb`. |

--- a/scripts/erc-4626/scan-vaults-all-chains.py
+++ b/scripts/erc-4626/scan-vaults-all-chains.py
@@ -25,7 +25,7 @@ Usage:
     # Include GRVT native vaults
     SCAN_GRVT=true python scripts/erc-4626/scan-vaults-all-chains.py
 
-    # Include Lighter native pools
+    # Include both Ethereum and Robinhood Lighter native pools
     SCAN_LIGHTER=true python scripts/erc-4626/scan-vaults-all-chains.py
 
     # Include Hibachi native vaults
@@ -49,7 +49,7 @@ Usage:
 
     # Looped mode: tick every 1h, major EVM chains on 8h, native protocols on 4h, Core3 and rest on 24h
     LOOP_INTERVAL_SECONDS=3600 \\
-    SCAN_CYCLES="Ethereum=8h,Base=8h,Arbitrum=8h,Hypercore=4h,GRVT=4h,Lighter=4h,Hibachi=4h,Core3=24h" \\
+    SCAN_CYCLES="Ethereum=8h,Base=8h,Arbitrum=8h,Hypercore=4h,GRVT=4h,Lighter Ethereum=4h,Lighter Robinhood=4h,Hibachi=4h,Core3=24h" \\
     DEFAULT_CYCLE=24h \\
     SCAN_HYPERCORE=true SCAN_GRVT=true SCAN_LIGHTER=true SCAN_HIBACHI=true \\
     python scripts/erc-4626/scan-vaults-all-chains.py
@@ -88,7 +88,7 @@ Environment variables:
     - SCAN_PRICES: "true" or "false" (default: "false")
     - SCAN_HYPERCORE: "true" to scan Hyperliquid native (Hypercore) vaults via REST API (default: "false")
     - SCAN_GRVT: "true" to scan GRVT native vaults via public endpoints (default: "false")
-    - SCAN_LIGHTER: "true" to scan Lighter native pools via public endpoints (default: "false")
+    - SCAN_LIGHTER: "true" to scan both Ethereum and Robinhood Lighter native pools via public endpoints (default: "false")
     - SCAN_VAULT_SETTLEMENTS: "false" to skip per-chain Lagoon and D2 settlement event scanning.
       When enabled, events are stored in vault-settlements.duckdb before price cleaning;
       vault_settlement_at is merged into the cleaned price frame during cleaning (default: "true")
@@ -119,7 +119,8 @@ Environment variables:
     - COINGECKO_DEMO_API_KEY: Optional CoinGecko demo API key for stablecoin rate refreshes
     - JSON_RPC_<CHAIN>: RPC URL for each chain (required per chain)
     - LOOP_INTERVAL_SECONDS: Seconds between ticks in looped mode (default: "0" = single run)
-    - SCAN_CYCLES: Per-chain/protocol cycle overrides, e.g. "Ethereum=8h,Base=8h,Arbitrum=8h,Hypercore=4h,GRVT=4h,Lighter=4h"
+    - SCAN_CYCLES: Per-chain/protocol cycle overrides, e.g. "Ethereum=8h,Base=8h,Arbitrum=8h,Hypercore=4h,GRVT=4h,Lighter Ethereum=4h,Lighter Robinhood=4h"
+      The legacy "Lighter=4h" form still applies the interval to both deployments.
     - DEFAULT_CYCLE: Default cycle interval for items not in SCAN_CYCLES (default: "24h")
     - MAX_CYCLES: Exit after N cycles in looped mode, for testing (default: "0" = unlimited)
     - FORCE_RESCAN: "true" to ignore cycle state and rescan all items on the first cycle (default: "false")

--- a/scripts/lighter/README-lighter-vaults.md
+++ b/scripts/lighter/README-lighter-vaults.md
@@ -2,8 +2,8 @@
 
 ## Overview
 
-Scans Lighter DEX native pools (vaults), fetches share price history
-from the public REST API, and merges the data into the existing
+Scans the Ethereum and Robinhood Chain Lighter DEX deployments, fetches
+native pool (vault) share price history from their public REST APIs, and merges the data into the existing
 ERC-4626 vault metrics pipeline so that `vault-analysis-json.py` produces
 a single unified JSON with EVM, Hyperliquid, GRVT, and Lighter pools.
 
@@ -16,8 +16,9 @@ pipeline as EVM vaults.
 
 - [Lighter homepage](https://lighter.xyz)
 - [Public pools app](https://app.lighter.xyz/public-pools)
-- [Public pools documentation](https://docs.lighter.xyz/perpetual-futures/public-pools)
-- [Fees documentation](https://docs.lighter.xyz/perpetual-futures/fees)
+- [Robinhood Lighter app](https://robinhoodchain.lighter.xyz/public-pools)
+- [Public pools documentation](https://docs.lighter.xyz/trading/public-pools)
+- [Fees documentation](https://docs.lighter.xyz/trading/trading-fees)
 - [API reference (Swagger)](https://apidocs.lighter.xyz/)
 - [DeFi Llama](https://defillama.com/protocol/lighter-perps)
 
@@ -60,30 +61,93 @@ lighter-pools.duckdb  ------merge----->  vault-metadata-db.pickle
                                           EVM + Hyperliquid + GRVT + Lighter
 ```
 
-### Chain ID
+### Deployments and chain IDs
 
-Lighter pools use synthetic chain ID `9998` (constant `LIGHTER_CHAIN_ID`).
+Lighter pools use deployment-specific synthetic chain IDs because they are
+native rollup pools rather than EVM ERC-4626 contracts:
+
+| Deployment | API | Synthetic chain ID | Associated EVM chain ID | Denomination | Address format |
+|------------|-----|--------------------|-------------------------|--------------|----------------|
+| Ethereum | `https://mainnet.zklighter.elliot.ai` | `9998` | `1` | USDC | `lighter-pool-{account_index}` |
+| Robinhood Chain | `https://api.rh.lighter.xyz` | `9998` | `4663` | USDG | `lighter-pool-robinhood-{account_index}` |
+
+Both deployments intentionally share synthetic chain `9998` because it is the
+native Lighter dataset namespace. Their deployment-specific synthetic address
+prefixes provide VaultSpec and price-series uniqueness even when Lighter reuses
+the same account index on both deployments.
+
+These settings cover native pool discovery, metrics storage and vault-dataset
+export. The Lagoon custody and Guard helpers remain Ethereum-only because they
+target the verified Ethereum `ZkLighter` proxy and its USDC asset index.
+Supporting Robinhood custody requires the canonical Robinhood Relayer contract
+address and ABI to be published and verified before those transaction helpers
+can be parameterised safely.
+
+### Lifetime-metrics chain identity
+
+Lighter needs two chain identities in `calculate_lifetime_metrics()` output:
+
+- `chain_id` is the shared synthetic native-pool dataset identity (`9998`).
+  It keys price partitions and `VaultSpec` records and must not be replaced by
+  an EVM chain ID.
+- `deployment_chain_id` is the associated EVM deployment chain (`1` for
+  Ethereum or `4663` for Robinhood Chain).
+- `deployment` is the stable deployment slug (`ethereum` or `robinhood`).
+
+For now the two additive deployment fields exist specifically to support
+Lighter on Robinhood in lifetime-metrics and JSON consumers. They are carried
+through Lighter `VaultRow` metadata; existing non-Lighter vault rows export
+`None`. No DuckDB or Parquet migration is required, because the normal Lighter
+metadata merge refreshes the pickle rows with these fields.
 
 ### Denomination token
 
-All Lighter pools are denominated in USDC.
+Ethereum Lighter pools are denominated in USDC. Robinhood Lighter pools are
+denominated in USDG.
 
 ### Pool discovery
 
-Pools are discovered via `/api/v1/publicPoolsMetadata`. The LLP
-(Lighter Liquidity Pool) is a special system pool **not** listed in
-this endpoint — it is fetched separately from `/api/v1/account` using
-the `liquidity_pool_index` from `/api/v1/systemConfig`.
+Pools are discovered via `/api/v1/publicPoolsMetadata`. When a deployment's
+LLP (Lighter Liquidity Pool) is not listed there, it is fetched separately
+from `/api/v1/account` using the `liquidity_pool_index` from
+`/api/v1/systemConfig`. Robinhood currently lists its LLP directly with
+account type `3`.
 
-Each pool has a single integer identifier:
+Each pool has a deployment-local integer identifier:
 
-- **Account index** (e.g. `281474976710654` for LLP) — primary key across all endpoints
+- **Account index** (e.g. `281474976710654` for LLP) — unique only within one deployment
 
-Pool addresses in the pipeline are synthetic strings: `lighter-pool-{account_index}`.
+Account indexes overlap between deployments: `281474976710654` is used by
+both Ethereum and Robinhood Lighter. DuckDB therefore keys rows by
+`(deployment, account_index)` and price rows by
+`(deployment, account_index, date)`.
+
+### Robinhood pool availability
+
+As checked against the live API on 2026-07-22, Robinhood Lighter exposes one
+active pool through `publicPoolsMetadata`:
+
+- Account index `281474976710654`
+- Account type `3`, the protocol-operated LLP/insurance pool
+- USDG denomination and 0% operator fee
+- Daily share-price and total-share history available from the standard
+  `account` and `pnl` endpoints
+
+The Robinhood API currently leaves the pool name and description empty, so the
+scanner supplies the canonical `Lighter Liquidity Provider (LLP)` label. Its
+`systemConfig.liquidity_pool_index` points to `281474976710655`, which is not
+yet an initialised account; account type `3` is therefore also used to identify
+the live LLP. TVL and APY are deliberately read live rather than documented as
+fixed values.
+
+Robinhood's product documentation confirms that the deployment uses USDG on
+Robinhood Chain and that liquidation fees and bankrupt positions flow to the
+LLP insurance fund: <https://robinhood.com/us/en/support/articles/robinhood-wallet-perpetual-futures/>.
 
 ### Public API endpoints
 
-Base URL: `https://mainnet.zklighter.elliot.ai`
+Base URLs are `https://mainnet.zklighter.elliot.ai` for Ethereum and
+`https://api.rh.lighter.xyz` for Robinhood.
 
 All endpoints are GET requests. No authentication required.
 
@@ -116,10 +180,10 @@ Response fields per pool in `public_pools[]`:
 | `annual_percentage_yield` | float | Current APY |
 | `sharpe_ratio` | string | Risk-adjusted return metric |
 | `operator_fee` | string | Fee percentage (e.g. "10" = 10%) |
-| `total_asset_value` | string | TVL in USDC |
+| `total_asset_value` | string | TVL in the deployment's collateral currency |
 | `total_shares` | int | Outstanding shares |
 | `status` | int | 0 = active |
-| `account_type` | int | 2 = pool |
+| `account_type` | int | 2 = public pool; 3 = protocol liquidity/insurance pool |
 | `master_account_index` | int | Operator's main account |
 | `created_at` | int | Unix timestamp |
 
@@ -138,7 +202,7 @@ Response fields (inside `accounts[0]`):
 |-------|------|-------------|
 | `name` | string | Pool name |
 | `description` | string | Pool strategy description |
-| `total_asset_value` | string | TVL in USDC |
+| `total_asset_value` | string | TVL in the deployment's collateral currency |
 | `pool_info.share_prices` | array | `[{"timestamp": int, "share_price": float}, ...]` |
 | `pool_info.daily_returns` | array | `[{"timestamp": int, "daily_return": float}, ...]` |
 | `pool_info.operator_fee` | string | Operator fee percentage |
@@ -219,8 +283,9 @@ retention window.
 ```
 pool_metadata                         pool_daily_prices
 =============                         =================
-account_index    BIGINT PK            account_index  BIGINT  \
-name             VARCHAR               date           DATE    > composite PK
+deployment       VARCHAR \            deployment     VARCHAR \
+account_index    BIGINT   > PK         account_index  BIGINT  > composite PK
+name             VARCHAR               date           DATE   /
 description      VARCHAR               share_price    DOUBLE
 l1_address       VARCHAR               tvl            DOUBLE
 is_llp           BOOLEAN               daily_return   DOUBLE
@@ -231,6 +296,9 @@ sharpe_ratio     DOUBLE
 created_at       TIMESTAMP
 last_updated     TIMESTAMP
 ```
+
+Opening a legacy database performs a transactional migration. All existing
+rows are retained and labelled `ethereum`; no rescan is needed.
 
 ### Fees
 
@@ -287,7 +355,7 @@ MIN_TVL=10000 MAX_POOLS=20 \
 | `LOG_LEVEL` | `warning` | Logging level |
 | `DB_PATH` | `~/.tradingstrategy/vaults/lighter-pools.duckdb` | DuckDB database path |
 | `POOL_INDICES` | *(all pools)* | Comma-separated pool account indices to scan |
-| `MIN_TVL` | `1000` | Minimum TVL in USDC to include a pool |
+| `MIN_TVL` | `1000` | Minimum TVL in the deployment's collateral currency |
 | `MAX_POOLS` | `200` | Maximum number of pools to scan |
 | `MAX_WORKERS` | `16` | Number of parallel workers |
 | `VAULT_DB_PATH` | `~/.tradingstrategy/vaults/vault-metadata-db.pickle` | VaultDatabase pickle path |
@@ -305,7 +373,7 @@ MIN_TVL=10000 MAX_POOLS=20 \
 
 ## Running the full pipeline (Lighter only)
 
-To run the full pipeline scanning only Lighter pools (no EVM chains),
+To run the full pipeline scanning both Lighter deployments (no EVM chains),
 disable all other chains and set `SCAN_LIGHTER=true`:
 
 ```shell
@@ -319,7 +387,7 @@ poetry run python scripts/erc-4626/scan-vaults-all-chains.py
 
 This runs through the following stages:
 
-1. **Lighter scan** (~20s) — discovers pools from the public API, fetches share price
+1. **Lighter scans** — independently discovers Ethereum and Robinhood pools from their public APIs, fetches share price
    history and total shares, stores in `lighter-pools.duckdb`
 2. **Merge vault metadata** — upserts Lighter VaultRows into `vault-metadata-db.pickle`
 3. **Merge prices** — appends Lighter daily prices into `vault-prices-1h.parquet`
@@ -354,12 +422,16 @@ daily prices before they are merged into the unified pipeline.
 
 ### Step 2: Purge Lighter rows from the uncleaned Parquet
 
-Use `purge-price-data.py` with the Lighter synthetic chain ID
-(`9998`) to strip Lighter rows from the shared Parquet file:
+Use `purge-price-data.py` with the shared Lighter synthetic chain ID to strip
+Lighter rows from the shared Parquet file:
 
 ```shell
 CHAIN_ID=9998 python scripts/erc-4626/purge-price-data.py
 ```
+
+The pipeline automatically removes any rows written under the legacy
+Robinhood-only synthetic chain `9996` during the next successful Lighter price
+merge; operators do not need to purge that temporary partition manually.
 
 ### Step 3: Rescan
 

--- a/scripts/lighter/README-lighter-vaults.md
+++ b/scripts/lighter/README-lighter-vaults.md
@@ -104,6 +104,9 @@ The underlying Lighter storage migration is automatic. Opening an older
 `lighter-pools.duckdb` transactionally adds the `deployment` column and changes
 the primary keys to `(deployment, account_index)` and
 `(deployment, account_index, date)`, labelling existing rows as `ethereum`.
+This assumes the database predates Robinhood support, as production databases
+do. If a development database was created by an intermediate, unmerged version
+of the Robinhood work, delete that development database and rescan it.
 The metadata merge refreshes existing pickle rows with deployment identity.
 The price merge removes the short-lived Robinhood synthetic-chain `9996`
 partition only after fresh Robinhood data is available to replace it.

--- a/scripts/lighter/README-lighter-vaults.md
+++ b/scripts/lighter/README-lighter-vaults.md
@@ -28,17 +28,17 @@ pipeline as EVM vaults.
 Lighter public endpoints               ERC-4626 pipeline
 ========================               =================
 /api/v1/systemConfig                   vault-metadata-db.pickle
-  liquidity_pool_index (LLP ID)        vault-prices-1h.parquet (uncleaned)
+  reported liquidity_pool_index        vault-prices-1h.parquet (uncleaned)
       |                                        |
       v                                        |
 /api/v1/publicPoolsMetadata                    |
-  bulk pool listing (~300 pools)               |
+  bulk pool listing                            |
   name, APY, sharpe_ratio, TVL                 |
       |                                        |
       v                                        |
 /api/v1/account?by=index&value={idx}           |
   per-pool share price history                 |
-  pool_info.share_prices (~379 entries)        |
+  pool_info.share_prices                       |
   pool_info.daily_returns                      |
       |                                        |
       v                                        |
@@ -63,8 +63,9 @@ lighter-pools.duckdb  ------merge----->  vault-metadata-db.pickle
 
 ### Deployments and chain IDs
 
-Lighter pools use deployment-specific synthetic chain IDs because they are
-native rollup pools rather than EVM ERC-4626 contracts:
+Lighter pools use a shared synthetic chain ID because they are native pools
+rather than EVM ERC-4626 contracts. A second chain ID records the EVM chain
+associated with each deployment:
 
 | Deployment | API | Synthetic chain ID | Associated EVM chain ID | Denomination | Address format |
 |------------|-----|--------------------|-------------------------|--------------|----------------|
@@ -79,9 +80,9 @@ the same account index on both deployments.
 These settings cover native pool discovery, metrics storage and vault-dataset
 export. The Lagoon custody and Guard helpers remain Ethereum-only because they
 target the verified Ethereum `ZkLighter` proxy and its USDC asset index.
-Supporting Robinhood custody requires the canonical Robinhood Relayer contract
-address and ABI to be published and verified before those transaction helpers
-can be parameterised safely.
+Robinhood product documentation describes deposits to a Lighter Relayer smart
+contract, but this repository does not yet configure or verify that contract's
+address and ABI for custody operations.
 
 ### Lifetime-metrics chain identity
 
@@ -97,8 +98,15 @@ Lighter needs two chain identities in `calculate_lifetime_metrics()` output:
 For now the two additive deployment fields exist specifically to support
 Lighter on Robinhood in lifetime-metrics and JSON consumers. They are carried
 through Lighter `VaultRow` metadata; existing non-Lighter vault rows export
-`None`. No DuckDB or Parquet migration is required, because the normal Lighter
-metadata merge refreshes the pickle rows with these fields.
+`None`. These export fields do not add columns to the price Parquet files.
+
+The underlying Lighter storage migration is automatic. Opening an older
+`lighter-pools.duckdb` transactionally adds the `deployment` column and changes
+the primary keys to `(deployment, account_index)` and
+`(deployment, account_index, date)`, labelling existing rows as `ethereum`.
+The metadata merge refreshes existing pickle rows with deployment identity.
+The price merge removes the short-lived Robinhood synthetic-chain `9996`
+partition only after fresh Robinhood data is available to replace it.
 
 ### Denomination token
 
@@ -107,11 +115,17 @@ denominated in USDG.
 
 ### Pool discovery
 
-Pools are discovered via `/api/v1/publicPoolsMetadata`. When a deployment's
-LLP (Lighter Liquidity Pool) is not listed there, it is fetched separately
-from `/api/v1/account` using the `liquidity_pool_index` from
-`/api/v1/systemConfig`. Robinhood currently lists its LLP directly with
-account type `3`.
+Pools are discovered via `/api/v1/publicPoolsMetadata`. The canonical LLP
+(Lighter Liquidity Pool) is identified by an exact deployment-local account
+index. Ethereum uses the `liquidity_pool_index` reported by
+`/api/v1/systemConfig`; if that pool is absent from the listing, it is fetched
+separately from `/api/v1/account`.
+
+For now Robinhood uses the configured account-index override
+`281474976710654`, because its live `systemConfig` response reports the
+uninitialised account `281474976710655`. The scanner does not identify LLP from
+`account_type == 3`: Ethereum also exposes XLP with type `3`, so that fallback
+would misclassify a second protocol pool as LLP.
 
 Each pool has a deployment-local integer identifier:
 
@@ -134,11 +148,11 @@ active pool through `publicPoolsMetadata`:
   `account` and `pnl` endpoints
 
 The Robinhood API currently leaves the pool name and description empty, so the
-scanner supplies the canonical `Lighter Liquidity Provider (LLP)` label. Its
-`systemConfig.liquidity_pool_index` points to `281474976710655`, which is not
-yet an initialised account; account type `3` is therefore also used to identify
-the live LLP. TVL and APY are deliberately read live rather than documented as
-fixed values.
+scanner supplies the `Lighter Liquidity Provider (LLP)` label. Its
+`systemConfig.liquidity_pool_index` points to `281474976710655`, which was not
+an initialised account when checked. The deployment configuration therefore
+identifies the live LLP by its exact account index, not by account type. TVL
+and APY are deliberately read live rather than documented as fixed values.
 
 Robinhood's product documentation confirms that the deployment uses USDG on
 Robinhood Chain and that liquidation fees and bankrupt positions flow to the
@@ -157,7 +171,7 @@ Returns system configuration including the LLP account index.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `liquidity_pool_index` | int | Account index of the LLP protocol pool |
+| `liquidity_pool_index` | int | Reported LLP account index. The Robinhood value was stale when checked on 2026-07-22, so its deployment config supplies an explicit override. |
 | `liquidity_pool_cooldown_period` | int | Withdrawal cooldown in milliseconds (300000 = 5 min) |
 
 #### Pool listing (`/api/v1/publicPoolsMetadata`)
@@ -176,7 +190,7 @@ Response fields per pool in `public_pools[]`:
 |-------|------|-------------|
 | `account_index` | int | Primary identifier |
 | `name` | string | Pool display name (e.g. "ETH 3x long") |
-| `l1_address` | string | L1 Ethereum address of the pool operator |
+| `l1_address` | string | Operator address reported by the API; the legacy field name is retained across deployments |
 | `annual_percentage_yield` | float | Current APY |
 | `sharpe_ratio` | string | Risk-adjusted return metric |
 | `operator_fee` | string | Fee percentage (e.g. "10" = 10%) |
@@ -235,11 +249,11 @@ Response fields (inside `pnl[]`):
 | Field | Type | Description |
 |-------|------|-------------|
 | `timestamp` | int | Unix timestamp |
-| `trade_pnl` | float | Cumulative trading PnL (USDC) |
+| `trade_pnl` | float | Cumulative trading PnL in the deployment's collateral currency |
 | `trade_spot_pnl` | float | Cumulative spot PnL |
 | `pool_pnl` | float | Pool-level PnL |
-| `pool_inflow` | float | Cumulative deposit inflow (USDC) |
-| `pool_outflow` | float | Cumulative withdrawal outflow (USDC) |
+| `pool_inflow` | float | Cumulative deposit inflow in the deployment's collateral currency |
+| `pool_outflow` | float | Cumulative withdrawal outflow in the deployment's collateral currency |
 | `pool_total_shares` | int | Total outstanding shares at this point |
 | `staking_pnl` | float | LIT staking PnL |
 | `staking_inflow` | float | Staking inflow |
@@ -254,29 +268,21 @@ this endpoint for its TVL/balance chart, but uses the separate
 
 ### Share price history limitations
 
-The `/api/v1/account` endpoint's `share_prices` array has **different
-retention depending on pool type**:
-
-| Pool type | History | Entries (as of Mar 2026) |
-|-----------|---------|------------------------|
-| **LLP (protocol pool)** | Full history from inception (Jan 2025) | ~409 |
-| **User-created pools** | Rolling window of ~208 days | ~208 max |
-
-User pools created before the rolling window cutoff (around Aug 2025)
-have their earliest share price entries truncated. Pools created within
-the window have full history from their creation date.
+The `/api/v1/account` endpoint's `share_prices` array has shown different
+retention depending on pool and deployment. Protocol pools may expose longer
+histories, while older user pools can return a rolling window. The API does not
+promise a fixed entry count, so consumers must not rely on the historical
+counts observed during development.
 
 **Implication for the pipeline:** The pipeline should run at least daily
 to capture share prices before they fall off the rolling window for user
 pools. The DuckDB database preserves all previously fetched data, so
 historical entries are not lost once stored.
 
-The `/api/v1/pnl` endpoint **does** return full history (409+ entries)
-for all pools, but only provides `pool_total_shares` and cumulative PnL
-fields — not share prices. The Lighter website's "All-time" TVL chart
-uses this PnL endpoint (which is why TVL goes back to Jan 2025 for all
-pools), while the NAV/share-price chart is limited by the `share_prices`
-retention window.
+The `/api/v1/pnl` endpoint can expose a longer history, but it only provides
+`pool_total_shares` and cumulative PnL fields — not share prices. It therefore
+cannot fill missing NAV/share-price observations without a separate, verified
+reconstruction model.
 
 ### DuckDB schema
 
@@ -306,7 +312,7 @@ Lighter pool fees are per-pool `operator_fee` values set by pool operators:
 
 - **Operator fee**: 0–100%, a performance fee deducted from PnL
 - **LLP**: 0% operator fee
-- **User pools**: Variable (commonly 10–20%)
+- **User pools**: Variable, as reported by each pool
 
 The fee mode is `internalised_skimming` — the operator fee is already
 reflected in the share prices returned by the API. The pipeline treats
@@ -325,18 +331,22 @@ All Lighter pools get the `perp_dex_trading_vault` flag.
 
 ### LLP (Lighter Liquidity Pool)
 
-The LLP is the main protocol liquidity pool (~$227M TVL). It is special
-because:
+The LLP is the protocol-operated liquidity and insurance pool. Its TVL is read
+live. Discovery differs by deployment:
 
-- It is **not** listed in `publicPoolsMetadata`
-- Its account index comes from `systemConfig.liquidity_pool_index`
-- It has 0% operator fee
-- It is fetched separately via the `/api/v1/account` endpoint
+- Ethereum obtains the canonical account index from
+  `systemConfig.liquidity_pool_index` and fetches the account separately when
+  it is absent from `publicPoolsMetadata`.
+- For now Robinhood uses the explicit live account index
+  `281474976710654`, because its reported system-config index is uninitialised.
+  The pool is present in `publicPoolsMetadata`.
+- LLP identity is based on the exact deployment-local account index, not the
+  non-unique account type.
 
 ## Quick start
 
 ```shell
-# Basic usage with defaults
+# Legacy standalone Ethereum scan with defaults
 LOG_LEVEL=info poetry run python scripts/lighter/daily-pool-metrics.py
 
 # Scan specific pools by account index
@@ -349,6 +359,10 @@ MIN_TVL=10000 MAX_POOLS=20 \
 ```
 
 ## Environment variables
+
+These variables configure the standalone Ethereum scanner. Use
+`scan-vaults-all-chains.py` with `SCAN_LIGHTER=true` for the supported
+two-deployment scan.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -391,15 +405,15 @@ This runs through the following stages:
    history and total shares, stores in `lighter-pools.duckdb`
 2. **Merge vault metadata** — upserts Lighter VaultRows into `vault-metadata-db.pickle`
 3. **Merge prices** — appends Lighter daily prices into `vault-prices-1h.parquet`
-   (uncleaned), replacing any prior Lighter rows
+   (uncleaned), replacing only the deployment address namespaces present in
+   the fresh export. A failed or omitted deployment retains its prior rows.
 4. **Clean prices** — runs `process_raw_vault_scan_data()` (outlier detection,
    return calculation) producing `cleaned-vault-prices-1h.parquet`
-5. **Export** (~6min) — generates sparklines, protocol metadata, and uploads to R2
+5. **Export** — generates sparklines, protocol metadata, and uploads to R2
 
-Total time: ~7 minutes.
-
-To rebuild only the Lighter DuckDB without running the rest of the
-pipeline (no merge, no clean, no upload):
+The standalone command below is retained for backwards-compatible Ethereum
+operations. It scans Ethereum, merges metadata and prices, and runs cleaning,
+but does not scan Robinhood or upload exports:
 
 ```shell
 LOG_LEVEL=info poetry run python scripts/lighter/daily-pool-metrics.py
@@ -426,7 +440,7 @@ Use `purge-price-data.py` with the shared Lighter synthetic chain ID to strip
 Lighter rows from the shared Parquet file:
 
 ```shell
-CHAIN_ID=9998 python scripts/erc-4626/purge-price-data.py
+CHAIN_ID=9998 poetry run python scripts/erc-4626/purge-price-data.py
 ```
 
 The pipeline automatically removes any rows written under the legacy
@@ -442,11 +456,11 @@ SCAN_LIGHTER=true \
 DISABLE_CHAINS=Sonic,Monad,Hyperliquid,Base,Arbitrum,Ethereum,Linea,Gnosis,Zora,Polygon,Avalanche,Berachain,Unichain,Hemi,Plasma,Binance,Mantle,Katana,Ink,Blast,Soneium,Optimism \
 MAX_WORKERS=20 \
 LOG_LEVEL=info \
-python scripts/erc-4626/scan-vaults-all-chains.py
+poetry run python scripts/erc-4626/scan-vaults-all-chains.py
 ```
 
-## Running Lighter-specic tests
+## Running Lighter-specific tests
 
 ```shell
-poetry run pytest tests/lighter/ -x --timeout=300
+source .local-test.env && poetry run pytest tests/lighter/ -x --timeout=300
 ```

--- a/scripts/lighter/daily-pool-metrics.py
+++ b/scripts/lighter/daily-pool-metrics.py
@@ -1,8 +1,12 @@
-"""Daily Lighter pool metrics pipeline.
+"""Legacy Ethereum Lighter daily pool metrics pipeline.
 
-Discovers Lighter pools via the public API, fetches share price history,
-stores metrics in DuckDB, and merges the data into the existing
+Discovers pools from the original Ethereum Lighter public API, fetches share
+price history, stores metrics in DuckDB, and merges the data into the existing
 ERC-4626 vault pipeline files (VaultDatabase pickle and cleaned Parquet).
+
+Use ``scripts/erc-4626/scan-vaults-all-chains.py`` with ``SCAN_LIGHTER=true``
+to scan both the Ethereum and Robinhood deployments. This standalone script
+retains the historical Ethereum defaults for compatibility.
 
 No authentication is required — all data comes from public endpoints.
 
@@ -126,7 +130,7 @@ def main():
         db.close()
 
     # Step 4: Run the cleaning pipeline
-    print(f"\nStep 4: Running cleaning pipeline...")
+    print("\nStep 4: Running cleaning pipeline...")
     generate_cleaned_vault_datasets(
         vault_db_path=vault_db_path,
         price_df_path=uncleaned_path,

--- a/tests/erc_4626/test_native_protocol_batch_merge.py
+++ b/tests/erc_4626/test_native_protocol_batch_merge.py
@@ -58,7 +58,8 @@ def test_merge_native_protocols_rewrites_parquet_once_and_preserves_empty_source
             _prices(1, "0xevm", "2025-01-01"),
             _prices(HYPERCORE_CHAIN_ID, "hypercore-old", "2025-01-01"),
             _prices(GRVT_CHAIN_ID, "grvt-old", "2025-01-01"),
-            _prices(LIGHTER_CHAIN_ID, "lighter-old", "2025-01-01"),
+            _prices(LIGHTER_CHAIN_ID, "lighter-pool-100", "2025-01-01"),
+            _prices(LIGHTER_CHAIN_ID, "lighter-pool-robinhood-100", "2025-01-01"),
             _prices(LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID, "lighter-robinhood-legacy-old", "2025-01-01"),
             _prices(HIBACHI_CHAIN_ID, "hibachi-old", "2025-01-01"),
         ],
@@ -78,8 +79,8 @@ def test_merge_native_protocols_rewrites_parquet_once_and_preserves_empty_source
     fresh_grvt = _prices(GRVT_CHAIN_ID, "grvt-new", "2025-01-02")
     fresh_lighter = pd.concat(
         [
-            _prices(LIGHTER_CHAIN_ID, "lighter-new", "2025-01-02"),
-            _prices(LIGHTER_CHAIN_ID, "lighter-robinhood-new", "2025-01-02"),
+            _prices(LIGHTER_CHAIN_ID, "lighter-pool-200", "2025-01-02"),
+            _prices(LIGHTER_CHAIN_ID, "lighter-pool-robinhood-200", "2025-01-02"),
         ],
         ignore_index=True,
     )
@@ -136,13 +137,64 @@ def test_merge_native_protocols_rewrites_parquet_once_and_preserves_empty_source
         "0xevm",
         "hypercore-new",
         "grvt-new",
-        "lighter-new",
-        "lighter-robinhood-new",
+        "lighter-pool-200",
+        "lighter-pool-robinhood-200",
         "hibachi-old",
     }
     assert LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID not in set(result_df["chain"])
     assert set(result_df.loc[result_df["address"].str.startswith("lighter-"), "chain"]) == {LIGHTER_CHAIN_ID}
     assert result_df.loc[result_df["address"] == "hypercore-new", "account_pnl"].iloc[0] == pytest.approx(123.0)
+
+
+def test_partial_lighter_merge_preserves_other_deployment_and_legacy_partition(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replace only fresh Lighter deployment addresses within shared chain 9998.
+
+    1. Create current Ethereum and Robinhood rows plus legacy Robinhood 9996.
+    2. Export only fresh Ethereum data, modelling a partial or standalone scan.
+    3. Run the native merge.
+    4. Assert Ethereum is replaced while both Robinhood histories survive.
+    """
+    parquet_path = tmp_path / "vault-prices-1h.parquet"
+    existing_df = pd.concat(
+        [
+            _prices(LIGHTER_CHAIN_ID, "lighter-pool-100", "2025-01-01"),
+            _prices(LIGHTER_CHAIN_ID, "lighter-pool-robinhood-100", "2025-01-01"),
+            _prices(LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID, "lighter-pool-robinhood-legacy", "2025-01-01"),
+        ],
+        ignore_index=True,
+    )
+    VaultHistoricalRead.write_uncleaned_parquet(existing_df, parquet_path)
+
+    class FakeDatabase:
+        """Provide the close method required by the post-processing pipeline."""
+
+        def __init__(self, _: Path) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+    fresh_ethereum = _prices(LIGHTER_CHAIN_ID, "lighter-pool-200", "2025-01-02")
+    monkeypatch.setattr(post_processing, "LighterDailyMetricsDatabase", FakeDatabase)
+    monkeypatch.setattr(post_processing, "build_lighter_prices_dataframe", lambda _: fresh_ethereum)
+
+    steps = post_processing.merge_native_protocols(
+        merge_lighter=True,
+        uncleaned_parquet_path=parquet_path,
+        lighter_db_path=tmp_path / "lighter.duckdb",
+    )
+
+    result_df = pd.read_parquet(parquet_path)
+    assert steps == {"lighter-price-merge": True}
+    assert set(result_df["address"]) == {
+        "lighter-pool-200",
+        "lighter-pool-robinhood-100",
+        "lighter-pool-robinhood-legacy",
+    }
+    assert set(result_df.loc[result_df["address"] == "lighter-pool-robinhood-legacy", "chain"]) == {LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID}
 
 
 def test_build_hypercore_prices_dataframe_prefers_high_frequency_duplicate(

--- a/tests/erc_4626/test_native_protocol_batch_merge.py
+++ b/tests/erc_4626/test_native_protocol_batch_merge.py
@@ -9,7 +9,7 @@ from eth_defi.grvt.constants import GRVT_CHAIN_ID
 from eth_defi.hibachi.constants import HIBACHI_CHAIN_ID
 from eth_defi.hyperliquid import vault_data_export
 from eth_defi.hyperliquid.constants import HYPERCORE_CHAIN_ID
-from eth_defi.lighter.constants import LIGHTER_CHAIN_ID
+from eth_defi.lighter.constants import LIGHTER_CHAIN_ID, LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID
 from eth_defi.vault import base, post_processing
 from eth_defi.vault.base import ParquetVerificationError, VaultHistoricalRead
 
@@ -59,6 +59,7 @@ def test_merge_native_protocols_rewrites_parquet_once_and_preserves_empty_source
             _prices(HYPERCORE_CHAIN_ID, "hypercore-old", "2025-01-01"),
             _prices(GRVT_CHAIN_ID, "grvt-old", "2025-01-01"),
             _prices(LIGHTER_CHAIN_ID, "lighter-old", "2025-01-01"),
+            _prices(LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID, "lighter-robinhood-legacy-old", "2025-01-01"),
             _prices(HIBACHI_CHAIN_ID, "hibachi-old", "2025-01-01"),
         ],
         ignore_index=True,
@@ -75,7 +76,13 @@ def test_merge_native_protocols_rewrites_parquet_once_and_preserves_empty_source
             pass
 
     fresh_grvt = _prices(GRVT_CHAIN_ID, "grvt-new", "2025-01-02")
-    fresh_lighter = _prices(LIGHTER_CHAIN_ID, "lighter-new", "2025-01-02")
+    fresh_lighter = pd.concat(
+        [
+            _prices(LIGHTER_CHAIN_ID, "lighter-new", "2025-01-02"),
+            _prices(LIGHTER_CHAIN_ID, "lighter-robinhood-new", "2025-01-02"),
+        ],
+        ignore_index=True,
+    )
     fresh_hypercore = _prices(HYPERCORE_CHAIN_ID, "hypercore-new", "2025-01-02")
     fresh_hypercore["account_pnl"] = 123.0
     monkeypatch.setattr(post_processing, "HyperliquidDailyMetricsDatabase", FakeDatabase)
@@ -130,8 +137,11 @@ def test_merge_native_protocols_rewrites_parquet_once_and_preserves_empty_source
         "hypercore-new",
         "grvt-new",
         "lighter-new",
+        "lighter-robinhood-new",
         "hibachi-old",
     }
+    assert LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID not in set(result_df["chain"])
+    assert set(result_df.loc[result_df["address"].str.startswith("lighter-"), "chain"]) == {LIGHTER_CHAIN_ID}
     assert result_df.loc[result_df["address"] == "hypercore-new", "account_pnl"].iloc[0] == pytest.approx(123.0)
 
 

--- a/tests/lighter/test_multi_deployment.py
+++ b/tests/lighter/test_multi_deployment.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import duckdb
+import pandas as pd
 
 from eth_defi.lighter.constants import (
     LIGHTER_CHAIN_ID,
@@ -16,8 +17,8 @@ from eth_defi.lighter.constants import (
 from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase
 from eth_defi.lighter.session import LighterSession
 from eth_defi.lighter.vault import fetch_all_pools
-from eth_defi.lighter.vault_data_export import build_raw_prices_dataframe, create_lighter_pool_row, merge_into_vault_database
-from eth_defi.vault.base import VaultSpec
+from eth_defi.lighter.vault_data_export import build_raw_prices_dataframe, create_lighter_pool_row, merge_into_uncleaned_parquet, merge_into_vault_database
+from eth_defi.vault.base import VaultHistoricalRead, VaultSpec
 from eth_defi.vault.vaultdb import VaultDatabase
 
 ACCOUNT_INDEX = 281474976710654
@@ -239,5 +240,54 @@ def test_vault_database_merge_removes_legacy_robinhood_chain(tmp_path: Path) -> 
         assert len(merged.rows) == 1
         assert merged.rows[new_spec]["_deployment"] == "robinhood"
         assert merged.rows[new_spec]["_deployment_chain_id"] == 4663
+    finally:
+        metrics_db.close()
+
+
+def test_standalone_ethereum_parquet_merge_preserves_robinhood_history(tmp_path: Path) -> None:
+    """Retain current and legacy Robinhood rows during an Ethereum-only export."""
+    metrics_path = tmp_path / "lighter-pools.duckdb"
+    parquet_path = tmp_path / "vault-prices-1h.parquet"
+    metrics_db = LighterDailyMetricsDatabase(metrics_path)
+    try:
+        metrics_db.upsert_daily_prices(
+            deployment=LIGHTER_ETHEREUM.slug,
+            rows=[
+                (
+                    ACCOUNT_INDEX,
+                    datetime.date(2026, 7, 1),
+                    1.0,
+                    1_000.0,
+                    0.0,
+                    5.0,
+                    datetime.datetime(2026, 7, 1),
+                )
+            ],
+        )
+        existing_df = pd.DataFrame(
+            {
+                "chain": pd.array(
+                    [LIGHTER_CHAIN_ID, LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID],
+                    dtype="uint32",
+                ),
+                "address": [
+                    LIGHTER_ROBINHOOD.format_pool_address(ACCOUNT_INDEX),
+                    LIGHTER_ROBINHOOD.format_pool_address(ACCOUNT_INDEX - 1),
+                ],
+                "timestamp": pd.to_datetime(["2026-06-30", "2026-06-30"]),
+                "share_price": [0.001, 0.001],
+            }
+        )
+        VaultHistoricalRead.write_uncleaned_parquet(existing_df, parquet_path)
+
+        merged_df = merge_into_uncleaned_parquet(metrics_db, parquet_path)
+
+        assert set(merged_df["address"]) == {
+            LIGHTER_ETHEREUM.format_pool_address(ACCOUNT_INDEX),
+            LIGHTER_ROBINHOOD.format_pool_address(ACCOUNT_INDEX),
+            LIGHTER_ROBINHOOD.format_pool_address(ACCOUNT_INDEX - 1),
+        }
+        legacy_address = LIGHTER_ROBINHOOD.format_pool_address(ACCOUNT_INDEX - 1)
+        assert set(merged_df.loc[merged_df["address"] == legacy_address, "chain"]) == {LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID}
     finally:
         metrics_db.close()

--- a/tests/lighter/test_multi_deployment.py
+++ b/tests/lighter/test_multi_deployment.py
@@ -13,6 +13,7 @@ from eth_defi.lighter.constants import (
     LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID,
     LIGHTER_ROBINHOOD,
     LIGHTER_ROBINHOOD_LLP_ACCOUNT_INDEX,
+    identify_lighter_pool_deployment,
 )
 from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase
 from eth_defi.lighter.session import LighterSession
@@ -22,6 +23,17 @@ from eth_defi.vault.base import VaultHistoricalRead, VaultSpec
 from eth_defi.vault.vaultdb import VaultDatabase
 
 ACCOUNT_INDEX = 281474976710654
+
+
+def test_synthetic_pool_addresses_resolve_to_exact_deployment() -> None:
+    """Do not let the shorter Ethereum prefix capture Robinhood addresses."""
+    ethereum_address = LIGHTER_ETHEREUM.format_pool_address(ACCOUNT_INDEX)
+    robinhood_address = LIGHTER_ROBINHOOD.format_pool_address(ACCOUNT_INDEX)
+
+    assert identify_lighter_pool_deployment(ethereum_address) == LIGHTER_ETHEREUM
+    assert identify_lighter_pool_deployment(robinhood_address) == LIGHTER_ROBINHOOD
+    assert identify_lighter_pool_deployment("lighter-pool-robinhood-not-an-index") is None
+    assert identify_lighter_pool_deployment("lighter-pool-robinhood-123-extra") is None
 
 
 def test_robinhood_llp_override_does_not_misclassify_other_type_three_pools() -> None:

--- a/tests/lighter/test_multi_deployment.py
+++ b/tests/lighter/test_multi_deployment.py
@@ -1,0 +1,243 @@
+"""Test deployment-aware Lighter metrics storage and export."""
+
+import datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import duckdb
+
+from eth_defi.lighter.constants import (
+    LIGHTER_CHAIN_ID,
+    LIGHTER_ETHEREUM,
+    LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID,
+    LIGHTER_ROBINHOOD,
+    LIGHTER_ROBINHOOD_LLP_ACCOUNT_INDEX,
+)
+from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase
+from eth_defi.lighter.session import LighterSession
+from eth_defi.lighter.vault import fetch_all_pools
+from eth_defi.lighter.vault_data_export import build_raw_prices_dataframe, create_lighter_pool_row, merge_into_vault_database
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.vaultdb import VaultDatabase
+
+ACCOUNT_INDEX = 281474976710654
+
+
+def test_robinhood_llp_override_does_not_misclassify_other_type_three_pools() -> None:
+    """Use the Robinhood LLP override without treating every type-three pool as LLP."""
+    system_config_response = MagicMock()
+    system_config_response.json.return_value = {"liquidity_pool_index": 281474976710655}
+
+    pool_listing_response = MagicMock()
+    pool_listing_response.json.return_value = {
+        "public_pools": [
+            {
+                "account_index": LIGHTER_ROBINHOOD_LLP_ACCOUNT_INDEX,
+                "account_type": 3,
+                "name": "",
+                "total_asset_value": "1000",
+            },
+            {
+                "account_index": LIGHTER_ROBINHOOD_LLP_ACCOUNT_INDEX - 1,
+                "account_type": 3,
+                "name": "Another protocol liquidity pool",
+                "total_asset_value": "500",
+            },
+        ]
+    }
+
+    session = LighterSession(deployment=LIGHTER_ROBINHOOD)
+    session.get = MagicMock(side_effect=[system_config_response, pool_listing_response])
+    try:
+        pools = fetch_all_pools(session)
+    finally:
+        session.close()
+
+    llp_pools = [pool for pool in pools if pool.is_llp]
+    assert len(llp_pools) == 1
+    assert llp_pools[0].account_index == LIGHTER_ROBINHOOD_LLP_ACCOUNT_INDEX
+
+
+def _create_legacy_database(path: Path) -> None:
+    """Create the pre-multi-deployment Lighter DuckDB schema.
+
+    :param path:
+        Database path to create.
+    """
+    con = duckdb.connect(str(path))
+    try:
+        con.execute("""
+            CREATE TABLE pool_metadata (
+                account_index BIGINT PRIMARY KEY,
+                name VARCHAR NOT NULL,
+                description VARCHAR,
+                l1_address VARCHAR,
+                is_llp BOOLEAN DEFAULT FALSE,
+                status INTEGER DEFAULT 0,
+                operator_fee DOUBLE,
+                total_asset_value DOUBLE,
+                annual_percentage_yield DOUBLE,
+                sharpe_ratio DOUBLE,
+                created_at TIMESTAMP,
+                last_updated TIMESTAMP NOT NULL
+            )
+        """)
+        con.execute(
+            "INSERT INTO pool_metadata VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                ACCOUNT_INDEX,
+                "Ethereum LLP",
+                "Legacy Ethereum row",
+                "0x0000000000000000000000000000000000000000",
+                True,
+                0,
+                0.0,
+                1_000.0,
+                5.0,
+                1.0,
+                datetime.datetime(2025, 1, 1),
+                datetime.datetime(2026, 7, 1),
+            ],
+        )
+        con.execute("""
+            CREATE TABLE pool_daily_prices (
+                account_index BIGINT NOT NULL,
+                date DATE NOT NULL,
+                share_price DOUBLE NOT NULL,
+                tvl DOUBLE,
+                daily_return DOUBLE,
+                annual_percentage_yield DOUBLE,
+                written_at TIMESTAMP,
+                PRIMARY KEY (account_index, date)
+            )
+        """)
+        con.execute(
+            "INSERT INTO pool_daily_prices VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [
+                ACCOUNT_INDEX,
+                datetime.date(2026, 7, 1),
+                1.0,
+                1_000.0,
+                0.0,
+                5.0,
+                datetime.datetime(2026, 7, 1),
+            ],
+        )
+    finally:
+        con.close()
+
+
+def test_legacy_database_migrates_to_composite_deployment_keys(tmp_path: Path) -> None:
+    """Preserve Ethereum rows while allowing the same Robinhood account index."""
+    path = tmp_path / "lighter-pools.duckdb"
+    _create_legacy_database(path)
+
+    db = LighterDailyMetricsDatabase(path)
+    try:
+        migrated_metadata = db.get_all_pool_metadata()
+        migrated_prices = db.get_all_daily_prices()
+        assert migrated_metadata["deployment"].tolist() == [LIGHTER_ETHEREUM.slug]
+        assert migrated_prices["deployment"].tolist() == [LIGHTER_ETHEREUM.slug]
+
+        db.upsert_pool_metadata(
+            deployment=LIGHTER_ROBINHOOD.slug,
+            account_index=ACCOUNT_INDEX,
+            name="Robinhood LLP",
+            description="Robinhood deployment row",
+            is_llp=True,
+            total_asset_value=2_000.0,
+            created_at=datetime.datetime(2026, 7, 1),
+        )
+        db.upsert_daily_prices(
+            deployment=LIGHTER_ROBINHOOD.slug,
+            rows=[
+                (
+                    ACCOUNT_INDEX,
+                    datetime.date(2026, 7, 1),
+                    0.001,
+                    2_000.0,
+                    0.0,
+                    10.0,
+                    datetime.datetime(2026, 7, 1),
+                )
+            ],
+        )
+
+        assert db.get_pool_count() == 2
+        assert db.get_pool_count(LIGHTER_ETHEREUM.slug) == 1
+        assert db.get_pool_count(LIGHTER_ROBINHOOD.slug) == 1
+
+        prices = build_raw_prices_dataframe(db)
+        assert LIGHTER_ETHEREUM.chain_id == LIGHTER_ROBINHOOD.chain_id == LIGHTER_CHAIN_ID
+        assert set(prices["chain"]) == {LIGHTER_CHAIN_ID}
+        assert set(prices["address"]) == {
+            LIGHTER_ETHEREUM.format_pool_address(ACCOUNT_INDEX),
+            LIGHTER_ROBINHOOD.format_pool_address(ACCOUNT_INDEX),
+        }
+    finally:
+        db.close()
+
+
+def test_robinhood_pool_export_uses_deployment_metadata() -> None:
+    """Export Robinhood pools with USDG, a distinct address, and Robinhood app link."""
+    spec, row = create_lighter_pool_row(
+        account_index=ACCOUNT_INDEX,
+        name="Lighter Liquidity Provider (LLP)",
+        description="Robinhood LLP",
+        tvl=123_000.0,
+        created_at=datetime.datetime(2026, 7, 1),
+        is_llp=True,
+        deployment=LIGHTER_ROBINHOOD,
+    )
+
+    assert spec.chain_id == LIGHTER_ROBINHOOD.chain_id
+    assert spec.vault_address == LIGHTER_ROBINHOOD.format_pool_address(ACCOUNT_INDEX)
+    assert row["Denomination"] == "USDG"
+    assert row["_denomination_token"]["symbol"] == "USDG"
+    assert row["Link"] == LIGHTER_ROBINHOOD.format_pool_link(ACCOUNT_INDEX)
+    assert row["_lockup"] == datetime.timedelta(0)
+    assert "USDG-denominated protocol insurance fund" in row["_notes"]
+    assert "USDC deposited" not in row["_notes"]
+    assert row["_deployment"] == "robinhood"
+    assert row["_deployment_chain_id"] == 4663
+
+
+def test_vault_database_merge_removes_legacy_robinhood_chain(tmp_path: Path) -> None:
+    """Move Robinhood metadata from legacy chain 9996 into shared Lighter chain 9998."""
+    metrics_path = tmp_path / "lighter-pools.duckdb"
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    metrics_db = LighterDailyMetricsDatabase(metrics_path)
+    try:
+        metrics_db.upsert_pool_metadata(
+            deployment=LIGHTER_ROBINHOOD.slug,
+            account_index=ACCOUNT_INDEX,
+            name="Robinhood LLP",
+            description="Robinhood deployment row",
+            is_llp=True,
+            total_asset_value=2_000.0,
+            created_at=datetime.datetime(2026, 7, 1),
+        )
+        new_spec, robinhood_row = create_lighter_pool_row(
+            account_index=ACCOUNT_INDEX,
+            name="Robinhood LLP",
+            description="Legacy Robinhood deployment row",
+            tvl=2_000.0,
+            created_at=datetime.datetime(2026, 7, 1),
+            is_llp=True,
+            deployment=LIGHTER_ROBINHOOD,
+        )
+        legacy_spec = VaultSpec(
+            chain_id=LIGHTER_LEGACY_ROBINHOOD_CHAIN_ID,
+            vault_address=new_spec.vault_address,
+        )
+        VaultDatabase(rows={legacy_spec: robinhood_row}).write(vault_db_path)
+
+        merged = merge_into_vault_database(metrics_db, vault_db_path)
+
+        assert legacy_spec not in merged.rows
+        assert new_spec in merged.rows
+        assert len(merged.rows) == 1
+        assert merged.rows[new_spec]["_deployment"] == "robinhood"
+        assert merged.rows[new_spec]["_deployment_chain_id"] == 4663
+    finally:
+        metrics_db.close()

--- a/tests/lighter/test_scan_loop_integration.py
+++ b/tests/lighter/test_scan_loop_integration.py
@@ -42,6 +42,8 @@ def test_scan_loop_lighter_single_cycle(tmp_path: Path, monkeypatch: pytest.Monk
     monkeypatch.setenv("SCAN_HYPERCORE", "false")
     monkeypatch.setenv("SCAN_GRVT", "false")
     monkeypatch.setenv("SCAN_LIGHTER", "true")
+    monkeypatch.setenv("SKIP_CORE3", "true")
+    monkeypatch.setenv("SKIP_CURRENCY_RATES", "true")
     monkeypatch.setenv("SKIP_POST_PROCESSING", "true")
     monkeypatch.setenv("MAX_WORKERS", "4")
     monkeypatch.setenv("LOG_LEVEL", "info")
@@ -53,7 +55,8 @@ def test_scan_loop_lighter_single_cycle(tmp_path: Path, monkeypatch: pytest.Monk
     assert state_file.exists(), "Cycle state file not created"
     state = json.loads(state_file.read_text())
     cycle_items = state.get("items", state)
-    assert "Lighter" in cycle_items, f"Lighter not in cycle state: {state}"
+    assert "Lighter Ethereum" in cycle_items, f"Lighter Ethereum not in cycle state: {state}"
+    assert "Lighter Robinhood" in cycle_items, f"Lighter Robinhood not in cycle state: {state}"
 
     # 2. Verify Lighter DuckDB has pools
     duckdb_path = tmp_path / "lighter-pools.duckdb"

--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -12,6 +12,8 @@ import zstandard as zstd
 from plotly.graph_objects import Figure
 
 from eth_defi.erc_4626.vault_protocol.d2.vault import D2_PROTOCOL_NAME, format_d2_vault_note
+from eth_defi.lighter.constants import LIGHTER_ETHEREUM, LIGHTER_ROBINHOOD, LighterAPIConfig
+from eth_defi.lighter.vault_data_export import create_lighter_pool_row
 from eth_defi.research import vault_metrics
 from eth_defi.research.sparkline import export_sparkline_as_png, export_sparkline_as_svg, extract_vault_price_data, render_sparkline_simple
 from eth_defi.research.vault_benchmark import visualise_vault_return_benchmark
@@ -421,6 +423,49 @@ def test_calculate_lifetime_metrics(
 
     # Verify period_results is not in formatted output
     # assert "period_results" not in formatted.columns
+
+
+@pytest.mark.parametrize(
+    ("deployment", "expected_slug", "expected_deployment_chain_id"),
+    (
+        (LIGHTER_ETHEREUM, "ethereum", 1),
+        (LIGHTER_ROBINHOOD, "robinhood", 4663),
+    ),
+)
+def test_calculate_lifetime_metrics_exports_lighter_deployment_chain(
+    price_df: pd.DataFrame,
+    deployment: LighterAPIConfig,
+    expected_slug: str,
+    expected_deployment_chain_id: int,
+) -> None:
+    """Keep Lighter dataset identity separate from its associated EVM chain."""
+    source_vault_id = "43111-0x05c2e246156d37b39a825a25dd08d5589e3fd883"
+    spec, vault_row = create_lighter_pool_row(
+        account_index=281474976710654,
+        name="Lighter Liquidity Provider (LLP)",
+        description="Lighter protocol liquidity and insurance pool.",
+        tvl=1_000_000.0,
+        created_at=None,
+        is_llp=True,
+        deployment=deployment,
+    )
+    vault_prices = price_df.loc[price_df["id"] == source_vault_id].copy()
+    vault_prices["id"] = spec.as_string_id()
+    vault_prices["chain"] = deployment.chain_id
+
+    metrics = calculate_lifetime_metrics(vault_prices, {spec: vault_row})
+
+    row = metrics.iloc[0]
+    # The synthetic ID must remain unchanged because it keys the Lighter price
+    # partition; the added fields identify Ethereum versus Robinhood Lighter.
+    assert row["chain_id"] == deployment.chain_id
+    assert row["deployment"] == expected_slug
+    assert row["deployment_chain_id"] == expected_deployment_chain_id
+
+    exported = export_lifetime_row(row)
+    assert exported["chain_id"] == deployment.chain_id
+    assert exported["deployment"] == expected_slug
+    assert exported["deployment_chain_id"] == expected_deployment_chain_id
 
 
 @pytest.mark.parametrize(

--- a/tests/vault/test_scan_all_chains_config.py
+++ b/tests/vault/test_scan_all_chains_config.py
@@ -1,11 +1,13 @@
 """Test all-chain vault scanner configuration."""
 
+import datetime
 import json
 from pathlib import Path
 
 import pytest
 
 from eth_defi.chain import POA_MIDDLEWARE_NEEDED_CHAIN_IDS
+from eth_defi.lighter.constants import LIGHTER_DEPLOYMENTS
 from eth_defi.vault import scan_all_chains
 from eth_defi.vault.scan_all_chains import build_chain_configs
 from eth_defi.version_info import VersionInfo
@@ -21,6 +23,28 @@ def test_robinhood_chain_is_scheduled_for_vault_scans():
     robinhood = configs["Robinhood"]
     assert robinhood.env_var == "JSON_RPC_ROBINHOOD"
     assert robinhood.scan_vaults is True
+
+
+def test_both_lighter_deployments_are_scheduled() -> None:
+    """``SCAN_LIGHTER`` expands into independently resumable deployment scans."""
+    protocols = scan_all_chains.build_active_protocols(
+        scan_hypercore=False,
+        scan_grvt=False,
+        scan_lighter=True,
+        scan_hibachi=False,
+        scan_core3=False,
+        scan_currency_rates=False,
+    )
+
+    assert protocols == [deployment.name for deployment in LIGHTER_DEPLOYMENTS]
+
+
+def test_legacy_lighter_cycle_override_applies_to_both_deployments() -> None:
+    """Keep existing ``Lighter=4h`` operator configuration working."""
+    cycle = datetime.timedelta(hours=4)
+    overrides = scan_all_chains.ensure_default_scan_cycles({"Lighter": cycle})
+
+    assert all(overrides[deployment.name] == cycle for deployment in LIGHTER_DEPLOYMENTS)
 
 
 def test_tempo_chain_is_scheduled_for_vault_scans():

--- a/tests/vault/test_scan_all_chains_config.py
+++ b/tests/vault/test_scan_all_chains_config.py
@@ -45,6 +45,7 @@ def test_legacy_lighter_cycle_override_applies_to_both_deployments() -> None:
     overrides = scan_all_chains.ensure_default_scan_cycles({"Lighter": cycle})
 
     assert all(overrides[deployment.name] == cycle for deployment in LIGHTER_DEPLOYMENTS)
+    assert "Lighter" not in overrides
 
 
 def test_tempo_chain_is_scheduled_for_vault_scans():


### PR DESCRIPTION
## Why

Lighter now has a dedicated deployment on Robinhood Chain, while the native vault pipeline assumed a single Ethereum deployment. The scanner needs to ingest both deployments without changing the shared synthetic Lighter dataset chain identity, and lifetime metrics need to expose the associated EVM deployment chain.

## Lessons learnt

Lighter account indexes overlap across deployments, so deployment must be part of DuckDB primary keys and synthetic vault addresses must remain deployment-specific. Robinhood system configuration currently points at an uninitialised LLP account, while account type 3 is not unique because Ethereum XLP uses it too; canonical LLP identity therefore needs a deployment-scoped override. The DuckDB migration must be transactional, while Parquet replacement must be scoped to deployments with fresh data so one failed scan cannot erase another deployment history.

## Summary

- Add deployment-aware Lighter configuration and sessions for Ethereum and Robinhood Chain while retaining shared synthetic `chain_id=9998`.
- Export `deployment` and `deployment_chain_id` so lifetime metrics distinguish Ethereum chain 1 from Robinhood Chain 4663.
- Migrate Lighter DuckDB tables automatically to deployment-aware composite keys and preserve legacy Ethereum history.
- Schedule Ethereum and Robinhood scans independently and retain compatibility with the legacy `Lighter` scan-cycle override.
- Merge both deployments into the shared raw-price partition, replacing only deployments represented by fresh data.
- Remove the short-lived Robinhood chain 9996 partition only after fresh Robinhood data is available to replace it.
- Correct LLP detection so Ethereum XLP is not misclassified, and add a Robinhood-specific USDG insurance-fund note.
- Clarify that Guard, Lagoon custody and standalone script defaults remain Ethereum-only; native pool metrics support both deployments.
- Add migration, partial-scan, scanner, export and live API regression coverage.

## Related issues and PRs

Builds on the existing native Lighter vault metrics pipeline. No linked issue.

## Unrelated CI and test fixes

None.