### PR TITLE
fix: classify known Lagoon vault interfaces

### DIFF
--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -22,7 +22,7 @@ from eth_defi.erc_4626.vault_protocol.frax.constants import FRAX_STAKING_VAULT_A
 from eth_defi.erc_4626.vault_protocol.kiloex.constants import KILOEX_VAULT_ADDRESSES, KILOEX_VAULTS_BY_CHAIN
 from eth_defi.erc_4626.vault_protocol.nara.constants import NARAUSD_PLUS_VAULT
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult, MultiprocessMulticallReader, read_multicall_chunked
-from eth_defi.event_reader.web3factory import SimpleWeb3Factory, Web3Factory
+from eth_defi.event_reader.web3factory import Web3Factory
 from eth_defi.midas.constants import MIDAS_PRODUCTS, MIDAS_PRODUCTS_BY_TOKEN
 from eth_defi.tokenised_fund.asseto.constants import ASSETO_PRODUCTS, ASSETO_PRODUCTS_BY_TOKEN
 from eth_defi.tokenised_fund.centrifuge.constants import CENTRIFUGE_TRANCHE_PRODUCTS, CENTRIFUGE_TRANCHE_PRODUCTS_BY_TOKEN
@@ -850,7 +850,7 @@ def create_probe_calls(
                 extra_data=None,
             )
 
-        # Lagoon
+        # Older Lagoon releases.
         # https://basescan.org/address/0x6a5ea384e394083149ce39db29d5787a658aa98a#readContract
         yield EncodedCall.from_keccak_signature(
             address=address,
@@ -860,6 +860,15 @@ def create_probe_calls(
             extra_data=None,
         )
 
+        # Recent Lagoon deployments expose this protocol-specific accessor.
+        # https://github.com/hopperlabsxyz/lagoon-v0/blob/v0.5.0/src/v0.5.0/Vault.sol
+        yield EncodedCall.from_keccak_signature(
+            address=address,
+            signature=Web3.keccak(text="isTotalAssetsValid()")[0:4],
+            function="isTotalAssetsValid",
+            data=b"",
+            extra_data=None,
+        )
         # T3tris - ERC-4626-derived asynchronous vaults on Arbitrum.
         # Live app ABI exposes this protocol-specific accounting getter.
         # https://app.t3tris.finance/vaults
@@ -1353,6 +1362,19 @@ def _is_nonzero_abi_address(result: EncodedCallResult) -> bool:
     return result.success and len(result.result) == ABI_ENCODED_ADDRESS_LENGTH and int.from_bytes(result.result, byteorder="big") != 0
 
 
+def _is_abi_encoded_boolean(result: EncodedCallResult) -> bool:
+    """Check whether a probe returned an ABI-encoded boolean.
+
+    :param result:
+        Result returned by the boolean accessor probe.
+
+    :return:
+        ``True`` when the result is a valid ABI boolean, whether its value is
+        true or false.
+    """
+    return result.success and len(result.result) == ABI_ENCODED_ADDRESS_LENGTH and int.from_bytes(result.result, byteorder="big") in {0, 1}
+
+
 def identify_vault_features(
     address: HexAddress,
     calls: dict[str, EncodedCallResult],
@@ -1462,14 +1484,17 @@ def identify_vault_features(
     if _is_nonzero_abi_address(calls["withdrawalQueue"]):
         features.add(ERC4626Feature.symbiotic_like)
 
-    if calls["MAX_MANAGEMENT_RATE"].success:
+    # Legacy releases expose MAX_MANAGEMENT_RATE(). Recent releases expose the
+    # Lagoon-specific total-assets-validity accessor instead.
+    lagoon_recent_interface = _is_abi_encoded_boolean(calls["isTotalAssetsValid"])
+    if calls["MAX_MANAGEMENT_RATE"].success or lagoon_recent_interface:
         if ERC4626Feature.erc_7540_like in features:
             features.add(ERC4626Feature.lagoon_like)
         else:
-            # False positive: contract has MAX_MANAGEMENT_RATE() but lacks ERC-7540 isOperator(),
-            # so it is not a real Lagoon vault.
+            # False positive: contract has a Lagoon-specific accessor but lacks
+            # ERC-7540 isOperator(), so it is not a real Lagoon vault.
             # E.g. 0x7be599a641c6b99a5d7c8beb062fc3915ff9dd4f on Base.
-            logger.warning("Vault has MAX_MANAGEMENT_RATE but lacks ERC-7540 isOperator, skipping Lagoon classification: %s", debug_text)
+            logger.warning("Vault has Lagoon-specific accessors but lacks ERC-7540 isOperator, skipping Lagoon classification: %s", debug_text)
 
     if calls["getGrossTVL"].success:
         features.add(ERC4626Feature.t3tris_like)

--- a/scripts/erc-4626/migrate-lagoon-classification.py
+++ b/scripts/erc-4626/migrate-lagoon-classification.py
@@ -1,0 +1,389 @@
+"""Migrate cached ERC-7540 vault rows to automatic Lagoon classification.
+
+The Lagoon detector recognises legacy and recent Lagoon deployments from
+their contract interface. Vault rows cached before this detector existed keep
+their former ``<unknown ERC-7540>`` classification until they are re-probed.
+This migration reads the cached metadata database, re-probes every ERC-7540
+candidate (and existing Lagoon row), and persists only rows now identified as
+Lagoon.
+
+The migration changes metadata only. It does not touch price Parquet files,
+reader state, discovery leads, or any vault history.
+
+Usage:
+
+.. code-block:: shell
+
+    # Inspect the rows that would change; this is the default.
+    source .local-test.env && DRY_RUN=true \\
+        poetry run python scripts/erc-4626/migrate-lagoon-classification.py
+
+    # Back up and persist the corrected cached classifications.
+    source .local-test.env && DRY_RUN=false \\
+        poetry run python scripts/erc-4626/migrate-lagoon-classification.py
+
+Environment variables:
+
+- ``VAULT_DB_PATH``: Optional path to ``vault-metadata-db.pickle``. Falls
+  back to ``VAULT_DB`` and then the production metadata path.
+- ``DRY_RUN``: Set to ``true`` to report without writing. Defaults to ``true``.
+- ``LOG_LEVEL``: Optional log level. Defaults to ``info``.
+- ``JSON_RPC_<CHAIN>``: An RPC URL is required for every chain with an
+  ERC-7540 or existing Lagoon row in the metadata cache.
+"""
+
+import logging
+import os
+import shutil
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+from eth_typing import HexAddress
+from tabulate import tabulate
+from tqdm_loggable.auto import tqdm
+from web3 import Web3
+from web3.exceptions import Web3Exception
+
+from eth_defi.erc_4626.classification import detect_vault_features
+from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
+from eth_defi.provider.env import read_json_rpc_url
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.vaultdb import DEFAULT_VAULT_DATABASE, VaultDatabase, VaultRow
+
+logger = logging.getLogger(__name__)
+
+#: Canonical scan-record protocol name for Lagoon vaults.
+LAGOON_PROTOCOL_NAME = "Lagoon Finance"
+
+#: Stable public protocol slug derived from :data:`LAGOON_PROTOCOL_NAME`.
+LAGOON_PROTOCOL_SLUG = "lagoon-finance"
+
+#: Maximum number of changed rows printed by the command.
+MAX_UPDATED_ROWS_SHOWN = 100
+
+
+@dataclass(slots=True, frozen=True)
+class LagoonClassificationUpdate:
+    """One cached vault classification requiring a Lagoon update."""
+
+    #: Chain and address of the corrected vault.
+    spec: VaultSpec
+
+    #: Cached human-readable vault name.
+    name: str
+
+    #: Protocol label before automatic reclassification.
+    old_protocol: str
+
+    #: Cached feature values before automatic reclassification.
+    old_features: frozenset[ERC4626Feature]
+
+    #: Cached and re-probed feature values to persist.
+    new_features: frozenset[ERC4626Feature]
+
+
+@dataclass(slots=True, frozen=True)
+class LagoonClassificationMigrationResult:
+    """Summary of the cached Lagoon classification migration."""
+
+    #: All metadata rows inspected.
+    inspected_rows: int
+
+    #: Cached ERC-7540 or existing Lagoon rows re-probed.
+    candidate_rows: int
+
+    #: Candidates recognised as Lagoon by the current automatic detector.
+    recognised_lagoon_rows: int
+
+    #: Rows that were or would be updated.
+    updated_rows: tuple[LagoonClassificationUpdate, ...]
+
+
+Detector = Callable[[Web3, HexAddress], set[ERC4626Feature]]
+
+
+def parse_boolean_env(value: str | None, *, default: bool) -> bool:
+    """Parse an explicit boolean environment value.
+
+    An unset variable uses ``default``. Any value other than a conventional
+    boolean spelling raises instead of unexpectedly switching the migration to
+    write mode.
+
+    :param value:
+        Environment value to parse, or ``None`` when it is unset.
+    :param default:
+        Value to return for an unset environment variable.
+    :return:
+        Parsed boolean value.
+    """
+    if value is None:
+        return default
+
+    normalised_value = value.strip().lower()
+    if normalised_value in {"1", "true", "yes", "on"}:
+        return True
+    if normalised_value in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"Expected a boolean environment value, got {value!r}")
+
+
+def _get_cached_features(row: VaultRow) -> set[ERC4626Feature]:
+    """Return the best available persisted feature set for a vault row.
+
+    :param row:
+        Cached vault metadata row.
+
+    :return:
+        Top-level features, falling back to the detection envelope.
+    """
+    features = row.get("features")
+    if features is not None:
+        return set(features)
+
+    detection = row.get("_detection_data")
+    if isinstance(detection, ERC4262VaultDetection):
+        return set(detection.features)
+    return set()
+
+
+def _is_lagoon_candidate(row: VaultRow) -> bool:
+    """Determine whether a cached row needs a Lagoon classification probe.
+
+    Every supported Lagoon vault implements ERC-7540. Existing Lagoon-labelled
+    rows are included as well, so their stored feature envelope is refreshed.
+
+    :param row:
+        Cached vault metadata row.
+
+    :return:
+        ``True`` if the row requires current automatic detection.
+    """
+    return ERC4626Feature.erc_7540_like in _get_cached_features(row) or row.get("Protocol") == LAGOON_PROTOCOL_NAME
+
+
+def _format_features(features: Iterable[ERC4626Feature]) -> str:
+    """Format feature values for the operator report.
+
+    :param features:
+        Features to display.
+
+    :return:
+        Comma-separated stable feature values.
+    """
+    return ", ".join(sorted(feature.value for feature in features))
+
+
+def apply_lagoon_classification_updates(vault_db: VaultDatabase, updates: Iterable[LagoonClassificationUpdate]) -> None:
+    """Apply selected Lagoon metadata updates without altering other row fields.
+
+    :param vault_db:
+        In-memory metadata database to update.
+    :param updates:
+        Re-probed Lagoon classification updates to persist.
+    :return:
+        ``None`` after updating the in-memory database.
+    """
+    for update in updates:
+        row = vault_db.rows[update.spec].copy()
+        features = set(update.new_features)
+        row["features"] = features
+        row["Features"] = ", ".join(sorted(feature.name for feature in features))
+        row["Protocol"] = LAGOON_PROTOCOL_NAME
+        row["protocol_slug"] = LAGOON_PROTOCOL_SLUG
+
+        detection = row.get("_detection_data")
+        if isinstance(detection, ERC4262VaultDetection):
+            row["_detection_data"] = replace(detection, features=features)
+
+        vault_db.rows[update.spec] = row
+
+
+def create_backup_path(vault_db_path: Path) -> Path:
+    """Choose a non-overwriting backup path for the metadata cache.
+
+    :param vault_db_path:
+        Existing metadata cache to protect.
+
+    :return:
+        Sibling backup path that does not already exist.
+    """
+    backup_path = vault_db_path.with_suffix(".pickle.bak-lagoon-classification")
+    if not backup_path.exists():
+        return backup_path
+
+    backup_index = 1
+    while True:
+        indexed_backup_path = Path(f"{backup_path}.{backup_index}")
+        if not indexed_backup_path.exists():
+            return indexed_backup_path
+        backup_index += 1
+
+
+def _create_web3_by_chain(candidate_specs: Iterable[VaultSpec]) -> dict[int, Web3]:
+    """Create one JSON-RPC client per candidate chain.
+
+    :param candidate_specs:
+        Candidate vault specifications from the metadata cache.
+
+    :return:
+        Chain id mapped to a configured multi-provider Web3 client.
+    """
+    chain_ids = sorted({spec.chain_id for spec in candidate_specs})
+    return {chain_id: create_multi_provider_web3(read_json_rpc_url(chain_id)) for chain_id in chain_ids}
+
+
+def _collect_lagoon_classification_updates(
+    candidate_rows: list[tuple[VaultSpec, VaultRow]],
+    web3_by_chain: Mapping[int, Web3],
+    detector: Detector,
+) -> tuple[int, list[LagoonClassificationUpdate]]:
+    """Re-probe candidates and collect the required metadata updates.
+
+    :param candidate_rows:
+        Cached ERC-7540 or Lagoon-labelled rows to re-probe.
+    :param web3_by_chain:
+        Configured RPC clients by candidate chain id.
+    :param detector:
+        Automatic vault feature detector.
+    :return:
+        Number of recognised Lagoon rows and updates to apply.
+    """
+    recognised_lagoon_rows = 0
+    updates: list[LagoonClassificationUpdate] = []
+
+    for spec, row in tqdm(candidate_rows, desc="Re-probing Lagoon candidates"):
+        old_features = frozenset(_get_cached_features(row))
+        try:
+            detected_features = detector(web3_by_chain[spec.chain_id], spec.vault_address)
+        except (ConnectionError, TimeoutError, ValueError, Web3Exception) as error:
+            raise RuntimeError(f"Could not re-probe Lagoon candidate {spec}. No metadata cache was written.") from error
+
+        if ERC4626Feature.lagoon_like not in detected_features:
+            continue
+
+        recognised_lagoon_rows += 1
+        new_features = old_features | detected_features
+        detection = row.get("_detection_data")
+        is_current = row.get("Protocol") == LAGOON_PROTOCOL_NAME and row.get("protocol_slug") == LAGOON_PROTOCOL_SLUG and _get_cached_features(row) == new_features and (not isinstance(detection, ERC4262VaultDetection) or detection.features == new_features)
+        if is_current:
+            continue
+
+        updates.append(
+            LagoonClassificationUpdate(
+                spec=spec,
+                name=str(row.get("Name", "")),
+                old_protocol=str(row.get("Protocol", "")),
+                old_features=old_features,
+                new_features=frozenset(new_features),
+            )
+        )
+
+    return recognised_lagoon_rows, updates
+
+
+def migrate_lagoon_classifications(
+    vault_db_path: Path = DEFAULT_VAULT_DATABASE,
+    *,
+    dry_run: bool,
+    web3_by_chain: Mapping[int, Web3] | None = None,
+    detector: Detector | None = None,
+) -> LagoonClassificationMigrationResult:
+    """Re-probe cached ERC-7540 rows and migrate automatic Lagoon matches.
+
+    Every candidate is probed before the cache is written. A failed probe aborts
+    the migration before any write, ensuring an operator cannot accidentally
+    persist a partial all-Lagoon repair.
+
+    :param vault_db_path:
+        Metadata cache to inspect or update.
+    :param dry_run:
+        Report matching rows without writing the cache.
+    :param web3_by_chain:
+        Optional preconfigured clients, primarily for programmatic use and
+        tests. Missing candidate chains raise an error.
+    :param detector:
+        Optional automatic feature detector. Defaults to the production
+        multicall detector.
+    :return:
+        Counts and detailed rows that were or would be updated.
+    """
+    vault_db = VaultDatabase.read(vault_db_path)
+    candidate_rows = [(spec, row) for spec, row in vault_db.rows.items() if _is_lagoon_candidate(row)]
+    detector = detector or (lambda web3, address: detect_vault_features(web3, address, verbose=False))
+    web3_by_chain = dict(web3_by_chain) if web3_by_chain is not None else _create_web3_by_chain(spec for spec, _ in candidate_rows)
+
+    missing_chains = sorted({spec.chain_id for spec, _ in candidate_rows}.difference(web3_by_chain))
+    if missing_chains:
+        raise ValueError(f"Missing Web3 clients for Lagoon migration chains: {missing_chains}")
+
+    recognised_lagoon_rows, updates = _collect_lagoon_classification_updates(candidate_rows, web3_by_chain, detector)
+
+    if updates:
+        table_rows = [
+            [
+                update.spec.chain_id,
+                update.spec.vault_address,
+                update.name,
+                update.old_protocol,
+                LAGOON_PROTOCOL_NAME,
+                _format_features(update.old_features),
+                _format_features(update.new_features),
+            ]
+            for update in updates[:MAX_UPDATED_ROWS_SHOWN]
+        ]
+        print(tabulate(table_rows, headers=["Chain", "Address", "Name", "Old protocol", "New protocol", "Old features", "New features"], tablefmt="simple"))
+        if len(updates) > MAX_UPDATED_ROWS_SHOWN:
+            print(f"... {len(updates) - MAX_UPDATED_ROWS_SHOWN:,} more updated rows not shown")
+
+    result = LagoonClassificationMigrationResult(
+        inspected_rows=len(vault_db.rows),
+        candidate_rows=len(candidate_rows),
+        recognised_lagoon_rows=recognised_lagoon_rows,
+        updated_rows=tuple(updates),
+    )
+    if not result.updated_rows:
+        logger.info("No cached Lagoon classifications need repair in %s", vault_db_path)
+        return result
+
+    if dry_run:
+        logger.info("DRY RUN: would update %d Lagoon classifications in %s", len(result.updated_rows), vault_db_path)
+        return result
+
+    backup_path = create_backup_path(vault_db_path)
+    logger.info("Creating vault metadata backup at %s", backup_path)
+    shutil.copy2(vault_db_path, backup_path)
+    apply_lagoon_classification_updates(vault_db, result.updated_rows)
+    vault_db.write(vault_db_path)
+    logger.info("Updated %d Lagoon classifications in %s", len(result.updated_rows), vault_db_path)
+    return result
+
+
+def main() -> None:
+    """Run the cached Lagoon classification migration.
+
+    :return:
+        ``None``. Raises if the cache is unavailable or a candidate cannot be
+        re-probed.
+    """
+    setup_console_logging(
+        default_log_level=os.environ.get("LOG_LEVEL", "info"),
+        log_file=Path("logs/migrate-lagoon-classification.log"),
+    )
+    vault_db_path = Path(os.environ.get("VAULT_DB_PATH", os.environ.get("VAULT_DB", str(DEFAULT_VAULT_DATABASE)))).expanduser()
+    dry_run = parse_boolean_env(os.environ.get("DRY_RUN"), default=True)
+    if not vault_db_path.exists():
+        raise FileNotFoundError(f"Vault database not found: {vault_db_path}")
+
+    result = migrate_lagoon_classifications(vault_db_path, dry_run=dry_run)
+    print(f"Inspected {result.inspected_rows:,} rows, re-probed {result.candidate_rows:,} candidates, recognised {result.recognised_lagoon_rows:,} Lagoon vaults, updated {len(result.updated_rows):,}.")
+    if dry_run:
+        print("Dry run - no changes written.")
+    elif result.updated_rows:
+        print(f"Saved migrated vault metadata to {vault_db_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/erc_4626/test_classification.py
+++ b/tests/erc_4626/test_classification.py
@@ -49,6 +49,58 @@ def test_frax_staking_vaults_are_hardcoded_on_ethereum() -> None:
         assert _get_hardcoded_protocol_features(address, chain_id=ARBITRUM) is None
 
 
+def test_lagoon_legacy_and_recent_interfaces_are_detected() -> None:
+    """Identify Lagoon through its legacy and recent contract interfaces."""
+
+    probe_names = {call.func_name for call in create_probe_calls(["0x03d1ec0d01b659b89a87eabb56e4af5cb6e14bfc"], chain_id=ETHEREUM_MAINNET)}
+    assert "isTotalAssetsValid" in probe_names
+
+    erc4626_probe = SimpleNamespace(success=True, result=eth_abi.encode(["uint256"], [1]))
+    bool_probe = SimpleNamespace(success=True, result=eth_abi.encode(["bool"], [False]))
+    legacy_probe = SimpleNamespace(success=True, result=eth_abi.encode(["uint256"], [1]))
+
+    legacy_features = identify_vault_features(
+        "0x03d1ec0d01b659b89a87eabb56e4af5cb6e14bfc",
+        _ProbeResultsDict(
+            {
+                "convertToShares": erc4626_probe,
+                "isOperator": bool_probe,
+                "MAX_MANAGEMENT_RATE": legacy_probe,
+            }
+        ),
+        debug_text=None,
+        chain_id=ETHEREUM_MAINNET,
+    )
+    assert legacy_features == {ERC4626Feature.erc_7540_like, ERC4626Feature.lagoon_like}
+
+    recent_features = identify_vault_features(
+        "0x03d1ec0d01b659b89a87eabb56e4af5cb6e14bfc",
+        _ProbeResultsDict(
+            {
+                "convertToShares": erc4626_probe,
+                "isOperator": bool_probe,
+                "isTotalAssetsValid": bool_probe,
+            }
+        ),
+        debug_text=None,
+        chain_id=ETHEREUM_MAINNET,
+    )
+    assert recent_features == {ERC4626Feature.erc_7540_like, ERC4626Feature.lagoon_like}
+
+    non_erc7540_features = identify_vault_features(
+        "0x03d1ec0d01b659b89a87eabb56e4af5cb6e14bfc",
+        _ProbeResultsDict(
+            {
+                "convertToShares": erc4626_probe,
+                "isTotalAssetsValid": bool_probe,
+            }
+        ),
+        debug_text=None,
+        chain_id=ETHEREUM_MAINNET,
+    )
+    assert ERC4626Feature.lagoon_like not in non_erc7540_features
+
+
 def test_fraxlend_probe_requires_event_derived_deployer() -> None:
     """Accept the single Fraxlend probe only for a reviewed Frax deployer."""
 

--- a/tests/erc_4626/test_migrate_lagoon_classification.py
+++ b/tests/erc_4626/test_migrate_lagoon_classification.py
@@ -1,0 +1,229 @@
+"""Tests for the cached Lagoon classification migration."""
+
+import datetime
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.vaultdb import VaultDatabase
+
+
+def load_migration_module():
+    """Load the Lagoon cache migration script as a test module.
+
+    :return:
+        Loaded migration module.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "erc-4626" / "migrate-lagoon-classification.py"
+    spec = importlib.util.spec_from_file_location("migrate_lagoon_classification", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def create_detection(spec: VaultSpec, features: set[ERC4626Feature]) -> ERC4262VaultDetection:
+    """Create cached detection metadata for a vault fixture.
+
+    :param spec:
+        Vault identity.
+    :param features:
+        Cached scanner features.
+    :return:
+        Detection envelope matching metadata cache rows.
+    """
+    timestamp = datetime.datetime(2026, 7, 28, tzinfo=datetime.UTC).replace(tzinfo=None)
+    return ERC4262VaultDetection(
+        chain=spec.chain_id,
+        address=spec.vault_address,
+        first_seen_at_block=1,
+        first_seen_at=timestamp,
+        features=set(features),
+        updated_at=timestamp,
+        deposit_count=1,
+        redeem_count=1,
+    )
+
+
+def create_row(spec: VaultSpec, protocol: str, features: set[ERC4626Feature], protocol_slug: str) -> dict:
+    """Create one minimal cached vault metadata row.
+
+    :param spec:
+        Vault identity.
+    :param protocol:
+        Cached protocol label.
+    :param features:
+        Cached feature flags.
+    :param protocol_slug:
+        Cached protocol URL slug.
+    :return:
+        Vault metadata row.
+    """
+    return {
+        "Name": f"Vault {spec.vault_address[-4:]}",
+        "Protocol": protocol,
+        "Features": ", ".join(sorted(feature.name for feature in features)),
+        "features": set(features),
+        "protocol_slug": protocol_slug,
+        "_detection_data": create_detection(spec, features),
+    }
+
+
+def test_migrate_lagoon_classifications_updates_only_automatic_matches(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Re-probing updates recognised Lagoon cache rows and preserves others."""
+    migration = load_migration_module()
+    unknown_spec = VaultSpec(1, "0x0000000000000000000000000000000000000001")
+    stale_lagoon_spec = VaultSpec(1, "0x0000000000000000000000000000000000000002")
+    generic_erc7540_spec = VaultSpec(1, "0x0000000000000000000000000000000000000003")
+    morpho_spec = VaultSpec(1, "0x0000000000000000000000000000000000000004")
+    stale_features = {ERC4626Feature.erc_7540_like, ERC4626Feature.erc_7575_like}
+    lagoon_features = {ERC4626Feature.lagoon_like, *stale_features}
+
+    vault_db = VaultDatabase(
+        rows={
+            unknown_spec: create_row(unknown_spec, "<unknown ERC-7540>", stale_features, "unknown"),
+            stale_lagoon_spec: create_row(stale_lagoon_spec, "Lagoon Finance", stale_features, "unknown"),
+            generic_erc7540_spec: create_row(generic_erc7540_spec, "<unknown ERC-7540>", stale_features, "unknown"),
+            morpho_spec: create_row(morpho_spec, "Morpho", {ERC4626Feature.morpho_like}, "morpho"),
+        }
+    )
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    vault_db.write(vault_db_path)
+
+    def detector(_web3: object, address: str) -> set[ERC4626Feature]:
+        """Return current automatic features for the migration fixture."""
+        if address in {unknown_spec.vault_address, stale_lagoon_spec.vault_address}:
+            return set(lagoon_features)
+        assert address == generic_erc7540_spec.vault_address
+        return set(stale_features)
+
+    result = migration.migrate_lagoon_classifications(
+        vault_db_path,
+        dry_run=False,
+        web3_by_chain={1: object()},
+        detector=detector,
+    )
+    captured = capsys.readouterr()
+
+    assert result.inspected_rows == len(vault_db.rows)
+    assert result.candidate_rows == len({unknown_spec, stale_lagoon_spec, generic_erc7540_spec})
+    assert result.recognised_lagoon_rows == len({unknown_spec, stale_lagoon_spec})
+    assert {update.spec for update in result.updated_rows} == {unknown_spec, stale_lagoon_spec}
+    assert "Old protocol" in captured.out
+    assert unknown_spec.vault_address in captured.out
+    assert (tmp_path / "vault-metadata-db.pickle.bak-lagoon-classification").exists()
+
+    migrated_db = VaultDatabase.read(vault_db_path)
+    for spec in (unknown_spec, stale_lagoon_spec):
+        row = migrated_db.rows[spec]
+        assert row["Protocol"] == "Lagoon Finance"
+        assert row["protocol_slug"] == "lagoon-finance"
+        assert row["features"] == lagoon_features
+        assert row["_detection_data"].features == lagoon_features
+    assert migrated_db.rows[generic_erc7540_spec]["Protocol"] == "<unknown ERC-7540>"
+    assert migrated_db.rows[morpho_spec]["Protocol"] == "Morpho"
+
+
+def test_migrate_lagoon_classifications_dry_run_does_not_write(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Dry runs show recognised Lagoon rows without changing the cache."""
+    migration = load_migration_module()
+    spec = VaultSpec(1, "0x0000000000000000000000000000000000000001")
+    stale_features = {ERC4626Feature.erc_7540_like, ERC4626Feature.erc_7575_like}
+    lagoon_features = {ERC4626Feature.lagoon_like, *stale_features}
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    VaultDatabase(rows={spec: create_row(spec, "<unknown ERC-7540>", stale_features, "unknown")}).write(vault_db_path)
+
+    result = migration.migrate_lagoon_classifications(
+        vault_db_path,
+        dry_run=True,
+        web3_by_chain={1: object()},
+        detector=lambda _web3, _address: set(lagoon_features),
+    )
+    captured = capsys.readouterr()
+
+    assert len(result.updated_rows) == 1
+    assert spec.vault_address in captured.out
+    unchanged_db = VaultDatabase.read(vault_db_path)
+    assert unchanged_db.rows[spec]["Protocol"] == "<unknown ERC-7540>"
+    assert unchanged_db.rows[spec]["protocol_slug"] == "unknown"
+    assert not (tmp_path / "vault-metadata-db.pickle.bak-lagoon-classification").exists()
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, True),
+        ("true", True),
+        ("1", True),
+        ("yes", True),
+        ("false", False),
+        ("0", False),
+        ("no", False),
+    ],
+)
+def test_parse_boolean_env_is_explicit(value: str | None, expected: object) -> None:
+    """The write-mode switch accepts conventional explicit boolean values."""
+    migration = load_migration_module()
+
+    assert migration.parse_boolean_env(value, default=True) is expected
+
+
+def test_parse_boolean_env_rejects_ambiguous_value() -> None:
+    """An accidental dry-run value cannot turn a migration into a write."""
+    migration = load_migration_module()
+
+    with pytest.raises(ValueError, match="Expected a boolean"):
+        migration.parse_boolean_env("definitely", default=True)
+
+
+def test_migrate_lagoon_classifications_preserves_cached_non_lagoon_features(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A targeted reclassification cannot erase unrelated cached features."""
+    migration = load_migration_module()
+    spec = VaultSpec(1, "0x0000000000000000000000000000000000000001")
+    cached_features = {ERC4626Feature.erc_7540_like, ERC4626Feature.erc_7575_like}
+    detected_features = {ERC4626Feature.erc_7540_like, ERC4626Feature.lagoon_like}
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    VaultDatabase(rows={spec: create_row(spec, "<unknown ERC-7540>", cached_features, "unknown")}).write(vault_db_path)
+
+    migration.migrate_lagoon_classifications(
+        vault_db_path,
+        dry_run=False,
+        web3_by_chain={1: object()},
+        detector=lambda _web3, _address: set(detected_features),
+    )
+    capsys.readouterr()
+
+    migrated_row = VaultDatabase.read(vault_db_path).rows[spec]
+    assert migrated_row["features"] == cached_features | detected_features
+    assert migrated_row["_detection_data"].features == cached_features | detected_features
+
+
+def test_migrate_lagoon_classifications_aborts_before_writing_on_probe_error(tmp_path: Path) -> None:
+    """A failed re-probe preserves the cache and does not create a backup."""
+    migration = load_migration_module()
+    spec = VaultSpec(1, "0x0000000000000000000000000000000000000001")
+    features = {ERC4626Feature.erc_7540_like}
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    VaultDatabase(rows={spec: create_row(spec, "<unknown ERC-7540>", features, "unknown")}).write(vault_db_path)
+    original_contents = vault_db_path.read_bytes()
+
+    def failed_detector(_web3: object, _address: str) -> set[ERC4626Feature]:
+        """Simulate a re-probe failure."""
+        error_message = "RPC timeout"
+        raise TimeoutError(error_message)
+
+    with pytest.raises(RuntimeError, match="No metadata cache was written"):
+        migration.migrate_lagoon_classifications(
+            vault_db_path,
+            dry_run=False,
+            web3_by_chain={1: object()},
+            detector=failed_detector,
+        )
+
+    assert vault_db_path.read_bytes() == original_contents
+    assert not (tmp_path / "vault-metadata-db.pickle.bak-lagoon-classification").exists()


### PR DESCRIPTION
## Why

A cached Lagoon v0.6 vault was classified as `<unknown ERC-7540>` because it does not respond to the legacy `MAX_MANAGEMENT_RATE()` probe.

## Lessons learnt

Protocol detection should rely on stable, protocol-specific interface families. Updating a detector also requires an explicit migration for persisted metadata.

## Summary

- Detect legacy Lagoon vaults through `MAX_MANAGEMENT_RATE()` and recent Lagoon vaults through `isTotalAssetsValid()`.
- Add a dry-run-first cache migration that reports every updated vault and creates a backup before writes.
- Preserve cached non-Lagoon feature flags during this targeted classification repair.

## Related issues and PRs

None.