### PR TITLE
fix: manually flag apyUSD depeg

### DIFF
--- a/eth_defi/data/stablecoins/apyusd.yaml
+++ b/eth_defi/data/stablecoins/apyusd.yaml
@@ -44,7 +44,11 @@ peg_rate: ''
 peg_rate_currency: ''
 rate_fetch_failed_at: '2026-07-17T18:45:14'
 rate_fetch_failed_reason: missing_source_currency
-depegged_at: ''
+# Manually marked after apyUSD's $0.9736 low on 26 June 2026. Automatic
+# detection excludes yield-bearing ERC-4626 shares because their USD value is
+# not nominally fixed, but this incident follows the apxUSD collateral depeg
+# and must blacklist apyUSD-denominated vaults.
+depegged_at: '2026-06-26T00:00:00'
 checks:
   twitter_last_post_at: ''
   domain_up_at: ''

--- a/eth_defi/data/stablecoins/apyusd.yaml
+++ b/eth_defi/data/stablecoins/apyusd.yaml
@@ -15,6 +15,13 @@ long_description: |
   Collateral backing consists of a diversified basket of variable-rate perpetual preferred shares from DAT companies (Strategy STRC, Strive SATA) supplemented by cash and short-duration US Treasuries. Apyx publishes monthly third-party attestations prepared by Wolf & Company, P.C., a PCAOB-registered audit firm.
 
   apyUSD launched on Ethereum mainnet in February 2026 and is also deployed on Base. It is listed on [CoinGecko](https://www.coingecko.com/en/coins/apyusd) and tracked on [DefiLlama](https://defillama.com/rwa/asset/apyusd).
+
+  ## Depeg
+
+  apyUSD fell to $0.9736 during the June 2026 Apyx collateral event, alongside
+  the more material apxUSD depeg. [CoinDesk's 4 June report](https://www.coindesk.com/markets/2026/06/04/apyx-s-stablecoin-suffers-a-brief-depeg-protocol-says-its-a-feature-not-bug)
+  documents the STRC-driven discount and explains apyUSD's relationship to its
+  underlying dollar token.
 links:
   homepage: https://apyx.fi/
   coingecko: https://www.coingecko.com/en/coins/apyusd

--- a/tests/feed/test_stablecoin_rate.py
+++ b/tests/feed/test_stablecoin_rate.py
@@ -1463,3 +1463,16 @@ def test_packaged_duplicate_symbol_stablecoins_match_by_contract_only() -> None:
     assert (1, "0x7b43e3875440b44613dc3bc08e7763e6da63c8f8") in depegged_contracts  # StablR USD
     assert (1, "0x5bc25f649fc4e26069ddf4cf4010f9f706c23831") in depegged_contracts  # DefiDollar DUSD
     assert (1, "0x674c6ad92fd080e4004b2312b45f796a192d27a0") in depegged_contracts  # Neutrino USD (USDN)
+
+
+def test_packaged_apyusd_manual_depeg_blacklists_pinned_contracts() -> None:
+    """The manually reviewed apyUSD depeg blacklists both deployed contracts.
+
+    apyUSD is an ERC-4626 yield-bearing share, so automated dollar-peg detection
+    intentionally skips it. A manually set ``depegged_at`` marker must still
+    protect vault discovery from its underlying apxUSD collateral depeg.
+    """
+    depegged_contracts, _depegged_symbols = build_depegged_stablecoin_lookups()
+
+    assert (1, "0x38eeb52f0771140d10c4e9a9a72349a329fe8a6a") in depegged_contracts
+    assert (8453, "0x2c271ddf484ac0386d216eb7eb9ff02d4dc0f6aa") in depegged_contracts


### PR DESCRIPTION
## Why

apyUSD reached $0.9736 during the June 2026 Apyx collateral event. As a yield-bearing ERC-4626 share, it is deliberately excluded from automatic nominal-peg detection, so affected vaults need a reviewed manual depeg marker.

## Lessons learnt

`depegged_at` is a sticky manual override that blacklists every pinned contract address, including yield-bearing tokens. It must be explicitly cleared if the asset recovers.

## Summary

- Mark apyUSD manually depegged from 26 June 2026.
- Add coverage for Ethereum and Base contract blacklisting.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.