### PR TITLE
fix(gmx): honour configured executionBuffer in async converter

### DIFF
--- a/eth_defi/gmx/ccxt/async_support/exchange.py
+++ b/eth_defi/gmx/ccxt/async_support/exchange.py
@@ -4095,7 +4095,10 @@ class GMX(Exchange):
         leverage = params.get("leverage", 1.0)
         collateral_symbol = params.get("collateral_symbol", "USDC")
         slippage_percent = params.get("slippage_percent", 0.003)
-        execution_buffer = params.get("execution_buffer", 2.2)
+        # Sync/async lockstep — the sync adapter falls back to the configured
+        # ``executionBuffer`` rather than the hardcoded default, so an adapter
+        # constructed with one does not silently price orders at 2.2x.
+        execution_buffer = params.get("execution_buffer", self.execution_buffer)
         reduceOnly = params.get("reduceOnly", False)
 
         # GMX Extension: Support direct USD sizing via size_usd parameter

--- a/tests/gmx/ccxt/test_execution_buffer_forwarding.py
+++ b/tests/gmx/ccxt/test_execution_buffer_forwarding.py
@@ -12,7 +12,11 @@ oracle prices before it builds order parameters. The forwarding is intercepted a
 ``GMXTrading.open_position`` so nothing is broadcast.
 """
 
+import asyncio
+
 import pytest
+
+from eth_defi.gmx.ccxt.async_support import exchange as async_exchange
 
 #: Distinctive value, unlike any default in the codebase, so a match cannot be
 #: coincidental.
@@ -85,3 +89,38 @@ def test_explicit_execution_buffer_wins_over_the_instance_default(ccxt_gmx_fork_
     _open(gmx, {"execution_buffer": 3.5})
 
     assert captured.get("execution_buffer") == 3.5
+
+
+def _convert_async(execution_buffer: float, params: dict) -> dict:
+    """Run the async converter with a bare instance, no network or chain needed."""
+    exchange = async_exchange.GMX.__new__(async_exchange.GMX)
+    exchange.execution_buffer = execution_buffer
+    return asyncio.run(
+        exchange._convert_ccxt_to_gmx_params_async(
+            symbol="ETH/USDC:USDC",
+            type="market",
+            side="buy",
+            amount=0,
+            price=None,
+            params={"size_usd": 10.0, "leverage": 2.0, **params},
+        )
+    )
+
+
+def test_async_converter_uses_the_configured_execution_buffer():
+    """The async converter must not hardcode the buffer past the configured one.
+
+    ``_convert_ccxt_to_gmx_params_async()`` read ``params["execution_buffer"]``
+    with a literal ``2.2`` fallback, so an async adapter constructed with
+    ``executionBuffer`` and not repeating it per order was priced at 2.2x.
+    """
+    gmx_params = _convert_async(SENTINEL_BUFFER, {})
+
+    assert gmx_params["execution_buffer"] == SENTINEL_BUFFER
+
+
+def test_async_explicit_execution_buffer_wins_over_the_instance_default():
+    """A per-order buffer must still override the instance default."""
+    gmx_params = _convert_async(SENTINEL_BUFFER, {"execution_buffer": 3.5})
+
+    assert gmx_params["execution_buffer"] == 3.5


### PR DESCRIPTION
## Summary

- `_convert_ccxt_to_gmx_params_async()` read `params["execution_buffer"]` with a hardcoded `2.2` fallback, so an async adapter constructed with `executionBuffer` and not repeating it per order was silently priced at 2.2x and GMX rejects the underfunded order with `InsufficientExecutionFee`.
- Falls back to `self.execution_buffer` instead, matching the sync adapter (`create_order()`) and the async cancel paths, which already do this. A per-order `execution_buffer` still wins.

## Related issues

Closes #1398

## Checklist

- [x] Type hints on all new function arguments and return values
- [x] Tests added or updated for new/changed behaviour
- [x] `poetry run ruff format` run on changed files
- [ ] CHANGELOG.md updated (for new features — use format: `Description (YYYY-MM-DD, [#PR](url))`) — N/A, bug fix
- [x] Sphinx docstrings added for new public functions and classes — N/A, no new public API

Two regression tests were added to the existing `tests/gmx/ccxt/test_execution_buffer_forwarding.py`; they drive the async converter directly, so no fork or RPC is needed. The first fails with `assert 2.2 == 17.5` without the fix and passes with it.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
