### PR TITLE
fix: add Atoma vault name migration

### DIFF
--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -1225,6 +1225,33 @@ source .local-test.env && \
 | `JSON_RPC_<CHAIN>` | Required for every recognised EVM chain represented in the vault database. |
 | `LOG_LEVEL` | Optional. Default: info. |
 
+### migrate-atoma-vault-names.py
+
+Persist the curated strategy names for the two supported Atoma vaults on
+Arbitrum. This migration targets only those two cached rows, makes no RPC
+calls, and creates a sibling metadata-pickle backup before writing. Do not use
+`migrate-vault-token-metadata.py` for this repair: that generic command reads
+the contracts' generic onchain token names and would overwrite the curated
+strategy labels.
+
+```shell
+# Report the two name updates without writing (default)
+source .local-test.env && \
+  DRY_RUN=true \
+  poetry run python scripts/erc-4626/migrate-atoma-vault-names.py
+
+# Back up and persist the curated display names
+source .local-test.env && \
+  DRY_RUN=false \
+  poetry run python scripts/erc-4626/migrate-atoma-vault-names.py
+```
+
+| Variable | Description |
+|----------|-------------|
+| `VAULT_DB_PATH` | Optional vault metadata pickle path. Default: `~/.tradingstrategy/vaults/vault-metadata-db.pickle`. |
+| `DRY_RUN` | Optional. Report only when true. Default: true. |
+| `LOG_LEVEL` | Optional. Default: info. |
+
 ### prepopulate-timestamps.py
 
 Prepopulate the Hypersync block timestamp DuckDB cache for all scanner chains.

--- a/scripts/erc-4626/migrate-atoma-vault-names.py
+++ b/scripts/erc-4626/migrate-atoma-vault-names.py
@@ -1,0 +1,224 @@
+"""Apply curated display names to the two cached Atoma vault records.
+
+Atoma's ERC-4626 share-token ``name()`` values are generic and do not identify
+the strategy.  The Atoma adapter now provides reviewed address-scoped display
+names, but existing vault metadata pickles retain the previous onchain values.
+This targeted migration persists the two curated names without making RPC
+calls, rescanning vaults, or modifying any price, reader-state, or other
+metadata fields.
+
+The generic ``migrate-vault-token-metadata.py`` command must not be used for
+this repair: it deliberately reads the onchain token names and would overwrite
+these curated names.
+
+Usage:
+
+.. code-block:: shell
+
+    # Inspect the two expected updates without writing (the default)
+    source .local-test.env && poetry run python scripts/erc-4626/migrate-atoma-vault-names.py
+
+    # Back up and persist the curated names
+    source .local-test.env && DRY_RUN=false \\
+        poetry run python scripts/erc-4626/migrate-atoma-vault-names.py
+
+Environment variables:
+
+- ``VAULT_DB_PATH``: Optional path to ``vault-metadata-db.pickle``.
+- ``DRY_RUN``: Set to ``false`` to write changes. Defaults to ``true``.
+- ``LOG_LEVEL``: Optional console log level. Defaults to ``info``.
+"""
+
+import logging
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from tabulate import tabulate
+
+from eth_defi.erc_4626.vault_protocol.atoma.vault import ATOMA_VAULT_NAME_OVERLAY
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.vaultdb import DEFAULT_VAULT_DATABASE, VaultDatabase
+
+logger = logging.getLogger(__name__)
+
+#: Atoma vaults are ERC-4626 deployments on Arbitrum One.
+ATOMA_CHAIN_ID = 42_161
+
+#: Exact cached rows and their reviewed display names.
+ATOMA_VAULT_NAME_UPDATES: dict[VaultSpec, str] = {VaultSpec(ATOMA_CHAIN_ID, address): name for address, name in ATOMA_VAULT_NAME_OVERLAY.items()}
+
+
+@dataclass(slots=True, frozen=True)
+class AtomaVaultNameUpdate:
+    """Describe one cached Atoma vault display-name change."""
+
+    #: Chain and vault address identifying the cached metadata row.
+    spec: VaultSpec
+
+    #: Generic name currently persisted in the metadata database.
+    old_name: str | None
+
+    #: Curated address-scoped display name to persist.
+    new_name: str
+
+
+@dataclass(slots=True, frozen=True)
+class AtomaVaultNameMigrationResult:
+    """Summarise the targeted Atoma display-name migration."""
+
+    #: Total vault metadata rows in the source cache.
+    inspected_rows: int
+
+    #: Rows that were or would be updated.
+    updates: tuple[AtomaVaultNameUpdate, ...]
+
+
+def parse_boolean_env(value: str | None, *, default: bool) -> bool:
+    """Parse an explicit environment boolean without unsafe fallbacks.
+
+    :param value:
+        Environment value, or ``None`` when it is absent.
+    :param default:
+        Value to return for an absent environment variable.
+    :return:
+        Parsed boolean value.
+    """
+
+    if value is None:
+        return default
+
+    normalised_value = value.strip().lower()
+    if normalised_value in {"1", "true", "yes", "on"}:
+        return True
+    if normalised_value in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"Expected a boolean environment value, got {value!r}")
+
+
+def create_backup_path(vault_db_path: Path) -> Path:
+    """Choose a non-overwriting backup path for the metadata pickle.
+
+    :param vault_db_path:
+        Existing metadata cache that will be backed up before a write.
+    :return:
+        Unused sibling backup path.
+    """
+
+    backup_path = vault_db_path.with_suffix(".pickle.bak-atoma-vault-names")
+    if not backup_path.exists():
+        return backup_path
+
+    backup_index = 1
+    while True:
+        indexed_backup_path = Path(f"{backup_path}.{backup_index}")
+        if not indexed_backup_path.exists():
+            return indexed_backup_path
+        backup_index += 1
+
+
+def collect_atoma_vault_name_updates(vault_db: VaultDatabase) -> tuple[AtomaVaultNameUpdate, ...]:
+    """Collect the two reviewed Atoma name updates from a metadata cache.
+
+    Both target rows must be present before the migration can continue. This
+    prevents an incomplete or unrelated cache from receiving a partial repair.
+
+    :param vault_db:
+        Persisted vault metadata loaded into memory.
+    :return:
+        Changed rows in deterministic address order.
+    :raises KeyError:
+        If either expected Atoma vault row is absent.
+    """
+
+    missing_specs = sorted(
+        set(ATOMA_VAULT_NAME_UPDATES).difference(vault_db.rows),
+        key=lambda spec: (spec.chain_id, spec.vault_address),
+    )
+    if missing_specs:
+        formatted_specs = ", ".join(f"{spec.chain_id}-{spec.vault_address}" for spec in missing_specs)
+        raise KeyError(f"Expected Atoma vault metadata rows are missing: {formatted_specs}")
+
+    updates = []
+    for spec, new_name in sorted(
+        ATOMA_VAULT_NAME_UPDATES.items(),
+        key=lambda item: (item[0].chain_id, item[0].vault_address),
+    ):
+        old_name = vault_db.rows[spec].get("Name")
+        if old_name != new_name:
+            updates.append(AtomaVaultNameUpdate(spec=spec, old_name=old_name, new_name=new_name))
+    return tuple(updates)
+
+
+def migrate_atoma_vault_names(
+    vault_db_path: Path = DEFAULT_VAULT_DATABASE,
+    *,
+    dry_run: bool,
+) -> AtomaVaultNameMigrationResult:
+    """Persist address-scoped Atoma strategy names in a vault metadata cache.
+
+    The migration is idempotent and writes only ``Name`` on the two known
+    Arbitrum Atoma rows. It creates a sibling backup before its first write.
+
+    :param vault_db_path:
+        Existing vault metadata pickle to inspect and optionally update.
+    :param dry_run:
+        Report updates without modifying the pickle when ``True``.
+    :return:
+        Inspection count and changed rows.
+    """
+
+    vault_db = VaultDatabase.read(vault_db_path)
+    updates = collect_atoma_vault_name_updates(vault_db)
+    result = AtomaVaultNameMigrationResult(inspected_rows=len(vault_db.rows), updates=updates)
+
+    if updates:
+        print(
+            tabulate(
+                [[update.spec.chain_id, update.spec.vault_address, update.old_name, update.new_name] for update in updates],
+                headers=["chain", "address", "old name", "new name"],
+                tablefmt="simple",
+            )
+        )
+
+    if not updates:
+        logger.info("No stale Atoma vault names found in %s", vault_db_path)
+        return result
+    if dry_run:
+        logger.info("DRY RUN: would update %d Atoma vault names in %s", len(updates), vault_db_path)
+        return result
+
+    backup_path = create_backup_path(vault_db_path)
+    logger.info("Creating vault metadata backup at %s", backup_path)
+    shutil.copy2(vault_db_path, backup_path)
+    for update in updates:
+        vault_db.rows[update.spec]["Name"] = update.new_name
+    vault_db.write(vault_db_path)
+    logger.info("Updated %d Atoma vault names in %s", len(updates), vault_db_path)
+    return result
+
+
+def main() -> None:
+    """Run the Atoma name migration from environment configuration.
+
+    :return:
+        ``None``. Raises if the metadata cache is missing or incomplete.
+    """
+
+    setup_console_logging(default_log_level=os.environ.get("LOG_LEVEL", "info"))
+    vault_db_path = Path(os.environ.get("VAULT_DB_PATH", str(DEFAULT_VAULT_DATABASE))).expanduser()
+    if not vault_db_path.exists():
+        raise FileNotFoundError(f"Vault database not found: {vault_db_path}")
+    dry_run = parse_boolean_env(os.environ.get("DRY_RUN"), default=True)
+    result = migrate_atoma_vault_names(vault_db_path, dry_run=dry_run)
+    print(f"Inspected {result.inspected_rows:,} rows and updated {len(result.updates):,} Atoma vault names.")
+    if dry_run:
+        print("Dry run - no changes written.")
+    elif result.updates:
+        print(f"Saved migrated vault metadata to {vault_db_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/erc_4626/test_migrate_atoma_vault_names.py
+++ b/tests/erc_4626/test_migrate_atoma_vault_names.py
@@ -1,0 +1,117 @@
+"""Tests for the targeted Atoma vault-name migration."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.vaultdb import VaultDatabase
+
+
+def load_migration_module():
+    """Load the Atoma migration script as a test module.
+
+    :return:
+        Loaded migration module.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "erc-4626" / "migrate-atoma-vault-names.py"
+    spec = importlib.util.spec_from_file_location("migrate_atoma_vault_names", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def create_row(name: str) -> dict:
+    """Create a minimal vault metadata row for migration tests.
+
+    :param name:
+        Persisted vault name.
+    :return:
+        Compatible minimal metadata row.
+    """
+
+    return {"Name": name, "Protocol": "Atoma"}
+
+
+def create_vault_database(migration) -> VaultDatabase:
+    """Create a metadata cache with both Atoma rows and one unrelated row.
+
+    :param migration:
+        Loaded migration module exposing the target update mapping.
+    :return:
+        Vault database fixture.
+    """
+
+    rows = {spec: create_row("Atoma Vault Share") for spec in migration.ATOMA_VAULT_NAME_UPDATES}
+    rows[VaultSpec(1, "0x0000000000000000000000000000000000000001")] = create_row("Unrelated vault")
+    return VaultDatabase(rows=rows)
+
+
+def test_migrate_atoma_vault_names_updates_only_the_two_target_rows(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The write migration persists both curated names and preserves other rows."""
+
+    migration = load_migration_module()
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    vault_db = create_vault_database(migration)
+    vault_db.write(vault_db_path)
+
+    result = migration.migrate_atoma_vault_names(vault_db_path, dry_run=False)
+    captured = capsys.readouterr()
+
+    assert result.inspected_rows == len(migration.ATOMA_VAULT_NAME_UPDATES) + 1
+    assert {update.spec for update in result.updates} == set(migration.ATOMA_VAULT_NAME_UPDATES)
+    assert "old name" in captured.out
+    assert (tmp_path / "vault-metadata-db.pickle.bak-atoma-vault-names").exists()
+
+    migrated_db = VaultDatabase.read(vault_db_path)
+    for spec, expected_name in migration.ATOMA_VAULT_NAME_UPDATES.items():
+        assert migrated_db.rows[spec]["Name"] == expected_name
+        assert migrated_db.rows[spec]["Protocol"] == "Atoma"
+    unrelated_spec = VaultSpec(1, "0x0000000000000000000000000000000000000001")
+    assert migrated_db.rows[unrelated_spec]["Name"] == "Unrelated vault"
+
+
+def test_migrate_atoma_vault_names_dry_run_does_not_write(tmp_path: Path) -> None:
+    """Dry run reports updates without modifying the metadata pickle."""
+
+    migration = load_migration_module()
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    create_vault_database(migration).write(vault_db_path)
+
+    result = migration.migrate_atoma_vault_names(vault_db_path, dry_run=True)
+
+    assert len(result.updates) == len(migration.ATOMA_VAULT_NAME_UPDATES)
+    unchanged_db = VaultDatabase.read(vault_db_path)
+    assert {row["Name"] for spec, row in unchanged_db.rows.items() if spec in migration.ATOMA_VAULT_NAME_UPDATES} == {"Atoma Vault Share"}
+    assert not (tmp_path / "vault-metadata-db.pickle.bak-atoma-vault-names").exists()
+
+
+def test_migrate_atoma_vault_names_requires_both_target_rows(tmp_path: Path) -> None:
+    """An incomplete cache cannot receive a partial targeted migration."""
+
+    migration = load_migration_module()
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    present_spec = next(iter(migration.ATOMA_VAULT_NAME_UPDATES))
+    VaultDatabase(rows={present_spec: create_row("Atoma Vault Share")}).write(vault_db_path)
+
+    with pytest.raises(KeyError, match="Expected Atoma vault metadata rows are missing"):
+        migration.migrate_atoma_vault_names(vault_db_path, dry_run=False)
+
+    assert VaultDatabase.read(vault_db_path).rows[present_spec]["Name"] == "Atoma Vault Share"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(None, True), ("true", True), ("1", True), ("false", False), ("0", False)],
+)
+def test_parse_boolean_env(value: str | None, expected: object) -> None:
+    """The write-mode switch recognises explicit conventional boolean values."""
+
+    migration = load_migration_module()
+
+    assert migration.parse_boolean_env(value, default=True) is expected


### PR DESCRIPTION
## Why

The Atoma adapter now supplies curated strategy names, but existing metadata pickles retain generic on-chain share-token names. A safe data migration is needed for the two cached vault rows.

## Lessons learnt

The generic token-metadata migration reads on-chain `name()` values across every EVM vault. It must not be used for curated display-name overlays because it would restore generic names.

## Summary

- Add a dry-run-first, address-scoped migration for the two Arbitrum Atoma vaults.
- Back up the metadata pickle before a write and refuse partial migrations when either target row is missing.
- Document the operator commands and add focused coverage.