### PR TITLE
feat: simulate async vault redemption settlement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 1.2
 
+- feat: Complete Anvil settlement for Ember direct payouts and Plutus role-gated redemptions, with terminal evidence, typed settlement failures and shared warm-fork coverage (2026-07-29)
+
 - feat: Export vault share-price provenance and add Lighter ownership, account snapshots and conservative net-flow metrics (2026-07-28)
 
 - feat: Read complete Accountable fee-manager terms and effective vault deposit minimums onchain across legacy and current contract versions (2026-07-28)

--- a/eth_defi/erc_4626/vault_protocol/ember/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/ember/deposit_redeem.py
@@ -22,8 +22,9 @@ from web3.contract.contract import ContractFunction
 from eth_defi.abi import ZERO_ADDRESS_STR, get_topic_signature_from_event
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager, ERC4626DepositRequest
 from eth_defi.erc_4626.flow import deposit_4626
-from eth_defi.provider.anvil import is_anvil
+from eth_defi.provider.anvil import is_anvil, make_anvil_custom_rpc_request
 from eth_defi.timestamp import get_block_timestamp
+from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.vault.deposit_redeem import (
     AsyncVaultRequestStatus,
     CannotParseRedemptionTransaction,
@@ -33,6 +34,7 @@ from eth_defi.vault.deposit_redeem import (
     RedemptionRequest,
     RedemptionTicket,
     UnsupportedVaultSimulation,
+    VaultDirectPayoutEvidence,
     VaultFlowUnavailable,
     VaultForcedSettlementResult,
     create_synchronous_settlement_result,
@@ -48,10 +50,6 @@ from eth_defi.vault.flow_events import (
 
 if TYPE_CHECKING:
     from eth_defi.erc_4626.vault_protocol.ember.vault import EmberVault
-
-
-#: Ember operator processing pays directly and never creates a claimable ticket.
-EMBER_ANVIL_SETTLEMENT_UNSUPPORTED_REASON = "ember_operator_settlement_has_no_claimable_ticket_status"
 
 
 @dataclass(slots=True)
@@ -191,11 +189,11 @@ class EmberDepositManager(ERC4626DepositManager):
     ``minWithdrawableShares``.
 
     **Anvil settlement (force_settle).** Ember has no claimable ticket state:
-    an operator may process a request and pay the receiver directly, leaving the
-    ticket in :attr:`AsyncVaultRequestStatus.none`. This cannot satisfy the
-    public forced-settlement proof contract, so asynchronous settlement is
-    explicitly unsupported. :meth:`force_settle` refuses a redemption ticket
-    before impersonating an operator or broadcasting a transaction.
+    its configured operator processes a request and pays the receiver directly,
+    leaving the ticket in :attr:`AsyncVaultRequestStatus.none`. The Anvil driver
+    therefore accepts only the configured ``roles()[1]`` operator, validates the
+    matching ``RequestProcessed`` event and returns direct-payout evidence only
+    when the receiver's denomination-token balance increased.
     """
 
     def __init__(self, vault: "EmberVault"):
@@ -485,27 +483,30 @@ class EmberDepositManager(ERC4626DepositManager):
         mock: object | None = None,
         ignore_liquidity: bool = False,
     ) -> VaultForcedSettlementResult:
-        """Refuse Ember redemption settlement before broadcasting on a fork.
+        """Process an Ember redemption through its configured Anvil operator.
 
-        Ember's operator-finalised request does not become a claimable ticket,
-        so processing it would falsely advertise a successful generic async
-        simulation. A synchronous deposit remains a no-op settlement.
+        Ember uses a direct payout rather than a user claim. The driver accepts
+        it as terminal only after the exact request's ``RequestProcessed``
+        event and a positive denomination-token balance delta prove the payout.
+        A synchronous deposit remains a no-op settlement.
 
         :param ticket:
             Pending :class:`EmberRedemptionTicket`, or ``None`` for the
             synchronous-deposit no-op.
         :param mock:
-            A deployed ``MockEmberVault`` only for local mock tests. The mock
-            runs its operator processing call; the terminal status is ``none``
-            because Ember pays directly instead of creating a user claim.
+            A local ``MockEmberVault`` that exposes its deterministic queue for
+            GuardV0 lifecycle tests. Its payout still needs the same terminal
+            event and balance-delta evidence as a fork settlement.
         :param ignore_liquidity:
             Unsupported because Ember's mock models operator processing rather
             than a redeemable-liquidity preflight.
         :return:
-            Synchronous no-op result when ``ticket`` is ``None``.
+            Synchronous no-op or direct-payout terminal settlement result.
         :raise UnsupportedVaultSimulation:
-            For every Ember redemption ticket, with the stable capability
-            reason and without an operator transaction.
+            When the provider is not Anvil, the configured operator cannot be
+            identified, the ticket is no longer in the global queue, or the
+            operator transaction does not prove this ticket received a direct
+            payout.
         """
         if ignore_liquidity:
             return super().force_settle(ticket, mock=mock, ignore_liquidity=True)
@@ -513,22 +514,194 @@ class EmberDepositManager(ERC4626DepositManager):
         if ticket is None:
             return create_synchronous_settlement_result()
 
-        if mock is not None:
-            assert isinstance(ticket, EmberRedemptionTicket), f"Ember mock settlement requires EmberRedemptionTicket, got {type(ticket)}"
-            if not is_anvil(self.web3):
-                raise UnsupportedVaultSimulation("Ember mock settlement requires an Anvil provider", unsupported_reason="anvil_provider_required")
-            tx_hash = mock.functions.processWithdrawalRequests(1).transact({"from": self.web3.eth.accounts[0]})
-            return VaultForcedSettlementResult(
-                ticket=ticket,
-                settlement_required=True,
-                status_before=AsyncVaultRequestStatus.pending,
-                status_after=AsyncVaultRequestStatus.none,
-                transaction_hashes=(HexBytes(tx_hash),),
+        if not isinstance(ticket, EmberRedemptionTicket):
+            raise UnsupportedVaultSimulation(
+                f"Ember force_settle requires EmberRedemptionTicket, got {type(ticket)}",
+                unsupported_reason="anvil_settlement_ticket_unsupported",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
             )
 
+        if not is_anvil(self.web3):
+            raise UnsupportedVaultSimulation(
+                "Ember operator settlement requires an Anvil provider",
+                unsupported_reason="anvil_provider_required",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            )
+
+        if mock is not None:
+            return self._force_settle_mock(ticket, mock)
+
+        status_before = self.get_redemption_request_status(ticket)
+        if status_before is not AsyncVaultRequestStatus.pending:
+            raise UnsupportedVaultSimulation(
+                f"Ember request {ticket.get_request_id()} is {status_before.value}, not pending",
+                unsupported_reason="ember_direct_payout_not_proven",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            )
+
+        _admin, operator, _rate_manager = self.vault.vault_contract.functions.roles().call()
+        operator = Web3.to_checksum_address(operator)
+        if operator == ZERO_ADDRESS_STR:
+            raise UnsupportedVaultSimulation(
+                f"Ember vault {self.vault.address} has no configured withdrawal operator",
+                unsupported_reason="ember_operator_not_discoverable",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            )
+
+        pending_index = self.fetch_pending_withdrawal_index(ticket)
+        denomination_token = self.vault.denomination_token
+        balance_before = denomination_token.fetch_raw_balance_of(ticket.to)
+        make_anvil_custom_rpc_request(self.web3, "anvil_impersonateAccount", [operator])
+        try:
+            make_anvil_custom_rpc_request(self.web3, "anvil_setBalance", [operator, hex(10**18)])
+            tx_hash = HexBytes(self.vault.vault_contract.functions.processWithdrawalRequests(pending_index + 1).transact({"from": operator, "gas": 1_000_000}))
+            assert_transaction_success_with_explanation(self.web3, tx_hash)
+        finally:
+            make_anvil_custom_rpc_request(self.web3, "anvil_stopImpersonatingAccount", [operator])
+
+        return self._create_direct_payout_result(ticket, status_before, tx_hash, balance_before=balance_before)
+
+    def _force_settle_mock(self, ticket: EmberRedemptionTicket, mock: object) -> VaultForcedSettlementResult:
+        """Settle a local Ember mock while retaining production terminal checks.
+
+        The mock retains a public ``nextRequestToProcess`` cursor.  It is used
+        only to determine how many FIFO items the mock needs to process; the
+        production adapter always resolves its queue index from the vault.
+
+        :param ticket:
+            Ember request selected by the mock's monotonic sequence number.
+        :param mock:
+            Deployed local ``MockEmberVault`` contract binding.
+        :return:
+            Evidence-backed terminal direct-payout settlement result.
+        :raise UnsupportedVaultSimulation:
+            If the ticket precedes the mock queue cursor or processing does not
+            prove its direct payout.
+        """
+        next_request = int(mock.functions.nextRequestToProcess().call())
+        request_count = ticket.request_sequence_number - next_request + 1
+        if request_count <= 0:
+            raise UnsupportedVaultSimulation(
+                f"Ember mock request {ticket.get_request_id()} is before queue cursor {next_request}",
+                unsupported_reason="ember_operator_processing_not_reproducible",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            )
+
+        balance_before = self.vault.denomination_token.fetch_raw_balance_of(ticket.to)
+        tx_hash = HexBytes(mock.functions.processWithdrawalRequests(request_count).transact({"from": self.web3.eth.accounts[0]}))
+        assert_transaction_success_with_explanation(self.web3, tx_hash)
+        return self._create_direct_payout_result(ticket, AsyncVaultRequestStatus.pending, tx_hash, balance_before=balance_before)
+
+    def _create_direct_payout_result(
+        self,
+        ticket: EmberRedemptionTicket,
+        status_before: AsyncVaultRequestStatus,
+        tx_hash: HexBytes,
+        *,
+        balance_before: int,
+    ) -> VaultForcedSettlementResult:
+        """Validate receipt and balance evidence for one direct Ember payout.
+
+        :param ticket:
+            Ember request expected in ``tx_hash``.
+        :param status_before:
+            Request state immediately before settlement.
+        :param tx_hash:
+            Operator or local mock transaction that processed the queue.
+        :param balance_before:
+            Receiver balance observed before the transaction.
+        :return:
+            Terminal direct-payout result with request-specific evidence.
+        :raise UnsupportedVaultSimulation:
+            If receipt, event identity, or balance delta cannot prove payout.
+        """
+        denomination_token = self.vault.denomination_token
+        receipt = self.web3.eth.get_transaction_receipt(tx_hash)
+        decoded_logs = self.vault.vault_contract.events.RequestProcessed().process_receipt(receipt, errors=EventLogErrorFlags.Discard)
+        matches = [log for log in decoded_logs if int(log["args"]["requestSequenceNumber"]) == ticket.request_sequence_number]
+        if len(matches) != 1:
+            raise UnsupportedVaultSimulation(
+                f"Ember operator processing did not emit one RequestProcessed event for request {ticket.get_request_id()}",
+                unsupported_reason="ember_operator_processing_not_reproducible",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            )
+
+        args = matches[0]["args"]
+        try:
+            self._validate_processed_event(ticket, args)
+        except ValueError as error:
+            raise UnsupportedVaultSimulation(
+                f"Ember operator processing emitted an invalid event for request {ticket.get_request_id()}: {error}",
+                unsupported_reason="ember_operator_processing_not_reproducible",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            ) from error
+        balance_after = denomination_token.fetch_raw_balance_of(ticket.to)
+        evidence = VaultDirectPayoutEvidence(
+            request_id=ticket.get_request_id(),
+            receiver=Web3.to_checksum_address(ticket.to),
+            denomination_token=Web3.to_checksum_address(denomination_token.address),
+            raw_balance_before=balance_before,
+            raw_balance_after=balance_after,
+            event_name="RequestProcessed",
+            transaction_hash=tx_hash,
+        )
+        result = VaultForcedSettlementResult(
+            ticket=ticket,
+            settlement_required=True,
+            status_before=status_before,
+            status_after=AsyncVaultRequestStatus.none,
+            transaction_hashes=(tx_hash,),
+            direct_payout_evidence=evidence,
+        )
+        if args["skipped"] or args["cancelled"] or not result.is_terminal_success():
+            raise UnsupportedVaultSimulation(
+                f"Ember operator processing did not prove a direct payout for request {ticket.get_request_id()}",
+                unsupported_reason="ember_direct_payout_not_proven",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            )
+        return result
+
+    def fetch_pending_withdrawal_index(self, ticket: EmberRedemptionTicket) -> int:
+        """Locate an Ember ticket in the vault-global pending queue.
+
+        ``processWithdrawalRequests(n)`` consumes the first ``n`` queue items,
+        rather than selecting an owner or request id.  Resolving the exact
+        index before broadcasting ensures the operator transaction reaches the
+        requested ticket even when older requests are pending.
+
+        :param ticket:
+            Persisted Ember redemption request to locate.
+        :return:
+            Zero-based queue index of ``ticket``.
+        :raise UnsupportedVaultSimulation:
+            If the exact request sequence is no longer pending in the global
+            queue.
+        """
+        pending_count = int(self.vault.vault_contract.functions.getPendingWithdrawalsLength().call())
+        for index in range(pending_count):
+            request = self.vault.vault_contract.functions.getPendingWithdrawal(index).call()
+            if int(request[5]) == ticket.request_sequence_number:
+                return index
+
         raise UnsupportedVaultSimulation(
-            f"Ember settlement cannot prove a claimable ticket for vault {self.vault.address} on chain {self.vault.chain_id}",
-            unsupported_reason=EMBER_ANVIL_SETTLEMENT_UNSUPPORTED_REASON,
+            f"Ember request {ticket.get_request_id()} is absent from the global pending queue",
+            unsupported_reason="ember_operator_processing_not_reproducible",
             protocol=self.vault.get_protocol_name(),
             vault_address=self.vault.address,
             direction="redeem",

--- a/eth_defi/erc_4626/vault_protocol/ember/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/ember/vault.py
@@ -154,7 +154,6 @@ class EmberVault(ERC4626Vault):
         :return:
             Ember's public deposit-manager capability metadata.
         """
-        from eth_defi.erc_4626.vault_protocol.ember.deposit_redeem import EMBER_ANVIL_SETTLEMENT_UNSUPPORTED_REASON
         from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
 
         return VaultDepositManagerCapability(
@@ -162,12 +161,9 @@ class EmberVault(ERC4626Vault):
             can_redeem=True,
             deposit_flow="synchronous",
             redemption_flow="asynchronous",
-            # Ember's operator processing leaves this non-claim ERC-7540-style
-            # ticket terminal rather than claimable.  Do not publish a true
-            # capability until the executor can prove the required claimable
-            # status for the exact deployment.
-            supports_anvil_settlement=False,
-            anvil_settlement_unsupported_reason=EMBER_ANVIL_SETTLEMENT_UNSUPPORTED_REASON,
+            # Ember redemption is terminal only after force_settle validates a
+            # request-specific operator event and positive direct payout.
+            supports_anvil_settlement=True,
         )
 
     def get_notes(self) -> str | None:

--- a/eth_defi/erc_4626/vault_protocol/gains/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/gains/deposit_redeem.py
@@ -405,7 +405,22 @@ class GainsDepositManager(ERC4626DepositManager):
         from eth_defi.erc_4626.vault_protocol.gains.testing import force_next_gains_epoch
 
         if not is_anvil(self.web3):
-            raise UnsupportedVaultSimulation("GainsDepositManager.force_settle() requires an Anvil provider")
+            raise UnsupportedVaultSimulation(
+                "GainsDepositManager.force_settle() requires an Anvil provider",
+                unsupported_reason="anvil_provider_required",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem" if ticket is not None else None,
+            )
+
+        if self.web3.eth.chain_id != self.vault.chain_id:
+            raise UnsupportedVaultSimulation(
+                f"Gains settlement Web3 chain {self.web3.eth.chain_id} does not match vault chain {self.vault.chain_id}",
+                unsupported_reason="gains_settlement_web3_chain_mismatch",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem" if ticket is not None else None,
+            )
 
         if ticket is None:
             return VaultForcedSettlementResult(
@@ -415,7 +430,14 @@ class GainsDepositManager(ERC4626DepositManager):
                 status_after=None,
             )
 
-        assert isinstance(ticket, GainsRedemptionTicket), f"Gains force_settle requires GainsRedemptionTicket, got {type(ticket)}"
+        if not isinstance(ticket, GainsRedemptionTicket):
+            raise UnsupportedVaultSimulation(
+                f"Gains force_settle requires GainsRedemptionTicket, got {type(ticket)}",
+                unsupported_reason="anvil_settlement_ticket_unsupported",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            )
 
         if mock is not None:
             transaction_hashes: list[HexBytes] = []
@@ -423,7 +445,13 @@ class GainsDepositManager(ERC4626DepositManager):
                 tx_hash = mock.functions.forceNewEpoch().transact({"from": self.web3.eth.accounts[0]})
                 transaction_hashes.append(HexBytes(tx_hash))
                 if len(transaction_hashes) >= GAINS_MAX_SETTLEMENT_EPOCHS:
-                    raise UnsupportedVaultSimulation(f"Gains mock settlement did not unlock ticket {ticket.get_request_id()} within {GAINS_MAX_SETTLEMENT_EPOCHS} epochs")
+                    raise UnsupportedVaultSimulation(
+                        f"Gains mock settlement did not unlock ticket {ticket.get_request_id()} within {GAINS_MAX_SETTLEMENT_EPOCHS} epochs",
+                        unsupported_reason="gains_redemption_not_claimable_after_epoch_advance",
+                        protocol=self.vault.get_protocol_name(),
+                        vault_address=self.vault.address,
+                        direction="redeem",
+                    )
             return VaultForcedSettlementResult(
                 ticket=ticket,
                 settlement_required=bool(transaction_hashes),
@@ -449,12 +477,24 @@ class GainsDepositManager(ERC4626DepositManager):
                 transaction_hashes.append(HexBytes(tx_hash))
             new_epoch = self.vault.fetch_current_epoch()
             if new_epoch <= old_epoch:
-                raise UnsupportedVaultSimulation(f"Gains epoch did not advance while settling redemption for vault {self.vault.address} on chain {self.vault.chain_id}: epoch stayed at {old_epoch}")
+                raise UnsupportedVaultSimulation(
+                    f"Gains epoch did not advance while settling redemption for vault {self.vault.address} on chain {self.vault.chain_id}: epoch stayed at {old_epoch}",
+                    unsupported_reason="gains_epoch_did_not_advance",
+                    protocol=self.vault.get_protocol_name(),
+                    vault_address=self.vault.address,
+                    direction="redeem",
+                )
             if self.can_finish_redeem(ticket):
                 break
 
         if not self.can_finish_redeem(ticket):
-            raise UnsupportedVaultSimulation(f"Gains settlement did not unlock redemption for vault {self.vault.address} on chain {self.vault.chain_id}: current epoch {self.vault.fetch_current_epoch()} < unlock epoch {ticket.unlock_epoch}")
+            raise UnsupportedVaultSimulation(
+                f"Gains settlement did not unlock redemption for vault {self.vault.address} on chain {self.vault.chain_id}: current epoch {self.vault.fetch_current_epoch()} < unlock epoch {ticket.unlock_epoch}",
+                unsupported_reason="gains_redemption_not_claimable_after_epoch_advance",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            )
 
         return VaultForcedSettlementResult(
             ticket=ticket,

--- a/eth_defi/erc_4626/vault_protocol/gains/testing.py
+++ b/eth_defi/erc_4626/vault_protocol/gains/testing.py
@@ -17,9 +17,10 @@ from hexbytes import HexBytes
 from web3 import Web3
 
 from eth_defi.erc_4626.vault_protocol.gains.vault import GainsVault
-from eth_defi.provider.anvil import mine
+from eth_defi.provider.anvil import is_anvil, mine
 from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.utils import to_unix_timestamp, from_unix_timestamp
+from eth_defi.vault.deposit_redeem import UnsupportedVaultSimulation
 
 logger = logging.getLogger(__name__)
 
@@ -28,20 +29,37 @@ def force_next_gains_epoch(
     vault: GainsVault,
     any_account: HexAddress,
     padding_seconds: int = 1,
-    gas_limit=3_000_000,
+    gas_limit: int = 3_000_000,
 ) -> HexBytes:
     """Advance Gains vault to a next epoch by using Anvil hacks.
 
     :param any_account:
-        Burn gas
+        Account that submits the epoch-advance transaction.
+
+    :param padding_seconds:
+        Seconds added after the scheduled epoch boundary before mining.
+
+    :param gas_limit:
+        Gas limit for ``forceNewEpoch()``.
 
     :return:
         Transaction hash of the ``forceNewEpoch()`` call.
+
+    :raise UnsupportedVaultSimulation:
+        If ``vault`` is not connected to an Anvil provider.
     """
 
     assert isinstance(vault, GainsVault), f"Expected GainsVault, got {type(vault)}"
 
     web3 = vault.web3
+    if not is_anvil(web3):
+        raise UnsupportedVaultSimulation(
+            "Gains epoch forcing requires an Anvil provider",
+            unsupported_reason="anvil_provider_required",
+            protocol=vault.get_protocol_name(),
+            vault_address=vault.address,
+            direction="redeem",
+        )
 
     current_epoch = vault.fetch_current_epoch()
 

--- a/eth_defi/erc_4626/vault_protocol/lagoon/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/deposit_redeem.py
@@ -170,72 +170,99 @@ class LagoonDepositManager(GenericERC7540DepositManager):
             )
 
         if not is_anvil(self.web3):
-            raise UnsupportedVaultSimulation("Lagoon force_settle() requires an Anvil provider")
+            raise UnsupportedVaultSimulation(
+                "Lagoon force_settle() requires an Anvil provider",
+                unsupported_reason="anvil_provider_required",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+            )
         if ticket is None:
-            raise UnsupportedVaultSimulation("Lagoon force_settle() requires an async request ticket")
+            raise UnsupportedVaultSimulation(
+                "Lagoon force_settle() requires an async request ticket",
+                unsupported_reason="anvil_settlement_ticket_required",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+            )
 
         if isinstance(ticket, ERC7540DepositTicket):
             status_before = self.get_deposit_request_status(ticket)
         elif isinstance(ticket, ERC7540RedemptionTicket):
             status_before = self.get_redemption_request_status(ticket)
         else:
-            raise UnsupportedVaultSimulation(f"Unsupported Lagoon ticket type: {type(ticket)}")
+            raise UnsupportedVaultSimulation(
+                f"Unsupported Lagoon ticket type: {type(ticket)}",
+                unsupported_reason="anvil_settlement_ticket_unsupported",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+            )
 
         from eth_defi.erc_4626.vault_protocol.lagoon.testing import force_lagoon_settle
 
         valuation_manager = self.vault.valuation_manager
         safe_address = self.vault.safe_address
-        make_anvil_custom_rpc_request(self.web3, "anvil_impersonateAccount", [valuation_manager])
-        make_anvil_custom_rpc_request(self.web3, "anvil_setBalance", [valuation_manager, hex(10**18)])
-        make_anvil_custom_rpc_request(self.web3, "anvil_impersonateAccount", [safe_address])
-        make_anvil_custom_rpc_request(self.web3, "anvil_setBalance", [safe_address, hex(10**18)])
+        try:
+            make_anvil_custom_rpc_request(self.web3, "anvil_impersonateAccount", [valuation_manager])
+            make_anvil_custom_rpc_request(self.web3, "anvil_setBalance", [valuation_manager, hex(10**18)])
+            make_anvil_custom_rpc_request(self.web3, "anvil_impersonateAccount", [safe_address])
+            make_anvil_custom_rpc_request(self.web3, "anvil_setBalance", [safe_address, hex(10**18)])
 
-        # WS1: provision the Safe BEFORE settlement. Lagoon's settleDeposit()
-        # always runs _settleRedeem() afterwards, which pays queued redemptions
-        # by pulling the denomination token FROM the Safe. On third-party
-        # deployments that leg fails two ways our own deploy script prevents in
-        # production (missing standing approval; Safe short of liquidity). This
-        # issues the missing approval and, only when explicitly requested,
-        # tops up the Safe, returning any synthetic amount injected so the
-        # result can flag it honestly. The
-        # provisioning must run for BOTH deposit and redemption tickets because
-        # _settleRedeem always executes after settleDeposit. See the helper for
-        # the full rationale.
-        liquidity_tx_hashes, synthetic_injected_raw = self._provision_safe_for_settlement(
-            safe_address,
-            ignore_liquidity=ignore_liquidity,
-        )
+            # WS1: provision the Safe BEFORE settlement. Lagoon's settleDeposit()
+            # always runs _settleRedeem() afterwards, which pays queued redemptions
+            # by pulling the denomination token FROM the Safe. On third-party
+            # deployments that leg fails two ways our own deploy script prevents in
+            # production (missing standing approval; Safe short of liquidity). This
+            # issues the missing approval and, only when explicitly requested,
+            # tops up the Safe, returning any synthetic amount injected so the
+            # result can flag it honestly. The
+            # provisioning must run for BOTH deposit and redemption tickets because
+            # _settleRedeem always executes after settleDeposit. See the helper for
+            # the full rationale.
+            liquidity_tx_hashes, synthetic_injected_raw = self._provision_safe_for_settlement(
+                safe_address,
+                ignore_liquidity=ignore_liquidity,
+            )
 
-        settle_tx_hashes = force_lagoon_settle(
-            self.vault,
-            valuation_manager,
-            settlement_manager=safe_address,
-        )
-        # Approval/top-up transactions precede the valuation + settlement ones.
-        tx_hashes = (*liquidity_tx_hashes, *settle_tx_hashes)
+            settle_tx_hashes = force_lagoon_settle(
+                self.vault,
+                valuation_manager,
+                settlement_manager=safe_address,
+            )
+            # Approval/top-up transactions precede the valuation + settlement ones.
+            tx_hashes = (*liquidity_tx_hashes, *settle_tx_hashes)
 
-        if isinstance(ticket, ERC7540DepositTicket):
-            status_after = self.get_deposit_request_status(ticket)
-        else:
-            status_after = self.get_redemption_request_status(ticket)
+            if isinstance(ticket, ERC7540DepositTicket):
+                status_after = self.get_deposit_request_status(ticket)
+            else:
+                status_after = self.get_redemption_request_status(ticket)
 
-        if status_after is not AsyncVaultRequestStatus.claimable:
-            # Fail loudly with the concrete before/after status rather than
-            # returning a misleading "pending -> pending" success.
-            raise UnsupportedVaultSimulation(f"Lagoon settlement did not make {type(ticket).__name__} claimable: {status_before.value} -> {status_after.value}")
+            if status_after is not AsyncVaultRequestStatus.claimable:
+                # Fail loudly with the concrete before/after status rather than
+                # returning a misleading "pending -> pending" success.
+                raise UnsupportedVaultSimulation(
+                    f"Lagoon settlement did not make {type(ticket).__name__} claimable: {status_before.value} -> {status_after.value}",
+                    unsupported_reason="lagoon_settlement_not_claimable",
+                    protocol=self.vault.get_protocol_name(),
+                    vault_address=self.vault.address,
+                    direction="deposit" if isinstance(ticket, ERC7540DepositTicket) else "redeem",
+                )
 
-        return VaultForcedSettlementResult(
-            ticket=ticket,
-            settlement_required=True,
-            status_before=status_before,
-            status_after=status_after,
-            transaction_hashes=tuple(HexBytes(h) for h in tx_hashes),
-            # Honest signalling: non-zero means the fork Safe was topped up with
-            # synthetic liquidity, so `claimable` here does NOT prove the live
-            # vault is solvent (see VaultForcedSettlementResult docstring).
-            synthetic_assets_injected_raw=synthetic_injected_raw,
-            liquidity_constraints_ignored=synthetic_injected_raw > 0,
-        )
+            return VaultForcedSettlementResult(
+                ticket=ticket,
+                settlement_required=True,
+                status_before=status_before,
+                status_after=status_after,
+                transaction_hashes=tuple(HexBytes(h) for h in tx_hashes),
+                # Honest signalling: non-zero means the fork Safe was topped up with
+                # synthetic liquidity, so `claimable` here does NOT prove the live
+                # vault is solvent (see VaultForcedSettlementResult docstring).
+                synthetic_assets_injected_raw=synthetic_injected_raw,
+                liquidity_constraints_ignored=synthetic_injected_raw > 0,
+            )
+        finally:
+            # Snapshot reversion restores contract state but not this Anvil node
+            # setting. Always release both accounts, including failure paths.
+            make_anvil_custom_rpc_request(self.web3, "anvil_stopImpersonatingAccount", [safe_address])
+            make_anvil_custom_rpc_request(self.web3, "anvil_stopImpersonatingAccount", [valuation_manager])
 
     def _provision_safe_for_settlement(
         self,
@@ -305,7 +332,13 @@ class LagoonDepositManager(GenericERC7540DepositManager):
         # provider even if a future caller forgets the is_anvil() guard that
         # force_settle() already applies.
         if not is_anvil(web3):
-            raise UnsupportedVaultSimulation("Lagoon Safe settlement provisioning is Anvil-only")
+            raise UnsupportedVaultSimulation(
+                "Lagoon Safe settlement provisioning is Anvil-only",
+                unsupported_reason="anvil_provider_required",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            )
 
         denomination_token = self.vault.denomination_token
         tx_hashes: list[HexBytes] = []

--- a/eth_defi/erc_4626/vault_protocol/plutus/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/plutus/deposit_redeem.py
@@ -10,12 +10,12 @@ later ``fulfillRedeem``s the request, and the owner claims with
 
 This manager models that flow: synchronous deposits (inherited) plus an
 asynchronous redemption request/ticket/status/claim lifecycle with typed
-preflight errors. On-fork operator settlement (``fulfillRedeem``) is role-gated
-by OpenZeppelin AccessControl and is not reproduced here, so
-``supports_anvil_settlement`` is explicitly ``False`` with a stable reason.
+preflight errors. On an Anvil fork it discovers ``OPERATOR_ROLE`` candidates
+from indexed ``RoleGranted`` history, verifies the candidate with ``hasRole``
+at the fork head, and then impersonates only that verified holder.
 """
 
-import datetime
+import os
 from dataclasses import dataclass
 from decimal import Decimal
 
@@ -24,8 +24,11 @@ from hexbytes import HexBytes
 from web3 import Web3
 from web3._utils.events import EventLogErrorFlags
 
+from eth_defi.abi import get_topic_signature_from_event
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
-from eth_defi.provider.anvil import is_anvil
+from eth_defi.hypersync.utils import configure_hypersync_from_env
+from eth_defi.provider.anvil import is_anvil, make_anvil_custom_rpc_request
+from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.vault.deposit_redeem import (
     AsyncVaultRequestStatus,
     CannotParseRedemptionTransaction,
@@ -37,6 +40,7 @@ from eth_defi.vault.deposit_redeem import (
     VaultForcedSettlementResult,
     create_synchronous_settlement_result,
 )
+from eth_defi.vault.flow_events import fetch_vault_flow_logs_hypersync
 
 #: ``UseRequestRedeem()`` — standard ERC-4626 ``redeem`` is disabled; use the
 #: asynchronous request flow. ``keccak("UseRequestRedeem()")[:4]``.
@@ -45,7 +49,8 @@ USE_REQUEST_REDEEM_SELECTOR = HexBytes("0x797f246a")
 #: ``WithdrawalsArePaused()`` custom-error selector.
 WITHDRAWALS_ARE_PAUSED_SELECTOR = HexBytes("0xe14e66da")
 
-#: Plutus fulfilment is role-gated and cannot be reproduced from the vault ABI.
+#: Historical false-capability reason retained as a consumer compatibility
+#: contract for deployments that do not expose a verifiable fulfiller.
 PLUTUS_ANVIL_SETTLEMENT_UNSUPPORTED_REASON = "plutus_redeem_fulfilment_is_access_control_role_gated"
 
 
@@ -151,13 +156,14 @@ class PlutusAsyncDepositManager(ERC4626DepositManager):
     withdrawals are paused (``withdrawalsPaused`` /
     :data:`WITHDRAWALS_ARE_PAUSED_SELECTOR`) or the owner holds too few shares.
 
-    **Anvil settlement (force_settle).** Deferred. A ``None`` (synchronous
-    deposit) ticket returns the shared no-op, but a redemption ticket cannot be
-    settled on a fork: ``fulfillRedeem`` is gated by OpenZeppelin AccessControl
-    and its role holder is deployment-specific and not discoverable from the vault
-    interface, so :meth:`force_settle` raises
-    :class:`~eth_defi.vault.deposit_redeem.UnsupportedVaultSimulation` rather than
-    forging a fulfilment.
+    **Anvil settlement (force_settle).** A ``None`` (synchronous deposit)
+    ticket returns the shared no-op. For a redemption ticket,
+    :meth:`force_settle` uses Hypersync ``RoleGranted`` history bounded at the
+    fork head to find candidates, validates ``OPERATOR_ROLE`` with the live
+    fork state, and impersonates only the verified holder for
+    ``fulfillRedeem``. If this cannot be proven, it raises a typed
+    :class:`~eth_defi.vault.deposit_redeem.UnsupportedVaultSimulation` rather
+    than forging a role.
     """
 
     def estimate_deposit(
@@ -387,13 +393,14 @@ class PlutusAsyncDepositManager(ERC4626DepositManager):
         mock: object | None = None,
         ignore_liquidity: bool = False,
     ) -> VaultForcedSettlementResult:
-        """Report that Plutus operator fulfilment is not reproducible on a fork.
+        """Fulfil a Plutus redemption from a verified Anvil operator.
 
-        Plutus ``fulfillRedeem`` is gated by OpenZeppelin AccessControl; the
-        fulfilment role and its holder are deployment-specific and not
-        discoverable from the vault interface alone, so the request cannot be
-        safely progressed to claimable on a fork. Synchronous ``None`` calls
-        return the shared no-op.
+        Plutus protects ``fulfillRedeem`` with OpenZeppelin ``OPERATOR_ROLE``.
+        The implementation does not enumerate role members, so this method
+        obtains role-grant candidates from the indexed ``RoleGranted`` history
+        bounded at the current Anvil fork head, then validates each candidate
+        with the contract's current ``hasRole`` state before impersonation.
+        Synchronous ``None`` calls return the shared no-op.
 
         :param ticket:
             Pending redemption ticket, or ``None``.
@@ -405,20 +412,34 @@ class PlutusAsyncDepositManager(ERC4626DepositManager):
             Unsupported because Plutus fulfilment is an operator boundary, not
             a local immediate-liquidity gate.
         :return:
-            No-op result for ``None``.
+            No-op result for ``None`` or a pending-to-claimable fulfilment.
         :raise UnsupportedVaultSimulation:
-            For a redemption ticket, because operator fulfilment cannot be
-            reproduced without role discovery.
+            If no currently authorised fulfiller can be discovered or the
+            fulfilment transaction does not make the exact ticket claimable.
         """
         if ignore_liquidity:
             return super().force_settle(ticket, mock=mock, ignore_liquidity=True)
 
         if ticket is None:
             return create_synchronous_settlement_result()
+
+        if not isinstance(ticket, PlutusRedemptionTicket):
+            raise UnsupportedVaultSimulation(
+                f"Plutus force_settle requires PlutusRedemptionTicket, got {type(ticket)}",
+                unsupported_reason="anvil_settlement_ticket_unsupported",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            )
         if mock is not None:
-            assert isinstance(ticket, PlutusRedemptionTicket), f"Plutus mock settlement requires PlutusRedemptionTicket, got {type(ticket)}"
             if not is_anvil(self.web3):
-                raise UnsupportedVaultSimulation("Plutus mock settlement requires an Anvil provider", unsupported_reason="anvil_provider_required")
+                raise UnsupportedVaultSimulation(
+                    "Plutus mock settlement requires an Anvil provider",
+                    unsupported_reason="anvil_provider_required",
+                    protocol=self.vault.get_protocol_name(),
+                    vault_address=self.vault.address,
+                    direction="redeem",
+                )
             tx_hash = mock.functions.fulfillRedeem(ticket.request_id).transact({"from": self.web3.eth.accounts[0]})
             return VaultForcedSettlementResult(
                 ticket=ticket,
@@ -427,9 +448,119 @@ class PlutusAsyncDepositManager(ERC4626DepositManager):
                 status_after=AsyncVaultRequestStatus.claimable,
                 transaction_hashes=(HexBytes(tx_hash),),
             )
+
+        if not is_anvil(self.web3):
+            raise UnsupportedVaultSimulation(
+                "Plutus operator fulfilment requires an Anvil provider",
+                unsupported_reason="anvil_provider_required",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            )
+
+        status_before = self.get_redemption_request_status(ticket)
+        if status_before is AsyncVaultRequestStatus.claimable:
+            return VaultForcedSettlementResult(
+                ticket=ticket,
+                settlement_required=False,
+                status_before=status_before,
+                status_after=status_before,
+            )
+        if status_before is not AsyncVaultRequestStatus.pending:
+            raise UnsupportedVaultSimulation(
+                f"Plutus request {ticket.request_id} is {status_before.value}, not pending",
+                unsupported_reason="plutus_fulfilment_not_claimable",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            )
+
+        fulfiller = self._fetch_fulfiller()
+        make_anvil_custom_rpc_request(self.web3, "anvil_impersonateAccount", [fulfiller])
+        try:
+            make_anvil_custom_rpc_request(self.web3, "anvil_setBalance", [fulfiller, hex(10**18)])
+            tx_hash = HexBytes(self.vault.vault_contract.functions.fulfillRedeem(ticket.request_id).transact({"from": fulfiller, "gas": 1_000_000}))
+            assert_transaction_success_with_explanation(self.web3, tx_hash)
+        finally:
+            make_anvil_custom_rpc_request(self.web3, "anvil_stopImpersonatingAccount", [fulfiller])
+
+        status_after = self.get_redemption_request_status(ticket)
+        if status_after is not AsyncVaultRequestStatus.claimable:
+            raise UnsupportedVaultSimulation(
+                f"Plutus fulfiller did not make request {ticket.request_id} claimable: {status_before.value} -> {status_after.value}",
+                unsupported_reason="plutus_fulfilment_not_claimable",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            )
+        return VaultForcedSettlementResult(
+            ticket=ticket,
+            settlement_required=True,
+            status_before=status_before,
+            status_after=status_after,
+            transaction_hashes=(tx_hash,),
+        )
+
+    def _fetch_fulfiller(self) -> HexAddress:
+        """Resolve a currently authorised ``OPERATOR_ROLE`` holder at fork head.
+
+        The ABI exposes ``hasRole`` but not AccessControlEnumerable. Hypersync
+        therefore provides historical candidates while the fork's contract
+        state is the authority for whether a candidate remains authorised.
+
+        :return:
+            A checksum address that currently has ``OPERATOR_ROLE``.
+        :raise UnsupportedVaultSimulation:
+            If the indexed role history has no currently authorised candidate.
+        """
+        if not is_anvil(self.web3):
+            raise UnsupportedVaultSimulation(
+                "Plutus fulfiller discovery requires an Anvil provider",
+                unsupported_reason="anvil_provider_required",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            )
+
+        if not os.environ.get("HYPERSYNC_API_KEY"):
+            raise UnsupportedVaultSimulation(
+                "Plutus fulfiller history requires HYPERSYNC_API_KEY",
+                unsupported_reason="plutus_fulfilment_role_not_discoverable",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            )
+
+        hypersync_config = configure_hypersync_from_env(self.web3)
+        hypersync_client = hypersync_config.hypersync_client
+        if hypersync_client is None:
+            raise UnsupportedVaultSimulation(
+                f"Plutus fulfiller history is unavailable for vault {self.vault.address}",
+                unsupported_reason="plutus_fulfilment_role_not_discoverable",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            )
+
+        contract = self.vault.vault_contract
+        operator_role = contract.functions.OPERATOR_ROLE().call()
+        role_granted_topic = get_topic_signature_from_event(contract.events.RoleGranted).lower()
+        head = int(self.web3.eth.block_number)
+        logs = fetch_vault_flow_logs_hypersync(
+            hypersync_client=hypersync_client,
+            vault_address=self.vault.address,
+            topic0_list=[role_granted_topic],
+            start_block=0,
+            end_block=head,
+        )
+        candidates = [Web3.to_checksum_address("0x" + log.topics[2][-40:]) for log in logs if log.topics[1] is not None and bytes.fromhex(log.topics[1][2:]) == operator_role]
+        for candidate in reversed(candidates):
+            if contract.functions.hasRole(operator_role, candidate).call():
+                return candidate
+
         raise UnsupportedVaultSimulation(
-            f"Plutus Hedge fulfilment is role-gated (AccessControl) and not reproducible on a fork for vault {self.vault.address}",
-            unsupported_reason=PLUTUS_ANVIL_SETTLEMENT_UNSUPPORTED_REASON,
+            f"No current Plutus OPERATOR_ROLE holder could be verified for vault {self.vault.address} at fork head {head}",
+            unsupported_reason="plutus_fulfilment_role_not_discoverable",
             protocol=self.vault.get_protocol_name(),
             vault_address=self.vault.address,
             direction="redeem",

--- a/eth_defi/erc_4626/vault_protocol/plutus/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/plutus/vault.py
@@ -13,7 +13,7 @@ from eth_defi.abi import ZERO_ADDRESS_STR, get_deployed_contract
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
-from eth_defi.erc_4626.vault_protocol.plutus.deposit_redeem import PLUTUS_ANVIL_SETTLEMENT_UNSUPPORTED_REASON, PlutusAsyncDepositManager
+from eth_defi.erc_4626.vault_protocol.plutus.deposit_redeem import PlutusAsyncDepositManager
 from eth_defi.event_reader.conversion import convert_int256_bytes_to_int
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.vault.base import (
@@ -245,8 +245,7 @@ class PlutusVault(ERC4626Vault):
                 can_redeem=True,
                 deposit_flow="synchronous",
                 redemption_flow="asynchronous",
-                supports_anvil_settlement=False,
-                anvil_settlement_unsupported_reason=PLUTUS_ANVIL_SETTLEMENT_UNSUPPORTED_REASON,
+                supports_anvil_settlement=True,
             )
         return self.get_synchronous_deposit_manager_capability()
 

--- a/eth_defi/vault/deposit_redeem.py
+++ b/eth_defi/vault/deposit_redeem.py
@@ -573,6 +573,49 @@ class RedemptionTicket:
 
 
 @dataclass(frozen=True, slots=True)
+class VaultDirectPayoutEvidence:
+    """Evidence for an asynchronous request settled by direct token payment.
+
+    Some protocols consume a request and pay the receiver without exposing an
+    intermediate claimable state.  Such a transition is terminal only when
+    the request-specific event and the receiver's denomination-token balance
+    agree.  This intentionally contains no protocol-specific event payload so
+    consumers can apply the same terminal-result rule to every adapter.
+
+    :param request_id:
+        Identifier of the request consumed by the settlement transaction.
+    :param receiver:
+        Receiver whose denomination-token balance was observed.
+    :param denomination_token:
+        Token paid by the direct settlement.
+    :param raw_balance_before:
+        Receiver balance immediately before the settlement transaction.
+    :param raw_balance_after:
+        Receiver balance immediately after the settlement transaction.
+    :param event_name:
+        Name of the decoded request-specific settlement event.
+    :param transaction_hash:
+        Transaction that emitted ``event_name`` and paid the receiver.
+    """
+
+    request_id: int
+    receiver: HexAddress
+    denomination_token: HexAddress
+    raw_balance_before: int
+    raw_balance_after: int
+    event_name: str
+    transaction_hash: HexBytes
+
+    def has_positive_balance_delta(self) -> bool:
+        """Return whether the observed direct payment increased the balance.
+
+        :return:
+            ``True`` only when the receiver received a positive raw amount.
+        """
+        return self.raw_balance_after > self.raw_balance_before
+
+
+@dataclass(frozen=True, slots=True)
 class VaultForcedSettlementResult:
     """Outcome of an Anvil-only forced settlement attempt.
 
@@ -620,6 +663,41 @@ class VaultForcedSettlementResult:
     #: mechanics only. It is never evidence that the live deployment has
     #: enough immediately available redemption liquidity.
     liquidity_constraints_ignored: bool = False
+
+    #: Evidence for terminal direct-payout protocols such as Ember.  It is
+    #: required whenever ``status_after`` is ``none`` for an asynchronous
+    #: settlement result.
+    direct_payout_evidence: VaultDirectPayoutEvidence | None = None
+
+    def is_terminal_success(self) -> bool:
+        """Return whether this result proves its protocol settlement finished.
+
+        Claimable tickets are terminal settlement success: the caller can now
+        execute the ordinary protocol claim.  A protocol that pays directly
+        may instead return ``none`` only with request-specific event evidence
+        and a positive receiver balance delta.  A pending, missing, or
+        evidence-free consumed status is never a successful forced settlement.
+
+        :return:
+            ``True`` for a synchronous no-op, a claimable async ticket, or a
+            validated direct-payout terminal transition.
+        """
+        if not self.settlement_required:
+            if self.ticket is None:
+                return self.status_before is None and self.status_after is None and not self.transaction_hashes
+            return self.status_after is AsyncVaultRequestStatus.claimable and not self.transaction_hashes and self.direct_payout_evidence is None
+
+        if self.ticket is None or not self.transaction_hashes:
+            return False
+
+        if self.status_after is AsyncVaultRequestStatus.claimable:
+            return self.direct_payout_evidence is None
+
+        evidence = self.direct_payout_evidence
+        if self.status_after is not AsyncVaultRequestStatus.none or evidence is None or not isinstance(self.ticket, RedemptionTicket):
+            return False
+
+        return evidence.request_id == self.ticket.get_request_id() and Web3.to_checksum_address(evidence.receiver) == Web3.to_checksum_address(self.ticket.to) and bool(evidence.event_name) and evidence.transaction_hash in self.transaction_hashes and evidence.has_positive_balance_delta()
 
 
 def create_synchronous_settlement_result() -> VaultForcedSettlementResult:

--- a/tests/erc_4626/vault_protocol/test_ember_deposit_redeem.py
+++ b/tests/erc_4626/vault_protocol/test_ember_deposit_redeem.py
@@ -2,6 +2,7 @@
 
 import datetime
 import os
+from collections.abc import Iterator
 from decimal import Decimal
 
 import pytest
@@ -13,38 +14,51 @@ from eth_defi.abi import get_topic_signature_from_event
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.vault_protocol.ember.deposit_redeem import EmberDepositManager, EmberRedemptionTicket
 from eth_defi.erc_4626.vault_protocol.ember.vault import EmberVault
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
+from eth_defi.provider.anvil import AnvilLaunch
 from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
+from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
 from eth_defi.token import USDC_WHALE, TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
-from eth_defi.vault.deposit_redeem import AsyncVaultRequestStatus, UnsupportedVaultSimulation, VaultFlowUnavailable
+from eth_defi.vault.deposit_redeem import AsyncVaultRequestStatus, VaultFlowUnavailable
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 EMBER_VAULT = HexAddress(HexStr("0xf3190A3ECC109F88e7947b849b281918c798A0C4"))
 EMBER_OPERATOR = HexAddress(HexStr("0x116046991e3F0B0967723073a87820eF5edB29f2"))
 FORK_BLOCK = 24_496_689
+EMBER_EXACT_VAULTS = (
+    HexAddress(HexStr("0x9be9294722f8aad37b11a9792be2c782182cafa2")),
+    HexAddress(HexStr("0x0b9342c15143e8f54a83f887c280a922f4c48771")),
+    EMBER_VAULT,
+    HexAddress(HexStr("0x373152feef81cc59502da2c8de877b3d5ae2e342")),
+)
 
-pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests")
+pytestmark = [
+    pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests"),
+    pytest.mark.xdist_group("fork:ethereum:24496689"),
+]
 
 
 @pytest.fixture(scope="module")
-def anvil_ethereum_ember_fork() -> AnvilLaunch:
-    """Fork Ember v1.1.1 with its operator and an Ethereum USDC whale unlocked."""
-    launch = fork_network_anvil(
+def anvil_ethereum_ember_fork(anvil_fork_pool: AnvilForkPool) -> AnvilLaunch:
+    """Reuse the warmed Ethereum fork for all Ember deployment trials."""
+    return anvil_fork_pool.get_launch(
         JSON_RPC_ETHEREUM,
-        fork_block_number=FORK_BLOCK,
-        unlocked_addresses=[USDC_WHALE[1], EMBER_OPERATOR],
+        FORK_BLOCK,
+        unlocked_addresses=[USDC_WHALE[1]],
     )
-    try:
-        yield launch
-    finally:
-        launch.close()
 
 
 @pytest.fixture(scope="module")
 def web3(anvil_ethereum_ember_fork: AnvilLaunch) -> Web3:
     """Connect to the reproducible Ember Anvil fork."""
     return create_multi_provider_web3(anvil_ethereum_ember_fork.json_rpc_url, retries=2)
+
+
+@pytest.fixture
+def ember_snapshot(anvil_ethereum_ember_fork: AnvilLaunch) -> Iterator[None]:
+    """Restore pooled fork state after each mutating Ember lifecycle trial."""
+    yield from evm_snapshot_revert(anvil_ethereum_ember_fork)
 
 
 @pytest.fixture(scope="module")
@@ -61,7 +75,7 @@ def usdc(web3: Web3) -> TokenDetails:
     return fetch_erc20_details(web3, "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
 
 
-def test_ember_deposit_redeem_lifecycle(web3: Web3, vault: EmberVault, usdc: TokenDetails) -> None:
+def test_ember_deposit_redeem_lifecycle(web3: Web3, vault: EmberVault, usdc: TokenDetails, ember_snapshot: None) -> None:
     """Deposit, request redemption, operator-process and analyse exact Ember amounts."""
     # 1. Pin the deployed ABI and public mixed-flow capability.
     manager = vault.get_deposit_manager()
@@ -91,8 +105,7 @@ def test_ember_deposit_redeem_lifecycle(web3: Web3, vault: EmberVault, usdc: Tok
         "can_redeem": True,
         "deposit_flow": "synchronous",
         "redemption_flow": "asynchronous",
-        "supports_anvil_settlement": False,
-        "anvil_settlement_unsupported_reason": "ember_operator_settlement_has_no_claimable_ticket_status",
+        "supports_anvil_settlement": True,
     }
     # Keep the exact deployment's operator layout in coverage even though its
     # direct-pay queue cannot satisfy generic claimable-ticket settlement.
@@ -116,37 +129,50 @@ def test_ember_deposit_redeem_lifecycle(web3: Web3, vault: EmberVault, usdc: Tok
     assert raw_shares == 97_218_907
     assert manager.estimate_redeem(owner, Decimal("97.218907"), "latest") > Decimal("99")
 
-    # 3. Queue the redemption and persist its request identity.
-    redemption_request = manager.create_redemption_request(owner=owner, raw_shares=raw_shares)
+    # 3. Queue two requests. The target request is deliberately second, proving
+    # that forced settlement locates it in Ember's vault-global FIFO queue.
+    first_raw_shares = 10_000_000
+    first_request = manager.create_redemption_request(owner=owner, raw_shares=first_raw_shares)
+    assert len(first_request.funcs) == 2
+    first_ticket = first_request.broadcast(from_=owner)
+    redemption_request = manager.create_redemption_request(owner=owner, raw_shares=raw_shares - first_raw_shares)
     assert len(redemption_request.funcs) == 2
     ticket = redemption_request.broadcast(from_=owner)
+    assert isinstance(first_ticket, EmberRedemptionTicket)
+    assert first_ticket.request_sequence_number == 145
     assert isinstance(ticket, EmberRedemptionTicket)
-    assert ticket.request_sequence_number == 145
-    assert ticket.raw_shares == raw_shares
+    assert ticket.request_sequence_number == 146
+    assert ticket.raw_shares == raw_shares - first_raw_shares
     assert ticket.block_timestamp.tzinfo is None
     assert manager.reconstruct_redemption_ticket(manager.serialize_redemption_ticket(ticket)) == ticket
     assert manager.get_redemption_request_status(ticket) == AsyncVaultRequestStatus.pending
     assert manager.is_redemption_in_progress(owner) is True
     account_state = vault.vault_contract.functions.getAccountState(owner).call()
-    assert account_state == [raw_shares, [145], []]
+    assert account_state == [raw_shares, [145, 146], []]
     assert manager.fetch_completed_redemption_tx_hash(ticket) is None
+    assert manager.fetch_pending_withdrawal_index(ticket) == 1
     assert manager.can_finish_redeem(ticket) is False
     assert manager.finish_redemption(ticket) is None
 
-    # 4. Ember has no claimable ticket state, so force-settlement must refuse
-    # before impersonating the operator or broadcasting its queue processor.
-    with pytest.raises(UnsupportedVaultSimulation, match="cannot prove a claimable") as exc_info:
-        manager.force_settle(ticket)
-    assert exc_info.value.unsupported_reason == "ember_operator_settlement_has_no_claimable_ticket_status"
-    assert exc_info.value.protocol == vault.get_protocol_name()
-    assert exc_info.value.vault_address == vault.address
-    assert exc_info.value.direction == "redeem"
-    assert exc_info.value.phase == "settlement"
-    assert manager.get_redemption_request_status(ticket) == AsyncVaultRequestStatus.pending
-    assert vault.vault_contract.functions.getAccountState(owner).call() == [raw_shares, [145], []]
+    # 4. Ember's configured operator pays directly rather than marking the
+    # request claimable. The result must carry the matching event and a
+    # positive USDC balance delta before it is terminal success.
+    usdc_before = usdc.fetch_raw_balance_of(owner)
+    settlement = manager.force_settle(ticket)
+    assert settlement.status_before is AsyncVaultRequestStatus.pending
+    assert settlement.status_after is AsyncVaultRequestStatus.none
+    assert settlement.direct_payout_evidence is not None
+    assert settlement.direct_payout_evidence.request_id == ticket.request_sequence_number
+    assert settlement.direct_payout_evidence.receiver == owner
+    assert settlement.direct_payout_evidence.event_name == "RequestProcessed"
+    assert settlement.direct_payout_evidence.raw_balance_after > settlement.direct_payout_evidence.raw_balance_before
+    assert settlement.is_terminal_success() is True
+    assert usdc.fetch_raw_balance_of(owner) > usdc_before
+    assert manager.get_redemption_request_status(ticket) is AsyncVaultRequestStatus.none
+    assert manager.fetch_completed_redemption_tx_hash(ticket) == settlement.transaction_hashes[0]
 
 
-def test_ember_redemption_minimum_is_checked_before_call_binding(web3: Web3, vault: EmberVault) -> None:
+def test_ember_redemption_minimum_is_checked_before_call_binding(web3: Web3, vault: EmberVault, ember_snapshot: None) -> None:
     """Reject a request below the exact configured Ember minimum share amount."""
     manager = vault.get_deposit_manager()
     with pytest.raises(VaultFlowUnavailable, match="below minimum") as exc_info:
@@ -183,3 +209,13 @@ def test_ember_ticket_identity_validation() -> None:
                 "shares": 30_000_000,
             },
         )
+
+
+@pytest.mark.parametrize("vault_address", EMBER_EXACT_VAULTS)
+def test_all_exact_ember_vaults_expose_a_settlement_operator(web3: Web3, vault_address: HexAddress) -> None:
+    """Characterise each matrix deployment on the same fixed, warmed fork."""
+    vault = create_vault_instance_autodetect(web3, vault_address)
+    assert isinstance(vault, EmberVault)
+    _admin, operator, _rate_manager = vault.vault_contract.functions.roles().call()
+    assert Web3.to_checksum_address(operator) != "0x0000000000000000000000000000000000000000"
+    assert vault.get_deposit_manager_capability().supports_anvil_settlement is True

--- a/tests/erc_4626/vault_protocol/test_plutus.py
+++ b/tests/erc_4626/vault_protocol/test_plutus.py
@@ -14,7 +14,7 @@ from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.vault_protocol.plutus.deposit_redeem import PlutusAsyncDepositManager, PlutusRedemptionTicket
 from eth_defi.erc_4626.vault_protocol.plutus.vault import PlutusHistoricalReader, PlutusVault
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
+from eth_defi.provider.anvil import AnvilLaunch
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
@@ -65,8 +65,7 @@ def test_plutus(
         "can_redeem": True,
         "deposit_flow": "synchronous",
         "redemption_flow": "asynchronous",
-        "supports_anvil_settlement": False,
-        "anvil_settlement_unsupported_reason": "plutus_redeem_fulfilment_is_access_control_role_gated",
+        "supports_anvil_settlement": True,
     }
     manager = vault.get_deposit_manager()
     assert isinstance(manager, PlutusAsyncDepositManager)
@@ -161,8 +160,8 @@ def test_plutus_async_redemption_lifecycle(midnight_web3: Web3, plutus_snapshot:
     """Deposit synchronously, then request an asynchronous redemption on the Hedge vault.
 
     Validates the ERC-7540-style flow: ``requestRedeem`` produces a pending
-    ticket, the request is not yet claimable, and forced settlement is refused
-    with a precise reason because operator fulfilment is role-gated.
+    ticket, discovers and verifies the role-gated operator, fulfils the request,
+    then claims the released assets.
     """
     vault = create_vault_instance_autodetect(midnight_web3, vault_address=PLUTUS_HEDGE_VAULT)
     assert isinstance(vault, PlutusVault)
@@ -198,12 +197,27 @@ def test_plutus_async_redemption_lifecycle(midnight_web3: Web3, plutus_snapshot:
     assert manager.can_finish_redeem(ticket) is False
     assert manager.reconstruct_redemption_ticket(manager.serialize_redemption_ticket(ticket)) == ticket
 
-    # Operator fulfilment is role-gated; forced settlement is refused precisely.
+    # Hypersync discovers role-grant candidates, then the fork verifies the
+    # active OPERATOR_ROLE holder before fulfilment and the ordinary claim.
     assert manager.force_settle(None).settlement_required is False
-    with pytest.raises(UnsupportedVaultSimulation, match="role-gated") as exc_info:
-        manager.force_settle(ticket)
-    assert exc_info.value.unsupported_reason == "plutus_redeem_fulfilment_is_access_control_role_gated"
-    assert exc_info.value.protocol == vault.get_protocol_name()
-    assert exc_info.value.vault_address == vault.address
-    assert exc_info.value.direction == "redeem"
-    assert exc_info.value.phase == "settlement"
+    settlement = manager.force_settle(ticket)
+    assert settlement.status_before is AsyncVaultRequestStatus.pending
+    assert settlement.status_after is AsyncVaultRequestStatus.claimable
+    assert settlement.transaction_hashes
+    assert settlement.is_terminal_success() is True
+    usdc_before = usdc.fetch_raw_balance_of(owner)
+    assert_transaction_success_with_explanation(midnight_web3, manager.finish_redemption(ticket).transact({"from": owner}))
+    assert usdc.fetch_raw_balance_of(owner) > usdc_before
+
+
+@pytest.mark.xdist_group("fork:arbitrum:midnight")
+def test_plutus_fulfiller_discovery_requires_hypersync_key(midnight_web3: Web3, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return a typed refusal when role history cannot be read."""
+    vault = create_vault_instance_autodetect(midnight_web3, vault_address=PLUTUS_HEDGE_VAULT)
+    assert isinstance(vault, PlutusVault)
+    manager = vault.get_deposit_manager()
+    assert isinstance(manager, PlutusAsyncDepositManager)
+    monkeypatch.delenv("HYPERSYNC_API_KEY", raising=False)
+    with pytest.raises(UnsupportedVaultSimulation) as exc_info:
+        manager._fetch_fulfiller()
+    assert exc_info.value.unsupported_reason == "plutus_fulfilment_role_not_discoverable"

--- a/tests/vault/test_deposit_redeem.py
+++ b/tests/vault/test_deposit_redeem.py
@@ -3,7 +3,15 @@
 from eth_typing import HexAddress
 from hexbytes import HexBytes
 
-from eth_defi.vault.deposit_redeem import UnsupportedVaultSimulation, VaultFlowUnavailable
+from eth_defi.erc_4626.vault_protocol.plutus.deposit_redeem import PlutusRedemptionTicket
+from eth_defi.vault.deposit_redeem import (
+    AsyncVaultRequestStatus,
+    UnsupportedVaultSimulation,
+    VaultDirectPayoutEvidence,
+    VaultFlowUnavailable,
+    VaultForcedSettlementResult,
+    create_synchronous_settlement_result,
+)
 
 REQUESTED_RAW_AMOUNT = 101
 AVAILABLE_RAW_AMOUNT = 100
@@ -65,3 +73,141 @@ def test_vault_flow_unavailable_preserves_access_context() -> None:
     assert error.error_selector == HexBytes("0x068ca9d8")
     assert error.access_delay == ACCESS_DELAY
     assert str(error) == "Access must be scheduled (caller=0x0000000000000000000000000000000000000002, direction=deposit, function_selector=6e553f65, error_selector=068ca9d8, access_delay=3600)"
+
+
+def test_forced_settlement_result_requires_terminal_evidence() -> None:
+    """Accept claimable and verified direct payouts, never a pending ticket."""
+    receiver = HexAddress("0x0000000000000000000000000000000000000002")
+    ticket = PlutusRedemptionTicket(
+        vault_address=HexAddress("0x0000000000000000000000000000000000000001"),
+        owner=receiver,
+        to=receiver,
+        raw_shares=1,
+        tx_hash=HexBytes("0x01"),
+        request_id=7,
+    )
+    transaction_hash = HexBytes("0x02")
+
+    assert create_synchronous_settlement_result().is_terminal_success() is True
+    assert (
+        VaultForcedSettlementResult(
+            ticket=ticket,
+            settlement_required=True,
+            status_before=AsyncVaultRequestStatus.pending,
+            status_after=AsyncVaultRequestStatus.pending,
+            transaction_hashes=(transaction_hash,),
+        ).is_terminal_success()
+        is False
+    )
+    assert (
+        VaultForcedSettlementResult(
+            ticket=ticket,
+            settlement_required=True,
+            status_before=AsyncVaultRequestStatus.pending,
+            status_after=AsyncVaultRequestStatus.claimable,
+            transaction_hashes=(transaction_hash,),
+        ).is_terminal_success()
+        is True
+    )
+    assert (
+        VaultForcedSettlementResult(
+            ticket=ticket,
+            settlement_required=False,
+            status_before=AsyncVaultRequestStatus.claimable,
+            status_after=AsyncVaultRequestStatus.claimable,
+        ).is_terminal_success()
+        is True
+    )
+    assert (
+        VaultForcedSettlementResult(
+            ticket=ticket,
+            settlement_required=False,
+            status_before=AsyncVaultRequestStatus.pending,
+            status_after=AsyncVaultRequestStatus.claimable,
+        ).is_terminal_success()
+        is True
+    )
+
+    mismatched_request = VaultDirectPayoutEvidence(
+        request_id=ticket.request_id + 1,
+        receiver=receiver,
+        denomination_token=HexAddress("0x0000000000000000000000000000000000000003"),
+        raw_balance_before=100,
+        raw_balance_after=101,
+        event_name="RequestProcessed",
+        transaction_hash=transaction_hash,
+    )
+    assert (
+        VaultForcedSettlementResult(
+            ticket=ticket,
+            settlement_required=True,
+            status_before=AsyncVaultRequestStatus.pending,
+            status_after=AsyncVaultRequestStatus.none,
+            transaction_hashes=(transaction_hash,),
+            direct_payout_evidence=mismatched_request,
+        ).is_terminal_success()
+        is False
+    )
+
+    zero_delta = VaultDirectPayoutEvidence(
+        request_id=ticket.request_id,
+        receiver=receiver,
+        denomination_token=HexAddress("0x0000000000000000000000000000000000000003"),
+        raw_balance_before=100,
+        raw_balance_after=100,
+        event_name="RequestProcessed",
+        transaction_hash=transaction_hash,
+    )
+    assert (
+        VaultForcedSettlementResult(
+            ticket=ticket,
+            settlement_required=True,
+            status_before=AsyncVaultRequestStatus.pending,
+            status_after=AsyncVaultRequestStatus.none,
+            transaction_hashes=(transaction_hash,),
+            direct_payout_evidence=zero_delta,
+        ).is_terminal_success()
+        is False
+    )
+
+    verified_direct_payout = VaultDirectPayoutEvidence(
+        request_id=ticket.request_id,
+        receiver=receiver,
+        denomination_token=HexAddress("0x0000000000000000000000000000000000000003"),
+        raw_balance_before=100,
+        raw_balance_after=101,
+        event_name="RequestProcessed",
+        transaction_hash=transaction_hash,
+    )
+    assert (
+        VaultForcedSettlementResult(
+            ticket=ticket,
+            settlement_required=True,
+            status_before=AsyncVaultRequestStatus.pending,
+            status_after=AsyncVaultRequestStatus.none,
+            transaction_hashes=(transaction_hash,),
+            direct_payout_evidence=verified_direct_payout,
+        ).is_terminal_success()
+        is True
+    )
+
+    lower_case_receiver = VaultDirectPayoutEvidence(
+        request_id=ticket.request_id,
+        receiver=HexAddress(receiver.lower()),
+        denomination_token=HexAddress("0x0000000000000000000000000000000000000003"),
+        raw_balance_before=100,
+        raw_balance_after=101,
+        event_name="RequestProcessed",
+        transaction_hash=transaction_hash,
+    )
+    assert (
+        VaultForcedSettlementResult(
+            ticket=ticket,
+            settlement_required=True,
+            status_before=AsyncVaultRequestStatus.pending,
+            status_after=AsyncVaultRequestStatus.none,
+            transaction_hashes=(transaction_hash,),
+            direct_payout_evidence=lower_case_receiver,
+        ).is_terminal_success()
+        is True
+    )


### PR DESCRIPTION
## Why

Async redemption probes must prove a terminal protocol result. Ember pays directly through an operator, while Plutus requires a verified AccessControl fulfiller; neither should be represented as a generic pending or unsupported result when the fixed fork can reproduce it.

## Lessons learnt

A consumed async request is not success by itself. Ember requires a request-specific event and positive denomination-token balance delta; Plutus requires indexed role discovery followed by an on-fork `hasRole` check. Shared fixed-block Anvil forks confirm the operator configuration for all affected Ember deployments, while the Crosschain USD deployment covers the full direct-payout lifecycle.

## Summary

- Add neutral terminal-settlement validation and direct-payout evidence.
- Simulate Ember operator payouts, including global FIFO targeting, and Plutus fulfil-and-claim paths on Anvil.
- Harden Lagoon impersonation cleanup and typed settlement failures.
- Add Gains chain and epoch safety checks.
- Reuse warm Anvil forks for Ember coverage and add focused lifecycle tests.

## Related issues and PRs

- Continues the settlement trial plan in tradingstrategy-ai/trade-executor#1584.

## Unrelated CI and test fixes

- None.