### PR TITLE
fix: harden vault settlement preflights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 1.2
 
+- fix: Harden vault settlement diagnostics with canonical wrapped Gains redemption evidence, exact Ember operator preflights, cSigma daily pause detection and typed Morpho V2 redemption reverts (2026-07-29)
+
 - feat: Complete Anvil settlement for Ember direct payouts and Plutus role-gated redemptions, with terminal evidence, typed settlement failures and shared warm-fork coverage (2026-07-29)
 
 - feat: Export vault share-price provenance and add Lighter ownership, account snapshots and conservative net-flow metrics (2026-07-28)

--- a/docs/source/api/erc_4626/index.rst
+++ b/docs/source/api/erc_4626/index.rst
@@ -51,3 +51,4 @@ More info
    eth_defi.erc_4626.vault_protocol.accountable.deposit_redeem
    eth_defi.erc_4626.vault_protocol.accountable.settlement
    eth_defi.erc_4626.vault_protocol.csigma.deposit_redeem
+   eth_defi.erc_4626.vault_protocol.morpho.deposit_redeem

--- a/eth_defi/erc_4626/vault_protocol/csigma/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/csigma/vault.py
@@ -34,18 +34,8 @@ from eth_defi.vault.deposit_redeem import VaultDepositManager, VaultDepositManag
 
 logger = logging.getLogger(__name__)
 
-
-#: Minimal verified ``Pausable`` read for cSigma pools whose generic ERC-4626
-#: ABI does not include the inherited OpenZeppelin view.
-CSIGMA_PAUSED_ABI = [
-    {
-        "inputs": [],
-        "name": "paused",
-        "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
-        "stateMutability": "view",
-        "type": "function",
-    },
-]
+#: Seconds in cSigma's UTC day calculation.
+SECONDS_PER_DAY = 86_400
 
 
 #: cSigma V2 pool with verified synchronous ERC-4626 lifecycle support.
@@ -93,18 +83,18 @@ class CsigmaVault(ERC4626Vault):
 
     @cached_property
     def vault_contract(self) -> Contract:
-        """Bind cSuperior's verified implementation ABI to its proxy address.
+        """Bind the verified implementation ABI to known V2 pool proxies.
 
         The generic ERC-4626 interface omits cSigma custom errors and the
-        queue-state methods required by the capacity preflight. The exact V2
-        deployment therefore uses its verified implementation ABI while other
+        queue and pause-state methods required by protocol preflights. Known V2
+        deployments therefore use the verified implementation ABI while other
         cSigma deployments retain the generic binding.
 
         :return:
-            Verified cSigma V2 contract for cSuperior, otherwise the generic
-            ERC-4626 binding.
+            Verified cSigma V2 contract for known synchronous pools, otherwise
+            the generic ERC-4626 binding.
         """
-        if self.chain_id == CSIGMA_V2_POOL_CHAIN_ID and self.address.lower() == CSIGMA_V2_POOL_ADDRESS:
+        if self.chain_id == CSIGMA_V2_POOL_CHAIN_ID and self.address.lower() in CSIGMA_SYNCHRONOUS_POOL_ADDRESSES:
             return get_deployed_contract(self.web3, "csigma/CsigmaV2Pool.json", self.address)
         return super().vault_contract
 
@@ -197,19 +187,34 @@ class CsigmaVault(ERC4626Vault):
     def fetch_deposit_closed_reason(self) -> str | None:
         """Return a closure reason only when the cSigma pool is paused.
 
-        cSigma's verified pools inherit OpenZeppelin ``Pausable``. A pause is a
-        vault-wide temporary closure suitable for non-broadcast Guard
-        validation; an ordinary ``maxDeposit`` shortfall remains capacity and
-        never enters that path.
+        cSigma's verified V2 implementation inherits OpenZeppelin ``Pausable``
+        and enforces a separate configurable daily pause window. This mirrors
+        ``_requireNotInDefaultPauseWindow()`` from the `verified implementation
+        <https://etherscan.io/address/0xa5b7555775a33ca79818702f63b34b14dc9aec4d#code>`__,
+        including its inclusive, non-wrapping seconds-of-day comparison. Either
+        pause is suitable for non-broadcast Guard validation; an ordinary
+        ``maxDeposit`` shortfall remains capacity and never enters that path.
 
         :return:
             Pause reason, or ``None`` when the pool is not paused or the view
             cannot be read.
         """
-        paused_contract = self.web3.eth.contract(address=self.address, abi=CSIGMA_PAUSED_ABI)
+        if self.chain_id != CSIGMA_V2_POOL_CHAIN_ID or self.address.lower() not in CSIGMA_SYNCHRONOUS_POOL_ADDRESSES:
+            return None
+
+        pause_state_contract = self.vault_contract
         try:
-            if paused_contract.functions.paused().call():
-                return "cSigma deposits paused"
+            if pause_state_contract.functions.paused().call():
+                return "cSigma deposits paused by governance"
         except (BadFunctionCallOutput, ContractLogicError, ValueError):
             logger.debug("Could not read cSigma paused() state for %s", self.address)
+
+        try:
+            pause_start_time = int(pause_state_contract.functions.pauseStartTime().call())
+            pause_duration = int(pause_state_contract.functions.pauseDuration().call())
+            current_second = int(self.web3.eth.get_block("latest")["timestamp"]) % SECONDS_PER_DAY
+            if pause_start_time <= current_second <= pause_start_time + pause_duration:
+                return "cSigma deposits paused during daily window"
+        except (BadFunctionCallOutput, ContractLogicError, ValueError):
+            logger.debug("Could not read cSigma daily pause window for %s", self.address)
         return None

--- a/eth_defi/erc_4626/vault_protocol/ember/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/ember/deposit_redeem.py
@@ -18,6 +18,7 @@ from hexbytes import HexBytes
 from web3 import Web3
 from web3._utils.events import EventLogErrorFlags
 from web3.contract.contract import ContractFunction
+from web3.exceptions import ContractLogicError
 
 from eth_defi.abi import ZERO_ADDRESS_STR, get_topic_signature_from_event
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager, ERC4626DepositRequest
@@ -38,6 +39,7 @@ from eth_defi.vault.deposit_redeem import (
     VaultFlowUnavailable,
     VaultForcedSettlementResult,
     create_synchronous_settlement_result,
+    extract_revert_data,
 )
 from eth_defi.vault.flow_events import (
     PendingVaultFlow,
@@ -50,6 +52,10 @@ from eth_defi.vault.flow_events import (
 
 if TYPE_CHECKING:
     from eth_defi.erc_4626.vault_protocol.ember.vault import EmberVault
+
+
+#: ``InsufficientBalance()`` from Ember's operator withdrawal processor.
+EMBER_INSUFFICIENT_BALANCE_SELECTOR = HexBytes("0xf4d678b8")
 
 
 @dataclass(slots=True)
@@ -558,11 +564,32 @@ class EmberDepositManager(ERC4626DepositManager):
 
         pending_index = self.fetch_pending_withdrawal_index(ticket)
         denomination_token = self.vault.denomination_token
+        process_withdrawals = self.vault.vault_contract.functions.processWithdrawalRequests(pending_index + 1)
+        try:
+            process_withdrawals.call({"from": operator})
+        except (ContractLogicError, ValueError) as error:
+            revert_data = extract_revert_data(error)
+            if revert_data is None or revert_data[:4] != EMBER_INSUFFICIENT_BALANCE_SELECTOR:
+                raise UnsupportedVaultSimulation(
+                    f"Ember operator preflight reverted for request {ticket.get_request_id()}: {error}",
+                    unsupported_reason="ember_operator_processing_not_reproducible",
+                    protocol=self.vault.get_protocol_name(),
+                    vault_address=self.vault.address,
+                    direction="redeem",
+                ) from error
+            raise UnsupportedVaultSimulation(
+                f"Ember operator lacks denomination-token liquidity to process queue through request {ticket.get_request_id()}",
+                unsupported_reason="ember_operator_insufficient_liquidity",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            ) from error
+
         balance_before = denomination_token.fetch_raw_balance_of(ticket.to)
         make_anvil_custom_rpc_request(self.web3, "anvil_impersonateAccount", [operator])
         try:
             make_anvil_custom_rpc_request(self.web3, "anvil_setBalance", [operator, hex(10**18)])
-            tx_hash = HexBytes(self.vault.vault_contract.functions.processWithdrawalRequests(pending_index + 1).transact({"from": operator, "gas": 1_000_000}))
+            tx_hash = HexBytes(process_withdrawals.transact({"from": operator, "gas": 1_000_000}))
             assert_transaction_success_with_explanation(self.web3, tx_hash)
         finally:
             make_anvil_custom_rpc_request(self.web3, "anvil_stopImpersonatingAccount", [operator])

--- a/eth_defi/erc_4626/vault_protocol/gains/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/gains/deposit_redeem.py
@@ -18,6 +18,7 @@ from web3.contract.contract import ContractFunction
 from eth_defi.abi import get_topic_signature_from_event
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
 from eth_defi.provider.anvil import is_anvil
+from eth_defi.revert_reason import fetch_transaction_revert_reason
 from eth_defi.timestamp import get_block_timestamp
 from eth_defi.utils import from_unix_timestamp
 from eth_defi.vault.deposit_redeem import (
@@ -310,6 +311,78 @@ class GainsDepositManager(ERC4626DepositManager):
             redemption_ticket.raw_shares,
             redemption_ticket.to,
             redemption_ticket.owner,
+        )
+
+    def analyse_redemption(
+        self,
+        claim_tx_hash: HexBytes | str,
+        redemption_ticket: RedemptionTicket | None,
+    ) -> DepositRedeemEventAnalysis | DepositRedeemEventFailure:
+        """Analyse a Gains claim independently of its outer transaction wrapper.
+
+        Lagoon and other guarded vaults submit the claim through a module, so
+        the outer transaction target is neither the Gains vault nor the share
+        owner. The protocol's canonical ``Withdraw`` event is the authoritative
+        evidence: it must originate from this Gains vault and match the persisted
+        ticket owner, receiver and share amount.
+
+        :param claim_tx_hash:
+            Mined direct, GuardV0 or Lagoon-module claim transaction.
+        :param redemption_ticket:
+            Persisted Gains request identity.
+        :return:
+            Executed redemption amounts or a structured transaction failure.
+        """
+        assert isinstance(redemption_ticket, GainsRedemptionTicket), "Gains redemption analysis requires GainsRedemptionTicket"
+        tx_hash = HexBytes(claim_tx_hash)
+        receipt = self.web3.eth.get_transaction_receipt(tx_hash)
+        if receipt["status"] != 1:
+            return DepositRedeemEventFailure(
+                tx_hash=tx_hash,
+                revert_reason=fetch_transaction_revert_reason(self.web3, tx_hash),
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+                phase="claim",
+                receipt_status=int(receipt["status"]),
+            )
+
+        logs = self.vault.vault_contract.events.Withdraw().process_receipt(receipt, errors=EventLogErrorFlags.Discard)
+        logs = [log for log in logs if log["address"].lower() == self.vault.address.lower()]
+        if len(logs) != 1:
+            return self._create_redemption_analysis_failure(tx_hash, f"Expected exactly one Gains Withdraw event from {self.vault.address}, got {logs!r}")
+
+        args = logs[0]["args"]
+        owner = Web3.to_checksum_address(args["owner"])
+        receiver = Web3.to_checksum_address(args["receiver"])
+        if owner != Web3.to_checksum_address(redemption_ticket.owner):
+            return self._create_redemption_analysis_failure(tx_hash, f"Gains Withdraw owner mismatch: {owner} != {redemption_ticket.owner}")
+        if receiver != Web3.to_checksum_address(redemption_ticket.to):
+            return self._create_redemption_analysis_failure(tx_hash, f"Gains Withdraw receiver mismatch: {receiver} != {redemption_ticket.to}")
+        if int(args["shares"]) != redemption_ticket.raw_shares:
+            return self._create_redemption_analysis_failure(tx_hash, f"Gains Withdraw shares mismatch: {args['shares']} != {redemption_ticket.raw_shares}")
+
+        block_number = int(receipt["blockNumber"])
+        return DepositRedeemEventAnalysis(
+            from_=owner,
+            to=receiver,
+            denomination_amount=self.vault.denomination_token.convert_to_decimals(int(args["assets"])),
+            share_count=self.vault.share_token.convert_to_decimals(int(args["shares"])),
+            tx_hash=tx_hash,
+            block_number=block_number,
+            block_timestamp=get_block_timestamp(self.web3, block_number),
+        )
+
+    def _create_redemption_analysis_failure(self, tx_hash: HexBytes, reason: str) -> DepositRedeemEventFailure:
+        """Create a structured failure for unexpected Gains claim evidence."""
+        return DepositRedeemEventFailure(
+            tx_hash=tx_hash,
+            revert_reason=reason,
+            protocol=self.vault.get_protocol_name(),
+            vault_address=self.vault.address,
+            direction="redeem",
+            phase="claim",
+            receipt_status=1,
         )
 
     def serialize_redemption_ticket(self, ticket: GainsRedemptionTicket) -> dict:

--- a/eth_defi/erc_4626/vault_protocol/morpho/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/deposit_redeem.py
@@ -1,0 +1,104 @@
+"""Morpho Vault V2 redemption transaction preflights.
+
+Morpho Vault V2 deliberately returns zero from its ERC-4626 maximum functions,
+so exact transaction simulation is needed to expose failures before broadcast.
+See the `official Vault V2 liquidity and ERC-4626 documentation
+<https://github.com/morpho-org/vault-v2#liquidity>`__.
+"""
+
+from decimal import Decimal
+
+from eth_typing import HexAddress
+from hexbytes import HexBytes
+from web3.exceptions import ContractLogicError
+
+from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager, ERC4626RedemptionRequest
+from eth_defi.vault.deposit_redeem import VaultFlowUnavailable, extract_revert_data
+
+#: ``TransferReverted()`` from Morpho Vault V2's ``SafeERC20Lib.safeTransfer``.
+#: The library is used for the final redemption asset payout:
+#: https://github.com/morpho-org/vault-v2/blob/main/src/libraries/SafeERC20Lib.sol
+MORPHO_V2_TRANSFER_REVERTED_SELECTOR = HexBytes("0xace2a47e")
+
+
+class MorphoV2DepositManager(ERC4626DepositManager):
+    """Simulate Morpho Vault V2 redemptions before transaction broadcast.
+
+    Morpho's maximum functions cannot advertise live availability. This manager
+    therefore retains the generic request construction and adds an ``eth_call``
+    of the exact redemption from its eventual caller.
+    """
+
+    def create_redemption_request(  # noqa: PLR0917
+        self,
+        owner: HexAddress,
+        to: HexAddress | None = None,
+        shares: Decimal | None = None,
+        raw_shares: int | None = None,
+        check_max_deposit: bool = True,  # noqa: FBT001, FBT002
+        check_enough_token: bool = True,  # noqa: FBT001, FBT002
+        check_max_redeem: bool = True,  # noqa: FBT001, FBT002
+    ) -> ERC4626RedemptionRequest:
+        """Build a redemption only when its exact call passes simulation.
+
+        Morpho Vault V2 may accept request construction even when its final
+        denomination-token payout reverts. The protocol's
+        ``SafeERC20Lib.safeTransfer`` maps that condition to
+        ``TransferReverted()``. This preflight reports the protocol error without
+        claiming whether liquidity, token policy, or another token-level
+        condition caused the transfer to revert.
+
+        :param owner:
+            Share owner and eventual redemption caller.
+        :param to:
+            Asset receiver. The generic Morpho V2 request currently requires it
+            to default to ``owner``.
+        :param shares:
+            Human-readable share amount, mutually exclusive with ``raw_shares``.
+        :param raw_shares:
+            Raw share amount, mutually exclusive with ``shares``.
+        :param check_max_deposit:
+            Compatibility argument forwarded to the generic manager.
+        :param check_enough_token:
+            Check the owner's current share balance.
+        :param check_max_redeem:
+            Compatibility argument forwarded to the generic manager.
+        :return:
+            A redemption request whose exact call completed successfully under
+            ``eth_call``.
+        :raise VaultFlowUnavailable:
+            If the exact Morpho redemption call reverts.
+        """
+        request = super().create_redemption_request(
+            owner=owner,
+            to=to,
+            shares=shares,
+            raw_shares=raw_shares,
+            check_max_deposit=check_max_deposit,
+            check_enough_token=check_enough_token,
+            check_max_redeem=check_max_redeem,
+        )
+        try:
+            request.funcs[0].call({"from": owner})
+        except (ContractLogicError, ValueError) as error:
+            revert_data = extract_revert_data(error)
+            if revert_data is None and isinstance(error, ValueError):
+                raise
+
+            selector_length = len(MORPHO_V2_TRANSFER_REVERTED_SELECTOR)
+            error_selector = revert_data[:selector_length] if revert_data and len(revert_data) >= selector_length else None
+            transfer_failed = error_selector == MORPHO_V2_TRANSFER_REVERTED_SELECTOR
+            raise VaultFlowUnavailable(
+                (f"Morpho Vault V2 redemption asset transfer failed for vault {self.vault.address} on chain {self.vault.chain_id}" if transfer_failed else f"Morpho Vault V2 redemption call reverted for vault {self.vault.address} on chain {self.vault.chain_id}"),
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                caller=owner,
+                direction="redeem",
+                phase="preflight",
+                decoded_error="TransferReverted" if transfer_failed else None,
+                preflight_result="redemption_asset_transfer_failed" if transfer_failed else "redemption_call_reverted",
+                raw_revert_data=revert_data,
+                requested_raw_amount=request.raw_shares,
+                error_selector=error_selector,
+            ) from error
+        return request

--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
@@ -27,6 +27,7 @@ from web3 import Web3
 
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
+from eth_defi.erc_4626.vault_protocol.morpho.deposit_redeem import MorphoV2DepositManager
 from eth_defi.erc_4626.vault_protocol.morpho.flag_analytics import analyze_morpho_flags
 from eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata import (
     MorphoVaultAPIResult,
@@ -219,6 +220,18 @@ class MorphoV2Vault(ERC4626Vault):
             Always ``True`` under the current operating assumption.
         """
         return True
+
+    def get_deposit_manager(self) -> MorphoV2DepositManager:
+        """Create a manager that simulates exact Morpho V2 redemptions.
+
+        Morpho V2 returns zero from its ERC-4626 maximum functions, so the
+        manager performs an exact ``eth_call`` before returning a redemption
+        request.
+
+        :return:
+            Morpho V2-specific synchronous deposit and redemption manager.
+        """
+        return MorphoV2DepositManager(self)
 
     @cached_property
     def morpho_api_result(self) -> MorphoVaultAPIResult:

--- a/eth_defi/vault/deposit_redeem.py
+++ b/eth_defi/vault/deposit_redeem.py
@@ -357,6 +357,29 @@ class VaultFlowError(Exception):
         return f"{self.reason} ({', '.join(context)})" if context else self.reason
 
 
+def extract_revert_data(error: BaseException) -> HexBytes | None:
+    """Extract raw EVM revert data from common Web3 exception shapes.
+
+    :param error:
+        Web3 exception raised by ``eth_call``.
+    :return:
+        Raw revert payload when exposed by the provider.
+    """
+    candidates = [getattr(error, "data", None)]
+    if error.args:
+        candidates.append(error.args[0])
+
+    for candidate in candidates:
+        if isinstance(candidate, dict):
+            candidate = candidate.get("data")
+        if isinstance(candidate, (bytes, str)):
+            try:
+                return HexBytes(candidate)
+            except ValueError:
+                continue
+    return None
+
+
 class VaultTransactionFailed(VaultFlowError):  # noqa: N818
     """One of vault deposit/redeem transactions reverted."""
 

--- a/tests/erc_4626/vault_protocol/test_csigma.py
+++ b/tests/erc_4626/vault_protocol/test_csigma.py
@@ -168,7 +168,8 @@ def test_csigma_daily_pause_window_is_detected_before_deposit(
         assert vault.vault_contract.functions.paused().call() is False
         assert vault.vault_contract.functions.pauseStartTime().call() == EXPECTED_CSIGMA_PAUSE_START
         assert vault.vault_contract.functions.pauseDuration().call() == EXPECTED_CSIGMA_PAUSE_DURATION
-        assert int(csigma_midnight_web3.eth.get_block("latest")["timestamp"]) % SECONDS_PER_DAY == EXPECTED_CSIGMA_PAUSE_START
+        current_second = int(csigma_midnight_web3.eth.get_block("latest")["timestamp"]) % SECONDS_PER_DAY
+        assert EXPECTED_CSIGMA_PAUSE_START <= current_second <= EXPECTED_CSIGMA_PAUSE_START + EXPECTED_CSIGMA_PAUSE_DURATION
 
         # 3. Read closure through the protocol-specific pause-window state.
         assert vault.fetch_deposit_closed_reason() == "cSigma deposits paused during daily window"

--- a/tests/erc_4626/vault_protocol/test_csigma.py
+++ b/tests/erc_4626/vault_protocol/test_csigma.py
@@ -1,9 +1,10 @@
 """Test cSigma Finance vault metadata."""
 
 import os
+from collections.abc import Iterator
 from decimal import Decimal
 from types import SimpleNamespace
-from unittest.mock import ANY, MagicMock
+from unittest.mock import MagicMock
 
 import flaky
 import pytest
@@ -13,10 +14,11 @@ from web3 import Web3
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault_protocol.csigma.deposit_redeem import CSIGMA_WITHDRAWAL_PENDING_SELECTOR, CsigmaDepositManager
-from eth_defi.erc_4626.vault_protocol.csigma.vault import CSIGMA_V2_POOL_ADDRESS, CsigmaVault
-from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil, fund_erc20_on_anvil
+from eth_defi.erc_4626.vault_protocol.csigma.vault import CSIGMA_V2_POOL_ADDRESS, SECONDS_PER_DAY, CsigmaVault
+from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil, fund_erc20_on_anvil, make_anvil_custom_rpc_request
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.testing.anvil_fork_pool import AnvilForkPool
+from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
 from eth_defi.testing.fork_blocks import ETHEREUM_MIDNIGHT_BLOCK
 from eth_defi.token import USDC_WHALE
 from eth_defi.trace import assert_transaction_success_with_explanation
@@ -29,6 +31,9 @@ JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 EXPECTED_V2_DEPOSITED_RAW_SHARES = 94_348_140
 EXPECTED_SUPQPV_DEPOSITED_RAW_SHARES = 94_445_037
 EXPECTED_CSUPERIOR_QUEUE_DUE_RAW_SHARES = 41_603_916_251
+CSIGMA_PAUSE_FORK_BLOCK = 25_598_869
+EXPECTED_CSIGMA_PAUSE_START = 0
+EXPECTED_CSIGMA_PAUSE_DURATION = 1_800
 
 pytestmark = pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests")
 
@@ -91,18 +96,93 @@ def test_csigma(
     assert vault.can_check_redeem() is False
 
 
-def test_csigma_paused_deposit_is_a_guard_validation_closure() -> None:
-    """Treat only cSigma's Pausable state as a closed-deposit fallback trigger."""
+def test_csigma_paused_deposit_is_a_guard_validation_closure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Treat cSigma's global Pausable state as a closed-deposit trigger.
+
+    The ABI loader is mocked because this unit test isolates closure semantics;
+    the production ABI binding is covered by the fixed-fork pause-window test.
+
+    1. Return a cSigma binding whose global ``paused()`` state is true.
+    2. Fetch the protocol-specific deposit closure reason.
+    3. Assert the vault reports a closed deposit without reading the daily window.
+    """
+    # 1. Return a cSigma binding whose global paused() state is true.
     paused_contract = MagicMock()
     paused_contract.functions.paused().call.return_value = True
-    web3 = SimpleNamespace(eth=SimpleNamespace(contract=MagicMock(return_value=paused_contract)))
+    web3 = SimpleNamespace()
+    monkeypatch.setattr("eth_defi.erc_4626.vault_protocol.csigma.vault.get_deployed_contract", lambda *_args: paused_contract)
     vault = object.__new__(CsigmaVault)
     vault.web3 = web3
     vault.spec = VaultSpec(chain_id=1, vault_address=CSIGMA_USD_VAULT)
 
+    # 2. Fetch the protocol-specific deposit closure reason.
     assert vault.can_check_deposit() is False
-    assert vault.fetch_deposit_closed_reason() == "cSigma deposits paused"
-    web3.eth.contract.assert_called_once_with(address=vault.address, abi=ANY)
+
+    # 3. Assert the vault reports a closed deposit without reading the daily window.
+    assert vault.fetch_deposit_closed_reason() == "cSigma deposits paused by governance"
+
+
+@pytest.fixture(scope="module")
+def csigma_midnight_fork(anvil_fork_pool: AnvilForkPool) -> AnvilLaunch:
+    """Share the production-rerun fork at cSigma's pause boundary."""
+    return anvil_fork_pool.get_launch(JSON_RPC_ETHEREUM, CSIGMA_PAUSE_FORK_BLOCK)
+
+
+@pytest.fixture(scope="module")
+def csigma_midnight_web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Connect to the cSigma production-rerun fork."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ETHEREUM, CSIGMA_PAUSE_FORK_BLOCK)
+
+
+@pytest.fixture
+def csigma_midnight_snapshot(csigma_midnight_fork: AnvilLaunch) -> Iterator[None]:
+    """Restore the pause-boundary fork after the closure test."""
+    yield from evm_snapshot_revert(csigma_midnight_fork)
+
+
+@pytest.mark.xdist_group("fork:ethereum:midnight")
+def test_csigma_daily_pause_window_is_detected_before_deposit(
+    csigma_midnight_web3: Web3,
+    csigma_midnight_snapshot: None,
+) -> None:
+    """Detect cSigma's daily pause window independently of paused().
+
+    1. Advance the fixed fork across the protocol's pause boundary.
+    2. Pin the deployed pause configuration and current second.
+    3. Read closure through the protocol-specific pause-window state.
+    4. Assert request construction returns a typed closed-deposit refusal.
+    """
+    del csigma_midnight_snapshot
+
+    # 1. Advance the fixed fork across the protocol's pause boundary.
+    make_anvil_custom_rpc_request(csigma_midnight_web3, "evm_increaseTime", [1])
+    make_anvil_custom_rpc_request(csigma_midnight_web3, "evm_mine", [])
+    for vault_address in [
+        CSIGMA_USD_VAULT,
+        "0x438982ea288763370946625fd76c2508ee1fb229",
+    ]:
+        vault = create_vault_instance_autodetect(csigma_midnight_web3, vault_address)
+        assert isinstance(vault, CsigmaVault)
+
+        # 2. Pin the deployed pause configuration and current second.
+        assert vault.vault_contract.functions.paused().call() is False
+        assert vault.vault_contract.functions.pauseStartTime().call() == EXPECTED_CSIGMA_PAUSE_START
+        assert vault.vault_contract.functions.pauseDuration().call() == EXPECTED_CSIGMA_PAUSE_DURATION
+        assert int(csigma_midnight_web3.eth.get_block("latest")["timestamp"]) % SECONDS_PER_DAY == EXPECTED_CSIGMA_PAUSE_START
+
+        # 3. Read closure through the protocol-specific pause-window state.
+        assert vault.fetch_deposit_closed_reason() == "cSigma deposits paused during daily window"
+
+        # 4. Refuse request construction before any approval or deposit transaction.
+        manager = vault.get_deposit_manager()
+        with pytest.raises(VaultFlowUnavailable) as exc_info:
+            manager.create_deposit_request(
+                owner=csigma_midnight_web3.eth.accounts[0],
+                raw_amount=1_000_000,
+                check_enough_token=False,
+            )
+        assert exc_info.value.preflight_result == "deposit_closed"
+        assert exc_info.value.available_raw_amount == 0
 
 
 @flaky.flaky
@@ -387,8 +467,8 @@ def test_csigma_usd_redemption_capacity_preflight(midnight_web3: Web3) -> None:
     ``WithdrawalPending`` onchain; the manager must refuse it before broadcast
     with a typed :class:`VaultFlowUnavailable` carrying the decoded error. This
     is verified at the current-state midnight block (the pool was not deployed
-    at the 21.9M lifecycle block, and its deposits are ``Pausable``-paused now,
-    so only the read-only capacity preflight is exercised here).
+    at the 21.9M lifecycle block, and the fixed timestamp is inside its daily
+    pause window, so only the read-only capacity preflight is exercised here).
     """
     vault = create_vault_instance_autodetect(midnight_web3, vault_address=CSIGMA_USD_VAULT)
     assert isinstance(vault, CsigmaVault)

--- a/tests/erc_4626/vault_protocol/test_ember_operator_liquidity.py
+++ b/tests/erc_4626/vault_protocol/test_ember_operator_liquidity.py
@@ -1,0 +1,91 @@
+"""Exercise Ember operator liquidity preflight failures."""
+
+import os
+from collections.abc import Iterator
+from decimal import Decimal
+
+import pytest
+from eth_typing import HexAddress
+from web3 import Web3
+
+from eth_defi.erc_4626.classification import create_vault_instance_autodetect
+from eth_defi.erc_4626.vault_protocol.ember.deposit_redeem import EmberDepositManager
+from eth_defi.erc_4626.vault_protocol.ember.vault import EmberVault
+from eth_defi.provider.anvil import AnvilLaunch, fund_erc20_on_anvil
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
+from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
+from eth_defi.trace import assert_transaction_success_with_explanation
+from eth_defi.vault.deposit_redeem import UnsupportedVaultSimulation
+
+JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
+
+EMBER_INSUFFICIENT_LIQUIDITY_VAULTS = (
+    HexAddress("0x9be9294722f8aad37b11a9792be2c782182cafa2"),
+    HexAddress("0x0b9342c15143e8f54a83f887c280a922f4c48771"),
+)
+EXPECTED_PENDING_WITHDRAWAL_INDEX = 2
+EMBER_OPERATOR_LIQUIDITY_FORK_BLOCK = 25_598_869
+
+pytestmark = [
+    pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests"),
+    pytest.mark.xdist_group("fork:ethereum:midnight"),
+]
+
+
+@pytest.fixture(scope="module")
+def ember_fork(anvil_fork_pool: AnvilForkPool) -> AnvilLaunch:
+    """Share the production-rerun fork where two Ember queues lack liquidity."""
+    return anvil_fork_pool.get_launch(JSON_RPC_ETHEREUM, EMBER_OPERATOR_LIQUIDITY_FORK_BLOCK)
+
+
+@pytest.fixture(scope="module")
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Connect to the shared Ember liquidity fork."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ETHEREUM, EMBER_OPERATOR_LIQUIDITY_FORK_BLOCK)
+
+
+@pytest.fixture
+def ember_snapshot(ember_fork: AnvilLaunch) -> Iterator[None]:
+    """Restore the shared fork after each affected Ember vault."""
+    yield from evm_snapshot_revert(ember_fork)
+
+
+@pytest.mark.parametrize("vault_address", EMBER_INSUFFICIENT_LIQUIDITY_VAULTS)
+def test_ember_operator_liquidity_refusal_is_typed(
+    web3: Web3,
+    vault_address: HexAddress,
+    ember_snapshot: None,
+) -> None:
+    """Return a stable refusal before the operator broadcasts an unfunded queue.
+
+    1. Deposit into an affected Ember vault at the production-rerun block.
+    2. Queue all newly minted shares behind the existing FIFO requests.
+    3. Assert settlement reports insufficient operator liquidity without mining
+       a reverted processing transaction.
+    """
+    del ember_snapshot
+
+    # 1. Deposit into an affected Ember vault at the production-rerun block.
+    vault = create_vault_instance_autodetect(web3, vault_address)
+    assert isinstance(vault, EmberVault)
+    manager = vault.get_deposit_manager()
+    assert isinstance(manager, EmberDepositManager)
+    owner = web3.eth.accounts[0]
+    amount = Decimal(1001)
+    fund_erc20_on_anvil(web3, vault.denomination_token.address, owner, vault.denomination_token.convert_to_raw(amount))
+    approval_hash = vault.denomination_token.approve(vault.address, amount).transact({"from": owner})
+    assert_transaction_success_with_explanation(web3, approval_hash)
+    manager.create_deposit_request(owner=owner, amount=amount).broadcast(from_=owner)
+
+    # 2. Queue all newly minted shares behind the existing FIFO requests.
+    raw_shares = vault.share_token.fetch_raw_balance_of(owner)
+    ticket = manager.create_redemption_request(owner=owner, raw_shares=raw_shares).broadcast(from_=owner)
+    assert manager.fetch_pending_withdrawal_index(ticket) == EXPECTED_PENDING_WITHDRAWAL_INDEX
+
+    # 3. Refuse before broadcasting the operator transaction.
+    block_before = web3.eth.block_number
+    with pytest.raises(UnsupportedVaultSimulation) as exc_info:
+        manager.force_settle(ticket)
+    assert exc_info.value.unsupported_reason == "ember_operator_insufficient_liquidity"
+    assert exc_info.value.direction == "redeem"
+    assert web3.eth.block_number == block_before

--- a/tests/erc_4626/vault_protocol/test_morpho_v2_redemption.py
+++ b/tests/erc_4626/vault_protocol/test_morpho_v2_redemption.py
@@ -1,0 +1,85 @@
+"""Exercise Morpho Vault V2 redemption transfer preflights."""
+
+import os
+from collections.abc import Iterator
+from decimal import Decimal
+
+import pytest
+from web3 import Web3
+
+from eth_defi.erc_4626.classification import create_vault_instance_autodetect
+from eth_defi.erc_4626.vault_protocol.morpho.deposit_redeem import MORPHO_V2_TRANSFER_REVERTED_SELECTOR, MorphoV2DepositManager
+from eth_defi.erc_4626.vault_protocol.morpho.vault_v2 import MorphoV2Vault
+from eth_defi.provider.anvil import AnvilLaunch, fund_erc20_on_anvil, make_anvil_custom_rpc_request
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
+from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
+from eth_defi.trace import assert_transaction_success_with_explanation
+from eth_defi.vault.deposit_redeem import VaultFlowUnavailable
+
+JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
+APYX_USDC_VAULT = "0x069662d2588fcac24b5c209456db965d151556f0"
+MORPHO_V2_REDEMPTION_FORK_BLOCK = 25_598_869
+
+pytestmark = [
+    pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests"),
+    pytest.mark.xdist_group("fork:ethereum:midnight"),
+]
+
+
+@pytest.fixture(scope="module")
+def morpho_v2_fork(anvil_fork_pool: AnvilForkPool) -> AnvilLaunch:
+    """Share the production-rerun fork where Apyx redemption payout fails."""
+    return anvil_fork_pool.get_launch(JSON_RPC_ETHEREUM, MORPHO_V2_REDEMPTION_FORK_BLOCK)
+
+
+@pytest.fixture(scope="module")
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Connect to the production-rerun Morpho V2 fork."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ETHEREUM, MORPHO_V2_REDEMPTION_FORK_BLOCK)
+
+
+@pytest.fixture
+def morpho_v2_snapshot(morpho_v2_fork: AnvilLaunch) -> Iterator[None]:
+    """Restore the shared fork after the redemption preflight test."""
+    yield from evm_snapshot_revert(morpho_v2_fork)
+
+
+def test_morpho_v2_transfer_revert_is_a_typed_transfer_refusal(web3: Web3, morpho_v2_snapshot: None) -> None:
+    """Map Apyx's final asset-transfer failure before broadcasting redemption.
+
+    1. Deposit into Apyx immediately before the observed failure boundary.
+    2. Advance the fork into the failing redemption state.
+    3. Assert exact-call redemption simulation returns typed liquidity evidence
+       without mining a reverted redemption transaction.
+    """
+    del morpho_v2_snapshot
+
+    # 1. Deposit into Apyx immediately before the observed failure boundary.
+    vault = create_vault_instance_autodetect(web3, APYX_USDC_VAULT)
+    assert isinstance(vault, MorphoV2Vault)
+    manager = vault.get_deposit_manager()
+    assert isinstance(manager, MorphoV2DepositManager)
+    owner = web3.eth.accounts[0]
+    amount = Decimal(1001)
+    raw_amount = vault.denomination_token.convert_to_raw(amount)
+    fund_erc20_on_anvil(web3, vault.denomination_token.address, owner, raw_amount)
+    approval_hash = vault.denomination_token.contract.functions.approve(vault.address, raw_amount).transact({"from": owner})
+    assert_transaction_success_with_explanation(web3, approval_hash)
+    manager.create_deposit_request(owner=owner, raw_amount=raw_amount).broadcast(from_=owner)
+    raw_shares = vault.share_token.fetch_raw_balance_of(owner)
+
+    # 2. Advance the fork into the failing redemption state.
+    make_anvil_custom_rpc_request(web3, "evm_increaseTime", [1])
+    make_anvil_custom_rpc_request(web3, "evm_mine", [])
+
+    # 3. Return typed evidence without mining a reverted redemption transaction.
+    block_before = web3.eth.block_number
+    with pytest.raises(VaultFlowUnavailable) as exc_info:
+        manager.create_redemption_request(owner=owner, raw_shares=raw_shares)
+    error = exc_info.value
+    assert error.decoded_error == "TransferReverted"
+    assert error.preflight_result == "redemption_asset_transfer_failed"
+    assert error.error_selector == MORPHO_V2_TRANSFER_REVERTED_SELECTOR
+    assert error.raw_revert_data[:4] == MORPHO_V2_TRANSFER_REVERTED_SELECTOR
+    assert error.requested_raw_amount == raw_shares
+    assert web3.eth.block_number == block_before

--- a/tests/guard/test_guard_simple_vault_plutus.py
+++ b/tests/guard/test_guard_simple_vault_plutus.py
@@ -2,21 +2,27 @@
 
 import os
 from collections.abc import Iterator
+from decimal import Decimal
 
 import pytest
 from eth_typing import HexAddress
+from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract import Contract
+from web3.contract.contract import ContractFunction
 
 from eth_defi.abi import get_deployed_contract
 from eth_defi.deploy import GUARD_LIBRARIES, deploy_contract
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
+from eth_defi.erc_4626.vault_protocol.plutus.deposit_redeem import PlutusAsyncDepositManager, PlutusRedemptionTicket
 from eth_defi.erc_4626.vault_protocol.plutus.vault import PlutusVault
+from eth_defi.provider.anvil import AnvilLaunch, fund_erc20_on_anvil
 from eth_defi.simple_vault.transact import encode_simple_vault_transaction
 from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
 from eth_defi.testing.fork_blocks import ARBITRUM_MIDNIGHT_BLOCK
 from eth_defi.trace import TransactionAssertionError, assert_transaction_success_with_explanation
+from eth_defi.vault.deposit_redeem import AsyncVaultRequestStatus
 
 JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
 
@@ -30,7 +36,7 @@ pytestmark = [
 
 
 @pytest.fixture(scope="module")
-def plutus_anvil_fork(anvil_fork_pool: AnvilForkPool):
+def plutus_anvil_fork(anvil_fork_pool: AnvilForkPool) -> AnvilLaunch:
     """Return the shared Arbitrum fork for ERC-7540 guard tests."""
     return anvil_fork_pool.get_launch(JSON_RPC_ARBITRUM, ARBITRUM_MIDNIGHT_BLOCK)
 
@@ -42,7 +48,7 @@ def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
 
 
 @pytest.fixture(autouse=True)
-def _evm_snapshot(plutus_anvil_fork) -> Iterator[None]:
+def _evm_snapshot(plutus_anvil_fork: AnvilLaunch) -> Iterator[None]:
     """Revert every guard configuration and deployment before the next test."""
     yield from evm_snapshot_revert(plutus_anvil_fork)
 
@@ -67,6 +73,79 @@ def guarded_simple_vault(web3: Web3, plutus_vault: PlutusVault) -> tuple[Contrac
     whitelist_hash = guard.functions.whitelistERC4626(plutus_vault.address, "Allow Plutus ERC-7540").transact({"from": deployer})
     assert_transaction_success_with_explanation(web3, whitelist_hash)
     return simple_vault, asset_manager
+
+
+def _perform_guarded_call(
+    web3: Web3,
+    simple_vault: Contract,
+    asset_manager: HexAddress,
+    func: ContractFunction,
+) -> HexBytes:
+    """Execute one Plutus manager call through SimpleVaultV0 and GuardV0.
+
+    The helper retains the production call path so every lifecycle phase is
+    checked by GuardV0 before the SimpleVault forwards it.
+
+    :param web3:
+        Arbitrum fork connection.
+    :param simple_vault:
+        Guarded contract that owns the Plutus position.
+    :param asset_manager:
+        Authorised SimpleVault transaction sender.
+    :param func:
+        Bound Plutus or token function to forward.
+    :return:
+        Successful guarded transaction hash.
+    """
+    target, call_data = encode_simple_vault_transaction(func)
+    tx_hash = simple_vault.functions.performCall(target, call_data).transact({"from": asset_manager, "gas": 2_000_000})
+    assert_transaction_success_with_explanation(web3, tx_hash)
+    return HexBytes(tx_hash)
+
+
+def test_guarded_plutus_fulfilment_and_claim_lifecycle(
+    web3: Web3,
+    plutus_vault: PlutusVault,
+    guarded_simple_vault: tuple[Contract, HexAddress],
+) -> None:
+    """Prove Plutus fulfilment and claim when a guarded contract owns shares.
+
+    1. Fund SimpleVaultV0 and deposit into Plutus through GuardV0.
+    2. Request redemption and fulfil it with the discovered active operator.
+    3. Claim through GuardV0 and verify the denomination-token payout.
+    """
+    simple_vault, asset_manager = guarded_simple_vault
+    manager = plutus_vault.get_deposit_manager()
+    assert isinstance(manager, PlutusAsyncDepositManager)
+    amount = Decimal(100)
+    raw_amount = plutus_vault.denomination_token.convert_to_raw(amount)
+
+    # 1. Fund SimpleVaultV0 and deposit into Plutus through GuardV0.
+    fund_erc20_on_anvil(web3, plutus_vault.denomination_token.address, simple_vault.address, raw_amount)
+    approval = plutus_vault.denomination_token.contract.functions.approve(plutus_vault.address, raw_amount)
+    _perform_guarded_call(web3, simple_vault, asset_manager, approval)
+    deposit_request = manager.create_deposit_request(owner=simple_vault.address, raw_amount=raw_amount)
+    _perform_guarded_call(web3, simple_vault, asset_manager, deposit_request.funcs[0])
+    raw_shares = plutus_vault.share_token.fetch_raw_balance_of(simple_vault.address)
+
+    # 2. Request redemption and fulfil it with the discovered active operator.
+    redemption_request = manager.create_redemption_request(owner=simple_vault.address, raw_shares=raw_shares)
+    request_hash = _perform_guarded_call(web3, simple_vault, asset_manager, redemption_request.funcs[0])
+    ticket = redemption_request.parse_redeem_transaction([request_hash])
+    assert isinstance(ticket, PlutusRedemptionTicket)
+    assert manager.get_redemption_request_status(ticket) is AsyncVaultRequestStatus.pending
+    settlement = manager.force_settle(ticket)
+    assert settlement.status_after is AsyncVaultRequestStatus.claimable
+
+    # 3. Claim through GuardV0 and verify the denomination-token payout.
+    balance_before = plutus_vault.denomination_token.fetch_raw_balance_of(simple_vault.address)
+    claim_hash = _perform_guarded_call(web3, simple_vault, asset_manager, manager.finish_redemption(ticket))
+    assert web3.eth.get_transaction_receipt(claim_hash)["status"] == 1
+    balance_after = plutus_vault.denomination_token.fetch_raw_balance_of(simple_vault.address)
+    assert raw_shares == 79_007_315
+    assert balance_before == 0
+    assert balance_after == 99_999_999
+    assert manager.get_redemption_request_status(ticket) is AsyncVaultRequestStatus.none
 
 
 @pytest.mark.parametrize(

--- a/tests/lagoon/test_lagoon_gains.py
+++ b/tests/lagoon/test_lagoon_gains.py
@@ -1,54 +1,61 @@
 """Lagoon deposit/withdrawal from other ERC-7540 vaults tests."""
 
 import os
+from collections.abc import Iterator
 from decimal import Decimal
 
 import pytest
 from eth_typing import HexAddress
 from web3 import Web3
-import flaky
 
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.vault_protocol.gains.testing import force_next_gains_epoch
 from eth_defi.erc_4626.vault_protocol.gains.vault import GainsVault
-from eth_defi.hotwallet import HotWallet
 from eth_defi.erc_4626.vault_protocol.lagoon.deployment import LagoonDeploymentParameters, deploy_automated_lagoon_vault
-from eth_defi.provider.anvil import mine, fork_network_anvil, AnvilLaunch
+from eth_defi.hotwallet import HotWallet
+from eth_defi.provider.anvil import AnvilLaunch
 from eth_defi.provider.multi_provider import create_multi_provider_web3
-from eth_defi.token import TokenDetails, USDC_NATIVE_TOKEN, USDC_WHALE, fetch_erc20_details
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
+from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
+from eth_defi.token import USDC_NATIVE_TOKEN, USDC_WHALE, TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
 
 JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
+FORK_BLOCK = 375_216_652
 
 CI = os.environ.get("CI") == "true"
 
+pytestmark = [
+    pytest.mark.skipif(JSON_RPC_ARBITRUM is None, reason="JSON_RPC_ARBITRUM needed to run this test"),
+    pytest.mark.xdist_group("fork:arbitrum:375216652"),
+]
 
-@pytest.fixture()
-def anvil_arbitrum_fork(request, asset_manager) -> AnvilLaunch:
-    """Reset write state between tests"""
 
-    usdc_whale = USDC_WHALE[42161]
-
-    launch = fork_network_anvil(
+@pytest.fixture(scope="module")
+def anvil_arbitrum_fork(anvil_fork_pool: AnvilForkPool, asset_manager: HexAddress) -> AnvilLaunch:
+    """Share the fixed Arbitrum fork required by the historical Gains epoch."""
+    return anvil_fork_pool.get_launch(
         JSON_RPC_ARBITRUM,
-        fork_block_number=375_216_652,
-        unlocked_addresses=[usdc_whale, asset_manager],
+        FORK_BLOCK,
+        unlocked_addresses=[USDC_WHALE[42161], asset_manager],
     )
-    try:
-        yield launch
-    finally:
-        # Wind down Anvil process after the test is complete
-        launch.close()
 
 
-@pytest.fixture()
-def web3(anvil_arbitrum_fork):
-    web3 = create_multi_provider_web3(anvil_arbitrum_fork.json_rpc_url)
-    return web3
+@pytest.fixture
+def web3(anvil_arbitrum_fork: AnvilLaunch) -> Web3:
+    """Connect to the fixed Arbitrum Gains fork."""
+    return create_multi_provider_web3(anvil_arbitrum_fork.json_rpc_url)
 
 
-@pytest.fixture()
-def topped_up_asset_manager(web3, asset_manager) -> HexAddress:
+@pytest.fixture(autouse=True)
+def _evm_snapshot(anvil_arbitrum_fork: AnvilLaunch) -> Iterator[None]:
+    """Restore the historical Gains fork after the lifecycle test."""
+    yield from evm_snapshot_revert(anvil_arbitrum_fork)
+
+
+@pytest.fixture
+def topped_up_asset_manager(web3: Web3, asset_manager: HexAddress) -> HexAddress:
+    """Fund the Lagoon asset manager with native gas tokens."""
     # Topped up with some ETH
     tx_hash = web3.eth.send_transaction(
         {
@@ -61,26 +68,26 @@ def topped_up_asset_manager(web3, asset_manager) -> HexAddress:
     return asset_manager
 
 
-@pytest.fixture()
-def usdc(web3) -> TokenDetails:
-    usdc = fetch_erc20_details(
+@pytest.fixture
+def usdc(web3: Web3) -> TokenDetails:
+    """Open native Arbitrum USDC."""
+    return fetch_erc20_details(
         web3,
         USDC_NATIVE_TOKEN[42161],
     )
-    return usdc
 
 
 @pytest.fixture
-def gains_vault(web3) -> GainsVault:
-    """gTrade USDC vault on Arbitrum"""
+def gains_vault(web3: Web3) -> GainsVault:
+    """Open the gTrade USDC vault on Arbitrum."""
     vault_address = "0xd3443ee1e91af28e5fb858fbd0d72a63ba8046e0"
     vault = create_vault_instance_autodetect(web3, vault_address)
     assert isinstance(vault, GainsVault)
     return vault
 
 
-@pytest.fixture()
-def new_depositor(web3, usdc) -> HexAddress:
+@pytest.fixture
+def new_depositor(web3: Web3, usdc: TokenDetails) -> HexAddress:
     """User with some USDC ready to deposit.
 
     - Start with 500 USDC
@@ -92,7 +99,6 @@ def new_depositor(web3, usdc) -> HexAddress:
     return new_depositor
 
 
-#
 @pytest.mark.skipif(CI, reason="Too Flaky on CI because of RPC issues with Anvil")
 def test_lagoon_gains(
     web3: Web3,
@@ -103,18 +109,18 @@ def test_lagoon_gains(
     multisig_owners: list[HexAddress],
     new_depositor: HexAddress,
     asset_manager: HexAddress,
-):
-    """Perform a deposit/withdrawal into another ERC-7540 vault from Lagoon vault.
+) -> None:
+    """Exercise a Gains deposit and redemption owned by a Lagoon Safe.
 
-
-    - Check TradingStrategyModuleV0 is configured and guard are working
-
+    1. Deploy a Lagoon vault whose GuardV0 allows the Gains vault.
+    2. Deposit USDC into Lagoon and settle its deposit queue.
+    3. Deposit Lagoon's USDC into Gains through its strategy module.
+    4. Request redemption through the same guarded module.
+    5. Advance Gains epochs until the request is claimable.
+    6. Claim through the module and analyse the canonical Gains event.
     """
 
-    #
     # 1. Deploy new Lagoon vault where the target vault is whitelisted on the guard
-    #
-
     chain_id = web3.eth.chain_id
     asset_manager = topped_up_asset_manager
     assert asset_manager.startswith("0x")
@@ -142,10 +148,7 @@ def test_lagoon_gains(
         use_forge=True,
     )
 
-    #
-    # 2. Fund our vault
-    #
-
+    # 2. Deposit USDC into Lagoon and settle its deposit queue.
     vault = deploy_info.vault
     our_address = vault.safe_address
     assert not vault.trading_strategy_module.functions.anyAsset().call()
@@ -156,10 +159,11 @@ def test_lagoon_gains(
     assert_transaction_success_with_explanation(web3, tx_hash)
 
     # Deposit 9.00 USDC into the vault
-    usdc_amount = 9 * 10**6
-    tx_hash = usdc.contract.functions.approve(vault.address, usdc_amount).transact({"from": depositor})
+    lagoon_deposit_amount = Decimal(9)
+    raw_lagoon_deposit_amount = usdc.convert_to_raw(lagoon_deposit_amount)
+    tx_hash = usdc.approve(vault.address, lagoon_deposit_amount).transact({"from": depositor})
     assert_transaction_success_with_explanation(web3, tx_hash)
-    deposit_func = vault.request_deposit(depositor, usdc_amount)
+    deposit_func = vault.request_deposit(depositor, raw_lagoon_deposit_amount)
     tx_hash = deposit_func.transact({"from": depositor})
     assert_transaction_success_with_explanation(web3, tx_hash)
 
@@ -184,20 +188,15 @@ def test_lagoon_gains(
         tracing=True,
     )
 
-    #
-    # 3. Deposit into the target vault
-    #
-
+    # 3. Deposit Lagoon's USDC into Gains through its strategy module.
     deposit_manager = target_vault.deposit_manager
 
     assert deposit_manager.can_create_deposit_request(our_address)
 
     # Request deposit to the target vault from our vault
-    usdc_amount = Decimal(9)
-
-    deposit_request = deposit_manager.create_deposit_request(our_address, amount=usdc_amount)
+    deposit_request = deposit_manager.create_deposit_request(our_address, amount=lagoon_deposit_amount)
     fn_calls = [
-        usdc.approve(target_vault.vault_address, usdc_amount),
+        usdc.approve(target_vault.vault_address, lagoon_deposit_amount),
         deposit_request.funcs[0],
     ]
     for fn_call in fn_calls:
@@ -208,21 +207,13 @@ def test_lagoon_gains(
     # We got our shares
     share_token = target_vault.share_token
     share_amount = share_token.fetch_balance_of(our_address)
-    assert share_amount > 0
 
-    #
-    #
-    #
-
-    # 0. Clear epoch
+    # 4. Request redemption through the same guarded module.
+    # Clear the current epoch before opening the request.
     force_next_gains_epoch(
         target_vault,
         asset_manager,
     )
-
-    #
-    # 5. Request redeem
-    #
 
     assert deposit_manager.can_create_redemption_request(our_address)
 
@@ -231,7 +222,7 @@ def test_lagoon_gains(
         shares=share_amount,
     )
     fn_calls = [
-        share_token.approve(target_vault.vault_address, usdc_amount),
+        share_token.approve(target_vault.vault_address, share_amount),
         redeem_request.funcs[0],
     ]
     for fn_call in fn_calls:
@@ -244,8 +235,8 @@ def test_lagoon_gains(
     # Cannot redeem yet, need to wait for the next epoch
     assert deposit_manager.can_finish_redeem(redemption_ticket) is False
 
-    # 3. Move forward few epochs where our request unlocks
-    for i in range(0, 3):
+    # 5. Advance Gains epochs until the request is claimable.
+    for _ in range(3):
         force_next_gains_epoch(
             target_vault,
             asset_manager,
@@ -253,14 +244,22 @@ def test_lagoon_gains(
 
     assert target_vault.fetch_current_epoch() >= 200
 
-    # Cannot redeem yet, need to wait for the next epoch
     assert deposit_manager.can_finish_redeem(redemption_ticket) is True
-    #
-    # 7. Finish redeem
-    #
 
+    # 6. Claim through the module and analyse the canonical Gains event.
     fn_calls = [deposit_manager.finish_redemption(redemption_ticket)]
     for fn_call in fn_calls:
         moduled_tx = vault.transact_via_trading_strategy_module(fn_call)
         tx_hash = moduled_tx.transact({"from": asset_manager, "gas": 1_000_000})
         assert_transaction_success_with_explanation(web3, tx_hash, func=fn_call)
+
+    # The outer target is Lagoon's module, while the Gains event identifies the
+    # Safe owner and receiver. Analysis must not confuse these addresses.
+    assert web3.eth.get_transaction(tx_hash)["to"] == vault.trading_strategy_module.address
+    assert vault.trading_strategy_module.address != redemption_ticket.owner
+    redemption_analysis = deposit_manager.analyse_redemption(tx_hash, redemption_ticket)
+    assert redemption_analysis.from_ == redemption_ticket.owner
+    assert redemption_analysis.to == redemption_ticket.to
+    assert share_amount == Decimal("7.338782")
+    assert redemption_analysis.share_count == Decimal("7.338782")
+    assert redemption_analysis.denomination_amount == Decimal("8.999999")

--- a/tests/vault/test_deposit_redeem.py
+++ b/tests/vault/test_deposit_redeem.py
@@ -11,11 +11,25 @@ from eth_defi.vault.deposit_redeem import (
     VaultFlowUnavailable,
     VaultForcedSettlementResult,
     create_synchronous_settlement_result,
+    extract_revert_data,
 )
 
 REQUESTED_RAW_AMOUNT = 101
 AVAILABLE_RAW_AMOUNT = 100
 ACCESS_DELAY = 3600
+
+
+def test_extract_revert_data_from_web3_exception_shapes() -> None:
+    """Normalise provider-specific EVM revert payload locations.
+
+    1. Extract a revert payload exposed through an exception ``data`` mapping.
+    2. Return no payload for an ordinary exception without EVM data.
+    """
+    # 1. Extract a revert payload exposed through an exception data mapping.
+    assert extract_revert_data(ValueError({"data": "0xace2a47e"})) == HexBytes("0xace2a47e")
+
+    # 2. Return no payload for an ordinary exception without EVM data.
+    assert extract_revert_data(ValueError("ordinary error")) is None
 
 
 def test_vault_flow_unavailable_preserves_context() -> None:


### PR DESCRIPTION
## Why

The production vault simulation rerun exposed protocol-specific cases that the generic ERC-4626 path could not classify reliably:

- Gains claims submitted through Lagoon modules could not be analysed from the outer transaction target.
- Ember operator processing reverted when the vault could not fund the exact FIFO prefix.
- cSigma's daily pause window was not represented by its generic ERC-4626 binding.
- Morpho Vault V2 reports zero ERC-4626 maxima and can still reject the exact redemption call.
- Plutus needed guarded contract-owner evidence for fulfilment and claim.

These gaps produced raw reverts or incomplete evidence instead of stable results that downstream vault-universe tooling can consume.

## Lessons learnt

- The canonical protocol event is the authority for a wrapped Gains claim; the outer transaction target may be a Safe module.
- Ember queue settlement must be simulated through the exact operator call. Request-time estimates do not capture current rates, cancellation, blacklist or fee behaviour.
- cSigma's verified implementation uses an inclusive, non-wrapping seconds-of-day pause condition. The adapter must mirror the deployed Solidity rather than normalising it into a different window model.
- Morpho's `TransferReverted()` proves that the final denomination-token transfer failed, but does not identify liquidity as the root cause.
- Revert selectors must be compared against the first four bytes of provider-supplied revert data, not searched as substrings in exception text.

## Summary

- Analyse Gains redemption claims from the vault's canonical `Withdraw` event and return structured failures for mismatched evidence.
- Preflight Ember settlement with the exact operator `processWithdrawalRequests()` call and expose a typed insufficient-liquidity reason.
- Reuse the verified cSigma V2 ABI for known deployments and distinguish governance pauses from the deployed daily pause window.
- Add a Morpho V2 manager that exact-simulates redemptions and preserves known and unknown revert payloads as typed preflight results.
- Add a shared Web3 revert-data extractor.
- Extend fixed-fork coverage for wrapped Gains claims, Ember operator failures, Morpho V2 transfer failures, cSigma pause state and guarded Plutus fulfilment and claim.
- Add the Morpho manager to the API documentation and record the change in the changelog.

## Related issues and PRs

- Continues #1406.
- Supports tradingstrategy-ai/trade-executor#1584.
