### PR TITLE
fix: batch Hypercore vault guard whitelisting

### DIFF
--- a/docs/README-Hypercore-guard.md
+++ b/docs/README-Hypercore-guard.md
@@ -68,8 +68,8 @@ dynamic policy intentionally makes any explicit vault list irrelevant.
        │
        ├─ 4. Deploy TradingStrategyModuleV0 (guard)
        │      └─ Always requires big blocks (~5.4M gas)
-       │      └─ Whitelists: CoreWriter, CoreDepositWallet, and either an
-       │         explicit vault address or the dynamic native-vault policy
+       │      └─ Whitelists: CoreWriter, CoreDepositWallet, and either
+       │         explicit vault addresses or the dynamic native-vault policy
        │
        └─ 5. Disable big blocks (return to fast ~1s confirmations)
 ```
@@ -209,6 +209,18 @@ When the EVM block finishes execution, all queued CoreWriter actions are process
 sequentially on HyperCore (~47k gas per action). This is implicit batching at the
 block level.
 
+### Guard deployment batches
+
+Guard configuration is separate from the trading multicalls above. When a Lagoon
+deployment supplies an explicit Hypercore vault allowlist, setup sends at most
+40 `whitelistHypercoreVault()` calls in each guard multicall. The first batch
+also configures USDC, CoreWriter and CoreDepositWallet. This size is
+regression-tested on the fixed HyperEVM fork to remain below the 2M fast-block
+gas limit; it must not be replaced with the generic caller-configurable
+multicall chunk size. Each batch is a separate transaction, so a failed later
+batch leaves earlier vault permissions in place; rerun the deployment after
+resolving the failure to finish the explicit allowlist.
+
 ## Guard security model
 
 The guard prevents:
@@ -291,7 +303,7 @@ This has major implications for deploying Lagoon vaults and guard contracts.
 
 | Property | Small blocks | Large blocks |
 |----------|-------------|-------------|
-| Gas limit | ~2–3M | 30M |
+| Gas limit | 2M | 30M |
 | Cadence | Every ~1 second | Every ~1 minute |
 | Transactions per block | Multiple | 1 |
 | Use case | Normal transactions | Contract deployments, heavy computation |

--- a/eth_defi/erc_4626/vault_protocol/lagoon/deployment.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/deployment.py
@@ -47,6 +47,7 @@ from eth_defi.foundry.forge import deploy_contract_with_forge
 from eth_defi.gas import apply_gas, estimate_gas_price
 from eth_defi.gmx.whitelist import GMXDeployment, resolve_gmx_market_labels
 from eth_defi.hotwallet import HotWallet
+from eth_defi.hyperliquid.block import HYPEREVM_FAST_BLOCK_GAS_LIMIT
 from eth_defi.hyperliquid.core_writer import CORE_DEPOSIT_WALLET, CORE_WRITER_ADDRESS
 from eth_defi.hyperliquid.guard_whitelist import get_core_deposit_wallet
 from eth_defi.lighter.deployment import LighterDeployment, setup_lighter_whitelisting
@@ -99,6 +100,13 @@ LAGOON_SETTLEMENT_LIMIT_INTERNAL_VERSION = 3
 #: only charged for gas actually used, so over-provisioning the limit is free.
 DEFAULT_DEPLOYMENT_GAS_MULTIPLIER = 2.0
 
+#: Maximum explicit Hypercore native vaults whitelisted in one GuardV0
+#: multicall. HyperEVM fast blocks have a 2M gas limit, so do not use the
+#: caller-configurable generic multicall chunk size here.
+#: The 40-vault batch, including CoreWriter and USDC setup, is regression-tested
+#: to consume less than 2M gas on the fixed HyperEVM fork.
+HYPERCORE_MULTICALL_CHUNK_SIZE = 40
+
 
 CONTRACTS_ROOT = Path(os.path.dirname(__file__)) / ".." / ".." / ".." / ".." / "contracts"
 
@@ -138,6 +146,7 @@ def _validate_lagoon_settlement_limit_config(
         return
 
     assert isinstance(max_settlement_amount, Decimal), "max_settlement_amount must be Decimal"
+    assert max_settlement_amount.is_finite(), "max_settlement_amount must be finite"
     assert max_settlement_amount >= 0, "max_settlement_amount cannot be negative"
     assert type(settlement_cooldown) is int, "settlement_cooldown must be an int number of seconds"
     assert settlement_cooldown > 0, "settlement_cooldown must be positive when max_settlement_amount is configured"
@@ -1961,7 +1970,8 @@ def setup_guard(
         logger.info("Not whitelisted: CCTP")
 
     # Whitelist Hypercore native vault support (HyperEVM only).
-    # Batch CoreWriter + all vault whitelisting into a single multicall transaction.
+    # The first batch configures CoreWriter and the required underlying token;
+    # explicit vaults are split so they fit in HyperEVM fast blocks.
     if should_enable_hypercore_guard(
         chain_id=web3.eth.chain_id,
         any_hypercore_vault=any_hypercore_vault,
@@ -1975,7 +1985,7 @@ def setup_guard(
             cdw_address,
         )
 
-        multicalls = []
+        initial_multicalls = []
 
         # The bridge flow starts with approve(USDC, CoreDepositWallet).
         # In explicit-asset mode we must whitelist the underlying token.
@@ -1990,14 +2000,14 @@ def setup_guard(
             else:
                 raise ValueError("Hypercore guard setup without any_asset requires either vault or underlying_token_address")
 
-            multicalls.append(
+            initial_multicalls.append(
                 module.functions.whitelistToken(
                     underlying_address,
                     "Underlying token for Hypercore deposit approve",
                 )
             )
 
-        multicalls.append(
+        initial_multicalls.append(
             module.functions.whitelistCoreWriter(
                 Web3.to_checksum_address(CORE_WRITER_ADDRESS),
                 Web3.to_checksum_address(cdw_address),
@@ -2006,18 +2016,36 @@ def setup_guard(
         )
 
         explicit_hypercore_vaults = hypercore_vaults or []
-        for idx, hv_address in enumerate(explicit_hypercore_vaults, start=1):
-            logger.info("Whitelisting Hypercore vault #%d: %s", idx, hv_address)
-            multicalls.append(
-                module.functions.whitelistHypercoreVault(
-                    Web3.to_checksum_address(hv_address),
-                    f"Hypercore vault: {hv_address}",
-                )
+        if explicit_hypercore_vaults:
+            hypercore_vault_chunks = chunked(
+                explicit_hypercore_vaults,
+                HYPERCORE_MULTICALL_CHUNK_SIZE,
             )
+        else:
+            # Dynamic Hypercore policy has no explicit vaults, but still needs
+            # the underlying-token and CoreWriter configuration above.
+            hypercore_vault_chunks = [[]]
 
-        call = module.functions.multicall(encode_multicalls(multicalls))
-        tx_hash = _broadcast(call)
-        assert_transaction_success_with_explanation(web3, tx_hash, timeout=DEFAULT_TX_CONFIRMATION_TIMEOUT)
+        for chunk_id, chunk in enumerate(hypercore_vault_chunks, start=1):
+            multicalls = list(initial_multicalls) if chunk_id == 1 else []
+            logger.info(
+                "Processing Hypercore vault batch #%d, size %d",
+                chunk_id,
+                len(chunk),
+            )
+            start_index = (chunk_id - 1) * HYPERCORE_MULTICALL_CHUNK_SIZE + 1
+            for idx, hv_address in enumerate(chunk, start=start_index):
+                logger.info("Whitelisting Hypercore vault #%d: %s", idx, hv_address)
+                multicalls.append(
+                    module.functions.whitelistHypercoreVault(
+                        Web3.to_checksum_address(hv_address),
+                        f"Hypercore vault: {hv_address}",
+                    )
+                )
+
+            call = module.functions.multicall(encode_multicalls(multicalls))
+            tx_hash = _broadcast(call)
+            assert_transaction_success_with_explanation(web3, tx_hash, timeout=DEFAULT_TX_CONFIRMATION_TIMEOUT)
 
         entries.append(WhitelistEntry("Hypercore", "CoreWriter", CORE_WRITER_ADDRESS))
         entries.append(WhitelistEntry("Hypercore", "CoreDepositWallet", cdw_address))
@@ -2363,6 +2391,11 @@ def deploy_automated_lagoon_vault(
             try:
                 estimated_gas = bound_func.estimate_gas({"from": deployer.address})
                 gas_limit = int(estimated_gas * DEFAULT_DEPLOYMENT_GAS_MULTIPLIER)
+                if web3.eth.chain_id in (998, 999) and bound_func.fn_name == "multicall":
+                    # Guard configuration runs in a fast block. Do not let the
+                    # generic multiplier create a transaction the node rejects
+                    # before it can use the measured safe batch size.
+                    gas_limit = min(gas_limit, HYPEREVM_FAST_BLOCK_GAS_LIMIT)
             except (ValueError, ContractLogicError) as e:
                 logger.warning("Gas estimation failed for %s, using node auto-estimate: %s", bound_func.fn_name, e)
             tx_hash = deployer.transact_and_broadcast_with_contract(bound_func, gas_limit=gas_limit)

--- a/eth_defi/hyperliquid/block.py
+++ b/eth_defi/hyperliquid/block.py
@@ -2,7 +2,7 @@
 
 HyperEVM produces two types of blocks:
 
-- **Small blocks** (~2-3M gas, every ~1 second): normal transactions
+- **Small blocks** (2M gas, every ~1 second): normal transactions
 - **Large blocks** (30M gas, every ~1 minute): contract deployments, heavy computation
 
 Transactions are routed to independent mempools based on the sender's
@@ -58,10 +58,17 @@ HYPEREVM_CHAIN_IDS: set[int] = {998, 999}
 
 #: Gas limit for HyperEVM large blocks (30M).
 #:
-#: Small blocks have ~2-3M gas; large blocks always have 30M.
+#: Small blocks have a 2M gas cap; large blocks always have 30M.
 #: Used to override ``eth_getBlock("latest")["gasLimit"]`` which may return
 #: a small block's limit even when the deployer has big blocks enabled.
 HYPEREVM_BIG_BLOCK_GAS_LIMIT: int = 30_000_000
+
+#: Conservative gas cap for HyperEVM fast-block transactions.
+#:
+#: Guard configuration must use fast blocks after contract deployment. Keep a
+#: transaction's declared gas limit at or below this value, rather than letting
+#: a generic estimate multiplier make an otherwise valid call unpublishable.
+HYPEREVM_FAST_BLOCK_GAS_LIMIT: int = 2_000_000
 
 #: Hyperliquid exchange API URL (mainnet).
 HYPERLIQUID_EXCHANGE_API_MAINNET = "https://api.hyperliquid.xyz"

--- a/tests/guard/test_guard_hypercore_vault_lagoon.py
+++ b/tests/guard/test_guard_hypercore_vault_lagoon.py
@@ -24,6 +24,7 @@ from web3.contract import Contract
 
 from eth_defi.abi import encode_function_call
 from eth_defi.erc_4626.vault_protocol.lagoon.deployment import (
+    HYPERCORE_MULTICALL_CHUNK_SIZE,
     LagoonAutomatedDeployment,
     LagoonConfig,
     LagoonDeploymentParameters,
@@ -52,6 +53,7 @@ from eth_defi.hyperliquid.testing import (
     deploy_mock_core_deposit_wallet,
     deploy_mock_core_writer,
 )
+from eth_defi.hyperliquid.block import HYPEREVM_FAST_BLOCK_GAS_LIMIT
 from eth_defi.provider.anvil import (
     ANVIL_OWNER_1,
     ANVIL_OWNER_2,
@@ -85,9 +87,14 @@ DEPLOYER_PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d
 #: Test vault address (arbitrary, just needs to be whitelisted)
 TEST_HYPERCORE_VAULT = HexAddress(HexStr("0x1111111111111111111111111111111111111111"))
 
+#: More than one Hypercore guard batch, including the vault used for deposits.
+HYPERCORE_VAULTS_FOR_BATCH_TEST = [
+    TEST_HYPERCORE_VAULT,
+    *[HexAddress(HexStr(f"0x{vault_id:040x}")) for vault_id in range(1, HYPERCORE_MULTICALL_CHUNK_SIZE + 1)],
+]
+
 #: HyperEVM USDC address
 USDC_ADDRESS = USDC_NATIVE_TOKEN[999]
-
 
 def _perform_call(module: Contract, fn_call, asset_manager: str):
     """Encode and submit a performCall transaction on TradingStrategyModuleV0."""
@@ -228,7 +235,7 @@ def lagoon_deployment(
         asset_managers=[deployer.address],
         safe_owners=[ANVIL_OWNER_1, ANVIL_OWNER_2],
         safe_threshold=2,
-        hypercore_vaults=[TEST_HYPERCORE_VAULT],
+        hypercore_vaults=HYPERCORE_VAULTS_FOR_BATCH_TEST,
         safe_salt_nonce=42,
     )
 
@@ -263,6 +270,48 @@ def _restore_hypercore_lagoon_state(
 
     assert lagoon_deployment.trading_strategy_module is not None
     yield from evm_snapshot_revert(anvil_hyperliquid)
+
+
+@pytest.mark.timeout(600)
+def test_lagoon_hypercore_vault_whitelisting_is_batched(
+    web3: Web3,
+    lagoon_deployment: LagoonAutomatedDeployment,
+) -> None:
+    """Deploy more vaults than one Hypercore multicall can contain.
+
+    1. Deploy the Lagoon fixture with one more explicit vault than the batch cap.
+    2. Read the guard's Hypercore-vault approval events.
+    3. Verify every vault is approved across two transactions below the
+       HyperEVM fast-block gas limit.
+    """
+    # 1. The shared fixture includes one more vault than one batch can hold.
+    assert len(HYPERCORE_VAULTS_FOR_BATCH_TEST) == HYPERCORE_MULTICALL_CHUNK_SIZE + 1
+    module = lagoon_deployment.trading_strategy_module
+
+    # 2. Read all explicit Hypercore-vault approvals from the deployed module.
+    approval_logs = web3.eth.get_logs(
+        {
+            "fromBlock": 0,
+            "toBlock": "latest",
+            "address": module.address,
+            "topics": [Web3.keccak(text="HypercoreVaultApproved(address,string)").hex()],
+        }
+    )
+
+    # 3. Every intended vault is approved in fast-block-safe transactions.
+    assert len(approval_logs) == len(HYPERCORE_VAULTS_FOR_BATCH_TEST)
+    approved_vaults = {
+        Web3.to_checksum_address(decode(["address", "string"], log["data"])[0])
+        for log in approval_logs
+    }
+    assert approved_vaults == {
+        Web3.to_checksum_address(vault)
+        for vault in HYPERCORE_VAULTS_FOR_BATCH_TEST
+    }
+    transaction_hashes = {log["transactionHash"] for log in approval_logs}
+    assert len(transaction_hashes) == 2
+    assert all(web3.eth.get_transaction_receipt(tx_hash)["gasUsed"] < HYPEREVM_FAST_BLOCK_GAS_LIMIT for tx_hash in transaction_hashes)
+    assert all(web3.eth.get_transaction(tx_hash)["gas"] <= HYPEREVM_FAST_BLOCK_GAS_LIMIT for tx_hash in transaction_hashes)
 
 
 @pytest.mark.timeout(600)

--- a/tests/guard/test_guard_hypercore_vault_lagoon.py
+++ b/tests/guard/test_guard_hypercore_vault_lagoon.py
@@ -96,6 +96,7 @@ HYPERCORE_VAULTS_FOR_BATCH_TEST = [
 #: HyperEVM USDC address
 USDC_ADDRESS = USDC_NATIVE_TOKEN[999]
 
+
 def _perform_call(module: Contract, fn_call, asset_manager: str):
     """Encode and submit a performCall transaction on TradingStrategyModuleV0."""
     target = fn_call.address
@@ -300,14 +301,8 @@ def test_lagoon_hypercore_vault_whitelisting_is_batched(
 
     # 3. Every intended vault is approved in fast-block-safe transactions.
     assert len(approval_logs) == len(HYPERCORE_VAULTS_FOR_BATCH_TEST)
-    approved_vaults = {
-        Web3.to_checksum_address(decode(["address", "string"], log["data"])[0])
-        for log in approval_logs
-    }
-    assert approved_vaults == {
-        Web3.to_checksum_address(vault)
-        for vault in HYPERCORE_VAULTS_FOR_BATCH_TEST
-    }
+    approved_vaults = {Web3.to_checksum_address(decode(["address", "string"], log["data"])[0]) for log in approval_logs}
+    assert approved_vaults == {Web3.to_checksum_address(vault) for vault in HYPERCORE_VAULTS_FOR_BATCH_TEST}
     transaction_hashes = {log["transactionHash"] for log in approval_logs}
     assert len(transaction_hashes) == 2
     assert all(web3.eth.get_transaction_receipt(tx_hash)["gasUsed"] < HYPEREVM_FAST_BLOCK_GAS_LIMIT for tx_hash in transaction_hashes)


### PR DESCRIPTION
## Why

HyperEVM fast blocks have a 2M gas limit. A full Hyper-AI vault universe can contain hundreds of explicit vault permissions, so configuring them in one guard multicall risks reverting before the restrictive policy is installed.

## Lessons learnt

The generic guard multicall chunk size is not a safe HyperEVM deployment setting. The first Hypercore batch also configures USDC, CoreWriter and CoreDepositWallet, so the limit must be measured on a fixed fork rather than inferred from calldata size.

## Summary

- Batch explicit Hypercore vault guard permissions in groups of 40.
- Preserve the one-time USDC and CoreWriter setup in the first batch.
- Cap the published HyperEVM guard multicall gas limit at 2M, avoiding the generic two-times-estimate multiplier exceeding a fast-block limit.
- Add fixed-fork coverage proving every batch's consumed and submitted gas remains below the fast-block limit.
- Document the deployment-specific batching policy.

## Related issues and PRs

- Required by tradingstrategy-ai/trade-executor#1603, which constructs and deploys the strategy-universe allowlist through `lagoon-deploy-vault`.
