### PR TITLE
fix: handle duplicate vault price timestamps

### DIFF
--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -1648,10 +1648,13 @@ def fix_outlier_share_prices(
         abnormal_mask = (group["pct_change_prev"] > max_diff) | (group["pct_change_next"] > max_diff)
 
         group["fixed_share_price"] = np.nan
+        fixed_share_price_col = group.columns.get_loc("fixed_share_price")
 
-        # Print pass, figure out damanged entries
-        for idx in group[abnormal_mask].index:
-            idx_loc = group.index.get_loc(idx)
+        # Work with row positions because timestamp labels are not unique on
+        # high-throughput chains. ``get_loc()`` and ``loc[]`` would otherwise
+        # select every row with the same timestamp.
+        abnormal_positions = np.flatnonzero(abnormal_mask.to_numpy(dtype=bool, na_value=False))
+        for idx_loc in abnormal_positions:
             current_price = group.iloc[idx_loc]["share_price"]
             next_price = group.iloc[idx_loc]["next_price_candidate"]
             prev_price = group.iloc[idx_loc]["prev_price_candidate"]
@@ -1668,11 +1671,12 @@ def fix_outlier_share_prices(
                 # Maybe a genuine crash
                 fixed_price = current_price
 
-            # logger(f"Abnormal share price detected for {vault_id} at index {idx} ({idx_loc}): fixing: {current_price} -> {fixed_price}, prev: {prev_price}, next: {next_price}")
-            group.loc[idx, "fixed_share_price"] = fixed_price
+            group.iat[idx_loc, fixed_share_price_col] = fixed_price
 
         # Apply the fixes
-        group.loc[pd.notna(group["fixed_share_price"]), "share_price"] = group["fixed_share_price"]
+        share_price_col = group.columns.get_loc("share_price")
+        fixed_positions = np.flatnonzero(group["fixed_share_price"].notna().to_numpy(dtype=bool, na_value=False))
+        group.iloc[fixed_positions, share_price_col] = group.iloc[fixed_positions, fixed_share_price_col].to_numpy()
         # group["id"] = vault_id
 
         # Don't export extra columns, only needed for calculations and debugging

--- a/tests/research/test_clean_prices.py
+++ b/tests/research/test_clean_prices.py
@@ -1128,3 +1128,36 @@ def test_fix_outlier_ipor_tau_yield_bond_spike():
     normal_rows = result[(result["block_number"] != 24700201)]
     changed = normal_rows[normal_rows["share_price"] != normal_rows["raw_share_price"]]
     assert len(changed) == 0, f"Expected no changes to normal rows, but {len(changed)} rows were modified"
+
+
+def test_fix_outlier_share_prices_with_duplicate_timestamps():
+    """Clean an outlier without treating a repeated timestamp as multiple rows.
+
+    Modern chains can emit several block observations in one second. The
+    cleaner must select the abnormal observation by its row position, because
+    label-based ``loc[]`` access returns every row sharing that timestamp.
+    """
+    df = pd.DataFrame(
+        {
+            "id": ["duplicate-timestamp-vault"] * 5,
+            "block_number": [1, 2, 3, 4, 5],
+            "share_price": [1.0, 1.0, 10.0, 1.0, 1.0],
+        },
+        index=pd.to_datetime(
+            [
+                "2026-07-01 00:00:00",
+                "2026-07-01 01:00:00",
+                "2026-07-01 01:00:00",
+                "2026-07-01 02:00:00",
+                "2026-07-01 03:00:00",
+            ]
+        ),
+    )
+
+    result = fix_outlier_share_prices(df, logger=lambda _: None, look_back_hours=1, look_ahead_hours=1)
+
+    spike = result[result["block_number"] == 3].iloc[0]
+    assert spike["raw_share_price"] == 10.0
+    assert spike["share_price"] == 1.0
+    assert len(result) == len(df)
+    assert result.index.duplicated().any()


### PR DESCRIPTION
## Why

The clean-price pipeline retains separate observations from blocks which share a Unix-second timestamp. The outlier cleaner still resolved and assigned rows through timestamp labels; Pandas returned multiple rows for duplicated labels and price cleaning failed.

## Lessons learnt

Raw vault observations are identified by their position and block identity, not by timestamps. All cleaner reads and writes that act on one observation must use row positions when duplicate timestamps are possible.

## Summary

- Use positional selection and assignment for abnormal share-price rows.
- Add regression coverage for an outlier at a duplicated timestamp.
- Verify the full production raw artefact can be cleaned into an isolated Parquet export.

## Related issues and PRs

- Follow-up to #1367 and #1377.

## Unrelated CI and test fixes

- None.