### PR TITLE
fix: handle nullable vault supply masks

### DIFF
--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -1009,13 +1009,16 @@ def remove_inactive_lead_time(
         # timestamp label through the index. A vault can have multiple
         # observations with the same timestamp, in which case get_loc()
         # returns a slice rather than one integer position.
-        first_valid_loc = int(valid_supply_mask.to_numpy().argmax())
+        first_valid_loc = int(valid_supply_mask.to_numpy(dtype=bool, na_value=False).argmax())
         initial_supply = group.iloc[first_valid_loc]["total_supply"]
 
         # Find the first index where total_supply differs from initial value
         # Only consider rows from first_valid_loc onwards
         remaining_group = group.iloc[first_valid_loc:]
-        supply_changed_mask = remaining_group["total_supply"] != initial_supply
+        # The raw Parquet is read using the PyArrow nullable dtype backend.
+        # A missing supply reading is not an activation change, and must not
+        # leave ``pd.NA`` values in the NumPy array used to locate a change.
+        supply_changed_mask = (remaining_group["total_supply"] != initial_supply).fillna(False)
 
         if not supply_changed_mask.any():
             # Total supply never changed after initial valid value - keep from first valid
@@ -1025,7 +1028,7 @@ def remove_inactive_lead_time(
             return remaining_group
 
         # Get the index of the first change
-        first_change_loc = int(supply_changed_mask.to_numpy().argmax())
+        first_change_loc = int(supply_changed_mask.to_numpy(dtype=bool, na_value=False).argmax())
 
         # Calculate total rows to remove (invalid initial rows + constant supply rows)
         total_lead_rows = first_valid_loc + first_change_loc

--- a/tests/research/test_clean_prices.py
+++ b/tests/research/test_clean_prices.py
@@ -298,6 +298,27 @@ def test_remove_inactive_lead_time_with_duplicate_timestamps():
     assert duplicate_activation.index.duplicated().any()
 
 
+def test_remove_inactive_lead_time_with_nullable_pyarrow_supply():
+    """Ignore missing supply readings when locating the first supply change.
+
+    ``generate_cleaned_vault_datasets()`` loads raw Parquet with
+    ``dtype_backend="pyarrow"``. A missing supply therefore becomes
+    ``pd.NA`` rather than ``numpy.nan``. The mask must remain usable even
+    when the missing reading follows the first detected supply change.
+    """
+    df = pd.DataFrame(
+        {
+            "id": ["nullable-supply-vault"] * 5,
+            "total_supply": pd.array([100, 0, None, 0, 200], dtype="float64[pyarrow]"),
+            "timestamp": pd.date_range("2026-07-01", periods=5, freq="h"),
+        }
+    ).set_index("timestamp")
+
+    result = remove_inactive_lead_time(df, logger=lambda _: None)
+
+    assert result["total_supply"].tolist() == [0.0, pd.NA, 0.0, 200.0]
+
+
 def test_approximate_hypercore_share_prices_from_pnl_nav() -> None:
     """PnL changes drive the clean index while capital flows leave it flat."""
     prices_df = pd.DataFrame(


### PR DESCRIPTION
## Why

The clean-price pipeline reads raw Parquet with nullable PyArrow dtypes. A missing `total_supply` produced `pd.NA` in the supply-change mask, causing NumPy `argmax()` to fail and skipping clean-price and top-vault exports.

## Lessons learnt

When converting Pandas nullable Boolean masks for NumPy positional operations, materialise missing values as `False`. Missing supply readings are not activation changes.

## Summary

- Materialise valid-supply and supply-change masks as non-null Boolean arrays before locating positions.
- Add a regression test for nullable PyArrow `total_supply` after an activation change.

## Related issues and PRs

- Follow-up to #1367, which fixed duplicate timestamps but introduced this nullable-mask regression.

## Unrelated CI and test fixes

- None.