### PR TITLE
test: warm read-only vault forks

### DIFF
--- a/tests/erc_4626/test_umami.py
+++ b/tests/erc_4626/test_umami.py
@@ -8,32 +8,21 @@ import pytest
 from web3 import Web3
 
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
-from eth_defi.erc_4626.core import get_vault_protocol_name
 from eth_defi.erc_4626.vault_protocol.umami.vault import UmamiVault
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
-from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.vault.base import VaultTechnicalRisk
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 
 JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
 
-pytestmark = pytest.mark.skipif(JSON_RPC_ARBITRUM is None, reason="JSON_RPC_ARBITRUM needed to run these tests")
+pytestmark = [
+    pytest.mark.skipif(JSON_RPC_ARBITRUM is None, reason="JSON_RPC_ARBITRUM needed to run these tests"),
+    pytest.mark.xdist_group("fork:arbitrum:392313989"),
+]
 
 
 @pytest.fixture(scope="module")
-def anvil_arbitrum_fork(request) -> AnvilLaunch:
-    """Read gmUSDC vault at a specific block"""
-    launch = fork_network_anvil(JSON_RPC_ARBITRUM, fork_block_number=392_313_989)
-    try:
-        yield launch
-    finally:
-        # Wind down Anvil process after the test is complete
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_arbitrum_fork):
-    web3 = create_multi_provider_web3(anvil_arbitrum_fork.json_rpc_url, default_http_timeout=(3.0, 90.0))
-    return web3
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Umami fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ARBITRUM, 392_313_989, web3_http_timeout=(3.0, 90.0))
 
 
 @flaky.flaky

--- a/tests/erc_4626/vault_protocol/test_aave.py
+++ b/tests/erc_4626/vault_protocol/test_aave.py
@@ -17,12 +17,14 @@ from web3 import Web3
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault_protocol.aave.vault import AaveVault
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
-from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 
-pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests")
+pytestmark = [
+    pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests"),
+    pytest.mark.xdist_group("fork:ethereum:25354000"),
+]
 
 #: Aave v4 CORE_USDC Tokenization Spoke on Ethereum mainnet
 #: https://etherscan.io/address/0x531E90a2376902DE8915789Fcc1075e3B0c153E7
@@ -30,20 +32,9 @@ AAVE_CORE_USDC_SPOKE = "0x531E90a2376902DE8915789Fcc1075e3B0c153E7"
 
 
 @pytest.fixture(scope="module")
-def anvil_ethereum_fork(request) -> AnvilLaunch:
-    """Fork mainnet at a fixed block for reproducible values."""
-    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=25_354_000)
-    try:
-        yield launch
-    finally:
-        # Wind down Anvil process after the test is complete
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_ethereum_fork: AnvilLaunch) -> Web3:
-    web3 = create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url, retries=2)
-    return web3
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Aave fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ETHEREUM, 25_354_000, web3_retries=2)
 
 
 @flaky.flaky

--- a/tests/erc_4626/vault_protocol/test_aera.py
+++ b/tests/erc_4626/vault_protocol/test_aera.py
@@ -10,17 +10,16 @@ from web3 import Web3
 from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS, create_vault_instance_autodetect, detect_vault_features
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault_protocol.aera.vault import AeraVault, convert_aera_tvl_fee_to_annual_management_fee
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
-from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.vault.base import VaultTechnicalRisk
 from eth_defi.vault.fee import VaultFeeMode
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 
-pytestmark = pytest.mark.skipif(
-    JSON_RPC_ETHEREUM is None,
-    reason="JSON_RPC_ETHEREUM needed to run these tests",
-)
+pytestmark = [
+    pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests"),
+    pytest.mark.xdist_group("fork:ethereum:25301420"),
+]
 
 #: USDC AeraVault Strategy on Ethereum.
 AERA_USDC_STRATEGY: HexAddress = "0x6593bb7272237f36444dee44df46ab3b0233a9a0"
@@ -51,20 +50,9 @@ AERA_VAULT_ADDRESSES: set[HexAddress] = {
 
 
 @pytest.fixture(scope="module")
-def anvil_ethereum_fork() -> AnvilLaunch:
-    """Fork Ethereum at a specific block for reproducibility."""
-    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=25_301_420)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_ethereum_fork: AnvilLaunch) -> Web3:
-    """Create Web3 connection to the Anvil fork."""
-    web3 = create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url, retries=2)
-    return web3
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Aera fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ETHEREUM, 25_301_420, web3_retries=2)
 
 
 def test_aera_hardcoded_addresses() -> None:

--- a/tests/erc_4626/vault_protocol/test_brink.py
+++ b/tests/erc_4626/vault_protocol/test_brink.py
@@ -19,28 +19,20 @@ from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault_protocol.brink.vault import BrinkVault
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
-from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 
 JSON_RPC_MANTLE = os.environ.get("JSON_RPC_MANTLE")
 
-pytestmark = pytest.mark.skipif(JSON_RPC_MANTLE is None, reason="JSON_RPC_MANTLE needed to run these tests")
+pytestmark = [
+    pytest.mark.skipif(JSON_RPC_MANTLE is None, reason="JSON_RPC_MANTLE needed to run these tests"),
+    pytest.mark.xdist_group("fork:mantle:90059927"),
+]
 
 
 @pytest.fixture(scope="module")
-def anvil_mantle_fork(request) -> AnvilLaunch:
-    """Fork at a specific block for reproducibility."""
-    launch = fork_network_anvil(JSON_RPC_MANTLE, fork_block_number=90_059_927)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_mantle_fork):
-    web3 = create_multi_provider_web3(anvil_mantle_fork.json_rpc_url)
-    return web3
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Brink fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_MANTLE, 90_059_927)
 
 
 @flaky.flaky

--- a/tests/erc_4626/vault_protocol/test_bulla.py
+++ b/tests/erc_4626/vault_protocol/test_bulla.py
@@ -12,9 +12,8 @@ from eth_defi.erc_4626.classification import create_probe_calls, create_vault_in
 from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name
 from eth_defi.erc_4626.vault_protocol.bulla.offchain_metadata import get_bulla_vault_metadata
 from eth_defi.erc_4626.vault_protocol.bulla.vault import BullaFeeData, BullaVault
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
-from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.research.vault_metrics import slugify_protocol
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.vault.fee import VaultFeeMode, get_vault_fee_mode
 from eth_defi.vault.protocol_metadata import build_metadata_json
 from eth_defi.vault.risk import VaultTechnicalRisk, get_vault_risk
@@ -25,6 +24,8 @@ BULLA_FORK_BLOCK = 486_151_800
 BULLA_PROTOCOL_FEE_BPS = 30
 BULLA_TARGET_YIELD_BPS = 800
 BULLA_INVOICE_UPFRONT_BPS = 10_000
+
+pytestmark = pytest.mark.xdist_group("fork:arbitrum:486151800")
 
 
 def test_bulla_uses_one_protocol_specific_probe() -> None:
@@ -37,19 +38,9 @@ def test_bulla_uses_one_protocol_specific_probe() -> None:
 
 
 @pytest.fixture(scope="module")
-def anvil_arbitrum_fork() -> AnvilLaunch:
-    """Fork Arbitrum at the Bulla integration's recorded latest block."""
-    launch = fork_network_anvil(JSON_RPC_ARBITRUM, fork_block_number=BULLA_FORK_BLOCK)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_arbitrum_fork: AnvilLaunch) -> Web3:
-    """Create a Web3 client for the deterministic Arbitrum fork."""
-    return create_multi_provider_web3(anvil_arbitrum_fork.json_rpc_url)
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Bulla fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ARBITRUM, BULLA_FORK_BLOCK)
 
 
 @pytest.mark.skipif(JSON_RPC_ARBITRUM is None, reason="JSON_RPC_ARBITRUM needed to run this test")

--- a/tests/erc_4626/vault_protocol/test_d2.py
+++ b/tests/erc_4626/vault_protocol/test_d2.py
@@ -12,8 +12,7 @@ from web3 import Web3
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.vault_protocol.d2.vault import D2DepositManager, D2HistoricalReader, D2Vault, Epoch
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
-from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.vault.base import (
     DEPOSIT_CLOSED_FUNDING_PHASE,
     REDEMPTION_CLOSED_FUNDS_CUSTODIED,
@@ -22,24 +21,16 @@ from eth_defi.vault.deposit_redeem import VaultFlowUnavailable
 
 JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
 
-pytestmark = pytest.mark.skipif(JSON_RPC_ARBITRUM is None, reason="JSON_RPC_ARBITRUM needed to run these tests")
+pytestmark = [
+    pytest.mark.skipif(JSON_RPC_ARBITRUM is None, reason="JSON_RPC_ARBITRUM needed to run these tests"),
+    pytest.mark.xdist_group("fork:arbitrum:392313989"),
+]
 
 
 @pytest.fixture(scope="module")
-def anvil_arbitrum_fork(request) -> AnvilLaunch:
-    """Read gmUSDC vault at a specific block"""
-    launch = fork_network_anvil(JSON_RPC_ARBITRUM, fork_block_number=392_313_989)
-    try:
-        yield launch
-    finally:
-        # Wind down Anvil process after the test is complete
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_arbitrum_fork):
-    web3 = create_multi_provider_web3(anvil_arbitrum_fork.json_rpc_url)
-    return web3
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only D2 fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ARBITRUM, 392_313_989)
 
 
 @flaky.flaky

--- a/tests/erc_4626/vault_protocol/test_forgeyields.py
+++ b/tests/erc_4626/vault_protocol/test_forgeyields.py
@@ -17,35 +17,23 @@ from web3 import Web3
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault_protocol.forgeyields.vault import ForgeYieldsVault
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
-from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 
-pytestmark = pytest.mark.skipif(
-    JSON_RPC_ETHEREUM is None,
-    reason="JSON_RPC_ETHEREUM needed to run these tests",
-)
+pytestmark = [
+    pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests"),
+    pytest.mark.xdist_group("fork:ethereum:25171000"),
+]
 
 #: fyUSDC vault on Ethereum
 FYUSDC_ADDRESS = "0x943109DC7C950da4592d85ebd4Cfed007Af64670"
 
 
 @pytest.fixture(scope="module")
-def anvil_ethereum_fork() -> AnvilLaunch:
-    """Fork Ethereum at a specific block for reproducibility."""
-    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=25_171_000)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_ethereum_fork: AnvilLaunch) -> Web3:
-    """Create Web3 connection to the Anvil fork."""
-    web3 = create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url, retries=2)
-    return web3
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only ForgeYields fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ETHEREUM, 25_171_000, web3_retries=2)
 
 
 @flaky.flaky

--- a/tests/erc_4626/vault_protocol/test_infinifi.py
+++ b/tests/erc_4626/vault_protocol/test_infinifi.py
@@ -3,36 +3,28 @@
 import os
 from pathlib import Path
 
+import flaky
 import pytest
 from web3 import Web3
-import flaky
 
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault_protocol.infinifi.vault import InfiniFiVault
-from eth_defi.provider.anvil import fork_network_anvil, AnvilLaunch
-from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 
-pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests")
+pytestmark = [
+    pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests"),
+    pytest.mark.xdist_group("fork:ethereum:24263313"),
+]
 
 
 @pytest.fixture(scope="module")
-def anvil_ethereum_fork(request) -> AnvilLaunch:
-    """Fork Ethereum at a specific block for reproducibility"""
-    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=24_263_313)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_ethereum_fork):
-    web3 = create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url, retries=2)
-    return web3
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only InfiniFi fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ETHEREUM, 24_263_313, web3_retries=2)
 
 
 @flaky.flaky

--- a/tests/erc_4626/vault_protocol/test_mainstreet.py
+++ b/tests/erc_4626/vault_protocol/test_mainstreet.py
@@ -10,9 +10,8 @@ from web3 import Web3
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
-from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.erc_4626.vault_protocol.mainstreet.vault import MainstreetVault
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 
 JSON_RPC_SONIC = os.environ.get("JSON_RPC_SONIC")
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
@@ -21,22 +20,13 @@ pytestmark = pytest.mark.skipif(not JSON_RPC_ETHEREUM or not JSON_RPC_SONIC, rea
 
 
 @pytest.fixture(scope="module")
-def anvil_sonic_fork(request) -> AnvilLaunch:
-    """Fork at a specific block for reproducibility."""
-    launch = fork_network_anvil(JSON_RPC_SONIC, fork_block_number=59_684_622)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_sonic_fork):
-    web3 = create_multi_provider_web3(anvil_sonic_fork.json_rpc_url)
-    return web3
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Sonic Mainstreet fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_SONIC, 59_684_622)
 
 
 @flaky.flaky
+@pytest.mark.xdist_group("fork:sonic:59684622")
 def test_mainstreet_legacy_smsUSD(
     web3: Web3,
     tmp_path: Path,
@@ -71,24 +61,13 @@ def test_mainstreet_legacy_smsUSD(
 
 
 @pytest.fixture(scope="module")
-def anvil_ethereum_fork(request) -> AnvilLaunch:
-    """Fork Ethereum at a specific block for reproducibility."""
-    if JSON_RPC_ETHEREUM is None:
-        pytest.skip("JSON_RPC_ETHEREUM needed to run this test")
-    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=24_217_821)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3_ethereum(anvil_ethereum_fork):
-    web3 = create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url)
-    return web3
+def web3_ethereum(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Ethereum Mainstreet fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ETHEREUM, 24_217_821)
 
 
 @flaky.flaky
+@pytest.mark.xdist_group("fork:ethereum:24217821")
 def test_mainstreet_staked_msusd_ethereum(
     web3_ethereum: Web3,
     tmp_path: Path,

--- a/tests/erc_4626/vault_protocol/test_mellow.py
+++ b/tests/erc_4626/vault_protocol/test_mellow.py
@@ -13,8 +13,8 @@ from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
 from eth_defi.erc_4626.scan import create_vault_scan_record
 from eth_defi.mellow.vault import MellowVault
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.token import TokenDiskCache
 from eth_defi.vault.fee import VaultFeeMode
 
@@ -37,29 +37,16 @@ USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 USDT = "0xdAC17F958D2ee523a2206206994597C13D831ec7"
 USDE = "0x4c9EDD5852cd905f086C759E8383e09bff1E68B3"
 
-pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests")
+pytestmark = [
+    pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests"),
+    pytest.mark.xdist_group("fork:ethereum:25431636"),
+]
 
 
 @pytest.fixture(scope="module")
-def anvil_ethereum_fork() -> AnvilLaunch:
-    """Fork at a specific block for reproducibility.
-
-    Lido Earn USD was created through the Mellow Core Vault factory before this
-    block. The fixed block pins the component graph and share supply values.
-    """
-
-    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=FORK_BLOCK)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_ethereum_fork) -> Web3:
-    """Create Web3 connection to the Ethereum fork."""
-
-    return create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url, retries=2)
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Mellow fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ETHEREUM, FORK_BLOCK, web3_retries=2)
 
 
 @flaky.flaky

--- a/tests/erc_4626/vault_protocol/test_morpho_v2.py
+++ b/tests/erc_4626/vault_protocol/test_morpho_v2.py
@@ -15,8 +15,7 @@ from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature, is_lending_protocol
 from eth_defi.erc_4626.vault_protocol.morpho.vault_v2 import MorphoV2Vault, MorphoV2VaultHistoricalReader
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
-from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.vault.base import (
     DEPOSIT_CLOSED_CAP_REACHED,
     REDEMPTION_CLOSED_INSUFFICIENT_LIQUIDITY,
@@ -25,26 +24,16 @@ from eth_defi.vault.base import (
 JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
 CI = os.environ.get("CI") == "true"
 
-pytestmark = pytest.mark.skipif(JSON_RPC_ARBITRUM is None, reason="JSON_RPC_ARBITRUM needed to run these tests")
+pytestmark = [
+    pytest.mark.skipif(JSON_RPC_ARBITRUM is None, reason="JSON_RPC_ARBITRUM needed to run these tests"),
+    pytest.mark.xdist_group("fork:arbitrum:420581609"),
+]
 
 
 @pytest.fixture(scope="module")
-def anvil_arbitrum_fork(request) -> AnvilLaunch:
-    """Fork at a specific block for reproducibility."""
-    launch = fork_network_anvil(JSON_RPC_ARBITRUM, fork_block_number=420_581_609)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_arbitrum_fork):
-    web3 = create_multi_provider_web3(
-        anvil_arbitrum_fork.json_rpc_url,
-        default_http_timeout=(18.0, 180.0),
-    )
-    return web3
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Morpho V2 fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ARBITRUM, 420_581_609, web3_http_timeout=(18.0, 180.0))
 
 
 @flaky.flaky

--- a/tests/erc_4626/vault_protocol/test_plutus.py
+++ b/tests/erc_4626/vault_protocol/test_plutus.py
@@ -32,23 +32,13 @@ PLUTUS_HEDGE_VAULT = "0x58BfC95a864e18E8F3041D2FCD3418f48393fE6A"
 
 
 @pytest.fixture(scope="module")
-def anvil_arbitrum_fork(request) -> AnvilLaunch:
-    """Read gmUSDC vault at a specific block"""
-    launch = fork_network_anvil(JSON_RPC_ARBITRUM, fork_block_number=392_313_989)
-    try:
-        yield launch
-    finally:
-        # Wind down Anvil process after the test is complete
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_arbitrum_fork):
-    web3 = create_multi_provider_web3(anvil_arbitrum_fork.json_rpc_url)
-    return web3
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Plutus fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ARBITRUM, 392_313_989)
 
 
 @flaky.flaky
+@pytest.mark.xdist_group("fork:arbitrum:392313989")
 def test_plutus(
     web3: Web3,
     tmp_path: Path,

--- a/tests/erc_4626/vault_protocol/test_royco.py
+++ b/tests/erc_4626/vault_protocol/test_royco.py
@@ -14,12 +14,11 @@ from eth_defi.abi import ZERO_ADDRESS_STR, get_topic_signature_from_event
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.discovery_base import VaultEventKind, get_royco_tranche_discovery_events, get_vault_event_topic_map
-from eth_defi.erc_4626.vault_protocol.royco.offchain_metadata import fetch_royco_vaults
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader
+from eth_defi.erc_4626.vault_protocol.royco.offchain_metadata import fetch_royco_vaults
 from eth_defi.erc_4626.vault_protocol.royco.vault import RoycoTrancheHistoricalReader, RoycoTrancheVault, RoycoVault
 from eth_defi.erc_4626.vault_protocol.zerolend.vault import ZeroLendVault
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
-from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 ROYCO_TRANCHE_BLOCK = 25_251_545
@@ -30,38 +29,19 @@ pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHE
 
 
 @pytest.fixture(scope="module")
-def anvil_ethereum_fork() -> AnvilLaunch:
-    """Fork at a specific block for reproducibility."""
-    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=24167930)
-    try:
-        yield launch
-    finally:
-        launch.close()
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Royco fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ETHEREUM, 24_167_930)
 
 
 @pytest.fixture(scope="module")
-def web3(anvil_ethereum_fork):
-    web3 = create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url)
-    return web3
-
-
-@pytest.fixture(scope="module")
-def anvil_ethereum_royco_tranche_fork() -> AnvilLaunch:
-    """Fork after Royco tranche vault deployment."""
-    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=ROYCO_TRANCHE_BLOCK)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def royco_tranche_web3(anvil_ethereum_royco_tranche_fork):
-    web3 = create_multi_provider_web3(anvil_ethereum_royco_tranche_fork.json_rpc_url)
-    return web3
+def royco_tranche_web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Royco-tranche fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ETHEREUM, ROYCO_TRANCHE_BLOCK)
 
 
 @flaky.flaky
+@pytest.mark.xdist_group("fork:ethereum:24167930")
 def test_zerolend_royco_vault(
     web3: Web3,
 ):
@@ -127,6 +107,7 @@ def test_royco_tranche_redeem_topic_is_withdraw():
 
 
 @flaky.flaky
+@pytest.mark.xdist_group("fork:ethereum:25251545")
 @pytest.mark.parametrize(
     (
         "vault_address",
@@ -220,6 +201,7 @@ def test_royco_tranche_vault(
 
 
 @flaky.flaky
+@pytest.mark.xdist_group("fork:ethereum:25251545")
 def test_generic_reader_rejects_royco_tranche_tuple(
     royco_tranche_web3: Web3,
 ):

--- a/tests/erc_4626/vault_protocol/test_silo.py
+++ b/tests/erc_4626/vault_protocol/test_silo.py
@@ -11,30 +11,21 @@ from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature, is_lending_protocol
 from eth_defi.erc_4626.vault_protocol.silo.vault import SiloVault, SiloVaultHistoricalReader
-from eth_defi.erc_4626.vault_protocol.summer.vault import SummerVault
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
-from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.vault.fee import VaultFeeMode
 
 JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
 
-pytestmark = pytest.mark.skipif(JSON_RPC_ARBITRUM is None, reason="JSON_RPC_ARBITRUM needed to run these tests")
+pytestmark = [
+    pytest.mark.skipif(JSON_RPC_ARBITRUM is None, reason="JSON_RPC_ARBITRUM needed to run these tests"),
+    pytest.mark.xdist_group("fork:arbitrum:392313989"),
+]
 
 
 @pytest.fixture(scope="module")
-def anvil_arbitrum_fork(request) -> AnvilLaunch:
-    launch = fork_network_anvil(JSON_RPC_ARBITRUM, fork_block_number=392_313_989)
-    try:
-        yield launch
-    finally:
-        # Wind down Anvil process after the test is complete
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_arbitrum_fork):
-    web3 = create_multi_provider_web3(anvil_arbitrum_fork.json_rpc_url)
-    return web3
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Silo fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ARBITRUM, 392_313_989)
 
 
 def test_silo(

--- a/tests/erc_4626/vault_protocol/test_spark.py
+++ b/tests/erc_4626/vault_protocol/test_spark.py
@@ -11,11 +11,12 @@ from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS, create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name
 from eth_defi.erc_4626.vault_protocol.spark.vault import SparkVault
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
-from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.vault.base import VaultTechnicalRisk
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
+
+pytestmark = pytest.mark.xdist_group("fork:ethereum:24140000")
 
 
 def test_spark_spusdg_hardcoded_protocol() -> None:
@@ -29,19 +30,9 @@ def test_spark_spusdg_hardcoded_protocol() -> None:
 
 
 @pytest.fixture(scope="module")
-def anvil_ethereum_fork(request) -> AnvilLaunch:
-    """Fork at a specific block for reproducibility."""
-    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=24_140_000)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_ethereum_fork):
-    web3 = create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url)
-    return web3
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Spark fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ETHEREUM, 24_140_000)
 
 
 @pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run this test")

--- a/tests/erc_4626/vault_protocol/test_summer.py
+++ b/tests/erc_4626/vault_protocol/test_summer.py
@@ -4,37 +4,27 @@ import os
 from pathlib import Path
 
 import pytest
-
 from web3 import Web3
 
-
 from eth_defi.abi import ZERO_ADDRESS_STR
-from eth_defi.erc_4626.classification import create_vault_instance_autodetect, create_vault_instance
+from eth_defi.erc_4626.classification import create_vault_instance
 from eth_defi.erc_4626.core import ERC4626Feature
-from eth_defi.provider.anvil import fork_network_anvil, AnvilLaunch
-from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.erc_4626.vault_protocol.summer.vault import SummerVault
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.vault.fee import VaultFeeMode
 
 JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
 
-pytestmark = pytest.mark.skipif(JSON_RPC_ARBITRUM is None, reason="JSON_RPC_ARBITRUM needed to run these tests")
+pytestmark = [
+    pytest.mark.skipif(JSON_RPC_ARBITRUM is None, reason="JSON_RPC_ARBITRUM needed to run these tests"),
+    pytest.mark.xdist_group("fork:arbitrum:392313989"),
+]
 
 
 @pytest.fixture(scope="module")
-def anvil_arbitrum_fork(request) -> AnvilLaunch:
-    launch = fork_network_anvil(JSON_RPC_ARBITRUM, fork_block_number=392_313_989)
-    try:
-        yield launch
-    finally:
-        # Wind down Anvil process after the test is complete
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_arbitrum_fork):
-    web3 = create_multi_provider_web3(anvil_arbitrum_fork.json_rpc_url)
-    return web3
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Summer fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ARBITRUM, 392_313_989)
 
 
 @pytest.mark.skip(reason="Too slow")

--- a/tests/erc_4626/vault_protocol/test_symbiotic.py
+++ b/tests/erc_4626/vault_protocol/test_symbiotic.py
@@ -12,8 +12,7 @@ from web3 import Web3
 from eth_defi.erc_4626.classification import _ProbeResultsDict, _should_yield_probe, create_vault_instance_autodetect, identify_vault_features  # noqa: PLC2701 - checks missing-probe handling
 from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name
 from eth_defi.erc_4626.vault_protocol.symbiotic.vault import SymbioticVault
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
-from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.vault.fee import VaultFeeMode, get_vault_fee_mode
 from eth_defi.vault.protocol_metadata import build_metadata_json
 from eth_defi.vault.risk import VaultTechnicalRisk, get_vault_risk
@@ -22,6 +21,8 @@ JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 
 SYMBIOTIC_VAULT_ADDRESS = "0x007e0b8e99c6134e81a1eaae754460e3202cb671"
 SYMBIOTIC_FORK_BLOCK = 25_587_299
+
+pytestmark = pytest.mark.xdist_group("fork:ethereum:25587299")
 
 
 def test_symbiotic_probe_requires_v2_withdrawal_queue() -> None:
@@ -53,19 +54,9 @@ def test_symbiotic_probe_requires_v2_withdrawal_queue() -> None:
 
 
 @pytest.fixture(scope="module")
-def anvil_ethereum_fork() -> AnvilLaunch:
-    """Fork Ethereum after the Keyrock Flagship USDC vault's first deposit."""
-    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=SYMBIOTIC_FORK_BLOCK)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_ethereum_fork: AnvilLaunch) -> Web3:
-    """Create a Web3 client for the deterministic Symbiotic fork."""
-    return create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url)
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Symbiotic fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ETHEREUM, SYMBIOTIC_FORK_BLOCK)
 
 
 @pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run this test")

--- a/tests/erc_4626/vault_protocol/test_t3tris.py
+++ b/tests/erc_4626/vault_protocol/test_t3tris.py
@@ -13,8 +13,8 @@ from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader
 from eth_defi.erc_4626.vault_protocol.t3tris.vault import STALE_NAV_CORRECTED_ERROR, STALE_NAV_FIRST_SAMPLE_ERROR, T3trisHistoricalReader, T3trisVault
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader, VaultSpec
 from eth_defi.vault.fee import VaultFeeMode
 from eth_defi.vault.risk import VaultTechnicalRisk
@@ -41,6 +41,7 @@ STALE_NAV_GAP_BLOCK = 478_000_000
 STALE_NAV_AFTER_BLOCK = 478_353_946
 
 requires_arbitrum_rpc = pytest.mark.skipif(JSON_RPC_ARBITRUM is None, reason="JSON_RPC_ARBITRUM needed to run these tests")
+pytestmark = pytest.mark.xdist_group("fork:arbitrum:480900000")
 SYNTHETIC_SAMPLE_START = datetime.datetime(2026, 6, 27, 12, 0, tzinfo=datetime.UTC).replace(tzinfo=None)
 
 
@@ -511,25 +512,9 @@ def test_t3tris_reader_rejects_out_of_order_samples() -> None:
 
 
 @pytest.fixture(scope="module")
-def anvil_arbitrum_fork() -> AnvilLaunch:
-    """Fork Arbitrum at a specific block for reproducibility.
-
-    Gami USDC is a live T3tris vault at the pinned block. The fixed block pins
-    the classification probe response and fee configuration values.
-    """
-
-    launch = fork_network_anvil(JSON_RPC_ARBITRUM, fork_block_number=FORK_BLOCK)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_arbitrum_fork) -> Web3:
-    """Create Web3 connection to the Arbitrum fork."""
-
-    return create_multi_provider_web3(anvil_arbitrum_fork.json_rpc_url, retries=2)
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only T3tris fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ARBITRUM, FORK_BLOCK, web3_retries=2)
 
 
 @pytest.fixture(scope="module")

--- a/tests/erc_4626/vault_protocol/test_threejane.py
+++ b/tests/erc_4626/vault_protocol/test_threejane.py
@@ -16,28 +16,20 @@ from web3 import Web3
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault_protocol.threejane.vault import SUSD3_LOCK_DURATION, ThreeJaneVault
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
-from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 
-pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests")
+pytestmark = [
+    pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests"),
+    pytest.mark.xdist_group("fork:ethereum:25293000"),
+]
 
 
 @pytest.fixture(scope="module")
-def anvil_ethereum_fork(request) -> AnvilLaunch:
-    """Fork Ethereum mainnet at a specific block for reproducibility."""
-    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=25_293_000)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_ethereum_fork: AnvilLaunch) -> Web3:
-    web3 = create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url, retries=2)
-    return web3
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only ThreeJane fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ETHEREUM, 25_293_000, web3_retries=2)
 
 
 @flaky.flaky

--- a/tests/erc_4626/vault_protocol/test_wusdn.py
+++ b/tests/erc_4626/vault_protocol/test_wusdn.py
@@ -7,31 +7,21 @@ import flaky
 import pytest
 from web3 import Web3
 
-from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault_protocol.spectra.erc4626_wrapper_vault import SpectraERC4626WrapperVault
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 JSON_RPC_MONAD = os.environ.get("JSON_RPC_MONAD")
 
 
 @pytest.fixture(scope="module")
-def anvil_ethereum_fork(request) -> AnvilLaunch:
-    """Fork Ethereum mainnet at a specific block for reproducibility."""
-    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=21_757_000)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3_ethereum(anvil_ethereum_fork):
-    web3 = create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url)
-    return web3
+def web3_ethereum(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Spectra Ethereum fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ETHEREUM, 21_757_000)
 
 
 @pytest.fixture(scope="module")
@@ -56,6 +46,7 @@ def web3_monad(anvil_monad_fork):
 
 @flaky.flaky
 @pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run this test")
+@pytest.mark.xdist_group("fork:ethereum:21757000")
 def test_spectra_usdn_wrapper_vault(web3_ethereum: Web3):
     """Read Spectra USDN Wrapper vault metadata on Ethereum."""
 

--- a/tests/erc_4626/vault_protocol/test_yieldfi.py
+++ b/tests/erc_4626/vault_protocol/test_yieldfi.py
@@ -10,8 +10,7 @@ from web3 import Web3
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault_protocol.yieldfi.vault import YieldFiVault
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
-from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
@@ -21,22 +20,13 @@ pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHE
 
 
 @pytest.fixture(scope="module")
-def anvil_ethereum_fork(request) -> AnvilLaunch:
-    """Fork at a specific block for reproducibility"""
-    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=24181767)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_ethereum_fork):
-    web3 = create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url)
-    return web3
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Ethereum YieldFi fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ETHEREUM, 24_181_767)
 
 
 @flaky.flaky
+@pytest.mark.xdist_group("fork:ethereum:24181767")
 def test_yieldfi(
     web3: Web3,
     tmp_path: Path,
@@ -66,6 +56,7 @@ def test_yieldfi(
 
 
 @flaky.flaky
+@pytest.mark.xdist_group("fork:ethereum:24181767")
 def test_yieldfi_yusd_ethereum(
     web3: Web3,
 ):
@@ -94,6 +85,7 @@ def test_yieldfi_yusd_ethereum(
 
 
 @flaky.flaky
+@pytest.mark.xdist_group("fork:ethereum:24181767")
 def test_yieldfi_yusd_ethereum_2(
     web3: Web3,
 ):
@@ -122,24 +114,15 @@ def test_yieldfi_yusd_ethereum_2(
 
 
 @pytest.fixture(scope="module")
-def anvil_arbitrum_fork(request) -> AnvilLaunch:
-    """Fork Arbitrum at a specific block for reproducibility"""
+def web3_arbitrum(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Arbitrum YieldFi fork and its warmed RPC cache."""
     if JSON_RPC_ARBITRUM is None:
         pytest.skip("JSON_RPC_ARBITRUM needed to run this test")
-    launch = fork_network_anvil(JSON_RPC_ARBITRUM, fork_block_number=299000000)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3_arbitrum(anvil_arbitrum_fork):
-    web3 = create_multi_provider_web3(anvil_arbitrum_fork.json_rpc_url)
-    return web3
+    return anvil_fork_pool.get_web3(JSON_RPC_ARBITRUM, 299_000_000)
 
 
 @flaky.flaky
+@pytest.mark.xdist_group("fork:arbitrum:299000000")
 def test_yieldfi_arbitrum(
     web3_arbitrum: Web3,
 ):
@@ -168,24 +151,15 @@ def test_yieldfi_arbitrum(
 
 
 @pytest.fixture(scope="module")
-def anvil_base_fork(request) -> AnvilLaunch:
-    """Fork Base at a specific block for reproducibility"""
+def web3_base(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Base YieldFi fork and its warmed RPC cache."""
     if JSON_RPC_BASE is None:
         pytest.skip("JSON_RPC_BASE needed to run this test")
-    launch = fork_network_anvil(JSON_RPC_BASE, fork_block_number=41186545)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3_base(anvil_base_fork):
-    web3 = create_multi_provider_web3(anvil_base_fork.json_rpc_url)
-    return web3
+    return anvil_fork_pool.get_web3(JSON_RPC_BASE, 41_186_545)
 
 
 @flaky.flaky
+@pytest.mark.xdist_group("fork:base:41186545")
 def test_yieldfi_base(
     web3_base: Web3,
 ):

--- a/tests/erc_4626/vault_protocol/test_yo.py
+++ b/tests/erc_4626/vault_protocol/test_yo.py
@@ -9,8 +9,7 @@ from web3 import Web3
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault_protocol.yo.vault import YoVault
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
-from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.vault.base import VaultTechnicalRisk
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
@@ -18,35 +17,15 @@ JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
 
 
 @pytest.fixture(scope="module")
-def anvil_ethereum_fork(request) -> AnvilLaunch:
-    """Fork at a specific block for reproducibility."""
-    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=24303785)
-    try:
-        yield launch
-    finally:
-        launch.close()
+def web3_ethereum(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Ethereum Yo fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ETHEREUM, 24_303_785, web3_retries=2)
 
 
 @pytest.fixture(scope="module")
-def web3_ethereum(anvil_ethereum_fork):
-    web3 = create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url, retries=2)
-    return web3
-
-
-@pytest.fixture(scope="module")
-def anvil_base_fork(request) -> AnvilLaunch:
-    """Fork at a specific block for reproducibility."""
-    launch = fork_network_anvil(JSON_RPC_BASE, fork_block_number=26953285)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3_base(anvil_base_fork):
-    web3 = create_multi_provider_web3(anvil_base_fork.json_rpc_url, retries=2)
-    return web3
+def web3_base(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Base Yo fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_BASE, 26_953_285, web3_retries=2)
 
 
 @flaky.flaky
@@ -54,6 +33,7 @@ def web3_base(anvil_base_fork):
     JSON_RPC_ETHEREUM is None,
     reason="JSON_RPC_ETHEREUM needed to run this test",
 )
+@pytest.mark.xdist_group("fork:ethereum:24303785")
 def test_yo_vault_ethereum(web3_ethereum: Web3):
     """Read Yo vault metadata on Ethereum."""
 
@@ -90,6 +70,7 @@ def test_yo_vault_ethereum(web3_ethereum: Web3):
     JSON_RPC_BASE is None,
     reason="JSON_RPC_BASE needed to run this test",
 )
+@pytest.mark.xdist_group("fork:base:26953285")
 def test_yo_vault_base(web3_base: Web3):
     """Read Yo vault metadata on Base.
 

--- a/tests/gains/conftest.py
+++ b/tests/gains/conftest.py
@@ -5,29 +5,21 @@ import os
 from decimal import Decimal
 
 import pytest
+from web3 import Web3
 
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.token import TokenDetails, fetch_erc20_details, USDC_NATIVE_TOKEN, USDC_WHALE
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
+from eth_defi.token import USDC_NATIVE_TOKEN, USDC_WHALE, TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
 
 JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
 
 
 @pytest.fixture(scope="module")
-def anvil_arbitrum_fork(request) -> AnvilLaunch:
-    launch = fork_network_anvil(JSON_RPC_ARBITRUM, fork_block_number=375_216_652)
-    try:
-        yield launch
-    finally:
-        # Wind down Anvil process after the test is complete
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_arbitrum_fork):
-    web3 = create_multi_provider_web3(anvil_arbitrum_fork.json_rpc_url)
-    return web3
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Gains/Ostium fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ARBITRUM, 375_216_652)
 
 
 @pytest.fixture()

--- a/tests/gains/test_domination.py
+++ b/tests/gains/test_domination.py
@@ -9,32 +9,24 @@ from web3 import Web3
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect, detect_vault_features
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault_protocol.gains.vault import DominationFinanceVault, GainsVault
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
-from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.vault.fee import VaultFeeMode
 from eth_defi.vault.risk import VaultTechnicalRisk
 
 JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
 
-pytestmark = pytest.mark.skipif(not JSON_RPC_BASE, reason="Set JSON_RPC_BASE to run this test")
+pytestmark = [
+    pytest.mark.skipif(not JSON_RPC_BASE, reason="Set JSON_RPC_BASE to run this test"),
+    pytest.mark.xdist_group("fork:base:domination-46854858"),
+]
 
 DOMINATION_DFUSDC_ADDRESS = "0xA194082Aabb75Dd1Ca9Dc1BA573A5528BeB8c2Fb"
 
 
 @pytest.fixture(scope="module")
-def anvil_base_fork() -> AnvilLaunch:
-    """Fork Base at a specific block for reproducibility."""
-    launch = fork_network_anvil(JSON_RPC_BASE, fork_block_number=46_854_858)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_base_fork: AnvilLaunch) -> Web3:
-    """Create Web3 connection to the Anvil fork."""
-    return create_multi_provider_web3(anvil_base_fork.json_rpc_url, retries=2)
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Domination fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_BASE, 46_854_858)
 
 
 def test_domination_features(web3: Web3):

--- a/tests/gains/test_gtrade_usdc.py
+++ b/tests/gains/test_gtrade_usdc.py
@@ -22,7 +22,10 @@ from eth_defi.vault.deposit_redeem import AsyncVaultRequestStatus, VaultFlowUnav
 from eth_defi.vault.historical import VaultHistoricalReadMulticaller
 
 JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
-pytestmark = pytest.mark.skipif(not JSON_RPC_ARBITRUM, reason="Set JSON_RPC_ARBITRUM to run this test")
+pytestmark = [
+    pytest.mark.skipif(not JSON_RPC_ARBITRUM, reason="Set JSON_RPC_ARBITRUM to run this test"),
+    pytest.mark.xdist_group("fork:arbitrum:gains-375216652"),
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/gains/test_ostium.py
+++ b/tests/gains/test_ostium.py
@@ -5,7 +5,6 @@ import os
 from decimal import Decimal
 
 import pytest
-
 from web3 import Web3
 
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect, detect_vault_features
@@ -13,31 +12,23 @@ from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault_protocol.gains.deposit_redeem import GainsDepositManager, GainsRedemptionRequest
 from eth_defi.erc_4626.vault_protocol.gains.testing import force_next_gains_epoch
 from eth_defi.erc_4626.vault_protocol.gains.vault import GainsHistoricalReader, GainsVault, OstiumVault
-from eth_defi.provider.anvil import fork_network_anvil, AnvilLaunch
-from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.token import TokenDetails
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.vault.base import DEPOSIT_CLOSED_CAP_REACHED
 
 JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
 CI = os.environ.get("CI") == "true"
-pytestmark = pytest.mark.skipif(not JSON_RPC_ARBITRUM, reason="Set JSON_RPC_ARBITRUM to run this test")
+pytestmark = [
+    pytest.mark.skipif(not JSON_RPC_ARBITRUM, reason="Set JSON_RPC_ARBITRUM to run this test"),
+    pytest.mark.xdist_group("fork:arbitrum:gains-375216652"),
+]
 
 
 @pytest.fixture(scope="module")
-def anvil_arbitrum_fork(request) -> AnvilLaunch:
-    launch = fork_network_anvil(JSON_RPC_ARBITRUM, fork_block_number=375_216_652)
-    try:
-        yield launch
-    finally:
-        # Wind down Anvil process after the test is complete
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_arbitrum_fork):
-    web3 = create_multi_provider_web3(anvil_arbitrum_fork.json_rpc_url)
-    return web3
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Gains/Ostium fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ARBITRUM, 375_216_652)
 
 
 @pytest.fixture(scope="module")
@@ -58,7 +49,7 @@ def test_ostium_features(web3):
 
 @pytest.mark.skipif(CI, reason="This just does not work on Github due to some RPC errors even after changing provider")
 def test_ostium_read_data(web3, vault: GainsVault):
-    assert vault.name == f"Ostium Liquidity Pool Vault"
+    assert vault.name == "Ostium Liquidity Pool Vault"
     # https://arbiscan.io/address/0x20d419a8e12c45f88fda7c5760bb6923cee27f98#readContract
     assert vault.gains_open_trades_pnl_feed is None
     assert vault.open_pnl_contract.address == "0xE607aC9FF58697c5978AfA1Fc1C5C437a6D1858c"

--- a/tests/gains/test_ostium_v15.py
+++ b/tests/gains/test_ostium_v15.py
@@ -10,19 +10,18 @@ import os
 from decimal import Decimal
 
 import pytest
-
 from web3 import Web3
 
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect, detect_vault_features
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault_protocol.gains.deposit_redeem import (
+    OSTIUM_REQUEST_STATUS_CLAIMABLE,
+    OSTIUM_REQUEST_STATUS_PENDING,
     OstiumDepositRequest,
     OstiumDepositTicket,
     OstiumRedemptionRequest,
     OstiumRedemptionTicket,
     OstiumV15DepositManager,
-    OSTIUM_REQUEST_STATUS_CLAIMABLE,
-    OSTIUM_REQUEST_STATUS_PENDING,
 )
 from eth_defi.erc_4626.vault_protocol.gains.testing import force_ostium_v15_settlement
 from eth_defi.erc_4626.vault_protocol.gains.vault import (
@@ -30,33 +29,27 @@ from eth_defi.erc_4626.vault_protocol.gains.vault import (
     OstiumVault,
     OstiumVersion,
 )
-from eth_defi.provider.anvil import fork_network_anvil, AnvilLaunch
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.token import TokenDetails, fetch_erc20_details, USDC_NATIVE_TOKEN, USDC_WHALE
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
+from eth_defi.token import USDC_NATIVE_TOKEN, USDC_WHALE, TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
-
 
 JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
 CI = os.environ.get("CI") == "true"
-pytestmark = pytest.mark.skipif(not JSON_RPC_ARBITRUM, reason="Set JSON_RPC_ARBITRUM to run this test")
+pytestmark = [
+    pytest.mark.skipif(not JSON_RPC_ARBITRUM, reason="Set JSON_RPC_ARBITRUM to run this test"),
+    pytest.mark.xdist_group("fork:arbitrum:ostium-v15-470000000"),
+]
 
 #: Post-upgrade fork block (V1.5 was deployed at block 457,238,658)
 FORK_BLOCK = 470_000_000
 
 
 @pytest.fixture(scope="module")
-def anvil_arbitrum_fork(request) -> AnvilLaunch:
-    launch = fork_network_anvil(JSON_RPC_ARBITRUM, fork_block_number=FORK_BLOCK)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_arbitrum_fork):
-    web3 = create_multi_provider_web3(anvil_arbitrum_fork.json_rpc_url)
-    return web3
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the post-upgrade read-only fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ARBITRUM, FORK_BLOCK)
 
 
 @pytest.fixture()

--- a/tests/spiko/test_spiko_vault.py
+++ b/tests/spiko/test_spiko_vault.py
@@ -11,8 +11,7 @@ from web3 import Web3
 from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS, _get_hardcoded_protocol_features, create_vault_instance_autodetect  # noqa: PLC2701
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature, get_vault_protocol_name
 from eth_defi.erc_4626.scan import create_vault_scan_record
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
-from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.tokenised_fund.spiko.constants import USTBL_FIRST_SEEN_AT, USTBL_FIRST_SEEN_AT_BLOCK, USTBL_TOKEN_ADDRESS
 from eth_defi.tokenised_fund.spiko.historical import SpikoHistoricalReader, SpikoVaultReaderState
 from eth_defi.tokenised_fund.spiko.vault import SPIKO_PERMISSIONED_FLOW_REASON, USTBL_MANAGEMENT_FEE, SpikoVault
@@ -22,6 +21,8 @@ from eth_defi.vault.fee import VaultFeeMode
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 
+pytestmark = pytest.mark.xdist_group("fork:ethereum:25550000")
+
 SPIKO_TEST_BLOCK = 25_550_000
 EXPECTED_TOTAL_SUPPLY = Decimal("53782226.27927")
 EXPECTED_SHARE_PRICE = Decimal("1.029972")
@@ -29,28 +30,11 @@ EXPECTED_TOTAL_ASSETS = Decimal("55394187.16531228044")
 
 
 @pytest.fixture(scope="module")
-def anvil_ethereum_fork() -> AnvilLaunch:
-    """Fork Ethereum at a reproducible USTBL oracle observation.
-
-    :return: Running Anvil fork.
-    """
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Spiko/USYC fork and its warmed RPC cache."""
     if JSON_RPC_ETHEREUM is None:
         pytest.skip("JSON_RPC_ETHEREUM needed to run Spiko integration tests")
-    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=SPIKO_TEST_BLOCK)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_ethereum_fork: AnvilLaunch) -> Web3:
-    """Create Web3 connected to the fixed fork.
-
-    :param anvil_ethereum_fork: Running Anvil fork.
-    :return: Multi-provider Web3 instance.
-    """
-    return create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url, retries=2)
+    return anvil_fork_pool.get_web3(JSON_RPC_ETHEREUM, SPIKO_TEST_BLOCK, web3_retries=2)
 
 
 def test_spiko_hardcoded_protocol() -> None:

--- a/tests/usyc/test_usyc_vault.py
+++ b/tests/usyc/test_usyc_vault.py
@@ -11,8 +11,7 @@ from web3 import Web3
 from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS, _get_hardcoded_protocol_features, create_vault_instance_autodetect  # noqa: PLC2701
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature, get_vault_protocol_name
 from eth_defi.erc_4626.scan import create_vault_scan_record
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
-from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.tokenised_fund.usyc.constants import USYC_FIRST_SEEN_AT, USYC_FIRST_SEEN_AT_BLOCK, USYC_TOKEN_ADDRESS
 from eth_defi.tokenised_fund.usyc.historical import USYCHistoricalReader
 from eth_defi.tokenised_fund.usyc.vault import USYC_DEPOSIT_FEE, USYC_PERFORMANCE_FEE, USYC_PERMISSIONED_FLOW_REASON, USYC_WITHDRAW_FEE, USYCVault
@@ -20,7 +19,10 @@ from eth_defi.tokenised_fund.vault import TokenisedFundDepositManager
 from eth_defi.vault.fee import VaultFeeMode
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
-pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests")
+pytestmark = [
+    pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests"),
+    pytest.mark.xdist_group("fork:ethereum:25550000"),
+]
 
 USYC_TEST_BLOCK = 25_550_000
 USYC_EXPECTED_TOTAL_SUPPLY = Decimal("81015541.068726")
@@ -29,19 +31,9 @@ USYC_EXPECTED_TOTAL_ASSETS = USYC_EXPECTED_TOTAL_SUPPLY * USYC_EXPECTED_SHARE_PR
 
 
 @pytest.fixture(scope="module")
-def anvil_ethereum_fork() -> AnvilLaunch:
-    """Fork Ethereum at a fixed USYC oracle observation."""
-    launch = fork_network_anvil(JSON_RPC_ETHEREUM, fork_block_number=USYC_TEST_BLOCK)
-    try:
-        yield launch
-    finally:
-        launch.close()
-
-
-@pytest.fixture(scope="module")
-def web3(anvil_ethereum_fork: AnvilLaunch) -> Web3:
-    """Create Web3 connected to the deterministic fork."""
-    return create_multi_provider_web3(anvil_ethereum_fork.json_rpc_url, retries=2)
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Share the read-only Spiko/USYC fork and its warmed RPC cache."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ETHEREUM, USYC_TEST_BLOCK, web3_retries=2)
 
 
 def test_usyc_hardcoded_protocol() -> None:


### PR DESCRIPTION
## Why

Legacy per-module Anvil launches repeatedly replayed archive state and fragmented the Foundry RPC cache. Read-only characterisation tests can safely reuse fixed forks.

## Lessons learnt

A shared fork is appropriate only for read-only state. Transaction, deployment, whale-unlock and multi-block archive tests retain isolated or direct-RPC paths. Each pooled fixed fork needs an xdist group keyed to its exact chain and block.

## Summary

- Move 29 read-only Gains, vault-protocol and tokenised-fund modules to `anvil_fork_pool`.
- Preserve historical fixed blocks where assertions depend on them, while grouping matching blocks for in-session reuse and persistent Foundry cache warming.
- Keep mutating fixtures separate; no test transaction path now uses a shared pool.

## Related issues and PRs

- Continues the shared-fork work from #1360.
- Follows the RPC-flakiness investigation in #1386.

## Unrelated CI and test fixes

None.