### PR TITLE
fix: handle duplicate vault price timestamps

### DIFF
--- a/eth_defi/event_reader/multicall_timestamp.py
+++ b/eth_defi/event_reader/multicall_timestamp.py
@@ -222,6 +222,12 @@ def fetch_block_timestamps_multiprocess_auto_backend(
 
     :return:
         Pandas series block number (int) -> block timestamp (datetime)
+
+        The mapping is deliberately keyed by block number. Modern chains such
+        as Monad can produce multiple blocks in one second, while block-header
+        timestamps retain one-second precision. Do not reverse this mapping or
+        treat timestamp values as unique; retaining the same timestamp for
+        multiple blocks is correct for the scanner's intended precision.
     """
 
     if hypersync_client:

--- a/eth_defi/event_reader/timestamp_cache.py
+++ b/eth_defi/event_reader/timestamp_cache.py
@@ -26,6 +26,14 @@ class BlockTimestampDatabase:
     - Efficient selective loading and upserting
     - One second precision for disk space and speed savings
 
+    Modern high-throughput chains, including Monad, can produce multiple
+    blocks during one Unix-timestamp second. Block timestamps are therefore a
+    one-to-many mapping from timestamp to block number: equal timestamp values
+    are expected and must not be used as unique block or observation IDs. One
+    second precision is sufficient for this project's historical scans, so we
+    deliberately preserve the shared timestamp instead of inventing
+    higher-resolution values.
+
     For usage see `eth_defi.event_reader.multicall_timestamp.fetch_block_timestamps_multiprocess_auto_backend`
     """
 

--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -977,7 +977,11 @@ def remove_inactive_lead_time(
 
     :param prices_df:
         Price data with 'id' and 'total_supply' columns.
-        Assumes data is sorted by timestamp within each vault.
+        Assumes data is sorted chronologically within each vault. Timestamp
+        labels may repeat because modern chains such as Monad can create
+        multiple blocks per second. One-second accuracy is sufficient for
+        price cleaning, so equal timestamp rows are retained and evaluated by
+        their row positions instead of being deduplicated.
 
     :return:
         DataFrame with inactive lead time removed for each vault
@@ -1001,8 +1005,11 @@ def remove_inactive_lead_time(
             # No valid total_supply values - keep all data
             return group
 
-        first_valid_idx = valid_supply_mask.idxmax()
-        first_valid_loc = group.index.get_loc(first_valid_idx)
+        # Derive locations from the boolean mask, instead of resolving a
+        # timestamp label through the index. A vault can have multiple
+        # observations with the same timestamp, in which case get_loc()
+        # returns a slice rather than one integer position.
+        first_valid_loc = int(valid_supply_mask.to_numpy().argmax())
         initial_supply = group.iloc[first_valid_loc]["total_supply"]
 
         # Find the first index where total_supply differs from initial value
@@ -1018,8 +1025,7 @@ def remove_inactive_lead_time(
             return remaining_group
 
         # Get the index of the first change
-        first_change_idx = supply_changed_mask.idxmax()
-        first_change_loc = remaining_group.index.get_loc(first_change_idx)
+        first_change_loc = int(supply_changed_mask.to_numpy().argmax())
 
         # Calculate total rows to remove (invalid initial rows + constant supply rows)
         total_lead_rows = first_valid_loc + first_change_loc

--- a/eth_defi/vault/base.py
+++ b/eth_defi/vault/base.py
@@ -397,7 +397,13 @@ class RawVaultPriceRow(TypedDict, total=False):
     #: For native protocols without blocks this is a synthetic sequence number.
     block_number: int
 
-    #: Naive UTC timestamp of the block.
+    #: Naive UTC timestamp of the block, with one-second source precision.
+    #:
+    #: Modern high-throughput chains, including Monad, can produce multiple
+    #: blocks in the same second. This value may therefore repeat for the
+    #: same vault; raw-row identity is ``(chain, address, block_number)``, not
+    #: ``timestamp``. The Parquet millisecond logical type is used only for
+    #: compatibility, as one-second precision is sufficient for price scans.
     timestamp: "pd.Timestamp"
 
     #: Share price in denomination token units.

--- a/eth_defi/vault/historical.py
+++ b/eth_defi/vault/historical.py
@@ -692,6 +692,9 @@ def scan_historical_prices_to_parquet(
       provenance, matching vault scanner JSON exports
     - On Monad, dynamically clip the requested start to the provider's
       historical-state window before deleting or replacing Parquet rows
+    - Preserve separate sampled blocks even when their second-resolution
+      block timestamps are equal; modern chains such as Monad can produce
+      multiple blocks per second, and block number remains the row identity
 
     :param output_fname:
         Path to a destination Parquet file.
@@ -731,6 +734,11 @@ def scan_historical_prices_to_parquet(
 
     :param step:
         What is the step is in number of blocks.
+
+        Sampling is block-based, not timestamp-based. Equal timestamps from
+        separate blocks are valid input and output because the scanner only
+        requires one-second time accuracy, not synthetic higher-resolution
+        timestamps.
 
     :param chunk_size:
         How many rows to write to the Parquet file in one buffer.

--- a/tests/research/test_clean_prices.py
+++ b/tests/research/test_clean_prices.py
@@ -22,6 +22,7 @@ from eth_defi.research.wrangle_vault_prices import (
     discard_hypercore_pre_recapitalisation_history,
     fix_outlier_share_prices,
     generate_cleaned_vault_datasets,
+    remove_inactive_lead_time,
     replace_cleaned_vault_histories,
 )
 from eth_defi.vault.base import VaultHistoricalRead
@@ -240,8 +241,6 @@ def test_replace_cleaned_vault_histories_rejects_vault_removed_by_cleaning(
 
 def test_remove_inactive_lead_time():
     """Test removal of initial rows where total_supply hasn't changed."""
-    from eth_defi.research.wrangle_vault_prices import remove_inactive_lead_time
-
     # Create test data with inactive lead time
     data = {
         "id": ["vault1"] * 5 + ["vault2"] * 4,
@@ -260,6 +259,43 @@ def test_remove_inactive_lead_time():
 
     assert len(vault1_rows) == 2  # rows at index 3, 4
     assert len(vault2_rows) == 1  # row at index 3 (200)
+
+
+def test_remove_inactive_lead_time_with_duplicate_timestamps():
+    """Keep the correct rows when a vault has repeated observation timestamps.
+
+    Historical readers may emit separate observations from blocks which share
+    the same timestamp. The cleaner operates on chronological row positions,
+    not unique timestamp labels.
+    """
+    data = {
+        "id": ["vault-with-delayed-supply"] * 5 + ["vault-with-duplicate-activation"] * 5,
+        "total_supply": [0, 100, 100, 200, 300, 100, 100, 200, 200, 300],
+        "timestamp": pd.to_datetime(
+            [
+                "2024-01-01 00:00:00",
+                "2024-01-01 00:00:00",
+                "2024-01-01 01:00:00",
+                "2024-01-01 02:00:00",
+                "2024-01-01 03:00:00",
+                "2024-01-02 00:00:00",
+                "2024-01-02 01:00:00",
+                "2024-01-02 02:00:00",
+                "2024-01-02 02:00:00",
+                "2024-01-02 03:00:00",
+            ]
+        ),
+    }
+    df = pd.DataFrame(data).set_index("timestamp")
+
+    result = remove_inactive_lead_time(df, logger=lambda _: None)
+
+    delayed_supply = result[result["id"] == "vault-with-delayed-supply"]
+    duplicate_activation = result[result["id"] == "vault-with-duplicate-activation"]
+
+    assert delayed_supply["total_supply"].tolist() == [200, 300]
+    assert duplicate_activation["total_supply"].tolist() == [200, 200, 300]
+    assert duplicate_activation.index.duplicated().any()
 
 
 def test_approximate_hypercore_share_prices_from_pnl_nav() -> None:


### PR DESCRIPTION
## Why

Modern high-throughput chains, including Monad, can create more than one block during a Unix-timestamp second. The scanner deliberately keeps one-second timestamp accuracy, so separate block observations may correctly share a timestamp.

The price cleaner incorrectly treated timestamps as unique row identifiers. When the first valid supply or activation change had a duplicated timestamp, Pandas returned a slice rather than a single row location and clean-price post-processing crashed.

## Lessons learnt

The raw observation identity is `(chain, address, block_number)`, not `timestamp`. Timestamp caches and price-cleaning code must support equal timestamp labels while retaining every block observation. We do not need to manufacture higher-resolution timestamps: one-second accuracy is sufficient for the vault price pipeline.

## Summary

- Derive first valid-supply and first changed-supply locations from boolean-mask positions, not timestamp-label lookups.
- Add regression coverage for duplicated timestamps before valid supply and at vault activation.
- Document the one-second timestamp contract in the timestamp cache and fetcher, raw vault schema, historical scanner, and price cleaner.

## Related issues and PRs

- Fixes the vault-scanner clean-prices crash reported on 2026-07-24.