### PR TITLE
test: document and retry unstable CI integrations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,39 @@ No test plan or verification section. Use Markdown formatting, headings.
 - When watching CI for pull request merge readiness, never wait for documentation-only workflows like `Build documentation`; merge once non-documentation required checks are green, unless the user explicitly asks to wait for docs.
 - If continuous integration (CI) tests fail on your PR, and they are marked flaky, run tests locally to repeat the issue if it is real flakiness or regression
 
+### Healing flaky CI tests
+
+Use this escalation process for tests that fail nondeterministically because of
+RPC providers, Anvil forks, live APIs, indexed data services, timing or shared
+CI resources. A deterministic product or test regression must be fixed and
+must never be hidden behind retries or a CI skip.
+
+1. **Identify and reproduce the issue.** Read the complete failed-job traceback,
+   record the exact failing test and symptom, and check whether the affected
+   code differs from `master`. Run the focused test locally with
+   `.local-test.env`. Attempt a bounded root-cause fix first, such as pinning a
+   fork block, correcting an assertion, reducing cross-test contention or
+   installing a missing workflow dependency.
+2. **Mark a genuinely nondeterministic test flaky.** Add `@flaky.flaky` and a
+   source line comment immediately above it. The comment must state when the
+   problem was first observed, the concrete CI symptom, and the evidence that
+   the test passes locally, on retry or in a later CI run. Keep the test enabled
+   in CI; a flaky marker is a temporary diagnostic and retry mechanism, not a
+   substitute for fixing a reproducible defect. Move resource-heavy live or
+   fork tests to the slow workflow when reduced contention is the appropriate
+   fix, and ensure that workflow installs all required dependencies.
+3. **Disable an endemic test on CI only as a last resort.** If a flaky test
+   continues to fail on at least two distinct CI runs, still passes locally,
+   and the external or runner-specific cause cannot be fixed in this
+   repository, add a dated `@pytest.mark.skipif(CI, reason=...)`. The line
+   comment and skip reason must describe the recurring symptom. Keep the test
+   runnable locally; never add an unconditional skip. Retain or create focused
+   local coverage so the disabled integration does not silently disappear.
+
+Periodically audit CI-disabled tests. Re-enable one when the provider, workflow
+or fixture has been healed, run it locally, and require a green CI run before
+removing its flaky history comment.
+
 ## Pushing to master
 
 - If you push directly to master, the commit message most follow *Commentary format* section

--- a/tests/cctp/test_cctp_dual_fork.py
+++ b/tests/cctp/test_cctp_dual_fork.py
@@ -12,6 +12,7 @@ on the destination chain to simulate the mint.
 import logging
 import os
 
+import flaky
 import pytest
 from eth_typing import HexAddress, HexStr
 from web3 import Web3
@@ -163,6 +164,9 @@ def vault(
     return vault
 
 
+# CI flaky since 2026-07-22: the fixed Arbitrum fork recipient balance stayed
+# at zero after the spoofed whale transfer; the unchanged test passed locally.
+@flaky.flaky
 def test_dual_fork_cctp_transfer(  # noqa: PLR0917
     web3_ethereum: Web3,
     web3_arbitrum: Web3,  # noqa: ARG001

--- a/tests/erc_4626/test_scan.py
+++ b/tests/erc_4626/test_scan.py
@@ -3,6 +3,7 @@
 import logging
 import os
 
+import flaky
 import hypersync
 import pytest
 from joblib import Parallel, delayed
@@ -31,6 +32,9 @@ def web3() -> Web3:
     return web3
 
 
+# CI flaky since 2026-07-22: a 145-second Hypersync scan omitted the expected
+# Staked EURA row, although the same fixed range succeeds on other runs.
+@flaky.flaky
 def test_4626_scan_hypersync(web3):
     """Read vaults of early Base chain"""
 

--- a/tests/erc_4626/vault_protocol/test_bulla.py
+++ b/tests/erc_4626/vault_protocol/test_bulla.py
@@ -53,6 +53,8 @@ def web3(anvil_arbitrum_fork: AnvilLaunch) -> Web3:
 
 
 @pytest.mark.skipif(JSON_RPC_ARBITRUM is None, reason="JSON_RPC_ARBITRUM needed to run this test")
+# CI flaky since 2026-07-22: Anvil could not create the fork at block
+# 486,151,800 when the selected RPC lacked archive state; later runs pass.
 @flaky.flaky
 def test_bulla_factoring_classification(web3: Web3) -> None:
     """Classify Bulla's TCS Settlement Pool without advertising transaction support."""

--- a/tests/erc_4626/vault_protocol/test_upshift.py
+++ b/tests/erc_4626/vault_protocol/test_upshift.py
@@ -207,6 +207,8 @@ def test_upshift_multi_asset_fee_units(web3: Web3) -> None:
     assert fee_data.performance == UPSHIFT_GAMMA_BTC_PERFORMANCE_FEE
 
 
+# CI flaky since 2026-07-22: a fixed-fork historical RPC read timed out; the
+# retry passed in the same CI run without a code change.
 @flaky.flaky
 def test_upshift_tori_historical_reader_7d_share_price(
     tmp_path: Path,

--- a/tests/gains/test_gtrade_usdc.py
+++ b/tests/gains/test_gtrade_usdc.py
@@ -6,7 +6,6 @@ from decimal import Decimal
 
 import flaky
 import pytest
-
 from web3 import Web3
 
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect, detect_vault_features
@@ -16,7 +15,7 @@ from eth_defi.erc_4626.vault_protocol.gains.testing import force_next_gains_epoc
 from eth_defi.erc_4626.vault_protocol.gains.vault import GainsHistoricalReader, GainsVault
 from eth_defi.event_reader.multicall_batcher import read_multicall_historical_stateful
 from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
-from eth_defi.token import TokenDetails, fetch_erc20_details, USDC_NATIVE_TOKEN
+from eth_defi.token import USDC_NATIVE_TOKEN, TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.historical import VaultHistoricalReadMulticaller
@@ -40,6 +39,9 @@ def test_gains_features(web3):
     assert ERC4626Feature.gains_like in features, f"Got features: {features}"
 
 
+# CI flaky since 2026-07-21: Anvil stopped answering web3_clientVersion and
+# exhausted six 60-second retries; it passes locally and now runs in slow CI.
+@flaky.flaky
 @pytest.mark.slow
 def test_gains_read_data(web3, vault: GainsVault):
     assert vault.name == "gTrade (Gains Network USDC)"
@@ -191,6 +193,8 @@ def test_gains_deposit_withdraw(
     assert shares == 0
 
 
+# CI flaky since 2026-07-22: the live Arbitrum historical multicall raised
+# MulticallNonRetryable; the same reader passed on later CI and local runs.
 @flaky.flaky
 def test_gains_historical_stateful(tmp_path):
     """Read historical data of gTrade USDC vault using the stateful multicall reader.

--- a/tests/guard/test_guard_simple_vault_ember.py
+++ b/tests/guard/test_guard_simple_vault_ember.py
@@ -3,6 +3,7 @@
 import os
 from decimal import Decimal
 
+import flaky
 import pytest
 from eth_typing import HexAddress, HexStr
 from web3 import Web3
@@ -61,6 +62,9 @@ def usdc(web3: Web3) -> TokenDetails:
     return fetch_erc20_details(web3, "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
 
 
+# CI flaky since 2026-07-22: Ember's processWithdrawalRequests(1) reverted on
+# the fixed GitHub fork; the unchanged withdrawal cycle passed locally.
+@flaky.flaky
 def test_guarded_ember_deposit_and_redemption_cycle(web3: Web3, ember_vault: EmberVault, usdc: TokenDetails) -> None:
     """Guard approves, deposits, queues redemption and accepts only Safe payout."""
     # 1. Deploy SimpleVaultV0 and whitelist the Ember call surface.

--- a/tests/lagoon/test_lagoon_erc_7540.py
+++ b/tests/lagoon/test_lagoon_erc_7540.py
@@ -4,6 +4,7 @@ import os
 from decimal import Decimal
 from typing import cast
 
+import flaky
 import pytest
 from eth_typing import HexAddress
 from web3 import Web3
@@ -12,13 +13,13 @@ from eth_defi.erc_4626.classification import create_vault_instance
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.flow import approve_and_deposit_4626, approve_and_redeem_4626
 from eth_defi.erc_4626.vault import ERC4626Vault
-from eth_defi.hotwallet import HotWallet
 from eth_defi.erc_4626.vault_protocol.lagoon.deployment import LagoonAutomatedDeployment, LagoonDeploymentParameters, deploy_automated_lagoon_vault
 from eth_defi.erc_4626.vault_protocol.lagoon.testing import force_lagoon_settle
 from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault, LagoonVersion
-from eth_defi.provider.anvil import mine, fork_network_anvil, AnvilLaunch
-from eth_defi.token import TokenDetails, USDC_NATIVE_TOKEN
-from eth_defi.trace import assert_transaction_success_with_explanation, TransactionAssertionError
+from eth_defi.hotwallet import HotWallet
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil, mine
+from eth_defi.token import USDC_NATIVE_TOKEN, TokenDetails
+from eth_defi.trace import TransactionAssertionError, assert_transaction_success_with_explanation
 
 JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
 
@@ -77,6 +78,9 @@ def erc_vault_7540(web3) -> LagoonVault:
     return lagoon_vault
 
 
+# CI flaky since 2026-07-22: Base archive verification timed out at block
+# 41,950,000 during Anvil setup; the fixed-fork test passes on other runs.
+@flaky.flaky
 def test_lagoon_erc_7540(
     web3: Web3,
     automated_lagoon_vault: LagoonAutomatedDeployment,
@@ -260,6 +264,9 @@ def test_lagoon_erc_7540(
         assert_transaction_success_with_explanation(web3, tx_hash, func=fn_call)
 
 
+# CI flaky since 2026-07-22: Base archive verification timed out at block
+# 41,950,000 during Anvil setup; the fixed-fork test passes on other runs.
+@flaky.flaky
 def test_lagoon_erc_7540_malicious_redemption(
     web3: Web3,
     automated_lagoon_vault: LagoonAutomatedDeployment,

--- a/tests/lifi/test_lifi_crosschain.py
+++ b/tests/lifi/test_lifi_crosschain.py
@@ -14,8 +14,8 @@ To run:
 import os
 from decimal import Decimal
 
+import flaky
 import pytest
-
 from eth_account import Account
 
 from eth_defi.hotwallet import HotWallet
@@ -29,7 +29,6 @@ from eth_defi.lifi.crosschain import (
 from eth_defi.lifi.quote import fetch_lifi_quote
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.token import USDC_NATIVE_TOKEN
-
 
 pytestmark = pytest.mark.skipif(
     not os.environ.get("JSON_RPC_ETHEREUM") or not os.environ.get("JSON_RPC_BASE"),
@@ -124,6 +123,9 @@ def test_fetch_crosschain_gas_balances(ethereum_web3, base_web3, wallet):
         assert balances_usd[chain_id] == Decimal("0")
 
 
+# CI flaky since 2026-07-21: the live li.quest request timed out after 30
+# seconds; the integration succeeds when the external API is responsive.
+@flaky.flaky
 def test_prepare_crosschain_swaps_native(ethereum_web3, base_web3, wallet):
     """Dry run: prepare cross-chain swaps using native ETH as source token.
 

--- a/tests/vault/test_pending_vault_flow_events.py
+++ b/tests/vault/test_pending_vault_flow_events.py
@@ -3,6 +3,7 @@
 import datetime
 import os
 
+import flaky
 import hypersync
 import pytest
 
@@ -48,6 +49,9 @@ def _create_hypersync_client(chain_id: int) -> hypersync.HypersyncClient:
 
 
 @pytest.mark.skipif(not JSON_RPC_BASE, reason="JSON_RPC_BASE needed")
+# CI flaky since 2026-07-22: Hypersync returned HTTP 400 for this fixed Base
+# range while adjacent Ember and Ostium flow queries succeeded.
+@flaky.flaky
 def test_lagoon_fetch_vault_flow_events_from_hypersync() -> None:
     """Fetch Lagoon ERC-7540 deposit and redemption request events.
 


### PR DESCRIPTION
## Why

Live RPC, Anvil fork, Hypersync and third-party API failures have produced false-negative CI results even when the unchanged focused tests pass locally or on retry. Existing flaky markers also lacked enough history to explain when and why they were introduced.

The repository needs a consistent escalation process that preserves coverage while distinguishing nondeterministic infrastructure failures from deterministic regressions.

## Lessons learnt

- A flaky marker needs dated provenance and a concrete symptom so future maintainers can determine whether it is still justified.
- Deterministic regressions must be fixed rather than hidden by retries.
- CI-only disabling is appropriate only after repeated CI failures, successful local reproduction checks and exhaustion of repository-controlled fixes.
- Tests disabled on CI must remain runnable locally and be periodically reconsidered.

## Summary

- Add flaky retries to eight observed nondeterministic integration tests covering CCTP, Ember, Lagoon ERC-7540, Hypersync, LiFi and Gains.
- Add dated symptom comments to all eleven affected tests, including the existing Bulla, Gains historical and Upshift flaky markers.
- Document the identify, mark flaky and CI-only disable escalation process in CLAUDE.md.
- Keep every affected test enabled because all eleven focused tests currently pass locally and no unresolved test meets the CI-disable threshold.

## Related issues and PRs

- Follow-up to #1346, where the recurring fork and RPC failures were observed while monitoring CI.

## Unrelated CI and test fixes

None.