### PR TITLE
fix: downgrade retryable R2 export failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,13 @@ Run ruff to format code using Poetry:
 poetry run ruff format
 ```
 
+## Logging retries
+
+For a failure that is expected to be retried, log a concise `WARNING` without
+a traceback. Include enough context to identify the deferred operation. Log an
+`ERROR` with its traceback only after the final retry has failed and no further
+retry will be attempted.
+
 ## Git worktrees
 
 - For git worktrees, copy `.local-test.env` from the main repository checkout root into the current worktree root.

--- a/eth_defi/cloudflare_r2.py
+++ b/eth_defi/cloudflare_r2.py
@@ -37,6 +37,13 @@ R2_HTTP_STATUS_CONFLICT = 409
 #: Short access key IDs are left unmasked because masking would hide everything.
 R2_UNMASKED_ACCESS_KEY_ID_MAX_LENGTH = 8
 
+#: HTTP status codes for transient request failures outside the 5xx range.
+R2_RETRYABLE_HTTP_STATUS_CODES = frozenset((408, 429))
+
+#: Inclusive bounds for HTTP server-error status codes.
+R2_SERVER_ERROR_HTTP_STATUS_MIN = 500
+R2_SERVER_ERROR_HTTP_STATUS_MAX = 599
+
 
 @dataclass(slots=True)
 class R2SourceDigest:
@@ -127,6 +134,10 @@ R2_HEAD_OBJECT_RETRY = R2HeadObjectRetry()
 
 class R2OperationError(RuntimeError):
     """Raised when an R2 operation fails with enriched diagnostics."""
+
+
+class R2RetryableOperationError(R2OperationError):
+    """Raised when R2 has a transient failure that a later retry may resolve."""
 
 
 class R2AccessDeniedError(R2OperationError):
@@ -237,6 +248,8 @@ def _create_r2_operation_error(
         return R2ConflictError(" ".join(detail_lines))
 
     detail_lines.append(f"Original R2 error message: {error_message}")
+    if http_status in R2_RETRYABLE_HTTP_STATUS_CODES or (isinstance(http_status, int) and R2_SERVER_ERROR_HTTP_STATUS_MIN <= http_status <= R2_SERVER_ERROR_HTTP_STATUS_MAX):
+        return R2RetryableOperationError(" ".join(detail_lines))
     return R2OperationError(" ".join(detail_lines))
 
 

--- a/eth_defi/vault/post_processing.py
+++ b/eth_defi/vault/post_processing.py
@@ -22,7 +22,7 @@ import pyarrow.parquet as pq
 from eth_defi.apex.constants import APEX_CHAIN_ID, APEX_METRICS_DATABASE
 from eth_defi.apex.metrics import ApexMetricsDatabase
 from eth_defi.apex.vault_data_export import build_raw_prices_dataframe as build_apex_prices_dataframe
-from eth_defi.cloudflare_r2 import calculate_bytes_digest, copy_r2_object_daily_backup, create_r2_client, upload_bytes_to_r2, upload_file_to_r2
+from eth_defi.cloudflare_r2 import R2RetryableOperationError, calculate_bytes_digest, copy_r2_object_daily_backup, create_r2_client, upload_bytes_to_r2, upload_file_to_r2
 from eth_defi.grvt.constants import GRVT_CHAIN_ID, GRVT_DAILY_METRICS_DATABASE
 from eth_defi.grvt.daily_metrics import GRVTDailyMetricsDatabase
 from eth_defi.grvt.vault_data_export import build_raw_prices_dataframe as build_grvt_prices_dataframe
@@ -798,6 +798,9 @@ def export_data_files() -> bool:
         module.main()
         logger.info("Data file export complete")
         return True
+    except R2RetryableOperationError as exc:
+        logger.warning("Data file export deferred after retryable R2 failure: %s", exc)
+        return False
     except Exception:
         logger.exception("Export data files failed")
         return False

--- a/tests/erc_4626/test_post_processing.py
+++ b/tests/erc_4626/test_post_processing.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-brotli = pytest.importorskip("brotli", reason="brotli not installed (cloudflare_r2 extra)")
-
+from eth_defi.cloudflare_r2 import R2RetryableOperationError
 from eth_defi.vault import post_processing
+
+brotli = pytest.importorskip("brotli", reason="brotli not installed (cloudflare_r2 extra)")
 
 
 def test_clean_prices_uses_structured_logger(
@@ -28,6 +30,31 @@ def test_clean_prices_uses_structured_logger(
 
     assert post_processing.clean_prices()
     assert any(record.name == post_processing.__name__ and record.message == "Wrangler progress" for record in caplog.records)
+
+
+def test_export_data_files_logs_retryable_r2_failure_as_warning_without_traceback(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Transient R2 failures should await the scanner's next export attempt quietly."""
+    retryable_error = R2RetryableOperationError("R2 CompleteMultipartUpload failed with http_status=500")
+
+    def fake_main() -> None:
+        raise retryable_error
+
+    module = SimpleNamespace(main=fake_main)
+    spec = SimpleNamespace(loader=SimpleNamespace(exec_module=lambda _: None))
+    monkeypatch.setattr(post_processing.importlib.util, "spec_from_file_location", lambda *_: spec)
+    monkeypatch.setattr(post_processing.importlib.util, "module_from_spec", lambda _: module)
+
+    with caplog.at_level(logging.WARNING):
+        assert post_processing.export_data_files() is False
+
+    records = [record for record in caplog.records if record.name == post_processing.__name__]
+    assert len(records) == 1
+    assert records[0].levelno == logging.WARNING
+    assert "retryable R2 failure" in records[0].message
+    assert records[0].exc_info is None
 
 
 def test_export_top_vaults_json_passes_pipeline_data_dir(

--- a/tests/test_cloudflare_r2.py
+++ b/tests/test_cloudflare_r2.py
@@ -16,6 +16,7 @@ from eth_defi.cloudflare_r2 import (
     R2AccessDeniedError,
     R2ConflictError,
     R2HeadObjectRetry,
+    R2RetryableOperationError,
     calculate_bytes_digest,
     calculate_file_digest,
     copy_r2_object_daily_backup,
@@ -447,6 +448,21 @@ def test_fetch_r2_object_head_rejects_invalid_retry_policy(retry: R2HeadObjectRe
         )
 
     assert s3_client.head_call_counts == {}
+
+
+def test_r2_server_error_is_classified_as_retryable() -> None:
+    """R2 service failures should be distinguishable from permanent export errors."""
+    s3_client = FakeS3Client()
+    s3_client.head_exceptions["bucket", "core3.duckdb"] = ClientError(
+        {
+            "Error": {"Code": "InternalError", "Message": "Please try again"},
+            "ResponseMetadata": {"HTTPStatusCode": 500},
+        },
+        "HeadObject",
+    )
+
+    with pytest.raises(R2RetryableOperationError):
+        fetch_r2_object_head(s3_client, "bucket", "core3.duckdb")
 
 
 def test_upload_file_to_r2_continues_after_head_access_denied(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
## Why

Transient R2 service failures during a looped scanner export are retried later and should not produce an error-level traceback.

## Lessons learnt

Classify retryable remote-service responses separately from permanent export failures so operators can distinguish deferred work from actionable failures.

## Summary

- Classified HTTP 408, 429, and 5xx R2 responses as retryable.
- Log deferred data-file exports as warnings without tracebacks.
- Added regression coverage and retry logging guidance.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.