### PR TITLE
fix: discover T3tris migration-pool vaults

### DIFF
--- a/eth_defi/erc_4626/core.py
+++ b/eth_defi/erc_4626/core.py
@@ -860,7 +860,9 @@ def is_activity_filter_exempt(detection: "ERC4262VaultDetection") -> bool:
     contracts. Upshift multi-asset vaults are another exception: older
     production metadata can be seeded or refreshed by address after the custom
     event support lands, and targeted price rescans should not be blocked by a
-    stale low deposit counter.
+    stale low deposit counter. T3tris migration-pool vaults are a third case:
+    the migration can initialise the vault without vault-local flow events,
+    while its T3tris configuration batch identifies the vault.
 
     :param detection:
         Shared vault detection envelope.
@@ -874,6 +876,7 @@ def is_activity_filter_exempt(detection: "ERC4262VaultDetection") -> bool:
         for feature in (
             ERC4626Feature.mellow_like,
             ERC4626Feature.upshift_multi_asset_like,
+            ERC4626Feature.t3tris_like,
         )
     )
 

--- a/eth_defi/erc_4626/core.py
+++ b/eth_defi/erc_4626/core.py
@@ -22,6 +22,10 @@ from eth_defi.vault.base import VaultSpec
 #: Low-activity vaults are skipped unless protocol-specific exemptions apply.
 MIN_PRICE_SCAN_DEPOSIT_COUNT = 5
 
+#: Minimum configuration events for a T3tris migration-pool vault to bypass
+#: :py:data:`MIN_PRICE_SCAN_DEPOSIT_COUNT`.
+MIN_PRICE_SCAN_CONFIGURATION_EVENT_COUNT = 1
+
 
 class ERC4626Feature(enum.Enum):
     """Additional extensionsERc-4626 vault may have.
@@ -860,9 +864,9 @@ def is_activity_filter_exempt(detection: "ERC4262VaultDetection") -> bool:
     contracts. Upshift multi-asset vaults are another exception: older
     production metadata can be seeded or refreshed by address after the custom
     event support lands, and targeted price rescans should not be blocked by a
-    stale low deposit counter. T3tris migration-pool vaults are a third case:
-    the migration can initialise the vault without vault-local flow events,
-    while its T3tris configuration batch identifies the vault.
+    stale low deposit counter. T3tris migration-pool vaults are handled
+    separately by :py:func:`passes_price_scan_activity_filter`, which requires
+    a recorded configuration event instead of broadly exempting the protocol.
 
     :param detection:
         Shared vault detection envelope.
@@ -876,9 +880,28 @@ def is_activity_filter_exempt(detection: "ERC4262VaultDetection") -> bool:
         for feature in (
             ERC4626Feature.mellow_like,
             ERC4626Feature.upshift_multi_asset_like,
-            ERC4626Feature.t3tris_like,
         )
     )
+
+
+def passes_price_scan_activity_filter(detection: "ERC4262VaultDetection", min_deposit_threshold: int) -> bool:
+    """Check whether a vault has enough activity for historical price scanning.
+
+    :param detection:
+        Shared vault detection envelope.
+
+    :param min_deposit_threshold:
+        Minimum number of vault-local deposit events for ordinary vaults.
+
+    :return:
+        ``True`` when the deposit threshold is met, the protocol has a known
+        alternative activity source, or a T3tris vault has at least one
+        configuration event.
+    """
+    if detection.deposit_count >= min_deposit_threshold or is_activity_filter_exempt(detection):
+        return True
+
+    return ERC4626Feature.t3tris_like in detection.features and getattr(detection, "configuration_count", 0) >= MIN_PRICE_SCAN_CONFIGURATION_EVENT_COUNT
 
 
 GENERIC_ERC4626_PROTOCOL_NAME = "ERC-4626"
@@ -1291,6 +1314,13 @@ class ERC4262VaultDetection:
     #:
     #: Zero for native protocols that do not support on-chain event tracking.
     redeem_count: int
+
+    #: Number of vault configuration events observed.
+    #:
+    #: Used by T3tris migration-pool vaults, which may never emit vault-local
+    #: deposit events. ``getattr`` access in activity filtering keeps old
+    #: persisted detections compatible after this slot was added.
+    configuration_count: int = 0
 
     def get_spec(self) -> VaultSpec:
         """Chain id/address tuple identifying this vault."""

--- a/eth_defi/erc_4626/core.py
+++ b/eth_defi/erc_4626/core.py
@@ -1322,6 +1322,24 @@ class ERC4262VaultDetection:
     #: persisted detections compatible after this slot was added.
     configuration_count: int = 0
 
+    def __setstate__(self, state: list[object] | tuple[object, ...]) -> None:
+        """Restore persisted detections created before configuration events were tracked.
+
+        Vault metadata databases store this slotted dataclass in pickle files.  Pickles
+        written before :attr:`configuration_count` was introduced contain one fewer
+        value, so populate the new slot with its backwards-compatible default while
+        restoring the existing fields.
+
+        :param state:
+            Pickled dataclass field values in declaration order.
+        """
+        fields = dataclasses.fields(self)
+        for field, value in zip(fields, state):
+            object.__setattr__(self, field.name, value)
+
+        if len(state) < len(fields):
+            object.__setattr__(self, "configuration_count", 0)
+
     def get_spec(self) -> VaultSpec:
         """Chain id/address tuple identifying this vault."""
         return VaultSpec(self.chain, self.address)

--- a/eth_defi/erc_4626/discovery_base.py
+++ b/eth_defi/erc_4626/discovery_base.py
@@ -8,7 +8,7 @@
 - Supports Royco tranche Redeem event
 - Supports Upshift multi-asset Deposit/WithdrawalRequested/WithdrawalProcessed events
 - Supports Atoma WithdrawalClaimed events
-- Supports T3tris DepositRequest/RedeemRequest events
+- Supports T3tris flow and vault-configuration events
 - Supports Securitize DSToken Issue events
 """
 
@@ -29,6 +29,7 @@ from eth_defi.compat import native_datetime_utc_now
 from eth_defi.erc_4626.classification import ODA_FACT_HARDCODED_LEADS, probe_vaults
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature, get_erc_4626_contract
 from eth_defi.erc_4626.vault_protocol.nara.constants import NARAUSD_PLUS_HARDCODED_LEADS
+from eth_defi.erc_4626.vault_protocol.t3tris.constants import T3TRIS_HARDCODED_LEADS
 from eth_defi.midas.constants import MIDAS_HARDCODED_LEADS
 from eth_defi.tokenised_fund.asseto.constants import ASSETO_HARDCODED_LEADS
 from eth_defi.tokenised_fund.centrifuge.constants import CENTRIFUGE_TRANCHE_HARDCODED_LEADS
@@ -75,6 +76,7 @@ DEFAULT_HARDCODED_VAULT_LEAD_SOURCES: HardcodedVaultLeadSources = (
     ("Sygnum", SYGNUM_HARDCODED_LEADS),
     ("Theo iToken", THEO_ITOKEN_HARDCODED_LEADS),
     ("Nara", NARAUSD_PLUS_HARDCODED_LEADS),
+    ("T3tris", T3TRIS_HARDCODED_LEADS),
 )
 
 if TYPE_CHECKING:
@@ -90,6 +92,9 @@ class VaultEventKind(enum.Enum):
     #: Withdraw-like event (ERC-4626 Withdraw or BrinkVault WithdrawFunds)
     withdraw = "withdraw"
 
+    #: Vault setup or administrative configuration event.
+    configuration = "configuration"
+
 
 @dataclasses.dataclass(slots=True, frozen=False)
 class PotentialVaultMatch:
@@ -101,6 +106,8 @@ class PotentialVaultMatch:
     first_seen_at: datetime.datetime
     deposit_count: int = 0
     withdrawal_count: int = 0
+    #: Protocol-specific vault configuration events.
+    configuration_count: int = 0
     #: Mellow ``Factory.Created`` metadata when this lead came from a Mellow
     #: factory event instead of vault-local deposit/withdraw events.
     #:
@@ -114,14 +121,15 @@ class PotentialVaultMatch:
         if getattr(self, "mellow_factory_candidate", None) is not None:
             return True
 
-        # Deposit-only event streams are valid vault leads.
+        # Deposit-only event streams and protocol-specific configuration events
+        # are valid vault leads.
         # Large curated vaults can have deposits but no withdrawals yet because
         # they are in a pre-deposit phase, have an initial lock-up, or use a
         # delayed withdrawal process. Requiring withdrawal events made us miss
         # RockawayX/Upshift vaults such as Tori Ecosystem Vault and Earn ctUSD.
-        # Extra deposit-only matches are still filtered by the later
+        # Extra event matches are still filtered by the later
         # ``probe_vaults()`` feature-detection stage before export.
-        return self.deposit_count > 0
+        return self.deposit_count > 0 or getattr(self, "configuration_count", 0) > 0
 
 
 def get_brink_vault_contract(web3):
@@ -406,6 +414,23 @@ def get_t3tris_vault_discovery_events(web3) -> list[type[ContractEvent]]:
     ]
 
 
+def get_t3tris_vault_configuration_discovery_events(web3) -> list[type[ContractEvent]]:
+    """Get T3tris vault configuration events that can seed a lead.
+
+    ``T3treasuryUpdated`` is emitted by the reviewed T3tris migration-pool
+    deployment. Its T3tris-specific name makes it a narrower lead signal than
+    generic administration events. The normal feature probes still confirm
+    that the emitting contract is a T3tris vault.
+
+    :return:
+        T3tris vault-local configuration event types usable for discovery.
+    """
+    t3tris_vault_events = get_t3tris_vault_event_contract(web3)
+    return [
+        t3tris_vault_events.events.T3treasuryUpdated,
+    ]
+
+
 def get_securitize_dstoken_discovery_events(web3) -> list[Type[ContractEvent]]:
     """Get Securitize DSToken issuance events used for lead discovery.
 
@@ -448,7 +473,7 @@ def get_vault_discovery_events(web3) -> list[Type[ContractEvent]]:
     - Royco tranche Redeem event
     - Upshift multi-asset Deposit/WithdrawalRequested/WithdrawalProcessed events
     - Atoma WithdrawalClaimed event
-    - T3tris DepositRequest/RedeemRequest events
+    - T3tris DepositRequest/RedeemRequest and configuration events
     - Securitize DSToken Issue event
 
     :return:
@@ -461,9 +486,10 @@ def get_vault_discovery_events(web3) -> list[Type[ContractEvent]]:
          UpshiftMultiAsset.WithdrawalProcessed,
          AtomaVault.WithdrawalClaimed,
          T3trisVault.DepositRequest, T3trisVault.RedeemRequest,
+         T3trisVault.<configuration events>,
          SecuritizeDSToken.Issue]
     """
-    return get_standard_erc_4626_vault_discovery_events(web3) + get_brink_vault_discovery_events(web3) + get_ember_vault_discovery_events(web3) + get_token_gateway_discovery_events(web3) + get_royco_tranche_discovery_events(web3) + get_upshift_multi_asset_discovery_events(web3) + get_atoma_vault_discovery_events(web3) + get_t3tris_vault_discovery_events(web3) + get_securitize_dstoken_discovery_events(web3)
+    return get_standard_erc_4626_vault_discovery_events(web3) + get_brink_vault_discovery_events(web3) + get_ember_vault_discovery_events(web3) + get_token_gateway_discovery_events(web3) + get_royco_tranche_discovery_events(web3) + get_upshift_multi_asset_discovery_events(web3) + get_atoma_vault_discovery_events(web3) + get_t3tris_vault_discovery_events(web3) + get_t3tris_vault_configuration_discovery_events(web3) + get_securitize_dstoken_discovery_events(web3)
 
 
 def get_vault_event_topic_map(web3) -> dict[str, VaultEventKind]:
@@ -476,6 +502,7 @@ def get_vault_event_topic_map(web3) -> dict[str, VaultEventKind]:
     """
     from eth_defi.abi import get_topic_signature_from_event
 
+    t3tris_configuration_events = get_t3tris_vault_configuration_discovery_events(web3)
     event_groups = (
         (get_standard_erc_4626_vault_discovery_events(web3), (VaultEventKind.deposit, VaultEventKind.withdraw)),
         (get_brink_vault_discovery_events(web3), (VaultEventKind.deposit, VaultEventKind.withdraw)),
@@ -485,6 +512,7 @@ def get_vault_event_topic_map(web3) -> dict[str, VaultEventKind]:
         (get_upshift_multi_asset_discovery_events(web3), (VaultEventKind.deposit, VaultEventKind.withdraw, VaultEventKind.withdraw)),
         (get_atoma_vault_discovery_events(web3), (VaultEventKind.withdraw,)),
         (get_t3tris_vault_discovery_events(web3), (VaultEventKind.deposit, VaultEventKind.withdraw)),
+        (t3tris_configuration_events, (VaultEventKind.configuration,) * len(t3tris_configuration_events)),
         (get_securitize_dstoken_discovery_events(web3), (VaultEventKind.deposit,)),
     )
     return {get_topic_signature_from_event(event): event_kind for events, event_kinds in event_groups for event, event_kind in zip(events, event_kinds, strict=True)}
@@ -498,6 +526,11 @@ def is_deposit_event(event_kind: VaultEventKind) -> bool:
 def is_withdraw_event(event_kind: VaultEventKind) -> bool:
     """Check if the event kind represents a withdrawal."""
     return event_kind == VaultEventKind.withdraw
+
+
+def is_configuration_event(event_kind: VaultEventKind) -> bool:
+    """Check if an event kind is vault configuration."""
+    return event_kind == VaultEventKind.configuration
 
 
 @dataclass(slots=True)

--- a/eth_defi/erc_4626/discovery_base.py
+++ b/eth_defi/erc_4626/discovery_base.py
@@ -721,6 +721,9 @@ class VaultDiscoveryBase(abc.ABC):
                     first_seen_at=first_seen_at,
                     deposit_count=0,
                     withdrawal_count=0,
+                    # Reviewed migration-pool deployments have a verified
+                    # T3tris configuration event but no vault-local flow log.
+                    configuration_count=1 if protocol_name == "T3tris" else 0,
                 )
                 report.new_leads += 1
                 logger.info("Added hardcoded %s vault lead %s", protocol_name, address)
@@ -804,6 +807,7 @@ class VaultDiscoveryBase(abc.ABC):
                 updated_at=native_datetime_utc_now(),
                 deposit_count=lead.deposit_count,
                 redeem_count=lead.withdrawal_count,
+                configuration_count=getattr(lead, "configuration_count", 0),
             )
             report.detections[feature_probe.address] = detection
 

--- a/eth_defi/erc_4626/hypersync_discovery.py
+++ b/eth_defi/erc_4626/hypersync_discovery.py
@@ -18,7 +18,7 @@ from web3 import Web3
 from eth_defi.abi import get_topic_signature_from_event
 from eth_defi.chain import get_chain_name
 from eth_defi.compat import native_datetime_utc_fromtimestamp
-from eth_defi.erc_4626.discovery_base import HardcodedVaultLeadSources, LeadScanReport, PotentialVaultMatch, VaultDiscoveryBase, add_mellow_factory_candidate_lead, get_vault_discovery_events, get_vault_event_topic_map, is_deposit_event
+from eth_defi.erc_4626.discovery_base import HardcodedVaultLeadSources, LeadScanReport, PotentialVaultMatch, VaultDiscoveryBase, add_mellow_factory_candidate_lead, get_vault_discovery_events, get_vault_event_topic_map, is_configuration_event, is_deposit_event
 from eth_defi.event_reader.web3factory import Web3Factory
 from eth_defi.hypersync.hypersync_timestamp import HypersyncFlaky, get_hypersync_block_height_with_retries, is_hypersync_next_block_range_error, is_hypersync_rate_limit_error, is_hypersync_retryable_runtime_error
 from eth_defi.mellow.discovery import create_mellow_factory_candidate, fetch_mellow_created_event_topic, fetch_mellow_factories_for_chain, is_mellow_factory_log
@@ -269,6 +269,8 @@ class HypersyncVaultDiscover(VaultDiscoveryBase):
         if event_kind is not None and is_deposit_event(event_kind):
             lead.deposit_count += 1
             report.deposits += 1
+        elif event_kind is not None and is_configuration_event(event_kind):
+            lead.configuration_count = getattr(lead, "configuration_count", 0) + 1
         else:
             lead.withdrawal_count += 1
             report.withdrawals += 1

--- a/eth_defi/erc_4626/rpc_discovery.py
+++ b/eth_defi/erc_4626/rpc_discovery.py
@@ -21,6 +21,7 @@ from eth_defi.erc_4626.discovery_base import (
     add_mellow_factory_candidate_lead,
     get_vault_discovery_events,
     get_vault_event_topic_map,
+    is_configuration_event,
     is_deposit_event,
 )
 from eth_defi.event_reader.filter import Filter
@@ -74,7 +75,7 @@ class JSONRPCVaultDiscover(VaultDiscoveryBase):
         """Create a read_events_concurrent arguments to discover new vaults.
 
         Includes standard ERC-4626 events and all configured protocol-specific
-        vault flow events.
+        vault flow and configuration events.
 
         See :py:func:`eth_defi.event_reader.reader.read_events_concurrent`
         """
@@ -255,6 +256,8 @@ class JSONRPCVaultDiscover(VaultDiscoveryBase):
             if event_kind is not None and is_deposit_event(event_kind):
                 lead.deposit_count += 1
                 report.deposits += 1
+            elif event_kind is not None and is_configuration_event(event_kind):
+                lead.configuration_count = getattr(lead, "configuration_count", 0) + 1
             else:
                 lead.withdrawal_count += 1
                 report.withdrawals += 1

--- a/eth_defi/erc_4626/settlement_scan.py
+++ b/eth_defi/erc_4626/settlement_scan.py
@@ -20,7 +20,7 @@ from web3.datastructures import AttributeDict
 from web3.exceptions import Web3Exception
 
 from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS, create_vault_instance
-from eth_defi.erc_4626.core import MIN_PRICE_SCAN_DEPOSIT_COUNT, ERC4626Feature, is_activity_filter_exempt
+from eth_defi.erc_4626.core import MIN_PRICE_SCAN_DEPOSIT_COUNT, ERC4626Feature, passes_price_scan_activity_filter
 from eth_defi.erc_4626.settlement_events import (
     fetch_vault_settlement_logs_for_addresses,
     normalise_log_topic,
@@ -721,7 +721,7 @@ def _is_price_scan_candidate(row: VaultRow) -> bool:
     """
     detection = row["_detection_data"]
     address = str(detection.address).lower()
-    return int(detection.deposit_count) >= MIN_PRICE_SCAN_DEPOSIT_COUNT or address in HARDCODED_PROTOCOLS or is_activity_filter_exempt(detection)
+    return address in HARDCODED_PROTOCOLS or passes_price_scan_activity_filter(detection, MIN_PRICE_SCAN_DEPOSIT_COUNT)
 
 
 def _prepare_settlement_vault(

--- a/eth_defi/erc_4626/vault_protocol/t3tris/constants.py
+++ b/eth_defi/erc_4626/vault_protocol/t3tris/constants.py
@@ -1,0 +1,30 @@
+"""Reviewed T3tris vault discovery constants."""
+
+import datetime
+
+from eth_typing import HexAddress
+
+#: Arbitrum One chain id.
+ARBITRUM_CHAIN_ID = 42161
+
+#: Strada Yield T3tris vault on Arbitrum.
+#:
+#: The T3tris migration-pool setup did not emit vault-local deposit, withdrawal,
+#: or request-flow events. Retain this deployment as an explicit discovery lead.
+STRADA_YIELD_ARBITRUM_ADDRESS = HexAddress("0x5684b18275c0830dafb0b3cff595ba1beca926bd")
+
+#: Block that deployed and initialised :py:data:`STRADA_YIELD_ARBITRUM_ADDRESS`.
+STRADA_YIELD_ARBITRUM_FIRST_SEEN_AT_BLOCK = 483_858_363
+
+#: Deployment block timestamp as a naive UTC datetime.
+STRADA_YIELD_ARBITRUM_FIRST_SEEN_AT = datetime.datetime(2026, 7, 14, 18, 57, 55, tzinfo=datetime.UTC).replace(tzinfo=None)
+
+#: T3tris deployments that must be retained even without vault-local flow logs.
+T3TRIS_HARDCODED_LEADS = (
+    (
+        ARBITRUM_CHAIN_ID,
+        STRADA_YIELD_ARBITRUM_ADDRESS,
+        STRADA_YIELD_ARBITRUM_FIRST_SEEN_AT_BLOCK,
+        STRADA_YIELD_ARBITRUM_FIRST_SEEN_AT,
+    ),
+)

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -47,7 +47,7 @@ from eth_defi.currency_api.constants import (
 )
 from eth_defi.currency_api.scanner import run_incremental_scan as currency_run_incremental_scan
 from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS, create_vault_instance
-from eth_defi.erc_4626.core import MIN_PRICE_SCAN_DEPOSIT_COUNT, is_activity_filter_exempt
+from eth_defi.erc_4626.core import MIN_PRICE_SCAN_DEPOSIT_COUNT, passes_price_scan_activity_filter
 from eth_defi.erc_4626.lead_scan_core import scan_leads
 from eth_defi.erc_4626.settlement_scan import (
     fetch_and_store_vault_settlements_for_chain,
@@ -594,11 +594,11 @@ def scan_prices_for_chain(
         for row in chain_vaults:
             detection = row["_detection_data"]
 
-            # Skip vaults with low activity (but keep hardcoded protocol vaults
-            # and Mellow factory-discovered vaults). Mellow stores zero counts
-            # because the canonical Vault does not emit user flow events; those
-            # live on queue contracts and need a later second-stage scan.
-            if detection.deposit_count < min_deposit_threshold and detection.address.lower() not in HARDCODED_PROTOCOLS and not is_activity_filter_exempt(detection):
+            # Skip vaults with low activity while retaining hardcoded protocol
+            # vaults and protocol-specific alternative evidence. Mellow stores
+            # zero counts because its canonical Vault does not emit user flows;
+            # T3tris migration pools use a reviewed configuration event.
+            if detection.address.lower() not in HARDCODED_PROTOCOLS and not passes_price_scan_activity_filter(detection, min_deposit_threshold):
                 continue
 
             vault = create_vault_instance(web3, detection.address, detection.features, token_cache=token_cache)

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -343,7 +343,9 @@ poetry run python scripts/erc-4626/scan-prices.py
 Targeted repair script for all supported EVM T3tris vaults returned by the
 official T3tris API. The script has a baked API snapshot as a fallback, so
 operators can review the current vault address list in the script even if the
-API is temporarily unavailable.
+API is temporarily unavailable. It also always retains the reviewed migration
+registry, including Strada Yield, because these vaults can be absent from the
+frontend API and do not have vault-local flow events for discovery.
 
 This follows the [required protocol-specific lead migrations](#required-protocol-specific-lead-migrations)
 for adding T3tris vaults to an existing production database after protocol
@@ -364,7 +366,7 @@ source .local-test.env && poetry run python scripts/erc-4626/fix-t3tris-vaults.p
 |----------|-------------|
 | `DRY_RUN` | Optional. Show planned work without writing metadata or prices. Default: false. |
 | `T3TRIS_FETCH_API` | Optional. Fetch the live T3tris API and prefer it over the baked snapshot. Default: true. |
-| `T3TRIS_VERIFIED_ONLY` | Optional. Process only API-verified vaults. Default: false. |
+| `T3TRIS_VERIFIED_ONLY` | Optional. Process only API-verified vaults, while retaining reviewed migration vaults. Default: false. |
 | `T3TRIS_SCAN_PRICES` | Optional. Set to `false` to update only leads and metadata. Default: true. |
 | `T3TRIS_REWRITE_TARGETED` | Optional. Rescan every selected T3tris vault from its first known API block and rewrite only that vault's rows. Default: false. |
 | `T3TRIS_REFRESH_EXISTING_METADATA` | Optional. Refresh existing good metadata rows as well as missing or broken rows. Default: false. |

--- a/scripts/erc-4626/fix-t3tris-vaults.py
+++ b/scripts/erc-4626/fix-t3tris-vaults.py
@@ -94,6 +94,7 @@ from eth_defi.erc_4626.classification import create_vault_instance, detect_vault
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
 from eth_defi.erc_4626.discovery_base import PotentialVaultMatch
 from eth_defi.erc_4626.scan import create_vault_scan_record
+from eth_defi.erc_4626.vault_protocol.t3tris.constants import T3TRIS_HARDCODED_LEADS
 from eth_defi.hypersync.utils import configure_hypersync_from_env
 from eth_defi.provider.env import get_json_rpc_env
 from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
@@ -308,19 +309,68 @@ def fetch_t3tris_vaults(timeout: float = 30.0) -> list[T3trisVaultReference]:
     return parse_t3tris_payload(payload)
 
 
+def get_reviewed_t3tris_migration_references() -> list[T3trisVaultReference]:
+    """Get T3tris vaults that must be repaired even if absent from the API.
+
+    These migration-pool vaults do not emit vault-local flow events and can be
+    removed from the frontend API after migration. Keep their reviewed
+    deployment information in the scanner registry and always merge it into
+    the repair set.
+
+    :return:
+        Reviewed T3tris migration references.
+    """
+    return [
+        T3trisVaultReference(
+            chain_id=chain_id,
+            address=address,
+            name="Strada Yield",
+            first_seen_at_block=first_seen_at_block,
+            first_seen_at=first_seen_at,
+            curator_name=None,
+            verified=None,
+        )
+        for chain_id, address, first_seen_at_block, first_seen_at in T3TRIS_HARDCODED_LEADS
+    ]
+
+
+def is_reviewed_t3tris_migration_reference(ref: T3trisVaultReference) -> bool:
+    """Check whether a vault has reviewed migration-pool event evidence."""
+    return ref.get_spec() in {migration_ref.get_spec() for migration_ref in get_reviewed_t3tris_migration_references()}
+
+
+def merge_t3tris_vault_references(*reference_sets: list[T3trisVaultReference]) -> list[T3trisVaultReference]:
+    """Merge T3tris vault lists by canonical address, preferring later data.
+
+    :param reference_sets:
+        Reference lists in increasing priority order. The live API is passed
+        last so it can refresh metadata without dropping reviewed migrations.
+
+    :return:
+        De-duplicated T3tris vault references sorted by chain and address.
+    """
+    references = {}
+    for refs in reference_sets:
+        references.update({ref.get_spec(): ref for ref in refs})
+    return sorted(references.values(), key=lambda ref: (ref.chain_id, ref.address.lower()))
+
+
 def load_t3tris_vault_references() -> list[T3trisVaultReference]:
-    """Load live T3tris API vaults, falling back to the baked snapshot."""
+    """Load live T3tris API vaults with reviewed migration and snapshot fallbacks."""
     snapshot_refs = parse_t3tris_payload(json.loads(T3TRIS_VAULT_SNAPSHOT_JSON))
+    reviewed_refs = get_reviewed_t3tris_migration_references()
 
     if not parse_bool_env("T3TRIS_FETCH_API", default=True):
-        logger.info("Using baked T3tris API snapshot with %d vaults", len(snapshot_refs))
-        return snapshot_refs
+        refs = merge_t3tris_vault_references(snapshot_refs, reviewed_refs)
+        logger.info("Using baked T3tris API snapshot and reviewed registry with %d vaults", len(refs))
+        return refs
 
     try:
         live_refs = fetch_t3tris_vaults()
     except (HTTPError, URLError, TimeoutError, ValueError, json.JSONDecodeError, OSError) as e:
-        logger.warning("Could not fetch T3tris API, using baked snapshot: %s", e)
-        return snapshot_refs
+        refs = merge_t3tris_vault_references(snapshot_refs, reviewed_refs)
+        logger.warning("Could not fetch T3tris API, using baked snapshot and reviewed registry: %s", e)
+        return refs
 
     snapshot_specs = {ref.get_spec() for ref in snapshot_refs}
     live_specs = {ref.get_spec() for ref in live_refs}
@@ -331,15 +381,18 @@ def load_t3tris_vault_references() -> list[T3trisVaultReference]:
     if removed_specs:
         logger.warning("Baked T3tris snapshot has %d vaults no longer returned by the API", len(removed_specs))
 
-    logger.info("Fetched %d T3tris vaults from the live API", len(live_refs))
-    return live_refs
+    refs = merge_t3tris_vault_references(snapshot_refs, reviewed_refs, live_refs)
+    logger.info("Fetched %d T3tris vaults from the live API; repairing %d total reviewed, snapshot and API vaults", len(live_refs), len(refs))
+    return refs
 
 
 def filter_references(refs: list[T3trisVaultReference]) -> list[T3trisVaultReference]:
     """Apply operator filters."""
     if not parse_bool_env("T3TRIS_VERIFIED_ONLY", default=False):
         return refs
-    return [ref for ref in refs if ref.verified is True]
+
+    reviewed_specs = {ref.get_spec() for ref in get_reviewed_t3tris_migration_references()}
+    return [ref for ref in refs if ref.verified is True or ref.get_spec() in reviewed_specs]
 
 
 def get_rpc_env_candidates(chain_id: int) -> list[str]:
@@ -442,16 +495,17 @@ def upsert_lead(vault_db: VaultDatabase, ref: T3trisVaultReference) -> bool:
     """Upsert one API-listed T3tris vault into the lead map."""
     spec = ref.get_spec()
     existing = vault_db.leads.get(spec)
+    is_reviewed_migration = is_reviewed_t3tris_migration_reference(ref)
     lead = PotentialVaultMatch(
         chain=ref.chain_id,
         address=HexAddress(ref.address.lower()),
         first_seen_at_block=max(1, ref.first_seen_at_block),
         first_seen_at=getattr(existing, "first_seen_at", ref.first_seen_at) if existing else ref.first_seen_at,
-        # API-seeded leads did not come from a historical flow-event count.
-        # Keep non-zero deposit count so legacy candidate filters treat the
-        # operator-curated API list as intentional input.
-        deposit_count=max(getattr(existing, "deposit_count", 0) if existing else 0, 1),
+        # Migration-pool vaults have no vault-local deposit events. Their
+        # reviewed configuration event is the alternative lead threshold.
+        deposit_count=0 if is_reviewed_migration else getattr(existing, "deposit_count", 0) if existing else 0,
         withdrawal_count=getattr(existing, "withdrawal_count", 0) if existing else 0,
+        configuration_count=max(getattr(existing, "configuration_count", 0) if existing else 0, 1) if is_reviewed_migration else getattr(existing, "configuration_count", 0) if existing else 0,
     )
     vault_db.leads[spec] = lead
     return existing is None
@@ -466,11 +520,11 @@ def create_detection(ref: T3trisVaultReference, features: set[ERC4626Feature], u
         first_seen_at=ref.first_seen_at,
         features=features,
         updated_at=updated_at,
-        # API-seeded metadata does not have historical event counts. Use the
-        # minimum production threshold so targeted and future price scans do not
-        # discard known API vaults before feature-based protocol routing runs.
-        deposit_count=5,
+        # Migration-pool vaults qualify via one reviewed configuration event,
+        # not an invented deposit count.
+        deposit_count=0 if is_reviewed_t3tris_migration_reference(ref) else 5,
         redeem_count=0,
+        configuration_count=1 if is_reviewed_t3tris_migration_reference(ref) else 0,
     )
 
 

--- a/scripts/erc-4626/poke-hyperevm-vault-calls.py
+++ b/scripts/erc-4626/poke-hyperevm-vault-calls.py
@@ -55,7 +55,7 @@ from web3 import Web3
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS, create_vault_instance
-from eth_defi.erc_4626.core import ERC4262VaultDetection, get_vault_protocol_name, is_activity_filter_exempt
+from eth_defi.erc_4626.core import ERC4262VaultDetection, get_vault_protocol_name, passes_price_scan_activity_filter
 from eth_defi.event_reader.fast_json_rpc import get_last_headers
 from eth_defi.event_reader.multicall_batcher import EncodedCall
 from eth_defi.provider.env import read_json_rpc_url
@@ -353,7 +353,7 @@ def get_hyperevm_vault_rows(vault_db: VaultDatabase, min_deposit_threshold: int)
 
         address = detection.address.lower()
         if min_deposit_threshold > 0:
-            if detection.deposit_count < min_deposit_threshold and address not in HARDCODED_PROTOCOLS and not is_activity_filter_exempt(detection):
+            if address not in HARDCODED_PROTOCOLS and not passes_price_scan_activity_filter(detection, min_deposit_threshold):
                 continue
 
         selected.append((spec, row))

--- a/scripts/erc-4626/scan-prices.py
+++ b/scripts/erc-4626/scan-prices.py
@@ -102,7 +102,7 @@ except ImportError as e:
 
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS, create_vault_instance
-from eth_defi.erc_4626.core import ERC4262VaultDetection, is_activity_filter_exempt
+from eth_defi.erc_4626.core import ERC4262VaultDetection, passes_price_scan_activity_filter
 from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
 from eth_defi.provider.rpcdb import RPCRequestStats, RPCUsageDatabase, format_rpc_usage_report, resolve_rpc_tracking_database_path
 from eth_defi.token import TokenDiskCache
@@ -226,7 +226,7 @@ def _run_scan(stats: RPCRequestStats, metrics: dict) -> None:
         # flow events live on DepositQueue/RedeemQueue contracts. The metadata
         # database stores zero counts for compatibility, so use the central
         # feature-based exemption instead of looking at count field names.
-        if detection.deposit_count < min_deposit_threshold and address.lower() not in HARDCODED_PROTOCOLS and not is_activity_filter_exempt(detection):
+        if address.lower() not in HARDCODED_PROTOCOLS and not passes_price_scan_activity_filter(detection, min_deposit_threshold):
             # print(f"Vault does not have enough deposits: {address}, has: {detection.deposit_count}, threshold {min_deposit_threshold}")
             continue
 

--- a/tests/erc_4626/test_t3tris_events.py
+++ b/tests/erc_4626/test_t3tris_events.py
@@ -1,0 +1,94 @@
+"""Test T3tris migration-pool lead discovery."""
+
+import datetime
+from collections.abc import Iterator
+from types import SimpleNamespace
+
+import pytest
+from web3 import Web3
+
+from eth_defi.abi import get_topic_signature_from_event
+from eth_defi.erc_4626 import discovery_base as discovery_base_module
+from eth_defi.erc_4626.classification import VaultFeatureProbe
+from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature, is_activity_filter_exempt
+from eth_defi.erc_4626.discovery_base import DEFAULT_HARDCODED_VAULT_LEAD_SOURCES, LeadScanReport, PotentialVaultMatch, VaultDiscoveryBase, VaultEventKind, get_t3tris_vault_configuration_discovery_events, get_vault_discovery_events, get_vault_event_topic_map
+from eth_defi.erc_4626.vault_protocol.t3tris.constants import ARBITRUM_CHAIN_ID, STRADA_YIELD_ARBITRUM_ADDRESS, STRADA_YIELD_ARBITRUM_FIRST_SEEN_AT, STRADA_YIELD_ARBITRUM_FIRST_SEEN_AT_BLOCK, T3TRIS_HARDCODED_LEADS
+
+
+class DummyT3trisDiscovery(VaultDiscoveryBase):
+    """Minimal backend for testing the configured T3tris migration lead."""
+
+    web3 = SimpleNamespace(eth=SimpleNamespace(chain_id=ARBITRUM_CHAIN_ID))
+    web3factory = object()
+
+    def fetch_leads(self, _start_block: int, _end_block: int, _display_progress: bool = True) -> LeadScanReport:
+        """Return no event-derived leads so the registry injection is isolated."""
+        return LeadScanReport()
+
+
+def test_t3tris_configuration_topics_seed_discovery_candidates() -> None:
+    """Treat T3tris setup events as candidate leads when migration skips flows."""
+    web3 = Web3()
+    configuration_events = get_t3tris_vault_configuration_discovery_events(web3)
+    topic_map = get_vault_event_topic_map(web3)
+    all_topics = {get_topic_signature_from_event(event) for event in get_vault_discovery_events(web3)}
+
+    configuration_topics = {get_topic_signature_from_event(event) for event in configuration_events}
+    assert [event.event_name for event in configuration_events] == ["T3treasuryUpdated"]
+    assert configuration_topics <= all_topics
+    assert all(topic_map[topic] == VaultEventKind.configuration for topic in configuration_topics)
+
+    lead = PotentialVaultMatch(
+        chain=ARBITRUM_CHAIN_ID,
+        address=STRADA_YIELD_ARBITRUM_ADDRESS,
+        first_seen_at_block=STRADA_YIELD_ARBITRUM_FIRST_SEEN_AT_BLOCK,
+        first_seen_at=STRADA_YIELD_ARBITRUM_FIRST_SEEN_AT,
+        configuration_count=1,
+    )
+    assert lead.is_candidate()
+
+
+def test_t3tris_strada_yield_is_a_hardcoded_lead(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retain the known migration-pool vault without relying on activity logs."""
+
+    def fake_probe_vaults(chain: int, web3factory: object, addresses: list[str], **kwargs: object) -> Iterator[VaultFeatureProbe]:
+        """Yield the expected T3tris feature for the reviewed lead."""
+        assert chain == ARBITRUM_CHAIN_ID
+        assert web3factory is DummyT3trisDiscovery.web3factory
+        assert addresses == [STRADA_YIELD_ARBITRUM_ADDRESS]
+        yield VaultFeatureProbe(address=STRADA_YIELD_ARBITRUM_ADDRESS, features={ERC4626Feature.t3tris_like})
+
+    assert ("T3tris", T3TRIS_HARDCODED_LEADS) in DEFAULT_HARDCODED_VAULT_LEAD_SOURCES
+    assert T3TRIS_HARDCODED_LEADS == (
+        (
+            ARBITRUM_CHAIN_ID,
+            STRADA_YIELD_ARBITRUM_ADDRESS,
+            STRADA_YIELD_ARBITRUM_FIRST_SEEN_AT_BLOCK,
+            datetime.datetime(2026, 7, 14, 18, 57, 55, tzinfo=datetime.UTC).replace(tzinfo=None),
+        ),
+    )
+    monkeypatch.setattr(discovery_base_module, "probe_vaults", fake_probe_vaults)
+    report = DummyT3trisDiscovery(max_workers=1).scan_vaults(
+        0,
+        STRADA_YIELD_ARBITRUM_FIRST_SEEN_AT_BLOCK,
+        display_progress=False,
+        hardcoded_lead_sources=(("T3tris", T3TRIS_HARDCODED_LEADS),),
+    )
+    assert report.new_leads == 1
+    assert report.detections[STRADA_YIELD_ARBITRUM_ADDRESS].features == {ERC4626Feature.t3tris_like}
+
+
+def test_t3tris_migration_lead_is_not_dropped_for_missing_flow_events() -> None:
+    """Keep migrated T3tris vaults eligible for historical price scanning."""
+    detection = ERC4262VaultDetection(
+        chain=ARBITRUM_CHAIN_ID,
+        address=STRADA_YIELD_ARBITRUM_ADDRESS,
+        features={ERC4626Feature.t3tris_like},
+        first_seen_at_block=STRADA_YIELD_ARBITRUM_FIRST_SEEN_AT_BLOCK,
+        first_seen_at=STRADA_YIELD_ARBITRUM_FIRST_SEEN_AT,
+        updated_at=STRADA_YIELD_ARBITRUM_FIRST_SEEN_AT,
+        deposit_count=0,
+        redeem_count=0,
+    )
+
+    assert is_activity_filter_exempt(detection)

--- a/tests/erc_4626/test_t3tris_events.py
+++ b/tests/erc_4626/test_t3tris_events.py
@@ -1,5 +1,6 @@
 """Test T3tris migration-pool lead discovery."""
 
+import dataclasses
 import datetime
 from collections.abc import Iterator
 from types import SimpleNamespace
@@ -10,7 +11,7 @@ from web3 import Web3
 from eth_defi.abi import get_topic_signature_from_event
 from eth_defi.erc_4626 import discovery_base as discovery_base_module
 from eth_defi.erc_4626.classification import VaultFeatureProbe
-from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature, is_activity_filter_exempt
+from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature, is_activity_filter_exempt, passes_price_scan_activity_filter
 from eth_defi.erc_4626.discovery_base import DEFAULT_HARDCODED_VAULT_LEAD_SOURCES, LeadScanReport, PotentialVaultMatch, VaultDiscoveryBase, VaultEventKind, get_t3tris_vault_configuration_discovery_events, get_vault_discovery_events, get_vault_event_topic_map
 from eth_defi.erc_4626.vault_protocol.t3tris.constants import ARBITRUM_CHAIN_ID, STRADA_YIELD_ARBITRUM_ADDRESS, STRADA_YIELD_ARBITRUM_FIRST_SEEN_AT, STRADA_YIELD_ARBITRUM_FIRST_SEEN_AT_BLOCK, T3TRIS_HARDCODED_LEADS
 
@@ -76,10 +77,11 @@ def test_t3tris_strada_yield_is_a_hardcoded_lead(monkeypatch: pytest.MonkeyPatch
     )
     assert report.new_leads == 1
     assert report.detections[STRADA_YIELD_ARBITRUM_ADDRESS].features == {ERC4626Feature.t3tris_like}
+    assert report.detections[STRADA_YIELD_ARBITRUM_ADDRESS].configuration_count == 1
 
 
-def test_t3tris_migration_lead_is_not_dropped_for_missing_flow_events() -> None:
-    """Keep migrated T3tris vaults eligible for historical price scanning."""
+def test_t3tris_migration_lead_needs_configuration_event_for_missing_flow_events() -> None:
+    """Allow zero deposits only after a T3tris configuration event was recorded."""
     detection = ERC4262VaultDetection(
         chain=ARBITRUM_CHAIN_ID,
         address=STRADA_YIELD_ARBITRUM_ADDRESS,
@@ -89,6 +91,11 @@ def test_t3tris_migration_lead_is_not_dropped_for_missing_flow_events() -> None:
         updated_at=STRADA_YIELD_ARBITRUM_FIRST_SEEN_AT,
         deposit_count=0,
         redeem_count=0,
+        configuration_count=1,
     )
 
-    assert is_activity_filter_exempt(detection)
+    assert is_activity_filter_exempt(detection) is False
+    assert passes_price_scan_activity_filter(detection, min_deposit_threshold=5) is True
+
+    missing_configuration = dataclasses.replace(detection, configuration_count=0)
+    assert passes_price_scan_activity_filter(missing_configuration, min_deposit_threshold=5) is False

--- a/tests/erc_4626/vault_protocol/test_t3tris_repair_script.py
+++ b/tests/erc_4626/vault_protocol/test_t3tris_repair_script.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from eth_typing import HexAddress
 
+from eth_defi.erc_4626.vault_protocol.t3tris.constants import STRADA_YIELD_ARBITRUM_ADDRESS, STRADA_YIELD_ARBITRUM_FIRST_SEEN_AT_BLOCK
 from eth_defi.vault.vaultdb import VaultDatabase
 
 SCRIPT_PATH = Path(__file__).resolve().parents[3] / "scripts" / "erc-4626" / "fix-t3tris-vaults.py"
@@ -80,3 +81,41 @@ def test_t3tris_repair_preserves_existing_row_with_matching_curator() -> None:
     }
 
     assert not module.should_refresh_metadata(vault_db, ref)
+
+
+def test_t3tris_repair_keeps_reviewed_migration_vault_when_api_omits_it(monkeypatch) -> None:
+    """A migrated vault must remain repairable after the frontend API omits it."""
+    module = _load_fix_t3tris_module()
+    monkeypatch.setattr(module, "fetch_t3tris_vaults", lambda: [])
+
+    refs = module.load_t3tris_vault_references()
+
+    strada = next(ref for ref in refs if ref.address.lower() == STRADA_YIELD_ARBITRUM_ADDRESS.lower())
+    assert strada.name == "Strada Yield"
+    assert strada.first_seen_at_block == STRADA_YIELD_ARBITRUM_FIRST_SEEN_AT_BLOCK
+
+
+def test_t3tris_repair_keeps_reviewed_migration_vault_with_verified_filter(monkeypatch) -> None:
+    """A reviewed migration must not be discarded by an API-specific filter."""
+    module = _load_fix_t3tris_module()
+    monkeypatch.setenv("T3TRIS_VERIFIED_ONLY", "true")
+
+    refs = module.filter_references(module.get_reviewed_t3tris_migration_references())
+
+    assert [ref.address.lower() for ref in refs] == [STRADA_YIELD_ARBITRUM_ADDRESS.lower()]
+
+
+def test_t3tris_repair_uses_configuration_threshold_for_reviewed_migration() -> None:
+    """The repair must not invent deposits for a migration-pool vault."""
+    module = _load_fix_t3tris_module()
+    ref = next(ref for ref in module.get_reviewed_t3tris_migration_references() if ref.address.lower() == STRADA_YIELD_ARBITRUM_ADDRESS.lower())
+    vault_db = VaultDatabase()
+
+    module.upsert_lead(vault_db, ref)
+    detection = module.create_detection(ref, {module.ERC4626Feature.t3tris_like}, ref.first_seen_at)
+
+    lead = vault_db.leads[ref.get_spec()]
+    assert lead.deposit_count == 0
+    assert lead.configuration_count == 1
+    assert detection.deposit_count == 0
+    assert detection.configuration_count == 1

--- a/tests/research/test_clean_prices.py
+++ b/tests/research/test_clean_prices.py
@@ -1,5 +1,6 @@
 """Clean vault price data"""
 
+import dataclasses
 import logging
 import os.path
 import pickle
@@ -57,6 +58,16 @@ def raw_price_df() -> Path:
     """
     raw_prices = Path(os.path.dirname(__file__)) / "chain-hemi-raw-prices-1h.parquet"
     return raw_prices
+
+
+def test_vault_database_migrates_old_detection_event_counts(vault_db: Path) -> None:
+    """Old pickled detections receive the configuration-event count default."""
+    with vault_db.open("rb") as f:
+        database = pickle.load(f)
+
+    detection = next(iter(database.values()))["_detection_data"]
+    assert detection.configuration_count == 0
+    assert dataclasses.asdict(detection)["configuration_count"] == 0
 
 
 def test_clean_vault_price_data(


### PR DESCRIPTION
## Why

The Strada Yield T3tris vault was populated through the T3tris migration pool and emitted no vault-local deposit, withdrawal, or request-flow events. The scanner therefore did not retain it as a lead.

## Lessons learnt

T3tris migration-pool vaults can be identified from the T3tris-specific `T3treasuryUpdated` setup event. Keep this signal separate from deposit activity and confirm it through normal feature probes.

## Summary

- Add Strada Yield on Arbitrum to the T3tris hardcoded lead registry.
- Use `T3treasuryUpdated` as a configuration lead signal in both discovery backends.
- Preserve configuration activity separately and allow T3tris migration leads through the low-deposit price-scan filter.
- Add regression coverage for event discovery, hardcoded injection, and price-scan eligibility.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.