### PR TITLE
fix: populate direct ApeX vault links

### DIFF
--- a/docs/source/api/apex/index.rst
+++ b/docs/source/api/apex/index.rst
@@ -8,7 +8,8 @@ ApeX
 
 The ApeX integration reads public native-vault metadata and actual-timestamp
 NAV and TVL history into DuckDB. The all-chain scanner can also export the
-data into the shared vault metadata and price pipeline.
+data into the shared vault metadata and price pipeline, including a direct
+ApeX vault link for each exported vault.
 
 See the `ApeX public API documentation
 <https://api-docs.pro.apex.exchange/>`__ for the platform API.

--- a/eth_defi/apex/README-apex.md
+++ b/eth_defi/apex/README-apex.md
@@ -38,6 +38,10 @@ public application API and [official API documentation](https://api-docs.pro.ape
 - [ApeX public API documentation](https://api-docs.pro.apex.exchange/)
 - [Official Python SDK](https://github.com/ApeX-Protocol/apexpro-openapi)
 
+The shared vault metadata `Link` field targets each platform vault directly:
+`https://omni.apex.exchange/vaultInfo/{vaultId}/1`. The exporter derives this
+from the scanned `vaultId`, rather than using the generic ApeX Omni homepage.
+
 The two vault web-application endpoints used here are public but are not
 currently described in the official OpenAPI documentation or SDK. Their
 response shapes were verified directly against the live application API on

--- a/eth_defi/apex/constants.py
+++ b/eth_defi/apex/constants.py
@@ -12,6 +12,10 @@ APEX_CHAIN_ID: int = 9995
 #: ApeX Omni public REST API base URL.
 APEX_API_BASE_URL: str = "https://omni.apex.exchange/api/v3"
 
+#: Public destination URL template for one ApeX Omni vault.
+#: See https://www.apex.exchange/blog/detail/weekly-update-11may2026.
+APEX_VAULT_URL_TEMPLATE: str = "https://omni.apex.exchange/vaultInfo/{vault_id}/1"
+
 #: Default local metrics database.
 APEX_METRICS_DATABASE: Path = Path("~/.tradingstrategy/vaults/apex-vaults.duckdb").expanduser()
 

--- a/eth_defi/apex/vault_data_export.py
+++ b/eth_defi/apex/vault_data_export.py
@@ -10,10 +10,11 @@ import datetime
 import logging
 from decimal import Decimal
 from pathlib import Path
+from urllib.parse import quote
 
 import pandas as pd
 
-from eth_defi.apex.constants import APEX_CHAIN_ID, APEX_OFFICIAL_VAULTS
+from eth_defi.apex.constants import APEX_CHAIN_ID, APEX_OFFICIAL_VAULTS, APEX_VAULT_URL_TEMPLATE
 from eth_defi.apex.metrics import ApexMetricsDatabase
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
@@ -69,7 +70,13 @@ def create_apex_vault_row(
         Time after a subscription before its shares are redeemable.
     :return:
         Synthetic vault specification and metadata row.
+    :raises ValueError:
+        If the platform vault ID is blank.
     """
+    vault_id = vault_id.strip()
+    if not vault_id:
+        message = "ApeX vault ID is required"
+        raise ValueError(message)
     address = f"apex-vault-{vault_id}"
     detection = ERC4262VaultDetection(
         chain=APEX_CHAIN_ID,
@@ -97,7 +104,7 @@ def create_apex_vault_row(
         "NAV": Decimal(str(tvl or 0.0)),
         "Shares": Decimal(str(share_count or 0.0)),
         "Protocol": "ApeX",
-        "Link": "https://omni.apex.exchange/",
+        "Link": APEX_VAULT_URL_TEMPLATE.format(vault_id=quote(vault_id, safe="")),
         "First seen": created_at or first_seen,
         "Mgmt fee": None,
         "Perf fee": None,

--- a/scripts/apex/README-apex-vaults.md
+++ b/scripts/apex/README-apex-vaults.md
@@ -178,3 +178,5 @@ Duration examples include `30s`, `30m`, `1.5h` and `2d`.
 The stable reader address is `apex-vault-{vault_id}`. The
 `vaultEthAddress` returned by ApeX is retained only as metadata because one
 reported Ethereum address may be shared by multiple platform vault IDs.
+The shared metadata `Link` field uses the direct vault page described in the
+package-level [`README-apex.md`](../../eth_defi/apex/README-apex.md).

--- a/tests/apex/test_apex_export.py
+++ b/tests/apex/test_apex_export.py
@@ -71,10 +71,38 @@ def test_apex_synthetic_identity_is_a_shared_vault_spec() -> None:
     assert is_good_multichain_address(vault.synthetic_address)
     assert spec == VaultSpec(chain_id=APEX_CHAIN_ID, vault_address=vault.synthetic_address)
     assert row["Protocol"] == "ApeX"
+    assert row["Link"] == "https://omni.apex.exchange/vaultInfo/2044287989957394432/1"
     assert row["_fees"].fee_mode is None
     assert row["Perf fee"] is None
     assert row["_lockup"] == datetime.timedelta(days=1)
     assert get_vault_protocol_name({ERC4626Feature.apex_native}) == "ApeX"
+
+
+def test_apex_export_normalises_and_validates_vault_id() -> None:
+    """Use a canonical non-empty platform identity for the direct link."""
+    _, row = create_apex_vault_row(
+        vault_id=" 10001 ",
+        name="ApeX vault",
+        description=None,
+        tvl=None,
+        share_count=None,
+        created_at=None,
+        first_seen=datetime.datetime(2026, 7, 23, 12),
+        status="VAULT_IN_PROCESS",
+    )
+
+    assert row["Link"] == "https://omni.apex.exchange/vaultInfo/10001/1"
+    with pytest.raises(ValueError, match="vault ID is required"):
+        create_apex_vault_row(
+            vault_id=" ",
+            name="ApeX vault",
+            description=None,
+            tvl=None,
+            share_count=None,
+            created_at=None,
+            first_seen=datetime.datetime(2026, 7, 23, 12),
+            status="VAULT_IN_PROCESS",
+        )
 
 
 def test_apex_duckdb_exports_metadata_and_exact_timestamp_prices(tmp_path: Path) -> None:


### PR DESCRIPTION
# Why

ApeX vault metadata currently sends users to the generic ApeX Omni homepage instead of the selected vault.

# Lessons learnt

ApeX public vault pages use the scanner's stable platform `vaultId`, not the shared synthetic address.

# Summary

- Export a direct ApeX vault link from each scanned `vaultId`.
- Normalise IDs and reject blank IDs before publishing metadata.
- Document the canonical link derivation and cover it with regression tests.

# Related issues and PRs

None.

# Unrelated CI and test fixes

None.