### PR TITLE
feat: refresh Lagoon vault metadata daily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- feat: Refresh Lagoon offchain vault metadata daily in persistent scanner processes while retaining stale descriptions during transient API failures (2026-08-01)
 - feat: Add hardcoded classification and discovery for Axis's StakedUSDx Plasma rewards vault (2026-07-30)
 
 - feat: Add `extract_revert_data()` for provider-independent recovery of ABI-encoded custom errors from reverted `eth_call` simulations (2026-07-30)

--- a/eth_defi/erc_4626/vault_protocol/lagoon/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/offchain_metadata.py
@@ -1,29 +1,30 @@
 """Lagoon vault offchain metadata.
 
-- Lagoon stores vault descriptions in their web app, not on-chain or in a public data repository
-- We reverse-engineered the Lagoon Next.js app and discovered internal API endpoints
+- Lagoon stores vault descriptions in their web app, not onchain or in a public data repository
+- We reverse-engineered the Lagoon Next.js app and discovered web application API endpoints
   at ``app.lagoon.finance`` that serve vault metadata including descriptions
 - The listing endpoint ``/api/vaults`` returns paginated vault data without descriptions
 - The detail endpoint ``/api/vault`` returns full vault data including ``description`` and ``shortDescription``
 - We fetch and cache this data locally to avoid repeated API calls
-- Two-level caching: disk (2-day TTL) + in-process dictionary
+- Two-level caching: disk (1-day TTL) + an expiring in-process dictionary
 """
 
 import datetime
 import json
 import logging
+from dataclasses import dataclass
 from json import JSONDecodeError
 from pathlib import Path
 from typing import TypedDict
 
 import requests
-
-from web3 import Web3
+from atomicwrites import atomic_write
 from eth_typing import HexAddress
-from eth_defi.compat import native_datetime_utc_now, native_datetime_utc_fromtimestamp
+from web3 import Web3
+
+from eth_defi.compat import native_datetime_utc_fromtimestamp, native_datetime_utc_now
 from eth_defi.disk_cache import DEFAULT_CACHE_ROOT
 from eth_defi.utils import wait_other_writers
-
 
 #: Where we cache fetched Lagoon metadata files
 DEFAULT_CACHE_PATH = DEFAULT_CACHE_ROOT / "lagoon"
@@ -31,7 +32,44 @@ DEFAULT_CACHE_PATH = DEFAULT_CACHE_ROOT / "lagoon"
 #: Lagoon web app API base URL, reverse-engineered from their Next.js frontend
 DEFAULT_API_BASE_URL = "https://app.lagoon.finance/api"
 
+#: How long Lagoon metadata is cached before the scanner refreshes it.
+DEFAULT_CACHE_DURATION = datetime.timedelta(days=1)
+
+#: Prevent one failed refresh from being retried for every vault in the same scan.
+FAILED_REFRESH_RETRY_DELAY = datetime.timedelta(hours=1)
+
 logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class _LagoonMetadataCache:
+    """One chain's Lagoon metadata held by the long-running scanner.
+
+    The looped scanner stays in one Python process across scan cycles. Its
+    process cache therefore needs an explicit expiry in addition to the JSON
+    file expiry.
+    """
+
+    #: Metadata keyed by checksummed vault address.
+    vaults: dict[HexAddress, "LagoonVaultMetadata"]
+
+    #: Naive UTC time after which Lagoon metadata must be fetched again.
+    expires_at: datetime.datetime
+
+
+def _get_cache_file(cache_path: Path, chain_id: int) -> Path:
+    """Resolve one chain's Lagoon cache file.
+
+    :param cache_path:
+        Directory containing Lagoon metadata cache files.
+
+    :param chain_id:
+        EVM chain id.
+
+    :return:
+        Absolute path to the chain's JSON cache file.
+    """
+    return (cache_path / f"lagoon_vaults_chain_{chain_id}.json").resolve()
 
 
 class LagoonCuratorMetadata(TypedDict):
@@ -135,8 +173,11 @@ def _fetch_vault_listing_page(
     page_index: int = 0,
     page_size: int = 100,
     api_base_url: str = DEFAULT_API_BASE_URL,
-) -> dict:
+) -> dict | None:
     """Fetch a page of vault listings from the Lagoon web app API.
+
+    The official Lagoon web application uses this endpoint at
+    ``https://app.lagoon.finance/api/vaults``.
 
     :param chain_id:
         EVM chain id
@@ -151,7 +192,8 @@ def _fetch_vault_listing_page(
         Lagoon API base URL
 
     :return:
-        Raw JSON response dict with keys: ``vaults``, ``totalCount``, ``hasNextPage``
+        Raw JSON response dict with keys ``vaults``, ``totalCount`` and
+        ``hasNextPage``, or ``None`` when the request fails.
     """
     url = f"{api_base_url}/vaults?chainId={chain_id}&pageIndex={page_index}&pageSize={page_size}"
     logger.debug("Fetching Lagoon vault listing from %s", url)
@@ -161,15 +203,18 @@ def _fetch_vault_listing_page(
         return resp.json()
     except (requests.RequestException, JSONDecodeError) as e:
         logger.warning("Failed to fetch Lagoon vault listing from %s: %s", url, e)
-        return {"vaults": [], "totalCount": 0, "hasNextPage": False}
+        return None
 
 
 def _fetch_vault_detail(
     chain_id: int,
-    address: str,
+    address: HexAddress,
     api_base_url: str = DEFAULT_API_BASE_URL,
 ) -> dict | None:
     """Fetch detailed vault metadata from the Lagoon web app API.
+
+    The official Lagoon web application uses this endpoint at
+    ``https://app.lagoon.finance/api/vault``.
 
     :param chain_id:
         EVM chain id
@@ -181,7 +226,8 @@ def _fetch_vault_detail(
         Lagoon API base URL
 
     :return:
-        Raw JSON response dict, or None if the vault is not in Lagoon's database (HTTP 500)
+        Raw JSON response dict, or ``None`` when the request fails or Lagoon
+        does not have a record for the vault.
     """
     url = f"{api_base_url}/vault?chainId={chain_id}&address={address}"
     logger.debug("Fetching Lagoon vault detail from %s", url)
@@ -194,19 +240,50 @@ def _fetch_vault_detail(
         return None
 
 
+def _load_cached_vaults(file: Path, chain_id: int) -> dict[HexAddress, LagoonVaultMetadata]:
+    """Load one chain's Lagoon metadata JSON cache.
+
+    Cache corruption is raised as a hard error because silently replacing the
+    mapping with an empty result would erase metadata during the next vault
+    scan.
+
+    :param file:
+        JSON cache file to read.
+
+    :param chain_id:
+        EVM chain id used in error messages.
+
+    :return:
+        Metadata keyed by checksummed vault address.
+
+    :raises RuntimeError:
+        If the cache is not valid JSON.
+    """
+    try:
+        with file.open(encoding="utf-8") as cache_input:
+            return json.load(cache_input)
+    except (JSONDecodeError, UnicodeDecodeError) as e:
+        content = file.read_text(encoding="utf-8", errors="replace")
+        raise RuntimeError(f"Could not parse Lagoon vaults file for chain {chain_id} at {file}, length {len(content)} content starts with {content[:100]!r}") from e
+
+
 def fetch_lagoon_vaults_for_chain(
     chain_id: int,
     cache_path: Path = DEFAULT_CACHE_PATH,
     api_base_url: str = DEFAULT_API_BASE_URL,
     now_: datetime.datetime | None = None,
-    max_cache_duration: datetime.timedelta = datetime.timedelta(days=2),
-) -> dict[str, LagoonVaultMetadata]:
+    max_cache_duration: datetime.timedelta = DEFAULT_CACHE_DURATION,
+) -> dict[HexAddress, LagoonVaultMetadata]:
     """Fetch and cache Lagoon offchain vault metadata for a given chain.
 
     - Enumerates vaults using the listing endpoint, then fetches each vault's
       detail (including description) from the detail endpoint
     - One JSON cache file per chain
-    - Multiprocess safe via file lock
+    - Serialises concurrent readers and writers with a file lock
+    - Retains stale metadata when Lagoon has a transient API failure
+
+    The official Lagoon web application uses these endpoints under
+    ``https://app.lagoon.finance/api``.
 
     :param chain_id:
         EVM chain id
@@ -221,7 +298,7 @@ def fetch_lagoon_vaults_for_chain(
         Override current time (for testing)
 
     :param max_cache_duration:
-        How long before refreshing cache (default 2 days)
+        How long before refreshing cache (default 1 day)
 
     :return:
         Dict mapping checksummed vault address to :py:class:`LagoonVaultMetadata`
@@ -231,81 +308,117 @@ def fetch_lagoon_vaults_for_chain(
     assert isinstance(cache_path, Path), "cache_path must be Path instance"
 
     cache_path.mkdir(parents=True, exist_ok=True)
-    file = cache_path / f"lagoon_vaults_chain_{chain_id}.json"
-    file = file.resolve()
+    file = _get_cache_file(cache_path, chain_id)
 
-    file_size = file.stat().st_size if file.exists() else 0
+    now_ = now_ or native_datetime_utc_now()
 
-    if not now_:
-        now_ = native_datetime_utc_now()
-
-    # When running multiprocess vault scan, we have competition over this file write and
-    # if we do not wait the race condition may try to read zero-bytes file
+    # Multiple scanner threads may discover Lagoon vaults at the same time.
+    # Keep the freshness check and any replacement write under one file lock.
     with wait_other_writers(file):
-        if not file.exists() or (now_ - native_datetime_utc_fromtimestamp(file.stat().st_mtime)) > max_cache_duration or file_size == 0:
-            logger.info("Re-fetching Lagoon vaults metadata for chain %d from %s", chain_id, api_base_url)
+        has_cache = file.exists() and file.stat().st_size > 0
+        cached_vaults = _load_cached_vaults(file, chain_id) if has_cache else {}
+        if has_cache:
+            fetched_at = native_datetime_utc_fromtimestamp(file.stat().st_mtime)
+            if now_ - fetched_at < max_cache_duration:
+                logger.info("Using cached Lagoon vaults file for chain %d from %s, last fetched at %s, ago %s", chain_id, file, fetched_at.isoformat(), now_ - fetched_at)
+                return cached_vaults
 
-            # Step 1: Enumerate all vaults on this chain via listing endpoint
-            # Note: Lagoon's listing endpoint ignores the chainId parameter and returns
-            # ALL vaults across all chains, so we must filter by the vault's actual chainId
-            all_vault_addresses = []
-            page_index = 0
-            while True:
-                page_data = _fetch_vault_listing_page(chain_id, page_index=page_index, api_base_url=api_base_url)
-                vaults_in_page = page_data.get("vaults", [])
-                for v in vaults_in_page:
-                    addr = v.get("address")
-                    vault_chain_id = v.get("chain", {}).get("id")
-                    if addr and vault_chain_id is not None and int(vault_chain_id) == chain_id:
-                        all_vault_addresses.append(addr)
-                if not page_data.get("hasNextPage", False):
-                    break
-                page_index += 1
+        logger.info("Re-fetching Lagoon vaults metadata for chain %d from %s", chain_id, api_base_url)
 
-            logger.info("Found %d Lagoon vaults on chain %d, fetching details", len(all_vault_addresses), chain_id)
+        # Lagoon ignores chainId on the listing endpoint, so filter every page
+        # by the chain id embedded in each returned vault record.
+        all_vault_addresses: list[HexAddress] = []
+        page_index = 0
+        while True:
+            page_data = _fetch_vault_listing_page(chain_id, page_index=page_index, api_base_url=api_base_url)
+            if page_data is None:
+                logger.warning("Keeping %d stale Lagoon metadata entries for chain %d after a listing request failure", len(cached_vaults), chain_id)
+                return cached_vaults
 
-            # Step 2: Fetch detail for each vault to get descriptions
-            result: dict[str, LagoonVaultMetadata] = {}
-            for addr in all_vault_addresses:
-                detail = _fetch_vault_detail(chain_id, addr, api_base_url=api_base_url)
-                if detail is not None:
-                    checksummed = Web3.to_checksum_address(addr)
-                    result[checksummed] = _parse_vault_detail(detail)
+            for vault in page_data.get("vaults", []):
+                address = vault.get("address")
+                vault_chain_id = vault.get("chain", {}).get("id")
+                if address and vault_chain_id is not None and int(vault_chain_id) == chain_id:
+                    all_vault_addresses.append(HexAddress(address))
 
-            logger.info("Fetched metadata for %d Lagoon vaults on chain %d", len(result), chain_id)
+            if not page_data.get("hasNextPage", False):
+                break
+            page_index += 1
 
-            if not result:
-                logger.info("Lagoon API returned 0 vaults for chain %d, skipping cache write to avoid poisoning the cache", chain_id)
-                return {}
+        logger.info("Found %d Lagoon vaults on chain %d, fetching details", len(all_vault_addresses), chain_id)
 
-            # Serialise result dict so that TypedDict values are JSON-compatible
-            with file.open("wt") as f:
-                json.dump(result, f, indent=2)
+        if not all_vault_addresses and cached_vaults:
+            # An empty listing can also mean Lagoon changed its response shape.
+            # Do not erase known descriptions until a later refresh confirms it.
+            logger.warning("Lagoon returned no vaults for chain %d; keeping %d stale entries", chain_id, len(cached_vaults))
+            return cached_vaults
 
-            logger.info("Wrote Lagoon cache %s", file)
+        result: dict[HexAddress, LagoonVaultMetadata] = {}
+        fresh_detail_count = 0
+        for address in all_vault_addresses:
+            detail = _fetch_vault_detail(chain_id, address, api_base_url=api_base_url)
+            checksummed_address = Web3.to_checksum_address(address)
+            if detail is not None:
+                result[checksummed_address] = _parse_vault_detail(detail)
+                fresh_detail_count += 1
+            elif checksummed_address in cached_vaults:
+                # A single failed detail request must not erase metadata that
+                # the scanner already published for this vault.
+                result[checksummed_address] = cached_vaults[checksummed_address]
 
-            assert file.stat().st_size > 0, f"File {file} is empty after writing"
-            return result
+        logger.info("Fetched fresh metadata for %d/%d Lagoon vaults on chain %d", fresh_detail_count, len(all_vault_addresses), chain_id)
 
-        else:
-            timestamp = datetime.datetime.fromtimestamp(file.stat().st_mtime, tz=None)
-            ago = now_ - timestamp
-            logger.info("Using cached Lagoon vaults file for chain %d from %s, last fetched at %s, ago %s", chain_id, file, timestamp.isoformat(), ago)
+        if all_vault_addresses and fresh_detail_count == 0:
+            logger.warning("Lagoon API returned no fresh vault details for chain %d; keeping %d stale entries", chain_id, len(cached_vaults))
+            return cached_vaults
 
-            if file_size == 0:
-                return {}
+        # Atomic replacement prevents a scanner interruption from leaving a
+        # truncated JSON file that blocks every later metadata refresh.
+        with atomic_write(str(file), mode="w", overwrite=True, encoding="utf-8") as cache_output:
+            json.dump(result, cache_output, indent=2)
 
-            try:
-                return json.load(open(file, "rt"))
-            except JSONDecodeError as e:
-                content = open(file, "rt").read()
-                raise RuntimeError(f"Could not parse Lagoon vaults file for chain {chain_id} at {file}, length {len(content)} content starts with {content[:100]!r}") from e
+        logger.info("Wrote Lagoon cache %s", file)
+        assert file.stat().st_size > 0, f"File {file} is empty after writing"
+        return result
 
 
-def fetch_lagoon_vault_metadata(web3: Web3, vault_address: HexAddress) -> LagoonVaultMetadata | None:
+def _resolve_memory_cache_expiry(cache_path: Path, chain_id: int, now_: datetime.datetime) -> datetime.datetime:
+    """Resolve when one chain's in-memory Lagoon metadata expires.
+
+    A successful refresh writes the JSON file, so its modification time anchors
+    the normal one-day expiry. When a failed refresh returns stale data without
+    writing, use a short retry delay instead of retrying once per scanned vault.
+
+    :param cache_path:
+        Directory containing Lagoon metadata cache files.
+
+    :param chain_id:
+        EVM chain id.
+
+    :param now_:
+        Current naive UTC time.
+
+    :return:
+        Naive UTC expiry time for the in-memory entry.
+    """
+    cache_file = _get_cache_file(cache_path, chain_id)
+    if not cache_file.exists() or cache_file.stat().st_size == 0:
+        return now_ + FAILED_REFRESH_RETRY_DELAY
+
+    fetched_at = native_datetime_utc_fromtimestamp(cache_file.stat().st_mtime)
+    regular_expiry = fetched_at + DEFAULT_CACHE_DURATION
+    return regular_expiry if regular_expiry > now_ else now_ + FAILED_REFRESH_RETRY_DELAY
+
+
+def fetch_lagoon_vault_metadata(
+    web3: Web3,
+    vault_address: HexAddress,
+    now_: datetime.datetime | None = None,
+    cache_path: Path = DEFAULT_CACHE_PATH,
+) -> LagoonVaultMetadata | None:
     """Fetch vault metadata from Lagoon's offchain web app API.
 
-    - Do both in-process and disk cache to avoid repeated fetches
+    - Use both expiring in-process and disk caches to avoid repeated fetches
 
     :param web3:
         Web3 instance (used to get chain_id and checksum address)
@@ -313,26 +426,35 @@ def fetch_lagoon_vault_metadata(web3: Web3, vault_address: HexAddress) -> Lagoon
     :param vault_address:
         Vault contract address
 
+    :param now_:
+        Override the current naive UTC time for testing.
+
+    :param cache_path:
+        Directory containing Lagoon metadata cache files.
+
     :return:
         Metadata dict or None if the vault is not in Lagoon's app database
     """
-    global _cached_vaults
-
     chain_id = web3.eth.chain_id
+    now_ = now_ or native_datetime_utc_now()
+    cache_file = _get_cache_file(cache_path, chain_id)
+    cached = _cached_vaults.get(cache_file)
 
-    # Get per-chain copy of vault data into in-process cache
-    if chain_id not in _cached_vaults:
-        vaults = fetch_lagoon_vaults_for_chain(chain_id)
-        _cached_vaults[chain_id] = vaults
+    # Refresh the process cache as well as the disk cache. The looped scanner
+    # keeps this module loaded across scan cycles, so an unbounded dictionary
+    # would otherwise keep stale descriptions until the container restarts.
+    if cached is None or now_ >= cached.expires_at:
+        vaults = fetch_lagoon_vaults_for_chain(chain_id, cache_path=cache_path, now_=now_)
+        cached = _LagoonMetadataCache(
+            vaults=vaults,
+            expires_at=_resolve_memory_cache_expiry(cache_path, chain_id, now_),
+        )
+        _cached_vaults[cache_file] = cached
 
     # Extract vault from Lagoon cache
-    vaults = _cached_vaults[chain_id]
-    if vaults:
-        vault_address = Web3.to_checksum_address(vault_address)
-        return vaults.get(vault_address)
-
-    return None
+    vault_address = Web3.to_checksum_address(vault_address)
+    return cached.vaults.get(vault_address)
 
 
-#: In-process cache of fetched vaults
-_cached_vaults: dict[int, dict[HexAddress, LagoonVaultMetadata]] = {}
+#: Expiring in-process cache keyed by the chain's disk-cache file.
+_cached_vaults: dict[Path, _LagoonMetadataCache] = {}

--- a/tests/erc_4626/test_lagoon_metadata_cache.py
+++ b/tests/erc_4626/test_lagoon_metadata_cache.py
@@ -1,0 +1,341 @@
+"""Test Lagoon metadata cache freshness without live API or RPC access."""
+
+import datetime
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from eth_typing import HexAddress
+from pytest import MonkeyPatch
+from web3 import Web3
+
+from eth_defi.erc_4626.vault_protocol.lagoon import offchain_metadata
+
+ETHEREUM_CHAIN_ID = 1
+FLINT_ADDRESS = HexAddress("0x7f35dea44a192764aa50d50e5f0ece1d5a8b0e45")
+FLINT_CHECKSUM_ADDRESS = HexAddress("0x7f35dEa44a192764aa50d50e5f0eCE1d5a8b0e45")
+SECOND_ADDRESS = HexAddress("0x1111111111111111111111111111111111111111")
+EXPECTED_DAILY_FETCH_COUNT = 2
+EXPECTED_FAILED_REFRESH_COUNT = 2
+STARTED_AT = datetime.datetime(2026, 8, 1, 12, 0, 0)  # noqa: DTZ001 - Repository convention is naive UTC.
+
+
+def _make_metadata(description: str | None, short_description: str | None) -> offchain_metadata.LagoonVaultMetadata:
+    """Create complete Lagoon metadata for cache tests.
+
+    :param description:
+        Long strategy description.
+
+    :param short_description:
+        Short strategy description.
+
+    :return:
+        JSON-compatible Lagoon metadata.
+    """
+    return {
+        "name": "Flint USD",
+        "description": description,
+        "short_description": short_description,
+        "logo_url": None,
+        "transparency_url": None,
+        "average_settlement": None,
+        "curators": [],
+    }
+
+
+def _set_utc_mtime(path: Path, timestamp: datetime.datetime) -> float:
+    """Set a file modification time from a naive UTC datetime.
+
+    :param path:
+        File whose modification time is changed.
+
+    :param timestamp:
+        Naive UTC datetime to assign.
+
+    :return:
+        Assigned Unix timestamp.
+    """
+    unix_timestamp = timestamp.replace(tzinfo=datetime.UTC).timestamp()
+    os.utime(path, (unix_timestamp, unix_timestamp))
+    return unix_timestamp
+
+
+def _set_utc_mtime_after_write(path: Path, metadata: dict[HexAddress, offchain_metadata.LagoonVaultMetadata], timestamp: datetime.datetime) -> float:
+    """Write a Lagoon cache and assign its naive UTC modification time.
+
+    :param path:
+        Cache file to write.
+
+    :param metadata:
+        Lagoon metadata to serialise.
+
+    :param timestamp:
+        Naive UTC modification time to assign.
+
+    :return:
+        Assigned Unix timestamp.
+    """
+    path.write_text(json.dumps(metadata), encoding="utf-8")
+    return _set_utc_mtime(path, timestamp)
+
+
+def _make_web3() -> Web3:
+    """Create a Web3-shaped test double with an Ethereum chain id.
+
+    :return:
+        Web3-compatible test double that performs no RPC reads.
+    """
+    return cast(Web3, SimpleNamespace(eth=SimpleNamespace(chain_id=ETHEREUM_CHAIN_ID)))
+
+
+def test_lagoon_metadata_default_cache_refreshes_after_one_day(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Refresh the default Lagoon cache at the exact one-day boundary.
+
+    :param tmp_path:
+        Temporary cache directory.
+
+    :param monkeypatch:
+        Pytest monkeypatch fixture.
+    """
+    cache_file = offchain_metadata._get_cache_file(tmp_path, ETHEREUM_CHAIN_ID)
+    now_ = STARTED_AT
+    cache_file.write_text(json.dumps({FLINT_CHECKSUM_ADDRESS: _make_metadata(None, None)}), encoding="utf-8")
+    _set_utc_mtime(cache_file, now_ - datetime.timedelta(days=1))
+
+    def fetch_listing_page(chain_id: int, **_kwargs: object) -> dict[str, object]:
+        """Return one Lagoon listing row."""
+        return {"vaults": [{"address": FLINT_ADDRESS, "chain": {"id": str(chain_id)}}], "hasNextPage": False}
+
+    def fetch_vault_detail(chain_id: int, address: HexAddress, **_kwargs: object) -> dict[str, object]:
+        """Return refreshed Lagoon detail metadata."""
+        assert chain_id == ETHEREUM_CHAIN_ID
+        assert address == FLINT_ADDRESS
+        return {
+            "name": "Flint USD",
+            "description": "Refreshed long description.",
+            "shortDescription": "Refreshed short description.",
+            "curators": [],
+        }
+
+    monkeypatch.setattr(offchain_metadata, "_fetch_vault_listing_page", fetch_listing_page)
+    monkeypatch.setattr(offchain_metadata, "_fetch_vault_detail", fetch_vault_detail)
+
+    vaults = offchain_metadata.fetch_lagoon_vaults_for_chain(ETHEREUM_CHAIN_ID, cache_path=tmp_path, now_=now_)
+
+    assert vaults[FLINT_CHECKSUM_ADDRESS]["description"] == "Refreshed long description."
+    assert vaults[FLINT_CHECKSUM_ADDRESS]["short_description"] == "Refreshed short description."
+
+
+def test_lagoon_metadata_failed_listing_keeps_stale_cache(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Retain descriptions when Lagoon's listing endpoint is unavailable.
+
+    :param tmp_path:
+        Temporary cache directory.
+
+    :param monkeypatch:
+        Pytest monkeypatch fixture.
+    """
+    cache_file = offchain_metadata._get_cache_file(tmp_path, ETHEREUM_CHAIN_ID)
+    now_ = STARTED_AT
+    stale_timestamp = _set_utc_mtime_after_write(
+        cache_file,
+        {FLINT_CHECKSUM_ADDRESS: _make_metadata("Existing long description.", "Existing short description.")},
+        now_ - datetime.timedelta(days=1),
+    )
+
+    def fail_listing_page(chain_id: int, **_kwargs: object) -> None:
+        """Simulate a transient Lagoon listing request failure."""
+        assert chain_id == ETHEREUM_CHAIN_ID
+
+    monkeypatch.setattr(offchain_metadata, "_fetch_vault_listing_page", fail_listing_page)
+
+    vaults = offchain_metadata.fetch_lagoon_vaults_for_chain(ETHEREUM_CHAIN_ID, cache_path=tmp_path, now_=now_)
+
+    assert vaults[FLINT_CHECKSUM_ADDRESS]["description"] == "Existing long description."
+    assert cache_file.stat().st_mtime == pytest.approx(stale_timestamp)
+
+
+def test_lagoon_metadata_corrupt_cache_has_diagnostic(tmp_path: Path) -> None:
+    """Raise a diagnostic error for a non-UTF-8 Lagoon cache.
+
+    :param tmp_path:
+        Temporary cache directory.
+    """
+    cache_file = offchain_metadata._get_cache_file(tmp_path, ETHEREUM_CHAIN_ID)
+    cache_file.write_bytes(b"\xff")
+
+    with pytest.raises(RuntimeError, match="Could not parse Lagoon vaults file"):
+        offchain_metadata._load_cached_vaults(cache_file, ETHEREUM_CHAIN_ID)
+
+
+def test_lagoon_metadata_failed_detail_keeps_only_matching_stale_entry(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Merge a failed detail request from stale metadata into fresh results.
+
+    :param tmp_path:
+        Temporary cache directory.
+
+    :param monkeypatch:
+        Pytest monkeypatch fixture.
+    """
+    cache_file = offchain_metadata._get_cache_file(tmp_path, ETHEREUM_CHAIN_ID)
+    now_ = STARTED_AT
+    _set_utc_mtime_after_write(
+        cache_file,
+        {
+            FLINT_CHECKSUM_ADDRESS: _make_metadata("Old Flint description.", "Old Flint summary."),
+            SECOND_ADDRESS: _make_metadata("Retained description.", "Retained summary."),
+        },
+        now_ - datetime.timedelta(days=1),
+    )
+
+    def fetch_listing_page(_chain_id: int, **_kwargs: object) -> dict[str, object]:
+        """Return two Lagoon listing rows."""
+        return {
+            "vaults": [
+                {"address": FLINT_ADDRESS, "chain": {"id": ETHEREUM_CHAIN_ID}},
+                {"address": SECOND_ADDRESS, "chain": {"id": ETHEREUM_CHAIN_ID}},
+            ],
+            "hasNextPage": False,
+        }
+
+    def fetch_vault_detail(_chain_id: int, address: HexAddress, **_kwargs: object) -> dict[str, object] | None:
+        """Refresh Flint while failing the second detail request."""
+        if address == SECOND_ADDRESS:
+            return None
+        return {"name": "Flint USD", "description": "Fresh description.", "shortDescription": "Fresh summary.", "curators": []}
+
+    monkeypatch.setattr(offchain_metadata, "_fetch_vault_listing_page", fetch_listing_page)
+    monkeypatch.setattr(offchain_metadata, "_fetch_vault_detail", fetch_vault_detail)
+
+    vaults = offchain_metadata.fetch_lagoon_vaults_for_chain(ETHEREUM_CHAIN_ID, cache_path=tmp_path, now_=now_)
+
+    assert vaults[FLINT_CHECKSUM_ADDRESS]["description"] == "Fresh description."
+    assert vaults[SECOND_ADDRESS]["description"] == "Retained description."
+    assert json.loads(cache_file.read_text(encoding="utf-8"))[SECOND_ADDRESS]["description"] == "Retained description."
+
+
+def test_lagoon_metadata_empty_chain_is_cached(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Cache a successful empty listing instead of retrying it hourly.
+
+    :param tmp_path:
+        Temporary cache directory.
+
+    :param monkeypatch:
+        Pytest monkeypatch fixture.
+    """
+    now_ = STARTED_AT
+    listing_fetch_count = 0
+
+    def fetch_listing_page(_chain_id: int, **_kwargs: object) -> dict[str, object]:
+        """Return a successful empty listing."""
+        nonlocal listing_fetch_count
+        listing_fetch_count += 1
+        return {"vaults": [], "hasNextPage": False}
+
+    monkeypatch.setattr(offchain_metadata, "_fetch_vault_listing_page", fetch_listing_page)
+
+    first = offchain_metadata.fetch_lagoon_vaults_for_chain(ETHEREUM_CHAIN_ID, cache_path=tmp_path, now_=now_)
+    cache_file = offchain_metadata._get_cache_file(tmp_path, ETHEREUM_CHAIN_ID)
+    _set_utc_mtime(cache_file, now_)
+    second = offchain_metadata.fetch_lagoon_vaults_for_chain(ETHEREUM_CHAIN_ID, cache_path=tmp_path, now_=now_ + datetime.timedelta(hours=1))
+
+    assert first == second == {}
+    assert json.loads(cache_file.read_text(encoding="utf-8")) == {}
+    assert listing_fetch_count == 1
+
+
+def test_lagoon_metadata_empty_listing_keeps_populated_cache(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Do not erase known descriptions after an unexpectedly empty listing.
+
+    :param tmp_path:
+        Temporary cache directory.
+
+    :param monkeypatch:
+        Pytest monkeypatch fixture.
+    """
+    cache_file = offchain_metadata._get_cache_file(tmp_path, ETHEREUM_CHAIN_ID)
+    cached_metadata = {FLINT_CHECKSUM_ADDRESS: _make_metadata("Existing description.", "Existing summary.")}
+    stale_timestamp = _set_utc_mtime_after_write(cache_file, cached_metadata, STARTED_AT - datetime.timedelta(days=1))
+
+    def fetch_listing_page(_chain_id: int, **_kwargs: object) -> dict[str, object]:
+        """Return an unexpectedly empty listing."""
+        return {"vaults": [], "hasNextPage": False}
+
+    monkeypatch.setattr(offchain_metadata, "_fetch_vault_listing_page", fetch_listing_page)
+
+    vaults = offchain_metadata.fetch_lagoon_vaults_for_chain(ETHEREUM_CHAIN_ID, cache_path=tmp_path, now_=STARTED_AT)
+
+    assert vaults == cached_metadata
+    assert cache_file.stat().st_mtime == pytest.approx(stale_timestamp)
+
+
+def test_lagoon_metadata_memory_cache_refreshes_after_one_day(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Refresh metadata held by a continuously running scanner after one day.
+
+    :param tmp_path:
+        Temporary cache directory.
+
+    :param monkeypatch:
+        Pytest monkeypatch fixture.
+    """
+    started_at = STARTED_AT
+    fetch_count = 0
+
+    def fetch_chain_metadata(chain_id: int, cache_path: Path, now_: datetime.datetime, **_kwargs: object) -> dict[HexAddress, offchain_metadata.LagoonVaultMetadata]:
+        """Return a different description after each cache refresh."""
+        nonlocal fetch_count
+        assert chain_id == ETHEREUM_CHAIN_ID
+        fetch_count += 1
+        result = {FLINT_CHECKSUM_ADDRESS: _make_metadata(f"Long description {fetch_count}.", f"Short description {fetch_count}.")}
+        cache_file = offchain_metadata._get_cache_file(cache_path, chain_id)
+        _set_utc_mtime_after_write(cache_file, result, now_)
+        return result
+
+    monkeypatch.setattr(offchain_metadata, "fetch_lagoon_vaults_for_chain", fetch_chain_metadata)
+    monkeypatch.setattr(offchain_metadata, "_cached_vaults", {})
+    web3 = _make_web3()
+
+    first = offchain_metadata.fetch_lagoon_vault_metadata(web3, FLINT_ADDRESS, now_=started_at, cache_path=tmp_path)
+    cached = offchain_metadata.fetch_lagoon_vault_metadata(web3, FLINT_ADDRESS, now_=started_at + datetime.timedelta(hours=23), cache_path=tmp_path)
+    refreshed = offchain_metadata.fetch_lagoon_vault_metadata(web3, FLINT_ADDRESS, now_=started_at + datetime.timedelta(days=1), cache_path=tmp_path)
+
+    assert first is not None and first["description"] == "Long description 1."
+    assert cached is not None and cached["description"] == "Long description 1."
+    assert refreshed is not None and refreshed["description"] == "Long description 2."
+    assert fetch_count == EXPECTED_DAILY_FETCH_COUNT
+
+
+def test_lagoon_metadata_failed_memory_refresh_retries_after_one_hour(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Retry a failed stale-cache refresh once, not once per vault lookup.
+
+    :param tmp_path:
+        Temporary cache directory.
+
+    :param monkeypatch:
+        Pytest monkeypatch fixture.
+    """
+    started_at = STARTED_AT
+    stale_metadata = {FLINT_CHECKSUM_ADDRESS: _make_metadata("Stale description.", "Stale summary.")}
+    cache_file = offchain_metadata._get_cache_file(tmp_path, ETHEREUM_CHAIN_ID)
+    _set_utc_mtime_after_write(cache_file, stale_metadata, started_at - datetime.timedelta(days=1))
+    fetch_count = 0
+
+    def fail_refresh(_chain_id: int, **_kwargs: object) -> dict[HexAddress, offchain_metadata.LagoonVaultMetadata]:
+        """Return stale metadata without advancing the disk cache time."""
+        nonlocal fetch_count
+        fetch_count += 1
+        return stale_metadata
+
+    monkeypatch.setattr(offchain_metadata, "fetch_lagoon_vaults_for_chain", fail_refresh)
+    monkeypatch.setattr(offchain_metadata, "_cached_vaults", {})
+    web3 = _make_web3()
+
+    first = offchain_metadata.fetch_lagoon_vault_metadata(web3, FLINT_ADDRESS, now_=started_at, cache_path=tmp_path)
+    cached = offchain_metadata.fetch_lagoon_vault_metadata(web3, FLINT_ADDRESS, now_=started_at + datetime.timedelta(minutes=59), cache_path=tmp_path)
+    retried = offchain_metadata.fetch_lagoon_vault_metadata(web3, FLINT_ADDRESS, now_=started_at + datetime.timedelta(hours=1), cache_path=tmp_path)
+
+    assert first == cached == retried == stale_metadata[FLINT_CHECKSUM_ADDRESS]
+    assert fetch_count == EXPECTED_FAILED_REFRESH_COUNT


### PR DESCRIPTION
## Why

Lagoon strategy descriptions can change after vault discovery. The persistent scanner process kept its first metadata response indefinitely, so existing vault rows could continue publishing missing descriptions even after Lagoon added them.

## Lessons learnt

A disk TTL does not refresh data when a longer-lived process cache bypasses the disk freshness check. Enrichment refresh failures must also retain last-known-good metadata, otherwise a transient API response can erase published descriptions.

## Summary

- Refresh Lagoon disk and process metadata caches every 24 hours.
- Retain stale Lagoon metadata when listing or detail requests fail, with a bounded in-process retry delay.
- Atomically replace cache files and distinguish successful empty-chain responses from suspicious empty refreshes.
- Add network-free regression coverage for daily expiry, persistent scanner refresh, stale fallbacks, empty listings and corrupt caches.
- Document the two cache layers and add the feature changelog entry.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.