### PR TITLE
fix: unify vault settlement simulations

### DIFF
--- a/docs/superpowers/plans/2026-07-22-vault-deposit-redemption-full-support.md
+++ b/docs/superpowers/plans/2026-07-22-vault-deposit-redemption-full-support.md
@@ -1,0 +1,283 @@
+# Vault deposit and redemption support plan
+
+**Date:** 2026-07-22
+
+**Implementation status:** This is a roadmap, not a claim that every section
+is shipped. The current worktree implements the shared Anvil
+`force_settle()` API, the Lagoon settlement driver, Plutus and Accountable
+non-`previewDeposit()` estimates, the D2 closed-phase
+preflight error, Upshift ordered denomination-token discovery, and the
+Avalanche CCTP mapping. In particular, multi-asset Upshift transaction flows,
+the cSigma, Yearn, YieldNest, IPOR and Lagoon-admission fixes, and the four
+integration scenarios per protocol remain planned work. D2 has only a tested
+closed-phase failure; it does not yet have a fork-proven successful transaction
+path.
+
+**Goal:** Give each in-scope vault protocol one working deposit path and one working redemption path through `VaultDepositManager`, with one representative failure for each direction. Fix the concrete eth_defi defects exposed by the trade-executor coverage run without attempting exhaustive support for every asset, deployment generation, queue state or settlement variant.
+
+**Scope boundaries:** Ember and Gains remain outside this plan because their reported failures are in trade-executor routing. Base fork timeouts remain infrastructure issues until reproduced as eth_defi provider defects. Trade-executor position sizing and partial-close orchestration are outside this repository.
+
+## Test and documentation policy
+
+Each protocol manager receives four focused integration scenarios only:
+
+1. One successful deposit from request construction through receipt analysis.
+2. One failed deposit, preferably a typed preflight rejection; otherwise a decoded onchain failure.
+3. One successful redemption from request construction through receipt analysis.
+4. One failed redemption, preferably a typed preflight rejection; otherwise a decoded onchain failure.
+
+Every successful scenario invokes the standard Anvil-only `VaultDepositManager.force_settle()` test API. Synchronous managers call it with no ticket and receive a no-settlement-required result; asynchronous managers pass their request ticket, settle, claim and perform terminal analysis. This remains one happy path. Tests do not need to cover partial settlement, repeated epochs, every accepted asset, every exit asset, every deployment generation, operator delegation, cancellation/reclaim or every reported address unless that behaviour is necessary for the selected happy path.
+
+Every protocol-specific `VaultDepositManager` class docstring must include a **Supported simulation path** and **Known limitations** section. Document unimplemented or untested protocol functionality there, including relevant asset choices, deployment generations, queue behaviour, partial settlement, repeated epochs, operator delegation, cancellation/reclaim, maturity rules or private-vault restrictions. The docstring must not claim broader support than the four scenarios prove.
+
+## Implementation order
+
+1. Add the shared forced-settlement and diagnostic API from section 12.
+2. Reproduce the exact reported failure needed to select one representative happy and failed path per direction.
+3. Implement the smallest protocol manager change that makes those paths available through `VaultDepositManager`.
+4. Add the four focused integration scenarios and manager docstring limitations.
+5. Add API documentation stubs for new public modules and split shared API, individual protocol families and Avalanche CCTP into separate reviewable pull requests.
+
+## 1. Upshift multi-asset deposit and redemption
+
+**Issue description**
+
+`UpshiftVault.get_deposit_manager()` rejects the reported multi-asset Sentora vault, leaving it without any manager deposit or redemption path.
+
+**Changes needed**
+
+- Add `UpshiftVault.fetch_all_denomination_tokens()` to resolve every configured multi-asset denomination token in deterministic protocol order.
+- Override `UpshiftVault.fetch_denomination_token()` to return the first token from `fetch_all_denomination_tokens()` as the primary denomination token. Its docstring must state that only this first token is supported by the manager and all remaining tokens are intentionally unsupported for now.
+- Select a test vault whose first denomination token is USDC. Use that primary USDC token for the one supported multi-asset deposit and redemption path, including estimates, transaction construction and receipt analysis in `UpshiftDepositManager`.
+- Return a typed deposit or redemption failure when the primary-token path is unavailable instead of guessing another asset or conversion path.
+- Keep standard single-asset Upshift vaults on the generic ERC-4626 manager.
+- Document all non-USDC denomination tokens, alternative exit assets, routers, queues and deployment variants as known limitations in `UpshiftDepositManager`.
+
+**Integration test coverage expansion needed**
+
+- On an Ethereum fork, assert `fetch_all_denomination_tokens()` returns the expected ordered collection and `fetch_denomination_token()` returns its first USDC token.
+- Test one successful USDC deposit and one unavailable-primary-path or closed-vault deposit failure.
+- Test one successful USDC redemption and one unavailable-redemption failure.
+- Assert the USDC amounts, shares and final balances from strict receipt analysis.
+
+## 2. Plutus deposit and redemption lifecycle
+
+**Issue description**
+
+The affected Plutus Hedge Token is classified as ERC-7540, rejects `previewDeposit()` and currently receives a generic synchronous manager.
+
+**Changes needed**
+
+- Inspect `0x58bfc95a864e18e8f3041d2fcd3418f48393fe6a` and implement its actual deposit and redemption path in a Plutus-specific manager.
+- Use a non-reverting conversion method or an explicit unavailable estimate instead of weakening the generic estimator.
+- Implement only the request, settlement and claim phases required by the selected deployment.
+- Document unimplemented Plutus generations, operator modes, cancellation/reclaim and alternative queue behaviour in the manager docstring.
+
+**Integration test coverage expansion needed**
+
+- On an Arbitrum fork, test one successful deposit and one closed-window or unavailable-estimate deposit failure.
+- Test one successful redemption, calling `force_settle()` with its ticket if asynchronous or `None` if synchronous, and one redemption rejection such as no shares or a closed window.
+- Assert decoded asset/share amounts and final balances.
+
+## 3. Accountable estimation and exact-vault lifecycle
+
+**Issue description**
+
+`AccountableDepositManager` inherits a generic deposit estimator that fails for the ERC-7540-like Hyperithm vault even though its ordinary deposit and redemption path is otherwise supported.
+
+**Changes needed**
+
+- Implement a non-reverting Accountable deposit estimate for `0x7cd231120a60f500887444a9baf5e1bd753a5e59`.
+- Keep the existing synchronous deposit and asynchronous redemption implementation, changing only what the exact deployment needs.
+- Document partial claims, aggregate controller requests, repeated settlements and other Accountable generations as untested or unsupported where applicable.
+
+**Integration test coverage expansion needed**
+
+- On a latest-head Monad fork, test one successful estimated deposit and one zero/unavailable-estimate deposit failure.
+- Test one full redemption through request, forced settlement and claim, plus one rejected redemption such as no shares or a concurrent request.
+- Use state-relative assertions because Monad does not provide archive state.
+
+## 4. cSigma redemption capacity
+
+**Issue description**
+
+The generic cSigma path does not distinguish a currently redeemable amount from a larger requested redemption, producing an unhelpful sell failure when liquidity is throttled.
+
+**Changes needed**
+
+- Decode the failure on `0x438982ea288763370946625fd76c2508ee1fb229` and read the current redeemable capacity.
+- Add a `CsigmaDepositManager` only if needed to expose the supported immediate deposit and redemption calls.
+- Allow a redemption at or below current capacity and reject a larger request without silently clipping it.
+- Do not implement FIFO queue processing, partial-position orchestration, repeated claims or reserve replenishment in this plan; document them in the manager docstring as known limitations.
+
+**Integration test coverage expansion needed**
+
+- On an Ethereum fork, test one successful deposit and one representative rejected deposit.
+- Test one successful redemption within current capacity and one typed failure above current capacity or at zero capacity.
+- Assert that the failed redemption leaves all shares untouched.
+
+## 5. Yearn receipt analysis variant
+
+**Issue description**
+
+Arche USD redemption succeeded onchain but the generic analyser did not find a usable `Withdraw` event.
+
+**Changes needed**
+
+- Reproduce `0x33ffc177a7278ff84aab314a036bc7b799b7cc15` and identify the exact event or wrapper path.
+- Add the smallest Yearn-specific analyser or manager override needed for strict asset/share decoding.
+- Keep ordinary Yearn V3 behaviour unchanged.
+- Document untested Yearn generations, withdrawal overloads, queue selection and nested wrapper variants in the manager docstring.
+
+**Integration test coverage expansion needed**
+
+- On an Ethereum fork, test one successful Arche USD deposit and one representative deposit rejection.
+- Test one successful Arche USD redemption with strict event and balance assertions and one representative redemption rejection.
+- Do not add a generation matrix or tests for every same-signature/nested event combination.
+
+## 6. YieldNest deposit analysis and immediate redemption
+
+**Issue description**
+
+YieldNest RWA MAX completed a deposit but generic analysis failed, and its immediate-buffer redemption path is not represented by a dedicated manager.
+
+**Changes needed**
+
+- Decode the successful deposit receipt for `0x01ba69727e2860b37bc1a2bd56999c1afb4c15d8`.
+- Add a `YieldNestDepositManager` for the observed deposit and immediate-buffer redemption path.
+- Return a typed failure when redemption is locked or the immediate buffer is unavailable.
+- Document queued withdrawal, maturity variants, cancellation/reclaim and other YieldNest deployments as known limitations.
+
+**Integration test coverage expansion needed**
+
+- On an Ethereum fork, test one successful deposit with strict event analysis and one paused/ineligible deposit failure.
+- Test one successful immediate-buffer redemption and one locked or insufficient-buffer redemption failure.
+- Do not add separate before/after maturity, queue or cancellation scenarios.
+
+## 7. D2 pricing and epoch admission
+
+**Issue description**
+
+The HYPE++ estimate returned zero, causing a downstream division-by-zero error, while the generic manager did not explain the D2 epoch state.
+
+**Changes needed**
+
+- Inspect `0x75288264fdfea8ce68e6d852696ab1ce2f3e5004` and implement a D2-specific estimate/admission result for zero or undefined pricing.
+- Support one deposit during a valid funding phase and one redemption during a valid withdrawal phase.
+- Document other epoch transitions, custodied phases, operator NAV updates and delayed/queued variants in the manager docstring.
+
+**Integration test coverage expansion needed**
+
+- On an Arbitrum fork, test one successful deposit in an open phase and one zero-price or closed-phase deposit failure without division by zero.
+- Test one successful redemption in a permitted phase and one closed-phase redemption failure.
+- Drive only the state transition required for the selected happy redemption path.
+
+## 8. Lagoon adapter for unified Anvil forced settlement
+
+**Issue description**
+
+Lagoon tests call `force_lagoon_settle()` directly with protocol-specific role knowledge, so a generic simulator cannot settle a manager ticket.
+
+**Changes needed**
+
+- Implement `LagoonDepositManager.force_settle(ticket)` using the shared API from section 12.
+- Discover and impersonate the required Lagoon role internally, post one valid valuation and move the selected ticket to claimable state.
+- Keep `force_lagoon_settle()` as a low-level implementation helper, but remove it from caller-facing lifecycle tests.
+- Do not add partial settlement, repeated settlement epochs, operator delegation or cancellation/reclaim support; document these limitations in the manager docstring.
+
+**Integration test coverage expansion needed**
+
+- Reuse one Lagoon deployment for one successful deposit and one failed deposit.
+- Test one successful redemption, calling only `manager.force_settle(ticket)` before the ordinary claim, and one failed redemption.
+- Add one shared negative test proving `force_settle()` refuses a non-Anvil provider; do not repeat it for every protocol.
+
+## 9. IPOR Fusion access control and redemption delay
+
+**Issue description**
+
+Six IPOR Fusion vaults reverted deposits with `AccessManagedUnauthorized(address)` because admission does not check the actual caller and selector.
+
+**Changes needed**
+
+- Decode the custom error and add caller-specific `AccessManager.canCall()` admission for the deposit selector.
+- Use one public IPOR vault for the supported lifecycle and one of the six private vaults for the representative failure.
+- Respect the ordinary account redemption delay required by the selected public vault.
+- Document the other five failing addresses, untested IPOR generations and role/delay variants in the manager docstring rather than adding a test matrix.
+
+**Integration test coverage expansion needed**
+
+- On an Ethereum fork with the same Safe-shaped caller, test one successful public-vault deposit and one typed private-vault deposit rejection.
+- Test one successful redemption after the selected vault's delay and one premature-redemption failure.
+- Assert the failed deposit includes the decoded error and caller context.
+
+## 10. Lagoon admission diagnostics
+
+**Issue description**
+
+Seven Lagoon vaults reverted deposits with `XJy8`, while current admission checks only an optional pause flag.
+
+**Changes needed**
+
+- Reproduce one representative `XJy8` deployment and decode its actual admission condition.
+- Add the corresponding cheap admission check when a reliable view exists; otherwise preserve a structured decoded failure.
+- Reuse the Lagoon manager and four integration scenarios from section 8 rather than creating a second test matrix.
+- Document the remaining six addresses, untested deployment generations and unresolved admission variants in the Lagoon manager docstring.
+
+**Integration test coverage expansion needed**
+
+- Use one public Lagoon deposit as the happy deposit path and one representative `XJy8` address as the failed deposit path.
+- Reuse section 8's successful and failed redemption paths; do not test every `XJy8` address or generation.
+- Assert the failed path reports vault, caller, phase and decoded/raw reason.
+
+## 11. Avalanche CCTP V2 vault funding
+
+**Issue description**
+
+Avalanche vault tests cannot be funded because chain ID `43114` is missing from the CCTP V2 domain map.
+
+**Changes needed**
+
+- Add Avalanche domain `1`, chain ID `43114`, reverse resolution and display name to the CCTP V2 mappings.
+- Verify the shared V2 contracts and `localDomain()` on an Avalanche fork.
+- Add one native-USDC funding fixture and the minimum shared mapping needed by vault tests.
+- Do not add Fuji, every bridge direction, every affected vault address or a multichain deployment matrix in this plan.
+- Document which Avalanche vault path is tested and which reported deployments remain untested in the corresponding manager docstrings.
+
+**Integration test coverage expansion needed**
+
+- Add one successful Ethereum-to-Avalanche funding test and one unknown/incorrect-domain failure.
+- Use one representative affected Avalanche vault for one successful and one failed deposit, and one successful and one failed redemption.
+- Do not rerun all three reported Avalanche vaults or require return bridging as part of this issue.
+
+## 12. Shared manager settlement and diagnostics
+
+**Issue description**
+
+Callers lack a unified way to force asynchronous settlement on Anvil, and analysis failures lose protocol, phase and receipt context.
+
+**Changes needed**
+
+- Add `VaultDepositManager.force_settle(ticket: DepositTicket | RedemptionTicket | None) -> VaultForcedSettlementResult` as the single caller-facing Anvil settlement API.
+- Require every in-scope protocol manager to implement this method. Synchronous managers implement the common Anvil-validated no-op path with `ticket=None` and return `settlement_required=False`; asynchronous managers require their ticket and drive it to claimable state.
+- Check `eth_defi.provider.anvil.is_anvil()` before any mutation, including the synchronous no-op path, and raise `UnsupportedVaultSimulation` for a live provider. In-scope asynchronous managers must provide a driver for their selected happy path instead of returning unsupported.
+- Keep asynchronous settlement protocol-agnostic for callers: the manager discovers any role, valuation, time advance and protocol calls needed for its selected ticket.
+- Return the ticket identity, `settlement_required`, status before/after and settlement transaction hashes. Claims remain on `finish_deposit()` and `finish_redeem()`.
+- Migrate `force_lagoon_settle()` behind the Lagoon manager and implement the corresponding manager override for each other asynchronous protocol selected in this plan. Synchronous managers use the shared no-op implementation.
+- Add backwards-compatible structured failures containing protocol, vault, flow direction, phase, transaction hash, receipt status and decoded error.
+- Add forced-settlement capability metadata distinguishing synchronous no-op and asynchronous Anvil-driver support.
+- Update the base and protocol-manager docstrings with the supported simulation path and known limitations policy above.
+
+**Integration test coverage expansion needed**
+
+- Add one shared synchronous no-op `force_settle(None)` test and one asynchronous Lagoon `force_settle(ticket)` test, plus one failed non-Anvil-provider test.
+- In every protocol's selected happy path, call its manager `force_settle()` and assert either no settlement is required or the asynchronous ticket becomes claimable and can be claimed through the ordinary manager API.
+- Add one successful standard receipt-analysis test and one structured analysis-failure test.
+- Do not add partial settlement, repeated calls, cumulative-progress, cancellation, operator or per-protocol conformance matrices.
+
+## Completion criteria
+
+- Each in-scope protocol has exactly one happy and one failed integration path for deposit and for redemption, reusing scenarios where two issue sections concern the same manager.
+- Every in-scope manager implements `VaultDepositManager.force_settle()`. Successful paths use the Anvil-validated no-op for synchronous flows or ticket-driven settlement without protocol imports or caller-supplied privileged roles for asynchronous flows.
+- Receipt analysis reports executed asset/share amounts, and failed paths retain actionable protocol and phase context.
+- Every changed protocol manager docstring states its supported simulation path and known limitations.
+- Unsupported assets, deployments and lifecycle variants are documented rather than silently presented as supported.

--- a/eth_defi/abi/upshift/EnableOnlyAssetsWhitelist.json
+++ b/eth_defi/abi/upshift/EnableOnlyAssetsWhitelist.json
@@ -1,0 +1,15 @@
+[
+  {
+    "inputs": [],
+    "name": "getWhitelistedAssets",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/eth_defi/abi/upshift/README.md
+++ b/eth_defi/abi/upshift/README.md
@@ -17,6 +17,11 @@ to the read-only methods needed by vault classification and historical pricing:
 - `maxDepositAmount()`
 - `maxWithdrawalAmount()`
 
+`EnableOnlyAssetsWhitelist.json` is the narrow runtime interface used to
+resolve the ordered denomination-token whitelist of an Upshift multi-asset
+vault. It contains only `getWhitelistedAssets()` and was reduced from the
+shared verified implementation ABI below.
+
 `IMultiAssetVaultEvents.json` is an event-only interface for Upshift
 `multiAssetVault` discovery. It contains the custom multi-asset deposit event
 and the matching withdrawal request/processed events:

--- a/eth_defi/cctp/constants.py
+++ b/eth_defi/cctp/constants.py
@@ -47,6 +47,9 @@ CCTP_DOMAIN_BASE = 6
 #: CCTP domain ID for Polygon PoS
 CCTP_DOMAIN_POLYGON = 7
 
+#: CCTP domain ID for Avalanche C-Chain
+CCTP_DOMAIN_AVALANCHE = 1
+
 #: CCTP domain ID for Monad
 #:
 #: For the full list of supported chains and domains, see:
@@ -64,6 +67,7 @@ CCTP_DOMAIN_HYPEREVM = 19
 #: https://developers.circle.com/cctp/concepts/supported-chains-and-domains
 CHAIN_ID_TO_CCTP_DOMAIN: dict[int, int] = {
     1: CCTP_DOMAIN_ETHEREUM,
+    43114: CCTP_DOMAIN_AVALANCHE,
     42161: CCTP_DOMAIN_ARBITRUM,
     8453: CCTP_DOMAIN_BASE,
     137: CCTP_DOMAIN_POLYGON,
@@ -77,6 +81,7 @@ CCTP_DOMAIN_TO_CHAIN_ID: dict[int, int] = {v: k for k, v in CHAIN_ID_TO_CCTP_DOM
 #: Mapping from CCTP domain ID to human-readable chain name.
 CCTP_DOMAIN_NAMES: dict[int, str] = {
     CCTP_DOMAIN_ETHEREUM: "Ethereum",
+    CCTP_DOMAIN_AVALANCHE: "Avalanche",
     CCTP_DOMAIN_ARBITRUM: "Arbitrum",
     CCTP_DOMAIN_BASE: "Base",
     CCTP_DOMAIN_POLYGON: "Polygon",

--- a/eth_defi/erc_4626/deposit_redeem.py
+++ b/eth_defi/erc_4626/deposit_redeem.py
@@ -42,7 +42,20 @@ class ERC4626RedemptionRequest(RedemptionRequest):
 
 
 class ERC4626DepositManager(VaultDepositManager):
-    """Abstraction over different deposit/redeem flows of vaults."""
+    """Standard synchronous ERC-4626 deposit and redemption flow.
+
+    **Supported simulation path**
+
+    Standard ERC-4626 ``deposit`` and ``redeem`` calls complete in their
+    originating transaction.  :meth:`force_settle` therefore accepts
+    ``None`` and performs the Anvil-validated shared no-op.
+
+    **Known limitations**
+
+    This manager is suitable only for vaults whose selected asset uses the
+    standard ERC-4626 entry points.  Queued, delegated, multi-asset and
+    protocol-specific settlement flows must provide a specialised manager.
+    """
 
     def __init__(self, vault: "ERC4626Vault"):
         from eth_defi.erc_4626.vault import ERC4626Vault
@@ -215,7 +228,15 @@ class ERC4626DepositManager(VaultDepositManager):
                     denomination_amount=vault.denomination_token.convert_to_decimals(analysis.amount_in),
                 )
             case TradeFail():
-                return DepositRedeemEventFailure(tx_hash=HexBytes(claim_tx_hash), revert_reason=analysis.revert_reason)
+                return DepositRedeemEventFailure(
+                    tx_hash=HexBytes(claim_tx_hash),
+                    revert_reason=analysis.revert_reason,
+                    protocol=vault.get_protocol_name(),
+                    vault_address=vault.address,
+                    direction="deposit",
+                    phase="transaction",
+                    receipt_status=int(receipt["status"]),
+                )
             case _:
                 raise NotImplementedError(f"Unknown {type(analysis)}")
 
@@ -260,6 +281,14 @@ class ERC4626DepositManager(VaultDepositManager):
                     denomination_amount=vault.denomination_token.convert_to_decimals(analysis.amount_out),
                 )
             case TradeFail():
-                return DepositRedeemEventFailure(tx_hash=HexBytes(claim_tx_hash), revert_reason=analysis.revert_reason)
+                return DepositRedeemEventFailure(
+                    tx_hash=HexBytes(claim_tx_hash),
+                    revert_reason=analysis.revert_reason,
+                    protocol=vault.get_protocol_name(),
+                    vault_address=vault.address,
+                    direction="redeem",
+                    phase="transaction",
+                    receipt_status=int(receipt["status"]),
+                )
             case _:
                 raise NotImplementedError(f"Unknown {type(analysis)}")

--- a/eth_defi/erc_4626/vault_protocol/accountable/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/deposit_redeem.py
@@ -121,7 +121,49 @@ class AccountableRedemptionRequest(RedemptionRequest):
 
 
 class AccountableDepositManager(ERC4626DepositManager):
-    """Accountable adapter with synchronous deposits and claimed redemptions."""
+    """Accountable adapter with synchronous deposits and claimed redemptions.
+
+    Supported simulation path: standard ERC-4626 deposits complete
+    immediately and use the shared ``force_settle(None)`` Anvil no-op.
+
+    Known limitations: redemptions depend on the live strategy's valuation and
+    liquidity checks. This manager has no safe generic Anvil settlement driver
+    for an Accountable redemption ticket, so ``force_settle(ticket)`` raises
+    :class:`UnsupportedVaultSimulation`. Multiple concurrent controller
+    requests, partial claims, repeated settlement rounds and delegated
+    controllers are likewise unsupported.
+    """
+
+    def estimate_deposit(
+        self,
+        owner: HexAddress | None,
+        amount: Decimal,
+        block_identifier: BlockIdentifier = "latest",
+    ) -> Decimal:
+        """Estimate Accountable shares without calling ``previewDeposit``.
+
+        The reported Hyperithm deployment rejects the generic ERC-4626
+        preview call even though its conversion function remains available.
+        ``convertToShares`` is the value used by the contract's synchronous
+        deposit path and gives callers a non-reverting estimate.
+
+        :param owner:
+            Deposit owner. Accountable's conversion is owner-independent.
+        :param amount:
+            Denomination-token amount to deposit.
+        :param block_identifier:
+            Block number or ``"latest"``.
+        :return:
+            Estimated decimal share amount.
+        :raise ValueError:
+            If the vault reports a zero share estimate.
+        """
+        del owner
+        raw_amount = self.vault.denomination_token.convert_to_raw(amount)
+        raw_shares = self.vault.vault_contract.functions.convertToShares(raw_amount).call(block_identifier=block_identifier)
+        if raw_shares <= 0:
+            raise ValueError(f"Accountable deposit estimate is zero for {amount} {self.vault.denomination_token.symbol}")
+        return self.vault.share_token.convert_to_decimals(raw_shares)
 
     def create_deposit_request(
         self,

--- a/eth_defi/erc_4626/vault_protocol/d2/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/d2/vault.py
@@ -2,6 +2,7 @@
 
 import datetime
 from dataclasses import dataclass
+from decimal import Decimal
 from functools import cached_property
 import logging
 from typing import Iterable
@@ -10,6 +11,7 @@ from web3.contract import Contract
 from eth_typing import BlockIdentifier, HexAddress
 
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
+from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
 from eth_defi.event_reader.conversion import convert_int256_bytes_to_int
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
@@ -25,6 +27,52 @@ from eth_defi.vault.base import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class D2DepositManager(ERC4626DepositManager):
+    """D2 ERC-4626 lifecycle with explicit zero-price admission failure.
+
+    **Supported simulation path**
+
+    :meth:`force_settle` receives ``None`` and uses the shared Anvil-only
+    no-op implementation for a direct ERC-4626 call. This adapter only
+    improves preflight estimation; it does not certify a successful D2
+    transaction path.
+
+    **Known limitations**
+
+    Successful D2 deposits and redemptions have not yet been fork-proven.
+    Custodied epochs, operator NAV changes, delayed withdrawals and other
+    epoch transitions are deliberately outside this adapter.
+    """
+
+    def estimate_deposit(
+        self,
+        owner: HexAddress | None,
+        amount: Decimal,
+        block_identifier: BlockIdentifier = "latest",
+    ) -> Decimal:
+        """Return an estimate or an actionable zero-price failure.
+
+        :param owner:
+            Deposit owner passed to the standard ERC-4626 estimator.
+        :param amount:
+            Decimal denomination amount.
+        :param block_identifier:
+            Block number or ``"latest"``.
+        :return:
+            Estimated decimal shares.
+        :raise ValueError:
+            If D2 pricing is undefined or the funding phase is closed.
+        """
+        closed_reason = self.vault.fetch_deposit_closed_reason()
+        if closed_reason is not None:
+            raise ValueError(f"D2 deposit is unavailable: {closed_reason}")
+        estimate = super().estimate_deposit(owner, amount, block_identifier)
+        if estimate <= 0:
+            raise ValueError(f"D2 deposit estimate is zero for {amount} {self.vault.denomination_token.symbol}; pricing is unavailable")
+        return estimate
+
 
 D2_PROTOCOL_NAME = "D2 Finance"
 D2_STRATEGY_URL_TEMPLATE = "https://d2.finance/strategies/{address}"
@@ -341,6 +389,14 @@ class D2Vault(ERC4626Vault):
 
     def get_historical_reader(self, stateful) -> VaultHistoricalReader:
         return D2HistoricalReader(self, stateful)
+
+    def get_deposit_manager(self) -> D2DepositManager:
+        """Create the D2 phase-aware lifecycle manager.
+
+        :return:
+            D2 manager that avoids returning a zero share estimate.
+        """
+        return D2DepositManager(self)
 
     def get_link(self, referral: str | None = None) -> str:  # noqa: ARG002
         """Get the canonical public page for this D2 vault.

--- a/eth_defi/erc_4626/vault_protocol/lagoon/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/deposit_redeem.py
@@ -19,6 +19,7 @@ from eth_defi.abi import ZERO_ADDRESS_STR, get_topic_signature_from_event
 from eth_defi.event_reader.conversion import BadAddressError, convert_bytes32_to_address, convert_bytes32_to_uint, convert_int256_bytes_to_int
 from eth_defi.event_reader.multicall_batcher import EncodedCall
 from eth_defi.middleware import ProbablyNodeHasNoBlock
+from eth_defi.provider.anvil import is_anvil, make_anvil_custom_rpc_request
 from eth_defi.timestamp import get_block_timestamp
 from eth_defi.vault.flow_events import (
     PendingVaultFlow,
@@ -41,6 +42,8 @@ from eth_defi.vault.deposit_redeem import (
     RedemptionRequest,
     RedemptionTicket,
     VaultDepositManager,
+    UnsupportedVaultSimulation,
+    VaultForcedSettlementResult,
 )
 
 
@@ -166,13 +169,18 @@ class ERC7540RedemptionRequest(RedemptionRequest):
 class ERC7540DepositManager(VaultDepositManager):
     """ERC-7540 async deposit/redeem flow.
 
-    - Currently coded for Lagoon, but should work with any vault.
+    **Supported simulation path**
 
-    Example:
+    Lagoon deposit and redemption requests can be moved to claimable state on
+    an Anvil fork through :meth:`force_settle`. The manager resolves the
+    deployed valuation-manager and Safe roles and delegates the low-level calls to
+    :func:`eth_defi.erc_4626.vault_protocol.lagoon.testing.force_lagoon_settle`.
 
-    .. code-block:: python
+    **Known limitations**
 
-
+    This manager currently supports Lagoon only. It does not model partial
+    settlements, repeated epochs, operator delegation, cancellation or
+    reclaim.
     """
 
     def __init__(self, vault: "eth_defi.erc_7540.vault.ERC7540Vault"):
@@ -180,6 +188,62 @@ class ERC7540DepositManager(VaultDepositManager):
 
         assert isinstance(vault, LagoonVault), f"Got {type(vault)}"
         self.vault = vault
+
+    def force_settle(
+        self,
+        ticket: DepositTicket | RedemptionTicket | None,
+    ) -> VaultForcedSettlementResult:
+        """Force one Lagoon settlement round on an Anvil fork.
+
+        :param ticket:
+            Pending deposit or redemption ticket to progress.
+        :return:
+            Before/after status and settlement transaction hashes.
+        :raise UnsupportedVaultSimulation:
+            If the provider is not Anvil, the ticket is unsupported, or the
+            settlement does not make the request claimable.
+        """
+        if not is_anvil(self.web3):
+            raise UnsupportedVaultSimulation("Lagoon force_settle() requires an Anvil provider")
+        if ticket is None:
+            raise UnsupportedVaultSimulation("Lagoon force_settle() requires an async request ticket")
+
+        if isinstance(ticket, ERC7540DepositTicket):
+            status_before = self.get_deposit_request_status(ticket)
+        elif isinstance(ticket, ERC7540RedemptionTicket):
+            status_before = self.get_redemption_request_status(ticket)
+        else:
+            raise UnsupportedVaultSimulation(f"Unsupported Lagoon ticket type: {type(ticket)}")
+
+        from eth_defi.erc_4626.vault_protocol.lagoon.testing import force_lagoon_settle
+
+        valuation_manager = self.vault.valuation_manager
+        safe_address = self.vault.safe_address
+        make_anvil_custom_rpc_request(self.web3, "anvil_impersonateAccount", [valuation_manager])
+        make_anvil_custom_rpc_request(self.web3, "anvil_setBalance", [valuation_manager, hex(10**18)])
+        make_anvil_custom_rpc_request(self.web3, "anvil_impersonateAccount", [safe_address])
+        make_anvil_custom_rpc_request(self.web3, "anvil_setBalance", [safe_address, hex(10**18)])
+        tx_hashes = force_lagoon_settle(
+            self.vault,
+            valuation_manager,
+            settlement_manager=safe_address,
+        )
+
+        if isinstance(ticket, ERC7540DepositTicket):
+            status_after = self.get_deposit_request_status(ticket)
+        else:
+            status_after = self.get_redemption_request_status(ticket)
+
+        if status_after is not AsyncVaultRequestStatus.claimable:
+            raise UnsupportedVaultSimulation(f"Lagoon settlement did not make {type(ticket).__name__} claimable: {status_before.value} -> {status_after.value}")
+
+        return VaultForcedSettlementResult(
+            ticket=ticket,
+            settlement_required=True,
+            status_before=status_before,
+            status_after=status_after,
+            transaction_hashes=tx_hashes,
+        )
 
     def fetch_vault_flow_events(
         self,

--- a/eth_defi/erc_4626/vault_protocol/lagoon/testing.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/testing.py
@@ -4,6 +4,7 @@ import logging
 import time
 from decimal import Decimal
 
+from hexbytes import HexBytes
 from web3 import Web3
 
 from eth_typing import HexAddress
@@ -323,33 +324,39 @@ def redeem_vault_shares(
 def force_lagoon_settle(
     vault: LagoonVault,
     asset_manager: HexAddress,
-    raw_nav: int = None,
+    settlement_manager: HexAddress | None = None,
+    raw_nav: int | None = None,
     gas_limit: int = 15_000_000,
-):
+) -> tuple[HexBytes, HexBytes]:
     """Force settling of the Lagoon vault.
 
     - Used in the testing to move the vault to the next epoch
 
     :param asset_manager:
-        Spoofed account in Anvil
+        Valuation-manager account, spoofed in Anvil.
+    :param settlement_manager:
+        Safe account that submits the settlement. Defaults to
+        ``asset_manager`` for legacy test callers where both roles coincide.
     """
 
     assert asset_manager.startswith("0x"), f"asset_manager should be an address, got: {asset_manager}"
+    if settlement_manager is None:
+        settlement_manager = asset_manager
+    assert settlement_manager.startswith("0x"), f"settlement_manager should be an address, got: {settlement_manager}"
 
     web3 = vault.web3
-    balance = web3.eth.get_balance(asset_manager)
+    for account in (asset_manager, settlement_manager):
+        balance = web3.eth.get_balance(account)
+        if balance < 10**18:
+            tx_hash = web3.eth.send_transaction({"to": account, "from": web3.eth.accounts[0], "value": 5 * 10**18})
+            assert_transaction_success_with_explanation(web3, tx_hash)
 
-    # Top up if needed
-    if balance < 10**18:
-        tx_hash = web3.eth.send_transaction({"to": asset_manager, "from": web3.eth.accounts[0], "value": 5 * 10**18})
-        assert_transaction_success_with_explanation(web3, tx_hash)
-
-    if not raw_nav:
+    if raw_nav is None:
         nav = vault.fetch_nav()
         raw_nav = vault.denomination_token.convert_to_raw(nav)
 
-    tx_hash = vault.vault_contract.functions.updateNewTotalAssets(raw_nav).transact({"from": asset_manager, "gas": gas_limit})
-    assert_transaction_success_with_explanation(web3, tx_hash)
+    valuation_tx_hash = vault.vault_contract.functions.updateNewTotalAssets(raw_nav).transact({"from": asset_manager, "gas": gas_limit})
+    assert_transaction_success_with_explanation(web3, valuation_tx_hash)
 
     # Lagoon security fix
     #     function settleDeposit(uint256 _newTotalAssets) public virtual;
@@ -361,8 +368,9 @@ def force_lagoon_settle(
         extra_data=None,
     )
     tx_data = call.transact(
-        from_=asset_manager,
+        from_=settlement_manager,
         gas_limit=gas_limit,
     )
-    tx_hash = web3.eth.send_transaction(tx_data)
-    assert_transaction_success_with_explanation(web3, tx_hash)
+    settlement_tx_hash = web3.eth.send_transaction(tx_data)
+    assert_transaction_success_with_explanation(web3, settlement_tx_hash)
+    return HexBytes(valuation_tx_hash), HexBytes(settlement_tx_hash)

--- a/eth_defi/erc_4626/vault_protocol/plutus/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/plutus/vault.py
@@ -2,11 +2,13 @@
 
 import datetime
 import logging
+from decimal import Decimal
 from typing import Iterable
 
-from eth_typing import BlockIdentifier
+from eth_typing import BlockIdentifier, HexAddress
 
 from eth_defi.abi import ZERO_ADDRESS_STR
+from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
 from eth_defi.event_reader.conversion import convert_int256_bytes_to_int
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
@@ -18,6 +20,49 @@ from eth_defi.vault.base import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class PlutusDepositManager(ERC4626DepositManager):
+    """Plutus synchronous ERC-4626 lifecycle without ``previewDeposit``.
+
+    **Supported simulation path**
+
+    The selected Hedge Token deployment uses direct ERC-4626 deposit and
+    redeem calls. :meth:`force_settle` accepts ``None`` and performs the
+    shared Anvil-only no-op.
+
+    **Known limitations**
+
+    The adapter supports only direct calls while the manual deposit and
+    redemption windows are open. Queued generations, delegated operators,
+    cancellation and reclaim remain unsupported.
+    """
+
+    def estimate_deposit(
+        self,
+        owner: HexAddress | None,
+        amount: Decimal,
+        block_identifier: BlockIdentifier = "latest",
+    ) -> Decimal:
+        """Estimate shares through the non-reverting conversion function.
+
+        :param owner:
+            Unused because the conversion is not owner-specific.
+        :param amount:
+            Decimal denomination amount.
+        :param block_identifier:
+            Block number or ``"latest"``.
+        :return:
+            Estimated decimal shares.
+        :raise ValueError:
+            If the selected deposit window produces a zero estimate.
+        """
+        del owner
+        raw_amount = self.vault.denomination_token.convert_to_raw(amount)
+        raw_shares = self.vault.vault_contract.functions.convertToShares(raw_amount).call(block_identifier=block_identifier)
+        if raw_shares <= 0:
+            raise ValueError(f"Plutus deposit estimate is zero for {amount} {self.vault.denomination_token.symbol}")
+        return self.vault.share_token.convert_to_decimals(raw_shares)
 
 
 class PlutusHistoricalReader(ERC4626HistoricalReader):
@@ -96,6 +141,14 @@ class PlutusVault(ERC4626Vault):
 
     def get_historical_reader(self, stateful) -> VaultHistoricalReader:
         return PlutusHistoricalReader(self, stateful)
+
+    def get_deposit_manager(self) -> PlutusDepositManager:
+        """Create the Plutus lifecycle manager.
+
+        :return:
+            Manager that avoids Plutus' reverting ``previewDeposit`` path.
+        """
+        return PlutusDepositManager(self)
 
     def has_custom_fees(self) -> bool:
         """Deposit/withdrawal fees."""

--- a/eth_defi/erc_4626/vault_protocol/upshift/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/upshift/vault.py
@@ -15,7 +15,7 @@ from eth_defi.erc_4626.core import ERC4626Feature, get_deployed_erc_4626_contrac
 from eth_defi.erc_4626.vault import ERC4626Vault, VaultReaderState
 from eth_defi.event_reader.conversion import convert_int256_bytes_to_int
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
-from eth_defi.token import TokenDetails
+from eth_defi.token import TokenDetails, fetch_erc20_details
 from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
 
 logger = logging.getLogger(__name__)
@@ -256,6 +256,86 @@ class UpshiftVault(ERC4626Vault):
         """Alias for the Upshift implementation-specific vault contract."""
 
         return self.vault_contract
+
+    @cached_property
+    def assets_whitelist_contract(self) -> Contract:
+        """Get the multi-asset denomination-token whitelist contract.
+
+        :return:
+            The configured whitelist contract.
+        :raise ValueError:
+            If this is not an Upshift multi-asset vault.
+        """
+        if not self.multi_asset_like:
+            raise ValueError("Only Upshift multi-asset vaults have an assets whitelist")
+        address = self.upshift_contract.functions.assetsWhitelistAddress().call()
+        return get_deployed_contract(
+            self.web3,
+            "upshift/EnableOnlyAssetsWhitelist.json",
+            address,
+        )
+
+    def fetch_all_denomination_tokens(self) -> tuple[TokenDetails, ...]:
+        """Fetch every configured multi-asset denomination token.
+
+        The returned tuple preserves the onchain whitelist ordering. That
+        ordering determines the primary token returned by
+        :meth:`fetch_denomination_token`.
+
+        :return:
+            Whitelisted denomination tokens in protocol order. Standard
+            single-asset Upshift vaults return their normal denomination token.
+        :raise ValueError:
+            If a configured token cannot be read as an ERC-20.
+        """
+        if not self.multi_asset_like:
+            token = super().fetch_denomination_token()
+            return (token,) if token is not None else ()
+
+        addresses = self.assets_whitelist_contract.functions.getWhitelistedAssets().call()
+        if not addresses:
+            # Older multi-asset proxies can expose a whitelist contract before
+            # it has any configured assets. Their ERC-4626 asset remains the
+            # only observable primary denomination token.
+            token = super().fetch_denomination_token()
+            return (token,) if token is not None else ()
+        tokens = []
+        for address in addresses:
+            token = fetch_erc20_details(
+                self.web3,
+                address,
+                chain_id=self.spec.chain_id,
+                raise_on_error=False,
+                cause_diagnostics_message=f"Upshift vault {self.address} denomination token lookup",
+                cache=self.token_cache,
+            )
+            if token is None:
+                raise ValueError(f"Could not fetch Upshift denomination token {address} for vault {self.address}")
+            tokens.append(token)
+        return tuple(tokens)
+
+    def fetch_denomination_token(self) -> TokenDetails | None:
+        """Fetch Upshift's primary denomination token.
+
+        **Supported simulation path**
+
+        Multi-asset vaults use the first token in the onchain whitelist as
+        their primary denomination token. The representative integration path
+        uses a vault whose first token is USDC.
+
+        **Known limitations**
+
+        Only the first token is selected as the primary denomination token.
+        Remaining whitelisted tokens are discovered by
+        :meth:`fetch_all_denomination_tokens` but are not supported by the
+        deposit manager yet.
+
+        :return:
+            First whitelisted token for a multi-asset vault, or the normal
+            ERC-4626 denomination token for a standard Upshift vault.
+        """
+        tokens = self.fetch_all_denomination_tokens()
+        return tokens[0] if tokens else None
 
     def fetch_share_token_address(self, block_identifier: BlockIdentifier = "latest") -> HexAddress:
         """Get the share token address.

--- a/eth_defi/vault/deposit_redeem.py
+++ b/eth_defi/vault/deposit_redeem.py
@@ -16,6 +16,7 @@ from web3 import Web3
 from web3.contract.contract import ContractFunction
 
 from eth_defi.timestamp import get_block_timestamp
+from eth_defi.provider.anvil import is_anvil
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.vault.flow_events import PendingVaultFlow, VaultFlowDirection
 
@@ -118,10 +119,31 @@ class VaultTransactionFailed(Exception):
     """One of vault deposit/redeem transactions reverted"""
 
 
+class UnsupportedVaultSimulation(RuntimeError):
+    """A vault settlement simulation cannot safely run on this provider."""
+
+
 @dataclass(slots=True)
 class DepositRedeemEventFailure:
+    """Structured failed-flow diagnostic returned by a vault manager."""
+
     tx_hash: HexBytes
     revert_reason: str | None
+
+    #: Protocol adapter that analysed the failed flow, when available.
+    protocol: str | None = None
+
+    #: Vault whose lifecycle was being processed, when available.
+    vault_address: HexAddress | None = None
+
+    #: ``deposit`` or ``redeem`` when the manager knows the direction.
+    direction: Literal["deposit", "redeem"] | None = None
+
+    #: Lifecycle phase, such as ``request`` or ``claim``.
+    phase: str | None = None
+
+    #: Receipt status when it was available to the analyser.
+    receipt_status: int | None = None
 
 
 @dataclass(slots=True)
@@ -208,6 +230,32 @@ class RedemptionTicket:
         - Needed for settlement
         """
         raise NotImplementedError()
+
+
+@dataclass(frozen=True, slots=True)
+class VaultForcedSettlementResult:
+    """Outcome of an Anvil-only forced settlement attempt.
+
+    Synchronous managers return a no-op result because their successful
+    request transaction already completes the lifecycle. Asynchronous managers
+    return the ticket status before and after their protocol-specific
+    settlement transaction(s).
+    """
+
+    #: Ticket progressed by the simulation, or None for synchronous flows.
+    ticket: DepositTicket | RedemptionTicket | None
+
+    #: False when the completed flow does not need a settlement transaction.
+    settlement_required: bool
+
+    #: Request status before settlement, when a ticket was supplied.
+    status_before: AsyncVaultRequestStatus | None
+
+    #: Request status after settlement, when a ticket was supplied.
+    status_after: AsyncVaultRequestStatus | None
+
+    #: Transactions broadcast by the forced settlement helper.
+    transaction_hashes: tuple[HexBytes, ...] = ()
 
 
 class CannotParseRedemptionTransaction(Exception):
@@ -420,7 +468,18 @@ class DepositRequest:
 
 
 class VaultDepositManager(ABC):
-    """Abstraction over different deposit/redeem flows of vaults."""
+    """Abstraction over different deposit/redeem flows of vaults.
+
+    Supported simulation path: every manager exposes force_settle() for
+    Anvil-based integration tests. Synchronous managers use its no-op
+    implementation; asynchronous managers override it when their selected
+    test lifecycle needs settlement.
+
+    Known limitations: the common interface cannot infer protocol-specific
+    settlement roles, valuations or queues. Each protocol manager documents
+    the concrete asynchronous path it supports and raises
+    UnsupportedVaultSimulation when it has no safe Anvil driver.
+    """
 
     def __init__(
         self,
@@ -431,6 +490,36 @@ class VaultDepositManager(ABC):
     @property
     def web3(self) -> Web3:
         return self.vault.web3
+
+    def force_settle(
+        self,
+        ticket: DepositTicket | RedemptionTicket | None,
+    ) -> VaultForcedSettlementResult:
+        """Force the selected ticket forward on an Anvil simulation.
+
+        Synchronous managers do not require settlement and return a no-op
+        result when called with None. Asynchronous managers must override this
+        method and supply their request ticket.
+
+        :param ticket:
+            Pending async request ticket, or None for a synchronous flow.
+        :return:
+            Settlement outcome with before/after status and transaction hashes.
+        :raise UnsupportedVaultSimulation:
+            If the provider is not Anvil or an async manager lacks a driver.
+        """
+        if not is_anvil(self.web3):
+            raise UnsupportedVaultSimulation(f"{self.__class__.__name__}.force_settle() requires an Anvil provider")
+
+        if ticket is None and (self.has_synchronous_deposit() or self.has_synchronous_redemption()):
+            return VaultForcedSettlementResult(
+                ticket=None,
+                settlement_required=False,
+                status_before=None,
+                status_after=None,
+            )
+
+        raise UnsupportedVaultSimulation(f"{self.__class__.__name__} has no Anvil settlement driver for {type(ticket).__name__}")
 
     @abstractmethod
     def has_synchronous_deposit(self) -> bool:

--- a/tests/cctp/test_cctp_constants.py
+++ b/tests/cctp/test_cctp_constants.py
@@ -1,0 +1,18 @@
+"""CCTP mainnet domain mappings."""
+
+from eth_defi.cctp.constants import (
+    CCTP_DOMAIN_AVALANCHE,
+    CCTP_DOMAIN_NAMES,
+    CCTP_DOMAIN_TO_CHAIN_ID,
+    CHAIN_ID_TO_CCTP_DOMAIN,
+)
+
+AVALANCHE_CHAIN_ID = 43_114
+
+
+def test_avalanche_cctp_v2_domain_mapping() -> None:
+    """Map Avalanche C-Chain and CCTP domain 1 in both directions."""
+    assert CCTP_DOMAIN_AVALANCHE == 1
+    assert CHAIN_ID_TO_CCTP_DOMAIN[AVALANCHE_CHAIN_ID] == CCTP_DOMAIN_AVALANCHE
+    assert CCTP_DOMAIN_TO_CHAIN_ID[CCTP_DOMAIN_AVALANCHE] == AVALANCHE_CHAIN_ID
+    assert CCTP_DOMAIN_NAMES[CCTP_DOMAIN_AVALANCHE] == "Avalanche"

--- a/tests/erc_4626/vault_protocol/test_accountable.py
+++ b/tests/erc_4626/vault_protocol/test_accountable.py
@@ -114,6 +114,10 @@ def test_accountable_deposit_and_redemption_request_lifecycle(web3: Web3) -> Non
     assert manager.has_synchronous_deposit() is True
     assert manager.has_synchronous_redemption() is False
 
+    synchronous_settlement = manager.force_settle(None)
+    assert synchronous_settlement.settlement_required is False
+    assert synchronous_settlement.transaction_hashes == ()
+
     owner = web3.eth.accounts[0]
     usdc: TokenDetails = vault.denomination_token
     funding_hash = usdc.transfer(owner, DEPOSIT_AMOUNT).transact({"from": MONAD_USDC_WHALE})
@@ -121,6 +125,7 @@ def test_accountable_deposit_and_redemption_request_lifecycle(web3: Web3) -> Non
     approval_hash = usdc.approve(vault.address, DEPOSIT_AMOUNT).transact({"from": owner})
     assert_transaction_success_with_explanation(web3, approval_hash)
 
+    assert manager.estimate_deposit(owner, DEPOSIT_AMOUNT) > 0
     deposit_ticket = manager.create_deposit_request(owner=owner, amount=DEPOSIT_AMOUNT).broadcast(from_=owner)
     deposit_analysis = manager.analyse_deposit(deposit_ticket.tx_hash, deposit_ticket)
     assert deposit_analysis.denomination_amount == DEPOSIT_AMOUNT

--- a/tests/erc_4626/vault_protocol/test_d2.py
+++ b/tests/erc_4626/vault_protocol/test_d2.py
@@ -2,24 +2,21 @@
 
 import datetime
 import os
+from decimal import Decimal
 from pathlib import Path
 
-import pytest
-
-from web3 import Web3
 import flaky
-
-from decimal import Decimal
+import pytest
+from web3 import Web3
 
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
-from eth_defi.erc_4626.vault_protocol.d2.vault import D2HistoricalReader, D2Vault, Epoch
-from eth_defi.provider.anvil import fork_network_anvil, AnvilLaunch
+from eth_defi.erc_4626.vault_protocol.d2.vault import D2DepositManager, D2HistoricalReader, D2Vault, Epoch
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.vault.base import (
     DEPOSIT_CLOSED_FUNDING_PHASE,
     REDEMPTION_CLOSED_FUNDS_CUSTODIED,
-    VaultTechnicalRisk,
 )
 
 JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
@@ -61,6 +58,14 @@ def test_d2(
     assert vault.get_management_fee("latest") == 0.00
     assert vault.get_performance_fee("latest") == 0.20
     assert vault.has_custom_fees() is False
+
+    manager = vault.get_deposit_manager()
+    assert isinstance(manager, D2DepositManager)
+    with pytest.raises(ValueError, match="D2 deposit is unavailable"):
+        manager.estimate_deposit(web3.eth.accounts[0], Decimal("1"))
+    settlement = manager.force_settle(None)
+    assert settlement.settlement_required is False
+    assert settlement.transaction_hashes == ()
 
     epoch_id = vault.fetch_current_epoch_id()
     assert epoch_id == 12

--- a/tests/erc_4626/vault_protocol/test_plutus.py
+++ b/tests/erc_4626/vault_protocol/test_plutus.py
@@ -5,18 +5,15 @@ import os
 from decimal import Decimal
 from pathlib import Path
 
-import pytest
-
-from web3 import Web3
 import flaky
+import pytest
+from web3 import Web3
 
-from eth_defi.erc_4626.classification import create_vault_instance_autodetect
-from eth_defi.erc_4626.core import get_vault_protocol_name
-from eth_defi.erc_4626.vault_protocol.plutus.vault import PlutusHistoricalReader, PlutusVault
-from eth_defi.provider.anvil import fork_network_anvil, AnvilLaunch
-from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.erc_4626.vault_protocol.umami.vault import UmamiVault
 from eth_defi.abi import ZERO_ADDRESS_STR
+from eth_defi.erc_4626.classification import create_vault_instance_autodetect
+from eth_defi.erc_4626.vault_protocol.plutus.vault import PlutusDepositManager, PlutusHistoricalReader, PlutusVault
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
+from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.vault.base import REDEMPTION_CLOSED_BY_ADMIN, VaultTechnicalRisk
 
 JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
@@ -60,6 +57,15 @@ def test_plutus(
     assert vault.get_performance_fee("latest") == 0.12
     assert vault.has_custom_fees() is False
     assert vault.get_protocol_name() == "Plutus"
+
+    manager = vault.get_deposit_manager()
+    assert isinstance(manager, PlutusDepositManager)
+    estimated_deposit = manager.estimate_deposit(web3.eth.accounts[0], Decimal("1"))
+    expected_estimate = vault.share_token.convert_to_decimals(vault.vault_contract.functions.convertToShares(vault.denomination_token.convert_to_raw(Decimal("1"))).call())
+    assert estimated_deposit == expected_estimate
+    settlement = manager.force_settle(None)
+    assert settlement.settlement_required is False
+    assert settlement.transaction_hashes == ()
 
     # Verify Plutus-specific historical reader is returned
     reader = vault.get_historical_reader(stateful=False)

--- a/tests/erc_4626/vault_protocol/test_upshift.py
+++ b/tests/erc_4626/vault_protocol/test_upshift.py
@@ -100,7 +100,7 @@ def test_upshift(
 @pytest.mark.parametrize(
     "case",
     [
-        (UPSHIFT_TORI_VAULT, "Tori Ecosystem Vault", "etrUSD", "trUSD", 18),
+        (UPSHIFT_TORI_VAULT, "Tori Ecosystem Vault", "etrUSD", "USDC", 18),
         (UPSHIFT_CTUSD_VAULT, "Earn ctUSD", "EctUSD", "USDC", 6),
     ],
 )
@@ -119,7 +119,7 @@ def test_upshift_multi_asset_vault_metadata(
     Implementation: https://etherscan.io/address/0xEB5f80aCEa6060764E91c185bE93752Ab40F01c2#code
     """
 
-    vault_address, expected_name, expected_symbol, expected_denomination_symbol, expected_share_decimals = case
+    vault_address, expected_name, expected_symbol, expected_primary_denomination_symbol, expected_share_decimals = case
 
     vault = create_vault_instance_autodetect(
         web3,
@@ -134,7 +134,10 @@ def test_upshift_multi_asset_vault_metadata(
     assert vault.name == expected_name
     assert vault.symbol == expected_symbol
     assert vault.share_token.decimals == expected_share_decimals
-    assert vault.denomination_token.symbol == expected_denomination_symbol
+    denomination_tokens = vault.fetch_all_denomination_tokens()
+    assert denomination_tokens
+    assert denomination_tokens[0].symbol == expected_primary_denomination_symbol
+    assert vault.denomination_token == denomination_tokens[0]
 
     assert isinstance(vault.get_historical_reader(stateful=False), UpshiftMultiAssetHistoricalReader)
     assert vault.fetch_share_price(UPSHIFT_MULTI_ASSET_FORK_BLOCK) > 0

--- a/tests/lagoon/test_erc_7540_deposit_redeem.py
+++ b/tests/lagoon/test_erc_7540_deposit_redeem.py
@@ -1,27 +1,24 @@
 """ERC-7540 deposit/redeem tests."""
 
-import os
 import datetime
+import os
 from decimal import Decimal
 from typing import cast
 
 import flaky
 import pytest
+from eth_typing import HexAddress
 from web3 import Web3
 
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.lagoon.deposit_redeem import ERC7540DepositManager, ERC7540DepositRequest, ERC7540DepositTicket, ERC7540RedemptionTicket
-from eth_defi.erc_4626.vault_protocol.lagoon.testing import force_lagoon_settle
 from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault, LagoonVersion
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.token import fetch_erc20_details, TokenDetails, USDC_WHALE
+from eth_defi.token import USDC_WHALE, TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
-from eth_typing import HexAddress
-
-from eth_defi.utils import addr
-from eth_defi.vault.deposit_redeem import DepositRedeemEventAnalysis
+from eth_defi.vault.deposit_redeem import AsyncVaultRequestStatus, DepositRedeemEventAnalysis
 
 JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
 
@@ -32,14 +29,8 @@ pytestmark = pytest.mark.skipif(not JSON_RPC_BASE, reason="No JSON_RPC_BASE envi
 
 
 @pytest.fixture()
-def vault_manager() -> HexAddress:
-    # https://app.lagoon.finance/vault/8453/0xb09f761cb13baca8ec087ac476647361b6314f98
-    return addr("0x3B95C7cD4075B72ecbC4559AF99211C2B6591b2E")
-
-
-@pytest.fixture()
-def anvil_base_fork(request, vault_manager) -> AnvilLaunch:
-    """Create a testable fork of live BNB chain.
+def anvil_base_fork(request) -> AnvilLaunch:
+    """Create a testable fork of Base.
 
     :return: JSON-RPC URL for Web3
     """
@@ -47,7 +38,7 @@ def anvil_base_fork(request, vault_manager) -> AnvilLaunch:
     launch = fork_network_anvil(
         JSON_RPC_BASE,
         fork_block_number=35_094_246,
-        unlocked_addresses=[USDC_WHALE[8453], vault_manager],
+        unlocked_addresses=[USDC_WHALE[8453]],
     )
     try:
         yield launch
@@ -116,7 +107,6 @@ def test_erc_7540_deposit_722_capital(
     vault: ERC4626Vault,
     test_user: HexAddress,
     usdc: TokenDetails,
-    vault_manager: HexAddress,
 ):
     """Use DepositManager interface to deposit into ERC-7540 vault on Lagoon run by 722 Capital"""
     deposit_manager = vault.get_deposit_manager()
@@ -150,10 +140,12 @@ def test_erc_7540_deposit_722_capital(
     assert not deposit_manager.can_finish_deposit(deposit_ticket)
 
     # Settle
-    force_lagoon_settle(
-        vault,
-        vault_manager,
-    )
+    settlement = deposit_manager.force_settle(deposit_ticket)
+    assert settlement.settlement_required is True
+    assert settlement.ticket is deposit_ticket
+    assert settlement.status_before is AsyncVaultRequestStatus.pending
+    assert settlement.status_after is AsyncVaultRequestStatus.claimable
+    assert settlement.transaction_hashes
 
     # Claim
     assert deposit_manager.can_finish_deposit(deposit_ticket)
@@ -177,7 +169,7 @@ def test_erc_7540_deposit_722_capital(
     assert deposit_result.from_ == test_user
     assert deposit_result.to == test_user
     assert deposit_result.tx_hash == tx_hash
-    assert deposit_result.block_number >= 35094253
+    assert deposit_result.block_number == 35094252
     assert isinstance(deposit_result.block_timestamp, datetime.datetime)
     assert deposit_result.share_count == pytest.approx(Decimal("960.645517122092231912"))
     assert deposit_result.denomination_amount == pytest.approx(Decimal("1000"))
@@ -189,7 +181,6 @@ def test_erc_7540_redeem_722_capital(
     vault: ERC4626Vault,
     test_user: HexAddress,
     usdc: TokenDetails,
-    vault_manager: HexAddress,
 ):
     """Use DepositManager interface to redeem into ERC-7540 vault on Lagoon run by 722 Capital"""
     deposit_manager = vault.get_deposit_manager()
@@ -214,10 +205,12 @@ def test_erc_7540_redeem_722_capital(
     deposit_ticket = request.broadcast()
 
     # Settle
-    force_lagoon_settle(
-        vault,
-        vault_manager,
-    )
+    deposit_settlement = deposit_manager.force_settle(deposit_ticket)
+    assert deposit_settlement.settlement_required is True
+    assert deposit_settlement.ticket is deposit_ticket
+    assert deposit_settlement.status_before is AsyncVaultRequestStatus.pending
+    assert deposit_settlement.status_after is AsyncVaultRequestStatus.claimable
+    assert deposit_settlement.transaction_hashes
 
     # Claim
     func = deposit_manager.finish_deposit(deposit_ticket)
@@ -253,10 +246,12 @@ def test_erc_7540_redeem_722_capital(
     assert not deposit_manager.can_finish_redeem(redeem_ticket)
 
     # Settle
-    force_lagoon_settle(
-        vault,
-        vault_manager,
-    )
+    redemption_settlement = deposit_manager.force_settle(redeem_ticket)
+    assert redemption_settlement.settlement_required is True
+    assert redemption_settlement.ticket is redeem_ticket
+    assert redemption_settlement.status_before is AsyncVaultRequestStatus.pending
+    assert redemption_settlement.status_after is AsyncVaultRequestStatus.claimable
+    assert redemption_settlement.transaction_hashes
 
     # Claim
     assert deposit_manager.can_finish_redeem(redeem_ticket)
@@ -277,7 +272,7 @@ def test_erc_7540_redeem_722_capital(
     assert redeem_result.from_ == test_user
     assert redeem_result.to == test_user
     assert redeem_result.tx_hash == tx_hash
-    assert redeem_result.block_number >= 35094253
+    assert redeem_result.block_number == 35094257
     assert isinstance(redeem_result.block_timestamp, datetime.datetime)
     assert redeem_result.share_count == pytest.approx(Decimal("960.645517122092231912"))
     assert redeem_result.denomination_amount == pytest.approx(Decimal("1000"))


### PR DESCRIPTION
## Why

Trade-executor vault coverage found that eth_defi exposed uneven deposit and redemption behaviour: callers had no common way to drive asynchronous settlement in Anvil, some estimators reverted or returned unusable zero values, and a multi-asset vault did not expose its primary denomination token consistently.

The goal is to make `VaultDepositManager` the reliable caller-facing boundary for a deliberately small representative lifecycle: one happy path and one failed path for each deposit and redemption direction. The work must be explicit about unsupported queues, assets, deployments and protocol-specific settlement variants instead of implying complete support.

## Lessons learnt

Async settlement authority is protocol-specific. Lagoon needs separate valuation-manager and Safe roles, while Accountable redemption cannot currently be forced safely with a generic Anvil driver. A successful settlement transaction alone is insufficient: the manager must verify that the request became claimable.

## Summary

- Introduce the shared Anvil-only `force_settle()` API and structured failed-flow diagnostics for vault managers.
- Move Lagoon’s privileged valuation and settlement sequence behind its manager, verify ticket progression, and remove caller-supplied privileged role knowledge from the focused lifecycle tests.
- Improve targeted D2, Plutus and Accountable estimation/admission behaviour and document each manager’s supported simulation path and known limitations.
- Resolve Upshift’s ordered denomination-token whitelist so the supported primary token is explicit, while documenting that the remaining assets are not yet transaction-supported.
- Add Avalanche CCTP domain mapping coverage and a roadmap for completing the remaining protocol happy and failed paths without expanding into exhaustive queue or asset matrices.

## Related issues and PRs

Follow-up to the trade-executor vault deposit and redemption coverage feedback. The included roadmap tracks the remaining cSigma, Yearn, YieldNest, IPOR, Lagoon-admission and broader CCTP work.

## Unrelated CI and test fixes

None.