### PR TITLE
fix: close vault simulation adapter gaps

### DIFF
--- a/.github/workflows/test-vault-protocol.yml
+++ b/.github/workflows/test-vault-protocol.yml
@@ -69,7 +69,10 @@ jobs:
       github.event_name == 'workflow_dispatch'
     runs-on:
       group: Beefy runners
-    timeout-minutes: 30
+    # Archive-provider stalls can make several independent xdist groups each
+    # consume an eight-minute flaky retry. Two PR runs were still progressing
+    # when the previous 30-minute cap cancelled the whole suite.
+    timeout-minutes: 45
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/docs/source/api/upshift/index.rst
+++ b/docs/source/api/upshift/index.rst
@@ -13,4 +13,5 @@ vault API. Upshift does not publish an explicit curator field.
    :recursive:
 
    eth_defi.erc_4626.vault_protocol.upshift.vault
+   eth_defi.erc_4626.vault_protocol.upshift.deposit_redeem
    eth_defi.erc_4626.vault_protocol.upshift.offchain_metadata

--- a/eth_defi/abi/upshift/MultiAssetVault.json
+++ b/eth_defi/abi/upshift/MultiAssetVault.json
@@ -1,5 +1,16 @@
 [
   {
+    "inputs": [
+      {"internalType": "address", "name": "assetIn", "type": "address"},
+      {"internalType": "uint256", "name": "amountIn", "type": "uint256"},
+      {"internalType": "address", "name": "receiverAddr", "type": "address"}
+    ],
+    "name": "deposit",
+    "outputs": [{"internalType": "uint256", "name": "shares", "type": "uint256"}],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "asset",
     "outputs": [
@@ -40,6 +51,19 @@
   },
   {
     "inputs": [],
+    "name": "depositCap",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "getSharePrice",
     "outputs": [
       {
@@ -47,6 +71,19 @@
         "name": "",
         "type": "uint256"
       }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {"internalType": "address", "name": "assetIn", "type": "address"},
+      {"internalType": "uint256", "name": "amountIn", "type": "uint256"}
+    ],
+    "name": "previewDeposit",
+    "outputs": [
+      {"internalType": "uint256", "name": "", "type": "uint256"},
+      {"internalType": "uint256", "name": "", "type": "uint256"}
     ],
     "stateMutability": "view",
     "type": "function"

--- a/eth_defi/abi/upshift/README.md
+++ b/eth_defi/abi/upshift/README.md
@@ -5,13 +5,16 @@ the Upshift vault integration.
 
 `MultiAssetVault.json` is the narrow runtime interface used by the Upshift
 multi-asset adapter. It was reduced from the shared verified implementation ABI
-to the read-only methods needed by vault classification and historical pricing:
+to the methods needed by vault classification, historical pricing and deposits:
 
+- `deposit(address,uint256,address)`
 - `asset()`
 - `assetsWhitelistAddress()`
 - `lpTokenAddress()`
 - `getSharePrice()`
+- `previewDeposit(address,uint256)`
 - `getTotalAssets()`
+- `depositCap()`
 - `depositsPaused()`
 - `withdrawalsPaused()`
 - `maxDepositAmount()`

--- a/eth_defi/erc_4626/vault_protocol/accountable/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/deposit_redeem.py
@@ -29,6 +29,7 @@ from eth_defi.vault.deposit_redeem import (
     CannotParseRedemptionTransaction,
     RedemptionRequest,
     RedemptionTicket,
+    VaultFlowUnavailable,
 )
 from eth_defi.vault.flow_events import (
     PendingVaultFlow,
@@ -42,6 +43,10 @@ from eth_defi.vault.flow_events import (
 
 if TYPE_CHECKING:
     import hypersync
+
+
+#: ``InsufficientAmount()`` from the verified AccountableAsyncRedeemVault ABI.
+ACCOUNTABLE_INSUFFICIENT_AMOUNT_SELECTOR = HexBytes("0x5945ea56")
 
 
 @dataclass(slots=True)
@@ -194,6 +199,34 @@ class AccountableDepositManager(ERC4626DepositManager):
             raw_amount = self.vault.denomination_token.convert_to_raw(amount)
         if raw_amount <= 0:
             raise ValueError("Accountable deposit amount must be positive")
+        minimum = int(self.vault.vault_contract.functions.MIN_AMOUNT_WEI().call())
+        if raw_amount < minimum:
+            raise VaultFlowUnavailable(
+                f"Accountable deposit amount {raw_amount} is below minimum {minimum}",
+                protocol="Accountable",
+                vault_address=self.vault.address,
+                caller=owner,
+                direction="deposit",
+                phase="preflight",
+                decoded_error="InsufficientAmount",
+                requested_raw_amount=raw_amount,
+                minimum_raw_amount=minimum,
+                error_selector=ACCOUNTABLE_INSUFFICIENT_AMOUNT_SELECTOR,
+            )
+        if check_max_deposit:
+            max_deposit = int(self.vault.vault_contract.functions.maxDeposit(to).call())
+            if raw_amount > max_deposit:
+                reason = "Accountable deposit exceeds current admission capacity"
+                raise VaultFlowUnavailable(
+                    reason,
+                    protocol="Accountable",
+                    vault_address=self.vault.address,
+                    caller=owner,
+                    direction="deposit",
+                    phase="preflight",
+                    requested_raw_amount=raw_amount,
+                    available_raw_amount=max_deposit,
+                )
         func = deposit_4626(
             self.vault,
             owner,

--- a/eth_defi/erc_4626/vault_protocol/csigma/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/csigma/vault.py
@@ -37,6 +37,14 @@ CSIGMA_V2_POOL_ADDRESS: HexAddress = "0x438982ea288763370946625fd76c2508ee1fb229
 #: Ethereum mainnet, where the representative V2 pool was verified.
 CSIGMA_V2_POOL_CHAIN_ID = 1
 
+#: cSigma deployments whose synchronous ERC-4626 lifecycle is fork-proven.
+CSIGMA_SYNCHRONOUS_POOL_ADDRESSES = frozenset(
+    {
+        CSIGMA_V2_POOL_ADDRESS,
+        "0x50d59b785df23728d9948804f8ca3543237a1495",
+    }
+)
+
 
 class CsigmaVault(ERC4626Vault):
     """cSigma Finance vault support.
@@ -60,23 +68,27 @@ class CsigmaVault(ERC4626Vault):
         return False
 
     def get_management_fee(self, block_identifier: BlockIdentifier) -> float | None:
-        """Get the current management fee as a percent.
+        """Return the management fee represented by this adapter.
 
-        Generated: Human can add details later based on protocol documentation.
+        cSigma does not expose a separate management fee through the integrated
+        vault interface.
 
         :return:
-            0.1 = 10%
+            Zero.
         """
+        del block_identifier
         return 0
 
     def get_performance_fee(self, block_identifier: BlockIdentifier) -> float | None:
-        """Get the current performance fee as a percent.
+        """Return the performance fee represented by this adapter.
 
-        Generated: Human can add details later based on protocol documentation.
+        cSigma does not expose a separate performance fee through the
+        integrated vault interface.
 
         :return:
-            0.1 = 10%
+            Zero.
         """
+        del block_identifier
         return 0
 
     def get_estimated_lock_up(self) -> datetime.timedelta | None:
@@ -96,25 +108,27 @@ class CsigmaVault(ERC4626Vault):
         :return:
             Link to the csUSD vault page.
         """
+        del referral
         return "https://edge.csigma.finance/"
 
     def get_deposit_manager(self) -> VaultDepositManager:
         """Create the manager appropriate for this cSigma deployment.
 
         :return:
-            Capacity-aware manager for the verified V2 pool; otherwise the
-            unadvertised generic ERC-4626 manager inherited from the base class.
+            Capacity-aware manager for a verified synchronous pool; otherwise
+            the unadvertised generic ERC-4626 manager inherited from the base
+            class.
         """
-        if self.chain_id == CSIGMA_V2_POOL_CHAIN_ID and self.address.lower() == CSIGMA_V2_POOL_ADDRESS:
+        if self.chain_id == CSIGMA_V2_POOL_CHAIN_ID and self.address.lower() in CSIGMA_SYNCHRONOUS_POOL_ADDRESSES:
             return CsigmaDepositManager(self)
         return super().get_deposit_manager()
 
     def get_deposit_manager_capability(self) -> VaultDepositManagerCapability | None:
-        """Declare support only for the verified cSigma V2 pool.
+        """Declare support only for verified synchronous cSigma pools.
 
         :return:
-            Static support metadata for the V2 pool, otherwise ``None``.
+            Static support metadata for a verified pool, otherwise ``None``.
         """
-        if self.chain_id == CSIGMA_V2_POOL_CHAIN_ID and self.address.lower() == CSIGMA_V2_POOL_ADDRESS:
+        if self.chain_id == CSIGMA_V2_POOL_CHAIN_ID and self.address.lower() in CSIGMA_SYNCHRONOUS_POOL_ADDRESSES:
             return self.get_synchronous_deposit_manager_capability()
         return super().get_deposit_manager_capability()

--- a/eth_defi/erc_4626/vault_protocol/d2/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/d2/vault.py
@@ -5,13 +5,13 @@ from dataclasses import dataclass
 from decimal import Decimal
 from functools import cached_property
 import logging
-from typing import Iterable
+from typing import Iterable, Literal
 
 from web3.contract import Contract
 from eth_typing import BlockIdentifier, HexAddress
 
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
-from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
+from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager, ERC4626DepositRequest, ERC4626RedemptionRequest
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
 from eth_defi.event_reader.conversion import convert_int256_bytes_to_int
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
@@ -25,6 +25,7 @@ from eth_defi.vault.base import (
     VaultHistoricalReader,
     VaultTechnicalRisk,
 )
+from eth_defi.vault.deposit_redeem import VaultFlowUnavailable
 
 logger = logging.getLogger(__name__)
 
@@ -67,11 +68,83 @@ class D2DepositManager(ERC4626DepositManager):
         """
         closed_reason = self.vault.fetch_deposit_closed_reason()
         if closed_reason is not None:
-            raise ValueError(f"D2 deposit is unavailable: {closed_reason}")
+            raise VaultFlowUnavailable(
+                closed_reason,
+                protocol=D2_PROTOCOL_NAME,
+                vault_address=self.vault.address,
+                caller=owner,
+                direction="deposit",
+                phase="preflight",
+                next_open=self.vault.fetch_deposit_next_open(),
+            )
         estimate = super().estimate_deposit(owner, amount, block_identifier)
         if estimate <= 0:
-            raise ValueError(f"D2 deposit estimate is zero for {amount} {self.vault.denomination_token.symbol}; pricing is unavailable")
+            reason = f"D2 deposit estimate is zero for {amount} {self.vault.denomination_token.symbol}; pricing is unavailable"
+            raise ValueError(reason)
         return estimate
+
+    def _assert_flow_open(self, owner: HexAddress, direction: Literal["deposit", "redeem"]) -> None:
+        """Reject a known closed D2 epoch before constructing a transaction."""
+        if direction == "deposit":
+            reason = self.vault.fetch_deposit_closed_reason()
+            next_open = self.vault.fetch_deposit_next_open()
+        else:
+            reason = self.vault.fetch_redemption_closed_reason()
+            next_open = self.vault.fetch_redemption_next_open()
+        if reason is not None:
+            raise VaultFlowUnavailable(
+                reason,
+                protocol=D2_PROTOCOL_NAME,
+                vault_address=self.vault.address,
+                caller=owner,
+                direction=direction,
+                phase="preflight",
+                next_open=next_open,
+            )
+
+    def create_deposit_request(  # noqa: PLR0917
+        self,
+        owner: HexAddress,
+        to: HexAddress | None = None,
+        amount: Decimal | None = None,
+        raw_amount: int | None = None,
+        check_max_deposit: bool = True,  # noqa: FBT001, FBT002
+        check_enough_token: bool = True,  # noqa: FBT001, FBT002
+    ) -> ERC4626DepositRequest:
+        """Build a deposit only during D2's funding phase.
+
+        Arguments match the inherited ERC-4626 request interface so existing
+        positional callers remain compatible.
+
+        :return:
+            Standard synchronous deposit request.
+        :raise VaultFlowUnavailable:
+            If the current D2 epoch is not accepting deposits.
+        """
+        self._assert_flow_open(owner, "deposit")
+        return super().create_deposit_request(owner, to, amount, raw_amount, check_max_deposit, check_enough_token)
+
+    def create_redemption_request(  # noqa: PLR0917
+        self,
+        owner: HexAddress,
+        to: HexAddress | None = None,
+        shares: Decimal | None = None,
+        raw_shares: int | None = None,
+        check_max_deposit: bool = True,  # noqa: FBT001, FBT002
+        check_enough_token: bool = True,  # noqa: FBT001, FBT002
+    ) -> ERC4626RedemptionRequest:
+        """Build a redemption only during D2's withdrawal window.
+
+        Arguments match the inherited ERC-4626 request interface so existing
+        positional callers remain compatible.
+
+        :return:
+            Standard synchronous redemption request.
+        :raise VaultFlowUnavailable:
+            If the current D2 epoch is not accepting redemptions.
+        """
+        self._assert_flow_open(owner, "redeem")
+        return super().create_redemption_request(owner, to, shares, raw_shares, check_max_deposit, check_enough_token)
 
 
 D2_PROTOCOL_NAME = "D2 Finance"
@@ -452,17 +525,19 @@ class D2Vault(ERC4626Vault):
         return False
 
     def get_management_fee(self, block_identifier: BlockIdentifier) -> float:
-        """Non on-chain fee information available.
+        """Return the separately reported management fee.
 
         - D2 share price is fees-inclusive per them: https://x.com/D2_Finance/status/1988624499588116979
         """
+        del block_identifier
         return 0.0
 
     def get_performance_fee(self, block_identifier: BlockIdentifier) -> float | None:
-        """Fees are internalized in the share price.
+        """Return the performance fee internalised in the share price.
 
         - D2 share price is fees-inclusive per them: https://x.com/D2_Finance/status/1988624499588116979
         """
+        del block_identifier
         return 0.20
 
     def get_estimated_lock_up(self) -> datetime.timedelta:

--- a/eth_defi/erc_4626/vault_protocol/upshift/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/upshift/deposit_redeem.py
@@ -11,7 +11,7 @@ from web3._utils.events import EventLogErrorFlags  # noqa: PLC2701
 from eth_defi.abi import ZERO_ADDRESS_STR, get_deployed_contract
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager, ERC4626DepositRequest
 from eth_defi.timestamp import get_block_timestamp
-from eth_defi.token import TokenDetails
+from eth_defi.token import TokenDetails, fetch_erc20_details
 from eth_defi.vault.deposit_redeem import DepositRedeemEventAnalysis, DepositRedeemEventFailure, DepositTicket, VaultFlowUnavailable
 
 
@@ -389,7 +389,11 @@ class UpshiftMultiAssetDepositManager(ERC4626DepositManager):
             reason = f"Expected exactly one Upshift Deposit event, got {len(logs)} at {claim_tx_hash}"
             raise ValueError(reason)
         args = logs[0]["args"]
-        asset = self._fetch_accepted_asset(args["senderAddr"], args["assetIn"])
+        asset = fetch_erc20_details(
+            self.vault.web3,
+            args["assetIn"],
+            chain_id=self.vault.chain_id,
+        )
         return DepositRedeemEventAnalysis(
             from_=Web3.to_checksum_address(args["senderAddr"]),
             to=Web3.to_checksum_address(args["receiverAddr"]),

--- a/eth_defi/erc_4626/vault_protocol/upshift/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/upshift/deposit_redeem.py
@@ -1,0 +1,401 @@
+"""Upshift multi-asset deposit flow."""
+
+from decimal import Decimal
+from typing import Literal, NoReturn
+
+from eth_typing import BlockIdentifier, HexAddress
+from hexbytes import HexBytes
+from web3 import Web3
+from web3._utils.events import EventLogErrorFlags  # noqa: PLC2701
+
+from eth_defi.abi import ZERO_ADDRESS_STR, get_deployed_contract
+from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager, ERC4626DepositRequest
+from eth_defi.timestamp import get_block_timestamp
+from eth_defi.token import TokenDetails
+from eth_defi.vault.deposit_redeem import DepositRedeemEventAnalysis, DepositRedeemEventFailure, DepositTicket, VaultFlowUnavailable
+
+
+class UpshiftMultiAssetDepositManager(ERC4626DepositManager):
+    """Build and decode Upshift's direct multi-asset ``deposit`` flow.
+
+    The caller must select a token from the vault's onchain whitelist.  The
+    protocol currently has no fork-proven redemption lifecycle, so this
+    manager deliberately exposes no redemption request.
+    """
+
+    def _create_unavailable(
+        self,
+        reason: str,
+        owner: HexAddress | None,
+        direction: Literal["deposit", "redeem"],
+        phase: str,
+        *,
+        asset: HexAddress | None = None,
+        requested_raw_amount: int | None = None,
+        available_raw_amount: int | None = None,
+    ) -> VaultFlowUnavailable:
+        """Create a consistently contextualised Upshift flow rejection.
+
+        :param reason:
+            Human-readable rejection reason.
+        :param owner:
+            Account attempting the flow.
+        :param direction:
+            Deposit or redemption direction.
+        :param phase:
+            Lifecycle phase that rejected the flow.
+        :param asset:
+            Selected deposit asset, when available.
+        :param requested_raw_amount:
+            Requested token amount in native units.
+        :param available_raw_amount:
+            Available token amount in native units.
+        :return:
+            Structured exception ready to raise.
+        """
+        return VaultFlowUnavailable(
+            reason,
+            protocol="Upshift",
+            vault_address=self.vault.address,
+            caller=owner,
+            asset_address=asset,
+            direction=direction,
+            phase=phase,
+            requested_raw_amount=requested_raw_amount,
+            available_raw_amount=available_raw_amount,
+        )
+
+    def fetch_accepted_assets(self) -> tuple[TokenDetails, ...]:
+        """Return every token currently accepted by the vault.
+
+        :return:
+            Accepted tokens in the protocol whitelist order.
+        """
+        return self.vault.fetch_all_denomination_tokens()
+
+    def _fetch_accepted_asset(self, owner: HexAddress | None, accepted_asset: HexAddress | None) -> TokenDetails:
+        """Resolve and validate an explicitly selected deposit token.
+
+        :param owner:
+            Deposit owner used for structured error context.
+        :param accepted_asset:
+            Token address selected by the caller.
+        :return:
+            Selected token details.
+        :raise VaultFlowUnavailable:
+            If no token was selected or it is not accepted by the vault.
+        """
+        if accepted_asset is None:
+            reason = "Upshift multi-asset deposit requires an explicitly selected accepted asset"
+            raise self._create_unavailable(reason, owner, "deposit", "preflight")
+        asset = next((token for token in self.fetch_accepted_assets() if token.address_lower == accepted_asset.lower()), None)
+        if asset is None:
+            reason = "Upshift selected deposit asset is not on the vault whitelist"
+            raise self._create_unavailable(reason, owner, "deposit", "preflight", asset=accepted_asset)
+        return asset
+
+    def _fetch_deposit_preview(
+        self,
+        asset: TokenDetails,
+        raw_amount: int,
+        block_identifier: BlockIdentifier,
+    ) -> tuple[int, int]:
+        """Fetch Upshift's asset-aware deposit preview.
+
+        The verified interface returns minted raw shares followed by the input
+        value converted to the vault's raw reference-asset units.
+
+        :param asset:
+            Accepted deposit token.
+        :param raw_amount:
+            Input amount in the selected token's native units.
+        :param block_identifier:
+            Block at which to execute the preview.
+        :return:
+            Raw shares and raw reference-asset value.
+        """
+        raw_shares, raw_reference_amount = self.vault.upshift_contract.functions.previewDeposit(asset.address, raw_amount).call(block_identifier=block_identifier)
+        return int(raw_shares), int(raw_reference_amount)
+
+    def fetch_max_deposit_for_asset(self, accepted_asset: HexAddress, block_identifier: BlockIdentifier = "latest") -> int:
+        """Return current deposit capacity in selected-token raw units.
+
+        Upshift constrains both one deposit through ``maxDepositAmount`` and
+        total vault assets through ``depositCap``. The lower current reference
+        capacity is converted with the protocol's asset-aware preview.
+
+        :param accepted_asset:
+            Whitelisted token selected for the deposit.
+        :param block_identifier:
+            Block at which to read the cap.
+        :return:
+            Current maximum selected-token amount in native raw units.
+        :raise ValueError:
+            If the protocol reports a zero reference value for one token.
+        """
+        asset = self._fetch_accepted_asset(None, accepted_asset)
+        raw_asset_unit = asset.convert_to_raw(Decimal(1))
+        _, raw_reference_unit = self._fetch_deposit_preview(asset, raw_asset_unit, block_identifier)
+        if raw_reference_unit <= 0:
+            reason = f"Upshift preview returned a zero reference value for {asset.symbol}"
+            raise ValueError(reason)
+        functions = self.vault.upshift_contract.functions
+        raw_per_deposit_limit = int(functions.maxDepositAmount().call(block_identifier=block_identifier))
+        raw_total_limit = int(functions.depositCap().call(block_identifier=block_identifier))
+        raw_total_assets = int(functions.getTotalAssets().call(block_identifier=block_identifier))
+        raw_remaining_capacity = max(raw_total_limit - raw_total_assets, 0)
+        raw_reference_capacity = min(raw_per_deposit_limit, raw_remaining_capacity)
+        return raw_reference_capacity * raw_asset_unit // raw_reference_unit
+
+    def estimate_deposit(
+        self,
+        owner: HexAddress | None,
+        amount: Decimal,
+        block_identifier: BlockIdentifier = "latest",
+    ) -> Decimal:
+        """Refuse an ambiguous estimate without an accepted-asset selection.
+
+        :param owner:
+            Deposit owner used for structured error context.
+        :param amount:
+            Ambiguous amount whose token is not specified.
+        :param block_identifier:
+            Unused because the request is rejected before an onchain read.
+        :raise VaultFlowUnavailable:
+            Always, directing the caller to :meth:`estimate_deposit_for_asset`.
+        """
+        del amount, block_identifier
+        reason = "Upshift multi-asset deposit estimation requires an explicitly selected accepted asset"
+        raise self._create_unavailable(reason, owner, "deposit", "estimate")
+
+    def estimate_deposit_for_asset(
+        self,
+        owner: HexAddress | None,
+        amount: Decimal,
+        accepted_asset: HexAddress,
+        block_identifier: BlockIdentifier = "latest",
+    ) -> Decimal:
+        """Estimate LP shares for a selected accepted asset.
+
+        The estimate comes from Upshift's asset-aware ``previewDeposit`` call,
+        avoiding local assumptions about reference-asset conversion.
+
+        :param owner:
+            Deposit owner used for structured error context.
+        :param amount:
+            Selected accepted-asset amount.
+        :param accepted_asset:
+            Whitelisted deposit-token address.
+        :param block_identifier:
+            Block at which to read the share price.
+        :return:
+            Estimated LP shares rounded down to share-token precision.
+        """
+        asset = self._fetch_accepted_asset(owner, accepted_asset)
+        raw_amount = asset.convert_to_raw(amount)
+        raw_shares, _ = self._fetch_deposit_preview(asset, raw_amount, block_identifier)
+        return self.vault.share_token.convert_to_decimals(raw_shares)
+
+    def estimate_redeem(
+        self,
+        owner: HexAddress | None,
+        shares: Decimal,
+        block_identifier: BlockIdentifier = "latest",
+    ) -> NoReturn:
+        """Refuse estimates for the unimplemented redemption flow.
+
+        :param owner:
+            Share owner used for structured error context.
+        :param shares:
+            Unused requested share amount.
+        :param block_identifier:
+            Unused because the adapter has no redemption flow.
+        :raise VaultFlowUnavailable:
+            Always, because multi-asset redemption is not implemented.
+        """
+        del shares, block_identifier
+        reason = "Upshift multi-asset redemption flow is not implemented"
+        raise self._create_unavailable(reason, owner, "redeem", "estimate")
+
+    def can_create_deposit_request(self, owner: HexAddress) -> bool:
+        """Return whether the protocol-wide deposit gate is currently open.
+
+        :param owner:
+            Unused because Upshift's pause and cap are vault-wide.
+        :return:
+            ``True`` when deposits are neither paused nor configured with a
+            zero cap.
+        """
+        del owner
+        return self.vault.fetch_deposit_closed_reason() is None
+
+    def can_create_redemption_request(self, owner: HexAddress) -> bool:  # noqa: PLR6301
+        """Return false because no multi-asset redemption path is implemented.
+
+        :param owner:
+            Unused share owner.
+        :return:
+            Always ``False``.
+        """
+        del owner
+        return False
+
+    def has_synchronous_redemption(self) -> bool:  # noqa: PLR6301
+        """Return false because redemption is unsupported, not synchronous.
+
+        :return:
+            Always ``False``.
+        """
+        return False
+
+    def create_deposit_request(  # noqa: PLR0917
+        self,
+        owner: HexAddress,
+        to: HexAddress | None = None,
+        amount: Decimal | None = None,
+        raw_amount: int | None = None,
+        check_max_deposit: bool = True,  # noqa: FBT001, FBT002
+        check_enough_token: bool = True,  # noqa: FBT001, FBT002
+        *,
+        accepted_asset: HexAddress | None = None,
+    ) -> ERC4626DepositRequest:
+        """Create approval and deposit calls for one selected asset.
+
+        The returned synchronous request approves the vault and then calls its
+        multi-asset ``deposit`` entry point.
+
+        :param owner:
+            Address funding the deposit.
+        :param to:
+            Share receiver, defaulting to ``owner``.
+        :param amount:
+            Decimal selected-token amount, exclusive with ``raw_amount``.
+        :param raw_amount:
+            Native selected-token amount, exclusive with ``amount``.
+        :param check_max_deposit:
+            Whether to reject requests above the current protocol cap.
+        :param check_enough_token:
+            Whether to check the owner's selected-token balance.
+        :param accepted_asset:
+            Explicitly selected whitelist token.
+        :return:
+            Synchronous approval and deposit request.
+        :raise VaultFlowUnavailable:
+            If the asset is invalid or current protocol state rejects the flow.
+        """
+        asset = self._fetch_accepted_asset(owner, accepted_asset)
+        if (amount is None) == (raw_amount is None):
+            reason = "Give exactly one of amount or raw_amount"
+            raise ValueError(reason)
+        if raw_amount is None:
+            raw_amount = asset.convert_to_raw(amount)
+        if raw_amount <= 0:
+            reason = "Upshift deposit amount must be positive"
+            raise ValueError(reason)
+        closed_reason = self.vault.fetch_deposit_closed_reason()
+        if closed_reason is not None:
+            raise self._create_unavailable(closed_reason, owner, "deposit", "preflight", asset=asset.address)
+        if check_max_deposit:
+            max_deposit = self.fetch_max_deposit_for_asset(asset.address)
+            if raw_amount > max_deposit:
+                reason = "Upshift deposit exceeds current protocol limits"
+                raise self._create_unavailable(
+                    reason,
+                    owner,
+                    "deposit",
+                    "preflight",
+                    asset=asset.address,
+                    requested_raw_amount=raw_amount,
+                    available_raw_amount=max_deposit,
+                )
+        if check_enough_token:
+            balance = asset.fetch_raw_balance_of(owner)
+            if balance < raw_amount:
+                reason = "Insufficient selected Upshift deposit asset balance"
+                raise self._create_unavailable(
+                    reason,
+                    owner,
+                    "deposit",
+                    "preflight",
+                    asset=asset.address,
+                    requested_raw_amount=raw_amount,
+                    available_raw_amount=balance,
+                )
+        receiver = owner if to is None else to
+        if Web3.to_checksum_address(receiver) == Web3.to_checksum_address(ZERO_ADDRESS_STR):
+            reason = "Upshift deposit receiver cannot be the zero address"
+            raise ValueError(reason)
+        return ERC4626DepositRequest(
+            vault=self.vault,
+            owner=owner,
+            to=receiver,
+            amount=asset.convert_to_decimals(raw_amount),
+            raw_amount=raw_amount,
+            funcs=[
+                asset.contract.functions.approve(self.vault.address, raw_amount),
+                self.vault.upshift_contract.functions.deposit(asset.address, raw_amount, receiver),
+            ],
+        )
+
+    def create_redemption_request(  # noqa: PLR0917
+        self,
+        owner: HexAddress,
+        to: HexAddress | None = None,
+        shares: Decimal | None = None,
+        raw_shares: int | None = None,
+        check_max_deposit: bool = True,  # noqa: FBT001, FBT002
+        check_enough_token: bool = True,  # noqa: FBT001, FBT002
+    ) -> NoReturn:
+        """Refuse unverified Upshift multi-asset redemption handling.
+
+        :param owner:
+            Share owner used for structured error context.
+        :param to:
+            Unused receiver.
+        :param shares:
+            Unused decimal share amount.
+        :param raw_shares:
+            Unused native share amount.
+        :param check_max_deposit:
+            Unused base-interface compatibility flag.
+        :param check_enough_token:
+            Unused base-interface compatibility flag.
+        :raise VaultFlowUnavailable:
+            Always, because multi-asset redemption is not implemented.
+        """
+        del to, shares, raw_shares, check_max_deposit, check_enough_token
+        reason = "Upshift multi-asset redemption flow is not implemented"
+        raise self._create_unavailable(reason, owner, "redeem", "preflight")
+
+    def analyse_deposit(self, claim_tx_hash: HexBytes | str, deposit_ticket: DepositTicket | None) -> DepositRedeemEventAnalysis | DepositRedeemEventFailure:
+        """Decode Upshift's verified protocol deposit event.
+
+        :param claim_tx_hash:
+            Mined deposit transaction hash.
+        :param deposit_ticket:
+            Unused synchronous deposit ticket.
+        :return:
+            Executed deposit amounts or a structured transaction failure.
+        :raise ValueError:
+            If the receipt does not contain exactly one matching deposit event.
+        """
+        del deposit_ticket
+        receipt = self.vault.web3.eth.get_transaction_receipt(claim_tx_hash)
+        if receipt["status"] != 1:
+            return DepositRedeemEventFailure(HexBytes(claim_tx_hash), "Transaction reverted", protocol="Upshift", vault_address=self.vault.address, direction="deposit", phase="transaction", receipt_status=0)
+        event_contract = get_deployed_contract(self.vault.web3, "upshift/IMultiAssetVaultEvents.json", self.vault.address)
+        logs = event_contract.events.Deposit().process_receipt(receipt, errors=EventLogErrorFlags.Discard)
+        if len(logs) != 1:
+            reason = f"Expected exactly one Upshift Deposit event, got {len(logs)} at {claim_tx_hash}"
+            raise ValueError(reason)
+        args = logs[0]["args"]
+        asset = self._fetch_accepted_asset(args["senderAddr"], args["assetIn"])
+        return DepositRedeemEventAnalysis(
+            from_=Web3.to_checksum_address(args["senderAddr"]),
+            to=Web3.to_checksum_address(args["receiverAddr"]),
+            denomination_amount=asset.convert_to_decimals(int(args["amountIn"])),
+            share_count=self.vault.share_token.convert_to_decimals(int(args["shares"])),
+            tx_hash=HexBytes(claim_tx_hash),
+            block_number=int(receipt["blockNumber"]),
+            block_timestamp=get_block_timestamp(self.vault.web3, int(receipt["blockNumber"])),
+        )

--- a/eth_defi/erc_4626/vault_protocol/upshift/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/upshift/vault.py
@@ -13,6 +13,7 @@ from web3.contract import Contract
 from eth_defi.abi import get_deployed_contract
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault import ERC4626Vault, VaultReaderState
+from eth_defi.erc_4626.vault_protocol.upshift.deposit_redeem import UpshiftMultiAssetDepositManager
 from eth_defi.erc_4626.vault_protocol.upshift.offchain_metadata import UpshiftVaultMetadata, fetch_upshift_vault_metadata
 from eth_defi.event_reader.conversion import convert_int256_bytes_to_int
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
@@ -77,6 +78,7 @@ class UpshiftMultiAssetHistoricalReader(VaultHistoricalReader):
             "depositsPaused": upshift.depositsPaused(),
             "withdrawalsPaused": upshift.withdrawalsPaused(),
             "maxDepositAmount": upshift.maxDepositAmount(),
+            "depositCap": upshift.depositCap(),
             "maxWithdrawalAmount": upshift.maxWithdrawalAmount(),
         }
 
@@ -131,9 +133,11 @@ class UpshiftMultiAssetHistoricalReader(VaultHistoricalReader):
         else:
             errors.append("getSharePrice call failed")
 
+        raw_total_assets = None
         total_assets_result = call_by_name.get("getTotalAssets")
         if denomination_token is not None and total_assets_result is not None and total_assets_result.success:
-            total_assets = denomination_token.convert_to_decimals(convert_int256_bytes_to_int(total_assets_result.result))
+            raw_total_assets = convert_int256_bytes_to_int(total_assets_result.result)
+            total_assets = denomination_token.convert_to_decimals(raw_total_assets)
         else:
             errors.append("getTotalAssets call failed")
 
@@ -158,8 +162,14 @@ class UpshiftMultiAssetHistoricalReader(VaultHistoricalReader):
             redemption_open = not bool(convert_int256_bytes_to_int(withdrawals_paused_result.result))
 
         max_deposit_result = call_by_name.get("maxDepositAmount")
-        if denomination_token is not None and max_deposit_result is not None and max_deposit_result.success:
-            max_deposit = denomination_token.convert_to_decimals(convert_int256_bytes_to_int(max_deposit_result.result))
+        deposit_cap_result = call_by_name.get("depositCap")
+        if denomination_token is not None and raw_total_assets is not None and max_deposit_result is not None and max_deposit_result.success and deposit_cap_result is not None and deposit_cap_result.success:
+            raw_per_deposit_limit = convert_int256_bytes_to_int(max_deposit_result.result)
+            raw_total_limit = convert_int256_bytes_to_int(deposit_cap_result.result)
+            raw_remaining_capacity = max(raw_total_limit - raw_total_assets, 0)
+            max_deposit = denomination_token.convert_to_decimals(min(raw_per_deposit_limit, raw_remaining_capacity))
+            if deposits_open:
+                deposits_open = max_deposit > 0
 
         max_withdrawal_result = call_by_name.get("maxWithdrawalAmount")
         if denomination_token is not None and max_withdrawal_result is not None and max_withdrawal_result.success:
@@ -360,7 +370,8 @@ class UpshiftVault(ERC4626Vault):
             If this is not an Upshift multi-asset vault.
         """
         if not self.multi_asset_like:
-            raise ValueError("Only Upshift multi-asset vaults have an assets whitelist")
+            reason = "Only Upshift multi-asset vaults have an assets whitelist"
+            raise ValueError(reason)
         address = self.upshift_contract.functions.assetsWhitelistAddress().call()
         return get_deployed_contract(
             self.web3,
@@ -371,9 +382,9 @@ class UpshiftVault(ERC4626Vault):
     def fetch_all_denomination_tokens(self) -> tuple[TokenDetails, ...]:
         """Fetch every configured multi-asset denomination token.
 
-        The returned tuple preserves the onchain whitelist ordering. That
-        ordering determines the primary token returned by
-        :meth:`fetch_denomination_token`.
+        The returned tuple preserves the onchain whitelist ordering. These are
+        accepted deposit assets and may differ from the accounting asset
+        returned by :meth:`fetch_denomination_token`.
 
         :return:
             Whitelisted denomination tokens in protocol order. Standard
@@ -403,32 +414,31 @@ class UpshiftVault(ERC4626Vault):
                 cache=self.token_cache,
             )
             if token is None:
-                raise ValueError(f"Could not fetch Upshift denomination token {address} for vault {self.address}")
+                reason = f"Could not fetch Upshift denomination token {address} for vault {self.address}"
+                raise ValueError(reason)
             tokens.append(token)
         return tuple(tokens)
 
     def fetch_denomination_token(self) -> TokenDetails | None:
-        """Fetch Upshift's primary denomination token.
+        """Fetch Upshift's accounting denomination token.
 
         **Supported simulation path**
 
-        Multi-asset vaults use the first token in the onchain whitelist as
-        their primary denomination token. The representative integration path
-        uses a vault whose first token is USDC.
+        Multi-asset vaults retain the ERC-4626 ``asset()`` token as their
+        accounting unit even when deposits accept a separate token whitelist.
+        Keeping these concepts separate is required when the first accepted
+        token uses different decimals from the accounting asset.
 
         **Known limitations**
 
-        Only the first token is selected as the primary denomination token.
-        Remaining whitelisted tokens are discovered by
-        :meth:`fetch_all_denomination_tokens` but are not supported by the
-        deposit manager yet.
+        Accepted assets are exposed separately through
+        :meth:`fetch_all_denomination_tokens`; callers must explicitly select
+        one when creating or estimating a multi-asset deposit.
 
         :return:
-            First whitelisted token for a multi-asset vault, or the normal
-            ERC-4626 denomination token for a standard Upshift vault.
+            ERC-4626 accounting asset configured by the vault.
         """
-        tokens = self.fetch_all_denomination_tokens()
-        return tokens[0] if tokens else None
+        return super().fetch_denomination_token()
 
     def fetch_share_token_address(self, block_identifier: BlockIdentifier = "latest") -> HexAddress:
         """Get the share token address.
@@ -624,35 +634,35 @@ class UpshiftVault(ERC4626Vault):
         """
 
         if self.multi_asset_like:
-            raise NotImplementedError("Upshift multi-asset vault deposits are not supported by the generic ERC-4626 deposit manager")
+            return UpshiftMultiAssetDepositManager(self)
 
         return super().get_deposit_manager()
 
     def get_deposit_manager_capability(self) -> VaultDepositManagerCapability:
-        """Declare only Upshift's normal ERC-4626 vault shape.
+        """Declare Upshift's fork-proven directional lifecycle support.
 
-        Multi-asset accounting vaults use a separate application flow and must
-        never be represented as generic deposit-manager support. They expose a
-        deliberate refusing capability so consumers can report this as adapter
-        support rather than a failed transaction.
+        Multi-asset accounting vaults support synchronous deposits through
+        Upshift's protocol-specific ``deposit(asset, amount, receiver)`` entry
+        point. Redemption remains deliberately unsupported until its complete
+        request and settlement lifecycle is fork-proven.
 
         .. note::
 
-            Trade-executor must inspect this capability before calling
-            :meth:`get_deposit_manager` and map its stable reason to
-            ``adapter_unsupported`` without broadcasting an approval or
-            request.
+            Trade-executor must inspect the matching directional flag and use
+            ``deposit_assets`` to require an explicit accepted-asset selection.
 
         :return:
-            Synchronous two-way capability for the normal shape, or an explicit
-            refusing capability for multi-asset vaults.
+            Directional capability and accepted assets for the vault shape.
         """
         if self.multi_asset_like:
+            accepted_assets = tuple(token.address for token in self.fetch_all_denomination_tokens())
             return VaultDepositManagerCapability(
-                can_deposit=False,
+                can_deposit=True,
                 can_redeem=False,
-                deposit_unsupported_reason="multi_asset_application_flow_not_implemented",
+                deposit_flow="synchronous",
                 redemption_unsupported_reason="multi_asset_application_flow_not_implemented",
+                deposit_assets=accepted_assets,
+                publish_partial=True,
             )
 
         return VaultDepositManagerCapability(
@@ -684,9 +694,15 @@ class UpshiftVault(ERC4626Vault):
         if self.upshift_contract.functions.depositsPaused().call():
             return "Upshift depositsPaused() is true"
 
-        raw_max_deposit = self.upshift_contract.functions.maxDepositAmount().call()
+        functions = self.upshift_contract.functions
+        raw_max_deposit = functions.maxDepositAmount().call()
         if raw_max_deposit == 0:
             return "Upshift maxDepositAmount() is zero"
+
+        raw_deposit_cap = functions.depositCap().call()
+        raw_total_assets = functions.getTotalAssets().call()
+        if raw_total_assets >= raw_deposit_cap:
+            return "Upshift depositCap() has been reached"
 
         return None
 
@@ -734,7 +750,7 @@ class UpshiftVault(ERC4626Vault):
         raw_amount = self.upshift_contract.functions.maxWithdrawalAmount().call(block_identifier=block_identifier)
         return token.convert_to_decimals(raw_amount)
 
-    def get_historical_reader(self, stateful: bool) -> VaultHistoricalReader:
+    def get_historical_reader(self, stateful: bool) -> VaultHistoricalReader:  # noqa: FBT001
         """Get the historical reader for this Upshift vault.
 
         :param stateful:
@@ -765,6 +781,7 @@ class UpshiftVault(ERC4626Vault):
 
         URL format: https://app.upshift.finance/pools/{chain_id}/{checksummed_address}
         """
+        del referral
         chain_id = self.chain_id
         checksummed_address = Web3.to_checksum_address(self.vault_address)
         return f"https://app.upshift.finance/pools/{chain_id}/{checksummed_address}"

--- a/eth_defi/provider/anvil.py
+++ b/eth_defi/provider/anvil.py
@@ -50,7 +50,7 @@ from decimal import Decimal
 from functools import wraps
 from pathlib import Path
 from subprocess import DEVNULL, PIPE
-from typing import TYPE_CHECKING, Any, Callable, Concatenate, Optional, ParamSpec, TextIO, Union
+from typing import Any, Callable, Concatenate, Optional, ParamSpec, TextIO, Union
 
 import psutil
 import requests
@@ -58,10 +58,8 @@ from eth_typing import HexAddress
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from web3 import HTTPProvider, Web3
 
+from eth_defi.provider.rpc_proxy import RPCProxy, RPCProxyConfig, start_rpc_proxy
 from eth_defi.utils import is_localhost_port_listening, shutdown_hard
-
-if TYPE_CHECKING:
-    from eth_defi.provider.rpc_proxy import RPCProxy, RPCProxyConfig
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +71,14 @@ logger = logging.getLogger(__name__)
 #: unlinking a live lock file could let another worker create a new inode for
 #: the same port and acquire an independent lock.
 ANVIL_PORT_LOCK_FILE_PREFIX = "web3-ethereum-defi-anvil-port"
+
+#: Maximum duration of one automatic Anvil proxy request to an upstream.
+ANVIL_PROXY_MAX_ATTEMPT_TIMEOUT: float = 15.0
+
+#: Keep the automatic proxy's full provider pass below Web3's 60-second
+#: localhost read timeout. Explicit :class:`RPCProxyConfig` values are
+#: preserved unchanged.
+ANVIL_PROXY_TOTAL_TIMEOUT: float = 55.0
 
 #: Per-thread state tracking the last used RPC index for multi-RPC fork URLs.
 #: This is a workaround for test flakiness on CI: when multiple RPC endpoints
@@ -305,6 +311,34 @@ def _get_anvil_launch_metadata(json_rpc_url: str) -> AnvilForkMetadata | None:
 
     with _anvil_launch_metadata_lock:
         return _anvil_launch_metadata.get(json_rpc_url)
+
+
+def _create_default_anvil_proxy_config(provider_count: int) -> RPCProxyConfig:
+    """Create the bounded policy for automatic Anvil upstream failover.
+
+    Automatic proxying tries every configured provider once without sleeping
+    between distinct providers. Its full request budget stays below Web3's
+    default 60-second localhost read timeout.
+
+    :param provider_count:
+        Number of usable upstream JSON-RPC providers.
+
+    :return:
+        Bounded automatic proxy configuration.
+    """
+    assert provider_count > 1, f"Anvil proxy needs multiple providers, got {provider_count}"
+    per_provider_budget = ANVIL_PROXY_TOTAL_TIMEOUT / provider_count
+    if per_provider_budget <= 10:
+        # Requests applies the same value separately to connect and read when
+        # both fit below its five-second connect cap.
+        attempt_timeout = per_provider_budget / 2
+    else:
+        attempt_timeout = per_provider_budget - 5
+    return RPCProxyConfig(
+        timeout=min(ANVIL_PROXY_MAX_ATTEMPT_TIMEOUT, attempt_timeout),
+        retries=provider_count,
+        backoff=0.0,
+    )
 
 
 def _register_anvil_launch_metadata(
@@ -1304,11 +1338,7 @@ def launch_anvil(
         upstream_rpc_urls = tuple(available_rpcs)
 
         if len(available_rpcs) > 1 and proxy_multiple_upstream is not False:
-            from eth_defi.provider.rpc_proxy import RPCProxy as RPCProxyClass
-            from eth_defi.provider.rpc_proxy import RPCProxyConfig as RPCProxyConfigClass
-            from eth_defi.provider.rpc_proxy import start_rpc_proxy
-
-            if isinstance(proxy_multiple_upstream, RPCProxyClass):
+            if isinstance(proxy_multiple_upstream, RPCProxy):
                 # Caller provided a pre-built proxy — use it, but don't
                 # manage its lifecycle (caller is responsible for close()).
                 proxy = proxy_multiple_upstream
@@ -1321,7 +1351,13 @@ def launch_anvil(
             else:
                 # Start a failover proxy that sits between Anvil and multiple
                 # upstream RPCs, providing retry/timeout/switchover handling.
-                config = proxy_multiple_upstream if isinstance(proxy_multiple_upstream, RPCProxyConfigClass) else None
+                if isinstance(proxy_multiple_upstream, RPCProxyConfig):
+                    config = proxy_multiple_upstream
+                else:
+                    # Automatic Anvil proxying makes one bounded pass across
+                    # the configured providers. Retrying the same provider
+                    # again is left to an explicit caller configuration.
+                    config = _create_default_anvil_proxy_config(len(available_rpcs))
                 proxy = start_rpc_proxy(available_rpcs, config=config, suppress_client_disconnect_errors=True)
                 cleaned_fork_url = proxy.url
                 logger.info(

--- a/eth_defi/provider/multi_provider.py
+++ b/eth_defi/provider/multi_provider.py
@@ -26,6 +26,13 @@ from eth_defi.utils import get_url_domain
 
 logger = logging.getLogger(__name__)
 
+#: Retry count used for ordinary remote JSON-RPC providers.
+DEFAULT_RETRIES: int = 6
+
+#: A registered local Anvil already performs upstream failover. Retrying the
+#: localhost request can only multiply a wedged fork's timeout.
+DEFAULT_ANVIL_RETRIES: int = 0
+
 
 class MultiProviderConfigurationError(Exception):
     """Could not parse URL soup for configuring web3"""
@@ -132,6 +139,19 @@ def _apply_anvil_launch_metadata(provider: HTTPProvider) -> None:
     provider.anvil_effective_fork_url = metadata.effective_fork_url  # type: ignore[attr-defined]
 
 
+def _resolve_default_retries(call_endpoints: list[str]) -> int:
+    """Resolve the retry policy before Web3 or a subprocess factory is built.
+
+    :param call_endpoints:
+        Parsed standard JSON-RPC endpoints, excluding any ``mev+`` endpoint.
+
+    :return:
+        Concrete retry count safe to serialise to worker processes.
+    """
+    has_registered_anvil = len(call_endpoints) == 1 and _get_anvil_launch_metadata(call_endpoints[0]) is not None
+    return DEFAULT_ANVIL_RETRIES if has_registered_anvil else DEFAULT_RETRIES
+
+
 def create_multi_provider_web3(
     configuration_line: str,
     fallback_sleep=5.0,
@@ -140,7 +160,7 @@ def create_multi_provider_web3(
     session: Optional[Any] = None,
     switchover_noisiness=logging.WARNING,
     default_http_timeout=(3.0, 60.0),
-    retries: int = 6,
+    retries: int | None = None,
     hint: Optional[str] = "",
     unit_test=False,
     add_signing_middleware: LocalAccount | None = None,
@@ -213,6 +233,11 @@ def create_multi_provider_web3(
 
     :param retries:
         How many retry count we do calling JSON-RPC API if the API response fails.
+
+        When omitted, ordinary remote providers use six retries and a local
+        Anvil URL registered by :func:`eth_defi.provider.anvil.launch_anvil`
+        uses none. Anvil's upstream proxy already performs provider failover,
+        so retrying a wedged localhost request only multiplies the timeout.
 
     :param hint:
         A hint for error logs if something goes wrong.
@@ -291,6 +316,9 @@ def create_multi_provider_web3(
 
     if len(call_endpoints) == 0:
         raise MultiProviderConfigurationError(f"At least one call endpoint must be specified, configuration was {configuration_line}")
+
+    if retries is None:
+        retries = _resolve_default_retries(call_endpoints)
 
     if session is None:
         # https://stackoverflow.com/a/47475019/315168
@@ -434,9 +462,10 @@ class MultiProviderWeb3Factory:
     - Allows creating web3 connections from a config line in multiprocessing worker pools
     """
 
-    def __init__(self, rpc_url: str, retries=6, hint: str | None = "", skip_verification: bool = False, expected_chain_id: int | None = None, rpc_request_stats: RPCRequestStats | None = None):
+    def __init__(self, rpc_url: str, retries: int | None = None, hint: str | None = "", skip_verification: bool = False, expected_chain_id: int | None = None, rpc_request_stats: RPCRequestStats | None = None):
         self.rpc_url = rpc_url
-        self.retries = retries
+        call_endpoints = [endpoint for endpoint in rpc_url.split() if not endpoint.startswith("mev+")]
+        self.retries = retries if retries is not None else _resolve_default_retries(call_endpoints)
         self.hint = hint
         #: Skip the per-worker ``eth_chainId`` provider cross-check.
         #:

--- a/eth_defi/testing/anvil_fork_pool.py
+++ b/eth_defi/testing/anvil_fork_pool.py
@@ -55,6 +55,16 @@ Forking ``latest`` or a per-test arbitrary block breaks all three benefits: the
 cache key never repeats, nothing is shared, and every run pays full
 archive-replay latency. That is why the fixed shared block is mandatory.
 
+Bounded provider retries
+------------------------
+
+Pooled forks must also fail within a bounded period when an upstream archive
+provider is unavailable. For multi-provider configurations, the pool gives the
+Anvil RPC proxy one attempt per configured provider. The Web3 client then
+retries the local Anvil only once by default because the proxy has already
+performed upstream failover. Callers with legitimately slow fork operations can
+override the Web3 retry count and HTTP timeout in :meth:`AnvilForkPool.get_web3`.
+
 Reference tests to copy
 -----------------------
 
@@ -127,6 +137,16 @@ from web3 import Web3
 
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.provider.rpc_proxy import RPCProxy, RPCProxyConfig
+
+#: Maximum duration of one request to an upstream archive provider.
+POOL_PROXY_TIMEOUT: float = 15.0
+
+#: Do not multiply an already bounded Anvil/proxy failure through six Web3 retries.
+POOL_WEB3_RETRIES: int = 1
+
+#: Preserve the established connect/read timeout for legitimate cold-cache calls.
+POOL_WEB3_HTTP_TIMEOUT: tuple[float, float] = (3.0, 60.0)
 
 
 def _freeze(value: Any) -> Any:
@@ -145,6 +165,13 @@ def _freeze(value: Any) -> Any:
     """
     if isinstance(value, dict):
         return tuple(sorted((k, _freeze(v)) for k, v in value.items()))
+    if isinstance(value, RPCProxyConfig):
+        return (
+            RPCProxyConfig,
+            tuple((field.name, _freeze(getattr(value, field.name))) for field in dataclasses.fields(value)),
+        )
+    if isinstance(value, RPCProxy):
+        return (RPCProxy, id(value))
     if isinstance(value, (list, tuple)):
         return tuple(_freeze(v) for v in value)
     if isinstance(value, (set, frozenset)):
@@ -192,6 +219,20 @@ class AnvilForkPool:
         :return:
             The shared :class:`~eth_defi.provider.anvil.AnvilLaunch`.
         """
+        configured_rpc_urls = rpc_url.split()
+        standard_rpc_urls = [url for url in configured_rpc_urls if not url.startswith("mev+")]
+        available_rpc_count = len(standard_rpc_urls or configured_rpc_urls)
+        if available_rpc_count > 1 and "proxy_multiple_upstream" not in launch_kwargs:
+            # Bound the inner retry layer. The default proxy budget can take
+            # around 90 seconds; combining that with Web3's default six
+            # localhost retries made one unavailable archive request stall a
+            # pooled xdist group for about eight minutes. Try each configured
+            # upstream once before returning the error to Anvil.
+            launch_kwargs["proxy_multiple_upstream"] = RPCProxyConfig(
+                timeout=POOL_PROXY_TIMEOUT,
+                retries=available_rpc_count,
+            )
+
         key = (rpc_url, fork_block_number, _freeze(launch_kwargs))
         launch = self.launches.get(key)
         if launch is None:
@@ -207,6 +248,9 @@ class AnvilForkPool:
         self,
         rpc_url: str,
         fork_block_number: int,
+        *,
+        web3_retries: int = POOL_WEB3_RETRIES,
+        web3_http_timeout: tuple[float, float] = POOL_WEB3_HTTP_TIMEOUT,
         **launch_kwargs: Any,
     ) -> Web3:
         """Return a fresh Web3 pointed at a shared Anvil fork.
@@ -221,6 +265,14 @@ class AnvilForkPool:
         :param fork_block_number:
             Fixed block to fork at.
 
+        :param web3_retries:
+            Number of outer retries against the local Anvil endpoint. Keep this
+            low because the inner RPC proxy already performs provider failover.
+
+        :param web3_http_timeout:
+            Connect and read timeout for local Anvil requests. Override this for
+            a known slow cold-cache operation.
+
         :param launch_kwargs:
             Additional ``fork_network_anvil`` arguments (part of the cache key).
 
@@ -228,7 +280,11 @@ class AnvilForkPool:
             A :class:`web3.Web3` connected to the shared Anvil RPC endpoint.
         """
         launch = self.get_launch(rpc_url, fork_block_number, **launch_kwargs)
-        return create_multi_provider_web3(launch.json_rpc_url)
+        return create_multi_provider_web3(
+            launch.json_rpc_url,
+            default_http_timeout=web3_http_timeout,
+            retries=web3_retries,
+        )
 
     def close_all(self) -> None:
         """Tear down every launched Anvil process.

--- a/eth_defi/testing/anvil_fork_pool.py
+++ b/eth_defi/testing/anvil_fork_pool.py
@@ -58,12 +58,13 @@ archive-replay latency. That is why the fixed shared block is mandatory.
 Bounded provider retries
 ------------------------
 
-Pooled forks must also fail within a bounded period when an upstream archive
-provider is unavailable. For multi-provider configurations, the pool gives the
-Anvil RPC proxy one attempt per configured provider. The Web3 client then
-retries the local Anvil only once by default because the proxy has already
-performed upstream failover. Callers with legitimately slow fork operations can
-override the Web3 retry count and HTTP timeout in :meth:`AnvilForkPool.get_web3`.
+Forks must also fail within a bounded period when an upstream archive provider
+is unavailable. For multi-provider configurations,
+:func:`eth_defi.provider.anvil.launch_anvil` gives the automatic RPC proxy one
+attempt per configured provider. The pool's Web3 client does not retry the
+local Anvil because the proxy has already performed upstream failover. Callers
+with legitimately slow fork operations can override the Web3 retry count and
+HTTP timeout in :meth:`AnvilForkPool.get_web3`.
 
 Reference tests to copy
 -----------------------
@@ -139,11 +140,8 @@ from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.provider.rpc_proxy import RPCProxy, RPCProxyConfig
 
-#: Maximum duration of one request to an upstream archive provider.
-POOL_PROXY_TIMEOUT: float = 15.0
-
-#: Do not multiply an already bounded Anvil/proxy failure through six Web3 retries.
-POOL_WEB3_RETRIES: int = 1
+#: Do not retry a wedged local Anvil after its proxy has tried every upstream.
+POOL_WEB3_RETRIES: int = 0
 
 #: Preserve the established connect/read timeout for legitimate cold-cache calls.
 POOL_WEB3_HTTP_TIMEOUT: tuple[float, float] = (3.0, 60.0)
@@ -219,20 +217,6 @@ class AnvilForkPool:
         :return:
             The shared :class:`~eth_defi.provider.anvil.AnvilLaunch`.
         """
-        configured_rpc_urls = rpc_url.split()
-        standard_rpc_urls = [url for url in configured_rpc_urls if not url.startswith("mev+")]
-        available_rpc_count = len(standard_rpc_urls or configured_rpc_urls)
-        if available_rpc_count > 1 and "proxy_multiple_upstream" not in launch_kwargs:
-            # Bound the inner retry layer. The default proxy budget can take
-            # around 90 seconds; combining that with Web3's default six
-            # localhost retries made one unavailable archive request stall a
-            # pooled xdist group for about eight minutes. Try each configured
-            # upstream once before returning the error to Anvil.
-            launch_kwargs["proxy_multiple_upstream"] = RPCProxyConfig(
-                timeout=POOL_PROXY_TIMEOUT,
-                retries=available_rpc_count,
-            )
-
         key = (rpc_url, fork_block_number, _freeze(launch_kwargs))
         launch = self.launches.get(key)
         if launch is None:

--- a/eth_defi/vault/deposit_redeem.py
+++ b/eth_defi/vault/deposit_redeem.py
@@ -82,6 +82,12 @@ class VaultDepositManagerCapability:
     redemption_unsupported_reason: str | None = None
     supports_anvil_settlement: bool | None = None
 
+    #: Accepted token addresses for an explicit multi-asset deposit flow.
+    deposit_assets: tuple[HexAddress, ...] = ()
+
+    #: Allow the initial public schema to expose only one flow direction.
+    publish_partial: bool = False
+
     def __post_init__(self) -> None:
         """Validate that supported operations have a lifecycle declaration.
 
@@ -98,14 +104,16 @@ class VaultDepositManagerCapability:
             raise ValueError("redemption_unsupported_reason is valid only when redemptions are unsupported")
         if self.supports_anvil_settlement is not None and "asynchronous" not in (self.deposit_flow, self.redemption_flow):
             raise ValueError("supports_anvil_settlement requires an asynchronous lifecycle")
+        if self.deposit_assets and not self.can_deposit:
+            raise ValueError("deposit_assets requires deposit support")
 
-    def as_dict(self) -> dict[str, bool | str]:
+    def as_dict(self) -> dict[str, bool | str | list[HexAddress]]:
         """Convert the capability to JSON-compatible primitives.
 
         :return:
             Directional capability object suitable for internal persistence.
         """
-        result: dict[str, bool | str] = {
+        result: dict[str, bool | str | list[HexAddress]] = {
             "can_deposit": self.can_deposit,
             "can_redeem": self.can_redeem,
         }
@@ -119,23 +127,21 @@ class VaultDepositManagerCapability:
             result["redemption_unsupported_reason"] = self.redemption_unsupported_reason
         if self.supports_anvil_settlement is not None:
             result["supports_anvil_settlement"] = self.supports_anvil_settlement
+        if self.deposit_assets:
+            result["deposit_assets"] = list(self.deposit_assets)
         return result
 
-    def as_initial_public_schema(self) -> dict[str, bool | str] | None:
-        """Return the initial public schema or fail closed for partial support.
+    def as_initial_public_schema(self) -> dict[str, bool | str | list[HexAddress]] | None:
+        """Return the initial public capability schema.
 
-        The first export version advertises only symmetric manager support:
-        both directions must either be implemented or explicitly unsupported.
-        Keeping the internal representation directional leaves room for a
-        future schema revision without making a partial manager look
-        depositable today. An explicit ``False``/``False`` capability remains
-        useful because it distinguishes a deliberate refusing manager from an
-        adapter whose transaction support is unknown.
+        Existing partial adapters remain fail-closed unless they explicitly
+        opt in after their supported direction has been fork-proven.
 
         :return:
-            Symmetric public capability object, or ``None`` for partial support.
+            JSON-compatible capability object, or ``None`` for an unpublished
+            partial adapter.
         """
-        if self.can_deposit != self.can_redeem:
+        if self.can_deposit != self.can_redeem and not self.publish_partial:
             return None
         return self.as_dict()
 
@@ -220,6 +226,8 @@ class VaultFlowError(Exception):
         Vault address whose flow was attempted, when known.
     :param caller:
         Address for which the flow was prepared, when known.
+    :param asset_address:
+        Input asset selected for a multi-asset flow, when known.
     :param direction:
         ``deposit`` or ``redeem`` when known.
     :param phase:
@@ -232,6 +240,8 @@ class VaultFlowError(Exception):
         Requested amount in the contract's native raw unit, when applicable.
     :param available_raw_amount:
         Available amount in the contract's native raw unit, when applicable.
+    :param minimum_raw_amount:
+        Protocol minimum in the contract's native raw unit, when applicable.
     :param function_selector:
         Four-byte selector of the denied protocol entry point, when known.
     :param error_selector:
@@ -239,6 +249,8 @@ class VaultFlowError(Exception):
     :param access_delay:
         Access-manager scheduling delay in seconds, when a caller is eligible
         only after delayed execution.
+    :param next_open:
+        Naive UTC time at which a predictable closed protocol window next opens.
     """
 
     def __init__(
@@ -248,15 +260,18 @@ class VaultFlowError(Exception):
         protocol: str | None = None,
         vault_address: HexAddress | None = None,
         caller: HexAddress | None = None,
+        asset_address: HexAddress | None = None,
         direction: Literal["deposit", "redeem"] | None = None,
         phase: str | None = None,
         decoded_error: str | None = None,
         raw_revert_data: HexBytes | None = None,
         requested_raw_amount: int | None = None,
         available_raw_amount: int | None = None,
+        minimum_raw_amount: int | None = None,
         function_selector: HexBytes | None = None,
         error_selector: HexBytes | None = None,
         access_delay: int | None = None,
+        next_open: datetime.datetime | None = None,
     ) -> None:
         """Store structured context for a vault-flow failure."""
         super().__init__(reason)
@@ -264,15 +279,18 @@ class VaultFlowError(Exception):
         self.protocol = protocol
         self.vault_address = vault_address
         self.caller = caller
+        self.asset_address = asset_address
         self.direction = direction
         self.phase = phase
         self.decoded_error = decoded_error
         self.raw_revert_data = raw_revert_data
         self.requested_raw_amount = requested_raw_amount
         self.available_raw_amount = available_raw_amount
+        self.minimum_raw_amount = minimum_raw_amount
         self.function_selector = function_selector
         self.error_selector = error_selector
         self.access_delay = access_delay
+        self.next_open = next_open
 
     def __str__(self) -> str:
         """Format the failure reason with available flow context."""
@@ -283,6 +301,8 @@ class VaultFlowError(Exception):
             context.append(f"vault={self.vault_address}")
         if self.caller:
             context.append(f"caller={self.caller}")
+        if self.asset_address:
+            context.append(f"asset={self.asset_address}")
         if self.direction:
             context.append(f"direction={self.direction}")
         if self.phase:
@@ -295,10 +315,14 @@ class VaultFlowError(Exception):
             context.append(f"error_selector={self.error_selector.hex()}")
         if self.access_delay is not None:
             context.append(f"access_delay={self.access_delay}")
+        if self.next_open is not None:
+            context.append(f"next_open={self.next_open.isoformat()}")
         if self.requested_raw_amount is not None:
             context.append(f"requested_raw_amount={self.requested_raw_amount}")
         if self.available_raw_amount is not None:
             context.append(f"available_raw_amount={self.available_raw_amount}")
+        if self.minimum_raw_amount is not None:
+            context.append(f"minimum_raw_amount={self.minimum_raw_amount}")
         return f"{self.reason} ({', '.join(context)})" if context else self.reason
 
 

--- a/tests/erc_4626/test_deposit_probe.py
+++ b/tests/erc_4626/test_deposit_probe.py
@@ -22,8 +22,8 @@ from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability, VaultFl
 from eth_defi.vault.vaultdb import VaultDatabase
 
 
-def test_vault_deposit_manager_capability_suppresses_partial_public_support() -> None:
-    """The initial JSON schema advertises only symmetric manager support."""
+def test_vault_deposit_manager_capability_exposes_directional_public_support() -> None:
+    """The public JSON schema preserves directional and multi-asset support."""
     complete = VaultDepositManagerCapability(True, True, "synchronous", "asynchronous")
     assert complete.as_initial_public_schema() == {
         "can_deposit": True,
@@ -36,6 +36,19 @@ def test_vault_deposit_manager_capability_suppresses_partial_public_support() ->
         "can_redeem": False,
     }
     assert VaultDepositManagerCapability(True, False, "synchronous", None).as_initial_public_schema() is None
+    assert VaultDepositManagerCapability(
+        True,
+        False,
+        "synchronous",
+        None,
+        deposit_assets=("0x0000000000000000000000000000000000000001",),
+        publish_partial=True,
+    ).as_initial_public_schema() == {
+        "can_deposit": True,
+        "can_redeem": False,
+        "deposit_flow": "synchronous",
+        "deposit_assets": ["0x0000000000000000000000000000000000000001"],
+    }
     assert VaultDepositManagerCapability(False, True, None, "asynchronous").as_initial_public_schema() is None
     with pytest.raises(ValueError, match="deposit_flow"):
         VaultDepositManagerCapability(True, True, None, "asynchronous")
@@ -43,6 +56,8 @@ def test_vault_deposit_manager_capability_suppresses_partial_public_support() ->
         VaultDepositManagerCapability(True, True, "synchronous", "synchronous", deposit_unsupported_reason="unsupported")
     with pytest.raises(ValueError, match="supports_anvil_settlement"):
         VaultDepositManagerCapability(True, True, "synchronous", "synchronous", supports_anvil_settlement=True)
+    with pytest.raises(ValueError, match="deposit_assets"):
+        VaultDepositManagerCapability(False, False, deposit_assets=("0x0000000000000000000000000000000000000001",))
 
 
 def test_lagoon_capability_advertises_verified_anvil_settlement() -> None:

--- a/tests/erc_4626/vault_protocol/test_accountable.py
+++ b/tests/erc_4626/vault_protocol/test_accountable.py
@@ -18,7 +18,7 @@ from web3 import Web3
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature
-from eth_defi.erc_4626.vault_protocol.accountable.deposit_redeem import AccountableDepositManager, AccountableRedemptionTicket
+from eth_defi.erc_4626.vault_protocol.accountable.deposit_redeem import ACCOUNTABLE_INSUFFICIENT_AMOUNT_SELECTOR, AccountableDepositManager, AccountableRedemptionTicket
 from eth_defi.erc_4626.vault_protocol.accountable.offchain_metadata import (
     fetch_accountable_vaults,
 )
@@ -27,7 +27,7 @@ from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.token import TokenDetails
 from eth_defi.trace import assert_transaction_success_with_explanation
-from eth_defi.vault.deposit_redeem import AsyncVaultRequestStatus
+from eth_defi.vault.deposit_redeem import AsyncVaultRequestStatus, VaultFlowUnavailable
 
 JSON_RPC_MONAD = os.environ.get("JSON_RPC_MONAD")
 MONAD_USDC_WHALE = HexAddress(HexStr("0xf89d7b9c864f589bbF53a82105107622B35EaA40"))
@@ -113,6 +113,21 @@ def test_accountable_deposit_and_redemption_request_lifecycle(web3: Web3) -> Non
     assert isinstance(manager, AccountableDepositManager)
     assert manager.has_synchronous_deposit() is True
     assert manager.has_synchronous_redemption() is False
+
+    minimum = int(vault.vault_contract.functions.MIN_AMOUNT_WEI().call())
+    with pytest.raises(VaultFlowUnavailable, match="below minimum") as exc_info:
+        manager.create_deposit_request(owner=web3.eth.accounts[1], raw_amount=minimum - 1)
+    assert exc_info.value.decoded_error == "InsufficientAmount"
+    assert exc_info.value.error_selector == ACCOUNTABLE_INSUFFICIENT_AMOUNT_SELECTOR
+    assert exc_info.value.minimum_raw_amount == minimum
+    assert exc_info.value.available_raw_amount is None
+    unchecked_request = manager.create_deposit_request(
+        owner=web3.eth.accounts[1],
+        raw_amount=minimum,
+        check_max_deposit=False,
+        check_enough_token=False,
+    )
+    assert unchecked_request.raw_amount == minimum
 
     synchronous_settlement = manager.force_settle(None)
     assert synchronous_settlement.settlement_required is False

--- a/tests/erc_4626/vault_protocol/test_csigma.py
+++ b/tests/erc_4626/vault_protocol/test_csigma.py
@@ -11,7 +11,7 @@ from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault_protocol.csigma.deposit_redeem import CsigmaDepositManager
 from eth_defi.erc_4626.vault_protocol.csigma.vault import CSIGMA_V2_POOL_ADDRESS, CsigmaVault
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil, fund_erc20_on_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.token import USDC_WHALE
 from eth_defi.trace import assert_transaction_success_with_explanation
@@ -19,6 +19,7 @@ from eth_defi.vault.deposit_redeem import VaultFlowUnavailable
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 EXPECTED_V2_DEPOSITED_RAW_SHARES = 94_348_140
+EXPECTED_SUPQPV_DEPOSITED_RAW_SHARES = 94_445_037
 
 pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests")
 
@@ -196,7 +197,14 @@ def test_csigma_v2_pool_rejects_redemption_above_immediate_capacity(web3: Web3) 
 def test_csigma_supqpv(
     web3: Web3,
 ):
-    """Read cSigma Finance cSuperior Quality Private Credit vault metadata."""
+    """Verify the cSuperior Quality Private Credit synchronous lifecycle.
+
+    The fixed fork proves both request-capacity failures and a complete deposit
+    and redemption against the second cSigma pool advertised by the adapter.
+
+    :param web3:
+        Web3 client connected to the deterministic Ethereum fork.
+    """
 
     vault = create_vault_instance_autodetect(
         web3,
@@ -211,7 +219,43 @@ def test_csigma_supqpv(
     assert vault.get_management_fee("latest") == 0
     assert vault.get_performance_fee("latest") == 0
     assert vault.has_custom_fees() is False
-    assert vault.get_deposit_manager_capability() is None
+    assert isinstance(vault.get_deposit_manager(), CsigmaDepositManager)
+    assert vault.get_deposit_manager_capability().as_dict() == {
+        "can_deposit": True,
+        "can_redeem": True,
+        "deposit_flow": "synchronous",
+        "redemption_flow": "synchronous",
+    }
+    manager = vault.get_deposit_manager()
+    owner = web3.eth.accounts[2]
+    available_raw_assets = manager.fetch_depositable_raw_assets(owner)
+    with pytest.raises(VaultFlowUnavailable, match="deposit exceeds immediate asset capacity"):
+        manager.create_deposit_request(owner=owner, raw_amount=available_raw_assets + 1)
+    available_raw_shares = manager.fetch_redeemable_raw_shares(owner)
+    preflight = manager.fetch_redemption_preflight(owner, available_raw_shares + 1)
+    assert preflight.available is False
+    assert preflight.available_raw_shares == available_raw_shares
+    assert preflight.reason == "redemption_capacity_limited"
+
+    deposit_amount = Decimal(100)
+    denomination_token = vault.denomination_token
+    raw_deposit_amount = denomination_token.convert_to_raw(deposit_amount)
+    fund_erc20_on_anvil(web3, denomination_token.address, owner, raw_deposit_amount)
+    approval_hash = denomination_token.approve(vault.address, deposit_amount).transact({"from": owner})
+    assert_transaction_success_with_explanation(web3, approval_hash)
+
+    deposit_ticket = manager.create_deposit_request(owner=owner, raw_amount=raw_deposit_amount).broadcast(from_=owner)
+    deposit_analysis = manager.analyse_deposit(deposit_ticket.tx_hash, deposit_ticket)
+    assert deposit_analysis.denomination_amount == deposit_amount
+    assert deposit_analysis.share_count == vault.share_token.convert_to_decimals(EXPECTED_SUPQPV_DEPOSITED_RAW_SHARES)
+
+    raw_shares = vault.share_token.fetch_raw_balance_of(owner)
+    assert raw_shares == EXPECTED_SUPQPV_DEPOSITED_RAW_SHARES
+    redemption_ticket = manager.create_redemption_request(owner=owner, raw_shares=raw_shares).broadcast(from_=owner)
+    redemption_analysis = manager.analyse_redemption(redemption_ticket.tx_hash, redemption_ticket)
+    assert redemption_analysis.share_count == vault.share_token.convert_to_decimals(EXPECTED_SUPQPV_DEPOSITED_RAW_SHARES)
+    assert redemption_analysis.denomination_amount == Decimal("99.999999")
+    assert vault.share_token.fetch_raw_balance_of(owner) == 0
 
     # Check vault link
     assert vault.get_link() == "https://edge.csigma.finance/"

--- a/tests/erc_4626/vault_protocol/test_d2.py
+++ b/tests/erc_4626/vault_protocol/test_d2.py
@@ -18,6 +18,7 @@ from eth_defi.vault.base import (
     DEPOSIT_CLOSED_FUNDING_PHASE,
     REDEMPTION_CLOSED_FUNDS_CUSTODIED,
 )
+from eth_defi.vault.deposit_redeem import VaultFlowUnavailable
 
 JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
 
@@ -61,8 +62,15 @@ def test_d2(
 
     manager = vault.get_deposit_manager()
     assert isinstance(manager, D2DepositManager)
-    with pytest.raises(ValueError, match="D2 deposit is unavailable"):
+    with pytest.raises(VaultFlowUnavailable, match=DEPOSIT_CLOSED_FUNDING_PHASE) as exc_info:
         manager.estimate_deposit(web3.eth.accounts[0], Decimal("1"))
+    assert exc_info.value.direction == "deposit"
+    assert exc_info.value.phase == "preflight"
+    assert exc_info.value.next_open == datetime.datetime(2025, 11, 7, 8, 0)
+    with pytest.raises(VaultFlowUnavailable, match=DEPOSIT_CLOSED_FUNDING_PHASE):
+        manager.create_deposit_request(web3.eth.accounts[0], None, None, 1, True, True)
+    with pytest.raises(VaultFlowUnavailable, match=REDEMPTION_CLOSED_FUNDS_CUSTODIED):
+        manager.create_redemption_request(web3.eth.accounts[0], None, None, 1, True, True)
     settlement = manager.force_settle(None)
     assert settlement.settlement_required is False
     assert settlement.transaction_hashes == ()

--- a/tests/erc_4626/vault_protocol/test_upshift.py
+++ b/tests/erc_4626/vault_protocol/test_upshift.py
@@ -2,6 +2,8 @@
 
 import datetime
 import os
+from collections.abc import Iterator
+from decimal import Decimal
 from pathlib import Path
 
 import flaky
@@ -11,11 +13,16 @@ from web3 import Web3
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.classification import create_vault_instance, create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.erc_4626.vault_protocol.upshift.deposit_redeem import UpshiftMultiAssetDepositManager
 from eth_defi.erc_4626.vault_protocol.upshift.vault import UpshiftMultiAssetHistoricalReader, UpshiftVault
 from eth_defi.event_reader.multicall_batcher import read_multicall_historical
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil, fund_erc20_on_anvil
 from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
+from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
+from eth_defi.testing.fork_blocks import ETHEREUM_MIDNIGHT_BLOCK
 from eth_defi.token import TokenDiskCache
+from eth_defi.vault.deposit_redeem import VaultFlowUnavailable
 from eth_defi.vault.fee import VaultFeeMode
 from eth_defi.vault.risk import VaultTechnicalRisk
 
@@ -27,6 +34,7 @@ UPSHIFT_MULTI_ASSET_FORK_BLOCK = 25_405_251
 UPSHIFT_TORI_VAULT = "0xcd69123b3FBBfC666E1f6a501da27B564C00De54"
 UPSHIFT_CTUSD_VAULT = "0xc87DBBB8C67e4F19fCD2E297c05937567b2572Ce"
 UPSHIFT_SENTORA_USD_EARN_VAULT = "0x74ad2f789ed583dbd141bbdafc673fe1f033718b"
+UPSHIFT_SENTORA_ONE_USDT_RAW_SHARES = 969_683
 UPSHIFT_SENTORA_INSTANT_REDEMPTION_FEE = 0.002
 UPSHIFT_GAMMA_BTC_VAULT = "0x3e4ef6ccc7e4a045c9d3f48b08813d59df14e256"
 UPSHIFT_GAMMA_BTC_MANAGEMENT_FEE = 0.005
@@ -51,6 +59,24 @@ def anvil_ethereum_fork() -> AnvilLaunch:
 def web3(anvil_ethereum_fork):
     web3 = create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url)
     return web3
+
+
+@pytest.fixture(scope="module")
+def anvil_sentora_deposit_fork(anvil_fork_pool: AnvilForkPool) -> AnvilLaunch:
+    """Share the canonical fixed Ethereum fork for Sentora tests."""
+    return anvil_fork_pool.get_launch(JSON_RPC_ETHEREUM, ETHEREUM_MIDNIGHT_BLOCK)
+
+
+@pytest.fixture(scope="module")
+def sentora_web3(anvil_sentora_deposit_fork: AnvilLaunch) -> Web3:
+    """Connect to the deterministic Sentora lifecycle fork."""
+    return create_multi_provider_web3(anvil_sentora_deposit_fork.json_rpc_url)
+
+
+@pytest.fixture
+def sentora_snapshot(anvil_sentora_deposit_fork: AnvilLaunch) -> Iterator[None]:
+    """Restore the shared Sentora fork after a mutating lifecycle test."""
+    yield from evm_snapshot_revert(anvil_sentora_deposit_fork)
 
 
 @flaky.flaky
@@ -107,13 +133,13 @@ def test_upshift(
 @pytest.mark.parametrize(
     "case",
     [
-        (UPSHIFT_TORI_VAULT, "Tori Ecosystem Vault", "etrUSD", "USDC", 18),
-        (UPSHIFT_CTUSD_VAULT, "Earn ctUSD", "EctUSD", "USDC", 6),
+        (UPSHIFT_TORI_VAULT, "Tori Ecosystem Vault", "etrUSD", "trUSD", 18, None),
+        (UPSHIFT_CTUSD_VAULT, "Earn ctUSD", "EctUSD", "USDC", 6, "Upshift depositCap() has been reached"),
     ],
 )
 def test_upshift_multi_asset_vault_metadata(
     web3: Web3,
-    case: tuple[str, str, str, str, int],
+    case: tuple[str, str, str, str, int, str | None],
 ):
     """Read Upshift multi-asset vault metadata.
 
@@ -126,7 +152,7 @@ def test_upshift_multi_asset_vault_metadata(
     Implementation: https://etherscan.io/address/0xEB5f80aCEa6060764E91c185bE93752Ab40F01c2#code
     """
 
-    vault_address, expected_name, expected_symbol, expected_primary_denomination_symbol, expected_share_decimals = case
+    vault_address, expected_name, expected_symbol, expected_accounting_symbol, expected_share_decimals, expected_deposit_closed_reason = case
 
     vault = create_vault_instance_autodetect(
         web3,
@@ -143,30 +169,98 @@ def test_upshift_multi_asset_vault_metadata(
     assert vault.share_token.decimals == expected_share_decimals
     denomination_tokens = vault.fetch_all_denomination_tokens()
     assert denomination_tokens
-    assert denomination_tokens[0].symbol == expected_primary_denomination_symbol
-    assert vault.denomination_token == denomination_tokens[0]
+    assert vault.denomination_token.symbol == expected_accounting_symbol
 
     assert isinstance(vault.get_historical_reader(stateful=False), UpshiftMultiAssetHistoricalReader)
     assert vault.fetch_share_price(UPSHIFT_MULTI_ASSET_FORK_BLOCK) > 0
     assert vault.get_deposit_manager_capability().as_dict() == {
-        "can_deposit": False,
+        "can_deposit": True,
         "can_redeem": False,
-        "deposit_unsupported_reason": "multi_asset_application_flow_not_implemented",
+        "deposit_flow": "synchronous",
         "redemption_unsupported_reason": "multi_asset_application_flow_not_implemented",
+        "deposit_assets": [token.address for token in denomination_tokens],
     }
     assert vault.fetch_total_assets(UPSHIFT_MULTI_ASSET_FORK_BLOCK) > 0
     assert vault.fetch_total_supply(UPSHIFT_MULTI_ASSET_FORK_BLOCK) > 0
     assert vault.fetch_available_liquidity(UPSHIFT_MULTI_ASSET_FORK_BLOCK) is not None
-    assert vault.fetch_deposit_closed_reason() is None
+    assert vault.fetch_deposit_closed_reason() == expected_deposit_closed_reason
     assert vault.fetch_redemption_closed_reason() == "Upshift withdrawalsPaused() is true"
     assert vault.can_check_deposit() is False
 
-    with pytest.raises(NotImplementedError):
-        vault.get_deposit_manager()
+    assert isinstance(vault.get_deposit_manager(), UpshiftMultiAssetDepositManager)
 
     link = vault.get_link()
     assert "app.upshift.finance" in link
     assert Web3.to_checksum_address(vault_address) in link
+
+
+@flaky.flaky
+@pytest.mark.xdist_group("fork:ethereum:midnight")
+def test_upshift_sentora_multi_asset_deposit_lifecycle(sentora_web3: Web3, sentora_snapshot: None) -> None:
+    """Deposit the selected whitelist asset into Sentora USD Earn on Anvil.
+
+    The request contains its required ERC-20 approval followed by Upshift's
+    non-ERC-4626 ``deposit(asset, assets, receiver)`` call.  The exact vault's
+    fixed-block whitelist contains USDT, allowing the test to directly fund the
+    Anvil account without relying on a mutable mainnet token holder.
+    """
+    del sentora_snapshot
+    vault = create_vault_instance_autodetect(sentora_web3, vault_address=UPSHIFT_SENTORA_USD_EARN_VAULT)
+    assert isinstance(vault, UpshiftVault)
+    manager = vault.get_deposit_manager()
+    assert isinstance(manager, UpshiftMultiAssetDepositManager)
+
+    owner = sentora_web3.eth.accounts[0]
+    asset = next(asset for asset in manager.fetch_accepted_assets() if asset.symbol == "USDT")
+    raw_amount = asset.convert_to_raw(Decimal(1))
+    capability = vault.get_deposit_manager_capability()
+    assert capability.as_initial_public_schema() == {
+        "can_deposit": True,
+        "can_redeem": False,
+        "deposit_flow": "synchronous",
+        "redemption_unsupported_reason": "multi_asset_application_flow_not_implemented",
+        "deposit_assets": [token.address for token in manager.fetch_accepted_assets()],
+    }
+    assert manager.has_synchronous_deposit() is True
+    assert manager.has_synchronous_redemption() is False
+    assert manager.can_create_deposit_request(owner) is True
+    assert manager.can_create_redemption_request(owner) is False
+
+    with pytest.raises(VaultFlowUnavailable, match="explicitly selected"):
+        manager.create_deposit_request(owner=owner, raw_amount=raw_amount)
+    with pytest.raises(VaultFlowUnavailable, match="explicitly selected"):
+        manager.estimate_deposit(owner, Decimal(1))
+    with pytest.raises(VaultFlowUnavailable, match="not implemented"):
+        manager.estimate_redeem(owner, Decimal(1))
+
+    assert manager.estimate_deposit_for_asset(owner, Decimal(1), asset.address) == Decimal("0.969683")
+    max_deposit = manager.fetch_max_deposit_for_asset(asset.address)
+    assert max_deposit == asset.convert_to_raw(Decimal(100_000_000))
+    eighteen_decimal_asset = next(token for token in manager.fetch_accepted_assets() if token.decimals == 18)
+    assert manager.estimate_deposit_for_asset(owner, Decimal(1), eighteen_decimal_asset.address) == Decimal("0.969683")
+    eighteen_decimal_max_deposit = manager.fetch_max_deposit_for_asset(eighteen_decimal_asset.address)
+    assert eighteen_decimal_asset.convert_to_decimals(eighteen_decimal_max_deposit) == asset.convert_to_decimals(max_deposit)
+    with pytest.raises(VaultFlowUnavailable, match="protocol limits") as exc_info:
+        manager.create_deposit_request(
+            owner=owner,
+            raw_amount=max_deposit + 1,
+            accepted_asset=asset.address,
+            check_enough_token=False,
+        )
+    assert exc_info.value.available_raw_amount == max_deposit
+    assert exc_info.value.requested_raw_amount == max_deposit + 1
+
+    fund_erc20_on_anvil(sentora_web3, asset.address, owner, raw_amount)
+    deposit_ticket = manager.create_deposit_request(
+        owner=owner,
+        raw_amount=raw_amount,
+        accepted_asset=asset.address,
+    ).broadcast()
+    analysis = manager.analyse_deposit(deposit_ticket.tx_hash, deposit_ticket)
+    assert analysis.denomination_amount == Decimal(1)
+    assert analysis.share_count == Decimal("0.969683")
+    assert vault.share_token.fetch_raw_balance_of(owner) == UPSHIFT_SENTORA_ONE_USDT_RAW_SHARES
+    assert manager.force_settle(None).settlement_required is False
 
 
 @flaky.flaky

--- a/tests/erc_4626/vault_protocol/test_upshift.py
+++ b/tests/erc_4626/vault_protocol/test_upshift.py
@@ -39,6 +39,7 @@ UPSHIFT_SENTORA_INSTANT_REDEMPTION_FEE = 0.002
 UPSHIFT_GAMMA_BTC_VAULT = "0x3e4ef6ccc7e4a045c9d3f48b08813d59df14e256"
 UPSHIFT_GAMMA_BTC_MANAGEMENT_FEE = 0.005
 UPSHIFT_GAMMA_BTC_PERFORMANCE_FEE = 0.1
+EIGHTEEN_DECIMALS = 18
 UPSHIFT_TORI_HISTORY_START_BLOCK = 25_355_071
 UPSHIFT_TORI_HISTORY_STEP_BLOCKS = 7_200
 UPSHIFT_TORI_HISTORY_SAMPLE_COUNT = 8
@@ -194,9 +195,8 @@ def test_upshift_multi_asset_vault_metadata(
     assert Web3.to_checksum_address(vault_address) in link
 
 
-@flaky.flaky
 @pytest.mark.xdist_group("fork:ethereum:midnight")
-def test_upshift_sentora_multi_asset_deposit_lifecycle(sentora_web3: Web3, sentora_snapshot: None) -> None:
+def test_upshift_sentora_multi_asset_deposit_lifecycle(sentora_web3: Web3, sentora_snapshot: None, monkeypatch: pytest.MonkeyPatch) -> None:
     """Deposit the selected whitelist asset into Sentora USD Earn on Anvil.
 
     The request contains its required ERC-20 approval followed by Upshift's
@@ -236,7 +236,7 @@ def test_upshift_sentora_multi_asset_deposit_lifecycle(sentora_web3: Web3, sento
     assert manager.estimate_deposit_for_asset(owner, Decimal(1), asset.address) == Decimal("0.969683")
     max_deposit = manager.fetch_max_deposit_for_asset(asset.address)
     assert max_deposit == asset.convert_to_raw(Decimal(100_000_000))
-    eighteen_decimal_asset = next(token for token in manager.fetch_accepted_assets() if token.decimals == 18)
+    eighteen_decimal_asset = next(token for token in manager.fetch_accepted_assets() if token.decimals == EIGHTEEN_DECIMALS)
     assert manager.estimate_deposit_for_asset(owner, Decimal(1), eighteen_decimal_asset.address) == Decimal("0.969683")
     eighteen_decimal_max_deposit = manager.fetch_max_deposit_for_asset(eighteen_decimal_asset.address)
     assert eighteen_decimal_asset.convert_to_decimals(eighteen_decimal_max_deposit) == asset.convert_to_decimals(max_deposit)
@@ -256,6 +256,7 @@ def test_upshift_sentora_multi_asset_deposit_lifecycle(sentora_web3: Web3, sento
         raw_amount=raw_amount,
         accepted_asset=asset.address,
     ).broadcast()
+    monkeypatch.setattr(manager, "fetch_accepted_assets", lambda: ())
     analysis = manager.analyse_deposit(deposit_ticket.tx_hash, deposit_ticket)
     assert analysis.denomination_amount == Decimal(1)
     assert analysis.share_count == Decimal("0.969683")

--- a/tests/erc_4626/vault_protocol/test_upshift.py
+++ b/tests/erc_4626/vault_protocol/test_upshift.py
@@ -16,7 +16,7 @@ from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault_protocol.upshift.deposit_redeem import UpshiftMultiAssetDepositManager
 from eth_defi.erc_4626.vault_protocol.upshift.vault import UpshiftMultiAssetHistoricalReader, UpshiftVault
 from eth_defi.event_reader.multicall_batcher import read_multicall_historical
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil, fund_erc20_on_anvil
+from eth_defi.provider.anvil import AnvilLaunch, fund_erc20_on_anvil
 from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
 from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
@@ -47,19 +47,15 @@ UPSHIFT_TORI_HISTORY_END_BLOCK = UPSHIFT_TORI_HISTORY_START_BLOCK + UPSHIFT_TORI
 
 
 @pytest.fixture(scope="module")
-def anvil_ethereum_fork() -> AnvilLaunch:
-    """Fork at a specific block for reproducibility"""
-    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=UPSHIFT_MULTI_ASSET_FORK_BLOCK)
-    try:
-        yield launch
-    finally:
-        launch.close()
+def anvil_ethereum_fork(anvil_fork_pool: AnvilForkPool) -> AnvilLaunch:
+    """Share the established fixed Ethereum fork for Upshift metadata tests."""
+    return anvil_fork_pool.get_launch(JSON_RPC_ETHEREUM, UPSHIFT_MULTI_ASSET_FORK_BLOCK)
 
 
 @pytest.fixture(scope="module")
-def web3(anvil_ethereum_fork):
-    web3 = create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url)
-    return web3
+def web3(anvil_ethereum_fork: AnvilLaunch) -> Web3:
+    """Connect to the shared deterministic Upshift fork."""
+    return create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url)
 
 
 @pytest.fixture(scope="module")
@@ -80,7 +76,7 @@ def sentora_snapshot(anvil_sentora_deposit_fork: AnvilLaunch) -> Iterator[None]:
     yield from evm_snapshot_revert(anvil_sentora_deposit_fork)
 
 
-@flaky.flaky
+@pytest.mark.xdist_group("fork:ethereum:upshift-metadata")
 def test_upshift(
     web3: Web3,
 ):
@@ -130,7 +126,10 @@ def test_upshift(
     assert vault.can_check_redeem() is False
 
 
+# CI flaky since 2026-07-24: archive-backed Anvil reads timed out under xdist;
+# case 1 passed on retry in the same CI run and both cases pass locally.
 @flaky.flaky
+@pytest.mark.xdist_group("fork:ethereum:upshift-metadata")
 @pytest.mark.parametrize(
     "case",
     [
@@ -264,7 +263,7 @@ def test_upshift_sentora_multi_asset_deposit_lifecycle(sentora_web3: Web3, sento
     assert manager.force_settle(None).settlement_required is False
 
 
-@flaky.flaky
+@pytest.mark.xdist_group("fork:ethereum:upshift-metadata")
 def test_upshift_multi_asset_fee_data(web3: Web3) -> None:
     """Read the complete shared fee model from Sentora USD Earn.
 
@@ -290,7 +289,10 @@ def test_upshift_multi_asset_fee_data(web3: Web3) -> None:
     assert fee_data.withdraw == 0.0
 
 
+# CI flaky since 2026-07-24: the archive-backed fee read timed out on attempt 2;
+# the identical test passed on attempt 1 without a code change.
 @flaky.flaky
+@pytest.mark.xdist_group("fork:ethereum:upshift-metadata")
 def test_upshift_multi_asset_fee_units(web3: Web3) -> None:
     """Read non-zero Upshift multi-asset fees with their protocol-specific units.
 

--- a/tests/rpc/test_multi_provider.py
+++ b/tests/rpc/test_multi_provider.py
@@ -10,7 +10,7 @@ from eth_defi.chain import has_graphql_support
 from eth_defi.hotwallet import HotWallet
 from eth_defi.provider import multi_provider as multi_provider_module
 from eth_defi.provider.anvil import AnvilForkMetadata, AnvilLaunch, launch_anvil
-from eth_defi.provider.multi_provider import MultiProviderConfigurationError, create_multi_provider_web3
+from eth_defi.provider.multi_provider import DEFAULT_ANVIL_RETRIES, DEFAULT_RETRIES, MultiProviderConfigurationError, MultiProviderWeb3Factory, create_multi_provider_web3
 from eth_defi.provider.named import get_provider_name
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.tx import get_tx_broadcast_data
@@ -158,10 +158,48 @@ def test_multi_provider_anvil_launch_metadata(anvil: AnvilLaunch, monkeypatch: p
     )
 
     web3 = create_multi_provider_web3(anvil.json_rpc_url)
+    factory = MultiProviderWeb3Factory(anvil.json_rpc_url)
     provider = web3.get_active_call_provider()
-    context = web3.get_fallback_provider().get_provider_context_for_log(provider)
+    fallback_provider = web3.get_fallback_provider()
+    context = fallback_provider.get_provider_context_for_log(provider)
 
+    assert fallback_provider.retries == DEFAULT_ANVIL_RETRIES
+    assert factory.retries == DEFAULT_ANVIL_RETRIES
     assert context["chain_id"] == anvil.chain_id
     assert context["anvil_upstream_rpc_providers"] == ["rpc.example.test"]
     assert context["anvil_fork_block_number"] == 12_345
     assert context["anvil_effective_fork_provider"] == "127.0.0.1:12345"
+
+    explicit_retries = 4
+    explicitly_retried_web3 = create_multi_provider_web3(
+        anvil.json_rpc_url,
+        retries=explicit_retries,
+    )
+    assert explicitly_retried_web3.get_fallback_provider().retries == explicit_retries
+
+
+def test_multi_provider_keeps_remote_default_retries(
+    anvil: AnvilLaunch,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Use the established retry default without registered Anvil metadata.
+
+    :param anvil:
+        Running local test node used as a responsive ordinary endpoint.
+
+    :param monkeypatch:
+        Pytest monkeypatch fixture.
+
+    :return:
+        None.
+    """
+
+    monkeypatch.setattr(
+        multi_provider_module,
+        "_get_anvil_launch_metadata",
+        lambda _json_rpc_url: None,
+    )
+
+    web3 = create_multi_provider_web3(anvil.json_rpc_url)
+
+    assert web3.get_fallback_provider().retries == DEFAULT_RETRIES

--- a/tests/test_anvil_fork_pool.py
+++ b/tests/test_anvil_fork_pool.py
@@ -1,0 +1,159 @@
+"""Unit tests for the shared Anvil fork pool."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from eth_defi.provider.rpc_proxy import RPCProxy, RPCProxyConfig
+from eth_defi.testing import anvil_fork_pool as pool_module
+from eth_defi.testing.anvil_fork_pool import (
+    POOL_PROXY_TIMEOUT,
+    POOL_WEB3_HTTP_TIMEOUT,
+    POOL_WEB3_RETRIES,
+    AnvilForkPool,
+)
+
+
+def test_anvil_fork_pool_bounds_nested_rpc_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bound proxy and Web3 retries while preserving launch reuse.
+
+    A pooled Anvil may stop answering while it waits for an unavailable
+    archive provider. Verify that the proxy owns the provider failover budget
+    and the outer Web3 client does not multiply the same localhost failure by
+    its general-purpose retry defaults.
+
+    :param monkeypatch:
+        Pytest monkeypatch fixture.
+
+    :return:
+        None.
+    """
+    launch = Mock(json_rpc_url="http://localhost:23456")
+    fork_network_anvil = Mock(return_value=launch)
+    first_client = Mock()
+    second_client = Mock()
+    create_web3 = Mock(side_effect=[first_client, second_client])
+    monkeypatch.setattr(pool_module, "fork_network_anvil", fork_network_anvil)
+    monkeypatch.setattr(pool_module, "create_multi_provider_web3", create_web3)
+
+    pool = AnvilForkPool()
+    rpc_url = "https://primary.example https://fallback.example"
+
+    first_web3 = pool.get_web3(rpc_url, 123)
+    second_web3 = pool.get_web3(rpc_url, 123)
+
+    assert first_web3 is first_client
+    assert second_web3 is second_client
+    assert fork_network_anvil.call_count == 1
+    assert create_web3.call_count == len((first_client, second_client))
+
+    proxy_config = fork_network_anvil.call_args.kwargs["proxy_multiple_upstream"]
+    assert isinstance(proxy_config, RPCProxyConfig)
+    assert proxy_config.timeout == POOL_PROXY_TIMEOUT
+    assert proxy_config.retries == len(rpc_url.split())
+    create_web3.assert_called_with(
+        launch.json_rpc_url,
+        default_http_timeout=POOL_WEB3_HTTP_TIMEOUT,
+        retries=POOL_WEB3_RETRIES,
+    )
+
+
+def test_anvil_fork_pool_preserves_explicit_proxy_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Do not replace an explicit caller proxy configuration.
+
+    :param monkeypatch:
+        Pytest monkeypatch fixture.
+
+    :return:
+        None.
+    """
+    launch = Mock(json_rpc_url="http://localhost:23457")
+    fork_network_anvil = Mock(return_value=launch)
+    monkeypatch.setattr(pool_module, "fork_network_anvil", fork_network_anvil)
+
+    explicit_config = RPCProxyConfig(timeout=7.0, retries=3)
+    pool = AnvilForkPool()
+    returned_launch = pool.get_launch(
+        "https://primary.example https://fallback.example",
+        456,
+        proxy_multiple_upstream=explicit_config,
+    )
+
+    assert returned_launch is launch
+    assert fork_network_anvil.call_args.kwargs["proxy_multiple_upstream"] is explicit_config
+
+
+def test_anvil_fork_pool_tries_every_standard_upstream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Size the bounded proxy attempt count to the usable provider set.
+
+    :param monkeypatch:
+        Pytest monkeypatch fixture.
+
+    :return:
+        None.
+    """
+    launch = Mock(json_rpc_url="http://localhost:23458")
+    fork_network_anvil = Mock(return_value=launch)
+    monkeypatch.setattr(pool_module, "fork_network_anvil", fork_network_anvil)
+
+    pool = AnvilForkPool()
+    standard_rpc_urls = (
+        "https://primary.example",
+        "https://fallback.example",
+        "https://last-resort.example",
+    )
+    pool.get_launch(
+        " ".join(("mev+https://transactions.example", *standard_rpc_urls)),
+        789,
+    )
+
+    proxy_config = fork_network_anvil.call_args.kwargs["proxy_multiple_upstream"]
+    assert proxy_config.retries == len(standard_rpc_urls)
+
+
+def test_anvil_fork_pool_allows_web3_policy_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Allow known slow callers to override the bounded Web3 defaults.
+
+    :param monkeypatch:
+        Pytest monkeypatch fixture.
+
+    :return:
+        None.
+    """
+    launch = Mock(json_rpc_url="http://localhost:23459")
+    monkeypatch.setattr(
+        pool_module,
+        "fork_network_anvil",
+        Mock(return_value=launch),
+    )
+    create_web3 = Mock(return_value=Mock())
+    monkeypatch.setattr(pool_module, "create_multi_provider_web3", create_web3)
+
+    pool = AnvilForkPool()
+    pool.get_web3(
+        "https://primary.example",
+        987,
+        web3_retries=4,
+        web3_http_timeout=(5.0, 120.0),
+    )
+
+    create_web3.assert_called_once_with(
+        launch.json_rpc_url,
+        default_http_timeout=(5.0, 120.0),
+        retries=4,
+    )
+
+
+def test_anvil_fork_pool_keys_running_proxy_by_identity() -> None:
+    """Avoid deep-copying the locks and server state of a running proxy.
+
+    :return:
+        None.
+    """
+    running_proxy = object.__new__(RPCProxy)
+
+    assert pool_module._freeze(running_proxy) == (RPCProxy, id(running_proxy))

--- a/tests/test_anvil_fork_pool.py
+++ b/tests/test_anvil_fork_pool.py
@@ -4,10 +4,10 @@ from unittest.mock import Mock
 
 import pytest
 
+from eth_defi.provider import anvil as anvil_module
 from eth_defi.provider.rpc_proxy import RPCProxy, RPCProxyConfig
 from eth_defi.testing import anvil_fork_pool as pool_module
 from eth_defi.testing.anvil_fork_pool import (
-    POOL_PROXY_TIMEOUT,
     POOL_WEB3_HTTP_TIMEOUT,
     POOL_WEB3_RETRIES,
     AnvilForkPool,
@@ -47,15 +47,94 @@ def test_anvil_fork_pool_bounds_nested_rpc_retries(monkeypatch: pytest.MonkeyPat
     assert fork_network_anvil.call_count == 1
     assert create_web3.call_count == len((first_client, second_client))
 
-    proxy_config = fork_network_anvil.call_args.kwargs["proxy_multiple_upstream"]
-    assert isinstance(proxy_config, RPCProxyConfig)
-    assert proxy_config.timeout == POOL_PROXY_TIMEOUT
-    assert proxy_config.retries == len(rpc_url.split())
+    fork_network_anvil.assert_called_once_with(
+        rpc_url,
+        fork_block_number=123,
+    )
     create_web3.assert_called_with(
         launch.json_rpc_url,
         default_http_timeout=POOL_WEB3_HTTP_TIMEOUT,
         retries=POOL_WEB3_RETRIES,
     )
+
+
+@pytest.mark.parametrize("provider_count", [2, 3, 4, 10])
+def test_default_anvil_proxy_policy_is_bounded(provider_count: int) -> None:
+    """Try each automatic upstream once within the local read timeout.
+
+    :param provider_count:
+        Number of configured standard upstream providers.
+
+    :return:
+        None.
+    """
+
+    config = anvil_module._create_default_anvil_proxy_config(provider_count)
+
+    assert config.retries == provider_count
+    assert config.backoff == 0
+    combined_requests_timeout = min(config.timeout, 5.0) + config.timeout
+    assert combined_requests_timeout * provider_count <= anvil_module.ANVIL_PROXY_TOTAL_TIMEOUT
+
+
+def test_launch_anvil_preserves_proxy_modes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Wire the bounded automatic policy without changing explicit modes.
+
+    The deliberately dead upstreams stop each launch at its smoke test, after
+    the proxy-selection branch has run but before an Anvil process is spawned.
+
+    :param monkeypatch:
+        Pytest monkeypatch fixture.
+
+    :return:
+        None.
+    """
+    rpc_url = "http://127.0.0.1:1 http://127.0.0.1:2"
+    managed_proxy = Mock(spec=RPCProxy)
+    managed_proxy.url = "http://127.0.0.1:23456"
+    start_rpc_proxy = Mock(return_value=managed_proxy)
+    monkeypatch.setattr(anvil_module, "start_rpc_proxy", start_rpc_proxy)
+
+    with pytest.raises(ValueError, match="RPC smoke test failed"):
+        anvil_module.launch_anvil(
+            rpc_url,
+            proxy_multiple_upstream=True,
+            test_request_timeout=0.01,
+        )
+
+    automatic_config = start_rpc_proxy.call_args.kwargs["config"]
+    expected_config = anvil_module._create_default_anvil_proxy_config(2)
+    assert automatic_config == expected_config
+    assert start_rpc_proxy.call_args.kwargs["suppress_client_disconnect_errors"] is True
+
+    explicit_config = RPCProxyConfig(timeout=7.0, retries=3)
+    start_rpc_proxy.reset_mock()
+    with pytest.raises(ValueError, match="RPC smoke test failed"):
+        anvil_module.launch_anvil(
+            rpc_url,
+            proxy_multiple_upstream=explicit_config,
+            test_request_timeout=0.01,
+        )
+    assert start_rpc_proxy.call_args.kwargs["config"] is explicit_config
+
+    start_rpc_proxy.reset_mock()
+    with pytest.raises(ValueError, match="RPC smoke test failed"):
+        anvil_module.launch_anvil(
+            rpc_url,
+            proxy_multiple_upstream=False,
+            test_request_timeout=0.01,
+        )
+    start_rpc_proxy.assert_not_called()
+
+    caller_proxy = object.__new__(RPCProxy)
+    caller_proxy.url = "http://127.0.0.1:23457"
+    with pytest.raises(ValueError, match="RPC smoke test failed"):
+        anvil_module.launch_anvil(
+            rpc_url,
+            proxy_multiple_upstream=caller_proxy,
+            test_request_timeout=0.01,
+        )
+    start_rpc_proxy.assert_not_called()
 
 
 def test_anvil_fork_pool_preserves_explicit_proxy_config(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -81,36 +160,6 @@ def test_anvil_fork_pool_preserves_explicit_proxy_config(monkeypatch: pytest.Mon
 
     assert returned_launch is launch
     assert fork_network_anvil.call_args.kwargs["proxy_multiple_upstream"] is explicit_config
-
-
-def test_anvil_fork_pool_tries_every_standard_upstream(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Size the bounded proxy attempt count to the usable provider set.
-
-    :param monkeypatch:
-        Pytest monkeypatch fixture.
-
-    :return:
-        None.
-    """
-    launch = Mock(json_rpc_url="http://localhost:23458")
-    fork_network_anvil = Mock(return_value=launch)
-    monkeypatch.setattr(pool_module, "fork_network_anvil", fork_network_anvil)
-
-    pool = AnvilForkPool()
-    standard_rpc_urls = (
-        "https://primary.example",
-        "https://fallback.example",
-        "https://last-resort.example",
-    )
-    pool.get_launch(
-        " ".join(("mev+https://transactions.example", *standard_rpc_urls)),
-        789,
-    )
-
-    proxy_config = fork_network_anvil.call_args.kwargs["proxy_multiple_upstream"]
-    assert proxy_config.retries == len(standard_rpc_urls)
 
 
 def test_anvil_fork_pool_allows_web3_policy_override(


### PR DESCRIPTION
## Why

The trade-executor cross-chain vault simulation exposed confirmed eth-defi adapter gaps for Upshift multi-asset deposits, D2 epoch preflights, Accountable minimum deposits, and cSigma manager selection. These predictable protocol states need typed results before broadcast so trade-executor can distinguish unsupported or closed flows from transaction and receipt-analysis failures.

## Lessons learnt

- An Upshift vault's ERC-4626 accounting asset can differ from its accepted deposit assets.
- Upshift applies both a per-deposit maximum and a total vault cap; its asset-aware `previewDeposit()` is the authoritative conversion path.
- Partial manager capability publication must be explicit so adding Upshift support does not expose unrelated partial adapters.
- The originally reported Accountable Monad address no longer exposes usable current contract state, so the regression uses a live deployment with the same authoritative ABI and minimum-error selector.

## Summary

- Add an Upshift multi-asset deposit manager with explicit asset selection, protocol previews, approval/deposit construction, typed failures, capability metadata, and receipt decoding.
- Account for Upshift's per-deposit and remaining total capacity in live and historical reads.
- Return typed Accountable minimum-deposit and D2 closed-window preflight failures with structured context.
- Certify both cSigma pools only after fork-proving capacity checks and complete synchronous deposit/redemption lifecycles.
- Add focused Ethereum, Arbitrum, and Monad fork coverage and publish the new Upshift API module.

## Related issues and PRs

- Continues the eth-defi hand-off from tradingstrategy-ai/trade-executor#1577: https://github.com/tradingstrategy-ai/trade-executor/pull/1577#issuecomment-5074456670

## Unrelated CI and test fixes

- Co-locate Upshift fork tests on shared pooled Anvil instances to avoid duplicate archive-backed forks under xdist.
- Raise the dedicated vault workflow timeout from 30 to 45 minutes after two runs were cancelled while tests were still progressing.
- Bound automatic Anvil proxy and local Web3 retry layers so one unavailable archive request cannot stall a fork-test group for eight minutes.
