### PR TITLE
Add curator vault rankings

### DIFF
--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -163,6 +163,9 @@ class PeriodMetrics:
     #: Rank among vaults in the same protocol (1 = best), based on CAGR
     ranking_protocol: int | None = None
 
+    #: Rank among vaults managed by the same curator (1 = best), based on CAGR
+    ranking_curator: int | None = None
+
     #: Average utilisation over the period (lending vaults only, 0.0–1.0)
     avg_utilisation: Percent | None = None
 
@@ -2296,6 +2299,7 @@ def calculate_vault_rankings(
     results_df: pd.DataFrame,
     min_tvl_chain_protocol: float = 10_000,
     min_tvl_overall: float = 50_000,
+    min_tvl_curator: float = 100,
 ) -> pd.DataFrame:
     """Calculate rankings for all periods inside PeriodMetrics objects.
 
@@ -2306,7 +2310,7 @@ def calculate_vault_rankings(
     - They have no CAGR data (zero or NaN)
     - They have an error_reason set
     - They are blacklisted (risk == VaultTechnicalRisk.blacklisted)
-    - Their period TVL is below the threshold
+    - Their period TVL is below the applicable ranking threshold
 
     :param results_df:
         DataFrame from calculate_lifetime_metrics()
@@ -2317,6 +2321,9 @@ def calculate_vault_rankings(
     :param min_tvl_overall:
         Minimum TVL required for overall rankings (default: $50,000)
 
+    :param min_tvl_curator:
+        Minimum TVL required for curator rankings (default: $100)
+
     :return:
         DataFrame with rankings updated in PeriodMetrics objects
     """
@@ -2326,6 +2333,7 @@ def calculate_vault_rankings(
         # Build Series of CAGR values for this period with different TVL thresholds
         cagr_values_chain_protocol = []
         cagr_values_overall = []
+        cagr_values_curator = []
 
         for idx in results_df.index:
             row = results_df.loc[idx]
@@ -2335,6 +2343,7 @@ def calculate_vault_rankings(
             if pm is None or pm.error_reason is not None:
                 cagr_values_chain_protocol.append(pd.NA)
                 cagr_values_overall.append(pd.NA)
+                cagr_values_curator.append(pd.NA)
                 continue
 
             # Use net CAGR, fall back to gross
@@ -2352,6 +2361,14 @@ def calculate_vault_rankings(
             else:
                 cagr_values_chain_protocol.append(cagr)
 
+            # Curator rankings include smaller vaults, but still omit unknown
+            # curators because there is no meaningful comparison group.
+            has_low_tvl_curator = tvl < min_tvl_curator
+            if is_blacklisted or has_low_tvl_curator or has_no_cagr:
+                cagr_values_curator.append(pd.NA)
+            else:
+                cagr_values_curator.append(cagr)
+
             # Overall rankings use higher TVL threshold
             has_low_tvl_overall = tvl < min_tvl_overall
             if is_blacklisted or has_low_tvl_overall or has_no_cagr:
@@ -2361,11 +2378,13 @@ def calculate_vault_rankings(
 
         cagr_series_chain_protocol = pd.Series(cagr_values_chain_protocol, index=results_df.index)
         cagr_series_overall = pd.Series(cagr_values_overall, index=results_df.index)
+        cagr_series_curator = pd.Series(cagr_values_curator, index=results_df.index)
 
         # Calculate rankings with different series
         overall_ranks = cagr_series_overall.rank(method="min", ascending=False, na_option="keep")
         chain_ranks = cagr_series_chain_protocol.groupby(results_df["chain"]).rank(method="min", ascending=False, na_option="keep")
         protocol_ranks = cagr_series_chain_protocol.groupby(results_df["protocol_slug"]).rank(method="min", ascending=False, na_option="keep")
+        curator_ranks = cagr_series_curator.groupby(results_df["curator_slug"]).rank(method="min", ascending=False, na_option="keep")
 
         # Update PeriodMetrics objects in-place
         for idx in results_df.index:
@@ -2374,6 +2393,7 @@ def calculate_vault_rankings(
                 pm.ranking_overall = int(overall_ranks[idx]) if pd.notna(overall_ranks[idx]) else None
                 pm.ranking_chain = int(chain_ranks[idx]) if pd.notna(chain_ranks[idx]) else None
                 pm.ranking_protocol = int(protocol_ranks[idx]) if pd.notna(protocol_ranks[idx]) else None
+                pm.ranking_curator = int(curator_ranks[idx]) if pd.notna(curator_ranks[idx]) else None
 
     return results_df
 
@@ -2724,6 +2744,7 @@ def format_lifetime_table(
     _del("ranking_overall_3m")
     _del("ranking_chain_3m")
     _del("ranking_protocol_3m")
+    _del("ranking_curator_3m")
 
     # Lending protocol statistics are kept in the table (formatted above)
 

--- a/tests/research/test_vault_metrics.py
+++ b/tests/research/test_vault_metrics.py
@@ -46,6 +46,40 @@ def test_get_trading_strategy_links_use_canonical_vault_routes():
     assert vault_metrics._get_trading_strategy_chain_link("Hypercore") == "https://tradingstrategy.ai/trading-view/vaults/chains/hyperliquid"
 
 
+def test_calculate_vault_rankings_includes_per_curator_ranks_at_one_hundred_dollars() -> None:
+    """Rank eligible vaults within each curator while excluding smaller and unknown groups.
+
+    Curator cohorts deliberately use the lower $100 TVL eligibility threshold,
+    independently of the $10,000 threshold for chain and protocol cohorts.
+    """
+    results_df = pd.DataFrame(
+        {
+            "chain": ["Ethereum"] * 5,
+            "protocol_slug": ["morpho"] * 5,
+            "curator_slug": ["alpha", "alpha", "beta", "alpha", None],
+            "risk": [VaultTechnicalRisk.negligible] * 5,
+            "period_results": [
+                [PeriodMetrics(period="1W", cagr_net=0.10, tvl_end=100)],
+                [PeriodMetrics(period="1W", cagr_net=0.20, tvl_end=100)],
+                [PeriodMetrics(period="1W", cagr_net=0.30, tvl_end=100)],
+                [PeriodMetrics(period="1W", cagr_net=0.40, tvl_end=99)],
+                [PeriodMetrics(period="1W", cagr_net=0.50, tvl_end=100)],
+            ],
+        },
+        index=["alpha-lower", "alpha-higher", "beta", "alpha-too-small", "unknown"],
+    )
+
+    vault_metrics.calculate_vault_rankings(results_df)
+
+    expected_lower_rank = 2
+    expected_best_rank = 1
+    assert results_df.loc["alpha-lower", "period_results"][0].ranking_curator == expected_lower_rank
+    assert results_df.loc["alpha-higher", "period_results"][0].ranking_curator == expected_best_rank
+    assert results_df.loc["beta", "period_results"][0].ranking_curator == expected_best_rank
+    assert results_df.loc["alpha-too-small", "period_results"][0].ranking_curator is None
+    assert results_df.loc["unknown", "period_results"][0].ranking_curator is None
+
+
 def test_calculate_net_profit_accepts_one_hundred_percent_performance_fee() -> None:
     """Euler vaults may charge the valid 100% performance-fee boundary."""
     start = pd.Timestamp("2026-01-01").to_pydatetime()
@@ -390,6 +424,7 @@ def test_calculate_lifetime_metrics(
         assert hasattr(pm, "ranking_overall")
         assert hasattr(pm, "ranking_chain")
         assert hasattr(pm, "ranking_protocol")
+        assert hasattr(pm, "ranking_curator")
         # avg_utilisation must be present on every period (None for non-lending vaults)
         assert hasattr(pm, "avg_utilisation")
 


### PR DESCRIPTION
## Why

Vault performance rankings previously covered overall, chain, and protocol cohorts, but not the vaults managed by the same curator.

## Lessons learnt

Curator rankings need their own $100 TVL eligibility threshold so smaller curated vault sets can be compared without inheriting the $10,000 chain/protocol threshold.

## Summary

- Add `ranking_curator` to period metrics, ranked by CAGR within each known curator.
- Exclude uncurated, blacklisted, invalid, and sub-$100-TVL vaults.
- Add regression and integration coverage.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.