### PR TITLE
fix: accept ApeX official vault listing response

### DIFF
--- a/eth_defi/apex/vault.py
+++ b/eth_defi/apex/vault.py
@@ -287,8 +287,10 @@ def parse_official_vaults(payload: object) -> tuple[ApexVaultSummary, ...]:
     duplicates = sorted(vault_id for vault_id, count in Counter(identifiers).items() if count > 1)
     if duplicates:
         raise ApexAPIError(f"ApeX official vaults contain duplicate vault IDs: {duplicates}")
-    if len(page.vaults) != page.total_size:
-        raise ApexAPIError(f"ApeX official vaults returned {len(page.vaults)} rows but reported {page.total_size}")
+    # ``official-vaults`` is not paginated. ApeX currently returns
+    # ``totalSize=0`` even when ``vaultList`` contains the complete listing,
+    # so unlike the paginated ranking endpoint this field is not a membership
+    # completeness invariant.
     return page.vaults
 
 

--- a/tests/apex/fixtures/official-vaults.json
+++ b/tests/apex/fixtures/official-vaults.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "totalSize": 2,
+    "totalSize": 0,
     "vaultList": [
       {
         "vaultId": "10000",

--- a/tests/apex/test_apex_vault.py
+++ b/tests/apex/test_apex_vault.py
@@ -9,7 +9,7 @@ from typing import Callable
 
 import pytest
 
-from eth_defi.apex.session import ApexAPIError
+from eth_defi.apex.session import ApexAPIError, create_apex_session_pool
 from eth_defi.apex.vault import (
     ApexRankingPage,
     fetch_official_vault_histories,
@@ -230,3 +230,18 @@ def test_fetch_official_vault_endpoints_use_distinct_listing_and_batch_paths() -
         ("vault/official-vaults", {}),
         ("vault/fund-net-value-batch", {"vaultIds": "10000,10001"}),
     ]
+
+
+@pytest.mark.live
+@pytest.mark.timeout(30)
+def test_live_official_vault_listing_accepts_non_paginated_total_size() -> None:
+    """Accept the live official listing despite its non-paginated ``totalSize`` value.
+
+    ApeX currently reports ``totalSize=0`` while returning its official vaults
+    in ``vaultList``. This focused integration check exercises the real HTTP
+    response and parser without writing scanner state or reading history.
+    """
+    with create_apex_session_pool(pool_maxsize=1, retries=0) as session_pool:
+        vaults = fetch_official_vaults(session_pool, operation_timeout=30)
+
+    assert {vault.vault_id for vault in vaults} >= {"10000", "10001"}


### PR DESCRIPTION
## Why

ApeX's non-paginated official-vault endpoint returns its vault rows while reporting `totalSize: 0`. Treating that field as a paginated membership invariant aborted every ApeX scan before its official liquidity-provider vaults could be exported.

## Lessons learnt

ApeX endpoint fields must be validated according to that endpoint's semantics. A live, focused parser test protects integration code where fixtures alone can diverge from the API.

## Summary

- Accept the populated official-vault listing when its non-paginated `totalSize` is zero.
- Make the fixture reproduce the live response shape.
- Add a one-request live API integration test for the official vault listing.

## Related issues and PRs

Continues #1396, which added official ApeX liquidity-provider vault discovery.

## Unrelated CI and test fixes

None.