### PR TITLE
fix: retain post feed history

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -341,6 +341,9 @@ services:
       USE_X_LIST_TIMELINE: ${USE_X_LIST_TIMELINE:-true}
       SYNC_X_LIST: ${SYNC_X_LIST:-true}
       LOOP_INTERVAL_SECONDS: ${POST_SCAN_LOOP_INTERVAL:-28800}
+      # Retain old feed entries: the post DuckDB database is small, so this
+      # does not create a meaningful storage-growth concern.
+      MAX_POST_AGE_DAYS: ${MAX_POST_AGE_DAYS:-36135}
       LOG_LEVEL: ${LOG_LEVEL:-warning}
       WEBSHARE_API_KEY: ${WEBSHARE_API_KEY:-}
       REFRESH_STABLECOIN_RATES: ${REFRESH_STABLECOIN_RATES:-true}

--- a/eth_defi/feed/README-feed.md
+++ b/eth_defi/feed/README-feed.md
@@ -604,7 +604,7 @@ The first table shows totals for the whole run:
 - **Posts inserted** — genuinely new posts written to the database this run
   (idempotent: re-running inserts 0 if nothing changed)
 - **Posts pruned** — old posts removed by the retention window
-  (`MAX_POST_AGE_DAYS`, default 365)
+  (`MAX_POST_AGE_DAYS`, default 36,135 days / 99 years)
 
 ### Per-source breakdown
 
@@ -639,6 +639,10 @@ Columns:
   nothing new since the last run
 - **Last post** — publish timestamp of the most recent post in the database for
   this source; `-` if no posts have ever been collected
+
+When a scan inserts posts, a third dashboard table lists each new post's title
+or short description, capped at 80 characters. This makes an unexpected
+backfill visible without writing complete post bodies to daemon logs.
 
 ### Failed sources table
 
@@ -686,7 +690,7 @@ Environment variables accepted by the main scanner:
 - `WEBSHARE_API_KEY`: optional Webshare API token for proxy-backed feed fetches
 - `WEBSHARE_PROXY_MODE`: optional Webshare proxy pool mode
 - `MAX_POST_AGE_DAYS`: retention window in days for pruning old posts, default
-  `365`
+  `36135` (99 years)
 - `X_LIST_ID`: optional X list ID override for list sync
 - `X_LIST_NAME`: optional X list name to resolve when `X_LIST_ID` is unset,
   default `Best builders in DeFi`

--- a/eth_defi/feed/collector.py
+++ b/eth_defi/feed/collector.py
@@ -8,7 +8,7 @@ import logging
 import re
 import time
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Iterator, Sequence
 
 import feedparser
@@ -31,6 +31,9 @@ _RETRYABLE_STATUS_CODES = {403, 429, 502, 503, 504}
 #: Status codes that indicate the URL itself is broken, not the proxy.
 #: These should fail immediately without proxy rotation or retry.
 _PERMANENT_FAILURE_STATUS_CODES = {404, 410}
+
+#: Smallest title/description preview that can accommodate an ellipsis.
+_MIN_POST_PREVIEW_LENGTH = 4
 
 
 class AllBridgesFailedError(RuntimeError):
@@ -145,6 +148,12 @@ class CollectedSourceResult:
     posts_fetched: int = 0
     #: Number of inserted posts after deduplication.
     posts_inserted: int = 0
+    #: Titles or short descriptions of posts newly inserted in this scan.
+    #:
+    #: Each preview is normalised and capped at 80 characters for the
+    #: operator dashboard.  The database remains the authoritative store for
+    #: complete post text.
+    inserted_post_previews: list[str] = field(default_factory=list)
     #: Last published timestamp seen in this source, if any.
     last_post_published_at: datetime.datetime | None = None
     #: Error message when the source failed or was skipped.
@@ -240,6 +249,30 @@ def _extract_short_description(entry, full_text: str, max_length: int = 200) -> 
     if title:
         return title[:max_length]
     return full_text[:max_length]
+
+
+def _format_inserted_post_preview(post: CollectedPost, max_length: int = 80) -> str:
+    """Create a bounded dashboard preview for a newly persisted post.
+
+    Titles are preferred because they make the dashboard easy to scan.  Some
+    social posts have no title, so their already-normalised short description
+    becomes the fallback.  The bound keeps a large initial feed backfill from
+    making daemon logs unmanageably wide.
+
+    :param post:
+        Newly inserted normalised post.
+    :param max_length:
+        Maximum preview length, including the ellipsis when truncation occurs.
+    :return:
+        Whitespace-normalised title or short description, capped at
+        ``max_length`` characters.
+    """
+
+    assert max_length >= _MIN_POST_PREVIEW_LENGTH, f"Expected max_length of at least {_MIN_POST_PREVIEW_LENGTH}, got {max_length}"
+    text = _normalise_whitespace(post.title or post.short_description)
+    if len(text) <= max_length:
+        return text
+    return f"{text[: max_length - 3].rstrip()}..."
 
 
 def _extract_published_at(entry) -> datetime.datetime | None:
@@ -689,7 +722,8 @@ def collect_posts(
             summary.source_results.append(source_result)
             continue
 
-        inserted = db.insert_posts(source_id, posts)
+        inserted_posts = db.insert_posts_with_details(source_id, posts)
+        inserted = len(inserted_posts)
         db.mark_source_success(
             source_id,
             checked_at=checked_at,
@@ -699,6 +733,7 @@ def collect_posts(
         summary.posts_fetched += len(posts)
         summary.posts_inserted += inserted
         source_result.posts_inserted = inserted
+        source_result.inserted_post_previews = [_format_inserted_post_preview(post) for post in inserted_posts]
         summary.source_results.append(source_result)
 
     return summary
@@ -801,7 +836,8 @@ def collect_twitter_list_posts(
                 )
 
         latest_post_at = max((post.published_at for post in posts if post.published_at is not None), default=None)
-        inserted = db.insert_posts(source_id, posts)
+        inserted_posts = db.insert_posts_with_details(source_id, posts)
+        inserted = len(inserted_posts)
         db.mark_source_success(
             source_id,
             checked_at=checked_at,
@@ -816,6 +852,7 @@ def collect_twitter_list_posts(
             status="success",
             posts_fetched=len(posts),
             posts_inserted=inserted,
+            inserted_post_previews=[_format_inserted_post_preview(post) for post in inserted_posts],
             last_post_published_at=latest_post_at,
         )
         summary.sources_succeeded += 1

--- a/eth_defi/feed/database.py
+++ b/eth_defi/feed/database.py
@@ -622,11 +622,48 @@ class VaultPostDatabase:
     def insert_posts(self, source_id: int, posts: Iterable[CollectedPost]) -> int:
         """Insert posts for a source and return the number of new rows."""
 
+        return len(self.insert_posts_with_details(source_id, posts))
+
+    def insert_posts_with_details(self, source_id: int, posts: Iterable[CollectedPost]) -> list[CollectedPost]:
+        """Insert posts and return precisely the rows newly persisted.
+
+        Post collection needs the actual inserted entries for operator-facing
+        diagnostics.  Looking only at the number of rows after an
+        ``ON CONFLICT DO NOTHING`` insert cannot say which feed entries were
+        new, while the source-local primary key makes the external post ID a
+        stable and inexpensive lookup key.
+
+        :param source_id:
+            Numeric tracked-source identifier owning the posts.
+        :param posts:
+            Normalised feed entries to persist.
+        :return:
+            Entries that were absent from the database and inserted during this
+            call, in feed order.
+        """
+
         rows = list(posts)
         if not rows:
-            return 0
+            return []
 
-        before_count = int(self.con.execute("SELECT COUNT(*) FROM posts WHERE source_id = ?", [source_id]).fetchone()[0])
+        post_ids = {post.external_post_id for post in rows}
+        placeholders = ", ".join("?" * len(post_ids))
+        existing_rows = self.con.execute(
+            f"SELECT external_post_id FROM posts WHERE source_id = ? AND external_post_id IN ({placeholders})",  # noqa: S608
+            [source_id, *post_ids],
+        ).fetchall()
+        existing_ids = {row[0] for row in existing_rows}
+
+        inserted_posts: list[CollectedPost] = []
+        seen_ids: set[str] = set()
+        for post in rows:
+            if post.external_post_id not in existing_ids and post.external_post_id not in seen_ids:
+                inserted_posts.append(post)
+                seen_ids.add(post.external_post_id)
+
+        if not inserted_posts:
+            return []
+
         self.con.executemany(
             """
             INSERT INTO posts (
@@ -656,11 +693,10 @@ class VaultPostDatabase:
                     post.ai_summary,
                     post.raw_payload,
                 )
-                for post in rows
+                for post in inserted_posts
             ],
         )
-        after_count = int(self.con.execute("SELECT COUNT(*) FROM posts WHERE source_id = ?", [source_id]).fetchone()[0])
-        return after_count - before_count
+        return inserted_posts
 
     def prune_posts(self, max_post_age_days: int) -> int:
         """Delete posts older than the configured retention period."""

--- a/scripts/erc-4626/scan-vault-posts.py
+++ b/scripts/erc-4626/scan-vault-posts.py
@@ -42,7 +42,7 @@ Environment variables:
 - ``WEBSHARE_API_KEY``: Optional. Enable Webshare-backed proxy rotation.
 - ``WEBSHARE_PROXY_MODE``: Optional. Webshare proxy pool mode.
 - ``MAX_PROXY_ROTATIONS``: Optional. Default: 3.
-- ``MAX_POST_AGE_DAYS``: Optional. Default: 365.
+- ``MAX_POST_AGE_DAYS``: Optional. Default: 36135 (99 years).
 - ``LOOP_INTERVAL_SECONDS``: Optional. Default: 28800 (8 hours). Set to 0 for single run.
 - ``LIMIT``: Optional. Limit sources per type for test runs.
 - ``DEATH_DETECTION_PERIOD``: Optional. Default: 180 days.
@@ -74,6 +74,12 @@ from eth_defi.utils import setup_console_logging
 logger = logging.getLogger(__name__)
 
 SECONDS_PER_MINUTE = 60
+
+#: Keep historical posts long enough that old but still-present RSS entries do
+#: not get inserted and immediately pruned on every collection cycle.
+#: The post database is small, so retaining this history does not create a
+#: meaningful storage-growth concern.
+DEFAULT_MAX_POST_AGE_DAYS = 99 * 365
 
 
 def _parse_csv(raw_value: str | None) -> list[str]:
@@ -203,6 +209,17 @@ def _print_dashboard(summary) -> None:
         )
     )
 
+    inserted_post_rows = [[result.feeder_id, result.role, result.source_type, preview] for result in source_results for preview in result.inserted_post_previews]
+    if inserted_post_rows:
+        print()
+        print(
+            tabulate(
+                inserted_post_rows,
+                headers=["Feeder", "Role", "Source", "New post title / summary (max 80 chars)"],
+                tablefmt="fancy_grid",
+            )
+        )
+
     failed_results = [r for r in source_results if r.status == "failed"]
     if failed_results:
         failed_rows = [[r.feeder_id, r.role, r.source_type, (r.error or "")[:60]] for r in failed_results]
@@ -233,7 +250,7 @@ def _build_config() -> PostScanConfig:
         max_posts_per_source=int(os.environ.get("MAX_POSTS_PER_SOURCE", "20")),
         request_timeout=float(os.environ.get("REQUEST_TIMEOUT", "20")),
         request_delay_seconds=float(os.environ.get("REQUEST_DELAY_SECONDS", "1")),
-        max_post_age_days=int(os.environ.get("MAX_POST_AGE_DAYS", "365")),
+        max_post_age_days=int(os.environ.get("MAX_POST_AGE_DAYS", str(DEFAULT_MAX_POST_AGE_DAYS))),
         max_proxy_rotations=int(os.environ.get("MAX_PROXY_ROTATIONS", "3")),
         twitter_bearer_token=os.environ.get("TWITTER_BEARER_TOKEN"),
         twitter_consumer_key=os.environ.get("TWITTER_CONSUMER_KEY"),

--- a/tests/feed/test_collector.py
+++ b/tests/feed/test_collector.py
@@ -8,7 +8,7 @@ import pytest
 import requests
 
 from eth_defi.compat import native_datetime_utc_now
-from eth_defi.feed.collector import AllBridgesFailedError, collect_posts, collect_posts_for_source, collect_twitter_list_posts
+from eth_defi.feed.collector import AllBridgesFailedError, _format_inserted_post_preview, collect_posts, collect_posts_for_source, collect_twitter_list_posts
 from eth_defi.feed.database import CollectedPost, VaultPostDatabase
 from eth_defi.feed.sources import (
     FEEDS_DATA_DIR,
@@ -82,6 +82,25 @@ class DummyResponse:
             raise requests.HTTPError(f"HTTP {self.status_code}", response=self)
 
 
+def test_format_inserted_post_preview_caps_title_at_80_characters() -> None:
+    """Render a bounded title preview for the post-scanner dashboard."""
+
+    post = CollectedPost(
+        external_post_id="post-1",
+        title="A" * 100,
+        post_url="https://example.com/post-1",
+        published_at=native_datetime_utc_now(),
+        fetched_at=native_datetime_utc_now(),
+        short_description="Unused because the title is present",
+        full_text="Unused because the title is present",
+    )
+
+    preview = _format_inserted_post_preview(post)
+
+    assert len(preview) == 80
+    assert preview == f"{'A' * 77}..."
+
+
 def test_end_to_end_collection_with_dedup(tmp_path: Path, monkeypatch) -> None:
     """Collect mixed source types and keep inserts idempotent across repeated runs.
 
@@ -140,6 +159,8 @@ def test_end_to_end_collection_with_dedup(tmp_path: Path, monkeypatch) -> None:
         assert summary_first.sources_succeeded == 2
         assert summary_first.posts_inserted == 2
         assert summary_second.posts_inserted == 0
+        assert sorted(preview for result in summary_first.source_results for preview in result.inserted_post_previews) == ["Atom entry", "Protocol launch"]
+        assert all(not result.inserted_post_previews for result in summary_second.source_results)
         assert len(tracked_df) == 2
         assert len(posts_df) == 2
         assert set(tracked_df["feeder_id"]) == {"morpho", "gauntlet"}


### PR DESCRIPTION
## Why

Old RSS entries were inserted and immediately pruned on every scan, inflating dashboard insert counts and causing needless database writes.

## Lessons learnt

Feed retention must exceed the publication age of repeatedly fetched source entries unless collection filters expired entries before insertion. The small vault-post DuckDB database can safely retain this history.

## Summary

- Retain vault-post records for 99 years by default and pass the setting through Compose.
- Show the titles or summaries of precisely inserted posts in the dashboard, capped at 80 characters.
- Preserve the count-based insertion API while exposing exact newly stored posts for dashboard diagnostics.

## Related issues and PRs

- None.

## Unrelated CI and test fixes

- None.