### PR TITLE
notes: Flag Tulipa USDC misleading valuation

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -86,6 +86,9 @@ class VaultFlag(str, enum.Enum):
     #: Share price is unrealistically high (> $1M), likely a broken contract
     abnormal_share_price = "abnormal_share_price"
 
+    #: Vault reported an incorrect share price because of misleading accounting
+    misleading_valuation = "misleading_valuation"
+
     #: Annualised volatility is unrealistically high
     abnormal_volatility = "abnormal_volatility"
 
@@ -123,6 +126,7 @@ BAD_FLAGS = {
     VaultFlag.unofficial,
     VaultFlag.abnormal_price_on_low_tvl,
     VaultFlag.abnormal_share_price,
+    VaultFlag.misleading_valuation,
     VaultFlag.abnormal_volatility,
     VaultFlag.subvault,
     VaultFlag.irregular_reporting,
@@ -325,6 +329,8 @@ ABNORMAL_TVL = "The TVL on this vault is abnormal"
 
 ABNORMAL_SHARE_PRICE = "Share price is unrealistically high, likely a broken smart contract"
 
+MISLEADING_VALUATION = "This vault incorrectly reported its share price in the past, due to misleading accounting"
+
 ABNORMAL_VOLATILITY = "Annualised volatility is unrealistically high, likely a low-TVL vault with very few trades"
 
 HYPERCORE_VAULT_NOTE = "Profit and loss (PnL) results here differ from the method used on the Hyperliquid website. Instead of raw account PnL, the data is cleaned from deposit/redeem flow and reflects better the actual profitability of the underlying trading activity."
@@ -463,6 +469,8 @@ The system checks your total equity meets the minimum for your tier when you att
 #:
 #: Make sure address is lowercased
 VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
+    # Tulipa USDC
+    "0xce0b790ae0d8cf91e01f3fb69025e14569b574f3": (VaultFlag.misleading_valuation, MISLEADING_VALUATION),
     # Borrowable USDC Deposit, SiloId: 127
     "0x2433d6ac11193b4695d9ca73530de93c538ad18a": (VaultFlag.illiquid, XUSD_MESSAGE),
     # https://tradingstrategy.ai/trading-view/sonic/vaults/borrowable-xusd-deposit-siloid-112

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -32,6 +32,11 @@ def test_eth_strategy_long_duration_flag_is_not_bad_flag() -> None:
     assert get_vault_risk("ETH Strategy", address) == VaultTechnicalRisk.low
 
 
+def test_misleading_valuation_is_bad_flag():
+    """Vaults with misleading historical valuations are blacklisted."""
+    assert VaultFlag.misleading_valuation in BAD_FLAGS
+
+
 def test_oda_fact_risk_is_low() -> None:
     """ODA-FACT protocol risk is classified as low."""
     assert get_vault_risk("Kinexys") == VaultTechnicalRisk.low
@@ -145,6 +150,7 @@ def test_old_mainnet_out_of_gas_contract_is_skipped_by_multicall_blacklist() -> 
 @pytest.mark.parametrize(
     ("address", "protocol", "expected_flag", "expected_note"),
     [
+        ("0xce0b790ae0d8cf91e01f3fb69025e14569b574f3", "Lagoon Finance", VaultFlag.misleading_valuation, "misleading accounting"),
         ("0x4f55e28d36b30a638c3aa1d5cbf9c4ccb3831506", "Silo Finance", VaultFlag.illiquid, "likely illiquid"),
         ("0xae79b0d94e1c53cd2e8160899b8d58ec138d341f", "Silo Finance", VaultFlag.illiquid, "illiquid"),
         ("0xbed7c02887efd6b5eb9a547ac1a4d5e582791647", "<protocol not yet identified>", VaultFlag.abnormal_share_price, "abnormal high returns"),


### PR DESCRIPTION
## Why

Tulipa USDC incorrectly reported its share price in the past because of misleading accounting, so it must be excluded from vault datasets.

## Lessons learnt

Historical share-price reporting can invalidate performance metrics even when a vault is otherwise operational.

## Summary

- Added and blacklisted `VaultFlag.misleading_valuation`.
- Added the default misleading-accounting note.
- Marked Tulipa USDC and added focused regression coverage.

## Related issues and PRs

None.