### PR TITLE
feat: refresh Asseto product registry

### DIFF
--- a/.claude/plans/asseto-dynamic-registry.md
+++ b/.claude/plans/asseto-dynamic-registry.md
@@ -1,0 +1,414 @@
+# Asseto dynamic registry plan
+
+## Goal
+
+Make the scheduled `Asseto` scan self-contained after every process restart.
+Each due Asseto cycle must fetch and validate the current EVM product registry,
+merge maintained manual overlays, refresh supported product metadata, and scan
+prices from that same registry snapshot. A locked, atomic disk cache must make
+the last valid snapshot available after a process restart without allowing a
+failed or empty API response to replace it.
+
+Asseto API data is the default source for product names, symbols,
+descriptions, denominations and public price-series identifiers. Manual data
+must be limited to explicit, source-backed fields that Asseto does not publish
+or publishes incorrectly.
+
+## Current failure
+
+The historical Asseto backfill fetches the public registry and inserts
+temporary `AssetoProduct` objects into the process-local `ASSETO_PRODUCTS`
+mapping. The recurring tokenised-fund runner does not perform that preparation.
+After a scanner restart, the mapping contains only the hardcoded HashKey AoABT
+entry, while the persistent vault database still contains dynamically
+discovered products such as Ethereum
+`0x78e80da0616887b46a31f39310c2a8b0fbd6a42d`.
+
+The scheduled runner selects that row by its `asseto_like` feature, but
+`AssetoVault` cannot find a matching `AssetoProduct` and raises
+`Unsupported Asseto product`. Retrying the cycle cannot repair the missing
+process-local registry.
+
+## Source and precedence rules
+
+Use one documented field-level merge policy in fresh mode. Do not keep complete
+copied `AssetoProduct` records when only one or two fields need manual
+correction.
+
+| Priority | Source | Intended fields |
+| --- | --- | --- |
+| 1 | Maintained product overlay | Reviewed corrections and data Asseto does not expose: manager, pricer, fee terms, homepage, denomination correction or an exceptional description |
+| 2 | Current Asseto detail API | Long description and richer current product metadata when the endpoint returns a valid non-empty value |
+| 3 | Current Asseto registry API | Chain, token address, product id/key, name, symbol, type, denomination, introduction, displayed TVL/APY and public price-history identity |
+| 4 | Onchain reads | Contract existence, deployment block/time, token metadata, supply and onchain pricer values |
+| 5 | Previous detail metadata for the same product | Preserve a non-empty detail description when an optional current detail request fails or becomes empty |
+| 6 | Generic text | Only when neither a maintained overlay nor current Asseto data supplies a meaningful description |
+
+This table applies only when the registry result is `fresh`. A `stale` result
+may reconstruct runtime adapters for already-known products, but must perform
+zero metadata upserts. Previous registry fields are never merged into current
+metadata as if they were fresh. Onchain values remain canonical for supply and
+contract state; Asseto's displayed TVL and APY are informational metadata.
+
+Validation has two severities. Snapshot-fatal errors include duplicate
+`(chain_id, address)` keys, conflicting product ids or chains for the same
+identity, an empty 200 response and an invalid response envelope. They reject
+the candidate before any metadata or Parquet write and retain the previous
+cache. Product-fatal errors such as an invalid address, unknown chain or missing
+denomination exclude only that product with a diagnostic. An excluded malformed
+product is not treated as absent from an otherwise complete response for
+lifecycle decisions.
+
+## Existing offchain metadata practices
+
+The repository does not currently contain modules literally named
+`offchain_data.py`; the established equivalents are the protocol
+`offchain_metadata.py` modules. Follow the strongest shared patterns from
+Lagoon, IPOR, Morpho and Accountable:
+
+- keep raw HTTP parsing separate from cache and lifecycle policy;
+- use a disk JSON cache under `DEFAULT_CACHE_ROOT` so valid data survives a
+  scanner restart;
+- use an expiring in-process cache as well as the disk cache, with keys that
+  include the cache path/source so tests and alternate endpoints are isolated;
+- inject `now_` and cache duration into public fetch helpers for deterministic
+  TTL tests;
+- protect freshness checks and replacement writes with `wait_other_writers()`;
+- write successful cache replacements with `atomic_write()`;
+- never silently reset a corrupt cache to an empty mapping: quarantine it with
+  a timestamped name and visible error when a complete validated fresh response
+  can replace it, or hard-fail when the API cannot provide such a response;
+- never overwrite a non-empty cache with an empty, partial or malformed API
+  response;
+- retain individual stale records when a detail request fails, as Lagoon does;
+- distinguish `found`, `not_found` and `transient_error` outcomes where absence
+  changes product lifecycle behaviour, following Morpho's three-way result;
+- short-circuit permanently unsupported chains before making repeated API or
+  RPC requests;
+- preserve durable descriptions when a formerly listed vault is omitted, as
+  Accountable does.
+
+Asseto differs because the offchain registry also supplies adapter-critical
+product ids and daily price-series identity. Its cache is therefore required
+for adapter construction, not merely optional description enrichment.
+
+## Maintained overlays
+
+Replace the implicit mixture of hardcoded products, curator mappings and logo
+lookups with explicit overlay records:
+
+- add a frozen, slotted `AssetoProductOverlay` keyed by `VaultSpec`;
+- use an explicit unset sentinel so “not overridden” differs from “override
+  this field to null”;
+- require every overlay to include a canonical source URL, reason and review
+  date;
+- allow an explicit `allow_api_missing` flag only for a reviewed deployment
+  that is intentionally supported without a current API registry row;
+- keep curator name/slug and partner-logo resolution as reviewed overlays,
+  but give them the same provenance fields and validation;
+- apply overlays field by field after parsing the API, leaving all unspecified
+  names, descriptions and product data under Asseto's control;
+- remove the universal AoABT homepage behaviour: use a product-specific API
+  link or the Asseto product index by default, with the AoABT documentation
+  link supplied only by its overlay.
+
+Permit a standalone product only with `allow_api_missing=True`. If Asseto later
+publishes the same `VaultSpec`, use the API record as the base, apply the
+standalone fields as an overlay, and emit a warning and audit finding so the
+record can be demoted to a normal field overlay.
+
+Add an offline structural validator that rejects malformed addresses, unknown
+curator slugs, duplicate keys and overlays without provenance. A separate
+read-only operator command should reconcile the live API snapshot and overlays,
+report new, removed and changed products, orphan overlays without
+`allow_api_missing`, and API-missing active products. It must not modify the
+cache or vault database and must not take the cache write lock.
+
+## Shared offchain metadata and registry services
+
+Keep `offchain_api.py` as the raw HTTP/envelope/parser layer. Add
+`eth_defi/tokenised_fund/asseto/offchain_metadata.py` for two-level caching,
+refresh status and stale-record retention, and add `registry.py` for overlay
+merge plus runtime/onchain preparation. Move reusable registry logic out of the
+command-oriented `backfill.py` module.
+
+The service should expose `dataclass(frozen=True, slots=True)` result objects,
+use `HexAddress` for addresses and `Percent` for APY values, such as:
+
+- `AssetoOffchainRegistryResult`: `fresh`, `stale`, `not_found` or
+  `transient_error` status, source timestamp, cache age, normalised API products
+  and diagnostics;
+- `AssetoRegistrySnapshot`: offchain source status, validated API products,
+  merged runtime products and diagnostics;
+- `AssetoRegistryRefreshResult`: added, updated, unchanged, inactive,
+  unsupported-chain and missing-source product sets;
+- `fetch_asseto_registry_snapshot(...)`: perform one registry fetch, optional
+  detail enrichment, validation and overlay merge;
+- `fetch_asseto_deployment_data(...)`: resolve supported chains, reuse persisted
+  deployment data for known products and perform onchain deployment discovery
+  only for new products;
+- `apply_asseto_registry(...)`: take already-fetched API and deployment data and
+  atomically upsert leads/metadata without performing network reads;
+- `install_asseto_runtime_registry(...)`: replace API-derived entries as one
+  operation while retaining explicit standalone overlays.
+
+The backfill and recurring scheduler must both call this service. Remove the
+current ad-hoc mutation of `ASSETO_PRODUCTS` from `backfill_chain()` so there is
+only one construction and merge implementation.
+
+Fetch `/api/home/products` at most once per due Asseto cycle, not once per chain
+or vault. A due cycle must pass `force_refresh=True` (or a zero `max_age`) so it
+always attempts one HTTP refresh; cache freshness must not suppress the next
+daily request. Use an in-process success TTL of one hour only for reuse within a
+cycle and a failure retry delay configured by
+`ASSETO_REGISTRY_FAILED_REFRESH_RETRY_SECONDS`, defaulting to 900 seconds, so a
+failed item does not hammer the endpoint on every loop tick. Keep the last valid
+disk record indefinitely, report its age, and apply a configurable seven-day
+maximum stale age for adapter use. A record older than that yields `failed`, not
+`degraded`.
+
+Fetch optional detail descriptions only for selected EVM products; if a detail
+call fails, keep its prior cached detail or fall back to the current registry
+introduction. Specify bounded connect/read timeouts, retry count and backoff in
+`offchain_api.py`: retries log warnings without tracebacks and the final failure
+logs one error with traceback. If detail calls are parallelised, use
+`joblib.Parallel` with the threading backend and expose
+`ASSETO_REGISTRY_MAX_WORKERS`, defaulting conservatively to four.
+
+Store the cache and its lock together under the mounted `DEFAULT_CACHE_ROOT`,
+for example `~/.tradingstrategy/asseto/registry-cache.json`, so separate scanner
+containers coordinate. Lock acquisition has a bounded timeout; timeout yields
+`transient_error` and never permission to write. The cache file must store a
+normalised, versioned JSON envelope containing the source fetch timestamp and
+products keyed by `(chain_id, lowercase_address)`.
+Each product also records `first_seen_in_api_at`, `last_seen_in_api_at` and
+whether it was present in the latest complete response. When a valid response
+omits a previously known product, retain its last valid record as an explicitly
+missing entry instead of dropping the adapter-critical product id. Do not
+pickle runtime `AssetoProduct` objects. Validate the complete merged candidate
+snapshot before atomically replacing the cache. An unknown or older envelope
+version is `not_found` and triggers a refetch, rather than being treated as
+corruption; never write an older version over a newer file.
+
+Prefer passing the immutable `AssetoRegistrySnapshot` explicitly into adapter
+construction. If a compatibility runtime global remains, build a new dict and
+atomically rebind a `MappingProxyType`; never mutate the shared mapping with
+`clear()` or `update()` while threaded scans may read it. Show progress with
+`tqdm_loggable.auto` if onchain preparation can run for more than a minute.
+
+## Scheduled Asseto cycle
+
+Give Asseto an explicit preparation hook or dedicated runner in
+`eth_defi/tokenised_fund/scan.py` instead of relying solely on the generic
+feature-to-adapter path:
+
+1. Force one refresh attempt for the due cycle or load one validated stale
+   Asseto snapshot after that attempt fails. Record the explicit source status.
+2. Merge maintained overlays and install the complete runtime mapping before
+   constructing any `AssetoVault`.
+3. Group supported EVM products by chain. Skip unsupported chains and missing
+   RPC configuration with visible diagnostics.
+4. Reuse `first_seen_at_block` and `first_seen_at` from existing vault
+   detections. Query an archive RPC for deployment information only when a new
+   product is first registered. Respect per-chain historical-state capability;
+   never assume archive-complete state or probe arbitrary old state on Monad.
+5. Only for a `fresh` result, upsert new products and refresh existing Asseto
+   metadata from the merged snapshot. A `stale` result reconstructs existing
+   adapters but hard-skips every metadata upsert. Preserve historical rows;
+   never delete a product merely because it disappears from one API response.
+6. Load any required non-USD conversion history from the same currency-rate
+   database used by the existing Asseto backfill.
+7. Select price-capable products from the successfully prepared snapshot and
+   invoke the existing address-scoped daily historical price path. Scope every
+   deletion and write to `(chain_id, address)`. Initialise reader state for a
+   new product independently at its deployment block and backfill only that
+   address; its older deployment block must never lower a chain-wide start block
+   or delete another product's rows.
+8. Publish registry counts, skipped products, source status/cache age, API
+   freshness and price results on the `Asseto` dashboard row. Record one of
+   three states: `ok` for a fresh completed cycle (advance the cycle key),
+   `degraded` for a stale or per-product coverage failure (advance the cycle key
+   and publish its age/reasons), or `failed` when no valid snapshot exists or a
+   registry-wide write fails (do not advance the cycle key).
+
+Pass the currency database path and Asseto registry worker limit through
+`TokenisedFundPriceScanContext`, `run_scan_tick()` and production Compose
+configuration. The manual recurring-path backfill must use the same Asseto
+preparation service, including exact product filters.
+
+## Failure and product-lifecycle behaviour
+
+- A transient, empty, malformed or internally inconsistent registry response
+  must not replace the last valid disk cache. If a valid stale snapshot exists,
+  use it only to reconstruct adapters for known products and leave stored
+  metadata untouched, while exposing the stale source timestamp and refresh
+  failure in diagnostics.
+- If neither a fresh response nor a valid stale cache exists, abort the Asseto
+  item before any metadata or raw-price write. Existing pipeline data stays
+  untouched and the cycle key is not advanced, so the next loop retries.
+- Do not use a stale snapshot to register a product as new, mark a product
+  removed, or erase/replace current metadata. Stale data may only retain known
+  products and support their existing price adapters.
+- A retry within `ASSETO_REGISTRY_FAILED_REFRESH_RETRY_SECONDS` reuses the
+  in-process failure result without issuing HTTP. A failed Asseto item must
+  never block or delay later tokenised-fund protocols in the same tick.
+- Optional detail or role requests may fall back to other valid API fields and
+  add diagnostics; they must not replace good descriptions with blank text.
+- A product removed from a valid API snapshot is retained in the cache,
+  metadata and raw history with its last-seen timestamp. If it has zero supply
+  it becomes inactive and is not rescanned.
+- A missing API product with positive supply or an expected price feed is a
+  per-product coverage error unless a maintained `allow_api_missing` overlay
+  supplies the required adapter data. Retain its metadata and price rows,
+  exclude it from price scanning, publish an error diagnostic and continue the
+  overall cycle as `degraded`; only registry-wide failures abort the item.
+- A new supported product is registered automatically, then enters the same
+  daily price scan. A new product without a usable denomination or price source
+  remains visible with an explicit diagnostic and cannot silently claim fresh
+  price coverage.
+- Per-product API price histories remain cached inside the adapter for the
+  duration of the cycle. No API request is made for every sampled block. Track
+  registry/detail and price-history endpoint health separately; after three
+  consecutive price endpoint failures in a cycle, short-circuit the remaining
+  products with one diagnostic and record the cycle as `degraded`.
+- Missing FX coverage is a per-product error: make no Parquet write and never
+  substitute a 1.0 rate. Continue the cycle as `degraded`.
+- Registry or adapter failures must never widen a Parquet deletion window or
+  discard another product's existing rows.
+
+## Code changes
+
+1. Add `eth_defi/tokenised_fund/asseto/offchain_metadata.py` for the versioned
+   disk cache, expiring in-process cache and explicit refresh outcomes.
+2. Add `eth_defi/tokenised_fund/asseto/registry.py` for validation, overlay
+   merge, deployment reuse/discovery and metadata upserts.
+3. Refactor `constants.py` into immutable standalone products plus maintained
+   field overlays; keep the runtime registry clearly labelled as process-local.
+4. Refactor `backfill.py` to consume the shared registry service and retain
+   only command configuration, plan rendering and historical repair control.
+5. Update `vault.py` to consume merged runtime products, return product-specific
+   links, and use API descriptions unless an explicit overlay wins.
+6. Add the Asseto preparation/runner hook and currency-database context to
+   `eth_defi/tokenised_fund/scan.py` and `scan_all_chains.py`.
+7. Add a read-only `scripts/erc-4626/check-asseto-registry.py` audit command.
+8. Update Compose environment forwarding for any new Asseto settings.
+9. Add API stubs for the new modules under `docs/source/api` and include them in
+   the relevant API index. Add `README-Asseto.md` to the README table in
+   `CLAUDE.md`.
+10. Add a dated `CHANGELOG.md` feature entry and use a `feat:` PR title.
+
+## Tests
+
+Use captured API fixtures for deterministic CI; do not make the normal test
+suite depend on Asseto availability.
+
+Add focused coverage for:
+
+- rebuilding the runtime registry in a fresh process before adapter creation;
+- the exact Ethereum regression product
+  `0x78e80da0616887b46a31f39310c2a8b0fbd6a42d`;
+- one registry request per cycle and reuse across chains/products;
+- two consecutive due cycles issuing two registry requests;
+- fresh, stale, not-found and transient registry outcomes;
+- stale registry data reconstructing adapters while producing zero metadata
+  writes;
+- disk-cache survival across a simulated process restart;
+- a cold process with no cache reconstructing from a healthy API;
+- cache-path/source isolation and injected-time TTL behaviour;
+- cache envelope version mismatch and lock timeout yielding `transient_error`;
+- atomic replacement and concurrent-reader locking;
+- corrupt cache plus healthy API being quarantined and recovered, and corrupt
+  cache plus API failure causing zero writes and no cycle-key advance;
+- empty/partial API responses retaining the last complete snapshot;
+- per-product detail failures retaining cached descriptions;
+- new-product metadata registration and existing-product description refresh;
+- API description defaults and field-level overlay precedence;
+- offline overlay structure/provenance validation and online orphan-overlay
+  reconciliation;
+- standalone-overlay and API `VaultSpec` collision behaviour;
+- snapshot-fatal records failing before writes and product-fatal records being
+  excluded without marking them removed;
+- API outage preserving metadata, reader state and Parquet rows;
+- total price-endpoint outage short-circuiting after three consecutive failures;
+- unsupported chains and missing RPCs producing diagnostics;
+- non-USD exchange-rate loading and the existing synthetic-USD rule;
+- missing FX coverage skipping the affected product without a 1.0 fallback;
+- removed zero-supply products being retained but inactive;
+- a fresh snapshot omitting a product retaining its metadata and history;
+- active products missing from the API requiring a maintained overlay;
+- a newly registered product with an older deployment block leaving all other
+  products' Parquet rows and reader state unchanged;
+- the manual Asseto backfill and recurring cycle producing the same merged
+  `AssetoProduct` values;
+- the Asseto cycle failing without advancing cycle state when preparation
+  fails, while later tokenised-fund protocols still run;
+- `degraded` dashboard contents, staleness alert threshold and cycle-key
+  advancement;
+- the audit command not mutating the cache or vault database.
+
+Keep a separately invoked live API smoke test or audit command for operators;
+CI should test parsing and merge behaviour from recorded responses.
+
+## README-Asseto.md
+
+Add `eth_defi/tokenised_fund/asseto/README-Asseto.md` as the operational and
+architectural source of truth. It should contain:
+
+- what Asseto products are and why they use `VaultBase` rather than ERC-4626;
+- the public application endpoints and their undocumented/stability caveat;
+- the two-level cache, forced daily refresh, one-hour in-process reuse, 15-minute
+  failed-refresh delay, seven-day stale limit and source-age diagnostics;
+- the registry/detail/onchain/overlay precedence table;
+- the scheduled cycle from registry refresh through metadata and daily prices;
+- product identity, supported-chain filtering and new/removed product handling;
+- onchain pricer versus Asseto daily API price sources;
+- USD, stablecoin, synthetic-USD and historical FX conversion rules;
+- the exact purpose, format, provenance and maintenance process for overlays;
+- KYC-gated subscription/redemption limitations;
+- failure behaviour, dashboard diagnostics and safe retry semantics;
+- environment variables and examples for registry audit, dry-run backfill and
+  targeted repair;
+- relevant implementation files and focused tests.
+
+Link this README from the Asseto API and vault Sphinx pages and from
+`scripts/erc-4626/README-vault-scripts.md`. Update those shorter documents to
+defer detailed behaviour to the README and remove claims that the recurring
+cycle does not yet implement. Add API stubs for new modules to the Sphinx API
+index, but per repository guidance do not build Sphinx during development.
+
+## Production rollout
+
+1. Run the registry audit against production configuration and review every
+   supported, unsupported, removed and overlaid product.
+2. Run the Asseto cycle in dry-run mode and confirm the Ethereum regression
+   address resolves without relying on prior process state.
+3. Back up the vault metadata, raw-price files and Asseto registry cache through
+   the existing pipeline backup mechanism.
+4. Run one targeted production Asseto cycle, then inspect product counts,
+   descriptions, denominations, source diagnostics and daily price rows.
+5. Exercise two cold starts: move the cache aside with the API reachable to
+   prove reconstruction from a fresh fetch, then restore the cache and block the
+   API to prove restart survival from disk. Preserve the moved cache for
+   recovery and perform both checks as dry runs.
+6. Enable the normal 24-hour schedule and monitor the `Asseto` dashboard row
+   for at least two cycles, with an alert when source age reaches the configured
+   stale limit.
+
+## Acceptance criteria
+
+The work is complete when:
+
+1. a fresh scanner process can construct every supported registered Asseto
+   adapter from a newly fetched and validated API snapshot;
+2. new supported EVM products can enter metadata and daily scanning without a
+   code release or manual backfill;
+3. API names, descriptions and product data are used by default, while every
+   manual field has explicit provenance and deterministic precedence;
+4. API failures or unexplained active-product gaps preserve existing data;
+   valid stale caches remain explicitly stale, while a missing valid snapshot
+   leaves the Asseto cycle failed/retryable;
+5. the Ethereum regression address scans successfully after a container
+   restart;
+6. the backfill and recurring scanner share one registry implementation;
+7. `README-Asseto.md` accurately documents sources, overlays, lifecycle,
+   pricing, operations and failure semantics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- feat: Refresh and persist the dynamic Asseto product registry before each daily Asseto price cycle, allowing known products to recover after scanner restarts and new supported products to enter the address-scoped daily scan safely (2026-08-01)
 - feat: Schedule reviewed tokenised-fund price feeds independently, retain daily samples for unchanged NAVs, and provide a recurring-path targeted price backfill command (2026-08-01)
 - feat: Refresh Lagoon offchain vault metadata daily in persistent scanner processes while retaining stale descriptions during transient API failures (2026-08-01)
 - feat: Add hardcoded classification and discovery for Axis's StakedUSDx Plasma rewards vault (2026-07-30)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -468,6 +468,7 @@ Consult these for domain-specific context. Logo READMEs under `eth_defi/data/vau
 | `eth_defi/xerberus/README-xerberus.md` | Xerberus vault risk scores — per-vault pool ratings, DuckDB, export, scripts |
 | `eth_defi/currency_api/README-currency-api.md` | Historical exchange rate ingestion (fawazahmed0 Exchange API) into DuckDB |
 | `eth_defi/data/vaults/README.md` | Vault protocol metadata and logo system |
+| `eth_defi/tokenised_fund/asseto/README-Asseto.md` | Asseto dynamic registry, daily NAV history and operations |
 | `eth_defi/erc_4626/vault_protocol/README-reader-states.md` | Vault reader states and warmup system |
 | `eth_defi/erc_4626/vault_protocol/README-utilisation.md` | Utilisation and available liquidity metrics for lending vaults |
 | `eth_defi/erc_4626/vault_protocol/README-vault-redeemable.md` | Why utilisation ≠ redeemable liquidity for Morpho/IPOR multi-market vaults |

--- a/docs/source/api/asseto/index.rst
+++ b/docs/source/api/asseto/index.rst
@@ -18,4 +18,6 @@ It also exposes public partner roles through
    eth_defi.tokenised_fund.asseto.historical
    eth_defi.tokenised_fund.asseto.constants
    eth_defi.tokenised_fund.asseto.offchain_api
+   eth_defi.tokenised_fund.asseto.offchain_metadata
+   eth_defi.tokenised_fund.asseto.registry
    eth_defi.tokenised_fund.asseto.backfill

--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -107,9 +107,6 @@ ODA_FACT_HARDCODED_PROTOCOLS = {
 #: Midas hardcoded classification flags.
 MIDAS_HARDCODED_PROTOCOLS = {token: {ERC4626Feature.midas_like} for token in MIDAS_PRODUCTS_BY_TOKEN}
 
-#: Asseto tokenised fund products require chain-aware address matching.
-ASSETO_HARDCODED_PROTOCOLS = {token: {ERC4626Feature.asseto_like} for token in ASSETO_PRODUCTS_BY_TOKEN}
-
 #: Ondo issuer share tokens are chain-aware, non-ERC-4626 products whose NAV
 #: is published by separate issuer oracles.
 ONDO_HARDCODED_PROTOCOLS = {token: {ERC4626Feature.ondo_like} for token in ONDO_PRODUCTS_BY_TOKEN}
@@ -387,8 +384,8 @@ def _get_hardcoded_protocol_features(address: HexAddress | str, chain_id: int | 
                 return OPENEDEN_HARDCODED_PROTOCOLS[normalised_address]
             return None
         if (chain_id, normalised_address) in ASSETO_PRODUCTS:
-            return ASSETO_HARDCODED_PROTOCOLS[normalised_address]
-        if normalised_address in ASSETO_HARDCODED_PROTOCOLS:
+            return {ERC4626Feature.asseto_like}
+        if normalised_address in ASSETO_PRODUCTS_BY_TOKEN:
             return None
         if (chain_id, normalised_address) in ONDO_PRODUCTS:
             return ONDO_HARDCODED_PROTOCOLS[normalised_address]
@@ -2593,7 +2590,6 @@ def create_vault_instance_autodetect(
 HARDCODED_PROTOCOLS = {
     **ODA_FACT_HARDCODED_PROTOCOLS,
     **MIDAS_HARDCODED_PROTOCOLS,
-    **ASSETO_HARDCODED_PROTOCOLS,
     **ONDO_HARDCODED_PROTOCOLS,
     **USYC_HARDCODED_PROTOCOLS,
     **FRANKLIN_HARDCODED_PROTOCOLS,

--- a/eth_defi/tokenised_fund/asseto/README-Asseto.md
+++ b/eth_defi/tokenised_fund/asseto/README-Asseto.md
@@ -1,0 +1,61 @@
+# Asseto tokenised funds
+
+Asseto products are permissioned tokenised fund shares. They are represented by
+`AssetoVault`, a read-only `VaultBase` adapter, rather than ERC-4626 because
+subscriptions and redemptions are KYC-gated request/claim workflows and NAV is
+published independently of an ERC-4626 conversion function.
+
+## Registry and metadata
+
+Asseto's public web application exposes undocumented endpoints at
+`/api/home/products`, `/api/product/get` and `/api/product/price/list`. They
+are useful for product identity, description, denomination and daily displayed
+NAV history, but are not a versioned API. Onchain token supply and a published
+`Pricer`, when present, remain canonical valuation inputs.
+
+The scheduled `Asseto` row fetches the registry once per due daily cycle before
+constructing adapters. A normalised JSON snapshot is stored at
+`~/.tradingstrategy/cache/asseto/registry-cache.json`, shared by the scanner
+containers. A failed, empty or duplicate response cannot overwrite this cache.
+For up to seven days the scanner may use a stale snapshot only to reconstruct
+already-known adapters; it never writes stale descriptions or registers a new
+product. The dashboard diagnostic reports `registry=fresh` or `registry=stale`.
+
+Fresh data is preferred field by field: reviewed corrections, current detail
+description, current registry values, then onchain state. The only maintained
+product-specific override is AoABT's documentation link; other products fall
+back to the Asseto product index. Curator mappings remain reviewed constants
+because Asseto publishes partner logos rather than a stable textual curator id.
+
+## Scheduled and manual history
+
+The Asseto feed samples approximate daily (`1d`) history. Each token is scanned
+and rewritten independently, so a newly registered old deployment cannot widen
+another product's Parquet deletion window. A fresh supported EVM product is
+registered into the vault database from the same registry snapshot before its
+first price scan. Products without a denomination, an RPC or usable NAV source
+remain visible through diagnostics and do not claim a fresh price.
+
+`scripts/backfill-tokenised-funds.py` uses the same persisted registry for
+Asseto metadata and history. For an address-scoped repair, use
+`scripts/erc-4626/backfill-tokenised-fund-prices.py` with
+`TOKENISED_FUND_PROTOCOLS=asseto`; it shares the recurring price writer and
+preserves all other products' rows.
+
+USD, USDC and USDT are already USD accounting denominations. Other
+denominations require historical rates from the shared currency-rate database;
+no synthetic 1.0 FX rate is used. Asseto `stoken` products without an explicit
+denomination are treated as USD only where the existing integration explicitly
+recognises that product type.
+
+## Operations
+
+The current stale-registry limit is seven days. The first failed registry read
+retains a valid cache; if no usable snapshot exists, the Asseto item fails
+without writing metadata or raw prices while later tokenised-fund protocols
+continue.
+
+Use `DRY_RUN=true PROTOCOLS=asseto poetry run python
+scripts/backfill-tokenised-funds.py` to inspect a registry-based backfill. The
+registry cache is adapter-critical state and should be included with vault
+metadata and raw-price backups.

--- a/eth_defi/tokenised_fund/asseto/backfill.py
+++ b/eth_defi/tokenised_fund/asseto/backfill.py
@@ -90,8 +90,9 @@ from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_mu
 from eth_defi.provider.named import get_provider_name
 from eth_defi.research.wrangle_vault_prices import replace_cleaned_vault_histories
 from eth_defi.token import TokenDiskCache, is_stablecoin_like
-from eth_defi.tokenised_fund.asseto.constants import ASSETO_PRODUCTS, ASSETO_USD_DENOMINATIONS, AssetoProduct
-from eth_defi.tokenised_fund.asseto.offchain_api import AssetoOffchainProduct, fetch_asseto_products
+from eth_defi.tokenised_fund.asseto.constants import ASSETO_USD_DENOMINATIONS, AssetoProduct, install_asseto_runtime_products
+from eth_defi.tokenised_fund.asseto.offchain_api import AssetoOffchainProduct
+from eth_defi.tokenised_fund.asseto.offchain_metadata import fetch_asseto_registry
 from eth_defi.utils import setup_console_logging
 from eth_defi.vault.base import VaultBase, VaultSpec
 from eth_defi.vault.data_file_export import resolve_exchange_rate_database_path
@@ -237,7 +238,12 @@ def iter_selected_products() -> Iterable[AssetoOffchainProduct]:
     networks = parse_csv_env("NETWORKS")
     products = parse_csv_env("PRODUCTS")
     seen: set[tuple[int, HexAddress]] = set()
-    for product in fetch_asseto_products():
+    registry = fetch_asseto_registry()
+    if not registry.is_usable:
+        raise RuntimeError(f"Asseto registry is unavailable: {registry.diagnostics}")
+    if registry.status == "stale":
+        logger.warning("Asseto backfill is using stale registry metadata from %s: %s", registry.source_timestamp, registry.diagnostics)
+    for product in registry.products:
         key = (product.chain_id, product.contract_address)
         if key in seen:
             continue
@@ -714,8 +720,9 @@ def backfill_chain(  # noqa: PLR0914 - explicit production pipeline state keeps 
         denomination_symbol = resolve_asseto_denomination_symbol(product)
         exchange_rates = usd_exchange_rates_by_symbol.get(denomination_symbol or "", ())
         runtime_product = create_runtime_product(product, deployment_block, first_seen_at, exchange_rates)
-        ASSETO_PRODUCTS[runtime_product.chain_id, runtime_product.token] = runtime_product
         runtime_products.append(runtime_product)
+
+    install_asseto_runtime_products(runtime_products)
 
     leads = {product.token: create_asseto_lead(product) for product in runtime_products}
     rows = {

--- a/eth_defi/tokenised_fund/asseto/backfill.py
+++ b/eth_defi/tokenised_fund/asseto/backfill.py
@@ -76,12 +76,8 @@ from tabulate import tabulate
 from web3 import Web3
 
 from eth_defi.chain import CHAIN_NAMES, get_chain_name
-from eth_defi.compat import native_datetime_utc_now
-from eth_defi.currency_api.constants import SOURCE_NAME
-from eth_defi.currency_api.database import CurrencyRateDatabase
 from eth_defi.erc_4626.classification import create_vault_instance
-from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
-from eth_defi.erc_4626.discovery_base import PotentialVaultMatch
+from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.scan import create_vault_scan_record
 from eth_defi.hypersync.server import is_hypersync_supported_chain
 from eth_defi.hypersync.utils import configure_hypersync_from_env
@@ -90,9 +86,12 @@ from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_mu
 from eth_defi.provider.named import get_provider_name
 from eth_defi.research.wrangle_vault_prices import replace_cleaned_vault_histories
 from eth_defi.token import TokenDiskCache, is_stablecoin_like
-from eth_defi.tokenised_fund.asseto.constants import ASSETO_USD_DENOMINATIONS, AssetoProduct, install_asseto_runtime_products
+from eth_defi.tokenised_fund.asseto.constants import AssetoProduct, install_asseto_runtime_products
 from eth_defi.tokenised_fund.asseto.offchain_api import AssetoOffchainProduct
 from eth_defi.tokenised_fund.asseto.offchain_metadata import fetch_asseto_registry
+from eth_defi.tokenised_fund.asseto.registry import create_asseto_detection, create_asseto_lead, load_usd_exchange_rates, resolve_asseto_denomination_symbol
+from eth_defi.tokenised_fund.asseto.registry import create_asseto_runtime_product as create_runtime_product
+from eth_defi.tokenised_fund.asseto.registry import fetch_asseto_deployment_block as fetch_contract_deployment_block
 from eth_defi.utils import setup_console_logging
 from eth_defi.vault.base import VaultBase, VaultSpec
 from eth_defi.vault.data_file_export import resolve_exchange_rate_database_path
@@ -306,46 +305,6 @@ def resolve_price_scan_start_block(
     return deployment_start_block
 
 
-def create_asseto_detection(product: AssetoProduct) -> ERC4262VaultDetection:
-    """Create a synthetic shared scanner detection for an Asseto product.
-
-    :param product:
-        Asseto product metadata.
-    :return:
-        Detection compatible with metadata scan record generation.
-    """
-
-    return ERC4262VaultDetection(
-        chain=product.chain_id,
-        address=product.token,
-        first_seen_at_block=product.first_seen_at_block,
-        first_seen_at=product.first_seen_at,
-        features={ERC4626Feature.asseto_like},
-        updated_at=native_datetime_utc_now(),
-        deposit_count=0,
-        redeem_count=0,
-    )
-
-
-def create_asseto_lead(product: AssetoProduct) -> PotentialVaultMatch:
-    """Create a synthetic discovery lead for an Asseto product.
-
-    :param product:
-        Asseto product metadata.
-    :return:
-        Lead compatible with the vault metadata database.
-    """
-
-    return PotentialVaultMatch(
-        chain=product.chain_id,
-        address=product.token,
-        first_seen_at_block=product.first_seen_at_block,
-        first_seen_at=product.first_seen_at,
-        deposit_count=0,
-        withdrawal_count=0,
-    )
-
-
 def read_vault_database(path: Path) -> VaultDatabase:
     """Read or initialise the vault metadata database.
 
@@ -507,150 +466,6 @@ def validate_active_asseto_coverage(
     invalid_active_rows = [VaultSpec(product.chain_id, product.token).as_string_id() for product in runtime_products if product.token.lower() in active_product_ids and (rows[VaultSpec(product.chain_id, product.token)].get("NAV") is None or rows[VaultSpec(product.chain_id, product.token)].get("NAV") <= 0 or not is_stablecoin_like(rows[VaultSpec(product.chain_id, product.token)].get("Denomination")))]
     if invalid_active_rows:
         raise RuntimeError(f"Active Asseto products do not have positive USD-compatible live metadata: {', '.join(sorted(invalid_active_rows))}")
-
-
-def resolve_asseto_denomination_symbol(product: AssetoOffchainProduct) -> str | None:
-    """Resolve the currency in which Asseto publishes a product's NAV.
-
-    Asseto omits ``tokenSymbol`` for its ``stoken`` products even though their
-    product pages and NAV series use United States dollars. Treat this registry
-    category as synthetic USD accounting, while retaining explicit symbols for
-    UDA products such as USDC, USDT and HKD.
-
-    :param product:
-        Public Asseto registry entry.
-    :return:
-        Upper-case accounting denomination, or ``None`` if Asseto publishes
-        neither a symbol nor a recognised product category.
-    """
-
-    if product.denomination_symbol:
-        return product.denomination_symbol.upper()
-    if product.product_type and product.product_type.casefold() == "stoken":
-        return "USD"
-    return None
-
-
-def load_usd_exchange_rates(
-    database_path: Path,
-    denomination_symbols: Iterable[str | None],
-) -> dict[str, tuple[tuple[int, Decimal], ...]]:
-    """Load historical fiat conversion rates needed by selected products.
-
-    Stored rates are units of quote currency per one USD. Asseto NAV values in
-    a non-USD currency are consequently divided by the matching rate before
-    they enter the shared USD-denominated cleaned history.
-
-    :param database_path:
-        Currency API DuckDB produced by ``scan-currencies``.
-    :param denomination_symbols:
-        Asseto accounting currencies selected for this run.
-    :return:
-        Rates keyed by upper-case quote currency, each ordered by UTC day.
-    :raise RuntimeError:
-        If a required database or currency history is missing.
-    """
-
-    required = {symbol.upper() for symbol in denomination_symbols if symbol and symbol.upper() not in ASSETO_USD_DENOMINATIONS}
-    if not required:
-        return {}
-    if not database_path.exists():
-        currencies = ", ".join(sorted(required))
-        raise RuntimeError(f"Asseto products require {currencies}/USD history, but the currency database does not exist at {database_path}; run scan-currencies first")
-
-    database = CurrencyRateDatabase(database_path)
-    try:
-        rates_df = database.get_rates_dataframe(base_currency="usd", source=SOURCE_NAME)
-    finally:
-        database.close()
-
-    result: dict[str, tuple[tuple[int, Decimal], ...]] = {}
-    for symbol in sorted(required):
-        selected = rates_df.loc[rates_df["quote_currency"].str.casefold() == symbol.casefold()].sort_values("date")
-        if selected.empty:
-            raise RuntimeError(f"Asseto product history requires {symbol}/USD rates in {database_path}; run scan-currencies with QUOTE_CURRENCIES including {symbol.lower()}")
-        result[symbol] = tuple(
-            (
-                int(datetime.datetime.combine(row.date, datetime.time.min, tzinfo=datetime.UTC).timestamp()),
-                Decimal(str(row.rate)),
-            )
-            for row in selected.itertuples(index=False)
-        )
-    return result
-
-
-def fetch_contract_deployment_block(web3: Web3, address: HexAddress, end_block: int) -> int:
-    """Find the first block containing runtime code for an Asseto token.
-
-    :param web3:
-        Archive-capable connection for the product chain.
-    :param address:
-        Asseto ERC-20 token address.
-    :param end_block:
-        Highest block that may be checked.
-    :return:
-        First block containing contract code.
-    :raise ValueError:
-        If the public registry address has no contract code on this chain.
-    """
-
-    address = Web3.to_checksum_address(address)
-    if not web3.eth.get_code(address, block_identifier=end_block):
-        raise ValueError(f"No contract code for Asseto product {address} at block {end_block}")
-
-    low = 0
-    high = end_block
-    while low < high:
-        middle = (low + high) // 2
-        if web3.eth.get_code(address, block_identifier=middle):
-            high = middle
-        else:
-            low = middle + 1
-    return low
-
-
-def create_runtime_product(
-    product: AssetoOffchainProduct,
-    deployment_block: int,
-    first_seen_at: datetime.datetime,
-    usd_exchange_rates: tuple[tuple[int, Decimal], ...] = (),
-) -> AssetoProduct:
-    """Convert one public registry entry to a temporary scanner product.
-
-    Public registry products do not all expose Asseto's request/claim manager
-    and ``Pricer`` contracts. The generic adapter therefore uses their
-    published daily NAV history, while preserving the exact token identity and
-    deployment information read from the configured archive RPC.
-
-    :param product:
-        Asseto public EVM product entry.
-    :param deployment_block:
-        First token-code block found on-chain.
-    :param first_seen_at:
-        Naive UTC deployment timestamp.
-    :param usd_exchange_rates:
-        Historical units of the product denomination per USD. Empty for
-        products already denominated in USD or a USD stablecoin.
-    :return:
-        Runtime Asseto adapter product metadata.
-    """
-
-    return AssetoProduct(
-        chain_id=product.chain_id,
-        token=product.contract_address,
-        symbol=product.symbol or product.product_name,
-        product_name=product.full_name or product.product_name,
-        manager=None,
-        pricer=None,
-        collateral=product.denomination_address,
-        first_seen_at_block=deployment_block,
-        first_seen_at=first_seen_at,
-        denomination_symbol=resolve_asseto_denomination_symbol(product),
-        usd_exchange_rates=usd_exchange_rates,
-        offchain_product_id=product.product_id,
-        offchain_product_name=product.product_name,
-        description=product.introduction,
-    )
 
 
 def backfill_chain(  # noqa: PLR0914 - explicit production pipeline state keeps the write path auditable.

--- a/eth_defi/tokenised_fund/asseto/constants.py
+++ b/eth_defi/tokenised_fund/asseto/constants.py
@@ -69,6 +69,8 @@ class AssetoProduct:
     offchain_product_name: str | None = None
     #: Informational public product description.
     description: str | None = None
+    #: Reviewed product-specific homepage, when Asseto does not publish one.
+    homepage: str | None = None
 
 
 @dataclass(slots=True, frozen=True)
@@ -105,6 +107,7 @@ ASSETO_AOABT_HASHKEY = AssetoProduct(
     has_custom_fees=True,
     denomination_symbol="USDT",
     description="AoABT tokenises the Asseto Orient Arbitrage Strategy and offers daily U.S. dollar yields backed one-to-one by the underlying strategy.",
+    homepage="https://asseto.gitbook.io/asseto/products/aoabt/introduction",
 )
 
 #: Product lookup used by the adapter and chain-aware classification.
@@ -114,6 +117,25 @@ ASSETO_PRODUCTS: dict[tuple[int, HexAddress], AssetoProduct] = {
 
 #: Address-only lookup used for hardcoded protocol routing.
 ASSETO_PRODUCTS_BY_TOKEN: dict[HexAddress, AssetoProduct] = {product.token: product for product in ASSETO_PRODUCTS.values()}
+
+
+def install_asseto_runtime_products(products: list[AssetoProduct]) -> None:
+    """Install API-derived products for the lifetime of this scanner process.
+
+    The classification module imports these mutable mappings during process
+    startup, so retain their identity while replacing only the entries owned by
+    the fresh or validated stale Asseto registry.  The scheduled scanner calls
+    this before constructing any :class:`AssetoVault` adapters.
+
+    :param products:
+        Fully prepared product records keyed by chain and token.
+    :return:
+        None.
+    """
+
+    ASSETO_PRODUCTS.update({(product.chain_id, product.token): product for product in products})
+    ASSETO_PRODUCTS_BY_TOKEN.update({product.token: product for product in products})
+
 
 #: Reviewed manager attribution for Asseto products on supported EVM chains.
 #:

--- a/eth_defi/tokenised_fund/asseto/offchain_metadata.py
+++ b/eth_defi/tokenised_fund/asseto/offchain_metadata.py
@@ -36,7 +36,7 @@ ASSETO_REGISTRY_CACHE_VERSION = 1
 #: Longest safe age for a cached registry used to construct existing adapters.
 DEFAULT_MAX_STALE_AGE = datetime.timedelta(days=7)
 
-AssetoRegistryStatus = Literal["fresh", "stale", "not_found", "transient_error"]
+AssetoRegistryStatus = Literal["fresh", "stale", "transient_error"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -145,21 +145,18 @@ def _write_cache(cache_path: Path, products: tuple[AssetoOffchainProduct, ...], 
 def fetch_asseto_registry(
     *,
     cache_path: Path = DEFAULT_ASSETO_REGISTRY_CACHE_PATH,
-    force_refresh: bool = True,
     now_: datetime.datetime | None = None,
     max_stale_age: datetime.timedelta = DEFAULT_MAX_STALE_AGE,
 ) -> AssetoOffchainRegistryResult:
     """Fetch Asseto's registry with a safe persisted stale fallback.
 
-    A due scanner cycle passes ``force_refresh=True`` so the daily scheduler
-    always attempts one request.  A malformed, empty or duplicate snapshot
-    cannot replace an existing cache.  On failure, the cache can only rebuild
-    existing adapters and callers must not use it for metadata writes.
+    The daily scheduler always calls this helper once per due Asseto item. A
+    malformed, empty or duplicate snapshot cannot replace an existing cache.
+    On failure, the cache can only rebuild existing adapters and callers must
+    not use it for metadata writes.
 
     :param cache_path:
         JSON cache path. Override in tests or isolated operator runs.
-    :param force_refresh:
-        Whether to make one immediate registry request.
     :param now_:
         Naive UTC timestamp override for deterministic tests.
     :param max_stale_age:
@@ -182,9 +179,6 @@ def fetch_asseto_registry(
             except (OSError, ValueError, json.JSONDecodeError) as exc:
                 cache_error = exc
                 logger.error("Asseto registry cache %s is corrupt: %s", cache_path, exc, exc_info=True)
-
-        if not force_refresh and cached_products is not None:
-            return AssetoOffchainRegistryResult("stale", cached_products, cached_at, "cache reuse requested")
 
         try:
             products = tuple(fetch_asseto_products())

--- a/eth_defi/tokenised_fund/asseto/offchain_metadata.py
+++ b/eth_defi/tokenised_fund/asseto/offchain_metadata.py
@@ -1,0 +1,212 @@
+"""Persist Asseto's public product registry for scheduled vault scans.
+
+Asseto exposes its registry through an undocumented web-application endpoint.
+The registry is nevertheless adapter-critical because it supplies the product
+identifier used for public daily NAV history.  This module keeps HTTP parsing
+in :mod:`eth_defi.tokenised_fund.asseto.offchain_api` and owns only cache and
+freshness policy.
+"""
+
+import datetime
+import json
+import logging
+from dataclasses import asdict, dataclass
+from decimal import Decimal
+from pathlib import Path
+from typing import Literal
+
+import requests
+from atomicwrites import atomic_write
+from eth_typing import HexAddress
+
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.disk_cache import DEFAULT_CACHE_ROOT
+from eth_defi.tokenised_fund.asseto.offchain_api import AssetoAPIError, AssetoOffchainProduct, fetch_asseto_products
+from eth_defi.utils import wait_other_writers
+
+logger = logging.getLogger(__name__)
+
+
+#: Persistent cache shared by the scanner containers through ``DEFAULT_CACHE_ROOT``.
+DEFAULT_ASSETO_REGISTRY_CACHE_PATH = DEFAULT_CACHE_ROOT / "asseto" / "registry-cache.json"
+
+#: Current normalised JSON envelope version.
+ASSETO_REGISTRY_CACHE_VERSION = 1
+
+#: Longest safe age for a cached registry used to construct existing adapters.
+DEFAULT_MAX_STALE_AGE = datetime.timedelta(days=7)
+
+AssetoRegistryStatus = Literal["fresh", "stale", "not_found", "transient_error"]
+
+
+@dataclass(frozen=True, slots=True)
+class AssetoOffchainRegistryResult:
+    """One fresh or stale Asseto registry read.
+
+    :param status:
+        Whether products came from a new API response or a retained cache.
+    :param products:
+        Normalised EVM registry products keyed by Asseto's API.
+    :param source_timestamp:
+        UTC timestamp at which the source snapshot was fetched.
+    :param diagnostics:
+        Safe operator-facing explanation of a stale or failed read.
+    """
+
+    status: AssetoRegistryStatus
+    products: tuple[AssetoOffchainProduct, ...]
+    source_timestamp: datetime.datetime | None
+    diagnostics: str | None = None
+
+    @property
+    def is_usable(self) -> bool:
+        """Return whether the result can construct known runtime adapters."""
+
+        return self.status in {"fresh", "stale"} and bool(self.products)
+
+
+def _encode_product(product: AssetoOffchainProduct) -> dict[str, object]:
+    """Convert one product to JSON-compatible cache data."""
+
+    data = asdict(product)
+    for key in ("contract_address", "denomination_address"):
+        if data[key] is not None:
+            data[key] = str(data[key])
+    for key in ("tvl", "apy"):
+        if data[key] is not None:
+            data[key] = str(data[key])
+    return data
+
+
+def _decode_product(data: object) -> AssetoOffchainProduct:
+    """Parse one cache record using the same types as the live API client."""
+
+    if not isinstance(data, dict):
+        message = "Asseto registry cache product is not an object"
+        raise ValueError(message)
+    try:
+        return AssetoOffchainProduct(
+            product_id=int(data["product_id"]),
+            product_name=str(data["product_name"]),
+            full_name=data.get("full_name") if isinstance(data.get("full_name"), str) else None,
+            symbol=data.get("symbol") if isinstance(data.get("symbol"), str) else None,
+            product_type=data.get("product_type") if isinstance(data.get("product_type"), str) else None,
+            chain_id=int(data["chain_id"]),
+            chain_name=data.get("chain_name") if isinstance(data.get("chain_name"), str) else None,
+            contract_address=HexAddress(str(data["contract_address"]).lower()),
+            denomination_symbol=data.get("denomination_symbol") if isinstance(data.get("denomination_symbol"), str) else None,
+            denomination_address=HexAddress(str(data["denomination_address"]).lower()) if data.get("denomination_address") else None,
+            tvl=Decimal(str(data["tvl"])) if data.get("tvl") is not None else None,
+            apy=Decimal(str(data["apy"])) if data.get("apy") is not None else None,
+            introduction=data.get("introduction") if isinstance(data.get("introduction"), str) else None,
+            protocol=data.get("protocol") if isinstance(data.get("protocol"), str) else None,
+        )
+    except (KeyError, TypeError, ValueError, ArithmeticError) as exc:
+        message = "Asseto registry cache contains an invalid product"
+        raise ValueError(message) from exc
+
+
+def _load_cache(cache_path: Path) -> tuple[tuple[AssetoOffchainProduct, ...], datetime.datetime]:
+    """Load one validated versioned registry cache envelope."""
+
+    with cache_path.open("rt", encoding="utf-8") as inp:
+        payload = json.load(inp)
+    if not isinstance(payload, dict) or payload.get("version") != ASSETO_REGISTRY_CACHE_VERSION:
+        message = "Asseto registry cache has an unknown version"
+        raise ValueError(message)
+    source_timestamp = datetime.datetime.fromisoformat(str(payload["fetched_at"]))
+    if source_timestamp.tzinfo is not None:
+        source_timestamp = source_timestamp.replace(tzinfo=None)
+    raw_products = payload.get("products")
+    if not isinstance(raw_products, list) or not raw_products:
+        message = "Asseto registry cache has no products"
+        raise ValueError(message)
+    products = tuple(_decode_product(product) for product in raw_products)
+    keys = {(product.chain_id, product.contract_address.lower()) for product in products}
+    if len(keys) != len(products):
+        message = "Asseto registry cache contains duplicate chain/address products"
+        raise ValueError(message)
+    return products, source_timestamp
+
+
+def _write_cache(cache_path: Path, products: tuple[AssetoOffchainProduct, ...], fetched_at: datetime.datetime) -> None:
+    """Atomically persist a complete validated registry snapshot."""
+
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": ASSETO_REGISTRY_CACHE_VERSION,
+        "fetched_at": fetched_at.isoformat(),
+        "products": [_encode_product(product) for product in products],
+    }
+    with atomic_write(str(cache_path), mode="w", encoding="utf-8", overwrite=True) as out:
+        json.dump(payload, out, indent=2, sort_keys=True)
+
+
+def fetch_asseto_registry(
+    *,
+    cache_path: Path = DEFAULT_ASSETO_REGISTRY_CACHE_PATH,
+    force_refresh: bool = True,
+    now_: datetime.datetime | None = None,
+    max_stale_age: datetime.timedelta = DEFAULT_MAX_STALE_AGE,
+) -> AssetoOffchainRegistryResult:
+    """Fetch Asseto's registry with a safe persisted stale fallback.
+
+    A due scanner cycle passes ``force_refresh=True`` so the daily scheduler
+    always attempts one request.  A malformed, empty or duplicate snapshot
+    cannot replace an existing cache.  On failure, the cache can only rebuild
+    existing adapters and callers must not use it for metadata writes.
+
+    :param cache_path:
+        JSON cache path. Override in tests or isolated operator runs.
+    :param force_refresh:
+        Whether to make one immediate registry request.
+    :param now_:
+        Naive UTC timestamp override for deterministic tests.
+    :param max_stale_age:
+        Maximum cache age eligible for degraded adapter construction.
+    :return:
+        Fresh, stale or failed registry result.
+    """
+
+    now_ = now_ or native_datetime_utc_now()
+    cache_path = cache_path.expanduser().resolve()
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cached_products: tuple[AssetoOffchainProduct, ...] | None = None
+    cached_at: datetime.datetime | None = None
+    cache_error: Exception | None = None
+
+    with wait_other_writers(cache_path):
+        if cache_path.exists():
+            try:
+                cached_products, cached_at = _load_cache(cache_path)
+            except (OSError, ValueError, json.JSONDecodeError) as exc:
+                cache_error = exc
+                logger.error("Asseto registry cache %s is corrupt: %s", cache_path, exc, exc_info=True)
+
+        if not force_refresh and cached_products is not None:
+            return AssetoOffchainRegistryResult("stale", cached_products, cached_at, "cache reuse requested")
+
+        try:
+            products = tuple(fetch_asseto_products())
+            keys = {(product.chain_id, product.contract_address.lower()) for product in products}
+            if not products:
+                message = "Asseto registry returned no parseable EVM products"
+                raise AssetoAPIError(message)
+            if len(keys) != len(products):
+                message = "Asseto registry contains duplicate chain/address products"
+                raise AssetoAPIError(message)
+        except (AssetoAPIError, OSError, requests.RequestException) as exc:
+            if cached_products is not None and cached_at is not None and now_ - cached_at <= max_stale_age:
+                logger.warning("Asseto registry refresh failed; using stale cache from %s: %s", cached_at.isoformat(), exc)
+                return AssetoOffchainRegistryResult("stale", cached_products, cached_at, str(exc))
+            diagnostic = str(exc)
+            if cache_error is not None:
+                diagnostic = f"{diagnostic}; cache is unusable: {cache_error}"
+            return AssetoOffchainRegistryResult("transient_error", (), None, diagnostic)
+
+        if cache_error is not None and cache_path.exists():
+            quarantine_path = cache_path.with_name(f"{cache_path.stem}.corrupt-{now_.strftime('%Y%m%dT%H%M%S')}{cache_path.suffix}")
+            cache_path.replace(quarantine_path)
+            logger.error("Quarantined corrupt Asseto registry cache at %s", quarantine_path)
+        _write_cache(cache_path, products, now_)
+        return AssetoOffchainRegistryResult("fresh", products, now_)

--- a/eth_defi/tokenised_fund/asseto/registry.py
+++ b/eth_defi/tokenised_fund/asseto/registry.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from eth_typing import HexAddress
 from web3 import Web3
+from web3.exceptions import Web3Exception
 
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
@@ -31,11 +32,25 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True, slots=True)
 class AssetoRegistryRefreshResult:
-    """Summary of runtime registry preparation for one scanner invocation."""
+    """Summary of runtime registry preparation for one scanner invocation.
 
+    :ivar status:
+        Registry source status, either ``fresh`` or ``stale``.
+    :ivar runtime_product_count:
+        Number of products installed for adapter construction.
+    :ivar registered_product_count:
+        Number of newly persisted vault metadata records.
+    :ivar diagnostics:
+        Non-fatal skipped-product and stale-source diagnostics.
+    """
+
+    #: Registry source status, either ``fresh`` or ``stale``.
     status: str
+    #: Number of products installed for adapter construction.
     runtime_product_count: int
+    #: Number of newly persisted vault metadata records.
     registered_product_count: int
+    #: Non-fatal skipped-product and stale-source diagnostics.
     diagnostics: tuple[str, ...]
 
 
@@ -103,7 +118,7 @@ def _create_detection(product: AssetoProduct) -> ERC4262VaultDetection:
     )
 
 
-def prepare_asseto_registry(  # noqa: PLR0914 - explicit product registration state keeps database writes auditable.
+def fetch_asseto_registry_preparation(  # noqa: PLR0914 - explicit product registration state keeps database writes auditable.
     *,
     vault_db_path: Path,
     enabled_chain_ids: frozenset[int],
@@ -129,7 +144,7 @@ def prepare_asseto_registry(  # noqa: PLR0914 - explicit product registration st
         Preparation outcome and non-fatal product diagnostics.
     """
 
-    registry = fetch_asseto_registry(cache_path=cache_path, force_refresh=True)
+    registry = fetch_asseto_registry(cache_path=cache_path)
     if not registry.is_usable:
         raise RuntimeError(f"Asseto registry is unavailable: {registry.diagnostics}")
     vault_db = VaultDatabase.read(vault_db_path) if vault_db_path.exists() else VaultDatabase()
@@ -171,7 +186,7 @@ def prepare_asseto_registry(  # noqa: PLR0914 - explicit product registration st
                 # so register this one product before its first metadata read.
                 install_asseto_runtime_products([runtime_product])
                 row = create_vault_scan_record(web3, detection=_create_detection(runtime_product), block_identifier=end_block, token_cache=token_cache)
-            except (OSError, ValueError, RuntimeError) as exc:
+            except (OSError, ValueError, RuntimeError, Web3Exception) as exc:
                 diagnostics.append(f"could not register {offchain_product.contract_address}: {exc}")
                 logger.warning("Could not register Asseto product %s: %s", offchain_product.contract_address, exc)
                 continue

--- a/eth_defi/tokenised_fund/asseto/registry.py
+++ b/eth_defi/tokenised_fund/asseto/registry.py
@@ -8,7 +8,9 @@ products from the same fresh API snapshot.
 
 import datetime
 import logging
+from collections.abc import Iterable
 from dataclasses import dataclass
+from decimal import Decimal
 from pathlib import Path
 
 from eth_typing import HexAddress
@@ -16,15 +18,20 @@ from web3 import Web3
 from web3.exceptions import Web3Exception
 
 from eth_defi.compat import native_datetime_utc_now
+from eth_defi.currency_api.constants import SOURCE_NAME
+from eth_defi.currency_api.database import CurrencyRateDatabase
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
+from eth_defi.erc_4626.discovery_base import PotentialVaultMatch
 from eth_defi.erc_4626.scan import create_vault_scan_record
 from eth_defi.provider.env import read_json_rpc_url
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.token import TokenDiskCache
-from eth_defi.tokenised_fund.asseto.constants import AssetoProduct, install_asseto_runtime_products
+from eth_defi.tokenised_fund.asseto.constants import ASSETO_PRODUCTS, ASSETO_PRODUCTS_BY_TOKEN, ASSETO_USD_DENOMINATIONS, AssetoProduct, install_asseto_runtime_products
 from eth_defi.tokenised_fund.asseto.offchain_api import AssetoOffchainProduct
 from eth_defi.tokenised_fund.asseto.offchain_metadata import DEFAULT_ASSETO_REGISTRY_CACHE_PATH, fetch_asseto_registry
+from eth_defi.tokenised_fund.asseto.vault import create_asseto_short_description
 from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.data_file_export import resolve_exchange_rate_database_path
 from eth_defi.vault.vaultdb import VaultDatabase
 
 logger = logging.getLogger(__name__)
@@ -42,6 +49,8 @@ class AssetoRegistryRefreshResult:
         Number of newly persisted vault metadata records.
     :ivar diagnostics:
         Non-fatal skipped-product and stale-source diagnostics.
+    :ivar available_specs:
+        Persisted products with a runtime adapter installed for this cycle.
     """
 
     #: Registry source status, either ``fresh`` or ``stale``.
@@ -52,22 +61,98 @@ class AssetoRegistryRefreshResult:
     registered_product_count: int
     #: Non-fatal skipped-product and stale-source diagnostics.
     diagnostics: tuple[str, ...]
+    #: Persisted products with a runtime adapter installed for this cycle.
+    available_specs: frozenset[VaultSpec] = frozenset()
 
 
 def resolve_asseto_denomination_symbol(product: AssetoOffchainProduct) -> str | None:
-    """Resolve the accounting denomination from Asseto's public product data."""
+    """Resolve the accounting denomination from Asseto's public product data.
+
+    Asseto omits the symbol on its ``stoken`` products even though their NAV
+    series is USD-denominated. All other products need an explicit symbol so
+    the scanner can safely select a conversion history.
+
+    :param product:
+        Normalised product read from Asseto's public registry.
+    :return:
+        Upper-case accounting currency, or ``None`` when it is not usable.
+    """
 
     if product.denomination_symbol:
         return product.denomination_symbol.upper()
-    return "USD" if product.product_type == "stoken" else None
+    return "USD" if product.product_type and product.product_type.casefold() == "stoken" else None
+
+
+def load_usd_exchange_rates(
+    database_path: Path,
+    denomination_symbols: Iterable[str | None],
+) -> dict[str, tuple[tuple[int, Decimal], ...]]:
+    """Load historical quote-currency-per-USD rates for Asseto products.
+
+    Asseto NAV values in non-USD currencies are divided by these rates before
+    entering the shared USD history.  The targeted backfill and daily scanner
+    intentionally share this exact conversion rule.
+
+    :param database_path:
+        Currency API DuckDB produced by ``scan-currencies``.
+    :param denomination_symbols:
+        Accounting currencies requested by the selected products.
+    :return:
+        Exchange-rate history keyed by upper-case currency symbol.
+    :raise RuntimeError:
+        If required currency history is unavailable.
+    """
+
+    required = {symbol.upper() for symbol in denomination_symbols if symbol and symbol.upper() not in ASSETO_USD_DENOMINATIONS}
+    if not required:
+        return {}
+    if not database_path.exists():
+        currencies = ", ".join(sorted(required))
+        raise RuntimeError(f"Asseto products require {currencies}/USD history, but the currency database does not exist at {database_path}; run scan-currencies first")
+
+    database = CurrencyRateDatabase(database_path)
+    try:
+        rates_df = database.get_rates_dataframe(base_currency="usd", source=SOURCE_NAME)
+    finally:
+        database.close()
+
+    result: dict[str, tuple[tuple[int, Decimal], ...]] = {}
+    for symbol in sorted(required):
+        selected = rates_df.loc[rates_df["quote_currency"].str.casefold() == symbol.casefold()].sort_values("date")
+        if selected.empty:
+            raise RuntimeError(f"Asseto product history requires {symbol}/USD rates in {database_path}; run scan-currencies with QUOTE_CURRENCIES including {symbol.lower()}")
+        result[symbol] = tuple(
+            (
+                int(datetime.datetime.combine(row.date, datetime.time.min, tzinfo=datetime.UTC).timestamp()),
+                Decimal(str(row.rate)),
+            )
+            for row in selected.itertuples(index=False)
+        )
+    return result
 
 
 def create_asseto_runtime_product(
     product: AssetoOffchainProduct,
     first_seen_at_block: int,
     first_seen_at: datetime.datetime,
+    usd_exchange_rates: tuple[tuple[int, Decimal], ...] = (),
 ) -> AssetoProduct:
-    """Create one adapter product from API identity and onchain discovery data."""
+    """Create one adapter product from API identity and onchain discovery.
+
+    The scheduled and manual paths use this constructor so product identity,
+    offchain NAV lookup and non-USD conversion state cannot diverge.
+
+    :param product:
+        Normalised public Asseto product entry.
+    :param first_seen_at_block:
+        First onchain block containing the token's code.
+    :param first_seen_at:
+        Naive UTC token deployment timestamp.
+    :param usd_exchange_rates:
+        Historical units of the denomination currency per USD, if required.
+    :return:
+        Adapter-ready Asseto product record.
+    """
 
     return AssetoProduct(
         chain_id=product.chain_id,
@@ -80,6 +165,7 @@ def create_asseto_runtime_product(
         first_seen_at_block=first_seen_at_block,
         first_seen_at=first_seen_at,
         denomination_symbol=resolve_asseto_denomination_symbol(product),
+        usd_exchange_rates=usd_exchange_rates,
         offchain_product_id=product.product_id,
         offchain_product_name=product.product_name,
         description=product.introduction,
@@ -87,7 +173,22 @@ def create_asseto_runtime_product(
 
 
 def fetch_asseto_deployment_block(web3: Web3, address: HexAddress, end_block: int) -> int:
-    """Find the first token-code block for a newly registered product."""
+    """Find the first token-code block for a newly registered product.
+
+    The public registry has no deployment block, so a binary search over an
+    archive-capable provider supplies the start boundary for history scans.
+
+    :param web3:
+        Archive-capable product-chain connection.
+    :param address:
+        Asseto token contract address.
+    :param end_block:
+        Latest block at which the token must have deployed code.
+    :return:
+        Earliest block containing token runtime code.
+    :raise ValueError:
+        If the registry address has no code at ``end_block``.
+    """
 
     checksum_address = Web3.to_checksum_address(address)
     if not web3.eth.get_code(checksum_address, block_identifier=end_block):
@@ -103,8 +204,17 @@ def fetch_asseto_deployment_block(web3: Web3, address: HexAddress, end_block: in
     return low
 
 
-def _create_detection(product: AssetoProduct) -> ERC4262VaultDetection:
-    """Create the minimal synthetic detection needed for metadata upserts."""
+def create_asseto_detection(product: AssetoProduct) -> ERC4262VaultDetection:
+    """Create the minimal synthetic detection needed for metadata upserts.
+
+    Asseto products do not emit ERC-4626 discovery events, so their metadata
+    read uses this equivalent persisted detection record.
+
+    :param product:
+        Adapter-ready Asseto product record.
+    :return:
+        Detection compatible with the shared vault metadata scanner.
+    """
 
     return ERC4262VaultDetection(
         chain=product.chain_id,
@@ -116,6 +226,65 @@ def _create_detection(product: AssetoProduct) -> ERC4262VaultDetection:
         deposit_count=0,
         redeem_count=0,
     )
+
+
+def create_asseto_lead(product: AssetoProduct) -> PotentialVaultMatch:
+    """Create a synthetic discovery lead for one Asseto product.
+
+    :param product:
+        Fully resolved Asseto adapter product.
+    :return:
+        Lead compatible with the persistent vault metadata database.
+    """
+
+    return PotentialVaultMatch(
+        chain=product.chain_id,
+        address=product.token,
+        first_seen_at_block=product.first_seen_at_block,
+        first_seen_at=product.first_seen_at,
+        deposit_count=0,
+        withdrawal_count=0,
+    )
+
+
+def _is_usable_metadata_row(row: dict[str, object]) -> bool:
+    """Return whether a metadata read produced a publishable Asseto row.
+
+    :param row:
+        Record returned by the shared vault metadata scanner.
+    :return:
+        ``True`` when the row has a live NAV and is not a broken placeholder.
+    """
+
+    return row.get("NAV") is not None and not str(row.get("Name", "")).startswith("<broken:")
+
+
+def _restore_runtime_product(
+    product: AssetoProduct,
+    previous_product: AssetoProduct | None,
+    previous_product_by_token: AssetoProduct | None,
+) -> None:
+    """Restore runtime mappings after an unsuccessful temporary registration.
+
+    :param product:
+        Product temporarily installed for shared adapter construction.
+    :param previous_product:
+        Mapping value before the temporary installation, if any.
+    :param previous_product_by_token:
+        Address mapping value before the temporary installation, if any.
+    :return:
+        None.
+    """
+
+    key = (product.chain_id, product.token)
+    if previous_product is None:
+        ASSETO_PRODUCTS.pop(key, None)
+    else:
+        ASSETO_PRODUCTS[key] = previous_product
+    if previous_product_by_token is None:
+        ASSETO_PRODUCTS_BY_TOKEN.pop(product.token, None)
+    else:
+        ASSETO_PRODUCTS_BY_TOKEN[product.token] = previous_product_by_token
 
 
 def fetch_asseto_registry_preparation(  # noqa: PLR0914 - explicit product registration state keeps database writes auditable.
@@ -147,12 +316,22 @@ def fetch_asseto_registry_preparation(  # noqa: PLR0914 - explicit product regis
     registry = fetch_asseto_registry(cache_path=cache_path)
     if not registry.is_usable:
         raise RuntimeError(f"Asseto registry is unavailable: {registry.diagnostics}")
-    vault_db = VaultDatabase.read(vault_db_path) if vault_db_path.exists() else VaultDatabase()
     diagnostics: list[str] = [registry.diagnostics] if registry.diagnostics else []
+    if not vault_db_path.exists():
+        diagnostics.append(f"vault metadata database does not exist: {vault_db_path}")
+        return AssetoRegistryRefreshResult(registry.status, 0, 0, tuple(diagnostics))
+
+    vault_db = VaultDatabase.read(vault_db_path)
     runtime_products: list[AssetoProduct] = []
     new_rows = {}
     metadata_updated = False
     registered_count = 0
+    available_specs: set[VaultSpec] = set()
+    exchange_rate_database_path = resolve_exchange_rate_database_path(vault_db_path.parent)
+    exchange_rates_by_symbol: dict[str, tuple[tuple[int, Decimal], ...]] = {}
+    unusable_symbols: set[str] = set()
+    web3_by_chain: dict[int, Web3] = {}
+    end_blocks: dict[int, int] = {}
     owned_cache = token_cache is None
     if token_cache is None:
         token_cache = TokenDiskCache()
@@ -164,44 +343,74 @@ def fetch_asseto_registry_preparation(  # noqa: PLR0914 - explicit product regis
             if resolve_asseto_denomination_symbol(offchain_product) is None:
                 diagnostics.append(f"no denomination for {offchain_product.contract_address}")
                 continue
+            denomination_symbol = resolve_asseto_denomination_symbol(offchain_product)
+            assert denomination_symbol is not None
+            if denomination_symbol not in ASSETO_USD_DENOMINATIONS and denomination_symbol not in exchange_rates_by_symbol and denomination_symbol not in unusable_symbols:
+                try:
+                    exchange_rates_by_symbol.update(load_usd_exchange_rates(exchange_rate_database_path, (denomination_symbol,)))
+                except RuntimeError as exc:
+                    unusable_symbols.add(denomination_symbol)
+                    diagnostics.append(f"no {denomination_symbol}/USD history for {offchain_product.contract_address}: {exc}")
+            if denomination_symbol in unusable_symbols:
+                continue
             spec = VaultSpec(offchain_product.chain_id, offchain_product.contract_address)
             existing_row = vault_db.rows.get(spec)
             if existing_row is not None:
                 detection = existing_row["_detection_data"]
-                runtime_products.append(create_asseto_runtime_product(offchain_product, detection.first_seen_at_block, detection.first_seen_at))
-                if registry.status == "fresh" and offchain_product.introduction and existing_row.get("Description") != offchain_product.introduction:
-                    existing_row["Description"] = offchain_product.introduction
+                runtime_products.append(create_asseto_runtime_product(offchain_product, detection.first_seen_at_block, detection.first_seen_at, exchange_rates_by_symbol.get(denomination_symbol, ())))
+                available_specs.add(spec)
+                if registry.status == "fresh" and offchain_product.introduction and existing_row.get("_description") != offchain_product.introduction:
+                    existing_row["_description"] = offchain_product.introduction
+                    existing_row["_short_description"] = create_asseto_short_description(offchain_product.introduction)
                     metadata_updated = True
                 continue
             if registry.status != "fresh":
                 continue
+            runtime_product: AssetoProduct | None = None
+            previous_product: AssetoProduct | None = None
+            previous_product_by_token: AssetoProduct | None = None
             try:
-                web3 = create_multi_provider_web3(read_json_rpc_url(offchain_product.chain_id))
-                end_block = web3.eth.block_number
+                web3 = web3_by_chain.get(offchain_product.chain_id)
+                if web3 is None:
+                    web3 = create_multi_provider_web3(read_json_rpc_url(offchain_product.chain_id))
+                    web3_by_chain[offchain_product.chain_id] = web3
+                    end_blocks[offchain_product.chain_id] = web3.eth.block_number
+                end_block = end_blocks[offchain_product.chain_id]
                 deployment_block = fetch_asseto_deployment_block(web3, offchain_product.contract_address, end_block)
                 timestamp = web3.eth.get_block(deployment_block)["timestamp"]
                 first_seen_at = datetime.datetime.fromtimestamp(timestamp, tz=datetime.UTC).replace(tzinfo=None)
-                runtime_product = create_asseto_runtime_product(offchain_product, deployment_block, first_seen_at)
+                runtime_product = create_asseto_runtime_product(offchain_product, deployment_block, first_seen_at, exchange_rates_by_symbol.get(denomination_symbol, ()))
                 # ``create_vault_scan_record()`` constructs the normal adapter,
                 # so register this one product before its first metadata read.
+                previous_product = ASSETO_PRODUCTS.get((runtime_product.chain_id, runtime_product.token))
+                previous_product_by_token = ASSETO_PRODUCTS_BY_TOKEN.get(runtime_product.token)
                 install_asseto_runtime_products([runtime_product])
-                row = create_vault_scan_record(web3, detection=_create_detection(runtime_product), block_identifier=end_block, token_cache=token_cache)
+                row = create_vault_scan_record(web3, detection=create_asseto_detection(runtime_product), block_identifier=end_block, token_cache=token_cache)
             except (OSError, ValueError, RuntimeError, Web3Exception) as exc:
+                if runtime_product is not None:
+                    _restore_runtime_product(runtime_product, previous_product, previous_product_by_token)
                 diagnostics.append(f"could not register {offchain_product.contract_address}: {exc}")
                 logger.warning("Could not register Asseto product %s: %s", offchain_product.contract_address, exc)
                 continue
+            if not _is_usable_metadata_row(row):
+                assert runtime_product is not None
+                _restore_runtime_product(runtime_product, previous_product, previous_product_by_token)
+                diagnostics.append(f"metadata read for {offchain_product.contract_address} did not produce a usable NAV")
+                continue
             runtime_products.append(runtime_product)
             new_rows[spec] = row
+            available_specs.add(spec)
             registered_count += 1
 
         install_asseto_runtime_products(runtime_products)
         if registry.status == "fresh" and (new_rows or metadata_updated):
             if new_rows:
                 vault_db._merge_rows(new_rows)
+                vault_db.leads.update({VaultSpec(product.chain_id, product.token): create_asseto_lead(product) for product in runtime_products if VaultSpec(product.chain_id, product.token) in new_rows})
             vault_db_path.parent.mkdir(parents=True, exist_ok=True)
             vault_db.write(vault_db_path)
     finally:
         if owned_cache:
             token_cache.commit()
 
-    return AssetoRegistryRefreshResult(registry.status, len(runtime_products), registered_count, tuple(diagnostics))
+    return AssetoRegistryRefreshResult(registry.status, len(runtime_products), registered_count, tuple(diagnostics), frozenset(available_specs))

--- a/eth_defi/tokenised_fund/asseto/registry.py
+++ b/eth_defi/tokenised_fund/asseto/registry.py
@@ -1,0 +1,192 @@
+"""Build runtime Asseto adapter products from the persisted public registry.
+
+The recurring scanner persists Asseto vault rows across process restarts, while
+the adapter needs an in-memory product record.  This module rebuilds that
+runtime registry before a daily scan and registers newly published supported
+products from the same fresh API snapshot.
+"""
+
+import datetime
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from eth_typing import HexAddress
+from web3 import Web3
+
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
+from eth_defi.erc_4626.scan import create_vault_scan_record
+from eth_defi.provider.env import read_json_rpc_url
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.token import TokenDiskCache
+from eth_defi.tokenised_fund.asseto.constants import AssetoProduct, install_asseto_runtime_products
+from eth_defi.tokenised_fund.asseto.offchain_api import AssetoOffchainProduct
+from eth_defi.tokenised_fund.asseto.offchain_metadata import DEFAULT_ASSETO_REGISTRY_CACHE_PATH, fetch_asseto_registry
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.vaultdb import VaultDatabase
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class AssetoRegistryRefreshResult:
+    """Summary of runtime registry preparation for one scanner invocation."""
+
+    status: str
+    runtime_product_count: int
+    registered_product_count: int
+    diagnostics: tuple[str, ...]
+
+
+def resolve_asseto_denomination_symbol(product: AssetoOffchainProduct) -> str | None:
+    """Resolve the accounting denomination from Asseto's public product data."""
+
+    if product.denomination_symbol:
+        return product.denomination_symbol.upper()
+    return "USD" if product.product_type == "stoken" else None
+
+
+def create_asseto_runtime_product(
+    product: AssetoOffchainProduct,
+    first_seen_at_block: int,
+    first_seen_at: datetime.datetime,
+) -> AssetoProduct:
+    """Create one adapter product from API identity and onchain discovery data."""
+
+    return AssetoProduct(
+        chain_id=product.chain_id,
+        token=product.contract_address,
+        symbol=product.symbol or product.product_name,
+        product_name=product.full_name or product.product_name,
+        manager=None,
+        pricer=None,
+        collateral=product.denomination_address,
+        first_seen_at_block=first_seen_at_block,
+        first_seen_at=first_seen_at,
+        denomination_symbol=resolve_asseto_denomination_symbol(product),
+        offchain_product_id=product.product_id,
+        offchain_product_name=product.product_name,
+        description=product.introduction,
+    )
+
+
+def fetch_asseto_deployment_block(web3: Web3, address: HexAddress, end_block: int) -> int:
+    """Find the first token-code block for a newly registered product."""
+
+    checksum_address = Web3.to_checksum_address(address)
+    if not web3.eth.get_code(checksum_address, block_identifier=end_block):
+        raise ValueError(f"No contract code for Asseto product {address} at block {end_block}")
+    low = 0
+    high = end_block
+    while low < high:
+        middle = (low + high) // 2
+        if web3.eth.get_code(checksum_address, block_identifier=middle):
+            high = middle
+        else:
+            low = middle + 1
+    return low
+
+
+def _create_detection(product: AssetoProduct) -> ERC4262VaultDetection:
+    """Create the minimal synthetic detection needed for metadata upserts."""
+
+    return ERC4262VaultDetection(
+        chain=product.chain_id,
+        address=product.token,
+        first_seen_at_block=product.first_seen_at_block,
+        first_seen_at=product.first_seen_at,
+        features={ERC4626Feature.asseto_like},
+        updated_at=native_datetime_utc_now(),
+        deposit_count=0,
+        redeem_count=0,
+    )
+
+
+def prepare_asseto_registry(  # noqa: PLR0914 - explicit product registration state keeps database writes auditable.
+    *,
+    vault_db_path: Path,
+    enabled_chain_ids: frozenset[int],
+    cache_path: Path = DEFAULT_ASSETO_REGISTRY_CACHE_PATH,
+    token_cache: TokenDiskCache | None = None,
+) -> AssetoRegistryRefreshResult:
+    """Refresh Asseto metadata, register new products and rebuild adapters.
+
+    Fresh API data may register products and update their metadata.  Stale data
+    is deliberately limited to rebuilding runtime entries for already-persisted
+    Asseto rows, so an outage cannot write old API values into the vault
+    database.
+
+    :param vault_db_path:
+        Persistent vault metadata database used by the recurring scanner.
+    :param enabled_chain_ids:
+        Chains available to the operator in this invocation.
+    :param cache_path:
+        Shared Asseto registry cache path.
+    :param token_cache:
+        Optional shared token cache for metadata reads.
+    :return:
+        Preparation outcome and non-fatal product diagnostics.
+    """
+
+    registry = fetch_asseto_registry(cache_path=cache_path, force_refresh=True)
+    if not registry.is_usable:
+        raise RuntimeError(f"Asseto registry is unavailable: {registry.diagnostics}")
+    vault_db = VaultDatabase.read(vault_db_path) if vault_db_path.exists() else VaultDatabase()
+    diagnostics: list[str] = [registry.diagnostics] if registry.diagnostics else []
+    runtime_products: list[AssetoProduct] = []
+    new_rows = {}
+    metadata_updated = False
+    registered_count = 0
+    owned_cache = token_cache is None
+    if token_cache is None:
+        token_cache = TokenDiskCache()
+    try:
+        for offchain_product in registry.products:
+            if offchain_product.chain_id not in enabled_chain_ids:
+                diagnostics.append(f"chain {offchain_product.chain_id} is disabled for {offchain_product.contract_address}")
+                continue
+            if resolve_asseto_denomination_symbol(offchain_product) is None:
+                diagnostics.append(f"no denomination for {offchain_product.contract_address}")
+                continue
+            spec = VaultSpec(offchain_product.chain_id, offchain_product.contract_address)
+            existing_row = vault_db.rows.get(spec)
+            if existing_row is not None:
+                detection = existing_row["_detection_data"]
+                runtime_products.append(create_asseto_runtime_product(offchain_product, detection.first_seen_at_block, detection.first_seen_at))
+                if registry.status == "fresh" and offchain_product.introduction and existing_row.get("Description") != offchain_product.introduction:
+                    existing_row["Description"] = offchain_product.introduction
+                    metadata_updated = True
+                continue
+            if registry.status != "fresh":
+                continue
+            try:
+                web3 = create_multi_provider_web3(read_json_rpc_url(offchain_product.chain_id))
+                end_block = web3.eth.block_number
+                deployment_block = fetch_asseto_deployment_block(web3, offchain_product.contract_address, end_block)
+                timestamp = web3.eth.get_block(deployment_block)["timestamp"]
+                first_seen_at = datetime.datetime.fromtimestamp(timestamp, tz=datetime.UTC).replace(tzinfo=None)
+                runtime_product = create_asseto_runtime_product(offchain_product, deployment_block, first_seen_at)
+                # ``create_vault_scan_record()`` constructs the normal adapter,
+                # so register this one product before its first metadata read.
+                install_asseto_runtime_products([runtime_product])
+                row = create_vault_scan_record(web3, detection=_create_detection(runtime_product), block_identifier=end_block, token_cache=token_cache)
+            except (OSError, ValueError, RuntimeError) as exc:
+                diagnostics.append(f"could not register {offchain_product.contract_address}: {exc}")
+                logger.warning("Could not register Asseto product %s: %s", offchain_product.contract_address, exc)
+                continue
+            runtime_products.append(runtime_product)
+            new_rows[spec] = row
+            registered_count += 1
+
+        install_asseto_runtime_products(runtime_products)
+        if registry.status == "fresh" and (new_rows or metadata_updated):
+            if new_rows:
+                vault_db._merge_rows(new_rows)
+            vault_db_path.parent.mkdir(parents=True, exist_ok=True)
+            vault_db.write(vault_db_path)
+    finally:
+        if owned_cache:
+            token_cache.commit()
+
+    return AssetoRegistryRefreshResult(registry.status, len(runtime_products), registered_count, tuple(diagnostics))

--- a/eth_defi/tokenised_fund/asseto/vault.py
+++ b/eth_defi/tokenised_fund/asseto/vault.py
@@ -75,9 +75,9 @@ ASSETO_MANAGER_FEE_ABI = [
 #: Generic manager reason used to keep Asseto outside public transaction flows.
 ASSETO_BLOCKED_FLOW_REASON = "Asseto deposit manager is blocked: KYC-gated request/claim subscriptions and redemptions are not supported"
 
-#: Official Asseto documentation for the Orient Arbitrage Token. This is the
-#: public product landing page, rather than the token's block-explorer record.
-ASSETO_AOABT_HOMEPAGE = "https://asseto.gitbook.io/asseto/products/aoabt/introduction"
+#: Fallback Asseto product index for API-discovered products without a reviewed
+#: product-specific homepage.
+ASSETO_PRODUCT_INDEX_URL = "https://asseto.finance/product"
 
 
 def create_asseto_short_description(description: str | None) -> str | None:
@@ -294,16 +294,17 @@ class AssetoVault(TokenisedFundVault):
         return create_asseto_short_description(self.product.description)
 
     def get_link(self, referral: str | None = None) -> str:
-        """Return the official Asseto Orient Arbitrage product page.
+        """Return the official product page or the Asseto product index.
 
         :param referral:
             Ignored because Asseto does not expose referral URLs.
         :return:
-            Asseto's public product documentation.
+            Product-specific reviewed documentation when available, otherwise
+            Asseto's public product index.
         """
 
         _ = referral
-        return ASSETO_AOABT_HOMEPAGE
+        return self.product.homepage or ASSETO_PRODUCT_INDEX_URL
 
     @property
     def manager_name(self) -> str | None:

--- a/eth_defi/tokenised_fund/scan.py
+++ b/eth_defi/tokenised_fund/scan.py
@@ -26,6 +26,8 @@ from eth_defi.provider.env import read_json_rpc_url
 from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_multi_provider_web3
 from eth_defi.provider.rpcdb import RPCRequestStats
 from eth_defi.token import TokenDiskCache
+from eth_defi.tokenised_fund.asseto.offchain_metadata import DEFAULT_ASSETO_REGISTRY_CACHE_PATH
+from eth_defi.tokenised_fund.asseto.registry import prepare_asseto_registry
 from eth_defi.tokenised_fund.libeara.constants import LIBEARA_PRODUCTS
 from eth_defi.tokenised_fund.securitize.backfill import has_historical_price
 from eth_defi.tokenised_fund.securitize.description import SECURITIZE_PRODUCTS
@@ -102,6 +104,9 @@ class TokenisedFundPriceScanContext:
 
     #: Optional shared physical JSON-RPC request counter.
     rpc_request_stats: RPCRequestStats | None = None
+
+    #: Optional persistent Asseto registry cache override for isolated runs.
+    asseto_registry_cache_path: Path | None = None
 
 
 @dataclass(slots=True)
@@ -375,6 +380,16 @@ def run_tokenised_fund_price_scan(  # noqa: PLR0914 - explicit production resour
         If the metadata database or a selected product adapter is invalid.
     """
 
+    registry_diagnostics: list[str] = []
+    if spec.selector == "asseto":
+        registry_result = prepare_asseto_registry(
+            vault_db_path=context.vault_db_path,
+            enabled_chain_ids=context.enabled_chain_ids,
+            cache_path=context.asseto_registry_cache_path or DEFAULT_ASSETO_REGISTRY_CACHE_PATH,
+        )
+        registry_diagnostics.extend(registry_result.diagnostics)
+        registry_diagnostics.append(f"registry={registry_result.status}, runtime_products={registry_result.runtime_product_count}, registered_products={registry_result.registered_product_count}")
+
     if not context.vault_db_path.exists():
         raise RuntimeError(f"Tokenised-fund metadata database does not exist: {context.vault_db_path}")
     vault_db = VaultDatabase.read(context.vault_db_path)
@@ -382,11 +397,15 @@ def run_tokenised_fund_price_scan(  # noqa: PLR0914 - explicit production resour
     if context.vault_addresses is not None:
         target_rows = [(target, row) for target, row in target_rows if target.vault_address in context.vault_addresses]
     if not target_rows:
-        return TokenisedFundPriceScanResult(0, 0, None, None, None, "no registered price-capable products")
+        diagnostics = [*registry_diagnostics, "no registered price-capable products"]
+        return TokenisedFundPriceScanResult(0, 0, None, None, None, "; ".join(diagnostics))
 
     enabled_rows = [(target, row) for target, row in target_rows if target.chain_id in context.enabled_chain_ids]
     target_specs = {target for target, _ in enabled_rows}
-    diagnostics = [f"chain {target.chain_id} disabled by operator" for target, _ in target_rows if target.chain_id not in context.enabled_chain_ids]
+    diagnostics = [
+        *registry_diagnostics,
+        *(f"chain {target.chain_id} disabled by operator" for target, _ in target_rows if target.chain_id not in context.enabled_chain_ids),
+    ]
     if not enabled_rows:
         return TokenisedFundPriceScanResult(0, 0, None, None, None, "; ".join(sorted(set(diagnostics))))
 

--- a/eth_defi/tokenised_fund/scan.py
+++ b/eth_defi/tokenised_fund/scan.py
@@ -381,6 +381,7 @@ def run_tokenised_fund_price_scan(  # noqa: PLR0914 - explicit production resour
     """
 
     registry_diagnostics: list[str] = []
+    available_asseto_specs: frozenset[VaultSpec] | None = None
     if spec.selector == "asseto":
         registry_result = fetch_asseto_registry_preparation(
             vault_db_path=context.vault_db_path,
@@ -388,12 +389,17 @@ def run_tokenised_fund_price_scan(  # noqa: PLR0914 - explicit production resour
             cache_path=context.asseto_registry_cache_path or DEFAULT_ASSETO_REGISTRY_CACHE_PATH,
         )
         registry_diagnostics.extend(registry_result.diagnostics)
+        available_asseto_specs = registry_result.available_specs
         registry_diagnostics.append(f"registry={registry_result.status}, runtime_products={registry_result.runtime_product_count}, registered_products={registry_result.registered_product_count}")
 
     if not context.vault_db_path.exists():
         raise RuntimeError(f"Tokenised-fund metadata database does not exist: {context.vault_db_path}")
     vault_db = VaultDatabase.read(context.vault_db_path)
     target_rows = list(_iter_target_rows(vault_db, spec))
+    if available_asseto_specs is not None:
+        unavailable_targets = [target for target, _ in target_rows if target not in available_asseto_specs]
+        registry_diagnostics.extend(f"no usable Asseto runtime registry product for {target.as_string_id()}" for target in unavailable_targets)
+        target_rows = [(target, row) for target, row in target_rows if target in available_asseto_specs]
     if context.vault_addresses is not None:
         target_rows = [(target, row) for target, row in target_rows if target.vault_address in context.vault_addresses]
     if not target_rows:

--- a/eth_defi/tokenised_fund/scan.py
+++ b/eth_defi/tokenised_fund/scan.py
@@ -27,7 +27,7 @@ from eth_defi.provider.multi_provider import MultiProviderWeb3Factory, create_mu
 from eth_defi.provider.rpcdb import RPCRequestStats
 from eth_defi.token import TokenDiskCache
 from eth_defi.tokenised_fund.asseto.offchain_metadata import DEFAULT_ASSETO_REGISTRY_CACHE_PATH
-from eth_defi.tokenised_fund.asseto.registry import prepare_asseto_registry
+from eth_defi.tokenised_fund.asseto.registry import fetch_asseto_registry_preparation
 from eth_defi.tokenised_fund.libeara.constants import LIBEARA_PRODUCTS
 from eth_defi.tokenised_fund.securitize.backfill import has_historical_price
 from eth_defi.tokenised_fund.securitize.description import SECURITIZE_PRODUCTS
@@ -382,7 +382,7 @@ def run_tokenised_fund_price_scan(  # noqa: PLR0914 - explicit production resour
 
     registry_diagnostics: list[str] = []
     if spec.selector == "asseto":
-        registry_result = prepare_asseto_registry(
+        registry_result = fetch_asseto_registry_preparation(
             vault_db_path=context.vault_db_path,
             enabled_chain_ids=context.enabled_chain_ids,
             cache_path=context.asseto_registry_cache_path or DEFAULT_ASSETO_REGISTRY_CACHE_PATH,

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -245,7 +245,6 @@ poetry run python scripts/erc-4626/scan-vaults-all-chains.py
 | `TOKENISED_FUND_MAX_WORKERS` | Optional. Historical reader workers for tokenised-fund feeds. Default: 8. |
 | `WISDOMTREE_DATASPAN_API_KEY` | Optional. Enables the WisdomTree DataSpan NAV feed; without it WisdomTree remains visibly disabled. |
 | `RETRY_COUNT` | Optional. Number of retries on failure. |
-
 | `TEST_CHAINS` | Optional. Comma-separated chain names to scan (for testing). Use `none` to skip all EVM chains. |
 | `DISABLE_CHAINS` | Optional. Comma-separated chain names to exclude. |
 | `SKIP_POST_PROCESSING` | Optional. Skip post-processing steps. |
@@ -263,6 +262,7 @@ poetry run python scripts/erc-4626/scan-vaults-all-chains.py
 | `SCAN_LIGHTER` | Optional. Enable native pool scanning for both Lighter Ethereum and Lighter Robinhood. Default: false. |
 | `SCAN_HIBACHI` | Optional. Enable Hibachi native vault scanning. Default: false. |
 | `SCAN_APEX` | Optional. Enable ApeX native vault scanning and due history maintenance. Default: false. |
+
 | `SCAN_VAULT_SETTLEMENTS` | Optional. Scan Lagoon and D2 settlement events during each successful EVM chain cycle. Default: true. The scan fills `vault-settlements.duckdb` before price cleaning; `vault_settlement_at` is then merged into the cleaned price frame during cleaning. Set to `false` only for debugging runs where new settlement event reads are deliberately skipped. Settlement scan failures are logged and shown in the dashboard without aborting the rest of the scanner cycle. |
 | `VAULT_SETTLEMENT_START_BLOCK` | Optional. Inclusive settlement scan start block for forced backfills. Normally unset so scans continue incrementally from `vault-settlements.duckdb`. |
 | `VAULT_SETTLEMENT_END_BLOCK` | Optional. Inclusive settlement scan end block for forced backfills. Normally unset so scans continue up to the just-completed chain scan end block. |
@@ -325,6 +325,15 @@ source precedence, daily history, stale-cache and repair behaviour.
 Dedicated tokenised-fund feeds retain one daily sample per selected block even
 when the NAV is unchanged. This is intentional: a stable share price is still
 a fresh observation and must advance the dashboard's `Last data` timestamp.
+
+#### check-asseto-registry.py
+
+Inspect the live Asseto registry and report products that the scheduled scanner
+can or cannot use. The command is read-only.
+
+```shell
+poetry run python scripts/erc-4626/check-asseto-registry.py
+```
 
 Both Lighter deployments use synthetic native-pool chain ID `9998`; their
 address prefixes distinguish price series. Lifetime-metrics export the

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -245,6 +245,7 @@ poetry run python scripts/erc-4626/scan-vaults-all-chains.py
 | `TOKENISED_FUND_MAX_WORKERS` | Optional. Historical reader workers for tokenised-fund feeds. Default: 8. |
 | `WISDOMTREE_DATASPAN_API_KEY` | Optional. Enables the WisdomTree DataSpan NAV feed; without it WisdomTree remains visibly disabled. |
 | `RETRY_COUNT` | Optional. Number of retries on failure. |
+
 | `TEST_CHAINS` | Optional. Comma-separated chain names to scan (for testing). Use `none` to skip all EVM chains. |
 | `DISABLE_CHAINS` | Optional. Comma-separated chain names to exclude. |
 | `SKIP_POST_PROCESSING` | Optional. Skip post-processing steps. |
@@ -310,6 +311,16 @@ chain scanner. The dashboard's
 original publication time of an oracle or issuer observation. Securitize is
 therefore the recurring owner of BCAP and fills its missing sampled history as
 far back as its reviewed source permits.
+
+### Asseto registry refresh
+
+The daily `Asseto` tokenised-fund row refreshes Asseto's public product registry
+before it creates any Asseto adapter. The validated registry cache survives a
+scanner restart at `~/.tradingstrategy/cache/asseto/registry-cache.json`; a
+temporary upstream failure may rebuild known adapters from that cache but cannot
+write stale metadata or introduce a new product. See
+[`README-Asseto.md`](../../eth_defi/tokenised_fund/asseto/README-Asseto.md) for
+source precedence, daily history, stale-cache and repair behaviour.
 
 Dedicated tokenised-fund feeds retain one daily sample per selected block even
 when the NAV is unchanged. This is intentional: a stable share price is still

--- a/scripts/erc-4626/check-asseto-registry.py
+++ b/scripts/erc-4626/check-asseto-registry.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Print Asseto's current EVM registry without modifying scanner state.
+
+The command deliberately reads Asseto's public application endpoint directly:
+it neither writes the persistent registry cache nor opens the vault database.
+Use it before a production rollout to review supported chains, denominations
+and public daily-NAV identities.
+"""
+
+import logging
+import os
+
+from tabulate import tabulate
+
+from eth_defi.tokenised_fund.asseto.offchain_api import fetch_asseto_products
+from eth_defi.utils import setup_console_logging
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    """Fetch and print the current parseable EVM Asseto registry."""
+
+    setup_console_logging(default_log_level=os.environ.get("LOG_LEVEL", "info"))
+    products = list(fetch_asseto_products())
+    rows = [
+        {
+            "chain_id": product.chain_id,
+            "address": product.contract_address,
+            "symbol": product.symbol,
+            "denomination": product.denomination_symbol,
+            "product_id": product.product_id,
+            "product_name": product.product_name,
+        }
+        for product in products
+    ]
+    logger.info("Asseto public EVM registry\n%s", tabulate(rows, headers="keys", tablefmt="github"))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/asseto/test_asseto_backfill_history.py
+++ b/tests/asseto/test_asseto_backfill_history.py
@@ -16,11 +16,13 @@ from eth_defi.currency_api.database import CurrencyRateDatabase
 from eth_defi.tokenised_fund.asseto import backfill
 from eth_defi.tokenised_fund.asseto.constants import ASSETO_AOABT_HASHKEY
 from eth_defi.tokenised_fund.asseto.offchain_api import AssetoOffchainProduct
+from eth_defi.tokenised_fund.asseto.offchain_metadata import AssetoOffchainRegistryResult
 from eth_defi.tokenised_fund.asseto.vault import AssetoVault
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.historical import VaultHistoricalReadMulticaller
 
 EXPLICIT_START_BLOCK = 123_456
+REGISTRY_TIMESTAMP = datetime.datetime(2026, 8, 1, tzinfo=datetime.UTC).replace(tzinfo=None)
 
 
 def make_registry_product(chain_id: int, *, symbol: str = "AoABT") -> AssetoOffchainProduct:
@@ -64,7 +66,7 @@ def test_unsupported_asseto_chain_is_excluded_from_backfill(monkeypatch: pytest.
 
     assert ASSETO_AOABT_HASHKEY.chain_id not in CHAIN_NAMES
     assert not backfill_history_module.is_supported_asseto_chain(ASSETO_AOABT_HASHKEY.chain_id)
-    monkeypatch.setattr(backfill_history_module, "fetch_asseto_products", lambda: iter([make_registry_product(177)]))
+    monkeypatch.setattr(backfill_history_module, "fetch_asseto_registry", lambda: AssetoOffchainRegistryResult("fresh", (make_registry_product(177),), REGISTRY_TIMESTAMP))
     assert list(backfill_history_module.iter_selected_products()) == []
 
 
@@ -72,7 +74,7 @@ def test_supported_asseto_chain_uses_standard_rpc_configuration(monkeypatch: pyt
     """Select a registered HyperSync chain with its normal RPC environment variable."""
 
     ethereum_product = make_registry_product(1)
-    monkeypatch.setattr(backfill_history_module, "fetch_asseto_products", lambda: iter([ethereum_product]))
+    monkeypatch.setattr(backfill_history_module, "fetch_asseto_registry", lambda: AssetoOffchainRegistryResult("fresh", (ethereum_product,), REGISTRY_TIMESTAMP))
     monkeypatch.setenv("JSON_RPC_ETHEREUM", "https://ethereum-rpc.example")
 
     assert backfill_history_module.get_asseto_rpc_env(ethereum_product.chain_id) == "JSON_RPC_ETHEREUM"
@@ -83,7 +85,7 @@ def test_missing_rpc_excludes_supported_asseto_chain(monkeypatch: pytest.MonkeyP
     """Avoid partial backfills when the normal RPC variable is unset."""
 
     ethereum_product = make_registry_product(1)
-    monkeypatch.setattr(backfill_history_module, "fetch_asseto_products", lambda: iter([ethereum_product]))
+    monkeypatch.setattr(backfill_history_module, "fetch_asseto_registry", lambda: AssetoOffchainRegistryResult("fresh", (ethereum_product,), REGISTRY_TIMESTAMP))
     monkeypatch.delenv("JSON_RPC_ETHEREUM", raising=False)
 
     assert list(backfill_history_module.iter_selected_products()) == []
@@ -242,7 +244,7 @@ def test_iter_selected_products_honours_symbol_filter(monkeypatch: pytest.Monkey
     """Select a requested product when its chain meets all backfill requirements."""
 
     ethereum_product = make_registry_product(1)
-    monkeypatch.setattr(backfill_history_module, "fetch_asseto_products", lambda: iter([ethereum_product]))
+    monkeypatch.setattr(backfill_history_module, "fetch_asseto_registry", lambda: AssetoOffchainRegistryResult("fresh", (ethereum_product,), REGISTRY_TIMESTAMP))
     monkeypatch.setenv("PRODUCTS", "aoabt")
     monkeypatch.setenv("NETWORKS", "ethereum")
     monkeypatch.setenv("JSON_RPC_ETHEREUM", "https://ethereum-rpc.example")

--- a/tests/asseto/test_offchain_metadata.py
+++ b/tests/asseto/test_offchain_metadata.py
@@ -1,0 +1,146 @@
+"""Tests for Asseto registry cache and runtime preparation."""
+
+import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from eth_defi.tokenised_fund.asseto import offchain_metadata, registry
+from eth_defi.tokenised_fund.asseto.constants import ASSETO_PRODUCTS, ASSETO_PRODUCTS_BY_TOKEN
+from eth_defi.tokenised_fund.asseto.offchain_api import AssetoAPIError, AssetoOffchainProduct
+from eth_defi.tokenised_fund.asseto.offchain_metadata import AssetoOffchainRegistryResult
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.vaultdb import VaultDatabase
+
+NOW = datetime.datetime(2026, 8, 1, tzinfo=datetime.UTC).replace(tzinfo=None)
+
+
+def make_product() -> AssetoOffchainProduct:
+    """Create one deterministic public Asseto registry product."""
+
+    return AssetoOffchainProduct(
+        product_id=42,
+        product_name="BCAP",
+        full_name="Asseto test fund",
+        symbol="BCAP",
+        product_type="uda",
+        chain_id=1,
+        chain_name="Ethereum",
+        contract_address="0x78e80da0616887b46a31f39310c2a8b0fbd6a42d",
+        denomination_symbol="USDC",
+        denomination_address="0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        tvl=None,
+        apy=None,
+        introduction="Asseto supplied description",
+        protocol=None,
+    )
+
+
+def test_asseto_registry_cache_survives_api_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed refresh preserves the validated cached product identity."""
+
+    product = make_product()
+    cache_path = tmp_path / "registry.json"
+    now_ = NOW
+    monkeypatch.setattr(offchain_metadata, "fetch_asseto_products", lambda: iter([product]))
+
+    fresh = offchain_metadata.fetch_asseto_registry(cache_path=cache_path, now_=now_)
+
+    assert fresh.status == "fresh"
+    assert fresh.products == (product,)
+
+    def fail_fetch():
+        """Raise a deterministic upstream error."""
+
+        message = "upstream unavailable"
+        raise AssetoAPIError(message)
+
+    monkeypatch.setattr(offchain_metadata, "fetch_asseto_products", fail_fetch)
+    stale = offchain_metadata.fetch_asseto_registry(cache_path=cache_path, now_=now_ + datetime.timedelta(days=1))
+
+    assert stale.status == "stale"
+    assert stale.products == (product,)
+    assert "upstream unavailable" in (stale.diagnostics or "")
+
+
+def test_asseto_registry_rejects_empty_response_without_poisoning_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty API response falls back to the previous complete snapshot."""
+
+    product = make_product()
+    cache_path = tmp_path / "registry.json"
+    monkeypatch.setattr(offchain_metadata, "fetch_asseto_products", lambda: iter([product]))
+    offchain_metadata.fetch_asseto_registry(cache_path=cache_path, now_=NOW)
+    monkeypatch.setattr(offchain_metadata, "fetch_asseto_products", lambda: iter(()))
+
+    result = offchain_metadata.fetch_asseto_registry(cache_path=cache_path, now_=NOW + datetime.timedelta(days=1))
+
+    assert result.status == "stale"
+    assert result.products == (product,)
+
+
+def test_asseto_runtime_registry_rebuilds_existing_adapter_without_metadata_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stale snapshot rebuilds a restarted process without changing vault rows."""
+
+    product = make_product()
+    spec = VaultSpec(product.chain_id, product.contract_address)
+    detection = SimpleNamespace(first_seen_at_block=12_345, first_seen_at=datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC).replace(tzinfo=None))
+    vault_db_path = tmp_path / "vaults.pickle"
+    vault_db = VaultDatabase(rows={spec: {"_detection_data": detection, "Description": "stored metadata"}})
+    vault_db.write(vault_db_path)
+    monkeypatch.setattr(
+        registry,
+        "fetch_asseto_registry",
+        lambda **_kwargs: AssetoOffchainRegistryResult("stale", (product,), NOW, "offline"),
+    )
+    key = (product.chain_id, product.contract_address)
+    previous = ASSETO_PRODUCTS.get(key)
+    previous_by_token = ASSETO_PRODUCTS_BY_TOKEN.get(product.contract_address)
+    try:
+        result = registry.prepare_asseto_registry(vault_db_path=vault_db_path, enabled_chain_ids=frozenset({1}), cache_path=tmp_path / "registry.json")
+
+        assert result.status == "stale"
+        assert result.runtime_product_count == 1
+        assert result.registered_product_count == 0
+        assert ASSETO_PRODUCTS[key].offchain_product_id == product.product_id
+        assert VaultDatabase.read(vault_db_path).rows[spec]["Description"] == "stored metadata"
+    finally:
+        if previous is None:
+            ASSETO_PRODUCTS.pop(key, None)
+        else:
+            ASSETO_PRODUCTS[key] = previous
+        if previous_by_token is None:
+            ASSETO_PRODUCTS_BY_TOKEN.pop(product.contract_address, None)
+        else:
+            ASSETO_PRODUCTS_BY_TOKEN[product.contract_address] = previous_by_token
+
+
+def test_fresh_asseto_registry_updates_existing_description(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fresh API descriptions replace only the corresponding existing metadata."""
+
+    product = make_product()
+    spec = VaultSpec(product.chain_id, product.contract_address)
+    detection = SimpleNamespace(first_seen_at_block=12_345, first_seen_at=datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC).replace(tzinfo=None))
+    vault_db_path = tmp_path / "vaults.pickle"
+    VaultDatabase(rows={spec: {"_detection_data": detection, "Description": "old description"}}).write(vault_db_path)
+    monkeypatch.setattr(
+        registry,
+        "fetch_asseto_registry",
+        lambda **_kwargs: AssetoOffchainRegistryResult("fresh", (product,), NOW),
+    )
+    key = (product.chain_id, product.contract_address)
+    previous = ASSETO_PRODUCTS.get(key)
+    previous_by_token = ASSETO_PRODUCTS_BY_TOKEN.get(product.contract_address)
+    try:
+        registry.prepare_asseto_registry(vault_db_path=vault_db_path, enabled_chain_ids=frozenset({1}), cache_path=tmp_path / "registry.json")
+
+        assert VaultDatabase.read(vault_db_path).rows[spec]["Description"] == "Asseto supplied description"
+    finally:
+        if previous is None:
+            ASSETO_PRODUCTS.pop(key, None)
+        else:
+            ASSETO_PRODUCTS[key] = previous
+        if previous_by_token is None:
+            ASSETO_PRODUCTS_BY_TOKEN.pop(product.contract_address, None)
+        else:
+            ASSETO_PRODUCTS_BY_TOKEN[product.contract_address] = previous_by_token

--- a/tests/asseto/test_offchain_metadata.py
+++ b/tests/asseto/test_offchain_metadata.py
@@ -1,13 +1,17 @@
 """Tests for Asseto registry cache and runtime preparation."""
 
 import datetime
+from dataclasses import replace
+from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+from eth_defi.erc_4626 import classification
+from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.tokenised_fund.asseto import offchain_metadata, registry
-from eth_defi.tokenised_fund.asseto.constants import ASSETO_PRODUCTS, ASSETO_PRODUCTS_BY_TOKEN
+from eth_defi.tokenised_fund.asseto.constants import ASSETO_PRODUCTS, ASSETO_PRODUCTS_BY_TOKEN, install_asseto_runtime_products
 from eth_defi.tokenised_fund.asseto.offchain_api import AssetoAPIError, AssetoOffchainProduct
 from eth_defi.tokenised_fund.asseto.offchain_metadata import AssetoOffchainRegistryResult
 from eth_defi.vault.base import VaultSpec
@@ -79,10 +83,45 @@ def test_asseto_registry_rejects_empty_response_without_poisoning_cache(tmp_path
     assert result.products == (product,)
 
 
+def test_asseto_runtime_product_preserves_non_usd_exchange_rates() -> None:
+    """A scheduled non-USD product receives the same FX history as a backfill."""
+
+    product = replace(make_product(), denomination_symbol="HKD")
+    rates = ((1_700_000_000, Decimal("7.8")),)
+
+    runtime_product = registry.create_asseto_runtime_product(product, 12_345, NOW, rates)
+
+    assert runtime_product.denomination_symbol == "HKD"
+    assert runtime_product.usd_exchange_rates == rates
+
+
+def test_asseto_runtime_product_is_classified_without_stale_derived_mapping() -> None:
+    """A newly installed product is immediately recognised on its own chain."""
+
+    product = registry.create_asseto_runtime_product(make_product(), 12_345, NOW)
+    key = (product.chain_id, product.token)
+    previous = ASSETO_PRODUCTS.get(key)
+    previous_by_token = ASSETO_PRODUCTS_BY_TOKEN.get(product.token)
+    try:
+        install_asseto_runtime_products([product])
+
+        assert classification._get_hardcoded_protocol_features(product.token, product.chain_id) == {ERC4626Feature.asseto_like}
+        assert classification._get_hardcoded_protocol_features(product.token, 56) is None
+    finally:
+        if previous is None:
+            ASSETO_PRODUCTS.pop(key, None)
+        else:
+            ASSETO_PRODUCTS[key] = previous
+        if previous_by_token is None:
+            ASSETO_PRODUCTS_BY_TOKEN.pop(product.token, None)
+        else:
+            ASSETO_PRODUCTS_BY_TOKEN[product.token] = previous_by_token
+
+
 def test_asseto_runtime_registry_rebuilds_existing_adapter_without_metadata_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A stale snapshot rebuilds a restarted process without changing vault rows."""
 
-    product = make_product()
+    product = replace(make_product(), denomination_symbol="HKD")
     spec = VaultSpec(product.chain_id, product.contract_address)
     detection = SimpleNamespace(first_seen_at_block=12_345, first_seen_at=datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC).replace(tzinfo=None))
     vault_db_path = tmp_path / "vaults.pickle"
@@ -93,6 +132,7 @@ def test_asseto_runtime_registry_rebuilds_existing_adapter_without_metadata_writ
         "fetch_asseto_registry",
         lambda **_kwargs: AssetoOffchainRegistryResult("stale", (product,), NOW, "offline"),
     )
+    monkeypatch.setattr(registry, "load_usd_exchange_rates", lambda *_args: {"HKD": ((1_700_000_000, Decimal("7.8")),)})
     key = (product.chain_id, product.contract_address)
     previous = ASSETO_PRODUCTS.get(key)
     previous_by_token = ASSETO_PRODUCTS_BY_TOKEN.get(product.contract_address)
@@ -103,6 +143,7 @@ def test_asseto_runtime_registry_rebuilds_existing_adapter_without_metadata_writ
         assert result.runtime_product_count == 1
         assert result.registered_product_count == 0
         assert ASSETO_PRODUCTS[key].offchain_product_id == product.product_id
+        assert ASSETO_PRODUCTS[key].usd_exchange_rates == ((1_700_000_000, Decimal("7.8")),)
         assert VaultDatabase.read(vault_db_path).rows[spec]["Description"] == "stored metadata"
     finally:
         if previous is None:
@@ -122,7 +163,7 @@ def test_fresh_asseto_registry_updates_existing_description(tmp_path: Path, monk
     spec = VaultSpec(product.chain_id, product.contract_address)
     detection = SimpleNamespace(first_seen_at_block=12_345, first_seen_at=datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC).replace(tzinfo=None))
     vault_db_path = tmp_path / "vaults.pickle"
-    VaultDatabase(rows={spec: {"_detection_data": detection, "Description": "old description"}}).write(vault_db_path)
+    VaultDatabase(rows={spec: {"_detection_data": detection, "_description": "old description", "_short_description": "old description"}}).write(vault_db_path)
     monkeypatch.setattr(
         registry,
         "fetch_asseto_registry",
@@ -134,7 +175,9 @@ def test_fresh_asseto_registry_updates_existing_description(tmp_path: Path, monk
     try:
         registry.fetch_asseto_registry_preparation(vault_db_path=vault_db_path, enabled_chain_ids=frozenset({1}), cache_path=tmp_path / "registry.json")
 
-        assert VaultDatabase.read(vault_db_path).rows[spec]["Description"] == "Asseto supplied description"
+        refreshed_row = VaultDatabase.read(vault_db_path).rows[spec]
+        assert refreshed_row["_description"] == "Asseto supplied description"
+        assert refreshed_row["_short_description"] == "Asseto supplied description"
     finally:
         if previous is None:
             ASSETO_PRODUCTS.pop(key, None)

--- a/tests/asseto/test_offchain_metadata.py
+++ b/tests/asseto/test_offchain_metadata.py
@@ -97,7 +97,7 @@ def test_asseto_runtime_registry_rebuilds_existing_adapter_without_metadata_writ
     previous = ASSETO_PRODUCTS.get(key)
     previous_by_token = ASSETO_PRODUCTS_BY_TOKEN.get(product.contract_address)
     try:
-        result = registry.prepare_asseto_registry(vault_db_path=vault_db_path, enabled_chain_ids=frozenset({1}), cache_path=tmp_path / "registry.json")
+        result = registry.fetch_asseto_registry_preparation(vault_db_path=vault_db_path, enabled_chain_ids=frozenset({1}), cache_path=tmp_path / "registry.json")
 
         assert result.status == "stale"
         assert result.runtime_product_count == 1
@@ -132,7 +132,7 @@ def test_fresh_asseto_registry_updates_existing_description(tmp_path: Path, monk
     previous = ASSETO_PRODUCTS.get(key)
     previous_by_token = ASSETO_PRODUCTS_BY_TOKEN.get(product.contract_address)
     try:
-        registry.prepare_asseto_registry(vault_db_path=vault_db_path, enabled_chain_ids=frozenset({1}), cache_path=tmp_path / "registry.json")
+        registry.fetch_asseto_registry_preparation(vault_db_path=vault_db_path, enabled_chain_ids=frozenset({1}), cache_path=tmp_path / "registry.json")
 
         assert VaultDatabase.read(vault_db_path).rows[spec]["Description"] == "Asseto supplied description"
     finally:

--- a/tests/tokenised_fund/test_scheduled_price_scan.py
+++ b/tests/tokenised_fund/test_scheduled_price_scan.py
@@ -9,6 +9,7 @@ import pyarrow.parquet as pq
 import pytest
 
 from eth_defi.tokenised_fund import price_backfill
+from eth_defi.tokenised_fund.asseto.registry import AssetoRegistryRefreshResult
 from eth_defi.tokenised_fund.backfill import PROTOCOL_BACKFILLS
 from eth_defi.tokenised_fund.price_backfill import TokenisedFundPriceBackfillConfig, build_price_backfill_plan, parse_vault_addresses, run_price_backfill
 from eth_defi.tokenised_fund.scan import (
@@ -278,6 +279,33 @@ def test_missing_registered_targets_are_a_scheduled_noop(tmp_path: Path) -> None
     assert result.vault_count == 0
     assert result.price_rows == 0
     assert result.diagnostics == "no registered price-capable products"
+
+
+def test_asseto_scheduled_scan_prepares_registry_before_reading_metadata(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Rebuild the Asseto runtime registry before any adapter can be created."""
+
+    scanner = select_tokenised_fund_price_scanners("asseto")[0]
+    vault_db_path = tmp_path / "vaults.pickle"
+    VaultDatabase().write(vault_db_path)
+    calls = []
+    monkeypatch.setattr(
+        "eth_defi.tokenised_fund.scan.prepare_asseto_registry",
+        lambda **kwargs: calls.append(kwargs) or AssetoRegistryRefreshResult("stale", 1, 0, ("offline",)),
+    )
+
+    result = run_tokenised_fund_price_scan(
+        scanner,
+        TokenisedFundPriceScanContext(
+            vault_db_path=vault_db_path,
+            raw_price_path=tmp_path / "prices.parquet",
+            max_workers=1,
+            enabled_chain_ids=frozenset({1}),
+            asseto_registry_cache_path=tmp_path / "registry.json",
+        ),
+    )
+
+    assert calls == [{"vault_db_path": vault_db_path, "enabled_chain_ids": frozenset({1}), "cache_path": tmp_path / "registry.json"}]
+    assert "registry=stale" in (result.diagnostics or "")
 
 
 def test_build_active_protocols_includes_selected_tokenised_fund_feeds() -> None:

--- a/tests/tokenised_fund/test_scheduled_price_scan.py
+++ b/tests/tokenised_fund/test_scheduled_price_scan.py
@@ -289,7 +289,7 @@ def test_asseto_scheduled_scan_prepares_registry_before_reading_metadata(tmp_pat
     VaultDatabase().write(vault_db_path)
     calls = []
     monkeypatch.setattr(
-        "eth_defi.tokenised_fund.scan.prepare_asseto_registry",
+        "eth_defi.tokenised_fund.scan.fetch_asseto_registry_preparation",
         lambda **kwargs: calls.append(kwargs) or AssetoRegistryRefreshResult("stale", 1, 0, ("offline",)),
     )
 

--- a/tests/tokenised_fund/test_scheduled_price_scan.py
+++ b/tests/tokenised_fund/test_scheduled_price_scan.py
@@ -8,6 +8,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
+from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.tokenised_fund import price_backfill
 from eth_defi.tokenised_fund.asseto.registry import AssetoRegistryRefreshResult
 from eth_defi.tokenised_fund.backfill import PROTOCOL_BACKFILLS
@@ -306,6 +307,39 @@ def test_asseto_scheduled_scan_prepares_registry_before_reading_metadata(tmp_pat
 
     assert calls == [{"vault_db_path": vault_db_path, "enabled_chain_ids": frozenset({1}), "cache_path": tmp_path / "registry.json"}]
     assert "registry=stale" in (result.diagnostics or "")
+
+
+def test_asseto_scheduled_scan_skips_persisted_product_missing_from_runtime_registry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """One delisted Asseto product does not abort the healthy protocol cycle."""
+
+    scanner = select_tokenised_fund_price_scanners("asseto")[0]
+    vault_db_path = tmp_path / "vaults.pickle"
+    spec = VaultSpec(1, "0x78e80da0616887b46a31f39310c2a8b0fbd6a42d")
+    detection = SimpleNamespace(
+        chain=1,
+        address=spec.vault_address,
+        first_seen_at_block=NEW_VAULT_FIRST_BLOCK,
+        first_seen_at=datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC).replace(tzinfo=None),
+        features={ERC4626Feature.asseto_like},
+    )
+    VaultDatabase(rows={spec: {"_detection_data": detection}}).write(vault_db_path)
+    monkeypatch.setattr(
+        "eth_defi.tokenised_fund.scan.fetch_asseto_registry_preparation",
+        lambda **_kwargs: AssetoRegistryRefreshResult("fresh", 0, 0, ("Asseto no longer publishes the product",), frozenset()),
+    )
+
+    result = run_tokenised_fund_price_scan(
+        scanner,
+        TokenisedFundPriceScanContext(
+            vault_db_path=vault_db_path,
+            raw_price_path=tmp_path / "prices.parquet",
+            max_workers=1,
+            enabled_chain_ids=frozenset({1}),
+        ),
+    )
+
+    assert result.vault_count == 0
+    assert "no usable Asseto runtime registry product" in (result.diagnostics or "")
 
 
 def test_build_active_protocols_includes_selected_tokenised_fund_feeds() -> None:


### PR DESCRIPTION
## Why

Asseto API-derived products disappeared from the process-local adapter registry after a scanner restart, leaving recurring price scans unable to construct adapters for persisted Asseto vault rows.

## Lessons learnt

Adapter-critical offchain identity must survive process restarts. A stale registry may restore existing adapters during a transient outage, but must never overwrite vault metadata or widen a price rewrite window.

## Summary

- Persist and validate Asseto registry snapshots with safe stale fallback.
- Rebuild Asseto runtime products before every due Asseto scan and register fresh supported products.
- Reuse the registry cache for the manual Asseto backfill; add an audit command and operations documentation.
- Preserve address-scoped daily price writes and add restart, stale-cache and scheduler coverage.

## Related issues and PRs

Continues the tokenised-fund scheduled price-feed work merged in #1424.

## Unrelated CI and test fixes

None.