### PR TITLE
fix: correct Atoma Nado vault name

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/atoma/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/atoma/vault.py
@@ -105,7 +105,7 @@ ATOMA_VAULT_DESCRIPTION_OVERLAY: Final[dict[HexAddress, AtomaVaultDescription]] 
 
 #: Curated display names for Atoma vaults whose onchain share-token names are generic.
 ATOMA_VAULT_NAME_OVERLAY: Final[dict[HexAddress, str]] = {
-    ATOMA_VAULT_ADDRESS: "Extended and Nano arbitrage",
+    ATOMA_VAULT_ADDRESS: "Extended and Nado arbitrage",
     ATOMA_VAULT_2_ADDRESS: "Lighter and Trade.xyz arbitrage",
 }
 

--- a/scripts/erc-4626/migrate-atoma-vault-names.py
+++ b/scripts/erc-4626/migrate-atoma-vault-names.py
@@ -7,6 +7,9 @@ This targeted migration persists the two curated names without making RPC
 calls, rescanning vaults, or modifying any price, reader-state, or other
 metadata fields.
 
+The target names are ``Extended and Nado arbitrage`` and ``Lighter and
+Trade.xyz arbitrage``.
+
 The generic ``migrate-vault-token-metadata.py`` command must not be used for
 this repair: it deliberately reads the onchain token names and would overwrite
 these curated names.

--- a/tests/erc_4626/test_migrate_atoma_vault_names.py
+++ b/tests/erc_4626/test_migrate_atoma_vault_names.py
@@ -52,6 +52,17 @@ def create_vault_database(migration) -> VaultDatabase:
     return VaultDatabase(rows=rows)
 
 
+def test_atoma_vault_name_updates_use_the_reviewed_strategy_names() -> None:
+    """The migration maps both supported Atoma addresses to curated names."""
+
+    migration = load_migration_module()
+
+    assert migration.ATOMA_VAULT_NAME_UPDATES == {
+        VaultSpec(42_161, "0xcc56410e1a136af0eceb7241c6ae394f4d8b581c"): "Extended and Nado arbitrage",
+        VaultSpec(42_161, "0x1c788e14d8e5b446e3f71b5142e2edabcab36da1"): "Lighter and Trade.xyz arbitrage",
+    }
+
+
 def test_migrate_atoma_vault_names_updates_only_the_two_target_rows(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """The write migration persists both curated names and preserves other rows."""
 

--- a/tests/erc_4626/vault_protocol/test_atoma.py
+++ b/tests/erc_4626/vault_protocol/test_atoma.py
@@ -55,7 +55,7 @@ def test_atoma_static_fee_metadata() -> None:
     assert net_fee_data.withdraw == pytest.approx(0.005)
     assert vault.get_estimated_lock_up() == datetime.timedelta(days=7)
     assert vault.get_link() == "https://app.atoma.fi/"
-    assert vault.name == "Extended and Nano arbitrage"
+    assert vault.name == "Extended and Nado arbitrage"
     assert vault.short_description == "Market-neutral perpetuals strategy across Nado and Extended."
     assert vault.description is not None
     assert "funding-rate spreads across Nado and Extended perpetual DEXs" in vault.description


### PR DESCRIPTION
## Why

The first Atoma strategy name used “Nano”, but the underlying perpetual DEX is Nado. The display overlay and the metadata migration must use the same corrected name.

## Lessons learnt

Curated vault names are persisted into the metadata cache, so correcting an overlay also requires a rerunnable migration. Explicit migration-name assertions catch terminology errors that a mapping-only test would miss.

## Summary

- Rename the first Atoma strategy to `Extended and Nado arbitrage`.
- Update the targeted migration documentation and exact-name regression coverage.
- Cover the corrected adapter display name.