### PR TITLE
fix: add Centrifuge SPXA metadata migration

### DIFF
--- a/scripts/erc-4626/migrate-centrifuge-spxa-metadata.py
+++ b/scripts/erc-4626/migrate-centrifuge-spxa-metadata.py
@@ -1,0 +1,369 @@
+"""Persist reviewed Centrifuge SPXA and deSPXA metadata in the vault cache.
+
+The Centrifuge adapter now exposes address-scoped descriptions for the Janus
+Henderson Anemoy S&P 500 SPXA and deSPXA Base vaults, and the SPXA vault has a
+manual ``tokenised_fund`` flag. Existing ``vault-metadata-db.pickle`` rows keep
+their old ``_description``, ``_short_description`` and ``_flags`` values until
+the rows are rescanned or repaired.
+
+This targeted migration updates only those cached metadata fields for the two
+reviewed Base rows. It makes no RPC calls and does not alter vault leads,
+reader state or price Parquet files.
+
+Usage:
+
+.. code-block:: shell
+
+    # Inspect expected changes without writing (the default)
+    source .local-test.env && poetry run python scripts/erc-4626/migrate-centrifuge-spxa-metadata.py
+
+    # Back up and persist the reviewed metadata
+    source .local-test.env && DRY_RUN=false \\
+        poetry run python scripts/erc-4626/migrate-centrifuge-spxa-metadata.py
+
+Environment variables:
+
+- ``VAULT_DB_PATH``: Optional path to ``vault-metadata-db.pickle``.
+- ``DRY_RUN``: Set to ``false`` to write changes. Defaults to ``true``.
+- ``LOG_LEVEL``: Optional console log level. Defaults to ``info``.
+"""
+
+import logging
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from tabulate import tabulate
+
+from eth_defi.erc_4626.vault_protocol.centrifuge.vault import (
+    CENTRIFUGE_VAULT_DESCRIPTION_OVERLAY,
+    DESPXA_BASE_VAULT_ADDRESS,
+    SPXA_BASE_VAULT_ADDRESS,
+)
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.flag import VaultFlag, get_vault_special_flags
+from eth_defi.vault.vaultdb import DEFAULT_VAULT_DATABASE, VaultDatabase, VaultRow
+
+logger = logging.getLogger(__name__)
+
+#: Centrifuge SPXA and deSPXA vault rows are on Base.
+BASE_CHAIN_ID = 8_453
+
+#: Human-readable protocol label used by the cached vault rows.
+CENTRIFUGE_PROTOCOL_NAME = "Centrifuge"
+
+#: Exact cached rows repaired by this migration.
+CENTRIFUGE_SPXA_METADATA_SPECS = (
+    VaultSpec(BASE_CHAIN_ID, SPXA_BASE_VAULT_ADDRESS),
+    VaultSpec(BASE_CHAIN_ID, DESPXA_BASE_VAULT_ADDRESS),
+)
+
+
+@dataclass(slots=True, frozen=True)
+class CentrifugeSPXAMetadataUpdate:
+    """Describe one cached Centrifuge SPXA metadata repair.
+
+    :param spec:
+        Chain and vault address identifying the cached metadata row.
+    :param name:
+        Cached human-readable vault name used for reporting.
+    :param old_short_description:
+        Existing listing description in the metadata cache.
+    :param new_short_description:
+        Reviewed listing description from the Centrifuge adapter overlay.
+    :param old_description:
+        Existing full Markdown description in the metadata cache.
+    :param new_description:
+        Reviewed full Markdown description from the Centrifuge adapter overlay.
+    :param old_flags:
+        Existing persisted vault flag set.
+    :param new_flags:
+        Current adapter-equivalent manual flag set.
+    """
+
+    spec: VaultSpec
+    name: str
+    old_short_description: str | None
+    new_short_description: str
+    old_description: str | None
+    new_description: str
+    old_flags: frozenset[VaultFlag]
+    new_flags: frozenset[VaultFlag]
+
+
+@dataclass(slots=True, frozen=True)
+class CentrifugeSPXAMetadataMigrationResult:
+    """Summarise the targeted Centrifuge SPXA metadata migration.
+
+    :param inspected_rows:
+        Total vault metadata rows in the source cache.
+    :param updates:
+        Rows that were or would be updated.
+    """
+
+    inspected_rows: int
+    updates: tuple[CentrifugeSPXAMetadataUpdate, ...]
+
+
+def parse_boolean_env(value: str | None, *, default: bool) -> bool:
+    """Parse an explicit environment boolean value.
+
+    :param value:
+        Environment value, or ``None`` when unset.
+    :param default:
+        Value to use when ``value`` is unset.
+    :return:
+        Parsed boolean value.
+    """
+
+    if value is None:
+        return default
+
+    normalised_value = value.strip().lower()
+    if normalised_value in {"1", "true", "yes", "on"}:
+        return True
+    if normalised_value in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"Expected a boolean environment value, got {value!r}")
+
+
+def create_backup_path(vault_db_path: Path) -> Path:
+    """Choose a non-overwriting backup path for the metadata cache.
+
+    :param vault_db_path:
+        Existing metadata cache to protect.
+    :return:
+        Sibling backup path that does not already exist.
+    """
+
+    backup_path = vault_db_path.with_suffix(".pickle.bak-centrifuge-spxa-metadata")
+    if not backup_path.exists():
+        return backup_path
+
+    backup_index = 1
+    while True:
+        indexed_backup_path = Path(f"{backup_path}.{backup_index}")
+        if not indexed_backup_path.exists():
+            return indexed_backup_path
+        backup_index += 1
+
+
+def normalise_flags(flags: object) -> frozenset[VaultFlag]:
+    """Normalise a persisted flag collection to enum values.
+
+    Older or externally patched pickles can contain enum values, enum names or
+    enum string values. The migration compares normalised sets so it remains
+    idempotent across those serialisation variants.
+
+    :param flags:
+        Stored ``_flags`` value.
+    :return:
+        Immutable normalised flag set.
+    """
+
+    if not flags:
+        return frozenset()
+
+    normalised_flags = set()
+    for flag in flags:
+        if isinstance(flag, VaultFlag):
+            normalised_flags.add(flag)
+            continue
+
+        if isinstance(flag, str):
+            try:
+                normalised_flags.add(VaultFlag(flag))
+                continue
+            except ValueError:
+                pass
+
+            try:
+                normalised_flags.add(VaultFlag[flag])
+                continue
+            except KeyError:
+                logger.warning("Skipping unknown vault flag string: %s", flag)
+                continue
+
+        logger.warning("Skipping unsupported vault flag value: %r", flag)
+
+    return frozenset(normalised_flags)
+
+
+def format_flags(flags: frozenset[VaultFlag]) -> str:
+    """Format vault flags for tabular reporting.
+
+    :param flags:
+        Normalised flag values.
+    :return:
+        Comma-separated flag values or ``-`` for an empty set.
+    """
+
+    if not flags:
+        return "-"
+    return ", ".join(sorted(flag.value for flag in flags))
+
+
+def get_expected_metadata(spec: VaultSpec) -> tuple[str, str, frozenset[VaultFlag]]:
+    """Resolve the reviewed metadata expected for one target row.
+
+    :param spec:
+        Target Centrifuge vault row.
+    :return:
+        Short description, full description and manual flag set.
+    """
+
+    description_overlay = CENTRIFUGE_VAULT_DESCRIPTION_OVERLAY[spec.vault_address]
+    expected_flags = frozenset(get_vault_special_flags(spec.vault_address, CENTRIFUGE_PROTOCOL_NAME))
+    return description_overlay.short_description, description_overlay.description, expected_flags
+
+
+def collect_centrifuge_spxa_metadata_updates(vault_db: VaultDatabase) -> tuple[CentrifugeSPXAMetadataUpdate, ...]:
+    """Collect reviewed metadata repairs from a metadata cache.
+
+    Both target rows must be present before the migration can continue. This
+    prevents an incomplete or unrelated cache from receiving a partial repair.
+
+    :param vault_db:
+        Persisted vault metadata loaded into memory.
+    :return:
+        Changed rows in deterministic address order.
+    :raises KeyError:
+        If either expected Centrifuge row is absent.
+    """
+
+    missing_specs = sorted(
+        set(CENTRIFUGE_SPXA_METADATA_SPECS).difference(vault_db.rows),
+        key=lambda spec: (spec.chain_id, spec.vault_address),
+    )
+    if missing_specs:
+        formatted_specs = ", ".join(f"{spec.chain_id}-{spec.vault_address}" for spec in missing_specs)
+        raise KeyError(f"Expected Centrifuge SPXA metadata rows are missing: {formatted_specs}")
+
+    updates = []
+    for spec in sorted(CENTRIFUGE_SPXA_METADATA_SPECS, key=lambda item: (item.chain_id, item.vault_address)):
+        row = vault_db.rows[spec]
+        new_short_description, new_description, new_flags = get_expected_metadata(spec)
+        old_short_description = row.get("_short_description")
+        old_description = row.get("_description")
+        old_flags = normalise_flags(row.get("_flags"))
+
+        if (old_short_description, old_description, old_flags) == (new_short_description, new_description, new_flags):
+            continue
+
+        updates.append(
+            CentrifugeSPXAMetadataUpdate(
+                spec=spec,
+                name=str(row.get("Name") or ""),
+                old_short_description=old_short_description,
+                new_short_description=new_short_description,
+                old_description=old_description,
+                new_description=new_description,
+                old_flags=old_flags,
+                new_flags=new_flags,
+            )
+        )
+
+    return tuple(updates)
+
+
+def apply_centrifuge_spxa_metadata_updates(vault_db: VaultDatabase, updates: tuple[CentrifugeSPXAMetadataUpdate, ...]) -> None:
+    """Apply collected Centrifuge metadata repairs in memory.
+
+    :param vault_db:
+        Loaded metadata cache to mutate.
+    :param updates:
+        Reviewed updates collected from the same cache.
+    :return:
+        None.
+    """
+
+    for update in updates:
+        row: VaultRow = vault_db.rows[update.spec]
+        row["_short_description"] = update.new_short_description
+        row["_description"] = update.new_description
+        row["_flags"] = set(update.new_flags)
+
+
+def migrate_centrifuge_spxa_metadata(
+    vault_db_path: Path = DEFAULT_VAULT_DATABASE,
+    *,
+    dry_run: bool,
+) -> CentrifugeSPXAMetadataMigrationResult:
+    """Persist reviewed SPXA and deSPXA metadata in a vault metadata cache.
+
+    The migration is idempotent and writes only ``_short_description``,
+    ``_description`` and ``_flags`` on the two known Base Centrifuge rows. It
+    creates a sibling backup before its first write.
+
+    :param vault_db_path:
+        Existing vault metadata pickle to inspect and optionally update.
+    :param dry_run:
+        Report updates without modifying the pickle when ``True``.
+    :return:
+        Inspection count and changed rows.
+    """
+
+    vault_db = VaultDatabase.read(vault_db_path)
+    updates = collect_centrifuge_spxa_metadata_updates(vault_db)
+    result = CentrifugeSPXAMetadataMigrationResult(inspected_rows=len(vault_db.rows), updates=updates)
+
+    if updates:
+        print(
+            tabulate(
+                [
+                    [
+                        update.spec.chain_id,
+                        update.spec.vault_address,
+                        update.name,
+                        update.old_short_description,
+                        update.new_short_description,
+                        format_flags(update.old_flags),
+                        format_flags(update.new_flags),
+                    ]
+                    for update in updates
+                ],
+                headers=["chain", "address", "name", "old short description", "new short description", "old flags", "new flags"],
+                tablefmt="simple",
+            )
+        )
+
+    if not updates:
+        logger.info("No stale Centrifuge SPXA metadata found in %s", vault_db_path)
+        return result
+    if dry_run:
+        logger.info("DRY RUN: would update %d Centrifuge SPXA metadata rows in %s", len(updates), vault_db_path)
+        return result
+
+    backup_path = create_backup_path(vault_db_path)
+    logger.info("Creating vault metadata backup at %s", backup_path)
+    shutil.copy2(vault_db_path, backup_path)
+    apply_centrifuge_spxa_metadata_updates(vault_db, updates)
+    vault_db.write(vault_db_path)
+    logger.info("Updated %d Centrifuge SPXA metadata rows in %s", len(updates), vault_db_path)
+    return result
+
+
+def main() -> None:
+    """Run the Centrifuge SPXA metadata migration from environment configuration.
+
+    :return:
+        ``None``. Raises if the metadata cache is missing or incomplete.
+    """
+
+    setup_console_logging(default_log_level=os.environ.get("LOG_LEVEL", "info"))
+    vault_db_path = Path(os.environ.get("VAULT_DB_PATH", str(DEFAULT_VAULT_DATABASE))).expanduser()
+    if not vault_db_path.exists():
+        raise FileNotFoundError(f"Vault database not found: {vault_db_path}")
+    dry_run = parse_boolean_env(os.environ.get("DRY_RUN"), default=True)
+    result = migrate_centrifuge_spxa_metadata(vault_db_path, dry_run=dry_run)
+    print(f"Inspected {result.inspected_rows:,} rows and updated {len(result.updates):,} Centrifuge SPXA metadata rows.")
+    if dry_run:
+        print("Dry run - no changes written.")
+    elif result.updates:
+        print(f"Saved migrated vault metadata to {vault_db_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/erc_4626/test_migrate_centrifuge_spxa_metadata.py
+++ b/tests/erc_4626/test_migrate_centrifuge_spxa_metadata.py
@@ -1,0 +1,180 @@
+"""Tests for the targeted Centrifuge SPXA metadata migration."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from eth_defi.erc_4626.vault_protocol.centrifuge.vault import CENTRIFUGE_VAULT_DESCRIPTION_OVERLAY, DESPXA_BASE_VAULT_ADDRESS, SPXA_BASE_VAULT_ADDRESS
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.flag import VaultFlag
+from eth_defi.vault.vaultdb import VaultDatabase
+
+
+def load_migration_module():
+    """Load the Centrifuge SPXA migration script as a test module.
+
+    :return:
+        Loaded migration module.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "erc-4626" / "migrate-centrifuge-spxa-metadata.py"
+    spec = importlib.util.spec_from_file_location("migrate_centrifuge_spxa_metadata", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def create_row(name: str, *, flags: object = None, description: str | None = None, short_description: str | None = None) -> dict:
+    """Create a minimal vault metadata row for migration tests.
+
+    :param name:
+        Persisted vault name.
+    :param flags:
+        Persisted ``_flags`` value.
+    :param description:
+        Persisted long description.
+    :param short_description:
+        Persisted listing description.
+    :return:
+        Compatible minimal metadata row.
+    """
+
+    return {
+        "Name": name,
+        "Protocol": "Centrifuge",
+        "_description": description,
+        "_short_description": short_description,
+        "_flags": flags or set(),
+    }
+
+
+def create_vault_database(migration) -> VaultDatabase:
+    """Create a metadata cache with both target rows and one unrelated row.
+
+    :param migration:
+        Loaded migration module exposing the target specs.
+    :return:
+        Vault database fixture.
+    """
+
+    rows = {
+        VaultSpec(migration.BASE_CHAIN_ID, SPXA_BASE_VAULT_ADDRESS): create_row("Janus Henderson Anemoy S&P500 Fund"),
+        VaultSpec(migration.BASE_CHAIN_ID, DESPXA_BASE_VAULT_ADDRESS): create_row("DeFi Janus Henderson Anemoy S&P500 Fund Token"),
+        VaultSpec(1, "0x0000000000000000000000000000000000000001"): create_row("Unrelated vault", flags={VaultFlag.illiquid}),
+    }
+    return VaultDatabase(rows=rows)
+
+
+def test_centrifuge_spxa_metadata_targets_reviewed_base_rows() -> None:
+    """The migration targets SPXA and deSPXA and derives copy from the adapter."""
+
+    migration = load_migration_module()
+
+    assert migration.CENTRIFUGE_SPXA_METADATA_SPECS == (
+        VaultSpec(8_453, SPXA_BASE_VAULT_ADDRESS),
+        VaultSpec(8_453, DESPXA_BASE_VAULT_ADDRESS),
+    )
+    spxa_short, spxa_description, spxa_flags = migration.get_expected_metadata(VaultSpec(8_453, SPXA_BASE_VAULT_ADDRESS))
+    despxa_short, despxa_description, despxa_flags = migration.get_expected_metadata(VaultSpec(8_453, DESPXA_BASE_VAULT_ADDRESS))
+
+    assert spxa_short == CENTRIFUGE_VAULT_DESCRIPTION_OVERLAY[SPXA_BASE_VAULT_ADDRESS].short_description
+    assert spxa_description == CENTRIFUGE_VAULT_DESCRIPTION_OVERLAY[SPXA_BASE_VAULT_ADDRESS].description
+    assert spxa_flags == frozenset({VaultFlag.tokenised_fund})
+    assert despxa_short == CENTRIFUGE_VAULT_DESCRIPTION_OVERLAY[DESPXA_BASE_VAULT_ADDRESS].short_description
+    assert despxa_description == CENTRIFUGE_VAULT_DESCRIPTION_OVERLAY[DESPXA_BASE_VAULT_ADDRESS].description
+    assert despxa_flags == frozenset()
+
+
+def test_migrate_centrifuge_spxa_metadata_updates_only_target_fields(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The write migration persists reviewed descriptions and current flags."""
+
+    migration = load_migration_module()
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    create_vault_database(migration).write(vault_db_path)
+
+    result = migration.migrate_centrifuge_spxa_metadata(vault_db_path, dry_run=False)
+    captured = capsys.readouterr()
+
+    assert result.inspected_rows == len(migration.CENTRIFUGE_SPXA_METADATA_SPECS) + 1
+    assert {update.spec for update in result.updates} == set(migration.CENTRIFUGE_SPXA_METADATA_SPECS)
+    assert "new short description" in captured.out
+    assert (tmp_path / "vault-metadata-db.pickle.bak-centrifuge-spxa-metadata").exists()
+
+    migrated_db = VaultDatabase.read(vault_db_path)
+    spxa_spec = VaultSpec(migration.BASE_CHAIN_ID, SPXA_BASE_VAULT_ADDRESS)
+    despxa_spec = VaultSpec(migration.BASE_CHAIN_ID, DESPXA_BASE_VAULT_ADDRESS)
+    unrelated_spec = VaultSpec(1, "0x0000000000000000000000000000000000000001")
+
+    assert migrated_db.rows[spxa_spec]["_short_description"] == CENTRIFUGE_VAULT_DESCRIPTION_OVERLAY[SPXA_BASE_VAULT_ADDRESS].short_description
+    assert migrated_db.rows[spxa_spec]["_description"] == CENTRIFUGE_VAULT_DESCRIPTION_OVERLAY[SPXA_BASE_VAULT_ADDRESS].description
+    assert migrated_db.rows[spxa_spec]["_flags"] == {VaultFlag.tokenised_fund}
+    assert migrated_db.rows[despxa_spec]["_short_description"] == CENTRIFUGE_VAULT_DESCRIPTION_OVERLAY[DESPXA_BASE_VAULT_ADDRESS].short_description
+    assert migrated_db.rows[despxa_spec]["_description"] == CENTRIFUGE_VAULT_DESCRIPTION_OVERLAY[DESPXA_BASE_VAULT_ADDRESS].description
+    assert migrated_db.rows[despxa_spec]["_flags"] == set()
+    assert migrated_db.rows[unrelated_spec]["_flags"] == {VaultFlag.illiquid}
+    assert migrated_db.rows[unrelated_spec]["_description"] is None
+
+
+def test_migrate_centrifuge_spxa_metadata_dry_run_does_not_write(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Dry run reports updates without modifying the metadata pickle."""
+
+    migration = load_migration_module()
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    create_vault_database(migration).write(vault_db_path)
+
+    result = migration.migrate_centrifuge_spxa_metadata(vault_db_path, dry_run=True)
+    capsys.readouterr()
+
+    assert len(result.updates) == len(migration.CENTRIFUGE_SPXA_METADATA_SPECS)
+    unchanged_db = VaultDatabase.read(vault_db_path)
+    for spec in migration.CENTRIFUGE_SPXA_METADATA_SPECS:
+        assert unchanged_db.rows[spec]["_description"] is None
+        assert unchanged_db.rows[spec]["_short_description"] is None
+        assert unchanged_db.rows[spec]["_flags"] == set()
+    assert not (tmp_path / "vault-metadata-db.pickle.bak-centrifuge-spxa-metadata").exists()
+
+
+def test_migrate_centrifuge_spxa_metadata_is_idempotent(tmp_path: Path) -> None:
+    """A cache that already contains reviewed metadata is not rewritten."""
+
+    migration = load_migration_module()
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    vault_db = create_vault_database(migration)
+    updates = migration.collect_centrifuge_spxa_metadata_updates(vault_db)
+    migration.apply_centrifuge_spxa_metadata_updates(vault_db, updates)
+    vault_db.write(vault_db_path)
+
+    result = migration.migrate_centrifuge_spxa_metadata(vault_db_path, dry_run=False)
+
+    assert result.updates == ()
+    assert not (tmp_path / "vault-metadata-db.pickle.bak-centrifuge-spxa-metadata").exists()
+
+
+def test_migrate_centrifuge_spxa_metadata_requires_both_target_rows(tmp_path: Path) -> None:
+    """An incomplete cache cannot receive a partial targeted migration."""
+
+    migration = load_migration_module()
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    present_spec = VaultSpec(migration.BASE_CHAIN_ID, SPXA_BASE_VAULT_ADDRESS)
+    VaultDatabase(rows={present_spec: create_row("Janus Henderson Anemoy S&P500 Fund")}).write(vault_db_path)
+
+    with pytest.raises(KeyError, match="Expected Centrifuge SPXA metadata rows are missing"):
+        migration.migrate_centrifuge_spxa_metadata(vault_db_path, dry_run=False)
+
+    assert VaultDatabase.read(vault_db_path).rows[present_spec]["_description"] is None
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(None, True), ("true", True), ("1", True), ("false", False), ("0", False)],
+)
+def test_parse_boolean_env(value: str | None, expected: object) -> None:
+    """The write-mode switch recognises explicit conventional boolean values."""
+
+    migration = load_migration_module()
+
+    assert migration.parse_boolean_env(value, default=True) is expected


### PR DESCRIPTION
## Why

The Janus Henderson Anemoy SPXA and deSPXA Base vault descriptions, plus the SPXA `tokenised_fund` flag, were added to the adapter but existing production `vault-metadata-db.pickle` rows still export null descriptions and empty flags. The website reads the persisted metadata cache, so a metadata-only repair is needed without rescanning prices or touching reader state.

## Lessons learnt

Regenerating top-vault JSON from a stale metadata pickle does not pick up new adapter descriptions or manual flags. The cached rows must be explicitly refreshed or migrated before the frontend can display them.

## Summary

- Add `migrate-centrifuge-spxa-metadata.py` to patch the two reviewed Base Centrifuge rows.
- Persist reviewed `_short_description`, `_description`, and current adapter-equivalent `_flags` for SPXA and deSPXA.
- Keep the migration dry-run-first, idempotent, and protected by a non-overwriting backup.
- Add focused unit coverage for writes, dry runs, idempotence, missing-row protection, and environment boolean parsing.

## Related issues and PRs

- Follows #1448, which added the reviewed Centrifuge SPXA/deSPXA adapter metadata.

## Unrelated CI and test fixes

- None.