### PR TITLE
fix: map Growi Lending to curator

### DIFF
--- a/eth_defi/data/feeds/curators/growi-finance.yaml
+++ b/eth_defi/data/feeds/curators/growi-finance.yaml
@@ -7,6 +7,14 @@ long_description: |
   Growi.fi builds decentralised finance products that aim to make quantitative investment strategies easier to access.
   Its Growi.HF documentation describes an expert-driven protocol for bringing hedge fund-style quant strategies to DeFi through automated, transparent vault operations.
   The product uses Hyperliquid infrastructure and quantitative models to trade futures contracts while showing allocations and activity on-chain.
+  Growi Lending is a USDC Morpho Vault V2 on HyperEVM, where Growi acts as risk curator for the vault's overcollateralised lending-market allocations.
 twitter: GrowiFinance
 linkedin: growi-fi
 linkedin-rss-hub-disabled-at: 2026-06-09
+# 2026-08-06 maintain-curators: Added the official Growi Lending announcement
+# and Morpho configuration record as curator evidence for Growi USDC Core.
+other-links:
+  - title: Growi Lending - curated USDC lending on Morpho
+    url: https://growi.fi/lending/
+  - title: Morpho API - Growi USDC Core HyperEVM vault configuration
+    url: https://api.morpho.org/v0/vaults-v2/999:0x54E24C904CfC563Af7A1EE9DfAF1354d034e44e4

--- a/eth_defi/vault/curator.py
+++ b/eth_defi/vault/curator.py
@@ -341,6 +341,10 @@ PROTOCOL_MANAGER_YAML_FIELDS: dict[str, str] = {
 #: carries a co-branded protocol/issuer name that would otherwise win fuzzy
 #: matching.  Keys are ``(chain_id, lowercase_vault_address)``.
 CURATOR_ADDRESS_OVERRIDES: dict[tuple[int, str], str] = {
+    # Growi's official lending page identifies this HyperEVM Morpho Vault V2
+    # as Growi Lending / Growi USDC Core.
+    # https://growi.fi/lending/
+    (999, "0x54e24c904cfc563af7a1ee9dfaf1354d034e44e4"): "growi-finance",
     # RockawayX Dune dashboard, query 6932634, checked 2026-07-01.
     # https://dune.com/rockawayxvault/rockawayx-dashboard
     (1, "0xcd69123b3fbbfc666e1f6a501da27b564c00de54"): "rockawayx",

--- a/tests/vault/test_curator.py
+++ b/tests/vault/test_curator.py
@@ -482,6 +482,24 @@ def test_identify_morpho_curator_by_curator_metadata() -> None:
     assert slug == "gauntlet"
 
 
+def test_identify_growi_lending_vault_by_address_override() -> None:
+    """Map Growi's unbranded HyperEVM Morpho Vault V2 to its curator.
+
+    The explicit address rule preserves Growi attribution if the vault's
+    display name or share-token symbol later changes.
+    """
+
+    slug = identify_curator(
+        chain_id=999,
+        vault_token_symbol="GWUSDC1-HL",
+        vault_name="USDC Core",
+        vault_address="0x54E24C904CfC563Af7A1EE9DfAF1354d034e44e4",
+        protocol_slug="morpho",
+    )
+
+    assert slug == "growi-finance"
+
+
 def test_identify_galaxy_morpho_curator_by_curator_metadata() -> None:
     """Galaxy Curation maps to the Galaxy curator through Morpho manager metadata."""
 


### PR DESCRIPTION
## Why

Growi Lending is a Morpho Vault V2 whose curator attribution must remain stable even if its display name changes.

## Lessons learnt

Morpho Vault V2 configurations can expose a generic vault name, so reviewed HyperEVM vaults need exact address attribution where naming alone is insufficient.

## Summary

- Added Growi Lending and Morpho configuration references to the Growi Finance curator record.
- Mapped the Growi USDC Core HyperEVM vault address to `growi-finance`.
- Added a focused regression test.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.