### PR TITLE
fix: start Hypercore performance curves at $1,000 NAV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 1.2
 
+- fix: Start initial and post-wipe-out Hypercore performance curves at their first $1,000 NAV observation (2026-08-08)
+
 - feat: Add Yearn Curation curator metadata and automatically attribute all Yearn protocol vaults to Yearn (2026-08-07)
 - feat: Add curator risk-review status and documented incident metadata to the YAML and JSON export schemas (2026-08-07)
 

--- a/eth_defi/research/wrangle_vault_prices.py
+++ b/eth_defi/research/wrangle_vault_prices.py
@@ -67,10 +67,9 @@ MIN_HYPERCORE_RECAPITALISATION_ASSETS = 1_000.0
 
 #: A new Hypercore vault needs this NAV before its performance history is published.
 #:
-#: This is intentionally higher than the recapitalisation threshold. A newly
-#: reconstructed PnL/NAV index needs a material capital base, while a known
-#: post-wipe-out epoch only needs enough capital to resume its existing history.
-MIN_HYPERCORE_INITIAL_TRACKING_ASSETS = 20_000.0
+#: Use the same threshold as a post-wipe-out epoch, so a vault starts its
+#: initial and recovery curves from the first $1,000 NAV observation.
+MIN_HYPERCORE_INITIAL_TRACKING_ASSETS = MIN_HYPERCORE_RECAPITALISATION_ASSETS
 
 #: Ignore isolated zero-NAV observations that recover before this delay.
 MIN_HYPERCORE_RECAPITALISATION_RECOVERY_DELAY = pd.Timedelta(days=7)

--- a/tests/research/test_clean_prices.py
+++ b/tests/research/test_clean_prices.py
@@ -839,7 +839,7 @@ def test_approximate_hypercore_rejects_invalid_configuration() -> None:
 
 
 def test_discard_hypercore_initial_low_tvl_history() -> None:
-    """Only meaningful initial capital starts a Hypercore performance curve."""
+    """A Hypercore performance curve starts at its first $1,000 NAV observation."""
     funded_id = "9999-0xfunded"
     unfunded_id = "9999-0xunfunded"
     evm_id = "1-0xevm"
@@ -864,7 +864,7 @@ def test_discard_hypercore_initial_low_tvl_history() -> None:
     )
 
     messages: list[str] = []
-    result = discard_hypercore_initial_low_tvl_history(prices_df, logger=messages.append, min_tracking_assets=1_000.0)
+    result = discard_hypercore_initial_low_tvl_history(prices_df, logger=messages.append)
 
     funded = result[result["id"] == funded_id]
     assert funded.index.tolist() == [pd.Timestamp("2026-01-03"), pd.Timestamp("2026-01-04")]


### PR DESCRIPTION
## Why

Hypercore price histories are reconstructed PnL/NAV performance indices. A $20,000 initial NAV gate excluded vaults that had already reached a meaningful capital base and delayed the start of others unnecessarily. Use the same $1,000 threshold for an initial history and for a post-wipe-out recovery.

## Lessons learnt

A reconstructed index must establish its basis at a meaningful capital observation. Initial funding and recapitalisation are the same economic boundary for this purpose.

## Summary

- Add Hypercore initial low-TVL history filtering.
- Start initial and post-wipe-out cleaned curves at the first $1,000 NAV observation.
- Preserve raw data and retain all observations after a vault has crossed the threshold.
- Add coverage for initial and post-wipe-out threshold handling.

## Related issues and PRs

Continues #1446, “gate Hypercore curves by initial TVL”.

## Unrelated CI and test fixes

None.