### PR TITLE
fix: preserve vault simulation context

### DIFF
--- a/.claude/plans/2026-07-25-vault-simulation-round-3.md
+++ b/.claude/plans/2026-07-25-vault-simulation-round-3.md
@@ -1,5 +1,15 @@
 # Vault simulation round 3 hand-off plan
 
+## Delivery status
+
+This document remains the cross-repository completion plan; it is not a claim
+that every matrix row is implemented by this PR. The current eth-defi changes
+deliver the shared `preflight_result`/unsupported-settlement contract and
+focused paths for Ember Third Eye, Accountable Hyperithm, cSuperior, Gains
+Arbitrum, Plutus Hedge, and generic ERC-7540. Exact-address coverage for the
+remaining Ember, Gains Base, and Lagoon matrix rows remains pending, as does
+the trade-executor matrix consumer and final report.
+
 ## Purpose and boundary
 
 This is the binding eth-defi hand-off for the trade-executor acceptance matrix

--- a/.claude/plans/2026-07-25-vault-simulation-round-3.md
+++ b/.claude/plans/2026-07-25-vault-simulation-round-3.md
@@ -1,0 +1,285 @@
+# Vault simulation round 3 hand-off plan
+
+## Purpose and boundary
+
+This is the binding eth-defi hand-off for the trade-executor acceptance matrix
+in [trade-executor#1578, comment 5078633641](https://github.com/tradingstrategy-ai/trade-executor/pull/1578#issuecomment-5078633641).
+It supersedes the earlier suggestion-led approach. The work is complete only
+when the trade-executor matrix reports an allowed result for every exact vault
+ID below and no listed row has `transaction_reverted`, `broadcast_failed`,
+`execution_failed`, or `receipt_analysis_failed`.
+
+Eth-defi owns adapter behaviour, ABI coverage, capabilities, structured
+preflights, settlement proof and exact-vault fork tests. Trade-executor owns
+the matrix runner, result-string mapping, report persistence, and the final
+end-to-end command. Neither side may substitute a same-ABI deployment for an
+ID in this document.
+
+Eth-defi acceptance is independently complete when its exact-address focused
+tests pass and expose the schema below. The cross-repository programme is
+complete only after trade-executor consumes the released eth-defi revision and
+passes the final matrix. This distinction lets an eth-defi PR be reviewed on
+its own evidence without weakening the final matrix gate.
+
+The contract between the repositories is:
+
+- A predictable protocol state must raise `VaultFlowUnavailable`,
+  `WhitelistingRequired`, or `UnsupportedVaultSimulation` *before* broadcast.
+  Populate `protocol`, `vault_address`, `direction`, `phase`, and the relevant
+  decoded error and raw amount fields.
+- `supports_anvil_settlement=True` is a proof claim. A matching asynchronous
+  ticket passed to `force_settle()` must end with
+  `status_after is AsyncVaultRequestStatus.claimable`; assert that in the
+  manager and raise `UnsupportedVaultSimulation` if it cannot be achieved.
+- A protocol which cannot safely settle on Anvil must publish
+  `supports_anvil_settlement=False` and a stable concrete unsupported reason.
+  Trade-executor must emit `simulation_unsupported_async` before it builds or
+  broadcasts a settlement transaction.
+- `supports_anvil_settlement=None` means the *selected direction* is
+  synchronous. Trade-executor follows the ordinary request/receipt analyser
+  path and must not call `force_settle()`. For a mixed manager, inspect the
+  selected direction's flow first: the flag is relevant only when that flow is
+  asynchronous. `False` therefore must not block an independent synchronous
+  direction of the same manager.
+- Forced-fork asset top-ups must be exposed in the report as
+  `synthetic_assets_injected_raw > 0`. This is test-only liquidity, not a
+  statement about live redemption capacity.
+
+### Stable preflight-to-result mapping
+
+Do not infer results from exception prose. Add the optional
+`preflight_result: str | None` field to `VaultFlowError` and serialise it with
+the existing structured fields. The eth-defi adapter sets one of the exact
+strings below for a predictable refusal; trade-executor copies it verbatim only
+after verifying the accompanying exception and fields. This is the
+authoritative mapping:
+
+| Eth-defi signal | Required structured evidence | Result string |
+|---|---|---|
+| `WhitelistingRequired`, or `VaultFlowUnavailable(preflight_result="whitelisting-needed")` | `direction`, `phase`, protocol and vault address; access data when available | `whitelisting-needed` |
+| `VaultFlowUnavailable(preflight_result="below_minimum")` / `decoded_error="InsufficientAmount"` | `minimum_raw_amount`, `requested_raw_amount`, direction | `below_minimum` |
+| `VaultFlowUnavailable(preflight_result="redemption_capacity_limited")` / `decoded_error` `WithdrawalPending` or `ExceededMaxRedeem` | requested and available raw shares/amounts, direction=`redeem` | `redemption_capacity_limited` |
+| `VaultFlowUnavailable(preflight_result="redemption_paused")` / `decoded_error="WithdrawalsArePaused"` | direction=`redeem`, protocol and vault address | `redemption_paused` |
+| `VaultFlowUnavailable(preflight_result="redemption_window_closed")` / `decoded_error="EndOfEpoch"` | direction=`redeem`, `next_open` | `redemption_window_closed` |
+| `VaultFlowUnavailable(preflight_result="redemption_unavailable")` | direction=`redeem` and concrete protocol reason | `redemption_unavailable` |
+| `VaultFlowUnavailable(preflight_result="deposit_closed")` | direction=`deposit` and concrete close/cap reason | `deposit_closed` |
+| `UnsupportedVaultSimulation` with selected async flow and `supports_anvil_settlement=False` | concrete `unsupported_reason`, protocol, vault and direction | `simulation_unsupported_async` |
+
+`success (simulated)` is emitted only after a synchronous receipt analyser
+succeeds, or an asynchronous request has a proved `claimable` forced-settlement
+result and its claim receipt analyser succeeds. Any signal outside this table
+is a defect to fix in eth-defi or explicitly map in a future version; it may
+not fall through to a forbidden generic failure result.
+
+`VaultForcedSettlementResult` gains
+`synthetic_assets_injected_raw: int = 0`. The manager returns the exact raw
+amount injected by its own Anvil setup, and trade-executor writes the same
+numeric field and name in each `report.json` row. A successful forced
+settlement that required top-up must have a value greater than zero; a path
+that needed none records zero.
+
+## Acceptance matrix
+
+The following exact IDs are the required eth-defi test cases and final
+trade-executor inputs. “Typed” means a pre-broadcast exception with the
+structured data named in the work order; it must not reach an RPC broadcast.
+
+| # | Exact `vault_id` | Adapter work and allowed result |
+|---:|---|---|
+| 1 | `1-0x9be9294722f8aad37b11a9792be2c782182cafa2` | Ember Earn: proven successful redemption lifecycle, or false settlement capability with typed `simulation_unsupported_async`. |
+| 2 | `1-0x0b9342c15143e8f54a83f887c280a922f4c48771` | Ember Polymarket: same as #1. |
+| 3 | `1-0xf3190a3ecc109f88e7947b849b281918c798a0c4` | Ember Third Eye: same as #1. |
+| 4 | `1-0x373152feef81cc59502da2c8de877b3d5ae2e342` | Ember UDL: same as #1. |
+| 5 | `1-0x2b13311fd553e74b421d4ccc96e348f71e179dcf` | Ember Apollo ACRED: typed redeem `below_minimum`, including `minimum_raw_amount` and `direction="redeem"`. |
+| 6 | `1-0x438982ea288763370946625fd76c2508ee1fb229` | cSuperior: typed `redemption_capacity_limited` or `redemption_paused` before a redeem transaction is built. |
+| 7 | `143-0x7cd231120a60f500887444a9baf5e1bd753a5e59` | Accountable Hyperithm: decode `0x5945ea56` on this address and return typed `below_minimum`, `whitelisting-needed`, or typed unsupported. |
+| 8 | `42161-0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0` | Gains gTrade: `redemption_window_closed` with decoded `EndOfEpoch` and `next_open`, or successful lifecycle. |
+| 9 | `8453-0xad20523a7dc37babc1cc74897e4977232b3d02e5` | Gains gTrade Base: successful lifecycle with settlement proof, or false-capability typed async unsupported. |
+| 10 | `8453-0x2bff679b1a9fbcc202316c1402172747ba2fbf56` | Lagoon For Yield v2: successful lifecycle or typed unsupported; never an allowance broadcast failure. |
+| 11 | `8453-0x63b04d3ce2c14f6d308657ab73ac92fc1a0b1075` | Lagoon RB Capital: same as #10. |
+| 12 | `8453-0xbe7db44f4ce20dac83b578b94fd35087f66e9754` | Lagoon TruMarket: same as #10. |
+| 13 | `1-0xa00f63e85b3d242568a9edecb48f5e2cf879b07b` | Lagoon Moon Digital: successful lifecycle or typed unsupported, never `pending -> pending`. |
+| 14 | `42161-0x1723cb57af58efb35a013870c90fcc3d60174a4e` | Lagoon Angmar: same as #13. |
+| 15 | `42161-0x58bfc95a864e18e8f3041d2fcd3418f48393fe6a` | Plutus Hedge: successful lifecycle with proof, or false-capability typed async unsupported. |
+
+Regression controls: Syntropia
+(`1-0xd17049ed25d8f99fe3bfd10cef2263da9995cfd8`) remains
+`success (simulated)`; cSigma USD
+(`1-0xd5d097f278a735d0a3c609deee71234cac14b47e`) and YieldNest
+(`1-0x01ba69727e2860b37bc1a2bd56999c1afb4c15d8`) remain
+`redemption_capacity_limited`. Upshift Sentora is explicitly executor-side
+`incompatible_deposit_asset`, not an eth-defi target in this change.
+
+## Implementation sequence
+
+### 1. Establish a repeatable exact-address baseline
+
+1. Add a dedicated round-3 parametrised test module under
+   `tests/erc_4626/vault_protocol/`, split by chain if that makes fixtures
+   clearer. Keep a table containing every full `chain_id-address` identifier,
+   protocol, fork block, requested direction and required outcome.
+2. Use `AnvilForkPool`, the matching `*_MIDNIGHT_BLOCK`, matching
+   `xdist_group`, and `evm_snapshot_revert` for every mutating mainnet-fork
+   test. Never launch a private `latest` fork. Test an exact target address in
+   each case; existing representative tests are supplementary only.
+3. Monad has no archive-complete historical state. Use the exact Accountable
+   address at a recorded provider-supported recent block and state-relative
+   assertions, retaining the observed block and selector in failure output.
+   Do not attempt an old-state backfill or replace it with another Accountable
+   deployment. This is the repository-required exception to fixed historical
+   value assertions.
+4. Capture, per target, the request ticket, status before/after, thrown typed
+   fields, every transaction hash, and fork top-up amount. The test must fail
+   if an unexpected broadcast occurs, a known selector is undecoded, or a
+   forced settlement returns while still pending.
+
+### 2. Make the generic contract enforceable
+
+1. In `eth_defi/vault/deposit_redeem.py`, add `preflight_result` to the
+   structured error schema and `synthetic_assets_injected_raw` to
+   `VaultForcedSettlementResult`; add schema tests for the mapping above.
+   Document and validate capability publication so `True` is only published by
+   implementations that own a matching ticket-level `force_settle()` proof.
+   Keep `None` for a selected synchronous flow; use `False` plus a stable
+   `unsupported_reason` for an advertised asynchronous flow that has no safe
+   driver.
+2. Add a reusable helper or focused contract tests for the forced-settlement
+   result: it must carry the original ticket, `settlement_required=True`,
+   transaction hashes when a settlement transaction was attempted, and
+   `status_after == claimable`. Raise `UnsupportedVaultSimulation` with the
+   protocol, exact vault, direction and `unsupported_reason` otherwise; do not
+   return an ambiguous pending result.
+3. Audit predictable adapter-boundary failures in the target managers. Replace
+   request-time `assert`, `ValueError`, missing ABI function and known custom
+   revert paths with structured exceptions. Keep programmer-contract asserts
+   only where inputs cannot originate from user simulation state.
+4. Add exact decoding coverage for `0xa73449b9` (`EndOfEpoch`),
+   `0xb8b8b59c` (`ExceededMaxRedeem`), `0xb34f5c6c` (`WithdrawalPending`),
+   `0x5945ea56` (`InsufficientAmount`), and Plutus
+   `UseRequestRedeem`/`WithdrawalsArePaused`. The raised exception must include
+   the selector/name in `decoded_error` and all meaningful raw amount/window
+   fields.
+
+### 3. Repair Ember and Accountable exact-address paths
+
+1. In `ember/deposit_redeem.py`, convert paused withdrawals, below-minimum
+   redemption shares, balance/capacity checks and every predictable queue
+   refusal into structured typed exceptions. In particular, mirror the
+   `InsufficientAmount` treatment on the redemption path for Apollo ACRED;
+   include `minimum_raw_amount`, `requested_raw_amount`,
+   `direction="redeem"`, `phase="preflight"`, protocol, vault address and
+   `preflight_result="below_minimum"`.
+2. Add an Ember Anvil settlement implementation only after proving, for each
+   #1–#4 target, that the actual operator transaction changes that ticket from
+   pending to claimable/terminally payable. The driver itself must re-read the
+   ticket and enforce the status assertion. If operator privileges or the
+   off-chain queue make that impossible, publish `False` with the concrete
+   reason and make `force_settle()` raise typed unsupported before any
+   speculative broadcast. Set `preflight_result`/unsupported reason to the
+   exact false-capability contract. Do not advertise a partial driver as
+   success.
+3. In `accountable/deposit_redeem.py`, perform the Hyperithm exact-address
+   minimum/admission/access preflight before `deposit()` and decode
+   `0x5945ea56` as `InsufficientAmount`. Populate `minimum_raw_amount`,
+   requested amount, direction, phase and `preflight_result="below_minimum"`.
+   If Monad's present state makes the vault unusable, return an address-scoped
+   typed unsupported condition instead of testing the same ABI elsewhere.
+4. Extend `test_ember_deposit_redeem.py`, `test_ember_settlement.py`, and
+   `test_accountable.py` with the exact target IDs and direct assertions on
+   every reported structured field and no-broadcast guarantee.
+
+### 4. Repair cSuperior, Gains and Plutus preflights
+
+1. In `csigma/deposit_redeem.py`, make the cSuperior exact pool’s
+   `maxRedeem(owner)`/queue state the authoritative preflight. A pending FIFO
+   withdrawal must produce `VaultFlowUnavailable(decoded_error="WithdrawalPending",
+   preflight_result="redemption_capacity_limited")` before construction of
+   `redeem()`, with requested and available raw shares. If the authoritative
+   state is a pause instead, use `preflight_result="redemption_paused"`.
+   Retain the current cSigma USD behaviour as a regression case.
+2. In `gains/deposit_redeem.py` and its vault helpers, turn `EndOfEpoch` and
+   `ExceededMaxRedeem` into typed request refusals. Set
+   `preflight_result="redemption_window_closed"` for `EndOfEpoch` and expose
+   `next_open`; use `redemption_capacity_limited` for `ExceededMaxRedeem`.
+   Remove user-state assertions from the request path. Cover the exact Arbitrum
+   address (#8) and inspect the Base deployment (#9) rather than assuming its
+   ABI/version behaviour matches Arbitrum.
+3. In the Plutus manager/vault, decode `UseRequestRedeem` and
+   `WithdrawalsArePaused`; map the latter to `redemption_paused`. Either supply
+   a proved ticket settlement path or publish false Anvil capability with a
+   concrete role/queue reason. The exact Hedge vault must never defer into an
+   onchain revert.
+4. Add exact-target tests in `test_csigma.py`, `tests/gains/`, and
+   `test_plutus.py` that prove the accepted result and inspect exception fields
+   or `status_after` rather than merely asserting an exception type.
+
+### 5. Make Lagoon settlement deployment-aware
+
+1. Keep `LagoonDepositManager.force_settle()`'s post-settlement claimable
+   assertion as mandatory, but test #10–#14 individually. Verify the exact
+   vault version, safe, valuation manager, asset, allowance target and
+   settlement role before setting any capability claim.
+2. In the Anvil settlement path, provision the approval required by the exact
+   `settleDeposit()` flow from the impersonated Safe/manager. Re-read allowance
+   and surface a typed pre-broadcast unsupported condition when the fork cannot
+   make that approval or role transition. Do not let a failed settlement
+   transaction become `broadcast_failed`.
+3. If an exact Lagoon deployment cannot be safely driven because of an
+   operator-only/off-chain component, publish false capability for that
+   deployment (not a blanket success claim) and raise
+   `UnsupportedVaultSimulation` with the role/queue reason before settlement.
+4. Add exact-ID deposit and redemption lifecycle tests alongside
+   `tests/lagoon/test_erc_7540_deposit_redeem.py`. Each successful test must
+   assert pending → claimable, claim completion, receipt analysis and
+   `synthetic_assets_injected_raw > 0` where a fork top-up was needed.
+
+### 6. Consumer integration and release hand-off
+
+1. Publish the eth-defi branch/revision only after the focused exact-vault
+   tests pass. Give the trade-executor agent the revision, this matrix, and a
+   machine-readable fixture/report containing capability, exception fields,
+   selectors, ticket statuses and synthetic liquidity values.
+2. In trade-executor, consume the typed exceptions before generic error
+   handling and map `preflight_result` only through the authoritative table
+   above. Honour false capability before calling a settlement driver; for a
+   selected synchronous direction (`None`), use normal receipt analysis and
+   skip `force_settle()`. Retain every raw structured field, the capability
+   fields, `unsupported_reason` and `synthetic_assets_injected_raw` verbatim in
+   `report.json`.
+3. Run the mandatory command from the work order against all fifteen IDs in
+   one state directory. Paste the per-vault report table into the PR, including
+   success settlement status and synthetic liquidity or typed refusal fields.
+   Re-run the three accepted-now controls in the same dependency revision.
+
+## Verification and review gates
+
+Before implementation review, run focused eth-defi tests with
+`source .local-test.env && poetry run pytest …` (with a three-minute tool
+timeout), never the complete suite. At minimum cover the dedicated round-3
+module plus Ember, Accountable, cSigma, Gains, Plutus and Lagoon targeted
+modules. Run Ruff formatting before a PR.
+
+Before requesting final review, trade-executor must run:
+
+```shell
+source .local-test.env
+ASSET_MANAGEMENT_MODE=lagoon \\
+PYTHONPATH="$PWD:$PWD/deps/web3-ethereum-defi" \\
+poetry run trade-executor vault-test-trade \\
+  --id acceptance --state-file /tmp/acceptance/state.json \\
+  --auto-simulated --settle-async-on-anvil --amount 1.0 \\
+  --vault-id "<all 15 IDs above>" \\
+  --report-json /tmp/acceptance/report.json
+```
+
+Review checklist:
+
+- [ ] All fifteen exact IDs have a focused test and a final report row.
+- [ ] No report row has one of the four forbidden failure strings.
+- [ ] Every true Anvil capability has an in-code `claimable` postcondition and
+  a target-specific proof.
+- [ ] Every unreproducible async lifecycle is false-capability and typed before
+  broadcast, with its concrete unsupported reason asserted.
+- [ ] All six named protocol selectors/errors decode to structured fields.
+- [ ] Synthetic liquidity and the three accepted-now regression results are
+  present in the final report.

--- a/.claude/plans/2026-07-25-vault-simulation-round-3.md
+++ b/.claude/plans/2026-07-25-vault-simulation-round-3.md
@@ -40,8 +40,13 @@ The contract between the repositories is:
   path and must not call `force_settle()`. For a mixed manager, inspect the
   selected direction's flow first: the flag is relevant only when that flow is
   asynchronous. `False` therefore must not block an independent synchronous
-  direction of the same manager.
-- Forced-fork asset top-ups must be exposed in the report as
+  direction of the same manager. This directional inspection is already
+  implemented in trade-executor's `has_async_vault_lifecycle`; preserve it
+  while adding the preflight-result consumer.
+- `VaultForcedSettlementResult.synthetic_assets_injected_raw` already exists
+  in eth-defi revision `38fa4f945`. Managers must keep populating it and
+  trade-executor must copy it unchanged to the same report field. Forced-fork
+  asset top-ups must therefore be exposed in the report as
   `synthetic_assets_injected_raw > 0`. This is test-only liquidity, not a
   statement about live redemption capacity.
 
@@ -49,10 +54,12 @@ The contract between the repositories is:
 
 Do not infer results from exception prose. Add the optional
 `preflight_result: str | None` field to `VaultFlowError` and serialise it with
-the existing structured fields. The eth-defi adapter sets one of the exact
-strings below for a predictable refusal; trade-executor copies it verbatim only
-after verifying the accompanying exception and fields. This is the
-authoritative mapping:
+the existing structured fields. During the cross-repository migration every
+adapter must set both its protocol-level `decoded_error` and the exact
+result-string `preflight_result` below. Trade-executor must prefer a present
+`preflight_result`, then use its existing `decoded_error` mapping as a
+backwards-compatible fallback. The fallback remains until the minimum eth-defi
+dependency includes this new field. This is the authoritative mapping:
 
 | Eth-defi signal | Required structured evidence | Result string |
 |---|---|---|
@@ -71,7 +78,7 @@ result and its claim receipt analyser succeeds. Any signal outside this table
 is a defect to fix in eth-defi or explicitly map in a future version; it may
 not fall through to a forbidden generic failure result.
 
-`VaultForcedSettlementResult` gains
+`VaultForcedSettlementResult` already provides
 `synthetic_assets_injected_raw: int = 0`. The manager returns the exact raw
 amount injected by its own Anvil setup, and trade-executor writes the same
 numeric field and name in each `report.json` row. A successful forced
@@ -136,13 +143,14 @@ Regression controls: Syntropia
 ### 2. Make the generic contract enforceable
 
 1. In `eth_defi/vault/deposit_redeem.py`, add `preflight_result` to the
-   structured error schema and `synthetic_assets_injected_raw` to
-   `VaultForcedSettlementResult`; add schema tests for the mapping above.
-   Document and validate capability publication so `True` is only published by
-   implementations that own a matching ticket-level `force_settle()` proof.
-   Keep `None` for a selected synchronous flow; use `False` plus a stable
-   `unsupported_reason` for an advertised asynchronous flow that has no safe
-   driver.
+   structured error schema and add schema tests for the dual-field migration
+   mapping above. `synthetic_assets_injected_raw` is already present in
+   `VaultForcedSettlementResult` from `38fa4f945`; retain and populate it, do
+   not add a duplicate field. Document and validate capability publication so
+   `True` is only published by implementations that own a matching ticket-level
+   `force_settle()` proof. Keep `None` for a selected synchronous flow; use
+   `False` plus a stable `unsupported_reason` for an advertised asynchronous
+   flow that has no safe driver.
 2. Add a reusable helper or focused contract tests for the forced-settlement
    result: it must carry the original ticket, `settlement_required=True`,
    transaction hashes when a settlement transaction was attempted, and
@@ -196,7 +204,12 @@ Regression controls: Syntropia
    preflight_result="redemption_capacity_limited")` before construction of
    `redeem()`, with requested and available raw shares. If the authoritative
    state is a pause instead, use `preflight_result="redemption_paused"`.
-   Retain the current cSigma USD behaviour as a regression case.
+   The fixed acceptance matrix deliberately maps the FIFO queue state to
+   `redemption_capacity_limited`; preserve `decoded_error="WithdrawalPending"`
+   so consumers do not mistake queueing for economic capacity exhaustion. A
+   future `redemption_queued` result needs a deliberate cross-repository matrix
+   change, not an ad-hoc new result here. Retain the current cSigma USD
+   behaviour as a regression case.
 2. In `gains/deposit_redeem.py` and its vault helpers, turn `EndOfEpoch` and
    `ExceededMaxRedeem` into typed request refusals. Set
    `preflight_result="redemption_window_closed"` for `EndOfEpoch` and expose
@@ -240,10 +253,13 @@ Regression controls: Syntropia
    machine-readable fixture/report containing capability, exception fields,
    selectors, ticket statuses and synthetic liquidity values.
 2. In trade-executor, consume the typed exceptions before generic error
-   handling and map `preflight_result` only through the authoritative table
-   above. Honour false capability before calling a settlement driver; for a
-   selected synchronous direction (`None`), use normal receipt analysis and
-   skip `force_settle()`. Retain every raw structured field, the capability
+   handling. Prefer `preflight_result` and map it only through the
+   authoritative table above; retain the existing `decoded_error` mapping as a
+   fallback until all supported eth-defi revisions expose `preflight_result`.
+   Do not change the existing direction-aware `has_async_vault_lifecycle`
+   handling: honour false capability before calling a settlement driver, while
+   a selected synchronous direction (`None`) uses normal receipt analysis and
+   skips `force_settle()`. Retain every raw structured field, the capability
    fields, `unsupported_reason` and `synthetic_assets_injected_raw` verbatim in
    `report.json`.
 3. Run the mandatory command from the work order against all fifteen IDs in

--- a/eth_defi/erc_4626/deposit_probe.py
+++ b/eth_defi/erc_4626/deposit_probe.py
@@ -86,6 +86,7 @@ def _format_vault_flow_error_context(error: VaultFlowError) -> dict[str, object]
         "direction": error.direction,
         "phase": error.phase,
         "decoded_error": error.decoded_error,
+        "preflight_result": error.preflight_result,
         "function_selector": error.function_selector.hex() if error.function_selector else None,
         "error_selector": error.error_selector.hex() if error.error_selector else None,
         "access_delay": error.access_delay,

--- a/eth_defi/erc_4626/vault_protocol/accountable/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/deposit_redeem.py
@@ -34,6 +34,7 @@ from eth_defi.vault.deposit_redeem import (
     UnsupportedVaultSimulation,
     VaultFlowUnavailable,
     VaultForcedSettlementResult,
+    create_synchronous_settlement_result,
 )
 from eth_defi.vault.flow_events import (
     PendingVaultFlow,
@@ -51,6 +52,9 @@ if TYPE_CHECKING:
 
 #: ``InsufficientAmount()`` from the verified AccountableAsyncRedeemVault ABI.
 ACCOUNTABLE_INSUFFICIENT_AMOUNT_SELECTOR = HexBytes("0x5945ea56")
+
+#: Accountable redemption settlement requires a strategy-operator action.
+ACCOUNTABLE_ANVIL_SETTLEMENT_UNSUPPORTED_REASON = "accountable_redemption_settlement_is_strategy_operator_controlled"
 
 
 @dataclass(slots=True)
@@ -456,15 +460,13 @@ class AccountableDepositManager(ERC4626DepositManager):
             reason.
         """
         if ticket is None:
-            return VaultForcedSettlementResult(
-                ticket=None,
-                settlement_required=False,
-                status_before=None,
-                status_after=None,
-            )
+            return create_synchronous_settlement_result()
         raise UnsupportedVaultSimulation(
             f"Accountable redemption settlement is strategy-operator controlled for vault {self.vault.address} on chain {self.vault.chain_id}",
-            unsupported_reason="accountable_redemption_settlement_is_strategy_operator_controlled",
+            unsupported_reason=ACCOUNTABLE_ANVIL_SETTLEMENT_UNSUPPORTED_REASON,
+            protocol=self.vault.get_protocol_name(),
+            vault_address=self.vault.address,
+            direction="redeem",
         )
 
     def has_synchronous_deposit(self) -> bool:

--- a/eth_defi/erc_4626/vault_protocol/accountable/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/deposit_redeem.py
@@ -28,9 +28,12 @@ from eth_defi.timestamp import get_block_timestamp
 from eth_defi.vault.deposit_redeem import (
     AsyncVaultRequestStatus,
     CannotParseRedemptionTransaction,
+    DepositTicket,
     RedemptionRequest,
     RedemptionTicket,
+    UnsupportedVaultSimulation,
     VaultFlowUnavailable,
+    VaultForcedSettlementResult,
 )
 from eth_defi.vault.flow_events import (
     PendingVaultFlow,
@@ -308,6 +311,7 @@ class AccountableDepositManager(ERC4626DepositManager):
                 direction="deposit",
                 phase="preflight",
                 decoded_error="InsufficientAmount",
+                preflight_result="below_minimum",
                 requested_raw_amount=raw_amount,
                 minimum_raw_amount=minimum,
                 error_selector=ACCOUNTABLE_INSUFFICIENT_AMOUNT_SELECTOR,
@@ -323,6 +327,7 @@ class AccountableDepositManager(ERC4626DepositManager):
                     caller=owner,
                     direction="deposit",
                     phase="preflight",
+                    preflight_result="deposit_closed",
                     requested_raw_amount=raw_amount,
                     available_raw_amount=max_deposit,
                 )
@@ -394,16 +399,37 @@ class AccountableDepositManager(ERC4626DepositManager):
                 direction="redeem",
                 phase="preflight",
                 decoded_error="InsufficientAmount",
+                preflight_result="below_minimum",
                 requested_raw_amount=raw_shares,
                 minimum_raw_amount=minimum,
                 error_selector=ACCOUNTABLE_INSUFFICIENT_AMOUNT_SELECTOR,
             )
         if self.is_redemption_in_progress(owner):
-            raise ValueError("Accountable has a pending or claimable redemption for this controller")
+            raise VaultFlowUnavailable(
+                "Accountable has a pending or claimable redemption for this controller",
+                protocol="Accountable",
+                vault_address=self.vault.address,
+                caller=owner,
+                direction="redeem",
+                phase="preflight",
+                decoded_error="RedemptionPending",
+                preflight_result="redemption_unavailable",
+            )
         if check_enough_token:
             balance = int(self.vault.share_token.fetch_raw_balance_of(owner))
             if balance < raw_shares:
-                raise ValueError(f"Insufficient Accountable shares: has {balance}, needs {raw_shares}")
+                raise VaultFlowUnavailable(
+                    f"Insufficient Accountable shares: has {balance}, needs {raw_shares}",
+                    protocol="Accountable",
+                    vault_address=self.vault.address,
+                    caller=owner,
+                    direction="redeem",
+                    phase="preflight",
+                    decoded_error="InsufficientShares",
+                    preflight_result="redemption_unavailable",
+                    requested_raw_amount=raw_shares,
+                    available_raw_amount=balance,
+                )
         return AccountableRedemptionRequest(
             vault=self.vault,
             owner=owner,
@@ -411,6 +437,34 @@ class AccountableDepositManager(ERC4626DepositManager):
             shares=self.vault.share_token.convert_to_decimals(raw_shares),
             raw_shares=raw_shares,
             funcs=[self.vault.vault_contract.functions.requestRedeem(raw_shares, owner, owner)],
+        )
+
+    def force_settle(self, ticket: DepositTicket | RedemptionTicket | None) -> VaultForcedSettlementResult:
+        """Refuse Accountable asynchronous settlement before any fork broadcast.
+
+        The selected deposit direction is synchronous and retains the base
+        no-op result. Accountable redemption settlement is controlled by a
+        strategy operator and does not expose a safe Anvil driver.
+
+        :param ticket:
+            ``None`` for a synchronous deposit, or an Accountable redemption
+            ticket to refuse.
+        :return:
+            Shared synchronous no-op outcome for ``None``.
+        :raise UnsupportedVaultSimulation:
+            For an asynchronous redemption ticket with the stable capability
+            reason.
+        """
+        if ticket is None:
+            return VaultForcedSettlementResult(
+                ticket=None,
+                settlement_required=False,
+                status_before=None,
+                status_after=None,
+            )
+        raise UnsupportedVaultSimulation(
+            f"Accountable redemption settlement is strategy-operator controlled for vault {self.vault.address} on chain {self.vault.chain_id}",
+            unsupported_reason="accountable_redemption_settlement_is_strategy_operator_controlled",
         )
 
     def has_synchronous_deposit(self) -> bool:

--- a/eth_defi/erc_4626/vault_protocol/accountable/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/vault.py
@@ -261,6 +261,8 @@ class AccountableVault(ERC4626Vault):
             can_redeem=True,
             deposit_flow="synchronous",
             redemption_flow="asynchronous",
+            supports_anvil_settlement=False,
+            anvil_settlement_unsupported_reason="accountable_redemption_settlement_is_strategy_operator_controlled",
         )
 
     @cached_property

--- a/eth_defi/erc_4626/vault_protocol/accountable/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/vault.py
@@ -11,7 +11,10 @@ from web3.contract import Contract
 
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
-from eth_defi.erc_4626.vault_protocol.accountable.deposit_redeem import AccountableDepositManager
+from eth_defi.erc_4626.vault_protocol.accountable.deposit_redeem import (
+    ACCOUNTABLE_ANVIL_SETTLEMENT_UNSUPPORTED_REASON,
+    AccountableDepositManager,
+)
 from eth_defi.erc_4626.vault_protocol.accountable.offchain_metadata import (
     AccountableVaultMetadata,
     fetch_accountable_vault_metadata,
@@ -262,7 +265,7 @@ class AccountableVault(ERC4626Vault):
             deposit_flow="synchronous",
             redemption_flow="asynchronous",
             supports_anvil_settlement=False,
-            anvil_settlement_unsupported_reason="accountable_redemption_settlement_is_strategy_operator_controlled",
+            anvil_settlement_unsupported_reason=ACCOUNTABLE_ANVIL_SETTLEMENT_UNSUPPORTED_REASON,
         )
 
     @cached_property

--- a/eth_defi/erc_4626/vault_protocol/csigma/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/csigma/deposit_redeem.py
@@ -202,7 +202,8 @@ class CsigmaDepositManager(ERC4626DepositManager):
                     vault_address=self.vault.address,
                     caller=owner,
                     direction="deposit",
-                    phase="request",
+                    phase="preflight",
+                    preflight_result="deposit_closed",
                     requested_raw_amount=raw_amount,
                     available_raw_amount=available_raw_assets,
                 )
@@ -262,10 +263,11 @@ class CsigmaDepositManager(ERC4626DepositManager):
                     vault_address=self.vault.address,
                     caller=owner,
                     direction="redeem",
-                    phase="request",
+                    phase="preflight",
                     requested_raw_amount=raw_shares,
                     available_raw_amount=preflight.available_raw_shares,
                     decoded_error="WithdrawalPending",
+                    preflight_result="redemption_capacity_limited",
                     error_selector=CSIGMA_WITHDRAWAL_PENDING_SELECTOR,
                 )
 

--- a/eth_defi/erc_4626/vault_protocol/ember/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/ember/deposit_redeem.py
@@ -34,6 +34,7 @@ from eth_defi.vault.deposit_redeem import (
     UnsupportedVaultSimulation,
     VaultFlowUnavailable,
     VaultForcedSettlementResult,
+    create_synchronous_settlement_result,
 )
 from eth_defi.vault.flow_events import (
     PendingVaultFlow,
@@ -46,6 +47,10 @@ from eth_defi.vault.flow_events import (
 
 if TYPE_CHECKING:
     from eth_defi.erc_4626.vault_protocol.ember.vault import EmberVault
+
+
+#: Ember operator processing pays directly and never creates a claimable ticket.
+EMBER_ANVIL_SETTLEMENT_UNSUPPORTED_REASON = "ember_operator_settlement_has_no_claimable_ticket_status"
 
 
 @dataclass(slots=True)
@@ -489,16 +494,14 @@ class EmberDepositManager(ERC4626DepositManager):
             reason and without an operator transaction.
         """
         if ticket is None:
-            return VaultForcedSettlementResult(
-                ticket=None,
-                settlement_required=False,
-                status_before=None,
-                status_after=None,
-            )
+            return create_synchronous_settlement_result()
 
         raise UnsupportedVaultSimulation(
             f"Ember settlement cannot prove a claimable ticket for vault {self.vault.address} on chain {self.vault.chain_id}",
-            unsupported_reason="ember_operator_settlement_has_no_claimable_ticket_status",
+            unsupported_reason=EMBER_ANVIL_SETTLEMENT_UNSUPPORTED_REASON,
+            protocol=self.vault.get_protocol_name(),
+            vault_address=self.vault.address,
+            direction="redeem",
         )
 
     def get_redemption_request_status(self, ticket: EmberRedemptionTicket) -> AsyncVaultRequestStatus:

--- a/eth_defi/erc_4626/vault_protocol/ember/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/ember/deposit_redeem.py
@@ -22,9 +22,7 @@ from web3.contract.contract import ContractFunction
 from eth_defi.abi import ZERO_ADDRESS_STR, get_topic_signature_from_event
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager, ERC4626DepositRequest
 from eth_defi.erc_4626.flow import deposit_4626
-from eth_defi.provider.anvil import is_anvil, make_anvil_custom_rpc_request
 from eth_defi.timestamp import get_block_timestamp
-from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.vault.deposit_redeem import (
     AsyncVaultRequestStatus,
     CannotParseRedemptionTransaction,
@@ -34,6 +32,7 @@ from eth_defi.vault.deposit_redeem import (
     RedemptionRequest,
     RedemptionTicket,
     UnsupportedVaultSimulation,
+    VaultFlowUnavailable,
     VaultForcedSettlementResult,
 )
 from eth_defi.vault.flow_events import (
@@ -47,10 +46,6 @@ from eth_defi.vault.flow_events import (
 
 if TYPE_CHECKING:
     from eth_defi.erc_4626.vault_protocol.ember.vault import EmberVault
-
-#: Safety cap on operator settlement batches when draining Ember's global
-#: withdrawal queue on an Anvil fork, so a stuck queue fails loudly.
-EMBER_MAX_SETTLEMENT_BATCHES = 50
 
 
 @dataclass(slots=True)
@@ -189,15 +184,12 @@ class EmberDepositManager(ERC4626DepositManager):
     only checks that withdrawals are unpaused and the owner holds at least
     ``minWithdrawableShares``.
 
-    **Anvil settlement (force_settle).** :meth:`force_settle` requires an Anvil
-    provider. It impersonates the ``roles()`` operator, funds it, then drains the
-    global queue with repeated ``processWithdrawalRequests`` calls (capped at
-    :data:`EMBER_MAX_SETTLEMENT_BATCHES`) until the ticket's sequence leaves the
-    owner's pending list. Because there is no claim step, a settled request ends
-    in :attr:`AsyncVaultRequestStatus.none` rather than ``claimable``; success is
-    defined as a matching, non-skipped, non-cancelled ``RequestProcessed`` event.
-    A still-pending, skipped or cancelled outcome raises
-    :class:`UnsupportedVaultSimulation`.
+    **Anvil settlement (force_settle).** Ember has no claimable ticket state:
+    an operator may process a request and pay the receiver directly, leaving the
+    ticket in :attr:`AsyncVaultRequestStatus.none`. This cannot satisfy the
+    public forced-settlement proof contract, so asynchronous settlement is
+    explicitly unsupported. :meth:`force_settle` refuses a redemption ticket
+    before impersonating an operator or broadcasting a transaction.
     """
 
     def __init__(self, vault: "EmberVault"):
@@ -308,15 +300,46 @@ class EmberDepositManager(ERC4626DepositManager):
         if raw_shares <= 0:
             raise ValueError("Ember redemption shares must be positive")
         if self._withdrawals_paused():
-            raise ValueError("Ember withdrawals are paused")
+            raise VaultFlowUnavailable(
+                "Ember withdrawals are paused",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                caller=owner,
+                direction="redeem",
+                phase="preflight",
+                decoded_error="WithdrawalsPaused",
+                preflight_result="redemption_paused",
+            )
 
         minimum = int(self.vault.vault_contract.functions.minWithdrawableShares().call())
         if raw_shares < minimum:
-            raise ValueError(f"Ember redemption shares {raw_shares} are below minimum {minimum}")
+            raise VaultFlowUnavailable(
+                f"Ember redemption shares {raw_shares} are below minimum {minimum}",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                caller=owner,
+                direction="redeem",
+                phase="preflight",
+                decoded_error="InsufficientAmount",
+                preflight_result="below_minimum",
+                requested_raw_amount=raw_shares,
+                minimum_raw_amount=minimum,
+            )
         if check_enough_token:
             balance = int(self.vault.share_token.fetch_raw_balance_of(owner))
             if balance < raw_shares:
-                raise ValueError(f"Insufficient Ember shares: has {balance}, needs {raw_shares}")
+                raise VaultFlowUnavailable(
+                    f"Insufficient Ember shares: has {balance}, needs {raw_shares}",
+                    protocol=self.vault.get_protocol_name(),
+                    vault_address=self.vault.address,
+                    caller=owner,
+                    direction="redeem",
+                    phase="preflight",
+                    decoded_error="InsufficientShares",
+                    preflight_result="redemption_unavailable",
+                    requested_raw_amount=raw_shares,
+                    available_raw_amount=balance,
+                )
 
         return EmberRedemptionRequest(
             vault=self.vault,
@@ -450,38 +473,22 @@ class EmberDepositManager(ERC4626DepositManager):
         return None
 
     def force_settle(self, ticket: DepositTicket | RedemptionTicket | None) -> VaultForcedSettlementResult:
-        """Drive an Ember redemption request to its terminal state on Anvil.
+        """Refuse Ember redemption settlement before broadcasting on a fork.
 
-        Ember withdrawals are paid by the vault operator's
-        ``processWithdrawalRequests`` call, not by the depositor, so a fork
-        simulation must impersonate that operator. The operator address is read
-        from the vault's onchain ``roles()`` tuple (``(admin, operator,
-        rateManager)``) rather than hardcoded, then the withdrawal queue is
-        drained until the ticket's request sequence is processed.
-
-        **Terminal-state semantics.** Ember has no depositor claim step. A
-        processed request leaves the owner's pending list, so
-        :meth:`get_redemption_request_status` returns
-        :attr:`AsyncVaultRequestStatus.none` — *not* ``claimable``. Success is
-        therefore defined as "a non-skipped, non-cancelled ``RequestProcessed``
-        event exists for this exact ticket", verified through
-        :meth:`analyse_redemption`.
+        Ember's operator-finalised request does not become a claimable ticket,
+        so processing it would falsely advertise a successful generic async
+        simulation. A synchronous deposit remains a no-op settlement.
 
         :param ticket:
             Pending :class:`EmberRedemptionTicket`, or ``None`` for the
             synchronous-deposit no-op.
         :return:
-            Settlement outcome with before/after status and operator
-            transaction hashes.
+            Synchronous no-op result when ``ticket`` is ``None``.
         :raise UnsupportedVaultSimulation:
-            If the provider is not Anvil, or the request cannot be moved to a
-            successful terminal state (still pending, skipped or cancelled).
+            For every Ember redemption ticket, with the stable capability
+            reason and without an operator transaction.
         """
-        if not is_anvil(self.web3):
-            raise UnsupportedVaultSimulation("EmberDepositManager.force_settle() requires an Anvil provider")
-
         if ticket is None:
-            # Ember deposits are synchronous; nothing to settle.
             return VaultForcedSettlementResult(
                 ticket=None,
                 settlement_required=False,
@@ -489,57 +496,9 @@ class EmberDepositManager(ERC4626DepositManager):
                 status_after=None,
             )
 
-        assert isinstance(ticket, EmberRedemptionTicket), f"Ember force_settle requires EmberRedemptionTicket, got {type(ticket)}"
-
-        status_before = self.get_redemption_request_status(ticket)
-        if status_before != AsyncVaultRequestStatus.pending:
-            # Already processed or cancelled; no operator action can progress it.
-            return VaultForcedSettlementResult(
-                ticket=ticket,
-                settlement_required=False,
-                status_before=status_before,
-                status_after=status_before,
-            )
-
-        operator = Web3.to_checksum_address(self.vault.vault_contract.functions.roles().call()[1])
-
-        make_anvil_custom_rpc_request(self.web3, "anvil_impersonateAccount", [operator])
-        make_anvil_custom_rpc_request(self.web3, "anvil_setBalance", [operator, hex(10**18)])
-
-        transaction_hashes: list[HexBytes] = []
-        try:
-            # The withdrawal queue is global (not per-owner). Drain it in
-            # batches until this ticket's sequence leaves the owner's pending
-            # list, with a cap so a stuck queue fails loudly instead of looping.
-            for _ in range(EMBER_MAX_SETTLEMENT_BATCHES):
-                pending_length = int(self.vault.vault_contract.functions.getPendingWithdrawalsLength().call())
-                if pending_length == 0:
-                    break
-                process_hash = self.vault.vault_contract.functions.processWithdrawalRequests(pending_length).transact({"from": operator})
-                assert_transaction_success_with_explanation(self.web3, process_hash)
-                transaction_hashes.append(HexBytes(process_hash))
-                if self.get_redemption_request_status(ticket) != AsyncVaultRequestStatus.pending:
-                    break
-        finally:
-            make_anvil_custom_rpc_request(self.web3, "anvil_stopImpersonatingAccount", [operator])
-
-        status_after = self.get_redemption_request_status(ticket)
-        completion_hash = self.fetch_completed_redemption_tx_hash(ticket)
-        if status_after == AsyncVaultRequestStatus.pending or completion_hash is None:
-            raise UnsupportedVaultSimulation(f"Ember settlement did not process request sequence {ticket.request_sequence_number} for vault {self.vault.address} on chain {self.vault.chain_id}: {status_before} -> {status_after}")
-
-        # Reject a skipped/cancelled terminal event: the operator handled the
-        # request but did not pay it, so the redemption did not settle.
-        analysis = self.analyse_redemption(completion_hash, ticket)
-        if isinstance(analysis, DepositRedeemEventFailure):
-            raise UnsupportedVaultSimulation(f"Ember settlement processed request sequence {ticket.request_sequence_number} for vault {self.vault.address} without payment: {analysis.revert_reason}")
-
-        return VaultForcedSettlementResult(
-            ticket=ticket,
-            settlement_required=True,
-            status_before=status_before,
-            status_after=status_after,
-            transaction_hashes=tuple(transaction_hashes),
+        raise UnsupportedVaultSimulation(
+            f"Ember settlement cannot prove a claimable ticket for vault {self.vault.address} on chain {self.vault.chain_id}",
+            unsupported_reason="ember_operator_settlement_has_no_claimable_ticket_status",
         )
 
     def get_redemption_request_status(self, ticket: EmberRedemptionTicket) -> AsyncVaultRequestStatus:

--- a/eth_defi/erc_4626/vault_protocol/ember/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/ember/vault.py
@@ -161,7 +161,12 @@ class EmberVault(ERC4626Vault):
             can_redeem=True,
             deposit_flow="synchronous",
             redemption_flow="asynchronous",
-            supports_anvil_settlement=True,
+            # Ember's operator processing leaves this non-claim ERC-7540-style
+            # ticket terminal rather than claimable.  Do not publish a true
+            # capability until the executor can prove the required claimable
+            # status for the exact deployment.
+            supports_anvil_settlement=False,
+            anvil_settlement_unsupported_reason="ember_operator_settlement_has_no_claimable_ticket_status",
         )
 
     def get_notes(self) -> str | None:

--- a/eth_defi/erc_4626/vault_protocol/ember/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/ember/vault.py
@@ -154,6 +154,7 @@ class EmberVault(ERC4626Vault):
         :return:
             Ember's public deposit-manager capability metadata.
         """
+        from eth_defi.erc_4626.vault_protocol.ember.deposit_redeem import EMBER_ANVIL_SETTLEMENT_UNSUPPORTED_REASON
         from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
 
         return VaultDepositManagerCapability(
@@ -166,7 +167,7 @@ class EmberVault(ERC4626Vault):
             # capability until the executor can prove the required claimable
             # status for the exact deployment.
             supports_anvil_settlement=False,
-            anvil_settlement_unsupported_reason="ember_operator_settlement_has_no_claimable_ticket_status",
+            anvil_settlement_unsupported_reason=EMBER_ANVIL_SETTLEMENT_UNSUPPORTED_REASON,
         )
 
     def get_notes(self) -> str | None:

--- a/eth_defi/erc_4626/vault_protocol/gains/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/gains/deposit_redeem.py
@@ -20,16 +20,6 @@ from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
 from eth_defi.provider.anvil import is_anvil
 from eth_defi.timestamp import get_block_timestamp
 from eth_defi.utils import from_unix_timestamp
-from eth_defi.vault.flow_events import (
-    PendingVaultFlow,
-    VaultFlowDirection,
-    create_pending_vault_flow,
-    decode_indexed_event_address,
-    decode_indexed_event_uint,
-    decode_single_uint256_event_data,
-    fetch_vault_flow_logs_hypersync,
-    normalise_event_topic,
-)
 from eth_defi.vault.deposit_redeem import (
     AsyncVaultRequestStatus,
     CannotParseRedemptionTransaction,
@@ -42,6 +32,16 @@ from eth_defi.vault.deposit_redeem import (
     UnsupportedVaultSimulation,
     VaultFlowUnavailable,
     VaultForcedSettlementResult,
+)
+from eth_defi.vault.flow_events import (
+    PendingVaultFlow,
+    VaultFlowDirection,
+    create_pending_vault_flow,
+    decode_indexed_event_address,
+    decode_indexed_event_uint,
+    decode_single_uint256_event_data,
+    fetch_vault_flow_logs_hypersync,
+    normalise_event_topic,
 )
 
 logger = logging.getLogger(__name__)
@@ -215,6 +215,8 @@ class GainsDepositManager(ERC4626DepositManager):
                 direction="redeem",
                 phase="preflight",
                 decoded_error="EndOfEpoch",
+                preflight_result="redemption_window_closed",
+                next_open=vault.fetch_redemption_next_open(),
                 error_selector=END_OF_EPOCH_SELECTOR,
             )
 
@@ -223,13 +225,34 @@ class GainsDepositManager(ERC4626DepositManager):
         else:
             raw_amount = raw_shares
 
-        assert type(raw_amount) == int, f"Got {raw_amount} {type(raw_amount)}"
+        if not isinstance(raw_amount, int):
+            raise VaultFlowUnavailable(
+                f"Gains redemption share amount must be an integer, got {type(raw_amount)}",
+                protocol=vault.get_protocol_name(),
+                vault_address=vault.address,
+                caller=owner,
+                direction="redeem",
+                phase="preflight",
+                preflight_result="redemption_unavailable",
+            )
         shares = vault.share_token
         block_number = self.web3.eth.block_number
 
         # Check we have shares
         owned_raw_amount = shares.fetch_raw_balance_of(owner, block_number)
-        assert owned_raw_amount >= raw_amount, f"Cannot redeem, has only {owned_raw_amount} shares when {raw_amount} needed"
+        if owned_raw_amount < raw_amount:
+            raise VaultFlowUnavailable(
+                f"Cannot redeem, has only {owned_raw_amount} shares when {raw_amount} needed",
+                protocol=vault.get_protocol_name(),
+                vault_address=vault.address,
+                caller=owner,
+                direction="redeem",
+                phase="preflight",
+                decoded_error="InsufficientShares",
+                preflight_result="redemption_unavailable",
+                requested_raw_amount=raw_amount,
+                available_raw_amount=owned_raw_amount,
+            )
 
         human_amount = shares.convert_to_decimals(raw_amount)
         total_shares = vault.fetch_total_supply(block_number)

--- a/eth_defi/erc_4626/vault_protocol/plutus/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/plutus/deposit_redeem.py
@@ -28,11 +28,13 @@ from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
 from eth_defi.vault.deposit_redeem import (
     AsyncVaultRequestStatus,
     CannotParseRedemptionTransaction,
+    DepositTicket,
     RedemptionRequest,
     RedemptionTicket,
     UnsupportedVaultSimulation,
     VaultFlowUnavailable,
     VaultForcedSettlementResult,
+    create_synchronous_settlement_result,
 )
 
 #: ``UseRequestRedeem()`` — standard ERC-4626 ``redeem`` is disabled; use the
@@ -41,6 +43,9 @@ USE_REQUEST_REDEEM_SELECTOR = HexBytes("0x797f246a")
 
 #: ``WithdrawalsArePaused()`` custom-error selector.
 WITHDRAWALS_ARE_PAUSED_SELECTOR = HexBytes("0xe14e66da")
+
+#: Plutus fulfilment is role-gated and cannot be reproduced from the vault ABI.
+PLUTUS_ANVIL_SETTLEMENT_UNSUPPORTED_REASON = "plutus_redeem_fulfilment_is_access_control_role_gated"
 
 
 @dataclass(slots=True)
@@ -374,7 +379,7 @@ class PlutusAsyncDepositManager(ERC4626DepositManager):
         assert isinstance(redemption_ticket, PlutusRedemptionTicket)
         return self.vault.vault_contract.functions.cancelRedeemRequest(redemption_ticket.request_id)
 
-    def force_settle(self, ticket) -> VaultForcedSettlementResult:
+    def force_settle(self, ticket: DepositTicket | RedemptionTicket | None) -> VaultForcedSettlementResult:
         """Report that Plutus operator fulfilment is not reproducible on a fork.
 
         Plutus ``fulfillRedeem`` is gated by OpenZeppelin AccessControl; the
@@ -392,13 +397,11 @@ class PlutusAsyncDepositManager(ERC4626DepositManager):
             reproduced without role discovery.
         """
         if ticket is None:
-            return VaultForcedSettlementResult(
-                ticket=None,
-                settlement_required=False,
-                status_before=None,
-                status_after=None,
-            )
+            return create_synchronous_settlement_result()
         raise UnsupportedVaultSimulation(
             f"Plutus Hedge fulfilment is role-gated (AccessControl) and not reproducible on a fork for vault {self.vault.address}",
-            unsupported_reason="plutus_redeem_fulfilment_is_access_control_role_gated",
+            unsupported_reason=PLUTUS_ANVIL_SETTLEMENT_UNSUPPORTED_REASON,
+            protocol=self.vault.get_protocol_name(),
+            vault_address=self.vault.address,
+            direction="redeem",
         )

--- a/eth_defi/erc_4626/vault_protocol/plutus/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/plutus/deposit_redeem.py
@@ -12,7 +12,7 @@ This manager models that flow: synchronous deposits (inherited) plus an
 asynchronous redemption request/ticket/status/claim lifecycle with typed
 preflight errors. On-fork operator settlement (``fulfillRedeem``) is role-gated
 by OpenZeppelin AccessControl and is not reproduced here, so
-``supports_anvil_settlement`` is left unset with a precise reason.
+``supports_anvil_settlement`` is explicitly ``False`` with a stable reason.
 """
 
 import datetime
@@ -31,8 +31,8 @@ from eth_defi.vault.deposit_redeem import (
     RedemptionRequest,
     RedemptionTicket,
     UnsupportedVaultSimulation,
-    VaultForcedSettlementResult,
     VaultFlowUnavailable,
+    VaultForcedSettlementResult,
 )
 
 #: ``UseRequestRedeem()`` — standard ERC-4626 ``redeem`` is disabled; use the
@@ -243,6 +243,7 @@ class PlutusAsyncDepositManager(ERC4626DepositManager):
                 direction="redeem",
                 phase="preflight",
                 decoded_error="WithdrawalsArePaused",
+                preflight_result="redemption_paused",
                 error_selector=WITHDRAWALS_ARE_PAUSED_SELECTOR,
             )
 
@@ -256,6 +257,7 @@ class PlutusAsyncDepositManager(ERC4626DepositManager):
                     caller=owner,
                     direction="redeem",
                     phase="preflight",
+                    preflight_result="redemption_unavailable",
                     requested_raw_amount=raw_shares,
                     available_raw_amount=balance,
                 )
@@ -396,4 +398,7 @@ class PlutusAsyncDepositManager(ERC4626DepositManager):
                 status_before=None,
                 status_after=None,
             )
-        raise UnsupportedVaultSimulation(f"Plutus Hedge fulfilment is role-gated (AccessControl) and not reproducible on a fork for vault {self.vault.address}")
+        raise UnsupportedVaultSimulation(
+            f"Plutus Hedge fulfilment is role-gated (AccessControl) and not reproducible on a fork for vault {self.vault.address}",
+            unsupported_reason="plutus_redeem_fulfilment_is_access_control_role_gated",
+        )

--- a/eth_defi/erc_4626/vault_protocol/plutus/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/plutus/vault.py
@@ -12,8 +12,8 @@ from web3.contract import Contract
 from eth_defi.abi import ZERO_ADDRESS_STR, get_deployed_contract
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
-from eth_defi.erc_4626.vault_protocol.plutus.deposit_redeem import PlutusAsyncDepositManager
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
+from eth_defi.erc_4626.vault_protocol.plutus.deposit_redeem import PlutusAsyncDepositManager
 from eth_defi.event_reader.conversion import convert_int256_bytes_to_int
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.vault.base import (
@@ -245,6 +245,8 @@ class PlutusVault(ERC4626Vault):
                 can_redeem=True,
                 deposit_flow="synchronous",
                 redemption_flow="asynchronous",
+                supports_anvil_settlement=False,
+                anvil_settlement_unsupported_reason="plutus_redeem_fulfilment_is_access_control_role_gated",
             )
         return self.get_synchronous_deposit_manager_capability()
 

--- a/eth_defi/erc_4626/vault_protocol/plutus/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/plutus/vault.py
@@ -13,7 +13,7 @@ from eth_defi.abi import ZERO_ADDRESS_STR, get_deployed_contract
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
-from eth_defi.erc_4626.vault_protocol.plutus.deposit_redeem import PlutusAsyncDepositManager
+from eth_defi.erc_4626.vault_protocol.plutus.deposit_redeem import PLUTUS_ANVIL_SETTLEMENT_UNSUPPORTED_REASON, PlutusAsyncDepositManager
 from eth_defi.event_reader.conversion import convert_int256_bytes_to_int
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.vault.base import (
@@ -246,7 +246,7 @@ class PlutusVault(ERC4626Vault):
                 deposit_flow="synchronous",
                 redemption_flow="asynchronous",
                 supports_anvil_settlement=False,
-                anvil_settlement_unsupported_reason="plutus_redeem_fulfilment_is_access_control_role_gated",
+                anvil_settlement_unsupported_reason=PLUTUS_ANVIL_SETTLEMENT_UNSUPPORTED_REASON,
             )
         return self.get_synchronous_deposit_manager_capability()
 

--- a/eth_defi/erc_7540/deposit_redeem.py
+++ b/eth_defi/erc_7540/deposit_redeem.py
@@ -33,6 +33,9 @@ from eth_defi.vault.deposit_redeem import (
     VaultFlowUnavailable,
     VaultForcedSettlementResult,
 )
+
+#: Generic ERC-7540 cannot know a protocol's operator settlement action.
+ERC7540_ANVIL_SETTLEMENT_UNSUPPORTED_REASON = "generic_erc_7540_settlement_driver_not_implemented"
 from eth_defi.vault.flow_events import (
     PendingVaultFlow,
     VaultFlowDirection,
@@ -729,10 +732,12 @@ class ERC7540DepositManager(VaultDepositManager):
         :raise UnsupportedVaultSimulation:
             Always, with the generic capability's stable reason.
         """
-        del ticket
         raise UnsupportedVaultSimulation(
             f"Generic ERC-7540 settlement driver is not implemented for vault {self.vault.address} on chain {self.vault.chain_id}",
-            unsupported_reason="generic_erc_7540_settlement_driver_not_implemented",
+            unsupported_reason=ERC7540_ANVIL_SETTLEMENT_UNSUPPORTED_REASON,
+            protocol=self.vault.get_protocol_name(),
+            vault_address=self.vault.address,
+            direction="deposit" if isinstance(ticket, DepositTicket) else "redeem" if isinstance(ticket, RedemptionTicket) else None,
         )
 
     def has_synchronous_deposit(self) -> bool:

--- a/eth_defi/erc_7540/deposit_redeem.py
+++ b/eth_defi/erc_7540/deposit_redeem.py
@@ -28,8 +28,10 @@ from eth_defi.vault.deposit_redeem import (
     DepositTicket,
     RedemptionRequest,
     RedemptionTicket,
+    UnsupportedVaultSimulation,
     VaultDepositManager,
     VaultFlowUnavailable,
+    VaultForcedSettlementResult,
 )
 from eth_defi.vault.flow_events import (
     PendingVaultFlow,
@@ -709,6 +711,29 @@ class ERC7540DepositManager(VaultDepositManager):
             return convert_int256_bytes_to_int(result) != 0
         except (ValueError, BadFunctionCallOutput, BadAddressError, ProbablyNodeHasNoBlock):
             return False
+
+    def force_settle(self, ticket: DepositTicket | RedemptionTicket | None) -> VaultForcedSettlementResult:
+        """Refuse generic ERC-7540 operator settlement before a fork broadcast.
+
+        ERC-7540 standardises request and claim interfaces but not the operator
+        action which makes a particular ticket claimable. Protocol-specific
+        managers must implement and prove that action before advertising an
+        Anvil settlement capability.
+
+        :param ticket:
+            Asynchronous deposit or redemption ticket whose settlement is not
+            implemented by this protocol-neutral manager.
+        :return:
+            This method never returns because both generic ERC-7540 directions
+            are asynchronous.
+        :raise UnsupportedVaultSimulation:
+            Always, with the generic capability's stable reason.
+        """
+        del ticket
+        raise UnsupportedVaultSimulation(
+            f"Generic ERC-7540 settlement driver is not implemented for vault {self.vault.address} on chain {self.vault.chain_id}",
+            unsupported_reason="generic_erc_7540_settlement_driver_not_implemented",
+        )
 
     def has_synchronous_deposit(self) -> bool:
         """Report that deposits use the asynchronous request lifecycle.

--- a/eth_defi/erc_7540/vault.py
+++ b/eth_defi/erc_7540/vault.py
@@ -183,6 +183,7 @@ class ERC7540Vault(ERC4626Vault):
             deposit_flow="asynchronous",
             redemption_flow="asynchronous",
             supports_anvil_settlement=False,
+            anvil_settlement_unsupported_reason="generic_erc_7540_settlement_driver_not_implemented",
         )
 
     def get_estimated_lock_up(self) -> datetime.timedelta | None:

--- a/eth_defi/erc_7540/vault.py
+++ b/eth_defi/erc_7540/vault.py
@@ -177,13 +177,15 @@ class ERC7540Vault(ERC4626Vault):
         :return:
             Two-way asynchronous capability.
         """
+        from eth_defi.erc_7540.deposit_redeem import ERC7540_ANVIL_SETTLEMENT_UNSUPPORTED_REASON
+
         return VaultDepositManagerCapability(
             can_deposit=True,
             can_redeem=True,
             deposit_flow="asynchronous",
             redemption_flow="asynchronous",
             supports_anvil_settlement=False,
-            anvil_settlement_unsupported_reason="generic_erc_7540_settlement_driver_not_implemented",
+            anvil_settlement_unsupported_reason=ERC7540_ANVIL_SETTLEMENT_UNSUPPORTED_REASON,
         )
 
     def get_estimated_lock_up(self) -> datetime.timedelta | None:

--- a/eth_defi/vault/deposit_redeem.py
+++ b/eth_defi/vault/deposit_redeem.py
@@ -71,7 +71,13 @@ class VaultDepositManagerCapability:
     :param supports_anvil_settlement:
         Whether the advertised asynchronous lifecycle can be advanced with its
         protocol-specific ticket on an Anvil fork. ``None`` means no
-        asynchronous lifecycle is advertised.
+        settlement assertion is needed for the selected synchronous direction.
+        ``False`` publishes an advertised asynchronous lifecycle which cannot
+        be safely advanced on Anvil.
+    :param anvil_settlement_unsupported_reason:
+        Stable concrete reason why an advertised asynchronous lifecycle cannot
+        be advanced on Anvil. Required when
+        ``supports_anvil_settlement=False`` and forbidden otherwise.
     """
 
     can_deposit: bool
@@ -81,6 +87,7 @@ class VaultDepositManagerCapability:
     deposit_unsupported_reason: str | None = None
     redemption_unsupported_reason: str | None = None
     supports_anvil_settlement: bool | None = None
+    anvil_settlement_unsupported_reason: str | None = None
 
     #: Accepted token addresses for an explicit multi-asset deposit flow.
     deposit_assets: tuple[HexAddress, ...] = ()
@@ -104,6 +111,10 @@ class VaultDepositManagerCapability:
             raise ValueError("redemption_unsupported_reason is valid only when redemptions are unsupported")
         if self.supports_anvil_settlement is not None and "asynchronous" not in (self.deposit_flow, self.redemption_flow):
             raise ValueError("supports_anvil_settlement requires an asynchronous lifecycle")
+        if self.supports_anvil_settlement is False and not self.anvil_settlement_unsupported_reason:
+            raise ValueError("supports_anvil_settlement=False requires anvil_settlement_unsupported_reason")
+        if self.supports_anvil_settlement is not False and self.anvil_settlement_unsupported_reason is not None:
+            raise ValueError("anvil_settlement_unsupported_reason is valid only when supports_anvil_settlement=False")
         if self.deposit_assets and not self.can_deposit:
             raise ValueError("deposit_assets requires deposit support")
 
@@ -127,6 +138,8 @@ class VaultDepositManagerCapability:
             result["redemption_unsupported_reason"] = self.redemption_unsupported_reason
         if self.supports_anvil_settlement is not None:
             result["supports_anvil_settlement"] = self.supports_anvil_settlement
+        if self.anvil_settlement_unsupported_reason is not None:
+            result["anvil_settlement_unsupported_reason"] = self.anvil_settlement_unsupported_reason
         if self.deposit_assets:
             result["deposit_assets"] = list(self.deposit_assets)
         return result
@@ -234,6 +247,10 @@ class VaultFlowError(Exception):
         Lifecycle phase such as ``request`` or ``transaction``.
     :param decoded_error:
         Protocol-specific decoded error name, when available.
+    :param preflight_result:
+        Stable consumer-facing result for a predictable refusal.  This is an
+        optional migration field: callers must fall back to ``decoded_error``
+        while supporting older eth-defi releases that do not populate it.
     :param raw_revert_data:
         Raw revert payload, when available.
     :param requested_raw_amount:
@@ -264,6 +281,7 @@ class VaultFlowError(Exception):
         direction: Literal["deposit", "redeem"] | None = None,
         phase: str | None = None,
         decoded_error: str | None = None,
+        preflight_result: str | None = None,
         raw_revert_data: HexBytes | None = None,
         requested_raw_amount: int | None = None,
         available_raw_amount: int | None = None,
@@ -283,6 +301,7 @@ class VaultFlowError(Exception):
         self.direction = direction
         self.phase = phase
         self.decoded_error = decoded_error
+        self.preflight_result = preflight_result
         self.raw_revert_data = raw_revert_data
         self.requested_raw_amount = requested_raw_amount
         self.available_raw_amount = available_raw_amount
@@ -309,6 +328,8 @@ class VaultFlowError(Exception):
             context.append(f"phase={self.phase}")
         if self.decoded_error:
             context.append(f"decoded_error={self.decoded_error}")
+        if self.preflight_result:
+            context.append(f"preflight_result={self.preflight_result}")
         if self.function_selector:
             context.append(f"function_selector={self.function_selector.hex()}")
         if self.error_selector:
@@ -381,7 +402,20 @@ class WhitelistingRequired(VaultFlowUnavailable):  # noqa: N818
 
 
 class UnsupportedVaultSimulation(RuntimeError):
-    """A vault settlement simulation cannot safely run on this provider."""
+    """A vault settlement simulation cannot safely run on this provider.
+
+    :param reason:
+        Human-readable explanation of why the simulation cannot run.
+    :param unsupported_reason:
+        Stable, machine-readable adapter reason.  This is retained separately
+        from ``reason`` so consumers never need to parse exception prose.
+    """
+
+    def __init__(self, reason: str, *, unsupported_reason: str | None = None) -> None:
+        """Store the human and stable simulation-refusal reasons."""
+        super().__init__(reason)
+        self.reason = reason
+        self.unsupported_reason = unsupported_reason
 
 
 @dataclass(slots=True)
@@ -919,7 +953,10 @@ class VaultDepositManager(ABC):
             If the provider is not Anvil or an async manager lacks a driver.
         """
         if not is_anvil(self.web3):
-            raise UnsupportedVaultSimulation(f"{self.__class__.__name__}.force_settle() requires an Anvil provider")
+            raise UnsupportedVaultSimulation(
+                f"{self.__class__.__name__}.force_settle() requires an Anvil provider",
+                unsupported_reason="anvil_provider_required",
+            )
 
         if ticket is None and (self.has_synchronous_deposit() or self.has_synchronous_redemption()):
             return VaultForcedSettlementResult(
@@ -929,7 +966,10 @@ class VaultDepositManager(ABC):
                 status_after=None,
             )
 
-        raise UnsupportedVaultSimulation(f"{self.__class__.__name__} has no Anvil settlement driver for {type(ticket).__name__}")
+        raise UnsupportedVaultSimulation(
+            f"{self.__class__.__name__} has no Anvil settlement driver for {type(ticket).__name__}",
+            unsupported_reason="anvil_settlement_driver_not_implemented",
+        )
 
     @abstractmethod
     def has_synchronous_deposit(self) -> bool:

--- a/eth_defi/vault/deposit_redeem.py
+++ b/eth_defi/vault/deposit_redeem.py
@@ -409,13 +409,48 @@ class UnsupportedVaultSimulation(RuntimeError):
     :param unsupported_reason:
         Stable, machine-readable adapter reason.  This is retained separately
         from ``reason`` so consumers never need to parse exception prose.
+    :param protocol:
+        Protocol adapter that rejected settlement, when known.
+    :param vault_address:
+        Vault whose settlement was rejected, when known.
+    :param direction:
+        ``deposit`` or ``redeem`` for the rejected asynchronous ticket.
+    :param phase:
+        Lifecycle phase that was rejected. Defaults to ``settlement``.
     """
 
-    def __init__(self, reason: str, *, unsupported_reason: str | None = None) -> None:
-        """Store the human and stable simulation-refusal reasons."""
+    def __init__(
+        self,
+        reason: str,
+        *,
+        unsupported_reason: str | None = None,
+        protocol: str | None = None,
+        vault_address: HexAddress | None = None,
+        direction: Literal["deposit", "redeem"] | None = None,
+        phase: str = "settlement",
+    ) -> None:
+        """Store a machine-readable settlement refusal and its vault context.
+
+        :param reason:
+            Human-readable explanation of the refusal.
+        :param unsupported_reason:
+            Stable adapter reason for consumer result mapping.
+        :param protocol:
+            Protocol adapter that rejected settlement, when known.
+        :param vault_address:
+            Vault whose settlement was rejected, when known.
+        :param direction:
+            Rejected asynchronous ticket direction, when known.
+        :param phase:
+            Rejected lifecycle phase.
+        """
         super().__init__(reason)
         self.reason = reason
         self.unsupported_reason = unsupported_reason
+        self.protocol = protocol
+        self.vault_address = vault_address
+        self.direction = direction
+        self.phase = phase
 
 
 @dataclass(slots=True)
@@ -565,6 +600,24 @@ class VaultForcedSettlementResult:
     #: advance tickets on a fork", not "the vault is solvent". Callers that need
     #: a real-liquidity guarantee must assert this is zero.
     synthetic_assets_injected_raw: int = 0
+
+
+def create_synchronous_settlement_result() -> VaultForcedSettlementResult:
+    """Create the standard no-op outcome for a synchronous vault flow.
+
+    Synchronous requests complete in their own transaction and therefore have
+    no ticket or settlement status to advance. Managers exposing mixed flows
+    reuse this value for their synchronous direction.
+
+    :return:
+        A zero-transaction result indicating no settlement is required.
+    """
+    return VaultForcedSettlementResult(
+        ticket=None,
+        settlement_required=False,
+        status_before=None,
+        status_after=None,
+    )
 
 
 class CannotParseRedemptionTransaction(Exception):
@@ -956,19 +1009,19 @@ class VaultDepositManager(ABC):
             raise UnsupportedVaultSimulation(
                 f"{self.__class__.__name__}.force_settle() requires an Anvil provider",
                 unsupported_reason="anvil_provider_required",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
             )
 
         if ticket is None and (self.has_synchronous_deposit() or self.has_synchronous_redemption()):
-            return VaultForcedSettlementResult(
-                ticket=None,
-                settlement_required=False,
-                status_before=None,
-                status_after=None,
-            )
+            return create_synchronous_settlement_result()
 
         raise UnsupportedVaultSimulation(
             f"{self.__class__.__name__} has no Anvil settlement driver for {type(ticket).__name__}",
             unsupported_reason="anvil_settlement_driver_not_implemented",
+            protocol=self.vault.get_protocol_name(),
+            vault_address=self.vault.address,
+            direction="deposit" if isinstance(ticket, DepositTicket) else "redeem" if isinstance(ticket, RedemptionTicket) else None,
         )
 
     @abstractmethod

--- a/tests/erc_4626/test_deposit_probe.py
+++ b/tests/erc_4626/test_deposit_probe.py
@@ -209,6 +209,7 @@ def test_probe_records_preflight_refusal_without_aborting() -> None:
                 direction="deposit",
                 phase="preflight",
                 decoded_error="NotWhitelisted",
+                preflight_result="whitelisting-needed",
                 function_selector=HexBytes("0x85b77f45"),
                 error_selector=HexBytes("0x584a7938"),
             )
@@ -236,6 +237,7 @@ def test_probe_records_preflight_refusal_without_aborting() -> None:
         "direction": "deposit",
         "phase": "preflight",
         "decoded_error": "NotWhitelisted",
+        "preflight_result": "whitelisting-needed",
         "function_selector": "85b77f45",
         "error_selector": "584a7938",
         "access_delay": None,
@@ -274,6 +276,7 @@ def test_probe_preserves_successful_deposit_when_redemption_is_unavailable() -> 
         "direction": "redeem",
         "phase": "preflight",
         "decoded_error": None,
+        "preflight_result": None,
         "function_selector": None,
         "error_selector": None,
         "access_delay": 3600,

--- a/tests/erc_4626/test_deposit_probe.py
+++ b/tests/erc_4626/test_deposit_probe.py
@@ -56,6 +56,10 @@ def test_vault_deposit_manager_capability_exposes_directional_public_support() -
         VaultDepositManagerCapability(True, True, "synchronous", "synchronous", deposit_unsupported_reason="unsupported")
     with pytest.raises(ValueError, match="supports_anvil_settlement"):
         VaultDepositManagerCapability(True, True, "synchronous", "synchronous", supports_anvil_settlement=True)
+    with pytest.raises(ValueError, match="anvil_settlement_unsupported_reason"):
+        VaultDepositManagerCapability(True, True, "synchronous", "asynchronous", supports_anvil_settlement=False)
+    with pytest.raises(ValueError, match="anvil_settlement_unsupported_reason"):
+        VaultDepositManagerCapability(True, True, "synchronous", "asynchronous", anvil_settlement_unsupported_reason="reason")
     with pytest.raises(ValueError, match="deposit_assets"):
         VaultDepositManagerCapability(False, False, deposit_assets=("0x0000000000000000000000000000000000000001",))
 

--- a/tests/erc_4626/vault_protocol/test_accountable.py
+++ b/tests/erc_4626/vault_protocol/test_accountable.py
@@ -176,6 +176,10 @@ def test_accountable_deposit_and_redemption_request_lifecycle(web3: Web3) -> Non
     with pytest.raises(UnsupportedVaultSimulation, match="strategy-operator controlled") as exc_info:
         manager.force_settle(ticket)
     assert exc_info.value.unsupported_reason == "accountable_redemption_settlement_is_strategy_operator_controlled"
+    assert exc_info.value.protocol == vault.get_protocol_name()
+    assert exc_info.value.vault_address == vault.address
+    assert exc_info.value.direction == "redeem"
+    assert exc_info.value.phase == "settlement"
 
 
 @pytest.mark.timeout(180)

--- a/tests/erc_4626/vault_protocol/test_accountable.py
+++ b/tests/erc_4626/vault_protocol/test_accountable.py
@@ -27,7 +27,7 @@ from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.token import TokenDetails
 from eth_defi.trace import assert_transaction_success_with_explanation
-from eth_defi.vault.deposit_redeem import AsyncVaultRequestStatus, VaultFlowUnavailable
+from eth_defi.vault.deposit_redeem import AsyncVaultRequestStatus, UnsupportedVaultSimulation, VaultFlowUnavailable
 
 JSON_RPC_MONAD = os.environ.get("JSON_RPC_MONAD")
 MONAD_USDC_WHALE = HexAddress(HexStr("0xf89d7b9c864f589bbF53a82105107622B35EaA40"))
@@ -83,6 +83,8 @@ def test_accountable_susn_vault(
         "can_redeem": True,
         "deposit_flow": "synchronous",
         "redemption_flow": "asynchronous",
+        "supports_anvil_settlement": False,
+        "anvil_settlement_unsupported_reason": "accountable_redemption_settlement_is_strategy_operator_controlled",
     }
 
     # Management fee not available, performance fee from offchain metadata
@@ -124,6 +126,7 @@ def test_accountable_deposit_and_redemption_request_lifecycle(web3: Web3) -> Non
     with pytest.raises(VaultFlowUnavailable, match="below minimum") as exc_info:
         manager.create_deposit_request(owner=web3.eth.accounts[1], raw_amount=minimum - 1)
     assert exc_info.value.decoded_error == "InsufficientAmount"
+    assert exc_info.value.preflight_result == "below_minimum"
     assert exc_info.value.error_selector == ACCOUNTABLE_INSUFFICIENT_AMOUNT_SELECTOR
     assert exc_info.value.minimum_raw_amount == minimum
     assert exc_info.value.available_raw_amount is None
@@ -170,6 +173,9 @@ def test_accountable_deposit_and_redemption_request_lifecycle(web3: Web3) -> Non
         AsyncVaultRequestStatus.pending,
         AsyncVaultRequestStatus.claimable,
     }
+    with pytest.raises(UnsupportedVaultSimulation, match="strategy-operator controlled") as exc_info:
+        manager.force_settle(ticket)
+    assert exc_info.value.unsupported_reason == "accountable_redemption_settlement_is_strategy_operator_controlled"
 
 
 @pytest.mark.timeout(180)
@@ -192,6 +198,7 @@ def test_accountable_redemption_request_rejects_contract_dust(web3: Web3) -> Non
             check_enough_token=False,
         )
     assert exc_info.value.decoded_error == "InsufficientAmount"
+    assert exc_info.value.preflight_result == "below_minimum"
     assert exc_info.value.direction == "redeem"
 
 
@@ -232,6 +239,7 @@ def test_accountable_hyperithm_strategy_min_deposit(web3: Web3) -> None:
             check_enough_token=False,
         )
     assert exc_info.value.decoded_error == "InsufficientAmount"
+    assert exc_info.value.preflight_result == "below_minimum"
     assert exc_info.value.error_selector == ACCOUNTABLE_INSUFFICIENT_AMOUNT_SELECTOR
     assert exc_info.value.minimum_raw_amount == strategy_minimum
     assert exc_info.value.direction == "deposit"

--- a/tests/erc_4626/vault_protocol/test_csigma.py
+++ b/tests/erc_4626/vault_protocol/test_csigma.py
@@ -206,6 +206,7 @@ def test_csigma_v2_pool_rejects_redemption_above_immediate_capacity(web3: Web3) 
     # The over-capacity case is exactly what reverts WithdrawalPending onchain
     # and queues the excess off-chain; the typed refusal carries that decode.
     assert error.decoded_error == "WithdrawalPending"
+    assert error.preflight_result == "redemption_capacity_limited"
     assert error.error_selector == CSIGMA_WITHDRAWAL_PENDING_SELECTOR
 
 
@@ -322,4 +323,5 @@ def test_csigma_usd_redemption_capacity_preflight(midnight_web3: Web3) -> None:
     assert error.requested_raw_amount == 1
     assert error.available_raw_amount == 0
     assert error.decoded_error == "WithdrawalPending"
+    assert error.preflight_result == "redemption_capacity_limited"
     assert error.error_selector == CSIGMA_WITHDRAWAL_PENDING_SELECTOR

--- a/tests/erc_4626/vault_protocol/test_ember_deposit_redeem.py
+++ b/tests/erc_4626/vault_protocol/test_ember_deposit_redeem.py
@@ -17,7 +17,7 @@ from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.token import USDC_WHALE, TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
-from eth_defi.vault.deposit_redeem import AsyncVaultRequestStatus
+from eth_defi.vault.deposit_redeem import AsyncVaultRequestStatus, UnsupportedVaultSimulation, VaultFlowUnavailable
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 EMBER_VAULT = HexAddress(HexStr("0xf3190A3ECC109F88e7947b849b281918c798A0C4"))
@@ -91,10 +91,11 @@ def test_ember_deposit_redeem_lifecycle(web3: Web3, vault: EmberVault, usdc: Tok
         "can_redeem": True,
         "deposit_flow": "synchronous",
         "redemption_flow": "asynchronous",
-        "supports_anvil_settlement": True,
+        "supports_anvil_settlement": False,
+        "anvil_settlement_unsupported_reason": "ember_operator_settlement_has_no_claimable_ticket_status",
     }
-    # The force_settle driver reads the operator from roles() rather than
-    # hardcoding it; assert the onchain layout matches the known operator.
+    # Keep the exact deployment's operator layout in coverage even though its
+    # direct-pay queue cannot satisfy generic claimable-ticket settlement.
     assert Web3.to_checksum_address(vault.vault_contract.functions.roles().call()[1]) == Web3.to_checksum_address(EMBER_OPERATOR)
 
     owner = web3.eth.accounts[0]
@@ -132,32 +133,28 @@ def test_ember_deposit_redeem_lifecycle(web3: Web3, vault: EmberVault, usdc: Tok
     assert manager.can_finish_redeem(ticket) is False
     assert manager.finish_redemption(ticket) is None
 
-    # 4. Force settlement through the operator-impersonating Anvil driver.
-    settlement = manager.force_settle(ticket)
-    assert settlement.settlement_required is True
-    assert settlement.status_before == AsyncVaultRequestStatus.pending
-    assert settlement.status_after == AsyncVaultRequestStatus.none
-    assert len(settlement.transaction_hashes) >= 1
-    completion_hash = manager.fetch_completed_redemption_tx_hash(ticket)
-    assert completion_hash == settlement.transaction_hashes[-1]
-    redemption_analysis = manager.analyse_redemption(completion_hash, ticket)
-    assert redemption_analysis.share_count == Decimal("97.218907")
-    assert redemption_analysis.denomination_amount == Decimal("99.999999")
-    assert manager.get_redemption_request_status(ticket) == AsyncVaultRequestStatus.none
-    assert vault.vault_contract.functions.getAccountState(owner).call() == [0, [], []]
-    assert vault.share_token.fetch_raw_balance_of(owner) == 0
-    assert usdc.fetch_raw_balance_of(owner) == 99_999_999
+    # 4. Ember has no claimable ticket state, so force-settlement must refuse
+    # before impersonating the operator or broadcasting its queue processor.
+    with pytest.raises(UnsupportedVaultSimulation, match="cannot prove a claimable") as exc_info:
+        manager.force_settle(ticket)
+    assert exc_info.value.unsupported_reason == "ember_operator_settlement_has_no_claimable_ticket_status"
+    assert manager.get_redemption_request_status(ticket) == AsyncVaultRequestStatus.pending
+    assert vault.vault_contract.functions.getAccountState(owner).call() == [raw_shares, [145], []]
 
 
 def test_ember_redemption_minimum_is_checked_before_call_binding(web3: Web3, vault: EmberVault) -> None:
     """Reject a request below the exact configured Ember minimum share amount."""
     manager = vault.get_deposit_manager()
-    with pytest.raises(ValueError, match="below minimum"):
+    with pytest.raises(VaultFlowUnavailable, match="below minimum") as exc_info:
         manager.create_redemption_request(
             owner=web3.eth.accounts[1],
             raw_shares=99_999,
             check_enough_token=False,
         )
+    assert exc_info.value.decoded_error == "InsufficientAmount"
+    assert exc_info.value.preflight_result == "below_minimum"
+    assert exc_info.value.direction == "redeem"
+    assert exc_info.value.minimum_raw_amount == 100_000
 
 
 def test_ember_ticket_identity_validation() -> None:

--- a/tests/erc_4626/vault_protocol/test_ember_deposit_redeem.py
+++ b/tests/erc_4626/vault_protocol/test_ember_deposit_redeem.py
@@ -138,6 +138,10 @@ def test_ember_deposit_redeem_lifecycle(web3: Web3, vault: EmberVault, usdc: Tok
     with pytest.raises(UnsupportedVaultSimulation, match="cannot prove a claimable") as exc_info:
         manager.force_settle(ticket)
     assert exc_info.value.unsupported_reason == "ember_operator_settlement_has_no_claimable_ticket_status"
+    assert exc_info.value.protocol == vault.get_protocol_name()
+    assert exc_info.value.vault_address == vault.address
+    assert exc_info.value.direction == "redeem"
+    assert exc_info.value.phase == "settlement"
     assert manager.get_redemption_request_status(ticket) == AsyncVaultRequestStatus.pending
     assert vault.vault_contract.functions.getAccountState(owner).call() == [raw_shares, [145], []]
 

--- a/tests/erc_4626/vault_protocol/test_plutus.py
+++ b/tests/erc_4626/vault_protocol/test_plutus.py
@@ -213,3 +213,7 @@ def test_plutus_async_redemption_lifecycle(midnight_web3: Web3, plutus_snapshot:
     with pytest.raises(UnsupportedVaultSimulation, match="role-gated") as exc_info:
         manager.force_settle(ticket)
     assert exc_info.value.unsupported_reason == "plutus_redeem_fulfilment_is_access_control_role_gated"
+    assert exc_info.value.protocol == vault.get_protocol_name()
+    assert exc_info.value.vault_address == vault.address
+    assert exc_info.value.direction == "redeem"
+    assert exc_info.value.phase == "settlement"

--- a/tests/erc_4626/vault_protocol/test_plutus.py
+++ b/tests/erc_4626/vault_protocol/test_plutus.py
@@ -2,14 +2,13 @@
 
 import datetime
 import os
+from collections.abc import Iterator
 from decimal import Decimal
 from pathlib import Path
 
 import flaky
 import pytest
 from web3 import Web3
-
-from collections.abc import Iterator
 
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
@@ -76,6 +75,8 @@ def test_plutus(
         "can_redeem": True,
         "deposit_flow": "synchronous",
         "redemption_flow": "asynchronous",
+        "supports_anvil_settlement": False,
+        "anvil_settlement_unsupported_reason": "plutus_redeem_fulfilment_is_access_control_role_gated",
     }
     manager = vault.get_deposit_manager()
     assert isinstance(manager, PlutusAsyncDepositManager)
@@ -209,5 +210,6 @@ def test_plutus_async_redemption_lifecycle(midnight_web3: Web3, plutus_snapshot:
 
     # Operator fulfilment is role-gated; forced settlement is refused precisely.
     assert manager.force_settle(None).settlement_required is False
-    with pytest.raises(UnsupportedVaultSimulation, match="role-gated"):
+    with pytest.raises(UnsupportedVaultSimulation, match="role-gated") as exc_info:
         manager.force_settle(ticket)
+    assert exc_info.value.unsupported_reason == "plutus_redeem_fulfilment_is_access_control_role_gated"

--- a/tests/erc_7540/test_generic_erc_7540_deposit_redeem.py
+++ b/tests/erc_7540/test_generic_erc_7540_deposit_redeem.py
@@ -9,7 +9,7 @@ from eth_defi.erc_4626.vault_protocol.usdai.vault import StakedUSDaiVault
 from eth_defi.erc_7540.deposit_redeem import ERC7540DepositManager, ERC7540DepositRequest, ERC7540RedemptionRequest
 from eth_defi.erc_7540.vault import ERC7540Vault
 from eth_defi.vault.base import VaultSpec
-from eth_defi.vault.deposit_redeem import DepositRedeemEventFailure
+from eth_defi.vault.deposit_redeem import DepositRedeemEventFailure, UnsupportedVaultSimulation
 
 VAULT_ADDRESS = "0x0000000000000000000000000000000000000001"
 OWNER_ADDRESS = "0x0000000000000000000000000000000000000002"
@@ -81,6 +81,7 @@ def test_non_lagoon_protocols_use_generic_erc7540_manager(vault_class: type[ERC7
         "deposit_flow": "asynchronous",
         "redemption_flow": "asynchronous",
         "supports_anvil_settlement": False,
+        "anvil_settlement_unsupported_reason": "generic_erc_7540_settlement_driver_not_implemented",
     }
 
 
@@ -101,6 +102,17 @@ def test_generic_erc7540_redemption_accepts_raw_shares() -> None:
     assert type(request) is ERC7540RedemptionRequest
     assert request.raw_shares == 123
     assert request.funcs == [redeem_function]
+
+
+def test_generic_erc7540_settlement_is_typed_unsupported() -> None:
+    """Generic ERC-7540 must not pretend it can settle an operator queue."""
+    vault = object.__new__(StakedUSDaiVault)
+    vault.spec = VaultSpec(chain_id=1, vault_address=VAULT_ADDRESS)
+    manager = vault.get_deposit_manager()
+
+    with pytest.raises(UnsupportedVaultSimulation, match="not implemented") as exc_info:
+        manager.force_settle(object())
+    assert exc_info.value.unsupported_reason == "generic_erc_7540_settlement_driver_not_implemented"
 
 
 @pytest.mark.parametrize(

--- a/tests/gains/test_gtrade_usdc.py
+++ b/tests/gains/test_gtrade_usdc.py
@@ -134,6 +134,8 @@ def test_gains_deposit_withdraw(
     with pytest.raises(VaultFlowUnavailable) as exc_info:
         deposit_manager.create_redemption_request(owner=test_user, shares=shares)
     assert exc_info.value.decoded_error == "EndOfEpoch"
+    assert exc_info.value.preflight_result == "redemption_window_closed"
+    assert exc_info.value.next_open is not None
     assert exc_info.value.error_selector == END_OF_EPOCH_SELECTOR
 
     # 0. Clear epoch

--- a/tests/vault/test_deposit_redeem.py
+++ b/tests/vault/test_deposit_redeem.py
@@ -20,15 +20,17 @@ def test_vault_flow_unavailable_preserves_context() -> None:
         direction="redeem",
         phase="request",
         decoded_error="CapacityExceeded",
+        preflight_result="redemption_capacity_limited",
         requested_raw_amount=REQUESTED_RAW_AMOUNT,
         available_raw_amount=AVAILABLE_RAW_AMOUNT,
     )
 
     assert error.reason == "Immediate redemption unavailable"
     assert error.decoded_error == "CapacityExceeded"
+    assert error.preflight_result == "redemption_capacity_limited"
     assert error.requested_raw_amount == REQUESTED_RAW_AMOUNT
     assert error.available_raw_amount == AVAILABLE_RAW_AMOUNT
-    assert str(error) == ("Immediate redemption unavailable (protocol=Example protocol, vault=0x0000000000000000000000000000000000000001, caller=0x0000000000000000000000000000000000000002, direction=redeem, phase=request, decoded_error=CapacityExceeded, requested_raw_amount=101, available_raw_amount=100)")
+    assert str(error) == ("Immediate redemption unavailable (protocol=Example protocol, vault=0x0000000000000000000000000000000000000001, caller=0x0000000000000000000000000000000000000002, direction=redeem, phase=request, decoded_error=CapacityExceeded, preflight_result=redemption_capacity_limited, requested_raw_amount=101, available_raw_amount=100)")
 
 
 def test_vault_flow_unavailable_preserves_access_context() -> None:

--- a/tests/vault/test_deposit_redeem.py
+++ b/tests/vault/test_deposit_redeem.py
@@ -3,7 +3,7 @@
 from eth_typing import HexAddress
 from hexbytes import HexBytes
 
-from eth_defi.vault.deposit_redeem import VaultFlowUnavailable
+from eth_defi.vault.deposit_redeem import UnsupportedVaultSimulation, VaultFlowUnavailable
 
 REQUESTED_RAW_AMOUNT = 101
 AVAILABLE_RAW_AMOUNT = 100
@@ -31,6 +31,23 @@ def test_vault_flow_unavailable_preserves_context() -> None:
     assert error.requested_raw_amount == REQUESTED_RAW_AMOUNT
     assert error.available_raw_amount == AVAILABLE_RAW_AMOUNT
     assert str(error) == ("Immediate redemption unavailable (protocol=Example protocol, vault=0x0000000000000000000000000000000000000001, caller=0x0000000000000000000000000000000000000002, direction=redeem, phase=request, decoded_error=CapacityExceeded, preflight_result=redemption_capacity_limited, requested_raw_amount=101, available_raw_amount=100)")
+
+
+def test_unsupported_vault_simulation_preserves_structured_context() -> None:
+    """A settlement refusal exposes stable mapping data without prose parsing."""
+    error = UnsupportedVaultSimulation(
+        "Operator settlement cannot be reproduced",
+        unsupported_reason="operator_role_not_available",
+        protocol="Example protocol",
+        vault_address="0x0000000000000000000000000000000000000001",
+        direction="redeem",
+    )
+
+    assert error.unsupported_reason == "operator_role_not_available"
+    assert error.protocol == "Example protocol"
+    assert error.vault_address == "0x0000000000000000000000000000000000000001"
+    assert error.direction == "redeem"
+    assert error.phase == "settlement"
 
 
 def test_vault_flow_unavailable_preserves_access_context() -> None:


### PR DESCRIPTION
## Why

Predictable vault-simulation outcomes need machine-readable context from eth-defi through to its probe output. Unsupported asynchronous settlement must also provide structured vault context, so a consumer never has to infer a result from exception prose.

## Lessons learnt

A false settlement capability is only useful when its stable reason, protocol, vault, direction, and phase are available as fields. A broad cross-repository matrix plan must distinguish the contract work delivered here from its remaining exact-deployment verification.

## Summary

- Serialise `preflight_result` in probe flow-error JSON alongside `decoded_error`.
- Add structured context to `UnsupportedVaultSimulation` and assert it for Ember, Accountable, and Plutus.
- Centralise adapter unsupported-settlement reasons and synchronous no-op settlement construction.
- Type the Plutus settlement override and document the plan's current delivery status.
- This PR implements the shared contract plus focused Ember Third Eye, Accountable Hyperithm, cSuperior, Gains Arbitrum, Plutus Hedge, and generic ERC-7540 paths. It does **not** complete the 15-vault exact-ID matrix.

## Related issues and PRs

- The [round-3 hand-off plan](https://github.com/tradingstrategy-ai/web3-ethereum-defi/pull/1375#issuecomment-5078667625) remains the completion plan; remaining Ember, Gains Base, Lagoon exact-ID coverage, and the final matrix report are follow-up work.
- Coordinates with [trade-executor PR #1578](https://github.com/tradingstrategy-ai/trade-executor/pull/1578), where the consumer must prefer `preflight_result` and fall back to `decoded_error`.

## Unrelated CI and test fixes

None.