### PR TITLE
fix: bound HyperCore read precompile eth_call gas

### DIFF
--- a/.claude/.claude
+++ b/.claude/.claude
@@ -1,0 +1,1 @@
+/home/mikko/code/trade-executor/deps/web3-ethereum-defi/.claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- fix: Send an explicit 100k gas limit with the HyperCore `coreUserExists` read precompile call instead of letting the node apply its own `eth_call` gas cap — a failing precompile consumes all remaining gas, so a transient node-side HyperCore read failure was reported as `out of gas: gas exhausted during precompiled contract execution: 300000000`, which reads like a caller mistake and hides the real cause (2026-08-07)
 - feat: Start published Hypercore performance curves only after vault TVL reaches $20,000, preventing insignificant bootstrap capital from producing misleading lifetime drawdowns (2026-08-05)
 - feat: Add a narrowly scoped Hypercore dynamic-vault guard flag, keeping generic anyAsset out of native-vault policy and covering the full Safe execution path on Anvil (2026-08-03)
 

--- a/eth_defi/hyperliquid/evm_escrow.py
+++ b/eth_defi/hyperliquid/evm_escrow.py
@@ -132,6 +132,27 @@ logger = logging.getLogger(__name__)
 #: See PrecompileLib.sol in hyper-evm-lib.
 CORE_USER_EXISTS_ADDRESS = "0x0000000000000000000000000000000000000810"
 
+#: Gas limit sent with HyperCore read precompile ``eth_call`` requests.
+#:
+#: HyperCore read precompiles are cheap - a few thousand gas - so this is a
+#: generous ceiling. It exists to bound the *failure* case, not the success
+#: case: when a node cannot serve a HyperCore read, the precompile fails and
+#: the EVM consumes all remaining gas, which the RPC then reports as an
+#: out-of-gas error quoting whatever limit was in play. An ``eth_call`` with
+#: no ``gas`` field is executed against the node's own RPC gas cap, so a
+#: transient precompile failure surfaces as::
+#:
+#:     {'code': -32003, 'message': 'out of gas: gas exhausted during
+#:      precompiled contract execution: 300000000'}
+#:
+#: That message reads like a caller mistake and hides the real cause, which is
+#: an unhealthy HyperCore view on one upstream node (the same class of
+#: node-dependent precompile behaviour documented in
+#: ``docs/README-hyperevm-goldsky-failure.md``). Sending an explicit small
+#: limit keeps the error honest and stops a node burning a 300M gas cap on a
+#: read that should cost a few thousand.
+CORE_PRECOMPILE_READ_GAS = 100_000
+
 #: Default USDC amount (raw, 6 decimals) for account activation.
 #: New HyperCore accounts incur a ~1 USDC fee, so the minimum
 #: activation deposit must comfortably exceed that.
@@ -189,6 +210,11 @@ def is_account_activated(
         (``CDW.deposit``) are in separate transactions, and the trade
         executor waits for activation receipt before proceeding.
 
+    The read is issued with an explicit
+    :py:data:`CORE_PRECOMPILE_READ_GAS` limit rather than the node's default
+    ``eth_call`` gas cap, so that a node unable to serve the HyperCore read
+    fails fast and legibly instead of reporting a 300M-gas out-of-gas error.
+
     Example::
 
         from eth_defi.hyperliquid.evm_escrow import is_account_activated
@@ -214,6 +240,8 @@ def is_account_activated(
         {
             "to": Web3.to_checksum_address(CORE_USER_EXISTS_ADDRESS),
             "data": "0x" + data.hex(),
+            # Bound the failure case - see CORE_PRECOMPILE_READ_GAS
+            "gas": CORE_PRECOMPILE_READ_GAS,
         }
     )
     provider_name = _get_loggable_rpc_provider_name(web3)

--- a/tests/hyperliquid/test_evm_escrow.py
+++ b/tests/hyperliquid/test_evm_escrow.py
@@ -10,7 +10,11 @@ from eth_defi.erc_4626.vault_protocol.lagoon.deployment import (
     should_enable_hypercore_guard,
     validate_hypercore_guard_config,
 )
+from eth_abi import encode
+
 from eth_defi.hyperliquid.evm_escrow import (
+    CORE_PRECOMPILE_READ_GAS,
+    CORE_USER_EXISTS_ADDRESS,
     HypercorePrecompileReadError,
     _assert_activation_guard_config,
     is_account_activated,
@@ -125,6 +129,44 @@ def test_is_account_activated_reports_empty_precompile_reply(caplog: pytest.LogC
     assert "rpc.hyperliquid.xyz" in str(exc_info.value)
     assert "Last RPC headers" in str(exc_info.value)
     assert "rpc.hyperliquid.xyz" in caplog.text
+
+
+def test_is_account_activated_sends_explicit_precompile_gas_limit():
+    """Test the HyperCore read precompile is called with a bounded gas limit.
+
+    An ``eth_call`` without a ``gas`` field runs against the node's own RPC gas
+    cap. A failing HyperCore precompile consumes all remaining gas, so the cap
+    is what gets reported back, producing a misleading
+    ``out of gas: gas exhausted during precompiled contract execution:
+    300000000`` for a read that should cost a few thousand gas.
+
+    1. Build a fake HyperEVM Web3 object that records the call parameters and
+       returns an ABI-encoded ``True``.
+    2. Call ``is_account_activated()`` for a valid address.
+    3. Verify the call carried an explicit, small gas limit and still decoded.
+    """
+    captured = {}
+
+    def _call(tx: dict) -> bytes:
+        # Mocked because the assertion is about the request we send, which a
+        # live RPC round trip would not expose to the test.
+        captured.update(tx)
+        return encode(["bool"], [True])
+
+    # 1. Build a fake HyperEVM Web3 object that records the call parameters.
+    web3 = SimpleNamespace(
+        provider=SimpleNamespace(endpoint_uri="https://rpc.hyperliquid.xyz/evm"),
+        eth=SimpleNamespace(call=_call),
+    )
+
+    # 2. Call is_account_activated() for a valid address.
+    activated = is_account_activated(web3, "0x49Be988d2090aa221586e9A51cacBA3D3A1eA087")
+
+    # 3. Verify the call carried an explicit, small gas limit and still decoded.
+    assert activated is True
+    assert captured["to"].lower() == CORE_USER_EXISTS_ADDRESS.lower()
+    assert captured["gas"] == CORE_PRECOMPILE_READ_GAS
+    assert CORE_PRECOMPILE_READ_GAS < 1_000_000
 
 
 def _monotonic_time():


### PR DESCRIPTION
## Why

A live `hyper-ai` trade-executor run hit this mid-cycle, between two successful HyperCore vault deposits:

```
Encountered JSON-RPC retryable error
{'code': -32003, 'message': 'out of gas: gas exhausted during precompiled contract execution: 300000000'}
When calling RPC method: eth_call({'to': '0x0000000000000000000000000000000000000810',
                                   'data': '0x...a8f8debb...'}, 'latest')
Provider context: {'chain_id': 999, 'provider': 'edge.goldsky.com'}
Retrying in 5.000000 seconds, retry #1 / 6
```

`0x…0810` is the HyperCore `coreUserExists` read precompile, called by `is_account_activated()` at the start of `setup_trades`. Nothing in the executor was short of gas — every transaction in that cycle carried `gas: 650000` and confirmed. The read itself is trivial and cannot legitimately burn 300M gas.

Two things combined to produce the misleading message:

1. `is_account_activated()` issued its `eth_call` with **no `gas` field**, so the node executed it against its own RPC gas cap — the `300000000` quoted in the error.
2. When a **precompile fails**, the EVM consumes all remaining gas and reports out-of-gas. So a node that could not serve the HyperCore read burned the whole 300M cap and returned an error naming a number that has nothing to do with the caller.

The underlying event is a node-side HyperCore read failure — the same class of node-dependent precompile behaviour already documented in `docs/README-hyperevm-goldsky-failure.md`, where `edge.goldsky.com` fans reads out to ~5 upstreams that each serve their own momentary HyperCore view. It fired ~13 seconds after a vault deposit settled, while HyperCore state for that Safe was actively churning.

The retry path already handled it correctly: `-32003` is classified retryable, the next attempt returned `coreUserExists: True`, and trading continued. Cost was ~6 seconds and one alarming log entry. This PR fixes the *legibility*, not the recovery.

## Lessons learnt

- **An out-of-gas error from an `eth_call` may say nothing about gas.** Precompile failure is an all-remaining-gas consumption event, so the number in the message is whatever limit happened to be in play — here, the node's RPC cap. Reading it as "the caller under-provisioned" sends you chasing the wrong thing entirely.
- **Omitting `gas` on an `eth_call` is not free.** It hands the node a blank cheque for the failure path. An explicit limit costs nothing on the success path and bounds the blast radius on the failure path.
- **HyperCore precompile reads are node-dependent by nature.** They read live HyperCore state, so they are inherently the least deterministic call class on HyperEVM — worth treating as a distinct category with its own diagnostics rather than as ordinary `eth_call` traffic.
- The clue that this was provider-side, not caller-side, was in the log all along: the error arrived immediately after a `Switched RPC providers` line, and the failing provider was named in the context block.

## Summary

- Added `CORE_PRECOMPILE_READ_GAS = 100_000` to `eth_defi/hyperliquid/evm_escrow.py`, documenting why the limit exists (bounding the failure case, not the success case) and quoting the exact error it prevents.
- `is_account_activated()` now sends this explicit gas limit with the `coreUserExists` precompile `eth_call`. HyperCore read precompiles cost a few thousand gas, so 100k is a generous ceiling with no effect on the success path.
- Noted the behaviour in the `is_account_activated()` docstring.
- Added `test_is_account_activated_sends_explicit_precompile_gas_limit`, which captures the outgoing call parameters through a fake Web3 and asserts the request carries a small explicit gas limit and still decodes correctly.
- Changelog entry.

This does not stop the underlying precompile failure — it makes it fail fast and legibly instead of a node burning a 300M gas cap on a read that should cost a few thousand. A follow-up option, not taken here, is to pin HyperCore precompile reads away from the goldsky consensus endpoint using the existing `pin_fallback_provider_by_host()` / `resolve_hyperevm_consensus_failover()` machinery in `multicall_batcher.py`.

## Related issues and PRs

- Builds on the HyperEVM provider analysis in `docs/README-hyperevm-goldsky-failure.md` (goldsky eRPC consensus failures on HyperCore-backed reads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
