### PR TITLE
feat: expose custom error revert data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 1.2
 
+- feat: Add `extract_revert_data()` for provider-independent recovery of ABI-encoded custom errors from reverted `eth_call` simulations (2026-07-30)
+
 - fix: Harden vault settlement diagnostics with canonical wrapped Gains redemption evidence, exact Ember operator preflights, cSigma daily pause detection and typed Morpho V2 redemption reverts (2026-07-29)
 
 - feat: Complete Anvil settlement for Ember direct payouts and Plutus role-gated redemptions, with terminal evidence, typed settlement failures and shared warm-fork coverage (2026-07-29)

--- a/eth_defi/revert_reason.py
+++ b/eth_defi/revert_reason.py
@@ -8,6 +8,7 @@ Further reading
 
 import logging
 import pprint
+import re
 from typing import Union
 
 try:
@@ -36,6 +37,87 @@ class TransactionReverted(Exception):
 
     def get_solidity_reason_message(self) -> str:
         return self.args[0]
+
+
+def extract_revert_data(error: Exception) -> bytes | None:
+    """Extract ABI-encoded custom-error data from a failed ``eth_call``.
+
+    Use this after catching a simulation exception when the caller needs to
+    distinguish an *expected, typed* contract decision from an unexpected
+    execution failure. Solidity custom errors encode a four-byte selector
+    followed by ABI-encoded arguments. Web3 and JSON-RPC providers do not use
+    one common exception shape: the same bytes may appear in ``error.data``, a
+    nested ``data``/``result`` mapping, or an exception argument string.
+
+    This is useful for preflight simulations such as GuardV0 settlement. A
+    gross-flow cap breach and an active cooldown are valid contract outcomes
+    that a caller may turn into a deferred action; insufficient liquidity,
+    access-control failures and unknown selectors must remain failures.
+    Recovering raw data lets protocol code decode only its explicitly supported
+    selectors instead of matching provider-specific error text.
+
+    Do not use this helper to suppress arbitrary exceptions. If it returns
+    ``None``, or if the selector is not one the caller explicitly supports,
+    re-raise the original exception. This helper only extracts transport data;
+    the calling protocol owns selector matching and ABI argument decoding.
+
+    Example custom-error handling:
+
+    .. code-block:: python
+
+        try:
+            web3.eth.call(transaction)
+        except Exception as exc:
+            revert_data = extract_revert_data(exc)
+            if revert_data is None:
+                raise
+
+            selector = revert_data[:4]
+            if selector == expected_error_selector:
+                value = abi_decode(["uint256"], revert_data[4:])[0]
+                handle_expected_contract_decision(value)
+            else:
+                raise
+
+    :param error:
+        Exception raised by a reverted ``eth_call`` or contract ``call()``.
+    :return:
+        Raw Solidity revert bytes, including the four-byte selector, or
+        ``None`` when no usable ABI payload is present.
+    """
+
+    def visit(value) -> str | bytes | None:
+        if isinstance(value, bytes):
+            return value
+        if isinstance(value, str):
+            match = re.search(r"0x[0-9a-fA-F]{10,}", value)
+            if match:
+                return match.group(0)
+        if isinstance(value, dict):
+            for key in ("data", "return", "result"):
+                result = visit(value.get(key))
+                if result is not None:
+                    return result
+            for nested_value in value.values():
+                result = visit(nested_value)
+                if result is not None:
+                    return result
+        if isinstance(value, (list, tuple)):
+            for nested_value in value:
+                result = visit(nested_value)
+                if result is not None:
+                    return result
+        return None
+
+    data = visit(getattr(error, "data", None)) or visit(error.args)
+    if data is None:
+        return None
+    if isinstance(data, bytes):
+        return data
+    try:
+        return Web3.to_bytes(hexstr=data)
+    except ValueError:
+        return None
 
 
 def fetch_transaction_revert_reason(

--- a/tests/test_revert_data.py
+++ b/tests/test_revert_data.py
@@ -1,0 +1,25 @@
+"""Tests for extracting ABI-encoded revert data from provider exceptions."""
+
+from eth_defi.revert_reason import extract_revert_data
+
+
+def test_extract_revert_data_handles_web3_and_json_rpc_error_shapes() -> None:
+    """Extract a custom-error payload without depending on a live RPC provider.
+
+    1. Prepare a representative Solidity custom-error payload.
+    2. Recover it from Web3's direct exception attribute and a nested JSON-RPC response.
+    3. Verify an exception without ABI data remains unclassified.
+    """
+    payload = bytes.fromhex("12345678" + "00" * 32)
+
+    # 1. Prepare a representative Solidity custom-error payload.
+    attribute_error = Exception("execution reverted")
+    attribute_error.data = payload
+    response_error = ValueError({"error": {"data": "0x" + payload.hex()}})
+
+    # 2. Recover it from Web3's direct exception attribute and a nested JSON-RPC response.
+    assert extract_revert_data(attribute_error) == payload
+    assert extract_revert_data(response_error) == payload
+
+    # 3. Verify an exception without ABI data remains unclassified.
+    assert extract_revert_data(Exception("execution reverted")) is None


### PR DESCRIPTION
## Why

Protocol preflight simulations need the ABI payload from provider-specific `eth_call` revert envelopes to distinguish typed contract decisions from unexpected failures.

## Lessons learnt

Web3 and RPC providers return custom-error data through several incompatible exception shapes. A shared transport parser keeps protocol code focused on selector matching and ABI decoding, while callers retain fail-fast behaviour for unknown errors.

## Summary

- Add public `extract_revert_data()` to `eth_defi.revert_reason`.
- Document use, failure semantics and a Sphinx-compatible example.
- Add pure regression coverage for Web3 and nested JSON-RPC exception shapes.

## Related issues and PRs

- Used by tradingstrategy-ai/trade-executor#1589 for GuardV0 Lagoon settlement preflight.