### PR TITLE
fix: add Atoma vault strategy descriptions

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/atoma/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/atoma/vault.py
@@ -70,11 +70,26 @@ ATOMA_VAULT_ADDRESSES: frozenset[HexAddress] = frozenset((ATOMA_VAULT_ADDRESS, A
 #: Official Atoma announcement for the AVS2 RWA vault.
 ATOMA_RWA_VAULT_LAUNCH_POST_URL: Final[str] = "https://x.com/atoma_fi/status/2079672209400832319?s=46"
 
+#: Official overview for Atoma Vault Share's perpetual DEX strategy.
+ATOMA_VAULT_OVERVIEW_URL: Final[str] = "https://atoma.fi/"
+
 #: Human-readable strategy copy for Atoma vaults without an offchain metadata API.
 #:
-#: AVS2 is the RWA vault announced by Atoma for Lighter and Trade.xyz perpetual
-#: markets. Keep this address-scoped, because AVS uses a different strategy.
+#: AVS uses Nado and Extended perpetual markets, while AVS2 is the RWA vault
+#: announced by Atoma for Lighter and Trade.xyz. Keep this address-scoped,
+#: because the vaults use different strategies.
 ATOMA_VAULT_DESCRIPTION_OVERLAY: Final[dict[HexAddress, AtomaVaultDescription]] = {
+    ATOMA_VAULT_ADDRESS: AtomaVaultDescription(
+        short_description="Market-neutral perpetuals strategy across Nado and Extended.",
+        description=" ".join(
+            (
+                "Atoma Vault is a delta-neutral USDC strategy that captures funding-rate spreads across Nado and Extended perpetual DEXs.",
+                "It holds offsetting long and short positions across the venues, seeking to avoid price-direction exposure.",
+                "Funding yield is paid into NAV in USDC, while Nado and Extended points accrue to depositors in weekly epochs.",
+                f"See [Atoma's vault overview]({ATOMA_VAULT_OVERVIEW_URL}).",
+            )
+        ),
+    ),
     ATOMA_VAULT_2_ADDRESS: AtomaVaultDescription(
         short_description="Market-neutral RWA perpetuals strategy across Lighter and Trade.xyz.",
         description=" ".join(
@@ -86,6 +101,12 @@ ATOMA_VAULT_DESCRIPTION_OVERLAY: Final[dict[HexAddress, AtomaVaultDescription]] 
             )
         ),
     ),
+}
+
+#: Curated display names for Atoma vaults whose onchain share-token names are generic.
+ATOMA_VAULT_NAME_OVERLAY: Final[dict[HexAddress, str]] = {
+    ATOMA_VAULT_ADDRESS: "Extended and Nano arbitrage",
+    ATOMA_VAULT_2_ADDRESS: "Lighter and Trade.xyz arbitrage",
 }
 
 #: Atoma performance fee in basis points.
@@ -120,6 +141,21 @@ class AtomaVault(ERC4626Vault):
     later ``claimWithdrawal(epochId)`` after the settlement epoch has been
     processed.
     """
+
+    @property
+    def name(self) -> str:
+        """Return a curated name for a known Atoma strategy.
+
+        AVS2's onchain share-token name is generic, so its address-scoped
+        overlay provides a descriptive name. Other Atoma vaults retain their
+        onchain token names.
+
+        :return:
+            Curated name when available, otherwise the onchain token name.
+        """
+
+        name = ATOMA_VAULT_NAME_OVERLAY.get(HexAddress(str(self.vault_address).lower()))
+        return name if name else super().name
 
     @property
     def description(self) -> str | None:

--- a/tests/erc_4626/vault_protocol/test_atoma.py
+++ b/tests/erc_4626/vault_protocol/test_atoma.py
@@ -8,7 +8,7 @@ from web3 import Web3
 
 from eth_defi.erc_4626.classification import HARDCODED_PROTOCOLS, create_vault_instance
 from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name
-from eth_defi.erc_4626.vault_protocol.atoma.vault import ATOMA_RWA_VAULT_LAUNCH_POST_URL, ATOMA_VAULT_2_ADDRESS, ATOMA_VAULT_ADDRESS, ATOMA_VAULT_ADDRESSES, AtomaVault
+from eth_defi.erc_4626.vault_protocol.atoma.vault import ATOMA_RWA_VAULT_LAUNCH_POST_URL, ATOMA_VAULT_2_ADDRESS, ATOMA_VAULT_ADDRESS, ATOMA_VAULT_ADDRESSES, ATOMA_VAULT_OVERVIEW_URL, AtomaVault
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.fee import VaultFeeMode
 from eth_defi.vault.risk import VaultTechnicalRisk
@@ -55,14 +55,19 @@ def test_atoma_static_fee_metadata() -> None:
     assert net_fee_data.withdraw == pytest.approx(0.005)
     assert vault.get_estimated_lock_up() == datetime.timedelta(days=7)
     assert vault.get_link() == "https://app.atoma.fi/"
-    assert vault.description is None
-    assert vault.short_description is None
+    assert vault.name == "Extended and Nano arbitrage"
+    assert vault.short_description == "Market-neutral perpetuals strategy across Nado and Extended."
+    assert vault.description is not None
+    assert "funding-rate spreads across Nado and Extended perpetual DEXs" in vault.description
+    assert "[Atoma's vault overview](https://atoma.fi/)" in vault.description
+    assert ATOMA_VAULT_OVERVIEW_URL in vault.description
 
 
 def test_atoma_rwa_vault_description_overlay() -> None:
-    """AVS2 has source-linked strategy copy specific to the RWA vault."""
+    """AVS2 has source-linked strategy copy and name specific to the RWA vault."""
     vault = AtomaVault(Web3(), VaultSpec(42161, ATOMA_VAULT_2_ADDRESS), features={ERC4626Feature.atoma_like})
 
+    assert vault.name == "Lighter and Trade.xyz arbitrage"
     assert vault.short_description == "Market-neutral RWA perpetuals strategy across Lighter and Trade.xyz."
     assert vault.description is not None
     assert "gold, oil and equity-index perpetuals" in vault.description


### PR DESCRIPTION
## Why

Atoma Vault Share 1 needs a clear strategy name and source-linked descriptions, matching the specialised metadata already available for Vault Share 2.

## Lessons learnt

Atoma describes Vault Share 1 as a delta-neutral funding-rate strategy across Nado and Extended; its requested display name retains the established Nano spelling.

## Summary

- Add address-specific names for both Atoma Vault Share vaults.
- Add short and long descriptions for Vault Share 1, linked to Atoma’s official overview.
- Cover both the name and descriptions with focused adapter tests.

## Related issues and PRs

- Builds on #1429, which mapped Atoma Vault Share 2.

## Unrelated CI and test fixes

- None.