### PR TITLE
Migrate vault-post DuckDB storage to Zstd

### DIFF
--- a/eth_defi/feed/database.py
+++ b/eth_defi/feed/database.py
@@ -3,9 +3,11 @@
 import datetime
 import logging
 import os
+import tempfile
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Self
+from typing import Self
 
 import duckdb
 import pandas as pd
@@ -13,12 +15,88 @@ import pandas as pd
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.feed.sources import TrackedPostSource
 
-
 logger = logging.getLogger(__name__)
 
 
 #: Default DuckDB path for collected vault posts.
 DEFAULT_VAULT_POST_DATABASE = Path("~/.tradingstrategy/vaults/vault-post-database.duckdb").expanduser()
+
+
+#: DuckDB storage version for new vault-post databases.
+#:
+#: ``latest`` enables native Zstandard compression for long post text and raw
+#: source API payloads. The resulting file requires its writer's DuckDB
+#: version or a newer version.
+VAULT_POST_DUCKDB_STORAGE_COMPATIBILITY_VERSION = "latest"
+
+#: Vault-post tables owned by :class:`VaultPostDatabase` and copied during migration.
+VAULT_POST_DATABASE_TABLES = (
+    "tracked_sources",
+    "posts",
+    "feed_sync_state",
+)
+
+#: Columns owned by each vault-post table, in the migration target's order.
+#:
+#: Existing database files can predate a nullable column added through
+#: ``ALTER TABLE``.  Migration copies by these names rather than source column
+#: position, preserving the historical schema variants.
+VAULT_POST_DATABASE_COLUMNS = {
+    "tracked_sources": (
+        "source_id",
+        "feeder_id",
+        "name",
+        "role",
+        "website",
+        "source_type",
+        "source_key",
+        "canonical_url",
+        "last_checked_at",
+        "last_success_at",
+        "last_error",
+        "last_post_published_at",
+        "added_at",
+        "updated_at",
+    ),
+    "posts": (
+        "source_id",
+        "external_post_id",
+        "title",
+        "post_url",
+        "published_at",
+        "fetched_at",
+        "short_description",
+        "full_text",
+        "ai_summary",
+        "raw_payload",
+    ),
+    "feed_sync_state": (
+        "key",
+        "value",
+        "updated_at",
+    ),
+}
+
+#: Nullable columns added after the original post-scanner schema.
+VAULT_POST_OPTIONAL_MIGRATION_COLUMNS = frozenset({"website", "raw_payload"})
+
+#: Per-column storage inspection queries for Zstandard-compressed post content.
+VAULT_POST_COMPRESSION_QUERIES = {
+    "full_text": """
+        SELECT DISTINCT compression
+        FROM pragma_storage_info('posts')
+        WHERE column_name = 'full_text'
+            AND segment_type = 'VARCHAR'
+            AND persistent
+    """,
+    "raw_payload": """
+        SELECT DISTINCT compression
+        FROM pragma_storage_info('posts')
+        WHERE column_name = 'raw_payload'
+            AND segment_type = 'VARCHAR'
+            AND persistent
+    """,
+}
 
 
 def resolve_feed_database_path() -> Path:
@@ -84,8 +162,14 @@ class VaultPostDatabase:
         path.parent.mkdir(parents=True, exist_ok=True)
 
         self.path = path
-        self.con = duckdb.connect(str(path))
-        self._init_schema()
+        if path.exists() and path.stat().st_size > 0:
+            self._migrate_to_latest_storage_format(path)
+
+        self.con = duckdb.connect(
+            str(path),
+            config={"storage_compatibility_version": VAULT_POST_DUCKDB_STORAGE_COMPATIBILITY_VERSION},
+        )
+        self._init_schema(self.con)
 
     def __enter__(self) -> Self:
         """Enter a context-managed database session."""
@@ -97,12 +181,25 @@ class VaultPostDatabase:
 
         self.close()
 
-    def _init_schema(self) -> None:
-        """Create database schema if needed."""
+    @staticmethod
+    def _init_schema(connection: duckdb.DuckDBPyConnection, sequence_start: int = 1) -> None:
+        """Create the vault-post schema with compressed text payloads.
 
-        self.con.execute("CREATE SEQUENCE IF NOT EXISTS tracked_sources_id_seq START 1")
+        ``sequence_start`` is used only while migrating an existing database.
+        DuckDB's latest storage format makes the ``source_id`` default depend
+        on its sequence, so the old drop-and-recreate sequence reset cannot be
+        used after the table exists.
 
-        self.con.execute("""
+        :param connection:
+            DuckDB connection for either the live database or a migration target.
+        :param sequence_start:
+            First identifier allocated by the tracked-source sequence.
+        """
+        assert sequence_start > 0, f"Expected positive sequence start, got {sequence_start}"
+
+        connection.execute(f"CREATE SEQUENCE IF NOT EXISTS tracked_sources_id_seq START {sequence_start}")
+
+        connection.execute("""
             CREATE TABLE IF NOT EXISTS tracked_sources (
                 source_id BIGINT PRIMARY KEY DEFAULT nextval('tracked_sources_id_seq'),
                 feeder_id VARCHAR NOT NULL,
@@ -121,18 +218,9 @@ class VaultPostDatabase:
                 UNIQUE (feeder_id, role, source_type, source_key)
             )
         """)
-        self.con.execute("ALTER TABLE tracked_sources ADD COLUMN IF NOT EXISTS website VARCHAR")
+        connection.execute("ALTER TABLE tracked_sources ADD COLUMN IF NOT EXISTS website VARCHAR")
 
-        # Sync the sequence past any existing rows so nextval() never collides
-        # with an existing primary key.  This guards against sequence state loss
-        # across container rebuilds while the database file persists on a volume.
-        max_id = self.con.execute("SELECT COALESCE(MAX(source_id), 0) FROM tracked_sources").fetchone()[0]
-        if max_id > 0:
-            # Advance the sequence past the current max by dropping and recreating
-            self.con.execute("DROP SEQUENCE IF EXISTS tracked_sources_id_seq")
-            self.con.execute(f"CREATE SEQUENCE tracked_sources_id_seq START {max_id + 1}")
-
-        self.con.execute("""
+        connection.execute("""
             CREATE TABLE IF NOT EXISTS posts (
                 source_id BIGINT NOT NULL,
                 external_post_id VARCHAR NOT NULL,
@@ -141,20 +229,243 @@ class VaultPostDatabase:
                 published_at TIMESTAMP,
                 fetched_at TIMESTAMP NOT NULL,
                 short_description VARCHAR NOT NULL,
-                full_text VARCHAR NOT NULL,
+                full_text VARCHAR USING COMPRESSION 'zstd' NOT NULL,
                 ai_summary VARCHAR,
+                raw_payload VARCHAR USING COMPRESSION 'zstd',
                 PRIMARY KEY (source_id, external_post_id)
             )
         """)
-        self.con.execute("ALTER TABLE posts ADD COLUMN IF NOT EXISTS raw_payload VARCHAR")
 
-        self.con.execute("""
+        connection.execute("""
             CREATE TABLE IF NOT EXISTS feed_sync_state (
                 key VARCHAR PRIMARY KEY,
                 value VARCHAR NOT NULL,
                 updated_at TIMESTAMP NOT NULL
             )
         """)
+
+    @staticmethod
+    def _fetch_storage_version(path: Path) -> str:
+        """Read the DuckDB storage format used by a database file.
+
+        :param path:
+            Existing DuckDB database file to inspect.
+        :return:
+            Storage format tag, such as ``v1.0.0+``.
+        """
+        connection = duckdb.connect(str(path), read_only=True)
+        try:
+            tags = connection.execute("SELECT tags FROM duckdb_databases() WHERE database_name = current_database()").fetchone()[0]
+        finally:
+            connection.close()
+
+        return tags["storage_version"]
+
+    @staticmethod
+    def _uses_latest_storage_format(storage_version: str) -> bool:
+        """Check whether a database uses this DuckDB version's latest format.
+
+        :param storage_version:
+            Database ``storage_version`` tag returned by DuckDB.
+        :return:
+            ``True`` when the file already uses the installed format.
+        """
+        major, minor, _patch = duckdb.__version__.split(".", maxsplit=2)
+        return storage_version == f"v{major}.{minor}.0+"
+
+    @classmethod
+    def _migrate_to_latest_storage_format(cls, path: Path) -> None:
+        """Rebuild a legacy vault-post database in the latest DuckDB format.
+
+        The migration writes a sibling database with Zstandard-compressed post
+        body and raw-payload columns, verifies all owned table row counts and
+        then atomically replaces the original. The original remains untouched
+        until the target has been checkpointed and verified.
+
+        :param path:
+            Existing vault-post DuckDB database file to migrate.
+        :return:
+            ``None``. The migrated database replaces ``path`` on success.
+        """
+        storage_version = cls._fetch_storage_version(path)
+        if cls._uses_latest_storage_format(storage_version):
+            return
+
+        # Replay any recovery WAL before attaching the source read-only. This
+        # prevents an old sidecar WAL from being left next to the replacement.
+        source_connection = duckdb.connect(str(path))
+        try:
+            source_connection.execute("CHECKPOINT")
+        finally:
+            source_connection.close()
+
+        logger.info(
+            "Migrating vault-post database at %s from DuckDB storage format %s to %s",
+            path,
+            storage_version,
+            VAULT_POST_DUCKDB_STORAGE_COMPATIBILITY_VERSION,
+        )
+
+        file_descriptor, migration_path_str = tempfile.mkstemp(
+            dir=path.parent,
+            prefix=f".{path.name}.migration-",
+            suffix=".duckdb",
+        )
+        os.close(file_descriptor)
+        migration_path = Path(migration_path_str)
+        migration_path.unlink()
+        replaced = False
+
+        try:
+            migration = duckdb.connect(
+                str(migration_path),
+                config={"storage_compatibility_version": VAULT_POST_DUCKDB_STORAGE_COMPATIBILITY_VERSION},
+            )
+            try:
+                quoted_path = str(path).replace("'", "''")
+                migration.execute(f"ATTACH '{quoted_path}' AS source (READ_ONLY)")
+                source_tables = {
+                    row[0]
+                    for row in migration.execute(
+                        """
+                        SELECT table_name
+                        FROM information_schema.tables
+                        WHERE table_catalog = 'source'
+                            AND table_schema = 'main'
+                        """
+                    ).fetchall()
+                }
+                source_max_id = cls._fetch_source_max_id(migration, source_tables)
+                cls._init_schema(migration, sequence_start=source_max_id + 1)
+
+                for table_name in VAULT_POST_DATABASE_TABLES:
+                    if table_name in source_tables:
+                        cls._copy_source_table(migration, table_name)
+
+                cls._validate_migration(migration, source_tables)
+                migration.execute("CHECKPOINT")
+            finally:
+                migration.close()
+
+            cls._validate_migrated_file(migration_path, source_tables)
+            os.replace(migration_path, path)
+            replaced = True
+        finally:
+            if not replaced and migration_path.exists():
+                migration_path.unlink()
+
+        logger.info("Completed vault-post database migration at %s", path)
+
+    @staticmethod
+    def _copy_source_table(connection: duckdb.DuckDBPyConnection, table_name: str) -> None:
+        """Copy an attached source table by name, including legacy nullable defaults.
+
+        Both ``website`` and ``raw_payload`` were introduced with ``ALTER
+        TABLE``.  Older database files therefore lack these columns, while
+        newer files have them appended to the source table.  Selecting named
+        columns avoids a positional schema mismatch and supplies ``NULL`` for
+        either missing nullable column.
+
+        :param connection:
+            Migration connection with the original database attached as ``source``.
+        :param table_name:
+            A fixed vault-post table name from :data:`VAULT_POST_DATABASE_TABLES`.
+        """
+        target_columns = VAULT_POST_DATABASE_COLUMNS[table_name]
+        source_columns = {
+            row[0]
+            for row in connection.execute(
+                """
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_catalog = 'source'
+                    AND table_schema = 'main'
+                    AND table_name = ?
+                """,
+                [table_name],
+            ).fetchall()
+        }
+        missing_required_columns = set(target_columns) - source_columns - VAULT_POST_OPTIONAL_MIGRATION_COLUMNS
+        if missing_required_columns:
+            raise RuntimeError(f"Vault-post database table {table_name} is missing required columns: {sorted(missing_required_columns)}")
+        extra_source_columns = source_columns - set(target_columns)
+        if extra_source_columns:
+            raise RuntimeError(f"Vault-post database table {table_name} has unrecognised columns: {sorted(extra_source_columns)}")
+
+        select_expressions = [column_name if column_name in source_columns else f"NULL AS {column_name}" for column_name in target_columns]
+        columns_sql = ", ".join(target_columns)
+        select_sql = ", ".join(select_expressions)
+        # Table and column names originate only from module constants.
+        connection.execute(f"INSERT INTO {table_name} ({columns_sql}) SELECT {select_sql} FROM source.{table_name}")  # noqa: S608
+
+    @staticmethod
+    def _fetch_source_max_id(connection: duckdb.DuckDBPyConnection, source_tables: set[str]) -> int:
+        """Read the maximum source ID from the attached migration source.
+
+        :param connection:
+            Migration connection with the original database attached as ``source``.
+        :param source_tables:
+            Tables present in the source database's main schema.
+        :return:
+            Largest source identifier, or zero when the source has no table or rows.
+        """
+        if "tracked_sources" not in source_tables:
+            return 0
+
+        return int(connection.execute("SELECT COALESCE(MAX(source_id), 0) FROM source.tracked_sources").fetchone()[0])
+
+    @staticmethod
+    def _validate_migration(connection: duckdb.DuckDBPyConnection, source_tables: set[str]) -> None:
+        """Check that an attached source database was copied without data loss.
+
+        :param connection:
+            Migration connection with the original database attached as ``source``.
+        :param source_tables:
+            Tables present in the source database's main schema.
+        :return:
+            ``None``. Raises :class:`RuntimeError` if validation fails.
+        """
+        for table_name in VAULT_POST_DATABASE_TABLES:
+            if table_name not in source_tables:
+                continue
+
+            # Table names are fixed module constants, not user input.
+            source_count = connection.execute(f"SELECT COUNT(*) FROM source.{table_name}").fetchone()[0]  # noqa: S608
+            migrated_count = connection.execute(f"SELECT COUNT(*) FROM {table_name}").fetchone()[0]  # noqa: S608
+            if source_count != migrated_count:
+                raise RuntimeError(f"Vault-post database migration copied {migrated_count} rows for {table_name}, expected {source_count}")
+
+    @classmethod
+    def _validate_migrated_file(cls, path: Path, source_tables: set[str]) -> None:
+        """Verify the checkpointed target and its Zstandard post-content columns.
+
+        :param path:
+            Checkpointed migration target to reopen read-only.
+        :param source_tables:
+            Tables present in the original vault-post database.
+        :return:
+            ``None``. Raises :class:`RuntimeError` if compression is absent.
+        """
+        connection = duckdb.connect(str(path), read_only=True)
+        try:
+            storage_version = connection.execute("SELECT tags['storage_version'] FROM duckdb_databases() WHERE database_name = current_database()").fetchone()[0]
+            if not cls._uses_latest_storage_format(storage_version):
+                raise RuntimeError(f"Vault-post database migration wrote unexpected storage format {storage_version}")
+
+            if "posts" not in source_tables:
+                return
+
+            for column_name, query in VAULT_POST_COMPRESSION_QUERIES.items():
+                # Column names are fixed module constants, not user input.
+                row_count = connection.execute(f"SELECT COUNT({column_name}) FROM posts").fetchone()[0]  # noqa: S608
+                if row_count == 0:
+                    continue
+
+                compressions = {row[0] for row in connection.execute(query).fetchall()}
+                if compressions != {"ZSTD"}:
+                    raise RuntimeError(f"Vault-post database migration did not Zstd-compress posts.{column_name}: {compressions}")
+        finally:
+            connection.close()
 
     def close(self) -> None:
         """Close the database connection."""

--- a/tests/feed/test_database.py
+++ b/tests/feed/test_database.py
@@ -1,0 +1,181 @@
+"""Tests for vault-post DuckDB schema management and migration."""
+
+import datetime
+import json
+from pathlib import Path
+
+import duckdb
+import pytest
+
+from eth_defi.feed.database import VAULT_POST_COMPRESSION_QUERIES, VaultPostDatabase
+from eth_defi.feed.sources import TrackedPostSource
+
+
+@pytest.mark.parametrize("legacy_has_raw_payload", (False, True), ids=("without-raw-payload", "with-raw-payload"))
+def test_migrate_legacy_database_to_latest_storage_with_zstd_post_content(tmp_path: Path, legacy_has_raw_payload: bool) -> None:
+    """Migrate legacy vault posts without loss and allocate new source IDs safely.
+
+    1. Create a legacy-format database with source, post, and sync-state rows.
+    2. Open it through :class:`VaultPostDatabase` to migrate and validate it.
+    3. Reopen it, insert a new source, and verify the ID sequence follows copied rows.
+    4. Verify the post body and, when present, raw API payload use native
+       Zstandard compression.
+
+    :param tmp_path:
+        Pytest-provided directory for the legacy and migrated DuckDB file.
+    :param legacy_has_raw_payload:
+        Whether the source database has the nullable column added by the
+        historical schema upgrade.
+    """
+    database_path = tmp_path / "legacy-vault-posts.duckdb"
+    timestamp = datetime.datetime(2026, 7, 24, 12, 0, 0)  # noqa: DTZ001 - repository datetimes are naive UTC
+    expected_new_source_id = 3
+    full_text = "Full note tweet body. " * 1_000
+    raw_payload = json.dumps({"data": "Raw API payload. " * 1_000})
+
+    legacy = duckdb.connect(str(database_path))
+    try:
+        legacy.execute("CREATE SEQUENCE tracked_sources_id_seq START 1")
+        legacy.execute("""
+            CREATE TABLE tracked_sources (
+                source_id BIGINT PRIMARY KEY DEFAULT nextval('tracked_sources_id_seq'),
+                feeder_id VARCHAR NOT NULL,
+                name VARCHAR NOT NULL,
+                role VARCHAR NOT NULL,
+                website VARCHAR,
+                source_type VARCHAR NOT NULL,
+                source_key VARCHAR NOT NULL,
+                canonical_url VARCHAR NOT NULL,
+                last_checked_at TIMESTAMP,
+                last_success_at TIMESTAMP,
+                last_error VARCHAR,
+                last_post_published_at TIMESTAMP,
+                added_at TIMESTAMP NOT NULL,
+                updated_at TIMESTAMP NOT NULL,
+                UNIQUE (feeder_id, role, source_type, source_key)
+            )
+        """)
+        legacy.execute("""
+            CREATE TABLE posts (
+                source_id BIGINT NOT NULL,
+                external_post_id VARCHAR NOT NULL,
+                title VARCHAR,
+                post_url VARCHAR,
+                published_at TIMESTAMP,
+                fetched_at TIMESTAMP NOT NULL,
+                short_description VARCHAR NOT NULL,
+                full_text VARCHAR NOT NULL,
+                ai_summary VARCHAR,
+                PRIMARY KEY (source_id, external_post_id)
+            )
+        """)
+        if legacy_has_raw_payload:
+            legacy.execute("ALTER TABLE posts ADD COLUMN raw_payload VARCHAR")
+        legacy.execute("""
+            CREATE TABLE feed_sync_state (
+                key VARCHAR PRIMARY KEY,
+                value VARCHAR NOT NULL,
+                updated_at TIMESTAMP NOT NULL
+            )
+        """)
+        legacy.execute(
+            """
+            INSERT INTO tracked_sources (
+                source_id, feeder_id, name, role, website, source_type,
+                source_key, canonical_url, added_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [2, "existing", "Existing source", "protocol", "https://existing.example", "rss", "existing", "https://existing.example/feed", timestamp, timestamp],
+        )
+        legacy.execute(
+            """
+            INSERT INTO posts (
+                source_id, external_post_id, title, post_url, published_at,
+                fetched_at, short_description, full_text, ai_summary
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [2, "post-1", "Post", "https://existing.example/post-1", timestamp, timestamp, "Short description", full_text, None],
+        )
+        if legacy_has_raw_payload:
+            legacy.execute("UPDATE posts SET raw_payload = ?", [raw_payload])
+        legacy.execute("INSERT INTO feed_sync_state VALUES (?, ?, ?)", ["cursor", "abc", timestamp])
+        legacy.execute("CHECKPOINT")
+    finally:
+        legacy.close()
+
+    database = VaultPostDatabase(database_path)
+    try:
+        assert len(database.get_tracked_sources_df()) == 1
+        assert len(database.get_posts_df()) == 1
+        assert database.get_sync_state("cursor") == "abc"
+        assert database.con.execute("SELECT raw_payload FROM posts").fetchone()[0] == (raw_payload if legacy_has_raw_payload else None)
+    finally:
+        database.close()
+
+    database = VaultPostDatabase(database_path)
+    try:
+        new_source_id = database.upsert_tracked_source(
+            TrackedPostSource(
+                feeder_id="new",
+                name="New source",
+                role="curator",
+                website="https://new.example",
+                source_type="rss",
+                source_key="new",
+                canonical_url="https://new.example/feed",
+                mapping_file=Path("new.yaml"),
+            )
+        )
+        assert new_source_id == expected_new_source_id
+    finally:
+        database.close()
+
+    connection = duckdb.connect(str(database_path), read_only=True)
+    try:
+        storage_version = connection.execute("SELECT tags['storage_version'] FROM duckdb_databases() WHERE database_name = current_database()").fetchone()[0]
+        assert VaultPostDatabase._uses_latest_storage_format(storage_version)
+        for column_name, query in VAULT_POST_COMPRESSION_QUERIES.items():
+            if column_name == "raw_payload" and not legacy_has_raw_payload:
+                continue
+            assert {row[0] for row in connection.execute(query).fetchall()} == {"ZSTD"}
+    finally:
+        connection.close()
+
+
+def test_migration_refuses_unrecognised_source_columns(tmp_path: Path) -> None:
+    """Retain the original database when its schema cannot be copied losslessly.
+
+    :param tmp_path:
+        Pytest-provided directory for the legacy database file.
+    """
+    database_path = tmp_path / "unknown-column-vault-posts.duckdb"
+    legacy = duckdb.connect(str(database_path))
+    try:
+        legacy.execute("""
+            CREATE TABLE posts (
+                source_id BIGINT NOT NULL,
+                external_post_id VARCHAR NOT NULL,
+                title VARCHAR,
+                post_url VARCHAR,
+                published_at TIMESTAMP,
+                fetched_at TIMESTAMP NOT NULL,
+                short_description VARCHAR NOT NULL,
+                full_text VARCHAR NOT NULL,
+                ai_summary VARCHAR,
+                raw_payload VARCHAR,
+                source_api_version VARCHAR
+            )
+        """)
+        legacy.execute("CHECKPOINT")
+    finally:
+        legacy.close()
+
+    with pytest.raises(RuntimeError, match="unrecognised columns"):
+        VaultPostDatabase(database_path)
+
+    legacy = duckdb.connect(str(database_path), read_only=True)
+    try:
+        columns = {row[1] for row in legacy.execute("PRAGMA table_info('posts')").fetchall()}
+        assert "source_api_version" in columns
+    finally:
+        legacy.close()


### PR DESCRIPTION
## Why

The post-scanner DuckDB database stored large post bodies and raw source payloads without native compression. Rebuilding it in DuckDB’s latest storage format with Zstandard substantially reduces storage while preserving scanner state.

## Lessons learnt

- DuckDB latest-format sequence defaults cannot use the prior drop-and-recreate reset approach.
- Legacy post databases may predate nullable columns added through ALTER TABLE, so migration must copy named columns and refuse unknown schema rather than silently losing data.

## Summary

- Enable latest DuckDB storage compatibility and Zstandard compression for post bodies and raw payloads.
- Atomically migrate existing post databases, validate counts, storage format, compression, and source-ID sequencing.
- Add compatibility and loss-prevention regression tests.

## Related issues and PRs

- Applies the Core3 DuckDB Zstandard migration approach to the post-scanner database.

## Unrelated CI and test fixes

- None.
