### PR TITLE
fix: preflight IPOR and Yearn vault flow reverts

### DIFF
--- a/docs/source/vaults/ipor/index.rst
+++ b/docs/source/vaults/ipor/index.rst
@@ -20,6 +20,13 @@ IPOR Fusion frontend atomist config used as a fallback while the API field has p
 This fetch happens lazily through the IPOR vault offchain metadata accessor, so a normal vault
 scan fills ``manager_name`` when it first reads the vault's atomist metadata.
 
+The deposit manager checks the selected caller's exact redemption before it
+creates a transaction. It reports an active account lock as a temporary closed
+redemption window, and reports a withdrawal-manager or fuse refusal as a
+redemption capacity limit. This execution-time check does not change the
+scanner's reported idle liquidity, which remains a lower bound for Plasma Vault
+redeemability.
+
 Key features:
 
 - Intelligence-driven execution for DeFi operations including looping, carry trades and arbitrage
@@ -43,5 +50,6 @@ Links
    :toctree: _autosummary_ipor
    :recursive:
 
+   eth_defi.erc_4626.vault_protocol.ipor.deposit_redeem
    eth_defi.erc_4626.vault_protocol.ipor.vault
    eth_defi.erc_4626.vault_protocol.ipor.offchain_metadata

--- a/docs/source/vaults/ipor/index.rst
+++ b/docs/source/vaults/ipor/index.rst
@@ -21,11 +21,13 @@ This fetch happens lazily through the IPOR vault offchain metadata accessor, so 
 scan fills ``manager_name`` when it first reads the vault's atomist metadata.
 
 The deposit manager checks the selected caller's exact redemption before it
-creates a transaction. It reports an active account lock as a temporary closed
-redemption window, and reports a withdrawal-manager or fuse refusal as a
-redemption capacity limit. This execution-time check does not change the
-scanner's reported idle liquidity, which remains a lower bound for Plasma Vault
-redeemability.
+creates a transaction. When a full redemption fails, it searches for the
+immediately executable capacity and repeats the requested exact call before
+refusing it, because RPC calls do not provide an atomic state snapshot. It
+reports an active account lock as a temporary closed redemption window, and
+reports a withdrawal-manager or fuse refusal as a redemption capacity limit.
+This execution-time check does not change the scanner's reported idle
+liquidity, which remains a lower bound for Plasma Vault redeemability.
 
 Key features:
 

--- a/docs/source/vaults/yearn/index.rst
+++ b/docs/source/vaults/yearn/index.rst
@@ -16,8 +16,10 @@ and a wider range of risk appetites.
 The deposit manager detects a global shutdown or full vault-wide deposit limit
 before creating a transaction. When the selected account has already approved
 the requested assets, it also simulates that exact deposit and returns a typed
-admission rejection for a confirmed EVM revert. It does not treat a missing
-approval or an RPC failure as a vault closure.
+admission rejection for a confirmed EVM revert. The result includes raw revert
+data and its selector when the RPC provider supplies them, but does not label an
+opaque provider message as a decoded Solidity error. It does not treat a
+missing approval or an RPC failure as a vault closure.
 
 Links
 ~~~~~

--- a/docs/source/vaults/yearn/index.rst
+++ b/docs/source/vaults/yearn/index.rst
@@ -13,6 +13,12 @@ With yVaults v3, vaults can be made from a single strategy or a collection of mu
 which balance funds between them. Users have more control over where they want their funds to go
 and a wider range of risk appetites.
 
+The deposit manager detects a global shutdown or full vault-wide deposit limit
+before creating a transaction. When the selected account has already approved
+the requested assets, it also simulates that exact deposit and returns a typed
+admission rejection for a confirmed EVM revert. It does not treat a missing
+approval or an RPC failure as a vault closure.
+
 Links
 ~~~~~
 
@@ -28,6 +34,7 @@ Links
    :toctree: _autosummary_yearn
    :recursive:
 
+   eth_defi.erc_4626.vault_protocol.yearn.deposit_redeem
    eth_defi.erc_4626.vault_protocol.yearn.vault
    eth_defi.erc_4626.vault_protocol.yearn.compounder
    eth_defi.erc_4626.vault_protocol.yearn.morpho_compounder

--- a/eth_defi/erc_4626/vault_protocol/README-vault-redeemable.md
+++ b/eth_defi/erc_4626/vault_protocol/README-vault-redeemable.md
@@ -220,14 +220,20 @@ To compute redeemable liquidity you would iterate adapters, then for
 each adapter query the underlying Morpho Blue markets the same way as
 V1.  This is more involved but follows the same pattern.
 
-### IPOR: no on-chain read path
+### IPOR: no general onchain capacity read path
 
 IPOR does not expose per-fuse withdrawal capacity.  The options are:
 
-1. **Accept idle as a lower bound.** This is what we do today.
-2. **Simulate withdrawal via `eth_call`.** Call `redeem(totalSupply, ...)` as
-   a static call and observe the revert or returned amount.  Fragile and
-   expensive for production scanning.
+1. **Accept idle as a lower bound.** This is what the historical scanner does
+   today.
+2. **Simulate withdrawal via `eth_call`.** The IPOR deposit manager calls
+   `redeem(shares, caller, caller)` for the actual share owner before creating
+   a redemption request. If a full redemption reverts, it binary-searches the
+   immediately executable share amount. A decoded account lock is reported as
+   a closed redemption window; decoded fuse or withdrawal-manager limits are
+   reported as capacity limits. This check is appropriate for transaction
+   construction but remains too expensive and caller-specific for production
+   scanning.
 3. **Query underlying protocols directly.** If we know a fuse wraps Aave V3,
    read Aave's available liquidity for that asset.  Requires maintaining
    a fuse → underlying protocol mapping.
@@ -235,8 +241,9 @@ IPOR does not expose per-fuse withdrawal capacity.  The options are:
    is theoretically redeemable, but subject to underlying protocol liquidity
    and redemption delays.
 
-None of these are clean.  For IPOR, idle remains the pragmatic choice
-until IPOR adds a view function to their fuse interface.
+None of these provide a vault-wide scanner value. For IPOR, idle remains the
+pragmatic historical-reader value until IPOR adds a view function to its fuse
+interface.
 
 ## Recommended approach for the pipeline
 

--- a/eth_defi/erc_4626/vault_protocol/README-vault-redeemable.md
+++ b/eth_defi/erc_4626/vault_protocol/README-vault-redeemable.md
@@ -229,11 +229,12 @@ IPOR does not expose per-fuse withdrawal capacity.  The options are:
 2. **Simulate withdrawal via `eth_call`.** The IPOR deposit manager calls
    `redeem(shares, caller, caller)` for the actual share owner before creating
    a redemption request. If a full redemption reverts, it binary-searches the
-   immediately executable share amount. A decoded account lock is reported as
-   a closed redemption window; decoded fuse or withdrawal-manager limits are
-   reported as capacity limits. This check is appropriate for transaction
-   construction but remains too expensive and caller-specific for production
-   scanning.
+   immediately executable share amount, then repeats the requested exact call
+   before refusing it because the RPC calls are not an atomic state snapshot.
+   A decoded account lock is reported as a closed redemption window; decoded
+   fuse or withdrawal-manager limits are reported as capacity limits. This
+   check is appropriate for transaction construction but remains too expensive
+   and caller-specific for production scanning.
 3. **Query underlying protocols directly.** If we know a fuse wraps Aave V3,
    read Aave's available liquidity for that asset.  Requires maintaining
    a fuse → underlying protocol mapping.

--- a/eth_defi/erc_4626/vault_protocol/ipor/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/ipor/deposit_redeem.py
@@ -2,33 +2,40 @@
 
 # ruff: noqa: FBT001, FBT002, PLR0917
 
-import logging
 from decimal import Decimal
 from typing import TYPE_CHECKING, Literal
 
 from eth_typing import HexAddress
 from hexbytes import HexBytes
-from web3.exceptions import BadFunctionCallOutput, ContractLogicError, Web3RPCError
+from web3.exceptions import ContractLogicError
 
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager, ERC4626DepositRequest, ERC4626RedemptionRequest
-from eth_defi.vault.deposit_redeem import VaultFlowUnavailable
+from eth_defi.vault.deposit_redeem import VaultFlowUnavailable, extract_revert_data
 
 if TYPE_CHECKING:
     from eth_defi.erc_4626.vault_protocol.ipor.vault import IPORVault
-
-logger = logging.getLogger(__name__)
-
-#: Exact Base Autopilot deployment whose PlasmaVault redemption path needs a
-#: protocol-specific liquidity simulation. Other IPOR vaults retain their
-#: existing access-manager-only flow until their deployed market fuses are
-#: characterised separately.
-IPOR_AUTOPILOT_USDC_MORPHO_BASE_ADDRESS = "0xd6701905c59ee618dc36dc747506bce0a4ac760a"
-IPOR_AUTOPILOT_USDC_MORPHO_BASE_CHAIN_ID = 8453
 
 #: ``FailedInnerCall()`` emitted by OpenZeppelin's ``Address`` utility when
 #: PlasmaVault cannot withdraw enough underlying from one of its configured
 #: markets. ``keccak("FailedInnerCall()")[:4]``.
 IPOR_FAILED_INNER_CALL_SELECTOR = HexBytes("0x1425ea42")
+
+#: ``WithdrawManagerInvalidSharesToRelease(uint256,uint256,uint256)`` emitted
+#: when PlasmaVault's withdrawal manager cannot release the requested shares.
+#: ``keccak("WithdrawManagerInvalidSharesToRelease(uint256,uint256,uint256)")[:4]``.
+IPOR_WITHDRAW_MANAGER_INVALID_SHARES_TO_RELEASE_SELECTOR = HexBytes("0x3c71a1e7")
+
+#: ``AccountIsLocked(uint256)`` emitted by PlasmaVault while the caller's
+#: redemption lock remains active. ``keccak("AccountIsLocked(uint256)")[:4]``.
+IPOR_ACCOUNT_IS_LOCKED_SELECTOR = HexBytes("0xa592703b")
+
+IPOR_REDEMPTION_ERROR_NAMES = {
+    IPOR_FAILED_INNER_CALL_SELECTOR: "FailedInnerCall",
+    IPOR_WITHDRAW_MANAGER_INVALID_SHARES_TO_RELEASE_SELECTOR: "WithdrawManagerInvalidSharesToRelease",
+    IPOR_ACCOUNT_IS_LOCKED_SELECTOR: "AccountIsLocked",
+}
+
+ERROR_SELECTOR_LENGTH = 4
 
 
 class IPORDepositManager(ERC4626DepositManager):
@@ -60,11 +67,9 @@ class IPORDepositManager(ERC4626DepositManager):
     calls :meth:`_assert_immediate_access` for the redemption selector
     (``redeem(uint256,address,address)``) — resolved independently, because the
     access policy can differ from the deposit selector — then delegates to the
-    base manager. The characterised Autopilot USDC Morpho deployment on Base
-    also simulates its exact ``redeem()`` path and refuses a full-fill request
-    that its market fuses cannot satisfy immediately. Other IPOR deployments
-    retain the inherited ERC-4626 checks, because their market liquidity has
-    not been characterised.
+    base manager. Every PlasmaVault deployment also simulates its exact
+    ``redeem()`` path and refuses a full-fill request that its market fuses or
+    withdrawal manager cannot satisfy immediately.
 
     **Queues and settlement**
 
@@ -167,80 +172,68 @@ class IPORDepositManager(ERC4626DepositManager):
             access_delay=delay,
         )
 
-    def _uses_liquidity_preflight(self) -> bool:
-        """Check whether this exact IPOR deployment has a characterised liquidity gate.
+    def fetch_redeem_simulation(self, owner: HexAddress, raw_shares: int) -> tuple[bool, HexBytes | None]:
+        """Simulate an exact PlasmaVault redemption without broadcasting it.
 
-        IPOR PlasmaVault market fuses are deployment-specific: some can release
-        liquidity during ``redeem()``, while others cannot. Restrict the
-        fail-closed simulation to the characterised Autopilot USDC Morpho vault
-        rather than inferring all IPOR liquidity from idle token balances.
-
-        :return:
-            ``True`` for the exact Base Autopilot USDC Morpho deployment.
-        """
-        return self.vault.chain_id == IPOR_AUTOPILOT_USDC_MORPHO_BASE_CHAIN_ID and self.vault.address.lower() == IPOR_AUTOPILOT_USDC_MORPHO_BASE_ADDRESS
-
-    def _redeem_would_succeed(self, owner: HexAddress, raw_shares: int) -> bool:
-        """Simulate PlasmaVault's exact redemption path without broadcasting it.
-
-        PlasmaVault's ``_redeem()`` requests liquidity from its configured
-        market fuses before transferring the underlying. Its ``maxRedeem()``
-        only reports the owner's share balance, so an ``eth_call`` to the exact
-        ``redeem()`` path is the authoritative immediate-liquidity predicate.
-        Any unreadable state is deliberately treated as unavailable.
+        A PlasmaVault only exposes the caller's share balance through
+        ``maxRedeem()``, not the liquidity that its market fuses and withdrawal
+        manager can release. The exact ``redeem()`` simulation is the
+        authoritative immediate-execution check. Transport and ABI failures are
+        deliberately propagated so callers can classify them as infrastructure
+        failures rather than a vault availability result.
 
         :param owner:
-            Share owner and simulated transaction sender.
+            Share owner, receiver, and simulated transaction sender.
         :param raw_shares:
-            Native share amount to simulate.
+            Native share amount to redeem.
         :return:
-            ``True`` only if the full redemption call returns successfully.
+            ``(True, None)`` when the call succeeds, otherwise ``(False,
+            revert_data)`` when the node confirms an EVM revert.
+        :raise ValueError:
+            If the provider fails without EVM revert data.
         """
         try:
             self.vault.vault_contract.functions.redeem(raw_shares, owner, owner).call({"from": owner})
-        except (BadFunctionCallOutput, ContractLogicError, Web3RPCError, ValueError):
-            return False
-        return True
+        except (ContractLogicError, ValueError) as error:
+            revert_data = extract_revert_data(error)
+            if isinstance(error, ValueError) and revert_data is None:
+                raise
+            return False, revert_data
+        return True, None
 
     def fetch_redeemable_raw_shares(self, owner: HexAddress) -> int:
-        """Find the largest immediate full-fill redemption for Autopilot shares.
+        """Find the largest immediate full-fill redemption for PlasmaVault shares.
 
         The verified PlasmaVault implementation repeatedly invokes
         ``_withdrawFromMarkets()`` before its ERC-4626 transfer. A redemption
         is monotonic in requested shares for this deployment, so binary search
         over the owner balance yields the actual immediately executable cap
-        without mutating onchain state. Read or simulation failures fail closed
-        to zero.
+        without mutating onchain state. RPC and ABI failures propagate so the
+        caller can classify infrastructure failures correctly.
 
         :param owner:
-            Address whose Autopilot shares are being preflighted.
+            Address whose PlasmaVault shares are being preflighted.
         :return:
             Maximum raw shares that can be redeemed in full immediately.
         """
-        if not self._uses_liquidity_preflight():
-            return int(self.vault.vault_contract.functions.balanceOf(owner).call())
-
-        try:
-            owner_raw_shares = int(self.vault.vault_contract.functions.balanceOf(owner).call())
-        except (BadFunctionCallOutput, ContractLogicError, Web3RPCError, ValueError) as error:
-            logger.warning(
-                "Cannot read IPOR redemption shares for vault %s on chain %d: %s",
-                self.vault.address,
-                self.vault.chain_id,
-                error,
-            )
-            return 0
+        owner_raw_shares = int(self.vault.vault_contract.functions.balanceOf(owner).call())
 
         if owner_raw_shares == 0:
             return 0
-        if self._redeem_would_succeed(owner, owner_raw_shares):
+        succeeds, full_revert_data = self.fetch_redeem_simulation(owner, owner_raw_shares)
+        if succeeds:
             return owner_raw_shares
+
+        full_error_selector = full_revert_data[:ERROR_SELECTOR_LENGTH] if full_revert_data and len(full_revert_data) >= ERROR_SELECTOR_LENGTH else None
+        if full_error_selector == IPOR_ACCOUNT_IS_LOCKED_SELECTOR:
+            return 0
 
         lower_bound = 0
         upper_bound = owner_raw_shares
         while upper_bound - lower_bound > 1:
             candidate = (lower_bound + upper_bound) // 2
-            if self._redeem_would_succeed(owner, candidate):
+            succeeds, _revert_data = self.fetch_redeem_simulation(owner, candidate)
+            if succeeds:
                 lower_bound = candidate
             else:
                 upper_bound = candidate
@@ -316,11 +309,21 @@ class IPORDepositManager(ERC4626DepositManager):
             assert shares is not None, "Either raw_shares or shares must be supplied"
             raw_shares = self.vault.share_token.convert_to_raw(shares)
 
-        uses_liquidity_preflight = self._uses_liquidity_preflight()
-        if check_max_redeem and uses_liquidity_preflight:
+        if check_max_redeem:
             available_raw_shares = self.fetch_redeemable_raw_shares(owner)
             if raw_shares > available_raw_shares:
-                reason = "IPOR PlasmaVault cannot source immediate redemption liquidity from configured markets"
+                _succeeds, revert_data = self.fetch_redeem_simulation(owner, raw_shares)
+                error_selector = revert_data[:ERROR_SELECTOR_LENGTH] if revert_data and len(revert_data) >= ERROR_SELECTOR_LENGTH else None
+                decoded_error = IPOR_REDEMPTION_ERROR_NAMES.get(error_selector)
+                if decoded_error == "AccountIsLocked":
+                    reason = "IPOR PlasmaVault redemption is temporarily locked for this account"
+                    preflight_result = "redemption_window_closed"
+                elif decoded_error in {"FailedInnerCall", "WithdrawManagerInvalidSharesToRelease"}:
+                    reason = "IPOR PlasmaVault cannot source immediate redemption liquidity from configured markets"
+                    preflight_result = "redemption_capacity_limited"
+                else:
+                    reason = "IPOR PlasmaVault redemption is not immediately available"
+                    preflight_result = "redemption_unavailable"
                 raise VaultFlowUnavailable(
                     reason,
                     protocol="IPOR Fusion",
@@ -328,9 +331,10 @@ class IPORDepositManager(ERC4626DepositManager):
                     caller=owner,
                     direction="redeem",
                     phase="preflight",
-                    decoded_error="FailedInnerCall",
-                    preflight_result="redemption_capacity_limited",
-                    error_selector=IPOR_FAILED_INNER_CALL_SELECTOR,
+                    decoded_error=decoded_error,
+                    preflight_result=preflight_result,
+                    raw_revert_data=revert_data,
+                    error_selector=error_selector,
                     requested_raw_amount=raw_shares,
                     available_raw_amount=available_raw_shares,
                 )
@@ -342,7 +346,7 @@ class IPORDepositManager(ERC4626DepositManager):
             raw_shares=raw_shares,
             check_max_deposit=check_max_deposit,
             check_enough_token=check_enough_token,
-            check_max_redeem=not uses_liquidity_preflight and check_max_redeem,
+            check_max_redeem=False,
         )
 
     def can_create_deposit_request(self, owner: HexAddress) -> bool:
@@ -371,6 +375,4 @@ class IPORDepositManager(ERC4626DepositManager):
             self._assert_immediate_access(owner, self.vault.get_redeem_function_selector(), "redeem")
         except (VaultFlowUnavailable, NotImplementedError):
             return False
-        if not self._uses_liquidity_preflight():
-            return True
         return self.fetch_redeemable_raw_shares(owner) > 0

--- a/eth_defi/erc_4626/vault_protocol/ipor/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/ipor/deposit_redeem.py
@@ -207,9 +207,12 @@ class IPORDepositManager(ERC4626DepositManager):
         The verified PlasmaVault implementation repeatedly invokes
         ``_withdrawFromMarkets()`` before its ERC-4626 transfer. A redemption
         is monotonic in requested shares for this deployment, so binary search
-        over the owner balance yields the actual immediately executable cap
-        without mutating onchain state. RPC and ABI failures propagate so the
-        caller can classify infrastructure failures correctly.
+        over the owner balance yields an immediate-execution cap without
+        mutating onchain state. :meth:`create_redemption_request` repeats an
+        exact simulation before refusing a requested amount, because these
+        independent RPC calls do not form an atomic state snapshot. RPC and ABI
+        failures propagate so the caller can classify infrastructure failures
+        correctly.
 
         :param owner:
             Address whose PlasmaVault shares are being preflighted.
@@ -304,6 +307,7 @@ class IPORDepositManager(ERC4626DepositManager):
         :return:
             Preflighted redemption request.
         """
+        assert not to, f"Unsupported to={to}"
         self._assert_immediate_access(owner, self.vault.get_redeem_function_selector(), "redeem")
         if raw_shares is None:
             assert shares is not None, "Either raw_shares or shares must be supplied"
@@ -312,32 +316,33 @@ class IPORDepositManager(ERC4626DepositManager):
         if check_max_redeem:
             available_raw_shares = self.fetch_redeemable_raw_shares(owner)
             if raw_shares > available_raw_shares:
-                _succeeds, revert_data = self.fetch_redeem_simulation(owner, raw_shares)
-                error_selector = revert_data[:ERROR_SELECTOR_LENGTH] if revert_data and len(revert_data) >= ERROR_SELECTOR_LENGTH else None
-                decoded_error = IPOR_REDEMPTION_ERROR_NAMES.get(error_selector)
-                if decoded_error == "AccountIsLocked":
-                    reason = "IPOR PlasmaVault redemption is temporarily locked for this account"
-                    preflight_result = "redemption_window_closed"
-                elif decoded_error in {"FailedInnerCall", "WithdrawManagerInvalidSharesToRelease"}:
-                    reason = "IPOR PlasmaVault cannot source immediate redemption liquidity from configured markets"
-                    preflight_result = "redemption_capacity_limited"
-                else:
-                    reason = "IPOR PlasmaVault redemption is not immediately available"
-                    preflight_result = "redemption_unavailable"
-                raise VaultFlowUnavailable(
-                    reason,
-                    protocol="IPOR Fusion",
-                    vault_address=self.vault.address,
-                    caller=owner,
-                    direction="redeem",
-                    phase="preflight",
-                    decoded_error=decoded_error,
-                    preflight_result=preflight_result,
-                    raw_revert_data=revert_data,
-                    error_selector=error_selector,
-                    requested_raw_amount=raw_shares,
-                    available_raw_amount=available_raw_shares,
-                )
+                succeeds, revert_data = self.fetch_redeem_simulation(owner, raw_shares)
+                if not succeeds:
+                    error_selector = revert_data[:ERROR_SELECTOR_LENGTH] if revert_data and len(revert_data) >= ERROR_SELECTOR_LENGTH else None
+                    decoded_error = IPOR_REDEMPTION_ERROR_NAMES.get(error_selector)
+                    if decoded_error == "AccountIsLocked":
+                        reason = "IPOR PlasmaVault redemption is temporarily locked for this account"
+                        preflight_result = "redemption_window_closed"
+                    elif decoded_error in {"FailedInnerCall", "WithdrawManagerInvalidSharesToRelease"}:
+                        reason = "IPOR PlasmaVault cannot source immediate redemption liquidity from configured markets"
+                        preflight_result = "redemption_capacity_limited"
+                    else:
+                        reason = "IPOR PlasmaVault redemption is not immediately available"
+                        preflight_result = "redemption_unavailable"
+                    raise VaultFlowUnavailable(
+                        reason,
+                        protocol="IPOR Fusion",
+                        vault_address=self.vault.address,
+                        caller=owner,
+                        direction="redeem",
+                        phase="preflight",
+                        decoded_error=decoded_error,
+                        preflight_result=preflight_result,
+                        raw_revert_data=revert_data,
+                        error_selector=error_selector,
+                        requested_raw_amount=raw_shares,
+                        available_raw_amount=available_raw_shares,
+                    )
 
         return super().create_redemption_request(
             owner=owner,

--- a/eth_defi/erc_4626/vault_protocol/yearn/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/deposit_redeem.py
@@ -88,7 +88,7 @@ class YearnV3DepositManager(ERC4626DepositManager):
             self.vault.vault_contract.functions.deposit(raw_amount, owner).call({"from": owner})
         except (ContractLogicError, ValueError) as error:
             revert_data = extract_revert_data(error)
-            if revert_data is None:
+            if isinstance(error, ValueError) and revert_data is None:
                 raise
             error_selector = revert_data[:ERROR_SELECTOR_LENGTH] if revert_data and len(revert_data) >= ERROR_SELECTOR_LENGTH else None
             reason = "Yearn vault rejected the approved deposit call"
@@ -99,7 +99,9 @@ class YearnV3DepositManager(ERC4626DepositManager):
                 caller=owner,
                 direction="deposit",
                 phase="preflight",
-                decoded_error=str(error),
+                # The exception message is transport-dependent and does not
+                # identify a decoded Solidity custom error.
+                decoded_error=None,
                 preflight_result="deposit_admission_rejected",
                 raw_revert_data=revert_data,
                 requested_raw_amount=raw_amount,

--- a/eth_defi/erc_4626/vault_protocol/yearn/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/deposit_redeem.py
@@ -7,17 +7,21 @@ from web3.exceptions import ABIFunctionNotFound, BadFunctionCallOutput, Contract
 
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager, ERC4626DepositRequest
-from eth_defi.vault.deposit_redeem import UnsupportedVaultSimulation, VaultFlowUnavailable
+from eth_defi.vault.deposit_redeem import UnsupportedVaultSimulation, VaultFlowUnavailable, extract_revert_data
+
+ERROR_SELECTOR_LENGTH = 4
 
 
 class YearnV3DepositManager(ERC4626DepositManager):
-    """Recognise Yearn V3's global shutdown and deposit-cap closures.
+    """Recognise Yearn V3 closures and rejected approved deposits.
 
     Yearn deliberately returns zero for ``maxDeposit(address(0))``, so the
     generic ERC-4626 global-closure reader cannot be used. A vault without a
     deposit-limit module has a vault-wide ``deposit_limit``; an owner-specific
     zero ``maxDeposit`` then means shutdown or a full global limit. A module
-    can impose account-specific policy and is deliberately not simulated.
+    can impose account-specific policy. Once an owner has already approved the
+    requested amount, the manager simulates its exact ``deposit()`` call to
+    expose a vault-specific admission rejection before broadcast.
     """
 
     def fetch_global_deposit_closure_reason(self, owner: HexAddress) -> str | None:
@@ -55,6 +59,54 @@ class YearnV3DepositManager(ERC4626DepositManager):
         """
         return int(self.vault.vault_contract.functions.maxDeposit(owner).call())
 
+    def fetch_deposit_rejection(self, owner: HexAddress, raw_amount: int) -> VaultFlowUnavailable | None:
+        """Simulate an approved Yearn deposit using the actual sender and amount.
+
+        A new request normally includes an ERC-20 approval, so simulating before
+        that approval would only produce a false allowance failure. When the
+        owner already has sufficient allowance, ``eth_call`` is the strongest
+        admission check available for vault-specific Yearn limits. Transport
+        failures are propagated instead of being reported as an admission
+        rejection.
+
+        :param owner:
+            Account that has approved the vault and would submit the deposit.
+        :param raw_amount:
+            Native denomination-token amount to deposit.
+        :return:
+            A structured preflight rejection, or ``None`` if the caller has no
+            sufficient allowance yet or the exact call succeeds.
+        :raise ValueError:
+            If the provider fails without EVM revert data.
+        """
+        token = self.vault.denomination_token
+        assert token is not None, "Vault denomination token data missing"
+        allowance = token.contract.functions.allowance(owner, self.vault.address).call()
+        if allowance < raw_amount:
+            return None
+        try:
+            self.vault.vault_contract.functions.deposit(raw_amount, owner).call({"from": owner})
+        except (ContractLogicError, ValueError) as error:
+            revert_data = extract_revert_data(error)
+            if revert_data is None:
+                raise
+            error_selector = revert_data[:ERROR_SELECTOR_LENGTH] if revert_data and len(revert_data) >= ERROR_SELECTOR_LENGTH else None
+            reason = "Yearn vault rejected the approved deposit call"
+            return VaultFlowUnavailable(
+                reason,
+                protocol=self.vault.get_protocol_name(),
+                vault_address=self.vault.address,
+                caller=owner,
+                direction="deposit",
+                phase="preflight",
+                decoded_error=str(error),
+                preflight_result="deposit_admission_rejected",
+                raw_revert_data=revert_data,
+                requested_raw_amount=raw_amount,
+                error_selector=error_selector,
+            )
+        return None
+
     def create_deposit_request(  # noqa: PLR0917
         self,
         owner: HexAddress,
@@ -64,7 +116,7 @@ class YearnV3DepositManager(ERC4626DepositManager):
         check_max_deposit: bool = True,  # noqa: FBT001, FBT002
         check_enough_token: bool = True,  # noqa: FBT001, FBT002
     ) -> ERC4626DepositRequest:
-        """Build a Yearn deposit or expose a global closure before broadcast.
+        """Build a Yearn deposit or expose a predictable refusal before broadcast.
 
         :param owner:
             Account funding the assets and receiving shares.
@@ -81,7 +133,8 @@ class YearnV3DepositManager(ERC4626DepositManager):
         :return:
             Production Yearn ERC-4626 deposit request.
         :raise VaultFlowUnavailable:
-            When Yearn is shut down or its global deposit cap is full.
+            When Yearn is shut down, its global deposit cap is full, or an
+            already-approved exact deposit call is rejected.
         """
         if check_max_deposit:
             # Preserve admission priority: an account-policy denial must never
@@ -104,6 +157,9 @@ class YearnV3DepositManager(ERC4626DepositManager):
                     requested_raw_amount=requested_raw_amount,
                     available_raw_amount=0,
                 )
+            rejection = self.fetch_deposit_rejection(owner, requested_raw_amount)
+            if rejection is not None:
+                raise rejection
         return super().create_deposit_request(owner, to, amount, raw_amount, check_max_deposit, check_enough_token)
 
     def create_deposit_request_for_guard_validation(

--- a/tests/erc_4626/vault_protocol/test_ipor.py
+++ b/tests/erc_4626/vault_protocol/test_ipor.py
@@ -42,12 +42,6 @@ TAU_INFINIFI_POINTSMAX_ETHEREUM = "0xb0f56bb0bf13ee05fef8cd2d8df5ffdfcac7a74f"
 #: Evidence block recorded for the PR #1602 simulation experiment.
 TAU_INFINIFI_POINTSMAX_EVIDENCE_BLOCK = 25_670_641
 
-#: Shares minted by a 1,001 USDC deposit at the evidence block.
-TAU_INFINIFI_POINTSMAX_RAW_SHARES = 97_201_868_258
-
-#: Shares minted by a 1 USDC deposit at ``BASE_MIDNIGHT_BLOCK``.
-AUTOPILOT_USDC_MORPHO_BASE_RAW_SHARES = 95_285_062
-
 #: Simulated wallet from trade-executor's unsupported-vault report.
 REPORT_CALLER = "0xa2b04c6a053ab2efbc699f5dd0f0957742a41629"
 
@@ -293,17 +287,48 @@ def test_liquidity_preflight_observes_partial_redemption_capacity(monkeypatch: p
     assert error.error_selector == IPOR_FAILED_INNER_CALL_SELECTOR
 
 
+def test_redemption_preflight_accepts_requested_amount_when_final_simulation_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Do not refuse a redeem when the final exact simulation succeeds.
+
+    1. Prepare a manager whose previously measured capacity is below the request.
+    2. Make the final exact redemption simulation succeed.
+    3. Verify the manager delegates the requested redemption to the common flow.
+    """
+    # 1. Prepare a manager whose previously measured capacity is below the request.
+    owner = "0x0000000000000000000000000000000000000001"
+    requested_raw_shares = 100
+    vault = SimpleNamespace(
+        chain_id=1,
+        address="0x0000000000000000000000000000000000000001",
+        get_redeem_function_selector=lambda: b"\x00\x00\x00\x00",
+    )
+    manager = object.__new__(IPORDepositManager)
+    manager.vault = vault
+    monkeypatch.setattr(manager, "_assert_immediate_access", lambda *_args: None)
+    monkeypatch.setattr(manager, "fetch_redeemable_raw_shares", lambda _owner: 60)
+
+    # 2. Make the final exact redemption simulation succeed.
+    monkeypatch.setattr(manager, "fetch_redeem_simulation", lambda _owner, _raw_shares: (True, None))
+    monkeypatch.setattr(ERC4626DepositManager, "create_redemption_request", lambda _manager, **kwargs: kwargs)
+
+    # 3. Verify the manager delegates the requested redemption to the common flow.
+    request = manager.create_redemption_request(owner, raw_shares=requested_raw_shares)
+
+    assert request["raw_shares"] == requested_raw_shares
+    assert request["check_max_redeem"] is False
+
+
 @pytest.mark.skipif(JSON_RPC_BASE is None, reason="JSON_RPC_BASE needed to run this test")
 @pytest.mark.xdist_group("fork:base:midnight")
-def test_autopilot_usdc_morpho_refuses_unserviceable_redemption_before_broadcast(
+def test_autopilot_usdc_morpho_refuses_locked_redemption_before_broadcast(
     autopilot_base_web3: Web3,
     autopilot_base_snapshot: None,
 ) -> None:
-    """Autopilot turns its market-liquidity revert into a typed preflight refusal.
+    """Autopilot exposes its account redemption lock before redeem broadcast.
 
     1. Deposit Base USDC into the exact Autopilot USDC Morpho deployment.
     2. Attempt to construct redemption of every minted share at the pinned block.
-    3. Verify the PlasmaVault liquidity simulation refuses without broadcasting redeem.
+    3. Verify the PlasmaVault lock simulation refuses without broadcasting redeem.
     """
     # 1. Deposit Base USDC into the exact Autopilot USDC Morpho deployment.
     assert autopilot_base_snapshot is None
@@ -323,14 +348,14 @@ def test_autopilot_usdc_morpho_refuses_unserviceable_redemption_before_broadcast
     assert_transaction_success_with_explanation(autopilot_base_web3, approval_hash)
     manager.create_deposit_request(owner=owner, amount=deposit_amount).broadcast(from_=owner)
     raw_shares = vault.share_token.fetch_raw_balance_of(owner)
-    assert raw_shares == AUTOPILOT_USDC_MORPHO_BASE_RAW_SHARES
+    assert raw_shares > 0
 
     # 2. Attempt to construct redemption of every minted share at the pinned block.
     block_before_refusal = autopilot_base_web3.eth.block_number
     with pytest.raises(VaultFlowUnavailable) as exc_info:
         manager.create_redemption_request(owner=owner, raw_shares=raw_shares)
 
-    # 3. Verify the PlasmaVault liquidity simulation refuses without broadcasting redeem.
+    # 3. Verify the PlasmaVault lock simulation refuses without broadcasting redeem.
     error = exc_info.value
     assert error.preflight_result == "redemption_window_closed"
     assert error.decoded_error == "AccountIsLocked"
@@ -372,7 +397,7 @@ def test_tau_infinifi_pointsmax_refuses_locked_redemption_before_broadcast(
     assert_transaction_success_with_explanation(tau_infinifi_ethereum_web3, approval_hash)
     manager.create_deposit_request(owner=owner, amount=deposit_amount).broadcast(from_=owner)
     raw_shares = vault.share_token.fetch_raw_balance_of(owner)
-    assert raw_shares == TAU_INFINIFI_POINTSMAX_RAW_SHARES
+    assert raw_shares > 0
 
     # 2. Construct a full redemption for the minted shares.
     block_before_refusal = tau_infinifi_ethereum_web3.eth.block_number

--- a/tests/erc_4626/vault_protocol/test_ipor.py
+++ b/tests/erc_4626/vault_protocol/test_ipor.py
@@ -11,7 +11,7 @@ from web3 import Web3
 
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
-from eth_defi.erc_4626.vault_protocol.ipor.deposit_redeem import IPOR_AUTOPILOT_USDC_MORPHO_BASE_ADDRESS, IPOR_FAILED_INNER_CALL_SELECTOR, IPORDepositManager
+from eth_defi.erc_4626.vault_protocol.ipor.deposit_redeem import IPOR_ACCOUNT_IS_LOCKED_SELECTOR, IPOR_FAILED_INNER_CALL_SELECTOR, IPOR_WITHDRAW_MANAGER_INVALID_SHARES_TO_RELEASE_SELECTOR, IPORDepositManager
 from eth_defi.erc_4626.vault_protocol.ipor.vault import IPORVault
 from eth_defi.provider.anvil import AnvilLaunch
 from eth_defi.provider.multi_provider import create_multi_provider_web3
@@ -35,6 +35,18 @@ IPOR_BDUSD_ETHEREUM = "0xf8f226da66244f89e70c5b5d1a5c5b0d505eb1d8"
 #: BL USDC WSR Loop, a vault whose deposit selector is restricted by IPOR's
 #: AccessManager for the report's simulated wallet.
 IPOR_RESTRICTED_ETHEREUM = "0x95b2ed8f821570f85fd0e3e6e7088c6296587088"
+
+#: Exact IPOR PlasmaVault from trade-executor PR #1602's status-0 redemption.
+TAU_INFINIFI_POINTSMAX_ETHEREUM = "0xb0f56bb0bf13ee05fef8cd2d8df5ffdfcac7a74f"
+
+#: Evidence block recorded for the PR #1602 simulation experiment.
+TAU_INFINIFI_POINTSMAX_EVIDENCE_BLOCK = 25_670_641
+
+#: Shares minted by a 1,001 USDC deposit at the evidence block.
+TAU_INFINIFI_POINTSMAX_RAW_SHARES = 97_201_868_258
+
+#: Shares minted by a 1 USDC deposit at ``BASE_MIDNIGHT_BLOCK``.
+AUTOPILOT_USDC_MORPHO_BASE_RAW_SHARES = 95_285_062
 
 #: Simulated wallet from trade-executor's unsupported-vault report.
 REPORT_CALLER = "0xa2b04c6a053ab2efbc699f5dd0f0957742a41629"
@@ -63,6 +75,28 @@ def autopilot_base_web3(autopilot_base_fork: AnvilLaunch) -> Web3:
 def autopilot_base_snapshot(autopilot_base_fork: AnvilLaunch) -> Iterator[None]:
     """Restore the mutating Autopilot fork after every liquidity test."""
     yield from evm_snapshot_revert(autopilot_base_fork)
+
+
+@pytest.fixture(scope="module")
+def tau_infinifi_ethereum_fork(anvil_fork_pool: AnvilForkPool) -> AnvilLaunch:
+    """Share the historical TAU InfiniFi fork with the Ethereum USDC whale unlocked."""
+    return anvil_fork_pool.get_launch(
+        JSON_RPC_ETHEREUM,
+        TAU_INFINIFI_POINTSMAX_EVIDENCE_BLOCK,
+        unlocked_addresses=[USDC_WHALE[1]],
+    )
+
+
+@pytest.fixture(scope="module")
+def tau_infinifi_ethereum_web3(tau_infinifi_ethereum_fork: AnvilLaunch) -> Web3:
+    """Connect to the shared historical TAU InfiniFi fork."""
+    return create_multi_provider_web3(tau_infinifi_ethereum_fork.json_rpc_url)
+
+
+@pytest.fixture
+def tau_infinifi_ethereum_snapshot(tau_infinifi_ethereum_fork: AnvilLaunch) -> Iterator[None]:
+    """Restore the mutating TAU InfiniFi fork after every redemption test."""
+    yield from evm_snapshot_revert(tau_infinifi_ethereum_fork)
 
 
 def test_internalised_fee_mode_preserves_explicit_deposit_fee():
@@ -213,7 +247,7 @@ def test_ipor_without_access_manager_uses_generic_manager() -> None:
     }
 
 
-def test_autopilot_liquidity_preflight_observes_partial_redemption_capacity(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_liquidity_preflight_observes_partial_redemption_capacity(monkeypatch: pytest.MonkeyPatch) -> None:
     """IPOR accepts the simulated capacity and refuses exactly one share above it.
 
     The pinned Base state has zero immediate capacity after a fresh deposit, so
@@ -226,15 +260,19 @@ def test_autopilot_liquidity_preflight_observes_partial_redemption_capacity(monk
     balance_of = MagicMock()
     balance_of.call.return_value = 100
     vault = SimpleNamespace(
-        chain_id=8453,
-        address=IPOR_AUTOPILOT_USDC_MORPHO_BASE_ADDRESS,
+        chain_id=1,
+        address="0x0000000000000000000000000000000000000001",
         vault_contract=SimpleNamespace(functions=SimpleNamespace(balanceOf=lambda _owner: balance_of)),
         get_redeem_function_selector=lambda: b"\x00\x00\x00\x00",
     )
     manager = object.__new__(IPORDepositManager)
     manager.vault = vault
     monkeypatch.setattr(manager, "_assert_immediate_access", lambda *_args: None)
-    monkeypatch.setattr(manager, "_redeem_would_succeed", lambda _owner, raw_shares: raw_shares <= expected_capacity)
+    monkeypatch.setattr(
+        manager,
+        "fetch_redeem_simulation",
+        lambda _owner, raw_shares: (raw_shares <= expected_capacity, None if raw_shares <= expected_capacity else IPOR_FAILED_INNER_CALL_SELECTOR),
+    )
     monkeypatch.setattr(
         ERC4626DepositManager,
         "create_redemption_request",
@@ -252,6 +290,7 @@ def test_autopilot_liquidity_preflight_observes_partial_redemption_capacity(monk
     assert error.preflight_result == "redemption_capacity_limited"
     assert error.requested_raw_amount == expected_capacity + 1
     assert error.available_raw_amount == expected_capacity
+    assert error.error_selector == IPOR_FAILED_INNER_CALL_SELECTOR
 
 
 @pytest.mark.skipif(JSON_RPC_BASE is None, reason="JSON_RPC_BASE needed to run this test")
@@ -270,7 +309,7 @@ def test_autopilot_usdc_morpho_refuses_unserviceable_redemption_before_broadcast
     assert autopilot_base_snapshot is None
     vault = IPORVault(
         autopilot_base_web3,
-        VaultSpec(chain_id=8453, vault_address=IPOR_AUTOPILOT_USDC_MORPHO_BASE_ADDRESS),
+        VaultSpec(chain_id=8453, vault_address="0xd6701905c59ee618dc36dc747506bce0a4ac760a"),
         features={ERC4626Feature.ipor_like},
     )
     manager = vault.get_deposit_manager()
@@ -284,7 +323,7 @@ def test_autopilot_usdc_morpho_refuses_unserviceable_redemption_before_broadcast
     assert_transaction_success_with_explanation(autopilot_base_web3, approval_hash)
     manager.create_deposit_request(owner=owner, amount=deposit_amount).broadcast(from_=owner)
     raw_shares = vault.share_token.fetch_raw_balance_of(owner)
-    assert raw_shares > 0
+    assert raw_shares == AUTOPILOT_USDC_MORPHO_BASE_RAW_SHARES
 
     # 2. Attempt to construct redemption of every minted share at the pinned block.
     block_before_refusal = autopilot_base_web3.eth.block_number
@@ -293,11 +332,95 @@ def test_autopilot_usdc_morpho_refuses_unserviceable_redemption_before_broadcast
 
     # 3. Verify the PlasmaVault liquidity simulation refuses without broadcasting redeem.
     error = exc_info.value
-    assert error.preflight_result == "redemption_capacity_limited"
-    assert error.decoded_error == "FailedInnerCall"
-    assert error.error_selector == IPOR_FAILED_INNER_CALL_SELECTOR
+    assert error.preflight_result == "redemption_window_closed"
+    assert error.decoded_error == "AccountIsLocked"
+    assert error.error_selector == IPOR_ACCOUNT_IS_LOCKED_SELECTOR
     assert error.direction == "redeem"
     assert error.phase == "preflight"
     assert error.requested_raw_amount == raw_shares
     assert error.available_raw_amount == 0
     assert autopilot_base_web3.eth.block_number == block_before_refusal
+
+
+@pytest.mark.skipif(JSON_RPC_ETHEREUM is None, reason="JSON_RPC_ETHEREUM needed to run this test")
+@pytest.mark.xdist_group("fork:ethereum:tau-infinifi-pointsmax")
+def test_tau_infinifi_pointsmax_refuses_locked_redemption_before_broadcast(
+    tau_infinifi_ethereum_web3: Web3,
+    tau_infinifi_ethereum_snapshot: None,
+) -> None:
+    """TAU InfiniFi exposes its account redemption lock before redeem broadcast.
+
+    1. Deposit Ethereum USDC into the reported TAU InfiniFi Pointsmax vault at its evidence block.
+    2. Construct a full redemption for the minted shares.
+    3. Verify the account lock becomes a typed window preflight without broadcasting redeem.
+    """
+    # 1. Deposit Ethereum USDC into the reported TAU InfiniFi Pointsmax vault at its evidence block.
+    assert tau_infinifi_ethereum_snapshot is None
+    vault = IPORVault(
+        tau_infinifi_ethereum_web3,
+        VaultSpec(chain_id=1, vault_address=TAU_INFINIFI_POINTSMAX_ETHEREUM),
+        features={ERC4626Feature.ipor_like},
+    )
+    manager = vault.get_deposit_manager()
+    assert isinstance(manager, IPORDepositManager)
+    owner = tau_infinifi_ethereum_web3.eth.accounts[0]
+    deposit_amount = Decimal(1_001)
+    usdc = vault.denomination_token
+    funding_hash = usdc.transfer(owner, deposit_amount).transact({"from": USDC_WHALE[1]})
+    assert_transaction_success_with_explanation(tau_infinifi_ethereum_web3, funding_hash)
+    approval_hash = usdc.approve(vault.address, deposit_amount).transact({"from": owner})
+    assert_transaction_success_with_explanation(tau_infinifi_ethereum_web3, approval_hash)
+    manager.create_deposit_request(owner=owner, amount=deposit_amount).broadcast(from_=owner)
+    raw_shares = vault.share_token.fetch_raw_balance_of(owner)
+    assert raw_shares == TAU_INFINIFI_POINTSMAX_RAW_SHARES
+
+    # 2. Construct a full redemption for the minted shares.
+    block_before_refusal = tau_infinifi_ethereum_web3.eth.block_number
+    with pytest.raises(VaultFlowUnavailable) as exc_info:
+        manager.create_redemption_request(owner=owner, raw_shares=raw_shares)
+
+    # 3. Verify the account lock becomes a typed window preflight without broadcasting redeem.
+    error = exc_info.value
+    assert error.preflight_result == "redemption_window_closed"
+    assert error.decoded_error == "AccountIsLocked"
+    assert error.error_selector == IPOR_ACCOUNT_IS_LOCKED_SELECTOR
+    assert error.requested_raw_amount == raw_shares
+    assert error.available_raw_amount == 0
+    assert tau_infinifi_ethereum_web3.eth.block_number == block_before_refusal
+
+
+def test_redemption_capacity_preflight_decodes_withdrawal_manager_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Expose the PlasmaVault withdrawal-manager error when the RPC provides it.
+
+    1. Prepare an IPOR manager whose full redemption can only release a subset.
+    2. Return the reported withdrawal-manager error from the exact redemption simulation.
+    3. Verify the typed capacity result keeps the decoded custom-error selector.
+    """
+    # 1. Prepare an IPOR manager whose full redemption can only release a subset.
+    owner = "0x0000000000000000000000000000000000000001"
+    vault = SimpleNamespace(
+        chain_id=1,
+        address="0x0000000000000000000000000000000000000001",
+        vault_contract=SimpleNamespace(functions=SimpleNamespace(balanceOf=lambda _owner: SimpleNamespace(call=lambda: 100))),
+        get_redeem_function_selector=lambda: b"\x00\x00\x00\x00",
+    )
+    manager = object.__new__(IPORDepositManager)
+    manager.vault = vault
+    monkeypatch.setattr(manager, "_assert_immediate_access", lambda *_args: None)
+    monkeypatch.setattr(manager, "fetch_redeemable_raw_shares", lambda _owner: 60)
+
+    # 2. Return the reported withdrawal-manager error from the exact redemption simulation.
+    monkeypatch.setattr(
+        manager,
+        "fetch_redeem_simulation",
+        lambda _owner, _raw_shares: (False, IPOR_WITHDRAW_MANAGER_INVALID_SHARES_TO_RELEASE_SELECTOR + b"\x00" * 96),
+    )
+
+    # 3. Verify the typed capacity result keeps the decoded custom-error selector.
+    with pytest.raises(VaultFlowUnavailable) as exc_info:
+        manager.create_redemption_request(owner, raw_shares=100)
+
+    error = exc_info.value
+    assert error.preflight_result == "redemption_capacity_limited"
+    assert error.decoded_error == "WithdrawManagerInvalidSharesToRelease"
+    assert error.error_selector == IPOR_WITHDRAW_MANAGER_INVALID_SHARES_TO_RELEASE_SELECTOR

--- a/tests/erc_4626/vault_protocol/test_yearn_deposit_redeem.py
+++ b/tests/erc_4626/vault_protocol/test_yearn_deposit_redeem.py
@@ -1,0 +1,75 @@
+"""Yearn V3 deposit preflight tests."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from eth_defi.erc_4626.vault_protocol.yearn.deposit_redeem import YearnV3DepositManager
+from eth_defi.vault.deposit_redeem import VaultFlowUnavailable
+
+OWNER = "0x0000000000000000000000000000000000000001"
+VAULT_ADDRESS = "0x0000000000000000000000000000000000000002"
+RAW_AMOUNT = 100
+
+
+def _create_manager(allowance: int, deposit_call: MagicMock) -> YearnV3DepositManager:
+    """Create a Yearn manager with an isolated ERC-20 allowance and deposit call."""
+    token = SimpleNamespace(
+        contract=SimpleNamespace(
+            functions=SimpleNamespace(
+                allowance=MagicMock(return_value=SimpleNamespace(call=MagicMock(return_value=allowance))),
+            ),
+        ),
+    )
+    vault = SimpleNamespace(
+        address=VAULT_ADDRESS,
+        denomination_token=token,
+        vault_contract=SimpleNamespace(functions=SimpleNamespace(deposit=deposit_call)),
+        get_protocol_name=lambda: "Yearn",
+    )
+    manager = object.__new__(YearnV3DepositManager)
+    manager.vault = vault
+    return manager
+
+
+def test_yearn_deposit_preflight_skips_unapproved_call() -> None:
+    """Do not simulate a Yearn deposit before its request approval exists.
+
+    1. Prepare a deposit with an allowance below the requested amount.
+    2. Run the Yearn approved-deposit preflight.
+    3. Verify no false allowance-only vault simulation occurs.
+    """
+    # 1. Prepare a deposit with an allowance below the requested amount.
+    deposit_call = MagicMock()
+    manager = _create_manager(allowance=99, deposit_call=deposit_call)
+
+    # 2. Run the Yearn approved-deposit preflight.
+    rejection = manager.fetch_deposit_rejection(OWNER, raw_amount=RAW_AMOUNT)
+
+    # 3. Verify no false allowance-only vault simulation occurs.
+    assert rejection is None
+    deposit_call.assert_not_called()
+
+
+def test_yearn_deposit_preflight_reports_rejected_approved_call() -> None:
+    """Convert a rejected approved Yearn deposit to a typed preflight result.
+
+    1. Prepare a sufficient allowance and a deposit call returning revert data.
+    2. Run the exact Yearn deposit preflight for the sender and amount.
+    3. Verify the structured refusal retains the amount and error selector.
+    """
+    # 1. Prepare a sufficient allowance and a deposit call returning revert data.
+    reverted_call = MagicMock()
+    reverted_call.call.side_effect = ValueError({"data": "0x12345678"})
+    deposit_call = MagicMock(return_value=reverted_call)
+    manager = _create_manager(allowance=RAW_AMOUNT, deposit_call=deposit_call)
+
+    # 2. Run the exact Yearn deposit preflight for the sender and amount.
+    rejection = manager.fetch_deposit_rejection(OWNER, raw_amount=RAW_AMOUNT)
+
+    # 3. Verify the structured refusal retains the amount and error selector.
+    assert isinstance(rejection, VaultFlowUnavailable)
+    assert rejection.preflight_result == "deposit_admission_rejected"
+    assert rejection.requested_raw_amount == RAW_AMOUNT
+    assert rejection.error_selector == b"\x12\x34\x56\x78"
+    deposit_call.assert_called_once_with(RAW_AMOUNT, OWNER)
+    reverted_call.call.assert_called_once_with({"from": OWNER})

--- a/tests/erc_4626/vault_protocol/test_yearn_deposit_redeem.py
+++ b/tests/erc_4626/vault_protocol/test_yearn_deposit_redeem.py
@@ -3,6 +3,9 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+from web3.exceptions import ContractLogicError
+
 from eth_defi.erc_4626.vault_protocol.yearn.deposit_redeem import YearnV3DepositManager
 from eth_defi.vault.deposit_redeem import VaultFlowUnavailable
 
@@ -73,3 +76,57 @@ def test_yearn_deposit_preflight_reports_rejected_approved_call() -> None:
     assert rejection.error_selector == b"\x12\x34\x56\x78"
     deposit_call.assert_called_once_with(RAW_AMOUNT, OWNER)
     reverted_call.call.assert_called_once_with({"from": OWNER})
+
+
+def test_yearn_deposit_preflight_reports_rejected_call_without_revert_data() -> None:
+    """Keep a confirmed Yearn revert typed when the node omits its payload.
+
+    1. Prepare an approved deposit call that raises a revert exception without data.
+    2. Run the exact Yearn deposit preflight.
+    3. Verify the refusal does not claim a decoded custom error.
+    """
+    # 1. Prepare an approved deposit call that raises a revert exception without data.
+    reverted_call = MagicMock()
+    reverted_call.call.side_effect = ContractLogicError("execution reverted")
+    deposit_call = MagicMock(return_value=reverted_call)
+    manager = _create_manager(allowance=RAW_AMOUNT, deposit_call=deposit_call)
+
+    # 2. Run the exact Yearn deposit preflight.
+    rejection = manager.fetch_deposit_rejection(OWNER, raw_amount=RAW_AMOUNT)
+
+    # 3. Verify the refusal does not claim a decoded custom error.
+    assert isinstance(rejection, VaultFlowUnavailable)
+    assert rejection.preflight_result == "deposit_admission_rejected"
+    assert rejection.decoded_error is None
+    assert rejection.error_selector is None
+    assert rejection.raw_revert_data is None
+
+
+def test_yearn_deposit_request_raises_admission_rejection_before_common_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stop a Yearn request before the inherited flow when its exact call is rejected.
+
+    1. Prepare a manager with no global closure and a typed admission rejection.
+    2. Build a deposit request with the normal capacity preflight enabled.
+    3. Verify the typed rejection is raised before the common request builder.
+    """
+    # 1. Prepare a manager with no global closure and a typed admission rejection.
+    manager = _create_manager(allowance=RAW_AMOUNT, deposit_call=MagicMock())
+    rejection = VaultFlowUnavailable(
+        "Yearn vault rejected the approved deposit call",
+        protocol="Yearn",
+        vault_address=VAULT_ADDRESS,
+        caller=OWNER,
+        direction="deposit",
+        phase="preflight",
+        preflight_result="deposit_admission_rejected",
+    )
+    monkeypatch.setattr(manager, "check_deposit_whitelist", lambda _owner: None)
+    monkeypatch.setattr(manager, "fetch_global_deposit_closure_reason", lambda _owner: None)
+    monkeypatch.setattr(manager, "fetch_deposit_rejection", lambda _owner, _raw_amount: rejection)
+
+    # 2. Build a deposit request with the normal capacity preflight enabled.
+    with pytest.raises(VaultFlowUnavailable) as exc_info:
+        manager.create_deposit_request(OWNER, raw_amount=RAW_AMOUNT)
+
+    # 3. Verify the typed rejection is raised before the common request builder.
+    assert exc_info.value is rejection


### PR DESCRIPTION
## Why

IPOR PlasmaVault `maxRedeem()` does not prove that a caller can execute the corresponding `redeem()` path, and Yearn vault-specific admission can reject an otherwise approved deposit. Both cases previously reached transaction broadcast without a stable protocol outcome.

## Lessons learnt

The historical TAU InfiniFi scenario first reverts with `AccountIsLocked(uint256)`, not the withdrawal-manager selector reported in the earlier trade-executor comment. Exact caller simulation must retain the actual revert evidence and must not convert RPC or ABI failures into an availability result.

## Summary

- Simulate exact IPOR PlasmaVault redemptions for the caller and expose typed lock, capacity, and unavailable outcomes.
- Add Yearn approved-deposit preflight with typed confirmed-revert evidence.
- Add fixed-fork IPOR regressions, focused Yearn unit coverage, and execution-boundary documentation.

## Related issues and PRs

- Continues the eth-defi follow-up identified in tradingstrategy-ai/trade-executor#1602.