### PR TITLE
fix: reset persistent SQLite throttles on scanner restart

### DIFF
--- a/eth_defi/hypersync/session.py
+++ b/eth_defi/hypersync/session.py
@@ -34,6 +34,7 @@ Usage::
 import asyncio
 import logging
 import os
+import time
 from pathlib import Path
 
 import hypersync
@@ -305,12 +306,19 @@ def _create_limiter(
     requests_per_minute: int = DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE,
     db_path: Path = HYPERSYNC_RATE_LIMIT_SQLITE_DATABASE,
 ) -> Limiter:
-    """Create a ``pyrate_limiter.Limiter`` with an SQLite-backed bucket."""
+    """Create a ``pyrate_limiter.Limiter`` with an SQLite-backed bucket.
+
+    SQLite stores the timestamps passed by the limiter.  Use Unix wall-clock
+    time instead of the default process-local monotonic clock, whose origin
+    changes after a host or container restart and would make old rows appear
+    to be years in the future.
+    """
     db_path.parent.mkdir(parents=True, exist_ok=True)
     return Limiter(
         RequestRate(requests_per_minute, Duration.MINUTE),
         bucket_class=SQLiteBucket,
         bucket_kwargs={"path": str(db_path)},
+        time_function=time.time,
     )
 
 

--- a/eth_defi/rate_limit.py
+++ b/eth_defi/rate_limit.py
@@ -1,0 +1,66 @@
+"""Persistent rate-limit state maintenance.
+
+The scanner keeps SQLite-backed :mod:`pyrate_limiter` buckets beneath
+``~/.tradingstrategy``.  These buckets are short-lived request accounting,
+not business data.  They are deliberately reset on every
+``scan-vaults-all-chains`` process restart, before its first network read.
+
+Persisting the SQLite files remains useful while one scanner process runs,
+because parallel workers share their API quota.  Carrying their timestamps
+across a restart is neither required nor safe: a changed clock source or a
+restarted monotonic clock can make a one-minute throttle appear to last for
+years.  This module therefore retains the database schemas but clears every
+``ratelimit_*`` request-history table at scanner startup.
+"""
+
+import logging
+import sqlite3
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Root directory for persistent scanner state and rate-limit databases.
+TRADING_STRATEGY_STATE_DIRECTORY = Path("~/.tradingstrategy").expanduser()
+
+#: File name used by every SQLite-backed scanner throttler.
+SQLITE_RATE_LIMIT_DATABASE_FILENAME = "rate-limit.sqlite"
+
+
+def clear_sqlite_rate_limit_databases(state_directory: Path = TRADING_STRATEGY_STATE_DIRECTORY) -> tuple[Path, ...]:
+    """Clear request history from all SQLite-backed throttlers.
+
+    The persistent rate-limit databases contain only short-lived request
+    timestamps.  They are intentionally reset after every scanner restart;
+    clearing their ``ratelimit_*`` tables is safe and leaves the SQLite schema
+    in place.  The caller must ensure no concurrent scan is using the
+    databases; :mod:`eth_defi.vault.scan_all_chains` does this while holding
+    its pipeline lock.
+
+    :param state_directory:
+        Root directory below which scanner throttler databases are searched.
+        Defaults to the persistent ``~/.tradingstrategy`` directory mounted
+        into the production scanner container.
+
+    :return:
+        Paths of databases whose rate-limit tables were cleared.
+
+    :raises sqlite3.DatabaseError:
+        If a matching database cannot be opened or changed.  Starting a scan
+        with potentially invalid throttle state is less safe than failing
+        before any network reads.
+    """
+    if not state_directory.exists():
+        return ()
+
+    cleared_databases: list[Path] = []
+    for database_path in sorted(state_directory.rglob(SQLITE_RATE_LIMIT_DATABASE_FILENAME)):
+        with sqlite3.connect(database_path, timeout=60) as connection:
+            table_rows = connection.execute("SELECT name FROM sqlite_master WHERE type = 'table' AND name GLOB 'ratelimit_*'").fetchall()
+            for (table_name,) in table_rows:
+                quoted_table_name = table_name.replace('"', '""')
+                connection.execute(f'DELETE FROM "{quoted_table_name}"')  # noqa: S608 -- SQLite identifiers cannot be bound parameters.
+
+        cleared_databases.append(database_path)
+        logger.info("Cleared SQLite rate-limit state: %s", database_path)
+
+    return tuple(cleared_databases)

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -76,6 +76,7 @@ from eth_defi.lighter.vault_data_export import merge_into_vault_database as ligh
 from eth_defi.provider.broken_provider import verify_archive_node
 from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
 from eth_defi.provider.rpcdb import RPCRequestStats, RPCUsageDatabase, format_rpc_usage_report, resolve_rpc_tracking_database_path
+from eth_defi.rate_limit import clear_sqlite_rate_limit_databases
 from eth_defi.token import TokenDiskCache
 from eth_defi.utils import setup_console_logging, wait_other_writers
 from eth_defi.vault.historical import scan_historical_prices_to_parquet
@@ -2795,6 +2796,7 @@ def main():
     schedule_tolerance = datetime.timedelta(seconds=loop_interval) / 2 if looped_mode else datetime.timedelta(0)
 
     cycle = 0
+    rate_limit_databases_cleared = False
     while True:
         cycle += 1
 
@@ -2802,6 +2804,11 @@ def main():
 
         try:
             with wait_other_writers(pipeline_lock_path, timeout=60):
+                if not rate_limit_databases_cleared:
+                    cleared_databases = clear_sqlite_rate_limit_databases()
+                    logger.info("Cleared %d SQLite rate-limit databases before scanning", len(cleared_databases))
+                    rate_limit_databases_cleared = True
+
                 if looped_mode:
                     state = load_cycle_state(cycle_state_path)
                     # Always resume from persisted cycle state, including cycle 1.

--- a/tests/hypersync/test_hypersync_session.py
+++ b/tests/hypersync/test_hypersync_session.py
@@ -6,12 +6,14 @@ parameters, and env var helpers. No network access or API key needed.
 
 import asyncio
 import logging
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
 import hypersync
+import pytest
+from pyrate_limiter import Duration, Limiter, RequestRate, SQLiteBucket
 
+import eth_defi.hypersync.session as hypersync_session
 from eth_defi.hypersync.session import (
     DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE,
     ThrottledHypersyncClient,
@@ -189,3 +191,25 @@ def test_get_hypersync_rpm_from_env_default():
     with patch.dict("os.environ", {}, clear=True):
         assert DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE == 80
         assert get_hypersync_rpm_from_env() == DEFAULT_HYPERSYNC_REQUESTS_PER_MINUTE
+
+
+def test_sqlite_limiter_uses_unix_time_across_restart(tmp_path):
+    """Discard an old monotonic timestamp when recreating a persistent limiter.
+
+    The old limiter simulates a prior host whose monotonic clock had advanced
+    well beyond the replacement host's clock.  The new limiter uses Unix time,
+    so it treats the incompatible persisted row as expired instead of waiting
+    for the old clock value to elapse.
+    """
+    database_path = tmp_path / "rate-limit.sqlite"
+    old_limiter = Limiter(
+        RequestRate(1, Duration.MINUTE),
+        bucket_class=SQLiteBucket,
+        bucket_kwargs={"path": str(database_path)},
+        time_function=lambda: 77_678_186.0,
+    )
+    old_limiter.try_acquire("hypersync")
+
+    limiter = hypersync_session._create_limiter(requests_per_minute=1, db_path=database_path)
+    assert limiter.time_function is time.time
+    limiter.try_acquire("hypersync")

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,38 @@
+"""Tests for persistent rate-limit state maintenance."""
+
+import sqlite3
+
+from eth_defi.rate_limit import clear_sqlite_rate_limit_databases
+
+
+def test_clear_sqlite_rate_limit_databases(tmp_path):
+    """Clear all scanner rate-limit tables without touching other SQLite data.
+
+    Creates rate-limit databases in multiple scanner subdirectories, inserts
+    stale request entries, and verifies that the scanner startup maintenance
+    removes only the throttle entries.
+    """
+    hypersync_database = tmp_path / "hypersync" / "rate-limit.sqlite"
+    core3_database = tmp_path / "vaults" / "core3" / "rate-limit.sqlite"
+    other_database = tmp_path / "vaults" / "business-data.sqlite"
+
+    for database_path in (hypersync_database, core3_database, other_database):
+        database_path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(database_path) as connection:
+            connection.execute("CREATE TABLE records (value INTEGER)")
+            connection.execute("INSERT INTO records VALUES (1)")
+
+    for database_path in (hypersync_database, core3_database):
+        with sqlite3.connect(database_path) as connection:
+            connection.execute("CREATE TABLE ratelimit_test (value REAL)")
+            connection.execute("INSERT INTO ratelimit_test VALUES (123.0)")
+
+    assert clear_sqlite_rate_limit_databases(tmp_path) == (hypersync_database, core3_database)
+
+    for database_path in (hypersync_database, core3_database):
+        with sqlite3.connect(database_path) as connection:
+            assert connection.execute("SELECT COUNT(*) FROM ratelimit_test").fetchone()[0] == 0
+            assert connection.execute("SELECT COUNT(*) FROM records").fetchone()[0] == 1
+
+    with sqlite3.connect(other_database) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM records").fetchone()[0] == 1


### PR DESCRIPTION
## Why

SQLite-backed rate-limit buckets were persisting process-local monotonic timestamps across a scanner restart. A reset clock made recent entries appear years in the future and blocked Hypersync.

## Lessons learnt

Persistent request accounting needs a restart-stable clock, but per-minute API quota history does not need to survive a scanner restart.

## Summary

- Use Unix wall-clock timestamps for the persistent Hypersync limiter.
- Clear every SQLite `ratelimit_*` request-history table once at `scan-vaults-all-chains` startup, while holding the pipeline lock.
- Document the intentional restart reset and add regression coverage.

## Related issues and PRs

- Follow-up to #1044, which introduced the SQLite-backed Hypersync limiter.

## Unrelated CI and test fixes

- None.