### PR TITLE
Audit vault withdrawal periods

### DIFF
--- a/docs/source/vaults/bulla/index.rst
+++ b/docs/source/vaults/bulla/index.rst
@@ -13,6 +13,19 @@ liquidity and underwriter-selection risk. Published `audit reports
 <https://github.com/bulla-network/factoring-contracts/tree/main/audits>`__
 are useful security evidence, but do not cover those economic risks.
 
+Withdrawal timing metadata
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For the reviewed TCS Settlement Pool, Bulla publishes a 30-day average
+redemption period. The scanner exports this as ``estimated_settlement`` (in
+seconds) for backtesting, with ``withdrawal_delay_type`` set to ``delay``.
+Invoice repayment and available pool liquidity determine the actual queue
+duration, so it is not a binding contract period: both
+``min_withdrawal_period`` and ``max_withdrawal_period`` are ``null``. Bulla's
+published 40-day maximum remains descriptive pool material rather than an
+exported smart-contract bound. See :doc:`../withdrawal-period-audit` for the
+public export contract.
+
 Links
 ~~~~~
 

--- a/docs/source/vaults/ember/index.rst
+++ b/docs/source/vaults/ember/index.rst
@@ -14,8 +14,20 @@ instead of the standard ``Withdraw`` event. Platform fees are embedded in the va
 Deposits are synchronous, while withdrawals call ``redeemShares`` to enter a
 pending queue. The Ember operator later processes the request and transfers
 assets directly to its chosen receiver: there is no depositor claim transaction.
-The displayed T+4 period is an off-chain operator service estimate, not an
-on-chain settlement deadline.
+The displayed T+4 period is an offchain operator service estimate, not an
+onchain settlement deadline.
+
+Withdrawal timing metadata
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The scanner reads Ember's per-vault offchain ``withdrawalPeriodDays`` metadata
+and exports it as ``estimated_settlement`` (in seconds) for backtesting. This
+field is a historical or operational estimate of the queue's redemption wait,
+not a promise that a request is claimable at that time. Ember does not expose
+a binding contract timing bound for this lifecycle, so
+``min_withdrawal_period`` and ``max_withdrawal_period`` are ``null`` and
+``withdrawal_delay_type`` is ``delay``. See :doc:`../withdrawal-period-audit`
+for the public export contract.
 
 Links
 ~~~~~

--- a/docs/source/vaults/index.rst
+++ b/docs/source/vaults/index.rst
@@ -120,6 +120,7 @@ Supported protocols
    :maxdepth: 1
 
    perp-dex-account-metrics
+   withdrawal-period-audit
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/vaults/index.rst
+++ b/docs/source/vaults/index.rst
@@ -51,7 +51,8 @@ is an alias of ``max_withdrawal_period``. ``min_withdrawal_period`` and
 ``max_withdrawal_period`` are seconds from a valid withdrawal request until
 normal redemption availability, derived from smart-contract timing rules.
 ``withdrawal_delay_type`` is ``instant`` for a direct ERC-4626 redemption
-without a protocol timing gate, ``delay`` for a request-and-claim cooldown
+without a protocol timing gate, ``delay`` for a request-and-claim cooldown or
+an asynchronous settlement lifecycle
 (for example `Gains gUSDC <https://gains.trade/vaults/gUSDC>`__ or Upshift's
 `NEMO USDC Yield <https://app.upshift.finance/pools/1/0x955256B31097dDf47a9E47A95aDfDFB4460D8522>`__)
 or ``epoch`` for a protocol withdrawal window (for example D2's `Texas Hedge
@@ -60,11 +61,11 @@ These are the values of :py:class:`eth_defi.vault.base.WithdrawalDelayType`.
 
 ``estimated_settlement`` is a separate optional backtesting field, also in
 seconds. It records a curator's or operator's historical or operational
-estimate of how often deposit and redemption batches are settled; it is not a contractual
-deadline. For example, `Lagoon's app <https://app.lagoon.finance/>`__ provides
-its per-vault ``averageSettlement`` metadata. Curators can settle earlier,
-later, or not at all, so this value must never be used to decide whether a
-request is claimable. Unlike ``estimated_settlement``, populated
+estimate of settlement cadence or a liquidity-dependent redemption wait; it is
+not a contractual deadline. For example, `Lagoon's app <https://app.lagoon.finance/>`__
+provides its per-vault ``averageSettlement`` metadata. Curators can settle
+earlier, later, or not at all, so this value must never be used to decide
+whether a request is claimable. Unlike ``estimated_settlement``, populated
 ``min_withdrawal_period`` and ``max_withdrawal_period`` are binding
 smart-contract timing rules; neither field promises liquidity or keeper
 execution. Unavailable values are ``null``.

--- a/docs/source/vaults/index.rst
+++ b/docs/source/vaults/index.rst
@@ -49,7 +49,8 @@ Public lifetime-metrics JSON records expose withdrawal timing separately from
 the legacy ``lockup`` field. When a withdrawal period is available, ``lockup``
 is an alias of ``max_withdrawal_period``. ``min_withdrawal_period`` and
 ``max_withdrawal_period`` are seconds from a valid withdrawal request until
-normal redemption availability. ``withdrawal_delay_type`` is either ``delay``
+normal redemption availability. ``withdrawal_delay_type`` is ``instant`` for
+a direct ERC-4626 redemption without a protocol timing gate, ``delay``
 for a request-and-claim cooldown (for example `Gains gUSDC <https://gains.trade/vaults/gUSDC>`__
 or Upshift's `NEMO USDC Yield <https://app.upshift.finance/pools/1/0x955256B31097dDf47a9E47A95aDfDFB4460D8522>`__)
 or ``epoch`` for a protocol withdrawal window (for example D2's `Texas Hedge

--- a/docs/source/vaults/index.rst
+++ b/docs/source/vaults/index.rst
@@ -59,8 +59,8 @@ strategy vault <https://d2.finance/strategies/0x208f63a7f60c319597c05fa5ec67fde4
 These are the values of :py:class:`eth_defi.vault.base.WithdrawalDelayType`.
 
 ``estimated_settlement`` is a separate optional backtesting field, also in
-seconds. It records a curator's historical or operational estimate of how
-often deposit and redemption batches are settled; it is not a contractual
+seconds. It records a curator's or operator's historical or operational
+estimate of how often deposit and redemption batches are settled; it is not a contractual
 deadline. For example, `Lagoon's app <https://app.lagoon.finance/>`__ provides
 its per-vault ``averageSettlement`` metadata. Curators can settle earlier,
 later, or not at all, so this value must never be used to decide whether a

--- a/docs/source/vaults/index.rst
+++ b/docs/source/vaults/index.rst
@@ -46,18 +46,28 @@ Withdrawal-period metadata
 --------------------------
 
 Public lifetime-metrics JSON records expose withdrawal timing separately from
-the legacy ``lockup`` field. When a withdrawal period is available, ``lockup``
+the legacy ``lockup`` field. When a binding maximum is available, ``lockup``
 is an alias of ``max_withdrawal_period``. ``min_withdrawal_period`` and
 ``max_withdrawal_period`` are seconds from a valid withdrawal request until
-normal redemption availability. ``withdrawal_delay_type`` is ``instant`` for
-a direct ERC-4626 redemption without a protocol timing gate, ``delay``
-for a request-and-claim cooldown (for example `Gains gUSDC <https://gains.trade/vaults/gUSDC>`__
-or Upshift's `NEMO USDC Yield <https://app.upshift.finance/pools/1/0x955256B31097dDf47a9E47A95aDfDFB4460D8522>`__)
+normal redemption availability, derived from smart-contract timing rules.
+``withdrawal_delay_type`` is ``instant`` for a direct ERC-4626 redemption
+without a protocol timing gate, ``delay`` for a request-and-claim cooldown
+(for example `Gains gUSDC <https://gains.trade/vaults/gUSDC>`__ or Upshift's
+`NEMO USDC Yield <https://app.upshift.finance/pools/1/0x955256B31097dDf47a9E47A95aDfDFB4460D8522>`__)
 or ``epoch`` for a protocol withdrawal window (for example D2's `Texas Hedge
 strategy vault <https://d2.finance/strategies/0x208f63a7f60c319597c05fa5ec67fde41839bad6>`__).
 These are the values of :py:class:`eth_defi.vault.base.WithdrawalDelayType`.
-The bounds do not promise liquidity or keeper execution and are ``null`` when
-the adapter cannot read reliable timing data.
+
+``estimated_settlement`` is a separate optional backtesting field, also in
+seconds. It records a curator's historical or operational estimate of how
+often deposit and redemption batches are settled; it is not a contractual
+deadline. For example, `Lagoon's app <https://app.lagoon.finance/>`__ provides
+its per-vault ``averageSettlement`` metadata. Curators can settle earlier,
+later, or not at all, so this value must never be used to decide whether a
+request is claimable. Unlike ``estimated_settlement``, populated
+``min_withdrawal_period`` and ``max_withdrawal_period`` are binding
+smart-contract timing rules; neither field promises liquidity or keeper
+execution. Unavailable values are ``null``.
 
 Deposit permission metadata
 ---------------------------

--- a/docs/source/vaults/lagoon/index.rst
+++ b/docs/source/vaults/lagoon/index.rst
@@ -3,7 +3,7 @@ Lagoon Finance API
 
 `Lagoon Finance <https://lagoon.finance/>`__ integration.
 
-Lagoon provides open, general-purpose, secure vault infrastructure to build and scale on-chain
+Lagoon provides open, general-purpose, secure vault infrastructure to build and scale onchain
 yield products. The platform is designed for asset managers, DAOs, DeFi protocols and market
 makers who need flexible vault infrastructure.
 
@@ -18,6 +18,19 @@ Key features:
 - Smart contract code reviewed seven times by reputable firms
 - Vault access controls with optional KYC/KYB integration
 - CoW Protocol integration for trade execution
+
+Withdrawal timing metadata
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The scanner reads each vault's ``averageSettlement`` field from Lagoon's app
+metadata and exports it as ``estimated_settlement`` (in seconds) for
+backtesting. It measures an observed or curator-provided settlement cadence,
+not the time at which a redemption becomes claimable. Curators can settle
+earlier, later, or not at all; Lagoon's ERC-7540 contracts do not make this a
+binding deadline. Accordingly, the scanner exports ``withdrawal_delay_type``
+as ``delay`` but leaves ``min_withdrawal_period`` and
+``max_withdrawal_period`` as ``null``. See :doc:`../withdrawal-period-audit`
+for the public export contract.
 
 Links
 ~~~~~

--- a/docs/source/vaults/withdrawal-period-audit.rst
+++ b/docs/source/vaults/withdrawal-period-audit.rst
@@ -35,12 +35,16 @@ The following adapters now return ``WithdrawalPeriod`` and populate
   USD3), marked ``delay``.
 * **Upshift** — the vault-specific ``lagDuration()`` value, marked ``delay``.
 * **USDai** — zero to the current 30-day redemption window, marked ``epoch``.
+* **Aave, Brink, Curvance, Dolomite, Foxify, Gearbox, Sentiment, Singularity
+  Finance and Term Finance** — direct ERC-4626 redemption with no protocol
+  request, cooldown or epoch, marked ``instant``. This does not promise that
+  the vault or its underlying lending market has sufficient liquidity.
 
-Zero-delay adapters
--------------------
+Instant adapters
+----------------
 
 Adapters that explicitly report a zero legacy lock-up are normalised by the
-scanner into a zero-to-zero ``delay`` period. This applies to
+scanner into a zero-to-zero ``instant`` period. This applies to
 Auto Finance, Deltr, Euler, Fluid, Frax, Goat, Harvest, HyperLend, HypurrFi,
 Inverse Finance, Kiln, LlamaLend, Morpho, Resolv, sBOLD, Silo, Sky, Spark,
 Spectra, Summer, USDD and Yearn (including its compounder variants). This
@@ -53,14 +57,13 @@ Timing that is not representable
 The current JSON model intentionally does **not** fabricate a period for the
 following adapters:
 
-* **Queue or liquidity dependent:** Aarna, Aave, Accountable, Aera, BaseVol,
-  Brink, Bulla, cSigma, Curvance, Dolomite, ETH Strategy, 40acres, Foxify,
-  Gearbox, Hyperdrive HL, Infinifi, Maple, NashPoint, Renalta, Royco, Secured
-  Finance, Sentiment, Singularity, Superform, Symbiotic, Term Finance, TrueFi,
-  Untangle, YieldFi, Yo, Yuzu Money and ZeroLend. Their contracts or operator
-  processes make redemption timing depend on liquidity, a queue position,
-  an underlying strategy or an unbounded operator action. The current
-  ``WithdrawalPeriod`` cannot express that conditional or unbounded wait.
+* **Queue or liquidity dependent:** Aarna, Accountable, Aera, BaseVol, Bulla,
+  cSigma, ETH Strategy, 40acres, Hyperdrive HL, Infinifi, Maple, NashPoint,
+  Renalta, Royco, Secured Finance, Superform, Symbiotic, TrueFi, Untangle,
+  YieldFi, Yo, Yuzu Money and ZeroLend. Their contracts or operator processes
+  make redemption timing depend on liquidity, a queue position, an underlying
+  strategy or an unbounded operator action. The current ``WithdrawalPeriod``
+  cannot express that conditional or unbounded wait.
 * **Variable or policy estimates:** Altura, Axis, Centrifuge, CrystalClear,
   Ember, ForgeYields, Frankencoin, Lagoon, Liquid Royalty, Maple AQRU, Plutus,
   Umami and YieldNest.

--- a/docs/source/vaults/withdrawal-period-audit.rst
+++ b/docs/source/vaults/withdrawal-period-audit.rst
@@ -43,13 +43,14 @@ The following adapters now return ``WithdrawalPeriod`` and populate
 Instant adapters
 ----------------
 
-Adapters that explicitly report a zero legacy lock-up are normalised by the
-scanner into a zero-to-zero ``instant`` period. This applies to
+Adapters with source-backed direct redemption explicitly implement
+``get_withdrawal_period()`` and return ``INSTANT_WITHDRAWAL_PERIOD``, a
+zero-to-zero ``instant`` period. This applies to
 Auto Finance, Deltr, Euler, Fluid, Frax, Goat, Harvest, HyperLend, HypurrFi,
 Inverse Finance, Kiln, LlamaLend, Morpho, Resolv, sBOLD, Silo, Sky, Spark,
 Spectra, Summer, USDD and Yearn (including its compounder variants). This
-means synchronous redemption is distinguished from an unavailable timing
-value, while the JSON caveat about liquidity still applies.
+means a source-backed direct redemption is distinguished from an unavailable
+timing value, while the JSON caveat about liquidity still applies.
 
 Timing that is not representable
 ---------------------------------

--- a/docs/source/vaults/withdrawal-period-audit.rst
+++ b/docs/source/vaults/withdrawal-period-audit.rst
@@ -51,6 +51,13 @@ to a settlement deadline, so ``min_withdrawal_period`` and
 ``max_withdrawal_period`` remain ``null``. The estimate is not a promise: a
 curator can settle earlier, later, or not at all.
 
+**Ember** exposes an offchain, per-vault ``withdrawalPeriodDays`` operator
+service estimate for its redemption queue. **Bulla** publishes an
+address-scoped 30-day average redemption period for its TCS pool, whose queue
+depends on invoice repayments and liquidity. Both are exported as
+``estimated_settlement`` for backtesting only, without contract-enforced
+minimum or maximum withdrawal periods.
+
 Instant adapters
 ----------------
 
@@ -69,8 +76,8 @@ Timing that is not representable
 The current JSON model intentionally does **not** fabricate a period for the
 following adapters:
 
-* **Queue or liquidity dependent:** Aarna, Accountable, Aera, BaseVol, Bulla,
-  Cap, cSigma, ETH Strategy, 40acres, Hyperdrive HL, Infinifi, Maple,
+* **Queue or liquidity dependent:** Aarna, Accountable, Aera, BaseVol, Cap,
+  cSigma, ETH Strategy, 40acres, Hyperdrive HL, Infinifi, Maple,
   NashPoint, Renalta, Royco, Secured Finance, Superform, Symbiotic, T3tris,
   TrueFi, Untangle, YieldFi, Yo, Yuzu Money and ZeroLend. Their contracts or
   operator processes make redemption timing depend on liquidity, a queue
@@ -78,7 +85,7 @@ following adapters:
   current ``WithdrawalPeriod`` cannot express that conditional or unbounded
   wait.
 * **Variable or policy estimates:** Altura, Axis, Centrifuge, CrystalClear,
-  Ember, ForgeYields, Frankencoin, Liquid Royalty, Maple AQRU, Plutus,
+  ForgeYields, Frankencoin, Liquid Royalty, Maple AQRU, Plutus,
   Umami and YieldNest.
   Their existing ``get_estimated_lock_up()`` values describe an epoch estimate,
   maturity date, operator service target, reward-interest delay, or strategy

--- a/docs/source/vaults/withdrawal-period-audit.rst
+++ b/docs/source/vaults/withdrawal-period-audit.rst
@@ -40,8 +40,8 @@ The following adapters now return ``WithdrawalPeriod`` and populate
   request, cooldown or epoch, marked ``instant``. This does not promise that
   the vault or its underlying lending market has sufficient liquidity.
 
-Operational settlement estimates
---------------------------------
+Offchain settlement and redemption estimates
+---------------------------------------------
 
 **Lagoon** exposes a curator-provided ``averageSettlement`` value through its
 offchain application metadata. The adapter exports it as
@@ -56,7 +56,9 @@ service estimate for its redemption queue. **Bulla** publishes an
 address-scoped 30-day average redemption period for its TCS pool, whose queue
 depends on invoice repayments and liquidity. Both are exported as
 ``estimated_settlement`` for backtesting only, without contract-enforced
-minimum or maximum withdrawal periods.
+minimum or maximum withdrawal periods. In particular, Bulla's published
+40-day maximum is descriptive pool material, not a smart-contract timing
+bound, and is therefore not exported as ``max_withdrawal_period``.
 
 Instant adapters
 ----------------

--- a/docs/source/vaults/withdrawal-period-audit.rst
+++ b/docs/source/vaults/withdrawal-period-audit.rst
@@ -1,0 +1,96 @@
+Withdrawal-period audit
+=======================
+
+This is the protocol-level audit of withdrawal timing for the adapters under
+``eth_defi.erc_4626.vault_protocol``. It records what the current
+``WithdrawalPeriod`` accessors can safely promise, rather than turning every
+protocol's marketing estimate into a machine-readable guarantee. Sources were
+checked against the protocol documentation linked in each adapter and, where
+available, the deployed contract accessor or verified ABI.
+
+Structured export
+-----------------
+
+The following adapters now return ``WithdrawalPeriod`` and populate
+``min_withdrawal_period``, ``max_withdrawal_period`` and
+``withdrawal_delay_type`` in lifetime JSON:
+
+* **Atoma** — zero to one ``epochDuration()`` interval; the verified vault
+  uses ``requestWithdrawal``/``claimWithdrawal``. See the
+  `Atoma vault implementation <https://arbitrum.blockscout.com/address/0xd4242FD8DE6E3128f0435b52DCe29155098CbBFF>`__.
+* **Avant, Ethena, Mainstreet, USDX Money** — the live
+  ``cooldownDuration()`` value, as a fixed ``delay``. The accessor is read
+  from each deployment instead of using the documented seven-day default.
+* **D2 Finance** — zero to one current trading epoch, marked ``epoch``.
+* **Gains and Ostium** — the existing version-specific ranges: one to three
+  Gains epochs for V1 and the onchain settlement interval plus scheduling
+  window for Ostium V1.5, marked ``delay`` for the request/claim lifecycle.
+* **IPOR** — the live ``REDEMPTION_DELAY_IN_SECONDS`` value, marked ``delay``.
+  Liquidity can still prevent a transaction after the delay.
+* **KiloEx** — one to three documented three-day epochs, marked ``epoch``.
+* **NaraUSD+** — the live ``cooldownDuration()`` value, marked ``delay``.
+* **Teller** — the pool-specific ``withdrawDelayTime()`` value, marked
+  ``delay``.
+* **3Jane** — the tranche-specific lock (one month for sUSD3 and zero for
+  USD3), marked ``delay``.
+* **Upshift** — the vault-specific ``lagDuration()`` value, marked ``delay``.
+* **USDai** — zero to the current 30-day redemption window, marked ``epoch``.
+
+Zero-delay adapters
+-------------------
+
+Adapters that explicitly report a zero legacy lock-up are normalised by the
+scanner into a zero-to-zero ``delay`` period. This applies to
+Auto Finance, Deltr, Euler, Fluid, Frax, Goat, Harvest, HyperLend, HypurrFi,
+Inverse Finance, Kiln, LlamaLend, Morpho, Resolv, sBOLD, Silo, Sky, Spark,
+Spectra, Summer, USDD and Yearn (including its compounder variants). This
+means synchronous redemption is distinguished from an unavailable timing
+value, while the JSON caveat about liquidity still applies.
+
+Timing that is not representable
+---------------------------------
+
+The current JSON model intentionally does **not** fabricate a period for the
+following adapters:
+
+* **Queue or liquidity dependent:** Aarna, Aave, Accountable, Aera, BaseVol,
+  Brink, Bulla, cSigma, Curvance, Dolomite, ETH Strategy, 40acres, Foxify,
+  Gearbox, Hyperdrive HL, Infinifi, Maple, NashPoint, Renalta, Royco, Secured
+  Finance, Sentiment, Singularity, Superform, Symbiotic, Term Finance, TrueFi,
+  Untangle, YieldFi, Yo, Yuzu Money and ZeroLend. Their contracts or operator
+  processes make redemption timing depend on liquidity, a queue position,
+  an underlying strategy or an unbounded operator action. The current
+  ``WithdrawalPeriod`` cannot express that conditional or unbounded wait.
+* **Variable or policy estimates:** Altura, Axis, Centrifuge, CrystalClear,
+  Ember, ForgeYields, Frankencoin, Lagoon, Liquid Royalty, Maple AQRU, Plutus,
+  Umami and YieldNest.
+  Their existing ``get_estimated_lock_up()`` values describe an epoch estimate,
+  maturity date, operator service target, reward-interest delay, or strategy
+  policy rather than a guaranteed request-to-redemption bound. They remain in
+  the legacy ``lockup`` field only for compatibility; their structured
+  withdrawal fields are null.
+
+Several of these protocols have useful YAML descriptions, but YAML is not a
+safe substitute for a per-vault onchain timing read. In particular, a generic
+``withdrawal_period`` YAML field would become stale when governance changes a
+cooldown, when a curator changes the underlying strategy, or when an operator
+queue has no deadline. Add a protocol-specific accessor once a canonical
+contract field or a bounded, source-backed SLA is available.
+
+Known model gaps
+---------------
+
+The two-value export cannot currently represent all of the following without
+new fields:
+
+* a maturity date that is independent of the withdrawal request;
+* an operator service target with no enforceable upper bound;
+* liquidity-dependent completion where the minimum is zero but the maximum is
+  unbounded;
+* penalty-free windows where withdrawal is possible immediately; or
+* multiple phase calendars and per-vault epoch lengths in one record.
+
+Until such fields are added, ``null`` is preferable to a misleading number.
+Consumers should also treat a non-null period as a timing rule only: it does
+not promise liquidity, permission, keeper execution, or a successful
+transaction.

--- a/docs/source/vaults/withdrawal-period-audit.rst
+++ b/docs/source/vaults/withdrawal-period-audit.rst
@@ -81,7 +81,7 @@ queue has no deadline. Add a protocol-specific accessor once a canonical
 contract field or a bounded, source-backed SLA is available.
 
 Known model gaps
----------------
+----------------
 
 The two-value export cannot currently represent all of the following without
 new fields:

--- a/docs/source/vaults/withdrawal-period-audit.rst
+++ b/docs/source/vaults/withdrawal-period-audit.rst
@@ -58,12 +58,13 @@ The current JSON model intentionally does **not** fabricate a period for the
 following adapters:
 
 * **Queue or liquidity dependent:** Aarna, Accountable, Aera, BaseVol, Bulla,
-  cSigma, ETH Strategy, 40acres, Hyperdrive HL, Infinifi, Maple, NashPoint,
-  Renalta, Royco, Secured Finance, Superform, Symbiotic, TrueFi, Untangle,
-  YieldFi, Yo, Yuzu Money and ZeroLend. Their contracts or operator processes
-  make redemption timing depend on liquidity, a queue position, an underlying
-  strategy or an unbounded operator action. The current ``WithdrawalPeriod``
-  cannot express that conditional or unbounded wait.
+  Cap, cSigma, ETH Strategy, 40acres, Hyperdrive HL, Infinifi, Maple,
+  NashPoint, Renalta, Royco, Secured Finance, Superform, Symbiotic, T3tris,
+  TrueFi, Untangle, YieldFi, Yo, Yuzu Money and ZeroLend. Their contracts or
+  operator processes make redemption timing depend on liquidity, a queue
+  position, an underlying strategy or an unbounded operator action. The
+  current ``WithdrawalPeriod`` cannot express that conditional or unbounded
+  wait.
 * **Variable or policy estimates:** Altura, Axis, Centrifuge, CrystalClear,
   Ember, ForgeYields, Frankencoin, Lagoon, Liquid Royalty, Maple AQRU, Plutus,
   Umami and YieldNest.

--- a/docs/source/vaults/withdrawal-period-audit.rst
+++ b/docs/source/vaults/withdrawal-period-audit.rst
@@ -12,8 +12,8 @@ Structured export
 -----------------
 
 The following adapters now return ``WithdrawalPeriod`` and populate
-``min_withdrawal_period``, ``max_withdrawal_period`` and
-``withdrawal_delay_type`` in lifetime JSON:
+``min_withdrawal_period``, ``max_withdrawal_period``,
+``withdrawal_delay_type`` and ``estimated_settlement`` in lifetime JSON:
 
 * **Atoma** — zero to one ``epochDuration()`` interval; the verified vault
   uses ``requestWithdrawal``/``claimWithdrawal``. See the
@@ -39,6 +39,17 @@ The following adapters now return ``WithdrawalPeriod`` and populate
   Finance and Term Finance** — direct ERC-4626 redemption with no protocol
   request, cooldown or epoch, marked ``instant``. This does not promise that
   the vault or its underlying lending market has sufficient liquidity.
+
+Operational settlement estimates
+--------------------------------
+
+**Lagoon** exposes a curator-provided ``averageSettlement`` value through its
+offchain application metadata. The adapter exports it as
+``estimated_settlement`` for backtesting the expected cadence of deposit and
+redemption settlement rounds. Lagoon's ERC-7540 contracts do not bind curators
+to a settlement deadline, so ``min_withdrawal_period`` and
+``max_withdrawal_period`` remain ``null``. The estimate is not a promise: a
+curator can settle earlier, later, or not at all.
 
 Instant adapters
 ----------------
@@ -67,7 +78,7 @@ following adapters:
   current ``WithdrawalPeriod`` cannot express that conditional or unbounded
   wait.
 * **Variable or policy estimates:** Altura, Axis, Centrifuge, CrystalClear,
-  Ember, ForgeYields, Frankencoin, Lagoon, Liquid Royalty, Maple AQRU, Plutus,
+  Ember, ForgeYields, Frankencoin, Liquid Royalty, Maple AQRU, Plutus,
   Umami and YieldNest.
   Their existing ``get_estimated_lock_up()`` values describe an epoch estimate,
   maturity date, operator service target, reward-interest delay, or strategy

--- a/eth_defi/erc_4626/scan.py
+++ b/eth_defi/erc_4626/scan.py
@@ -21,7 +21,7 @@ from eth_defi.erc_4626.vault_protocol.morpho.vault_v2 import MorphoV2Vault
 from eth_defi.event_reader.web3factory import Web3Factory
 from eth_defi.provider.fallback import ExtraValueError
 from eth_defi.token import TokenDiskCache
-from eth_defi.vault.base import VaultBase, WithdrawalDelayType, WithdrawalPeriod
+from eth_defi.vault.base import VaultBase, WithdrawalPeriod
 from eth_defi.vault.deposit_redeem import VaultDepositPermission
 from eth_defi.vault.fee import BROKEN_FEE_DATA, FeeData
 
@@ -397,12 +397,6 @@ def create_vault_scan_record(
 
             if lockup is not None:
                 assert isinstance(lockup, datetime.timedelta), f"Expected timedelta, got {type(lockup)}: {lockup}"
-                if lockup == datetime.timedelta(0):
-                    withdrawal_period = WithdrawalPeriod(
-                        min_period=lockup,
-                        max_period=lockup,
-                        delay_type=WithdrawalDelayType.instant,
-                    )
 
         # Resolve vault flags from the smart contract state
         try:

--- a/eth_defi/erc_4626/scan.py
+++ b/eth_defi/erc_4626/scan.py
@@ -401,7 +401,7 @@ def create_vault_scan_record(
                     withdrawal_period = WithdrawalPeriod(
                         min_period=lockup,
                         max_period=lockup,
-                        delay_type=WithdrawalDelayType.delay,
+                        delay_type=WithdrawalDelayType.instant,
                     )
 
         # Resolve vault flags from the smart contract state

--- a/eth_defi/erc_4626/scan.py
+++ b/eth_defi/erc_4626/scan.py
@@ -21,7 +21,7 @@ from eth_defi.erc_4626.vault_protocol.morpho.vault_v2 import MorphoV2Vault
 from eth_defi.event_reader.web3factory import Web3Factory
 from eth_defi.provider.fallback import ExtraValueError
 from eth_defi.token import TokenDiskCache
-from eth_defi.vault.base import VaultBase, WithdrawalPeriod
+from eth_defi.vault.base import VaultBase, WithdrawalDelayType, WithdrawalPeriod
 from eth_defi.vault.deposit_redeem import VaultDepositPermission
 from eth_defi.vault.fee import BROKEN_FEE_DATA, FeeData
 
@@ -397,6 +397,12 @@ def create_vault_scan_record(
 
             if lockup is not None:
                 assert isinstance(lockup, datetime.timedelta), f"Expected timedelta, got {type(lockup)}: {lockup}"
+                if lockup == datetime.timedelta(0):
+                    withdrawal_period = WithdrawalPeriod(
+                        min_period=lockup,
+                        max_period=lockup,
+                        delay_type=WithdrawalDelayType.delay,
+                    )
 
         # Resolve vault flags from the smart contract state
         try:

--- a/eth_defi/erc_4626/vault_protocol/aave/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/aave/vault.py
@@ -10,7 +10,7 @@ from web3.contract import Contract
 
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
 from eth_defi.erc_4626.vault import ERC4626Vault
-from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -123,7 +123,7 @@ class AaveVault(ERC4626Vault):
         :return:
             A zero-length ``instant`` period.
         """
-        return WithdrawalPeriod(datetime.timedelta(0), datetime.timedelta(0), WithdrawalDelayType.instant)
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Link to the Aave markets app.

--- a/eth_defi/erc_4626/vault_protocol/aave/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/aave/vault.py
@@ -10,6 +10,7 @@ from web3.contract import Contract
 
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +110,20 @@ class AaveVault(ERC4626Vault):
     def get_estimated_lock_up(self) -> datetime.timedelta | None:
         """Redemptions are liquid, subject to available Hub liquidity (no fixed lock-up)."""
         return None
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Report the absence of a protocol withdrawal timing gate.
+
+        ATokenVault and Tokenization Spoke redemption uses the direct ERC-4626
+        path. The Aave v4 Hub can still lack the assets required to settle a
+        redemption, but this is an availability constraint rather than a
+        request, cooldown, or epoch rule. See the `Aave v4 documentation
+        <https://aave.com/docs/aave-v4>`__.
+
+        :return:
+            A zero-length ``instant`` period.
+        """
+        return WithdrawalPeriod(datetime.timedelta(0), datetime.timedelta(0), WithdrawalDelayType.instant)
 
     def get_link(self, referral: str | None = None) -> str:
         """Link to the Aave markets app.

--- a/eth_defi/erc_4626/vault_protocol/atoma/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/atoma/vault.py
@@ -30,6 +30,7 @@ from eth_typing import BlockIdentifier, HexAddress
 from web3.exceptions import BadFunctionCallOutput, ContractLogicError, Web3Exception
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -241,6 +242,23 @@ class AtomaVault(ERC4626Vault):
             return datetime.timedelta(seconds=duration_seconds)
         except (BadFunctionCallOutput, ContractLogicError, ValueError, Web3Exception):
             return DEFAULT_EPOCH_DURATION
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the epoch-bounded Atoma request-to-claim window.
+
+        Atoma accepts a withdrawal request and pays it from the next processed
+        settlement epoch. A request can be made as soon as the current epoch
+        permits it, while the normal upper bound is one configured epoch.
+        See the `Atoma vault implementation <https://arbitrum.blockscout.com/address/0xd4242FD8DE6E3128f0435b52DCe29155098CbBFF>`__.
+
+        :return:
+            Zero-to-one epoch withdrawal period.
+        """
+        return WithdrawalPeriod(
+            min_period=datetime.timedelta(0),
+            max_period=self.get_estimated_lock_up(),
+            delay_type=WithdrawalDelayType.epoch,
+        )
 
     def get_link(self, referral: str | None = None) -> str:
         """Return the Atoma vault app link."""

--- a/eth_defi/erc_4626/vault_protocol/autopool/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/autopool/vault.py
@@ -12,17 +12,18 @@ price (``totalAssets / totalSupply``).
 """
 
 import datetime
+import logging
 from decimal import Decimal
 from functools import cached_property
-import logging
 
-from web3.contract import Contract
 from eth_typing import BlockIdentifier, HexAddress
+from web3.contract import Contract
 
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
 from eth_defi.erc_4626.deposit_redeem import ERC4626DepositManager
 from eth_defi.erc_4626.estimate import estimate_value_by_share_price
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +69,10 @@ class AutoPoolVault(ERC4626Vault):
 
     def get_estimated_lock_up(self) -> datetime.timedelta | None:
         return datetime.timedelta(days=0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_deposit_manager(self) -> "AutoPoolDepositManager":
         return AutoPoolDepositManager(self)

--- a/eth_defi/erc_4626/vault_protocol/autopool/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/autopool/vault.py
@@ -71,7 +71,6 @@ class AutoPoolVault(ERC4626Vault):
         return datetime.timedelta(days=0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_deposit_manager(self) -> "AutoPoolDepositManager":

--- a/eth_defi/erc_4626/vault_protocol/avant/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/avant/vault.py
@@ -23,6 +23,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +81,21 @@ class AvantVault(ERC4626Vault):
         This returns a conservative estimate.
         """
         return datetime.timedelta(days=7)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod | None:
+        """Read Avant's governance-controlled cooldown from the vault.
+
+        See the `Avant unstaking documentation <https://docs.avantprotocol.com/overview/using-the-avant-protocol/unstaking-savassets>`__.
+
+        :return:
+            Fixed cooldown duration, or ``None`` when the deployment does not
+            expose the canonical ``cooldownDuration()`` accessor.
+        """
+        try:
+            period = datetime.timedelta(seconds=self.vault_contract.functions.cooldownDuration().call())
+        except (AttributeError, ValueError):
+            return None
+        return WithdrawalPeriod(period, period, WithdrawalDelayType.delay)
 
     def get_link(self, referral: str | None = None) -> str:
         """Get the vault's web UI link.

--- a/eth_defi/erc_4626/vault_protocol/brink/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/brink/vault.py
@@ -21,7 +21,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
-from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +74,7 @@ class BrinkVault(ERC4626Vault):
         :return:
             A zero-length ``instant`` period.
         """
-        return WithdrawalPeriod(datetime.timedelta(0), datetime.timedelta(0), WithdrawalDelayType.instant)
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Get link to the vault page.

--- a/eth_defi/erc_4626/vault_protocol/brink/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/brink/vault.py
@@ -21,6 +21,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +63,18 @@ class BrinkVault(ERC4626Vault):
         Brink vaults support instant redemption.
         """
         return None
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Report Brink's direct redemption path.
+
+        Brink does not implement a withdrawal request, cooldown, or epoch for
+        this ERC-4626 vault adapter. See the `Brink application
+        <https://brink.money/app>`__ for an example vault interface.
+
+        :return:
+            A zero-length ``instant`` period.
+        """
+        return WithdrawalPeriod(datetime.timedelta(0), datetime.timedelta(0), WithdrawalDelayType.instant)
 
     def get_link(self, referral: str | None = None) -> str:
         """Get link to the vault page.

--- a/eth_defi/erc_4626/vault_protocol/bulla/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/bulla/offchain_metadata.py
@@ -36,6 +36,14 @@ class BullaVaultMetadata:
     #: Publicly named organisations managing the pool, if published by Bulla.
     manager_name: str | None
 
+    #: Publicly reported average redemption time in days. This is an operational
+    #: estimate tied to the selected pool's invoice collections, not a deadline.
+    average_redemption_period_days: int | None
+
+    #: Publicly reported maximum redemption time in days. This is descriptive
+    #: pool material and not a smart-contract-enforced withdrawal bound.
+    maximum_redemption_period_days: int | None
+
 
 #: TCS Settlement Pool Token V2.1 on Arbitrum.
 #:
@@ -56,6 +64,8 @@ _BULLA_VAULT_METADATA: dict[tuple[int, str], BullaVaultMetadata] = {
         short_description="Permissioned stablecoin pool financing short-term freight receivables through TCS Blockchain.",
         description=("The TCS Settlement Pool provides stablecoin liquidity for short-term freight receivables originated through TCS Blockchain. Bulla presents the pool as an offering for accredited investors, with exposure to 30-60 day invoices. Withdrawals depend on available liquidity; Bulla states an average 30-day redemption period and a maximum of 40 days. Returns depend on the repayment and collection of the financed invoices, so payment delays or impairments can affect both liquidity and returns."),
         manager_name="Bulla and TCS Blockchain",
+        average_redemption_period_days=30,
+        maximum_redemption_period_days=40,
     ),
 }
 

--- a/eth_defi/erc_4626/vault_protocol/bulla/offchain_metadata.py
+++ b/eth_defi/erc_4626/vault_protocol/bulla/offchain_metadata.py
@@ -40,10 +40,6 @@ class BullaVaultMetadata:
     #: estimate tied to the selected pool's invoice collections, not a deadline.
     average_redemption_period_days: int | None
 
-    #: Publicly reported maximum redemption time in days. This is descriptive
-    #: pool material and not a smart-contract-enforced withdrawal bound.
-    maximum_redemption_period_days: int | None
-
 
 #: TCS Settlement Pool Token V2.1 on Arbitrum.
 #:
@@ -65,7 +61,6 @@ _BULLA_VAULT_METADATA: dict[tuple[int, str], BullaVaultMetadata] = {
         description=("The TCS Settlement Pool provides stablecoin liquidity for short-term freight receivables originated through TCS Blockchain. Bulla presents the pool as an offering for accredited investors, with exposure to 30-60 day invoices. Withdrawals depend on available liquidity; Bulla states an average 30-day redemption period and a maximum of 40 days. Returns depend on the repayment and collection of the financed invoices, so payment delays or impairments can affect both liquidity and returns."),
         manager_name="Bulla and TCS Blockchain",
         average_redemption_period_days=30,
-        maximum_redemption_period_days=40,
     ),
 }
 

--- a/eth_defi/erc_4626/vault_protocol/bulla/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/bulla/vault.py
@@ -24,7 +24,7 @@ from web3 import Web3
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.bulla.offchain_metadata import BullaVaultMetadata, get_bulla_vault_metadata
 from eth_defi.types import Percent
-from eth_defi.vault.base import VaultDepositManager
+from eth_defi.vault.base import VaultDepositManager, WithdrawalDelayType, WithdrawalPeriod
 from eth_defi.vault.fee import FeeData, VaultFeeMode
 
 #: Public transaction flows need a pool-specific permission and redemption-queue adapter.
@@ -511,6 +511,31 @@ class BullaVault(ERC4626Vault):
         :return: ``None`` because redemption timing is pool-state dependent.
         """
         return None
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod | None:
+        """Return Bulla's published non-binding redemption estimate.
+
+        The reviewed TCS pool's public materials state an average redemption
+        period, but the actual queue is funded by invoice repayment and pool
+        liquidity. This is not a contract-enforced settlement cycle or a
+        maximum wait. Export the published average solely as
+        ``estimated_settlement`` for backtesting, with no binding
+        ``min_period`` or ``max_period``.
+
+        :return:
+            Queued-redemption metadata with an address-scoped operational
+            estimate, or ``None`` for pools without reviewed public terms.
+        """
+        metadata = self.bulla_metadata
+        average_redemption_period_days = metadata.average_redemption_period_days if metadata else None
+        if not isinstance(average_redemption_period_days, int) or average_redemption_period_days <= 0:
+            return None
+        return WithdrawalPeriod(
+            min_period=None,
+            max_period=None,
+            delay_type=WithdrawalDelayType.delay,
+            estimated_settlement=datetime.timedelta(days=average_redemption_period_days),
+        )
 
     def get_deposit_manager(self) -> VaultDepositManager:
         """Block the generic ERC-4626 transaction manager.

--- a/eth_defi/erc_4626/vault_protocol/curvance/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/curvance/vault.py
@@ -29,6 +29,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +80,19 @@ class CurvanceVault(ERC4626Vault):
         Users can withdraw at any time, subject to available liquidity.
         """
         return None
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Report Curvance's direct ERC-4626 redemption timing.
+
+        Curvance cTokens have no withdrawal request, cooldown, or epoch. A
+        redemption can nevertheless be limited by lending-market liquidity;
+        this does not create a protocol timing gate. See the `Curvance
+        documentation <https://docs.curvance.com/>`__.
+
+        :return:
+            A zero-length ``instant`` period.
+        """
+        return WithdrawalPeriod(datetime.timedelta(0), datetime.timedelta(0), WithdrawalDelayType.instant)
 
     def get_link(self, referral: str | None = None) -> str:
         """Return link to Curvance app."""

--- a/eth_defi/erc_4626/vault_protocol/curvance/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/curvance/vault.py
@@ -29,7 +29,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
-from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +92,7 @@ class CurvanceVault(ERC4626Vault):
         :return:
             A zero-length ``instant`` period.
         """
-        return WithdrawalPeriod(datetime.timedelta(0), datetime.timedelta(0), WithdrawalDelayType.instant)
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Return link to Curvance app."""

--- a/eth_defi/erc_4626/vault_protocol/deltr/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/deltr/vault.py
@@ -38,7 +38,6 @@ class DeltrVault(ERC4626Vault):
         return datetime.timedelta(days=0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:

--- a/eth_defi/erc_4626/vault_protocol/deltr/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/deltr/vault.py
@@ -9,6 +9,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,10 @@ class DeltrVault(ERC4626Vault):
 
     def get_estimated_lock_up(self) -> datetime.timedelta | None:
         return datetime.timedelta(days=0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         return None

--- a/eth_defi/erc_4626/vault_protocol/dolomite/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/dolomite/vault.py
@@ -6,7 +6,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
-from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +75,7 @@ class DolomiteVault(ERC4626Vault):
         :return:
             A zero-length ``instant`` period.
         """
-        return WithdrawalPeriod(datetime.timedelta(0), datetime.timedelta(0), WithdrawalDelayType.instant)
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Get link to Dolomite application."""

--- a/eth_defi/erc_4626/vault_protocol/dolomite/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/dolomite/vault.py
@@ -6,6 +6,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +63,19 @@ class DolomiteVault(ERC4626Vault):
         Deposits and withdrawals are instant, subject to market liquidity.
         """
         return None
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Report Dolomite's direct redemption timing.
+
+        Dolomite does not impose a cooldown, request-and-claim process, or
+        withdrawal epoch. Market liquidity can still limit the amount
+        redeemable in a transaction. See the `Dolomite documentation
+        <https://docs.dolomite.io/>`__.
+
+        :return:
+            A zero-length ``instant`` period.
+        """
+        return WithdrawalPeriod(datetime.timedelta(0), datetime.timedelta(0), WithdrawalDelayType.instant)
 
     def get_link(self, referral: str | None = None) -> str:
         """Get link to Dolomite application."""

--- a/eth_defi/erc_4626/vault_protocol/ember/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/ember/vault.py
@@ -32,6 +32,7 @@ from eth_defi.erc_4626.vault_protocol.ember.offchain_metadata import (
     EmberVaultMetadata,
     fetch_ember_vault_metadata,
 )
+from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -137,11 +138,35 @@ class EmberVault(ERC4626Vault):
         Uses the ``withdrawalPeriodDays`` from the offchain API if available,
         otherwise defaults to 4 days.
         """
-        if self.ember_metadata:
-            days = self.ember_metadata.get("withdrawal_period_days")
-            if days is not None:
-                return datetime.timedelta(days=days)
+        withdrawal_period = self.get_withdrawal_period()
+        if withdrawal_period:
+            return withdrawal_period.estimated_settlement
         return datetime.timedelta(days=4)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod | None:
+        """Return Ember's non-binding operator settlement estimate.
+
+        Ember's offchain API publishes the per-vault ``withdrawalPeriodDays``
+        service estimate for its operator-driven redemption queue. The contract
+        has no corresponding deadline: an operator can process a request
+        earlier, later, or not at all. The value is therefore exported only as
+        ``estimated_settlement`` for backtesting and does not produce binding
+        ``min_period`` or ``max_period`` values.
+
+        :return:
+            Asynchronous withdrawal metadata with an offchain settlement
+            estimate, or ``None`` when the API has no valid per-vault value.
+        """
+        metadata = self.ember_metadata
+        withdrawal_period_days = metadata.get("withdrawal_period_days") if metadata else None
+        if not isinstance(withdrawal_period_days, int) or withdrawal_period_days <= 0:
+            return None
+        return WithdrawalPeriod(
+            min_period=None,
+            max_period=None,
+            delay_type=WithdrawalDelayType.delay,
+            estimated_settlement=datetime.timedelta(days=withdrawal_period_days),
+        )
 
     def fetch_minimum_redemption(self, block_identifier: BlockIdentifier = "latest") -> Decimal | None:
         """Fetch Ember's minimum queued redemption in decimal share units.

--- a/eth_defi/erc_4626/vault_protocol/ethena/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/ethena/vault.py
@@ -27,6 +27,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +87,21 @@ class EthenaVault(ERC4626Vault):
         The actual cooldown duration can be read from the contract.
         """
         return datetime.timedelta(days=7)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod | None:
+        """Read Ethena's live cooldown duration.
+
+        The contract interface is documented in the `Ethena smart-contract repository <https://github.com/ethena-labs>`__.
+
+        :return:
+            Fixed cooldown duration, or ``None`` when the accessor is not
+            available on an older deployment.
+        """
+        try:
+            period = datetime.timedelta(seconds=self.vault_contract.functions.cooldownDuration().call())
+        except (AttributeError, ValueError):
+            return None
+        return WithdrawalPeriod(period, period, WithdrawalDelayType.delay)
 
     def get_link(self, referral: str | None = None) -> str:
         """Get the vault's web UI link.

--- a/eth_defi/erc_4626/vault_protocol/euler/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/euler/vault.py
@@ -407,7 +407,6 @@ class EulerVault(ERC4626Vault):
         return datetime.timedelta(days=0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
@@ -604,7 +603,6 @@ class EulerEarnVault(ERC4626Vault):
         return datetime.timedelta(days=0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:

--- a/eth_defi/erc_4626/vault_protocol/euler/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/euler/vault.py
@@ -24,7 +24,7 @@ from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.euler.offchain_metadata import EulerVaultMetadata, fetch_euler_vault_metadata
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.types import Percent
-from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader, VaultTechnicalRisk
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, VaultHistoricalRead, VaultHistoricalReader, VaultTechnicalRisk, WithdrawalPeriod
 from eth_defi.vault.flag import BAD_FLAGS, get_vault_special_flags
 
 logger = logging.getLogger(__name__)
@@ -406,6 +406,10 @@ class EulerVault(ERC4626Vault):
     def get_estimated_lock_up(self) -> datetime.timedelta | None:
         return datetime.timedelta(days=0)
 
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
+
     def get_link(self, referral: str | None = None) -> str:
         """Get link to the Euler EVK vault frontend.
 
@@ -598,6 +602,10 @@ class EulerEarnVault(ERC4626Vault):
         Users can withdraw at any time depending on available liquidity.
         """
         return datetime.timedelta(days=0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Get link to EulerEarn vault on Euler app.

--- a/eth_defi/erc_4626/vault_protocol/fluid/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/fluid/vault.py
@@ -27,7 +27,7 @@ from eth_typing import BlockIdentifier
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.types import Percent
-from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, VaultHistoricalRead, VaultHistoricalReader, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +72,10 @@ class FluidVault(ERC4626Vault):
     def get_estimated_lock_up(self) -> datetime.timedelta | None:
         """Fluid fTokens have instant liquidity - no lock-up period."""
         return datetime.timedelta(days=0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Get the Fluid protocol link.

--- a/eth_defi/erc_4626/vault_protocol/fluid/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/fluid/vault.py
@@ -74,7 +74,6 @@ class FluidVault(ERC4626Vault):
         return datetime.timedelta(days=0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:

--- a/eth_defi/erc_4626/vault_protocol/foxify/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/foxify/vault.py
@@ -6,7 +6,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
-from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ class FoxifyVault(ERC4626Vault):
         :return:
             A zero-length ``instant`` period.
         """
-        return WithdrawalPeriod(datetime.timedelta(0), datetime.timedelta(0), WithdrawalDelayType.instant)
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Get the vault's web UI link."""

--- a/eth_defi/erc_4626/vault_protocol/foxify/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/foxify/vault.py
@@ -6,6 +6,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +55,18 @@ class FoxifyVault(ERC4626Vault):
     def get_estimated_lock_up(self) -> datetime.timedelta | None:
         """No lock-up period for Foxify vaults."""
         return None
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Report Foxify's direct redemption timing.
+
+        The Foxify LP vault adapter has no withdrawal request, cooldown, or
+        epoch mechanism. See the `Foxify documentation
+        <https://docs.foxify.trade/>`__.
+
+        :return:
+            A zero-length ``instant`` period.
+        """
+        return WithdrawalPeriod(datetime.timedelta(0), datetime.timedelta(0), WithdrawalDelayType.instant)
 
     def get_link(self, referral: str | None = None) -> str:
         """Get the vault's web UI link."""

--- a/eth_defi/erc_4626/vault_protocol/frax/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/frax/vault.py
@@ -21,6 +21,7 @@ from web3 import Web3
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.frax.constants import FRAX_STAKING_VAULT_METADATA_BY_CHAIN, FRAXLEND_FEE_PRECISION, FRAXLEND_MAX_PROTOCOL_FEE_RAW, FRAXLEND_NOTES, FRAXLEND_SHORT_DESCRIPTION
 from eth_defi.types import Percent
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 from eth_defi.vault.fee import VaultFeeMode
 
 logger = logging.getLogger(__name__)
@@ -124,6 +125,10 @@ class FraxVault(ERC4626Vault):
         Lenders can withdraw at any time, subject to available liquidity.
         """
         return datetime.timedelta(days=0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:  # noqa: ARG002
         return f"https://app.frax.finance/fraxlend/pair/{self.vault_address}"

--- a/eth_defi/erc_4626/vault_protocol/frax/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/frax/vault.py
@@ -127,7 +127,6 @@ class FraxVault(ERC4626Vault):
         return datetime.timedelta(days=0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:  # noqa: ARG002

--- a/eth_defi/erc_4626/vault_protocol/gearbox/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/gearbox/vault.py
@@ -36,11 +36,11 @@ from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResu
 from eth_defi.types import Percent
 from eth_defi.vault.base import (
     DEPOSIT_CLOSED_PAUSED,
+    INSTANT_WITHDRAWAL_PERIOD,
     REDEMPTION_CLOSED_INSUFFICIENT_LIQUIDITY,
     REDEMPTION_CLOSED_PAUSED,
     VaultHistoricalRead,
     VaultHistoricalReader,
-    WithdrawalDelayType,
     WithdrawalPeriod,
 )
 
@@ -211,7 +211,7 @@ class GearboxVault(ERC4626Vault):
         :return:
             A zero-length ``instant`` period.
         """
-        return WithdrawalPeriod(datetime.timedelta(0), datetime.timedelta(0), WithdrawalDelayType.instant)
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Get link to the Gearbox app."""

--- a/eth_defi/erc_4626/vault_protocol/gearbox/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/gearbox/vault.py
@@ -40,6 +40,8 @@ from eth_defi.vault.base import (
     REDEMPTION_CLOSED_PAUSED,
     VaultHistoricalRead,
     VaultHistoricalReader,
+    WithdrawalDelayType,
+    WithdrawalPeriod,
 )
 
 logger = logging.getLogger(__name__)
@@ -196,6 +198,20 @@ class GearboxVault(ERC4626Vault):
     def get_estimated_lock_up(self) -> datetime.timedelta | None:
         """Gearbox pools have no lock-up for passive lenders."""
         return None
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Report Gearbox's direct redemption timing.
+
+        PoolV3 does not impose a request, cooldown, or epoch. Its available
+        liquidity may be lower than the requested redemption while credit
+        accounts are borrowed, which is intentionally exported separately
+        from timing. See the `Gearbox documentation
+        <https://docs.gearbox.finance/>`__.
+
+        :return:
+            A zero-length ``instant`` period.
+        """
+        return WithdrawalPeriod(datetime.timedelta(0), datetime.timedelta(0), WithdrawalDelayType.instant)
 
     def get_link(self, referral: str | None = None) -> str:
         """Get link to the Gearbox app."""

--- a/eth_defi/erc_4626/vault_protocol/goat/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/goat/vault.py
@@ -215,5 +215,4 @@ class GoatVault(ERC4626Vault):
         return datetime.timedelta(days=0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD

--- a/eth_defi/erc_4626/vault_protocol/goat/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/goat/vault.py
@@ -11,6 +11,7 @@ from web3.contract import Contract
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.goat.deposit_redeem import GoatDepositManager
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -212,3 +213,7 @@ class GoatVault(ERC4626Vault):
 
     def get_estimated_lock_up(self) -> datetime.timedelta:
         return datetime.timedelta(days=0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD

--- a/eth_defi/erc_4626/vault_protocol/harvest/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/harvest/vault.py
@@ -125,7 +125,6 @@ class HarvestVault(ERC4626Vault):
         return datetime.timedelta(0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:

--- a/eth_defi/erc_4626/vault_protocol/harvest/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/harvest/vault.py
@@ -1,17 +1,17 @@
 """Harvest Finance vault support."""
 
 import datetime
-from functools import cached_property
 import logging
+from functools import cached_property
 
-from web3.contract import Contract
 from eth_typing import BlockIdentifier
+from web3.contract import Contract
 
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.token import TokenDetails, fetch_erc20_details
-from eth_defi.vault.base import VaultTechnicalRisk
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, VaultTechnicalRisk, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +123,10 @@ class HarvestVault(ERC4626Vault):
 
     def get_estimated_lock_up(self) -> datetime.timedelta:
         return datetime.timedelta(0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Get link to the Harvest Finance app.

--- a/eth_defi/erc_4626/vault_protocol/hyperlend/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/hyperlend/vault.py
@@ -24,6 +24,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +87,10 @@ class WrappedHLPVault(ERC4626Vault):
         WHLP has no lock-up period.
         """
         return datetime.timedelta(days=0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Get the vault's web UI link.

--- a/eth_defi/erc_4626/vault_protocol/hyperlend/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/hyperlend/vault.py
@@ -89,7 +89,6 @@ class WrappedHLPVault(ERC4626Vault):
         return datetime.timedelta(days=0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:

--- a/eth_defi/erc_4626/vault_protocol/hypurrfi/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/hypurrfi/vault.py
@@ -61,7 +61,6 @@ class HypurrFiVault(ERC4626Vault):
         return datetime.timedelta(days=0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:

--- a/eth_defi/erc_4626/vault_protocol/hypurrfi/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/hypurrfi/vault.py
@@ -16,6 +16,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +59,10 @@ class HypurrFiVault(ERC4626Vault):
     def get_estimated_lock_up(self) -> datetime.timedelta | None:
         """No lock-up period for HypurrFi vaults."""
         return datetime.timedelta(days=0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Return link to HypurrFi app.

--- a/eth_defi/erc_4626/vault_protocol/inverse_finance/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/inverse_finance/vault.py
@@ -86,7 +86,6 @@ class InverseFinanceVault(ERC4626Vault):
         return datetime.timedelta(days=0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:

--- a/eth_defi/erc_4626/vault_protocol/inverse_finance/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/inverse_finance/vault.py
@@ -31,6 +31,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +84,10 @@ class InverseFinanceVault(ERC4626Vault):
         sDOLA vault has no lock-up period. Withdrawals are instant.
         """
         return datetime.timedelta(days=0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Get the vault's web UI link.

--- a/eth_defi/erc_4626/vault_protocol/ipor/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/ipor/vault.py
@@ -25,6 +25,8 @@ from eth_defi.vault.base import (
     DEPOSIT_CLOSED_UTILISATION,
     VaultHistoricalRead,
     VaultHistoricalReader,
+    WithdrawalDelayType,
+    WithdrawalPeriod,
 )
 from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
 from eth_defi.vault.flag import MISSING_IN_PROTOCOL_FRONTEND, VaultFlag
@@ -746,6 +748,16 @@ class IPORVault(ERC4626Vault):  # noqa: PLR0904
 
     def get_estimated_lock_up(self) -> datetime.timedelta | None:
         return self.get_redemption_delay()
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod | None:
+        """Return IPOR's onchain account redemption delay.
+
+        The accessor is part of IPOR's `Fusion vault access manager <https://app.ipor.io/>`__.
+        """
+        period = self.get_redemption_delay()
+        if period is None:
+            return None
+        return WithdrawalPeriod(period, period, WithdrawalDelayType.delay)
 
     # https://app.ipor.io/fusion/arbitrum/0x4c4f752fa54dafb6d51b4a39018271c90ba1156f
     def get_link(self, referral: str | None = None) -> str:

--- a/eth_defi/erc_4626/vault_protocol/kiln/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/kiln/vault.py
@@ -140,7 +140,6 @@ class KilnVault(ERC4626Vault):
         return datetime.timedelta(0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:  # noqa: PLR6301, ARG002

--- a/eth_defi/erc_4626/vault_protocol/kiln/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/kiln/vault.py
@@ -22,6 +22,7 @@ from eth_typing import BlockIdentifier
 from web3 import Web3
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 
 class KilnVault(ERC4626Vault):
@@ -137,6 +138,10 @@ class KilnVault(ERC4626Vault):
             Zero, because Kiln does not impose a protocol-level lock-up.
         """
         return datetime.timedelta(0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:  # noqa: PLR6301, ARG002
         """Return Kiln's DeFi product page.

--- a/eth_defi/erc_4626/vault_protocol/kiloex/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/kiloex/vault.py
@@ -6,6 +6,7 @@ from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.kiloex.constants import KILOEX_EARN_URL, KILOEX_VAULT_LINK_MATRIX
+from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
 
 
 class KiloExVault(ERC4626Vault):
@@ -68,6 +69,14 @@ class KiloExVault(ERC4626Vault):
             Nine days, the maximum documented withdrawal wait.
         """
         return datetime.timedelta(days=9)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return KiloEx's one-to-three epoch withdrawal range.
+
+        See the `KiloEx Hybrid Vault documentation <https://docs.kiloex.io/kiloex/about-kiloex/hybrid-vault>`__.
+        """
+        epoch = datetime.timedelta(days=3)
+        return WithdrawalPeriod(epoch, 3 * epoch, WithdrawalDelayType.epoch)
 
     def get_link(self, referral: str | None = None) -> str:  # noqa: ARG002
         """Get the KiloEx Earn page for this vault.

--- a/eth_defi/erc_4626/vault_protocol/lagoon/deposit_redeem.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/deposit_redeem.py
@@ -87,9 +87,9 @@ class LagoonDepositManager(GenericERC7540DepositManager):
 
     **Lockups and cooldowns.** There is no fixed cooldown; the wait is one
     settlement round, whose cadence is off-vault operational rather than an
-    onchain deadline. :meth:`LagoonFlowManager.get_estimated_lock_up` returns
-    Lagoon's offchain ``average_settlement`` metadata when available, otherwise
-    ``None``.
+    onchain deadline. :meth:`LagoonVault.get_withdrawal_period` exports
+    Lagoon's offchain ``average_settlement`` metadata as a non-binding
+    backtesting estimate when available, otherwise ``None``.
 
     **Whitelisting / access control.** Deposit admission is version specific and
     checked before broadcast by :meth:`_assert_deposit_request_available` /

--- a/eth_defi/erc_4626/vault_protocol/lagoon/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/vault.py
@@ -49,7 +49,7 @@ from eth_defi.event_reader.multicall_batcher import EncodedCall
 from eth_defi.provider.fallback import ExtraValueError
 from eth_defi.safe.safe_compat import create_safe_ethereum_client
 from eth_defi.trace import assert_transaction_success_with_explanation
-from eth_defi.vault.base import VaultFlowManager, VaultInfo, VaultSpec
+from eth_defi.vault.base import VaultFlowManager, VaultInfo, VaultSpec, WithdrawalDelayType, WithdrawalPeriod
 from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
 from eth_defi.vault.flag import MISSING_IN_PROTOCOL_FRONTEND, VaultFlag
 
@@ -574,6 +574,37 @@ class LagoonVault(ERC7540Vault, AutomatedSafe):
             return MISSING_IN_PROTOCOL_FRONTEND
         return self.description
 
+    def get_withdrawal_period(self) -> WithdrawalPeriod | None:
+        """Return Lagoon's non-binding curator settlement estimate for backtesting.
+
+        Lagoon redemptions follow the asynchronous `ERC-7540 lifecycle
+        <https://eips.ethereum.org/EIPS/eip-7540>`__: a request is only
+        claimable after the curator posts a valuation and the Safe settles the
+        batch. The contracts do not impose a time-bound settlement deadline.
+
+        The official Lagoon app supplies ``averageSettlement`` in its offchain
+        vault metadata. It describes the curator's estimated cadence for
+        deposit and redemption settlement cycles, not a contractual promise.
+        A curator may settle earlier, later, or not at all. Therefore the
+        binding ``min_period`` and ``max_period`` fields are ``None`` and only
+        ``estimated_settlement`` is populated for backtesting.
+
+        :return:
+            Asynchronous withdrawal metadata with an offchain settlement
+            estimate, or ``None`` if Lagoon has no valid estimate for the
+            vault.
+        """
+        metadata = self.lagoon_metadata
+        average_settlement = metadata.get("average_settlement") if metadata else None
+        if not isinstance(average_settlement, int) or average_settlement <= 0:
+            return None
+        return WithdrawalPeriod(
+            min_period=None,
+            max_period=None,
+            delay_type=WithdrawalDelayType.delay,
+            estimated_settlement=datetime.timedelta(seconds=average_settlement),
+        )
+
     @cached_property
     def vault_contract(self) -> Contract:
         """Get vault deployment."""
@@ -1070,14 +1101,15 @@ class LagoonFlowManager(VaultFlowManager):
         return shares_pending * share_price
 
     def get_estimated_lock_up(self) -> datetime.timedelta | None:
-        """Estimate lock up period from Lagoon's offchain metadata.
+        """Return Lagoon's legacy offchain settlement estimate.
 
-        - Uses ``average_settlement`` from Lagoon's web app API (in seconds)
-        - Returns None if metadata is not available
+        The structured :meth:`LagoonVault.get_withdrawal_period` accessor is
+        the source of truth. This compatibility accessor retains the estimate
+        for callers that still use the older flow-manager API.
+
+        :return:
+            Non-binding expected settlement cadence, or ``None`` when the
+            curator has not supplied a valid estimate.
         """
-        metadata = self.vault.lagoon_metadata
-        if metadata:
-            avg = metadata.get("average_settlement")
-            if avg is not None:
-                return datetime.timedelta(seconds=avg)
-        return None
+        withdrawal_period = self.vault.get_withdrawal_period()
+        return withdrawal_period.estimated_settlement if withdrawal_period else None

--- a/eth_defi/erc_4626/vault_protocol/llama_lend/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/llama_lend/vault.py
@@ -176,7 +176,6 @@ class LlamaLendVault(ERC4626Vault):
         return datetime.timedelta(days=0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:

--- a/eth_defi/erc_4626/vault_protocol/llama_lend/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/llama_lend/vault.py
@@ -19,8 +19,7 @@ from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.token import TokenDetails, fetch_erc20_details
 from eth_defi.types import Percent
-from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader, VaultTechnicalRisk
-
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, VaultHistoricalRead, VaultHistoricalReader, VaultTechnicalRisk, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -175,6 +174,10 @@ class LlamaLendVault(ERC4626Vault):
 
     def get_estimated_lock_up(self) -> datetime.timedelta:
         return datetime.timedelta(days=0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         chain_name = get_chain_name(self.chain_id).lower()

--- a/eth_defi/erc_4626/vault_protocol/mainstreet/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/mainstreet/vault.py
@@ -29,6 +29,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -114,6 +115,17 @@ class MainstreetVault(ERC4626Vault):
         The actual cooldown duration can be read from the contract.
         """
         return datetime.timedelta(days=7)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod | None:
+        """Read Mainstreet's live cooldown duration from ``StakedmsUSD``.
+
+        See the `Mainstreet protocol documentation <https://mainstreet-finance.gitbook.io/mainstreet.finance>`__.
+        """
+        try:
+            period = datetime.timedelta(seconds=self.vault_contract.functions.cooldownDuration().call())
+        except (AttributeError, ValueError):
+            return None
+        return WithdrawalPeriod(period, period, WithdrawalDelayType.delay)
 
     def get_link(self, referral: str | None = None) -> str:
         """Get the vault's web UI link.

--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v1.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v1.py
@@ -29,7 +29,7 @@ from eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata import (
 )
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.types import Percent
-from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, VaultHistoricalRead, VaultHistoricalReader, WithdrawalPeriod
 from eth_defi.vault.flag import NOT_IN_MORPHO_API, VaultFlag
 
 logger = logging.getLogger(__name__)
@@ -321,6 +321,10 @@ class MorphoV1Vault(ERC4626Vault):
 
     def get_estimated_lock_up(self) -> datetime.timedelta | None:
         return datetime.timedelta(days=0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         chain_name = get_chain_name(self.chain_id).lower()

--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v1.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v1.py
@@ -323,7 +323,6 @@ class MorphoV1Vault(ERC4626Vault):
         return datetime.timedelta(days=0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:

--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
@@ -499,7 +499,6 @@ class MorphoV2Vault(ERC4626Vault):
         return datetime.timedelta(days=0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:

--- a/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/vault_v2.py
@@ -40,7 +40,7 @@ from eth_defi.erc_4626.vault_protocol.morpho.offchain_metadata import (
 )
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.types import Percent
-from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, VaultHistoricalRead, VaultHistoricalReader, WithdrawalPeriod
 from eth_defi.vault.flag import NOT_IN_MORPHO_API, VaultFlag
 
 logger = logging.getLogger(__name__)
@@ -497,6 +497,10 @@ class MorphoV2Vault(ERC4626Vault):
         Users can withdraw at any time using regular withdraw or forceDeallocate.
         """
         return datetime.timedelta(days=0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Get link to the vault on Morpho app.

--- a/eth_defi/erc_4626/vault_protocol/nara/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/nara/vault.py
@@ -17,6 +17,7 @@ from web3.contract import Contract
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.nara.deposit_redeem import NaraDepositManager
+from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
 from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
 
 
@@ -71,6 +72,15 @@ class NaraVault(ERC4626Vault):
         """
         duration = int(self.narausd_plus_contract.functions.cooldownDuration().call())
         return datetime.timedelta(seconds=duration)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return NaraUSD+'s live cooldown duration.
+
+        See the `NaraUSD documentation <https://docs.nara.io/nara-protocol/narausd>`__.
+        """
+        period = self.get_estimated_lock_up()
+        assert period is not None
+        return WithdrawalPeriod(period, period, WithdrawalDelayType.delay)
 
     def get_deposit_manager(self) -> "NaraDepositManager":
         """Create the NaraUSD+ synchronous-deposit, asynchronous-redeem manager.

--- a/eth_defi/erc_4626/vault_protocol/resolv/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/resolv/vault.py
@@ -84,7 +84,6 @@ class ResolvVault(ERC4626Vault):
         return datetime.timedelta(days=0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:

--- a/eth_defi/erc_4626/vault_protocol/resolv/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/resolv/vault.py
@@ -29,6 +29,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +82,10 @@ class ResolvVault(ERC4626Vault):
         Resolv wstUSR vault has no lock-up period. Withdrawals are instant.
         """
         return datetime.timedelta(days=0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Get the vault's web UI link.

--- a/eth_defi/erc_4626/vault_protocol/sbold/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/sbold/vault.py
@@ -96,7 +96,6 @@ class SBOLDVault(ERC4626Vault):
         return datetime.timedelta(days=0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:

--- a/eth_defi/erc_4626/vault_protocol/sbold/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/sbold/vault.py
@@ -28,6 +28,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +94,10 @@ class SBOLDVault(ERC4626Vault):
         subject to available liquidity.
         """
         return datetime.timedelta(days=0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Get the vault's web UI link.

--- a/eth_defi/erc_4626/vault_protocol/sentiment/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/sentiment/vault.py
@@ -15,6 +15,7 @@ from web3 import Web3
 
 from eth_defi.abi import get_deployed_contract
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +83,19 @@ class SentimentVault(ERC4626Vault):
         Withdrawal may be limited if underlying pools have insufficient liquidity.
         """
         return None
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Report Sentiment's direct withdrawal timing.
+
+        SuperPools do not impose a request, cooldown, or epoch. Underlying
+        pool liquidity can still restrict an otherwise immediate redemption.
+        See the `Sentiment protocol source
+        <https://github.com/sentimentxyz/protocol-v2>`__.
+
+        :return:
+            A zero-length ``instant`` period.
+        """
+        return WithdrawalPeriod(datetime.timedelta(0), datetime.timedelta(0), WithdrawalDelayType.instant)
 
     def get_link(self, referral: str | None = None) -> str:
         """Get a link to the vault on Sentiment app.

--- a/eth_defi/erc_4626/vault_protocol/sentiment/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/sentiment/vault.py
@@ -15,7 +15,7 @@ from web3 import Web3
 
 from eth_defi.abi import get_deployed_contract
 from eth_defi.erc_4626.vault import ERC4626Vault
-from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +95,7 @@ class SentimentVault(ERC4626Vault):
         :return:
             A zero-length ``instant`` period.
         """
-        return WithdrawalPeriod(datetime.timedelta(0), datetime.timedelta(0), WithdrawalDelayType.instant)
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Get a link to the vault on Sentiment app.

--- a/eth_defi/erc_4626/vault_protocol/silo/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/silo/vault.py
@@ -75,7 +75,6 @@ class SiloVault(ERC4626Vault):
         return datetime.timedelta(days=0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_historical_reader(self, stateful: bool) -> VaultHistoricalReader:

--- a/eth_defi/erc_4626/vault_protocol/silo/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/silo/vault.py
@@ -1,22 +1,20 @@
 """Silo Finance vault support."""
 
 import datetime
+import logging
 from decimal import Decimal
 from functools import cached_property
-import logging
 from typing import Iterable
 
-from web3.contract import Contract
-
 from eth_typing import BlockIdentifier
+from web3.contract import Contract
 
 from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.types import Percent
-from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader, VaultTechnicalRisk
-
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, VaultHistoricalRead, VaultHistoricalReader, VaultTechnicalRisk, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +73,10 @@ class SiloVault(ERC4626Vault):
     def get_estimated_lock_up(self) -> datetime.timedelta:
         """Buffered withdraws"""
         return datetime.timedelta(days=0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_historical_reader(self, stateful: bool) -> VaultHistoricalReader:
         """Get Silo-specific historical reader with utilisation metrics."""

--- a/eth_defi/erc_4626/vault_protocol/singularity/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/singularity/vault.py
@@ -26,7 +26,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
-from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +78,7 @@ class SingularityVault(ERC4626Vault):
         :return:
             A zero-length ``instant`` period.
         """
-        return WithdrawalPeriod(datetime.timedelta(0), datetime.timedelta(0), WithdrawalDelayType.instant)
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Get link to the vault page.

--- a/eth_defi/erc_4626/vault_protocol/singularity/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/singularity/vault.py
@@ -26,6 +26,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +66,19 @@ class SingularityVault(ERC4626Vault):
         DynaVaults support instant redemption with EIP-5143 slippage protection.
         """
         return None
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Report DynaVault's direct EIP-5143 redemption timing.
+
+        EIP-5143 adds slippage protection to the direct ERC-4626 path; it does
+        not introduce a withdrawal request, cooldown, or epoch. See the
+        `DynaVault architecture
+        <https://docs.singularityfinance.ai/sfi-value-proposition/core-pillars-of-the-sfi-l2/sfi-vaults/architecture>`__.
+
+        :return:
+            A zero-length ``instant`` period.
+        """
+        return WithdrawalPeriod(datetime.timedelta(0), datetime.timedelta(0), WithdrawalDelayType.instant)
 
     def get_link(self, referral: str | None = None) -> str:
         """Get link to the vault page.

--- a/eth_defi/erc_4626/vault_protocol/sky/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/sky/vault.py
@@ -39,6 +39,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +95,10 @@ class SkyVault(ERC4626Vault):
         Sky stUSDS vault has no lock-up period. Withdrawals are instant.
         """
         return datetime.timedelta(days=0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Get the vault's web UI link.

--- a/eth_defi/erc_4626/vault_protocol/sky/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/sky/vault.py
@@ -97,7 +97,6 @@ class SkyVault(ERC4626Vault):
         return datetime.timedelta(days=0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:

--- a/eth_defi/erc_4626/vault_protocol/spark/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/spark/vault.py
@@ -30,6 +30,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +85,10 @@ class SparkVault(ERC4626Vault):
         subject to PSM liquidity.
         """
         return datetime.timedelta(days=0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Get the vault's web UI link.

--- a/eth_defi/erc_4626/vault_protocol/spark/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/spark/vault.py
@@ -87,7 +87,6 @@ class SparkVault(ERC4626Vault):
         return datetime.timedelta(days=0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:

--- a/eth_defi/erc_4626/vault_protocol/spectra/erc4626_wrapper_vault.py
+++ b/eth_defi/erc_4626/vault_protocol/spectra/erc4626_wrapper_vault.py
@@ -126,7 +126,6 @@ class SpectraERC4626WrapperVault(ERC4626Vault):
         return datetime.timedelta(0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:

--- a/eth_defi/erc_4626/vault_protocol/spectra/erc4626_wrapper_vault.py
+++ b/eth_defi/erc_4626/vault_protocol/spectra/erc4626_wrapper_vault.py
@@ -47,6 +47,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +124,10 @@ class SpectraERC4626WrapperVault(ERC4626Vault):
             Zero timedelta as there is no lock-up
         """
         return datetime.timedelta(0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Get the vault's web UI link.

--- a/eth_defi/erc_4626/vault_protocol/summer/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/summer/vault.py
@@ -66,7 +66,6 @@ class SummerVault(ERC4626Vault):
         return datetime.timedelta(days=0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def fetch_tip_rate(self, block_identifier: BlockIdentifier) -> float:

--- a/eth_defi/erc_4626/vault_protocol/summer/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/summer/vault.py
@@ -1,19 +1,16 @@
 """Summer finance vault support."""
 
 import datetime
-
-from functools import cached_property
 import logging
-
-from web3.contract import Contract
+from functools import cached_property
 
 from eth_typing import BlockIdentifier
+from web3.contract import Contract
 
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
 from eth_defi.erc_4626.vault import ERC4626Vault
 from eth_defi.token import TokenDetails, fetch_erc20_details
-from eth_defi.vault.base import VaultTechnicalRisk
-
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, VaultTechnicalRisk, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +64,10 @@ class SummerVault(ERC4626Vault):
     def get_estimated_lock_up(self) -> datetime.timedelta:
         """Buffered withdraws?"""
         return datetime.timedelta(days=0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def fetch_tip_rate(self, block_identifier: BlockIdentifier) -> float:
         return self.vault_contract.functions.tipRate().call(block_identifier=block_identifier) / 10**20

--- a/eth_defi/erc_4626/vault_protocol/teller/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/teller/vault.py
@@ -36,12 +36,13 @@ import datetime
 import logging
 from functools import cached_property
 
-from web3.contract import Contract
 from eth_typing import BlockIdentifier
+from web3.contract import Contract
 
+from eth_defi.chain import get_chain_name
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
 from eth_defi.erc_4626.vault import ERC4626Vault
-from eth_defi.chain import get_chain_name
+from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +125,22 @@ class TellerVault(ERC4626Vault):
             return datetime.timedelta(seconds=delay_seconds)
         except Exception:
             return None
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod | None:
+        """Read Teller's pool-specific withdrawal delay.
+
+        Teller's ``withdrawDelayTime()`` is measured in seconds and applies to
+        the request-to-claim flow for the pool.
+        See the `Teller V2 documentation <https://docs.teller.org/teller-v2>`__.
+
+        :return:
+            Fixed delay, or ``None`` when this deployment lacks the accessor.
+        """
+        try:
+            period = datetime.timedelta(seconds=self.vault_contract.functions.withdrawDelayTime().call())
+        except (AttributeError, ValueError):
+            return None
+        return WithdrawalPeriod(period, period, WithdrawalDelayType.delay)
 
     def get_link(self, referral: str | None = None) -> str:
         """Get the vault's web UI link.

--- a/eth_defi/erc_4626/vault_protocol/term_finance/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/term_finance/vault.py
@@ -37,6 +37,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +71,19 @@ class TermFinanceVault(ERC4626Vault):
     def get_estimated_lock_up(self) -> datetime.timedelta | None:
         """Term Finance vaults have no lock-up period."""
         return None
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Report Term Finance's direct ERC-4626 redemption timing.
+
+        Term vaults expose the Yearn V3 redemption path without a withdrawal
+        request, cooldown, or epoch. Liquidity remains dependent on the vault
+        strategy. See the `Term Finance developer documentation
+        <https://developers.term.finance/>`__.
+
+        :return:
+            A zero-length ``instant`` period.
+        """
+        return WithdrawalPeriod(datetime.timedelta(0), datetime.timedelta(0), WithdrawalDelayType.instant)
 
     def get_link(self, referral: str | None = None) -> str:
         """Get link to the Term Finance vault page.

--- a/eth_defi/erc_4626/vault_protocol/term_finance/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/term_finance/vault.py
@@ -37,7 +37,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
-from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +83,7 @@ class TermFinanceVault(ERC4626Vault):
         :return:
             A zero-length ``instant`` period.
         """
-        return WithdrawalPeriod(datetime.timedelta(0), datetime.timedelta(0), WithdrawalDelayType.instant)
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Get link to the Term Finance vault page.

--- a/eth_defi/erc_4626/vault_protocol/threejane/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/threejane/vault.py
@@ -34,6 +34,7 @@ import logging
 from web3.types import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -113,6 +114,14 @@ class ThreeJaneVault(ERC4626Vault):
         if self.vault_address.lower() == SUSD3_ADDRESS:
             return SUSD3_LOCK_DURATION
         return datetime.timedelta(0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the tranche-specific 3Jane redemption timing.
+
+        See the `3Jane documentation <https://docs.3jane.xyz/>`__.
+        """
+        period = self.get_estimated_lock_up()
+        return WithdrawalPeriod(period, period, WithdrawalDelayType.delay)
 
     def get_link(self, referral: str | None = None) -> str:
         return "https://www.3jane.xyz/"

--- a/eth_defi/erc_4626/vault_protocol/usdai/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/usdai/vault.py
@@ -10,6 +10,7 @@ from web3.exceptions import BadFunctionCallOutput, ContractLogicError
 
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
 from eth_defi.erc_7540.vault import ERC7540Vault
+from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +67,17 @@ class StakedUSDaiVault(ERC7540Vault):
             The protocol redemption window.
         """
         return USDAI_REDEMPTION_WINDOW
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return USDai's zero-to-one redemption-window range.
+
+        The queue and redemption timestamp are described in the `USDai contracts <https://github.com/metastreet-labs/metastreet-usdai-contracts>`__.
+        """
+        return WithdrawalPeriod(
+            min_period=datetime.timedelta(0),
+            max_period=USDAI_REDEMPTION_WINDOW,
+            delay_type=WithdrawalDelayType.epoch,
+        )
 
     def fetch_redemption_next_open(self) -> datetime.datetime | None:
         """Fetch the next USDai redemption processing timestamp.

--- a/eth_defi/erc_4626/vault_protocol/usdd/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/usdd/vault.py
@@ -26,6 +26,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +76,10 @@ class USSDVault(ERC4626Vault):
         USDD sUSDD vault has no lock-up period. Withdrawals are instant.
         """
         return datetime.timedelta(days=0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Get the vault's web UI link.

--- a/eth_defi/erc_4626/vault_protocol/usdd/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/usdd/vault.py
@@ -78,7 +78,6 @@ class USSDVault(ERC4626Vault):
         return datetime.timedelta(days=0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:

--- a/eth_defi/erc_4626/vault_protocol/usdx_money/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/usdx_money/vault.py
@@ -31,6 +31,7 @@ import logging
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +95,17 @@ class USDXMoneyVault(ERC4626Vault):
         The default cooldown duration is typically 7 days.
         """
         return datetime.timedelta(days=7)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod | None:
+        """Read USDX Money's live unstaking cooldown.
+
+        See the `USDX Money documentation <https://docs.usdx.money/>`__.
+        """
+        try:
+            period = datetime.timedelta(seconds=self.vault_contract.functions.cooldownDuration().call())
+        except (AttributeError, ValueError):
+            return None
+        return WithdrawalPeriod(period, period, WithdrawalDelayType.delay)
 
     def get_link(self, referral: str | None = None) -> str:
         """Get the vault's web UI link.

--- a/eth_defi/erc_4626/vault_protocol/yearn/compounder.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/compounder.py
@@ -95,7 +95,6 @@ class YearnCompounderVault(ERC4626Vault):
         return datetime.timedelta(0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:

--- a/eth_defi/erc_4626/vault_protocol/yearn/compounder.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/compounder.py
@@ -14,6 +14,7 @@ import datetime
 from eth_typing import BlockIdentifier
 
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 #: Yearn TokenizedStrategy fee precision: 10_000 basis points is 100%.
 PERFORMANCE_FEE_DENOMINATOR = 10_000
@@ -92,6 +93,10 @@ class YearnCompounderVault(ERC4626Vault):
             A zero-length lock-up.
         """
         return datetime.timedelta(0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         """Return the direct Yearn vault page.

--- a/eth_defi/erc_4626/vault_protocol/yearn/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/vault.py
@@ -194,7 +194,6 @@ class YearnV3Vault(ERC4626Vault):
         return datetime.timedelta(0)
 
     def get_withdrawal_period(self) -> WithdrawalPeriod:
-        """Return the adapter's direct redemption timing."""
         return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:

--- a/eth_defi/erc_4626/vault_protocol/yearn/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/yearn/vault.py
@@ -10,8 +10,9 @@ from web3.exceptions import ABIFunctionNotFound, BadFunctionCallOutput, Contract
 
 from eth_defi.abi import ZERO_ADDRESS_STR
 from eth_defi.erc_4626.core import get_deployed_erc_4626_contract
-from eth_defi.erc_4626.vault_protocol.yearn.deposit_redeem import YearnV3DepositManager
 from eth_defi.erc_4626.vault import ERC4626Vault
+from eth_defi.erc_4626.vault_protocol.yearn.deposit_redeem import YearnV3DepositManager
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalPeriod
 
 logger = logging.getLogger(__name__)
 
@@ -191,6 +192,10 @@ class YearnV3Vault(ERC4626Vault):
 
     def get_estimated_lock_up(self) -> datetime.timedelta:
         return datetime.timedelta(0)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return the adapter's direct redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
     def get_link(self, referral: str | None = None) -> str:
         return f"https://yearn.fi/v3/{self.chain_id}/{self.vault_address}"

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -1879,10 +1879,12 @@ def calculate_vault_record(
         min_withdrawal_period = None
         max_withdrawal_period = None
         withdrawal_delay_type = None
+        estimated_settlement = None
     else:
         min_withdrawal_period = withdrawal_period.min_period
         max_withdrawal_period = withdrawal_period.max_period
         withdrawal_delay_type = withdrawal_period.delay_type
+        estimated_settlement = withdrawal_period.estimated_settlement
         # Keep the long-standing public field as a backwards-compatible alias
         # for the maximum normal wait, rather than exposing a contradictory
         # generic adapter estimate beside the explicit range.
@@ -2287,6 +2289,7 @@ def calculate_vault_record(
             "min_withdrawal_period": min_withdrawal_period,
             "max_withdrawal_period": max_withdrawal_period,
             "withdrawal_delay_type": withdrawal_delay_type,
+            "estimated_settlement": estimated_settlement,
             "event_count": event_count,
             "protocol": protocol,
             "risk": risk,
@@ -2836,7 +2839,7 @@ def format_lifetime_table(
             return "---"
         return f"{period.total_seconds() / 86_400:g}"
 
-    for column in ("min_withdrawal_period", "max_withdrawal_period"):
+    for column in ("min_withdrawal_period", "max_withdrawal_period", "estimated_settlement"):
         if column in df.columns:
             df[column] = df[column].apply(_format_withdrawal_period)
     df["flags"] = df["flags"].apply(_str_enum_set)
@@ -2997,6 +3000,7 @@ def format_lifetime_table(
             "min_withdrawal_period": "Withdrawal min. days",
             "max_withdrawal_period": "Withdrawal max. days",
             "withdrawal_delay_type": "Withdrawal type",
+            "estimated_settlement": "Settlement est. days",
             "fee_label": "Fees (mgmt / perf / dep / with)",
             "flags": "Flags",
             "notes": "Notes",

--- a/eth_defi/vault/base.py
+++ b/eth_defi/vault/base.py
@@ -122,6 +122,22 @@ class WithdrawalPeriod:
     delay_type: WithdrawalDelayType
 
 
+#: Withdrawal metadata for adapters whose documented ERC-4626 redemption path
+#: has no request, cooldown, or epoch timing gate. It is a timing declaration,
+#: not a liquidity guarantee: callers must still check liquidity, permissions,
+#: pause state, and transaction preflight before attempting redemption.
+#:
+#: An adapter must return this value explicitly. A zero
+#: :meth:`VaultBase.get_estimated_lock_up` alone is not sufficient evidence:
+#: it can describe a different lifecycle, such as an unlocked asynchronous
+#: redemption queue.
+INSTANT_WITHDRAWAL_PERIOD = WithdrawalPeriod(
+    min_period=datetime.timedelta(0),
+    max_period=datetime.timedelta(0),
+    delay_type=WithdrawalDelayType.instant,
+)
+
+
 class ParquetVerificationError(Exception):
     """Raised when a parquet file fails post-write verification.
 

--- a/eth_defi/vault/base.py
+++ b/eth_defi/vault/base.py
@@ -75,7 +75,8 @@ class WithdrawalDelayType(enum.StrEnum):
     timing rule, not current liquidity, a pause, or keeper execution.
 
     ``delay`` applies when a request becomes claimable after a configured
-    cooldown. Examples include `Gains gUSDC <https://gains.trade/vaults/gUSDC>`__
+    cooldown, including a zero-second delay for synchronous ERC-4626
+    redemptions. Examples include `Gains gUSDC <https://gains.trade/vaults/gUSDC>`__
     and Upshift's `NEMO USDC Yield <https://app.upshift.finance/pools/1/0x955256B31097dDf47a9E47A95aDfDFB4460D8522>`__.
 
     ``epoch`` applies when withdrawal availability is determined by a

--- a/eth_defi/vault/base.py
+++ b/eth_defi/vault/base.py
@@ -105,21 +105,34 @@ class WithdrawalDelayType(enum.StrEnum):
 class WithdrawalPeriod:
     """Protocol withdrawal timing bounds exported by the vault scanner.
 
-    The range describes the normal wait from a valid withdrawal request to
-    redemption availability. It excludes liquidity shortages, keeper delays,
-    paused contracts and other exceptional operating conditions. Both values
-    are :class:`datetime.timedelta` objects and are serialised as seconds in
-    the public lifetime-metrics JSON export.
+    ``min_period`` and ``max_period`` describe the wait from a valid withdrawal
+    request to redemption availability when the protocol's smart contracts
+    enforce a timing rule. These binding values exclude liquidity shortages,
+    paused contracts, and other exceptional operating conditions. They are
+    serialised as seconds in the public lifetime-metrics JSON export.
+
+    ``estimated_settlement`` is deliberately separate. It is a non-binding
+    offchain operational-cadence estimate for backtesting, such as how often a
+    curator normally performs a request-batch settlement. It must not be used
+    to decide whether a withdrawal is claimable or promised to settle by a
+    particular time.
     """
 
-    #: Shortest configured wait before a withdrawal can become available.
-    min_period: datetime.timedelta
+    #: Shortest contract-enforced wait before a withdrawal can become available.
+    #: ``None`` when the protocol has no binding timing bound.
+    min_period: datetime.timedelta | None
 
-    #: Longest normal wait, including any protocol scheduling window.
-    max_period: datetime.timedelta
+    #: Longest contract-enforced wait, including any protocol scheduling window.
+    #: ``None`` when the protocol has no binding timing bound.
+    max_period: datetime.timedelta | None
 
     #: Whether the availability rule is a time delay or epoch window.
     delay_type: WithdrawalDelayType
+
+    #: Non-binding offchain estimate of the interval between curator settlement
+    #: cycles. Used exclusively for backtesting; it never replaces a binding
+    #: smart-contract withdrawal period and a settlement may not occur at all.
+    estimated_settlement: datetime.timedelta | None = None
 
 
 #: Withdrawal metadata for adapters whose documented ERC-4626 redemption path
@@ -1622,12 +1635,15 @@ class VaultBase(ABC):
         return None
 
     def get_withdrawal_period(self) -> WithdrawalPeriod | None:
-        """Return the normal withdrawal wait range and availability mechanism.
+        """Return binding withdrawal timing and optional settlement estimates.
 
         Unlike :meth:`get_estimated_lock_up`, this reports the redemption
-        lifecycle after a user submits a valid withdrawal request. Protocol
-        adapters return ``None`` when the contract does not expose reliable
-        timing data.
+        lifecycle after a user submits a valid withdrawal request. Adapters use
+        ``min_period`` and ``max_period`` only for a binding smart-contract
+        timing rule. An adapter may instead return a non-binding
+        ``estimated_settlement`` for backtesting an offchain curator cadence;
+        that estimate never establishes claimability and does not require a
+        synthetic timing bound.
 
         :return:
             Withdrawal period details, or ``None`` when unavailable.

--- a/eth_defi/vault/base.py
+++ b/eth_defi/vault/base.py
@@ -74,15 +74,23 @@ class WithdrawalDelayType(enum.StrEnum):
     lifetime metrics. It describes only the protocol's normal withdrawal
     timing rule, not current liquidity, a pause, or keeper execution.
 
+    ``instant`` applies when the protocol has no request, cooldown or epoch
+    gate; a direct ERC-4626 redemption is possible subject to liquidity.
+    Examples include `Aave <https://app.aave.com/markets/>`__ and
+    `Yearn V3 <https://yearn.fi/v3>`__.
+
     ``delay`` applies when a request becomes claimable after a configured
-    cooldown, including a zero-second delay for synchronous ERC-4626
-    redemptions. Examples include `Gains gUSDC <https://gains.trade/vaults/gUSDC>`__
+    cooldown. Examples include `Gains gUSDC <https://gains.trade/vaults/gUSDC>`__
     and Upshift's `NEMO USDC Yield <https://app.upshift.finance/pools/1/0x955256B31097dDf47a9E47A95aDfDFB4460D8522>`__.
 
     ``epoch`` applies when withdrawal availability is determined by a
     protocol-defined epoch window. An example is D2's `Texas Hedge strategy
     vault <https://d2.finance/strategies/0x208f63a7f60c319597c05fa5ec67fde41839bad6>`__.
     """
+
+    #: Immediate redemption without a protocol cooldown or epoch gate.
+    #: Aave and Yearn V3 are examples.
+    instant = "instant"
 
     #: A request becomes claimable after a fixed or configured time delay.
     #: Gains gUSDC and Upshift NEMO USDC Yield are examples.

--- a/eth_defi/vault/base.py
+++ b/eth_defi/vault/base.py
@@ -79,8 +79,8 @@ class WithdrawalDelayType(enum.StrEnum):
     Examples include `Aave <https://app.aave.com/markets/>`__ and
     `Yearn V3 <https://yearn.fi/v3>`__.
 
-    ``delay`` applies when a request becomes claimable after a configured
-    cooldown. Examples include `Gains gUSDC <https://gains.trade/vaults/gUSDC>`__
+    ``delay`` applies when a request follows a cooldown or asynchronous
+    settlement lifecycle. Examples include `Gains gUSDC <https://gains.trade/vaults/gUSDC>`__
     and Upshift's `NEMO USDC Yield <https://app.upshift.finance/pools/1/0x955256B31097dDf47a9E47A95aDfDFB4460D8522>`__.
 
     ``epoch`` applies when withdrawal availability is determined by a
@@ -92,7 +92,7 @@ class WithdrawalDelayType(enum.StrEnum):
     #: Aave and Yearn V3 are examples.
     instant = "instant"
 
-    #: A request becomes claimable after a fixed or configured time delay.
+    #: A request follows a fixed delay or asynchronous settlement lifecycle.
     #: Gains gUSDC and Upshift NEMO USDC Yield are examples.
     delay = "delay"
 
@@ -112,10 +112,10 @@ class WithdrawalPeriod:
     serialised as seconds in the public lifetime-metrics JSON export.
 
     ``estimated_settlement`` is deliberately separate. It is a non-binding
-    offchain operational-cadence estimate for backtesting, such as how often a
-    curator normally performs a request-batch settlement. It must not be used
-    to decide whether a withdrawal is claimable or promised to settle by a
-    particular time.
+    offchain operating estimate for backtesting, such as how often a curator
+    normally performs a request-batch settlement or the expected duration of a
+    liquidity-dependent redemption. It must not be used to decide whether a
+    withdrawal is claimable or promised to settle by a particular time.
     """
 
     #: Shortest contract-enforced wait before a withdrawal can become available.
@@ -129,9 +129,9 @@ class WithdrawalPeriod:
     #: Whether the availability rule is a time delay or epoch window.
     delay_type: WithdrawalDelayType
 
-    #: Non-binding offchain estimate of the interval between curator settlement
-    #: cycles. Used exclusively for backtesting; it never replaces a binding
-    #: smart-contract withdrawal period and a settlement may not occur at all.
+    #: Non-binding offchain estimate of a settlement cycle or redemption wait.
+    #: Used exclusively for backtesting; it never replaces a binding
+    #: smart-contract withdrawal period and settlement may not occur at all.
     estimated_settlement: datetime.timedelta | None = None
 
 
@@ -1641,9 +1641,9 @@ class VaultBase(ABC):
         lifecycle after a user submits a valid withdrawal request. Adapters use
         ``min_period`` and ``max_period`` only for a binding smart-contract
         timing rule. An adapter may instead return a non-binding
-        ``estimated_settlement`` for backtesting an offchain curator cadence;
-        that estimate never establishes claimability and does not require a
-        synthetic timing bound.
+        ``estimated_settlement`` for backtesting an offchain operating cadence
+        or redemption wait; that estimate never establishes claimability and
+        does not require a synthetic timing bound.
 
         :return:
             Withdrawal period details, or ``None`` when unavailable.

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -1239,6 +1239,46 @@ value when the live adapter read is inconclusive (`unknown`). Run
 | `JSON_RPC_<CHAIN>` | Required for every EVM chain represented in the cache. |
 | `LOG_LEVEL` | Optional console log level. Default: info. |
 
+### migrate-withdrawal-period-estimates.py
+
+Repair metadata pickles written before ``WithdrawalPeriod`` gained its nullable
+``estimated_settlement`` field. These legacy slotted objects load successfully,
+but lifetime-metrics export raises an attribute error when it reads the missing
+field. The migration replaces only those objects, preserving every binding
+timing value and setting ``estimated_settlement`` to ``None``. It performs no
+network reads and does not modify price Parquet files, reader state or any other
+metadata.
+
+Always inspect the dry run first:
+
+```shell
+source .local-test.env && \
+  DRY_RUN=true \
+  poetry run python scripts/erc-4626/migrate-withdrawal-period-estimates.py
+```
+
+Then back up and apply the metadata-only repair, followed by JSON export:
+
+```shell
+source ~/vault-scanner/vault-rpc.env && \
+  (cd ~/vault-scanner/web3-ethereum-defi && \
+    DRY_RUN=false \
+    poetry run python scripts/erc-4626/migrate-withdrawal-period-estimates.py)
+
+source ~/vault-scanner/vault-rpc.env && \
+  (cd ~/vault-scanner/web3-ethereum-defi && \
+    poetry run python scripts/erc-4626/export-data-files.py)
+```
+
+The migration creates a non-overwriting
+``*.pickle.bak-withdrawal-period-estimates`` backup before it writes.
+
+| Variable | Description |
+|----------|-------------|
+| `VAULT_DB_PATH` | Optional vault metadata pickle path. Defaults to `~/.tradingstrategy/vaults/vault-metadata-db.pickle`. |
+| `DRY_RUN` | Report only when true. Default: true. |
+| `LOG_LEVEL` | Optional console log level. Default: info. |
+
 ### migrate-vault-token-metadata.py
 
 Refresh persisted vault `Name` and `Symbol` fields when an ERC-20/ERC-4626

--- a/scripts/erc-4626/migrate-withdrawal-period-estimates.py
+++ b/scripts/erc-4626/migrate-withdrawal-period-estimates.py
@@ -1,0 +1,248 @@
+"""Add missing settlement estimates to cached withdrawal-period metadata.
+
+``WithdrawalPeriod`` gained the optional ``estimated_settlement`` field after
+some vault metadata pickles had already been written. Because the dataclass is
+slotted, an older pickled instance unpickles without that slot. Reading its new
+field then raises :class:`AttributeError` during lifetime-metrics export.
+
+This metadata-only migration replaces only those legacy instances with the
+current dataclass shape, setting ``estimated_settlement`` to ``None``. It does
+not infer a settlement estimate, alter binding withdrawal timing, scan prices,
+change reader state, or contact any network service.
+
+Usage:
+
+.. code-block:: shell
+
+    # Inspect legacy records without writing (the default)
+    source .local-test.env && \\
+        poetry run python scripts/erc-4626/migrate-withdrawal-period-estimates.py
+
+    # Back up and persist the compatible metadata pickle
+    source .local-test.env && \\
+        DRY_RUN=false \\
+        poetry run python scripts/erc-4626/migrate-withdrawal-period-estimates.py
+
+Environment variables:
+
+- ``VAULT_DB_PATH``: Optional path to ``vault-metadata-db.pickle``. Falls
+  back to ``VAULT_DB`` and then the normal pipeline location.
+- ``DRY_RUN``: Set to ``false`` to write. Defaults to ``true``.
+- ``LOG_LEVEL``: Optional console log level. Defaults to ``info``.
+"""
+
+import logging
+import os
+import shutil
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from tabulate import tabulate
+
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.base import VaultSpec, WithdrawalPeriod
+from eth_defi.vault.vaultdb import DEFAULT_VAULT_DATABASE, VaultDatabase
+
+logger = logging.getLogger(__name__)
+
+_MISSING_SETTLEMENT = object()
+
+
+@dataclass(slots=True, frozen=True)
+class WithdrawalPeriodEstimateUpdate:
+    """One legacy withdrawal-period object requiring the new nullable field."""
+
+    #: Chain and vault address identifying the cached metadata row.
+    spec: VaultSpec
+
+    #: Cached human-readable vault name.
+    name: str
+
+    #: Cached protocol label.
+    protocol: str
+
+
+@dataclass(slots=True, frozen=True)
+class WithdrawalPeriodEstimateMigrationResult:
+    """Summarise the compatible metadata updates selected by the migration."""
+
+    #: Total metadata rows inspected.
+    inspected_rows: int
+
+    #: Rows containing a structured withdrawal period.
+    structured_period_rows: int
+
+    #: Rows that were or would be rewritten with ``estimated_settlement=None``.
+    updates: tuple[WithdrawalPeriodEstimateUpdate, ...]
+
+
+def parse_boolean_env(value: str | None, *, default: bool) -> bool:
+    """Parse a conventional environment boolean without an unsafe default.
+
+    :param value:
+        Environment value, or ``None`` when unset.
+    :param default:
+        Value to use when ``value`` is unset.
+    :return:
+        Parsed boolean value.
+    """
+
+    if value is None:
+        return default
+
+    normalised_value = value.strip().lower()
+    if normalised_value in {"1", "true", "yes", "on"}:
+        return True
+    if normalised_value in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"Expected a boolean environment value, got {value!r}")
+
+
+def create_backup_path(vault_db_path: Path) -> Path:
+    """Choose an unused sibling path for a metadata-pickle backup.
+
+    :param vault_db_path:
+        Existing metadata pickle to protect before writing.
+    :return:
+        Non-existing sibling backup path.
+    """
+
+    backup_path = vault_db_path.with_suffix(".pickle.bak-withdrawal-period-estimates")
+    if not backup_path.exists():
+        return backup_path
+
+    backup_index = 1
+    while True:
+        indexed_backup_path = Path(f"{backup_path}.{backup_index}")
+        if not indexed_backup_path.exists():
+            return indexed_backup_path
+        backup_index += 1
+
+
+def collect_withdrawal_period_estimate_updates(vault_db: VaultDatabase) -> WithdrawalPeriodEstimateMigrationResult:
+    """Find cached periods serialised before ``estimated_settlement`` existed.
+
+    :param vault_db:
+        Loaded vault metadata cache, including old slotted dataclass instances.
+    :return:
+        Counts and metadata rows needing a compatible replacement.
+    """
+
+    updates: list[WithdrawalPeriodEstimateUpdate] = []
+    structured_period_rows = 0
+    for spec, row in vault_db.rows.items():
+        withdrawal_period = row.get("_withdrawal_period")
+        if not isinstance(withdrawal_period, WithdrawalPeriod):
+            continue
+
+        structured_period_rows += 1
+        if getattr(withdrawal_period, "estimated_settlement", _MISSING_SETTLEMENT) is not _MISSING_SETTLEMENT:
+            continue
+
+        updates.append(
+            WithdrawalPeriodEstimateUpdate(
+                spec=spec,
+                name=str(row.get("Name", "")),
+                protocol=str(row.get("Protocol", "")),
+            )
+        )
+
+    return WithdrawalPeriodEstimateMigrationResult(
+        inspected_rows=len(vault_db.rows),
+        structured_period_rows=structured_period_rows,
+        updates=tuple(updates),
+    )
+
+
+def apply_withdrawal_period_estimate_updates(vault_db: VaultDatabase, updates: Iterable[WithdrawalPeriodEstimateUpdate]) -> None:
+    """Replace legacy periods while preserving their binding timing metadata.
+
+    :param vault_db:
+        Loaded metadata cache to update in memory.
+    :param updates:
+        Legacy withdrawal-period rows returned by the collection pass.
+    :return:
+        None after replacing only the selected row values.
+    """
+
+    for update in updates:
+        row = vault_db.rows[update.spec].copy()
+        withdrawal_period = row["_withdrawal_period"]
+        assert isinstance(withdrawal_period, WithdrawalPeriod)
+        row["_withdrawal_period"] = WithdrawalPeriod(
+            min_period=withdrawal_period.min_period,
+            max_period=withdrawal_period.max_period,
+            delay_type=withdrawal_period.delay_type,
+            estimated_settlement=None,
+        )
+        vault_db.rows[update.spec] = row
+
+
+def migrate_withdrawal_period_estimates(vault_db_path: Path = DEFAULT_VAULT_DATABASE, *, dry_run: bool) -> WithdrawalPeriodEstimateMigrationResult:
+    """Migrate legacy withdrawal-period slots without any onchain reads.
+
+    A backup is made only when a non-dry run has at least one compatible
+    replacement to persist. The database writer performs an atomic replacement
+    after the original file has been copied.
+
+    :param vault_db_path:
+        Persisted vault metadata pickle to inspect or rewrite.
+    :param dry_run:
+        Report required changes without writing when ``True``.
+    :return:
+        Counts and rows that were or would be updated.
+    """
+
+    vault_db = VaultDatabase.read(vault_db_path)
+    result = collect_withdrawal_period_estimate_updates(vault_db)
+
+    if result.updates:
+        print(
+            tabulate(
+                [[update.spec.chain_id, update.spec.vault_address, update.name, update.protocol] for update in result.updates],
+                headers=["chain", "address", "name", "protocol"],
+                tablefmt="simple",
+            )
+        )
+
+    if dry_run:
+        logger.info("DRY RUN: would update %d legacy withdrawal periods in %s", len(result.updates), vault_db_path)
+        return result
+
+    if not result.updates:
+        logger.info("No legacy withdrawal periods need migration in %s", vault_db_path)
+        return result
+
+    backup_path = create_backup_path(vault_db_path)
+    logger.info("Creating vault metadata backup at %s", backup_path)
+    shutil.copy2(vault_db_path, backup_path)
+    apply_withdrawal_period_estimate_updates(vault_db, result.updates)
+    vault_db.write(vault_db_path)
+    logger.info("Updated %d legacy withdrawal periods in %s", len(result.updates), vault_db_path)
+    return result
+
+
+def main() -> None:
+    """Run the metadata migration using environment configuration.
+
+    :return:
+        None. Raises when the requested metadata pickle is unavailable.
+    """
+
+    setup_console_logging(default_log_level=os.environ.get("LOG_LEVEL", "info"))
+    vault_db_path = Path(os.environ.get("VAULT_DB_PATH", os.environ.get("VAULT_DB", str(DEFAULT_VAULT_DATABASE)))).expanduser()
+    dry_run = parse_boolean_env(os.environ.get("DRY_RUN"), default=True)
+    if not vault_db_path.exists():
+        raise FileNotFoundError(f"Vault database not found: {vault_db_path}")
+
+    result = migrate_withdrawal_period_estimates(vault_db_path, dry_run=dry_run)
+    print(f"Inspected {result.inspected_rows:,} rows, found {result.structured_period_rows:,} structured periods, and updated {len(result.updates):,} legacy periods.")
+    if dry_run:
+        print("Dry run - no changes written.")
+    elif result.updates:
+        print(f"Saved migrated vault metadata to {vault_db_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/erc_4626/test_migrate_withdrawal_period_estimates.py
+++ b/tests/erc_4626/test_migrate_withdrawal_period_estimates.py
@@ -1,0 +1,154 @@
+"""Tests for the cached withdrawal-period estimate migration."""
+
+import datetime
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from eth_defi.vault.base import VaultSpec, WithdrawalDelayType, WithdrawalPeriod
+from eth_defi.vault.vaultdb import VaultDatabase
+
+
+class LegacyWithdrawalPeriod:
+    """Serialise a withdrawal period with the pre-estimate three-slot state."""
+
+    def __reduce__(self) -> tuple[object, tuple[type[WithdrawalPeriod]], list[object]]:
+        """Make pickle construct the current class with an old slot sequence.
+
+        :return:
+            Pickle reducer that reproduces the persisted legacy object shape.
+        """
+
+        return (
+            object.__new__,
+            (WithdrawalPeriod,),
+            [
+                datetime.timedelta(days=1),
+                datetime.timedelta(days=3),
+                WithdrawalDelayType.delay,
+            ],
+        )
+
+
+def load_migration_module():
+    """Load the standalone migration script as a test module.
+
+    :return:
+        Loaded migration module.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "erc-4626" / "migrate-withdrawal-period-estimates.py"
+    spec = importlib.util.spec_from_file_location("migrate_withdrawal_period_estimates", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def create_row(name: str, withdrawal_period: object) -> dict:
+    """Create a minimal metadata row containing withdrawal timing.
+
+    :param name:
+        Persisted vault display name.
+    :param withdrawal_period:
+        Legacy or current structured withdrawal-period value.
+    :return:
+        Compatible minimal metadata row.
+    """
+
+    return {
+        "Name": name,
+        "Protocol": "Test protocol",
+        "_withdrawal_period": withdrawal_period,
+        "preserved_field": "unchanged",
+    }
+
+
+def test_migrate_withdrawal_period_estimates_rewrites_only_legacy_slots(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A write migration adds the nullable slot without changing timing data.
+
+    1. Persist a database containing a three-slot legacy pickle value.
+    2. Confirm the dry run detects but does not rewrite that value.
+    3. Persist the migration and verify its backup and field preservation.
+    """
+
+    migration = load_migration_module()
+    legacy_spec = VaultSpec(1, "0x0000000000000000000000000000000000000001")
+    current_spec = VaultSpec(1, "0x0000000000000000000000000000000000000002")
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    current_period = WithdrawalPeriod(
+        min_period=None,
+        max_period=None,
+        delay_type=WithdrawalDelayType.delay,
+        estimated_settlement=datetime.timedelta(days=2),
+    )
+    vault_db = VaultDatabase(
+        rows={
+            legacy_spec: create_row("Legacy vault", LegacyWithdrawalPeriod()),
+            current_spec: create_row("Current vault", current_period),
+        }
+    )
+    vault_db.write(vault_db_path)
+
+    # 1. Reading the historical pickle yields a current class lacking its new slot.
+    loaded_legacy_period = VaultDatabase.read(vault_db_path).rows[legacy_spec]["_withdrawal_period"]
+    assert isinstance(loaded_legacy_period, WithdrawalPeriod)
+    with pytest.raises(AttributeError):
+        _ = loaded_legacy_period.estimated_settlement
+
+    # 2. Dry run selects only the legacy object and leaves the pickle untouched.
+    original_contents = vault_db_path.read_bytes()
+    dry_run_result = migration.migrate_withdrawal_period_estimates(vault_db_path, dry_run=True)
+    assert dry_run_result.inspected_rows == len(vault_db.rows)
+    assert dry_run_result.structured_period_rows == len(vault_db.rows)
+    assert [update.spec for update in dry_run_result.updates] == [legacy_spec]
+    assert vault_db_path.read_bytes() == original_contents
+    assert not (tmp_path / "vault-metadata-db.pickle.bak-withdrawal-period-estimates").exists()
+    assert "Legacy vault" in capsys.readouterr().out
+
+    # 3. Writing preserves timing and unrelated metadata while adding ``None``.
+    write_result = migration.migrate_withdrawal_period_estimates(vault_db_path, dry_run=False)
+    assert [update.spec for update in write_result.updates] == [legacy_spec]
+    assert (tmp_path / "vault-metadata-db.pickle.bak-withdrawal-period-estimates").exists()
+    assert "Legacy vault" in capsys.readouterr().out
+    migrated_db = VaultDatabase.read(vault_db_path)
+    migrated_legacy_period = migrated_db.rows[legacy_spec]["_withdrawal_period"]
+    assert isinstance(migrated_legacy_period, WithdrawalPeriod)
+    assert migrated_legacy_period.min_period == datetime.timedelta(days=1)
+    assert migrated_legacy_period.max_period == datetime.timedelta(days=3)
+    assert migrated_legacy_period.delay_type == WithdrawalDelayType.delay
+    assert migrated_legacy_period.estimated_settlement is None
+    assert migrated_db.rows[legacy_spec]["preserved_field"] == "unchanged"
+    assert migrated_db.rows[current_spec]["_withdrawal_period"] == current_period
+
+
+def test_migrate_withdrawal_period_estimates_does_not_rewrite_current_rows(tmp_path: Path) -> None:
+    """A current metadata pickle does not receive a backup or a needless write."""
+
+    migration = load_migration_module()
+    spec = VaultSpec(1, "0x0000000000000000000000000000000000000001")
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    VaultDatabase(
+        rows={
+            spec: create_row(
+                "Current vault",
+                WithdrawalPeriod(
+                    min_period=datetime.timedelta(0),
+                    max_period=datetime.timedelta(0),
+                    delay_type=WithdrawalDelayType.instant,
+                ),
+            )
+        }
+    ).write(vault_db_path)
+    original_contents = vault_db_path.read_bytes()
+
+    result = migration.migrate_withdrawal_period_estimates(vault_db_path, dry_run=False)
+
+    assert result.inspected_rows == 1
+    assert result.structured_period_rows == 1
+    assert not result.updates
+    assert vault_db_path.read_bytes() == original_contents
+    assert not (tmp_path / "vault-metadata-db.pickle.bak-withdrawal-period-estimates").exists()

--- a/tests/erc_4626/test_scan_features.py
+++ b/tests/erc_4626/test_scan_features.py
@@ -7,7 +7,7 @@ import pytest
 
 import eth_defi.erc_4626.scan as scan_module
 from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
-from eth_defi.vault.base import WithdrawalDelayType, WithdrawalPeriod
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalDelayType, WithdrawalPeriod
 from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
 from eth_defi.vault.fee import FeeData, VaultFeeMode
 from eth_defi.vault.price_source import PriceSource
@@ -142,8 +142,17 @@ class _LegacyInstantFakeVault(_FakeVault):
 
     @staticmethod
     def get_withdrawal_period() -> None:
-        """Use the scanner's legacy compatibility path."""
+        """Report no structured withdrawal timing metadata."""
         return None
+
+
+class _ExplicitInstantFakeVault(_LegacyInstantFakeVault):
+    """Legacy zero-lockup adapter that explicitly declares direct redemption."""
+
+    @staticmethod
+    def get_withdrawal_period() -> WithdrawalPeriod:
+        """Return the adapter's explicit direct-redemption timing."""
+        return INSTANT_WITHDRAWAL_PERIOD
 
 
 def _create_detection(features: set[ERC4626Feature]) -> ERC4262VaultDetection:
@@ -213,10 +222,26 @@ def test_create_vault_scan_record_persists_deposit_permission(monkeypatch: pytes
     assert record["_whitelist_notes"] == "No permissioned hook checks were performed"
 
 
-def test_create_vault_scan_record_normalises_legacy_zero_lockup_to_instant(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Preserve the timing semantics of adapters that predate ``WithdrawalPeriod``."""
+def test_create_vault_scan_record_does_not_infer_instant_from_legacy_zero_lockup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A legacy lock-up estimate cannot establish a withdrawal lifecycle."""
     detection = _create_detection({ERC4626Feature.usdai_like})
     monkeypatch.setattr(scan_module, "create_vault_instance", lambda *_args, **_kwargs: _LegacyInstantFakeVault())
+
+    record = scan_module.create_vault_scan_record(
+        web3=None,
+        detection=detection,
+        block_identifier=1,
+        token_cache={},
+    )
+
+    assert record["_withdrawal_period"] is None
+    assert record["_lockup"] == datetime.timedelta(0)
+
+
+def test_create_vault_scan_record_exports_explicit_instant_period(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only an adapter's explicit direct-redemption declaration exports ``instant``."""
+    detection = _create_detection({ERC4626Feature.usdai_like})
+    monkeypatch.setattr(scan_module, "create_vault_instance", lambda *_args, **_kwargs: _ExplicitInstantFakeVault())
 
     record = scan_module.create_vault_scan_record(
         web3=None,
@@ -230,7 +255,6 @@ def test_create_vault_scan_record_normalises_legacy_zero_lockup_to_instant(monke
         max_period=datetime.timedelta(0),
         delay_type=WithdrawalDelayType.instant,
     )
-    assert record["_lockup"] == datetime.timedelta(0)
 
 
 def test_vault_database_dataframe_falls_back_to_detection_features() -> None:

--- a/tests/erc_4626/test_scan_features.py
+++ b/tests/erc_4626/test_scan_features.py
@@ -132,6 +132,20 @@ class _PermissionedFakeVault(_FakeVault):
         return "No permissioned hook checks were performed"
 
 
+class _LegacyInstantFakeVault(_FakeVault):
+    """Legacy adapter that explicitly reported a zero lock-up."""
+
+    @staticmethod
+    def get_estimated_lock_up() -> datetime.timedelta:
+        """Return the old zero-duration lock-up representation."""
+        return datetime.timedelta(0)
+
+    @staticmethod
+    def get_withdrawal_period() -> None:
+        """Use the scanner's legacy compatibility path."""
+        return None
+
+
 def _create_detection(features: set[ERC4626Feature]) -> ERC4262VaultDetection:
     """Create a detection object."""
     timestamp = datetime.datetime(2026, 7, 3, tzinfo=datetime.UTC).replace(tzinfo=None)
@@ -197,6 +211,26 @@ def test_create_vault_scan_record_persists_deposit_permission(monkeypatch: pytes
     }
     assert record["_deposit_permission"] == "whitelisted"
     assert record["_whitelist_notes"] == "No permissioned hook checks were performed"
+
+
+def test_create_vault_scan_record_normalises_legacy_zero_lockup_to_instant(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Preserve the timing semantics of adapters that predate ``WithdrawalPeriod``."""
+    detection = _create_detection({ERC4626Feature.usdai_like})
+    monkeypatch.setattr(scan_module, "create_vault_instance", lambda *_args, **_kwargs: _LegacyInstantFakeVault())
+
+    record = scan_module.create_vault_scan_record(
+        web3=None,
+        detection=detection,
+        block_identifier=1,
+        token_cache={},
+    )
+
+    assert record["_withdrawal_period"] == WithdrawalPeriod(
+        min_period=datetime.timedelta(0),
+        max_period=datetime.timedelta(0),
+        delay_type=WithdrawalDelayType.instant,
+    )
+    assert record["_lockup"] == datetime.timedelta(0)
 
 
 def test_vault_database_dataframe_falls_back_to_detection_features() -> None:

--- a/tests/erc_4626/vault_protocol/test_withdrawal_period.py
+++ b/tests/erc_4626/vault_protocol/test_withdrawal_period.py
@@ -6,21 +6,47 @@ from types import SimpleNamespace
 import pytest
 
 from eth_defi.erc_4626.vault_protocol.aave.vault import AaveVault
+from eth_defi.erc_4626.vault_protocol.autopool.vault import AutoPoolVault
 from eth_defi.erc_4626.vault_protocol.brink.vault import BrinkVault
 from eth_defi.erc_4626.vault_protocol.curvance.vault import CurvanceVault
 from eth_defi.erc_4626.vault_protocol.d2.vault import D2Vault
+from eth_defi.erc_4626.vault_protocol.deltr.vault import DeltrVault
 from eth_defi.erc_4626.vault_protocol.dolomite.vault import DolomiteVault
+from eth_defi.erc_4626.vault_protocol.euler.vault import EulerEarnVault, EulerVault
+from eth_defi.erc_4626.vault_protocol.fluid.vault import FluidVault
 from eth_defi.erc_4626.vault_protocol.foxify.vault import FoxifyVault
+from eth_defi.erc_4626.vault_protocol.frax.vault import FraxVault
 from eth_defi.erc_4626.vault_protocol.gains.vault import GainsVault, OstiumVault, OstiumVersion
 from eth_defi.erc_4626.vault_protocol.gearbox.vault import GearboxVault
+from eth_defi.erc_4626.vault_protocol.goat.vault import GoatVault
+from eth_defi.erc_4626.vault_protocol.harvest.vault import HarvestVault
+from eth_defi.erc_4626.vault_protocol.hyperlend.vault import WrappedHLPVault
+from eth_defi.erc_4626.vault_protocol.hypurrfi.vault import HypurrFiVault
+from eth_defi.erc_4626.vault_protocol.inverse_finance.vault import InverseFinanceVault
+from eth_defi.erc_4626.vault_protocol.kiln.vault import KilnVault
 from eth_defi.erc_4626.vault_protocol.kiloex.vault import KiloExVault
+from eth_defi.erc_4626.vault_protocol.llama_lend.vault import LlamaLendVault
+from eth_defi.erc_4626.vault_protocol.morpho.vault_v1 import MorphoV1Vault
+from eth_defi.erc_4626.vault_protocol.morpho.vault_v2 import MorphoV2Vault
 from eth_defi.erc_4626.vault_protocol.nara.vault import NaraVault
+from eth_defi.erc_4626.vault_protocol.resolv.vault import ResolvVault
+from eth_defi.erc_4626.vault_protocol.sbold.vault import SBOLDVault
 from eth_defi.erc_4626.vault_protocol.sentiment.vault import SentimentVault
+from eth_defi.erc_4626.vault_protocol.silo.vault import SiloVault
 from eth_defi.erc_4626.vault_protocol.singularity.vault import SingularityVault
+from eth_defi.erc_4626.vault_protocol.sky.vault import SkyVault
+from eth_defi.erc_4626.vault_protocol.spark.vault import SparkVault
+from eth_defi.erc_4626.vault_protocol.spectra.erc4626_wrapper_vault import SpectraERC4626WrapperVault
+from eth_defi.erc_4626.vault_protocol.summer.vault import SummerVault
 from eth_defi.erc_4626.vault_protocol.term_finance.vault import TermFinanceVault
+from eth_defi.erc_4626.vault_protocol.threejane.vault import ThreeJaneVault
 from eth_defi.erc_4626.vault_protocol.upshift.vault import UpshiftVault
 from eth_defi.erc_4626.vault_protocol.usdai.vault import StakedUSDaiVault
-from eth_defi.vault.base import WithdrawalDelayType
+from eth_defi.erc_4626.vault_protocol.usdd.vault import USSDVault
+from eth_defi.erc_4626.vault_protocol.yearn.compounder import YearnCompounderVault
+from eth_defi.erc_4626.vault_protocol.yearn.morpho_compounder import YearnMorphoCompounderStrategy
+from eth_defi.erc_4626.vault_protocol.yearn.vault import YearnV3Vault
+from eth_defi.vault.base import INSTANT_WITHDRAWAL_PERIOD, WithdrawalDelayType
 
 
 def _call(value: int) -> SimpleNamespace:
@@ -116,18 +142,56 @@ def test_usdai_withdrawal_period_is_redemption_window() -> None:
     assert period.delay_type is WithdrawalDelayType.epoch
 
 
+def test_zero_legacy_lockup_can_use_a_non_instant_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """3Jane keeps its explicit cooldown lifecycle when the senior tranche is unlocked."""
+    vault = object.__new__(ThreeJaneVault)
+    monkeypatch.setattr(ThreeJaneVault, "get_estimated_lock_up", lambda _vault: datetime.timedelta(0))
+
+    period = vault.get_withdrawal_period()
+
+    assert period.min_period == datetime.timedelta(0)
+    assert period.max_period == datetime.timedelta(0)
+    assert period.delay_type is WithdrawalDelayType.delay
+
+
 @pytest.mark.parametrize(
     "vault_class",
     [
         AaveVault,
+        AutoPoolVault,
         BrinkVault,
         CurvanceVault,
+        DeltrVault,
         DolomiteVault,
+        EulerVault,
+        EulerEarnVault,
+        FluidVault,
         FoxifyVault,
+        FraxVault,
         GearboxVault,
+        GoatVault,
+        HarvestVault,
+        WrappedHLPVault,
+        HypurrFiVault,
+        InverseFinanceVault,
+        KilnVault,
+        LlamaLendVault,
+        MorphoV1Vault,
+        MorphoV2Vault,
+        ResolvVault,
+        SBOLDVault,
         SentimentVault,
+        SiloVault,
         SingularityVault,
+        SkyVault,
+        SparkVault,
+        SpectraERC4626WrapperVault,
+        SummerVault,
         TermFinanceVault,
+        USSDVault,
+        YearnCompounderVault,
+        YearnMorphoCompounderStrategy,
+        YearnV3Vault,
     ],
 )
 def test_direct_redemption_vaults_export_instant_period(vault_class: type) -> None:
@@ -136,6 +200,7 @@ def test_direct_redemption_vaults_export_instant_period(vault_class: type) -> No
 
     period = vault.get_withdrawal_period()
 
+    assert period is INSTANT_WITHDRAWAL_PERIOD
     assert period.min_period == datetime.timedelta(0)
     assert period.max_period == datetime.timedelta(0)
     assert period.delay_type is WithdrawalDelayType.instant

--- a/tests/erc_4626/vault_protocol/test_withdrawal_period.py
+++ b/tests/erc_4626/vault_protocol/test_withdrawal_period.py
@@ -8,10 +8,12 @@ import pytest
 from eth_defi.erc_4626.vault_protocol.aave.vault import AaveVault
 from eth_defi.erc_4626.vault_protocol.autopool.vault import AutoPoolVault
 from eth_defi.erc_4626.vault_protocol.brink.vault import BrinkVault
+from eth_defi.erc_4626.vault_protocol.bulla.vault import BullaVault
 from eth_defi.erc_4626.vault_protocol.curvance.vault import CurvanceVault
 from eth_defi.erc_4626.vault_protocol.d2.vault import D2Vault
 from eth_defi.erc_4626.vault_protocol.deltr.vault import DeltrVault
 from eth_defi.erc_4626.vault_protocol.dolomite.vault import DolomiteVault
+from eth_defi.erc_4626.vault_protocol.ember.vault import EmberVault
 from eth_defi.erc_4626.vault_protocol.euler.vault import EulerEarnVault, EulerVault
 from eth_defi.erc_4626.vault_protocol.fluid.vault import FluidVault
 from eth_defi.erc_4626.vault_protocol.foxify.vault import FoxifyVault
@@ -167,6 +169,35 @@ def test_lagoon_withdrawal_period_exports_non_binding_settlement_estimate() -> N
     assert period.max_period is None
     assert period.delay_type is WithdrawalDelayType.delay
     assert period.estimated_settlement == datetime.timedelta(days=1)
+
+
+def test_ember_withdrawal_period_exports_non_binding_settlement_estimate() -> None:
+    """Ember exports its API's queued-redemption service estimate only."""
+    vault = object.__new__(EmberVault)
+    vault.__dict__["ember_metadata"] = {"withdrawal_period_days": 4}
+
+    period = vault.get_withdrawal_period()
+
+    assert period is not None
+    assert period.min_period is None
+    assert period.max_period is None
+    assert period.delay_type is WithdrawalDelayType.delay
+    assert period.estimated_settlement == datetime.timedelta(days=4)
+
+
+def test_bulla_withdrawal_period_exports_non_binding_redemption_estimate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bulla exports its address-scoped public average without fabricating a bound."""
+    vault = object.__new__(BullaVault)
+    metadata = SimpleNamespace(average_redemption_period_days=30)
+    monkeypatch.setattr(BullaVault, "bulla_metadata", property(lambda _vault: metadata))
+
+    period = vault.get_withdrawal_period()
+
+    assert period is not None
+    assert period.min_period is None
+    assert period.max_period is None
+    assert period.delay_type is WithdrawalDelayType.delay
+    assert period.estimated_settlement == datetime.timedelta(days=30)
 
 
 @pytest.mark.parametrize(

--- a/tests/erc_4626/vault_protocol/test_withdrawal_period.py
+++ b/tests/erc_4626/vault_protocol/test_withdrawal_period.py
@@ -5,10 +5,19 @@ from types import SimpleNamespace
 
 import pytest
 
+from eth_defi.erc_4626.vault_protocol.aave.vault import AaveVault
+from eth_defi.erc_4626.vault_protocol.brink.vault import BrinkVault
+from eth_defi.erc_4626.vault_protocol.curvance.vault import CurvanceVault
 from eth_defi.erc_4626.vault_protocol.d2.vault import D2Vault
+from eth_defi.erc_4626.vault_protocol.dolomite.vault import DolomiteVault
+from eth_defi.erc_4626.vault_protocol.foxify.vault import FoxifyVault
 from eth_defi.erc_4626.vault_protocol.gains.vault import GainsVault, OstiumVault, OstiumVersion
+from eth_defi.erc_4626.vault_protocol.gearbox.vault import GearboxVault
 from eth_defi.erc_4626.vault_protocol.kiloex.vault import KiloExVault
 from eth_defi.erc_4626.vault_protocol.nara.vault import NaraVault
+from eth_defi.erc_4626.vault_protocol.sentiment.vault import SentimentVault
+from eth_defi.erc_4626.vault_protocol.singularity.vault import SingularityVault
+from eth_defi.erc_4626.vault_protocol.term_finance.vault import TermFinanceVault
 from eth_defi.erc_4626.vault_protocol.upshift.vault import UpshiftVault
 from eth_defi.erc_4626.vault_protocol.usdai.vault import StakedUSDaiVault
 from eth_defi.vault.base import WithdrawalDelayType
@@ -105,3 +114,28 @@ def test_usdai_withdrawal_period_is_redemption_window() -> None:
     assert period.min_period == datetime.timedelta(0)
     assert period.max_period == datetime.timedelta(days=30)
     assert period.delay_type is WithdrawalDelayType.epoch
+
+
+@pytest.mark.parametrize(
+    "vault_class",
+    [
+        AaveVault,
+        BrinkVault,
+        CurvanceVault,
+        DolomiteVault,
+        FoxifyVault,
+        GearboxVault,
+        SentimentVault,
+        SingularityVault,
+        TermFinanceVault,
+    ],
+)
+def test_direct_redemption_vaults_export_instant_period(vault_class: type) -> None:
+    """Direct ERC-4626 adapters do not conflate a liquidity limit with a delay."""
+    vault = object.__new__(vault_class)
+
+    period = vault.get_withdrawal_period()
+
+    assert period.min_period == datetime.timedelta(0)
+    assert period.max_period == datetime.timedelta(0)
+    assert period.delay_type is WithdrawalDelayType.instant

--- a/tests/erc_4626/vault_protocol/test_withdrawal_period.py
+++ b/tests/erc_4626/vault_protocol/test_withdrawal_period.py
@@ -25,6 +25,7 @@ from eth_defi.erc_4626.vault_protocol.hypurrfi.vault import HypurrFiVault
 from eth_defi.erc_4626.vault_protocol.inverse_finance.vault import InverseFinanceVault
 from eth_defi.erc_4626.vault_protocol.kiln.vault import KilnVault
 from eth_defi.erc_4626.vault_protocol.kiloex.vault import KiloExVault
+from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
 from eth_defi.erc_4626.vault_protocol.llama_lend.vault import LlamaLendVault
 from eth_defi.erc_4626.vault_protocol.morpho.vault_v1 import MorphoV1Vault
 from eth_defi.erc_4626.vault_protocol.morpho.vault_v2 import MorphoV2Vault
@@ -152,6 +153,20 @@ def test_zero_legacy_lockup_can_use_a_non_instant_lifecycle(monkeypatch: pytest.
     assert period.min_period == datetime.timedelta(0)
     assert period.max_period == datetime.timedelta(0)
     assert period.delay_type is WithdrawalDelayType.delay
+
+
+def test_lagoon_withdrawal_period_exports_non_binding_settlement_estimate() -> None:
+    """Lagoon leaves contractual timing empty and exports curator cadence only."""
+    vault = object.__new__(LagoonVault)
+    vault.__dict__["lagoon_metadata"] = {"average_settlement": 86_400}
+
+    period = vault.get_withdrawal_period()
+
+    assert period is not None
+    assert period.min_period is None
+    assert period.max_period is None
+    assert period.delay_type is WithdrawalDelayType.delay
+    assert period.estimated_settlement == datetime.timedelta(days=1)
 
 
 @pytest.mark.parametrize(

--- a/tests/erc_4626/vault_protocol/test_withdrawal_period.py
+++ b/tests/erc_4626/vault_protocol/test_withdrawal_period.py
@@ -7,7 +7,10 @@ import pytest
 
 from eth_defi.erc_4626.vault_protocol.d2.vault import D2Vault
 from eth_defi.erc_4626.vault_protocol.gains.vault import GainsVault, OstiumVault, OstiumVersion
+from eth_defi.erc_4626.vault_protocol.kiloex.vault import KiloExVault
+from eth_defi.erc_4626.vault_protocol.nara.vault import NaraVault
 from eth_defi.erc_4626.vault_protocol.upshift.vault import UpshiftVault
+from eth_defi.erc_4626.vault_protocol.usdai.vault import StakedUSDaiVault
 from eth_defi.vault.base import WithdrawalDelayType
 
 
@@ -68,3 +71,37 @@ def test_upshift_withdrawal_period_uses_configured_lag_duration() -> None:
     assert period.min_period == datetime.timedelta(days=3)
     assert period.max_period == datetime.timedelta(days=3)
     assert period.delay_type is WithdrawalDelayType.delay
+
+
+def test_kiloex_withdrawal_period_covers_epoch_range() -> None:
+    """KiloEx exports its documented one-to-three epoch range."""
+    vault = object.__new__(KiloExVault)
+
+    period = vault.get_withdrawal_period()
+
+    assert period.min_period == datetime.timedelta(days=3)
+    assert period.max_period == datetime.timedelta(days=9)
+    assert period.delay_type is WithdrawalDelayType.epoch
+
+
+def test_nara_withdrawal_period_uses_cooldown(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Nara exports the live cooldown as a fixed delay."""
+    vault = object.__new__(NaraVault)
+    monkeypatch.setattr(NaraVault, "get_estimated_lock_up", lambda _vault: datetime.timedelta(days=7))
+
+    period = vault.get_withdrawal_period()
+
+    assert period.min_period == datetime.timedelta(days=7)
+    assert period.max_period == datetime.timedelta(days=7)
+    assert period.delay_type is WithdrawalDelayType.delay
+
+
+def test_usdai_withdrawal_period_is_redemption_window() -> None:
+    """USDai exports its thirty-day epoch window."""
+    vault = object.__new__(StakedUSDaiVault)
+
+    period = vault.get_withdrawal_period()
+
+    assert period.min_period == datetime.timedelta(0)
+    assert period.max_period == datetime.timedelta(days=30)
+    assert period.delay_type is WithdrawalDelayType.epoch

--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -467,6 +467,7 @@ def test_calculate_lifetime_metrics_exports_withdrawal_period(
         min_period=datetime.timedelta(days=1),
         max_period=datetime.timedelta(days=3),
         delay_type=WithdrawalDelayType.delay,
+        estimated_settlement=datetime.timedelta(days=2),
     )
 
     metrics = calculate_lifetime_metrics(price_df.loc[price_df["id"] == vault_id], {vault_spec: vault_row})
@@ -476,6 +477,7 @@ def test_calculate_lifetime_metrics_exports_withdrawal_period(
     assert exported["min_withdrawal_period"] == 86_400
     assert exported["max_withdrawal_period"] == 259_200
     assert exported["withdrawal_delay_type"] == "delay"
+    assert exported["estimated_settlement"] == 172_800
 
 
 def test_calculate_lifetime_metrics_defaults_legacy_deposit_permission_to_unknown(


### PR DESCRIPTION
## Why

Withdrawal timing is a user-facing lifecycle property, not a value that can safely be inferred from the legacy lock-up estimate. The follow-up makes `instant` an explicit adapter declaration throughout the audited vault protocols and separates non-binding curator or operator settlement estimates from binding onchain withdrawal timing.

## Lessons learnt

A zero legacy lock-up can still be an asynchronous lifecycle (for example, an unlocked 3Jane tranche). Structured withdrawal metadata must come from the adapter rather than the generic scanner. A curator or operator reported settlement cadence is useful for backtesting but cannot establish request claimability. Adding a field to a slotted dataclass used inside a persisted pickle needs an explicit compatibility migration.

## Summary

- Add a documented `INSTANT_WITHDRAWAL_PERIOD` constant for source-backed, direct ERC-4626 redemption.
- Require each audited direct-redemption adapter to implement `get_withdrawal_period()` and return that constant.
- Do not infer `instant` from a zero legacy lock-up in the scanner.
- Export `estimated_settlement` separately for non-binding, offchain backtesting estimates.
- Add Lagoon, Ember, and reviewed Bulla-pool support for offchain settlement or redemption estimates while retaining null binding min/max periods.
- Add a dry-run-first, backup-protected migration for legacy metadata pickles missing the `estimated_settlement` slot.
- Cover the concrete declarations, settlement estimates, migration, and zero-duration non-instant lifecycle with focused tests.
- Keep the withdrawal-period audit documentation aligned with the exported semantics.

## Related issues and PRs

Follow-up to #1452, which added `min_withdrawal_period`, `max_withdrawal_period`, `withdrawal_delay_type`, and the protocol audit.

## Unrelated CI and test fixes

None.