### PR TITLE
fix: classify Midas mTBILL as a tokenised fund

### DIFF
--- a/docs/protocol-research/midas-product-audit-2026-08-04.md
+++ b/docs/protocol-research/midas-product-audit-2026-08-04.md
@@ -1,0 +1,133 @@
+# Midas product audit (2026-08-04)
+
+## Decision
+
+Only **mTBILL** is approved as a `tokenised_fund` at this time.  It has
+reviewed short and long product descriptions in `MIDAS_PRODUCT_METADATA` and
+the migration applies them to every existing mTBILL record.
+
+This is deliberately a product-level decision, not a protocol-level one.
+Midas describes mTokens as financial instruments and says that they are not
+DeFi vaults.  That does not make every strategy token a tokenised fund for our
+catalogue.  A product gets the flag only after a review of its issuer,
+underlying portfolio, investor rights and suitable primary documentation.
+
+The current mTBILL decision is supported by the product documentation, its
+prospectus/secured-loan structure, the short-duration U.S. Treasury-bill
+portfolio, and independently published NAV attestations:
+
+- <https://midas.app/mtbill>
+- <https://docs.midas.app/tokens/mtbill>
+- <https://docs.midas.app/tokens/mtbill/independent-reporting>
+- <https://docs.midas.app/tokens/mtbill/bankruptcy-remoteness>
+
+## Registry scope and status
+
+The static registry snapshot contains **80 distinct symbols and 149 chain
+deployments**.  This table is deliberately by symbol: a classification and its
+copy must be identical across each deployment of the same product.  Chain IDs
+are the registry's raw IDs, including testnets, bridges, incomplete records and
+third-party/white-label products.
+
+`Approved fund` means set `tokenised_fund` and keep product copy current.
+`Not a fund` means do not set it.  `Needs product review` means do not set it
+or invent a description until there is an issuer page, legal terms and a clear
+portfolio/investor-rights review.  This is intentionally more conservative
+than treating the `m` prefix or a Midas integration as proof of fund status.
+
+| Product | Deployments (chain IDs) | Product assessment | Fund decision | Description assessment and next action |
+| --- | --- | --- | --- | --- |
+| `mTBILL` | 1, 30, 8453, 23294, 42161, 42793, 98866, 421614, 11155111 | Midas U.S. Treasury-bill investment product | **Approved fund** | **Updated**: registry has reviewed short/long copy and official link. |
+| `mBASIS` | 1, 8453, 42161, 42793, 98866, 11155111 | Crypto funding-rate/basis strategy | Not a fund | Official strategy documentation exists; do not label as a fund. |
+| `mBTC` | 1, 30, 11155111 | Bitcoin yield strategy product | Not a fund | Official product documentation exists; do not label as a fund. |
+| `mEDGE` | 1, 143, 239, 8453, 16661, 42161, 98866, 11155111 | Delta-neutral DeFi yield strategy | Not a fund | Official strategy documentation exists; do not label as a fund. |
+| `mMEV` | 1, 2390, 8453, 16661, 42161, 42793, 98866, 11155111 | Delta-neutral DeFi yield strategy | Not a fund | Official strategy documentation exists; do not label as a fund. |
+| `mRE7` | 1, 239, 8453, 16661, 42161, 42793, 11155111 | Managed mToken; mandate not reviewed here | Needs product review | Obtain current manager page, terms and portfolio mandate before adding copy or flag. |
+| `mSL` | 1, 8453, 42793, 98866, 11155111 | Midas Staked Liquidity / liquidity architecture token | Not a fund | Infrastructure/liquidity product, not a pooled investment-fund classification. |
+| `mFONE` | 1, 11155111 | Managed mToken; mandate not reviewed here | Needs product review | Obtain the product page and terms before adding copy or flag. |
+| `mHYPER` | 1, 143, 9745, 747474 | Managed mToken; mandate not reviewed here | Needs product review | Obtain the product page and terms before adding copy or flag. |
+| `mAPOLLO` | 1 | Managed mToken; mandate not reviewed here | Needs product review | Obtain the product page and terms before adding copy or flag. |
+| `mLIQUIDITY` | 1, 8453, 42793, 98866, 11155111 | Liquidity-oriented mToken; mandate not reviewed here | Needs product review | Obtain the product page and terms before adding copy or flag. |
+| `hypeETH` | 1, 11155111 | Third-party/white-label product | Needs product review | No verified product copy in the Midas registry; do not infer from symbol. |
+| `hypeBTC` | 1, 11155111 | Third-party/white-label product | Needs product review | No verified product copy in the Midas registry; do not infer from symbol. |
+| `hypeUSD` | 1, 11155111 | Third-party/white-label product | Needs product review | No verified product copy in the Midas registry; do not infer from symbol. |
+| `tUSDe` | 1, 11155111 | Third-party/white-label product | Needs product review | No verified product copy in the Midas registry; do not infer from symbol. |
+| `tETH` | 1, 11155111 | Third-party/white-label product | Needs product review | No verified product copy in the Midas registry; do not infer from symbol. |
+| `tBTC` | 1, 11155111 | Third-party/white-label product | Needs product review | No verified product copy in the Midas registry; do not infer from symbol. |
+| `mevBTC` | 1 | Managed mToken; mandate not reviewed here | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `mFARM` | 1 | Managed mToken; mandate not reviewed here | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `msyrupUSD` | 1 | Third-party/white-label product | Needs product review | No verified product copy in the Midas registry; do not infer from symbol. |
+| `msyrupUSDp` | 1 | Third-party/white-label product | Needs product review | No verified product copy in the Midas registry; do not infer from symbol. |
+| `TACmBTC` | 1 | Bridge/wrapped representation of mBTC | Not a fund | Bridge representation; do not duplicate an underlying product classification. |
+| `TACmEDGE` | 1 | Bridge/wrapped representation of mEDGE | Not a fund | Bridge representation; do not duplicate an underlying product classification. |
+| `TACmMEV` | 1 | Bridge/wrapped representation of mMEV | Not a fund | Bridge/wrapped representation; mMEV itself is a strategy, not a fund. |
+| `zeroGUSDV` | 1 | Bridge/wrapped representation | Not a fund | Bridge representation; no standalone product copy. |
+| `zeroGETHV` | 1 | Bridge/wrapped representation | Not a fund | Bridge representation; no standalone product copy. |
+| `zeroGBTCV` | 1 | Bridge/wrapped representation | Not a fund | Bridge representation; no standalone product copy. |
+| `JIV` | 1 | Managed/third-party product | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `mRE7BTC` | 1 | Managed mToken; mandate not reviewed here | Needs product review | Obtain current terms and portfolio mandate before adding copy or flag. |
+| `acremBTC1` | 1 | Managed/third-party product | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `mWildUSD` | 1 | Managed/third-party product | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `mEVUSD` | 1, 8453 | Managed mToken; mandate not reviewed here | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `mEVETH` | 1 | Managed mToken; mandate not reviewed here | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `obeatUSD` | 1, 999 | Managed/third-party product | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `mHyperETH` | 1, 30, 143 | Managed mToken; mandate not reviewed here | Needs product review | Obtain current terms and portfolio mandate before adding copy or flag. |
+| `mHyperBTC` | 1, 30, 143 | Managed mToken; mandate not reviewed here | Needs product review | Obtain current terms and portfolio mandate before adding copy or flag. |
+| `mPortofino` | 1 | Managed mToken; mandate not reviewed here | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `mKRalpha` | 1 | Managed mToken; mandate not reviewed here | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `mROX` | 1 | Managed mToken; mandate not reviewed here | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `mTU` | 1 | Managed mToken; mandate not reviewed here | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `mM1USD` | 1 | Managed mToken; mandate not reviewed here | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `mGLOBAL` | 1 | Managed mToken; mandate not reviewed here | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `bondUSD` | 1, 16661 | Third-party/white-label product | Needs product review | No verified product copy in the Midas registry; do not infer from symbol. |
+| `bondETH` | 1, 16661 | Third-party/white-label product | Needs product review | No verified product copy in the Midas registry; do not infer from symbol. |
+| `bondBTC` | 1, 16661 | Third-party/white-label product | Needs product review | No verified product copy in the Midas registry; do not infer from symbol. |
+| `stockMarketTRBasisTrade` | 1 | Turkish equity/single-stock-futures basis strategy | Not a fund | Existing handwritten strategy description is appropriate; retain as a strategy vault. |
+| `carryTradeUSDTRYLeverage` | 1 | Leveraged USD/TRY carry/futures basis strategy | Not a fund | Existing handwritten strategy description is appropriate; retain as a strategy vault. |
+| `mWIN` | 1 | Managed mToken; mandate not reviewed here | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `qHVNUSD` | 1 | Managed/third-party product | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `sGold` | 1 | Third-party/white-label product | Needs product review | No verified product copy in the Midas registry; do not infer from symbol. |
+| `turtlePST` | 1 | Managed/third-party product | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `mTEST` | 8453 | Test product | Not a fund | Test entry; never publish fund copy or flag. |
+| `mGLO` | 4663, 8453 | Managed mToken; mandate not reviewed here | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `hbUSDT` | 999, 11155111 | HyperEVM/bridge product | Needs product review | No verified product copy in the Midas registry; do not infer from symbol. |
+| `hbXAUt` | 999, 11155111 | HyperEVM/bridge product | Needs product review | No verified product copy in the Midas registry; do not infer from symbol. |
+| `lstHYPE` | 999 | HyperEVM liquidity/staking product | Not a fund | Product-style token; no basis for a fund classification. |
+| `liquidHYPE` | 999, 534352 | HyperEVM liquidity product | Not a fund | Product-style token; no basis for a fund classification. |
+| `hbUSDC` | 999 | HyperEVM/bridge product | Needs product review | No verified product copy in the Midas registry; do not infer from symbol. |
+| `wVLP` | 999 | HyperEVM vault/liquidity wrapper | Not a fund | Wrapper/vault-style product; not a tokenised fund. |
+| `dnHYPE` | 999 | HyperEVM directional product | Not a fund | Strategy/wrapper-style product; not a tokenised fund. |
+| `dnPUMP` | 999 | HyperEVM directional product | Not a fund | Strategy/wrapper-style product; not a tokenised fund. |
+| `dnFART` | 999 | HyperEVM directional product | Not a fund | Strategy/wrapper-style product; not a tokenised fund. |
+| `kitUSD` | 999 | HyperEVM packaged product | Needs product review | Obtain issuer and portfolio documentation before adding copy or flag. |
+| `kitHYPE` | 999 | HyperEVM packaged product | Needs product review | Obtain issuer and portfolio documentation before adding copy or flag. |
+| `kitBTC` | 999 | HyperEVM packaged product | Needs product review | Obtain issuer and portfolio documentation before adding copy or flag. |
+| `wNLP` | 999 | HyperEVM vault/liquidity wrapper | Not a fund | Wrapper/vault-style product; not a tokenised fund. |
+| `dnETH` | 999 | HyperEVM directional product | Not a fund | Strategy/wrapper-style product; not a tokenised fund. |
+| `dnTEST` | 56, 999, 1440000 | Test product | Not a fund | Test entry; never publish fund copy or flag. |
+| `mRE7SOL` | 747474 | Managed mToken; mandate not reviewed here | Needs product review | Obtain current terms and portfolio mandate before adding copy or flag. |
+| `kmiUSD` | 747474 | Managed/third-party product | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `mXRP` | 56, 1440000 | Managed mToken; mandate not reviewed here | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `tacTON` | 239 | Bridge/wrapped representation | Not a fund | Bridge representation; no standalone product copy. |
+| `plUSD` | 9745 | Managed/third-party product | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `splUSD` | 9745 | Managed/third-party product | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `cUSDO` | 56 | Managed/third-party product | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `liquidRESERVE` | 10, 534352 | Liquidity/reserve product | Not a fund | Product-style liquidity token; no basis for a fund classification. |
+| `weEUR` | 10, 534352 | Wrapped EUR product | Not a fund | Wrapper/settlement token, not a tokenised fund. |
+| `sLINJ` | 1776 | Managed/third-party product | Needs product review | Obtain issuer/manager documentation before adding copy or flag. |
+| `mRe7ETH` | 10 | Managed mToken; mandate not reviewed here | Needs product review | Obtain current terms and portfolio mandate before adding copy or flag. |
+| `liquidRWA` | 10 | RWA/liquidity product; mandate not reviewed here | Needs product review | Obtain issuer and investor-rights documentation before adding copy or flag. |
+
+## Implementation implications
+
+1. `MIDAS_PRODUCT_METADATA` is the single source for reviewed decisions and
+   display copy.  Product scanners must read it by symbol so one product is
+   classified consistently across all chains.
+2. The migration only touches pre-existing rows for approved products.  It
+   merges the `tokenised_fund` flag and replaces only the product description,
+   short description and Midas product link; it does not rescan, create rows or
+   change price data.
+3. Future products should enter this table as `Needs product review` first.
+   Add a metadata entry only with a source-backed product description and an
+   explicit decision.  Do not use token symbols, a NAV feed or a Midas contract
+   alone as evidence of fund status.

--- a/eth_defi/midas/constants.py
+++ b/eth_defi/midas/constants.py
@@ -51,11 +51,17 @@ class MidasProduct:
     #: Human-readable NAV denomination. The initial integration supports USD products.
     denomination: str = "USD"
 
-    #: Whether this particular product is a regulated tokenised fund.
-    #:
-    #: Midas also issues crypto-strategy products, so this must remain a
-    #: product-level decision instead of a property of the shared adapter.
+    #: Whether this particular product is a reviewed tokenised fund.
     is_tokenised_fund: bool = False
+
+    #: Listing-friendly strategy summary.
+    short_description: str | None = None
+
+    #: Longer product description for the vault detail page.
+    description: str | None = None
+
+    #: Official issuer product page, when reviewed product metadata exists.
+    product_link: str | None = None
 
 
 def _optional_hex_address(address: str | None) -> HexAddress | None:
@@ -105,7 +111,10 @@ def create_midas_product_from_registry(product: MidasRegistryProduct) -> MidasPr
         redemption_vault=_optional_hex_address(product.redemption_vault),
         first_seen_at_block=product.first_seen_at_block,
         first_seen_at=product.first_seen_at,
-        is_tokenised_fund=product.symbol == "mTBILL",
+        is_tokenised_fund=product.metadata.is_tokenised_fund if product.metadata else False,
+        short_description=product.metadata.short_description if product.metadata else None,
+        description=product.metadata.description if product.metadata else None,
+        product_link=product.metadata.product_link if product.metadata else None,
     )
 
 

--- a/eth_defi/midas/registry.py
+++ b/eth_defi/midas/registry.py
@@ -2030,6 +2030,54 @@ MIDAS_PRODUCT_SCAN_EXCLUSIONS: Final[dict[tuple[str, str], str]] = {
 
 
 @dataclass(slots=True, frozen=True)
+class MidasProductMetadata:
+    """Curated display and classification metadata for one Midas mToken product.
+
+    The upstream Midas contract registry provides deployed contract addresses,
+    but it does not state whether a product should appear in Trading Strategy's
+    tokenised-fund listing. Keep that reviewed decision beside the registry
+    integration, keyed by the issuer's product symbol, so every deployment of
+    the same mToken has identical classification and product copy.
+
+    :param is_tokenised_fund:
+        Whether the product represents a reviewed tokenised fund.
+    :param short_description:
+        Listing-friendly strategy summary.
+    :param description:
+        Longer product description for the vault detail page.
+    :param product_link:
+        Official issuer product page.
+    """
+
+    is_tokenised_fund: bool
+    short_description: str
+    description: str
+    product_link: str
+
+
+#: Reviewed Midas product classification and display metadata.
+#:
+#: mTBILL is a tokenised U.S. Treasury-bill investment product. Midas' product
+#: registry deploys it on several chains, sometimes at the same token address;
+#: keeping the decision keyed by product symbol makes all supported deployments
+#: inherit the same fund classification without treating the whole Midas
+#: protocol, or crypto-strategy products such as mBASIS, as tokenised funds.
+#:
+#: Sources:
+#: - https://midas.app/mtbill
+#: - https://docs.midas.app/tokens/mtbill
+#: - https://docs.midas.app/tokens/mtbill/bankruptcy-remoteness
+MIDAS_PRODUCT_METADATA: Final[dict[str, MidasProductMetadata]] = {
+    "mTBILL": MidasProductMetadata(
+        is_tokenised_fund=True,
+        short_description="Tokenised U.S. Treasury-bill investment product with USD NAV.",
+        description=("mTBILL is a tokenised investment product backed by short-duration U.S. Treasury Bills and Treasury-bill funds. Midas publishes its USD net asset value through an onchain data feed; issuance and redemption use separate Midas contracts and are subject to eligibility checks."),
+        product_link="https://midas.app/mtbill",
+    ),
+}
+
+
+@dataclass(slots=True, frozen=True)
 class MidasRegistryProduct:
     """Scanner-friendly Midas product entry."""
 
@@ -2065,6 +2113,9 @@ class MidasRegistryProduct:
 
     #: Raw product dictionary from :data:`MIDAS_ADDRESSES_PER_NETWORK`.
     raw: dict[str, Any]
+
+    #: Reviewed product metadata, when the product has been classified.
+    metadata: MidasProductMetadata | None
 
     @property
     def rpc_env_var(self) -> str | None:
@@ -2153,6 +2204,7 @@ def iter_midas_registry_products(
                 first_seen_at_block=deployment[0] if deployment else None,
                 first_seen_at=deployment[1] if deployment else None,
                 raw=raw,
+                metadata=MIDAS_PRODUCT_METADATA.get(symbol),
             )
 
             if require_historical_contracts and not product.has_required_historical_contracts:

--- a/eth_defi/midas/vault.py
+++ b/eth_defi/midas/vault.py
@@ -328,7 +328,7 @@ class MidasVault(VaultBase):
         metadata = get_handwritten_vault_metadata(self.chain_id, self.address)
         if metadata:
             return metadata.description
-        return self.product.product_name
+        return self.product.description or self.product.product_name
 
     @property
     def short_description(self) -> str | None:
@@ -337,7 +337,7 @@ class MidasVault(VaultBase):
         metadata = get_handwritten_vault_metadata(self.chain_id, self.address)
         if metadata:
             return metadata.short_description
-        return "Midas tokenised investment product with NAV published through the Midas oracle pipeline"
+        return self.product.short_description or "Midas tokenised investment product with NAV published through the Midas oracle pipeline"
 
     @property
     def manager_name(self) -> str | None:
@@ -348,11 +348,12 @@ class MidasVault(VaultBase):
     def get_flags(self) -> set[VaultFlag]:
         """Return the product-specific vault classification flags.
 
-        Midas serves both regulated tokenised funds and crypto strategy
-        products through the same contract family.  Only reviewed ``mTBILL``
-        product records receive the tokenised-fund listing flag.
+        Midas serves both tokenised funds and crypto strategy products through
+        the same contract family. Only products explicitly marked in the
+        reviewed Midas registry metadata receive the tokenised-fund listing
+        flag.
 
-        :return: Generic flags, with ``tokenised_fund`` for mTBILL only.
+        :return: Generic flags, with ``tokenised_fund`` for reviewed fund products.
         """
 
         flags = set(super().get_flags())
@@ -782,6 +783,4 @@ class MidasVault(VaultBase):
         metadata = get_handwritten_vault_metadata(self.chain_id, self.address)
         if metadata:
             return metadata.link
-        if self.product.is_tokenised_fund:
-            return "https://midas.app/mtbill"
-        return MIDAS_HOMEPAGE
+        return self.product.product_link or MIDAS_HOMEPAGE

--- a/scripts/midas/migrate-fund-metadata.py
+++ b/scripts/midas/migrate-fund-metadata.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Repair Midas tokenised-fund metadata in an existing vault database.
+
+The Midas registry now holds reviewed fund classification and display metadata.
+Rows already present in ``vault-metadata-db.pickle`` do not receive those
+values until a full rescan, so this targeted migration updates only existing
+Midas products explicitly classified as tokenised funds. It does not create
+rows or alter leads, scanner cursors, reader state, or price Parquet files.
+
+The script starts in dry-run mode. Inspect the proposed updates, then apply
+them explicitly:
+
+.. code-block:: shell
+
+    source .local-test.env && poetry run python scripts/midas/migrate-fund-metadata.py
+    source .local-test.env && DRY_RUN=false poetry run python scripts/midas/migrate-fund-metadata.py
+
+Configuration is through environment variables:
+
+``DRY_RUN``
+    Print proposed changes without writing. Defaults to ``true``.
+
+``NETWORKS``
+    Optional comma-separated chain ids or names, e.g. ``1,ethereum,base``.
+
+``PRODUCTS``
+    Optional comma-separated Midas product symbols, e.g. ``mTBILL``.
+
+``VAULT_DB_PATH``
+    Metadata database path. Defaults to the active pipeline data directory.
+
+``BACKUP_PATH``
+    Optional backup pickle path. By default a timestamped sibling of
+    ``VAULT_DB_PATH`` is created before a non-dry-run migration.
+"""
+
+import os
+import shutil
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+from tabulate import tabulate
+
+from eth_defi.chain import CHAIN_NAMES
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.midas.constants import MIDAS_PRODUCTS, MidasProduct
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.vaultdb import VaultDatabase, VaultRow, get_pipeline_data_dir
+
+
+@dataclass(slots=True, frozen=True)
+class FundMetadataMigration:
+    """One proposed Midas tokenised-fund metadata update.
+
+    :param vault_spec:
+        Existing vault database key.
+    :param product:
+        Reviewed Midas product metadata.
+    :param updates:
+        Replacement values for only the metadata fields owned by this migration.
+    :param changed_fields:
+        Fields whose existing database values differ from the reviewed values.
+    """
+
+    vault_spec: VaultSpec
+    product: MidasProduct
+    updates: dict[str, object]
+    changed_fields: tuple[str, ...]
+
+    @property
+    def changed(self) -> bool:
+        """Return whether this row needs a metadata update.
+
+        :return:
+            ``True`` when at least one Midas-owned field differs.
+        """
+
+        return bool(self.changed_fields)
+
+
+def parse_bool_env(name: str, *, default: bool) -> bool:
+    """Parse a boolean environment variable.
+
+    :param name:
+        Environment variable name.
+    :param default:
+        Value to use when the variable is unset.
+    :return:
+        Parsed truth value.
+    """
+
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def parse_csv_env(name: str) -> set[str] | None:
+    """Parse optional comma-separated environment selectors.
+
+    :param name:
+        Environment variable name.
+    :return:
+        Lower-case selectors, or ``None`` when the variable is unset.
+    """
+
+    value = os.environ.get(name, "").strip()
+    if not value:
+        return None
+    return {part.strip().lower() for part in value.split(",") if part.strip()}
+
+
+def get_chain_selectors(chain_id: int) -> set[str]:
+    """Return selectors that identify a chain in ``NETWORKS``.
+
+    :param chain_id:
+        EVM chain id.
+    :return:
+        Decimal chain id and, when known, lower-case chain name.
+    """
+
+    selectors = {str(chain_id)}
+    chain_name = CHAIN_NAMES.get(chain_id)
+    if chain_name:
+        selectors.add(chain_name.lower())
+    return selectors
+
+
+def iter_selected_fund_products() -> Iterator[MidasProduct]:
+    """Iterate selected reviewed Midas tokenised-fund products.
+
+    The registry supplies the classification, so this migration cannot
+    accidentally classify every Midas strategy product as a fund.
+
+    :return:
+        Unique reviewed fund products in registry order.
+    """
+
+    networks = parse_csv_env("NETWORKS")
+    products = parse_csv_env("PRODUCTS")
+    seen: set[tuple[int, str]] = set()
+
+    for product in MIDAS_PRODUCTS.values():
+        key = (product.chain_id, product.token)
+        if key in seen or not product.is_tokenised_fund:
+            continue
+        seen.add(key)
+
+        if networks and not (get_chain_selectors(product.chain_id) & networks):
+            continue
+        if products and product.symbol.lower() not in products:
+            continue
+        yield product
+
+
+def resolve_vault_database_path() -> Path:
+    """Resolve the metadata database targeted by the migration.
+
+    :return:
+        Explicit ``VAULT_DB_PATH`` or the active pipeline metadata database.
+    """
+
+    configured_path = os.environ.get("VAULT_DB_PATH")
+    if configured_path:
+        return Path(configured_path).expanduser()
+    return get_pipeline_data_dir() / "vault-metadata-db.pickle"
+
+
+def resolve_backup_path(vault_db_path: Path) -> Path:
+    """Resolve the one-time backup filename for a real migration.
+
+    :param vault_db_path:
+        Metadata database to back up.
+    :return:
+        Explicit ``BACKUP_PATH`` or a timestamped sibling path.
+    """
+
+    configured_path = os.environ.get("BACKUP_PATH")
+    if configured_path:
+        return Path(configured_path).expanduser()
+
+    timestamp = native_datetime_utc_now().strftime("%Y%m%d-%H%M%S")
+    return vault_db_path.with_name(f"{vault_db_path.stem}.before-midas-fund-metadata-migration-{timestamp}{vault_db_path.suffix}")
+
+
+def create_fund_metadata_migration(product: MidasProduct, existing_row: VaultRow) -> FundMetadataMigration:
+    """Construct a metadata-only repair for one reviewed Midas fund row.
+
+    :param product:
+        Registry product marked as a tokenised fund.
+    :param existing_row:
+        Current vault metadata row to compare.
+    :return:
+        Proposed update without mutating the database.
+    :raise ValueError:
+        If a product marked as a fund lacks its required reviewed display data.
+    """
+
+    if not product.is_tokenised_fund:
+        raise ValueError(f"Midas product is not a tokenised fund: {product.symbol}")
+    if not product.short_description or not product.description or not product.product_link:
+        raise ValueError(f"Reviewed Midas fund metadata is incomplete: {product.symbol}")
+
+    updates = {
+        "_flags": set(existing_row.get("_flags", set())) | {VaultFlag.tokenised_fund},
+        "_short_description": product.short_description,
+        "_description": product.description,
+        "Link": product.product_link,
+    }
+    changed_fields = tuple(field for field, value in updates.items() if existing_row.get(field) != value)
+
+    return FundMetadataMigration(
+        vault_spec=VaultSpec(chain_id=product.chain_id, vault_address=product.token),
+        product=product,
+        updates=updates,
+        changed_fields=changed_fields,
+    )
+
+
+def apply_migrations(vault_db: VaultDatabase, migrations: list[FundMetadataMigration]) -> None:
+    """Apply fund metadata updates to existing rows in memory.
+
+    :param vault_db:
+        Metadata database loaded from disk.
+    :param migrations:
+        Changed migration entries to apply.
+    :return:
+        ``None`` after updating only the selected existing rows.
+    """
+
+    for migration in migrations:
+        row = vault_db.rows[migration.vault_spec].copy()
+        row.update(migration.updates)
+        vault_db.rows[migration.vault_spec] = row
+
+
+def main() -> None:
+    """Run the metadata-only Midas tokenised-fund migration.
+
+    The migration is idempotent: a row that already has the reviewed flag,
+    descriptions and link is reported as unchanged. A backup is created only
+    immediately before a real write.
+
+    :return:
+        ``None`` after displaying the plan and optionally writing metadata.
+    """
+
+    dry_run = parse_bool_env("DRY_RUN", default=True)
+    vault_db_path = resolve_vault_database_path()
+    if not vault_db_path.exists():
+        raise FileNotFoundError(f"Vault metadata database does not exist: {vault_db_path}")
+
+    vault_db = VaultDatabase.read(vault_db_path)
+    selected_products = list(iter_selected_fund_products())
+    existing_products = [product for product in selected_products if VaultSpec(product.chain_id, product.token) in vault_db.rows]
+    missing_products = [product for product in selected_products if VaultSpec(product.chain_id, product.token) not in vault_db.rows]
+    if not existing_products:
+        message = "No selected Midas fund products have existing metadata rows to migrate"
+        raise RuntimeError(message)
+
+    migrations = [create_fund_metadata_migration(product, vault_db.rows[VaultSpec(product.chain_id, product.token)]) for product in existing_products]
+    changes = [migration for migration in migrations if migration.changed]
+
+    print(
+        tabulate(
+            [
+                [
+                    migration.product.chain_id,
+                    migration.product.symbol,
+                    ", ".join(migration.changed_fields) or "unchanged",
+                ]
+                for migration in migrations
+            ],
+            headers=["chain", "product", "metadata update"],
+            tablefmt="rounded_outline",
+        )
+    )
+    print(f"\nSelected existing Midas fund rows: {len(existing_products)}")
+    print(f"Rows requiring metadata migration: {len(changes)}")
+    if missing_products:
+        print(f"Registry fund products without existing rows (not created): {len(missing_products)}")
+
+    if dry_run:
+        print("Dry run: no files written. Re-run with DRY_RUN=false to apply these changes.")
+        return
+    if not changes:
+        print("No migration needed: metadata database already uses the reviewed Midas fund metadata.")
+        return
+
+    backup_path = resolve_backup_path(vault_db_path)
+    if backup_path.exists():
+        raise FileExistsError(f"Refusing to overwrite existing backup: {backup_path}")
+    backup_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(vault_db_path, backup_path)
+    apply_migrations(vault_db, changes)
+    vault_db.write(vault_db_path)
+    print(f"Migrated {len(changes)} Midas fund metadata rows in {vault_db_path}")
+    print(f"Backup written to {backup_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/midas/test_midas_fund_metadata_migration.py
+++ b/tests/midas/test_midas_fund_metadata_migration.py
@@ -1,0 +1,79 @@
+"""Regression tests for the Midas tokenised-fund metadata migration."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from eth_defi.midas.constants import MIDAS_MBASIS_ETHEREUM, MIDAS_MTBILL_ETHEREUM
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.vaultdb import VaultDatabase
+
+
+@pytest.fixture
+def fund_metadata_migration_module():
+    """Load the hyphenated Midas fund-metadata migration module."""
+
+    script_path = Path(__file__).parents[2] / "scripts" / "midas" / "migrate-fund-metadata.py"
+    spec = importlib.util.spec_from_file_location("midas_fund_metadata_migration", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_midas_fund_metadata_migration_updates_only_reviewed_funds(fund_metadata_migration_module) -> None:
+    """Repair mTBILL metadata without changing an unrelated Midas strategy product."""
+
+    mtbill_spec = VaultSpec(MIDAS_MTBILL_ETHEREUM.chain_id, MIDAS_MTBILL_ETHEREUM.token)
+    mbasis_spec = VaultSpec(MIDAS_MBASIS_ETHEREUM.chain_id, MIDAS_MBASIS_ETHEREUM.token)
+    vault_db = VaultDatabase(
+        rows={
+            mtbill_spec: {
+                "Name": "Midas US Treasury Bill Token",
+                "Link": "https://midas.app/products",
+                "_flags": set(),
+                "_short_description": "Old summary",
+                "_description": "Old description",
+                "unrelated_field": "preserved",
+            },
+            mbasis_spec: {
+                "Name": "Midas mBASIS",
+                "_flags": set(),
+                "_short_description": "Keep this strategy unchanged",
+            },
+        }
+    )
+
+    migration = fund_metadata_migration_module.create_fund_metadata_migration(
+        MIDAS_MTBILL_ETHEREUM,
+        vault_db.rows[mtbill_spec],
+    )
+
+    assert migration.changed_fields == ("_flags", "_short_description", "_description", "Link")
+    fund_metadata_migration_module.apply_migrations(vault_db, [migration])
+
+    mtbill_row = vault_db.rows[mtbill_spec]
+    assert VaultFlag.tokenised_fund in mtbill_row["_flags"]
+    assert mtbill_row["_short_description"] == MIDAS_MTBILL_ETHEREUM.short_description
+    assert mtbill_row["_description"] == MIDAS_MTBILL_ETHEREUM.description
+    assert mtbill_row["Link"] == MIDAS_MTBILL_ETHEREUM.product_link
+    assert mtbill_row["unrelated_field"] == "preserved"
+    assert vault_db.rows[mbasis_spec]["_short_description"] == "Keep this strategy unchanged"
+
+    repeated = fund_metadata_migration_module.create_fund_metadata_migration(MIDAS_MTBILL_ETHEREUM, mtbill_row)
+    assert not repeated.changed
+
+
+def test_midas_fund_metadata_migration_selects_all_mtbill_deployments(monkeypatch: pytest.MonkeyPatch, fund_metadata_migration_module) -> None:
+    """Select every reviewed mTBILL deployment by default, but no strategy products."""
+
+    monkeypatch.delenv("NETWORKS", raising=False)
+    monkeypatch.delenv("PRODUCTS", raising=False)
+
+    products = list(fund_metadata_migration_module.iter_selected_fund_products())
+
+    assert {product.symbol for product in products} == {"mTBILL"}
+    assert {product.chain_id for product in products} == {1, 42161, 8453}

--- a/tests/midas/test_midas_vault.py
+++ b/tests/midas/test_midas_vault.py
@@ -42,6 +42,7 @@ from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.research.vault_metrics import calculate_hourly_returns_for_all_vaults, calculate_lifetime_metrics, export_lifetime_row
 from eth_defi.token import TokenDetails
 from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.flag import VaultFlag
 from eth_defi.vault.top_vaults_json import validate_strict_json_serialisable
 from eth_defi.vault.vaultdb import VaultDatabase
 
@@ -349,7 +350,7 @@ def test_midas_anvil_forked_mtbill_properties(web3: Web3) -> None:
     assert vault.vault_address == vault.address
     assert vault.name == "Midas US Treasury Bill Token"
     assert vault.symbol == "mTBILL"
-    assert vault.description == MIDAS_MTBILL_ETHEREUM.product_name
+    assert vault.description == MIDAS_MTBILL_ETHEREUM.description
     assert vault.manager_name == "Midas"
     assert vault.get_link() == "https://midas.app/mtbill"
     assert vault.has_block_range_event_support() is False
@@ -577,6 +578,9 @@ def test_midas_scan_record_live_mtbill(web3: Web3) -> None:
     assert record["_denomination_token"]["address"] is None
     assert record["_share_token"]["symbol"] == "mTBILL"
     assert record["_manager_name"] == "Midas"
+    assert record["_short_description"] == "Tokenised U.S. Treasury-bill investment product with USD NAV."
+    assert record["_description"] == ("mTBILL is a tokenised investment product backed by short-duration U.S. Treasury Bills and Treasury-bill funds. Midas publishes its USD net asset value through an onchain data feed; issuance and redemption use separate Midas contracts and are subject to eligibility checks.")
+    assert VaultFlag.tokenised_fund in record["_flags"]
     assert record["_deposit_closed_reason"] == MIDAS_BESPOKE_FLOW_REASON
     assert record["_redemption_closed_reason"] == MIDAS_BESPOKE_FLOW_REASON
     assert record["_nav_source"] == MIDAS_NAV_SOURCE

--- a/tests/tokenised_fund/test_supported_chain_gaps.py
+++ b/tests/tokenised_fund/test_supported_chain_gaps.py
@@ -7,7 +7,8 @@ import pytest
 from eth_defi.erc_4626.classification import create_vault_instance, identify_vault_features
 from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name
 from eth_defi.erc_4626.scan import OPTIONAL_READ_EXCEPTIONS
-from eth_defi.midas.constants import MIDAS_MBASIS_ETHEREUM, MIDAS_MTBILL_ETHEREUM
+from eth_defi.midas.constants import MIDAS_MBASIS_ETHEREUM, MIDAS_MTBILL_ETHEREUM, MIDAS_PRODUCTS
+from eth_defi.midas.registry import iter_midas_registry_products
 from eth_defi.midas.vault import MidasVault
 from eth_defi.tokenised_fund.fdit.constants import FDIT_ETHEREUM, FDIT_HARDCODED_LEADS
 from eth_defi.tokenised_fund.fdit.vault import FditVault
@@ -21,10 +22,14 @@ from eth_defi.vault.flag import VaultFlag
 
 
 def test_midas_marks_only_mtbill_as_a_tokenised_fund() -> None:
-    """Keep Midas's product-level classification narrow."""
+    """Keep Midas's explicit product-level fund classification narrow."""
 
     assert MIDAS_MTBILL_ETHEREUM.is_tokenised_fund
     assert not MIDAS_MBASIS_ETHEREUM.is_tokenised_fund
+    mtbill_deployments = [product for product in iter_midas_registry_products(require_adapter_data=True) if product.symbol == "mTBILL"]
+    assert {product.chain_id for product in mtbill_deployments} == {1, 42161, 8453}
+    assert all(product.metadata is not None and product.metadata.is_tokenised_fund for product in mtbill_deployments)
+    assert all(MIDAS_PRODUCTS[product.chain_id, product.token.lower()].is_tokenised_fund for product in mtbill_deployments if product.token)
     web3 = SimpleNamespace(eth=SimpleNamespace(chain_id=1))
     mtbill = create_vault_instance(web3, MIDAS_MTBILL_ETHEREUM.token, features={ERC4626Feature.midas_like})
     mbasis = create_vault_instance(web3, MIDAS_MBASIS_ETHEREUM.token, features={ERC4626Feature.midas_like})


### PR DESCRIPTION
## Why

Midas serves both tokenised investment products and strategy or white-label vault products. The catalogue showed mTBILL as a fund through protocol inference, but the registry did not consistently carry the explicit `tokenised_fund` flag, product copy or a safe production backfill.

## Lessons learnt

Protocol membership, a NAV feed and an mToken symbol are not sufficient evidence that a product is a tokenised fund. Classification must be reviewed per product, then shared by symbol across its chain deployments.

## Summary

- Adds reviewed mTBILL metadata: `tokenised_fund`, short and long descriptions, and the official product link.
- Makes Midas scanner output consume that metadata for every mTBILL deployment.
- Adds an idempotent, dry-run-by-default production migration with backup and atomic-write protection.
- Audits all 80 Midas registry products (149 deployments), keeping unreviewed products unflagged.

## Related issues and PRs

- Frontend presentation fix: https://github.com/tradingstrategy-ai/frontend/pull/1367

## Unrelated CI and test fixes

None.