### PR TITLE
fix: do not assert 0x prefix in is_blacklisted_address()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.2
 
 - fix: Publish Bulla Network protocol metadata under the canonical `bulla-network` slug (2026-07-22)
+- fix: `is_blacklisted_address()` no longer asserts a `0x` prefix; synthetic non-EVM vault ids (e.g. Lighter `lighter-pool-`) return `False` instead of raising, since the rugpull blacklist only holds EVM addresses (2026-07-22)
 - feat: Add Bulla Network Factoring vault recognition, native fee reads and safe read-only support (2026-07-21)
 - feat: Add multi-deployment Lighter vault scanning for Ethereum and Robinhood Chain with deployment-aware metrics and automatic legacy data migration (2026-07-22)
 - feat: Track per-chain vault scanner JSON-RPC calls and errors in DuckDB (2026-07-20)

--- a/eth_defi/token_analysis/blacklist.py
+++ b/eth_defi/token_analysis/blacklist.py
@@ -33,7 +33,10 @@ def is_blacklisted_address(
     chain_id: int = None,
 ):
     assert isinstance(address, str)
-    assert address.startswith("0x")
+    # The rugpull blacklist only holds EVM 0x addresses; synthetic non-EVM vault
+    # ids (e.g. Lighter ``lighter-pool-``) can never match, so treat them as clean.
+    if not address.startswith("0x"):
+        return False
     return address in _rugpulls_by_address
 
 


### PR DESCRIPTION
## What

`is_blacklisted_address()` hardcoded `assert address.startswith("0x")`. It is also called with synthetic non-EVM vault ids (e.g. Lighter `lighter-pool-281474976539113`) during backtest position management, which raised `AssertionError`.

Since the rugpull blacklist (`_rugpulls_by_address`) only ever holds EVM `0x` addresses, a synthetic address can never match — so return `False` for non-`0x` addresses instead of asserting.

## Why

Needed to run a Lighter (chain 9998) vault-of-vaults backtest. Part of a set of small changes across `web3-ethereum-defi`, `trading-strategy` and `trade-executor` that add Lighter support.

## Impact

Additive only: EVM addresses take the unchanged lookup path; only the previously-crashing non-EVM case changes (now returns `False`). The `stablecoins/*.yaml` churn in the working tree is unrelated and deliberately excluded from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)