### PR TITLE
feat: export vault settlement estimates

### DIFF
--- a/eth_defi/erc_4626/vault_protocol/d2/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/d2/vault.py
@@ -765,10 +765,12 @@ class D2Vault(ERC4626Vault):
         :return:
             Current epoch-length withdrawal window bounds.
         """
+        epoch_length = self.get_estimated_lock_up()
         return WithdrawalPeriod(
             min_period=datetime.timedelta(0),
-            max_period=self.get_estimated_lock_up(),
+            max_period=epoch_length,
             delay_type=WithdrawalDelayType.epoch,
+            estimated_settlement=epoch_length / 2,
         )
 
     def fetch_observation_time(self) -> datetime.datetime:

--- a/eth_defi/erc_4626/vault_protocol/plutus/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/plutus/vault.py
@@ -19,6 +19,8 @@ from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResu
 from eth_defi.vault.base import (
     DEPOSIT_CLOSED_BY_ADMIN,
     REDEMPTION_CLOSED_BY_ADMIN,
+    WithdrawalDelayType,
+    WithdrawalPeriod,
     VaultHistoricalRead,
     VaultHistoricalReader,
 )
@@ -287,6 +289,20 @@ class PlutusVault(ERC4626Vault):
         We estimate one month lock-up for modelling purposes based on the discussion with Plutus in Discord.
         """
         return datetime.timedelta(days=30)
+
+    def get_withdrawal_period(self) -> WithdrawalPeriod:
+        """Return Plutus' non-binding redemption-settlement estimate.
+
+        Plutus windows are manually controlled and no onchain deadline exists
+        for the upgraded Hedge Vault's asynchronous redemption fulfilment.
+        """
+        # TODO pending real data: 14 days average delay estimated from 30 days cycle.
+        return WithdrawalPeriod(
+            min_period=None,
+            max_period=None,
+            delay_type=WithdrawalDelayType.delay,
+            estimated_settlement=datetime.timedelta(days=14),
+        )
 
     def get_link(self, referral: str | None = None) -> str:
         # No vault pages

--- a/tests/erc_4626/vault_protocol/test_withdrawal_period.py
+++ b/tests/erc_4626/vault_protocol/test_withdrawal_period.py
@@ -32,6 +32,7 @@ from eth_defi.erc_4626.vault_protocol.llama_lend.vault import LlamaLendVault
 from eth_defi.erc_4626.vault_protocol.morpho.vault_v1 import MorphoV1Vault
 from eth_defi.erc_4626.vault_protocol.morpho.vault_v2 import MorphoV2Vault
 from eth_defi.erc_4626.vault_protocol.nara.vault import NaraVault
+from eth_defi.erc_4626.vault_protocol.plutus.vault import PlutusVault
 from eth_defi.erc_4626.vault_protocol.resolv.vault import ResolvVault
 from eth_defi.erc_4626.vault_protocol.sbold.vault import SBOLDVault
 from eth_defi.erc_4626.vault_protocol.sentiment.vault import SentimentVault
@@ -97,6 +98,19 @@ def test_d2_withdrawal_period_is_epoch_based(monkeypatch: pytest.MonkeyPatch) ->
     assert period.min_period == datetime.timedelta(0)
     assert period.max_period == datetime.timedelta(days=30)
     assert period.delay_type is WithdrawalDelayType.epoch
+    assert period.estimated_settlement == datetime.timedelta(days=15)
+
+
+def test_plutus_withdrawal_period_uses_modelling_estimate() -> None:
+    """Plutus exports its conservative average manual-settlement estimate."""
+    vault = object.__new__(PlutusVault)
+
+    period = vault.get_withdrawal_period()
+
+    assert period.min_period is None
+    assert period.max_period is None
+    assert period.delay_type is WithdrawalDelayType.delay
+    assert period.estimated_settlement == datetime.timedelta(days=14)
 
 
 def test_upshift_withdrawal_period_uses_configured_lag_duration() -> None:


### PR DESCRIPTION
Export `WithdrawalPeriod.estimated_settlement` for the backtesting pipeline.

- D2 derives the average wait as half of its current epoch length.
- Plutus publishes the conservative 14-day estimate pending protocol-specific settlement history.
- Lagoon already exports its reported average settlement through the same field.