### PR TITLE
fix: describe Centrifuge SPXA vaults

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/centrifuge/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/centrifuge/vault.py
@@ -15,13 +15,80 @@ supported investment currency.
 
 import datetime
 import logging
+from dataclasses import dataclass
+from typing import Final
 
-from eth_typing import BlockIdentifier
+from eth_typing import BlockIdentifier, HexAddress
 
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.centrifuge.centrifuge_utils import fetch_pool_id, fetch_tranche_id
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class CentrifugeVaultDescription:
+    """Address-scoped display metadata for a Centrifuge vault.
+
+    Centrifuge's onchain vault interface does not expose product strategy
+    descriptions. Keep reviewed copy keyed by vault address because pools can
+    share an asset class while having different investor and transfer models.
+
+    :param short_description:
+        Listing-friendly product summary.
+    :param description:
+        Longer Markdown product description with authoritative sources.
+    """
+
+    #: Listing-friendly product summary.
+    short_description: str
+
+    #: Longer Markdown product description with authoritative sources.
+    description: str
+
+
+#: Janus Henderson Anemoy S&P500 Fund USDC vault on Base.
+#:
+#: https://docs.centrifuge.io/developer/protocol/deployments/
+SPXA_BASE_VAULT_ADDRESS = HexAddress("0x99e9092bae6d4394e54034ecb1e45441678323b9")
+
+#: DeFi Janus Henderson Anemoy S&P500 Fund Token USDC vault on Base.
+#:
+#: https://docs.centrifuge.io/developer/protocol/deployments/
+DESPXA_BASE_VAULT_ADDRESS = HexAddress("0x2da40f061536c2f3a8f95f23a5f4c133d07d393a")
+
+#: Official Anemoy product page for the SPXA fund share class.
+SPXA_FUND_PAGE_URL: Final[str] = "https://www.anemoy.io/funds/spxa"
+
+#: Official Centrifuge launch announcement for deSPXA.
+DESPXA_ANNOUNCEMENT_URL: Final[str] = "https://centrifuge.io/blog/despxa-on-base"
+
+#: Human-readable product copy for the Base SPXA and deSPXA vaults.
+#:
+#: These products have related S&P 500 exposure but are separate Centrifuge
+#: pools and share tokens. Keep the relationship explicit so downstream UIs do
+#: not present them as duplicate vault contracts or aggregate their NAV as
+#: independent fund assets.
+CENTRIFUGE_VAULT_DESCRIPTION_OVERLAY: Final[dict[HexAddress, CentrifugeVaultDescription]] = {
+    SPXA_BASE_VAULT_ADDRESS: CentrifugeVaultDescription(
+        short_description="Tokenised S&P 500 index fund share class for professional investors.",
+        description="\n\n".join(
+            (
+                f"[Janus Henderson Anemoy S&P500® Fund (SPXA)]({SPXA_FUND_PAGE_URL}) is a tokenised share class in an open-ended fund designed to track the S&P 500® Index. The fund is managed by Anemoy with Janus Henderson as sub-investment manager.",
+                f"**Relationship to deSPXA:** [deSPXA]({DESPXA_ANNOUNCEMENT_URL}) is a separate, freely transferable DeFi debt instrument whose NAV is linked to SPXA's NAV. SPXA is the permissioned fund share class, while deSPXA provides a DeFi distribution layer and is issued through its own Centrifuge pool. Their reported NAVs should not be added together as independent S&P 500 fund assets.",
+            )
+        ),
+    ),
+    DESPXA_BASE_VAULT_ADDRESS: CentrifugeVaultDescription(
+        short_description="Freely transferable DeFi token with NAV-linked S&P 500 fund exposure.",
+        description="\n\n".join(
+            (
+                f"[deSPXA]({DESPXA_ANNOUNCEMENT_URL}) is a Base-native, freely transferable ERC-20 debt instrument that gives holders exposure linked to the NAV of the Janus Henderson Anemoy S&P500® Fund. Eligible authorised participants mint and redeem it in USDC, while it can be traded and used in compatible DeFi applications.",
+                f"**Relationship to SPXA:** [SPXA]({SPXA_FUND_PAGE_URL}) is the permissioned share class of the underlying tokenised fund. deSPXA is a separately issued DeFi instrument linked to that share class's NAV, not a second independent S&P 500 portfolio. It has its own Centrifuge pool and contract, so it is listed separately; do not aggregate its NAV with SPXA as independent assets.",
+            )
+        ),
+    ),
+}
 
 
 class CentrifugeVault(ERC4626Vault):
@@ -48,6 +115,30 @@ class CentrifugeVault(ERC4626Vault):
     - Example vault on Etherscan: https://etherscan.io/address/0xa702ac7953e6a66d2b10a478eb2f0e2b8c8fd23e
     - Twitter: https://twitter.com/centrifuge
     """
+
+    @property
+    def description(self) -> str | None:
+        """Return reviewed Markdown product copy for known Centrifuge vaults.
+
+        :return:
+            Full product description, or ``None`` when the vault has no
+            address-scoped metadata overlay.
+        """
+
+        metadata = CENTRIFUGE_VAULT_DESCRIPTION_OVERLAY.get(HexAddress(str(self.vault_address).lower()))
+        return metadata.description if metadata else None
+
+    @property
+    def short_description(self) -> str | None:
+        """Return a concise product summary for known Centrifuge vaults.
+
+        :return:
+            Listing-friendly product summary, or ``None`` when the vault has
+            no address-scoped metadata overlay.
+        """
+
+        metadata = CENTRIFUGE_VAULT_DESCRIPTION_OVERLAY.get(HexAddress(str(self.vault_address).lower()))
+        return metadata.short_description if metadata else None
 
     def has_custom_fees(self) -> bool:
         """Centrifuge fees are managed at the pool/protocol level, not vault level."""

--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -188,6 +188,9 @@ VAULT_DESCRIPTIVE_FLAGS: dict[str, set[VaultFlag]] = {
     "0x1fecf3d9d4fee7f2c02917a66028a48c6706c179": {VaultFlag.tokenised_fund},
     "0x43415eb6ff9db7e26a15b704e7a3edce97d31c4e": {VaultFlag.tokenised_fund},
     "0x6a7c6aa2b8b8a6a891de552bdeffa87c3f53bd46": {VaultFlag.tokenised_fund},
+    # Centrifuge: Janus Henderson Anemoy S&P500® Fund (SPXA) USDC vault on Base.
+    # https://docs.centrifuge.io/developer/protocol/deployments/
+    "0x99e9092bae6d4394e54034ecb1e45441678323b9": {VaultFlag.tokenised_fund},
     USTBL_TOKEN_ADDRESS: {VaultFlag.tokenised_fund},
 }
 

--- a/tests/erc_4626/vault_protocol/test_centrifuge.py
+++ b/tests/erc_4626/vault_protocol/test_centrifuge.py
@@ -13,11 +13,10 @@ from web3 import Web3
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature
-from eth_defi.erc_4626.vault_protocol.centrifuge.vault import CentrifugeVault
-from eth_defi.vault.base import VaultTechnicalRisk
-
+from eth_defi.erc_4626.vault_protocol.centrifuge.vault import DESPXA_ANNOUNCEMENT_URL, DESPXA_BASE_VAULT_ADDRESS, SPXA_BASE_VAULT_ADDRESS, SPXA_FUND_PAGE_URL, CentrifugeVault
 from eth_defi.testing.anvil_fork_pool import AnvilForkPool
 from eth_defi.testing.fork_blocks import ETHEREUM_MIDNIGHT_BLOCK
+from eth_defi.vault.base import VaultSpec, VaultTechnicalRisk
 
 JSON_RPC_ETHEREUM = os.environ.get("JSON_RPC_ETHEREUM")
 
@@ -26,6 +25,25 @@ pytestmark = [
     # Shared with the other Ethereum midnight-block characterisation tests.
     pytest.mark.xdist_group("fork:ethereum:midnight"),
 ]
+
+
+def test_centrifuge_spxa_description_overlay() -> None:
+    """SPXA and deSPXA have address-scoped Markdown product descriptions."""
+
+    spxa = CentrifugeVault(Web3(), VaultSpec(8453, SPXA_BASE_VAULT_ADDRESS), features={ERC4626Feature.centrifuge_like})
+    despxa = CentrifugeVault(Web3(), VaultSpec(8453, DESPXA_BASE_VAULT_ADDRESS), features={ERC4626Feature.centrifuge_like})
+
+    assert spxa.short_description == "Tokenised S&P 500 index fund share class for professional investors."
+    assert spxa.description is not None
+    assert "**Relationship to deSPXA:**" in spxa.description
+    assert SPXA_FUND_PAGE_URL in spxa.description
+    assert DESPXA_ANNOUNCEMENT_URL in spxa.description
+
+    assert despxa.short_description == "Freely transferable DeFi token with NAV-linked S&P 500 fund exposure."
+    assert despxa.description is not None
+    assert "**Relationship to SPXA:**" in despxa.description
+    assert SPXA_FUND_PAGE_URL in despxa.description
+    assert DESPXA_ANNOUNCEMENT_URL in despxa.description
 
 
 @pytest.fixture(scope="module")

--- a/tests/erc_4626/vault_protocol/test_ember.py
+++ b/tests/erc_4626/vault_protocol/test_ember.py
@@ -79,8 +79,9 @@ def test_ember(
     assert vault.get_performance_fee("latest") is not None
     assert vault.get_performance_fee("latest") >= 0
 
-    # Manager info
-    assert vault.ember_metadata["manager_name"] == "Third Eye"
+    # The live API no longer populates its optional ``managers`` field, but
+    # retains the curator attribution in the public vault description.
+    assert "Third Eye" in vault.description
 
     # Withdrawal period from offchain API
     assert vault.get_estimated_lock_up().days == 4
@@ -106,7 +107,6 @@ def test_ember_offchain_fetch(tmp_path: Path):
     assert crosschain_vault["weekly_performance_fee"] is not None
     assert crosschain_vault["withdrawal_period_days"] is not None
     assert crosschain_vault["reported_apy"] is not None
-    assert crosschain_vault["manager_name"] is not None
 
     # New fields
     assert crosschain_vault["long_name"] is not None

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -37,6 +37,15 @@ def test_superstate_risk_is_low() -> None:
     assert get_vault_risk("Superstate") == VaultTechnicalRisk.low
 
 
+def test_spxa_is_a_tokenised_fund() -> None:
+    """The permissioned Base SPXA fund share class has the descriptive fund flag."""
+
+    flags = get_vault_special_flags("0x99e9092bae6d4394e54034ecb1e45441678323b9")
+
+    assert flags == {VaultFlag.tokenised_fund}
+    assert not is_flagged_vault("0x99e9092bae6d4394e54034ecb1e45441678323b9")
+
+
 @pytest.mark.parametrize(
     ("address", "expected_note"),
     [


### PR DESCRIPTION
## Why

SPXA and deSPXA are separate Centrifuge vault contracts with closely related S&P 500 exposure, but scanner exports lacked explanatory product metadata. SPXA also needs the tokenised-fund classification.

## Lessons learnt

deSPXA is a separately issued, freely transferable DeFi debt instrument linked to SPXA NAV; its reported NAV must not be treated as independent SPXA fund assets. Ember's live Bluefin API may omit optional manager records while retaining curator attribution in its public vault description.

## Summary

- Add address-scoped short and long Markdown descriptions for Centrifuge SPXA and deSPXA vaults.
- Mark the SPXA vault as a tokenised fund.
- Add coverage for the Centrifuge metadata and tokenised-fund flag.
- Make Ember live API coverage accept omitted optional manager records.

## Related issues and PRs

- None.

## Unrelated CI and test fixes

- Update Ember live API assertions after Bluefin stopped returning manager records for Crosschain USD Vault.