### PR TITLE
fix: respect Monad historical state window

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,26 @@ cache to be available inside the container; restore or prepopulate that cache
 on the host before a historical backfill rather than allowing a one-shot repair
 to bootstrap it with sparse timestamp requests.
 
+## Chain quirks
+
+### Monad
+
+Monad (chain ID 143) does not provide archive-complete historical state. Its
+full nodes retain all historical blocks, transactions, receipts, events and
+traces, but expose only a provider- and disk-dependent recent window of
+contract state. No provider offers arbitrary-depth historical state; see the
+[Monad historical data documentation](https://docs.monad.xyz/developer-essentials/historical-data).
+
+- Do not describe `JSON_RPC_MONAD` as an archive node, retry failed old
+  `eth_call` requests, or attempt a genesis-to-head state backfill. Once a
+  state trie has been evicted, those operations cannot succeed.
+- Use Hypersync for historical Monad events and timestamps. For historical
+  vault values, `scan_historical_prices_to_parquet()` probes Multicall and
+  begins at the oldest state block the configured provider can execute.
+- Preserve existing Monad price rows before that dynamically detected boundary:
+  the current provider cannot reconstruct them. Monad fork and historical tests
+  must use current-state or state-relative assertions.
+
 ## Running tests
 
 If we have not run tests before make sure the user has created a gitignored file `.local-test.env` in the repository root. This will use `source` shell command to include the actual test secrets which lie outside the repository structure. Note: this file does not contain actual environment variables, just a `source` command to get them from elsewhere. **Never edit this file**.
@@ -135,7 +155,9 @@ In the environment file, the RPC URLs are provided in the project-specific space
 
 - If there is a space in RPC URL given by a environment variable like `JSON_RPC_ETHEREUM`, it can be only used with Python call `create_multi_provider_web3()`
 - If you are going to use this RPC URL with other commands, like `curl`, you need to parse the RPC environment variable by spltting it by spaces and taking the first entry
-- All environment variables point to EVM archive nodes
+- Scanner RPC variables should point to archive-capable EVM nodes, except
+  `JSON_RPC_MONAD`, which can only serve its provider-dependent recent
+  historical-state window.
 
 ## Formatting code
 
@@ -275,7 +297,8 @@ removing its flaky history comment.
 - For DuckDB testing, make sure the database is always closed using finally clause or fixtures
 - Always use fixture and test functions, never use test classes
 - For Anvil mainnet fork based tests, whici use a fixed block number, in asserts check for absolute number values instead of relative values like above zero, because values never change.
-  Expect for Monad, as Monad blockchain does not support archive nodes and historical state.
+  Exception: Monad retains only a moving recent historical-state window, so use
+  latest-head or state-relative assertions instead of fixed historical blocks.
 - For reuseable testing code, use `testing` modules under `eth_defi` - do not nyt try to import "tests" as it does not work with pytest
 
 ### pyproject.toml
@@ -364,7 +387,7 @@ Never directly edit auto-generated sphinx files in `_autosummary*` folders.
 
 ## Parquet schema migrations
 
-The vault price pipeline accumulates months of historical data in `vault-prices-1h.parquet`. Losing this data requires days of re-scanning from archive nodes.
+The vault price pipeline accumulates months of historical data in `vault-prices-1h.parquet`. Losing this data requires days of re-scanning from archive nodes and may make older Monad data unrecoverable, because Monad does not provide archive-complete historical state.
 
 - **Never silently discard existing data.** If a schema migration (`migrate_parquet_schema()`, `cast()`) fails, the pipeline must abort with a hard error — never fall back to `existing_table = None`. Silent data loss is worse than a crash.
 - **Never catch `ArrowInvalid` and reset to empty.** If the existing parquet cannot be read or migrated, raise the exception so the operator can restore from a backup.
@@ -372,6 +395,7 @@ The vault price pipeline accumulates months of historical data in `vault-prices-
 - **Type changes need explicit migration.** If changing a column's type (e.g. `uint32` → `uint64`), verify `cast()` works on production data before merging — test with a copy of the real parquet, not just synthetic test data.
 - **Always test schema changes against the production parquet.** Download the current file and verify the migration path locally before deploying.
 - **Reader state loss causes full data wipe.** The scanner deletes existing chain rows from `start_block` onwards. If `reader-state.pickle` is lost, `start_block` falls back to the earliest vault block, deleting all historical data for that chain. Treat reader state files as critical production state.
+- **Preserve old Monad rows.** A Monad rescan can replace rows only at or after the dynamically probed provider boundary. Never reset its reader state or delete older rows in an attempt to rebuild unavailable state history.
 
 ## ERC-20
 

--- a/docs/source/tutorials/erc-4626-historical-apy.rst
+++ b/docs/source/tutorials/erc-4626-historical-apy.rst
@@ -17,6 +17,10 @@ Here is a Python example how to estimate the ERC-4626 `APY <https://tradingstrat
 - Uses EVM JSON-RPC and archive node, no external services needed. Public RPC nodes won't work,
   because they are not archive nodes. Get your Base node JSON-RPC access from `dRPC <https://drpc.io/>`__ or `Ethereumnodes.com <https://ethereumnodes.com/>`__.
 
+- Monad cannot provide arbitrary-depth historical APY calculations because it
+  retains only a provider-dependent recent window of contract state; see the
+  `Monad historical data documentation <https://docs.monad.xyz/developer-essentials/historical-data>`__.
+
 - Supported vaults include all ERC-4626, including but not limited to: Morpho, Euler, Lagoon Finance, Superform, IPOR, Yearn, Fluid
 
 Then to run this script:

--- a/docs/source/tutorials/erc-4626-scan-prices.rst
+++ b/docs/source/tutorials/erc-4626-scan-prices.rst
@@ -21,6 +21,16 @@ You need
 - Preferably ``screen`` or ``tmux`` to or similar utility to run long running processes in the background on servers
 - Some hours of patience
 
+.. important::
+
+    Monad does not provide archive-complete historical state. Its full nodes
+    retain historical transaction data, while contract-state availability is a
+    moving provider-dependent window; see the `Monad historical data
+    documentation <https://docs.monad.xyz/developer-essentials/historical-data>`__.
+    The price scanner starts at the oldest state block the configured provider
+    can read. Do not attempt a genesis-to-head Monad state backfill or delete
+    older price rows that the provider cannot reconstruct.
+
 This is a three step scripted process:
 
 - For each chain
@@ -75,6 +85,8 @@ Scanning historical prices
 After discovering the vaults on a chain, we scan their historical performance.
 This is done by ``scan-prices.py`` script. It will read the vaults from the database file created by the previous step.
 then use JSON-RPC archive nodes polling to extract historical prices and parameters like performance fees.
+On Monad, the scanner instead uses the provider's dynamically probed
+historical-state boundary and preserves existing rows before it.
 
 Scan process is stateful
 - It can resume, you can rerun the script and it will rescan from where the scan ended last time
@@ -158,4 +170,3 @@ Further reading
 
 - See :py:ref:`erc-4626` API documentation.
 - `For any questions please join to Discord chat <https://tradingstrategy.ai/community>`__.
-

--- a/eth_defi/provider/broken_provider.py
+++ b/eth_defi/provider/broken_provider.py
@@ -27,20 +27,10 @@ from eth_defi.utils import get_url_domain
 
 logger = logging.getLogger(__name__)
 
-# There are no archive nodes on Monad.
-#
-# This is a network-specific behavior. The Monad archive approach does not support historical state data, only historical transactional data (please see this for more info https://docs.monad.xyz/developer-essentials/historical-data).
-# "Well, I do understand where you're coming from. Having managed dozens of chains myself with the "full/archive" terminology, this sounds odd.
-# However, Monad being a high-throughput chain, it's not feasible to store every state since the genesis. If we do that, you would require a few TBs for every day (check TrieDB).
-# For this reason, we've multi-layered storage system:
-# - TrieDB (Hot) - Has states
-# - ArchiveDB (MongoDB) (Warm) - Doesn't have states
-# - Archive (Object Storage) (Cold) - Doesn't have states
-# So, "archive" in reference to Monad contains blocks, receipts, traces, etc., not states.
-# If you want to store more states locally, you can provision a beefy drive for TrieDB, but still you'd only make a few weeks.
-# Lastly, even without states, ArchiveDB is estimated to store hundreds of GBs of data per day if Monad throughput peaks at 10k TPS."
-
-MONAD_START_BLOCK = 50_000_000
+#: Monad retains historical transaction data but only a provider-dependent
+#: recent window of historical contract state. See
+#: https://docs.monad.xyz/developer-essentials/historical-data.
+MONAD_CHAIN_NAME = "monad"
 
 
 def get_default_block_tip_latency(web3: Web3) -> int:
@@ -270,15 +260,18 @@ def get_safe_cached_latest_block_number(
 
 
 def verify_archive_node(rpc_url: str, chain_name: str) -> tuple[str, int]:
-    """Verify RPC providers and filter out broken ones.
+    """Verify configured RPC providers and filter out broken ones.
 
     Parses the space-separated multi-RPC configuration line and tests each
-    endpoint individually. Checks that each provider can serve both block 1
-    and the latest block. Broken providers are logged at ERROR level and
-    filtered out; the scan continues with working providers only.
+    endpoint individually. On archive-capable chains, checks that each provider
+    can serve state at both block 1 and the latest block. Monad has no
+    archive-complete historical state, so it checks only current-state
+    availability and leaves the retained historical-state boundary to the vault
+    price scanner. Broken providers are logged at ERROR level and filtered out;
+    the scan continues with working providers only.
 
     :param rpc_url: RPC URL configuration line (may contain space-separated fallbacks, ``mev+`` prefixed endpoints are skipped)
-    :param chain_name: Chain name for logging
+    :param chain_name: Chain name for logging and Monad-specific verification
     :return: Tuple of (filtered RPC URL with only working providers, latest block number)
     :raises RuntimeError: If all providers fail verification
     """
@@ -286,6 +279,8 @@ def verify_archive_node(rpc_url: str, chain_name: str) -> tuple[str, int]:
     from eth_defi.provider.multi_provider import create_multi_provider_web3
 
     zero_address = "0x0000000000000000000000000000000000000000"
+    is_monad = chain_name.casefold() == MONAD_CHAIN_NAME
+    verification_label = "current-state RPC" if is_monad else "archive node"
 
     # Preserve mev+ transact-only endpoints as-is
     all_parts = [url.strip() for url in rpc_url.split() if url.strip()]
@@ -312,9 +307,10 @@ def verify_archive_node(rpc_url: str, chain_name: str) -> tuple[str, int]:
             if first_latest_block is None:
                 first_latest_block = latest_block
 
-            # Check block 1 (archive node test)
-            step = f"eth_getBalance({zero_address}, block=1)"
-            web3.eth.get_balance(zero_address, block_identifier=1)
+            if not is_monad:
+                # Check block 1 (archive node test).
+                step = f"eth_getBalance({zero_address}, block=1)"
+                web3.eth.get_balance(zero_address, block_identifier=1)
 
             # Check latest block is queryable
             step = f"eth_getBalance({zero_address}, block={latest_block:,})"
@@ -322,18 +318,20 @@ def verify_archive_node(rpc_url: str, chain_name: str) -> tuple[str, int]:
 
             working.append((endpoint, domain, latest_block))
             logger.info(
-                "%s: Provider %s passed archive node check (latest block %s)",
+                "%s: Provider %s passed %s check (latest block %s)",
                 chain_name,
                 domain,
+                verification_label,
                 f"{latest_block:,}",
             )
         except Exception as e:
             headers = get_last_headers()
             faulty.append((domain, str(e), headers, latest_block))
             logger.error(
-                "%s: Provider %s failed archive node check at step %s (block number %s): %s\nHTTP response headers: %s",
+                "%s: Provider %s failed %s check at step %s (block number %s): %s\nHTTP response headers: %s",
                 chain_name,
                 domain,
+                verification_label,
                 step,
                 f"{latest_block:,}" if latest_block is not None else "unknown",
                 e,
@@ -342,7 +340,7 @@ def verify_archive_node(rpc_url: str, chain_name: str) -> tuple[str, int]:
 
     if not working:
         faulty_str = ", ".join(f"{d} (block {b:,}, {err})" if b is not None else f"{d} ({err})" for d, err, _h, b in faulty)
-        raise RuntimeError(f"{chain_name}: All {len(endpoints)} RPC providers failed archive node verification. Faulty: [{faulty_str}].")
+        raise RuntimeError(f"{chain_name}: All {len(endpoints)} RPC providers failed {verification_label} verification. Faulty: [{faulty_str}].")
 
     if faulty:
         faulty_domains = ", ".join(d for d, _, _, _ in faulty)

--- a/eth_defi/vault/historical.py
+++ b/eth_defi/vault/historical.py
@@ -7,6 +7,10 @@
     - Fees
 
 See :py:class:`VaultHistoricalReadMulticaller` for usage.
+
+Monad does not provide archive-complete historical state. Its price scans probe
+the configured provider and begin at the oldest block where the scanner's
+Multicall contract can execute.
 """
 
 import datetime
@@ -27,15 +31,17 @@ from eth_typing import HexAddress
 from joblib import Parallel, delayed
 from tqdm_loggable.auto import tqdm
 from web3 import Web3
+from web3.exceptions import BadFunctionCallOutput, ContractLogicError
 
 from eth_defi import hypersync
 from eth_defi.chain import EVM_BLOCK_TIMES, get_chain_name
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.erc_4626.vault import VaultReaderState
 from eth_defi.erc_4626.warmup import warmup_vault_reader
-from eth_defi.event_reader.multicall_batcher import BatchCallState, EncodedCall, EncodedCallResult, read_multicall_historical, read_multicall_historical_stateful
+from eth_defi.event_reader.multicall_batcher import BatchCallState, EncodedCall, EncodedCallResult, get_multicall_contract, read_multicall_historical, read_multicall_historical_stateful
 from eth_defi.event_reader.timestamp_cache import DEFAULT_TIMESTAMP_CACHE_FOLDER
 from eth_defi.event_reader.web3factory import Web3Factory
+from eth_defi.middleware import ProbablyNodeHasNoBlock
 from eth_defi.provider.broken_provider import get_almost_latest_block_number
 from eth_defi.provider.rpcdb import RPCRequestStats
 from eth_defi.token import TokenDetails, TokenDiskCache, fetch_erc20_details
@@ -45,6 +51,13 @@ from eth_defi.vault.risk import BROKEN_VAULT_CONTRACTS
 from eth_defi.version_info import stamp_parquet_schema_metadata
 
 logger = logging.getLogger(__name__)
+
+
+#: Monad mainnet chain ID.
+MONAD_CHAIN_ID = 143
+
+#: Canonical explanation of Monad's provider-dependent historical state window.
+MONAD_HISTORICAL_DATA_DOCUMENTATION_URL = "https://docs.monad.xyz/developer-essentials/historical-data"
 
 
 #: List of contracts we cannot scan.
@@ -95,8 +108,83 @@ class VaultReadNotSupported(Exception):
     """Vault cannot be read due to misconfiguration somewhere."""
 
 
+def fetch_monad_historical_state_start_block(
+    web3: Web3,
+    start_block: int,
+    end_block: int,
+) -> int:
+    """Find the earliest block whose Monad state the connected provider can read.
+
+    Monad retains all historical transactional data, but its RPC providers retain
+    historical state only while their state tries fit on disk. The window is
+    provider-specific and may move forward over time. Probe the same Multicall3
+    contract used by the historical price reader and binary-search the boundary
+    between unavailable and available state before creating any output file.
+    See `Monad historical data documentation <https://docs.monad.xyz/developer-essentials/historical-data>`_.
+
+    :param web3:
+        Monad JSON-RPC connection to probe.
+
+    :param start_block:
+        Earliest block otherwise requested by the caller.
+
+    :param end_block:
+        Latest block otherwise requested by the caller. It must be readable,
+        because an unavailable end block indicates a provider failure rather
+        than ordinary historical-state eviction.
+
+    :return:
+        The earliest readable block within ``start_block`` and ``end_block``.
+
+    :raises RuntimeError:
+        If the provider cannot read state at ``end_block``.
+    """
+    assert web3.eth.chain_id == MONAD_CHAIN_ID, f"Expected Monad chain {MONAD_CHAIN_ID}, got {web3.eth.chain_id}"
+    assert start_block >= 0, f"Invalid start block: {start_block}"
+    assert end_block >= start_block, f"End block {end_block} is before start block {start_block}"
+
+    multicall = get_multicall_contract(web3)
+
+    def _is_state_available(block_number: int) -> bool:
+        """Probe whether the Multicall deployment executes at a historical block."""
+        try:
+            received_block_number = multicall.functions.getBlockNumber().call(block_identifier=block_number)
+        except (BadFunctionCallOutput, ContractLogicError, ProbablyNodeHasNoBlock):
+            return False
+        return received_block_number == block_number
+
+    if _is_state_available(start_block):
+        return start_block
+
+    if not _is_state_available(end_block):
+        raise RuntimeError(f"Monad provider cannot read state at requested end block {end_block:,}. Check the RPC provider and {MONAD_HISTORICAL_DATA_DOCUMENTATION_URL}.")
+
+    unavailable_block = start_block
+    available_block = end_block
+    while available_block - unavailable_block > 1:
+        candidate_block = (unavailable_block + available_block) // 2
+        if _is_state_available(candidate_block):
+            available_block = candidate_block
+        else:
+            unavailable_block = candidate_block
+
+    logger.warning(
+        "Monad historical state before block %d is unavailable from the configured RPC provider; clipping price scan start from %d. See %s",
+        available_block,
+        start_block,
+        MONAD_HISTORICAL_DATA_DOCUMENTATION_URL,
+    )
+    return available_block
+
+
 class VaultHistoricalReadMulticaller:
-    """Read historical data from multiple vaults using multicall and archive node polling."""
+    """Read historical data from multiple vaults using Multicall and JSON-RPC polling.
+
+    Archive-capable nodes provide the historical state needed on most EVM
+    chains. Monad instead has a provider-specific recent state window; callers
+    must use :func:`fetch_monad_historical_state_start_block` before starting a
+    scan.
+    """
 
     def __init__(
         self,
@@ -602,6 +690,8 @@ def scan_historical_prices_to_parquet(
     - The same Parquet file can contain data from multiple chains
     - Stamp the output schema with the current Docker ``metadata.version``
       provenance, matching vault scanner JSON exports
+    - On Monad, dynamically clip the requested start to the provider's
+      historical-state window before deleting or replacing Parquet rows
 
     :param output_fname:
         Path to a destination Parquet file.
@@ -625,7 +715,9 @@ def scan_historical_prices_to_parquet(
     :param start_block:
         First block to scan.
 
-        Leave empty to autodetect
+        Leave empty to autodetect. On Monad this is only a lower bound: the
+        scan starts at the oldest block whose state the configured provider can
+        read, because Monad has no arbitrary-depth historical state.
 
     :param end_block:
         Last block to scan.
@@ -716,6 +808,13 @@ def scan_historical_prices_to_parquet(
 
     if end_block is None:
         end_block = get_almost_latest_block_number(web3)
+
+    if chain_id == MONAD_CHAIN_ID:
+        start_block = fetch_monad_historical_state_start_block(
+            web3,
+            start_block=start_block,
+            end_block=end_block,
+        )
 
     reader = VaultHistoricalReadMulticaller(
         web3factory,

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -732,10 +732,10 @@ def scan_chain(
     # Verify RPC providers and filter out broken ones
     try:
         rpc_url, latest_block = verify_archive_node(rpc_url, config.name)
-        logger.info("%s: RPC archive node verification passed, latest block %s", config.name, f"{latest_block:,}")
+        logger.info("%s: RPC capability verification passed, latest block %s", config.name, f"{latest_block:,}")
         result.rpc_url = rpc_url
     except RuntimeError as e:
-        logger.error("%s: All archive node providers failed: %s", config.name, e)
+        logger.error("%s: All RPC providers failed capability verification: %s", config.name, e)
         result.status = "failed"
         result.error = str(e)
         result.duration = time.time() - start_time

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -5,6 +5,17 @@ Scripts for discovering, scanning, analysing, and debugging ERC-4626 vault data.
 All scripts use environment variables for configuration.
 Run with `poetry run python scripts/erc-4626/<script>.py`.
 
+### Monad historical state
+
+[Monad full nodes retain all historical transaction data but only a
+provider-dependent window of historical state](https://docs.monad.xyz/developer-essentials/historical-data).
+Before scanning Monad vault prices, the reader probes its Multicall contract and
+starts at the oldest block whose state the configured RPC can read. Existing
+price rows before that boundary are preserved; a provider cannot reconstruct
+them once its state trie has been evicted. Do not retry an old `eth_call`, set
+`START_BLOCK=1`, or delete these rows in an attempt to run a full Monad archive
+backfill: that state history is unavailable by design.
+
 ## Production pipeline
 
 These scripts form the core data pipeline for vault discovery, price scanning, and export.
@@ -1419,7 +1430,8 @@ poetry run python scripts/erc-4626/wrangle-single-vault.py
 
 ### read-historical-apy.py
 
-Example script to estimate the historical APY of an ERC-4626 vault. Requires an archive node.
+Example script to estimate the historical APY of an ERC-4626 vault. Requires an
+archive-state node; Monad cannot provide arbitrary-depth historical state.
 
 ```shell
 JSON_RPC_URL=$JSON_RPC_BASE poetry run python scripts/erc-4626/read-historical-apy.py

--- a/scripts/erc-4626/fix-upshift-vaults.py
+++ b/scripts/erc-4626/fix-upshift-vaults.py
@@ -19,6 +19,11 @@ the earliest block any selected Upshift vault needs, while parquet deletion
 remains scoped to those selected Upshift addresses. Each supported chain is
 scanned at most once per run.
 
+Monad does not provide archive-complete historical state. Its Upshift price
+scan probes the configured RPC provider and begins at the oldest block whose
+state it can read; do not retry it from genesis after state eviction. Existing
+earlier rows remain preserved.
+
 API documentation:
 
 - https://docs.upshift.finance/developer-docs/api-reference
@@ -49,7 +54,8 @@ Useful environment variables:
      - If ``false``, update only leads and metadata. Default: ``true``.
    * - ``UPSHIFT_REWRITE_TARGETED``
      - If ``true``, rescan each target vault from its first known block and rewrite only
-       that vault's rows. Default: ``false``.
+       that vault's rows. On Monad, the provider historical-state boundary still clips
+       the effective start block. Default: ``false``.
    * - ``MAX_WORKERS``
      - Historical multicall worker count. Default: ``8``.
    * - ``FREQUENCY``

--- a/scripts/erc-4626/read-historical-apy.py
+++ b/scripts/erc-4626/read-historical-apy.py
@@ -1,6 +1,8 @@
 """An example script to estimate the historical APY of an ERC-4626 vault.
 
-- Archive JSON-RPC node needed, public endpoint may not work.
+- Requires an archive-state JSON-RPC node; public endpoints may not work.
+- This example targets Base. Monad has no archive-complete historical state and
+  cannot support arbitrary-depth historical APY backfills.
 
 To run:
 

--- a/scripts/erc-4626/scan-prices.py
+++ b/scripts/erc-4626/scan-prices.py
@@ -3,6 +3,11 @@
 - Scan prices for all vaults discovered earlier with ``scan-vaults.py``
 - Write results to the Parquet file that is shared across all chains
 
+Monad does not provide archive-complete historical state. A Monad scan probes
+the configured RPC provider and starts at its oldest readable state block;
+setting ``START_BLOCK=1`` does not trigger an impossible genesis-to-head
+backfill. Existing earlier Parquet rows are preserved.
+
 Usage:
 
 .. code-block:: shell

--- a/tests/erc_4626/test_monad_historical_state.py
+++ b/tests/erc_4626/test_monad_historical_state.py
@@ -1,0 +1,90 @@
+"""Tests for Monad historical state retention handling."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from eth_defi.middleware import ProbablyNodeHasNoBlock
+from eth_defi.vault import historical
+
+GENESIS_BLOCK = 0
+MONAD_RETAINED_STATE_START_BLOCK = 600
+LATEST_BLOCK = 1_000
+MAX_BINARY_SEARCH_PROBES = 12
+HISTORICAL_STATE_EVICTED = "Monad historical state evicted"
+
+
+def _create_multicall_probe(available_from_block: int) -> tuple[SimpleNamespace, list[int]]:
+    """Create a Multicall mock with a contiguous historical state window.
+
+    :param available_from_block:
+        First block at which the mock provider can execute a historical call.
+
+    :return:
+        Mock contract and the probed block numbers.
+    """
+    calls: list[int] = []
+
+    def _call(*, block_identifier: int) -> int:
+        """Simulate a historical Multicall execution."""
+        calls.append(block_identifier)
+        if block_identifier < available_from_block:
+            raise ProbablyNodeHasNoBlock(HISTORICAL_STATE_EVICTED)
+        return block_identifier
+
+    def _get_block_number() -> SimpleNamespace:
+        """Create the bound ``getBlockNumber`` call mock."""
+        return SimpleNamespace(call=_call)
+
+    multicall = SimpleNamespace(
+        functions=SimpleNamespace(getBlockNumber=_get_block_number),
+    )
+    return multicall, calls
+
+
+def test_fetch_monad_historical_state_start_block_clips_to_provider_window(monkeypatch) -> None:
+    """Find the first readable block without attempting an old price scan."""
+    multicall, calls = _create_multicall_probe(available_from_block=MONAD_RETAINED_STATE_START_BLOCK)
+    web3 = SimpleNamespace(eth=SimpleNamespace(chain_id=143))
+    monkeypatch.setattr(historical, "get_multicall_contract", lambda _web3: multicall)
+
+    start_block = historical.fetch_monad_historical_state_start_block(
+        web3,
+        start_block=GENESIS_BLOCK,
+        end_block=LATEST_BLOCK,
+    )
+
+    assert start_block == MONAD_RETAINED_STATE_START_BLOCK
+    assert calls[0] == GENESIS_BLOCK
+    assert calls[1] == LATEST_BLOCK
+    assert len(calls) <= MAX_BINARY_SEARCH_PROBES
+
+
+def test_fetch_monad_historical_state_start_block_preserves_readable_start(monkeypatch) -> None:
+    """Avoid unnecessary boundary probing when all requested state is readable."""
+    multicall, calls = _create_multicall_probe(available_from_block=500)
+    web3 = SimpleNamespace(eth=SimpleNamespace(chain_id=143))
+    monkeypatch.setattr(historical, "get_multicall_contract", lambda _web3: multicall)
+
+    start_block = historical.fetch_monad_historical_state_start_block(
+        web3,
+        start_block=MONAD_RETAINED_STATE_START_BLOCK,
+        end_block=LATEST_BLOCK,
+    )
+
+    assert start_block == MONAD_RETAINED_STATE_START_BLOCK
+    assert calls == [MONAD_RETAINED_STATE_START_BLOCK]
+
+
+def test_fetch_monad_historical_state_start_block_rejects_unavailable_end(monkeypatch) -> None:
+    """Treat unavailable current state as a provider fault, not a retention boundary."""
+    multicall, _calls = _create_multicall_probe(available_from_block=1_001)
+    web3 = SimpleNamespace(eth=SimpleNamespace(chain_id=143))
+    monkeypatch.setattr(historical, "get_multicall_contract", lambda _web3: multicall)
+
+    with pytest.raises(RuntimeError, match="cannot read state"):
+        historical.fetch_monad_historical_state_start_block(
+            web3,
+            start_block=GENESIS_BLOCK,
+            end_block=LATEST_BLOCK,
+        )

--- a/tests/rpc/test_broken_provider.py
+++ b/tests/rpc/test_broken_provider.py
@@ -1,0 +1,47 @@
+"""Tests for RPC capability verification."""
+
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from eth_defi.provider import multi_provider
+from eth_defi.provider.broken_provider import verify_archive_node
+
+LATEST_BLOCK = 100
+
+
+@pytest.mark.parametrize(
+    ("chain_name", "expected_blocks"),
+    [
+        ("Monad", [LATEST_BLOCK]),
+        ("Base", [1, LATEST_BLOCK]),
+    ],
+)
+def test_verify_archive_node_skips_genesis_state_probe_for_monad(
+    monkeypatch: pytest.MonkeyPatch,
+    chain_name: str,
+    expected_blocks: list[int],
+) -> None:
+    """Monad verification must not make an impossible genesis-state request.
+
+    Monad checks only that the endpoint can read the current state, whereas
+    archive-capable chains retain the block-one verification probe.
+
+    :param monkeypatch:
+        Pytest monkeypatch fixture.
+    :param chain_name:
+        Chain name supplied to the verifier.
+    :param expected_blocks:
+        Blocks expected in balance probes.
+    """
+    get_balance = MagicMock()
+    web3 = MagicMock()
+    web3.eth.block_number = LATEST_BLOCK
+    web3.eth.get_balance = get_balance
+    monkeypatch.setattr(multi_provider, "create_multi_provider_web3", lambda *_args, **_kwargs: web3)
+
+    rpc_url, latest_block = verify_archive_node("https://rpc.example", chain_name)
+
+    assert rpc_url == "https://rpc.example"
+    assert latest_block == LATEST_BLOCK
+    assert get_balance.call_args_list == [call("0x0000000000000000000000000000000000000000", block_identifier=block_number) for block_number in expected_blocks]


### PR DESCRIPTION
## Why

Monad retains historical transaction data but only a provider-dependent recent window of contract state. Historical vault scans and the all-chain RPC preflight must not request evicted genesis-era state, because no retry or archive provider can recover it.

## Lessons learnt

A Monad provider can serve blocks, receipts and timestamps from genesis while still being unable to execute historical contract calls. Historical-value scanners must detect the readable state boundary and preserve already collected rows before it.

## Summary

- Probe the configured Monad provider through Multicall, binary-search its oldest readable state block, and clip the price scan before Parquet replacement.
- Treat Monad RPC preflight as a current-state capability check and skip the impossible block-one state probe.
- Document the restriction in `CLAUDE.md`, scanner and Upshift docstrings, the vault-script runbook, and public ERC-4626 tutorials.
- Add regression coverage for boundary detection and Monad RPC preflight behaviour.

## Related issues and PRs

- Follow-up to production Monad historical-state failures encountered during Upshift vault migration.

## Unrelated CI and test fixes

- None.