### PR TITLE
fix: distinguish Lighter LLP vault slugs

### DIFF
--- a/eth_defi/lighter/vault_data_export.py
+++ b/eth_defi/lighter/vault_data_export.py
@@ -120,6 +120,12 @@ def create_lighter_pool_row(
     address = deployment.format_pool_address(account_index)
     chain_id = deployment.chain_id
 
+    # LLP is the canonical protocol pool on every Lighter deployment. The API
+    # returns the same name for Ethereum and Robinhood, but vault slugs derive
+    # from the display name. Prefix it with the deployment name so the two
+    # pools have descriptive, stable names and distinct URL slugs.
+    display_name = f"{deployment.name} Liquidity Provider (LLP)" if is_llp else name
+
     # Convert operator_fee from percentage to decimal fraction
     perf_fee = operator_fee / 100.0 if operator_fee else 0.0
 
@@ -145,11 +151,11 @@ def create_lighter_pool_row(
     )
 
     row: VaultRow = {
-        "Symbol": (name or "")[:10],
-        "Name": name or "",
+        "Symbol": (display_name or "")[:10],
+        "Name": display_name or "",
         "Address": address,
         "Denomination": deployment.denomination,
-        "Share token": (name or "")[:10],
+        "Share token": (display_name or "")[:10],
         "NAV": Decimal(str(tvl)),
         "Shares": Decimal("0"),
         "Protocol": "Lighter",

--- a/tests/lighter/test_multi_deployment.py
+++ b/tests/lighter/test_multi_deployment.py
@@ -19,6 +19,7 @@ from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase
 from eth_defi.lighter.session import LighterSession
 from eth_defi.lighter.vault import fetch_all_pools
 from eth_defi.lighter.vault_data_export import build_raw_prices_dataframe, create_lighter_pool_row, merge_into_uncleaned_parquet, merge_into_vault_database
+from eth_defi.research.vault_metrics import slugify_vaults
 from eth_defi.vault.base import VaultHistoricalRead, VaultSpec
 from eth_defi.vault.vaultdb import VaultDatabase
 
@@ -213,6 +214,35 @@ def test_robinhood_pool_export_uses_deployment_metadata() -> None:
     assert "USDC deposited" not in row["_notes"]
     assert row["_deployment"] == "robinhood"
     assert row["_deployment_chain_id"] == 4663
+
+
+def test_llp_deployments_have_unique_display_names_and_slugs() -> None:
+    """Distinguish canonical LLP pools in the public vault catalogue."""
+    ethereum_spec, ethereum_row = create_lighter_pool_row(
+        account_index=ACCOUNT_INDEX,
+        name="Lighter Liquidity Provider (LLP)",
+        description="Ethereum LLP",
+        tvl=123_000.0,
+        created_at=datetime.datetime(2026, 7, 1),
+        is_llp=True,
+        deployment=LIGHTER_ETHEREUM,
+    )
+    robinhood_spec, robinhood_row = create_lighter_pool_row(
+        account_index=ACCOUNT_INDEX,
+        name="Lighter Liquidity Provider (LLP)",
+        description="Robinhood LLP",
+        tvl=123_000.0,
+        created_at=datetime.datetime(2026, 7, 1),
+        is_llp=True,
+        deployment=LIGHTER_ROBINHOOD,
+    )
+
+    slugify_vaults({ethereum_spec: ethereum_row, robinhood_spec: robinhood_row})
+
+    assert ethereum_row["Name"] == "Lighter Ethereum Liquidity Provider (LLP)"
+    assert robinhood_row["Name"] == "Lighter Robinhood Liquidity Provider (LLP)"
+    assert ethereum_row["vault_slug"] == "lighter-ethereum-liquidity-provider-llp"
+    assert robinhood_row["vault_slug"] == "lighter-robinhood-liquidity-provider-llp"
 
 
 def test_vault_database_merge_removes_legacy_robinhood_chain(tmp_path: Path) -> None:


### PR DESCRIPTION
## Why

The Ethereum and Robinhood LLP pools exported the same display name, producing colliding, order-dependent vault slugs.

## Lessons learnt

Native Lighter pools share a synthetic chain namespace, so deployment identity must be part of canonical LLP display metadata used for public URLs.

## Summary

- Export deployment-specific display names for canonical LLP pools.
- Add regression coverage for their distinct names and vault slugs.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.