### PR TITLE
fix: reduce Hypersync timestamp log spam

### DIFF
--- a/eth_defi/hypersync/hypersync_timestamp.py
+++ b/eth_defi/hypersync/hypersync_timestamp.py
@@ -198,7 +198,7 @@ async def get_block_timestamps_using_hypersync_async(
     if validate_chain_id:
         await _validate_hypersync_chain_id_async(client, chain_id, reason=reason)
 
-    logger.info(
+    logger.debug(
         "Hypersync stream open: chain %d, blocks %d-%d (%d blocks)%s",
         chain_id,
         start_block,


### PR DESCRIPTION
## Why

Per-request Hypersync timestamp stream logs are emitted once for every sampled block and overwhelm scanner output.

## Lessons learnt

Detailed stream diagnostics belong at debug level when a sampled fetch can issue many individual requests.

## Summary

- Demoted the Hypersync timestamp stream-open message from info to debug.