### PR TITLE
fix: complete wstGBP protocol-curator metadata

### DIFF
--- a/eth_defi/data/feeds/curators/wstgbp.yaml
+++ b/eth_defi/data/feeds/curators/wstgbp.yaml
@@ -1,0 +1,19 @@
+# wstGBP protocol-managed curator — feeds provided by protocols/wstgbp.yaml.
+# 2026-08-01 maintain-curators: official wstGBP site links to @wstgbp; this
+# curator alias deliberately inherits that protocol feed rather than tGBP's
+# BCP Technologies sources.
+feeder-id: wstgbp
+name: wstGBP
+role: curator
+canonical-feeder-id: wstgbp
+short_description: Wren Spire operates the wstGBP protocol, a reward-bearing wrapper for tGBP on Ethereum.
+long_description: |
+  Wren Spire (BVI) Ltd operates the wstGBP interface and protocol, which lets tGBP holders mint
+  and redeem wstGBP on Ethereum. wstGBP is a non-rebasing ERC-20 wrapper: holders' balances do
+  not change, while the token's redemption value in tGBP is represented by the onchain exchange
+  rate. tGBP is issued by BCP Technologies Ltd, an unaffiliated third party, so this curator
+  record remains separate from the tGBP stablecoin issuer.
+
+other-links:
+  - title: wstGBP official interface terms — Wren Spire operator and tGBP relationship
+    url: https://wstgbp.com/

--- a/eth_defi/data/feeds/protocols/wstgbp.yaml
+++ b/eth_defi/data/feeds/protocols/wstgbp.yaml
@@ -2,4 +2,12 @@ feeder-id: wstgbp
 name: wstGBP
 role: protocol
 website: https://wstgbp.com
-# rss: not found - the official site does not expose a blog or feed link
+short_description: wstGBP is Wren Spire's reward-bearing, non-rebasing wrapper for tGBP on Ethereum.
+long_description: |
+  wstGBP lets holders of tGBP mint and redeem a non-rebasing ERC-20 wrapper on Ethereum.
+  The wstGBP balance remains fixed while its redemption value in tGBP is represented by the
+  onchain exchange rate. Wren Spire (BVI) Ltd operates the wstGBP interface and protocol;
+  tGBP is issued by the separate, unaffiliated BCP Technologies Ltd.
+# 2026-08-01: The official wstGBP site links to @wstgbp. No RSS or LinkedIn
+# source is published there.
+twitter: wstgbp

--- a/eth_defi/data/stablecoins/tgbp.yaml
+++ b/eth_defi/data/stablecoins/tgbp.yaml
@@ -53,6 +53,6 @@ rate_fetch_failed_reason: missing_source_currency_rate
 depegged_at: ''
 checks:
   twitter_last_post_at: ''
-  domain_up_at: ''
+  domain_up_at: '2026-08-01'
   marked_dead_at: ''
   information_found_missing_at: ''

--- a/eth_defi/data/vaults/metadata/wstgbp.yaml
+++ b/eth_defi/data/vaults/metadata/wstgbp.yaml
@@ -1,9 +1,9 @@
 name: wstGBP
 slug: wstgbp
 short_description: |
-  Non-custodial tokenised sterling with onchain NAV and permissionless minting and redemption.
+  Wren Spire's non-rebasing tGBP wrapper with an onchain redemption rate and permissionless minting and redemption.
 long_description: |
-  wstGBP (Wren Staked tGBP) is a non-custodial, non-rebasing ERC-20 wrapper around tGBP, a pound sterling stablecoin issued by BCP Technologies, an FCA-registered cryptoasset firm, backed 1:1 by sterling reserves. Users mint and redeem permissionlessly on Ethereum at the onchain exchange rate. Balances stay fixed and rewards, when applied, are reflected in the wstGBP to tGBP exchange rate through periodic NAV updates. Minting is free and instant redemption carries a 25 bps fee, with no cooldown.
+  wstGBP (Wren Staked tGBP) is a non-rebasing ERC-20 wrapper around tGBP. Wren Spire (BVI) Ltd operates the wstGBP interface and protocol, while tGBP is issued by the separate, unaffiliated BCP Technologies Ltd. Users can mint and redeem wstGBP permissionlessly on Ethereum at the onchain exchange rate. Balances stay fixed and any change in the redemption value is represented by the wstGBP-to-tGBP exchange rate through periodic NAV updates. Minting is free and instant redemption carries a 25 bps fee, with no cooldown.
 fee_description: |
   Minting is free and instant redemption carries a 25 bps fee, with no cooldown.
 links:

--- a/tests/vault/test_curator.py
+++ b/tests/vault/test_curator.py
@@ -214,7 +214,7 @@ def test_curator_brandmarks_are_visible_on_dark_background() -> None:
 
 
 def test_identify_wstgbp_as_protocol_curated() -> None:
-    """wstGBP has no third-party curator."""
+    """wstGBP is curated by its protocol operator, Wren Spire."""
 
     slug = identify_curator(
         chain_id=1,
@@ -227,6 +227,22 @@ def test_identify_wstgbp_as_protocol_curated() -> None:
     assert slug == "wstgbp"
     assert is_protocol_curator(slug)
     assert get_curator_name(slug) == "wstGBP"
+
+
+def test_wstgbp_protocol_curator_metadata_uses_official_feed() -> None:
+    """Keep Wren's curator details separate from the tGBP issuer's feeds."""
+
+    metadata = build_curator_metadata_json(
+        Path("eth_defi/data/feeds/curators/wstgbp.yaml"),
+        public_url="https://example.com",
+    )
+
+    assert metadata["protocol_curator"] is True
+    assert metadata["canonical_feeder_id"] == "wstgbp"
+    assert metadata["website"] == "https://wstgbp.com"
+    assert metadata["twitter"] == "https://x.com/wstgbp"
+    assert "BCP Technologies" in metadata["long_description"]
+    assert metadata["logos"]["generic"] == "https://example.com/curator-metadata/wstgbp/generic.png"
 
 
 def test_identify_felix_vault() -> None:


### PR DESCRIPTION
## Why

The wstGBP curator page was emitted from synthetic protocol-curator metadata, so it lacked the protocol's description, website and official X account. Its curator information also needed to remain separate from tGBP's issuer, BCP Technologies.

## Lessons learnt

Protocol-curated slugs need a curator alias when their public curator identity needs metadata. The shared feeder hierarchy can inherit the protocol's feeds without mixing them with a separate stablecoin issuer.

## Summary

- Add a wstGBP protocol-managed curator alias that inherits Wren's official protocol feed.
- Publish the official @wstgbp account and clarify Wren Spire and BCP Technologies' distinct roles.
- Refresh tGBP's successful homepage liveness check and cover the curator metadata export.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.