### PR TITLE
notes: blacklist Mainstreet Finance and Altura vaults

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -801,6 +801,10 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0xe3ba8f17fe581dd473e6699cfad04502998a57c7": (VaultFlag.malicious, MALICIOUS_VAULT),
     # Mainstreet USDC (msUSDC, Morpho on Ethereum)
     "0xad755c6c31515aef8d2f830767d846774f7e9ea9": (VaultFlag.malicious, MALICIOUS_VAULT),
+    # Staked msUSD, Ethereum
+    "0x890a5122aa1da30fec4286de7904ff808f0bd74a": (None, MAINST_VAULT),
+    # Staked msUSD, Sonic
+    "0xc7990369da608c2f4903715e3bd22f2970536c29": (None, MAINST_VAULT),
     # Altura Vault Tokens (AVLT) on Hyperliquid
     "0xd0ee0cf300dfb598270cd7f4d0c6e0d8f6e13f29": (VaultFlag.controversial, CONTROVERSIAL_VAULT),
 }

--- a/eth_defi/vault/risk.py
+++ b/eth_defi/vault/risk.py
@@ -167,7 +167,7 @@ VAULT_PROTOCOL_RISK_MATRIX = {
     "Royco": None,
     "ETH Strategy": VaultTechnicalRisk.low,
     "Yuzu Money": VaultTechnicalRisk.low,
-    "Altura": VaultTechnicalRisk.severe,
+    "Altura": VaultTechnicalRisk.blacklisted,
     "Spectra": VaultTechnicalRisk.low,
     "Gearbox": VaultTechnicalRisk.low,
     # Mainstreet Finance vaults are blacklisted due to a reported scam.

--- a/eth_defi/vault/risk.py
+++ b/eth_defi/vault/risk.py
@@ -170,7 +170,8 @@ VAULT_PROTOCOL_RISK_MATRIX = {
     "Altura": VaultTechnicalRisk.severe,
     "Spectra": VaultTechnicalRisk.low,
     "Gearbox": VaultTechnicalRisk.low,
-    "Mainstreet Finance": None,
+    # Mainstreet Finance vaults are blacklisted due to a reported scam.
+    "Mainstreet Finance": VaultTechnicalRisk.blacklisted,
     "YieldFi": None,
     "Resolv": None,
     "Curvance": None,

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -110,6 +110,11 @@ def test_mainstreet_finance_vaults_are_blacklisted(address: str) -> None:
     assert get_notes(address) == "Main Street Market related products were wiped out in Oct 10th event https://x.com/Main_St_Finance/status/1976972055951147194"
 
 
+def test_altura_vaults_are_blacklisted() -> None:
+    """All Altura vaults are hard-blacklisted."""
+    assert get_vault_risk("Altura") == VaultTechnicalRisk.blacklisted
+
+
 def test_old_mainnet_out_of_gas_contract_is_skipped_by_multicall_blacklist() -> None:
     """Old mainnet contracts that poison Multicall3 batches are skipped."""
     address = "0xffaa9f9aa5e4361f552bada90dcacdd08e5b41eb"

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -95,6 +95,21 @@ def test_multicall_out_of_gas_vault_is_blacklisted(address: str) -> None:
     assert address in BROKEN_VAULT_CONTRACTS
 
 
+@pytest.mark.parametrize(
+    "address",
+    [
+        "0x890a5122aa1da30fec4286de7904ff808f0bd74a",
+        "0xc7990369da608c2f4903715e3bd22f2970536c29",
+    ],
+)
+def test_mainstreet_finance_vaults_are_blacklisted(address: str) -> None:
+    """Mainstreet Finance vaults are blacklisted due to a reported scam."""
+    assert get_vault_risk("Mainstreet Finance") == VaultTechnicalRisk.blacklisted
+    assert get_vault_risk("Mainstreet Finance", address) == VaultTechnicalRisk.blacklisted
+    assert get_vault_special_flags(address) == set()
+    assert get_notes(address) == "Main Street Market related products were wiped out in Oct 10th event https://x.com/Main_St_Finance/status/1976972055951147194"
+
+
 def test_old_mainnet_out_of_gas_contract_is_skipped_by_multicall_blacklist() -> None:
     """Old mainnet contracts that poison Multicall3 batches are skipped."""
     address = "0xffaa9f9aa5e4361f552bada90dcacdd08e5b41eb"


### PR DESCRIPTION
## Why

Mainstreet Finance and Altura vaults must be excluded from reports due to reported scam and safety concerns.

## Lessons learnt

Protocol-wide risk classifications ensure existing and future detected vaults receive the same hard blacklist treatment.

## Summary

- Marked Mainstreet Finance and Altura as blacklisted in the protocol risk matrix.
- Added incident notes for the Ethereum and Sonic Staked msUSD vaults.
- Added regression coverage for both protocol-wide classifications and the Mainstreet notes.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.