### PR TITLE
fix: preflight cSuperior redemption capacity

### DIFF
--- a/eth_defi/abi/csigma/README.md
+++ b/eth_defi/abi/csigma/README.md
@@ -2,8 +2,13 @@
 
 `CsigmaV2Pool.json` is the verified implementation ABI of the cSigma /
 cSuperior credit pool, including the FIFO withdrawal-queue surface behind the
-"Withdrawal pending" revert. It is used to model cSuperior redemption as an
-asynchronous queued request rather than a synchronous ERC-4626 `redeem`.
+"Withdrawal pending" revert. It is bound to the cSuperior proxy so the adapter
+can inspect its queue gate and decode its custom errors. The pool has no
+onchain per-lender request, claim or ticket surface: eth-defi models it as a
+synchronous, reserve-limited ERC-4626 redemption and refuses any redemption
+that cannot complete in full immediately. The offchain withdrawal manager may
+partially service queued lenders, but that partial-fill lifecycle is outside
+this adapter and trade-executor's current full-fill contract.
 
 Fetched on 2026-07-25 from the Etherscan v2 verified implementation
 `0xa5b7555775a33ca79818702f63b34b14dc9aec4d` (`ContractName=CsigmaV2Pool`)

--- a/eth_defi/erc_4626/vault_protocol/csigma/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/csigma/deposit_redeem.py
@@ -3,11 +3,11 @@
 cSigma redemption model (important — do not mistake it for ERC-7540 async):
 
 - The cSigma pool (``CsigmaV2Pool``) is a **reserve-limited synchronous**
-  ERC-4626 vault. A ``redeem`` succeeds immediately for up to the reserve-backed
-  capacity reported by ``maxRedeem(owner)``. Beyond that capacity — or when a
-  withdrawal is already queued for the owner — ``redeem`` reverts the pool's
-  custom ``WithdrawalPending()`` error (`0xb34f5c6c`), and the excess is queued
-  off-chain for the ``withdrawalManager`` to service later.
+  ERC-4626 vault. Its ``maxRedeem(owner)`` view is pool-wide and ignores
+  ``owner``, so it is not an immediate-redemption authority. A user ``redeem``
+  is blocked while the external ``withdrawalManager`` has queue debt; otherwise
+  it needs both the owner's shares and enough idle reserve for the entire fill.
+  The offchain manager may partially service queued lenders later.
 - The pool exposes **no onchain request/ticket/claim surface** for that queue
   (no ``requestRedeem`` / ``pendingRedeemRequest`` / ``claimableRedeemRequest``
   / request id). The queue is entirely off-chain, so the queued portion cannot
@@ -18,18 +18,42 @@ cSigma redemption model (important — do not mistake it for ERC-7540 async):
   rather than letting the raw revert escape.
 """
 
+import logging
 from decimal import Decimal
 
 from eth_typing import HexAddress
 from hexbytes import HexBytes
+from web3 import Web3
+from web3.exceptions import BadFunctionCallOutput, ContractLogicError
 
+from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager, ERC4626DepositRequest, ERC4626RedemptionRequest
 from eth_defi.vault.deposit_redeem import VaultFlowUnavailable, VaultRedemptionPreflight
+
+logger = logging.getLogger(__name__)
 
 #: ``WithdrawalPending()`` custom-error selector reverted by the cSigma pool
 #: when a redemption exceeds the immediate reserve-backed capacity or a
 #: withdrawal is already queued for the owner. ``keccak("WithdrawalPending()")[:4]``.
 CSIGMA_WITHDRAWAL_PENDING_SELECTOR = HexBytes("0xb34f5c6c")
+
+#: Exact cSuperior V2 deployment whose verified withdrawal-manager gate is
+#: required for full-fill simulation preflight.
+CSUPERIOR_V2_POOL_ADDRESS: HexAddress = "0x438982ea288763370946625fd76c2508ee1fb229"
+
+#: Verified ``CsigmaV2Pool.WithdrawManager`` interface has one capacity method.
+#: The pool source for the exact cSuperior proxy calls it before every user
+#: withdrawal. A one-function inline ABI is sufficient and avoids inventing a
+#: broader interface for the external manager contract.
+CSIGMA_WITHDRAWAL_MANAGER_TOTAL_DUE_ABI = [
+    {
+        "inputs": [],
+        "name": "totalDueLPToken",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+]
 
 
 class CsigmaDepositManager(ERC4626DepositManager):
@@ -56,8 +80,9 @@ class CsigmaDepositManager(ERC4626DepositManager):
     **Redemption process**
 
     Reserve-limited *synchronous* ``redeem`` — this is **not** an ERC-7540 async
-    flow. Only up to ``maxRedeem(owner)`` (:meth:`fetch_redeemable_raw_shares`)
-    is immediately redeemable against the pool reserve.
+    flow. :meth:`fetch_redeemable_raw_shares` uses the verified queue gate,
+    owner balance and idle reserve; it deliberately does not trust the
+    pool-wide ``maxRedeem(owner)`` view.
     :meth:`create_redemption_request` runs :meth:`fetch_redemption_preflight`
     (a raw-share comparison, no rounding-sensitive conversion); a request above
     the immediate capacity raises :class:`VaultFlowUnavailable` tagged with the
@@ -98,15 +123,68 @@ class CsigmaDepositManager(ERC4626DepositManager):
         transaction inclusion.
     """
 
+    def fetch_withdrawal_manager_due_raw_shares(self) -> int | None:
+        """Fetch queue debt that blocks all user-initiated cSigma redemptions.
+
+        The verified ``CsigmaV2Pool._withdraw()`` rejects a user redemption
+        while the external ``withdrawalManager.totalDueLPToken()`` is non-zero.
+        A read failure is deliberately fail-closed: callers receive ``None``
+        and must treat the immediate capacity as zero instead of broadcasting a
+        redemption known to be unsafe to simulate.
+
+        :return:
+            Raw queued share debt, or ``None`` when its authoritative state
+            cannot be read.
+        """
+        try:
+            withdrawal_manager = self.vault.vault_contract.functions.withdrawalManager().call()
+            if withdrawal_manager == ZERO_ADDRESS_STR:
+                return 0
+
+            manager_contract = self.web3.eth.contract(
+                address=Web3.to_checksum_address(withdrawal_manager),
+                abi=CSIGMA_WITHDRAWAL_MANAGER_TOTAL_DUE_ABI,
+            )
+            return int(manager_contract.functions.totalDueLPToken().call())
+        except (BadFunctionCallOutput, ContractLogicError, ValueError) as error:
+            logger.warning(
+                "Cannot read cSigma withdrawal-manager queue debt for vault %s on chain %d: %s",
+                self.vault.address,
+                self.vault.chain_id,
+                error,
+            )
+            return None
+
     def fetch_redeemable_raw_shares(self, owner: HexAddress) -> int:
-        """Fetch the cSigma redemption capacity expressed in raw shares.
+        """Fetch the queue-adjusted, owner-bounded immediate redemption capacity.
+
+        ``maxRedeem(owner)`` is deliberately not used: the verified V2 pool
+        ignores ``owner`` and returns pool-wide idle cash even for an account
+        with no shares. The actual ``redeem()`` path first rejects every user
+        redemption while the withdrawal manager has due shares, then requires
+        both an owner balance and enough idle reserve. This method mirrors those
+        conditions without trying to model the offchain partial-fill queue.
 
         :param owner:
-            Address whose immediate capacity is queried.
+            Address whose immediately redeemable shares are queried.
         :return:
-            Maximum raw vault shares redeemable immediately by ``owner``.
+            Maximum raw vault shares that can be redeemed in full immediately.
         """
-        return int(self.vault.vault_contract.functions.maxRedeem(owner).call())
+        if self.vault.address.lower() != CSUPERIOR_V2_POOL_ADDRESS:
+            # Other registered cSigma deployments do not expose the verified V2
+            # withdrawal-manager surface. Preserve their existing adapter
+            # behaviour; this exact-address repair must not guess their queue
+            # semantics from cSuperior's implementation.
+            return int(self.vault.vault_contract.functions.maxRedeem(owner).call())
+
+        due_raw_shares = self.fetch_withdrawal_manager_due_raw_shares()
+        if due_raw_shares is None or due_raw_shares > 0:
+            return 0
+
+        owner_raw_shares = int(self.vault.share_token.fetch_raw_balance_of(owner))
+        gross_immediate_raw_assets = int(self.vault.vault_contract.functions.maxWithdraw(owner).call())
+        gross_immediate_raw_shares = int(self.vault.vault_contract.functions.convertToShares(gross_immediate_raw_assets).call())
+        return min(owner_raw_shares, gross_immediate_raw_shares)
 
     def fetch_depositable_raw_assets(self, owner: HexAddress) -> int:
         """Fetch the cSigma deposit capacity expressed in raw assets.
@@ -126,9 +204,9 @@ class CsigmaDepositManager(ERC4626DepositManager):
     ) -> VaultRedemptionPreflight:
         """Check cSigma's owner-specific immediate redemption capacity.
 
-        ``maxRedeem(owner)`` is denominated in raw vault shares, so this
-        compares the requested and available values without a
-        rounding-sensitive share-to-asset conversion.
+        The queue-adjusted capacity is already denominated in raw vault shares,
+        so this compares the requested and available values without a
+        rounding-sensitive conversion.
 
         .. note::
 

--- a/eth_defi/erc_4626/vault_protocol/csigma/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/csigma/vault.py
@@ -21,18 +21,21 @@ to optimise yield performance.
 
 import datetime
 import logging
+from functools import cached_property
 
 from eth_typing import BlockIdentifier, HexAddress
+from web3.contract import Contract
 
+from eth_defi.abi import get_deployed_contract
 from eth_defi.erc_4626.vault import ERC4626Vault
-from eth_defi.erc_4626.vault_protocol.csigma.deposit_redeem import CsigmaDepositManager
+from eth_defi.erc_4626.vault_protocol.csigma.deposit_redeem import CSUPERIOR_V2_POOL_ADDRESS, CsigmaDepositManager
 from eth_defi.vault.deposit_redeem import VaultDepositManager, VaultDepositManagerCapability
 
 logger = logging.getLogger(__name__)
 
 
 #: cSigma V2 pool with verified synchronous ERC-4626 lifecycle support.
-CSIGMA_V2_POOL_ADDRESS: HexAddress = "0x438982ea288763370946625fd76c2508ee1fb229"
+CSIGMA_V2_POOL_ADDRESS: HexAddress = CSUPERIOR_V2_POOL_ADDRESS
 
 #: Ethereum mainnet, where the representative V2 pool was verified.
 CSIGMA_V2_POOL_CHAIN_ID = 1
@@ -73,6 +76,23 @@ class CsigmaVault(ERC4626Vault):
     - Twitter: https://x.com/csigmafinance
     - Contract: https://etherscan.io/address/0xd5d097f278a735d0a3c609deee71234cac14b47e
     """
+
+    @cached_property
+    def vault_contract(self) -> Contract:
+        """Bind cSuperior's verified implementation ABI to its proxy address.
+
+        The generic ERC-4626 interface omits cSigma custom errors and the
+        queue-state methods required by the capacity preflight. The exact V2
+        deployment therefore uses its verified implementation ABI while other
+        cSigma deployments retain the generic binding.
+
+        :return:
+            Verified cSigma V2 contract for cSuperior, otherwise the generic
+            ERC-4626 binding.
+        """
+        if self.chain_id == CSIGMA_V2_POOL_CHAIN_ID and self.address.lower() == CSIGMA_V2_POOL_ADDRESS:
+            return get_deployed_contract(self.web3, "csigma/CsigmaV2Pool.json", self.address)
+        return super().vault_contract
 
     def has_custom_fees(self) -> bool:
         """Whether this vault has deposit/withdrawal fees.

--- a/eth_defi/vault/deposit_redeem.py
+++ b/eth_defi/vault/deposit_redeem.py
@@ -166,8 +166,8 @@ class VaultRedemptionPreflight:
     The result is advisory because capacity can change before a transaction is
     mined. The manager's request constructor must repeat an available-capacity
     check before broadcasting. It is currently returned only by adapters that
-    have an owner-specific immediate-capacity query, such as cSigma's
-    `ERC-4626 maxRedeem <https://eips.ethereum.org/EIPS/eip-4626#maxredeem>`__.
+    can determine an immediate full-fill capacity from their authoritative
+    protocol state, such as cSigma's queue-adjusted reserve check.
 
     .. note::
 

--- a/tests/erc_4626/vault_protocol/test_csigma.py
+++ b/tests/erc_4626/vault_protocol/test_csigma.py
@@ -2,9 +2,12 @@
 
 import os
 from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import flaky
 import pytest
+from eth_typing import HexAddress
 from web3 import Web3
 
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
@@ -24,6 +27,7 @@ CSIGMA_USD_VAULT = "0xd5d097f278a735d0a3c609deee71234cac14b47e"
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 EXPECTED_V2_DEPOSITED_RAW_SHARES = 94_348_140
 EXPECTED_SUPQPV_DEPOSITED_RAW_SHARES = 94_445_037
+EXPECTED_CSUPERIOR_QUEUE_DUE_RAW_SHARES = 41_603_916_251
 
 pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests")
 
@@ -111,15 +115,17 @@ def test_csigma_v2_pool(
     # The V2 pool's owner-specific capacity views cannot be validated through a
     # zero-address probe, so generic ERC-4626 capability checks remain disabled.
     assert vault.can_check_redeem() is False
+    assert "WithdrawalPending" in {item["name"] for item in vault.vault_contract.abi if item["type"] == "error"}
 
 
 @flaky.flaky
-def test_csigma_v2_pool_deposit_and_redeem_lifecycle(web3: Web3) -> None:
-    """Complete one immediate cSigma deposit and redemption lifecycle.
+def test_csigma_v2_pool_deposit_then_refuses_redemption_when_queue_state_is_unavailable(web3: Web3) -> None:
+    """Fail closed when the historical fork cannot read cSuperior's queue state.
 
-    The selected fork exposes immediate liquidity for this representative V2
-    pool. The same manager uses ``force_settle(None)`` for both synchronous
-    operations.
+    The fork predates the current withdrawal-manager deployment, so its
+    authoritative queue state cannot be read. A deposit remains synchronous,
+    but the manager must not guess that a full or partial redemption is safe:
+    it returns the typed zero-capacity refusal before building ``redeem()``.
     """
     vault = create_vault_instance_autodetect(
         web3,
@@ -152,12 +158,17 @@ def test_csigma_v2_pool_deposit_and_redeem_lifecycle(web3: Web3) -> None:
 
     raw_shares = vault.share_token.fetch_raw_balance_of(owner)
     assert raw_shares == EXPECTED_V2_DEPOSITED_RAW_SHARES
-    assert manager.can_create_redemption_request(owner) is True
-    redemption_ticket = manager.create_redemption_request(owner=owner, raw_shares=raw_shares).broadcast(from_=owner)
-    redemption_analysis = manager.analyse_redemption(redemption_ticket.tx_hash, redemption_ticket)
-    assert redemption_analysis.share_count == pytest.approx(Decimal("94.34814"))
-    assert redemption_analysis.denomination_amount == pytest.approx(Decimal("99.999999"))
-    assert vault.share_token.fetch_raw_balance_of(owner) == 0
+    assert manager.can_create_redemption_request(owner) is False
+    block_before_refusal = web3.eth.block_number
+    with pytest.raises(VaultFlowUnavailable) as exc_info:
+        manager.create_redemption_request(owner=owner, raw_shares=raw_shares)
+    error = exc_info.value
+    assert error.available_raw_amount == 0
+    assert error.decoded_error == "WithdrawalPending"
+    assert error.error_selector == CSIGMA_WITHDRAWAL_PENDING_SELECTOR
+    assert error.preflight_result == "redemption_capacity_limited"
+    assert web3.eth.block_number == block_before_refusal
+    assert vault.share_token.fetch_raw_balance_of(owner) == raw_shares
     assert manager.force_settle(None).settlement_required is False
 
 
@@ -283,8 +294,71 @@ def test_csigma_supqpv(
 
 @pytest.fixture(scope="module")
 def midnight_web3(anvil_fork_pool: AnvilForkPool) -> Web3:
-    """Shared fixed Ethereum midnight-block fork for the current-state cSigma USD checks."""
-    return create_multi_provider_web3(anvil_fork_pool.get_launch(JSON_RPC_ETHEREUM, ETHEREUM_MIDNIGHT_BLOCK).json_rpc_url)
+    """Connect to the shared deterministic cSigma midnight fork."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ETHEREUM, ETHEREUM_MIDNIGHT_BLOCK)
+
+
+def test_csuperior_full_fill_capacity_boundary(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Allow a whole redemption only when the queue gate and reserve allow it.
+
+    The live cSuperior fork has queue debt, so it correctly offers zero
+    capacity. This isolated boundary check covers the complementary state: a
+    zero queue debt and 75 raw shares of reserve-backed capacity accepts 75,
+    but refuses 76 rather than silently offering a partial onchain fill.
+    """
+    owner: HexAddress = "0x1111111111111111111111111111111111111111"
+    immediate_capacity = 75
+    vault_contract = MagicMock()
+    vault_contract.functions.maxWithdraw(owner).call.return_value = 80
+    vault_contract.functions.convertToShares(80).call.return_value = immediate_capacity
+    manager = CsigmaDepositManager.__new__(CsigmaDepositManager)
+    manager.vault = SimpleNamespace(
+        address=CSIGMA_V2_POOL_ADDRESS,
+        share_token=SimpleNamespace(fetch_raw_balance_of=lambda _owner: 100),
+        vault_contract=vault_contract,
+    )
+    monkeypatch.setattr(manager, "fetch_withdrawal_manager_due_raw_shares", lambda: 0)
+
+    assert manager.fetch_redeemable_raw_shares(owner) == immediate_capacity
+    assert manager.fetch_redemption_preflight(owner, immediate_capacity).available is True
+    refused = manager.fetch_redemption_preflight(owner, immediate_capacity + 1)
+    assert refused.available is False
+    assert refused.available_raw_shares == immediate_capacity
+    assert refused.reason == "redemption_capacity_limited"
+
+
+@flaky.flaky
+@pytest.mark.xdist_group("fork:ethereum:midnight")
+def test_csuperior_queue_blocks_partial_user_redemption(midnight_web3: Web3) -> None:
+    """Refuse cSuperior's offchain partial-fill path before a redeem broadcast.
+
+    At the pinned block the withdrawal manager has outstanding queue debt, so
+    its verified ``_withdraw`` guard rejects every user redemption even though
+    the pool advertises gross idle reserve through ``maxRedeem``. Any positive
+    share request must therefore be preflight-refused in full rather than
+    partially filled and queued by an offchain actor.
+    """
+    vault = create_vault_instance_autodetect(midnight_web3, vault_address=CSIGMA_V2_POOL_ADDRESS)
+    assert isinstance(vault, CsigmaVault)
+    manager = vault.get_deposit_manager()
+    assert isinstance(manager, CsigmaDepositManager)
+    assert manager.fetch_withdrawal_manager_due_raw_shares() == EXPECTED_CSUPERIOR_QUEUE_DUE_RAW_SHARES
+
+    owner = midnight_web3.eth.accounts[4]
+    requested_raw_shares = 1
+    block_before_refusal = midnight_web3.eth.block_number
+    with pytest.raises(VaultFlowUnavailable) as exc_info:
+        manager.create_redemption_request(owner=owner, raw_shares=requested_raw_shares)
+
+    error = exc_info.value
+    assert error.decoded_error == "WithdrawalPending"
+    assert error.error_selector == CSIGMA_WITHDRAWAL_PENDING_SELECTOR
+    assert error.preflight_result == "redemption_capacity_limited"
+    assert error.direction == "redeem"
+    assert error.phase == "preflight"
+    assert error.requested_raw_amount == requested_raw_shares
+    assert error.available_raw_amount == 0
+    assert midnight_web3.eth.block_number == block_before_refusal
 
 
 @flaky.flaky


### PR DESCRIPTION
## Why

cSuperior’s `maxRedeem(owner)` is a pool-wide gross-reserve view and cannot establish whether a user redemption can complete. The exact V2 deployment blocks every user redemption while its external withdrawal manager has queue debt; its offchain manager may later service a queued lender partially, but eth-defi has no onchain ticket or claim surface for that lifecycle.

## Lessons learnt

Bind and test the exact deployed proxy, not a same-ABI substitute. Capacity needs to mirror the verified withdrawal gate and fail closed when that state cannot be read, rather than advertising an unsafe partial fill.

## Summary

- Bind cSuperior’s verified V2 ABI at `0x438982ea288763370946625fd76c2508ee1fb229`.
- Preflight queue debt, owner shares and reserve-backed capacity; refuse a non-full redemption before building `redeem()` with `WithdrawalPending` / `redemption_capacity_limited`.
- Preserve existing cSigma USD and other registered cSigma adapter behaviour.
- Add exact-deployment queue and full-fill-boundary coverage, and correct the cSigma ABI documentation.

## Related issues and PRs

- Follow-up to #1375.
- Addresses [the remaining cSigma partial-fill review item](https://github.com/tradingstrategy-ai/web3-ethereum-defi/pull/1375#issuecomment-5079051954).

## Unrelated CI and test fixes

None.