### PR TITLE
fix: tolerate missing Morpho V2 gate responses

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
@@ -24,6 +24,7 @@ from typing import Iterable
 
 from eth_typing import BlockIdentifier, HexAddress
 from web3 import Web3
+from web3.exceptions import BadFunctionCallOutput
 
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.chain import get_chain_name
@@ -58,6 +59,32 @@ PERFORMANCE_FEE_SIGNATURE = Web3.keccak(text="performanceFee()")[0:4]
 MANAGEMENT_FEE_SIGNATURE = Web3.keccak(text="managementFee()")[0:4]
 RECEIVE_SHARES_GATE_SIGNATURE = Web3.keccak(text="receiveSharesGate()")[0:4]
 SEND_ASSETS_GATE_SIGNATURE = Web3.keccak(text="sendAssetsGate()")[0:4]
+
+#: ABI return-word width for address getters
+ABI_ADDRESS_WORD_SIZE = 32
+
+
+class MorphoGateAddressMissing(BadFunctionCallOutput):
+    """A Morpho V2 gate getter did not return an ABI-encoded address.
+
+    The gate slots are optional, but a supported Morpho V2 vault must return
+    one 32-byte ABI word even when the configured gate is the zero address.
+    An empty or malformed response therefore means that the cached adapter
+    classification cannot be safely used for a permission read.
+    """
+
+    def __init__(
+        self,
+        vault_address: HexAddress,
+        function_name: str,
+        block_identifier: BlockIdentifier,
+        response: bytes,
+    ) -> None:
+        self.vault_address = vault_address
+        self.function_name = function_name
+        self.block_identifier = block_identifier
+        self.response = response
+        super().__init__(f"Morpho V2 gate getter {function_name}() returned {len(response)} bytes for vault {vault_address} at block {block_identifier}; expected one 32-byte ABI-encoded address, response=0x{response.hex()}")
 
 
 class MorphoV2VaultHistoricalReader(ERC4626HistoricalReader):
@@ -273,6 +300,11 @@ class MorphoV2Vault(ERC4626Vault):
             Block at which the gate is read.
         :return:
             Checksummed gate address.
+        :raise MorphoGateAddressMissing:
+            If the getter returns anything other than the 32-byte ABI word
+            required for an address. The exception includes the vault, getter,
+            block, and raw response for diagnosing stale classifications or
+            inconsistent RPC responses.
         """
         call = EncodedCall.from_keccak_signature(
             address=self.address,
@@ -282,6 +314,13 @@ class MorphoV2Vault(ERC4626Vault):
             extra_data=None,
         )
         data = call.call(self.web3, block_identifier)
+        if len(data) != ABI_ADDRESS_WORD_SIZE:
+            raise MorphoGateAddressMissing(
+                self.address,
+                function_name,
+                block_identifier,
+                data,
+            )
         return Web3.to_checksum_address(data[12:32])
 
     def get_deposit_manager(self) -> MorphoV2DepositManager:

--- a/scripts/erc-4626/migrate-vault-deposit-permissions.py
+++ b/scripts/erc-4626/migrate-vault-deposit-permissions.py
@@ -145,6 +145,11 @@ def create_backup_path(vault_db_path: Path) -> Path:
 def create_vault_for_permission_read(web3: Web3, detection: ERC4262VaultDetection) -> VaultBase | None:
     """Recreate the current adapter needed for a permission read.
 
+    A cached feature envelope can outlive an adapter's static product registry.
+    In particular, Asseto rejects a token that is not a supported product. Such
+    a row cannot provide a deposit-permission answer and is skipped like other
+    unsupported adapters; unrelated construction errors still propagate.
+
     :param web3:
         Verified chain connection for the detection.
     :param detection:
@@ -153,12 +158,18 @@ def create_vault_for_permission_read(web3: Web3, detection: ERC4262VaultDetectio
         Current adapter, or ``None`` when the envelope is unsupported.
     """
 
-    return create_vault_instance(
-        web3,
-        detection.address,
-        detection.features,
-        default_block_identifier="latest",
-    )
+    try:
+        return create_vault_instance(
+            web3,
+            detection.address,
+            detection.features,
+            default_block_identifier="latest",
+        )
+    except RuntimeError as error:
+        if not str(error).startswith("Unsupported Asseto product:"):
+            raise
+        logger.warning("Skipping unsupported cached Asseto product %s: %s", detection.address, error)
+        return None
 
 
 def create_web3_by_chain(candidate_specs: Iterable[VaultSpec]) -> dict[int, Web3]:

--- a/tests/erc_4626/test_migrate_vault_deposit_permissions.py
+++ b/tests/erc_4626/test_migrate_vault_deposit_permissions.py
@@ -4,7 +4,10 @@ import datetime
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
+from eth_defi.erc_4626.vault_protocol.morpho.vault_v2 import MorphoGateAddressMissing
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.vaultdb import VaultDatabase
 
@@ -82,6 +85,23 @@ class FakeVault:
         return self.whitelisted
 
 
+class MissingMorphoGateVault:
+    """Fixture adapter that reproduces a malformed Morpho V2 gate response."""
+
+    def __init__(self, address: str) -> None:
+        self.address = address
+
+    def is_whitelisted_deposit(self) -> bool:
+        """Raise the typed ABI-read failure produced by an empty gate response."""
+
+        raise MorphoGateAddressMissing(
+            self.address,
+            "receiveSharesGate",
+            "latest",
+            b"",
+        )
+
+
 def test_migrate_vault_deposit_permissions_updates_only_permission_field(tmp_path: Path) -> None:
     """Live permission reads correct stale cached classifications safely.
 
@@ -157,3 +177,59 @@ def test_migrate_vault_deposit_permissions_preserves_explicit_value_when_read_is
     assert result.unresolved_rows == 1
     assert vault_db_path.read_bytes() == original_contents
     assert not (tmp_path / "vault-metadata-db.pickle.bak-deposit-permission").exists()
+
+
+def test_migration_continues_after_missing_morpho_gate_address(tmp_path: Path) -> None:
+    """A malformed Morpho V2 gate response does not abort a metadata migration.
+
+    1. Create a cached explicit permission classification.
+    2. Reproduce the typed empty-gate failure through a fixture adapter.
+    3. Confirm the migration preserves the row as unresolved without writing.
+    """
+    # 1. Create a cached explicit permission classification.
+    migration = load_migration_module()
+    spec = VaultSpec(1, "0x0000000000000000000000000000000000000001")
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    VaultDatabase(rows={spec: create_row(spec, "whitelisted")}).write(vault_db_path)
+    original_contents = vault_db_path.read_bytes()
+
+    # 2. Reproduce the typed empty-gate failure through a fixture adapter.
+    def vault_factory(_web3: object, detection: ERC4262VaultDetection) -> MissingMorphoGateVault:
+        return MissingMorphoGateVault(detection.address)
+
+    result = migration.migrate_vault_deposit_permissions(
+        vault_db_path,
+        dry_run=False,
+        web3_by_chain={1: object()},
+        vault_factory=vault_factory,
+    )
+
+    # 3. Confirm the migration preserves the row as unresolved without writing.
+    assert not result.updated_rows
+    assert result.unresolved_rows == 1
+    assert vault_db_path.read_bytes() == original_contents
+    assert not (tmp_path / "vault-metadata-db.pickle.bak-deposit-permission").exists()
+
+
+def test_permission_adapter_factory_skips_unsupported_cached_asseto_product(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stale Asseto classification does not abort a metadata migration.
+
+    1. Create a cached feature envelope accepted by the migration.
+    2. Reproduce Asseto's explicit unsupported-product construction error.
+    3. Confirm the adapter factory marks only this error unsupported.
+    """
+    # 1. Create a cached feature envelope accepted by the migration.
+    migration = load_migration_module()
+    spec = VaultSpec(1, "0x0000000000000000000000000000000000000001")
+    detection = create_detection(spec)
+
+    # 2. Reproduce Asseto's explicit unsupported-product construction error.
+    unsupported_product_error = "Unsupported Asseto product: chain=1, token=0x0000000000000000000000000000000000000001"
+
+    def create_unsupported_product_vault(_web3: object, _address: str, _features: set, **_kwargs: object) -> None:
+        raise RuntimeError(unsupported_product_error)
+
+    monkeypatch.setattr(migration, "create_vault_instance", create_unsupported_product_vault)
+
+    # 3. Confirm the adapter factory marks only this error unsupported.
+    assert migration.create_vault_for_permission_read(object(), detection) is None

--- a/tests/erc_4626/vault_protocol/test_vault_permission_regressions.py
+++ b/tests/erc_4626/vault_protocol/test_vault_permission_regressions.py
@@ -1,5 +1,6 @@
 """Fixed-block regressions for vault deposit-permission classifications."""
 
+import datetime
 import os
 from unittest.mock import patch
 
@@ -7,7 +8,9 @@ import pytest
 from hexbytes import HexBytes
 from web3 import Web3
 
+from eth_defi.erc_4626 import scan as scan_module
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
+from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
 from eth_defi.erc_4626.scan import fetch_deposit_permission
 from eth_defi.erc_4626.vault_protocol.euler.vault import EulerEarnVault, EulerVault
 from eth_defi.erc_4626.vault_protocol.ipor.vault import IPORVault
@@ -15,6 +18,7 @@ from eth_defi.erc_4626.vault_protocol.morpho.vault_v1 import MorphoV1Vault
 from eth_defi.erc_4626.vault_protocol.morpho.vault_v2 import MorphoGateAddressMissing, MorphoV2Vault
 from eth_defi.event_reader.multicall_batcher import EncodedCall
 from eth_defi.testing.anvil_fork_pool import AnvilForkPool
+from eth_defi.token import TokenDiskCache
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.deposit_redeem import VaultDepositPermission
 
@@ -146,6 +150,53 @@ def test_morpho_v2_empty_gate_response_is_safe_for_permission_scans(web3: Web3) 
 
         # 3. Check typed diagnostics and that the scanner reports an unknown policy.
         assert fetch_deposit_permission(vault) == VaultDepositPermission.unknown
+
+
+def test_morpho_v2_empty_gate_response_keeps_scan_record(web3: Web3) -> None:
+    """Test a missing Morpho V2 gate address retains the vault JSON row.
+
+    1. Autodetect the production Morpho V2 vault and its persisted detection envelope.
+    2. Simulate an empty response from only the receive-shares gate getter.
+    3. Create a complete scan record and confirm the permission is unknown.
+    """
+    # 1. Autodetect the production Morpho V2 vault and its persisted detection envelope.
+    vault = create_vault_instance_autodetect(web3, MORPHO_V2_APYX_USDC)
+    assert isinstance(vault, MorphoV2Vault)
+    scan_timestamp = datetime.datetime(2026, 8, 2, 9, 0)  # noqa: DTZ001 - Repository convention is naive UTC.
+    detection = ERC4262VaultDetection(
+        chain=1,
+        address=vault.address,
+        first_seen_at_block=PERMISSION_REGRESSION_BLOCK,
+        first_seen_at=scan_timestamp,
+        features={ERC4626Feature.morpho_v2_like},
+        updated_at=scan_timestamp,
+        deposit_count=1,
+        redeem_count=1,
+    )
+    original_call = EncodedCall.call
+
+    def return_empty_receive_shares_gate(call, *args, **kwargs):
+        if call.func_name == "receiveSharesGate":
+            return HexBytes("0x")
+        return original_call(call, *args, **kwargs)
+
+    # 2. Simulate an empty response from only the receive-shares gate getter.
+    with (
+        patch.object(EncodedCall, "call", new=return_empty_receive_shares_gate),
+        patch.object(scan_module, "create_vault_instance", return_value=vault),
+    ):
+        # 3. Create a complete scan record and confirm the permission is unknown.
+        record = scan_module.create_vault_scan_record(
+            web3,
+            detection,
+            PERMISSION_REGRESSION_BLOCK,
+            token_cache=TokenDiskCache(),
+        )
+
+    assert record["Name"] == vault.name
+    assert record["Protocol"] == "Morpho"
+    assert record["_detection_data"] is detection
+    assert record["_deposit_permission"] == VaultDepositPermission.unknown.value
 
 
 @pytest.mark.parametrize("vault_address", EULER_VAULTS)

--- a/tests/erc_4626/vault_protocol/test_vault_permission_regressions.py
+++ b/tests/erc_4626/vault_protocol/test_vault_permission_regressions.py
@@ -1,17 +1,22 @@
 """Fixed-block regressions for vault deposit-permission classifications."""
 
 import os
+from unittest.mock import patch
 
 import pytest
+from hexbytes import HexBytes
 from web3 import Web3
 
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
+from eth_defi.erc_4626.scan import fetch_deposit_permission
 from eth_defi.erc_4626.vault_protocol.euler.vault import EulerEarnVault, EulerVault
 from eth_defi.erc_4626.vault_protocol.ipor.vault import IPORVault
 from eth_defi.erc_4626.vault_protocol.morpho.vault_v1 import MorphoV1Vault
-from eth_defi.erc_4626.vault_protocol.morpho.vault_v2 import MorphoV2Vault
+from eth_defi.erc_4626.vault_protocol.morpho.vault_v2 import MorphoGateAddressMissing, MorphoV2Vault
+from eth_defi.event_reader.multicall_batcher import EncodedCall
 from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.deposit_redeem import VaultDepositPermission
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 
@@ -114,6 +119,33 @@ def test_morpho_v2_gate_getters_are_permissionless(web3: Web3) -> None:
     assert int(receive_shares_gate, 16) == 0
     assert int(send_assets_gate, 16) == 0
     assert vault.is_whitelisted_deposit() is False
+
+
+def test_morpho_v2_empty_gate_response_is_safe_for_permission_scans(web3: Web3) -> None:
+    """Test a malformed gate response from the deployed Morpho V2 Apyx vault.
+
+    1. Autodetect the production Morpho V2 vault at the fixed block.
+    2. Simulate the empty gate response that interrupted the permission migration.
+    3. Check typed diagnostics and that the scanner reports an unknown policy.
+    """
+    # 1. Autodetect the production Morpho V2 vault at the fixed block.
+    vault = create_vault_instance_autodetect(web3, MORPHO_V2_APYX_USDC)
+    assert isinstance(vault, MorphoV2Vault)
+
+    # 2. Simulate the empty gate response that interrupted the permission migration.
+    with patch.object(EncodedCall, "call", return_value=HexBytes("0x")):
+        with pytest.raises(MorphoGateAddressMissing) as exception_info:
+            vault.fetch_deposit_gates()
+
+        error = exception_info.value
+        assert error.vault_address == vault.address
+        assert error.function_name == "receiveSharesGate"
+        assert error.response == HexBytes("0x")
+        assert vault.address in str(error)
+        assert "expected one 32-byte ABI-encoded address" in str(error)
+
+        # 3. Check typed diagnostics and that the scanner reports an unknown policy.
+        assert fetch_deposit_permission(vault) == VaultDepositPermission.unknown
 
 
 @pytest.mark.parametrize("vault_address", EULER_VAULTS)


### PR DESCRIPTION
## Why

A permission migration was aborted when a Morpho V2 gate getter returned an empty response and Web3 attempted to decode it as an address. The migration must preserve the affected vault as unresolved and continue processing the cache.

A stale Asseto feature envelope also raised its documented unsupported-product error during the same full-cache migration. The migration now skips only that explicit unsupported adapter outcome.

## Lessons learnt

Optional vault metadata reads must convert known ABI and adapter-support failures into an inconclusive result, while preserving unexpected implementation errors for diagnosis.

## Summary

- Add `MorphoGateAddressMissing` with vault, getter, block, and raw-response diagnostics.
- Treat malformed Morpho V2 gate responses as an unknown deposit permission.
- Retain a complete vault scan record for JSON export when a Morpho gate response is malformed.
- Skip explicitly unsupported cached Asseto products.
- Add migration and Anvil-fork regressions; complete a 39,967-row local dry run.