### PR TITLE
feat: export Lighter snapshots and vault price sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 1.2
 
+- feat: Export vault share-price provenance and add Lighter ownership, account snapshots and conservative net-flow metrics (2026-07-28)
+
 - feat: Read complete Accountable fee-manager terms and effective vault deposit minimums onchain across legacy and current contract versions (2026-07-28)
 
 - feat: Add Spiko EUTBL on Arbitrum with EUR source-denomination export and USD-normalised NAV history (2026-07-28)

--- a/docs/source/api/vault/index.rst
+++ b/docs/source/api/vault/index.rst
@@ -18,6 +18,7 @@ A generic high-level Python framework to integrate different vault providers.
    eth_defi.vault.base
    eth_defi.vault.flow_events
    eth_defi.vault.risk
+   eth_defi.vault.price_source
    eth_defi.vault.fee
    eth_defi.vault.deposit_redeem
    eth_defi.vault.vaultdb

--- a/eth_defi/erc_4626/scan.py
+++ b/eth_defi/erc_4626/scan.py
@@ -354,6 +354,7 @@ def create_vault_scan_record(
         "_deposit_manager": None,
         "_deposit_permission": VaultDepositPermission.unknown.value,
         "_whitelist_notes": None,
+        "_share_price_source": None,
     }
 
     vault = create_vault_instance(
@@ -407,6 +408,8 @@ def create_vault_scan_record(
         deposit_manager_capability = capability_resolver() if capability_resolver is not None else None
         whitelist_notes_resolver = getattr(vault, "get_whitelist_notes", None)
         whitelist_notes = whitelist_notes_resolver() if whitelist_notes_resolver is not None else None
+        share_price_source_resolver = getattr(vault, "get_share_price_source", None)
+        share_price_source = share_price_source_resolver() if share_price_source_resolver is not None else None
 
         data = {
             "Symbol": vault.symbol,
@@ -435,6 +438,7 @@ def create_vault_scan_record(
             "_short_description": short_description,
             "_notes": notes,
             "_manager_name": vault.manager_name,
+            "_share_price_source": share_price_source,
             "_morpho_offchain_data": vault.morpho_offchain_data if isinstance(vault, (MorphoV1Vault, MorphoV2Vault)) else None,
             "_deposit_manager": deposit_manager_capability.as_initial_public_schema() if deposit_manager_capability else None,
             "_deposit_permission": fetch_deposit_permission(vault).value,

--- a/eth_defi/erc_4626/vault.py
+++ b/eth_defi/erc_4626/vault.py
@@ -32,6 +32,7 @@ from eth_defi.token import TokenDetails, TokenDiskCache, fetch_erc20_details, is
 from eth_defi.vault.base import DEPOSIT_CLOSED_CAP_REACHED, REDEMPTION_CLOSED_INSUFFICIENT_LIQUIDITY, TradingUniverse, VaultBase, VaultFlowManager, VaultHistoricalRead, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
 from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
 from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.price_source import PriceSource
 
 logger = logging.getLogger(__name__)
 
@@ -905,6 +906,19 @@ class ERC4626Vault(VaultBase):
 
     def __repr__(self):
         return f"<{self.__class__.__name__}: {self.spec}>"
+
+    def get_share_price_source(self) -> PriceSource:  # noqa: PLR6301
+        """Return the standard ERC-4626 share-price source.
+
+        ERC-4626 prices are calculated from vault accounting values read at a
+        specific block, including protocol-specific overrides that expose the
+        same state through another contract view.
+
+        :return:
+            Smart-contract state source.
+        """
+
+        return PriceSource.smart_contract_state
 
     def _get_block_identifier(self) -> BlockIdentifier:
         """Resolve which block identifier to use for metadata reads.

--- a/eth_defi/grvt/vault_data_export.py
+++ b/eth_defi/grvt/vault_data_export.py
@@ -38,6 +38,7 @@ from eth_defi.grvt.daily_metrics import GRVTDailyMetricsDatabase
 from eth_defi.vault.base import VaultHistoricalRead, VaultSpec
 from eth_defi.vault.fee import FeeData
 from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.price_source import PriceSource
 from eth_defi.vault.vaultdb import VaultDatabase, VaultRow
 
 logger = logging.getLogger(__name__)
@@ -151,6 +152,7 @@ def create_grvt_vault_row(
         "_deposit_next_open": None,
         "_redemption_closed_reason": None,
         "_redemption_next_open": None,
+        "_share_price_source": PriceSource.api,
     }
 
     spec = VaultSpec(chain_id=chain_id, vault_address=address)

--- a/eth_defi/hibachi/vault_data_export.py
+++ b/eth_defi/hibachi/vault_data_export.py
@@ -38,6 +38,7 @@ from eth_defi.hibachi.daily_metrics import HibachiDailyMetricsDatabase
 from eth_defi.vault.base import VaultHistoricalRead, VaultSpec
 from eth_defi.vault.fee import FeeData
 from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.price_source import PriceSource
 from eth_defi.vault.vaultdb import VaultDatabase, VaultRow
 
 logger = logging.getLogger(__name__)
@@ -157,6 +158,7 @@ def create_hibachi_vault_row(
         "_deposit_next_open": None,
         "_redemption_closed_reason": None,
         "_redemption_next_open": None,
+        "_share_price_source": PriceSource.api,
     }
 
     spec = VaultSpec(chain_id=chain_id, vault_address=address)

--- a/eth_defi/hyperliquid/vault_data_export.py
+++ b/eth_defi/hyperliquid/vault_data_export.py
@@ -43,6 +43,7 @@ from eth_defi.hyperliquid.vault_review_sync import ReviewStatus
 from eth_defi.vault.base import VaultHistoricalRead, VaultSpec
 from eth_defi.vault.fee import FeeData
 from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.price_source import PriceSource
 from eth_defi.vault.risk import VaultTechnicalRisk
 from eth_defi.vault.vaultdb import VaultDatabase, VaultRow
 
@@ -257,6 +258,7 @@ def create_hyperliquid_vault_row(
         "_redemption_next_open": None,
         "_risk": risk,
         "_manual_review_status": manual_review_status,
+        "_share_price_source": PriceSource.approximation,
     }
 
     spec = VaultSpec(chain_id=chain_id, vault_address=address)

--- a/eth_defi/lighter/daily_metrics.py
+++ b/eth_defi/lighter/daily_metrics.py
@@ -7,8 +7,9 @@ The pipeline:
 
 1. Bulk-fetches all pools from ``/api/v1/publicPoolsMetadata``
 2. Filters by TVL and open status
-3. Fetches per-pool share price history via ``/api/v1/account``
-4. Stores daily prices and metadata in DuckDB
+3. Fetches per-pool share prices and current account state via ``/api/v1/account``
+4. Fetches historical PnL, volume, shares, and flow counters via ``/api/v1/pnl``
+5. Stores daily history, current metadata, and append-only snapshots in DuckDB
 
 Example::
 
@@ -23,11 +24,14 @@ Example::
 """
 
 import datetime
+import json
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 
 import duckdb
 import pandas as pd
+import requests
 from joblib import Parallel, delayed
 from tqdm_loggable.auto import tqdm
 
@@ -37,10 +41,11 @@ from eth_defi.lighter.perp_metrics import collect_lighter_pool_observations
 from eth_defi.lighter.session import LighterSession
 from eth_defi.lighter.vault import (
     LIGHTER_LLP_DESCRIPTION,
+    LighterPoolSnapshot,
     LighterPoolSummary,
     fetch_all_pools,
+    fetch_pool_daily_pnl_history,
     fetch_pool_detail,
-    fetch_pool_total_shares_history,
     pool_detail_to_daily_dataframe,
 )
 from eth_defi.perp_dex.storage import initialise_perp_vault_observation_schema
@@ -48,19 +53,192 @@ from eth_defi.perp_dex.storage import initialise_perp_vault_observation_schema
 logger = logging.getLogger(__name__)
 
 
+def _optional_dataframe_float(value: object) -> float | None:
+    """Convert an optional DataFrame cell to a Python float.
+
+    DuckDB/Pandas use several missing-value representations. Normalise all of
+    them to ``None`` before inserting nullable source metrics.
+
+    :param value:
+        DataFrame cell value.
+    :return:
+        Float value, or ``None`` when the cell is missing.
+    """
+    return float(value) if pd.notna(value) else None
+
+
+@dataclass(slots=True)
+class LighterDailyPriceRow:
+    """One Lighter daily price observation ready for DuckDB storage.
+
+    Stores source cumulative counters rather than derived daily flows. This
+    preserves valid history across bounded PnL API re-scans. Accounting fields
+    are populated only for dates observed by scans after these fields were
+    introduced. Migrated legacy rows may remain ``None`` permanently; the
+    scanner does not reconstruct or guarantee a historical backfill.
+    """
+
+    #: Lighter pool account index
+    account_index: int
+
+    #: UTC calendar date of the share-price observation
+    date: datetime.date
+
+    #: Pool share price in the deployment's collateral currency
+    share_price: float
+
+    #: Derived total value locked in the deployment's collateral currency
+    tvl: float
+
+    #: Price return for the UTC day
+    daily_return: float
+
+    #: Current API APY snapshot
+    annual_percentage_yield: float
+
+    #: Outstanding pool shares at this date
+    total_shares: int | None
+
+    #: Source cumulative pool inflow in the deployment's collateral currency
+    cumulative_pool_inflow: float | None
+
+    #: Source cumulative pool outflow in the deployment's collateral currency
+    cumulative_pool_outflow: float | None
+
+    #: Naive UTC time when the row was written
+    written_at: datetime.datetime
+
+    #: Source cumulative account-level inflow
+    cumulative_account_inflow: float | None = None
+
+    #: Source cumulative account-level outflow
+    cumulative_account_outflow: float | None = None
+
+    #: Source cumulative spot inflow
+    cumulative_spot_inflow: float | None = None
+
+    #: Source cumulative spot outflow
+    cumulative_spot_outflow: float | None = None
+
+    #: Source cumulative staking inflow
+    cumulative_staking_inflow: float | None = None
+
+    #: Source cumulative staking outflow
+    cumulative_staking_outflow: float | None = None
+
+    #: Source trade PnL
+    trade_pnl: float | None = None
+
+    #: Source spot-trade PnL
+    trade_spot_pnl: float | None = None
+
+    #: Source pool PnL
+    pool_pnl: float | None = None
+
+    #: Source staking PnL
+    staking_pnl: float | None = None
+
+    #: Source trading volume
+    volume: float | None = None
+
+    def as_db_tuple(self) -> tuple[object, ...]:
+        """Convert the row to the current DuckDB insert layout.
+
+        Keeps the positional SQL boundary in one place so callers cannot
+        accidentally desynchronise the dataclass and insert statement.
+
+        :return:
+            Twenty-one values in ``pool_daily_prices`` column order, excluding
+            the deployment slug supplied by the database method.
+        """
+        return (
+            self.account_index,
+            self.date,
+            self.share_price,
+            self.tvl,
+            self.daily_return,
+            self.annual_percentage_yield,
+            self.total_shares,
+            self.cumulative_pool_inflow,
+            self.cumulative_pool_outflow,
+            self.written_at,
+            self.cumulative_account_inflow,
+            self.cumulative_account_outflow,
+            self.cumulative_spot_inflow,
+            self.cumulative_spot_outflow,
+            self.cumulative_staking_inflow,
+            self.cumulative_staking_outflow,
+            self.trade_pnl,
+            self.trade_spot_pnl,
+            self.pool_pnl,
+            self.staking_pnl,
+            self.volume,
+        )
+
+
+def _normalise_daily_price_row(
+    row: LighterDailyPriceRow | tuple[object, ...],
+) -> tuple[object, ...]:
+    """Convert current and legacy daily-row inputs to the database layout.
+
+    Deployment-aware callers predating source-accounting fields pass a
+    seven-item tuple. Preserve that API while filling the new nullable fields
+    with ``None``. New scanner code uses :class:`LighterDailyPriceRow`.
+
+    :param row:
+        Typed current row or legacy seven-item tuple.
+    :return:
+        Twenty-one values matching ``pool_daily_prices`` after ``deployment``.
+    """
+    if isinstance(row, LighterDailyPriceRow):
+        return row.as_db_tuple()
+
+    if len(row) == 21:
+        return row
+    if len(row) != 7:
+        raise ValueError(f"Expected a LighterDailyPriceRow or 7-item legacy tuple, got {len(row)} items")
+
+    account_index, date, share_price, tvl, daily_return, annual_percentage_yield, written_at = row
+    return (
+        account_index,
+        date,
+        share_price,
+        tvl,
+        daily_return,
+        annual_percentage_yield,
+        None,
+        None,
+        None,
+        written_at,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+
+
 class LighterDailyMetricsDatabase:
     """DuckDB database for storing Lighter pool daily metrics.
 
-    Stores two tables:
+    Stores three tables:
 
     - ``pool_metadata``: Pool information (name, description, fees, TVL, etc.)
     - ``pool_daily_prices``: Daily share price time series with returns
+    - ``pool_snapshots``: Append-only scan-time account, ownership, risk, and
+      exposure observations
 
     :param path:
         Path to the DuckDB database file.
     """
 
-    def __init__(self, path: Path):
+    def __init__(self, path: Path) -> None:
         self.path = path
         path.parent.mkdir(parents=True, exist_ok=True)
         self.con = duckdb.connect(str(path))
@@ -69,9 +247,10 @@ class LighterDailyMetricsDatabase:
     def _init_schema(self) -> None:
         """Create or migrate the deployment-aware database schema.
 
-        The original schema keyed both tables only by ``account_index``.
+        The original schema keyed its tables only by ``account_index``.
         Lighter deployments reuse account indexes, so legacy rows are copied
         transactionally into composite-key tables and labelled ``ethereum``.
+        New source fields are nullable and preserve older rows as unknown.
         Any migration failure aborts database opening without discarding the
         original tables.
         """
@@ -81,62 +260,100 @@ class LighterDailyMetricsDatabase:
         if not self._table_exists("pool_daily_prices"):
             self._create_pool_daily_prices_table("pool_daily_prices")
 
+        self._ensure_columns(
+            "pool_metadata",
+            {
+                "status": "INTEGER DEFAULT 0",
+                "total_shares": "BIGINT",
+                "operator_shares": "BIGINT",
+            },
+        )
+        self._ensure_columns(
+            "pool_daily_prices",
+            {
+                "written_at": "TIMESTAMP",
+                "total_shares": "BIGINT",
+                "cumulative_pool_inflow": "DOUBLE",
+                "cumulative_pool_outflow": "DOUBLE",
+                "cumulative_account_inflow": "DOUBLE",
+                "cumulative_account_outflow": "DOUBLE",
+                "cumulative_spot_inflow": "DOUBLE",
+                "cumulative_spot_outflow": "DOUBLE",
+                "cumulative_staking_inflow": "DOUBLE",
+                "cumulative_staking_outflow": "DOUBLE",
+                "trade_pnl": "DOUBLE",
+                "trade_spot_pnl": "DOUBLE",
+                "pool_pnl": "DOUBLE",
+                "staking_pnl": "DOUBLE",
+                "volume": "DOUBLE",
+            },
+        )
+
         metadata_columns = self._get_table_columns("pool_metadata")
-        if "status" not in metadata_columns:
-            self.con.execute("ALTER TABLE pool_metadata ADD COLUMN status INTEGER DEFAULT 0")
-
         price_columns = self._get_table_columns("pool_daily_prices")
-        if "written_at" not in price_columns:
-            self.con.execute("ALTER TABLE pool_daily_prices ADD COLUMN written_at TIMESTAMP")
-
         metadata_needs_migration = "deployment" not in metadata_columns
         prices_need_migration = "deployment" not in price_columns
-        if not metadata_needs_migration and not prices_need_migration:
-            return
-
-        logger.info("Migrating legacy Lighter DuckDB schema to deployment-aware composite keys")
-        self.con.execute("BEGIN TRANSACTION")
-        try:
-            if metadata_needs_migration:
-                self._create_pool_metadata_table("pool_metadata_v2")
-                self.con.execute(
-                    """
-                    INSERT INTO pool_metadata_v2 (
-                        deployment, account_index, name, description, l1_address,
-                        is_llp, status, operator_fee, total_asset_value,
-                        annual_percentage_yield, sharpe_ratio, created_at, last_updated
+        if metadata_needs_migration or prices_need_migration:
+            logger.info("Migrating legacy Lighter DuckDB schema to deployment-aware composite keys")
+            self.con.execute("BEGIN TRANSACTION")
+            try:
+                if metadata_needs_migration:
+                    self._create_pool_metadata_table("pool_metadata_v2")
+                    self.con.execute(
+                        """
+                        INSERT INTO pool_metadata_v2 (
+                            deployment, account_index, name, description, l1_address,
+                            is_llp, status, operator_fee, total_asset_value,
+                            annual_percentage_yield, sharpe_ratio, total_shares,
+                            operator_shares, created_at, last_updated
+                        )
+                        SELECT ?, account_index, name, description, l1_address,
+                            is_llp, status, operator_fee, total_asset_value,
+                            annual_percentage_yield, sharpe_ratio, total_shares,
+                            operator_shares, created_at, last_updated
+                        FROM pool_metadata
+                        """,
+                        [LIGHTER_ETHEREUM.slug],
                     )
-                    SELECT ?, account_index, name, description, l1_address,
-                        is_llp, status, operator_fee, total_asset_value,
-                        annual_percentage_yield, sharpe_ratio, created_at, last_updated
-                    FROM pool_metadata
-                    """,
-                    [LIGHTER_ETHEREUM.slug],
-                )
-                self.con.execute("DROP TABLE pool_metadata")
-                self.con.execute("ALTER TABLE pool_metadata_v2 RENAME TO pool_metadata")
+                    self.con.execute("DROP TABLE pool_metadata")
+                    self.con.execute("ALTER TABLE pool_metadata_v2 RENAME TO pool_metadata")
 
-            if prices_need_migration:
-                self._create_pool_daily_prices_table("pool_daily_prices_v2")
-                self.con.execute(
-                    """
-                    INSERT INTO pool_daily_prices_v2 (
-                        deployment, account_index, date, share_price, tvl,
-                        daily_return, annual_percentage_yield, written_at
+                if prices_need_migration:
+                    self._create_pool_daily_prices_table("pool_daily_prices_v2")
+                    self.con.execute(
+                        """
+                        INSERT INTO pool_daily_prices_v2 (
+                            deployment, account_index, date, share_price, tvl,
+                            daily_return, annual_percentage_yield, total_shares,
+                            cumulative_pool_inflow, cumulative_pool_outflow,
+                            written_at, cumulative_account_inflow,
+                            cumulative_account_outflow, cumulative_spot_inflow,
+                            cumulative_spot_outflow, cumulative_staking_inflow,
+                            cumulative_staking_outflow, trade_pnl, trade_spot_pnl,
+                            pool_pnl, staking_pnl, volume
+                        )
+                        SELECT ?, account_index, date, share_price, tvl,
+                            daily_return, annual_percentage_yield, total_shares,
+                            cumulative_pool_inflow, cumulative_pool_outflow,
+                            written_at, cumulative_account_inflow,
+                            cumulative_account_outflow, cumulative_spot_inflow,
+                            cumulative_spot_outflow, cumulative_staking_inflow,
+                            cumulative_staking_outflow, trade_pnl, trade_spot_pnl,
+                            pool_pnl, staking_pnl, volume
+                        FROM pool_daily_prices
+                        """,
+                        [LIGHTER_ETHEREUM.slug],
                     )
-                    SELECT ?, account_index, date, share_price, tvl,
-                        daily_return, annual_percentage_yield, written_at
-                    FROM pool_daily_prices
-                    """,
-                    [LIGHTER_ETHEREUM.slug],
-                )
-                self.con.execute("DROP TABLE pool_daily_prices")
-                self.con.execute("ALTER TABLE pool_daily_prices_v2 RENAME TO pool_daily_prices")
-        except duckdb.Error:
-            self.con.execute("ROLLBACK")
-            raise
-        else:
-            self.con.execute("COMMIT")
+                    self.con.execute("DROP TABLE pool_daily_prices")
+                    self.con.execute("ALTER TABLE pool_daily_prices_v2 RENAME TO pool_daily_prices")
+            except duckdb.Error:
+                self.con.execute("ROLLBACK")
+                raise
+            else:
+                self.con.execute("COMMIT")
+
+        if not self._table_exists("pool_snapshots"):
+            self._create_pool_snapshots_table("pool_snapshots")
 
     def _table_exists(self, table_name: str) -> bool:
         """Check whether a DuckDB table exists.
@@ -162,6 +379,19 @@ class LighterDailyMetricsDatabase:
         """
         return {row[1] for row in self.con.execute(f"PRAGMA table_info('{table_name}')").fetchall()}
 
+    def _ensure_columns(self, table_name: str, columns: dict[str, str]) -> None:
+        """Add missing nullable source columns to an existing table.
+
+        :param table_name:
+            Trusted internal table name.
+        :param columns:
+            Mapping of column names to trusted DuckDB type declarations.
+        """
+        existing = self._get_table_columns(table_name)
+        for column_name, type_sql in columns.items():
+            if column_name not in existing:
+                self.con.execute(f"ALTER TABLE {table_name} ADD COLUMN {column_name} {type_sql}")
+
     def _create_pool_metadata_table(self, table_name: str) -> None:
         """Create a deployment-aware pool metadata table.
 
@@ -181,6 +411,8 @@ class LighterDailyMetricsDatabase:
                 total_asset_value DOUBLE,
                 annual_percentage_yield DOUBLE,
                 sharpe_ratio DOUBLE,
+                total_shares BIGINT,
+                operator_shares BIGINT,
                 created_at TIMESTAMP,
                 last_updated TIMESTAMP NOT NULL,
                 PRIMARY KEY (deployment, account_index)
@@ -202,8 +434,74 @@ class LighterDailyMetricsDatabase:
                 tvl DOUBLE,
                 daily_return DOUBLE,
                 annual_percentage_yield DOUBLE,
+                total_shares BIGINT,
+                cumulative_pool_inflow DOUBLE,
+                cumulative_pool_outflow DOUBLE,
                 written_at TIMESTAMP,
+                cumulative_account_inflow DOUBLE,
+                cumulative_account_outflow DOUBLE,
+                cumulative_spot_inflow DOUBLE,
+                cumulative_spot_outflow DOUBLE,
+                cumulative_staking_inflow DOUBLE,
+                cumulative_staking_outflow DOUBLE,
+                trade_pnl DOUBLE,
+                trade_spot_pnl DOUBLE,
+                pool_pnl DOUBLE,
+                staking_pnl DOUBLE,
+                volume DOUBLE,
                 PRIMARY KEY (deployment, account_index, date)
+            )
+        """)
+
+    def _create_pool_snapshots_table(self, table_name: str) -> None:
+        """Create a deployment-aware point-in-time snapshot table.
+
+        :param table_name:
+            Trusted internal table name.
+        """
+        self.con.execute(f"""
+            CREATE TABLE {table_name} (
+                deployment VARCHAR NOT NULL,
+                snapshot_timestamp TIMESTAMP NOT NULL,
+                account_index BIGINT NOT NULL,
+                account_status INTEGER,
+                pool_status INTEGER,
+                account_type INTEGER,
+                account_trading_mode INTEGER,
+                total_asset_value DOUBLE,
+                cross_asset_value DOUBLE,
+                collateral DOUBLE,
+                available_balance DOUBLE,
+                initial_margin_requirement DOUBLE,
+                maintenance_margin_requirement DOUBLE,
+                operator_fee DOUBLE,
+                min_operator_share_rate DOUBLE,
+                annual_percentage_yield DOUBLE,
+                sharpe_ratio DOUBLE,
+                total_shares BIGINT,
+                operator_shares BIGINT,
+                operator_share_fraction DOUBLE,
+                pending_order_count INTEGER,
+                total_order_count BIGINT,
+                total_isolated_order_count BIGINT,
+                transaction_time BIGINT,
+                position_count INTEGER,
+                gross_position_value DOUBLE,
+                net_position_value DOUBLE,
+                long_position_value DOUBLE,
+                short_position_value DOUBLE,
+                top_position_fraction DOUBLE,
+                allocated_margin DOUBLE,
+                unrealised_pnl DOUBLE,
+                realised_pnl DOUBLE,
+                funding_paid_out DOUBLE,
+                open_order_count INTEGER,
+                asset_count INTEGER,
+                strategy_count INTEGER,
+                strategy_collateral DOUBLE,
+                pending_unlock_count INTEGER,
+                source_account_json VARCHAR NOT NULL,
+                PRIMARY KEY (deployment, snapshot_timestamp, account_index)
             )
         """)
 
@@ -220,12 +518,15 @@ class LighterDailyMetricsDatabase:
         total_asset_value: float | None = None,
         annual_percentage_yield: float | None = None,
         sharpe_ratio: float | None = None,
+        total_shares: int | None = None,
+        operator_shares: int | None = None,
         created_at: datetime.datetime | None = None,
-    ):
+    ) -> None:
         """Insert or update pool metadata.
 
         :param deployment:
-            Stable deployment slug.
+            Stable deployment slug. Kept as the first positional argument for
+            compatibility with the deployment-aware public API.
         :param account_index:
             Pool account index, unique within the deployment.
         :param name:
@@ -246,6 +547,10 @@ class LighterDailyMetricsDatabase:
             Current APY.
         :param sharpe_ratio:
             Risk-adjusted return metric.
+        :param total_shares:
+            Current outstanding pool shares.
+        :param operator_shares:
+            Current shares owned by the pool operator.
         :param created_at:
             Pool creation timestamp.
         """
@@ -254,8 +559,8 @@ class LighterDailyMetricsDatabase:
             INSERT INTO pool_metadata (
                 deployment, account_index, name, description, l1_address, is_llp,
                 status, operator_fee, total_asset_value, annual_percentage_yield,
-                sharpe_ratio, created_at, last_updated
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                sharpe_ratio, total_shares, operator_shares, created_at, last_updated
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT (deployment, account_index) DO UPDATE SET
                 name = excluded.name,
                 description = excluded.description,
@@ -266,6 +571,8 @@ class LighterDailyMetricsDatabase:
                 total_asset_value = excluded.total_asset_value,
                 annual_percentage_yield = excluded.annual_percentage_yield,
                 sharpe_ratio = excluded.sharpe_ratio,
+                total_shares = excluded.total_shares,
+                operator_shares = excluded.operator_shares,
                 created_at = excluded.created_at,
                 last_updated = excluded.last_updated
             """,
@@ -281,6 +588,8 @@ class LighterDailyMetricsDatabase:
                 total_asset_value,
                 annual_percentage_yield,
                 sharpe_ratio,
+                total_shares,
+                operator_shares,
                 created_at,
                 native_datetime_utc_now(),
             ],
@@ -289,40 +598,196 @@ class LighterDailyMetricsDatabase:
     def upsert_daily_prices(
         self,
         deployment: str,
-        rows: list[tuple],
+        rows: list[LighterDailyPriceRow | tuple[object, ...]],
         cutoff_date: datetime.date | None = None,
-    ):
+    ) -> None:
         """Bulk upsert daily price rows for a pool.
 
         :param deployment:
             Stable deployment slug applied to every row.
         :param rows:
-            List of tuples: ``(account_index, date, share_price, tvl, daily_return, annual_percentage_yield, written_at)``.
+            Daily price rows with source share and cumulative flow counters.
         :param cutoff_date:
             If provided, only store rows up to this date (inclusive).
             Used for incremental scanning / testing.
         """
+        normalised_rows = [_normalise_daily_price_row(row) for row in rows]
         if cutoff_date is not None:
-            rows = [r for r in rows if r[1] <= cutoff_date]
+            normalised_rows = [row for row in normalised_rows if row[1] <= cutoff_date]
 
-        if not rows:
+        if not normalised_rows:
             return
 
         self.con.executemany(
             """
             INSERT INTO pool_daily_prices (
                 deployment, account_index, date, share_price, tvl,
-                daily_return, annual_percentage_yield, written_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                daily_return, annual_percentage_yield, total_shares,
+                cumulative_pool_inflow, cumulative_pool_outflow, written_at,
+                cumulative_account_inflow, cumulative_account_outflow,
+                cumulative_spot_inflow, cumulative_spot_outflow,
+                cumulative_staking_inflow, cumulative_staking_outflow,
+                trade_pnl, trade_spot_pnl, pool_pnl, staking_pnl, volume
+            ) VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
             ON CONFLICT (deployment, account_index, date) DO UPDATE SET
                 share_price = excluded.share_price,
                 tvl = excluded.tvl,
                 daily_return = excluded.daily_return,
                 annual_percentage_yield = excluded.annual_percentage_yield,
-                written_at = excluded.written_at
+                total_shares = COALESCE(excluded.total_shares, pool_daily_prices.total_shares),
+                cumulative_pool_inflow = COALESCE(excluded.cumulative_pool_inflow, pool_daily_prices.cumulative_pool_inflow),
+                cumulative_pool_outflow = COALESCE(excluded.cumulative_pool_outflow, pool_daily_prices.cumulative_pool_outflow),
+                written_at = excluded.written_at,
+                cumulative_account_inflow = COALESCE(excluded.cumulative_account_inflow, pool_daily_prices.cumulative_account_inflow),
+                cumulative_account_outflow = COALESCE(excluded.cumulative_account_outflow, pool_daily_prices.cumulative_account_outflow),
+                cumulative_spot_inflow = COALESCE(excluded.cumulative_spot_inflow, pool_daily_prices.cumulative_spot_inflow),
+                cumulative_spot_outflow = COALESCE(excluded.cumulative_spot_outflow, pool_daily_prices.cumulative_spot_outflow),
+                cumulative_staking_inflow = COALESCE(excluded.cumulative_staking_inflow, pool_daily_prices.cumulative_staking_inflow),
+                cumulative_staking_outflow = COALESCE(excluded.cumulative_staking_outflow, pool_daily_prices.cumulative_staking_outflow),
+                trade_pnl = COALESCE(excluded.trade_pnl, pool_daily_prices.trade_pnl),
+                trade_spot_pnl = COALESCE(excluded.trade_spot_pnl, pool_daily_prices.trade_spot_pnl),
+                pool_pnl = COALESCE(excluded.pool_pnl, pool_daily_prices.pool_pnl),
+                staking_pnl = COALESCE(excluded.staking_pnl, pool_daily_prices.staking_pnl),
+                volume = COALESCE(excluded.volume, pool_daily_prices.volume)
             """,
-            [(deployment, *row) for row in rows],
+            [(deployment, *row) for row in normalised_rows],
         )
+
+    def insert_pool_snapshot(
+        self,
+        snapshot: LighterPoolSnapshot,
+        deployment: str = LIGHTER_ETHEREUM.slug,
+    ) -> None:
+        """Insert one append-only Lighter pool snapshot.
+
+        Stores queryable selection and risk metrics plus a complete JSON copy
+        of the current account state. Historical price/return arrays are
+        removed from that JSON because the daily table already stores them.
+        The method does not backfill older dates: snapshots exist only from the
+        time this collector starts, and earlier history remains missing/``NaN``
+        in downstream joins.
+
+        :param snapshot:
+            Current account and pool state parsed from one public API response.
+        :param deployment:
+            Stable deployment slug. Defaults to Ethereum for compatibility.
+        """
+        self.con.execute(
+            """
+            INSERT INTO pool_snapshots (
+                deployment, snapshot_timestamp, account_index, account_status, pool_status,
+                account_type, account_trading_mode,
+                total_asset_value, cross_asset_value, collateral, available_balance,
+                initial_margin_requirement, maintenance_margin_requirement,
+                operator_fee, min_operator_share_rate, annual_percentage_yield,
+                sharpe_ratio, total_shares, operator_shares, operator_share_fraction,
+                pending_order_count, total_order_count, total_isolated_order_count,
+                transaction_time, position_count,
+                gross_position_value, net_position_value, long_position_value,
+                short_position_value, top_position_fraction, allocated_margin,
+                unrealised_pnl, realised_pnl, funding_paid_out, open_order_count,
+                asset_count, strategy_count, strategy_collateral, pending_unlock_count,
+                source_account_json
+            ) VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+            )
+            ON CONFLICT (deployment, snapshot_timestamp, account_index) DO NOTHING
+            """,
+            [
+                deployment,
+                snapshot.snapshot_timestamp,
+                snapshot.account_index,
+                snapshot.account_status,
+                snapshot.pool_status,
+                snapshot.account_type,
+                snapshot.account_trading_mode,
+                snapshot.total_asset_value,
+                snapshot.cross_asset_value,
+                snapshot.collateral,
+                snapshot.available_balance,
+                snapshot.initial_margin_requirement,
+                snapshot.maintenance_margin_requirement,
+                snapshot.operator_fee,
+                snapshot.min_operator_share_rate,
+                snapshot.annual_percentage_yield,
+                snapshot.sharpe_ratio,
+                snapshot.total_shares,
+                snapshot.operator_shares,
+                snapshot.operator_share_fraction,
+                snapshot.pending_order_count,
+                snapshot.total_order_count,
+                snapshot.total_isolated_order_count,
+                snapshot.transaction_time,
+                snapshot.position_count,
+                snapshot.gross_position_value,
+                snapshot.net_position_value,
+                snapshot.long_position_value,
+                snapshot.short_position_value,
+                snapshot.top_position_fraction,
+                snapshot.allocated_margin,
+                snapshot.unrealised_pnl,
+                snapshot.realised_pnl,
+                snapshot.funding_paid_out,
+                snapshot.open_order_count,
+                snapshot.asset_count,
+                snapshot.strategy_count,
+                snapshot.strategy_collateral,
+                snapshot.pending_unlock_count,
+                json.dumps(snapshot.source_account),
+            ],
+        )
+
+    def get_pool_snapshot_history(
+        self,
+        account_index: int,
+        deployment: str = LIGHTER_ETHEREUM.slug,
+    ) -> pd.DataFrame:
+        """Retrieve point-in-time snapshots for one Lighter pool.
+
+        :param account_index:
+            Lighter pool account index.
+        :param deployment:
+            Stable deployment slug. Defaults to Ethereum for compatibility.
+        :return:
+            Snapshot rows ordered from oldest to newest. The result starts at
+            the collection start date; no earlier values are fabricated.
+        """
+        return self.con.execute(
+            """
+            SELECT *
+            FROM pool_snapshots
+            WHERE deployment = ? AND account_index = ?
+            ORDER BY snapshot_timestamp
+            """,
+            [deployment, account_index],
+        ).fetchdf()
+
+    def get_latest_pool_snapshots(self, deployment: str | None = None) -> pd.DataFrame:
+        """Retrieve the most recent point-in-time snapshot for every pool.
+
+        :param deployment:
+            Optional deployment slug filter.
+        :return:
+            Latest snapshot per account, ordered by current TVL.
+        """
+        where_clause = "" if deployment is None else "WHERE deployment = ?"
+        parameters = [] if deployment is None else [deployment]
+        return self.con.execute(
+            f"""
+                SELECT *
+                FROM pool_snapshots
+                {where_clause}
+                QUALIFY ROW_NUMBER() OVER (
+                    PARTITION BY deployment, account_index
+                    ORDER BY snapshot_timestamp DESC
+                ) = 1
+                ORDER BY deployment, total_asset_value DESC NULLS LAST
+            """,
+            parameters,
+        ).fetchdf()
 
     def get_all_daily_prices(self, deployment: str | None = None) -> pd.DataFrame:
         """Retrieve all daily price data.
@@ -330,8 +795,7 @@ class LighterDailyMetricsDatabase:
         :param deployment:
             Optional deployment slug filter.
         :return:
-            DataFrame with columns: account_index, date, share_price, tvl,
-            daily_return, annual_percentage_yield.
+            DataFrame with price, source-share, and cumulative-flow columns.
         """
         if deployment is None:
             return self.con.execute("SELECT * FROM pool_daily_prices ORDER BY deployment, account_index, date").fetchdf()
@@ -437,11 +901,11 @@ class LighterDailyMetricsDatabase:
             return val.date() if hasattr(val, "date") else val
         return None
 
-    def save(self):
+    def save(self) -> None:
         """Force checkpoint to disk."""
         self.con.execute("CHECKPOINT")
 
-    def close(self):
+    def close(self) -> None:
         """Close database connection."""
         logger.info("Closing daily metrics database at %s", self.path)
         if self.con is not None:
@@ -473,7 +937,7 @@ def fetch_and_store_pool(
     """
     try:
         detail = fetch_pool_detail(session, summary.account_index, timeout=timeout)
-    except Exception as e:
+    except (requests.RequestException, KeyError, TypeError, ValueError) as e:
         logger.warning(
             "Failed to fetch pool details for %s (%d): %s",
             summary.name,
@@ -482,32 +946,25 @@ def fetch_and_store_pool(
         )
         return False
 
-    # Fetch historical total shares for TVL computation
+    # Fetch historical shares and source cumulative flow counters for TVL and
+    # later flow export. A failure must not discard share-price ingestion.
     try:
-        total_shares_by_date = fetch_pool_total_shares_history(
+        pnl_history_by_date = fetch_pool_daily_pnl_history(
             session,
             summary.account_index,
             timeout=timeout,
         )
-    except Exception as e:
+    except (requests.RequestException, KeyError, TypeError, ValueError) as e:
         logger.warning(
-            "Failed to fetch PnL shares for %s (%d), using current TVL: %s",
+            "Failed to fetch PnL history for %s (%d), storing null source counters: %s",
             summary.name,
             summary.account_index,
             e,
         )
-        total_shares_by_date = None
+        pnl_history_by_date = None
 
-    daily_df = pool_detail_to_daily_dataframe(detail, total_shares_by_date=total_shares_by_date)
-    if daily_df.empty:
-        logger.debug(
-            "Skipping pool %s (%d): empty share price history",
-            summary.name,
-            summary.account_index,
-        )
-        return False
-
-    # Store metadata
+    # Store current metadata and the point-in-time snapshot even when this
+    # account does not yet have enough price history for a daily row.
     db.upsert_pool_metadata(
         deployment=session.deployment.slug,
         account_index=summary.account_index,
@@ -520,22 +977,51 @@ def fetch_and_store_pool(
         total_asset_value=summary.total_asset_value,
         annual_percentage_yield=detail.annual_percentage_yield,
         sharpe_ratio=detail.sharpe_ratio,
+        total_shares=detail.total_shares,
+        operator_shares=detail.operator_shares,
         created_at=summary.created_at,
     )
+    db.insert_pool_snapshot(
+        detail.snapshot,
+        deployment=session.deployment.slug,
+    )
+
+    daily_df = pool_detail_to_daily_dataframe(detail, pnl_history_by_date=pnl_history_by_date)
+    if daily_df.empty:
+        logger.debug(
+            "Skipping daily prices for pool %s (%d): empty share price history",
+            summary.name,
+            summary.account_index,
+        )
+        return False
 
     # Build daily price rows
     written_at = native_datetime_utc_now()
-    rows = []
+    rows: list[LighterDailyPriceRow] = []
     for date_val, row_data in daily_df.iterrows():
         rows.append(
-            (
-                summary.account_index,
-                date_val,
-                row_data["share_price"],
-                row_data["tvl"],
-                row_data["daily_return"],
-                summary.annual_percentage_yield,
-                written_at,
+            LighterDailyPriceRow(
+                account_index=summary.account_index,
+                date=date_val,
+                share_price=float(row_data["share_price"]),
+                tvl=float(row_data["tvl"]),
+                daily_return=float(row_data["daily_return"]),
+                annual_percentage_yield=summary.annual_percentage_yield,
+                total_shares=int(row_data["total_shares"]) if pd.notna(row_data["total_shares"]) else None,
+                cumulative_pool_inflow=_optional_dataframe_float(row_data.get("cumulative_pool_inflow")),
+                cumulative_pool_outflow=_optional_dataframe_float(row_data.get("cumulative_pool_outflow")),
+                written_at=written_at,
+                cumulative_account_inflow=_optional_dataframe_float(row_data.get("cumulative_account_inflow")),
+                cumulative_account_outflow=_optional_dataframe_float(row_data.get("cumulative_account_outflow")),
+                cumulative_spot_inflow=_optional_dataframe_float(row_data.get("cumulative_spot_inflow")),
+                cumulative_spot_outflow=_optional_dataframe_float(row_data.get("cumulative_spot_outflow")),
+                cumulative_staking_inflow=_optional_dataframe_float(row_data.get("cumulative_staking_inflow")),
+                cumulative_staking_outflow=_optional_dataframe_float(row_data.get("cumulative_staking_outflow")),
+                trade_pnl=_optional_dataframe_float(row_data.get("trade_pnl")),
+                trade_spot_pnl=_optional_dataframe_float(row_data.get("trade_spot_pnl")),
+                pool_pnl=_optional_dataframe_float(row_data.get("pool_pnl")),
+                staking_pnl=_optional_dataframe_float(row_data.get("staking_pnl")),
+                volume=_optional_dataframe_float(row_data.get("volume")),
             )
         )
 
@@ -579,8 +1065,8 @@ def run_daily_scan(
 
     1. Bulk-fetches all pools from ``publicPoolsMetadata``
     2. Filters by TVL and pool limit (or by explicit index list)
-    3. Fetches per-pool details and share price history in parallel
-    4. Stores everything in DuckDB
+    3. Fetches per-pool details, daily PnL, and share-price history in parallel
+    4. Stores daily history and an append-only current-state snapshot in DuckDB
 
     :param session:
         HTTP session with rate limiting.

--- a/eth_defi/lighter/vault.py
+++ b/eth_defi/lighter/vault.py
@@ -24,6 +24,7 @@ from typing import Any
 
 import pandas as pd
 
+from eth_defi.compat import native_datetime_utc_now
 from eth_defi.lighter.session import LighterSession
 from eth_defi.types import Percent
 
@@ -124,6 +125,317 @@ class LighterPoolDetail:
     #: Operator's shares
     operator_shares: int
 
+    #: Point-in-time account and pool metrics observed by this API read
+    snapshot: "LighterPoolSnapshot"
+
+
+@dataclass(slots=True)
+class LighterPoolSnapshot:
+    """Point-in-time Lighter pool and account state.
+
+    Values come from one ``/api/v1/account`` response. Historical arrays such
+    as ``share_prices`` and ``daily_returns`` are deliberately excluded because
+    the daily-history pipeline handles them separately. Collection is
+    append-only from the collection start date; the API cannot reconstruct
+    earlier snapshots, so pre-collection values remain SQL ``NULL``/Pandas
+    ``NaN`` when joined to older price history.
+    """
+
+    #: Naive UTC time at which the API response was observed
+    snapshot_timestamp: datetime.datetime
+
+    #: Lighter pool account index
+    account_index: int
+
+    #: Account-level status code
+    account_status: int | None
+
+    #: Pool-level status code from ``pool_info``
+    pool_status: int | None
+
+    #: Lighter account type code
+    account_type: int | None
+
+    #: Lighter account trading-mode code
+    account_trading_mode: int | None
+
+    #: Canonical account NAV in the deployment's collateral currency
+    total_asset_value: float | None
+
+    #: Cross-margin asset value in the deployment's collateral currency
+    cross_asset_value: float | None
+
+    #: Account collateral in the deployment's collateral currency
+    collateral: float | None
+
+    #: Free account balance in the deployment's collateral currency
+    available_balance: float | None
+
+    #: Cross-margin initial requirement in the deployment's collateral currency
+    initial_margin_requirement: float | None
+
+    #: Cross-margin maintenance requirement in the deployment's collateral currency
+    maintenance_margin_requirement: float | None
+
+    #: Operator performance fee as reported by Lighter
+    operator_fee: Percent | None
+
+    #: Minimum operator ownership rate as reported by Lighter
+    min_operator_share_rate: Percent | None
+
+    #: API annual percentage yield snapshot
+    annual_percentage_yield: float | None
+
+    #: API Sharpe ratio snapshot
+    sharpe_ratio: float | None
+
+    #: Total outstanding pool shares
+    total_shares: int | None
+
+    #: Shares owned by the pool operator
+    operator_shares: int | None
+
+    #: Operator ownership fraction calculated from current share counts
+    operator_share_fraction: Percent | None
+
+    #: Account-level pending order count
+    pending_order_count: int | None
+
+    #: Lifetime order count
+    total_order_count: int | None
+
+    #: Lifetime isolated-order count
+    total_isolated_order_count: int | None
+
+    #: Source transaction time, in the API's integer time unit
+    transaction_time: int | None
+
+    #: Number of current position records
+    position_count: int | None
+
+    #: Sum of absolute position values in the deployment's collateral currency
+    gross_position_value: float | None
+
+    #: Signed position value in the deployment's collateral currency
+    net_position_value: float | None
+
+    #: Sum of long position values in the deployment's collateral currency
+    long_position_value: float | None
+
+    #: Sum of short position values in the deployment's collateral currency
+    short_position_value: float | None
+
+    #: Largest position value divided by gross position value
+    top_position_fraction: Percent | None
+
+    #: Sum of position allocated margin in the deployment's collateral currency
+    allocated_margin: float | None
+
+    #: Sum of unrealised position PnL in the deployment's collateral currency
+    unrealised_pnl: float | None
+
+    #: Sum of realised position PnL in the deployment's collateral currency
+    realised_pnl: float | None
+
+    #: Sum of funding paid out in the deployment's collateral currency
+    funding_paid_out: float | None
+
+    #: Sum of open-order counts attached to positions
+    open_order_count: int | None
+
+    #: Number of current asset records
+    asset_count: int | None
+
+    #: Number of configured strategy records
+    strategy_count: int | None
+
+    #: Sum of strategy collateral in the deployment's collateral currency
+    strategy_collateral: float | None
+
+    #: Number of pending unlock records
+    pending_unlock_count: int | None
+
+    #: Complete current-state account response with historical arrays removed
+    source_account: dict[str, Any]
+
+
+@dataclass(slots=True)
+class LighterPoolDailyPnl:
+    """One daily Lighter pool PnL observation.
+
+    The Lighter PnL endpoint exposes cumulative flow counters rather than
+    individual deposit and withdrawal events.  Keep the source counters intact
+    until export, where adjacent complete-day observations can be safely
+    differenced.
+    """
+
+    #: UTC calendar date of the observation
+    date: datetime.date
+
+    #: Outstanding pool shares at the observation
+    total_shares: int | None
+
+    #: Cumulative pool deposits in the deployment's collateral currency
+    cumulative_pool_inflow: float | None
+
+    #: Cumulative pool withdrawals in the deployment's collateral currency
+    cumulative_pool_outflow: float | None
+
+    #: Cumulative account-level inflow
+    cumulative_account_inflow: float | None
+
+    #: Cumulative account-level outflow
+    cumulative_account_outflow: float | None
+
+    #: Cumulative spot-account inflow
+    cumulative_spot_inflow: float | None
+
+    #: Cumulative spot-account outflow
+    cumulative_spot_outflow: float | None
+
+    #: Cumulative staking inflow
+    cumulative_staking_inflow: float | None
+
+    #: Cumulative staking outflow
+    cumulative_staking_outflow: float | None
+
+    #: Source trade PnL value
+    trade_pnl: float | None
+
+    #: Source spot-trade PnL value
+    trade_spot_pnl: float | None
+
+    #: Source pool PnL value
+    pool_pnl: float | None
+
+    #: Source staking PnL value
+    staking_pnl: float | None
+
+    #: Source trading-volume value
+    volume: float | None
+
+
+def _parse_optional_float(value: Any) -> float | None:
+    """Parse an optional numeric Lighter API value.
+
+    :param value:
+        API value, commonly a decimal string.
+    :return:
+        Parsed float, or ``None`` when the source value is absent.
+    """
+    return float(value) if value is not None and value != "" else None
+
+
+def _parse_optional_int(value: Any) -> int | None:
+    """Parse an optional integer Lighter API value.
+
+    :param value:
+        API value.
+    :return:
+        Parsed integer, or ``None`` when the source value is absent.
+    """
+    return int(value) if value is not None and value != "" else None
+
+
+def parse_lighter_pool_snapshot(
+    account: dict[str, Any],
+    pool_info: dict[str, Any],
+    snapshot_timestamp: datetime.datetime,
+) -> LighterPoolSnapshot:
+    """Build a point-in-time pool snapshot from one account response.
+
+    Captures every current account/pool collection exposed by the public API
+    while deriving queryable exposure aggregates from ``positions``. Historical
+    share-price and return arrays are excluded because the daily-history
+    pipeline handles them separately.
+
+    :param account:
+        Raw account object from ``/api/v1/account``.
+    :param pool_info:
+        Raw ``account["pool_info"]`` object.
+    :param snapshot_timestamp:
+        Naive UTC observation timestamp.
+    :return:
+        Parsed point-in-time snapshot.
+    """
+    positions_value = account.get("positions")
+    positions = positions_value if isinstance(positions_value, list) else None
+    position_records = [position for position in positions or [] if isinstance(position, dict)]
+
+    signed_position_values = [
+        (
+            _parse_optional_int(position.get("sign")) or 0,
+            abs(_parse_optional_float(position.get("position_value")) or 0.0),
+        )
+        for position in position_records
+    ]
+    gross_position_value = sum(value for _, value in signed_position_values) if positions is not None else None
+    long_position_value = sum(value for sign, value in signed_position_values if sign > 0) if positions is not None else None
+    short_position_value = sum(value for sign, value in signed_position_values if sign < 0) if positions is not None else None
+    net_position_value = sum(sign * value for sign, value in signed_position_values) if positions is not None else None
+    top_position_fraction: Percent | None = max((value for _, value in signed_position_values), default=0.0) / gross_position_value if gross_position_value else None
+
+    strategies_value = pool_info.get("strategies")
+    strategies = strategies_value if isinstance(strategies_value, list) else None
+    strategy_records = [strategy for strategy in strategies or [] if isinstance(strategy, dict)]
+    strategy_collateral = sum(_parse_optional_float(strategy.get("collateral")) or 0.0 for strategy in strategy_records) if strategies is not None else None
+
+    assets_value = account.get("assets")
+    assets = assets_value if isinstance(assets_value, list) else None
+    pending_unlocks_value = account.get("pending_unlocks")
+    pending_unlocks = pending_unlocks_value if isinstance(pending_unlocks_value, list) else None
+    source_account = dict(account)
+    source_pool_info = dict(pool_info)
+    source_pool_info.pop("share_prices", None)
+    source_pool_info.pop("daily_returns", None)
+    source_account["pool_info"] = source_pool_info
+
+    total_shares = _parse_optional_int(pool_info.get("total_shares"))
+    operator_shares = _parse_optional_int(pool_info.get("operator_shares"))
+    operator_share_fraction: Percent | None = operator_shares / total_shares if total_shares and operator_shares is not None else None
+
+    return LighterPoolSnapshot(
+        snapshot_timestamp=snapshot_timestamp,
+        account_index=int(account.get("account_index", account.get("index"))),
+        account_status=_parse_optional_int(account.get("status")),
+        pool_status=_parse_optional_int(pool_info.get("status")),
+        account_type=_parse_optional_int(account.get("account_type")),
+        account_trading_mode=_parse_optional_int(account.get("account_trading_mode")),
+        total_asset_value=_parse_optional_float(account.get("total_asset_value")),
+        cross_asset_value=_parse_optional_float(account.get("cross_asset_value")),
+        collateral=_parse_optional_float(account.get("collateral")),
+        available_balance=_parse_optional_float(account.get("available_balance")),
+        initial_margin_requirement=_parse_optional_float(account.get("cross_initial_margin_requirement")),
+        maintenance_margin_requirement=_parse_optional_float(account.get("cross_maintenance_margin_requirement")),
+        operator_fee=_parse_optional_float(pool_info.get("operator_fee")),
+        min_operator_share_rate=_parse_optional_float(pool_info.get("min_operator_share_rate")),
+        annual_percentage_yield=_parse_optional_float(pool_info.get("annual_percentage_yield")),
+        sharpe_ratio=_parse_optional_float(pool_info.get("sharpe_ratio")),
+        total_shares=total_shares,
+        operator_shares=operator_shares,
+        operator_share_fraction=operator_share_fraction,
+        pending_order_count=_parse_optional_int(account.get("pending_order_count")),
+        total_order_count=_parse_optional_int(account.get("total_order_count")),
+        total_isolated_order_count=_parse_optional_int(account.get("total_isolated_order_count")),
+        transaction_time=_parse_optional_int(account.get("transaction_time")),
+        position_count=len(position_records) if positions is not None else None,
+        gross_position_value=gross_position_value,
+        net_position_value=net_position_value,
+        long_position_value=long_position_value,
+        short_position_value=short_position_value,
+        top_position_fraction=top_position_fraction,
+        allocated_margin=sum(_parse_optional_float(position.get("allocated_margin")) or 0.0 for position in position_records) if positions is not None else None,
+        unrealised_pnl=sum(_parse_optional_float(position.get("unrealized_pnl")) or 0.0 for position in position_records) if positions is not None else None,
+        realised_pnl=sum(_parse_optional_float(position.get("realized_pnl")) or 0.0 for position in position_records) if positions is not None else None,
+        funding_paid_out=sum(_parse_optional_float(position.get("total_funding_paid_out")) or 0.0 for position in position_records) if positions is not None else None,
+        open_order_count=sum(_parse_optional_int(position.get("open_order_count")) or 0 for position in position_records) if positions is not None else None,
+        asset_count=len(assets) if assets is not None else None,
+        strategy_count=len(strategy_records) if strategies is not None else None,
+        strategy_collateral=strategy_collateral,
+        pending_unlock_count=len(pending_unlocks) if pending_unlocks is not None else None,
+        source_account=source_account,
+    )
+
 
 def fetch_system_config(
     session: LighterSession,
@@ -157,6 +469,8 @@ def fetch_all_pools(
     Uses ``/api/v1/publicPoolsMetadata`` with pagination.
     Also fetches system config and applies any deployment-specific LLP account
     override to identify the canonical pool exactly.
+    See the `Lighter public-pools API reference
+    <https://apidocs.lighter.xyz/reference/publicpoolsmetadata>`__.
 
     :param session:
         HTTP session.
@@ -203,7 +517,7 @@ def fetch_all_pools(
             # index needs the deployment override above.
             is_llp = account_index == llp_index
             created_ts = p.get("created_at")
-            created_at = datetime.datetime.fromtimestamp(created_ts) if created_ts else None
+            created_at = datetime.datetime.fromtimestamp(created_ts, tz=datetime.timezone.utc).replace(tzinfo=None) if created_ts else None
 
             sharpe_str = p.get("sharpe_ratio")
             sharpe_val = float(sharpe_str) if sharpe_str else None
@@ -278,6 +592,8 @@ def fetch_pool_detail(
     Uses ``/api/v1/account?by=index&value={account_index}``.
     The response includes ``pool_info`` with ``share_prices`` and
     ``daily_returns`` arrays for pool accounts.
+    See the `Lighter account API reference
+    <https://apidocs.lighter.xyz/reference/account-1>`__.
 
     :param session:
         HTTP session.
@@ -286,13 +602,15 @@ def fetch_pool_detail(
     :param timeout:
         HTTP request timeout.
     :return:
-        :py:class:`LighterPoolDetail` with share price history.
+        :py:class:`LighterPoolDetail` with share-price history and the current
+        point-in-time account/pool snapshot.
     """
     url = f"{session.api_url}/api/v1/account"
     params = {"by": "index", "value": str(account_index)}
     resp = session.get(url, params=params, timeout=timeout)
     resp.raise_for_status()
     data = resp.json()
+    snapshot_timestamp = native_datetime_utc_now()
 
     # The response wraps account data in an accounts array
     accounts = data.get("accounts", [])
@@ -333,23 +651,28 @@ def fetch_pool_detail(
         daily_returns=daily_returns_list,
         total_shares=int(pool_info.get("total_shares", 0)),
         operator_shares=int(pool_info.get("operator_shares", 0)),
+        snapshot=parse_lighter_pool_snapshot(account, pool_info, snapshot_timestamp),
     )
 
 
-def fetch_pool_total_shares_history(
+def fetch_pool_daily_pnl_history(
     session: LighterSession,
     account_index: int,
     start_timestamp: int | None = None,
     timeout: float = 30.0,
-) -> dict[datetime.date, int]:
-    """Fetch historical total shares from the PnL endpoint.
+) -> dict[datetime.date, LighterPoolDailyPnl]:
+    """Fetch daily Lighter pool accounting and activity history.
 
-    Uses ``/api/v1/pnl`` at daily resolution to get ``pool_total_shares``
-    at each timestamp. This is the only endpoint that provides full
-    history for all pool types (including user pools).
+    Uses ``/api/v1/pnl`` at daily resolution. This endpoint provides share
+    history for all pool types (including user pools) and exposes the
+    cumulative flow counters, PnL components, and trading volume.
+    See the `Lighter PnL API reference
+    <https://apidocs.lighter.xyz/reference/pnl>`__.
 
-    The returned shares can be combined with share prices to compute
-    historical TVL: ``tvl = pool_total_shares * share_price``.
+    Lighter reports human-readable values in the deployment's collateral
+    currency. The counters are retained as source values; do not calculate
+    flows here because a bounded re-scan must not overwrite a previously known
+    daily delta with an unknown first row.
 
     :param session:
         HTTP session.
@@ -360,13 +683,16 @@ def fetch_pool_total_shares_history(
     :param timeout:
         HTTP request timeout.
     :return:
-        Mapping of ``{date: pool_total_shares}``.
+        Mapping of UTC date to source PnL observation. Duplicate observations
+        for a date retain the last API entry.
     """
     if start_timestamp is None:
-        start_timestamp = int(datetime.datetime(2025, 1, 1).timestamp())
+        start_timestamp = int(datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc).timestamp())
 
-    # Use a far-future end timestamp to get all available data
-    end_timestamp = int(datetime.datetime(2030, 1, 1).timestamp())
+    # Bound the request at the current UTC time. A far-future range can make
+    # the API return a synthetic end-of-range observation as future history.
+    now = native_datetime_utc_now()
+    end_timestamp = int(now.replace(tzinfo=datetime.timezone.utc).timestamp())
 
     url = f"{session.api_url}/api/v1/pnl"
     params = {
@@ -376,35 +702,84 @@ def fetch_pool_total_shares_history(
         "start_timestamp": str(start_timestamp),
         "end_timestamp": str(end_timestamp),
         "count_back": "0",
-        "ignore_transfers": "true",
+        "ignore_transfers": "false",
     }
     resp = session.get(url, params=params, timeout=timeout)
     resp.raise_for_status()
     data = resp.json()
 
-    result = {}
-    now = datetime.datetime(2030, 1, 1)
+    result: dict[datetime.date, LighterPoolDailyPnl] = {}
     for entry in data.get("pnl", []):
         ts = int(entry["timestamp"])
-        dt = datetime.datetime.fromtimestamp(ts)
-        # Skip entries with future timestamps (API sometimes returns
-        # a "current state" entry with a far-future timestamp)
-        if dt > now:
+        dt = datetime.datetime.fromtimestamp(ts, tz=datetime.timezone.utc).replace(tzinfo=None)
+        # Defensive guard in case the API still includes a future state.
+        if dt.date() > now.date():
             continue
-        total_shares = int(entry.get("pool_total_shares", 0))
-        result[dt.date()] = total_shares
+        # Keep today's partial counters. They remain provisional during the
+        # current UTC day, but become the final observed values if a later scan
+        # does not refresh them. This is an accepted daily-scanner trade-off.
+        result[dt.date()] = LighterPoolDailyPnl(
+            date=dt.date(),
+            total_shares=_parse_optional_int(entry.get("pool_total_shares")),
+            cumulative_pool_inflow=_parse_optional_float(entry.get("pool_inflow")),
+            cumulative_pool_outflow=_parse_optional_float(entry.get("pool_outflow")),
+            cumulative_account_inflow=_parse_optional_float(entry.get("inflow")),
+            cumulative_account_outflow=_parse_optional_float(entry.get("outflow")),
+            cumulative_spot_inflow=_parse_optional_float(entry.get("spot_inflow")),
+            cumulative_spot_outflow=_parse_optional_float(entry.get("spot_outflow")),
+            cumulative_staking_inflow=_parse_optional_float(entry.get("staking_inflow")),
+            cumulative_staking_outflow=_parse_optional_float(entry.get("staking_outflow")),
+            trade_pnl=_parse_optional_float(entry.get("trade_pnl")),
+            trade_spot_pnl=_parse_optional_float(entry.get("trade_spot_pnl")),
+            pool_pnl=_parse_optional_float(entry.get("pool_pnl")),
+            staking_pnl=_parse_optional_float(entry.get("staking_pnl")),
+            volume=_parse_optional_float(entry.get("volume")),
+        )
 
     logger.debug(
-        "Fetched %d daily total_shares entries for pool %d",
+        "Fetched %d daily PnL entries for pool %d",
         len(result),
         account_index,
     )
     return result
 
 
+def fetch_pool_total_shares_history(
+    session: LighterSession,
+    account_index: int,
+    start_timestamp: int | None = None,
+    timeout: float = 30.0,
+) -> dict[datetime.date, int]:
+    """Fetch historical total shares from the daily PnL endpoint.
+
+    Compatibility helper for existing callers that only need the share
+    history. New pipeline code should use :py:func:`fetch_pool_daily_pnl_history`
+    to retain the cumulative flow counters as well.
+
+    :param session:
+        HTTP session.
+    :param account_index:
+        Pool account index.
+    :param start_timestamp:
+        Unix timestamp for the start of the range.
+    :param timeout:
+        HTTP request timeout.
+    :return:
+        Mapping of UTC date to total shares for entries that supply shares.
+    """
+    history = fetch_pool_daily_pnl_history(
+        session,
+        account_index,
+        start_timestamp=start_timestamp,
+        timeout=timeout,
+    )
+    return {date: observation.total_shares for date, observation in history.items() if observation.total_shares is not None}
+
+
 def pool_detail_to_daily_dataframe(
     detail: LighterPoolDetail,
     total_shares_by_date: dict[datetime.date, int] | None = None,
+    pnl_history_by_date: dict[datetime.date, LighterPoolDailyPnl] | None = None,
 ) -> pd.DataFrame:
     """Convert pool detail share prices into a daily DataFrame.
 
@@ -418,24 +793,33 @@ def pool_detail_to_daily_dataframe(
     defaults to 0.
 
     The share price array from the API contains daily entries with unix
-    timestamps. We convert to dates and compute daily returns via
+    timestamps. We convert to UTC dates and compute daily returns via
     ``pct_change()``.
+
+    PnL values are joined only on matching UTC dates. Total shares may be
+    forward-filled for TVL, but flow, PnL, and volume fields are never moved to
+    a different date.
 
     :param detail:
         Pool detail with share_prices array.
     :param total_shares_by_date:
         Mapping of ``{date: pool_total_shares}`` from the PnL endpoint.
         Used to compute historical TVL.
+    :param pnl_history_by_date:
+        Daily source PnL observations. When supplied, the output also includes
+        total shares; account, pool, spot, and staking flow counters; trade,
+        spot, pool, and staking PnL; and volume for later storage and export.
     :return:
-        DataFrame indexed by date with ``share_price``,
-        ``daily_return``, and ``tvl`` columns. Empty if insufficient data.
+        DataFrame indexed by date with ``share_price``, ``daily_return``, and
+        ``tvl`` columns plus available PnL source columns. Empty if
+        insufficient data.
     """
     if len(detail.share_prices) < 2:
         return pd.DataFrame(columns=["share_price", "daily_return", "tvl"])
 
     records = []
     for ts, price in detail.share_prices:
-        dt = datetime.datetime.fromtimestamp(ts)
+        dt = datetime.datetime.fromtimestamp(ts, tz=datetime.timezone.utc).replace(tzinfo=None)
         records.append(
             {
                 "date": dt.date(),
@@ -454,15 +838,45 @@ def pool_detail_to_daily_dataframe(
     daily["daily_return"] = daily["share_price"].pct_change().fillna(0.0)
 
     # Compute historical TVL from total_shares * share_price
+    if pnl_history_by_date:
+        total_shares_by_date = {date: observation.total_shares for date, observation in pnl_history_by_date.items() if observation.total_shares is not None}
+
     if total_shares_by_date:
         shares_series = pd.Series(total_shares_by_date, name="total_shares")
         shares_series.index = pd.to_datetime(shares_series.index)
         shares_series.index = shares_series.index.date
 
-        # Reindex to match daily dates, forward-fill gaps
-        shares_aligned = shares_series.reindex(daily.index).ffill().fillna(0)
+        # Reindex to match daily dates and forward-fill only after the first
+        # source observation. Earlier share counts and TVL remain unknown.
+        shares_aligned = shares_series.reindex(daily.index).ffill()
         daily["tvl"] = daily["share_price"] * shares_aligned
+        daily["total_shares"] = shares_aligned
     else:
         daily["tvl"] = 0.0
+        daily["total_shares"] = pd.NA
+
+    if pnl_history_by_date:
+        pnl_df = pd.DataFrame(
+            [
+                {
+                    "date": entry.date,
+                    "cumulative_pool_inflow": entry.cumulative_pool_inflow,
+                    "cumulative_pool_outflow": entry.cumulative_pool_outflow,
+                    "cumulative_account_inflow": entry.cumulative_account_inflow,
+                    "cumulative_account_outflow": entry.cumulative_account_outflow,
+                    "cumulative_spot_inflow": entry.cumulative_spot_inflow,
+                    "cumulative_spot_outflow": entry.cumulative_spot_outflow,
+                    "cumulative_staking_inflow": entry.cumulative_staking_inflow,
+                    "cumulative_staking_outflow": entry.cumulative_staking_outflow,
+                    "trade_pnl": entry.trade_pnl,
+                    "trade_spot_pnl": entry.trade_spot_pnl,
+                    "pool_pnl": entry.pool_pnl,
+                    "staking_pnl": entry.staking_pnl,
+                    "volume": entry.volume,
+                }
+                for entry in pnl_history_by_date.values()
+            ]
+        ).set_index("date")
+        daily = daily.join(pnl_df, how="left")
 
     return daily

--- a/eth_defi/lighter/vault_data_export.py
+++ b/eth_defi/lighter/vault_data_export.py
@@ -29,6 +29,7 @@ import logging
 from decimal import Decimal
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 
 from eth_defi.compat import native_datetime_utc_now
@@ -44,9 +45,11 @@ from eth_defi.lighter.constants import (
     identify_lighter_pool_deployment,
 )
 from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase
+from eth_defi.types import Percent
 from eth_defi.vault.base import VaultHistoricalRead, VaultSpec
 from eth_defi.vault.fee import FeeData
 from eth_defi.vault.flag import VaultFlag, get_notes
+from eth_defi.vault.price_source import PriceSource
 from eth_defi.vault.risk import get_vault_risk
 from eth_defi.vault.vaultdb import VaultDatabase, VaultRow
 
@@ -81,6 +84,9 @@ def create_lighter_pool_row(
     tvl: float,
     created_at: datetime.datetime | None,
     operator_fee: float = 0.0,
+    total_shares: int | None = None,
+    operator_shares: int | None = None,
+    ownership_updated_at: datetime.datetime | None = None,
     is_llp: bool = False,
     status: int = 0,
     deployment: LighterAPIConfig = LIGHTER_ETHEREUM,
@@ -107,6 +113,12 @@ def create_lighter_pool_row(
         Pool creation timestamp.
     :param operator_fee:
         Operator fee percentage (e.g. 10.0 = 10%).
+    :param total_shares:
+        Current total pool shares from the Lighter API.
+    :param operator_shares:
+        Current pool shares owned by the operator.
+    :param ownership_updated_at:
+        Naive UTC timestamp of the ownership snapshot.
     :param is_llp:
         Whether this is the LLP protocol pool.
     :param status:
@@ -128,6 +140,7 @@ def create_lighter_pool_row(
 
     # Convert operator_fee from percentage to decimal fraction
     perf_fee = operator_fee / 100.0 if operator_fee else 0.0
+    operator_share_fraction: Percent | None = operator_shares / total_shares if total_shares and operator_shares is not None else None
 
     flags = {VaultFlag.perp_dex_trading_vault}
 
@@ -186,6 +199,13 @@ def create_lighter_pool_row(
         # note must not inherit Ethereum LLP's USDC/LIT staking requirements.
         "_notes": get_notes(address, chain_id=chain_id, protocol_name="Lighter"),
         "_risk": get_vault_risk("Lighter", address),
+        "_lighter_operator_shares": operator_shares,
+        "_lighter_total_shares": total_shares,
+        "_lighter_operator_share_fraction": operator_share_fraction,
+        "_lighter_ownership_updated_at": ownership_updated_at,
+        # The PnL endpoint reports the current UTC day's counters before that
+        # day is complete. Let generic flow metrics exclude this observation.
+        "_daily_flow_current_day_is_provisional": True,
         # Keep the deployment slug in static vault metadata so the generic
         # lifetime-metrics code does not need to import Lighter configuration.
         # For now this is exported to distinguish Lighter on Robinhood from
@@ -196,10 +216,66 @@ def create_lighter_pool_row(
         # This associated EVM chain ID (1/4663) is additional metadata
         # introduced specifically for Lighter on Robinhood metrics consumers.
         "_deployment_chain_id": deployment.deployment_chain_id,
+        "_share_price_source": PriceSource.api,
     }
 
     spec = VaultSpec(chain_id=chain_id, vault_address=address)
     return spec, row
+
+
+def _derive_daily_flow_columns(
+    prices_df: pd.DataFrame,
+    current_date: datetime.date,
+) -> pd.DataFrame:
+    """Derive safe daily cash flows from Lighter cumulative counters.
+
+    A flow value is available only when the current and preceding observations
+    are consecutive completed UTC days and the corresponding cumulative counter
+    did not decrease. The current UTC day remains provisional, while gaps,
+    resets, and source-null counters remain unknown.
+
+    :param prices_df:
+        Lighter daily-price rows with cumulative source counters.
+    :param current_date:
+        Current UTC date, excluded from completed daily flow output.
+    :return:
+        Copy of ``prices_df`` with daily USD deposit and withdrawal columns.
+    """
+    group_columns = ["deployment", "account_index"]
+    result = prices_df.sort_values([*group_columns, "date"]).copy()
+    result["daily_deposit_usd"] = np.nan
+    result["daily_withdrawal_usd"] = np.nan
+
+    observation_dates = pd.to_datetime(result["date"])
+    group_values = [result[column] for column in group_columns]
+    prior_dates = observation_dates.groupby(group_values, sort=False).shift()
+    # A previously observed day becomes complete as UTC advances. If no later
+    # scan refreshed that day's counters, the latest partial observation is
+    # accepted as final; daily scanning is the operational freshness contract.
+    is_completed = observation_dates.dt.date < current_date
+    is_consecutive = (observation_dates - prior_dates).eq(pd.Timedelta(days=1))
+
+    for source_column, target_column in [
+        ("cumulative_pool_inflow", "daily_deposit_usd"),
+        ("cumulative_pool_outflow", "daily_withdrawal_usd"),
+    ]:
+        values = result[source_column]
+        prior_values = values.groupby(group_values, sort=False).shift()
+        delta = values - prior_values
+        values_known = values.notna() & prior_values.notna()
+        valid_delta = is_completed & is_consecutive & values_known & delta.ge(0)
+        decreased_counter = is_completed & is_consecutive & values_known & delta.lt(0)
+
+        if decreased_counter.any():
+            logger.warning(
+                "Lighter %s counter decreased for %d completed daily observations; withholding those flows",
+                source_column,
+                int(decreased_counter.sum()),
+            )
+
+        result[target_column] = delta.where(valid_delta)
+
+    return result
 
 
 def build_raw_prices_dataframe(db: LighterDailyMetricsDatabase) -> pd.DataFrame:
@@ -224,6 +300,8 @@ def build_raw_prices_dataframe(db: LighterDailyMetricsDatabase) -> pd.DataFrame:
     if prices_df.empty:
         return pd.DataFrame()
 
+    prices_df = _derive_daily_flow_columns(prices_df, current_date=native_datetime_utc_now().date())
+
     unknown_deployments = set(prices_df["deployment"].unique()) - set(LIGHTER_DEPLOYMENTS_BY_SLUG)
     if unknown_deployments:
         raise ValueError(f"Unknown Lighter deployments in daily metrics database: {sorted(unknown_deployments)}")
@@ -245,10 +323,16 @@ def build_raw_prices_dataframe(db: LighterDailyMetricsDatabase) -> pd.DataFrame:
             "timestamp": pd.to_datetime(prices_df["date"]).values,
             "share_price": prices_df["share_price"].values,
             "total_assets": prices_df["tvl"].values if "tvl" in prices_df.columns else 0.0,
-            "total_supply": 0.0,
+            "total_supply": prices_df["total_shares"].values if "total_shares" in prices_df.columns else np.nan,
             "performance_fee": 0.0,
             "management_fee": 0.0,
             "errors": "",
+            # Lighter's public PnL endpoint exposes cumulative monetary
+            # counters, not event-level counts. Keep count values unknown.
+            "daily_deposit_count": np.nan,
+            "daily_withdrawal_count": np.nan,
+            "daily_deposit_usd": prices_df["daily_deposit_usd"].values,
+            "daily_withdrawal_usd": prices_df["daily_withdrawal_usd"].values,
             "written_at": prices_df["written_at"].values if "written_at" in prices_df.columns else pd.NaT,
         },
     )
@@ -327,6 +411,12 @@ def merge_into_vault_database(
         operator_fee = 0.0 if pd.isna(operator_fee) else float(operator_fee)
         status = row.get("status")
         status = 0 if pd.isna(status) else int(status)
+        total_shares = row.get("total_shares")
+        total_shares = None if pd.isna(total_shares) else int(total_shares)
+        operator_shares = row.get("operator_shares")
+        operator_shares = None if pd.isna(operator_shares) else int(operator_shares)
+        ownership_updated_at = row.get("last_updated")
+        ownership_updated_at = None if pd.isna(ownership_updated_at) else ownership_updated_at
 
         spec, vault_row = create_lighter_pool_row(
             account_index=int(row["account_index"]),
@@ -335,6 +425,9 @@ def merge_into_vault_database(
             tvl=tvl,
             created_at=created_at,
             operator_fee=operator_fee,
+            total_shares=total_shares,
+            operator_shares=operator_shares,
+            ownership_updated_at=ownership_updated_at,
             is_llp=bool(row.get("is_llp", False)),
             status=status,
             deployment=deployment,

--- a/eth_defi/mellow/vault.py
+++ b/eth_defi/mellow/vault.py
@@ -136,6 +136,7 @@ from eth_defi.token import TokenDetails, fetch_erc20_details
 from eth_defi.vault.base import TradingUniverse, VaultBase, VaultDepositManager, VaultFlowManager, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
 from eth_defi.vault.fee import BROKEN_FEE_DATA, FeeData
 from eth_defi.vault.lower_case_dict import LowercaseDict
+from eth_defi.vault.price_source import PriceSource
 
 logger = logging.getLogger(__name__)
 
@@ -603,6 +604,18 @@ class MellowVault(VaultBase):
             timestamp=int(timestamp),
             is_suspicious=bool(is_suspicious),
         )
+
+    def get_share_price_source(self) -> PriceSource:
+        """Return the Mellow oracle price-source classification.
+
+        Mellow Core vault reports are read from the vault-coupled oracle
+        contract at the requested block.
+
+        :return:
+            Smart-contract state source.
+        """
+
+        return PriceSource.smart_contract_state
 
     def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal | None:
         """Fetch Mellow share price from the oracle report.

--- a/eth_defi/midas/vault.py
+++ b/eth_defi/midas/vault.py
@@ -29,6 +29,7 @@ from eth_defi.vault.fee import FeeData, VaultFeeMode
 from eth_defi.vault.flag import VaultFlag
 from eth_defi.vault.handwritten_metadata import get_handwritten_vault_metadata
 from eth_defi.vault.lower_case_dict import LowercaseDict
+from eth_defi.vault.price_source import PriceSource
 
 MIDAS_HOMEPAGE = "https://midas.app/products"
 MIDAS_CONTRACTS_GITHUB = "https://github.com/midas-apps/contracts"
@@ -498,6 +499,18 @@ class MidasVault(VaultBase):
         if self.product.is_tokenised_fund:
             return None
         return self.fetch_primary_payment_token()
+
+    def get_share_price_source(self) -> PriceSource:
+        """Return the Midas NAV source classification.
+
+        Midas share prices are read from its deployed data-feed contracts at
+        the requested archive block.
+
+        :return:
+            Smart-contract state source.
+        """
+
+        return PriceSource.smart_contract_state
 
     def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
         """Fetch Midas NAV per mToken.

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -54,6 +54,7 @@ from eth_defi.vault.flag import (
     VaultFlag,
     get_notes,
 )
+from eth_defi.vault.price_source import PriceSource
 from eth_defi.vault.risk import VaultTechnicalRisk, get_vault_risk
 from eth_defi.vault.vaultdb import VaultDatabase, VaultRow
 
@@ -180,28 +181,30 @@ class NetflowMetrics:
     Aggregates daily deposit/withdrawal event counts and USD values
     over a given period (e.g. ``"1d"``, ``"7d"``, ``"30d"``).
 
-    Only available for chains that support vault flow tracking
-    (currently Hyperliquid). For other chains this will be ``None``
-    in the vault record.
+    Only available for chains that support vault flow tracking. Sources that
+    expose monetary counters but not individual events retain null counts.
     """
 
     #: Period label (e.g. ``"1d"``, ``"7d"``, ``"30d"``)
     period: str
 
     #: Number of deposit events in the period
-    deposit_count: int = 0
+    deposit_count: int | None = None
 
     #: Number of withdrawal events in the period
-    withdrawal_count: int = 0
+    withdrawal_count: int | None = None
 
     #: Total USD deposited in the period
-    deposit_usd: float = 0.0
+    deposit_usd: float | None = None
 
     #: Total USD withdrawn in the period (positive value)
-    withdrawal_usd: float = 0.0
+    withdrawal_usd: float | None = None
 
     #: Net flow (deposit_usd - withdrawal_usd)
-    net_flow_usd: float = 0.0
+    net_flow_usd: float | None = None
+
+    #: Whether every daily monetary observation in the full period is known.
+    data_complete: bool = False
 
 
 #: Period -> Perioud duration, max sparse sample mismatch
@@ -302,6 +305,9 @@ class VaultMetricsRecord(TypedDict, total=False):
 
     #: Latest adaptive vault scan cycle, e.g. ``"large_tvl"`` or ``"peaked"``.
     vault_poll_frequency: str | None
+
+    #: Source used to produce the share-price series.
+    share_price_source: str | None
 
     #: Current net asset value in USD
     current_nav: float | None
@@ -1023,59 +1029,83 @@ def _unnullify(x: str | None, default: str = "<unknown>") -> str:
 def _calculate_netflow_metrics(
     prices_df: pd.DataFrame,
     now_: pd.Timestamp | None = None,
+    exclude_current_utc_day: bool = False,
 ) -> list[NetflowMetrics] | None:
     """Aggregate daily deposit/withdrawal flow data into period summaries.
 
     Computes :py:class:`NetflowMetrics` for 1d, 7d, and 30d periods by
     summing the daily flow columns in ``prices_df``.
 
-    Only complete days are considered. If the required flow columns are
-    missing or contain no non-null data, returns ``None``.
+    If monetary flow columns are missing or contain no non-null data, returns
+    ``None``. Count columns are optional because some native APIs expose only
+    cumulative monetary counters. A period is complete only when every UTC
+    day in its full calendar window has known monetary observations. Periods
+    with missing, source-null, or partial flow observations return null totals
+    rather than silently reporting a partial sum. Event counts follow the same
+    completeness rule when the source exposes them.
 
     :param prices_df:
         Cleaned price DataFrame with a DatetimeIndex and optional columns
-        ``daily_deposit_count``, ``daily_withdrawal_count``,
-        ``daily_deposit_usd``, ``daily_withdrawal_usd``.
+        ``daily_deposit_usd`` and ``daily_withdrawal_usd`` plus optional event
+        count columns.
     :param now_:
         Reference timestamp for period lookback. Defaults to the last
         timestamp in the DataFrame.
+    :param exclude_current_utc_day:
+        Exclude the current UTC day from the lookback when its source values
+        are intentionally provisional.
     :return:
         List of :py:class:`NetflowMetrics` for periods 1d, 7d, 30d,
         or ``None`` if flow data is unavailable.
     """
-    flow_cols = ["daily_deposit_count", "daily_withdrawal_count", "daily_deposit_usd", "daily_withdrawal_usd"]
-
-    if not all(col in prices_df.columns for col in flow_cols):
+    amount_cols = ["daily_deposit_usd", "daily_withdrawal_usd"]
+    count_cols = ["daily_deposit_count", "daily_withdrawal_count"]
+    if not all(col in prices_df.columns for col in amount_cols):
         return None
 
-    # Check if there is any non-null flow data at all
-    has_data = any(prices_df[col].notna().any() for col in flow_cols)
+    # Check if there is any non-null monetary flow data at all.
+    has_data = any(prices_df[col].notna().any() for col in amount_cols)
     if not has_data:
         return None
 
     if now_ is None:
         now_ = prices_df.index.max()
 
+    if exclude_current_utc_day and now_.date() == native_datetime_utc_now().date():
+        now_ -= pd.Timedelta(days=1)
+
     results = []
     for period_label, days in [("1d", 1), ("7d", 7), ("30d", 30)]:
         cutoff = now_ - pd.Timedelta(days=days)
-        mask = prices_df.index > cutoff
+        mask = (prices_df.index > cutoff) & (prices_df.index <= now_)
 
-        subset = prices_df.loc[mask, flow_cols].dropna(how="all")
+        subset = prices_df.loc[mask]
+        amounts = subset[amount_cols]
+        expected_dates = pd.date_range(end=now_.normalize(), periods=days, freq="D")
+        observed_dates = pd.DatetimeIndex(subset.index.normalize().unique())
+        data_complete = observed_dates.equals(expected_dates) and len(subset) == days and amounts.notna().all(axis=None)
 
-        dep_count = int(subset["daily_deposit_count"].sum()) if not subset.empty else 0
-        wd_count = int(subset["daily_withdrawal_count"].sum()) if not subset.empty else 0
-        dep_usd = float(subset["daily_deposit_usd"].sum()) if not subset.empty else 0.0
-        wd_usd = float(subset["daily_withdrawal_usd"].sum()) if not subset.empty else 0.0
+        if data_complete:
+            dep_usd = float(amounts["daily_deposit_usd"].sum())
+            wd_usd = float(amounts["daily_withdrawal_usd"].sum())
+            net_flow_usd = dep_usd - wd_usd
+        else:
+            dep_usd = None
+            wd_usd = None
+            net_flow_usd = None
+
+        deposit_count = int(subset["daily_deposit_count"].sum()) if data_complete and "daily_deposit_count" in subset and subset["daily_deposit_count"].notna().all() else None
+        withdrawal_count = int(subset["daily_withdrawal_count"].sum()) if data_complete and "daily_withdrawal_count" in subset and subset["daily_withdrawal_count"].notna().all() else None
 
         results.append(
             NetflowMetrics(
                 period=period_label,
-                deposit_count=dep_count,
-                withdrawal_count=wd_count,
+                deposit_count=deposit_count,
+                withdrawal_count=withdrawal_count,
                 deposit_usd=dep_usd,
                 withdrawal_usd=wd_usd,
-                net_flow_usd=dep_usd - wd_usd,
+                net_flow_usd=net_flow_usd,
+                data_complete=bool(data_complete),
             )
         )
 
@@ -1736,6 +1766,13 @@ def calculate_vault_record(
     risk = vault_metadata.get("_risk") or get_vault_risk(protocol, vault_address)
     notes = vault_metadata.get("_notes") or get_notes(vault_address, chain_id=chain_id)
     vault_poll_frequency = get_latest_vault_poll_frequency(prices_df)
+    raw_share_price_source = vault_metadata.get("_share_price_source")
+    if raw_share_price_source is None:
+        share_price_source = None
+    elif isinstance(raw_share_price_source, PriceSource):
+        share_price_source = raw_share_price_source.value
+    else:
+        share_price_source = PriceSource(raw_share_price_source).value
 
     flags = set(vault_metadata.get("_flags") or set())
     risk, notes, flags = apply_bad_flag_check(
@@ -1883,8 +1920,12 @@ def calculate_vault_record(
     now_ = prices_df.index.max()
 
     # Deposit/withdrawal flow metrics aggregated over 1d, 7d, 30d periods.
-    # Only available for chains with daily flow data (currently Hyperliquid).
-    netflow = _calculate_netflow_metrics(prices_df, now_=now_)
+    # Only available for native protocols with daily flow data.
+    netflow = _calculate_netflow_metrics(
+        prices_df,
+        now_=now_,
+        exclude_current_utc_day=vault_metadata.get("_daily_flow_current_day_is_provisional", False),
+    )
 
     # Vault descriptions from offchain metadata (Euler, Lagoon, etc.)
     description = vault_metadata.get("_description")
@@ -1952,6 +1993,17 @@ def calculate_vault_record(
     perp_dex_data = build_perp_dex_other_data(prices_df.iloc[-1])
     if perp_dex_data is not None:
         other_data["perp_dex"] = perp_dex_data
+
+    if protocol == "Lighter":
+        # Ownership is an API snapshot captured alongside pool metadata. It is
+        # deliberately not carried through historical price rows: doing so
+        # would make a current operator stake look like historical ownership.
+        other_data["lighter"] = {
+            "operator_shares": vault_metadata.get("_lighter_operator_shares"),
+            "total_shares": vault_metadata.get("_lighter_total_shares"),
+            "operator_share_fraction": vault_metadata.get("_lighter_operator_share_fraction"),
+            "ownership_updated_at": vault_metadata.get("_lighter_ownership_updated_at"),
+        }
 
     # Manual review decision from the Hyperliquid review Google Sheet.
     # Captured into the pickle by
@@ -2197,6 +2249,7 @@ def calculate_vault_record(
             "risk": risk,
             "risk_numeric": risk_numeric,
             "vault_poll_frequency": vault_poll_frequency,
+            "share_price_source": share_price_source,
             "id": id_val,
             "start_date": lifetime_start_date,
             "end_date": lifetime_end_date,
@@ -2284,7 +2337,11 @@ def calculate_lifetime_metrics(
 
     Lookback based on the last entry.
 
-    Each output row contains a ``denomination_token_rate`` value produced by
+    Each output row contains a ``share_price_source`` string describing how
+    the adapter obtained its share-price observations, or ``None`` for legacy
+    metadata and adapters without a price source.
+
+    Each output row also contains a ``denomination_token_rate`` value produced by
     :py:meth:`eth_defi.feed.stablecoin_rate.StablecoinRateFeeder.get_denomination_token_rate_section`.
     The value is a :py:class:`eth_defi.feed.stablecoin_rate.DenominationTokenRate`
     carrying both USD rate fields and, for non-USD stablecoins, native source
@@ -2868,6 +2925,7 @@ def format_lifetime_table(
             "protocol": "Protocol",
             "risk": "Risk",
             "vault_poll_frequency": "Scan cycle",
+            "share_price_source": "Share price source",
             # "end_date": "Latest deposit",
             "name": "Name",
             "lockup": "Lock up est. days",
@@ -3536,6 +3594,9 @@ def export_lifetime_row(row: pd.Series) -> dict:
     - Normalises pandas, numpy, datetime, and custom types.
     - Converts finite :class:`~decimal.Decimal` values to JSON number floats.
     - Preserves legacy fee field names.
+
+    The ``share_price_source`` column is retained as a stable
+    :py:class:`eth_defi.vault.price_source.PriceSource` string value.
 
     The ``denomination_token_rate`` dataclass from
     :py:class:`eth_defi.feed.stablecoin_rate.DenominationTokenRate` is converted

--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -1608,7 +1608,22 @@ def fix_outlier_share_prices(
         if len(prices_df) == 0:
             return prices_df
 
+        # Flow rows are interval observations, not state snapshots. Preserve
+        # their unknown markers while filling sparse vault state used by the
+        # share-price cleaner.
+        flow_columns = [
+            column
+            for column in (
+                "daily_deposit_count",
+                "daily_withdrawal_count",
+                "daily_deposit_usd",
+                "daily_withdrawal_usd",
+            )
+            if column in group.columns
+        ]
+        source_flows = group[flow_columns].copy()
         group = group.ffill()
+        group[flow_columns] = source_flows
 
         # Compute row-based shift from actual time spacing so that vaults
         # with non-hourly polling (daily, weekly) get a sensible window.

--- a/eth_defi/tokenised_fund/asseto/vault.py
+++ b/eth_defi/tokenised_fund/asseto/vault.py
@@ -30,6 +30,7 @@ from eth_defi.types import Percent
 from eth_defi.vault.base import TradingUniverse, VaultFlowManager, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
 from eth_defi.vault.fee import FeeData, VaultFeeMode
 from eth_defi.vault.lower_case_dict import LowercaseDict
+from eth_defi.vault.price_source import PriceSource
 
 logger = logging.getLogger(__name__)
 
@@ -499,6 +500,18 @@ class AssetoVault(TokenisedFundVault):
         if rate <= 0:
             raise RuntimeError(f"Invalid {symbol}/USD rate {rate} for Asseto product {self.product.symbol}")
         return value / rate
+
+    def get_share_price_source(self) -> PriceSource:
+        """Return the configured Asseto product price source.
+
+        Products with a published ``Pricer`` are read at an archive block.
+        Other reviewed products use Asseto's public daily NAV API.
+
+        :return:
+            Smart-contract state or API source for this product.
+        """
+
+        return PriceSource.smart_contract_state if self.uses_onchain_pricer() else PriceSource.api
 
     def fetch_offchain_price_history(self) -> tuple[AssetoPricePoint, ...]:
         """Fetch and cache Asseto's public daily NAV/share history.

--- a/eth_defi/tokenised_fund/kinexys/vault.py
+++ b/eth_defi/tokenised_fund/kinexys/vault.py
@@ -37,6 +37,7 @@ from eth_defi.types import Percent
 from eth_defi.vault.base import TradingUniverse, VaultFlowManager, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
 from eth_defi.vault.fee import BROKEN_FEE_DATA, FeeData, VaultFeeMode
 from eth_defi.vault.lower_case_dict import LowercaseDict
+from eth_defi.vault.price_source import PriceSource
 
 logger = logging.getLogger(__name__)
 
@@ -343,6 +344,18 @@ class OdaFactVault(TokenisedFundVault):
         """
 
         return None
+
+    def get_share_price_source(self) -> PriceSource | None:
+        """Return the ODA-FACT share-price source classification.
+
+        JLTXX is exported using the explicitly labelled USD 1 NAV estimate.
+        MONY has no share-price observation and therefore remains unknown.
+
+        :return:
+            Fixed-price source for JLTXX, otherwise ``None``.
+        """
+
+        return None if is_mony(self.address) else PriceSource.fixed_price
 
     def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal | None:
         """Fetch ODA-FACT share price when an authorised source is available.

--- a/eth_defi/tokenised_fund/securitize/vault.py
+++ b/eth_defi/tokenised_fund/securitize/vault.py
@@ -21,6 +21,7 @@ from eth_defi.types import Percent
 from eth_defi.vault.base import TradingUniverse, VaultFlowManager, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
 from eth_defi.vault.fee import BROKEN_FEE_DATA, FeeData
 from eth_defi.vault.lower_case_dict import LowercaseDict
+from eth_defi.vault.price_source import PriceSource
 
 #: Backwards-compatible aliases for the first registered Securitize product.
 BUIDL_ETHEREUM_CHAIN_ID = BUIDL_ETHEREUM.chain_id
@@ -32,6 +33,13 @@ BUIDL_HOMEPAGE = BUIDL_ETHEREUM.homepage
 SECURITIZE_HOMEPAGE = "https://securitize.io/"
 SECURITIZE_RESTRICTED_FLOW_REASON = "Securitize DSToken subscriptions, redemptions and transfers require approved investors and compliance checks"
 SECURITIZE_NAV_UNAVAILABLE_ERROR_PREFIX = "No on-chain NAV source configured for Securitize DSToken"
+
+#: Map executable Securitize NAV-source families to public classifications.
+SECURITIZE_PRICE_SOURCE_PREFIXES: dict[str, PriceSource] = {
+    "redstone_": PriceSource.redstone,
+    "chronicle_": PriceSource.chronicle,
+    "estimated_": PriceSource.fixed_price,
+}
 
 
 class SecuritizeVaultInfo(VaultInfo, total=False):
@@ -112,6 +120,21 @@ class SecuritizeVault(TokenisedFundVault):
         self.features = features or {ERC4626Feature.securitize_like}
         self.default_block_identifier = default_block_identifier
         self.product = SECURITIZE_PRODUCTS.get((spec.chain_id, HexAddress(spec.vault_address.lower())))
+
+    def get_share_price_source(self) -> PriceSource | None:
+        """Return the reviewed source configured for this Securitize product.
+
+        Source identifiers are mapped by family so newly reviewed RedStone,
+        Chronicle or estimated products do not require address-specific
+        branches in the adapter.
+
+        :return:
+            Product price source, or ``None`` when NAV is unconfigured.
+        """
+
+        if self.product is None:
+            return None
+        return next((source for prefix, source in SECURITIZE_PRICE_SOURCE_PREFIXES.items() if self.product.nav_source.startswith(prefix)), None)
 
     @property
     def chain_id(self) -> int:

--- a/eth_defi/vault/base.py
+++ b/eth_defi/vault/base.py
@@ -34,6 +34,7 @@ from eth_defi.types import Percent
 from eth_defi.utils import is_good_multichain_address
 from eth_defi.vault.deposit_redeem import VaultDepositManager, VaultDepositManagerCapability
 from eth_defi.vault.lower_case_dict import LowercaseDict
+from eth_defi.vault.price_source import PriceSource
 from eth_defi.version_info import stamp_parquet_schema_metadata
 
 from .fee import FeeData, VaultFeeMode, get_vault_fee_mode
@@ -1150,6 +1151,20 @@ class VaultBase(ABC):
         - Returns None if the protocol does not expose separate manager metadata
         - Override in subclasses that support manager or operator metadata
         """
+        return None
+
+    def get_share_price_source(self) -> PriceSource | None:  # noqa: PLR6301
+        """Return the source used for share-price observations.
+
+        Vault integrations override this method when they expose a share
+        price. Returning ``None`` distinguishes unsupported or unknown pricing
+        from a known source classification.
+
+        :return:
+            Share-price source, or ``None`` when the adapter does not provide
+            one.
+        """
+
         return None
 
     def fetch_scan_record_extra_data(self) -> dict[str, object]:  # noqa: PLR6301

--- a/eth_defi/vault/price_source.py
+++ b/eth_defi/vault/price_source.py
@@ -1,0 +1,32 @@
+"""Classify how a vault share price is obtained."""
+
+import enum
+
+
+class PriceSource(str, enum.Enum):
+    """Machine-readable source of a vault's share-price observations.
+
+    The classification describes the data path used by the vault adapter, not
+    the legal publisher of the underlying fund NAV. Values are stable public
+    export strings consumed by vault-data clients. A null value is valid and
+    means the adapter has not yet been mapped to a known price source; it does
+    not imply that the vault has no price source.
+    """
+
+    #: Read directly from historical smart-contract state.
+    smart_contract_state = "smart-contract-state"
+
+    #: Read from a protocol or product API.
+    api = "api"
+
+    #: Reconstructed or estimated because no authoritative price series exists.
+    approximation = "approximation"
+
+    #: Explicitly configured constant share price.
+    fixed_price = "fixed-price"
+
+    #: Read from a RedStone oracle or fundamental-value feed.
+    redstone = "redstone"
+
+    #: Read from a Chronicle oracle or Proof of Asset feed.
+    chronicle = "chronicle"

--- a/eth_defi/vault/vaultdb.py
+++ b/eth_defi/vault/vaultdb.py
@@ -19,6 +19,7 @@ from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature, get_va
 from eth_defi.erc_4626.discovery_base import PotentialVaultMatch
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.price_source import PriceSource
 from eth_defi.vault.risk import VaultTechnicalRisk
 
 logger = logging.getLogger(__name__)
@@ -160,6 +161,14 @@ class VaultRow(TypedDict):
     #: ``_detection_data`` because that ID is the Lighter price-partition and
     #: :class:`~eth_defi.vault.base.VaultSpec` identity.
     _deployment_chain_id: NotRequired[int | None]
+
+    #: Source used to produce the vault share-price series.
+    #:
+    #: Missing in legacy pickles and adapters without a known price source.
+    _share_price_source: NotRequired[PriceSource | None]
+
+    #: Whether the current UTC daily-flow observation is provisional.
+    _daily_flow_current_day_is_provisional: NotRequired[bool]
 
     __annotations__ = {
         "First seen at": datetime.datetime,

--- a/eth_defi/vault_street/vault.py
+++ b/eth_defi/vault_street/vault.py
@@ -26,6 +26,7 @@ from eth_defi.types import Percent
 from eth_defi.vault.base import TradingUniverse, VaultBase, VaultDepositManager, VaultFlowManager, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
 from eth_defi.vault.fee import FeeData, VaultFeeMode
 from eth_defi.vault.lower_case_dict import LowercaseDict
+from eth_defi.vault.price_source import PriceSource
 from eth_defi.vault_street.constants import (
     PRIME_USD_ADDRESS,
     PRIME_USD_DENOMINATION_TOKEN_ADDRESS,
@@ -284,6 +285,18 @@ class VaultStreetVault(VaultBase):
         """
 
         return Decimal(raw_price) / Decimal(10**PRIME_USD_PRICE_DECIMALS)
+
+    def get_share_price_source(self) -> PriceSource:
+        """Return the primeUSD NAV source classification.
+
+        The adapter reads the deployed ``PriceStorage`` oracle at the requested
+        block.
+
+        :return:
+            Smart-contract state source.
+        """
+
+        return PriceSource.smart_contract_state
 
     def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
         """Fetch primeUSD NAV per token from the PriceStorage oracle.

--- a/eth_defi/wstgbp/vault.py
+++ b/eth_defi/wstgbp/vault.py
@@ -22,6 +22,7 @@ from eth_defi.types import Percent
 from eth_defi.vault.base import TradingUniverse, VaultBase, VaultDepositManager, VaultFlowManager, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
 from eth_defi.vault.fee import FeeData, VaultFeeMode
 from eth_defi.vault.lower_case_dict import LowercaseDict
+from eth_defi.vault.price_source import PriceSource
 from eth_defi.wstgbp.historical import WSTGBPVaultHistoricalReader
 
 WSTGBP_HOMEPAGE = "https://wstgbp.com"
@@ -276,6 +277,18 @@ class WSTGBPVault(VaultBase):
             cache=self.token_cache,
             cause_diagnostics_message=f"Wren Staked tGBP denomination token for vault {self.address}",
         )
+
+    def get_share_price_source(self) -> PriceSource:
+        """Return the Wren Staked tGBP NAV source classification.
+
+        The adapter reads ``navprice()`` from the product contract at the
+        requested block.
+
+        :return:
+            Smart-contract state source.
+        """
+
+        return PriceSource.smart_contract_state
 
     def fetch_share_price(self, block_identifier: BlockIdentifier = "latest") -> Decimal:
         """Read Wren Staked tGBP NAV/share from ``navprice()``.

--- a/scripts/lighter/README-lighter-vaults.md
+++ b/scripts/lighter/README-lighter-vaults.md
@@ -54,11 +54,17 @@ Lighter public endpoints               ERC-4626 pipeline
   per-pool share price history                 |
   pool_info.share_prices                       |
   pool_info.daily_returns                      |
+  ownership, balances, margins, positions      |
+      |                                        |
+      v                                        |
+/api/v1/pnl                                    |
+  daily shares, flows, PnL, volume             |
       |                                        |
       v                                        |
 lighter-pools.duckdb  ------merge----->  vault-metadata-db.pickle
   pool_metadata table                    vault-prices-1h.parquet (uncleaned)
   pool_daily_prices table                      |
+  pool_snapshots table                         |
                                                v
                                         process_raw_vault_scan_data()
                                           fix_outlier_share_prices()
@@ -231,16 +237,57 @@ Response fields (inside `accounts[0]`):
 
 | Field | Type | Description |
 |-------|------|-------------|
+| `account_index` | int | Pool account index |
+| `index` | int | Account index alias returned by the endpoint |
+| `code` | int | Account code |
+| `created_at` | int | Account creation timestamp |
 | `name` | string | Pool name |
 | `description` | string | Pool strategy description |
+| `l1_address` | string | Pool account L1 address |
+| `status` | int | Account status |
+| `account_type` | int | Account type |
+| `account_trading_mode` | int | Trading mode |
 | `total_asset_value` | string | TVL in the deployment's collateral currency |
+| `cross_asset_value` | string | Cross-margin asset value in the deployment's collateral currency |
+| `collateral` | string | Account collateral in the deployment's collateral currency |
+| `available_balance` | string | Free balance in the deployment's collateral currency |
+| `cross_initial_margin_requirement` | string | Initial margin requirement in the deployment's collateral currency |
+| `cross_maintenance_margin_requirement` | string | Maintenance margin requirement in the deployment's collateral currency |
+| `pending_order_count` | int | Account-level pending orders |
+| `total_order_count` | int | Lifetime order count |
+| `total_isolated_order_count` | int | Lifetime isolated-order count |
+| `transaction_time` | int | Source transaction-time marker |
+| `positions` | array | Current per-market positions and attached order counts |
+| `assets` | array | Current asset balances and margin balances |
+| `pending_unlocks` | array | Current pending pool unlocks |
+| `shares` | array | Current account share records |
+| `metadata` | object | Current account metadata |
+| `can_invite` | bool | Whether invitations are enabled |
+| `can_rfq` | bool | Whether RFQ is enabled |
+| `can_rfq_market_ids` | array | RFQ-enabled market IDs |
+| `cancel_all_time` | int | Cancel-all source timestamp or sequence marker |
+| `referral_points_percentage` | string | Referral-points percentage |
 | `pool_info.share_prices` | array | `[{"timestamp": int, "share_price": float}, ...]` |
 | `pool_info.daily_returns` | array | `[{"timestamp": int, "daily_return": float}, ...]` |
 | `pool_info.operator_fee` | string | Operator fee percentage |
+| `pool_info.min_operator_share_rate` | string | Minimum operator ownership rate |
 | `pool_info.annual_percentage_yield` | float | Current APY |
 | `pool_info.sharpe_ratio` | string | Risk-adjusted return metric |
 | `pool_info.total_shares` | int | Outstanding shares |
 | `pool_info.operator_shares` | int | Operator's shares |
+| `pool_info.status` | int | Pool status |
+| `pool_info.strategies` | array | Current strategy collateral records |
+
+The scanner appends these current values to `pool_snapshots` on every
+successful scan. This creates historical operator ownership, fee, risk,
+activity, and exposure data from the collection start onwards. The unified
+metrics JSON exposes only the latest raw ownership counts and ratio under
+`other_data.lighter`.
+
+Lighter does not provide historical `/api/v1/account` snapshots. The scanner
+does not copy the first observed value backwards: all dates before collection
+started are missing and appear as SQL `NULL` or Pandas `NaN` when snapshot data
+is joined to older price history.
 
 Share price arrays have different retention depending on pool type
 (see [Share price history limitations](#share-price-history-limitations) below).
@@ -248,8 +295,8 @@ Share price arrays have different retention depending on pool type
 #### PnL history (`/api/v1/pnl`)
 
 Per-account PnL and balance history with configurable resolution and
-time range. This is the **only endpoint with full history** back to
-pool inception for all pools.
+time range. The pipeline uses it to obtain the historical counters for
+all pool types.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
@@ -269,12 +316,17 @@ Response fields (inside `pnl[]`):
 | `trade_pnl` | float | Cumulative trading PnL in the deployment's collateral currency |
 | `trade_spot_pnl` | float | Cumulative spot PnL |
 | `pool_pnl` | float | Pool-level PnL |
+| `inflow` | float | Cumulative account inflow |
+| `outflow` | float | Cumulative account outflow |
 | `pool_inflow` | float | Cumulative deposit inflow in the deployment's collateral currency |
 | `pool_outflow` | float | Cumulative withdrawal outflow in the deployment's collateral currency |
 | `pool_total_shares` | int | Total outstanding shares at this point |
+| `spot_inflow` | float | Cumulative spot inflow |
+| `spot_outflow` | float | Cumulative spot outflow |
 | `staking_pnl` | float | LIT staking PnL |
 | `staking_inflow` | float | Staking inflow |
 | `staking_outflow` | float | Staking outflow |
+| `volume` | float | Source trading-volume value |
 
 **Note:** This endpoint does **not** return `share_price`. The
 `pool_total_shares` field cannot be trivially combined with PnL fields
@@ -282,6 +334,22 @@ to reconstruct share price — the data model is more complex than
 `(inflow - outflow + trade_pnl) / shares`. The Lighter website uses
 this endpoint for its TVL/balance chart, but uses the separate
 `share_prices` array from `/api/v1/account` for the NAV chart.
+
+The pipeline stores every available matching-date PnL metric field above as
+source daily data. It
+differences only consecutive completed UTC-day `pool_inflow` and `pool_outflow`
+observations to produce daily deposit/withdrawal USD amounts. The first
+observation, a missing-day gap, a counter reset, and the current UTC day remain
+unknown rather than zero. The API does not expose transaction counts, so
+Lighter netflow records have null event-count fields. A netflow period with
+unknown amounts is marked `data_complete: false` and has null monetary totals
+rather than a misleading partial sum.
+
+`pool_daily_prices` remains a share-price-indexed table. A PnL observation is
+stored only when its UTC date matches a retained share-price date; total shares
+may be forward-filled for TVL, but flow, PnL and volume fields are not. An
+unmatched PnL date therefore remains unavailable to the current price-based
+export rather than being attached to the wrong date.
 
 ### Share price history limitations
 
@@ -306,19 +374,52 @@ reconstruction model.
 ```
 pool_metadata                         pool_daily_prices
 =============                         =================
-deployment       VARCHAR \            deployment     VARCHAR \
-account_index    BIGINT   > PK         account_index  BIGINT  > composite PK
-name             VARCHAR               date           DATE   /
-description      VARCHAR               share_price    DOUBLE
-l1_address       VARCHAR               tvl            DOUBLE
-is_llp           BOOLEAN               daily_return   DOUBLE
-operator_fee     DOUBLE                annual_percentage_yield DOUBLE
-total_asset_value DOUBLE
-annual_percentage_yield DOUBLE
-sharpe_ratio     DOUBLE
-created_at       TIMESTAMP
-last_updated     TIMESTAMP
+deployment                VARCHAR \    deployment                  VARCHAR \
+account_index             BIGINT   > PK account_index               BIGINT  > composite PK
+name                      VARCHAR      date                        DATE    /
+description               VARCHAR      share_price                 DOUBLE
+l1_address                VARCHAR      tvl                         DOUBLE
+is_llp                    BOOLEAN      daily_return                DOUBLE
+operator_fee              DOUBLE       annual_percentage_yield     DOUBLE
+total_shares              BIGINT       total_shares                BIGINT
+operator_shares           BIGINT       cumulative_pool_inflow      DOUBLE
+total_asset_value         DOUBLE       cumulative_pool_outflow     DOUBLE
+annual_percentage_yield   DOUBLE       written_at                  TIMESTAMP
+sharpe_ratio              DOUBLE
+created_at                TIMESTAMP
+last_updated              TIMESTAMP
 ```
+
+`pool_daily_prices` also retains all other `/api/v1/pnl` metric fields:
+account/spot/staking inflow and outflow, trade/spot/pool/staking PnL, and
+volume. These fields are collected only for matching share-price dates observed
+after the accounting fields were introduced. New nullable columns are added to
+existing databases, but legacy rows are not reconstructed and may remain
+`NULL` permanently.
+
+#### Point-in-time snapshots
+
+`pool_snapshots` is append-only with primary key
+`(deployment, snapshot_timestamp, account_index)`. Its columns are grouped as
+follows:
+
+| Group | Columns |
+|-------|---------|
+| Identity/status | `deployment`, `snapshot_timestamp`, `account_index`, `account_status`, `pool_status`, `account_type`, `account_trading_mode` |
+| Ownership/economics | `total_shares`, `operator_shares`, `operator_share_fraction`, `operator_fee`, `min_operator_share_rate`, `annual_percentage_yield`, `sharpe_ratio` |
+| Balance/margin | `total_asset_value`, `cross_asset_value`, `collateral`, `available_balance`, `initial_margin_requirement`, `maintenance_margin_requirement` |
+| Activity | `pending_order_count`, `total_order_count`, `total_isolated_order_count`, `transaction_time`, `open_order_count` |
+| Exposure | `position_count`, `gross_position_value`, `net_position_value`, `long_position_value`, `short_position_value`, `top_position_fraction`, `allocated_margin`, `unrealised_pnl`, `realised_pnl`, `funding_paid_out` |
+| Other current state | `asset_count`, `strategy_count`, `strategy_collateral`, `pending_unlock_count` |
+| Complete current state | `source_account_json` |
+
+`source_account_json` preserves all current scalar and nested fields even when
+Lighter adds new properties. Historical `share_prices` and `daily_returns`
+arrays are excluded from snapshot JSON because the daily-history pipeline
+handles those time series separately.
+
+No snapshot rows are backfilled before collection started; downstream joins
+must preserve those earlier values as `NULL`/`NaN`.
 
 Opening a legacy database performs a transactional migration. All existing
 rows are retained and labelled `ethereum`; no rescan is needed.
@@ -419,7 +520,8 @@ poetry run python scripts/erc-4626/scan-vaults-all-chains.py
 This runs through the following stages:
 
 1. **Lighter scans** — independently discovers Ethereum and Robinhood pools from their public APIs, fetches share price
-   history and total shares, stores in `lighter-pools.duckdb`
+   history, daily PnL/activity fields, and current ownership/risk/exposure
+   snapshots, then stores them in `lighter-pools.duckdb`
 2. **Merge vault metadata** — upserts Lighter VaultRows into `vault-metadata-db.pickle`
 3. **Merge prices** — appends Lighter daily prices into `vault-prices-1h.parquet`
    (uncleaned), replacing only the deployment address namespaces present in
@@ -436,39 +538,35 @@ but does not scan Robinhood or upload exports:
 LOG_LEVEL=info poetry run python scripts/lighter/daily-pool-metrics.py
 ```
 
-## Purging and rescanning
+## Repairing and rescanning
 
 If Lighter price data is stale or incorrect (e.g. after a bug fix
-that changes how TVL or share prices are computed), purge the old data
-and rescan from scratch.
+that changes how TVL or share prices are computed), preserve the existing
+database and rescan. The DuckDB contains append-only point-in-time snapshots
+and rolling-window price history that the public API may no longer expose.
 
-### Step 1: Delete the Lighter DuckDB
+Do not delete `lighter-pools.duckdb` or purge all chain `9998` rows from the
+shared Parquet. Those operations can permanently remove `pool_snapshots` and
+price history that cannot be reconstructed.
+
+### Step 1: Back up persistent state
 
 ```shell
-rm ~/.tradingstrategy/vaults/lighter-pools.duckdb
+cp ~/.tradingstrategy/vaults/lighter-pools.duckdb ~/.tradingstrategy/vaults/lighter-pools.duckdb.backup
+cp ~/.tradingstrategy/vaults/vault-prices-1h.parquet ~/.tradingstrategy/vaults/vault-prices-1h.parquet.backup
 ```
 
-This removes the intermediate DuckDB that holds pool metadata and
-daily prices before they are merged into the unified pipeline.
+Verify both backups before continuing. A normal rescan transactionally upserts
+fresh metadata and the share-price window currently available from Lighter,
+then replaces the corresponding Lighter address namespaces in the unified
+Parquet while retaining rows for failed or omitted deployments.
 
-### Step 2: Purge Lighter rows from the uncleaned Parquet
+### Step 2: Rescan
 
-Use `purge-price-data.py` with the shared Lighter synthetic chain ID to strip
-Lighter rows from the shared Parquet file:
-
-```shell
-CHAIN_ID=9998 poetry run python scripts/erc-4626/purge-price-data.py
-```
-
-The pipeline automatically removes any rows written under the legacy
-Robinhood-only synthetic chain `9996` during the next successful Lighter price
-merge; operators do not need to purge that temporary partition manually.
-
-### Step 3: Rescan
-
-Run the Lighter-only full pipeline to rebuild from scratch:
+Run the Lighter-only full pipeline:
 
 ```shell
+source .local-test.env && \
 SCAN_LIGHTER=true \
 DISABLE_CHAINS=Sonic,Monad,Hyperliquid,Base,Arbitrum,Ethereum,Linea,Gnosis,Zora,Polygon,Avalanche,Berachain,Unichain,Hemi,Plasma,Binance,Mantle,Katana,Ink,Blast,Soneium,Optimism \
 MAX_WORKERS=20 \
@@ -476,8 +574,30 @@ LOG_LEVEL=info \
 poetry run python scripts/erc-4626/scan-vaults-all-chains.py
 ```
 
+If a defect cannot be repaired by an ordinary upsert, prepare and test a
+deployment- and date-scoped migration against the backups. Modify only
+reconstructible `pool_daily_prices` rows; never delete or recreate
+`pool_snapshots`, the whole DuckDB, or the complete Lighter Parquet partition.
+
 ## Running Lighter-specific tests
 
 ```shell
 source .local-test.env && poetry run pytest tests/lighter/ -x --timeout=300
 ```
+
+## Running an isolated live cycle smoke test
+
+Use the manual smoke test to scan a small pool sample from both deployments
+into a new DuckDB and validate that metadata, daily prices, ownership,
+accounting fields, snapshots, source JSON, and common perp observations survive
+a close/reopen cycle:
+
+```shell
+LOG_LEVEL=info poetry run python scripts/lighter/smoke-test-daily-cycle.py
+```
+
+The script creates and retains a unique directory under the system temporary
+directory. It never opens the production Lighter DuckDB. Use
+`LIGHTER_TEST_OUTPUT_DIR` to choose a new inspection directory and `MAX_POOLS`,
+`MIN_TVL`, `MAX_WORKERS`, or `HTTP_TIMEOUT` to adjust the bounded live scan.
+The command exits non-zero if either deployment is missing required data.

--- a/scripts/lighter/smoke-test-daily-cycle.py
+++ b/scripts/lighter/smoke-test-daily-cycle.py
@@ -1,0 +1,377 @@
+"""Run an isolated live Lighter database population smoke test.
+
+Scans a small number of pools from every configured Lighter deployment into a
+new temporary DuckDB, closes and reopens the database, and validates metadata,
+daily prices, snapshots, ownership, source accounting fields, and source JSON.
+
+The script never opens the production Lighter database. By default it creates
+and retains a unique directory under the system temporary directory.
+
+Usage:
+
+.. code-block:: shell
+
+    LOG_LEVEL=info poetry run python scripts/lighter/smoke-test-daily-cycle.py
+
+    LIGHTER_TEST_OUTPUT_DIR=/tmp/lighter-cycle-check \
+      MAX_POOLS=5 \
+      MAX_WORKERS=2 \
+      poetry run python scripts/lighter/smoke-test-daily-cycle.py
+
+Environment variables:
+
+- ``LIGHTER_TEST_OUTPUT_DIR``: New output directory. Defaults to a unique
+  temporary directory. The script refuses a non-empty directory.
+- ``MIN_TVL``: Minimum pool TVL. Defaults to ``0``.
+- ``MAX_POOLS``: Maximum pools scanned per deployment. Defaults to ``3``.
+- ``MAX_WORKERS``: Thread workers per deployment. Defaults to ``2``.
+- ``HTTP_TIMEOUT``: Lighter API request timeout in seconds. Defaults to ``30``.
+- ``LOG_LEVEL``: Logging level. Defaults to ``info``.
+"""
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+from tabulate import tabulate
+
+from eth_defi.lighter.constants import LIGHTER_DEPLOYMENTS, LighterAPIConfig
+from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase, run_daily_scan
+from eth_defi.lighter.session import create_lighter_session
+from eth_defi.utils import setup_console_logging
+
+logger = logging.getLogger(__name__)
+
+SOURCE_ACCOUNTING_COLUMNS: tuple[str, ...] = (
+    "cumulative_pool_inflow",
+    "cumulative_pool_outflow",
+    "cumulative_account_inflow",
+    "cumulative_account_outflow",
+    "cumulative_spot_inflow",
+    "cumulative_spot_outflow",
+    "cumulative_staking_inflow",
+    "cumulative_staking_outflow",
+    "trade_pnl",
+    "trade_spot_pnl",
+    "pool_pnl",
+    "staking_pnl",
+    "volume",
+)
+
+
+def _resolve_output_directory() -> Path:
+    """Create the isolated directory used by this smoke test.
+
+    A caller-provided directory is accepted only when it is empty. This
+    prevents a manual test from mutating production or a previous test run
+    accidentally.
+
+    :return:
+        Existing empty or newly created output directory.
+    """
+    configured_path = os.environ.get("LIGHTER_TEST_OUTPUT_DIR")
+    if configured_path:
+        output_dir = Path(configured_path).expanduser().resolve()
+        output_dir.mkdir(parents=True, exist_ok=True)
+        if any(output_dir.iterdir()):
+            raise FileExistsError(f"Smoke-test output directory must be empty: {output_dir}")
+    else:
+        output_dir = Path(tempfile.mkdtemp(prefix="lighter-cycle-smoke-test-"))
+
+    return output_dir
+
+
+def _scan_deployment(
+    deployment: LighterAPIConfig,
+    *,
+    database_path: Path,
+    output_dir: Path,
+    min_tvl: float,
+    max_pools: int,
+    max_workers: int,
+    timeout: float,
+) -> None:
+    """Scan one Lighter deployment into the shared smoke-test database.
+
+    Each deployment receives an isolated rate-limit database while Ethereum
+    and Robinhood intentionally share the metrics DuckDB being validated.
+
+    :param deployment:
+        Lighter deployment configuration.
+    :param database_path:
+        Isolated metrics DuckDB path.
+    :param output_dir:
+        Directory for deployment-specific rate-limit state.
+    :param min_tvl:
+        Minimum pool TVL accepted by the scanner.
+    :param max_pools:
+        Maximum pools scanned for this deployment.
+    :param max_workers:
+        Thread worker count.
+    :param timeout:
+        Per-request HTTP timeout in seconds.
+    :return:
+        None.
+    """
+    logger.info("Scanning %s into %s", deployment.name, database_path)
+    rate_limit_path = output_dir / f"{deployment.slug}-rate-limit.sqlite"
+    with create_lighter_session(
+        deployment=deployment,
+        rate_limit_db_path=rate_limit_path,
+        pool_maxsize=max_workers,
+    ) as session:
+        database = run_daily_scan(
+            session=session,
+            db_path=database_path,
+            min_tvl=min_tvl,
+            max_pools=max_pools,
+            max_workers=max_workers,
+            timeout=timeout,
+        )
+        database.close()
+
+
+def _count_valid_source_json(snapshots: pd.DataFrame) -> int:
+    """Count snapshots containing valid source-account JSON objects.
+
+    :param snapshots:
+        Latest point-in-time snapshot rows.
+    :return:
+        Number of rows containing a JSON object.
+    """
+
+    def _is_json_object(value: object) -> bool:
+        """Validate one serialised source account.
+
+        :param value:
+            DuckDB source JSON cell.
+        :return:
+            ``True`` when the cell contains a JSON object.
+        """
+        if not isinstance(value, str):
+            return False
+        try:
+            return isinstance(json.loads(value), dict)
+        except json.JSONDecodeError:
+            return False
+
+    return int(snapshots["source_account_json"].apply(_is_json_object).sum())
+
+
+def _summarise_deployment(
+    deployment: LighterAPIConfig,
+    *,
+    metadata: pd.DataFrame,
+    prices: pd.DataFrame,
+    snapshots: pd.DataFrame,
+) -> tuple[dict[str, object], list[str]]:
+    """Validate and summarise rows for one Lighter deployment.
+
+    :param deployment:
+        Lighter deployment being validated.
+    :param metadata:
+        All pool metadata rows in the smoke-test database.
+    :param prices:
+        All daily price rows in the smoke-test database.
+    :param snapshots:
+        Latest snapshot rows in the smoke-test database.
+    :return:
+        Terminal summary row and validation failures.
+    """
+    deployment_metadata = metadata[metadata["deployment"] == deployment.slug]
+    deployment_prices = prices[prices["deployment"] == deployment.slug]
+    deployment_snapshots = snapshots[snapshots["deployment"] == deployment.slug]
+
+    price_pool_count = int(deployment_prices["account_index"].nunique())
+    snapshot_pool_count = int(deployment_snapshots["account_index"].nunique())
+    ownership_rows = int(deployment_metadata[["total_shares", "operator_shares"]].notna().all(axis=1).sum())
+    accounting_rows = int(deployment_prices[list(SOURCE_ACCOUNTING_COLUMNS)].notna().any(axis=1).sum())
+    valid_json_rows = _count_valid_source_json(deployment_snapshots) if not deployment_snapshots.empty else 0
+
+    summary = {
+        "deployment": deployment.slug,
+        "metadata pools": len(deployment_metadata),
+        "price pools": price_pool_count,
+        "daily rows": len(deployment_prices),
+        "snapshots": snapshot_pool_count,
+        "source JSON rows": valid_json_rows,
+        "ownership rows": ownership_rows,
+        "accounting rows": accounting_rows,
+        "first price": deployment_prices["date"].min() if not deployment_prices.empty else None,
+        "last price": deployment_prices["date"].max() if not deployment_prices.empty else None,
+    }
+    required_counts = {
+        "metadata pools": len(deployment_metadata),
+        "price pools": price_pool_count,
+        "daily rows": len(deployment_prices),
+        "snapshots": snapshot_pool_count,
+        "ownership rows": ownership_rows,
+        "accounting rows": accounting_rows,
+    }
+    failures = [f"{deployment.slug}: no {label}" for label, count in required_counts.items() if count == 0]
+    if valid_json_rows != len(deployment_snapshots):
+        failures.append(f"{deployment.slug}: {len(deployment_snapshots) - valid_json_rows} snapshots have invalid source_account_json")
+    return summary, failures
+
+
+def _summarise_observations(
+    deployment: LighterAPIConfig,
+    *,
+    accounts: pd.DataFrame,
+    positions: pd.DataFrame,
+    payloads: pd.DataFrame,
+) -> tuple[dict[str, int], list[str]]:
+    """Validate and summarise common perp observations for one deployment.
+
+    A successful source read may contain no open positions, so position rows
+    are reported but not required. Every account observation must, however,
+    have an available position set and a persisted source payload.
+
+    :param deployment:
+        Lighter deployment being validated.
+    :param accounts:
+        Common perp account observations.
+    :param positions:
+        Common perp position observations.
+    :param payloads:
+        Persisted raw source payloads.
+    :return:
+        Terminal summary fields and validation failures.
+    """
+    deployment_accounts = accounts[accounts["deployment_slug"] == deployment.slug]
+    available_count = int((deployment_accounts["position_data_status"] == "available").sum())
+    deployment_positions = positions[positions["snapshot_id"].isin(deployment_accounts["snapshot_id"])]
+    deployment_payloads = payloads[payloads["deployment_slug"] == deployment.slug]
+    summary = {
+        "account observations": len(deployment_accounts),
+        "available observations": available_count,
+        "position rows": len(deployment_positions),
+        "source payloads": len(deployment_payloads),
+    }
+    failures: list[str] = []
+    if deployment_accounts.empty:
+        failures.append(f"{deployment.slug}: no account observations")
+    elif available_count != len(deployment_accounts):
+        failures.append(f"{deployment.slug}: {len(deployment_accounts) - available_count} account observations are unavailable")
+    if deployment_payloads.empty:
+        failures.append(f"{deployment.slug}: no source payloads")
+    return summary, failures
+
+
+def _validate_database(database_path: Path) -> list[dict[str, object]]:
+    """Reopen and validate the populated Lighter DuckDB.
+
+    The smoke test requires each deployment to contain metadata, daily prices,
+    append-only snapshots, valid source JSON, ownership observations, and at
+    least one daily row with source accounting data.
+
+    :param database_path:
+        Closed smoke-test DuckDB produced by the live scans.
+    :return:
+        Per-deployment summary rows for terminal display.
+    :raises RuntimeError:
+        If any required population check fails.
+    """
+    database = LighterDailyMetricsDatabase(database_path)
+    failures: list[str] = []
+    summaries: list[dict[str, object]] = []
+    try:
+        metadata = database.get_all_pool_metadata()
+        prices = database.get_all_daily_prices()
+        snapshots = database.get_latest_pool_snapshots()
+        accounts = database.con.execute("SELECT * FROM perp_vault_account_observations").fetchdf()
+        positions = database.con.execute("SELECT * FROM perp_vault_position_observations").fetchdf()
+        payloads = database.con.execute("SELECT * FROM perp_vault_source_payloads").fetchdf()
+
+        expected_price_columns = {"deployment", "account_index", "date", "share_price", "total_shares", *SOURCE_ACCOUNTING_COLUMNS}
+        missing_price_columns = expected_price_columns - set(prices.columns)
+        if missing_price_columns:
+            failures.append(f"pool_daily_prices is missing columns: {sorted(missing_price_columns)}")
+
+        for deployment in LIGHTER_DEPLOYMENTS:
+            summary, deployment_failures = _summarise_deployment(
+                deployment,
+                metadata=metadata,
+                prices=prices,
+                snapshots=snapshots,
+            )
+            observation_summary, observation_failures = _summarise_observations(
+                deployment,
+                accounts=accounts,
+                positions=positions,
+                payloads=payloads,
+            )
+            summary.update(observation_summary)
+            summaries.append(summary)
+            failures.extend(deployment_failures)
+            failures.extend(observation_failures)
+
+        database.save()
+    finally:
+        database.close()
+
+    if failures:
+        raise RuntimeError("Lighter database population validation failed:\n- " + "\n- ".join(failures))
+    return summaries
+
+
+def main() -> None:
+    """Run both live Lighter scans and validate their isolated DuckDB.
+
+    Configuration is read only from environment variables. Test artefacts are
+    deliberately retained so operators can inspect the exact database after a
+    successful or failed run.
+
+    :return:
+        None.
+    """
+    output_dir = _resolve_output_directory()
+    database_path = output_dir / "lighter-pools.duckdb"
+    setup_console_logging(
+        default_log_level=os.environ.get("LOG_LEVEL", "info"),
+        log_file=output_dir / "lighter-cycle-smoke-test.log",
+    )
+
+    min_tvl = float(os.environ.get("MIN_TVL", "0"))
+    max_pools = int(os.environ.get("MAX_POOLS", "3"))
+    max_workers = int(os.environ.get("MAX_WORKERS", "2"))
+    timeout = float(os.environ.get("HTTP_TIMEOUT", "30"))
+
+    if min_tvl < 0:
+        raise ValueError(f"MIN_TVL must not be negative, got {min_tvl}")
+    if max_pools <= 0:
+        raise ValueError(f"MAX_POOLS must be positive, got {max_pools}")
+    if max_workers <= 0:
+        raise ValueError(f"MAX_WORKERS must be positive, got {max_workers}")
+    if timeout <= 0:
+        raise ValueError(f"HTTP_TIMEOUT must be positive, got {timeout}")
+
+    logger.info(
+        "Starting isolated Lighter cycle smoke test: output=%s, min_tvl=%f, max_pools=%d, max_workers=%d",
+        output_dir,
+        min_tvl,
+        max_pools,
+        max_workers,
+    )
+
+    for deployment in LIGHTER_DEPLOYMENTS:
+        _scan_deployment(
+            deployment=deployment,
+            database_path=database_path,
+            output_dir=output_dir,
+            min_tvl=min_tvl,
+            max_pools=max_pools,
+            max_workers=max_workers,
+            timeout=timeout,
+        )
+
+    summaries = _validate_database(database_path)
+    print(tabulate(summaries, headers="keys", tablefmt="rounded_outline"))
+    logger.info("Lighter cycle smoke test passed. Database retained at %s", database_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/erc_4626/test_scan_features.py
+++ b/tests/erc_4626/test_scan_features.py
@@ -8,6 +8,7 @@ import eth_defi.erc_4626.scan as scan_module
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
 from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
 from eth_defi.vault.fee import FeeData, VaultFeeMode
+from eth_defi.vault.price_source import PriceSource
 from eth_defi.vault.vaultdb import VaultDatabase
 
 
@@ -76,6 +77,11 @@ class _FakeVault:
         return None
 
     @staticmethod
+    def get_share_price_source() -> PriceSource:
+        """Return the standard contract-state source."""
+        return PriceSource.smart_contract_state
+
+    @staticmethod
     def fetch_scan_record_extra_data() -> dict:
         """Return no protocol-specific scan fields."""
         return {}
@@ -140,6 +146,7 @@ def test_create_vault_scan_record_persists_machine_readable_features(monkeypatch
     assert record["_detection_data"].features == features
     assert "erc_7575_like" in record["Features"]
     assert record["_deposit_manager"] is None
+    assert record["_share_price_source"] is PriceSource.smart_contract_state
 
 
 def test_create_vault_scan_record_persists_deposit_permission(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/hyperliquid/test_daily_metrics_integration.py
+++ b/tests/hyperliquid/test_daily_metrics_integration.py
@@ -428,8 +428,12 @@ def test_unified_vault_metrics_json(tmp_path):
         assert "deposit_usd" in nf
         assert "withdrawal_usd" in nf
         assert "net_flow_usd" in nf
-        assert nf["deposit_count"] >= 0
-        assert nf["withdrawal_count"] >= 0
+        if nf["data_complete"]:
+            assert nf["deposit_count"] >= 0
+            assert nf["withdrawal_count"] >= 0
+        else:
+            assert nf["deposit_count"] is None
+            assert nf["withdrawal_count"] is None
 
     # Arbitrum vault has no flow data — netflow should be null
     assert arb_vault.get("netflow") is None, f"Arbitrum vault should have null netflow, got: {arb_vault.get('netflow')}"

--- a/tests/lighter/test_daily_metrics.py
+++ b/tests/lighter/test_daily_metrics.py
@@ -125,6 +125,11 @@ def test_fetch_and_store_single_pool(tmp_path):
         metadata_df = db.get_all_pool_metadata()
         assert len(metadata_df) == 1
         assert metadata_df.iloc[0]["is_llp"]
+
+        snapshots = db.get_pool_snapshot_history(llp.account_index)
+        assert len(snapshots) == 1
+        assert snapshots.iloc[0]["operator_shares"] >= 0
+        assert snapshots.iloc[0]["source_account_json"]
     finally:
         db.close()
 

--- a/tests/lighter/test_lighter_api.py
+++ b/tests/lighter/test_lighter_api.py
@@ -9,7 +9,7 @@ import pytest
 from eth_defi.lighter.vault import (
     LighterPoolDetail,
     LighterPoolSummary,
-    fetch_all_pools,
+    fetch_pool_daily_pnl_history,
     fetch_pool_detail,
     fetch_system_config,
     pool_detail_to_daily_dataframe,
@@ -52,6 +52,13 @@ def test_fetch_pool_detail(lighter_session, lighter_llp_pool):
     assert detail.total_asset_value > 0
     assert len(detail.share_prices) > 0
     assert len(detail.daily_returns) > 0
+    assert detail.total_shares > 0
+    assert detail.operator_shares >= 0
+    assert detail.snapshot.total_shares == detail.total_shares
+    assert detail.snapshot.operator_shares == detail.operator_shares
+    assert detail.snapshot.total_asset_value == pytest.approx(detail.total_asset_value)
+    assert detail.snapshot.position_count is not None
+    assert detail.snapshot.source_account["positions"] is not None
     # LLP should have substantial history
     assert len(detail.share_prices) > 100
 
@@ -67,3 +74,21 @@ def test_pool_detail_to_daily_dataframe(lighter_session, lighter_llp_pool):
     assert "daily_return" in daily_df.columns
     assert len(daily_df) >= 2
     assert (daily_df["share_price"] > 0).all()
+
+
+@pytest.mark.timeout(60)
+def test_fetch_pool_daily_pnl_history(lighter_session, lighter_llp_pool):
+    """Fetch source shares and cumulative USDC flow counters for the LLP."""
+    history = fetch_pool_daily_pnl_history(lighter_session, lighter_llp_pool.account_index)
+
+    assert len(history) > 100
+    latest = history[max(history)]
+    assert latest.total_shares is not None
+    assert latest.total_shares > 0
+    assert latest.cumulative_pool_inflow is not None
+    assert latest.cumulative_pool_outflow is not None
+    assert latest.cumulative_pool_inflow >= 0
+    assert latest.cumulative_pool_outflow >= 0
+    assert latest.trade_pnl is not None
+    assert latest.pool_pnl is not None
+    assert latest.volume is not None

--- a/tests/lighter/test_lighter_flow_metrics.py
+++ b/tests/lighter/test_lighter_flow_metrics.py
@@ -1,0 +1,412 @@
+"""Lighter ownership snapshots and cumulative-flow export tests."""
+
+import datetime
+import json
+from unittest.mock import Mock
+
+import duckdb
+import numpy as np
+import pandas as pd
+import pytest
+
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.lighter.daily_metrics import LighterDailyMetricsDatabase, LighterDailyPriceRow
+from eth_defi.lighter.vault import fetch_pool_daily_pnl_history, parse_lighter_pool_snapshot, pool_detail_to_daily_dataframe
+from eth_defi.lighter.vault_data_export import _derive_daily_flow_columns, build_raw_prices_dataframe, create_lighter_pool_row, merge_into_uncleaned_parquet
+from eth_defi.research.vault_metrics import _calculate_netflow_metrics, calculate_hourly_returns_for_all_vaults, calculate_lifetime_metrics, export_lifetime_row
+from eth_defi.research.wrangle_vault_prices import process_raw_vault_scan_data
+
+
+def _make_daily_row(
+    date: datetime.date,
+    cumulative_pool_inflow: float | None,
+    cumulative_pool_outflow: float | None,
+    trade_pnl: float | None = None,
+    volume: float | None = None,
+) -> LighterDailyPriceRow:
+    """Create a stable synthetic Lighter daily observation."""
+    return LighterDailyPriceRow(
+        account_index=42,
+        date=date,
+        share_price=1.0,
+        tvl=1_000.0,
+        daily_return=0.0,
+        annual_percentage_yield=0.0,
+        total_shares=1_000,
+        cumulative_pool_inflow=cumulative_pool_inflow,
+        cumulative_pool_outflow=cumulative_pool_outflow,
+        written_at=datetime.datetime(2025, 1, 10),
+        trade_pnl=trade_pnl,
+        volume=volume,
+    )
+
+
+def test_lighter_pnl_history_excludes_future_and_preserves_unknown_leading_dates() -> None:
+    """Keep future placeholders out and pre-history shares unknown."""
+    known_timestamp = int(datetime.datetime(2025, 1, 2, tzinfo=datetime.timezone.utc).timestamp())
+    future_timestamp = int(datetime.datetime(2030, 1, 1, tzinfo=datetime.timezone.utc).timestamp())
+    response = Mock()
+    response.json.return_value = {
+        "pnl": [
+            {"timestamp": known_timestamp, "pool_total_shares": 1_000, "pool_inflow": 100.0, "pool_outflow": 10.0},
+            {"timestamp": future_timestamp, "pool_total_shares": 2_000, "pool_inflow": 200.0, "pool_outflow": 20.0},
+        ]
+    }
+    session = Mock(api_url="https://example.invalid")
+    session.get.return_value = response
+
+    history = fetch_pool_daily_pnl_history(session, account_index=42)
+
+    assert list(history) == [datetime.date(2025, 1, 2)]
+    assert history[datetime.date(2025, 1, 2)].cumulative_pool_inflow == pytest.approx(100.0)
+    assert session.get.call_args.kwargs["params"]["ignore_transfers"] == "false"
+
+    detail = Mock(
+        share_prices=[
+            (int(datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc).timestamp()), 1.0),
+            (known_timestamp, 1.1),
+        ]
+    )
+    daily = pool_detail_to_daily_dataframe(detail, pnl_history_by_date=history)
+    assert pd.isna(daily.loc[datetime.date(2025, 1, 1), "total_shares"])
+    assert pd.isna(daily.loc[datetime.date(2025, 1, 1), "tvl"])
+    assert daily.loc[datetime.date(2025, 1, 2), "total_shares"] == 1_000
+
+
+def test_lighter_database_migration_leaves_pre_collection_fields_unknown(tmp_path) -> None:
+    """Add nullable history fields without fabricating pre-collection values."""
+    db_path = tmp_path / "legacy-lighter.duckdb"
+    legacy = duckdb.connect(str(db_path))
+    try:
+        legacy.execute("""
+            CREATE TABLE pool_daily_prices (
+                account_index BIGINT NOT NULL,
+                date DATE NOT NULL,
+                share_price DOUBLE NOT NULL,
+                tvl DOUBLE,
+                daily_return DOUBLE,
+                annual_percentage_yield DOUBLE,
+                written_at TIMESTAMP,
+                PRIMARY KEY (account_index, date)
+            )
+        """)
+        legacy.execute("INSERT INTO pool_daily_prices VALUES (42, '2025-01-01', 1.0, 1000.0, 0.0, 0.0, '2025-01-02')")
+    finally:
+        legacy.close()
+
+    migrated = LighterDailyMetricsDatabase(db_path)
+    try:
+        historical = migrated.get_pool_daily_prices(42).iloc[0]
+        assert pd.isna(historical["trade_pnl"])
+        assert pd.isna(historical["volume"])
+        assert pd.isna(historical["cumulative_account_inflow"])
+        assert migrated.get_pool_snapshot_history(42).empty
+    finally:
+        migrated.close()
+
+
+def test_lighter_database_preserves_cumulative_counters_and_ownership(tmp_path) -> None:
+    """Store raw Lighter accounting counters without fabricating event counts."""
+    db = LighterDailyMetricsDatabase(tmp_path / "lighter.duckdb")
+    try:
+        db.upsert_pool_metadata(
+            deployment="ethereum",
+            account_index=42,
+            name="Test pool",
+            total_shares=1_000,
+            operator_shares=125,
+        )
+        db.upsert_daily_prices(
+            "ethereum",
+            [
+                _make_daily_row(datetime.date(2025, 1, 1), 100.0, 0.0, trade_pnl=10.0, volume=1_000.0),
+                _make_daily_row(datetime.date(2025, 1, 2), 125.0, 0.0, trade_pnl=12.0, volume=1_200.0),
+                _make_daily_row(datetime.date(2025, 1, 3), 125.0, 20.0, trade_pnl=9.0, volume=900.0),
+            ],
+        )
+        assert db.get_pool_snapshot_history(42).empty, "Existing daily history must not be given fabricated snapshots"
+
+        snapshot = parse_lighter_pool_snapshot(
+            {
+                "account_index": 42,
+                "name": "Test pool",
+                "description": "Test strategy",
+                "l1_address": "0x0000000000000000000000000000000000000042",
+                "status": 1,
+                "account_type": 2,
+                "account_trading_mode": 1,
+                "total_asset_value": "1000",
+                "cross_asset_value": "1002",
+                "collateral": "990",
+                "available_balance": "700",
+                "cross_initial_margin_requirement": "100",
+                "cross_maintenance_margin_requirement": "50",
+                "pending_order_count": 2,
+                "total_order_count": 50,
+                "total_isolated_order_count": 3,
+                "transaction_time": 123456,
+                "can_invite": True,
+                "can_rfq": False,
+                "cancel_all_time": 0,
+                "referral_points_percentage": "10",
+                "positions": [
+                    {
+                        "market_id": 0,
+                        "symbol": "ETH",
+                        "sign": 1,
+                        "position_value": "100",
+                        "allocated_margin": "10",
+                        "unrealized_pnl": "5",
+                        "realized_pnl": "2",
+                        "total_funding_paid_out": "-1",
+                        "open_order_count": 2,
+                    },
+                    {
+                        "market_id": 1,
+                        "symbol": "BTC",
+                        "sign": -1,
+                        "position_value": "40",
+                        "allocated_margin": "4",
+                        "unrealized_pnl": "-1",
+                        "realized_pnl": "3",
+                        "total_funding_paid_out": "0.5",
+                        "open_order_count": 1,
+                    },
+                ],
+                "assets": [{"symbol": "USDC", "margin_balance": "990"}],
+                "pending_unlocks": [],
+                "shares": [],
+                "metadata": {"colour": "blue"},
+                "can_rfq_market_ids": [0, 1],
+            },
+            {
+                "status": 0,
+                "operator_fee": "10",
+                "min_operator_share_rate": "0.05",
+                "annual_percentage_yield": "12",
+                "sharpe_ratio": "1.5",
+                "total_shares": 1_000,
+                "operator_shares": 125,
+                "strategies": [{"collateral": "600"}, {"collateral": "390"}],
+            },
+            datetime.datetime(2025, 1, 10),
+        )
+        db.insert_pool_snapshot(snapshot)
+
+        # A bounded re-scan with an unavailable counter must not erase source
+        # data already retained for the same date.
+        db.upsert_daily_prices("ethereum", [_make_daily_row(datetime.date(2025, 1, 2), None, None)])
+
+        metadata = db.get_all_pool_metadata().iloc[0]
+        assert metadata["total_shares"] == 1_000
+        assert metadata["operator_shares"] == 125
+
+        prices = db.get_pool_daily_prices(42)
+        assert prices["total_shares"].tolist() == [1_000, 1_000, 1_000]
+        assert prices["cumulative_pool_inflow"].tolist() == [100.0, 125.0, 125.0]
+        assert prices["cumulative_pool_outflow"].tolist() == [0.0, 0.0, 20.0]
+        assert prices["trade_pnl"].tolist() == [10.0, 12.0, 9.0]
+        assert prices["volume"].tolist() == [1_000.0, 1_200.0, 900.0]
+
+        raw = build_raw_prices_dataframe(db).sort_values("timestamp").reset_index(drop=True)
+        assert raw["total_supply"].tolist() == [1_000, 1_000, 1_000]
+        assert pd.isna(raw.loc[0, "daily_deposit_usd"])
+        assert raw.loc[1, "daily_deposit_usd"] == pytest.approx(25.0)
+        assert raw.loc[1, "daily_withdrawal_usd"] == pytest.approx(0.0)
+        assert raw.loc[2, "daily_deposit_usd"] == pytest.approx(0.0)
+        assert raw.loc[2, "daily_withdrawal_usd"] == pytest.approx(20.0)
+        assert raw["daily_deposit_count"].isna().all()
+        assert raw["daily_withdrawal_count"].isna().all()
+
+        snapshots = db.get_pool_snapshot_history(42)
+        assert len(snapshots) == 1
+        assert snapshots.iloc[0]["operator_share_fraction"] == pytest.approx(0.125)
+        assert snapshots.iloc[0]["gross_position_value"] == pytest.approx(140.0)
+        assert snapshots.iloc[0]["net_position_value"] == pytest.approx(60.0)
+        assert snapshots.iloc[0]["strategy_collateral"] == pytest.approx(990.0)
+        assert json.loads(snapshots.iloc[0]["source_account_json"])["positions"][0]["symbol"] == "ETH"
+
+        merged = merge_into_uncleaned_parquet(db, tmp_path / "vault-prices-1h.parquet")
+        assert {"total_supply", "daily_deposit_usd", "daily_withdrawal_usd"} <= set(merged.columns)
+    finally:
+        db.close()
+
+
+def test_lighter_flow_derivation_rejects_gaps_resets_and_current_day() -> None:
+    """Leave invalid, incomplete, and provisional Lighter flow intervals unknown."""
+    prices = pd.DataFrame(
+        {
+            "deployment": ["ethereum", "ethereum", "ethereum", "ethereum", "ethereum", "robinhood", "robinhood"],
+            "account_index": [42, 42, 42, 42, 42, 42, 42],
+            "date": [
+                datetime.date(2025, 1, 1),
+                datetime.date(2025, 1, 2),
+                datetime.date(2025, 1, 4),
+                datetime.date(2025, 1, 5),
+                datetime.date(2025, 1, 6),
+                datetime.date(2025, 1, 1),
+                datetime.date(2025, 1, 2),
+            ],
+            "cumulative_pool_inflow": [100.0, 120.0, 130.0, 5.0, 10.0, 50.0, 70.0],
+            "cumulative_pool_outflow": [0.0, 0.0, 0.0, 0.0, 0.0, 10.0, 12.0],
+        }
+    )
+
+    result = _derive_daily_flow_columns(prices, current_date=datetime.date(2025, 1, 6))
+
+    assert pd.isna(result.loc[0, "daily_deposit_usd"])
+    assert result.loc[1, "daily_deposit_usd"] == pytest.approx(20.0)
+    assert pd.isna(result.loc[2, "daily_deposit_usd"]), "A gap must not be assigned to its closing day"
+    assert pd.isna(result.loc[3, "daily_deposit_usd"]), "A counter reset must not become an outflow"
+    assert pd.isna(result.loc[4, "daily_deposit_usd"]), "The current UTC day is provisional"
+    assert result.loc[6, "daily_deposit_usd"] == pytest.approx(20.0), "Deployments sharing an account index must be isolated"
+    assert result.loc[6, "daily_withdrawal_usd"] == pytest.approx(2.0)
+
+
+def test_netflow_preserves_unknown_counts_and_incomplete_amounts() -> None:
+    """Keep unavailable counts and incomplete monetary totals unknown."""
+    dates = pd.date_range("2025-01-01", periods=3, freq="D")
+    prices = pd.DataFrame(
+        {
+            "daily_deposit_usd": [10.0, 0.0, 5.0],
+            "daily_withdrawal_usd": [0.0, 3.0, 0.0],
+            "daily_deposit_count": [np.nan, np.nan, np.nan],
+            "daily_withdrawal_count": [np.nan, np.nan, np.nan],
+        },
+        index=dates,
+    )
+
+    netflow = _calculate_netflow_metrics(prices, now_=dates[-1])
+    assert netflow is not None
+    day = next(row for row in netflow if row.period == "1d")
+    assert day.data_complete
+    assert day.deposit_count is None
+    assert day.withdrawal_count is None
+    assert day.deposit_usd == pytest.approx(5.0)
+    assert day.withdrawal_usd == pytest.approx(0.0)
+    assert day.net_flow_usd == pytest.approx(5.0)
+
+    week = next(row for row in netflow if row.period == "7d")
+    assert not week.data_complete
+    assert week.deposit_count is None
+    assert week.withdrawal_count is None
+    assert week.deposit_usd is None
+    assert week.withdrawal_usd is None
+    assert week.net_flow_usd is None
+
+    prices.loc[dates[-1], "daily_deposit_usd"] = np.nan
+    incomplete = _calculate_netflow_metrics(prices, now_=dates[-1])
+    assert incomplete is not None
+    day = next(row for row in incomplete if row.period == "1d")
+    assert not day.data_complete
+    assert day.deposit_count is None
+    assert day.withdrawal_count is None
+    assert day.deposit_usd is None
+    assert day.withdrawal_usd is None
+    assert day.net_flow_usd is None
+
+
+def test_netflow_never_exports_partial_event_counts() -> None:
+    """Require complete amount and count observations for event-count totals."""
+    dates = pd.date_range("2025-01-01", periods=7, freq="D")
+    prices = pd.DataFrame(
+        {
+            "daily_deposit_usd": [1.0] * 7,
+            "daily_withdrawal_usd": [0.0] * 7,
+            "daily_deposit_count": [1.0] * 6 + [np.nan],
+            "daily_withdrawal_count": [0.0] * 7,
+        },
+        index=dates,
+    )
+
+    netflow = _calculate_netflow_metrics(prices, now_=dates[-1])
+
+    assert netflow is not None
+    week = next(row for row in netflow if row.period == "7d")
+    assert week.data_complete
+    assert week.deposit_usd == pytest.approx(7.0)
+    assert week.withdrawal_usd == pytest.approx(0.0)
+    assert week.deposit_count is None
+    assert week.withdrawal_count == 0
+
+
+def test_lighter_netflow_excludes_current_provisional_day() -> None:
+    """Calculate trailing Lighter flows through the latest completed UTC day."""
+    today = pd.Timestamp(native_datetime_utc_now().date())
+    dates = pd.date_range(today - pd.Timedelta(days=7), periods=8, freq="D")
+    prices = pd.DataFrame(
+        {
+            "daily_deposit_usd": [1.0] * 7 + [np.nan],
+            "daily_withdrawal_usd": [0.0] * 7 + [np.nan],
+        },
+        index=dates,
+    )
+
+    netflow = _calculate_netflow_metrics(prices, now_=today, exclude_current_utc_day=True)
+
+    assert netflow is not None
+    week = next(row for row in netflow if row.period == "7d")
+    assert week.data_complete
+    assert week.deposit_usd == pytest.approx(7.0)
+    assert week.withdrawal_usd == pytest.approx(0.0)
+    assert week.net_flow_usd == pytest.approx(7.0)
+
+
+def test_lighter_ownership_reaches_metrics_json(tmp_path) -> None:
+    """Expose the current Lighter ownership snapshot only in JSON extension data."""
+    db = LighterDailyMetricsDatabase(tmp_path / "lighter.duckdb")
+    start = datetime.date(2025, 1, 1)
+    try:
+        db.upsert_pool_metadata(
+            deployment="ethereum",
+            account_index=42,
+            name="Test pool",
+            total_shares=1_000,
+            operator_shares=125,
+        )
+        db.upsert_daily_prices(
+            "ethereum",
+            [
+                LighterDailyPriceRow(
+                    account_index=42,
+                    date=start + datetime.timedelta(days=offset),
+                    share_price=1.0 + offset * 0.0001,
+                    tvl=1_000.0 + offset * 0.1,
+                    daily_return=0.0001,
+                    annual_percentage_yield=0.0,
+                    total_shares=1_000,
+                    cumulative_pool_inflow=10.0 if offset == 89 else 1_000.0 + offset,
+                    cumulative_pool_outflow=0.0,
+                    written_at=datetime.datetime(2025, 4, 1),
+                )
+                for offset in range(91)
+            ],
+        )
+        raw = build_raw_prices_dataframe(db)
+        spec, vault_row = create_lighter_pool_row(
+            account_index=42,
+            name="Test pool",
+            description=None,
+            tvl=1_000.0,
+            created_at=datetime.datetime(2025, 1, 1),
+            total_shares=1_000,
+            operator_shares=125,
+            ownership_updated_at=datetime.datetime(2025, 4, 1),
+        )
+        cleaned = process_raw_vault_scan_data({spec: vault_row}, raw, logger=lambda _: None, display=lambda _: None)
+        reset_timestamp = pd.Timestamp(start + datetime.timedelta(days=89))
+        assert pd.isna(cleaned.loc[reset_timestamp, "daily_deposit_usd"]), "Cleaning must preserve unknown reset intervals"
+        returns = calculate_hourly_returns_for_all_vaults(cleaned)
+        metrics = calculate_lifetime_metrics(returns, {spec: vault_row})
+        exported = export_lifetime_row(metrics.iloc[0])
+
+        lighter = exported["other_data"]["lighter"]
+        assert lighter["operator_shares"] == 125
+        assert lighter["total_shares"] == 1_000
+        assert lighter["operator_share_fraction"] == pytest.approx(0.125)
+        assert lighter["ownership_updated_at"] == "2025-04-01T00:00:00"
+        week = next(row for row in exported["netflow"] if row["period"] == "7d")
+        assert not week["data_complete"]
+        assert week["net_flow_usd"] is None
+    finally:
+        db.close()

--- a/tests/lighter/test_multi_deployment.py
+++ b/tests/lighter/test_multi_deployment.py
@@ -154,9 +154,9 @@ def test_legacy_database_migrates_to_composite_deployment_keys(tmp_path: Path) -
         assert migrated_prices["deployment"].tolist() == [LIGHTER_ETHEREUM.slug]
 
         db.upsert_pool_metadata(
-            deployment=LIGHTER_ROBINHOOD.slug,
-            account_index=ACCOUNT_INDEX,
-            name="Robinhood LLP",
+            LIGHTER_ROBINHOOD.slug,
+            ACCOUNT_INDEX,
+            "Robinhood LLP",
             description="Robinhood deployment row",
             is_llp=True,
             total_asset_value=2_000.0,

--- a/tests/oda_fact/test_oda_fact_vault.py
+++ b/tests/oda_fact/test_oda_fact_vault.py
@@ -22,6 +22,7 @@ from eth_defi.tokenised_fund.kinexys.historical import OdaFactVaultHistoricalRea
 from eth_defi.tokenised_fund.kinexys.vault import KINEXYS_WHITELISTED_FLOW_REASON, OdaFactVault
 from eth_defi.tokenised_fund.vault import TokenisedFundDepositManager
 from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.price_source import PriceSource
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 JLTXX_EXPECTED_MANAGEMENT_FEE = 0.0016
@@ -212,6 +213,7 @@ def test_oda_fact_scan_record_live_jltxx(web3: Web3) -> None:
     assert "JLTXX fact sheet" in record["_notes"]
     assert record["_nav_source"] == "estimated_jltxx_usd_1"
     assert record["_nav_estimated"] is True
+    assert record["_share_price_source"] is PriceSource.fixed_price
     assert record["_synthetic_usd_denomination"] is True
     assert record["_gross_expense_ratio"] == JLTXX_EXPECTED_GROSS_EXPENSE_RATIO
     assert record["_net_expense_ratio"] == JLTXX_EXPECTED_MANAGEMENT_FEE

--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -31,6 +31,7 @@ from eth_defi.research.vault_metrics import (
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.fee import FeeData, VaultFeeMode
 from eth_defi.vault.flag import NOT_IN_MORPHO_API, VaultFlag
+from eth_defi.vault.price_source import PriceSource
 from eth_defi.vault.risk import VaultTechnicalRisk
 from eth_defi.vault.vaultdb import VaultDatabase
 
@@ -996,6 +997,26 @@ def test_export_lifetime_metrics(
     # Verify they serialize to JSON properly (None becomes null)
     assert r["available_liquidity"] is None or isinstance(r["available_liquidity"], (int, float))
     assert r["utilisation"] is None or isinstance(r["utilisation"], (int, float))
+
+
+def test_calculate_lifetime_metrics_exports_share_price_source(
+    vault_db: VaultDatabase,
+    price_df: pd.DataFrame,
+) -> None:
+    """Adapter price-source metadata reaches the DataFrame and JSON export."""
+
+    vault_id = "43111-0x05c2e246156d37b39a825a25dd08d5589e3fd883"
+    spec = VaultSpec.parse_string(vault_id)
+    vault_row = dict(vault_db.rows[spec])
+    vault_row["_share_price_source"] = PriceSource.smart_contract_state
+
+    metrics = calculate_lifetime_metrics(
+        price_df.loc[price_df["id"] == vault_id],
+        {spec: vault_row},
+    )
+
+    assert metrics.iloc[0]["share_price_source"] == "smart-contract-state"
+    assert export_lifetime_row(metrics.iloc[0])["share_price_source"] == "smart-contract-state"
 
 
 def test_export_lifetime_row_nat_serialization():

--- a/tests/vault/test_price_source.py
+++ b/tests/vault/test_price_source.py
@@ -1,0 +1,84 @@
+"""Test vault share-price source classification."""
+
+import datetime
+from dataclasses import replace
+
+from web3 import Web3
+
+from eth_defi.erc_4626.classification import ODA_FACT_JLTXX_ADDRESS, ODA_FACT_MONY_ADDRESS
+from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.grvt.vault_data_export import create_grvt_vault_row
+from eth_defi.hibachi.vault_data_export import create_hibachi_vault_row
+from eth_defi.hyperliquid.vault_data_export import create_hyperliquid_vault_row
+from eth_defi.lighter.vault_data_export import create_lighter_pool_row
+from eth_defi.tokenised_fund.asseto.constants import ASSETO_AOABT_HASHKEY
+from eth_defi.tokenised_fund.asseto.vault import AssetoVault
+from eth_defi.tokenised_fund.kinexys.vault import OdaFactVault
+from eth_defi.tokenised_fund.securitize.description import ACRED_ETHEREUM, ARCOIN_ETHEREUM, BUIDL_ETHEREUM
+from eth_defi.tokenised_fund.securitize.vault import SecuritizeVault
+from eth_defi.vault.base import VaultBase, VaultSpec
+from eth_defi.vault.price_source import PriceSource
+
+
+def test_price_source_public_values() -> None:
+    """Price-source enum values are stable public export strings."""
+
+    assert {source.value for source in PriceSource} == {
+        "smart-contract-state",
+        "api",
+        "approximation",
+        "fixed-price",
+        "redstone",
+        "chronicle",
+    }
+
+
+def test_vault_adapter_price_sources() -> None:
+    """Contract, API, oracle and estimated adapters report their real source."""
+
+    web3 = Web3()
+    erc4626 = ERC4626Vault(
+        web3,
+        VaultSpec(chain_id=1, vault_address="0x0000000000000000000000000000000000000001"),
+        features={ERC4626Feature.morpho_like},
+    )
+    assert VaultBase.get_share_price_source(object()) is None
+    assert erc4626.get_share_price_source() is PriceSource.smart_contract_state
+
+    asseto = AssetoVault(web3, VaultSpec(ASSETO_AOABT_HASHKEY.chain_id, ASSETO_AOABT_HASHKEY.token))
+    assert asseto.get_share_price_source() is PriceSource.smart_contract_state
+    asseto.product = replace(ASSETO_AOABT_HASHKEY, pricer=None, offchain_product_id=1)
+    assert asseto.get_share_price_source() is PriceSource.api
+
+    buidl = SecuritizeVault(web3, VaultSpec(BUIDL_ETHEREUM.chain_id, BUIDL_ETHEREUM.token))
+    acred = SecuritizeVault(web3, VaultSpec(ACRED_ETHEREUM.chain_id, ACRED_ETHEREUM.token))
+    arcoin = SecuritizeVault(web3, VaultSpec(ARCOIN_ETHEREUM.chain_id, ARCOIN_ETHEREUM.token))
+    jltxx = OdaFactVault(web3, VaultSpec(chain_id=1, vault_address=ODA_FACT_JLTXX_ADDRESS))
+    mony = OdaFactVault(web3, VaultSpec(chain_id=1, vault_address=ODA_FACT_MONY_ADDRESS))
+    assert buidl.get_share_price_source() is PriceSource.fixed_price
+    assert acred.get_share_price_source() is PriceSource.redstone
+    assert arcoin.get_share_price_source() is None
+    assert jltxx.get_share_price_source() is PriceSource.fixed_price
+    assert mony.get_share_price_source() is None
+
+
+def test_native_vault_row_price_sources() -> None:
+    """Native protocol importers persist API and approximation classifications."""
+
+    timestamp = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC).replace(tzinfo=None)
+    _, lighter = create_lighter_pool_row(1, "Lighter", None, 1_000, timestamp)
+    _, grvt = create_grvt_vault_row("VLT:test", 1, "GRVT", None, 1_000)
+    _, hibachi = create_hibachi_vault_row(1, "HIB", "Hibachi", None, 1_000)
+    _, hyperliquid = create_hyperliquid_vault_row(
+        "0x0000000000000000000000000000000000000001",
+        "Hyperliquid",
+        None,
+        1_000,
+        timestamp,
+    )
+
+    assert lighter["_share_price_source"] is PriceSource.api
+    assert grvt["_share_price_source"] is PriceSource.api
+    assert hibachi["_share_price_source"] is PriceSource.api
+    assert hyperliquid["_share_price_source"] is PriceSource.approximation


### PR DESCRIPTION
## Why

Vault consumers need to know whether a share-price series came from smart-contract state, an API, an oracle, a fixed estimate, or reconstruction. Lighter's public API also exposes ownership, current account state and cumulative flows that were previously discarded.

## Lessons learnt

Snapshot values become history only after collection starts, so older values must remain unknown. Cumulative flow counters are source data, not event logs: derive flows only across consecutive completed days and leave gaps, resets and provisional observations null. A price-source label describes the adapter data path, not the legal NAV publisher.

## Summary

- Add the public `PriceSource` enum, persist it in vault metadata, and export `share_price_source` through lifetime metrics and JSON.
- Classify ERC-4626, tokenised-fund and native vault adapters, including explicit unknown handling for Kinexys MONY.
- Store Lighter ownership, append-only account snapshots and retained API source data in deployment-aware DuckDB tables.
- Retain Lighter PnL counters and export conservative USD net flows without fabricating event counts or historical ownership.
- Add focused migration, source-classification, flow-completeness and live API regression coverage.

## Related issues and PRs

- Replaces #1352 and #1307, rebased and simplified for current `master`.

## Unrelated CI and test fixes

- None.
