### PR TITLE
fix: preflight 40acres redemption liquidity

### DIFF
--- a/eth_defi/erc_4626/core.py
+++ b/eth_defi/erc_4626/core.py
@@ -869,6 +869,7 @@ LENDING_PROTOCOL_FEATURES: frozenset[ERC4626Feature] = frozenset(
         ERC4626Feature.fluid_like,
         ERC4626Feature.silo_like,
         ERC4626Feature.llamma_like,
+        ERC4626Feature.forty_acres_like,
     }
 )
 

--- a/eth_defi/erc_4626/vault_protocol/forty_acres/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/forty_acres/deposit_redeem.py
@@ -18,13 +18,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-#: Legacy ERC-20 revert emitted when the vault's direct USDC transfer cannot
-#: cover a synchronous redemption. The exact Pharaoh deployment does not use
-#: OpenZeppelin 5's ``ERC20InsufficientBalance`` custom error.
+#: Legacy ERC-20 revert emitted when a 40acres vault's direct USDC transfer
+#: cannot cover a synchronous redemption. The verified deployments use this
+#: rather than OpenZeppelin 5's ``ERC20InsufficientBalance`` custom error.
 FORTY_ACRES_INSUFFICIENT_LIQUIDITY_ERROR = "ERC20: transfer amount exceeds balance"
 
-#: Exact Pharaoh deployment whose verified ``redeem()`` path transfers USDC
-#: directly from the vault and cannot source loan-deployed capital.
+#: Kept as a public identifier for the established Pharaoh fork tests.
 PHARAOH_USDC_AVALANCHE_ADDRESS: HexAddress = "0x124d00b1ce4453ffc5a5f65ce83af13a7709bac7"
 PHARAOH_USDC_AVALANCHE_CHAIN_ID = 43114
 
@@ -33,19 +32,14 @@ FORTY_ACRES_LIQUIDITY_SEARCH_MAX_ATTEMPTS = 16
 
 
 class FortyAcresDepositManager(ERC4626DepositManager):
-    """Pharaoh ERC-4626 manager with a direct-underlying redemption preflight.
+    """40acres ERC-4626 manager with a direct-underlying redemption preflight.
 
-    The exact Pharaoh deployment includes loan-deployed assets in
-    ``totalAssets()``, but its verified ``redeem()`` implementation pays lenders
-    by directly transferring the underlying from the vault. It cannot pull
-    liquidity from its loan contract during a redemption. This manager therefore
-    limits an immediate redemption to the current underlying balance held by the
-    vault and refuses a larger request before constructing ``redeem()``.
-
-    Other 40acres deployments use the generic ERC-4626 manager. The direct
-    balance rule is not generalised from this one verified deployment because
-    Aerodrome, for example, has independently demonstrated a successful
-    redemption with no meaningful idle balance.
+    The verified 40acres ``Vault.sol`` implementations include loan-deployed
+    assets in ``totalAssets()``, yet inherit OpenZeppelin ERC-4626's direct
+    underlying transfer during ``redeem()``. They cannot pull liquidity from
+    their loan contract during that call. This manager therefore limits an
+    immediate redemption to the current underlying balance held by the vault
+    and refuses a larger request before constructing ``redeem()``.
 
     Deposits remain the inherited synchronous ERC-4626 flow. Redemptions remain
     synchronous too; the manager does not model a loan repayment queue because
@@ -56,8 +50,8 @@ class FortyAcresDepositManager(ERC4626DepositManager):
         """Bind the manager to a 40acres vault.
 
         :param vault:
-            Exact Pharaoh ERC-4626 vault whose direct underlying balance
-            authorises immediate redemptions.
+            40acres ERC-4626 vault whose direct underlying balance authorises
+            immediate redemptions.
         """
         super().__init__(vault)
 
@@ -112,7 +106,7 @@ class FortyAcresDepositManager(ERC4626DepositManager):
         return min(owner_raw_shares, idle_raw_shares)
 
     def _read_redemption_capacity(self, owner: HexAddress, raw_shares: int) -> dict[str, int]:
-        """Read one Pharaoh capacity snapshot in raw units."""
+        """Read one 40acres capacity snapshot in raw units."""
         vault_contract = self.vault.vault_contract
         token = self.vault.denomination_token
         return {
@@ -147,9 +141,9 @@ class FortyAcresDepositManager(ERC4626DepositManager):
         raw_shares: int,
         failure: VaultFlowUnavailable,
     ) -> VaultRedemptionSimulationIntervention:
-        """Provision Pharaoh's direct fork liquidity for one real redemption.
+        """Provision 40acres direct fork liquidity for one real redemption.
 
-        Adding USDC changes both Pharaoh's direct balance and ERC-4626 share
+        Adding USDC changes both the direct balance and ERC-4626 share
         conversion. A bounded monotonic search therefore tests each candidate
         against the manager capacity and the unchanged ``redeem`` call before
         returning the smallest successful Anvil-only injection.

--- a/eth_defi/erc_4626/vault_protocol/forty_acres/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/forty_acres/vault.py
@@ -16,18 +16,23 @@ earn organic yield sourced from real DEX trading fees and bribes.
 The protocol's 5% treasury cut is taken from borrower rewards, not from depositor
 principal or yield. There are no explicit fee functions on the vault contract.
 
-The vault uses UUPS upgradeable proxy pattern with a ``_loanContract`` reference
-to the protocol's lending engine.
+The vault's ``totalAssets()`` includes a ``_loanContract`` reference to the
+protocol's lending engine.
 """
 
 import datetime
 import logging
+from collections.abc import Iterable
+from decimal import Decimal
 
 from eth_typing import BlockIdentifier
 
 from eth_defi.chain import get_chain_name
-from eth_defi.erc_4626.vault import ERC4626Vault
-from eth_defi.erc_4626.vault_protocol.forty_acres.deposit_redeem import PHARAOH_USDC_AVALANCHE_ADDRESS, PHARAOH_USDC_AVALANCHE_CHAIN_ID, FortyAcresDepositManager
+from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
+from eth_defi.erc_4626.vault_protocol.forty_acres.deposit_redeem import FortyAcresDepositManager
+from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
+from eth_defi.types import Percent
+from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
 from eth_defi.vault.deposit_redeem import VaultDepositManager
 
 logger = logging.getLogger(__name__)
@@ -45,6 +50,62 @@ VAULT_NAMES: dict[str, str] = {
     # Blackhole USDC vault on Avalanche
     "0xc0485c4bafb594ae1457820fb6e5b67e8a04bcfd": "Blackhole USDC",
 }
+
+
+class FortyAcresVaultHistoricalReader(ERC4626HistoricalReader):
+    """Read 40acres ERC-4626 state and immediately redeemable liquidity."""
+
+    def construct_multicalls(self) -> Iterable[EncodedCall]:
+        """Add the vault's direct USDC balance to the standard ERC-4626 reads."""
+        yield from self.construct_core_erc_4626_multicall()
+        yield EncodedCall.from_contract_call(
+            self.vault.denomination_token.contract.functions.balanceOf(self.vault.address),
+            extra_data={
+                "function": "idle_assets",
+                "vault": self.vault.address,
+            },
+            first_block_number=self.first_block,
+        )
+
+    def process_result(
+        self,
+        block_number: int,
+        timestamp: datetime.datetime,
+        call_results: list[EncodedCallResult],
+    ) -> VaultHistoricalRead:
+        """Decode core ERC-4626 state and direct-balance redemption capacity."""
+        call_by_name = self.dictify_multicall_results(block_number, call_results)
+        share_price, total_supply, total_assets, errors, max_deposit = self.process_core_erc_4626_result(call_by_name)
+
+        available_liquidity = None
+        utilisation = None
+        idle_result = call_by_name.get("idle_assets")
+        if idle_result is not None and idle_result.success:
+            idle_raw = int.from_bytes(idle_result.result[0:32], byteorder="big")
+            available_liquidity = self.vault.denomination_token.convert_to_decimals(idle_raw)
+            if total_assets is not None:
+                if total_assets == 0:
+                    utilisation = 0.0
+                else:
+                    total_assets_raw = self.vault.denomination_token.convert_to_raw(total_assets)
+                    utilisation = (total_assets_raw - idle_raw) / total_assets_raw
+        elif idle_result is not None:
+            errors.append("idle_assets call failed")
+
+        return VaultHistoricalRead(
+            vault=self.vault,
+            block_number=block_number,
+            timestamp=timestamp,
+            share_price=share_price,
+            total_assets=total_assets,
+            total_supply=total_supply,
+            performance_fee=0.0,
+            management_fee=0.0,
+            errors=errors,
+            max_deposit=max_deposit,
+            available_liquidity=available_liquidity,
+            utilisation=utilisation,
+        )
 
 
 class FortyAcresVault(ERC4626Vault):
@@ -90,6 +151,27 @@ class FortyAcresVault(ERC4626Vault):
 
     See `LoanV2._processFees() <https://github.com/40-Acres/loan-contracts/blob/main/src/LoanV2.sol>`__
     for the fee distribution implementation.
+
+    **Immediate redemption limitation**
+
+    The verified ``Vault.sol`` implementation only overrides ``totalAssets()``.
+    It inherits OpenZeppelin ERC-4626's ``redeem()`` and ``_withdraw()`` path,
+    which burns shares and directly transfers USDC from the vault address. It
+    does not recall capital from ``_loanContract`` as part of redemption.
+
+    Consequently, ``totalAssets()``, ``previewRedeem()`` and ``maxRedeem()``
+    can value or authorise shares backed by outstanding loans without proving
+    that the vault can transfer USDC now. Immediate redemption capacity is the
+    vault's direct USDC balance converted to shares, bounded by the owner's
+    shares. When that balance is insufficient, the legacy implementation
+    reverts with ``ERC20: transfer amount exceeds balance``.
+
+    The adapter performs this direct-balance preflight for every recognised
+    40acres vault and reports a typed ``redemption_capacity_limited`` result
+    instead of submitting a reverting transaction. Fork simulations may add
+    the smallest required USDC balance on Anvil to demonstrate that the
+    unchanged redemption path works; the intervention is recorded and does
+    not represent live liquidity or a production redemption solution.
 
     Example vaults:
 
@@ -139,8 +221,9 @@ class FortyAcresVault(ERC4626Vault):
     def get_estimated_lock_up(self) -> datetime.timedelta | None:
         """Withdrawals depend on vault utilisation.
 
-        No explicit lock-up, but an 80% utilisation cap means 20% of reserves
-        must remain accessible. When fully utilised, lenders wait for repayments.
+        There is no explicit lock-up or on-chain redemption queue. Immediate
+        withdrawals require direct USDC held by the vault; loan-deployed assets
+        require a borrower repayment before they become transferable.
         """
         return None
 
@@ -161,12 +244,32 @@ class FortyAcresVault(ERC4626Vault):
         return "https://app.40acres.finance/"
 
     def get_deposit_manager(self) -> VaultDepositManager:
-        """Create the deployment-specific 40acres redemption manager.
+        """Create the 40acres manager with direct-balance redemption preflight.
 
         :return:
-            The specialised Pharaoh manager when its exact deployment is bound;
-            otherwise the generic ERC-4626 manager.
+            The 40acres ERC-4626 manager.
         """
-        if self.chain_id == PHARAOH_USDC_AVALANCHE_CHAIN_ID and self.address.lower() == PHARAOH_USDC_AVALANCHE_ADDRESS:
-            return FortyAcresDepositManager(self)
-        return super().get_deposit_manager()
+        return FortyAcresDepositManager(self)
+
+    def get_historical_reader(self, stateful: bool) -> VaultHistoricalReader:  # noqa: FBT001
+        """Get the 40acres reader with immediate-liquidity metrics."""
+        return FortyAcresVaultHistoricalReader(self, stateful)
+
+    def fetch_available_liquidity(self, block_identifier: BlockIdentifier = "latest") -> Decimal | None:
+        """Read direct USDC currently available for immediate redemption."""
+        try:
+            idle_raw = self.denomination_token.contract.functions.balanceOf(self.address).call(block_identifier=block_identifier)
+            return self.denomination_token.convert_to_decimals(idle_raw)
+        except Exception:
+            return None
+
+    def fetch_utilisation_percent(self, block_identifier: BlockIdentifier = "latest") -> Percent | None:
+        """Read the share of reported assets that is not held directly by the vault."""
+        try:
+            total_assets = self.vault_contract.functions.totalAssets().call(block_identifier=block_identifier)
+            idle_raw = self.denomination_token.contract.functions.balanceOf(self.address).call(block_identifier=block_identifier)
+            if total_assets == 0:
+                return 0.0
+            return (total_assets - idle_raw) / total_assets
+        except Exception:
+            return None

--- a/tests/erc_4626/vault_protocol/test_forty_acres.py
+++ b/tests/erc_4626/vault_protocol/test_forty_acres.py
@@ -4,6 +4,7 @@
 with ERC-4626 USDC supply vaults on Avalanche, Base, and Optimism.
 """
 
+import datetime
 import os
 from collections.abc import Iterator
 from decimal import Decimal
@@ -13,8 +14,7 @@ import pytest
 from web3 import Web3
 
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
-from eth_defi.erc_4626.core import ERC4626Feature
-from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
+from eth_defi.erc_4626.core import ERC4626Feature, is_lending_protocol
 from eth_defi.erc_4626.vault_protocol.forty_acres.deposit_redeem import FORTY_ACRES_INSUFFICIENT_LIQUIDITY_ERROR, PHARAOH_USDC_AVALANCHE_ADDRESS, FortyAcresDepositManager
 from eth_defi.erc_4626.vault_protocol.forty_acres.vault import FortyAcresVault
 from eth_defi.provider.anvil import AnvilLaunch, fork_network_anvil, fund_erc20_on_anvil, set_balance
@@ -29,8 +29,7 @@ from eth_defi.vault.deposit_redeem import VaultFlowUnavailable
 JSON_RPC_AVALANCHE = os.environ.get("JSON_RPC_AVALANCHE")
 JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
 
-#: Exact 40acres Aerodrome deployment whose live redemption proves that the
-#: Pharaoh direct-balance rule is not protocol-wide.
+#: 40acres Aerodrome USDC supply vault on Base.
 AERODROME_USDC_VAULT = "0xb99b6df96d4d5448cc0a5b3e0ef7896df9507cf5"
 
 
@@ -104,6 +103,7 @@ def test_forty_acres_blackhole(
     1. Auto-detect the vault protocol from the hardcoded address
     2. Verify the vault instance type and protocol name
     3. Check the lender-facing fees are explicitly zero
+    4. Verify the historical reader records direct liquidity and utilisation
     """
 
     # 1. Auto-detect the vault protocol
@@ -124,6 +124,19 @@ def test_forty_acres_blackhole(
     # fee"), not None, which the vault API reserves for "fee not exposed".
     assert vault.get_management_fee("latest") == 0.0
     assert vault.get_performance_fee("latest") == 0.0
+    assert is_lending_protocol(vault.features) is True
+
+    # 4. Verify the historical reader records direct liquidity and utilisation.
+    reader = vault.get_historical_reader(stateful=False)
+    block_number = web3.eth.block_number
+    calls = list(reader.construct_multicalls())
+    call_results = [call.call_as_result(web3=web3, block_identifier=block_number) for call in calls]
+    timestamp = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc).replace(tzinfo=None)
+    vault_read = reader.process_result(block_number, timestamp, call_results)
+    assert vault_read.available_liquidity is not None
+    assert vault_read.utilisation is not None
+    assert vault_read.available_liquidity == vault.fetch_available_liquidity(block_number)
+    assert vault_read.utilisation == pytest.approx(vault.fetch_utilisation_percent(block_number))
 
 
 @pytest.mark.skipif(JSON_RPC_AVALANCHE is None, reason="JSON_RPC_AVALANCHE needed to run this test")
@@ -236,25 +249,25 @@ def test_pharaoh_anvil_capacity_increase_preserves_real_redemption(
 
 @pytest.mark.skipif(JSON_RPC_BASE is None, reason="JSON_RPC_BASE needed to run this test")
 @pytest.mark.xdist_group("fork:base:midnight")
-def test_aerodrome_uses_generic_manager_and_redeems(
+def test_aerodrome_redemption_capacity_preflight_and_anvil_liquidity_intervention(
     aerodrome_base_web3: Web3,
     aerodrome_base_snapshot: None,
 ) -> None:
-    """Aerodrome keeps the generic flow and completes a real redemption.
+    """Aerodrome fails gracefully when loan capital is not directly redeemable.
 
-    Aerodrome has demonstrated a successful redemption despite little idle
-    underlying, so it is the regression control for Pharaoh's address-scoped
-    direct-balance preflight.
+    1. Deposit USDC into the real Aerodrome vault at the pinned Base block.
+    2. Remove its direct USDC on Anvil to model all capital deployed to loans.
+    3. Verify that the normal redemption request returns a typed preflight failure.
+    4. Add the smallest simulated liquidity and redeem the unchanged shares.
     """
+    # 1. Deposit USDC into the real Aerodrome vault at the pinned Base block.
     assert aerodrome_base_snapshot is None
     vault = create_vault_instance_autodetect(aerodrome_base_web3, vault_address=AERODROME_USDC_VAULT)
     assert isinstance(vault, FortyAcresVault)
     manager = vault.get_deposit_manager()
-    assert isinstance(manager, ERC4626DepositManager)
-    assert not isinstance(manager, FortyAcresDepositManager)
+    assert isinstance(manager, FortyAcresDepositManager)
     owner = aerodrome_base_web3.eth.accounts[0]
     deposit_amount = Decimal(1)
-    denomination_balance_before = vault.denomination_token.fetch_raw_balance_of(owner)
     funding_hash = vault.denomination_token.transfer(owner, deposit_amount).transact({"from": USDC_WHALE[8453]})
     assert_transaction_success_with_explanation(aerodrome_base_web3, funding_hash)
     approval_hash = vault.denomination_token.approve(vault.address, deposit_amount).transact({"from": owner})
@@ -263,6 +276,25 @@ def test_aerodrome_uses_generic_manager_and_redeems(
     raw_shares = vault.share_token.fetch_raw_balance_of(owner)
     assert raw_shares > 0
 
+    # 2. Remove its direct USDC on Anvil to model all capital deployed to loans.
+    fund_erc20_on_anvil(aerodrome_base_web3, vault.denomination_token.address, vault.address, 0)
+    assert vault.denomination_token.fetch_raw_balance_of(vault.address) == 0
+
+    # 3. Verify that the normal redemption request returns a typed preflight failure.
+    block_before_refusal = aerodrome_base_web3.eth.block_number
+    with pytest.raises(VaultFlowUnavailable) as exc_info:
+        manager.create_redemption_request(owner=owner, raw_shares=raw_shares)
+    failure = exc_info.value
+    assert failure.preflight_result == "redemption_capacity_limited"
+    assert failure.decoded_error == FORTY_ACRES_INSUFFICIENT_LIQUIDITY_ERROR
+    assert failure.available_raw_amount == 0
+    assert aerodrome_base_web3.eth.block_number == block_before_refusal
+
+    # 4. Add the smallest simulated liquidity and redeem the unchanged shares.
+    intervention = manager.force_redemption_liquidity(owner, raw_shares, failure)
+    assert intervention.kind == "redemption_capacity_increased"
+    assert intervention.evidence["available_raw_shares_after"] >= raw_shares
+    denomination_balance_before = vault.denomination_token.fetch_raw_balance_of(owner)
     redemption_ticket = manager.create_redemption_request(owner=owner, raw_shares=raw_shares).broadcast(from_=owner)
 
     assert redemption_ticket.raw_shares == raw_shares

--- a/tests/guard/test_guard_simple_vault_forty_acres.py
+++ b/tests/guard/test_guard_simple_vault_forty_acres.py
@@ -1,4 +1,4 @@
-"""Certify the liquid 40acres Aerodrome vault through a non-governance GuardV0."""
+"""Certify guarded 40acres Aerodrome deposits and redemptions through GuardV0."""
 
 import os
 from collections.abc import Iterator
@@ -15,7 +15,6 @@ from web3.contract.contract import ContractFunction
 from eth_defi.abi import get_deployed_contract
 from eth_defi.deploy import GUARD_LIBRARIES, deploy_contract
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
-from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
 from eth_defi.erc_4626.vault_protocol.forty_acres.deposit_redeem import FortyAcresDepositManager
 from eth_defi.erc_4626.vault_protocol.forty_acres.vault import FortyAcresVault
 from eth_defi.hotwallet import HotWallet
@@ -28,9 +27,7 @@ from eth_defi.trace import TransactionAssertionError, assert_transaction_success
 
 JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
 
-#: A real 40acres vault whose deployed capital can be redeemed at the pinned
-#: Base state. This is deliberately not the Pharaoh deployment, which has a
-#: direct-underlying liquidity constraint and uses FortyAcresDepositManager.
+#: A real 40acres vault whose direct USDC balance is preflighted before redemption.
 AERODROME_USDC_VAULT: HexAddress = "0xb99b6df96d4d5448cc0a5b3e0ef7896df9507cf5"
 
 pytestmark = [
@@ -111,15 +108,20 @@ def test_guarded_forty_acres_aerodrome_deposit_and_redeem(
     protocol_vault: FortyAcresVault,
     guarded_simple_vault: tuple[Contract, Contract, HotWallet],
 ) -> None:
-    """Deposit and redeem against actual Aerodrome liquidity through GuardV0."""
+    """Redeem a direct USDC contribution through GuardV0.
+
+    1. Create the specialised 40acres redemption manager.
+    2. Fund and deposit USDC through the guarded SimpleVault.
+    3. Redeem the resulting shares while the direct contribution is available.
+    """
+    # 1. Create the specialised 40acres redemption manager.
     simple_vault, guard, asset_manager = guarded_simple_vault
     manager = protocol_vault.get_deposit_manager()
-    assert isinstance(manager, ERC4626DepositManager)
-    assert not isinstance(manager, FortyAcresDepositManager)
+    assert isinstance(manager, FortyAcresDepositManager)
 
+    # 2. Fund and deposit USDC through the guarded SimpleVault.
     raw_amount = protocol_vault.denomination_token.convert_to_raw(Decimal(10))
-    # Only the test wallet is funded. The vault and its loan deployment retain
-    # their unmodified Base-fork balances, which the redemption must use.
+    # The test deposit supplies the direct USDC needed for this guarded redemption.
     fund_erc20_on_anvil(web3, protocol_vault.denomination_token.address, simple_vault.address, raw_amount)
     approval = protocol_vault.denomination_token.contract.functions.approve(protocol_vault.address, raw_amount)
     _perform_guarded_call(web3, simple_vault, asset_manager, approval)
@@ -135,6 +137,8 @@ def test_guarded_forty_acres_aerodrome_deposit_and_redeem(
     raw_shares = protocol_vault.share_token.fetch_raw_balance_of(simple_vault.address)
     assert raw_shares > 0
     assert manager.force_settle(None).settlement_required is False
+
+    # 3. Redeem the resulting shares while the direct contribution is available.
     redemption_request = manager.create_redemption_request(owner=simple_vault.address, raw_shares=raw_shares)
     redemption_hash = _perform_guarded_call(web3, simple_vault, asset_manager, redemption_request.funcs[0])
     redemption_ticket = redemption_request.parse_redeem_transaction([redemption_hash])
@@ -150,9 +154,18 @@ def test_guarded_forty_acres_aerodrome_rejects_substituted_addresses(
     protocol_vault: FortyAcresVault,
     guarded_simple_vault: tuple[Contract, Contract, HotWallet],
 ) -> None:
-    """Reject unwhitelisted ERC-4626 receivers and share owners for 40acres."""
+    """Reject substituted ERC-4626 addresses for 40acres.
+
+    1. Use the guarded Aerodrome vault and its asset manager.
+    2. Attempt deposit and redemption calls with substituted receiver or owner addresses.
+    3. Verify GuardV0 rejects every altered address.
+    """
+    # 1. Use the guarded Aerodrome vault and its asset manager.
     simple_vault, _guard, asset_manager = guarded_simple_vault
     outsider = HexAddress(web3.eth.accounts[3])
+
+    # 2. Attempt deposit and redemption calls with substituted receiver or owner addresses.
+    # 3. Verify GuardV0 rejects every altered address.
     _assert_guarded_call_rejected(
         web3,
         simple_vault,


### PR DESCRIPTION
## Why

40acres `totalAssets()` includes loan-deployed capital, but the verified ERC-4626 redemption path transfers USDC directly from the vault. A nonzero `maxRedeem()` therefore does not prove immediate redeemability, and Base Aerodrome could reach a legacy ERC-20 balance revert.

## Lessons learnt

Valuation methods and immediate redemption capacity are distinct for lending vaults. The direct underlying balance must be preflighted, and Anvil liquidity changes must remain explicit simulation evidence.

## Summary

- Apply the 40acres direct-balance redemption preflight to every recognised 40acres vault.
- Add historical `available_liquidity` and `utilisation` readings.
- Document the limitation and correct the Aerodrome assumptions.
- Cover graceful preflight failure and disclosed simulated liquidity on Base.

## Related issues and PRs

- Continues the vault-test-trade investigation from trade-executor PR #1602.