### PR TITLE
fix: simulate Lagoon settlement with synthetic Safe liquidity

### DIFF
--- a/eth_defi/erc_4626/README-vault-protocol-support.md
+++ b/eth_defi/erc_4626/README-vault-protocol-support.md
@@ -255,9 +255,13 @@ claimable.
 #### Liquidity-bypass simulations
 
 ``force_settle(..., ignore_liquidity=False)`` defaults to a real-liquidity
-simulation. A driver must refuse to report success when its settlement payer
-or immediate-redemption buffer is short. ``ignore_liquidity=True`` is an
-explicit Anvil-only test fixture, not a production capability and not a
+simulation for generic and non-Lagoon drivers. Lagoon defaults to synthetic
+Safe provisioning because ``settleDeposit`` always processes the whole shared
+redemption queue, including the simulated redemption and unrelated requests. A
+claimable synthetic result therefore proves settlement mechanics only. A caller
+requiring real Lagoon Safe liquidity must pass
+``ignore_liquidity=False`` explicitly. ``ignore_liquidity=True`` is an
+Anvil-only test fixture, not a production capability and not a
 request-construction override. It is allowed only for a manager with a tested
 driver and must set
 ``VaultForcedSettlementResult.liquidity_constraints_ignored``. A non-zero
@@ -268,7 +272,7 @@ The current opt-in drivers are deliberately narrow:
 
 | Protocol | What the option changes | Evidence it does not provide |
 | --- | --- | --- |
-| Lagoon | Tops up a short Safe on an Anvil fork before a settlement round. Without the option, the driver fails before settlement. | That the live Safe can pay queued redemptions. |
+| Lagoon | By default, tops up a short Safe on an Anvil fork before a settlement round. ``ignore_liquidity=False`` fails before settlement. | That the live Safe can pay queued redemptions. |
 | YieldNest | Switches a dedicated ``MockYieldNestVault`` immediate ``maxRedeem`` gate on before the guarded standard ERC-4626 redeem call. | That a live YieldNest buffer exists, or that the maturity-aware queue is implemented. |
 
 cSigma, Morpho, IPOR and Forty Acres also have liquidity or capacity

--- a/eth_defi/erc_4626/vault_protocol/lagoon/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/deposit_redeem.py
@@ -112,10 +112,11 @@ class LagoonDepositManager(GenericERC7540DepositManager):
     via :func:`~eth_defi.erc_4626.vault_protocol.lagoon.testing.force_lagoon_settle`.
     Because ``settleDeposit`` always triggers ``_settleRedeem``,
     :meth:`_provision_safe_for_settlement` first grants the Safe's missing standing
-    ``approve(vault, max)``. By default it rejects a Safe that is short of the
-    liquidity needed to pay every queued redemption before running settlement.
-    Only ``force_settle(..., ignore_liquidity=True)`` on Anvil tops the Safe up
-    with synthetic denomination tokens; the injected amount and the
+    ``approve(vault, max)``. It defaults to synthetic Safe provisioning because
+    every settlement processes the whole shared redemption queue, including the
+    simulated redemption when applicable. Call
+    ``force_settle(..., ignore_liquidity=False)`` to require real Safe liquidity.
+    The injected amount and the
     ``liquidity_constraints_ignored`` result flag disclose that a ``claimable``
     result proves settlement mechanics, not live solvency. Success requires
     the ticket to reach :attr:`AsyncVaultRequestStatus.claimable`; otherwise it raises
@@ -139,7 +140,7 @@ class LagoonDepositManager(GenericERC7540DepositManager):
         ticket: DepositTicket | RedemptionTicket | None,
         *,
         mock: object | None = None,
-        ignore_liquidity: bool = False,
+        ignore_liquidity: bool = True,
     ) -> VaultForcedSettlementResult:
         """Force one Lagoon settlement round on an Anvil fork.
 
@@ -153,8 +154,9 @@ class LagoonDepositManager(GenericERC7540DepositManager):
             use the existing real Anvil-fork driver without this argument.
         :param ignore_liquidity:
             On an Anvil fork only, permit the driver to top up a Safe that is
-            short of redemption assets. Defaults to ``False`` so a successful
-            settlement normally proves the fork had enough liquid assets.
+            short of redemption assets. Defaults to ``True`` because settlement
+            processes the shared redemption queue. Pass ``False`` to require
+            real Safe liquidity.
         :return:
             Before/after status and settlement transaction hashes.
         :raise UnsupportedVaultSimulation:
@@ -206,17 +208,8 @@ class LagoonDepositManager(GenericERC7540DepositManager):
             make_anvil_custom_rpc_request(self.web3, "anvil_impersonateAccount", [safe_address])
             make_anvil_custom_rpc_request(self.web3, "anvil_setBalance", [safe_address, hex(10**18)])
 
-            # WS1: provision the Safe BEFORE settlement. Lagoon's settleDeposit()
-            # always runs _settleRedeem() afterwards, which pays queued redemptions
-            # by pulling the denomination token FROM the Safe. On third-party
-            # deployments that leg fails two ways our own deploy script prevents in
-            # production (missing standing approval; Safe short of liquidity). This
-            # issues the missing approval and, only when explicitly requested,
-            # tops up the Safe, returning any synthetic amount injected so the
-            # result can flag it honestly. The
-            # provisioning must run for BOTH deposit and redemption tickets because
-            # _settleRedeem always executes after settleDeposit. See the helper for
-            # the full rationale.
+            # settleDeposit() always settles the shared redemption queue. Prepare
+            # its Safe allowance and, by default, its Anvil-only synthetic balance.
             liquidity_tx_hashes, synthetic_injected_raw = self._provision_safe_for_settlement(
                 safe_address,
                 ignore_liquidity=ignore_liquidity,
@@ -302,10 +295,11 @@ class LagoonDepositManager(GenericERC7540DepositManager):
         disclose it — a non-zero injection means a ``claimable`` result proves
         the settlement *mechanism*, NOT that the live vault is solvent.
 
-        **Correctness of the shortfall estimate.**
+        **Scope of the shortfall estimate.**
         :meth:`LagoonFlowManager.calculate_underlying_needed_for_redemptions`
         returns ``siloShareBalance * currentSharePrice`` — i.e. every pending
-        redemption (not just this ticket). ``force_lagoon_settle`` calls
+        redemption, including the selected redemption ticket when applicable.
+        ``force_lagoon_settle`` calls
         ``updateNewTotalAssets(current NAV)`` immediately before
         ``settleDeposit``, so the settled share price equals the current share
         price and this estimate matches ``convertToAssets()`` at settlement. A
@@ -318,8 +312,9 @@ class LagoonDepositManager(GenericERC7540DepositManager):
         :param safe_address:
             The vault Safe address, already impersonated by the caller.
         :param ignore_liquidity:
-            Whether an Anvil-only synthetic Safe top-up may cover an observed
-            redemption shortfall. ``False`` raises before settlement instead.
+            Whether an Anvil-only synthetic Safe top-up may cover the whole
+            redemption queue's observed shortfall. ``False`` raises before
+            settlement instead.
         :return:
             A ``(transaction_hashes, synthetic_assets_injected_raw)`` pair. The
             hashes are the approval (and any not-yet-mined provisioning) txs;
@@ -355,13 +350,12 @@ class LagoonDepositManager(GenericERC7540DepositManager):
         if needed_raw > 0:
             needed_raw += denomination_token.convert_to_raw(Decimal(1))
 
-        # Check liquidity before mutating approval state. With the default
-        # setting this fails before a partially successful settlement round can
-        # settle deposits while silently leaving a redemption pending.
+        # Strict mode fails before mutating approval state or running a partial
+        # settlement round that can settle deposits while leaving redemption pending.
         current_raw = denomination_token.fetch_raw_balance_of(safe_address)
         if needed_raw > current_raw and not ignore_liquidity:
             raise UnsupportedVaultSimulation(
-                f"Lagoon Safe {safe_address} lacks redemption liquidity for fork settlement: needs {needed_raw} raw {denomination_token.symbol}, has {current_raw}. Pass ignore_liquidity=True only for an explicitly synthetic Anvil simulation.",
+                f"Lagoon Safe {safe_address} lacks redemption liquidity for strict fork settlement: needs {needed_raw} raw {denomination_token.symbol}, has {current_raw}.",
                 unsupported_reason="lagoon_settlement_insufficient_liquidity",
                 protocol=self.vault.get_protocol_name(),
                 vault_address=self.vault.address,

--- a/eth_defi/vault/deposit_redeem.py
+++ b/eth_defi/vault/deposit_redeem.py
@@ -700,6 +700,9 @@ class VaultForcedSettlementResult:
         may instead return ``none`` only with request-specific event evidence
         and a positive receiver balance delta.  A pending, missing, or
         evidence-free consumed status is never a successful forced settlement.
+        This evaluates settlement state only: callers requiring live-liquidity
+        evidence must also assert ``synthetic_assets_injected_raw == 0`` and
+        ``not liquidity_constraints_ignored``.
 
         :return:
             ``True`` for a synchronous no-op, a claimable async ticket, or a
@@ -1158,9 +1161,9 @@ class VaultDepositManager(ABC):
     result) because the request transaction already completed the lifecycle.
     Asynchronous managers must override it with a protocol-specific driver; the
     base raises :class:`UnsupportedVaultSimulation` when no safe driver exists.
-    ``ignore_liquidity=False`` preserves a real-liquidity simulation. The
-    opt-in ``ignore_liquidity=True`` is valid only for an explicitly documented
-    mock/fork driver and its result must mark
+    ``ignore_liquidity=False`` preserves a real-liquidity simulation. An
+    explicitly documented protocol driver may override the default to enable an
+    Anvil-only liquidity-bypass simulation; its result must mark
     :attr:`VaultForcedSettlementResult.liquidity_constraints_ignored`; it is
     never live redemption evidence or a way to bypass production preflights.
     """
@@ -1265,10 +1268,11 @@ class VaultDepositManager(ABC):
             implement mock settlement remains a typed unsupported simulation.
         :param ignore_liquidity:
             Permit a protocol-specific, Anvil-only mock or fork driver to
-            bypass an otherwise unavailable redemption-liquidity gate. Defaults
-            to ``False``. Managers must reject this request unless they have a
-            tested, explicit implementation; it must never weaken a production
-            preflight or live settlement path.
+            bypass an otherwise unavailable redemption-liquidity gate. This base
+            implementation defaults to ``False``; a documented protocol override
+            may choose a different Anvil-only default. Managers must reject this
+            request unless they have a tested, explicit implementation; it must
+            never weaken a production preflight or live settlement path.
         :return:
             Settlement outcome with before/after status and transaction hashes.
         :raise UnsupportedVaultSimulation:

--- a/tests/lagoon/test_erc_7540_deposit_redeem.py
+++ b/tests/lagoon/test_erc_7540_deposit_redeem.py
@@ -19,7 +19,7 @@ from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil, fund_erc20_
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.token import USDC_WHALE, TokenDetails, fetch_erc20_details
 from eth_defi.trace import assert_transaction_success_with_explanation
-from eth_defi.vault.deposit_redeem import AsyncVaultRequestStatus, DepositRedeemEventAnalysis
+from eth_defi.vault.deposit_redeem import AsyncVaultRequestStatus, DepositRedeemEventAnalysis, UnsupportedVaultSimulation
 
 JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
 
@@ -286,38 +286,43 @@ def test_erc_7540_redeem_722_capital(
 
 
 @flaky.flaky
-def test_erc_7540_settle_recovers_missing_approval_and_liquidity(
+def test_erc_7540_settle_synthetically_provisions_shared_redemption_queue_by_default(
     vault: ERC4626Vault,
     test_user: HexAddress,
     usdc: TokenDetails,
-):
-    """Forced settlement recovers a Safe that lacks the standing approval and redemption liquidity.
+) -> None:
+    """Simulated Lagoon settlement must tolerate a short Safe redemption queue.
 
-    Third-party Lagoon deployments fail settlement two ways our own deploy
-    script prevents (allowance revert; Safe short of liquidity). This
-    synthesises both failure modes on the reference vault — revoking the Safe's
-    approval and draining its denomination balance after a redemption is queued
-    — then asserts the WS1 driver re-approves, tops up, and settles the ticket,
-    disclosing the injected amount via ``synthetic_assets_injected_raw``.
+    1. Deposit, settle and claim shares on the reference Lagoon vault.
+    2. Confirm that the healthy deposit settlement needed no synthetic liquidity.
+    3. Queue a redemption and reproduce a Safe with no allowance or liquid assets.
+    4. Verify strict mode refuses the short Safe before settlement.
+    5. Verify the default Anvil simulation restores the allowance, injects
+       synthetic liquidity and makes the request claimable with honest metadata.
+    6. Claim the settled redemption.
     """
     web3 = vault.web3
     deposit_manager = vault.get_deposit_manager()
     assert isinstance(deposit_manager, LagoonDepositManager)
 
-    # Deposit -> settle -> claim shares.
+    # 1. Deposit -> settle -> claim shares.
     amount = Decimal(1_000)
     assert_transaction_success_with_explanation(web3, usdc.approve(vault.address, amount).transact({"from": test_user}))
     deposit_ticket = deposit_manager.create_deposit_request(test_user, amount=amount).broadcast()
-    deposit_manager.force_settle(deposit_ticket)
+    deposit_settlement = deposit_manager.force_settle(deposit_ticket)
+
+    # 2. The healthy deposit settlement uses only real fork state.
+    assert deposit_settlement.synthetic_assets_injected_raw == 0
+    assert deposit_settlement.liquidity_constraints_ignored is False
     assert_transaction_success_with_explanation(web3, deposit_manager.finish_deposit(deposit_ticket).transact({"from": test_user, "gas": 1_000_000}))
     share_count = vault.share_token.fetch_balance_of(test_user)
 
-    # Queue a redemption.
+    # 2. Queue a redemption.
     assert_transaction_success_with_explanation(web3, vault.share_token.approve(vault.address, share_count).transact({"from": test_user}))
     redeem_ticket = deposit_manager.create_redemption_request(test_user, shares=share_count).broadcast()
     assert isinstance(redeem_ticket, ERC7540RedemptionTicket)
 
-    # Reproduce the third-party failure modes on the Safe:
+    # 3. Reproduce the short Safe and missing approval:
     #  (b) revoke the standing approval so _settleRedeem's transferFrom reverts;
     #  (a) drain the Safe's USDC so _settleRedeem would silently stall.
     safe_address = vault.safe_address
@@ -328,15 +333,23 @@ def test_erc_7540_settle_recovers_missing_approval_and_liquidity(
     assert int(usdc.contract.functions.allowance(safe_address, vault.address).call()) == 0
     assert usdc.fetch_raw_balance_of(safe_address) == 1
 
-    # The driver must re-approve, top up the shortfall, and settle to claimable.
-    redemption_settlement = deposit_manager.force_settle(redeem_ticket, ignore_liquidity=True)
+    # 4. Strict mode retains the real-liquidity validation for callers that
+    # need it, without broadcasting a partially successful settlement.
+    with pytest.raises(UnsupportedVaultSimulation) as exc_info:
+        deposit_manager.force_settle(redeem_ticket, ignore_liquidity=False)
+    assert exc_info.value.unsupported_reason == "lagoon_settlement_insufficient_liquidity"
+
+    # 5. Default Anvil simulation must re-approve, top up the shortfall and
+    # settle to claimable. This is the path used by vault-trade simulation.
+    redemption_settlement = deposit_manager.force_settle(redeem_ticket)
     assert redemption_settlement.status_before is AsyncVaultRequestStatus.pending
     assert redemption_settlement.status_after is AsyncVaultRequestStatus.claimable
     # Non-zero: liquidity was synthetically injected, so a claimable result here
     # does NOT prove the live vault could pay this redemption.
     assert redemption_settlement.synthetic_assets_injected_raw > 0
+    assert redemption_settlement.liquidity_constraints_ignored is True
 
-    # The claim now succeeds and the user receives the underlying.
+    # 6. The claim now succeeds and the user receives the underlying.
     assert deposit_manager.can_finish_redeem(redeem_ticket)
     usdc_before = usdc.fetch_raw_balance_of(test_user)
     assert_transaction_success_with_explanation(web3, deposit_manager.finish_redemption(redeem_ticket).transact({"from": test_user, "gas": 1_000_000}))


### PR DESCRIPTION
## Why

Lagoon settlement processes the entire shared redemption queue. An Anvil simulation must be able to exercise that lifecycle even when the Safe on the fork lacks transferable denomination liquidity. Synthetic provisioning may cover the selected redemption as well as unrelated queued requests, so it proves settlement mechanics only, never live Safe solvency.

## Lessons learnt

A claimable ticket on a synthetically provisioned fork is valid simulation evidence, not redemption-liquidity evidence. The result must disclose injected assets, and callers requiring real liquidity must use `ignore_liquidity=False` and assert no synthetic injection.

## Summary

- Default Lagoon Anvil settlement to synthetic Safe provisioning for its full shared redemption queue.
- Preserve `ignore_liquidity=False` for strict real-Safe-liquidity simulation.
- Record zero-injection and synthetic paths in a Base-fork test.
- Clarify the base API, protocol support guide, and settlement-result semantics.

## Related issues and PRs

- Continues the vault simulation status work in tradingstrategy-ai/trade-executor#1590.