### PR TITLE
fix: invalidate stale vault metadata cache

### DIFF
--- a/eth_defi/erc_4626/lead_discovery_state.py
+++ b/eth_defi/erc_4626/lead_discovery_state.py
@@ -23,6 +23,11 @@ from eth_defi.erc_4626.discovery_base import get_vault_discovery_events
 LEAD_DISCOVERY_STATE_SCHEMA_VERSION = 1
 DEFAULT_LEAD_DISCOVERY_STATE_TIMEOUT = datetime.timedelta(days=7)
 
+# Bump this whenever a change alters values persisted by create_vault_scan_record()
+# or its protocol adapters.  The discovery cursor alone cannot detect those
+# changes, but existing rows must be regenerated before they are exported.
+VAULT_METADATA_REFRESH_VERSION = 2
+
 
 def _remove_docstring(node: ast.AST) -> None:
     """Remove a function or class docstring before source hashing.
@@ -74,11 +79,11 @@ def hash_function_source(function: Callable[..., Any]) -> str:
 
 
 def create_lead_discovery_signature(enabled_chains: Iterable[tuple[str, str]]) -> tuple[str, dict[str, Any]]:
-    """Create the cache signature from detection code and enabled chains.
+    """Create the cache signature from detection code, metadata version, and enabled chains.
 
-    Only the lead-detection function and the enabled EVM chain configuration
-    participate. Scheduler and price-scan settings must not invalidate a lead
-    cache.
+    Scheduler and price-scan settings do not invalidate a lead cache. Metadata
+    changes use an explicit version because adapter behaviour is not a direct
+    dependency of the event-discovery function hash.
 
     :param enabled_chains:
         Iterable of ``(chain name, RPC environment variable)`` pairs for
@@ -89,6 +94,7 @@ def create_lead_discovery_signature(enabled_chains: Iterable[tuple[str, str]]) -
 
     configuration = {
         "lead_detection_function_hash": hash_function_source(get_vault_discovery_events),
+        "vault_metadata_refresh_version": VAULT_METADATA_REFRESH_VERSION,
         "enabled_chains": [{"name": name, "rpc_environment_variable": env_var} for name, env_var in sorted(enabled_chains)],
     }
     encoded = json.dumps(configuration, sort_keys=True, separators=(",", ":")).encode("utf-8")

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -1159,6 +1159,42 @@ source .local-test.env && poetry run python scripts/erc-4626/heal-broken-vaults.
 | `JSON_RPC_<CHAIN>` | Required per chain with broken vaults. |
 | `LOG_LEVEL` | Optional. Default: info. |
 
+### migrate-vault-deposit-permissions.py
+
+Refresh cached `_deposit_permission` values through each vault's current
+protocol adapter. Use this targeted metadata-only repair after a reviewed
+permission-classification fix when waiting for the normal metadata scan is not
+appropriate. It does not change vault discovery, prices, reader state, or any
+other cached metadata field.
+
+First inspect live differences without modifying the pickle:
+
+```shell
+source .local-test.env && \
+  DRY_RUN=true \
+  poetry run python scripts/erc-4626/migrate-vault-deposit-permissions.py
+```
+
+Then persist the reviewed differences:
+
+```shell
+source .local-test.env && \
+  DRY_RUN=false \
+  poetry run python scripts/erc-4626/migrate-vault-deposit-permissions.py
+```
+
+The migration creates a non-overwriting `*.bak-deposit-permission` backup
+before writing. It preserves an existing `whitelisted` or `permissionless`
+value when the live adapter read is inconclusive (`unknown`). Run
+`export-data-files.py` afterwards to publish the corrected JSON.
+
+| Variable | Description |
+|----------|-------------|
+| `VAULT_DB_PATH` | Optional vault metadata pickle path. Defaults to `~/.tradingstrategy/vaults/vault-metadata-db.pickle`. |
+| `DRY_RUN` | Report only when true. Default: true. |
+| `JSON_RPC_<CHAIN>` | Required for every EVM chain represented in the cache. |
+| `LOG_LEVEL` | Optional console log level. Default: info. |
+
 ### migrate-vault-token-metadata.py
 
 Refresh persisted vault `Name` and `Symbol` fields when an ERC-20/ERC-4626

--- a/scripts/erc-4626/migrate-vault-deposit-permissions.py
+++ b/scripts/erc-4626/migrate-vault-deposit-permissions.py
@@ -1,0 +1,375 @@
+"""Refresh cached vault deposit-permission classifications from live adapters.
+
+The vault metadata database persists ``_deposit_permission`` for JSON export.
+When an adapter's canonical permission read changes, rows created before that
+change keep their old value until metadata is refreshed. This migration reads
+the existing detection envelope, reconstructs the current adapter, and updates
+only the persisted permission classification.
+
+The command does not discover leads, alter prices, reader state, or any other
+vault metadata. It is dry-run-first and creates a non-overwriting backup before
+writing the pickle.
+
+Usage:
+
+.. code-block:: shell
+
+    # Review live permission differences without writing (the default)
+    source .local-test.env && poetry run python scripts/erc-4626/migrate-vault-deposit-permissions.py
+
+    # Persist reviewed differences
+    source .local-test.env && DRY_RUN=false \\
+        poetry run python scripts/erc-4626/migrate-vault-deposit-permissions.py
+
+Environment variables:
+
+- ``VAULT_DB_PATH``: Optional path to ``vault-metadata-db.pickle``.
+- ``DRY_RUN``: Set to ``false`` to write changes. Defaults to ``true``.
+- ``JSON_RPC_<CHAIN>``: RPC URL for every EVM chain represented in the cache.
+- ``LOG_LEVEL``: Optional console log level. Defaults to ``info``.
+"""
+
+import logging
+import os
+import shutil
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from tabulate import tabulate
+from tqdm_loggable.auto import tqdm
+from web3 import Web3
+
+from eth_defi.chain import EVM_BLOCK_TIMES
+from eth_defi.erc_4626.classification import create_vault_instance
+from eth_defi.erc_4626.core import ERC4262VaultDetection
+from eth_defi.erc_4626.scan import fetch_deposit_permission
+from eth_defi.provider.env import read_json_rpc_url
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.base import VaultBase, VaultSpec
+from eth_defi.vault.deposit_redeem import VaultDepositPermission
+from eth_defi.vault.vaultdb import DEFAULT_VAULT_DATABASE, VaultDatabase, VaultRow
+
+logger = logging.getLogger(__name__)
+
+VaultFactory = Callable[[Web3, ERC4262VaultDetection], VaultBase | None]
+
+
+@dataclass(slots=True, frozen=True)
+class VaultDepositPermissionUpdate:
+    """One cached vault permission classification requiring correction."""
+
+    #: Chain and vault address identifying the metadata row.
+    spec: VaultSpec
+
+    #: Cached human-readable vault name.
+    name: str
+
+    #: Cached protocol label.
+    protocol: str
+
+    #: Existing persisted permission classification.
+    old_permission: str
+
+    #: Current adapter-derived permission classification.
+    new_permission: str
+
+
+@dataclass(slots=True, frozen=True)
+class VaultDepositPermissionMigrationResult:
+    """Summary of a cached vault deposit-permission migration."""
+
+    #: Total metadata rows inspected.
+    inspected_rows: int
+
+    #: EVM rows with a compatible stored detection envelope.
+    candidate_rows: int
+
+    #: Rows whose persisted permission classification was or would be updated.
+    updated_rows: tuple[VaultDepositPermissionUpdate, ...]
+
+    #: Native or synthetic-chain rows excluded from adapter reads.
+    skipped_non_evm_rows: int
+
+    #: Rows whose detection does not construct a supported vault adapter.
+    skipped_unsupported_rows: int
+
+    #: Rows whose live read is inconclusive and therefore remain unchanged.
+    unresolved_rows: int
+
+
+def parse_boolean_env(value: str | None, *, default: bool) -> bool:
+    """Parse an explicit boolean environment value.
+
+    :param value:
+        Environment value, or ``None`` when unset.
+    :param default:
+        Value to use when ``value`` is unset.
+    :return:
+        Parsed boolean value.
+    """
+
+    if value is None:
+        return default
+
+    normalised_value = value.strip().lower()
+    if normalised_value in {"1", "true", "yes", "on"}:
+        return True
+    if normalised_value in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"Expected a boolean environment value, got {value!r}")
+
+
+def create_backup_path(vault_db_path: Path) -> Path:
+    """Choose a non-overwriting backup path for the metadata cache.
+
+    :param vault_db_path:
+        Existing metadata cache to protect.
+    :return:
+        Sibling backup path that does not already exist.
+    """
+
+    backup_path = vault_db_path.with_suffix(".pickle.bak-deposit-permission")
+    if not backup_path.exists():
+        return backup_path
+
+    backup_index = 1
+    while True:
+        indexed_backup_path = Path(f"{backup_path}.{backup_index}")
+        if not indexed_backup_path.exists():
+            return indexed_backup_path
+        backup_index += 1
+
+
+def create_vault_for_permission_read(web3: Web3, detection: ERC4262VaultDetection) -> VaultBase | None:
+    """Recreate the current adapter needed for a permission read.
+
+    :param web3:
+        Verified chain connection for the detection.
+    :param detection:
+        Persisted vault feature envelope.
+    :return:
+        Current adapter, or ``None`` when the envelope is unsupported.
+    """
+
+    return create_vault_instance(
+        web3,
+        detection.address,
+        detection.features,
+        default_block_identifier="latest",
+    )
+
+
+def create_web3_by_chain(candidate_specs: Iterable[VaultSpec]) -> dict[int, Web3]:
+    """Create one verified JSON-RPC connection per candidate chain.
+
+    :param candidate_specs:
+        EVM vaults selected from the metadata cache.
+    :return:
+        Chain id mapped to a live multi-provider Web3 client.
+    """
+
+    chain_ids = sorted({spec.chain_id for spec in candidate_specs})
+    return {chain_id: create_multi_provider_web3(read_json_rpc_url(chain_id), expected_chain_id=chain_id) for chain_id in chain_ids}
+
+
+def select_permission_candidates(vault_db: VaultDatabase) -> tuple[list[tuple[VaultSpec, VaultRow]], int]:
+    """Select cached EVM rows that retain a usable detection envelope.
+
+    :param vault_db:
+        Loaded persisted metadata cache.
+    :return:
+        Candidate rows and count of non-EVM or non-detection rows excluded.
+    """
+
+    candidate_rows: list[tuple[VaultSpec, VaultRow]] = []
+    skipped_rows = 0
+    for spec, row in vault_db.rows.items():
+        detection = row.get("_detection_data")
+        if spec.chain_id not in EVM_BLOCK_TIMES or not isinstance(detection, ERC4262VaultDetection):
+            skipped_rows += 1
+            continue
+        if detection.chain != spec.chain_id or detection.address.lower() != spec.vault_address.lower():
+            raise RuntimeError(f"Stored detection does not match vault row {spec}")
+        candidate_rows.append((spec, row))
+    return candidate_rows, skipped_rows
+
+
+def fetch_permission_updates(
+    candidate_rows: Iterable[tuple[VaultSpec, VaultRow]],
+    web3_by_chain: Mapping[int, Web3],
+    vault_factory: VaultFactory,
+) -> tuple[list[VaultDepositPermissionUpdate], int, int]:
+    """Read live permission policy and collect only safe differences.
+
+    A transient or unsupported adapter read becomes ``unknown`` through the
+    scanner helper. Such a result must not overwrite an existing explicit
+    classification during a repair, because it would replace evidence with an
+    inconclusive transport outcome.
+
+    :param candidate_rows:
+        EVM cache rows selected for live reads.
+    :param web3_by_chain:
+        Verified connections by chain id.
+    :param vault_factory:
+        Current adapter constructor, injectable for tests.
+    :return:
+        Changes, unsupported adapter count, and unresolved-read count.
+    """
+
+    updates: list[VaultDepositPermissionUpdate] = []
+    skipped_unsupported_rows = 0
+    unresolved_rows = 0
+    for spec, row in tqdm(candidate_rows, desc="Reading vault deposit permissions"):
+        detection = row["_detection_data"]
+        assert isinstance(detection, ERC4262VaultDetection)
+        vault = vault_factory(web3_by_chain[spec.chain_id], detection)
+        if vault is None:
+            skipped_unsupported_rows += 1
+            continue
+
+        old_permission = row.get("_deposit_permission", VaultDepositPermission.unknown.value)
+        try:
+            old_permission = VaultDepositPermission(old_permission).value
+        except (TypeError, ValueError):
+            old_permission = VaultDepositPermission.unknown.value
+        new_permission = fetch_deposit_permission(vault).value
+        if new_permission == VaultDepositPermission.unknown.value:
+            unresolved_rows += 1
+            continue
+        if old_permission == new_permission:
+            continue
+
+        updates.append(
+            VaultDepositPermissionUpdate(
+                spec=spec,
+                name=str(row.get("Name", "")),
+                protocol=str(row.get("Protocol", "")),
+                old_permission=old_permission,
+                new_permission=new_permission,
+            )
+        )
+
+    return updates, skipped_unsupported_rows, unresolved_rows
+
+
+def apply_permission_updates(vault_db: VaultDatabase, updates: Iterable[VaultDepositPermissionUpdate]) -> None:
+    """Apply permission updates without altering other metadata fields.
+
+    :param vault_db:
+        Loaded metadata cache to mutate in memory.
+    :param updates:
+        Reviewed live permission differences.
+    :return:
+        None after updating the in-memory cache.
+    """
+
+    for update in updates:
+        row = vault_db.rows[update.spec].copy()
+        row["_deposit_permission"] = update.new_permission
+        vault_db.rows[update.spec] = row
+
+
+def migrate_vault_deposit_permissions(
+    vault_db_path: Path = DEFAULT_VAULT_DATABASE,
+    *,
+    dry_run: bool,
+    web3_by_chain: Mapping[int, Web3] | None = None,
+    vault_factory: VaultFactory = create_vault_for_permission_read,
+) -> VaultDepositPermissionMigrationResult:
+    """Refresh cached deposit permissions without a discovery or price scan.
+
+    Every selected adapter is queried before a backup or pickle write. An
+    unexpected adapter failure therefore aborts before any partial result can
+    be persisted.
+
+    :param vault_db_path:
+        Persisted vault metadata cache to inspect or update.
+    :param dry_run:
+        Report differences without writing when ``True``.
+    :param web3_by_chain:
+        Optional verified clients, primarily for tests.
+    :param vault_factory:
+        Current adapter constructor, injectable for tests.
+    :return:
+        Counts and permission updates that were or would be applied.
+    """
+
+    vault_db = VaultDatabase.read(vault_db_path)
+    candidate_rows, skipped_non_evm_rows = select_permission_candidates(vault_db)
+    web3_by_chain = dict(web3_by_chain) if web3_by_chain is not None else create_web3_by_chain(spec for spec, _ in candidate_rows)
+
+    missing_chains = sorted({spec.chain_id for spec, _ in candidate_rows}.difference(web3_by_chain))
+    if missing_chains:
+        raise ValueError(f"Missing Web3 clients for deposit-permission migration chains: {missing_chains}")
+
+    updates, skipped_unsupported_rows, unresolved_rows = fetch_permission_updates(candidate_rows, web3_by_chain, vault_factory)
+    result = VaultDepositPermissionMigrationResult(
+        inspected_rows=len(vault_db.rows),
+        candidate_rows=len(candidate_rows),
+        updated_rows=tuple(updates),
+        skipped_non_evm_rows=skipped_non_evm_rows,
+        skipped_unsupported_rows=skipped_unsupported_rows,
+        unresolved_rows=unresolved_rows,
+    )
+
+    if result.updated_rows:
+        print(
+            tabulate(
+                [
+                    [
+                        update.spec.chain_id,
+                        update.spec.vault_address,
+                        update.name,
+                        update.protocol,
+                        update.old_permission,
+                        update.new_permission,
+                    ]
+                    for update in result.updated_rows
+                ],
+                headers=["chain", "address", "name", "protocol", "old permission", "new permission"],
+                tablefmt="simple",
+            )
+        )
+
+    if dry_run:
+        logger.info("DRY RUN: would update %d vault deposit permissions in %s", len(result.updated_rows), vault_db_path)
+        return result
+
+    if not result.updated_rows:
+        logger.info("No cached vault deposit permissions need repair in %s", vault_db_path)
+        return result
+
+    backup_path = create_backup_path(vault_db_path)
+    logger.info("Creating vault metadata backup at %s", backup_path)
+    shutil.copy2(vault_db_path, backup_path)
+    apply_permission_updates(vault_db, result.updated_rows)
+    vault_db.write(vault_db_path)
+    logger.info("Updated %d vault deposit permissions in %s", len(result.updated_rows), vault_db_path)
+    return result
+
+
+def main() -> None:
+    """Run the vault deposit-permission migration from environment configuration.
+
+    :return:
+        None. Raises when the metadata cache or a required RPC is unavailable.
+    """
+
+    setup_console_logging(default_log_level=os.environ.get("LOG_LEVEL", "info"))
+    vault_db_path = Path(os.environ.get("VAULT_DB_PATH", os.environ.get("VAULT_DB", str(DEFAULT_VAULT_DATABASE)))).expanduser()
+    dry_run = parse_boolean_env(os.environ.get("DRY_RUN"), default=True)
+    if not vault_db_path.exists():
+        raise FileNotFoundError(f"Vault database not found: {vault_db_path}")
+
+    result = migrate_vault_deposit_permissions(vault_db_path, dry_run=dry_run)
+    print(f"Inspected {result.inspected_rows:,} rows, selected {result.candidate_rows:,} EVM rows, updated {len(result.updated_rows):,}, skipped {result.skipped_non_evm_rows:,} non-EVM rows, skipped {result.skipped_unsupported_rows:,} unsupported rows, and left {result.unresolved_rows:,} unresolved.")
+    if dry_run:
+        print("Dry run - no changes written.")
+    elif result.updated_rows:
+        print(f"Saved migrated vault metadata to {vault_db_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/erc_4626/test_lead_discovery_state.py
+++ b/tests/erc_4626/test_lead_discovery_state.py
@@ -9,8 +9,10 @@ import pytest
 from eth_typing import HexAddress
 
 from eth_defi.compat import native_datetime_utc_now
+from eth_defi.erc_4626 import lead_discovery_state
 from eth_defi.erc_4626.discovery_base import LeadScanReport, PotentialVaultMatch
 from eth_defi.erc_4626.lead_discovery_state import (
+    VAULT_METADATA_REFRESH_VERSION,
     LeadDiscoveryState,
     create_lead_discovery_signature,
     get_lead_discovery_state_path,
@@ -48,18 +50,35 @@ def test_function_source_hash_ignores_name_and_docstring() -> None:
     assert hash_function_source(first) != hash_function_source(changed)
 
 
-def test_signature_changes_only_for_enabled_chain_configuration(
+def test_signature_includes_metadata_refresh_version_and_enabled_chain_configuration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The signature includes enabled chains but excludes disabled chains."""
+    """The signature records metadata semantics alongside enabled chain scope.
 
+    1. Create signatures with distinct enabled-chain configurations.
+    2. Confirm the persisted diagnostics include the metadata refresh version.
+    3. Confirm a metadata-version bump changes the signature.
+    4. Confirm disabled chains do not affect the signature input.
+    """
+
+    # 1. Create signatures with distinct enabled-chain configurations.
     original_signature, original_configuration = create_lead_discovery_signature([("Ethereum", "JSON_RPC_ETHEREUM")])
     changed_signature, changed_configuration = create_lead_discovery_signature([("Ethereum", "JSON_RPC_ETHEREUM"), ("Base", "JSON_RPC_BASE")])
 
+    # 2. Confirm the persisted diagnostics include the metadata refresh version.
     assert original_signature != changed_signature
+    assert original_configuration["vault_metadata_refresh_version"] == VAULT_METADATA_REFRESH_VERSION
     assert original_configuration["enabled_chains"] == [{"name": "Ethereum", "rpc_environment_variable": "JSON_RPC_ETHEREUM"}]
     assert changed_configuration["enabled_chains"][0]["name"] == "Base"
 
+    # 3. Confirm a metadata-version bump changes the signature.
+    with monkeypatch.context() as metadata_version_patch:
+        metadata_version_patch.setattr(lead_discovery_state, "VAULT_METADATA_REFRESH_VERSION", VAULT_METADATA_REFRESH_VERSION + 1)
+        refreshed_signature, refreshed_configuration = create_lead_discovery_signature([("Ethereum", "JSON_RPC_ETHEREUM")])
+    assert refreshed_signature != original_signature
+    assert refreshed_configuration["vault_metadata_refresh_version"] == VAULT_METADATA_REFRESH_VERSION + 1
+
+    # 4. Confirm disabled chains do not affect the signature input.
     monkeypatch.setattr(
         scan_all_chains,
         "build_chain_configs",

--- a/tests/erc_4626/test_migrate_vault_deposit_permissions.py
+++ b/tests/erc_4626/test_migrate_vault_deposit_permissions.py
@@ -1,0 +1,159 @@
+"""Tests for the cached vault deposit-permission migration."""
+
+import datetime
+import importlib.util
+from pathlib import Path
+
+from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.vaultdb import VaultDatabase
+
+
+def load_migration_module():
+    """Load the deposit-permission migration script as a test module.
+
+    :return:
+        Loaded migration module.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "erc-4626" / "migrate-vault-deposit-permissions.py"
+    spec = importlib.util.spec_from_file_location("migrate_vault_deposit_permissions", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def create_detection(spec: VaultSpec) -> ERC4262VaultDetection:
+    """Create cached detection metadata for a vault fixture.
+
+    :param spec:
+        Vault identity.
+    :return:
+        Detection envelope matching a metadata cache row.
+    """
+
+    timestamp = datetime.datetime(2026, 8, 1, 12, 0)  # noqa: DTZ001 - Repository convention is naive UTC.
+    return ERC4262VaultDetection(
+        chain=spec.chain_id,
+        address=spec.vault_address,
+        first_seen_at_block=1,
+        first_seen_at=timestamp,
+        features={ERC4626Feature.morpho_like},
+        updated_at=timestamp,
+        deposit_count=1,
+        redeem_count=1,
+    )
+
+
+def create_row(spec: VaultSpec, permission: str) -> dict:
+    """Create one minimal cached permission row.
+
+    :param spec:
+        Vault identity.
+    :param permission:
+        Cached permission classification.
+    :return:
+        Vault metadata row.
+    """
+
+    return {
+        "Name": f"Vault {spec.vault_address[-4:]}",
+        "Protocol": "Morpho",
+        "_detection_data": create_detection(spec),
+        "_deposit_permission": permission,
+    }
+
+
+class FakeVault:
+    """Minimal adapter substitute exposing one live permission result."""
+
+    def __init__(self, address: str, *, whitelisted: bool | None) -> None:
+        self.address = address
+        self.whitelisted = whitelisted
+
+    def is_whitelisted_deposit(self) -> bool:
+        """Return the fixture policy or simulate an unsupported read."""
+
+        if self.whitelisted is None:
+            raise NotImplementedError()
+        return self.whitelisted
+
+
+def test_migrate_vault_deposit_permissions_updates_only_permission_field(tmp_path: Path) -> None:
+    """Live permission reads correct stale cached classifications safely.
+
+    1. Create EVM and synthetic cached metadata rows.
+    2. Read live permission values through fixture adapters.
+    3. Persist only the stale EVM permission with a backup.
+    """
+
+    # 1. Create EVM and synthetic cached metadata rows.
+    migration = load_migration_module()
+    stale_spec = VaultSpec(1, "0x0000000000000000000000000000000000000001")
+    current_spec = VaultSpec(1, "0x0000000000000000000000000000000000000002")
+    synthetic_spec = VaultSpec(9999, "0x0000000000000000000000000000000000000003")
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    rows = {
+        stale_spec: create_row(stale_spec, "whitelisted"),
+        current_spec: create_row(current_spec, "permissionless"),
+        synthetic_spec: create_row(synthetic_spec, "whitelisted"),
+    }
+    VaultDatabase(rows=rows).write(vault_db_path)
+
+    # 2. Read live permission values through fixture adapters.
+    def vault_factory(_web3: object, detection: ERC4262VaultDetection) -> FakeVault:
+        return FakeVault(detection.address, whitelisted=False)
+
+    result = migration.migrate_vault_deposit_permissions(
+        vault_db_path,
+        dry_run=False,
+        web3_by_chain={1: object()},
+        vault_factory=vault_factory,
+    )
+
+    # 3. Persist only the stale EVM permission with a backup.
+    migrated_db = VaultDatabase.read(vault_db_path)
+    assert result.inspected_rows == len(rows)
+    assert result.candidate_rows == len(rows) - 1
+    assert len(result.updated_rows) == 1
+    assert result.updated_rows[0].spec == stale_spec
+    assert (tmp_path / "vault-metadata-db.pickle.bak-deposit-permission").exists()
+    assert migrated_db.rows[stale_spec]["_deposit_permission"] == "permissionless"
+    assert migrated_db.rows[current_spec]["_deposit_permission"] == "permissionless"
+    assert migrated_db.rows[synthetic_spec]["_deposit_permission"] == "whitelisted"
+
+
+def test_migrate_vault_deposit_permissions_preserves_explicit_value_when_read_is_unknown(tmp_path: Path) -> None:
+    """An inconclusive adapter read does not overwrite an explicit policy.
+
+    1. Create a cached explicit permission classification.
+    2. Simulate an adapter read that resolves to unknown.
+    3. Confirm the migration leaves the pickle and backup untouched.
+    """
+
+    # 1. Create a cached explicit permission classification.
+    migration = load_migration_module()
+    spec = VaultSpec(1, "0x0000000000000000000000000000000000000001")
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    VaultDatabase(rows={spec: create_row(spec, "whitelisted")}).write(vault_db_path)
+    original_contents = vault_db_path.read_bytes()
+
+    # 2. Simulate an adapter read that resolves to unknown.
+    def vault_factory(_web3: object, detection: ERC4262VaultDetection) -> FakeVault:
+        return FakeVault(detection.address, whitelisted=None)
+
+    result = migration.migrate_vault_deposit_permissions(
+        vault_db_path,
+        dry_run=False,
+        web3_by_chain={1: object()},
+        vault_factory=vault_factory,
+    )
+
+    # 3. Confirm the migration leaves the pickle and backup untouched.
+    assert not result.updated_rows
+    assert result.unresolved_rows == 1
+    assert vault_db_path.read_bytes() == original_contents
+    assert not (tmp_path / "vault-metadata-db.pickle.bak-deposit-permission").exists()


### PR DESCRIPTION
## Why

The production vault JSON was regenerated from current code but retained pre-fix permission classifications because the valid lead-discovery cache skipped persisted metadata extraction. Production needs both a future-safe cache invalidation and a narrowly scoped way to repair the already persisted metadata immediately.

## Lessons learnt

Cache provenance must cover persisted metadata semantics, not only event discovery. A generated JSON timestamp and current source commit do not prove that every cached metadata field was recomputed.

## Summary

- Add a versioned metadata-refresh input to the lead-discovery signature.
- Bump it to invalidate existing state and refresh all persisted vault rows once.
- Add a dry-run-first `migrate-vault-deposit-permissions.py` repair that re-reads only `_deposit_permission`, creates a non-overwriting backup, and preserves explicit values when a live read is unknown.
- Document the repair and test its scoped write and safety behaviour.

## Related issues and PRs

- [trade-executor#1601](https://github.com/tradingstrategy-ai/trade-executor/pull/1601)