### PR TITLE
fix: expose vault test adapter capabilities

### DIFF
--- a/docs/superpowers/plans/2026-07-23-vault-test-follow-up.md
+++ b/docs/superpowers/plans/2026-07-23-vault-test-follow-up.md
@@ -1,0 +1,334 @@
+# Vault-test follow-up plan
+
+**Date:** 2026-07-23
+
+**Source:** [trade-executor PR #1576 follow-up](https://github.com/tradingstrategy-ai/trade-executor/pull/1576#issuecomment-5062126018)
+
+**Status:** Eth-defi implementation complete; trade-executor integration
+intentionally deferred to its repository.
+
+## Goal
+
+Make the vault-test result describe what actually happened. A mined and
+correctly decoded vault action must be successful; a known unsupported adapter,
+an unavailable redemption capacity, an async lifecycle that cannot be settled
+on Anvil, a receipt-parser failure, and a trade-executor statistics failure
+must remain distinct outcomes.
+
+The work crosses two repositories:
+
+- **web3-ethereum-defi** owns the vault-manager contract, protocol ABIs,
+  protocol receipt parsers, live preflight data and capability metadata.
+- **trade-executor** owns manager dispatch, batch outcome mapping, Anvil
+  lifecycle selection and diagnostic statistics serialisation.
+
+Implement the eth-defi changes first, publish the dependency, then change
+trade-executor to use the new or existing manager surface. Do not paper over a
+missing adapter by accepting a status-1 receipt without strict amount decoding.
+
+## Current-state findings
+
+The reported interface is partly already present in the current eth-defi
+master. `VaultDepositManager` declares `analyse_deposit()` and
+`analyse_redemption()` in `eth_defi/vault/deposit_redeem.py`; the standard
+implementation is in `eth_defi/erc_4626/deposit_redeem.py`. In particular,
+`EmberDepositManager` already decodes and validates `VaultDeposit` and
+`RequestProcessed` in
+`eth_defi/erc_4626/vault_protocol/ember/deposit_redeem.py`.
+
+The consumer-side synchronous route still calls
+`analyse_4626_flow_transaction()` directly in
+`tradeexecutor/ethereum/vault/vault_routing.py`. It also constructs synchronous
+transactions with generic ERC-4626 helpers rather than the selected manager.
+Consequently Ember's parser and cSigma's amount-aware request preflight are
+bypassed. The first change must remove those bypasses; a second competing
+receipt-analysis interface is neither necessary nor desirable.
+
+`CsigmaDepositManager` already reads `maxRedeem(owner)` and raises structured
+`VaultFlowUnavailable` during `create_redemption_request()`. The remaining gap
+is an explicit, caller-consumable amount preflight and correct batch mapping.
+
+`UpshiftVault` deliberately returns no capability and raises for the multi-asset
+shape. `LagoonDepositManager.force_settle()` already handles ERC-7540 tickets
+on Anvil, but callers cannot discover that support from static capability
+metadata. The bundled YieldNest ABI has callable functions but no events, so
+the generic ERC-4626 parser raises `NoABIEventsFound` before it can inspect the
+receipt.
+
+## Outcome contract
+
+Use these outcomes in the trade-executor report. Preserve raw values and the
+underlying manager diagnostic in the JSON output.
+
+| Condition | Outcome | Required context |
+|---|---|---|
+| Manager declares the operation unsupported | `adapter_unsupported` | Protocol, vault, direction and stable unsupported reason |
+| Manager preflight finds insufficient immediate redemption capacity | `redemption_capacity_limited` | Requested and available raw shares, owner and vault |
+| Async request lacks a safe Anvil settlement driver in full-lifecycle mode | `simulation_unsupported_async` | Manager capability and ticket type |
+| Broadcast transaction reverts | Existing execution-failure outcome | Receipt status and decoded revert data when available |
+| Status-1 transaction cannot be decoded by its manager | `receipt_analysis_failed` | Parser exception, transaction hash, protocol and vault |
+| Diagnostic statistics have no trades | Do not change the completed action outcome | Empty statistics representation or omitted diagnostic position |
+
+Do not convert a capacity limit into a clipped partial redemption, retry any of
+these outcomes automatically, or classify a post-action statistics assertion as
+a receipt-analysis failure.
+
+## 1. Route every vault action through its manager
+
+### eth-defi contract
+
+- Keep `VaultDepositManager.analyse_deposit()` and
+  `analyse_redemption()` as the only adapter receipt-analysis API. The current
+  `ERC4626DepositManager` methods remain the default standard-event
+  implementation.
+- Add a small shared helper only if needed to convert
+  `DepositRedeemEventAnalysis` into common executed asset/share values. Keep
+  the manager return dataclasses stable; do not make protocol managers return
+  `TradeSuccess` merely for the legacy consumer.
+- Ensure every protocol-specific analyser returns a
+  `DepositRedeemEventFailure` for a mined revert and lets unknown ABI, RPC and
+  event-shape errors raise. A successful receipt with an unrecognised event is
+  a parser failure, not a successful trade.
+
+### trade-executor changes
+
+- In `VaultRouting.deposit_or_redeem()`, build both synchronous and
+  asynchronous requests using `create_deposit_request()` or
+  `create_redemption_request()` on the selected manager. Build approvals using
+  `get_deposit_approval_target()` and sign every request function against its
+  actual bound contract, so manager requests with multiple contracts continue
+  to work.
+- Retain the generic ERC-4626 helpers only as private implementation details of
+  `ERC4626DepositManager`; remove their use as a routing bypass.
+- Catch `VaultFlowUnavailable` from manager request construction before the
+  generic request-error handler. Map a cSigma redemption-capacity failure to
+  `redemption_capacity_limited` (including both raw amounts), and map any other
+  verified typed preflight condition to its dedicated outcome. It must never
+  become `receipt_analysis_failed` merely because no transaction was sent.
+- In `VaultRouting.settle_trade()`, call `manager.analyse_deposit()` or
+  `manager.analyse_redemption()` for synchronous receipts. Convert the returned
+  decimal asset and share amounts into existing trade accounting, preserving
+  the current signs for sell amounts and validating the pair's denomination and
+  share tokens before `mark_trade_success()`.
+- Treat `DepositRedeemEventFailure` and parser exceptions separately. Only the
+  latter for a status-1 receipt becomes `receipt_analysis_failed`; a reverted
+  receipt follows the execution-failure path.
+- Add an end-to-end routing test with a fake specialised manager to prove that
+  both transaction construction and receipt analysis use manager overrides,
+  while an ordinary ERC-4626 test proves the default path has not changed. Add
+  a status-1 fake receipt whose manager analyser raises, and assert that it is
+  specifically `receipt_analysis_failed`, rather than an execution failure.
+
+## 2. Dispatch Ember deposits through the existing parser
+
+- Do not duplicate `EmberDepositManager.analyse_deposit()`. Its strict
+  `VaultDeposit` validation is the intended eth-defi implementation.
+- Add an Ethereum fork regression for Apollo ACRED
+  (`0x2b13311fd553e74b421d4ccc96e348f71e179dcf`) that funds a test caller,
+  deposits through the manager, invokes the generic routing analysis path, and
+  checks decoded assets, minted shares, owner, receiver and final balances.
+- Retest the remaining four reported Ember vault IDs through
+  `vault-test-trade --auto-simulated --rerun`: Earn
+  (`0x9be9294722f8aad37b11a9792be2c782182cafa2`), Polymarket
+  (`0x0b9342c15143e8f54a83f887c280a922f4c48771`), Third Eye
+  (`0xf3190a3ecc109f88e7947b849b281918c798a0c4`) and UDL
+  (`0x373152feef81cc59502da2c8de877b3d5ae2e342`). These are validation
+  samples, not a five-vault lifecycle test matrix.
+
+## 3. Add YieldNest RWA MAX receipt support
+
+### Reconnaissance
+
+- On a deterministic Ethereum fork, reproduce a deposit into ynRWAx
+  (`0x01ba69727e2860b37bc1a2bd56999c1afb4c15d8`) and save the proxy
+  implementation address, exact event topics, emitters and asset/share
+  balances.
+- Obtain the verified implementation ABI or an application-exported interface.
+  Record its canonical source in `eth_defi/abi/yieldnest/README.md`. Do not
+  infer event fields from transfers or from ERC-4626 assumptions.
+- Identify whether the receipt includes a standard vault-emitted `Deposit`.
+  If it does, extend `yieldnest/Vault.json` with that verified event and retain
+  the default parser; otherwise identify the single authoritative
+  YieldNest-specific event that supplies both deposited assets and minted
+  shares.
+
+### Implementation
+
+- Replace the trimmed `eth_defi/abi/yieldnest/Vault.json` with the minimal
+  verified event ABI required by the selected path, retaining the existing
+  callable functions.
+- Add `YieldNestDepositManager` under
+  `eth_defi/erc_4626/vault_protocol/yieldnest/` only when the verified event is
+  not a standard ERC-4626 `Deposit`. Override only the necessary analyser,
+  filter by the selected vault address and validate owner, receiver, assets and
+  shares before creating `DepositRedeemEventAnalysis`.
+- Make `YieldNestVault.get_deposit_manager()` return that manager and advertise
+  a synchronous deposit capability only after the fork regression is stable.
+  Preserve the existing generic behaviour for events that are genuinely
+  standard.
+- Keep queued withdrawal, maturity handling, alternative YieldNest deployments
+  and unsupported event variants out of this item. Their support requires
+  independent evidence.
+
+### Tests
+
+- Add the exact-vault fork test to
+  `tests/erc_4626/vault_protocol/test_yieldnest.py`, asserting ABI event
+  availability, the decoded raw-to-decimal amounts and balance deltas.
+- Add trade-executor coverage proving the row is no longer
+  `receipt_analysis_failed` because of an empty ABI.
+
+## 4. Make Upshift multi-asset non-support explicit
+
+The safe scope for this work item is honest classification, not an unverified
+application-flow implementation.
+
+- Extend `VaultDepositManagerCapability` with optional stable,
+  JSON-serialisable unsupported reasons for each direction. Validate that a
+  reason can accompany only an operation with `can_deposit` or `can_redeem`
+  set to `False`; retain compatibility for current callers that construct the
+  dataclass without reasons.
+- Change `UpshiftVault.get_deposit_manager_capability()` for
+  `multi_asset_like` vaults to return explicit false/false capability metadata
+  with a reason such as `multi_asset_application_flow_not_implemented`, rather
+  than `None`. Continue to raise a dedicated unsupported-flow exception when a
+  caller ignores metadata and asks for a manager.
+- In trade-executor, inspect capability before constructing a manager. Map this
+  known static condition to `adapter_unsupported` without broadcasting an
+  approval or deposit transaction. Persist the reason in the report.
+- Add no-RPC capability-schema tests and a trade-executor candidate/runner test
+  for Sentora USD Earn
+  (`0x74ad2f789ed583dbd141bbdafc673fe1f033718b`).
+
+A future Upshift feature may replace this with an `UpshiftMultiAssetDepositManager`
+only after it proves the exact input asset, conversion, capacity rules,
+settlement lifecycle and round-trip event accounting on a fork. That is a
+separate feature, not a fallback hidden in this reporting fix.
+
+## 5. Advertise and use Anvil settlement support
+
+- Extend static capability metadata with an optional
+  `supports_anvil_settlement` flag. Its meaning is narrow: an advertised async
+  lifecycle can be advanced with a correctly typed ticket on an Anvil fork.
+  `None` means the operation is synchronous or no async lifecycle is
+  advertised; `False` means a ticketed lifecycle is supported but has no safe
+  simulation driver.
+- Set the flag to `True` for Lagoon's ERC-7540 deposit and redemption ticket
+  types, because `LagoonDepositManager.force_settle()` already validates and
+  settles both. Keep generic ERC-7540 and any manager without a protocol-safe
+  driver as `False`.
+- Add no-RPC schema validation and focused Lagoon tests for both ticket types,
+  non-Anvil rejection and an invalid ticket type. The flag must agree with the
+  manager's actual `force_settle()` acceptance.
+- In trade-executor, retain the current default request-only async behaviour.
+  Make the full-lifecycle batch mode opt into forced settlement only when the
+  manager capability is `True`; otherwise emit
+  `simulation_unsupported_async` with the capability reason before attempting
+  settlement. Wire the existing `--settle-async-on-anvil` option (or its
+  documented full-lifecycle replacement) through this check.
+- Run one Lagoon deposit and redemption in full-lifecycle batch mode and verify
+  that a supported row proceeds from request, settlement and claim to the
+  normal manager analyser. Do not claim that every Lagoon deployment or other
+  ERC-7540 adapter can be settled.
+- Add a runner-level fake or generic-ERC-7540 capability test with
+  `supports_anvil_settlement=False`. It must emit
+  `simulation_unsupported_async` before calling `force_settle()`. This is
+  separate from the Lagoon `True` full-lifecycle regression.
+
+## 6. Promote cSigma redemption capacity to an amount preflight
+
+- Add a public, amount-aware redemption preflight result for adapters that
+  have an owner-specific capacity query, for example a small immutable result
+  containing availability, requested raw amount, available raw amount and an
+  optional structured reason. Do not add a generic default that could imply a
+  live capacity check where none exists.
+- Implement the cSigma override with `maxRedeem(owner)`. It must return the
+  exact raw share capacity and identify a requested amount above it as
+  unavailable. Refactor `create_redemption_request()` to use that one result,
+  while retaining its authoritative `VaultFlowUnavailable` safeguard for the
+  race between preflight and broadcast.
+- In trade-executor, call the preflight before scheduling a redemption. Map a
+  cSigma unavailable result to `redemption_capacity_limited`, retain both raw
+  values, and do not sign or retry the request. Continue to handle any
+  inclusion-time revert as an execution failure. Catch the existing
+  `VaultFlowUnavailable` raised by `create_redemption_request()` through the
+  same mapping, so a stale or bypassed preflight cannot fall through to the
+  generic request-error or receipt-analysis paths.
+- Extend `tests/erc_4626/vault_protocol/test_csigma.py` with a fixed Ethereum
+  fork assertion that capacity equals `maxRedeem(owner)`, an at-or-below-cap
+  redemption path, and an above-cap result that leaves shares unchanged. Add a
+  consumer test that verifies the dedicated result mapping.
+
+## 7. Keep statistics from changing the vault result
+
+- In `tradeexecutor/statistics/statistics_table.py` and its caller, make
+  long/short statistics serialisation return an empty or explicitly
+  not-applicable table when a diagnostic vault position has no executed trades.
+  Do not call position-side long/short classification in that case.
+- Keep ordinary positions with executed trades unchanged and preserve genuine
+  statistics errors that are unrelated to an empty diagnostic position.
+- Add a regression that completes a simulated vault action with the diagnostic
+  no-trade position and verifies the saved action outcome survives statistics
+  generation. Add a normal executed long and short regression so the table
+  still contains both sides.
+- Add a separate regression that deliberately raises a statistics exception
+  after a completed action and asserts it is retained in a statistics
+  diagnostic field without overwriting that action's result.
+- Change the batch exception boundary so, after typed capability and
+  `VaultFlowUnavailable` branches have been handled, only a status-1 manager
+  receipt-analysis exception may produce `receipt_analysis_failed`.
+  Statistics exceptions must have their own diagnostic field and must not
+  overwrite a completed action.
+
+## Delivery order
+
+1. Land the manager-routing refactor, typed `VaultFlowUnavailable` outcome
+   mapping and fake-manager tests in trade-executor as one release; this
+   activates the already-shipped Ember and cSigma manager code without a
+   cSigma classification regression.
+2. Land eth-defi capability and amount-preflight schema changes with no-RPC
+   compatibility tests. Publish the release and update trade-executor's
+   eth-defi dependency before it consumes the new fields.
+3. Land the Upshift explicit unsupported classification and cSigma preflight
+   override, then update trade-executor outcome mapping.
+4. Land Lagoon Anvil-settlement metadata, publish the eth-defi release, update
+   the trade-executor dependency, then land the full-lifecycle batch wiring.
+5. Complete YieldNest ABI reconnaissance, parser and exact-vault fork test,
+   then update the eth-defi dependency and add the trade-executor regression.
+6. Land the statistics isolation fix and rerun the affected report rows.
+
+Each protocol or consumer change should be independently reviewable. Do not
+combine the speculative Upshift implementation, unrelated vault adapters, ABI
+refreshes or broad reporting redesign with this work.
+
+## Verification
+
+Run only focused tests, using the required repository environment:
+
+```shell
+source .local-test.env && poetry run pytest tests/erc_4626/vault_protocol/test_ember_deposit_redeem.py -v
+source .local-test.env && poetry run pytest tests/erc_4626/vault_protocol/test_yieldnest.py -v
+source .local-test.env && poetry run pytest tests/erc_4626/vault_protocol/test_csigma.py -v
+source .local-test.env && poetry run pytest tests/lagoon/test_erc_7540_deposit_redeem.py -v
+source .local-test.env && poetry run pytest tests/erc_4626/test_deposit_probe.py -v
+```
+
+In trade-executor, add and run only the corresponding routing, vault-test
+runner and statistics tests. Finally rerun these representative IDs with the
+normal Lagoon test environment:
+
+```shell
+VAULT_ID=1-0x2b13311fd553e74b421d4ccc96e348f71e179dcf poetry run trade-executor vault-test-trade --auto-simulated --rerun
+VAULT_ID=1-0x01ba69727e2860b37bc1a2bd56999c1afb4c15d8 poetry run trade-executor vault-test-trade --auto-simulated --rerun
+VAULT_ID=1-0x74ad2f789ed583dbd141bbdafc673fe1f033718b poetry run trade-executor vault-test-trade --auto-simulated --rerun
+VAULT_ID=1-0xd5d097f278a735d0a3c609deee71234cac14b47e poetry run trade-executor vault-test-trade --auto-simulated --rerun
+VAULT_ID=1-0x06973fbca7c589d10dfbe45d694dce634bff6165 poetry run trade-executor vault-test-trade --auto-simulated --rerun --settle-async-on-anvil
+```
+
+The expected classifications are respectively: successful Ember analysis,
+successful YieldNest analysis, explicit `adapter_unsupported`, explicit
+`redemption_capacity_limited`, and a Lagoon full lifecycle where its selected
+request can be force-settled. Re-run one previously affected no-trade
+statistics row to confirm its completed action is retained. The
+`simulation_unsupported_async` false-capability branch is deliberately covered
+by the focused runner test above, not by these five representative IDs.

--- a/eth_defi/abi/yieldnest/README.md
+++ b/eth_defi/abi/yieldnest/README.md
@@ -1,0 +1,13 @@
+# YieldNest ABI sources
+
+`Vault.json` contains the callable interface used by the YieldNest adapter and
+the standard ERC-4626 `Deposit` and `Withdraw` event definitions. The tested
+adapter currently uses `Deposit` for synchronous receipt analysis; `Withdraw`
+is retained for a future maturity-aware redemption manager.
+
+The event signatures were taken on 2026-07-23 from the
+[Blockscout-verified implementation](https://eth.blockscout.com/address/0xb46d7014c1a29b6a82d8ecde5ad29d5b09ac7a1b?tab=contract) of the ynRWAx proxy.
+The fixed-block fork regression proves that the events decode for the tested
+historical route; it does not assert that a later proxy upgrade is identical.
+The proxy address is
+[0x01ba69727e2860b37bc1a2bd56999c1afb4c15d8](https://eth.blockscout.com/address/0x01ba69727e2860b37bc1a2bd56999c1afb4c15d8?tab=contract).

--- a/eth_defi/abi/yieldnest/Vault.json
+++ b/eth_defi/abi/yieldnest/Vault.json
@@ -1,5 +1,73 @@
 [
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "Deposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "assets",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "Withdraw",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "baseWithdrawalFee",
     "outputs": [

--- a/eth_defi/erc_4626/vault_protocol/csigma/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/csigma/deposit_redeem.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from eth_typing import HexAddress
 
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager, ERC4626DepositRequest, ERC4626RedemptionRequest
-from eth_defi.vault.deposit_redeem import VaultFlowUnavailable
+from eth_defi.vault.deposit_redeem import VaultFlowUnavailable, VaultRedemptionPreflight
 
 
 class CsigmaDepositManager(ERC4626DepositManager):
@@ -44,6 +44,46 @@ class CsigmaDepositManager(ERC4626DepositManager):
             ``owner``.
         """
         return int(self.vault.vault_contract.functions.maxDeposit(owner).call())
+
+    def fetch_redemption_preflight(
+        self,
+        owner: HexAddress,
+        raw_shares: int,
+    ) -> VaultRedemptionPreflight:
+        """Check cSigma's owner-specific immediate redemption capacity.
+
+        ``maxRedeem(owner)`` is denominated in raw vault shares, so this
+        compares the requested and available values without a
+        rounding-sensitive share-to-asset conversion.
+
+        .. note::
+
+            Trade-executor must map an unavailable result, or the matching
+            :class:`VaultFlowUnavailable` from
+            :meth:`create_redemption_request`, to
+            ``redemption_capacity_limited`` before treating generic request
+            failures as receipt-analysis failures.
+
+        :param owner:
+            Address whose immediate capacity is queried.
+        :param raw_shares:
+            Requested raw cSigma vault shares.
+        :return:
+            Available capacity result in raw shares.
+        """
+        available_raw_shares = self.fetch_redeemable_raw_shares(owner)
+        if raw_shares <= available_raw_shares:
+            return VaultRedemptionPreflight(
+                available=True,
+                requested_raw_shares=raw_shares,
+                available_raw_shares=available_raw_shares,
+            )
+        return VaultRedemptionPreflight(
+            available=False,
+            requested_raw_shares=raw_shares,
+            available_raw_shares=available_raw_shares,
+            reason="redemption_capacity_limited",
+        )
 
     def create_deposit_request(  # noqa: PLR0917
         self,
@@ -135,8 +175,8 @@ class CsigmaDepositManager(ERC4626DepositManager):
             raw_shares = self.vault.share_token.convert_to_raw(shares)
 
         if check_max_deposit:
-            available_raw_shares = self.fetch_redeemable_raw_shares(owner)
-            if raw_shares > available_raw_shares:
+            preflight = self.fetch_redemption_preflight(owner, raw_shares)
+            if not preflight.available:
                 reason = "cSigma redemption exceeds immediate share capacity"
                 raise VaultFlowUnavailable(
                     reason,
@@ -146,7 +186,7 @@ class CsigmaDepositManager(ERC4626DepositManager):
                     direction="redeem",
                     phase="request",
                     requested_raw_amount=raw_shares,
-                    available_raw_amount=available_raw_shares,
+                    available_raw_amount=preflight.available_raw_shares,
                 )
 
         return super().create_redemption_request(

--- a/eth_defi/erc_4626/vault_protocol/lagoon/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/vault.py
@@ -50,6 +50,7 @@ from eth_defi.provider.fallback import ExtraValueError
 from eth_defi.safe.safe_compat import create_safe_ethereum_client
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.vault.base import VaultFlowManager, VaultInfo, VaultSpec
+from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
 from eth_defi.vault.flag import MISSING_IN_PROTOCOL_FRONTEND, VaultFlag
 
 if TYPE_CHECKING:
@@ -975,6 +976,30 @@ class LagoonVault(ERC7540Vault, AutomatedSafe):
         from eth_defi.erc_4626.vault_protocol.lagoon.deposit_redeem import LagoonDepositManager
 
         return LagoonDepositManager(self)
+
+    def get_deposit_manager_capability(self) -> VaultDepositManagerCapability:
+        """Declare Lagoon's asynchronously settleable manager lifecycle.
+
+        Lagoon accepts the standard ERC-7540 request types and its selected
+        manager can force-settle both ticket directions on Anvil.
+
+        .. note::
+
+            Trade-executor may call ``force_settle()`` for a full-lifecycle
+            simulation only when this capability flag is true and it holds the
+            matching ERC-7540 request ticket. Request-only behaviour remains
+            unchanged.
+
+        :return:
+            Two-way asynchronous capability with Anvil settlement support.
+        """
+        return VaultDepositManagerCapability(
+            can_deposit=True,
+            can_redeem=True,
+            deposit_flow="asynchronous",
+            redemption_flow="asynchronous",
+            supports_anvil_settlement=True,
+        )
 
     def can_check_deposit(self) -> bool:
         """Lagoon's maxDeposit does not work correctly for deposit availability checks."""

--- a/eth_defi/erc_4626/vault_protocol/upshift/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/upshift/vault.py
@@ -17,6 +17,7 @@ from eth_defi.event_reader.conversion import convert_int256_bytes_to_int
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.token import TokenDetails, fetch_erc20_details
 from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
+from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
 from eth_defi.vault.fee import VaultFeeMode
 
 logger = logging.getLogger(__name__)
@@ -545,20 +546,32 @@ class UpshiftVault(ERC4626Vault):
 
         return super().get_deposit_manager()
 
-    def get_deposit_manager_capability(self) -> "VaultDepositManagerCapability | None":
+    def get_deposit_manager_capability(self) -> VaultDepositManagerCapability:
         """Declare only Upshift's normal ERC-4626 vault shape.
 
         Multi-asset accounting vaults use a separate application flow and must
-        never be represented as generic deposit-manager support.
+        never be represented as generic deposit-manager support. They expose a
+        deliberate refusing capability so consumers can report this as adapter
+        support rather than a failed transaction.
+
+        .. note::
+
+            Trade-executor must inspect this capability before calling
+            :meth:`get_deposit_manager` and map its stable reason to
+            ``adapter_unsupported`` without broadcasting an approval or
+            request.
 
         :return:
-            Synchronous two-way capability for the normal shape, or ``None``
-            for multi-asset vaults.
+            Synchronous two-way capability for the normal shape, or an explicit
+            refusing capability for multi-asset vaults.
         """
         if self.multi_asset_like:
-            return None
-
-        from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
+            return VaultDepositManagerCapability(
+                can_deposit=False,
+                can_redeem=False,
+                deposit_unsupported_reason="multi_asset_application_flow_not_implemented",
+                redemption_unsupported_reason="multi_asset_application_flow_not_implemented",
+            )
 
         return VaultDepositManagerCapability(
             can_deposit=True,

--- a/eth_defi/erc_4626/vault_protocol/yieldnest/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/yieldnest/vault.py
@@ -11,6 +11,7 @@ from web3.contract import Contract
 from eth_defi.abi import get_deployed_contract
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
 
 logger = logging.getLogger(__name__)
 
@@ -113,3 +114,29 @@ class YieldNestVault(ERC4626Vault):
         The contract returns empty data for maxDeposit(address(0)).
         """
         return False
+
+    def get_deposit_manager_capability(self) -> VaultDepositManagerCapability:
+        """Declare YieldNest's verified synchronous deposit lifecycle.
+
+        The bundled ABI contains the standard ERC-4626 ``Deposit`` event, so
+        the inherited manager can decode the tested deposit receipt without a
+        YieldNest-only parser. The generic redemption manager cannot query
+        ynRWAx's pre-maturity ``maxRedeem``, so its maturity-aware redemption
+        lifecycle remains unsupported.
+
+        .. note::
+
+            Trade-executor must use the selected manager's
+            ``analyse_deposit()`` hook rather than a generic analyser. It must
+            treat the redemption reason as ``adapter_unsupported`` and not
+            construct a generic redemption request.
+
+        :return:
+            Partial capability with a synchronous deposit flow only.
+        """
+        return VaultDepositManagerCapability(
+            can_deposit=True,
+            can_redeem=False,
+            deposit_flow="synchronous",
+            redemption_unsupported_reason="maturity_aware_redemption_flow_not_implemented",
+        )

--- a/eth_defi/erc_7540/vault.py
+++ b/eth_defi/erc_7540/vault.py
@@ -8,10 +8,10 @@ from eth_typing import HexAddress
 from web3.contract.contract import ContractFunction
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
 
 if TYPE_CHECKING:
     from eth_defi.erc_7540.deposit_redeem import ERC7540DepositManager
-    from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
 
 
 logger = logging.getLogger(__name__)
@@ -168,7 +168,7 @@ class ERC7540Vault(ERC4626Vault):
 
         return ERC7540DepositManager(self)
 
-    def get_deposit_manager_capability(self) -> "VaultDepositManagerCapability":
+    def get_deposit_manager_capability(self) -> VaultDepositManagerCapability:
         """Declare the standard ERC-7540 request-and-claim lifecycle.
 
         Both directions require a request followed by operator settlement and
@@ -177,13 +177,12 @@ class ERC7540Vault(ERC4626Vault):
         :return:
             Two-way asynchronous capability.
         """
-        from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
-
         return VaultDepositManagerCapability(
             can_deposit=True,
             can_redeem=True,
             deposit_flow="asynchronous",
             redemption_flow="asynchronous",
+            supports_anvil_settlement=False,
         )
 
     def get_estimated_lock_up(self) -> datetime.timedelta | None:

--- a/eth_defi/vault/deposit_redeem.py
+++ b/eth_defi/vault/deposit_redeem.py
@@ -64,12 +64,23 @@ class VaultDepositManagerCapability:
         Request lifecycle for deposits when supported.
     :param redemption_flow:
         Request lifecycle for redemptions when supported.
+    :param deposit_unsupported_reason:
+        Stable adapter reason when deposits are deliberately unsupported.
+    :param redemption_unsupported_reason:
+        Stable adapter reason when redemptions are deliberately unsupported.
+    :param supports_anvil_settlement:
+        Whether the advertised asynchronous lifecycle can be advanced with its
+        protocol-specific ticket on an Anvil fork. ``None`` means no
+        asynchronous lifecycle is advertised.
     """
 
     can_deposit: bool
     can_redeem: bool
     deposit_flow: VaultDepositFlow | None = None
     redemption_flow: VaultDepositFlow | None = None
+    deposit_unsupported_reason: str | None = None
+    redemption_unsupported_reason: str | None = None
+    supports_anvil_settlement: bool | None = None
 
     def __post_init__(self) -> None:
         """Validate that supported operations have a lifecycle declaration.
@@ -81,6 +92,12 @@ class VaultDepositManagerCapability:
             raise ValueError("deposit_flow must be present exactly when deposits are supported")
         if (self.redemption_flow is not None) != self.can_redeem:
             raise ValueError("redemption_flow must be present exactly when redemptions are supported")
+        if self.can_deposit and self.deposit_unsupported_reason is not None:
+            raise ValueError("deposit_unsupported_reason is valid only when deposits are unsupported")
+        if self.can_redeem and self.redemption_unsupported_reason is not None:
+            raise ValueError("redemption_unsupported_reason is valid only when redemptions are unsupported")
+        if self.supports_anvil_settlement is not None and "asynchronous" not in (self.deposit_flow, self.redemption_flow):
+            raise ValueError("supports_anvil_settlement requires an asynchronous lifecycle")
 
     def as_dict(self) -> dict[str, bool | str]:
         """Convert the capability to JSON-compatible primitives.
@@ -96,6 +113,12 @@ class VaultDepositManagerCapability:
             result["deposit_flow"] = self.deposit_flow
         if self.redemption_flow is not None:
             result["redemption_flow"] = self.redemption_flow
+        if self.deposit_unsupported_reason is not None:
+            result["deposit_unsupported_reason"] = self.deposit_unsupported_reason
+        if self.redemption_unsupported_reason is not None:
+            result["redemption_unsupported_reason"] = self.redemption_unsupported_reason
+        if self.supports_anvil_settlement is not None:
+            result["supports_anvil_settlement"] = self.supports_anvil_settlement
         return result
 
     def as_initial_public_schema(self) -> dict[str, bool | str] | None:
@@ -115,6 +138,48 @@ class VaultDepositManagerCapability:
         if self.can_deposit != self.can_redeem:
             return None
         return self.as_dict()
+
+
+@dataclass(frozen=True, slots=True)
+class VaultRedemptionPreflight:
+    """Amount-aware immediate-redemption guidance from a vault manager.
+
+    The result is advisory because capacity can change before a transaction is
+    mined. The manager's request constructor must repeat an available-capacity
+    check before broadcasting. It is currently returned only by adapters that
+    have an owner-specific immediate-capacity query, such as cSigma's
+    `ERC-4626 maxRedeem <https://eips.ethereum.org/EIPS/eip-4626#maxredeem>`__.
+
+    .. note::
+
+        Trade-executor integrations must map an unavailable result, or a
+        matching :class:`VaultFlowUnavailable` from request construction, to a
+        capacity result before their generic receipt-analysis error handling.
+
+    :param available:
+        Whether the requested raw shares can be redeemed immediately.
+    :param requested_raw_shares:
+        Requested vault-share amount in native units.
+    :param available_raw_shares:
+        Current immediate capacity in native share units, when the adapter can
+        determine it.
+    :param reason:
+        Stable adapter reason when the request is unavailable.
+    """
+
+    available: bool
+    requested_raw_shares: int
+    available_raw_shares: int | None = None
+    reason: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate the available-capacity representation."""
+        if self.requested_raw_shares < 0:
+            raise ValueError("requested_raw_shares must not be negative")
+        if self.available and self.reason is not None:
+            raise ValueError("available preflight cannot have an unavailable reason")
+        if not self.available and self.reason is None:
+            raise ValueError("unavailable preflight must have a reason")
 
 
 class AsyncVaultRequestStatus(enum.Enum):

--- a/tests/erc_4626/test_deposit_probe.py
+++ b/tests/erc_4626/test_deposit_probe.py
@@ -11,8 +11,10 @@ import eth_defi.erc_4626.deposit_redeem as erc_4626_deposit_redeem
 from eth_defi.erc_4626.deposit_probe import DEFAULT_STATUS_PATH, VaultDepositProbeCandidate, VaultDepositProbeOutput, fetch_max_deposit_guidance, log_probe_tables, merge_redemption_flow_failure, prepare_probe_deposit_request, require_simulation, run_from_environment, select_candidates, update_status
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
 from eth_defi.erc_4626.vault import CERTIFIED_SYNCHRONOUS_DEPOSIT_MANAGER_CLASSES, ERC4626Vault
+from eth_defi.erc_4626.vault_protocol.csigma.deposit_redeem import CsigmaDepositManager
 from eth_defi.erc_4626.vault_protocol.gains.deposit_redeem import GainsDepositManager, GainsRedemptionTicket
 from eth_defi.erc_4626.vault_protocol.kiln.vault import KilnVault
+from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
 from eth_defi.erc_4626.vault_protocol.summer.vault import SummerVault
 from eth_defi.erc_4626.vault_protocol.yearn.vault import YearnV3Vault
 from eth_defi.vault.base import VaultSpec
@@ -37,6 +39,62 @@ def test_vault_deposit_manager_capability_suppresses_partial_public_support() ->
     assert VaultDepositManagerCapability(False, True, None, "asynchronous").as_initial_public_schema() is None
     with pytest.raises(ValueError, match="deposit_flow"):
         VaultDepositManagerCapability(True, True, None, "asynchronous")
+    with pytest.raises(ValueError, match="deposit_unsupported_reason"):
+        VaultDepositManagerCapability(True, True, "synchronous", "synchronous", deposit_unsupported_reason="unsupported")
+    with pytest.raises(ValueError, match="supports_anvil_settlement"):
+        VaultDepositManagerCapability(True, True, "synchronous", "synchronous", supports_anvil_settlement=True)
+
+
+def test_lagoon_capability_advertises_verified_anvil_settlement() -> None:
+    """Lagoon advertises only the ticketed settlement driver it implements."""
+    assert object.__new__(LagoonVault).get_deposit_manager_capability().as_dict() == {
+        "can_deposit": True,
+        "can_redeem": True,
+        "deposit_flow": "asynchronous",
+        "redemption_flow": "asynchronous",
+        "supports_anvil_settlement": True,
+    }
+
+
+def test_csigma_redemption_preflight_preserves_raw_share_capacity() -> None:
+    """cSigma exposes maxRedeem() as an amount-aware preflight result."""
+
+    available_raw_shares = 45_388
+    requested_raw_shares = 907_757
+
+    class Call:
+        """Minimal contract-call result."""
+
+        @staticmethod
+        def call() -> int:
+            """Return fixed immediate redemption capacity."""
+            return available_raw_shares
+
+    class Functions:
+        """Minimal cSigma contract namespace."""
+
+        @staticmethod
+        def maxRedeem(owner: str) -> Call:  # noqa: N802
+            """Build an owner-specific capacity call."""
+            assert owner == "0x0000000000000000000000000000000000000001"
+            return Call()
+
+    manager = object.__new__(CsigmaDepositManager)
+    manager.vault = type("Vault", (), {"vault_contract": type("Contract", (), {"functions": Functions()})()})()
+
+    available = manager.fetch_redemption_preflight("0x0000000000000000000000000000000000000001", available_raw_shares)
+    assert available.available is True
+    assert available.available_raw_shares == available_raw_shares
+
+    zero = manager.fetch_redemption_preflight("0x0000000000000000000000000000000000000001", 0)
+    assert zero.available is True
+    assert zero.requested_raw_shares == 0
+
+    unavailable = manager.fetch_redemption_preflight("0x0000000000000000000000000000000000000001", requested_raw_shares)
+    assert unavailable.available is False
+    assert unavailable.requested_raw_shares == requested_raw_shares
+    assert unavailable.available_raw_shares == available_raw_shares
+    assert unavailable.reason == "redemption_capacity_limited"
 
 
 def test_erc4626_subclass_can_use_probe_generic_fallback_after_interface_check() -> None:

--- a/tests/erc_4626/vault_protocol/test_upshift.py
+++ b/tests/erc_4626/vault_protocol/test_upshift.py
@@ -148,6 +148,12 @@ def test_upshift_multi_asset_vault_metadata(
 
     assert isinstance(vault.get_historical_reader(stateful=False), UpshiftMultiAssetHistoricalReader)
     assert vault.fetch_share_price(UPSHIFT_MULTI_ASSET_FORK_BLOCK) > 0
+    assert vault.get_deposit_manager_capability().as_dict() == {
+        "can_deposit": False,
+        "can_redeem": False,
+        "deposit_unsupported_reason": "multi_asset_application_flow_not_implemented",
+        "redemption_unsupported_reason": "multi_asset_application_flow_not_implemented",
+    }
     assert vault.fetch_total_assets(UPSHIFT_MULTI_ASSET_FORK_BLOCK) > 0
     assert vault.fetch_total_supply(UPSHIFT_MULTI_ASSET_FORK_BLOCK) > 0
     assert vault.fetch_available_liquidity(UPSHIFT_MULTI_ASSET_FORK_BLOCK) is not None

--- a/tests/erc_4626/vault_protocol/test_yieldnest.py
+++ b/tests/erc_4626/vault_protocol/test_yieldnest.py
@@ -2,7 +2,8 @@
 
 import datetime
 import os
-from pathlib import Path
+from collections.abc import Iterator
+from decimal import Decimal
 
 import flaky
 import pytest
@@ -13,6 +14,8 @@ from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name
 from eth_defi.erc_4626.vault_protocol.yieldnest.vault import YNRWAX_VAULT_ADDRESS, YieldNestVault
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.token import USDC_WHALE
+from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.vault.base import VaultTechnicalRisk
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
@@ -21,13 +24,17 @@ pytestmark = pytest.mark.skipif(not JSON_RPC_ETHEREUM, reason="JSON_RPC_ETHEREUM
 
 
 @pytest.fixture(scope="module")
-def anvil_ethereum_fork(request) -> AnvilLaunch:
+def anvil_ethereum_fork() -> Iterator[AnvilLaunch]:
     """Fork at a specific block for reproducibility
 
     Contract created at block 22,674,309 in June 2024
     Latest block as of 2026-01-15: 24,239,327
     """
-    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=24_239_327)
+    launch = fork_network_anvil(
+        JSON_RPC_ETHEREUM,
+        fork_block_number=24_239_327,
+        unlocked_addresses=[USDC_WHALE[1]],
+    )
     try:
         yield launch
     finally:
@@ -35,7 +42,7 @@ def anvil_ethereum_fork(request) -> AnvilLaunch:
 
 
 @pytest.fixture(scope="module")
-def web3(anvil_ethereum_fork):
+def web3(anvil_ethereum_fork: AnvilLaunch) -> Web3:
     web3 = create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url, retries=2)
     return web3
 
@@ -43,8 +50,7 @@ def web3(anvil_ethereum_fork):
 @flaky.flaky
 def test_yieldnest_ynrwax(
     web3: Web3,
-    tmp_path: Path,
-):
+) -> None:
     """Read YieldNest ynRWAx vault metadata.
 
     This tests the hardcoded ynRWAx vault which is detected by address.
@@ -58,6 +64,29 @@ def test_yieldnest_ynrwax(
     assert isinstance(vault, YieldNestVault)
     assert vault.get_protocol_name() == "YieldNest"
     assert vault.features == {ERC4626Feature.yieldnest_like}
+    assert vault.get_deposit_manager_capability().as_dict() == {
+        "can_deposit": True,
+        "can_redeem": False,
+        "deposit_flow": "synchronous",
+        "redemption_unsupported_reason": "maturity_aware_redemption_flow_not_implemented",
+    }
+    assert vault.vault_contract.events.Deposit is not None
+    assert vault.vault_contract.events.Withdraw is not None
+
+    owner = web3.eth.accounts[0]
+    deposit_amount = Decimal(10)
+    usdc = vault.denomination_token
+    funding_hash = usdc.transfer(owner, deposit_amount).transact({"from": USDC_WHALE[1]})
+    assert_transaction_success_with_explanation(web3, funding_hash)
+    approval_hash = usdc.approve(vault.address, deposit_amount).transact({"from": owner})
+    assert_transaction_success_with_explanation(web3, approval_hash)
+
+    manager = vault.get_deposit_manager()
+    deposit_ticket = manager.create_deposit_request(owner=owner, amount=deposit_amount).broadcast(from_=owner)
+    analysis = manager.analyse_deposit(deposit_ticket.tx_hash, deposit_ticket)
+    assert analysis.denomination_amount == deposit_amount
+    assert analysis.share_count == Decimal("9.737608735845247309")
+    assert vault.share_token.fetch_raw_balance_of(owner) == 9_737_608_735_845_247_309
 
     # Check that management and performance fees are zero
     assert vault.get_management_fee("latest") == 0.0

--- a/tests/erc_7540/test_generic_erc_7540_deposit_redeem.py
+++ b/tests/erc_7540/test_generic_erc_7540_deposit_redeem.py
@@ -80,6 +80,7 @@ def test_non_lagoon_protocols_use_generic_erc7540_manager(vault_class: type[ERC7
         "can_redeem": True,
         "deposit_flow": "asynchronous",
         "redemption_flow": "asynchronous",
+        "supports_anvil_settlement": False,
     }
 
 


### PR DESCRIPTION
## Why

The vault-test rerun conflated adapter support, live redemption capacity, Anvil settlement support and receipt-analysis gaps. Eth-defi already contained part of the needed protocol behaviour, but did not expose enough static or amount-aware information for consumers to classify those cases before or after a request.

## Lessons learnt

A vault manager capability must describe implemented adapter behaviour separately from current vault state. Amount-aware capacity checks remain advisory until the request builder repeats them immediately before transaction construction. A standard ERC-4626 event can be unusable if the deployment ABI omits it, even when the event is emitted correctly onchain.

## Summary

- Add explicit unsupported-operation reasons and Anvil-settlement support to deposit-manager capability metadata.
- Expose cSigma immediate redemption capacity through a raw-share preflight result.
- Mark Upshift multi-asset flows as deliberately unsupported, and advertise Lagoon ticket settlement support.
- Add the verified YieldNest ERC-4626 receipt events and a fork deposit-decoding regression.
- Document the deferred trade-executor integration in code comments and the accompanying implementation plan.

## Related issues and PRs

- Implements the eth-defi portion of [trade-executor PR #1576 follow-up](https://github.com/tradingstrategy-ai/trade-executor/pull/1576#issuecomment-5062126018).
- Trade-executor routing, outcome mapping and statistics changes are deliberately not included in this PR.

## Unrelated CI and test fixes

- None.