### PR TITLE
fix: preflight IPOR and 40acres redemptions

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/forty_acres/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/forty_acres/deposit_redeem.py
@@ -22,16 +22,26 @@ logger = logging.getLogger(__name__)
 #: OpenZeppelin 5's ``ERC20InsufficientBalance`` custom error.
 FORTY_ACRES_INSUFFICIENT_LIQUIDITY_ERROR = "ERC20: transfer amount exceeds balance"
 
+#: Exact Pharaoh deployment whose verified ``redeem()`` path transfers USDC
+#: directly from the vault and cannot source loan-deployed capital.
+PHARAOH_USDC_AVALANCHE_ADDRESS: HexAddress = "0x124d00b1ce4453ffc5a5f65ce83af13a7709bac7"
+PHARAOH_USDC_AVALANCHE_CHAIN_ID = 43114
+
 
 class FortyAcresDepositManager(ERC4626DepositManager):
-    """40acres ERC-4626 manager with a direct-underlying redemption preflight.
+    """Pharaoh ERC-4626 manager with a direct-underlying redemption preflight.
 
-    40acres includes deployed loans in ``totalAssets()``, but its verified
-    ERC-4626 ``redeem()`` implementation pays lenders by directly transferring
-    the underlying from the vault. It cannot pull liquidity from its loan
-    contract during a redemption. This manager therefore limits an immediate
-    redemption to the current underlying balance held by the vault and refuses
-    a larger request before constructing ``redeem()``.
+    The exact Pharaoh deployment includes loan-deployed assets in
+    ``totalAssets()``, but its verified ``redeem()`` implementation pays lenders
+    by directly transferring the underlying from the vault. It cannot pull
+    liquidity from its loan contract during a redemption. This manager therefore
+    limits an immediate redemption to the current underlying balance held by the
+    vault and refuses a larger request before constructing ``redeem()``.
+
+    Other 40acres deployments use the generic ERC-4626 manager. The direct
+    balance rule is not generalised from this one verified deployment because
+    Aerodrome, for example, has independently demonstrated a successful
+    redemption with no meaningful idle balance.
 
     Deposits remain the inherited synchronous ERC-4626 flow. Redemptions remain
     synchronous too; the manager does not model a loan repayment queue because
@@ -42,8 +52,8 @@ class FortyAcresDepositManager(ERC4626DepositManager):
         """Bind the manager to a 40acres vault.
 
         :param vault:
-            40acres ERC-4626 vault whose direct underlying balance authorises
-            immediate redemptions.
+            Exact Pharaoh ERC-4626 vault whose direct underlying balance
+            authorises immediate redemptions.
         """
         super().__init__(vault)
 

--- a/eth_defi/erc_4626/vault_protocol/forty_acres/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/forty_acres/deposit_redeem.py
@@ -1,0 +1,169 @@
+"""Immediate-liquidity preflight for 40acres ERC-4626 redemptions."""
+
+# ruff: noqa: FBT001, FBT002, PLR0917
+
+import logging
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from eth_typing import HexAddress
+from web3.exceptions import BadFunctionCallOutput, ContractLogicError, Web3RPCError
+
+from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager, ERC4626RedemptionRequest
+from eth_defi.vault.deposit_redeem import VaultFlowUnavailable
+
+if TYPE_CHECKING:
+    from eth_defi.erc_4626.vault_protocol.forty_acres.vault import FortyAcresVault
+
+logger = logging.getLogger(__name__)
+
+#: Legacy ERC-20 revert emitted when the vault's direct USDC transfer cannot
+#: cover a synchronous redemption. The exact Pharaoh deployment does not use
+#: OpenZeppelin 5's ``ERC20InsufficientBalance`` custom error.
+FORTY_ACRES_INSUFFICIENT_LIQUIDITY_ERROR = "ERC20: transfer amount exceeds balance"
+
+
+class FortyAcresDepositManager(ERC4626DepositManager):
+    """40acres ERC-4626 manager with a direct-underlying redemption preflight.
+
+    40acres includes deployed loans in ``totalAssets()``, but its verified
+    ERC-4626 ``redeem()`` implementation pays lenders by directly transferring
+    the underlying from the vault. It cannot pull liquidity from its loan
+    contract during a redemption. This manager therefore limits an immediate
+    redemption to the current underlying balance held by the vault and refuses
+    a larger request before constructing ``redeem()``.
+
+    Deposits remain the inherited synchronous ERC-4626 flow. Redemptions remain
+    synchronous too; the manager does not model a loan repayment queue because
+    the protocol exposes no public redemption request or claim lifecycle.
+    """
+
+    def __init__(self, vault: "FortyAcresVault") -> None:
+        """Bind the manager to a 40acres vault.
+
+        :param vault:
+            40acres ERC-4626 vault whose direct underlying balance authorises
+            immediate redemptions.
+        """
+        super().__init__(vault)
+
+    @property
+    def vault(self) -> "FortyAcresVault":
+        """Return the bound 40acres vault with its concrete type.
+
+        :return:
+            Bound 40acres vault adapter.
+        """
+        return self._vault
+
+    @vault.setter
+    def vault(self, vault: "FortyAcresVault") -> None:
+        """Store the vault accepted by the shared manager constructor.
+
+        :param vault:
+            40acres vault to retain for request creation.
+        """
+        self._vault = vault
+
+    def fetch_redeemable_raw_shares(self, owner: HexAddress) -> int:
+        """Read the owner-bounded share amount the vault can redeem immediately.
+
+        The verified 40acres implementation is standard OpenZeppelin ERC-4626:
+        its ``_withdraw()`` transfers the requested assets directly from the
+        vault. ``totalAssets()`` also includes lent capital and is therefore not
+        a payout authority. A failed balance or conversion read is fail-closed
+        and reports zero capacity.
+
+        :param owner:
+            Address whose shares would be redeemed.
+        :return:
+            Maximum raw shares that can be redeemed in full immediately.
+        """
+        try:
+            owner_raw_shares = int(self.vault.vault_contract.functions.balanceOf(owner).call())
+            idle_raw_assets = int(self.vault.denomination_token.fetch_raw_balance_of(self.vault.address))
+            idle_raw_shares = int(self.vault.vault_contract.functions.convertToShares(idle_raw_assets).call())
+        except (BadFunctionCallOutput, ContractLogicError, Web3RPCError, ValueError) as error:
+            logger.warning(
+                "Cannot read 40acres immediate redemption capacity for vault %s on chain %d: %s",
+                self.vault.address,
+                self.vault.chain_id,
+                error,
+            )
+            return 0
+
+        return min(owner_raw_shares, idle_raw_shares)
+
+    def create_redemption_request(
+        self,
+        owner: HexAddress,
+        to: HexAddress | None = None,
+        shares: Decimal | None = None,
+        raw_shares: int | None = None,
+        check_max_deposit: bool = True,
+        check_enough_token: bool = True,
+        check_max_redeem: bool = True,
+    ) -> ERC4626RedemptionRequest:
+        """Preflight 40acres liquidity before constructing a redemption call.
+
+        :param owner:
+            Share owner and transaction caller.
+        :param to:
+            Unsupported alternative receiver retained for the shared API.
+        :param shares:
+            Human-readable share amount when ``raw_shares`` is absent.
+        :param raw_shares:
+            Native share amount to redeem.
+        :param check_max_deposit:
+            Retained for shared manager API compatibility.
+        :param check_enough_token:
+            Whether the inherited manager checks the owner share balance.
+        :param check_max_redeem:
+            Whether to enforce the protocol-specific immediate liquidity cap.
+        :return:
+            Synchronous ERC-4626 redemption request when capacity is sufficient.
+        :raises VaultFlowUnavailable:
+            If the requested redemption exceeds direct underlying liquidity.
+        """
+        if raw_shares is None:
+            assert shares is not None, "Either raw_shares or shares must be supplied"
+            raw_shares = self.vault.share_token.convert_to_raw(shares)
+
+        if check_max_redeem:
+            available_raw_shares = self.fetch_redeemable_raw_shares(owner)
+            if raw_shares > available_raw_shares:
+                reason = "40acres vault lacks immediate underlying liquidity for redemption"
+                raise VaultFlowUnavailable(
+                    reason,
+                    protocol=self.vault.get_protocol_name(),
+                    vault_address=self.vault.address,
+                    caller=owner,
+                    direction="redeem",
+                    phase="preflight",
+                    decoded_error=FORTY_ACRES_INSUFFICIENT_LIQUIDITY_ERROR,
+                    preflight_result="redemption_capacity_limited",
+                    requested_raw_amount=raw_shares,
+                    available_raw_amount=available_raw_shares,
+                )
+
+        return super().create_redemption_request(
+            owner=owner,
+            to=to,
+            shares=shares,
+            raw_shares=raw_shares,
+            check_max_deposit=check_max_deposit,
+            check_enough_token=check_enough_token,
+            # OpenZeppelin's generic maxRedeem() returns owner shares and does
+            # not describe 40acres' direct-underlying payout capacity.
+            check_max_redeem=False,
+        )
+
+    def can_create_redemption_request(self, owner: HexAddress) -> bool:
+        """Report whether 40acres has any immediate redemption liquidity.
+
+        :param owner:
+            Address whose current redemption capacity is checked.
+        :return:
+            ``True`` when at least one raw share can complete immediately.
+        """
+        return self.fetch_redeemable_raw_shares(owner) > 0

--- a/eth_defi/erc_4626/vault_protocol/forty_acres/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/forty_acres/vault.py
@@ -27,7 +27,7 @@ from eth_typing import BlockIdentifier
 
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.vault import ERC4626Vault
-from eth_defi.erc_4626.vault_protocol.forty_acres.deposit_redeem import FortyAcresDepositManager
+from eth_defi.erc_4626.vault_protocol.forty_acres.deposit_redeem import PHARAOH_USDC_AVALANCHE_ADDRESS, PHARAOH_USDC_AVALANCHE_CHAIN_ID, FortyAcresDepositManager
 from eth_defi.vault.deposit_redeem import VaultDepositManager
 
 logger = logging.getLogger(__name__)
@@ -149,10 +149,12 @@ class FortyAcresVault(ERC4626Vault):
         return "https://app.40acres.finance/"
 
     def get_deposit_manager(self) -> VaultDepositManager:
-        """Create the 40acres manager with redemption-liquidity preflight.
+        """Create the deployment-specific 40acres redemption manager.
 
         :return:
-            Specialised synchronous manager that refuses a redemption the vault
-            cannot pay from its direct underlying balance.
+            The specialised Pharaoh manager when its exact deployment is bound;
+            otherwise the generic ERC-4626 manager.
         """
-        return FortyAcresDepositManager(self)
+        if self.chain_id == PHARAOH_USDC_AVALANCHE_CHAIN_ID and self.address.lower() == PHARAOH_USDC_AVALANCHE_ADDRESS:
+            return FortyAcresDepositManager(self)
+        return super().get_deposit_manager()

--- a/eth_defi/erc_4626/vault_protocol/forty_acres/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/forty_acres/vault.py
@@ -27,6 +27,8 @@ from eth_typing import BlockIdentifier
 
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.erc_4626.vault_protocol.forty_acres.deposit_redeem import FortyAcresDepositManager
+from eth_defi.vault.deposit_redeem import VaultDepositManager
 
 logger = logging.getLogger(__name__)
 
@@ -145,3 +147,12 @@ class FortyAcresVault(ERC4626Vault):
     def get_link(self, referral: str | None = None) -> str:
         """Link to the 40acres app."""
         return "https://app.40acres.finance/"
+
+    def get_deposit_manager(self) -> VaultDepositManager:
+        """Create the 40acres manager with redemption-liquidity preflight.
+
+        :return:
+            Specialised synchronous manager that refuses a redemption the vault
+            cannot pay from its direct underlying balance.
+        """
+        return FortyAcresDepositManager(self)

--- a/eth_defi/erc_4626/vault_protocol/ipor/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/ipor/deposit_redeem.py
@@ -2,17 +2,33 @@
 
 # ruff: noqa: FBT001, FBT002, PLR0917
 
+import logging
 from decimal import Decimal
 from typing import TYPE_CHECKING, Literal
 
 from eth_typing import HexAddress
 from hexbytes import HexBytes
+from web3.exceptions import BadFunctionCallOutput, ContractLogicError, Web3RPCError
 
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager, ERC4626DepositRequest, ERC4626RedemptionRequest
 from eth_defi.vault.deposit_redeem import VaultFlowUnavailable
 
 if TYPE_CHECKING:
     from eth_defi.erc_4626.vault_protocol.ipor.vault import IPORVault
+
+logger = logging.getLogger(__name__)
+
+#: Exact Base Autopilot deployment whose PlasmaVault redemption path needs a
+#: protocol-specific liquidity simulation. Other IPOR vaults retain their
+#: existing access-manager-only flow until their deployed market fuses are
+#: characterised separately.
+IPOR_AUTOPILOT_USDC_MORPHO_BASE_ADDRESS = "0xd6701905c59ee618dc36dc747506bce0a4ac760a"
+IPOR_AUTOPILOT_USDC_MORPHO_BASE_CHAIN_ID = 8453
+
+#: ``FailedInnerCall()`` emitted by OpenZeppelin's ``Address`` utility when
+#: PlasmaVault cannot withdraw enough underlying from one of its configured
+#: markets. ``keccak("FailedInnerCall()")[:4]``.
+IPOR_FAILED_INNER_CALL_SELECTOR = HexBytes("0x1425ea42")
 
 
 class IPORDepositManager(ERC4626DepositManager):
@@ -44,9 +60,11 @@ class IPORDepositManager(ERC4626DepositManager):
     calls :meth:`_assert_immediate_access` for the redemption selector
     (``redeem(uint256,address,address)``) — resolved independently, because the
     access policy can differ from the deposit selector — then delegates to the
-    base manager. There is no reserve/buffer capacity model here beyond the
-    inherited ERC-4626 checks (``maxRedeem`` is unreliable on IPOR and is
-    skipped).
+    base manager. The characterised Autopilot USDC Morpho deployment on Base
+    also simulates its exact ``redeem()`` path and refuses a full-fill request
+    that its market fuses cannot satisfy immediately. Other IPOR deployments
+    retain the inherited ERC-4626 checks, because their market liquidity has
+    not been characterised.
 
     **Queues and settlement**
 
@@ -149,6 +167,85 @@ class IPORDepositManager(ERC4626DepositManager):
             access_delay=delay,
         )
 
+    def _uses_liquidity_preflight(self) -> bool:
+        """Check whether this exact IPOR deployment has a characterised liquidity gate.
+
+        IPOR PlasmaVault market fuses are deployment-specific: some can release
+        liquidity during ``redeem()``, while others cannot. Restrict the
+        fail-closed simulation to the characterised Autopilot USDC Morpho vault
+        rather than inferring all IPOR liquidity from idle token balances.
+
+        :return:
+            ``True`` for the exact Base Autopilot USDC Morpho deployment.
+        """
+        return self.vault.chain_id == IPOR_AUTOPILOT_USDC_MORPHO_BASE_CHAIN_ID and self.vault.address.lower() == IPOR_AUTOPILOT_USDC_MORPHO_BASE_ADDRESS
+
+    def _redeem_would_succeed(self, owner: HexAddress, raw_shares: int) -> bool:
+        """Simulate PlasmaVault's exact redemption path without broadcasting it.
+
+        PlasmaVault's ``_redeem()`` requests liquidity from its configured
+        market fuses before transferring the underlying. Its ``maxRedeem()``
+        only reports the owner's share balance, so an ``eth_call`` to the exact
+        ``redeem()`` path is the authoritative immediate-liquidity predicate.
+        Any unreadable state is deliberately treated as unavailable.
+
+        :param owner:
+            Share owner and simulated transaction sender.
+        :param raw_shares:
+            Native share amount to simulate.
+        :return:
+            ``True`` only if the full redemption call returns successfully.
+        """
+        try:
+            self.vault.vault_contract.functions.redeem(raw_shares, owner, owner).call({"from": owner})
+        except (BadFunctionCallOutput, ContractLogicError, Web3RPCError, ValueError):
+            return False
+        return True
+
+    def fetch_redeemable_raw_shares(self, owner: HexAddress) -> int:
+        """Find the largest immediate full-fill redemption for Autopilot shares.
+
+        The verified PlasmaVault implementation repeatedly invokes
+        ``_withdrawFromMarkets()`` before its ERC-4626 transfer. A redemption
+        is monotonic in requested shares for this deployment, so binary search
+        over the owner balance yields the actual immediately executable cap
+        without mutating onchain state. Read or simulation failures fail closed
+        to zero.
+
+        :param owner:
+            Address whose Autopilot shares are being preflighted.
+        :return:
+            Maximum raw shares that can be redeemed in full immediately.
+        """
+        if not self._uses_liquidity_preflight():
+            return int(self.vault.vault_contract.functions.balanceOf(owner).call())
+
+        try:
+            owner_raw_shares = int(self.vault.vault_contract.functions.balanceOf(owner).call())
+        except (BadFunctionCallOutput, ContractLogicError, Web3RPCError, ValueError) as error:
+            logger.warning(
+                "Cannot read IPOR redemption shares for vault %s on chain %d: %s",
+                self.vault.address,
+                self.vault.chain_id,
+                error,
+            )
+            return 0
+
+        if owner_raw_shares == 0:
+            return 0
+        if self._redeem_would_succeed(owner, owner_raw_shares):
+            return owner_raw_shares
+
+        lower_bound = 0
+        upper_bound = owner_raw_shares
+        while upper_bound - lower_bound > 1:
+            candidate = (lower_bound + upper_bound) // 2
+            if self._redeem_would_succeed(owner, candidate):
+                lower_bound = candidate
+            else:
+                upper_bound = candidate
+        return lower_bound
+
     def create_deposit_request(
         self,
         owner: HexAddress,
@@ -193,8 +290,9 @@ class IPORDepositManager(ERC4626DepositManager):
         raw_shares: int | None = None,
         check_max_deposit: bool = True,
         check_enough_token: bool = True,
+        check_max_redeem: bool = True,
     ) -> ERC4626RedemptionRequest:
-        """Create a standard ERC-4626 redemption after access admission.
+        """Create a standard ERC-4626 redemption after access and liquidity preflight.
 
         :param owner:
             Account submitting and signing the redemption.
@@ -208,10 +306,35 @@ class IPORDepositManager(ERC4626DepositManager):
             Compatibility argument forwarded to the shared manager.
         :param check_enough_token:
             Whether to run the shared share-balance check.
+        :param check_max_redeem:
+            Whether to check immediately redeemable capacity.
         :return:
             Preflighted redemption request.
         """
         self._assert_immediate_access(owner, self.vault.get_redeem_function_selector(), "redeem")
+        if raw_shares is None:
+            assert shares is not None, "Either raw_shares or shares must be supplied"
+            raw_shares = self.vault.share_token.convert_to_raw(shares)
+
+        uses_liquidity_preflight = self._uses_liquidity_preflight()
+        if check_max_redeem and uses_liquidity_preflight:
+            available_raw_shares = self.fetch_redeemable_raw_shares(owner)
+            if raw_shares > available_raw_shares:
+                reason = "IPOR PlasmaVault cannot source immediate redemption liquidity from configured markets"
+                raise VaultFlowUnavailable(
+                    reason,
+                    protocol="IPOR Fusion",
+                    vault_address=self.vault.address,
+                    caller=owner,
+                    direction="redeem",
+                    phase="preflight",
+                    decoded_error="FailedInnerCall",
+                    preflight_result="redemption_capacity_limited",
+                    error_selector=IPOR_FAILED_INNER_CALL_SELECTOR,
+                    requested_raw_amount=raw_shares,
+                    available_raw_amount=available_raw_shares,
+                )
+
         return super().create_redemption_request(
             owner=owner,
             to=to,
@@ -219,6 +342,7 @@ class IPORDepositManager(ERC4626DepositManager):
             raw_shares=raw_shares,
             check_max_deposit=check_max_deposit,
             check_enough_token=check_enough_token,
+            check_max_redeem=not uses_liquidity_preflight and check_max_redeem,
         )
 
     def can_create_deposit_request(self, owner: HexAddress) -> bool:
@@ -247,4 +371,6 @@ class IPORDepositManager(ERC4626DepositManager):
             self._assert_immediate_access(owner, self.vault.get_redeem_function_selector(), "redeem")
         except (VaultFlowUnavailable, NotImplementedError):
             return False
-        return True
+        if not self._uses_liquidity_preflight():
+            return True
+        return self.fetch_redeemable_raw_shares(owner) > 0

--- a/tests/erc_4626/vault_protocol/test_forty_acres.py
+++ b/tests/erc_4626/vault_protocol/test_forty_acres.py
@@ -14,24 +14,24 @@ from web3 import Web3
 
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature
-from eth_defi.erc_4626.vault_protocol.forty_acres.deposit_redeem import FORTY_ACRES_INSUFFICIENT_LIQUIDITY_ERROR, FortyAcresDepositManager
+from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
+from eth_defi.erc_4626.vault_protocol.forty_acres.deposit_redeem import FORTY_ACRES_INSUFFICIENT_LIQUIDITY_ERROR, PHARAOH_USDC_AVALANCHE_ADDRESS, FortyAcresDepositManager
 from eth_defi.erc_4626.vault_protocol.forty_acres.vault import FortyAcresVault
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil, fund_erc20_on_anvil, set_balance
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
-from eth_defi.testing.fork_blocks import AVALANCHE_MIDNIGHT_BLOCK
+from eth_defi.testing.fork_blocks import AVALANCHE_MIDNIGHT_BLOCK, BASE_MIDNIGHT_BLOCK
+from eth_defi.token import USDC_WHALE
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.vault.deposit_redeem import VaultFlowUnavailable
 
 JSON_RPC_AVALANCHE = os.environ.get("JSON_RPC_AVALANCHE")
+JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
 
-PHARAOH_USDC_VAULT = "0x124d00b1ce4453ffc5a5f65ce83af13a7709bac7"
-
-pytestmark = pytest.mark.skipif(
-    JSON_RPC_AVALANCHE is None,
-    reason="JSON_RPC_AVALANCHE needed to run these tests",
-)
+#: Exact 40acres Aerodrome deployment whose live redemption proves that the
+#: Pharaoh direct-balance rule is not protocol-wide.
+AERODROME_USDC_VAULT = "0xb99b6df96d4d5448cc0a5b3e0ef7896df9507cf5"
 
 
 @pytest.fixture(scope="module")
@@ -56,7 +56,7 @@ def pharaoh_avalanche_fork(anvil_fork_pool: AnvilForkPool) -> AnvilLaunch:
     return anvil_fork_pool.get_launch(
         JSON_RPC_AVALANCHE,
         AVALANCHE_MIDNIGHT_BLOCK,
-        unlocked_addresses=[PHARAOH_USDC_VAULT],
+        unlocked_addresses=[PHARAOH_USDC_AVALANCHE_ADDRESS],
     )
 
 
@@ -72,6 +72,29 @@ def pharaoh_avalanche_snapshot(pharaoh_avalanche_fork: AnvilLaunch) -> Iterator[
     yield from evm_snapshot_revert(pharaoh_avalanche_fork)
 
 
+@pytest.fixture(scope="module")
+def aerodrome_base_fork(anvil_fork_pool: AnvilForkPool) -> AnvilLaunch:
+    """Share the canonical Base fork with the USDC whale unlocked."""
+    return anvil_fork_pool.get_launch(
+        JSON_RPC_BASE,
+        BASE_MIDNIGHT_BLOCK,
+        unlocked_addresses=[USDC_WHALE[8453]],
+    )
+
+
+@pytest.fixture(scope="module")
+def aerodrome_base_web3(aerodrome_base_fork: AnvilLaunch) -> Web3:
+    """Connect to the shared Base Aerodrome fork."""
+    return create_multi_provider_web3(aerodrome_base_fork.json_rpc_url)
+
+
+@pytest.fixture
+def aerodrome_base_snapshot(aerodrome_base_fork: AnvilLaunch) -> Iterator[None]:
+    """Restore the mutating Aerodrome fork after the redemption test."""
+    yield from evm_snapshot_revert(aerodrome_base_fork)
+
+
+@pytest.mark.skipif(JSON_RPC_AVALANCHE is None, reason="JSON_RPC_AVALANCHE needed to run this test")
 @flaky.flaky
 def test_forty_acres_blackhole(
     web3: Web3,
@@ -102,6 +125,7 @@ def test_forty_acres_blackhole(
     assert vault.get_performance_fee("latest") == 0.0
 
 
+@pytest.mark.skipif(JSON_RPC_AVALANCHE is None, reason="JSON_RPC_AVALANCHE needed to run this test")
 @pytest.mark.xdist_group("fork:avalanche:midnight")
 def test_pharaoh_refuses_redemption_without_direct_underlying_liquidity(
     pharaoh_avalanche_web3: Web3,
@@ -116,7 +140,7 @@ def test_pharaoh_refuses_redemption_without_direct_underlying_liquidity(
     """
     # 1. Fund and deposit USDC into the exact Pharaoh vault at the pinned block.
     assert pharaoh_avalanche_snapshot is None
-    vault = create_vault_instance_autodetect(pharaoh_avalanche_web3, vault_address=PHARAOH_USDC_VAULT)
+    vault = create_vault_instance_autodetect(pharaoh_avalanche_web3, vault_address=PHARAOH_USDC_AVALANCHE_ADDRESS)
     assert isinstance(vault, FortyAcresVault)
     manager = vault.get_deposit_manager()
     assert isinstance(manager, FortyAcresDepositManager)
@@ -159,3 +183,39 @@ def test_pharaoh_refuses_redemption_without_direct_underlying_liquidity(
     assert error.requested_raw_amount == available_raw_shares + 1
     assert error.available_raw_amount == available_raw_shares
     assert pharaoh_avalanche_web3.eth.block_number == block_before_refusal
+
+
+@pytest.mark.skipif(JSON_RPC_BASE is None, reason="JSON_RPC_BASE needed to run this test")
+@pytest.mark.xdist_group("fork:base:midnight")
+def test_aerodrome_uses_generic_manager_and_redeems(
+    aerodrome_base_web3: Web3,
+    aerodrome_base_snapshot: None,
+) -> None:
+    """Aerodrome keeps the generic flow and completes a real redemption.
+
+    Aerodrome has demonstrated a successful redemption despite little idle
+    underlying, so it is the regression control for Pharaoh's address-scoped
+    direct-balance preflight.
+    """
+    assert aerodrome_base_snapshot is None
+    vault = create_vault_instance_autodetect(aerodrome_base_web3, vault_address=AERODROME_USDC_VAULT)
+    assert isinstance(vault, FortyAcresVault)
+    manager = vault.get_deposit_manager()
+    assert isinstance(manager, ERC4626DepositManager)
+    assert not isinstance(manager, FortyAcresDepositManager)
+    owner = aerodrome_base_web3.eth.accounts[0]
+    deposit_amount = Decimal(1)
+    denomination_balance_before = vault.denomination_token.fetch_raw_balance_of(owner)
+    funding_hash = vault.denomination_token.transfer(owner, deposit_amount).transact({"from": USDC_WHALE[8453]})
+    assert_transaction_success_with_explanation(aerodrome_base_web3, funding_hash)
+    approval_hash = vault.denomination_token.approve(vault.address, deposit_amount).transact({"from": owner})
+    assert_transaction_success_with_explanation(aerodrome_base_web3, approval_hash)
+    manager.create_deposit_request(owner=owner, amount=deposit_amount).broadcast(from_=owner)
+    raw_shares = vault.share_token.fetch_raw_balance_of(owner)
+    assert raw_shares > 0
+
+    redemption_ticket = manager.create_redemption_request(owner=owner, raw_shares=raw_shares).broadcast(from_=owner)
+
+    assert redemption_ticket.raw_shares == raw_shares
+    assert vault.share_token.fetch_raw_balance_of(owner) == 0
+    assert vault.denomination_token.fetch_raw_balance_of(owner) > denomination_balance_before

--- a/tests/erc_4626/vault_protocol/test_forty_acres.py
+++ b/tests/erc_4626/vault_protocol/test_forty_acres.py
@@ -5,7 +5,8 @@ with ERC-4626 USDC supply vaults on Avalanche, Base, and Optimism.
 """
 
 import os
-from pathlib import Path
+from collections.abc import Iterator
+from decimal import Decimal
 
 import flaky
 import pytest
@@ -13,11 +14,19 @@ from web3 import Web3
 
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.erc_4626.vault_protocol.forty_acres.deposit_redeem import FORTY_ACRES_INSUFFICIENT_LIQUIDITY_ERROR, FortyAcresDepositManager
 from eth_defi.erc_4626.vault_protocol.forty_acres.vault import FortyAcresVault
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil, fund_erc20_on_anvil, set_balance
 from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
+from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
+from eth_defi.testing.fork_blocks import AVALANCHE_MIDNIGHT_BLOCK
+from eth_defi.trace import assert_transaction_success_with_explanation
+from eth_defi.vault.deposit_redeem import VaultFlowUnavailable
 
 JSON_RPC_AVALANCHE = os.environ.get("JSON_RPC_AVALANCHE")
+
+PHARAOH_USDC_VAULT = "0x124d00b1ce4453ffc5a5f65ce83af13a7709bac7"
 
 pytestmark = pytest.mark.skipif(
     JSON_RPC_AVALANCHE is None,
@@ -26,7 +35,7 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.fixture(scope="module")
-def anvil_avalanche_fork(request) -> AnvilLaunch:
+def anvil_avalanche_fork() -> AnvilLaunch:
     """Fork Avalanche at a specific block for reproducibility."""
     launch = fork_network_anvil(JSON_RPC_AVALANCHE, fork_block_number=84244698)
     try:
@@ -41,10 +50,31 @@ def web3(anvil_avalanche_fork: AnvilLaunch):
     return web3
 
 
+@pytest.fixture(scope="module")
+def pharaoh_avalanche_fork(anvil_fork_pool: AnvilForkPool) -> AnvilLaunch:
+    """Share the canonical Avalanche fork for Pharaoh redemption capacity."""
+    return anvil_fork_pool.get_launch(
+        JSON_RPC_AVALANCHE,
+        AVALANCHE_MIDNIGHT_BLOCK,
+        unlocked_addresses=[PHARAOH_USDC_VAULT],
+    )
+
+
+@pytest.fixture(scope="module")
+def pharaoh_avalanche_web3(pharaoh_avalanche_fork: AnvilLaunch) -> Web3:
+    """Connect to the shared Avalanche Pharaoh fork."""
+    return create_multi_provider_web3(pharaoh_avalanche_fork.json_rpc_url)
+
+
+@pytest.fixture
+def pharaoh_avalanche_snapshot(pharaoh_avalanche_fork: AnvilLaunch) -> Iterator[None]:
+    """Restore the mutating Pharaoh fork after the liquidity test."""
+    yield from evm_snapshot_revert(pharaoh_avalanche_fork)
+
+
 @flaky.flaky
 def test_forty_acres_blackhole(
     web3: Web3,
-    tmp_path: Path,
 ):
     """Read 40acres Blackhole USDC vault metadata on Avalanche.
 
@@ -70,3 +100,62 @@ def test_forty_acres_blackhole(
     # fee"), not None, which the vault API reserves for "fee not exposed".
     assert vault.get_management_fee("latest") == 0.0
     assert vault.get_performance_fee("latest") == 0.0
+
+
+@pytest.mark.xdist_group("fork:avalanche:midnight")
+def test_pharaoh_refuses_redemption_without_direct_underlying_liquidity(
+    pharaoh_avalanche_web3: Web3,
+    pharaoh_avalanche_snapshot: None,
+) -> None:
+    """Pharaoh refuses a redemption that its direct USDC balance cannot pay.
+
+    1. Fund and deposit USDC into the exact Pharaoh vault at the pinned block.
+    2. Drain direct underlying on Anvil to model loan-deployed capital.
+    3. Prove the measured partial capacity is accepted and one raw share above is refused.
+    4. Verify the 40acres preflight refuses before any redeem transaction exists.
+    """
+    # 1. Fund and deposit USDC into the exact Pharaoh vault at the pinned block.
+    assert pharaoh_avalanche_snapshot is None
+    vault = create_vault_instance_autodetect(pharaoh_avalanche_web3, vault_address=PHARAOH_USDC_VAULT)
+    assert isinstance(vault, FortyAcresVault)
+    manager = vault.get_deposit_manager()
+    assert isinstance(manager, FortyAcresDepositManager)
+    owner = pharaoh_avalanche_web3.eth.accounts[0]
+    raw_deposit_amount = vault.denomination_token.convert_to_raw(Decimal(1))
+    fund_erc20_on_anvil(pharaoh_avalanche_web3, vault.denomination_token.address, owner, raw_deposit_amount)
+    approval_hash = vault.denomination_token.approve(vault.address, Decimal(1)).transact({"from": owner})
+    assert_transaction_success_with_explanation(pharaoh_avalanche_web3, approval_hash)
+    manager.create_deposit_request(owner=owner, raw_amount=raw_deposit_amount).broadcast(from_=owner)
+    raw_shares = vault.share_token.fetch_raw_balance_of(owner)
+    assert raw_shares > 0
+    assert manager.create_redemption_request(owner=owner, raw_shares=raw_shares).funcs
+
+    # 2. Drain all but half a USDC unit on Anvil to model deployed loan capital.
+    set_balance(pharaoh_avalanche_web3, vault.address, 10**18)
+    idle_raw_assets = vault.denomination_token.fetch_raw_balance_of(vault.address)
+    assert idle_raw_assets >= raw_deposit_amount
+    remaining_raw_assets = raw_deposit_amount // 2
+    drain_hash = vault.denomination_token.transfer(
+        pharaoh_avalanche_web3.eth.accounts[1],
+        vault.denomination_token.convert_to_decimals(idle_raw_assets - remaining_raw_assets),
+    ).transact({"from": vault.address})
+    assert_transaction_success_with_explanation(pharaoh_avalanche_web3, drain_hash)
+    assert vault.denomination_token.fetch_raw_balance_of(vault.address) == remaining_raw_assets
+
+    # 3. Construct a redemption at the real cap, then attempt one raw share above it.
+    available_raw_shares = manager.fetch_redeemable_raw_shares(owner)
+    assert 0 < available_raw_shares < raw_shares
+    assert manager.create_redemption_request(owner=owner, raw_shares=available_raw_shares).funcs
+    block_before_refusal = pharaoh_avalanche_web3.eth.block_number
+    with pytest.raises(VaultFlowUnavailable) as exc_info:
+        manager.create_redemption_request(owner=owner, raw_shares=available_raw_shares + 1)
+
+    # 4. Verify the 40acres preflight refuses before any redeem transaction exists.
+    error = exc_info.value
+    assert error.preflight_result == "redemption_capacity_limited"
+    assert error.decoded_error == FORTY_ACRES_INSUFFICIENT_LIQUIDITY_ERROR
+    assert error.direction == "redeem"
+    assert error.phase == "preflight"
+    assert error.requested_raw_amount == available_raw_shares + 1
+    assert error.available_raw_amount == available_raw_shares
+    assert pharaoh_avalanche_web3.eth.block_number == block_before_refusal

--- a/tests/erc_4626/vault_protocol/test_ipor.py
+++ b/tests/erc_4626/vault_protocol/test_ipor.py
@@ -1,21 +1,31 @@
 """IPOR Fusion vault tests."""
 
 import os
+from collections.abc import Iterator
 from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 from web3 import Web3
 
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
-from eth_defi.erc_4626.vault_protocol.ipor.deposit_redeem import IPORDepositManager
+from eth_defi.erc_4626.vault_protocol.ipor.deposit_redeem import IPOR_AUTOPILOT_USDC_MORPHO_BASE_ADDRESS, IPOR_FAILED_INNER_CALL_SELECTOR, IPORDepositManager
 from eth_defi.erc_4626.vault_protocol.ipor.vault import IPORVault
+from eth_defi.provider.anvil import AnvilLaunch
 from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
+from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
+from eth_defi.testing.fork_blocks import BASE_MIDNIGHT_BLOCK
+from eth_defi.token import USDC_WHALE
+from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.deposit_redeem import VaultFlowUnavailable
 from eth_defi.vault.fee import FeeData, VaultFeeMode
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
+JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
 
 #: Bitcoin Dollar USDC vault on Ethereum.
 #:
@@ -31,6 +41,28 @@ REPORT_CALLER = "0xa2b04c6a053ab2efbc699f5dd0f0957742a41629"
 
 #: This fee has been set to 0 on-chain as of 2026-05-22.
 IPOR_BDUSD_DEPOSIT_FEE = 0.0
+
+
+@pytest.fixture(scope="module")
+def autopilot_base_fork(anvil_fork_pool: AnvilForkPool) -> AnvilLaunch:
+    """Share the fixed Base fork with the USDC whale unlocked for Autopilot."""
+    return anvil_fork_pool.get_launch(
+        JSON_RPC_BASE,
+        BASE_MIDNIGHT_BLOCK,
+        unlocked_addresses=[USDC_WHALE[8453]],
+    )
+
+
+@pytest.fixture(scope="module")
+def autopilot_base_web3(autopilot_base_fork: AnvilLaunch) -> Web3:
+    """Connect to the shared Base Autopilot fork."""
+    return create_multi_provider_web3(autopilot_base_fork.json_rpc_url)
+
+
+@pytest.fixture
+def autopilot_base_snapshot(autopilot_base_fork: AnvilLaunch) -> Iterator[None]:
+    """Restore the mutating Autopilot fork after every liquidity test."""
+    yield from evm_snapshot_revert(autopilot_base_fork)
 
 
 def test_internalised_fee_mode_preserves_explicit_deposit_fee():
@@ -179,3 +211,93 @@ def test_ipor_without_access_manager_uses_generic_manager() -> None:
         "deposit_flow": "synchronous",
         "redemption_flow": "synchronous",
     }
+
+
+def test_autopilot_liquidity_preflight_observes_partial_redemption_capacity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """IPOR accepts the simulated capacity and refuses exactly one share above it.
+
+    The pinned Base state has zero immediate capacity after a fresh deposit, so
+    this state-level boundary test models a market fuse that serves 61 of 100
+    shares. It proves the binary-search figure is not a constant while the
+    fork test below covers the reported live failure.
+    """
+    owner = "0x0000000000000000000000000000000000000001"
+    expected_capacity = 61
+    balance_of = MagicMock()
+    balance_of.call.return_value = 100
+    vault = SimpleNamespace(
+        chain_id=8453,
+        address=IPOR_AUTOPILOT_USDC_MORPHO_BASE_ADDRESS,
+        vault_contract=SimpleNamespace(functions=SimpleNamespace(balanceOf=lambda _owner: balance_of)),
+        get_redeem_function_selector=lambda: b"\x00\x00\x00\x00",
+    )
+    manager = object.__new__(IPORDepositManager)
+    manager.vault = vault
+    monkeypatch.setattr(manager, "_assert_immediate_access", lambda *_args: None)
+    monkeypatch.setattr(manager, "_redeem_would_succeed", lambda _owner, raw_shares: raw_shares <= expected_capacity)
+    monkeypatch.setattr(
+        ERC4626DepositManager,
+        "create_redemption_request",
+        lambda _manager, **kwargs: kwargs,
+    )
+
+    available_raw_shares = manager.fetch_redeemable_raw_shares(owner)
+
+    assert available_raw_shares == expected_capacity
+    assert manager.create_redemption_request(owner, raw_shares=available_raw_shares)["raw_shares"] == available_raw_shares
+    with pytest.raises(VaultFlowUnavailable) as exc_info:
+        manager.create_redemption_request(owner, raw_shares=available_raw_shares + 1)
+
+    error = exc_info.value
+    assert error.preflight_result == "redemption_capacity_limited"
+    assert error.requested_raw_amount == expected_capacity + 1
+    assert error.available_raw_amount == expected_capacity
+
+
+@pytest.mark.skipif(JSON_RPC_BASE is None, reason="JSON_RPC_BASE needed to run this test")
+@pytest.mark.xdist_group("fork:base:midnight")
+def test_autopilot_usdc_morpho_refuses_unserviceable_redemption_before_broadcast(
+    autopilot_base_web3: Web3,
+    autopilot_base_snapshot: None,
+) -> None:
+    """Autopilot turns its market-liquidity revert into a typed preflight refusal.
+
+    1. Deposit Base USDC into the exact Autopilot USDC Morpho deployment.
+    2. Attempt to construct redemption of every minted share at the pinned block.
+    3. Verify the PlasmaVault liquidity simulation refuses without broadcasting redeem.
+    """
+    # 1. Deposit Base USDC into the exact Autopilot USDC Morpho deployment.
+    assert autopilot_base_snapshot is None
+    vault = IPORVault(
+        autopilot_base_web3,
+        VaultSpec(chain_id=8453, vault_address=IPOR_AUTOPILOT_USDC_MORPHO_BASE_ADDRESS),
+        features={ERC4626Feature.ipor_like},
+    )
+    manager = vault.get_deposit_manager()
+    assert isinstance(manager, IPORDepositManager)
+    owner = autopilot_base_web3.eth.accounts[0]
+    deposit_amount = Decimal(1)
+    usdc = vault.denomination_token
+    funding_hash = usdc.transfer(owner, deposit_amount).transact({"from": USDC_WHALE[8453]})
+    assert_transaction_success_with_explanation(autopilot_base_web3, funding_hash)
+    approval_hash = usdc.approve(vault.address, deposit_amount).transact({"from": owner})
+    assert_transaction_success_with_explanation(autopilot_base_web3, approval_hash)
+    manager.create_deposit_request(owner=owner, amount=deposit_amount).broadcast(from_=owner)
+    raw_shares = vault.share_token.fetch_raw_balance_of(owner)
+    assert raw_shares > 0
+
+    # 2. Attempt to construct redemption of every minted share at the pinned block.
+    block_before_refusal = autopilot_base_web3.eth.block_number
+    with pytest.raises(VaultFlowUnavailable) as exc_info:
+        manager.create_redemption_request(owner=owner, raw_shares=raw_shares)
+
+    # 3. Verify the PlasmaVault liquidity simulation refuses without broadcasting redeem.
+    error = exc_info.value
+    assert error.preflight_result == "redemption_capacity_limited"
+    assert error.decoded_error == "FailedInnerCall"
+    assert error.error_selector == IPOR_FAILED_INNER_CALL_SELECTOR
+    assert error.direction == "redeem"
+    assert error.phase == "preflight"
+    assert error.requested_raw_amount == raw_shares
+    assert error.available_raw_amount == 0
+    assert autopilot_base_web3.eth.block_number == block_before_refusal


### PR DESCRIPTION
## Why

The final two forbidden results in trade-executor’s cross-chain vault matrix were raw redemption reverts. IPOR Autopilot cannot always withdraw from its configured markets, while the exact 40acres Pharaoh deployment can only pay from its direct USDC balance. Both conditions must be reported by the owning adapter before a redemption transaction is built.

## Lessons learnt

- Idle underlying balance is protocol-specific evidence: it is authoritative for Pharaoh’s verified direct-transfer path, but not for a generic ERC-4626 vault or Morpho.
- IPOR PlasmaVault `maxRedeem()` only reports owner shares. Simulating its actual `redeem()` path is the immediate-liquidity authority for the characterised Autopilot deployment.
- Preserve the exact legacy 40acres revert text rather than claiming an OpenZeppelin custom error that the deployed Pharaoh vault does not emit.
- Do not generalise an adapter rule from one same-protocol deployment: Aerodrome is an exact fork-tested regression control and retains the generic manager.

## Summary

- add a Pharaoh-only 40acres deposit manager that caps redemption by direct underlying liquidity and returns typed `redemption_capacity_limited` refusals
- retain the generic ERC-4626 manager for Aerodrome and other 40acres deployments
- add an exact-address IPOR Autopilot preflight that simulates `redeem()` and binary-searches partial immediate capacity
- expose structured preflight context for both target protocols, including decoded causes and requested/available raw share amounts
- add exact pinned-fork tests, including partial-capacity boundaries, no-broadcast assertions, and a real Aerodrome redemption regression test

## Related issues and PRs

- Continues the vault-matrix work in [trade-executor #1578](https://github.com/tradingstrategy-ai/trade-executor/pull/1578), specifically [the IPOR/40acres work order](https://github.com/tradingstrategy-ai/trade-executor/pull/1578#issuecomment-5080713270).
- Follows eth-defi [#1376](https://github.com/tradingstrategy-ai/web3-ethereum-defi/pull/1376), which applied the same typed-preflight approach to cSuperior.

## Unrelated CI and test fixes

None.