### PR TITLE
fix: move flaky Gains history scan to slow CI

### DIFF
--- a/tests/gains/test_gtrade_usdc.py
+++ b/tests/gains/test_gtrade_usdc.py
@@ -205,7 +205,11 @@ def test_gains_deposit_withdraw(
 
 # CI flaky since 2026-07-22: the live Arbitrum historical multicall raised
 # MulticallNonRetryable; the same reader passed on later CI and local runs.
+# CI failed again on 2026-07-26 in two main-suite runs because both configured
+# archive providers lacked state trie nodes. Keep this live historical scan in
+# the slower, lower-contention workflow while retaining local coverage.
 @flaky.flaky
+@pytest.mark.slow
 def test_gains_historical_stateful(tmp_path):
     """Read historical data of gTrade USDC vault using the stateful multicall reader.
 


### PR DESCRIPTION
## Why

The live Arbitrum historical scan `test_gains_historical_stateful` failed twice in the main Python 3.14 CI job, including its built-in retry. Both configured fallback providers returned missing historical state trie nodes, while the exact test passed locally.

## Lessons learnt

A week-long historical multicall scan depends on external archive-state availability and should not compete with the main parallel suite. It remains enabled in the lower-contention slow integration workflow and continues to run locally.

## Summary

- Mark the live Gains historical scan as slow while retaining its existing flaky retry marker.
- Record the two CI runs and archive-provider failure mode next to the test.

## Related issues and PRs

- Split from #1384 so the vault cleaner production fix could merge independently.

## Unrelated CI and test fixes

- Moves an existing live historical integration test to slow CI; no vault-cleaner behaviour changes.