### PR TITLE
fix: classify vault permissions from protocol state

### DIFF
--- a/docs/source/vaults/accountable/index.rst
+++ b/docs/source/vaults/accountable/index.rst
@@ -23,6 +23,18 @@ The public manager only auto-claims self-controlled redemptions to their share
 owner. This avoids routing a controller-level aggregate to a custom receiver;
 delegated-controller historical requests are discovered but not auto-claimed.
 
+Deposit permissions
+~~~~~~~~~~~~~~~~~~~
+
+The `verified Accountable vault source <https://monadscan.com/address/0x7Cd231120a60F500887444a9bAF5e1BD753A5e59#code>`__
+defines three constructor-selected permission levels. ``None`` is
+permissionless, ``KYC`` verifies an Accountable-signed payload appended to each
+call, and ``Whitelist`` checks persistent ``allowed(address)`` membership.
+When the share receiver and controller differ, the vault checks both accounts.
+The Hyperithm Delta Neutral deployment uses ``None``. Its strategy capacity,
+loan state and minimum amount are separate lifecycle constraints and must not
+be reported as KYC.
+
 Links
 ~~~~~
 
@@ -34,9 +46,9 @@ Links
 Notes
 ~~~~~
 
-- No public GitHub repository available for smart contracts
-- Smart contracts are verified via Sourcify on Monad block explorers
-- Fee information is not publicly exposed on-chain
+- No canonical public source repository is linked from the verified deployment
+- Smart contract source is verified on MonadScan
+- Fee terms are read from the deployment's Accountable fee-manager contract
 
 .. autosummary::
    :toctree: _autosummary_accountable

--- a/docs/source/vaults/euler/index.rst
+++ b/docs/source/vaults/euler/index.rst
@@ -21,6 +21,17 @@ Key features:
 - Market-leading risk-adjusted rates for lenders and borrowers
 - Institutional-grade security with multiple audits
 
+Deposit permissions
+~~~~~~~~~~~~~~~~~~~
+
+Euler Earn deposits are permissionless. EVK vaults expose a hook target and
+operation bitmap through ``hookConfig()``. When neither the deposit nor mint
+operation is hooked, deposits are permissionless. A non-zero custom hook can
+implement arbitrary policy, so the adapter leaves it unknown until that hook
+implementation is recognised. A zero hook target with operation bits set is a
+global operation disable, not an account whitelist. See the `EVK hook design
+<https://github.com/euler-xyz/euler-vault-kit/blob/master/docs/whitepaper.md#hooks>`__.
+
 Links
 ~~~~~
 

--- a/docs/source/vaults/morpho/index.rst
+++ b/docs/source/vaults/morpho/index.rst
@@ -19,6 +19,17 @@ across multiple yield sources through smart contract adapters. V2 vaults use
 - Timelocked governance with curator/allocator roles
 - Non-custodial exits via ``forceDeallocate``
 
+Deposit permissions
+~~~~~~~~~~~~~~~~~~~
+
+MetaMorpho V1 deposits are permissionless. Morpho V2 is also permissionless
+when ``receiveSharesGate`` and ``sendAssetsGate`` are both zero. A V2
+deployment may configure custom implementations of the `Morpho gate interfaces
+<https://github.com/morpho-org/vault-v2/blob/main/src/interfaces/IGate.sol>`__
+for the share receiver and asset sender independently. The adapter therefore
+reports a zero-gate deployment as permissionless and leaves an unrecognised
+custom gate unknown instead of assuming either KYC or public access.
+
 Robinhood Chain temporary API workaround
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/eth_defi/abi/accountable/README.md
+++ b/eth_defi/abi/accountable/README.md
@@ -3,6 +3,27 @@
 `AccountableAsyncRedeemVault.json` is the Accountable vault interface used by
 the adapter (synchronous deposits, operator-finalised async redemptions).
 
+## Deposit permissions
+
+The verified vault source exposes an explicit ``PermissionLevel`` enum:
+
+- ``None = 0``: permissionless; ``onlyAuth`` accepts every account
+- ``KYC = 1``: Accountable-signed authorisation is appended to each call
+- ``Whitelist = 2``: persistent account admission is read with
+  ``allowed(address)`` and managed through ``setAllowed(address[], bool[])``
+
+The strategy's ``setLenders`` function is only a relay to the vault's
+``setAllowed`` method and the latter reverts unless the vault is in whitelist
+mode. It is not a second strategy-level permission policy. The Hyperithm Delta
+Neutral deployment was constructed with ``permissionLevel_ = 0`` and is thus
+permissionless; its ``loan().minDeposit``, loan state, and capacity checks are
+economic/lifecycle conditions rather than KYC.
+
+Verified sources:
+
+- https://monadscan.com/address/0x7Cd231120a60F500887444a9bAF5e1BD753A5e59#code
+- https://monadscan.com/address/0x647c9584072a4f1c96d5f82a7133af5642f39402#code
+
 `OpenTermCompoundV1.json` is the verified implementation ABI of the Accountable
 strategy contract that the vault delegates deposits to via `strategy()`. It
 exposes the per-loan terms (`loan()` with `minDeposit` / `minRedeem`) and the

--- a/eth_defi/abi/accountable/README.md
+++ b/eth_defi/abi/accountable/README.md
@@ -5,18 +5,18 @@ the adapter (synchronous deposits, operator-finalised async redemptions).
 
 ## Deposit permissions
 
-The verified vault source exposes an explicit ``PermissionLevel`` enum:
+The verified vault source exposes an explicit `PermissionLevel` enum:
 
-- ``None = 0``: permissionless; ``onlyAuth`` accepts every account
-- ``KYC = 1``: Accountable-signed authorisation is appended to each call
-- ``Whitelist = 2``: persistent account admission is read with
-  ``allowed(address)`` and managed through ``setAllowed(address[], bool[])``
+- `None = 0`: permissionless; `onlyAuth` accepts every account
+- `KYC = 1`: Accountable-signed authorisation is appended to each call
+- `Whitelist = 2`: persistent account admission is read with
+  `allowed(address)` and managed through `setAllowed(address[], bool[])`
 
-The strategy's ``setLenders`` function is only a relay to the vault's
-``setAllowed`` method and the latter reverts unless the vault is in whitelist
+The strategy's `setLenders` function is only a relay to the vault's
+`setAllowed` method and the latter reverts unless the vault is in whitelist
 mode. It is not a second strategy-level permission policy. The Hyperithm Delta
-Neutral deployment was constructed with ``permissionLevel_ = 0`` and is thus
-permissionless; its ``loan().minDeposit``, loan state, and capacity checks are
+Neutral deployment was constructed with `permissionLevel_ = 0` and is thus
+permissionless; its `loan().minDeposit`, loan state, and capacity checks are
 economic/lifecycle conditions rather than KYC.
 
 Verified sources:

--- a/eth_defi/erc_4626/analysis.py
+++ b/eth_defi/erc_4626/analysis.py
@@ -106,7 +106,11 @@ def analyse_4626_flow_transaction(
     else:
         raise AssertionError(f"Can handle only single event per tx, got {len(swap_events)}. Receipt: {tx_receipt}")
 
-    assert amount_out > 0, "amount out should be negative for ERC-4626 flow event"
+    # ERC-4626 events use unsigned integers, but some compatible vault
+    # implementations and legacy decoders expose a signed transfer direction.
+    # Direction is already known from the event type, so accept either sign and
+    # normalise below. Only a zero output is an invalid successful flow.
+    assert amount_out != 0, "amount out must be non-zero for ERC-4626 flow event"
 
     amount_out_cleaned = Decimal(abs(amount_out)) / Decimal(10**out_token_details.decimals)
     amount_in_cleaned = Decimal(abs(amount_in)) / Decimal(10**in_token_details.decimals)

--- a/eth_defi/erc_4626/analysis.py
+++ b/eth_defi/erc_4626/analysis.py
@@ -109,7 +109,23 @@ def analyse_4626_flow_transaction(
     # ERC-4626 events use unsigned integers, but some compatible vault
     # implementations and legacy decoders expose a signed transfer direction.
     # Direction is already known from the event type, so accept either sign and
-    # normalise below. Only a zero output is an invalid successful flow.
+    # normalise below. Some Yearn-compatible vaults emit a zero ``assets`` value
+    # in ``Withdraw`` even though the successful transaction transfers the
+    # denomination token to the event receiver. Recover that observable output
+    # from the token's Transfer event before rejecting the receipt.
+    if amount_out == 0:
+        receiver = first_event["args"].get("receiver")
+        transfer_event = out_token_details.contract.events.Transfer()
+        transfer_events = transfer_event.process_receipt(tx_receipt, errors=DISCARD)
+        matching_transfers = [
+            event
+            for event in transfer_events
+            if event["address"].lower() == out_token_details.address_lower
+            and receiver is not None
+            and event["args"]["to"].lower() == receiver.lower()
+            and event["args"]["value"] > 0
+        ]
+        amount_out = sum(event["args"]["value"] for event in matching_transfers)
     assert amount_out != 0, "amount out must be non-zero for ERC-4626 flow event"
 
     amount_out_cleaned = Decimal(abs(amount_out)) / Decimal(10**out_token_details.decimals)

--- a/eth_defi/erc_4626/analysis.py
+++ b/eth_defi/erc_4626/analysis.py
@@ -109,10 +109,12 @@ def analyse_4626_flow_transaction(
     # ERC-4626 events use unsigned integers, but some compatible vault
     # implementations and legacy decoders expose a signed transfer direction.
     # Direction is already known from the event type, so normalise either sign.
-    # A successful redemption may also burn shares for zero assets, as Arche
-    # USD does when its Yearn withdrawal queue cannot return liquidity. The
-    # mined economic outcome must be reported as zero instead of turning an
+    # A successful redemption may also burn shares for zero assets. The mined
+    # economic outcome must be reported as zero instead of turning an
     # irreversible successful transaction into a receipt-analysis failure.
+
+    assert amount_in != 0, f"{direction} event input amount must not be zero"
+    assert direction == "redeem" or amount_out != 0, "Deposit event output shares must not be zero"
 
     amount_out_cleaned = Decimal(abs(amount_out)) / Decimal(10**out_token_details.decimals)
     amount_in_cleaned = Decimal(abs(amount_in)) / Decimal(10**in_token_details.decimals)

--- a/eth_defi/erc_4626/analysis.py
+++ b/eth_defi/erc_4626/analysis.py
@@ -108,25 +108,11 @@ def analyse_4626_flow_transaction(
 
     # ERC-4626 events use unsigned integers, but some compatible vault
     # implementations and legacy decoders expose a signed transfer direction.
-    # Direction is already known from the event type, so accept either sign and
-    # normalise below. Some Yearn-compatible vaults emit a zero ``assets`` value
-    # in ``Withdraw`` even though the successful transaction transfers the
-    # denomination token to the event receiver. Recover that observable output
-    # from the token's Transfer event before rejecting the receipt.
-    if amount_out == 0:
-        receiver = first_event["args"].get("receiver")
-        transfer_event = out_token_details.contract.events.Transfer()
-        transfer_events = transfer_event.process_receipt(tx_receipt, errors=DISCARD)
-        matching_transfers = [
-            event
-            for event in transfer_events
-            if event["address"].lower() == out_token_details.address_lower
-            and receiver is not None
-            and event["args"]["to"].lower() == receiver.lower()
-            and event["args"]["value"] > 0
-        ]
-        amount_out = sum(event["args"]["value"] for event in matching_transfers)
-    assert amount_out != 0, "amount out must be non-zero for ERC-4626 flow event"
+    # Direction is already known from the event type, so normalise either sign.
+    # A successful redemption may also burn shares for zero assets, as Arche
+    # USD does when its Yearn withdrawal queue cannot return liquidity. The
+    # mined economic outcome must be reported as zero instead of turning an
+    # irreversible successful transaction into a receipt-analysis failure.
 
     amount_out_cleaned = Decimal(abs(amount_out)) / Decimal(10**out_token_details.decimals)
     amount_in_cleaned = Decimal(abs(amount_in)) / Decimal(10**in_token_details.decimals)

--- a/eth_defi/erc_4626/analysis.py
+++ b/eth_defi/erc_4626/analysis.py
@@ -106,18 +106,19 @@ def analyse_4626_flow_transaction(
     else:
         raise AssertionError(f"Can handle only single event per tx, got {len(swap_events)}. Receipt: {tx_receipt}")
 
-    # ERC-4626 events use unsigned integers, but some compatible vault
-    # implementations and legacy decoders expose a signed transfer direction.
-    # Direction is already known from the event type, so normalise either sign.
+    # ERC-4626 Deposit and Withdraw event amounts are uint256 values. Keep the
+    # decoded event values as-is so malformed negative values cannot produce a
+    # plausible-looking trade result.
     # A successful redemption may also burn shares for zero assets. The mined
     # economic outcome must be reported as zero instead of turning an
     # irreversible successful transaction into a receipt-analysis failure.
 
-    assert amount_in != 0, f"{direction} event input amount must not be zero"
-    assert direction == "redeem" or amount_out != 0, "Deposit event output shares must not be zero"
+    assert amount_in > 0, f"{direction} event input amount must be positive"
+    assert amount_out >= 0, f"{direction} event output amount must not be negative"
+    assert direction == "redeem" or amount_out > 0, "Deposit event output shares must be positive"
 
-    amount_out_cleaned = Decimal(abs(amount_out)) / Decimal(10**out_token_details.decimals)
-    amount_in_cleaned = Decimal(abs(amount_in)) / Decimal(10**in_token_details.decimals)
+    amount_out_cleaned = Decimal(amount_out) / Decimal(10**out_token_details.decimals)
+    amount_in_cleaned = Decimal(amount_in) / Decimal(10**in_token_details.decimals)
 
     price = amount_out_cleaned / amount_in_cleaned
 
@@ -130,7 +131,7 @@ def analyse_4626_flow_transaction(
         path,
         amount_in,
         amount_out_min,
-        abs(amount_out),
+        amount_out,
         price,
         in_token_details.decimals,
         out_token_details.decimals,

--- a/eth_defi/erc_4626/vault_protocol/accountable/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/deposit_redeem.py
@@ -194,8 +194,11 @@ class AccountableDepositManager(ERC4626DepositManager):
 
     **Whitelisting / access control**
 
-    Permissionless. There is no per-account whitelist or access manager; deposit
-    availability is advised only by ``maxDeposit(owner) > 0``.
+    Accountable exposes an immutable vault-wide ``permissionLevel``. Mode
+    ``None`` is permissionless, ``KYC`` requires signed per-call authorisation,
+    and ``Whitelist`` checks persistent ``allowed(address)`` membership. The
+    manager performs this admission check independently from minimum amount,
+    loan state, and ``maxDeposit(owner)`` capacity. Hyperithm uses ``None``.
 
     **Anvil settlement (force_settle)**
 
@@ -295,6 +298,9 @@ class AccountableDepositManager(ERC4626DepositManager):
             to = owner
         if Web3.to_checksum_address(to) == Web3.to_checksum_address(ZERO_ADDRESS_STR):
             raise ValueError("Accountable deposit receiver cannot be the zero address")
+        self.check_deposit_whitelist(owner)
+        if Web3.to_checksum_address(to) != Web3.to_checksum_address(owner):
+            self.check_deposit_whitelist(to)
         if raw_amount is None:
             raw_amount = self.vault.denomination_token.convert_to_raw(amount)
         if raw_amount <= 0:

--- a/eth_defi/erc_4626/vault_protocol/accountable/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/deposit_redeem.py
@@ -35,6 +35,7 @@ from eth_defi.vault.deposit_redeem import (
     UnsupportedVaultSimulation,
     VaultFlowUnavailable,
     VaultForcedSettlementResult,
+    WhitelistingRequired,
     create_synchronous_settlement_result,
 )
 from eth_defi.vault.flow_events import (
@@ -298,9 +299,18 @@ class AccountableDepositManager(ERC4626DepositManager):
             to = owner
         if Web3.to_checksum_address(to) == Web3.to_checksum_address(ZERO_ADDRESS_STR):
             raise ValueError("Accountable deposit receiver cannot be the zero address")
-        self.check_deposit_whitelist(owner)
-        if Web3.to_checksum_address(to) != Web3.to_checksum_address(owner):
-            self.check_deposit_whitelist(to)
+        permission_level = self.vault.fetch_permission_level()
+        accounts = {Web3.to_checksum_address(owner), Web3.to_checksum_address(to)}
+        for account in accounts:
+            if not self.vault.is_account_whitelisted(account, permission_level):
+                raise WhitelistingRequired(
+                    f"Depositor {account} is not admitted for Accountable vault {self.vault.address} on chain {self.vault.chain_id}",
+                    protocol="Accountable",
+                    vault_address=self.vault.address,
+                    caller=account,
+                    direction="deposit",
+                    phase="preflight",
+                )
         if raw_amount is None:
             raw_amount = self.vault.denomination_token.convert_to_raw(amount)
         if raw_amount <= 0:

--- a/eth_defi/erc_4626/vault_protocol/accountable/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/deposit_redeem.py
@@ -194,7 +194,7 @@ class AccountableDepositManager(ERC4626DepositManager):
 
     **Whitelisting / access control**
 
-    Accountable exposes an immutable vault-wide ``permissionLevel``. Mode
+    Accountable exposes a constructor-selected vault-wide ``permissionLevel``. Mode
     ``None`` is permissionless, ``KYC`` requires signed per-call authorisation,
     and ``Whitelist`` checks persistent ``allowed(address)`` membership. The
     manager performs this admission check independently from minimum amount,

--- a/eth_defi/erc_4626/vault_protocol/accountable/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/deposit_redeem.py
@@ -300,7 +300,11 @@ class AccountableDepositManager(ERC4626DepositManager):
         if Web3.to_checksum_address(to) == Web3.to_checksum_address(ZERO_ADDRESS_STR):
             raise ValueError("Accountable deposit receiver cannot be the zero address")
         permission_level = self.vault.fetch_permission_level()
-        accounts = {Web3.to_checksum_address(owner), Web3.to_checksum_address(to)}
+        owner = Web3.to_checksum_address(owner)
+        to = Web3.to_checksum_address(to)
+        accounts = [owner]
+        if to != owner:
+            accounts.append(to)
         for account in accounts:
             if not self.vault.is_account_whitelisted(account, permission_level):
                 raise WhitelistingRequired(

--- a/eth_defi/erc_4626/vault_protocol/accountable/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/vault.py
@@ -474,7 +474,11 @@ class AccountableVault(ERC4626Vault):  # noqa: PLR0904
         """
         return self.fetch_permission_level() is not AccountablePermissionLevel.none
 
-    def is_account_whitelisted(self, address: HexAddress) -> bool:
+    def is_account_whitelisted(
+        self,
+        address: HexAddress,
+        permission_level: AccountablePermissionLevel | None = None,
+    ) -> bool:
         """Check whether a bare account can use the configured admission mode.
 
         Whitelist mode has persistent membership through ``allowed(address)``.
@@ -484,10 +488,14 @@ class AccountableVault(ERC4626Vault):  # noqa: PLR0904
 
         :param address:
             Deposit controller or receiver to inspect.
+        :param permission_level:
+            Previously read permission mode. Supplying it avoids a duplicate
+            onchain read when several accounts are checked for one call.
         :return:
             Whether the standard adapter call is admitted for this account.
         """
-        permission_level = self.fetch_permission_level()
+        if permission_level is None:
+            permission_level = self.fetch_permission_level()
         if permission_level is AccountablePermissionLevel.none:
             return True
         if permission_level is AccountablePermissionLevel.whitelist:

--- a/eth_defi/erc_4626/vault_protocol/accountable/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/vault.py
@@ -38,8 +38,13 @@ logger = logging.getLogger(__name__)
 class AccountablePermissionLevel(enum.IntEnum):
     """Accountable vault access modes from ``IAccess.PermissionLevel``."""
 
+    #: No account admission check.
     none = 0
+
+    #: Accountable-signed authorisation appended to each call.
     kyc = 1
+
+    #: Persistent membership exposed through ``allowed(address)``.
     whitelist = 2
 
 
@@ -443,7 +448,7 @@ class AccountableVault(ERC4626Vault):  # noqa: PLR0904
         mode, and reads ``allowed(account)`` in whitelist mode.
 
         :param block_identifier:
-            Block at which to inspect the immutable permission mode.
+            Block at which to inspect the configured permission mode.
         :return:
             Typed Accountable permission level.
         :raise NotImplementedError:

--- a/eth_defi/erc_4626/vault_protocol/accountable/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/accountable/vault.py
@@ -1,6 +1,7 @@
 """Accountable Capital vault support."""
 
 import datetime
+import enum
 import logging
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -32,6 +33,14 @@ from eth_defi.vault.fee import FeeData, VaultFeeMode
 from eth_defi.vault.handwritten_metadata import get_handwritten_vault_metadata
 
 logger = logging.getLogger(__name__)
+
+
+class AccountablePermissionLevel(enum.IntEnum):
+    """Accountable vault access modes from ``IAccess.PermissionLevel``."""
+
+    none = 0
+    kyc = 1
+    whitelist = 2
 
 
 @dataclass(slots=True, frozen=True)
@@ -424,6 +433,65 @@ class AccountableVault(ERC4626Vault):  # noqa: PLR0904
             Protocol-specific request and claim manager.
         """
         return AccountableDepositManager(self)
+
+    def fetch_permission_level(self, block_identifier: BlockIdentifier | None = None) -> AccountablePermissionLevel:
+        """Read Accountable's explicit vault-wide admission mode.
+
+        Verified Accountable source defines ``None = 0``, ``KYC = 1`` and
+        ``Whitelist = 2``. The vault's ``onlyAuth`` modifier permits every
+        account in mode zero, requires a signed per-call authorisation in KYC
+        mode, and reads ``allowed(account)`` in whitelist mode.
+
+        :param block_identifier:
+            Block at which to inspect the immutable permission mode.
+        :return:
+            Typed Accountable permission level.
+        :raise NotImplementedError:
+            If a future deployment returns an unknown enum value.
+        """
+        if block_identifier is None:
+            block_identifier = self._get_block_identifier()
+        raw_level = int(self.vault_contract.functions.permissionLevel().call(block_identifier=block_identifier))
+        try:
+            return AccountablePermissionLevel(raw_level)
+        except ValueError as error:
+            raise NotImplementedError(f"Unknown Accountable permission level {raw_level}") from error
+
+    def is_whitelisted_deposit(self) -> bool:
+        """Report whether Accountable requires identity-based admission.
+
+        Minimum deposits, strategy capacity, loan state, and redemption queues
+        are independent lifecycle conditions and do not affect this result.
+
+        :return:
+            ``False`` for Accountable's ``None`` mode and ``True`` for KYC or
+            explicit whitelist modes.
+        """
+        return self.fetch_permission_level() is not AccountablePermissionLevel.none
+
+    def is_account_whitelisted(self, address: HexAddress) -> bool:
+        """Check whether a bare account can use the configured admission mode.
+
+        Whitelist mode has persistent membership through ``allowed(address)``.
+        KYC mode instead requires Accountable-signed authorisation appended to
+        each call; the standard ERC-4626 transaction builder supplies no such
+        payload, so an address-only request is not admitted.
+
+        :param address:
+            Deposit controller or receiver to inspect.
+        :return:
+            Whether the standard adapter call is admitted for this account.
+        """
+        permission_level = self.fetch_permission_level()
+        if permission_level is AccountablePermissionLevel.none:
+            return True
+        if permission_level is AccountablePermissionLevel.whitelist:
+            return bool(
+                self.vault_contract.functions.allowed(address).call(
+                    block_identifier=self._get_block_identifier(),
+                )
+            )
+        return False
 
     def get_deposit_manager_capability(self) -> VaultDepositManagerCapability:  # noqa: PLR6301
         """Declare Accountable's public request lifecycle.

--- a/eth_defi/erc_4626/vault_protocol/csigma/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/csigma/vault.py
@@ -149,6 +149,17 @@ class CsigmaVault(ERC4626Vault):
         del referral
         return "https://edge.csigma.finance/"
 
+    def is_whitelisted_deposit(self) -> bool:  # noqa: PLR6301
+        """Report cSigma pools as permissionless.
+
+        Verified pool implementations expose only global pause, daily window,
+        and capacity controls; none are per-account identity admission.
+
+        :return:
+            Always ``False``.
+        """
+        return False
+
     def get_deposit_manager(self) -> VaultDepositManager:
         """Create the manager appropriate for this cSigma deployment.
 

--- a/eth_defi/erc_4626/vault_protocol/csigma/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/csigma/vault.py
@@ -150,10 +150,11 @@ class CsigmaVault(ERC4626Vault):
         return "https://edge.csigma.finance/"
 
     def is_whitelisted_deposit(self) -> bool:  # noqa: PLR6301
-        """Report cSigma pools as permissionless.
+        """Report the cSigma adapter family's default permission policy.
 
-        Verified pool implementations expose only global pause, daily window,
-        and capacity controls; none are per-account identity admission.
+        Supported cSigma pools are treated as permissionless by default.
+        Global pause, daily-window and capacity checks are reported separately
+        by the deposit manager and do not change this identity-policy default.
 
         :return:
             Always ``False``.

--- a/eth_defi/erc_4626/vault_protocol/d2/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/d2/vault.py
@@ -10,6 +10,7 @@ from typing import Literal
 
 from eth_typing import BlockIdentifier, HexAddress
 from web3.contract import Contract
+from web3.exceptions import BadFunctionCallOutput, ContractLogicError
 
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
@@ -157,7 +158,22 @@ class D2DepositManager(ERC4626DepositManager):
             )
 
     def _assert_account_eligible(self, owner: HexAddress, direction: Literal["deposit", "redeem"]) -> None:
-        """Enforce D2's public asset-balance eligibility without calling it KYC."""
+        """Enforce D2's account eligibility without conflating it with KYC.
+
+        Mapping-only deployments use the shared whitelist preflight. Public
+        deployments accept either mapping membership or an asset balance above
+        the configured threshold and report an unmet threshold as a typed
+        minimum condition.
+
+        :param owner:
+            Deposit controller or redemption owner to inspect.
+        :param direction:
+            Flow direction used in structured failure evidence.
+        :raise VaultFlowUnavailable:
+            If a public deployment's balance threshold is not met.
+        :raise WhitelistingRequired:
+            If a mapping-only deployment does not admit the account.
+        """
         if self.vault.is_whitelisted_deposit():
             # A mapping-only D2 deployment is a genuine account allow-list.
             self.check_deposit_whitelist(owner)
@@ -584,7 +600,7 @@ class D2Vault(ERC4626Vault):
         """
         return D2DepositManager(self)
 
-    def is_whitelisted_deposit(self) -> bool:  # noqa: PLR6301
+    def is_whitelisted_deposit(self) -> bool:
         """Report whether D2 uses a mapping-only identity gate.
 
         The historical ``onlyWhitelisted`` name is misleading for public
@@ -633,7 +649,19 @@ class D2Vault(ERC4626Vault):
         return whitelist_token.fetch_raw_balance_of(address) > whitelist_balance
 
     def is_account_whitelisted(self, address: HexAddress) -> bool:
-        """Read mapping membership for a mapping-only D2 deployment."""
+        """Read D2 mapping membership when no public balance route exists.
+
+        Public asset-balance eligibility is deliberately exposed through
+        :meth:`is_account_eligible` instead of being labelled as whitelist
+        membership.
+
+        :param address:
+            Account whose explicit D2 mapping membership is inspected.
+        :return:
+            Whether the account is present in the explicit mapping.
+        :raise NotImplementedError:
+            If the deployment has a public asset-balance eligibility route.
+        """
         if not self.is_whitelisted_deposit():
             raise NotImplementedError("Public D2 asset-balance eligibility is not KYC membership")
         return bool(self.vault_contract.functions.whitelisted(address).call())
@@ -712,7 +740,15 @@ class D2Vault(ERC4626Vault):
         return epoch.epoch_end - epoch.epoch_start
 
     def fetch_observation_time(self) -> datetime.datetime:
-        """Read the EVM timestamp used by the current vault observation."""
+        """Read the EVM timestamp used by the current vault observation.
+
+        Delay calculations use the same block context as the vault state
+        instead of the wall clock, which keeps historical and forked reads
+        deterministic.
+
+        :return:
+            Naive UTC timestamp of the adapter's configured block.
+        """
         block = self.web3.eth.get_block(self._get_block_identifier())
         return from_unix_timestamp(block["timestamp"])
 
@@ -729,8 +765,8 @@ class D2Vault(ERC4626Vault):
                         return f"{DEPOSIT_CLOSED_FUNDING_PHASE} (opens in {hours:.0f}h)"
                     return f"{DEPOSIT_CLOSED_FUNDING_PHASE} (opens in {hours / 24:.1f}d)"
                 return DEPOSIT_CLOSED_FUNDING_PHASE
-        except Exception:
-            pass
+        except (BadFunctionCallOutput, ContractLogicError, ValueError) as error:
+            logger.debug("Could not read D2 deposit phase for %s: %s", self.address, error)
         return None
 
     def fetch_redemption_closed_reason(self) -> str | None:
@@ -746,8 +782,8 @@ class D2Vault(ERC4626Vault):
                         return f"{REDEMPTION_CLOSED_FUNDS_CUSTODIED} (opens in {hours:.0f}h)"
                     return f"{REDEMPTION_CLOSED_FUNDS_CUSTODIED} (opens in {hours / 24:.1f}d)"
                 return REDEMPTION_CLOSED_FUNDS_CUSTODIED
-        except Exception:
-            pass
+        except (BadFunctionCallOutput, ContractLogicError, ValueError) as error:
+            logger.debug("Could not read D2 redemption phase for %s: %s", self.address, error)
         return None
 
     def fetch_deposit_next_open(self) -> datetime.datetime | None:
@@ -761,7 +797,8 @@ class D2Vault(ERC4626Vault):
             epoch = self.fetch_current_epoch_info()
             observation_time = self.fetch_observation_time()
             return epoch.epoch_end if epoch.epoch_end > observation_time else None
-        except Exception:
+        except (BadFunctionCallOutput, ContractLogicError, ValueError) as error:
+            logger.debug("Could not read D2 next deposit opening for %s: %s", self.address, error)
             return None
 
     def fetch_redemption_next_open(self) -> datetime.datetime | None:
@@ -775,5 +812,6 @@ class D2Vault(ERC4626Vault):
             epoch = self.fetch_current_epoch_info()
             observation_time = self.fetch_observation_time()
             return epoch.epoch_end if epoch.epoch_end > observation_time else None
-        except Exception:
+        except (BadFunctionCallOutput, ContractLogicError, ValueError) as error:
+            logger.debug("Could not read D2 next redemption opening for %s: %s", self.address, error)
             return None

--- a/eth_defi/erc_4626/vault_protocol/d2/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/d2/vault.py
@@ -12,7 +12,6 @@ from eth_typing import BlockIdentifier, HexAddress
 from web3.contract import Contract
 
 from eth_defi.abi import ZERO_ADDRESS_STR
-from eth_defi.compat import native_datetime_utc_now
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager, ERC4626DepositRequest, ERC4626RedemptionRequest
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
@@ -82,15 +81,13 @@ class D2DepositManager(ERC4626DepositManager):
     trading epoch and can only be redeemed once the vault returns to a
     not-custodied, not-in-epoch state.
 
-    **Whitelisting / access control**
+    **Deposit eligibility**
 
-    Permissioned onchain. The ``VaultV1Whitelisted`` ``onlyWhitelisted``
-    modifier admits an account only if it is on the vault's ``whitelisted``
-    mapping or holds more than ``whitelistBalance`` of ``whitelistAsset``
-    (typically USDC). The inherited :meth:`check_deposit_whitelist` preflight
-    queries this policy for deposits. This manager repeats that preflight for
-    redemption because the same modifier protects ``redeem()`` and a balance-
-    based admission can cease to hold after depositing the underlying asset.
+    The historical ``onlyWhitelisted`` modifier is not an identity/KYC gate:
+    it also admits any account holding more than the public minimum balance of
+    ``whitelistAsset``. The lifecycle experiment funds that eligibility asset
+    where necessary and reports a failed balance condition as flow
+    availability, never as ``whitelisting-needed``.
 
     **Anvil settlement (force_settle)**
 
@@ -190,8 +187,7 @@ class D2DepositManager(ERC4626DepositManager):
 
         This narrow diagnostic exception bypasses D2's temporary funding window
         and ordinary amount/balance checks so a caller can validate the exact
-        manager-generated deposit call through GuardV0. The parent constructor
-        still enforces ``check_deposit_whitelist(owner)``. It intentionally does
+        manager-generated deposit call through GuardV0. It intentionally does
         not construct or validate an ERC-20 approval, nor prove an
         approval-before-deposit sequence: those checks add no evidence to a
         standalone ``validateCall()`` policy check and remain normal live
@@ -203,8 +199,6 @@ class D2DepositManager(ERC4626DepositManager):
             Raw D2 denomination-token amount from the rejected preflight.
         :return:
             One standard ERC-4626 deposit call for isolated GuardV0 validation.
-        :raise WhitelistingRequired:
-            If D2 account admission excludes ``owner``.
         """
         self._assert_anvil_guard_validation()
         return ERC4626DepositManager.create_deposit_request(
@@ -236,11 +230,6 @@ class D2DepositManager(ERC4626DepositManager):
             If the current D2 epoch is not accepting redemptions.
         """
         self._assert_flow_open(owner, "redeem")
-        # D2 applies ``onlyWhitelisted`` to redemption as well as deposit.
-        # A holder admitted through its USDC balance can lose admission after
-        # depositing that USDC, so re-check the live policy before creating a
-        # transaction which would otherwise deterministically revert.
-        self.check_deposit_whitelist(owner)
         return super().create_redemption_request(owner, to, shares, raw_shares, check_max_deposit, check_enough_token)
 
 
@@ -559,20 +548,20 @@ class D2Vault(ERC4626Vault):
         return D2DepositManager(self)
 
     def is_whitelisted_deposit(self) -> bool:  # noqa: PLR6301
-        """Report D2's unconditional ``onlyWhitelisted`` admission policy.
+        """Report D2 deposits as permissionless.
 
-        The policy can be met by either the explicit mapping or a qualifying
-        balance of the configured whitelist asset. A zero whitelist-asset
-        address disables only the balance alternative, not the mapping-based
-        modifier.
+        The historical ``onlyWhitelisted`` name is misleading for public
+        status purposes: any account can satisfy the rule by holding the
+        configured public asset minimum. It is an economic eligibility
+        condition, not KYC or manual identity approval.
 
         :return:
-            Always ``True`` because every D2 deposit evaluates the modifier.
+            Always ``False``.
         """
-        return True
+        return False
 
     def is_account_whitelisted(self, address: HexAddress) -> bool:
-        """Evaluate D2's mapping-or-asset-balance admission rule for an account.
+        """Evaluate D2's legacy mapping-or-asset-balance eligibility rule.
 
         Both ``deposit()`` and ``redeem()`` execute ``onlyWhitelisted``. The
         balance branch is deliberately read at request construction time,
@@ -580,7 +569,7 @@ class D2Vault(ERC4626Vault):
         granted admission.
 
         :param address:
-            Account whose D2 admission policy is queried.
+            Account whose D2 economic eligibility is queried.
         :return:
             ``True`` when the explicit mapping or configured asset balance
             currently admits the account.
@@ -675,6 +664,11 @@ class D2Vault(ERC4626Vault):
         epoch = self.fetch_current_epoch_info()
         return epoch.epoch_end - epoch.epoch_start
 
+    def fetch_observation_time(self) -> datetime.datetime:
+        """Read the EVM timestamp used by the current vault observation."""
+        block = self.web3.eth.get_block(self._get_block_identifier())
+        return from_unix_timestamp(block["timestamp"])
+
     def fetch_deposit_closed_reason(self) -> str | None:
         """Deposits open during isFunding() phase."""
         try:
@@ -682,7 +676,7 @@ class D2Vault(ERC4626Vault):
             if not is_funding:
                 next_open = self.fetch_deposit_next_open()
                 if next_open:
-                    remaining = next_open - native_datetime_utc_now()
+                    remaining = next_open - self.fetch_observation_time()
                     hours = remaining.total_seconds() / 3600
                     if hours < 24:
                         return f"{DEPOSIT_CLOSED_FUNDING_PHASE} (opens in {hours:.0f}h)"
@@ -699,7 +693,7 @@ class D2Vault(ERC4626Vault):
             if not can_redeem:
                 next_open = self.fetch_redemption_next_open()
                 if next_open:
-                    remaining = next_open - native_datetime_utc_now()
+                    remaining = next_open - self.fetch_observation_time()
                     hours = remaining.total_seconds() / 3600
                     if hours < 24:
                         return f"{REDEMPTION_CLOSED_FUNDS_CUSTODIED} (opens in {hours:.0f}h)"
@@ -718,7 +712,8 @@ class D2Vault(ERC4626Vault):
             if self.vault_contract.functions.isFunding().call():
                 return None  # Already open
             epoch = self.fetch_current_epoch_info()
-            return epoch.epoch_end  # Next funding starts after epoch ends
+            observation_time = self.fetch_observation_time()
+            return epoch.epoch_end if epoch.epoch_end > observation_time else None
         except Exception:
             return None
 
@@ -731,6 +726,7 @@ class D2Vault(ERC4626Vault):
             if self.vault_contract.functions.notCustodiedAndNotDuringEpoch().call():
                 return None  # Already open
             epoch = self.fetch_current_epoch_info()
-            return epoch.epoch_end
+            observation_time = self.fetch_observation_time()
+            return epoch.epoch_end if epoch.epoch_end > observation_time else None
         except Exception:
             return None

--- a/eth_defi/erc_4626/vault_protocol/d2/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/d2/vault.py
@@ -156,6 +156,40 @@ class D2DepositManager(ERC4626DepositManager):
                 next_open=next_open,
             )
 
+    def _assert_account_eligible(self, owner: HexAddress, direction: Literal["deposit", "redeem"]) -> None:
+        """Enforce D2's public asset-balance eligibility without calling it KYC."""
+        if self.vault.is_whitelisted_deposit():
+            # A mapping-only D2 deployment is a genuine account allow-list.
+            self.check_deposit_whitelist(owner)
+            return
+
+        if self.vault.is_account_eligible(owner):
+            return
+
+        whitelist_asset = self.vault.vault_contract.functions.whitelistAsset().call()
+        whitelist_balance = self.vault.vault_contract.functions.whitelistBalance().call()
+        eligibility_token = fetch_erc20_details(
+            self.web3,
+            whitelist_asset,
+            chain_id=self.vault.chain_id,
+            cause_diagnostics_message=f"D2 vault {self.vault.address} eligibility check",
+        )
+        available_balance = eligibility_token.fetch_raw_balance_of(owner)
+        minimum_balance = whitelist_balance + 1
+        raise VaultFlowUnavailable(
+            f"D2 account {owner} does not meet the public {eligibility_token.symbol} balance eligibility minimum",
+            protocol=D2_PROTOCOL_NAME,
+            vault_address=self.vault.address,
+            caller=owner,
+            asset_address=eligibility_token.address,
+            direction=direction,
+            phase="preflight",
+            decoded_error="InsufficientEligibilityBalance",
+            preflight_result="below_minimum",
+            available_raw_amount=available_balance,
+            minimum_raw_amount=minimum_balance,
+        )
+
     def create_deposit_request(  # noqa: PLR0917
         self,
         owner: HexAddress,
@@ -176,6 +210,7 @@ class D2DepositManager(ERC4626DepositManager):
             If the current D2 epoch is not accepting deposits.
         """
         self._assert_flow_open(owner, "deposit")
+        self._assert_account_eligible(owner, "deposit")
         return super().create_deposit_request(owner, to, amount, raw_amount, check_max_deposit, check_enough_token)
 
     def create_deposit_request_for_guard_validation(
@@ -201,6 +236,7 @@ class D2DepositManager(ERC4626DepositManager):
             One standard ERC-4626 deposit call for isolated GuardV0 validation.
         """
         self._assert_anvil_guard_validation()
+        self._assert_account_eligible(owner, "deposit")
         return ERC4626DepositManager.create_deposit_request(
             self,
             owner=owner,
@@ -230,6 +266,7 @@ class D2DepositManager(ERC4626DepositManager):
             If the current D2 epoch is not accepting redemptions.
         """
         self._assert_flow_open(owner, "redeem")
+        self._assert_account_eligible(owner, "redeem")
         return super().create_redemption_request(owner, to, shares, raw_shares, check_max_deposit, check_enough_token)
 
 
@@ -548,19 +585,23 @@ class D2Vault(ERC4626Vault):
         return D2DepositManager(self)
 
     def is_whitelisted_deposit(self) -> bool:  # noqa: PLR6301
-        """Report D2 deposits as permissionless.
+        """Report whether D2 uses a mapping-only identity gate.
 
         The historical ``onlyWhitelisted`` name is misleading for public
         status purposes: any account can satisfy the rule by holding the
         configured public asset minimum. It is an economic eligibility
-        condition, not KYC or manual identity approval.
+        condition, not KYC or manual identity approval. A zero whitelist-asset
+        address removes that public route and leaves only the explicit mapping,
+        which is a genuine account allow-list.
 
         :return:
-            Always ``False``.
+            ``False`` when public asset-balance admission is configured;
+            otherwise ``True`` for a mapping-only deployment.
         """
-        return False
+        whitelist_asset = self.vault_contract.functions.whitelistAsset().call()
+        return whitelist_asset.lower() == ZERO_ADDRESS_STR
 
-    def is_account_whitelisted(self, address: HexAddress) -> bool:
+    def is_account_eligible(self, address: HexAddress) -> bool:
         """Evaluate D2's legacy mapping-or-asset-balance eligibility rule.
 
         Both ``deposit()`` and ``redeem()`` execute ``onlyWhitelisted``. The
@@ -590,6 +631,12 @@ class D2Vault(ERC4626Vault):
             cause_diagnostics_message=f"D2 vault {self.address} whitelist admission check",
         )
         return whitelist_token.fetch_raw_balance_of(address) > whitelist_balance
+
+    def is_account_whitelisted(self, address: HexAddress) -> bool:
+        """Read mapping membership for a mapping-only D2 deployment."""
+        if not self.is_whitelisted_deposit():
+            raise NotImplementedError("Public D2 asset-balance eligibility is not KYC membership")
+        return bool(self.vault_contract.functions.whitelisted(address).call())
 
     def get_link(self, referral: str | None = None) -> str:  # noqa: ARG002
         """Get the canonical public page for this D2 vault.

--- a/eth_defi/erc_4626/vault_protocol/d2/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/d2/vault.py
@@ -26,7 +26,7 @@ from eth_defi.vault.base import (
     VaultHistoricalRead,
     VaultHistoricalReader,
 )
-from eth_defi.vault.deposit_redeem import VaultFlowUnavailable
+from eth_defi.vault.deposit_redeem import VaultFlowUnavailable, WhitelistingRequired
 
 logger = logging.getLogger(__name__)
 
@@ -174,16 +174,22 @@ class D2DepositManager(ERC4626DepositManager):
         :raise WhitelistingRequired:
             If a mapping-only deployment does not admit the account.
         """
-        if self.vault.is_whitelisted_deposit():
-            # A mapping-only D2 deployment is a genuine account allow-list.
-            self.check_deposit_whitelist(owner)
+        vault_contract = self.vault.vault_contract
+        if vault_contract.functions.whitelisted(owner).call():
             return
 
-        if self.vault.is_account_eligible(owner):
-            return
+        whitelist_asset = vault_contract.functions.whitelistAsset().call()
+        if whitelist_asset.lower() == ZERO_ADDRESS_STR:
+            raise WhitelistingRequired(
+                f"Depositor {owner} is not whitelisted for D2 vault {self.vault.address} on chain {self.vault.chain_id}",
+                protocol=D2_PROTOCOL_NAME,
+                vault_address=self.vault.address,
+                caller=owner,
+                direction=direction,
+                phase="preflight",
+            )
 
-        whitelist_asset = self.vault.vault_contract.functions.whitelistAsset().call()
-        whitelist_balance = self.vault.vault_contract.functions.whitelistBalance().call()
+        whitelist_balance = vault_contract.functions.whitelistBalance().call()
         eligibility_token = fetch_erc20_details(
             self.web3,
             whitelist_asset,
@@ -191,6 +197,9 @@ class D2DepositManager(ERC4626DepositManager):
             cause_diagnostics_message=f"D2 vault {self.vault.address} eligibility check",
         )
         available_balance = eligibility_token.fetch_raw_balance_of(owner)
+        if available_balance > whitelist_balance:
+            return
+
         minimum_balance = whitelist_balance + 1
         raise VaultFlowUnavailable(
             f"D2 account {owner} does not meet the public {eligibility_token.symbol} balance eligibility minimum",
@@ -237,8 +246,9 @@ class D2DepositManager(ERC4626DepositManager):
         """Build D2 deposit calldata while its funding epoch is closed.
 
         This narrow diagnostic exception bypasses D2's temporary funding window
-        and ordinary amount/balance checks so a caller can validate the exact
-        manager-generated deposit call through GuardV0. It intentionally does
+        and denomination-token amount/balance checks so a caller can validate
+        the exact manager-generated deposit call through GuardV0. D2's separate
+        mapping-or-eligibility-asset admission check still applies. It intentionally does
         not construct or validate an ERC-20 approval, nor prove an
         approval-before-deposit sequence: those checks add no evidence to a
         standalone ``validateCall()`` policy check and remain normal live
@@ -250,6 +260,10 @@ class D2DepositManager(ERC4626DepositManager):
             Raw D2 denomination-token amount from the rejected preflight.
         :return:
             One standard ERC-4626 deposit call for isolated GuardV0 validation.
+        :raise VaultFlowUnavailable:
+            If the owner does not meet a public eligibility-asset minimum.
+        :raise WhitelistingRequired:
+            If a mapping-only deployment does not admit the owner.
         """
         self._assert_anvil_guard_validation()
         self._assert_account_eligible(owner, "deposit")

--- a/eth_defi/erc_4626/vault_protocol/ember/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/ember/vault.py
@@ -102,10 +102,11 @@ class EmberVault(ERC4626Vault):
         return None
 
     def is_whitelisted_deposit(self) -> bool:  # noqa: PLR6301
-        """Report Ember depositor access as permissionless.
+        """Report the Ember adapter family's default permission policy.
 
-        Ember's vault contract only applies global pause and capacity checks;
-        it has no per-account KYC or allowlist policy.
+        Supported Ember deployments are treated as permissionless by default.
+        Global pause, capacity and minimum checks are independent lifecycle
+        conditions handled by the deposit manager.
 
         :return:
             Always ``False``.

--- a/eth_defi/erc_4626/vault_protocol/ember/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/ember/vault.py
@@ -101,6 +101,17 @@ class EmberVault(ERC4626Vault):
             return self.ember_metadata.get("management_fee")
         return None
 
+    def is_whitelisted_deposit(self) -> bool:  # noqa: PLR6301
+        """Report Ember depositor access as permissionless.
+
+        Ember's vault contract only applies global pause and capacity checks;
+        it has no per-account KYC or allowlist policy.
+
+        :return:
+            Always ``False``.
+        """
+        return False
+
     def get_performance_fee(self, block_identifier: BlockIdentifier) -> float | None:
         """Weekly performance fee from Ember's offchain API.
 

--- a/eth_defi/erc_4626/vault_protocol/euler/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/euler/vault.py
@@ -15,16 +15,16 @@ from decimal import Decimal
 from functools import cached_property
 from typing import Iterable
 
-from eth_typing import BlockIdentifier
+from eth_typing import BlockIdentifier, HexAddress
 from web3 import Web3
 
+from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.euler.offchain_metadata import EulerVaultMetadata, fetch_euler_vault_metadata
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.types import Percent
 from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader, VaultTechnicalRisk
-from eth_defi.vault.deposit_redeem import PERMISSIONED_HOOK_CHECKS_NOT_PERFORMED_NOTE
 from eth_defi.vault.flag import BAD_FLAGS, get_vault_special_flags
 
 logger = logging.getLogger(__name__)
@@ -33,6 +33,11 @@ logger = logging.getLogger(__name__)
 CASH_SIGNATURE = Web3.keccak(text="cash()")[0:4]
 TOTAL_BORROWS_SIGNATURE = Web3.keccak(text="totalBorrows()")[0:4]
 INTEREST_FEE_SIGNATURE = Web3.keccak(text="interestFee()")[0:4]
+HOOK_CONFIG_SIGNATURE = Web3.keccak(text="hookConfig()")[0:4]
+
+#: EVK operation bitmap values from ``Constants.sol``.
+EULER_OP_DEPOSIT = 1 << 0
+EULER_OP_MINT = 1 << 1
 
 #: Monad mainnet chain id.
 MONAD_CHAIN_ID = 143
@@ -257,18 +262,40 @@ class EulerVault(ERC4626Vault):
     TODO: Fees
     """
 
-    whitelist_notes = PERMISSIONED_HOOK_CHECKS_NOT_PERFORMED_NOTE
-
     def is_whitelisted_deposit(self) -> bool:
-        """Apply the requested whitelist assumption to every Euler EVK vault.
+        """Determine whether EVK deposit hooks impose an identity gate.
 
-        This deliberately does not inspect optional account-specific hooks.
-        The public export carries that limitation in ``whitelist.notes``.
+        Euler Vault Kit exposes the hook target and operation bitmap through
+        ``hookConfig()``. Deposits are permissionless when neither ``deposit``
+        nor ``mint`` is hooked. A zero hook target with either bit set disables
+        that operation for everyone, which is availability rather than KYC.
+        A non-zero custom hook is not assumed to be an allow-list because EVK
+        hooks are arbitrary protocol extensions.
 
         :return:
-            Always ``True`` under the current operating assumption.
+            ``False`` for the canonical unhooked or globally disabled cases.
+        :raise NotImplementedError:
+            If a custom deposit or mint hook needs protocol-specific analysis.
         """
-        return True
+        hook_target, hooked_ops = self.fetch_hook_config()
+        deposit_hooks = hooked_ops & (EULER_OP_DEPOSIT | EULER_OP_MINT)
+        if deposit_hooks == 0 or hook_target.lower() == ZERO_ADDRESS_STR:
+            return False
+        raise NotImplementedError(f"Euler EVK vault {self.address} uses custom deposit hooks {hook_target} with operation bitmap {hooked_ops:#x}")
+
+    def fetch_hook_config(self, block_identifier: BlockIdentifier | None = None) -> tuple[HexAddress, int]:
+        """Read the canonical EVK hook target and operation bitmap."""
+        call = EncodedCall.from_keccak_signature(
+            address=self.address,
+            signature=HOOK_CONFIG_SIGNATURE,
+            function="hookConfig",
+            data=b"",
+            extra_data=None,
+        )
+        data = call.call(self.web3, block_identifier or self._get_block_identifier())
+        hook_target = Web3.to_checksum_address(data[12:32])
+        hooked_ops = int.from_bytes(data[32:64], byteorder="big")
+        return hook_target, hooked_ops
 
     def get_risk(self) -> VaultTechnicalRisk | None:
         # Check for vault-specific flags (e.g., xUSD exposure) first
@@ -476,18 +503,13 @@ class EulerEarnVault(ERC4626Vault):
     - Example vault: https://snowtrace.io/address/0xE1A62FDcC6666847d5EA752634E45e134B2F824B
     """
 
-    whitelist_notes = PERMISSIONED_HOOK_CHECKS_NOT_PERFORMED_NOTE
-
     def is_whitelisted_deposit(self) -> bool:
-        """Apply the requested whitelist assumption to every EulerEarn vault.
-
-        This deliberately does not inspect optional account-specific hooks.
-        The public export carries that limitation in ``whitelist.notes``.
+        """Report canonical EulerEarn vault deposits as permissionless.
 
         :return:
-            Always ``True`` under the current operating assumption.
+            Always ``False`` because EulerEarn has no depositor identity gate.
         """
-        return True
+        return False
 
     def get_risk(self) -> VaultTechnicalRisk | None:
         """EulerEarn vaults have negligible risk due to battle-tested infrastructure.

--- a/eth_defi/erc_4626/vault_protocol/euler/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/euler/vault.py
@@ -284,7 +284,19 @@ class EulerVault(ERC4626Vault):
         raise NotImplementedError(f"Euler EVK vault {self.address} uses custom deposit hooks {hook_target} with operation bitmap {hooked_ops:#x}")
 
     def fetch_hook_config(self, block_identifier: BlockIdentifier | None = None) -> tuple[HexAddress, int]:
-        """Read the canonical EVK hook target and operation bitmap."""
+        """Read the canonical EVK hook target and operation bitmap.
+
+        EVK's `hookConfig()` packs the hook contract and operation bitmap into
+        its standard return tuple. Deposit permission classification only uses
+        the deposit and mint bits.
+
+        See `Euler Vault Kit hooks <https://github.com/euler-xyz/euler-vault-kit/blob/master/docs/whitepaper.md#hooks>`__.
+
+        :param block_identifier:
+            Block at which the EVK configuration is inspected.
+        :return:
+            Hook contract address and complete hooked-operation bitmap.
+        """
         call = EncodedCall.from_keccak_signature(
             address=self.address,
             signature=HOOK_CONFIG_SIGNATURE,
@@ -292,7 +304,9 @@ class EulerVault(ERC4626Vault):
             data=b"",
             extra_data=None,
         )
-        data = call.call(self.web3, block_identifier or self._get_block_identifier())
+        if block_identifier is None:
+            block_identifier = self._get_block_identifier()
+        data = call.call(self.web3, block_identifier)
         hook_target = Web3.to_checksum_address(data[12:32])
         hooked_ops = int.from_bytes(data[32:64], byteorder="big")
         return hook_target, hooked_ops

--- a/eth_defi/erc_4626/vault_protocol/forty_acres/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/forty_acres/vault.py
@@ -144,6 +144,18 @@ class FortyAcresVault(ERC4626Vault):
         """
         return None
 
+    def is_whitelisted_deposit(self) -> bool:  # noqa: PLR6301
+        """Report 40acres lender deposits as permissionless.
+
+        The verified supply-vault implementation has no account admission
+        module. Utilisation and available liquidity can limit a deposit, but
+        these are public economic conditions rather than identity checks.
+
+        :return:
+            Always ``False``.
+        """
+        return False
+
     def get_link(self, referral: str | None = None) -> str:
         """Link to the 40acres app."""
         return "https://app.40acres.finance/"

--- a/eth_defi/erc_4626/vault_protocol/forty_acres/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/forty_acres/vault.py
@@ -145,11 +145,11 @@ class FortyAcresVault(ERC4626Vault):
         return None
 
     def is_whitelisted_deposit(self) -> bool:  # noqa: PLR6301
-        """Report 40acres lender deposits as permissionless.
+        """Report the 40acres adapter family's default permission policy.
 
-        The verified supply-vault implementation has no account admission
-        module. Utilisation and available liquidity can limit a deposit, but
-        these are public economic conditions rather than identity checks.
+        Supported 40acres supply vaults are treated as permissionless by
+        default. Utilisation and available liquidity remain independent
+        economic conditions.
 
         :return:
             Always ``False``.

--- a/eth_defi/erc_4626/vault_protocol/morpho/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/deposit_redeem.py
@@ -12,8 +12,10 @@ from eth_typing import HexAddress
 from hexbytes import HexBytes
 from web3.exceptions import ContractLogicError
 
+from eth_defi.abi import get_deployed_contract
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager, ERC4626RedemptionRequest
-from eth_defi.vault.deposit_redeem import VaultFlowUnavailable, extract_revert_data
+from eth_defi.provider.anvil import fund_erc20_on_anvil, is_anvil
+from eth_defi.vault.deposit_redeem import UnsupportedVaultSimulation, VaultFlowUnavailable, VaultRedemptionSimulationIntervention, extract_revert_data
 
 #: ``TransferReverted()`` from Morpho Vault V2's ``SafeERC20Lib.safeTransfer``.
 #: The library is used for the final redemption asset payout:
@@ -28,6 +30,92 @@ class MorphoV2DepositManager(ERC4626DepositManager):
     therefore retains the generic request construction and adds an ``eth_call``
     of the exact redemption from its eventual caller.
     """
+
+    def force_redemption_liquidity(
+        self,
+        owner: HexAddress,
+        raw_shares: int,
+        failure: VaultFlowUnavailable,
+    ) -> VaultRedemptionSimulationIntervention:
+        """Inject only the missing payout asset for a proven transfer failure.
+
+        Morpho Vault V2 deallocates a redemption shortfall from its configured
+        liquidity adapter before paying from the vault. When the exact call
+        fails in that SafeERC20 transfer chain on an Anvil fork, provision the
+        adapter with only the shortfall returned by ``previewRedeem`` and let
+        the caller retry the unchanged redemption transaction. A deployment
+        without a liquidity adapter is provisioned at the vault's idle-asset
+        balance instead. Vault V2 accounts through its stored ``_totalAssets``;
+        the helper adds one native unit for retry-time fee rounding. No gate,
+        minimum or time condition is bypassed.
+        """
+        if not is_anvil(self.web3):
+            raise UnsupportedVaultSimulation(
+                "Morpho Vault V2 redemption liquidity injection requires Anvil",
+                unsupported_reason="anvil_provider_required",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            )
+        if failure.decoded_error != "TransferReverted" or failure.error_selector != MORPHO_V2_TRANSFER_REVERTED_SELECTOR:
+            raise UnsupportedVaultSimulation(
+                "Morpho Vault V2 liquidity injection requires a proven TransferReverted redemption preflight",
+                unsupported_reason="redemption_failure_not_liquidity_transfer",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            )
+
+        token = self.vault.denomination_token
+        morpho_v2_contract = get_deployed_contract(
+            self.web3,
+            "morpho/IVaultV2.json",
+            self.vault.address,
+        )
+        liquidity_adapter = morpho_v2_contract.functions.liquidityAdapter().call()
+        target = liquidity_adapter if int(liquidity_adapter, 16) != 0 else self.vault.address
+        injected_raw = 0
+        for _attempt in range(4):
+            required_raw = int(self.vault.vault_contract.functions.previewRedeem(raw_shares).call())
+            vault_balance_raw = token.fetch_raw_balance_of(self.vault.address)
+            target_balance_raw = token.fetch_raw_balance_of(target)
+            available_raw = vault_balance_raw if target == self.vault.address else vault_balance_raw + target_balance_raw
+            if available_raw >= required_raw:
+                break
+            # Include one native unit because Vault V2's fee/accrual rounding
+            # can increase previewRedeem between the provisioning reads.
+            top_up_raw = required_raw - available_raw + 1
+            fund_erc20_on_anvil(
+                self.web3,
+                token.address,
+                target,
+                target_balance_raw + top_up_raw,
+            )
+            injected_raw += top_up_raw
+        else:
+            raise UnsupportedVaultSimulation(
+                "Morpho Vault V2 redemption liquidity did not converge after provisioning",
+                unsupported_reason="morpho_v2_redemption_liquidity_not_reproducible",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            )
+        if injected_raw == 0:
+            raise UnsupportedVaultSimulation(
+                "Morpho Vault V2 transfer failed despite sufficient redemption liquidity",
+                unsupported_reason="redemption_transfer_failure_not_balance_shortfall",
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                direction="redeem",
+            )
+        return VaultRedemptionSimulationIntervention(
+            kind="liquidity_injected",
+            token=token.address,
+            target=target,
+            raw_amount=injected_raw,
+            original_reason=failure.reason,
+            original_preflight_result=failure.preflight_result,
+        )
 
     def create_redemption_request(  # noqa: PLR0917
         self,
@@ -88,6 +176,9 @@ class MorphoV2DepositManager(ERC4626DepositManager):
             selector_length = len(MORPHO_V2_TRANSFER_REVERTED_SELECTOR)
             error_selector = revert_data[:selector_length] if revert_data and len(revert_data) >= selector_length else None
             transfer_failed = error_selector == MORPHO_V2_TRANSFER_REVERTED_SELECTOR
+            required_raw = int(self.vault.vault_contract.functions.previewRedeem(request.raw_shares).call())
+            available_raw = self.vault.denomination_token.fetch_raw_balance_of(self.vault.address)
+            liquidity_shortfall = transfer_failed and available_raw < required_raw
             raise VaultFlowUnavailable(
                 (f"Morpho Vault V2 redemption asset transfer failed for vault {self.vault.address} on chain {self.vault.chain_id}" if transfer_failed else f"Morpho Vault V2 redemption call reverted for vault {self.vault.address} on chain {self.vault.chain_id}"),
                 protocol=self.vault.get_protocol_name(),
@@ -96,9 +187,10 @@ class MorphoV2DepositManager(ERC4626DepositManager):
                 direction="redeem",
                 phase="preflight",
                 decoded_error="TransferReverted" if transfer_failed else None,
-                preflight_result="redemption_asset_transfer_failed" if transfer_failed else "redemption_call_reverted",
+                preflight_result="redemption_liquidity_unavailable" if liquidity_shortfall else "redemption_asset_transfer_failed" if transfer_failed else "redemption_call_reverted",
                 raw_revert_data=revert_data,
                 requested_raw_amount=request.raw_shares,
+                available_raw_amount=available_raw if transfer_failed else None,
                 error_selector=error_selector,
             ) from error
         return request

--- a/eth_defi/erc_4626/vault_protocol/morpho/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/deposit_redeem.py
@@ -31,6 +31,33 @@ class MorphoV2DepositManager(ERC4626DepositManager):
     of the exact redemption from its eventual caller.
     """
 
+    def fetch_redemption_liquidity(self) -> tuple[HexAddress, int, int]:
+        """Read balances that can satisfy a Morpho V2 redemption payout.
+
+        Vault V2 may hold idle assets directly or pull them through its
+        configured liquidity adapter. This helper reports both the funding
+        target and the combined immediately visible token balance.
+
+        See `Morpho Vault V2 liquidity documentation <https://github.com/morpho-org/vault-v2#liquidity>`__.
+
+        :return:
+            ``(target, target_balance, available_balance)`` in raw denomination
+            token units. ``target`` is the liquidity adapter when configured,
+            otherwise the vault itself.
+        """
+        morpho_v2_contract = get_deployed_contract(
+            self.web3,
+            "morpho/IVaultV2.json",
+            self.vault.address,
+        )
+        liquidity_adapter = morpho_v2_contract.functions.liquidityAdapter().call()
+        target = liquidity_adapter if int(liquidity_adapter, 16) != 0 else self.vault.address
+        token = self.vault.denomination_token
+        vault_balance_raw = token.fetch_raw_balance_of(self.vault.address)
+        target_balance_raw = vault_balance_raw if target == self.vault.address else token.fetch_raw_balance_of(target)
+        available_raw = vault_balance_raw if target == self.vault.address else vault_balance_raw + target_balance_raw
+        return target, target_balance_raw, available_raw
+
     def force_redemption_liquidity(
         self,
         owner: HexAddress,
@@ -48,7 +75,20 @@ class MorphoV2DepositManager(ERC4626DepositManager):
         balance instead. Vault V2 accounts through its stored ``_totalAssets``;
         the helper adds one native unit for retry-time fee rounding. No gate,
         minimum or time condition is bypassed.
+
+        :param owner:
+            Redemption owner. Retained for the common intervention interface.
+        :param raw_shares:
+            Exact raw share quantity that the unchanged retry will redeem.
+        :param failure:
+            Source preflight failure proving the transfer path reverted.
+        :return:
+            Structured evidence describing the Anvil-only token injection.
+        :raise UnsupportedVaultSimulation:
+            If the provider is not Anvil, the failure is not the recognised
+            transfer error, or balance provisioning does not reproduce safely.
         """
+        del owner
         if not is_anvil(self.web3):
             raise UnsupportedVaultSimulation(
                 "Morpho Vault V2 redemption liquidity injection requires Anvil",
@@ -67,19 +107,10 @@ class MorphoV2DepositManager(ERC4626DepositManager):
             )
 
         token = self.vault.denomination_token
-        morpho_v2_contract = get_deployed_contract(
-            self.web3,
-            "morpho/IVaultV2.json",
-            self.vault.address,
-        )
-        liquidity_adapter = morpho_v2_contract.functions.liquidityAdapter().call()
-        target = liquidity_adapter if int(liquidity_adapter, 16) != 0 else self.vault.address
         injected_raw = 0
         for _attempt in range(4):
             required_raw = int(self.vault.vault_contract.functions.previewRedeem(raw_shares).call())
-            vault_balance_raw = token.fetch_raw_balance_of(self.vault.address)
-            target_balance_raw = token.fetch_raw_balance_of(target)
-            available_raw = vault_balance_raw if target == self.vault.address else vault_balance_raw + target_balance_raw
+            target, target_balance_raw, available_raw = self.fetch_redemption_liquidity()
             if available_raw >= required_raw:
                 break
             # Include one native unit because Vault V2's fee/accrual rounding
@@ -176,9 +207,18 @@ class MorphoV2DepositManager(ERC4626DepositManager):
             selector_length = len(MORPHO_V2_TRANSFER_REVERTED_SELECTOR)
             error_selector = revert_data[:selector_length] if revert_data and len(revert_data) >= selector_length else None
             transfer_failed = error_selector == MORPHO_V2_TRANSFER_REVERTED_SELECTOR
-            required_raw = int(self.vault.vault_contract.functions.previewRedeem(request.raw_shares).call())
-            available_raw = self.vault.denomination_token.fetch_raw_balance_of(self.vault.address)
-            liquidity_shortfall = transfer_failed and available_raw < required_raw
+            available_raw = None
+            liquidity_shortfall = False
+            if transfer_failed:
+                required_raw = int(self.vault.vault_contract.functions.previewRedeem(request.raw_shares).call())
+                _target, _target_balance_raw, available_raw = self.fetch_redemption_liquidity()
+                liquidity_shortfall = available_raw < required_raw
+            if liquidity_shortfall:
+                preflight_result = "redemption_liquidity_unavailable"
+            elif transfer_failed:
+                preflight_result = "redemption_asset_transfer_failed"
+            else:
+                preflight_result = "redemption_call_reverted"
             raise VaultFlowUnavailable(
                 (f"Morpho Vault V2 redemption asset transfer failed for vault {self.vault.address} on chain {self.vault.chain_id}" if transfer_failed else f"Morpho Vault V2 redemption call reverted for vault {self.vault.address} on chain {self.vault.chain_id}"),
                 protocol=self.vault.get_protocol_name(),
@@ -187,7 +227,7 @@ class MorphoV2DepositManager(ERC4626DepositManager):
                 direction="redeem",
                 phase="preflight",
                 decoded_error="TransferReverted" if transfer_failed else None,
-                preflight_result="redemption_liquidity_unavailable" if liquidity_shortfall else "redemption_asset_transfer_failed" if transfer_failed else "redemption_call_reverted",
+                preflight_result=preflight_result,
                 raw_revert_data=revert_data,
                 requested_raw_amount=request.raw_shares,
                 available_raw_amount=available_raw if transfer_failed else None,

--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v1.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v1.py
@@ -30,7 +30,6 @@ from eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata import (
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.types import Percent
 from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
-from eth_defi.vault.deposit_redeem import PERMISSIONED_HOOK_CHECKS_NOT_PERFORMED_NOTE
 from eth_defi.vault.flag import NOT_IN_MORPHO_API, VaultFlag
 
 logger = logging.getLogger(__name__)
@@ -163,18 +162,13 @@ class MorphoV1Vault(ERC4626Vault):
     for the newer adapter-based architecture.
     """
 
-    whitelist_notes = PERMISSIONED_HOOK_CHECKS_NOT_PERFORMED_NOTE
-
     def is_whitelisted_deposit(self) -> bool:
-        """Apply the requested whitelist assumption to every Morpho V1 vault.
-
-        This deliberately does not inspect optional account-specific hooks.
-        The public export carries that limitation in ``whitelist.notes``.
+        """Report canonical MetaMorpho deposits as permissionless.
 
         :return:
-            Always ``True`` under the current operating assumption.
+            Always ``False`` because MetaMorpho has no depositor identity gate.
         """
-        return True
+        return False
 
     @cached_property
     def morpho_api_result(self) -> MorphoVaultAPIResult:

--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
@@ -22,9 +22,10 @@ from decimal import Decimal
 from functools import cached_property
 from typing import Iterable
 
-from eth_typing import BlockIdentifier
+from eth_typing import BlockIdentifier, HexAddress
 from web3 import Web3
 
+from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.morpho.deposit_redeem import MorphoV2DepositManager
@@ -39,7 +40,6 @@ from eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata import (
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.types import Percent
 from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
-from eth_defi.vault.deposit_redeem import PERMISSIONED_HOOK_CHECKS_NOT_PERFORMED_NOTE
 from eth_defi.vault.flag import NOT_IN_MORPHO_API, VaultFlag
 
 logger = logging.getLogger(__name__)
@@ -56,6 +56,8 @@ FEE_DENOMINATOR = 10**18
 #: Keccak signatures for fee multicalls
 PERFORMANCE_FEE_SIGNATURE = Web3.keccak(text="performanceFee()")[0:4]
 MANAGEMENT_FEE_SIGNATURE = Web3.keccak(text="managementFee()")[0:4]
+RECEIVE_SHARES_GATE_SIGNATURE = Web3.keccak(text="receiveSharesGate()")[0:4]
+SEND_ASSETS_GATE_SIGNATURE = Web3.keccak(text="sendAssetsGate()")[0:4]
 
 
 class MorphoV2VaultHistoricalReader(ERC4626HistoricalReader):
@@ -208,18 +210,55 @@ class MorphoV2Vault(ERC4626Vault):
     for the original MetaMorpho architecture.
     """
 
-    whitelist_notes = PERMISSIONED_HOOK_CHECKS_NOT_PERFORMED_NOTE
-
     def is_whitelisted_deposit(self) -> bool:
-        """Apply the requested whitelist assumption to every Morpho V2 vault.
+        """Determine whether Morpho V2 has depositor gates configured.
 
-        This deliberately does not inspect optional account-specific hooks.
-        The public export carries that limitation in ``whitelist.notes``.
+        Canonical Morpho V2 vaults are permissionless when both optional gate
+        addresses are zero. A configured gate is an arbitrary ``Irm``-style
+        predicate and cannot safely be called KYC without recognising its
+        implementation.
 
         :return:
-            Always ``True`` under the current operating assumption.
+            ``False`` when both canonical gate slots are disabled.
+        :raise NotImplementedError:
+            If a deployed gate requires implementation-specific analysis.
         """
-        return True
+        receive_shares_gate, send_assets_gate = self.fetch_deposit_gates()
+        if receive_shares_gate.lower() == ZERO_ADDRESS_STR and send_assets_gate.lower() == ZERO_ADDRESS_STR:
+            return False
+        raise NotImplementedError(f"Morpho V2 vault {self.address} has custom gates: receiveSharesGate={receive_shares_gate}, sendAssetsGate={send_assets_gate}")
+
+    def fetch_deposit_gates(self, block_identifier: BlockIdentifier | None = None) -> tuple[HexAddress, HexAddress]:
+        """Read Morpho V2's canonical receiver and sender gate slots."""
+        block_identifier = block_identifier or self._get_block_identifier()
+        receive_shares_gate = self._fetch_gate_address(
+            RECEIVE_SHARES_GATE_SIGNATURE,
+            "receiveSharesGate",
+            block_identifier,
+        )
+        send_assets_gate = self._fetch_gate_address(
+            SEND_ASSETS_GATE_SIGNATURE,
+            "sendAssetsGate",
+            block_identifier,
+        )
+        return receive_shares_gate, send_assets_gate
+
+    def _fetch_gate_address(
+        self,
+        signature: bytes,
+        function_name: str,
+        block_identifier: BlockIdentifier,
+    ) -> HexAddress:
+        """Read one Morpho V2 gate address without widening the ERC-4626 ABI."""
+        call = EncodedCall.from_keccak_signature(
+            address=self.address,
+            signature=signature,
+            function=function_name,
+            data=b"",
+            extra_data=None,
+        )
+        data = call.call(self.web3, block_identifier)
+        return Web3.to_checksum_address(data[12:32])
 
     def get_deposit_manager(self) -> MorphoV2DepositManager:
         """Create a manager that simulates exact Morpho V2 redemptions.

--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
@@ -214,9 +214,9 @@ class MorphoV2Vault(ERC4626Vault):
         """Determine whether Morpho V2 has depositor gates configured.
 
         Canonical Morpho V2 vaults are permissionless when both optional gate
-        addresses are zero. A configured gate is an arbitrary ``Irm``-style
-        predicate and cannot safely be called KYC without recognising its
-        implementation.
+        addresses are zero. Configured gates implement Morpho's
+        ``IReceiveSharesGate`` and ``ISendAssetsGate`` predicates and cannot
+        safely be called KYC without recognising their implementation.
 
         :return:
             ``False`` when both canonical gate slots are disabled.
@@ -229,8 +229,21 @@ class MorphoV2Vault(ERC4626Vault):
         raise NotImplementedError(f"Morpho V2 vault {self.address} has custom gates: receiveSharesGate={receive_shares_gate}, sendAssetsGate={send_assets_gate}")
 
     def fetch_deposit_gates(self, block_identifier: BlockIdentifier | None = None) -> tuple[HexAddress, HexAddress]:
-        """Read Morpho V2's canonical receiver and sender gate slots."""
-        block_identifier = block_identifier or self._get_block_identifier()
+        """Read Morpho V2's canonical receiver and sender gate slots.
+
+        Deposits can be restricted independently by the account receiving
+        shares and the account sending assets. The zero address disables each
+        corresponding gate.
+
+        See `Morpho Vault V2 gate interfaces <https://github.com/morpho-org/vault-v2/blob/main/src/interfaces/IGate.sol>`__.
+
+        :param block_identifier:
+            Block at which both gate slots are inspected.
+        :return:
+            ``(receiveSharesGate, sendAssetsGate)`` addresses.
+        """
+        if block_identifier is None:
+            block_identifier = self._get_block_identifier()
         receive_shares_gate = self._fetch_gate_address(
             RECEIVE_SHARES_GATE_SIGNATURE,
             "receiveSharesGate",
@@ -249,7 +262,17 @@ class MorphoV2Vault(ERC4626Vault):
         function_name: str,
         block_identifier: BlockIdentifier,
     ) -> HexAddress:
-        """Read one Morpho V2 gate address without widening the ERC-4626 ABI."""
+        """Read one Morpho V2 gate address without widening the ERC-4626 ABI.
+
+        :param signature:
+            Four-byte getter selector.
+        :param function_name:
+            Human-readable getter name used in diagnostics.
+        :param block_identifier:
+            Block at which the gate is read.
+        :return:
+            Checksummed gate address.
+        """
         call = EncodedCall.from_keccak_signature(
             address=self.address,
             signature=signature,

--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
@@ -235,7 +235,8 @@ class MorphoV2Vault(ERC4626Vault):
         shares and the account sending assets. The zero address disables each
         corresponding gate.
 
-        See `Morpho Vault V2 gate interfaces <https://github.com/morpho-org/vault-v2/blob/main/src/interfaces/IGate.sol>`__.
+        See `Morpho Vault V2 gate documentation <https://github.com/morpho-org/vault-v2#Gates>`__
+        and `gate interfaces <https://github.com/morpho-org/vault-v2/blob/main/src/interfaces/IGate.sol>`__.
 
         :param block_identifier:
             Block at which both gate slots are inspected.

--- a/eth_defi/erc_4626/vault_protocol/plutus/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/plutus/vault.py
@@ -232,10 +232,11 @@ class PlutusVault(ERC4626Vault):
         return PlutusDepositManager(self)
 
     def is_whitelisted_deposit(self) -> bool:  # noqa: PLR6301
-        """Report Plutus deposits as permissionless.
+        """Report the Plutus adapter family's default permission policy.
 
-        The protocol controls deposit and withdrawal windows globally and does
-        not maintain a depositor KYC or allowlist policy.
+        Supported Plutus deployments are treated as permissionless by default.
+        Deposit and withdrawal windows remain independent global lifecycle
+        controls.
 
         :return:
             Always ``False``.

--- a/eth_defi/erc_4626/vault_protocol/plutus/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/plutus/vault.py
@@ -231,6 +231,17 @@ class PlutusVault(ERC4626Vault):
             return PlutusAsyncDepositManager(self)
         return PlutusDepositManager(self)
 
+    def is_whitelisted_deposit(self) -> bool:  # noqa: PLR6301
+        """Report Plutus deposits as permissionless.
+
+        The protocol controls deposit and withdrawal windows globally and does
+        not maintain a depositor KYC or allowlist policy.
+
+        :return:
+            Always ``False``.
+        """
+        return False
+
     def get_deposit_manager_capability(self) -> VaultDepositManagerCapability:
         """Declare the deployment-specific deposit/redemption capability.
 

--- a/eth_defi/erc_4626/vault_protocol/upshift/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/upshift/vault.py
@@ -254,6 +254,19 @@ class UpshiftVault(ERC4626Vault):
 
         return fetch_upshift_vault_metadata(self.web3, self.vault_address)
 
+    def is_whitelisted_deposit(self) -> bool:  # noqa: PLR6301
+        """Report Upshift account admission independently of its asset list.
+
+        Both supported Upshift families accept deposits from any account.
+        Multi-asset vaults separately restrict which input tokens may be used;
+        that token whitelist is validated by
+        :class:`UpshiftMultiAssetDepositManager` and is not KYC.
+
+        :return:
+            Always ``False`` because deposits have no per-account gate.
+        """
+        return False
+
     @property
     def description(self) -> str | None:
         """Return the full Upshift-supplied vault strategy description.

--- a/eth_defi/erc_4626/vault_protocol/upshift/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/upshift/vault.py
@@ -259,7 +259,7 @@ class UpshiftVault(ERC4626Vault):
 
         Both supported Upshift families accept deposits from any account.
         Multi-asset vaults separately restrict which input tokens may be used;
-        that token whitelist is validated by
+        that accepted-asset set is validated by
         :class:`UpshiftMultiAssetDepositManager` and is not KYC.
 
         :return:

--- a/eth_defi/erc_4626/vault_protocol/yearn/compounder.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/compounder.py
@@ -38,6 +38,17 @@ class YearnCompounderVault(ERC4626Vault):
     strategy reporting and therefore is already reflected in the share price.
     """
 
+    def is_whitelisted_deposit(self) -> bool:  # noqa: PLR6301
+        """Report Yearn TokenizedStrategy compounders as permissionless.
+
+        The canonical TokenizedStrategy deposit path has global shutdown and
+        deposit-limit controls, but no receiver-specific KYC or allowlist.
+
+        :return:
+            Always ``False``.
+        """
+        return False
+
     def get_management_fee(self, block_identifier: BlockIdentifier) -> float:  # noqa: PLR6301
         """Return the absent Yearn compounder management fee.
 

--- a/eth_defi/erc_4626/vault_protocol/yearn/compounder.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/compounder.py
@@ -39,10 +39,11 @@ class YearnCompounderVault(ERC4626Vault):
     """
 
     def is_whitelisted_deposit(self) -> bool:  # noqa: PLR6301
-        """Report Yearn TokenizedStrategy compounders as permissionless.
+        """Report the TokenizedStrategy adapter family's default permission policy.
 
-        The canonical TokenizedStrategy deposit path has global shutdown and
-        deposit-limit controls, but no receiver-specific KYC or allowlist.
+        Supported Yearn TokenizedStrategy compounders are treated as
+        permissionless by default. Shutdown and deposit-limit controls remain
+        independent global lifecycle conditions.
 
         :return:
             Always ``False``.

--- a/eth_defi/erc_4626/vault_protocol/yearn/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/vault.py
@@ -7,6 +7,7 @@ from functools import cached_property
 from eth_typing import BlockIdentifier, HexAddress
 from web3.contract import Contract
 
+from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
 from eth_defi.erc_4626.vault_protocol.yearn.deposit_redeem import YearnV3DepositManager
 from eth_defi.erc_4626.vault import ERC4626Vault
@@ -137,6 +138,29 @@ class YearnV3Vault(ERC4626Vault):
             even while deposits are open.
         """
         return False
+
+    def is_whitelisted_deposit(self) -> bool:
+        """Classify the configured Yearn V3 deposit-limit mechanism.
+
+        A canonical Yearn V3 vault with no deposit-limit module uses only its
+        vault-wide limit and shutdown state, so deposits are permissionless.
+        A custom module can inspect the receiver and its semantics cannot be
+        inferred from the Yearn vault itself; keep that case explicitly
+        unknown instead of assuming either public or allow-listed access.
+
+        :return:
+            ``False`` when no custom deposit-limit module is configured.
+        :raise NotImplementedError:
+            If a custom module controls owner-specific deposit capacity.
+        """
+        deposit_limit_module = self.vault_contract.functions.deposit_limit_module().call(
+            block_identifier=self._get_block_identifier(),
+        )
+        if deposit_limit_module.lower() == ZERO_ADDRESS_STR.lower():
+            return False
+        raise NotImplementedError(
+            f"Yearn V3 deposit-limit module {deposit_limit_module} requires module-specific permission inspection"
+        )
 
     def fetch_strategies(self) -> list[Contract]:
         return self.vault_contract.functions.getStrategies().call()

--- a/eth_defi/erc_4626/vault_protocol/yearn/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/vault.py
@@ -163,7 +163,14 @@ class YearnV3Vault(ERC4626Vault):
             deposit_limit_module = self.vault_contract.functions.deposit_limit_module().call(
                 block_identifier=self._get_block_identifier(),
             )
-        except (ABIFunctionNotFound, BadFunctionCallOutput, ContractLogicError, ValueError):
+        except (ABIFunctionNotFound, BadFunctionCallOutput, ContractLogicError):
+            return False
+        except ValueError as error:
+            # Some providers return an old deployment's unknown-selector
+            # revert as ValueError instead of ContractLogicError. Do not turn
+            # unrelated RPC and transport failures into permissionless status.
+            if "revert" not in str(error).lower():
+                raise
             return False
         if deposit_limit_module.lower() == ZERO_ADDRESS_STR.lower():
             return False

--- a/eth_defi/erc_4626/vault_protocol/yearn/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/vault.py
@@ -107,7 +107,7 @@ class YearnV3Vault(ERC4626Vault):
             ```
     """
 
-    whitelist_notes = "Legacy Yearn deployments without deposit_limit_module() are treated as permissionless by default; an explicit custom module remains unknown."
+    whitelist_notes = "Legacy Yearn deployments without deposit_limit_module() use the adapter's permissionless compatibility default; an explicit custom module remains unknown."
 
     @cached_property
     def vault_contract(self) -> Contract:
@@ -147,9 +147,9 @@ class YearnV3Vault(ERC4626Vault):
 
         A canonical Yearn V3 vault with no deposit-limit module uses only its
         vault-wide limit and shutdown state, so deposits are permissionless.
-        Older Yearn deployments that predate the module getter are also
-        permissionless by default because their standard deposit path has no
-        receiver-specific admission module.
+        Older Yearn deployments that predate the module getter use the
+        adapter's permissionless compatibility default because no module can
+        be inspected through this interface.
         A custom module can inspect the receiver and its semantics cannot be
         inferred from the Yearn vault itself; keep that case explicitly
         unknown instead of assuming either public or allow-listed access.

--- a/eth_defi/erc_4626/vault_protocol/yearn/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/vault.py
@@ -6,6 +6,7 @@ from functools import cached_property
 
 from eth_typing import BlockIdentifier, HexAddress
 from web3.contract import Contract
+from web3.exceptions import ABIFunctionNotFound, BadFunctionCallOutput, ContractLogicError
 
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
@@ -153,9 +154,12 @@ class YearnV3Vault(ERC4626Vault):
         :raise NotImplementedError:
             If a custom module controls owner-specific deposit capacity.
         """
-        deposit_limit_module = self.vault_contract.functions.deposit_limit_module().call(
-            block_identifier=self._get_block_identifier(),
-        )
+        try:
+            deposit_limit_module = self.vault_contract.functions.deposit_limit_module().call(
+                block_identifier=self._get_block_identifier(),
+            )
+        except (ABIFunctionNotFound, BadFunctionCallOutput, ContractLogicError, ValueError) as error:
+            raise NotImplementedError("Yearn deployment does not expose a readable deposit-limit module") from error
         if deposit_limit_module.lower() == ZERO_ADDRESS_STR.lower():
             return False
         raise NotImplementedError(f"Yearn V3 deposit-limit module {deposit_limit_module} requires module-specific permission inspection")

--- a/eth_defi/erc_4626/vault_protocol/yearn/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/vault.py
@@ -158,9 +158,7 @@ class YearnV3Vault(ERC4626Vault):
         )
         if deposit_limit_module.lower() == ZERO_ADDRESS_STR.lower():
             return False
-        raise NotImplementedError(
-            f"Yearn V3 deposit-limit module {deposit_limit_module} requires module-specific permission inspection"
-        )
+        raise NotImplementedError(f"Yearn V3 deposit-limit module {deposit_limit_module} requires module-specific permission inspection")
 
     def fetch_strategies(self) -> list[Contract]:
         return self.vault_contract.functions.getStrategies().call()

--- a/eth_defi/erc_4626/vault_protocol/yearn/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/vault.py
@@ -107,6 +107,8 @@ class YearnV3Vault(ERC4626Vault):
             ```
     """
 
+    whitelist_notes = "Legacy Yearn deployments without deposit_limit_module() are treated as permissionless by default; an explicit custom module remains unknown."
+
     @cached_property
     def vault_contract(self) -> Contract:
         """Get vault deployment."""
@@ -145,6 +147,9 @@ class YearnV3Vault(ERC4626Vault):
 
         A canonical Yearn V3 vault with no deposit-limit module uses only its
         vault-wide limit and shutdown state, so deposits are permissionless.
+        Older Yearn deployments that predate the module getter are also
+        permissionless by default because their standard deposit path has no
+        receiver-specific admission module.
         A custom module can inspect the receiver and its semantics cannot be
         inferred from the Yearn vault itself; keep that case explicitly
         unknown instead of assuming either public or allow-listed access.
@@ -152,14 +157,14 @@ class YearnV3Vault(ERC4626Vault):
         :return:
             ``False`` when no custom deposit-limit module is configured.
         :raise NotImplementedError:
-            If a custom module controls owner-specific deposit capacity.
+            If a readable custom module controls owner-specific capacity.
         """
         try:
             deposit_limit_module = self.vault_contract.functions.deposit_limit_module().call(
                 block_identifier=self._get_block_identifier(),
             )
-        except (ABIFunctionNotFound, BadFunctionCallOutput, ContractLogicError, ValueError) as error:
-            raise NotImplementedError("Yearn deployment does not expose a readable deposit-limit module") from error
+        except (ABIFunctionNotFound, BadFunctionCallOutput, ContractLogicError, ValueError):
+            return False
         if deposit_limit_module.lower() == ZERO_ADDRESS_STR.lower():
             return False
         raise NotImplementedError(f"Yearn V3 deposit-limit module {deposit_limit_module} requires module-specific permission inspection")

--- a/eth_defi/erc_4626/vault_protocol/yieldnest/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/yieldnest/deposit_redeem.py
@@ -80,9 +80,10 @@ class YieldNestDepositManager(ERC4626DepositManager):
 
     **Anvil settlement (force_settle)**
 
-    No real settlement is modelled and the public capability remains
-    deposit-only. A synchronous deposit uses the inherited no-op
-    :meth:`force_settle` behaviour. Focused local tests may explicitly call
+    No real settlement is modelled. The adapter implements the immediate
+    synchronous redemption call, while current live capacity remains a
+    separate ``maxRedeem(owner)`` observation. A synchronous deposit uses the
+    inherited no-op :meth:`force_settle` behaviour. Focused local tests may explicitly call
     ``force_settle(None, mock=..., ignore_liquidity=True)`` on a
     ``MockYieldNestVault``. It switches only that mock's ``maxRedeem`` gate on,
     allowing the standard guarded redemption call to be tested. It never makes

--- a/eth_defi/erc_4626/vault_protocol/yieldnest/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/yieldnest/deposit_redeem.py
@@ -17,7 +17,9 @@ from web3 import Web3
 from web3.exceptions import ABIFunctionNotFound
 
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager, ERC4626RedemptionRequest
+from eth_defi.erc_4626.vault_protocol.yieldnest.vault import YNRWAX_MATURITY_DATE, YNRWAX_VAULT_ADDRESS
 from eth_defi.provider.anvil import is_anvil
+from eth_defi.timestamp import get_block_timestamp
 from eth_defi.vault.deposit_redeem import DepositTicket, RedemptionTicket, UnsupportedVaultSimulation, VaultFlowUnavailable, VaultForcedSettlementResult
 
 #: ``ExceededMaxRedeem(address owner, uint256 shares, uint256 maxShares)``
@@ -52,13 +54,11 @@ class YieldNestDepositManager(ERC4626DepositManager):
     ``ExceededMaxRedeem(address,uint256,uint256)`` error and its selector
     ``0xb8b8b59c``, then delegates to the base manager with the duplicate
     ``maxRedeem`` read disabled. Withdrawal fees are dynamic
-    (``baseWithdrawalFee()``). Note that
-    :meth:`YieldNestVault.get_deposit_manager_capability` still advertises
-    ``can_redeem=False`` (``maturity_aware_redemption_flow_not_implemented``) to
-    trade-executor: no non-zero immediate capacity and successful redemption
-    receipt have been fork-proven for the maturity-bearing vaults. This helper
-    is therefore a fail-closed capacity reader, not a supported public
-    redemption lifecycle.
+    (``baseWithdrawalFee()``). The manager advertises the implemented
+    synchronous lifecycle independently from live availability. ynRWAx
+    requests before 15 October 2026 return the typed
+    ``redemption_not_yet_matured`` result; after maturity the immediate buffer
+    preflight applies normally.
 
     **Queues and settlement**
 
@@ -217,6 +217,22 @@ class YieldNestDepositManager(ERC4626DepositManager):
         """
         if raw_shares is None and shares is not None:
             raw_shares = self.vault.share_token.convert_to_raw(shares)
+
+        if self.vault.address.lower() == YNRWAX_VAULT_ADDRESS:
+            block_timestamp = get_block_timestamp(self.web3, self.web3.eth.block_number)
+            if block_timestamp < YNRWAX_MATURITY_DATE:
+                raise VaultFlowUnavailable(
+                    f"YieldNest ynRWAx does not mature until {YNRWAX_MATURITY_DATE.isoformat()}",
+                    protocol=self.vault.get_protocol_name(),
+                    vault_address=self.vault.address,
+                    caller=owner,
+                    direction="redeem",
+                    phase="preflight",
+                    decoded_error="RedemptionBeforeMaturity",
+                    preflight_result="redemption_not_yet_matured",
+                    requested_raw_amount=raw_shares,
+                    next_open=YNRWAX_MATURITY_DATE,
+                )
 
         if check_max_redeem and raw_shares is not None:
             # maxRedeem(owner) is queryable per-owner (only the address(0)

--- a/eth_defi/erc_4626/vault_protocol/yieldnest/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/yieldnest/vault.py
@@ -3,15 +3,18 @@
 import datetime
 import logging
 from functools import cached_property
+from typing import TYPE_CHECKING
 
 from eth_typing import BlockIdentifier, HexAddress
-from web3 import Web3
 from web3.contract import Contract
 
 from eth_defi.abi import get_deployed_contract
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
+
+if TYPE_CHECKING:
+    from eth_defi.erc_4626.vault_protocol.yieldnest.deposit_redeem import YieldNestDepositManager
 
 logger = logging.getLogger(__name__)
 
@@ -151,10 +154,11 @@ class YieldNestVault(ERC4626Vault):
 
         The bundled ABI contains the standard ERC-4626 ``Deposit`` event, so
         the inherited manager can decode the tested deposit receipt without a
-        YieldNest-only parser. The specialised manager can read an owner's
-        immediate ``maxRedeem`` capacity, but no non-zero capacity and matching
-        redemption receipt are fork-proven for ynRWAx. Its maturity-aware and
-        any buffer-fallback redemption lifecycle therefore remain unsupported.
+        YieldNest-only parser. The specialised manager implements the standard
+        synchronous redemption and reads an owner's immediate ``maxRedeem``
+        capacity. For ynRWAx it first enforces the product's 15 October 2026
+        maturity as a typed ``redemption_not_yet_matured`` preflight instead of
+        misreporting the implemented direction as adapter-unsupported.
         The manager's ``ignore_liquidity`` simulation option operates only on
         ``MockYieldNestVault`` in a local Anvil test. It proves GuardV0's
         standard ERC-4626 redemption validation, not a live YieldNest buffer
@@ -162,17 +166,16 @@ class YieldNestVault(ERC4626Vault):
 
         .. note::
 
-            Trade-executor must use the selected manager's
-            ``analyse_deposit()`` hook rather than a generic analyser. It must
-            treat the redemption reason as ``adapter_unsupported`` and not
-            construct a redemption request from this partial helper.
+            Trade-executor must use the selected manager's receipt-analysis
+            hooks rather than a generic analyser and preserve typed live-state
+            redemption refusals.
 
         :return:
-            Partial capability with a synchronous deposit flow only.
+            Synchronous deposit and redemption capability.
         """
         return VaultDepositManagerCapability(
             can_deposit=True,
-            can_redeem=False,
+            can_redeem=True,
             deposit_flow="synchronous",
-            redemption_unsupported_reason="maturity_aware_redemption_flow_not_implemented",
+            redemption_flow="synchronous",
         )

--- a/eth_defi/erc_4626/vault_protocol/yieldnest/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/yieldnest/vault.py
@@ -150,13 +150,14 @@ class YieldNestVault(ERC4626Vault):
         return False
 
     def get_deposit_manager_capability(self) -> VaultDepositManagerCapability:
-        """Declare YieldNest's verified synchronous deposit lifecycle.
+        """Declare YieldNest's implemented synchronous lifecycle.
 
         The bundled ABI contains the standard ERC-4626 ``Deposit`` event, so
         the inherited manager can decode the tested deposit receipt without a
         YieldNest-only parser. The specialised manager implements the standard
         synchronous redemption and reads an owner's immediate ``maxRedeem``
-        capacity. For ynRWAx it first enforces the product's 15 October 2026
+        capacity. Capability describes the adapter implementation, not current
+        live redemption capacity. For ynRWAx the manager first enforces the product's 15 October 2026
         maturity as a typed ``redemption_not_yet_matured`` preflight instead of
         misreporting the implemented direction as adapter-unsupported.
         The manager's ``ignore_liquidity`` simulation option operates only on

--- a/eth_defi/trade.py
+++ b/eth_defi/trade.py
@@ -144,6 +144,10 @@ class TradeSuccess(TradeResult):
             otherwise `token1`.
         """
         if reverse_token_order:
+            if self.price == 0:
+                # A successful transaction may have a genuine zero output.
+                # Its reciprocal is positive infinity, not an analysis error.
+                return Decimal("Infinity")
             return Decimal(1) / self.price
         else:
             return self.price

--- a/eth_defi/vault/deposit_redeem.py
+++ b/eth_defi/vault/deposit_redeem.py
@@ -726,6 +726,37 @@ class VaultForcedSettlementResult:
         return evidence.request_id == self.ticket.get_request_id() and Web3.to_checksum_address(evidence.receiver) == Web3.to_checksum_address(self.ticket.to) and bool(evidence.event_name) and evidence.transaction_hash in self.transaction_hashes and evidence.has_positive_balance_delta()
 
 
+@dataclass(frozen=True, slots=True)
+class VaultRedemptionSimulationIntervention:
+    """Disclosed Anvil-only intervention used before a real redemption call.
+
+    The intervention changes fork state only.  A caller must still build,
+    broadcast and analyse the protocol's real redemption transaction after
+    this result is returned.  It must never be interpreted as evidence that
+    the live vault had enough redemption liquidity.
+    """
+
+    kind: Literal["liquidity_injected"]
+    token: HexAddress
+    target: HexAddress
+    raw_amount: int
+    original_reason: str
+    original_preflight_result: str | None = None
+
+    def as_dict(self) -> dict[str, str]:
+        """Return JSON-safe intervention evidence."""
+        result = {
+            "kind": self.kind,
+            "token": self.token,
+            "target": self.target,
+            "raw_amount": str(self.raw_amount),
+            "original_reason": self.original_reason,
+        }
+        if self.original_preflight_result is not None:
+            result["original_preflight_result"] = self.original_preflight_result
+        return result
+
+
 def create_synchronous_settlement_result() -> VaultForcedSettlementResult:
     """Create the standard no-op outcome for a synchronous vault flow.
 
@@ -1243,6 +1274,27 @@ class VaultDepositManager(ABC):
             caller=owner,
             direction="deposit",
             phase="preflight",
+        )
+
+    def force_redemption_liquidity(
+        self,
+        owner: HexAddress,
+        raw_shares: int,
+        failure: VaultFlowUnavailable,
+    ) -> VaultRedemptionSimulationIntervention:
+        """Provision an unavailable synchronous redemption on an Anvil fork.
+
+        Concrete managers may implement this only for a source-proven
+        liquidity failure.  The default is deliberately unsupported: this
+        hook must never bypass admission, minimums, maturity or time locks.
+        """
+        del owner, raw_shares, failure
+        raise UnsupportedVaultSimulation(
+            f"{self.__class__.__name__} has no Anvil redemption-liquidity driver",
+            unsupported_reason="redemption_liquidity_simulation_not_implemented",
+            protocol=self.vault.get_protocol_name(),
+            vault_address=self.vault.address,
+            direction="redeem",
         )
 
     def force_settle(

--- a/eth_defi/vault/deposit_redeem.py
+++ b/eth_defi/vault/deposit_redeem.py
@@ -736,15 +736,33 @@ class VaultRedemptionSimulationIntervention:
     the live vault had enough redemption liquidity.
     """
 
+    #: Intervention type for machine-readable reports.
     kind: Literal["liquidity_injected"]
+
+    #: Denomination token whose forked balance was changed.
     token: HexAddress
+
+    #: Vault or protocol liquidity adapter that received the token.
     target: HexAddress
+
+    #: Raw token quantity added on the fork.
     raw_amount: int
+
+    #: Original typed preflight explanation.
     original_reason: str
+
+    #: Original machine-readable preflight result when available.
     original_preflight_result: str | None = None
 
     def as_dict(self) -> dict[str, str]:
-        """Return JSON-safe intervention evidence."""
+        """Return JSON-safe intervention evidence.
+
+        Integer quantities are serialised as decimal strings so large token
+        values remain exact across JSON consumers.
+
+        :return:
+            Machine-readable intervention fields.
+        """
         result = {
             "kind": self.kind,
             "token": self.token,
@@ -1287,6 +1305,17 @@ class VaultDepositManager(ABC):
         Concrete managers may implement this only for a source-proven
         liquidity failure.  The default is deliberately unsupported: this
         hook must never bypass admission, minimums, maturity or time locks.
+
+        :param owner:
+            Redemption owner.
+        :param raw_shares:
+            Exact raw share quantity requested.
+        :param failure:
+            Typed preflight failure that prompted the intervention request.
+        :return:
+            Structured intervention evidence from a concrete manager.
+        :raise UnsupportedVaultSimulation:
+            Always for managers without a protocol-specific implementation.
         """
         del owner, raw_shares, failure
         raise UnsupportedVaultSimulation(

--- a/eth_defi/vault/deposit_redeem.py
+++ b/eth_defi/vault/deposit_redeem.py
@@ -27,10 +27,6 @@ logger = logging.getLogger(__name__)
 
 VaultDepositFlow = Literal["synchronous", "asynchronous"]
 
-#: Export caveat for classifications made without inspecting optional
-#: protocol-specific permission hooks.
-PERMISSIONED_HOOK_CHECKS_NOT_PERFORMED_NOTE = "No permissioned hook checks were performed"
-
 
 class VaultDepositPermission(str, enum.Enum):
     """Whether deposits require KYC or comparable identity approval.

--- a/tests/erc_4626/test_analysis_signed_amounts.py
+++ b/tests/erc_4626/test_analysis_signed_amounts.py
@@ -61,3 +61,76 @@ def test_redemption_analysis_accepts_signed_compatible_event_amount() -> None:
     assert isinstance(result, TradeSuccess)
     assert result.amount_in == 10**18
     assert result.amount_out == 10**6
+
+
+def test_redemption_analysis_recovers_zero_event_assets_from_transfer() -> None:
+    """A zero-valued compatible Withdraw event uses the actual token transfer.
+
+    1. Build a successful redemption whose Withdraw event reports zero assets.
+    2. Include the non-zero denomination-token transfer to the receiver.
+    3. Confirm receipt analysis uses the transferred output amount.
+    """
+    # 1. Build a successful redemption whose Withdraw event reports zero assets.
+    vault_address = "0x1111111111111111111111111111111111111111"
+    receiver = "0x2222222222222222222222222222222222222222"
+    asset_address = "0x3333333333333333333333333333333333333333"
+    withdraw_event = MagicMock()
+    withdraw_event.process_receipt.return_value = [
+        {
+            "address": vault_address,
+            "args": {
+                "receiver": receiver,
+                "shares": 10**18,
+                "assets": 0,
+            },
+        }
+    ]
+    transfer_event = MagicMock()
+    transfer_event.process_receipt.return_value = [
+        {
+            "address": asset_address,
+            "args": {
+                "from": vault_address,
+                "to": receiver,
+                "value": 10**6,
+            },
+        }
+    ]
+    contract = MagicMock()
+    contract.events.Withdraw.return_value = withdraw_event
+    asset_contract = MagicMock()
+    asset_contract.events.Transfer.return_value = transfer_event
+    vault = SimpleNamespace(
+        web3=MagicMock(),
+        address=vault_address,
+        vault_address=vault_address,
+        vault_contract=contract,
+        share_token=SimpleNamespace(
+            address_lower="0x4444444444444444444444444444444444444444",
+            decimals=18,
+        ),
+        denomination_token=SimpleNamespace(
+            address_lower=asset_address,
+            decimals=6,
+            contract=asset_contract,
+        ),
+    )
+    receipt = {
+        "to": vault_address,
+        "status": 1,
+        "gasUsed": 100_000,
+        "effectiveGasPrice": 1,
+    }
+
+    # 2. Include the non-zero denomination-token transfer to the receiver.
+    result = analyse_4626_flow_transaction(
+        vault=vault,
+        tx_hash="0x" + "00" * 32,
+        tx_receipt=receipt,
+        direction="redeem",
+    )
+
+    # 3. Confirm receipt analysis uses the transferred output amount.
+    assert isinstance(result, TradeSuccess)
+    assert result.amount_in == 10**18
+    assert result.amount_out == 10**6

--- a/tests/erc_4626/test_analysis_signed_amounts.py
+++ b/tests/erc_4626/test_analysis_signed_amounts.py
@@ -1,0 +1,63 @@
+"""Regression tests for ERC-4626 event amount normalisation."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from eth_defi.erc_4626.analysis import analyse_4626_flow_transaction
+from eth_defi.trade import TradeSuccess
+
+
+def test_redemption_analysis_accepts_signed_compatible_event_amount() -> None:
+    """Test a compatible vault's signed redemption output is normalised.
+
+    1. Build a successful redemption receipt with a negative decoded asset amount.
+    2. Analyse it through the shared ERC-4626 receipt path.
+    3. Confirm the successful result carries the absolute output amount.
+    """
+    # 1. Build a successful redemption receipt with a negative decoded asset amount.
+    vault_address = "0x1111111111111111111111111111111111111111"
+    withdraw_event = MagicMock()
+    withdraw_event.process_receipt.return_value = [
+        {
+            "address": vault_address,
+            "args": {
+                "shares": 10**18,
+                "assets": -(10**6),
+            },
+        }
+    ]
+    contract = MagicMock()
+    contract.events.Withdraw.return_value = withdraw_event
+    vault = SimpleNamespace(
+        web3=MagicMock(),
+        address=vault_address,
+        vault_address=vault_address,
+        vault_contract=contract,
+        share_token=SimpleNamespace(
+            address_lower="0x2222222222222222222222222222222222222222",
+            decimals=18,
+        ),
+        denomination_token=SimpleNamespace(
+            address_lower="0x3333333333333333333333333333333333333333",
+            decimals=6,
+        ),
+    )
+    receipt = {
+        "to": vault_address,
+        "status": 1,
+        "gasUsed": 100_000,
+        "effectiveGasPrice": 1,
+    }
+
+    # 2. Analyse it through the shared ERC-4626 receipt path.
+    result = analyse_4626_flow_transaction(
+        vault=vault,
+        tx_hash="0x" + "00" * 32,
+        tx_receipt=receipt,
+        direction="redeem",
+    )
+
+    # 3. Confirm the successful result carries the absolute output amount.
+    assert isinstance(result, TradeSuccess)
+    assert result.amount_in == 10**18
+    assert result.amount_out == 10**6

--- a/tests/erc_4626/test_analysis_signed_amounts.py
+++ b/tests/erc_4626/test_analysis_signed_amounts.py
@@ -1,18 +1,21 @@
-"""Regression tests for ERC-4626 event amount normalisation."""
+"""Regression tests for ERC-4626 zero-output receipt analysis."""
 
+from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+import pytest
 
 from eth_defi.erc_4626.analysis import analyse_4626_flow_transaction
 from eth_defi.trade import TradeSuccess
 
 
-def test_redemption_analysis_accepts_signed_compatible_event_amount() -> None:
-    """Test a compatible vault's signed redemption output is normalised.
+def test_redemption_analysis_rejects_negative_event_amount() -> None:
+    """Reject a malformed negative value for an unsigned ERC-4626 event field.
 
     1. Build a successful redemption receipt with a negative decoded asset amount.
     2. Analyse it through the shared ERC-4626 receipt path.
-    3. Confirm the successful result carries the absolute output amount.
+    3. Confirm receipt analysis rejects the ABI-incompatible value.
     """
     # 1. Build a successful redemption receipt with a negative decoded asset amount.
     vault_address = "0x1111111111111111111111111111111111111111"
@@ -50,17 +53,15 @@ def test_redemption_analysis_accepts_signed_compatible_event_amount() -> None:
     }
 
     # 2. Analyse it through the shared ERC-4626 receipt path.
-    result = analyse_4626_flow_transaction(
-        vault=vault,
-        tx_hash="0x" + "00" * 32,
-        tx_receipt=receipt,
-        direction="redeem",
-    )
+    with pytest.raises(AssertionError, match="output amount must not be negative"):
+        analyse_4626_flow_transaction(
+            vault=vault,
+            tx_hash="0x" + "00" * 32,
+            tx_receipt=receipt,
+            direction="redeem",
+        )
 
-    # 3. Confirm the successful result carries the absolute output amount.
-    assert isinstance(result, TradeSuccess)
-    assert result.amount_in == 10**18
-    assert result.amount_out == 10**6
+    # 3. The ABI-incompatible value was not converted to a plausible trade.
 
 
 def test_redemption_analysis_preserves_zero_output() -> None:
@@ -120,3 +121,4 @@ def test_redemption_analysis_preserves_zero_output() -> None:
     assert result.amount_in == 10**18
     assert result.amount_out == 0
     assert result.price == 0
+    assert result.get_human_price(reverse_token_order=True) == Decimal("Infinity")

--- a/tests/erc_4626/test_analysis_signed_amounts.py
+++ b/tests/erc_4626/test_analysis_signed_amounts.py
@@ -63,17 +63,16 @@ def test_redemption_analysis_accepts_signed_compatible_event_amount() -> None:
     assert result.amount_out == 10**6
 
 
-def test_redemption_analysis_recovers_zero_event_assets_from_transfer() -> None:
-    """A zero-valued compatible Withdraw event uses the actual token transfer.
+def test_redemption_analysis_preserves_zero_output() -> None:
+    """A successful zero-output Withdraw event remains analysable.
 
     1. Build a successful redemption whose Withdraw event reports zero assets.
-    2. Include the non-zero denomination-token transfer to the receiver.
-    3. Confirm receipt analysis uses the transferred output amount.
+    2. Analyse the receipt without inventing an output amount.
+    3. Confirm the mined zero-value economic outcome is preserved.
     """
     # 1. Build a successful redemption whose Withdraw event reports zero assets.
     vault_address = "0x1111111111111111111111111111111111111111"
     receiver = "0x2222222222222222222222222222222222222222"
-    asset_address = "0x3333333333333333333333333333333333333333"
     withdraw_event = MagicMock()
     withdraw_event.process_receipt.return_value = [
         {
@@ -85,21 +84,8 @@ def test_redemption_analysis_recovers_zero_event_assets_from_transfer() -> None:
             },
         }
     ]
-    transfer_event = MagicMock()
-    transfer_event.process_receipt.return_value = [
-        {
-            "address": asset_address,
-            "args": {
-                "from": vault_address,
-                "to": receiver,
-                "value": 10**6,
-            },
-        }
-    ]
     contract = MagicMock()
     contract.events.Withdraw.return_value = withdraw_event
-    asset_contract = MagicMock()
-    asset_contract.events.Transfer.return_value = transfer_event
     vault = SimpleNamespace(
         web3=MagicMock(),
         address=vault_address,
@@ -110,9 +96,8 @@ def test_redemption_analysis_recovers_zero_event_assets_from_transfer() -> None:
             decimals=18,
         ),
         denomination_token=SimpleNamespace(
-            address_lower=asset_address,
+            address_lower="0x3333333333333333333333333333333333333333",
             decimals=6,
-            contract=asset_contract,
         ),
     )
     receipt = {
@@ -122,7 +107,7 @@ def test_redemption_analysis_recovers_zero_event_assets_from_transfer() -> None:
         "effectiveGasPrice": 1,
     }
 
-    # 2. Include the non-zero denomination-token transfer to the receiver.
+    # 2. Analyse the receipt without inventing an output amount.
     result = analyse_4626_flow_transaction(
         vault=vault,
         tx_hash="0x" + "00" * 32,
@@ -130,7 +115,8 @@ def test_redemption_analysis_recovers_zero_event_assets_from_transfer() -> None:
         direction="redeem",
     )
 
-    # 3. Confirm receipt analysis uses the transferred output amount.
+    # 3. Confirm the mined zero-value economic outcome is preserved.
     assert isinstance(result, TradeSuccess)
     assert result.amount_in == 10**18
-    assert result.amount_out == 10**6
+    assert result.amount_out == 0
+    assert result.price == 0

--- a/tests/erc_4626/test_deposit_probe.py
+++ b/tests/erc_4626/test_deposit_probe.py
@@ -339,10 +339,17 @@ def test_d2_guard_validation_request_bypasses_only_the_closed_epoch(monkeypatch:
 
     monkeypatch.setattr(ERC4626DepositManager, "create_deposit_request", parent_create_deposit_request)
     monkeypatch.setattr(manager, "_assert_anvil_guard_validation", lambda: None)
+    eligibility_checks: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        manager,
+        "_assert_account_eligible",
+        lambda checked_owner, direction: eligibility_checks.append((checked_owner, direction)),
+    )
 
     request = manager.create_deposit_request_for_guard_validation(owner, raw_amount=123)
 
     assert request is expected_request
+    assert eligibility_checks == [(owner, "deposit")]
     assert observed == {
         "owner": owner,
         "to": owner,

--- a/tests/erc_4626/vault_protocol/test_accountable.py
+++ b/tests/erc_4626/vault_protocol/test_accountable.py
@@ -22,7 +22,7 @@ from eth_defi.erc_4626.vault_protocol.accountable.deposit_redeem import ACCOUNTA
 from eth_defi.erc_4626.vault_protocol.accountable.offchain_metadata import (
     fetch_accountable_vaults,
 )
-from eth_defi.erc_4626.vault_protocol.accountable.vault import AccountableHistoricalReader, AccountableVault
+from eth_defi.erc_4626.vault_protocol.accountable.vault import AccountableHistoricalReader, AccountablePermissionLevel, AccountableVault
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.token import TokenDetails
@@ -309,6 +309,8 @@ def test_accountable_hyperithm_strategy_min_deposit(web3: Web3) -> None:
     """
     vault = create_vault_instance_autodetect(web3, vault_address="0x7cd231120a60f500887444a9baf5e1bd753a5e59")
     assert isinstance(vault, AccountableVault)
+    assert vault.fetch_permission_level() is AccountablePermissionLevel.none
+    assert vault.is_whitelisted_deposit() is False
     manager = vault.get_deposit_manager()
     assert isinstance(manager, AccountableDepositManager)
 

--- a/tests/erc_4626/vault_protocol/test_csigma.py
+++ b/tests/erc_4626/vault_protocol/test_csigma.py
@@ -72,6 +72,7 @@ def test_csigma(
     assert isinstance(vault, CsigmaVault)
     assert vault.get_protocol_name() == "cSigma Finance"
     assert vault.features == {ERC4626Feature.csigma_like}
+    assert vault.is_whitelisted_deposit() is False
 
     # Fees are not yet known for cSigma
     assert vault.get_management_fee("latest") == 0
@@ -200,6 +201,7 @@ def test_csigma_v2_pool(
     assert isinstance(vault, CsigmaVault)
     assert vault.get_protocol_name() == "cSigma Finance"
     assert vault.features == {ERC4626Feature.csigma_like}
+    assert vault.is_whitelisted_deposit() is False
 
     # Fees are not yet known for cSigma
     assert vault.get_management_fee("latest") == 0

--- a/tests/erc_4626/vault_protocol/test_d2.py
+++ b/tests/erc_4626/vault_protocol/test_d2.py
@@ -50,7 +50,7 @@ def test_d2(
     assert vault.get_management_fee("latest") == 0.00
     assert vault.get_performance_fee("latest") == 0.20
     assert vault.has_custom_fees() is False
-    assert vault.is_whitelisted_deposit() is True
+    assert vault.is_whitelisted_deposit() is False
 
     manager = vault.get_deposit_manager()
     assert isinstance(manager, D2DepositManager)

--- a/tests/erc_4626/vault_protocol/test_d2_deposit_permissions.py
+++ b/tests/erc_4626/vault_protocol/test_d2_deposit_permissions.py
@@ -1,5 +1,7 @@
 """Unit tests for D2 public-balance deposit eligibility."""
 
+from unittest.mock import MagicMock
+
 from eth_defi.erc_4626.vault_protocol.d2.vault import D2Vault
 
 
@@ -12,6 +14,9 @@ def test_d2_balance_eligibility_is_not_kyc() -> None:
     """
     # 1. Construct a D2 adapter without making an RPC call.
     vault = object.__new__(D2Vault)
+    vault_contract = MagicMock()
+    vault_contract.functions.whitelistAsset.return_value.call.return_value = "0x1111111111111111111111111111111111111111"
+    vault.__dict__["vault_contract"] = vault_contract
 
     # 2. Query its vault-wide identity policy.
     permissioned = vault.is_whitelisted_deposit()

--- a/tests/erc_4626/vault_protocol/test_d2_deposit_permissions.py
+++ b/tests/erc_4626/vault_protocol/test_d2_deposit_permissions.py
@@ -1,10 +1,20 @@
-"""Unit tests for D2 vault token-gated deposit admission."""
+"""Unit tests for D2 public-balance deposit eligibility."""
 
 from eth_defi.erc_4626.vault_protocol.d2.vault import D2Vault
 
 
-def test_d2_token_eligibility_requires_deposit_admission_check() -> None:
-    """D2's mapping-or-token-balance gate must run before a deposit request."""
+def test_d2_balance_eligibility_is_not_kyc() -> None:
+    """Test D2's public asset minimum is not reported as KYC.
+
+    1. Construct a D2 adapter without making an RPC call.
+    2. Query its vault-wide identity policy.
+    3. Confirm the public economic condition is permissionless.
+    """
+    # 1. Construct a D2 adapter without making an RPC call.
     vault = object.__new__(D2Vault)
 
-    assert vault.is_whitelisted_deposit() is True
+    # 2. Query its vault-wide identity policy.
+    permissioned = vault.is_whitelisted_deposit()
+
+    # 3. Confirm the public economic condition is permissionless.
+    assert permissioned is False

--- a/tests/erc_4626/vault_protocol/test_ember.py
+++ b/tests/erc_4626/vault_protocol/test_ember.py
@@ -54,6 +54,7 @@ def test_ember(
     assert isinstance(vault, EmberVault)
     assert vault.get_protocol_name() == "Ember"
     assert vault.features == {ERC4626Feature.ember_like}
+    assert vault.is_whitelisted_deposit() is False
 
     # Check risk level (open-source contracts on GitHub)
     assert vault.get_risk() == VaultTechnicalRisk.low

--- a/tests/erc_4626/vault_protocol/test_forty_acres.py
+++ b/tests/erc_4626/vault_protocol/test_forty_acres.py
@@ -116,6 +116,7 @@ def test_forty_acres_blackhole(
     assert isinstance(vault, FortyAcresVault)
     assert vault.get_protocol_name() == "40acres"
     assert ERC4626Feature.forty_acres_like in vault.features
+    assert vault.is_whitelisted_deposit() is False
 
     # 3. Check fee methods. 40acres charges lenders no explicit management or
     # performance fee — the protocol's 5% treasury cut is taken from borrower

--- a/tests/erc_4626/vault_protocol/test_morpho_euler_deposit_permissions.py
+++ b/tests/erc_4626/vault_protocol/test_morpho_euler_deposit_permissions.py
@@ -1,16 +1,80 @@
-"""Unit coverage for the requested Morpho and Euler whitelist assumption."""
+"""Unit coverage for Morpho and Euler deposit-permission discovery."""
+
+from unittest.mock import patch
 
 import pytest
 
-from eth_defi.erc_4626.vault_protocol.euler.vault import EulerEarnVault, EulerVault
+from eth_defi.abi import ZERO_ADDRESS_STR
+from eth_defi.erc_4626.vault_protocol.euler.vault import EULER_OP_DEPOSIT, EulerEarnVault, EulerVault
 from eth_defi.erc_4626.vault_protocol.morpho.vault_v1 import MorphoV1Vault
 from eth_defi.erc_4626.vault_protocol.morpho.vault_v2 import MorphoV2Vault
-from eth_defi.vault.deposit_redeem import PERMISSIONED_HOOK_CHECKS_NOT_PERFORMED_NOTE
 
 
-@pytest.mark.parametrize("vault_class", (MorphoV1Vault, MorphoV2Vault, EulerVault, EulerEarnVault))
-def test_morpho_and_euler_vaults_use_requested_whitelist_assumption(vault_class: type) -> None:
-    """Every supported Morpho and Euler adapter exposes the requested caveat."""
-    vault = object.__new__(vault_class)
-    assert vault.is_whitelisted_deposit() is True
-    assert vault.get_whitelist_notes() == PERMISSIONED_HOOK_CHECKS_NOT_PERFORMED_NOTE
+def test_canonical_morpho_and_euler_earn_vaults_are_permissionless() -> None:
+    """Test canonical adapters do not invent a KYC requirement.
+
+    1. Construct adapters whose policy does not need an RPC read.
+    2. Query their vault-wide deposit permission.
+    3. Confirm each canonical protocol is permissionless.
+    """
+    # 1. Construct adapters whose policy does not need an RPC read.
+    vaults = (
+        object.__new__(MorphoV1Vault),
+        object.__new__(EulerEarnVault),
+    )
+
+    # 2. Query their vault-wide deposit permission.
+    permissions = [vault.is_whitelisted_deposit() for vault in vaults]
+
+    # 3. Confirm each canonical protocol is permissionless.
+    assert permissions == [False, False]
+
+
+def test_euler_evk_hook_policy() -> None:
+    """Test EVK distinguishes open, disabled, and custom-hook deposits.
+
+    1. Supply representative canonical hook configurations.
+    2. Query deposit permissions for open and globally disabled operations.
+    3. Confirm an arbitrary custom hook remains explicitly unknown.
+    """
+    # 1. Supply representative canonical hook configurations.
+    vault = object.__new__(EulerVault)
+    custom_hook = "0x1111111111111111111111111111111111111111"
+
+    # 2. Query deposit permissions for open and globally disabled operations.
+    with patch.object(EulerVault, "fetch_hook_config", return_value=(ZERO_ADDRESS_STR, 0)):
+        assert vault.is_whitelisted_deposit() is False
+    with patch.object(EulerVault, "fetch_hook_config", return_value=(ZERO_ADDRESS_STR, EULER_OP_DEPOSIT)):
+        assert vault.is_whitelisted_deposit() is False
+
+    # 3. Confirm an arbitrary custom hook remains explicitly unknown.
+    with (
+        patch.object(EulerVault, "fetch_hook_config", return_value=(custom_hook, EULER_OP_DEPOSIT)),
+        patch.object(EulerVault, "address", custom_hook),
+        pytest.raises(NotImplementedError, match="custom deposit hooks"),
+    ):
+        vault.is_whitelisted_deposit()
+
+
+def test_morpho_v2_gate_policy() -> None:
+    """Test Morpho V2 distinguishes canonical open vaults from custom gates.
+
+    1. Supply zero and non-zero gate configurations.
+    2. Query the canonical ungated vault policy.
+    3. Confirm an arbitrary custom gate remains explicitly unknown.
+    """
+    # 1. Supply zero and non-zero gate configurations.
+    vault = object.__new__(MorphoV2Vault)
+    custom_gate = "0x1111111111111111111111111111111111111111"
+
+    # 2. Query the canonical ungated vault policy.
+    with patch.object(MorphoV2Vault, "fetch_deposit_gates", return_value=(ZERO_ADDRESS_STR, ZERO_ADDRESS_STR)):
+        assert vault.is_whitelisted_deposit() is False
+
+    # 3. Confirm an arbitrary custom gate remains explicitly unknown.
+    with (
+        patch.object(MorphoV2Vault, "fetch_deposit_gates", return_value=(custom_gate, ZERO_ADDRESS_STR)),
+        patch.object(MorphoV2Vault, "address", custom_gate),
+        pytest.raises(NotImplementedError, match="custom gates"),
+    ):
+        vault.is_whitelisted_deposit()

--- a/tests/erc_4626/vault_protocol/test_morpho_v2_redemption.py
+++ b/tests/erc_4626/vault_protocol/test_morpho_v2_redemption.py
@@ -8,6 +8,7 @@ import flaky
 import pytest
 from web3 import Web3
 
+from eth_defi.abi import get_deployed_contract
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.vault_protocol.morpho.deposit_redeem import MORPHO_V2_TRANSFER_REVERTED_SELECTOR, MorphoV2DepositManager
 from eth_defi.erc_4626.vault_protocol.morpho.vault_v2 import MorphoV2Vault
@@ -49,12 +50,13 @@ def morpho_v2_snapshot(morpho_v2_fork: AnvilLaunch) -> Iterator[None]:
 # while the fixed-fork test passed locally; the live fork's transfer preflight is nondeterministic.
 @flaky.flaky
 def test_morpho_v2_transfer_revert_is_a_typed_transfer_refusal(web3: Web3, morpho_v2_snapshot: None) -> None:
-    """Map Apyx's final asset-transfer failure before broadcasting redemption.
+    """Map Apyx's transfer failure, inject liquidity and redeem normally.
 
     1. Deposit into Apyx and remove the locally injected idle USDC.
     2. Advance the fork into the failing redemption state.
     3. Assert exact-call redemption simulation returns typed transfer evidence
        without mining a reverted redemption transaction.
+    4. Inject only the missing payout asset and analyse the real redemption.
     """
     del morpho_v2_snapshot
 
@@ -85,8 +87,27 @@ def test_morpho_v2_transfer_revert_is_a_typed_transfer_refusal(web3: Web3, morph
         manager.create_redemption_request(owner=owner, raw_shares=raw_shares)
     error = exc_info.value
     assert error.decoded_error == "TransferReverted"
-    assert error.preflight_result == "redemption_asset_transfer_failed"
+    assert error.preflight_result == "redemption_liquidity_unavailable"
     assert error.error_selector == MORPHO_V2_TRANSFER_REVERTED_SELECTOR
     assert error.raw_revert_data[:4] == MORPHO_V2_TRANSFER_REVERTED_SELECTOR
     assert error.requested_raw_amount == raw_shares
     assert web3.eth.block_number == block_before
+
+    # 4. The manager-owned Anvil intervention discloses the exact synthetic
+    # liquidity, after which the unchanged redemption succeeds and its real
+    # receipt is analysed.
+    intervention = manager.force_redemption_liquidity(owner, raw_shares, error)
+    assert intervention.kind == "liquidity_injected"
+    assert intervention.token == vault.denomination_token.address
+    morpho_v2_contract = get_deployed_contract(web3, "morpho/IVaultV2.json", vault.address)
+    liquidity_adapter = morpho_v2_contract.functions.liquidityAdapter().call()
+    assert intervention.target == (vault.address if int(liquidity_adapter, 16) == 0 else liquidity_adapter)
+    assert intervention.raw_amount > 0
+    retry_required = vault.vault_contract.functions.previewRedeem(raw_shares).call()
+    retry_available = vault.denomination_token.fetch_raw_balance_of(vault.address)
+    assert retry_available >= retry_required, (retry_available, retry_required)
+    request = manager.create_redemption_request(owner=owner, raw_shares=raw_shares)
+    ticket = request.broadcast(from_=owner)
+    analysis = manager.analyse_redemption(ticket.tx_hash, ticket)
+    assert analysis.share_count > 0
+    assert analysis.denomination_amount > 0

--- a/tests/erc_4626/vault_protocol/test_permissionless_adapter_defaults.py
+++ b/tests/erc_4626/vault_protocol/test_permissionless_adapter_defaults.py
@@ -1,0 +1,73 @@
+"""Unit regressions for protocol-level deposit permission defaults."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from eth_defi.erc_4626.vault_protocol.accountable.vault import AccountablePermissionLevel, AccountableVault
+from eth_defi.erc_4626.vault_protocol.csigma.vault import CsigmaVault
+from eth_defi.erc_4626.vault_protocol.ember.vault import EmberVault
+from eth_defi.erc_4626.vault_protocol.forty_acres.vault import FortyAcresVault
+from eth_defi.erc_4626.vault_protocol.plutus.vault import PlutusVault
+from eth_defi.erc_4626.vault_protocol.yearn.compounder import YearnCompounderVault
+
+OWNER = "0x0000000000000000000000000000000000000001"
+
+
+@pytest.mark.parametrize(
+    "vault_type",
+    (FortyAcresVault, EmberVault, PlutusVault, CsigmaVault, YearnCompounderVault),
+)
+def test_protocol_adapters_default_to_permissionless(vault_type: type) -> None:
+    """Public protocol adapters must not inherit the base unknown policy.
+
+    1. Construct each adapter without reading unrelated live vault state.
+    2. Read its protocol-level identity admission policy.
+    3. Confirm the adapter reports permissionless access.
+    """
+    # 1. Construct each adapter without reading unrelated live vault state.
+    vault = object.__new__(vault_type)
+
+    # 2. Read its protocol-level identity admission policy.
+    permissioned = vault.is_whitelisted_deposit()
+
+    # 3. Confirm the adapter reports permissionless access.
+    assert permissioned is False
+
+
+def test_accountable_uses_explicit_contract_permission_level() -> None:
+    """Accountable must distinguish public, KYC, and whitelist deployments.
+
+    1. Prepare an Accountable adapter with its verified permission ABI.
+    2. Check mode zero and both identity-gated modes.
+    3. Confirm whitelist mode reads persistent account membership.
+    4. Refuse unknown future enum values instead of guessing.
+    """
+    # 1. Prepare an Accountable adapter with its verified permission ABI.
+    vault = object.__new__(AccountableVault)
+    vault.__dict__["vault_contract"] = MagicMock()
+    vault._get_block_identifier = MagicMock(return_value=123)
+    permission_call = vault.vault_contract.functions.permissionLevel.return_value.call
+    allowed_call = vault.vault_contract.functions.allowed.return_value.call
+
+    # 2. Check mode zero and both identity-gated modes.
+    permission_call.return_value = AccountablePermissionLevel.none
+    assert vault.fetch_permission_level() is AccountablePermissionLevel.none
+    assert vault.is_whitelisted_deposit() is False
+    assert vault.is_account_whitelisted(OWNER) is True
+    permission_call.return_value = AccountablePermissionLevel.kyc
+    assert vault.is_whitelisted_deposit() is True
+    assert vault.is_account_whitelisted(OWNER) is False
+    assert not allowed_call.called
+
+    # 3. Confirm whitelist mode reads persistent account membership.
+    permission_call.return_value = AccountablePermissionLevel.whitelist
+    allowed_call.return_value = True
+    assert vault.is_whitelisted_deposit() is True
+    assert vault.is_account_whitelisted(OWNER) is True
+    allowed_call.assert_called_once_with(block_identifier=123)
+
+    # 4. Refuse unknown future enum values instead of guessing.
+    permission_call.return_value = 3
+    with pytest.raises(NotImplementedError, match="Unknown Accountable permission level 3"):
+        vault.fetch_permission_level()

--- a/tests/erc_4626/vault_protocol/test_plutus.py
+++ b/tests/erc_4626/vault_protocol/test_plutus.py
@@ -51,6 +51,7 @@ def test_plutus(
     )
 
     assert isinstance(vault, PlutusVault)
+    assert vault.is_whitelisted_deposit() is False
 
     assert vault.get_risk() == VaultTechnicalRisk.severe
     assert vault.get_management_fee("latest") == 0.00

--- a/tests/erc_4626/vault_protocol/test_vault_permission_regressions.py
+++ b/tests/erc_4626/vault_protocol/test_vault_permission_regressions.py
@@ -9,6 +9,7 @@ from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.vault_protocol.euler.vault import EulerEarnVault, EulerVault
 from eth_defi.erc_4626.vault_protocol.ipor.vault import IPORVault
 from eth_defi.erc_4626.vault_protocol.morpho.vault_v1 import MorphoV1Vault
+from eth_defi.erc_4626.vault_protocol.morpho.vault_v2 import MorphoV2Vault
 from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.vault.base import VaultSpec
 
@@ -27,6 +28,7 @@ EXECUTOR_SAFE = "0xa2b04c6a053AB2EFBC699f5DD0F0957742A41629"
 TESS_USDT_SUSDS = "0x9fec8a63a6c6ef9eadddfbd79daba5918965794e"
 IPOR_BITCOIN_DOLLAR_USDC = "0xf8f226da66244f89e70c5b5d1a5c5b0d505eb1d8"
 MORPHO_9S_USR = "0x00b6f2c15e4439749f192d10c70f65354848cf4b"
+MORPHO_V2_APYX_USDC = "0x069662d2588fcac24b5c209456db965d151556f0"
 EULER_VAULTS = (
     "0x3cd3718f8f047aa32f775e2cb4245a164e1c99fb",
     "0x8aff4fe319c30475d27ec623d7d44bd5ecfe9616",
@@ -91,6 +93,26 @@ def test_morpho_9s_is_permissionless(web3: Web3) -> None:
     assert isinstance(vault, MorphoV1Vault)
 
     # 3. Confirm deposits do not require identity approval.
+    assert vault.is_whitelisted_deposit() is False
+
+
+def test_morpho_v2_gate_getters_are_permissionless(web3: Web3) -> None:
+    """Test Morpho V2's deployed gate getters and public default.
+
+    1. Autodetect the production Apyx vault at the fixed block.
+    2. Read the source-defined share-receiver and asset-sender gate slots.
+    3. Confirm both gates are disabled and deposits are permissionless.
+    """
+    # 1. Autodetect the production Apyx vault at the fixed block.
+    vault = create_vault_instance_autodetect(web3, MORPHO_V2_APYX_USDC)
+    assert isinstance(vault, MorphoV2Vault)
+
+    # 2. Read the source-defined share-receiver and asset-sender gate slots.
+    receive_shares_gate, send_assets_gate = vault.fetch_deposit_gates()
+
+    # 3. Confirm both gates are disabled and deposits are permissionless.
+    assert int(receive_shares_gate, 16) == 0
+    assert int(send_assets_gate, 16) == 0
     assert vault.is_whitelisted_deposit() is False
 
 

--- a/tests/erc_4626/vault_protocol/test_vault_permission_regressions.py
+++ b/tests/erc_4626/vault_protocol/test_vault_permission_regressions.py
@@ -1,0 +1,112 @@
+"""Fixed-block regressions for vault deposit-permission classifications."""
+
+import os
+
+import pytest
+from web3 import Web3
+
+from eth_defi.erc_4626.classification import create_vault_instance_autodetect
+from eth_defi.erc_4626.vault_protocol.euler.vault import EulerEarnVault, EulerVault
+from eth_defi.erc_4626.vault_protocol.ipor.vault import IPORVault
+from eth_defi.erc_4626.vault_protocol.morpho.vault_v1 import MorphoV1Vault
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
+from eth_defi.vault.base import VaultSpec
+
+JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
+
+#: Block used to independently verify the TESS AccessManager configuration.
+PERMISSION_REGRESSION_BLOCK = 25_651_723
+
+#: IPOR role assigned to allow-listed depositors.
+IPOR_WHITELIST_ROLE = 800
+
+#: Trade-executor Safe used by the production vault simulation.
+EXECUTOR_SAFE = "0xa2b04c6a053AB2EFBC699f5DD0F0957742A41629"
+
+#: Exact vaults from the production classification report.
+TESS_USDT_SUSDS = "0x9fec8a63a6c6ef9eadddfbd79daba5918965794e"
+IPOR_BITCOIN_DOLLAR_USDC = "0xf8f226da66244f89e70c5b5d1a5c5b0d505eb1d8"
+MORPHO_9S_USR = "0x00b6f2c15e4439749f192d10c70f65354848cf4b"
+EULER_VAULTS = (
+    "0x3cd3718f8f047aa32f775e2cb4245a164e1c99fb",
+    "0x8aff4fe319c30475d27ec623d7d44bd5ecfe9616",
+    "0x9bd52f2805c6af014132874124686e7b248c2cbb",
+    "0xab2726daf820aa9270d14db9b18c8d187cbf2f30",
+)
+
+pytestmark = [
+    pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run these tests"),
+    pytest.mark.xdist_group("fork:ethereum:vault-permission-regressions"),
+]
+
+
+@pytest.fixture(scope="module")
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Create one shared fixed Ethereum fork for all permission controls."""
+    return anvil_fork_pool.get_web3(JSON_RPC_ETHEREUM, PERMISSION_REGRESSION_BLOCK)
+
+
+def test_ipor_tess_restricted_and_public_controls(web3: Web3) -> None:
+    """Test IPOR's selector role retains both restricted and public controls.
+
+    1. Bind the exact TESS and Bitcoin Dollar IPOR deployments.
+    2. Read TESS authority, selector role, and executor Safe access.
+    3. Confirm TESS remains restricted while Bitcoin Dollar remains public.
+    """
+    # 1. Bind the exact TESS and Bitcoin Dollar IPOR deployments.
+    tess = IPORVault(web3, VaultSpec(1, TESS_USDT_SUSDS))
+    public = IPORVault(web3, VaultSpec(1, IPOR_BITCOIN_DOLLAR_USDC))
+
+    # 2. Read TESS authority, selector role, and executor Safe access.
+    access_manager = tess.access_manager
+    assert access_manager is not None
+    authority = tess.plasma_vault.functions.authority().call()
+    configured_manager = tess.plasma_vault.functions.getAccessManagerAddress().call()
+    role = access_manager.functions.getTargetFunctionRole(
+        tess.address,
+        tess.get_deposit_function_selector(),
+    ).call()
+    admitted, delay = tess.fetch_selector_access(EXECUTOR_SAFE, tess.get_deposit_function_selector())
+
+    # 3. Confirm TESS remains restricted while Bitcoin Dollar remains public.
+    assert authority == configured_manager == access_manager.address
+    assert role == IPOR_WHITELIST_ROLE
+    assert admitted is False
+    assert delay == 0
+    assert tess.is_whitelisted_deposit() is True
+    assert public.is_whitelisted_deposit() is False
+
+
+def test_morpho_9s_is_permissionless(web3: Web3) -> None:
+    """Test the exact 9S Mount Kosciuszko MetaMorpho vault is public.
+
+    1. Autodetect the production vault at the fixed block.
+    2. Confirm it uses the canonical MetaMorpho V1 adapter.
+    3. Confirm deposits do not require identity approval.
+    """
+    # 1. Autodetect the production vault at the fixed block.
+    vault = create_vault_instance_autodetect(web3, MORPHO_9S_USR)
+
+    # 2. Confirm it uses the canonical MetaMorpho V1 adapter.
+    assert isinstance(vault, MorphoV1Vault)
+
+    # 3. Confirm deposits do not require identity approval.
+    assert vault.is_whitelisted_deposit() is False
+
+
+@pytest.mark.parametrize("vault_address", EULER_VAULTS)
+def test_reported_euler_vaults_are_permissionless(web3: Web3, vault_address: str) -> None:
+    """Test each reported Euler false positive against its deployed hook state.
+
+    1. Autodetect the exact production vault at the fixed block.
+    2. Confirm the deployment uses an Euler EVK or EulerEarn adapter.
+    3. Confirm its canonical deposit path does not require identity approval.
+    """
+    # 1. Autodetect the exact production vault at the fixed block.
+    vault = create_vault_instance_autodetect(web3, vault_address)
+
+    # 2. Confirm the deployment uses an Euler EVK or EulerEarn adapter.
+    assert isinstance(vault, (EulerVault, EulerEarnVault))
+
+    # 3. Confirm its canonical deposit path does not require identity approval.
+    assert vault.is_whitelisted_deposit() is False

--- a/tests/erc_4626/vault_protocol/test_yearn_compounder.py
+++ b/tests/erc_4626/vault_protocol/test_yearn_compounder.py
@@ -69,6 +69,7 @@ def test_yearn_legacy_compounder_fee_data(web3: Web3) -> None:
     assert isinstance(vault, YearnCompounderVault)
     assert vault.features == {ERC4626Feature.yearn_compounder_like}
     assert vault.get_protocol_name() == "Yearn"
+    assert vault.is_whitelisted_deposit() is False
 
     fee_data = vault.get_fee_data()
     assert fee_data.fee_mode == VaultFeeMode.internalised_skimming
@@ -93,6 +94,7 @@ def test_yearn_modern_compounder_fee_data() -> None:
 
         assert isinstance(vault, YearnCompounderVault)
         assert vault.features == {ERC4626Feature.yearn_compounder_like}
+        assert vault.is_whitelisted_deposit() is False
         assert vault.get_fee_data().performance == MOONWELL_PERFORMANCE_FEE
     finally:
         launch.close()

--- a/tests/erc_4626/vault_protocol/test_yearn_upshift_deposit_permissions.py
+++ b/tests/erc_4626/vault_protocol/test_yearn_upshift_deposit_permissions.py
@@ -56,6 +56,29 @@ def test_yearn_custom_deposit_limit_module_remains_unknown() -> None:
     )
 
 
+def test_yearn_unreadable_deposit_limit_module_remains_unknown() -> None:
+    """A Yearn-like deployment without the V3 module getter must fail closed.
+
+    1. Prepare a Yearn deployment whose deposit-limit module call reverts.
+    2. Read the vault-wide deposit permission classification.
+    3. Confirm the adapter reports an unknown policy instead of leaking the RPC error.
+    """
+    # 1. Prepare a Yearn deployment whose deposit-limit module call reverts.
+    vault = object.__new__(YearnV3Vault)
+    vault.__dict__["vault_contract"] = MagicMock()
+    vault.vault_contract.functions.deposit_limit_module.return_value.call.side_effect = ValueError("execution reverted")
+    vault._get_block_identifier = MagicMock(return_value=123)
+
+    # 2. Read the vault-wide deposit permission classification.
+    with pytest.raises(NotImplementedError, match="does not expose a readable deposit-limit module"):
+        vault.is_whitelisted_deposit()
+
+    # 3. Confirm the adapter reports an unknown policy instead of leaking the RPC error.
+    vault.vault_contract.functions.deposit_limit_module.return_value.call.assert_called_once_with(
+        block_identifier=123,
+    )
+
+
 def test_upshift_account_deposits_are_permissionless() -> None:
     """Upshift's accepted-asset list is not an account whitelist.
 

--- a/tests/erc_4626/vault_protocol/test_yearn_upshift_deposit_permissions.py
+++ b/tests/erc_4626/vault_protocol/test_yearn_upshift_deposit_permissions.py
@@ -80,6 +80,26 @@ def test_legacy_yearn_without_deposit_limit_module_defaults_permissionless() -> 
     )
 
 
+def test_yearn_permission_read_does_not_hide_rpc_failures() -> None:
+    """Do not misclassify a Yearn vault when its permission read fails in transit.
+
+    1. Prepare a Yearn deposit-limit read that fails without an EVM revert.
+    2. Ask the adapter to classify deposit permission.
+    3. Confirm the RPC failure propagates to the scanner's unknown-status guard.
+    """
+    # 1. Prepare a Yearn deposit-limit read that fails without an EVM revert.
+    vault = object.__new__(YearnV3Vault)
+    vault.__dict__["vault_contract"] = MagicMock()
+    vault._get_block_identifier = MagicMock(return_value=123)
+    vault.vault_contract.functions.deposit_limit_module.return_value.call.side_effect = ValueError("RPC request timed out")
+
+    # 2. Ask the adapter to classify deposit permission.
+    with pytest.raises(ValueError, match="RPC request timed out"):
+        vault.is_whitelisted_deposit()
+
+    # 3. The transport failure propagated instead of becoming permissionless.
+
+
 def test_upshift_account_deposits_are_permissionless() -> None:
     """Upshift's accepted-asset list is not an account whitelist.
 

--- a/tests/erc_4626/vault_protocol/test_yearn_upshift_deposit_permissions.py
+++ b/tests/erc_4626/vault_protocol/test_yearn_upshift_deposit_permissions.py
@@ -56,12 +56,12 @@ def test_yearn_custom_deposit_limit_module_remains_unknown() -> None:
     )
 
 
-def test_yearn_unreadable_deposit_limit_module_remains_unknown() -> None:
-    """A Yearn-like deployment without the V3 module getter must fail closed.
+def test_legacy_yearn_without_deposit_limit_module_defaults_permissionless() -> None:
+    """A legacy Yearn deployment without the V3 module getter defaults public.
 
     1. Prepare a Yearn deployment whose deposit-limit module call reverts.
     2. Read the vault-wide deposit permission classification.
-    3. Confirm the adapter reports an unknown policy instead of leaking the RPC error.
+    3. Confirm the adapter reports permissionless with an explicit caveat.
     """
     # 1. Prepare a Yearn deployment whose deposit-limit module call reverts.
     vault = object.__new__(YearnV3Vault)
@@ -70,10 +70,11 @@ def test_yearn_unreadable_deposit_limit_module_remains_unknown() -> None:
     vault._get_block_identifier = MagicMock(return_value=123)
 
     # 2. Read the vault-wide deposit permission classification.
-    with pytest.raises(NotImplementedError, match="does not expose a readable deposit-limit module"):
-        vault.is_whitelisted_deposit()
+    permissioned = vault.is_whitelisted_deposit()
 
-    # 3. Confirm the adapter reports an unknown policy instead of leaking the RPC error.
+    # 3. Confirm the adapter reports permissionless with an explicit caveat.
+    assert permissioned is False
+    assert "treated as permissionless by default" in vault.get_whitelist_notes()
     vault.vault_contract.functions.deposit_limit_module.return_value.call.assert_called_once_with(
         block_identifier=123,
     )

--- a/tests/erc_4626/vault_protocol/test_yearn_upshift_deposit_permissions.py
+++ b/tests/erc_4626/vault_protocol/test_yearn_upshift_deposit_permissions.py
@@ -1,0 +1,73 @@
+"""Unit coverage for Yearn and Upshift deposit-permission discovery."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from eth_defi.abi import ZERO_ADDRESS_STR
+from eth_defi.erc_4626.vault_protocol.upshift.vault import UpshiftVault
+from eth_defi.erc_4626.vault_protocol.yearn.vault import YearnV3Vault
+
+
+def test_yearn_without_deposit_limit_module_is_permissionless() -> None:
+    """Canonical Yearn V3 limits are not account admission gates.
+
+    1. Prepare a Yearn V3 vault with its deposit-limit module disabled.
+    2. Read the vault-wide deposit permission classification.
+    3. Confirm the canonical configuration is permissionless.
+    """
+    # 1. Prepare a Yearn V3 vault with its deposit-limit module disabled.
+    vault = object.__new__(YearnV3Vault)
+    vault.__dict__["vault_contract"] = MagicMock()
+    vault.vault_contract.functions.deposit_limit_module.return_value.call.return_value = ZERO_ADDRESS_STR
+    vault._get_block_identifier = MagicMock(return_value=123)
+
+    # 2. Read the vault-wide deposit permission classification.
+    permissioned = vault.is_whitelisted_deposit()
+
+    # 3. Confirm the canonical configuration is permissionless.
+    assert permissioned is False
+    vault.vault_contract.functions.deposit_limit_module.return_value.call.assert_called_once_with(
+        block_identifier=123,
+    )
+
+
+def test_yearn_custom_deposit_limit_module_remains_unknown() -> None:
+    """A custom Yearn module must not be assumed public or allow-listed.
+
+    1. Prepare a Yearn V3 vault with a non-zero deposit-limit module.
+    2. Read the vault-wide deposit permission classification.
+    3. Confirm the adapter requires module-specific inspection.
+    """
+    # 1. Prepare a Yearn V3 vault with a non-zero deposit-limit module.
+    module = "0x1111111111111111111111111111111111111111"
+    vault = object.__new__(YearnV3Vault)
+    vault.__dict__["vault_contract"] = MagicMock()
+    vault.vault_contract.functions.deposit_limit_module.return_value.call.return_value = module
+    vault._get_block_identifier = MagicMock(return_value=123)
+
+    # 2. Read the vault-wide deposit permission classification.
+    with pytest.raises(NotImplementedError, match=module):
+        vault.is_whitelisted_deposit()
+
+    # 3. Confirm the adapter requires module-specific inspection.
+    vault.vault_contract.functions.deposit_limit_module.return_value.call.assert_called_once_with(
+        block_identifier=123,
+    )
+
+
+def test_upshift_account_deposits_are_permissionless() -> None:
+    """Upshift's accepted-asset list is not an account whitelist.
+
+    1. Prepare an Upshift vault adapter without querying chain state.
+    2. Read its account deposit permission classification.
+    3. Confirm account admission is permissionless.
+    """
+    # 1. Prepare an Upshift vault adapter without querying chain state.
+    vault = object.__new__(UpshiftVault)
+
+    # 2. Read its account deposit permission classification.
+    permissioned = vault.is_whitelisted_deposit()
+
+    # 3. Confirm account admission is permissionless.
+    assert permissioned is False

--- a/tests/erc_4626/vault_protocol/test_yearn_upshift_deposit_permissions.py
+++ b/tests/erc_4626/vault_protocol/test_yearn_upshift_deposit_permissions.py
@@ -74,7 +74,7 @@ def test_legacy_yearn_without_deposit_limit_module_defaults_permissionless() -> 
 
     # 3. Confirm the adapter reports permissionless with an explicit caveat.
     assert permissioned is False
-    assert "treated as permissionless by default" in vault.get_whitelist_notes()
+    assert "permissionless compatibility default" in vault.get_whitelist_notes()
     vault.vault_contract.functions.deposit_limit_module.return_value.call.assert_called_once_with(
         block_identifier=123,
     )

--- a/tests/erc_4626/vault_protocol/test_yearn_yvault.py
+++ b/tests/erc_4626/vault_protocol/test_yearn_yvault.py
@@ -53,6 +53,7 @@ def test_yvault_usdce_symbol(
 
     assert isinstance(vault, YearnV3Vault)
     assert vault.get_protocol_name() == "Yearn"
+    assert vault.is_whitelisted_deposit() is False
     assert vault.denomination_token.address == "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8"
     assert vault.denomination_token.symbol == "USDC.e"
     assert vault.get_management_fee("latest") == 0.00

--- a/tests/erc_4626/vault_protocol/test_yieldnest.py
+++ b/tests/erc_4626/vault_protocol/test_yieldnest.py
@@ -18,7 +18,7 @@ from web3 import Web3
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature
-from eth_defi.erc_4626.vault_protocol.yieldnest.deposit_redeem import EXCEEDED_MAX_REDEEM_SELECTOR, YieldNestDepositManager
+from eth_defi.erc_4626.vault_protocol.yieldnest.deposit_redeem import YieldNestDepositManager
 from eth_defi.erc_4626.vault_protocol.yieldnest.vault import YNRWAX_VAULT_ADDRESS, YieldNestVault
 from eth_defi.provider.anvil import AnvilLaunch
 from eth_defi.provider.multi_provider import create_multi_provider_web3
@@ -75,9 +75,9 @@ def test_yieldnest_ynrwax_metadata(web3: Web3) -> None:
     assert vault.is_whitelisted_deposit() is False
     assert vault.get_deposit_manager_capability().as_dict() == {
         "can_deposit": True,
-        "can_redeem": False,
+        "can_redeem": True,
         "deposit_flow": "synchronous",
-        "redemption_unsupported_reason": "maturity_aware_redemption_flow_not_implemented",
+        "redemption_flow": "synchronous",
     }
     assert isinstance(vault.get_deposit_manager(), YieldNestDepositManager)
     assert vault.vault_contract.events.Deposit is not None
@@ -132,13 +132,12 @@ def test_yieldnest_ynrwax_deposit_and_redemption_preflight(web3: Web3, yieldnest
     with pytest.raises(TransactionAssertionError, match="custom error 0xb8b8b59c"):
         assert_transaction_success_with_explanation(web3, direct_redeem_hash)
 
-    # The manager refuses the full position before broadcast with a typed error
-    # carrying the decoded ExceededMaxRedeem selector, instead of leaking the
-    # raw 0xb8b8b59c revert.
+    # The manager refuses the full position before broadcast with the product's
+    # explicit maturity date. Live buffer capacity remains a separate state.
     with pytest.raises(VaultFlowUnavailable) as exc_info:
         manager.create_redemption_request(owner=owner, raw_shares=raw_shares)
     error = exc_info.value
-    assert error.decoded_error == "ExceededMaxRedeem"
-    assert error.error_selector == EXCEEDED_MAX_REDEEM_SELECTOR
+    assert error.decoded_error == "RedemptionBeforeMaturity"
+    assert error.preflight_result == "redemption_not_yet_matured"
+    assert error.next_open == datetime.datetime(2026, 10, 15)
     assert error.requested_raw_amount == raw_shares
-    assert error.available_raw_amount == max_redeem

--- a/tests/guard/test_guard_closed_deposit_validation.py
+++ b/tests/guard/test_guard_closed_deposit_validation.py
@@ -24,7 +24,7 @@ from eth_defi.provider.fallback import ExtraValueError
 from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
 from eth_defi.trace import assert_transaction_success_with_explanation
-from eth_defi.vault.deposit_redeem import VaultFlowUnavailable, WhitelistingRequired, validate_closed_deposit_request_with_guard
+from eth_defi.vault.deposit_redeem import VaultFlowUnavailable, validate_closed_deposit_request_with_guard
 
 JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
 
@@ -79,7 +79,7 @@ def test_closed_d2_deposit_calldata_passes_guard_validation_without_broadcast(we
     raw_amount = vault.denomination_token.convert_to_raw(10)
     admission_balance = int(vault.vault_contract.functions.whitelistBalance().call()) + raw_amount + 1
     fund_erc20_on_anvil(web3, vault.denomination_token.address, simple_vault.address, admission_balance)
-    assert vault.is_account_whitelisted(simple_vault.address) is True
+    assert vault.is_account_eligible(simple_vault.address) is True
 
     with pytest.raises(VaultFlowUnavailable) as exc_info:
         manager.create_deposit_request(owner=simple_vault.address, raw_amount=raw_amount)
@@ -148,6 +148,8 @@ def test_closed_d2_guard_validation_retains_protocol_account_admission(web3: Web
     unadmitted_owner = HexAddress(web3.eth.accounts[2])
     raw_amount = vault.denomination_token.convert_to_raw(10)
 
-    assert vault.is_account_whitelisted(unadmitted_owner) is False
-    with pytest.raises(WhitelistingRequired, match="not whitelisted"):
+    assert vault.is_account_eligible(unadmitted_owner) is False
+    with pytest.raises(VaultFlowUnavailable, match="public USDC balance eligibility minimum") as exc_info:
         manager.create_deposit_request_for_guard_validation(unadmitted_owner, raw_amount)
+    assert exc_info.value.preflight_result == "below_minimum"
+    assert exc_info.value.decoded_error == "InsufficientEligibilityBalance"

--- a/tests/guard/test_guard_simple_vault_standard_erc4626.py
+++ b/tests/guard/test_guard_simple_vault_standard_erc4626.py
@@ -46,7 +46,7 @@ from eth_defi.simple_vault.transact import encode_simple_vault_transaction
 from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.testing.evm_snapshot_fixture import evm_snapshot_revert
 from eth_defi.trace import TransactionAssertionError, assert_transaction_success_with_explanation
-from eth_defi.vault.deposit_redeem import WhitelistingRequired
+from eth_defi.vault.deposit_redeem import VaultFlowUnavailable
 
 JSON_RPC_ARBITRUM = os.environ.get("JSON_RPC_ARBITRUM")
 
@@ -218,9 +218,10 @@ def test_guarded_standard_erc4626_deposit_and_redeem(  # noqa: PLR0914
             _perform_guarded_call(web3, simple_vault, control, deposit_request.funcs[0])
             raw_shares = protocol_vault.share_token.fetch_raw_balance_of(simple_vault.address)
             assert raw_shares > 0
-            assert protocol_vault.is_account_whitelisted(simple_vault.address) is False
-            with pytest.raises(WhitelistingRequired, match="not whitelisted"):
+            assert protocol_vault.is_account_eligible(simple_vault.address) is False
+            with pytest.raises(VaultFlowUnavailable, match="public USDC balance eligibility minimum") as exc_info:
                 manager.create_redemption_request(owner=simple_vault.address, raw_shares=raw_shares)
+            assert exc_info.value.preflight_result == "below_minimum"
         finally:
             assert web3.provider.make_request("evm_revert", [snapshot_id])["result"] is True
             # Anvil restores the account nonce but a HotWallet intentionally


### PR DESCRIPTION
## Why

The production 129-vault lifecycle matrix exposed cases where protocol availability was being mistaken for investor whitelisting. Permissionless Morpho, Euler, D2, Yearn, Upshift and other public ERC-4626 adapters were therefore blocked before simulation, while predictable redemption constraints could escape as raw failures.

HYPE++ and texasHedge are permissionless D2 vaults with funding and withdrawal phases, not KYC vaults. Morpho and Euler are permissionless by default unless their canonical gate or hook state proves otherwise. IPOR remains account-gated when its AccessManager reports a restricted deposit-selector role. Accountable exposes its configured permission mode directly.

## Lessons learnt

Vault-wide permission, temporary availability, accepted deposit assets and caller eligibility are independent dimensions. An adapter must derive each from canonical contract state and return `unknown` when an explicit custom gate cannot be interpreted safely.

Accountable defines `None=0`, `KYC=1` and `Whitelist=2`. Whitelist mode uses `allowed(address)`, while KYC verifies a signed payload appended to each call. D2's public token-balance eligibility is an economic minimum, not identity approval.

A mined redemption may burn shares for zero assets. Receipt analysis must preserve that cause-neutral economic outcome without inventing liquidity or transfer claims, and reverse-price presentation must not fail on the resulting zero price.

## Summary

- Classify MetaMorpho V1, Morpho V2, Euler, D2, Yearn V3 and Upshift deposits from protocol state instead of blanket whitelist assumptions.
- Add explicit permissionless defaults for the supported 40acres, Ember, Plutus, cSigma and Yearn Compounder implementation families while retaining unknown for inspectable custom gates.
- Classify Accountable from `permissionLevel()` and preflight both deposit controller and receiver under the configured mode.
- Preserve genuine IPOR selector-role checks, including the restricted TESS deployment and a permissionless control.
- Add fixed-block evidence for reported Morpho V1, Morpho V2, Euler and IPOR deployments.
- Model D2 funding/withdrawal phases and public eligibility independently from identity permission.
- Add source-scoped Morpho V2 redemption-liquidity simulation with structured intervention evidence.
- Report YieldNest maturity and immediate buffer constraints as live state while keeping adapter capability separate.
- Preserve zero-output ERC-4626 redemption receipts and reject malformed negative unsigned event values.
- Document Accountable, Morpho and Euler permission mechanisms and their safe classification boundaries.

## Related issues and PRs

- trading-strategy metadata PR: https://github.com/tradingstrategy-ai/trading-strategy/pull/246
- trade-executor experiment and integration PR: https://github.com/tradingstrategy-ai/trade-executor/pull/1597
