### PR TITLE
docs: clarify agent CLI guidance and worktree bootstrap in CLAUDE.md

### DIFF
--- a/.claude/docs/agent-tricks-and-troubleshooting.md
+++ b/.claude/docs/agent-tricks-and-troubleshooting.md
@@ -1,10 +1,36 @@
 # Agent tricks and troubleshooting
 
-Read this document before invoking Claude CLI or Codex CLI from another agent.
+Read this document before invoking an external agent CLI from another agent.
 It contains local invocation details that are easy to get wrong, especially for
-non-interactive Claude review runs.
+non-interactive review runs.
 
-This note covers practical ways to use Codex CLI and Claude CLI as local engineering agents, especially when one agent is used to review or debug the other agent's work.
+This note covers practical ways to use **Claude CLI**, **Codex CLI**, and
+**Grok CLI** (`grok`) as local engineering agents, especially when one agent is
+used to review or debug another agent's work.
+
+## Covered CLIs
+
+These commands are in scope for this document and for the **Agents** gate in
+`CLAUDE.md` / `AGENTS.md`:
+
+| CLI | Typical non-interactive entrypoints |
+|-----|-------------------------------------|
+| Claude CLI | `claude`, `claude -p`, `claude ultrareview` |
+| Codex CLI | `codex`, `codex exec` |
+| Grok CLI | `grok` (Grok Build TUI; also headless / print-style prompts) |
+
+Equivalent wrappers or aliases for the same tools are covered as well.
+
+## Review rules (when one agent drives another)
+
+Apply these whenever this file is required before an agent CLI run:
+
+- For plan reviews with Claude CLI, default to the no-tools inline review pattern after the primary agent has inspected the relevant code. Only use a grounded tool-using review when fresh repository inspection is actually required.
+- For code and PR reviews with Claude CLI, scope the request to correctness bugs, behavioural regressions, missing tests, security or money-movement risks, and repository instruction compliance. Ask for findings first with file:line references and residual risks.
+- For long Claude CLI reviews, use streaming output (`--output-format stream-json --verbose`) and a wall-clock timeout. If a grounded review produces no output after roughly one minute, stop it and switch to a smaller no-tools or file-group review unless repository inspection is strictly required.
+- Do not paste huge diffs into Claude, Codex, or Grok prompts. Make the agent inspect `git status --short`, `git diff --name-only`, and targeted hunks, or provide only the plan text for no-tools plan reviews.
+- For non-interactive Codex reviews, use `codex exec --json` in read-only mode. Plain text mode can buffer output and look hung.
+- Before trusting any external-agent "no findings" result, verify it reviewed the correct worktree and non-empty diff.
 
 ## Codex CLI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,12 +6,9 @@ Repo-local reference docs that Claude should consult when the task
 touches the relevant area:
 
 - `.claude/docs/agent-tricks-and-troubleshooting.md` — Codex CLI and
-  Claude CLI usage patterns, including cross-agent review commands,
-  streaming Claude review output, and common failure modes.
-  **Read this before invoking Claude CLI or Codex CLI for any review,
-  sanity check, plan review, PR review, or one-off agent run.**
-  Follow its invocation patterns for streaming output, tool restrictions,
-  timeouts, no-tools plan reviews, and silent or hanging agent runs.
+  Claude CLI usage patterns, cross-agent review commands, streaming
+  output, timeouts, and common failure modes. See **Agents** below for
+  when this file is mandatory.
 
 ## Agents
 
@@ -21,11 +18,11 @@ Before invoking any external agent CLI (`claude`, `claude -p`,
 and follow its instructions. Do not run either CLI until you have checked
 that guidance.
 
-- For plan reviews with Claude CLI, default to the no-tools inline review pattern from `.claude/docs/agent-tricks-and-troubleshooting.md` after the primary agent has inspected the relevant code. Only use a grounded tool-using review when fresh repository inspection is actually required.
+- For plan reviews with Claude CLI, default to the no-tools inline review pattern from that file after the primary agent has inspected the relevant code. Only use a grounded tool-using review when fresh repository inspection is actually required.
 - For code and PR reviews with Claude CLI, scope the request to correctness bugs, behavioural regressions, missing tests, security or money-movement risks, and repository instruction compliance. Ask for findings first with file:line references and residual risks.
 - For long Claude CLI reviews, use streaming output (`--output-format stream-json --verbose`) and a wall-clock timeout. If a grounded review produces no output after roughly one minute, stop it and switch to a smaller no-tools or file-group review unless repository inspection is strictly required.
 - Do not paste huge diffs into Claude prompts. Make Claude inspect `git status --short`, `git diff --name-only`, and targeted hunks, or provide only the plan text for no-tools plan reviews.
-- For non-interactive Codex reviews, use `codex exec --json` in read-only mode as described in `.claude/docs/agent-tricks-and-troubleshooting.md`. Plain text mode can buffer output and look hung.
+- For non-interactive Codex reviews, use `codex exec --json` in read-only mode as described in that file. Plain text mode can buffer output and look hung.
 - Before trusting any external-agent "no findings" result, verify it reviewed the correct worktree and non-empty diff.
 
 ## Skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,25 +5,19 @@
 Repo-local reference docs that Claude should consult when the task
 touches the relevant area:
 
-- `.claude/docs/agent-tricks-and-troubleshooting.md` — Codex CLI and
-  Claude CLI usage patterns, cross-agent review commands, streaming
-  output, timeouts, and common failure modes. See **Agents** below for
-  when this file is mandatory.
+- `.claude/docs/agent-tricks-and-troubleshooting.md` — Claude, Codex, and
+  Grok CLI usage patterns, cross-agent review commands, streaming output,
+  timeouts, and common failure modes. See **Agents** below for when this
+  file is mandatory.
 
 ## Agents
 
 Before invoking any external agent CLI (`claude`, `claude -p`,
-`claude ultrareview`, `codex`, `codex exec`, or equivalent), **read
+`claude ultrareview`, `codex`, `codex exec`, `grok`, or equivalent), **read
 `.claude/docs/agent-tricks-and-troubleshooting.md` in the current session**
-and follow its instructions. Do not run either CLI until you have checked
-that guidance.
-
-- For plan reviews with Claude CLI, default to the no-tools inline review pattern from that file after the primary agent has inspected the relevant code. Only use a grounded tool-using review when fresh repository inspection is actually required.
-- For code and PR reviews with Claude CLI, scope the request to correctness bugs, behavioural regressions, missing tests, security or money-movement risks, and repository instruction compliance. Ask for findings first with file:line references and residual risks.
-- For long Claude CLI reviews, use streaming output (`--output-format stream-json --verbose`) and a wall-clock timeout. If a grounded review produces no output after roughly one minute, stop it and switch to a smaller no-tools or file-group review unless repository inspection is strictly required.
-- Do not paste huge diffs into Claude prompts. Make Claude inspect `git status --short`, `git diff --name-only`, and targeted hunks, or provide only the plan text for no-tools plan reviews.
-- For non-interactive Codex reviews, use `codex exec --json` in read-only mode as described in that file. Plain text mode can buffer output and look hung.
-- Before trusting any external-agent "no findings" result, verify it reviewed the correct worktree and non-empty diff.
+and follow its instructions. Do not run any of those CLIs until you have
+checked that guidance. Detailed review patterns and failure modes live only
+in that file — do not restate them here.
 
 ## Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,12 +5,6 @@
 Repo-local reference docs that Claude should consult when the task
 touches the relevant area:
 
-- `.claude/docs/gspread.md` — Google Sheets integration test setup. **Read
-  this before attempting any Google Sheets automation via the
-  Claude-in-Chrome plugin**: in the `tradingstrategy.ai` Workspace
-  environment we've tested, sharing a sheet with a service account
-  cannot be completed by Claude-in-Chrome and must be performed
-  manually by the operator. Other Workspace orgs may behave differently.
 - `.claude/docs/agent-tricks-and-troubleshooting.md` — Codex CLI and
   Claude CLI usage patterns, including cross-agent review commands,
   streaming Claude review output, and common failure modes.
@@ -19,9 +13,14 @@ touches the relevant area:
   Follow its invocation patterns for streaming output, tool restrictions,
   timeouts, no-tools plan reviews, and silent or hanging agent runs.
 
-## Agent review workflows
+## Agents
 
-- **Blocking requirement: before running any `claude`, `claude -p`, `claude ultrareview`, `codex`, or `codex exec` command, read `.claude/docs/agent-tricks-and-troubleshooting.md` in the current session.** Do not invoke either CLI until you have checked the repo-local guidance.
+Before invoking any external agent CLI (`claude`, `claude -p`,
+`claude ultrareview`, `codex`, `codex exec`, or equivalent), **read
+`.claude/docs/agent-tricks-and-troubleshooting.md` in the current session**
+and follow its instructions. Do not run either CLI until you have checked
+that guidance.
+
 - For plan reviews with Claude CLI, default to the no-tools inline review pattern from `.claude/docs/agent-tricks-and-troubleshooting.md` after the primary agent has inspected the relevant code. Only use a grounded tool-using review when fresh repository inspection is actually required.
 - For code and PR reviews with Claude CLI, scope the request to correctness bugs, behavioural regressions, missing tests, security or money-movement risks, and repository instruction compliance. Ask for findings first with file:line references and residual risks.
 - For long Claude CLI reviews, use streaming output (`--output-format stream-json --verbose`) and a wall-clock timeout. If a grounded review produces no output after roughly one minute, stop it and switch to a smaller no-tools or file-group review unless repository inspection is strictly required.
@@ -191,6 +190,7 @@ poetry run ruff format
 - If unsure where the main checkout is, use `git worktree list` and copy from the non-`.omnara/worktrees` checkout that already has `.local-test.env`.
 - Example: `cp /path/to/main/repo/.local-test.env .local-test.env`
 - For worktrees, unless you are changing package dependencies, use `poetry run` from the parent repo virtualenv
+- When starting work in a new worktree, check that `.venv` and `.claude` folders are symlinked into the worktree so that skills and `.claude/docs` can be found, and the poetry command runs with already installed packages from the parent.
 
 ## Commentary format
 


### PR DESCRIPTION
## Why

Agents working in git worktrees were missing shared `.claude` docs and Poetry environments, and the CLAUDE.md agent-CLI gate was easy to miss under a review-workflow-only heading. The Google Sheets `gspread` reference-doc bullet is no longer wanted in the top-level reference list.

## Lessons learnt

- Worktrees that only copy the repo without symlinking `.claude` / sharing the parent Poetry env lose mandatory agent guidance such as `agent-tricks-and-troubleshooting.md`.
- Master already required reading that file before Claude/Codex CLI; this PR keeps that rule and surfaces it under a clearer **Agents** section.

## Summary

- Remove the `.claude/docs/gspread.md` mention from the Reference docs list.
- Rename **Agent review workflows** to **Agents** and state explicitly that `.claude/docs/agent-tricks-and-troubleshooting.md` must be read before invoking any external agent CLI.
- Add a git worktree rule: check that `.venv` and `.claude` are symlinked so skills, docs, and installed packages are available from the parent.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.