### PR TITLE
notes: mark Apostro Resolv illiquid

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -337,6 +337,8 @@ ETHEREALM_USDC_ILLIQUID = "Etherealm USDC is illiquid"
 
 APOSTRO_USDC_FRONTIER_ILLIQUID = "Apostro USDC Frontier is illiquid"
 
+APOSTRO_RESOLV_ILLIQUID = "Apostro Resolv is illiquid"
+
 HYUSDT0_HWHLP_ILLIQUID = "hyUSD₮0 (hwHLP) vault is illiquid"
 
 RESOLV_ILLIQUID = "Resolv vault is illiquid"
@@ -685,6 +687,8 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0xcca902f2d3d265151f123d8ce8fdac38ba9745ed": (VaultFlag.unofficial, MISSING_IN_PROTOCOL_FRONTEND),
     # Apostro USDC Frontier (Euler on Ethereum)
     "0xed9278c5188f37670b33ef3b00729e38260cd5d5": (VaultFlag.illiquid, APOSTRO_USDC_FRONTIER_ILLIQUID),
+    # Apostro Resolv (Euler on Base)
+    "0xc063c3b3625df5f362f60f35b0bcd98e0fa650fb": (VaultFlag.illiquid, APOSTRO_RESOLV_ILLIQUID),
     # Blue Chip USDC Vault (Prime) on Ethereum - Morpho
     "0x74847d0d124ce5c89ca8f4e7547aecd09e86b2e0": (VaultFlag.unofficial, MISSING_IN_PROTOCOL_FRONTEND),
     # VaultMorpho on Ethereum - Morpho

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -105,6 +105,7 @@ def test_old_mainnet_out_of_gas_contract_is_skipped_by_multicall_blacklist() -> 
         ("0x82c4c641ccc38719ae1f0fbd16a64808d838fdfd", "Morpho", VaultFlag.illiquid, "illiquid"),
         ("0x7193794ec82f527efb618ac50c078d348ecba4b6", "Morpho", VaultFlag.illiquid, "illiquid"),
         ("0xed9278c5188f37670b33ef3b00729e38260cd5d5", "Euler", VaultFlag.illiquid, "illiquid"),
+        ("0xc063c3b3625df5f362f60f35b0bcd98e0fa650fb", "Euler", VaultFlag.illiquid, "illiquid"),
         ("0xcbc9b61177444a793b85442d3a953b90f6170b7d", "Euler", VaultFlag.illiquid, "illiquid"),
         ("0x01864ae3c7d5f507cc4c24ca67b4cabbdda37ecd", "Euler", VaultFlag.illiquid, "Stream xUSD"),
         ("0x49c5733d71511a78a3e12925ea832f49031c97e9", "Euler", VaultFlag.illiquid, "Stream xUSD"),


### PR DESCRIPTION
## Why

Apostro Resolv on Euler Base needs an illiquid marker so vault listings exclude it from normal user-facing recommendations.

## Lessons learnt

Vault pages expose their canonical chain ID and EVM address in Open Graph metadata, which is a reliable way to resolve a vault targeted by its human-readable URL.

## Summary

Added an illiquid flag and note for the Apostro Resolv vault on Base.

Extended the vault flag regression matrix for the new Euler entry.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.