### PR TITLE
fix: recover T3tris Robinhood vaults

### DIFF
--- a/eth_defi/erc_4626/classification.py
+++ b/eth_defi/erc_4626/classification.py
@@ -518,7 +518,7 @@ CHAIN_RESTRICTED_PROBES: dict[str, set[int]] = {
     "DEPLOYER_ADDRESS": {1, 42161},  # Fraxlend - Ethereum, Arbitrum
     "shareManager": MELLOW_CORE_CHAIN_IDS,  # Mellow Core - Ethereum, Plasma, Arbitrum, Monad
     "getAssetCount": MELLOW_CORE_CHAIN_IDS,  # Mellow Core - Ethereum, Plasma, Arbitrum, Monad
-    "getGrossTVL": {42161},  # T3tris - Arbitrum
+    "getGrossTVL": {42161, 4663},  # T3tris - Arbitrum, Robinhood
     # Two chain protocols
     "claimableKeeper": {137, 42161},  # Untangle Finance - Polygon, Arbitrum
     # Three chain protocols
@@ -894,7 +894,7 @@ def create_probe_calls(
             data=b"",
             extra_data=None,
         )
-        # T3tris - ERC-4626-derived asynchronous vaults on Arbitrum.
+        # T3tris - ERC-4626-derived asynchronous vaults on Arbitrum and Robinhood.
         # Live app ABI exposes this protocol-specific accounting getter.
         # https://app.t3tris.finance/vaults
         if _should_yield_probe("getGrossTVL", chain_id):

--- a/eth_defi/erc_4626/scan.py
+++ b/eth_defi/erc_4626/scan.py
@@ -222,7 +222,11 @@ def _export_denomination_token(vault: VaultBase) -> dict | None:
 
 
 def _fetch_activity_status(vault: VaultBase, total_assets: Decimal | None) -> dict[str, object]:
-    """Fetch deposit and redemption status fields for sizeable vaults.
+    """Fetch current deposit status and sizeable-vault activity fields.
+
+    Deposit availability is always collected when an adapter has an
+    authoritative state read. Closure reasons, redemption state and opening
+    schedules remain limited to sizeable vaults to control scan cost.
 
     :param vault:
         Vault adapter instance.
@@ -235,11 +239,17 @@ def _fetch_activity_status(vault: VaultBase, total_assets: Decimal | None) -> di
     """
 
     status = {
+        "_deposits_open": None,
         "_deposit_closed_reason": None,
         "_redemption_closed_reason": None,
         "_deposit_next_open": None,
         "_redemption_next_open": None,
     }
+
+    # Deposit availability is compact current metadata, not a costly activity
+    # diagnostic. In particular, T3tris needs this field even for a new or
+    # empty vault whose native async flow makes ERC-4626 maxDeposit unusable.
+    status["_deposits_open"] = _best_effort_vault_read(vault.fetch_deposit_open)
 
     if total_assets is None or total_assets <= ACTIVITY_STATUS_MIN_NAV:
         return status

--- a/eth_defi/erc_4626/scan.py
+++ b/eth_defi/erc_4626/scan.py
@@ -249,7 +249,9 @@ def _fetch_activity_status(vault: VaultBase, total_assets: Decimal | None) -> di
     # Deposit availability is compact current metadata, not a costly activity
     # diagnostic. In particular, T3tris needs this field even for a new or
     # empty vault whose native async flow makes ERC-4626 maxDeposit unusable.
-    status["_deposits_open"] = _best_effort_vault_read(vault.fetch_deposit_open)
+    fetch_deposit_open = getattr(vault, "fetch_deposit_open", None)
+    if fetch_deposit_open is not None:
+        status["_deposits_open"] = _best_effort_vault_read(fetch_deposit_open)
 
     if total_assets is None or total_assets <= ACTIVITY_STATUS_MIN_NAV:
         return status

--- a/eth_defi/erc_4626/vault.py
+++ b/eth_defi/erc_4626/vault.py
@@ -1511,19 +1511,36 @@ class ERC4626Vault(VaultBase):
 
         :return:
             Human-readable string if deposits are closed/restricted,
-            or None if deposits are open (maxDeposit > 0).
+            or ``None`` if deposits are open or this adapter cannot safely use
+            zero-address ``maxDeposit`` as a global availability read.
+        """
+        deposits_open = self.fetch_deposit_open()
+        if deposits_open is False:
+            return f"{DEPOSIT_CLOSED_CAP_REACHED} (maxDeposit=0)"
+        return None
+
+    def fetch_deposit_open(self) -> bool | None:
+        """Read global deposit availability through ``maxDeposit(address(0))``.
+
+        ERC-4626 only makes this inference for adapters that explicitly opt in
+        through :py:meth:`can_check_deposit`.  Async vaults and vaults with
+        account-dependent admission must override this method with their own
+        authoritative state instead of treating zero-address ``maxDeposit`` as
+        a capacity cap.
+
+        :return:
+            ``True`` or ``False`` when the ERC-4626 implementation supports
+            the global check, otherwise ``None``.
         """
         if not self.can_check_deposit():
             return None
 
         try:
             max_deposit_raw = self.vault_contract.functions.maxDeposit(ZERO_ADDRESS_STR).call()
-            if max_deposit_raw == 0:
-                return f"{DEPOSIT_CLOSED_CAP_REACHED} (maxDeposit=0)"
+        except (BadFunctionCallOutput, ContractLogicError, ValueError, Web3Exception):
+            return None
 
-            return None  # Deposits are open
-        except Exception:
-            return None  # Cannot determine, assume open
+        return max_deposit_raw > 0
 
     def fetch_redemption_closed_reason(self) -> str | None:
         """Check if redemptions are closed using maxRedeem(address(0)).

--- a/eth_defi/erc_4626/vault.py
+++ b/eth_defi/erc_4626/vault.py
@@ -1514,33 +1514,17 @@ class ERC4626Vault(VaultBase):
             or ``None`` if deposits are open or this adapter cannot safely use
             zero-address ``maxDeposit`` as a global availability read.
         """
-        deposits_open = self.fetch_deposit_open()
-        if deposits_open is False:
-            return f"{DEPOSIT_CLOSED_CAP_REACHED} (maxDeposit=0)"
-        return None
-
-    def fetch_deposit_open(self) -> bool | None:
-        """Read global deposit availability through ``maxDeposit(address(0))``.
-
-        ERC-4626 only makes this inference for adapters that explicitly opt in
-        through :py:meth:`can_check_deposit`.  Async vaults and vaults with
-        account-dependent admission must override this method with their own
-        authoritative state instead of treating zero-address ``maxDeposit`` as
-        a capacity cap.
-
-        :return:
-            ``True`` or ``False`` when the ERC-4626 implementation supports
-            the global check, otherwise ``None``.
-        """
         if not self.can_check_deposit():
             return None
 
         try:
             max_deposit_raw = self.vault_contract.functions.maxDeposit(ZERO_ADDRESS_STR).call()
-        except (BadFunctionCallOutput, ContractLogicError, ValueError, Web3Exception):
+        except (BadFunctionCallOutput, ContractLogicError, HTTPError, OSError, ValueError, Web3Exception):
             return None
 
-        return max_deposit_raw > 0
+        if max_deposit_raw == 0:
+            return f"{DEPOSIT_CLOSED_CAP_REACHED} (maxDeposit=0)"
+        return None
 
     def fetch_redemption_closed_reason(self) -> str | None:
         """Check if redemptions are closed using maxRedeem(address(0)).

--- a/eth_defi/erc_4626/vault_protocol/t3tris/README-t3tris.md
+++ b/eth_defi/erc_4626/vault_protocol/t3tris/README-t3tris.md
@@ -423,8 +423,8 @@ Example vaults seen in the API:
 | --- | --- |
 | `0x394c4db21b6b429848e123272f206f1f9d8d74b0` | Arbitrum USDC test vault with non-zero accounting and pending deposits during research |
 | `0x98e43a491a464f0886bc5e57207c340bbed0d01f` | Arbitrum USDC vault observed in earlier app data |
-| `0x5b93dd3eb7fd224565498045f5e1a2ebda49e672` | Robinhood Morini vault; first T3tris configuration event at block 27,650,917 |
-| `0xd4d607239dcbdb5cc3a301266433810bb63c63bf` | Robinhood Kingfisher vault; first T3tris configuration event at block 21,034,332 |
+| `0x5b93dd3eb7fd224565498045f5e1a2ebda49e672` | Robinhood Morini vault; first seen in the API at block 27,650,917 |
+| `0xd4d607239dcbdb5cc3a301266433810bb63c63bf` | Robinhood Kingfisher vault; first seen in the API at block 21,034,332 |
 
 ## ABI files and sources
 

--- a/eth_defi/erc_4626/vault_protocol/t3tris/README-t3tris.md
+++ b/eth_defi/erc_4626/vault_protocol/t3tris/README-t3tris.md
@@ -411,9 +411,11 @@ Example discovery query:
 }
 ```
 
-As of the initial research, the app-indexed live vaults were on Arbitrum
-(`chainId = 42161`) and shared protocol address
-`0x0000000000cc53b5fd649b80f08b05405779cc71`.
+The initial app-indexed live vaults were on Arbitrum (`chainId = 42161`) and
+shared protocol address `0x0000000000cc53b5fd649b80f08b05405779cc71`. T3tris
+also deploys vaults on Robinhood Chain (`chainId = 4663`); the scanner supports
+both chains. Robinhood vaults must be classified through their T3tris
+``getGrossTVL`` interface, rather than treated as generic ERC-4626 vaults.
 
 Example vaults seen in the API:
 
@@ -421,6 +423,8 @@ Example vaults seen in the API:
 | --- | --- |
 | `0x394c4db21b6b429848e123272f206f1f9d8d74b0` | Arbitrum USDC test vault with non-zero accounting and pending deposits during research |
 | `0x98e43a491a464f0886bc5e57207c340bbed0d01f` | Arbitrum USDC vault observed in earlier app data |
+| `0x5b93dd3eb7fd224565498045f5e1a2ebda49e672` | Robinhood Morini vault; first T3tris configuration event at block 27,650,917 |
+| `0xd4d607239dcbdb5cc3a301266433810bb63c63bf` | Robinhood Kingfisher vault; first T3tris configuration event at block 21,034,332 |
 
 ## ABI files and sources
 

--- a/eth_defi/erc_4626/vault_protocol/t3tris/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/t3tris/vault.py
@@ -26,7 +26,7 @@ from eth_defi.erc_4626.vault import ERC4626HistoricalReader, ERC4626Vault
 from eth_defi.erc_4626.vault_protocol.t3tris.offchain_metadata import T3trisVaultMetadata, fetch_t3tris_vault_metadata
 from eth_defi.event_reader.conversion import convert_int256_bytes_to_int, convert_uint256_bytes_to_address
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
-from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader
+from eth_defi.vault.base import DEPOSIT_CLOSED_BY_ADMIN, VaultHistoricalRead, VaultHistoricalReader
 
 logger = logging.getLogger(__name__)
 
@@ -71,9 +71,10 @@ class T3trisHistoricalReader(ERC4626HistoricalReader):
 
     PPS scenarios handled by this reader:
 
-    - **Sync/open vault:** ``isVaultOpen()`` returns ``True``. T3tris is using
-      live vault accounting, so the generic ERC-4626 PPS is already the
-      effective PPS. No stale-NAV correction is applied.
+    - **Synchronous-accounting vault:** ``isVaultOpen()`` returns ``True``.
+      T3tris is using live vault accounting, so the generic ERC-4626 PPS is
+      already the effective PPS. This mode flag is not deposit availability;
+      no stale-NAV correction is applied.
     - **Normal async vault:** ``isVaultOpen()`` returns ``False`` but supply and
       PPS move without a large supply-driven collapse. The raw
       ``convertToAssets(1 share)`` value is accepted and stored as the next
@@ -140,7 +141,8 @@ class T3trisHistoricalReader(ERC4626HistoricalReader):
         """Get on-chain calls needed for corrected T3tris historical prices.
 
         In addition to the generic ERC-4626 calls we read ``isVaultOpen()`` to
-        distinguish sync and async vault modes, and
+        distinguish sync and async vault modes, ``isDepositEnabled()`` for the
+        protocol-defined historical deposit state, and
         ``lastValuationTimestamp()`` from the configured oracle to observe
         valuation refreshes.
 
@@ -153,6 +155,15 @@ class T3trisHistoricalReader(ERC4626HistoricalReader):
             self.vault.vault_contract.functions.isVaultOpen(),
             extra_data={
                 "function": "isVaultOpen",
+                "vault": self.vault.address,
+            },
+            first_block_number=self.first_block,
+        )
+
+        yield EncodedCall.from_contract_call(
+            self.vault.vault_contract.functions.isDepositEnabled(),
+            extra_data={
+                "function": "isDepositEnabled",
                 "vault": self.vault.address,
             },
             first_block_number=self.first_block,
@@ -321,7 +332,7 @@ class T3trisHistoricalReader(ERC4626HistoricalReader):
         stale_nav_gap = async_vault and (starts_new_gap or continues_existing_gap)
         return stale_nav_gap, possible_first_gap_sample
 
-    def process_result(
+    def process_result(  # noqa: PLR0914
         self,
         block_number: int,
         timestamp: datetime.datetime,
@@ -390,6 +401,7 @@ class T3trisHistoricalReader(ERC4626HistoricalReader):
         share_price, total_supply, total_assets, errors, max_deposit, reader_state = self._process_core_without_state_update(call_by_name)
 
         is_vault_open = self._decode_bool_call(call_by_name, "isVaultOpen", errors)
+        deposits_open = self._decode_bool_call(call_by_name, "isDepositEnabled", errors)
         last_valuation_timestamp = self._decode_uint_call(call_by_name, "lastValuationTimestamp", errors)
         protocol_reads_failed = is_vault_open is None or last_valuation_timestamp is None
         raw_price_collapsed = self.last_good_share_price is not None and share_price is not None and share_price < self.last_good_share_price * STALE_NAV_SHARE_PRICE_DROP_THRESHOLD
@@ -446,6 +458,7 @@ class T3trisHistoricalReader(ERC4626HistoricalReader):
             management_fee=None,
             errors=errors or None,
             max_deposit=max_deposit,
+            deposits_open=deposits_open,
         )
 
     @staticmethod
@@ -527,6 +540,59 @@ class T3trisVault(ERC4626Vault):
                     attempts=2,
                 )
             )
+
+    def can_check_deposit(self) -> bool:  # noqa: PLR6301
+        """Disable the generic zero-address ``maxDeposit`` availability probe.
+
+        T3tris async vaults return zero from the synchronous ERC-4626 preview
+        method even while they accept ``requestDeposit``.  The native
+        ``isDepositEnabled`` flag is the authoritative vault-wide admission
+        state, so the inherited cap inference must not run.
+
+        :return:
+            Always ``False`` because T3tris does not support the generic
+            ERC-4626 availability interpretation.
+        """
+        return False
+
+    def fetch_deposit_open(self) -> bool | None:
+        """Fetch the native T3tris deposit availability state.
+
+        This state deliberately excludes whitelist policy: a whitelisted vault
+        can be accepting deposits for permitted accounts and is therefore
+        operationally open.  The scanner records its policy separately through
+        :py:meth:`is_whitelisted_deposit`.
+
+        :return:
+            ``True`` when T3tris accepts deposit requests and ``False`` when
+            its administrator has disabled deposits.
+        """
+        return self.vault_contract.functions.isDepositEnabled().call()
+
+    def fetch_deposit_closed_reason(self) -> str | None:
+        """Explain a native T3tris deposit closure.
+
+        T3tris' ERC-4626 ``maxDeposit`` result describes only the synchronous
+        flow and must not be rendered as a global capacity cap for its async
+        request flow.
+
+        :return:
+            Administrative closure reason, or ``None`` when deposit requests
+            are enabled.
+        """
+        return None if self.fetch_deposit_open() else DEPOSIT_CLOSED_BY_ADMIN
+
+    def is_whitelisted_deposit(self) -> bool:
+        """Fetch the vault-wide T3tris deposit whitelist policy.
+
+        This is a policy read, not an account eligibility check.  It remains
+        independent of the deposit-enabled state recorded by
+        :py:meth:`fetch_deposit_open`.
+
+        :return:
+            ``True`` when deposit requests require whitelisting.
+        """
+        return self.vault_contract.functions.isDepositWhitelistEnabled().call()
 
     @property
     def description(self) -> str | None:

--- a/eth_defi/erc_4626/vault_protocol/t3tris/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/t3tris/vault.py
@@ -353,7 +353,8 @@ class T3trisHistoricalReader(ERC4626HistoricalReader):
            update adaptive scanner state. The raw values may be a known-bad
            T3tris stale-NAV sample, so state must only be updated after the
            T3tris correction decision is made.
-        2. Decode ``isVaultOpen()`` and oracle ``lastValuationTimestamp()``.
+        2. Decode ``isVaultOpen()``, ``isDepositEnabled()`` and oracle
+           ``lastValuationTimestamp()``.
            ``isVaultOpen() == True`` means sync/live accounting. ``False`` means
            async/oracle accounting and may need stale-NAV correction.
         3. Reject out-of-order blocks. The stale-NAV detector depends on the
@@ -567,7 +568,7 @@ class T3trisVault(ERC4626Vault):
             ``True`` when T3tris accepts deposit requests and ``False`` when
             its administrator has disabled deposits.
         """
-        return self.vault_contract.functions.isDepositEnabled().call()
+        return self.vault_contract.functions.isDepositEnabled().call(block_identifier=self._get_block_identifier())
 
     def fetch_deposit_closed_reason(self) -> str | None:
         """Explain a native T3tris deposit closure.
@@ -592,7 +593,7 @@ class T3trisVault(ERC4626Vault):
         :return:
             ``True`` when deposit requests require whitelisting.
         """
-        return self.vault_contract.functions.isDepositWhitelistEnabled().call()
+        return self.vault_contract.functions.isDepositWhitelistEnabled().call(block_identifier=self._get_block_identifier())
 
     @property
     def description(self) -> str | None:

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -1904,6 +1904,7 @@ def calculate_vault_record(
     # because PyArrow does not accept None for string columns in the
     # cleaned parquet DataFrame.
     deposit_closed_reason = vault_metadata.get("_deposit_closed_reason")
+    deposits_open = vault_metadata.get("_deposits_open")
     redemption_closed_reason = vault_metadata.get("_redemption_closed_reason")
     deposit_next_open = vault_metadata.get("_deposit_next_open")
     redemption_next_open = vault_metadata.get("_redemption_next_open")
@@ -2329,6 +2330,7 @@ def calculate_vault_record(
             "period_results": period_results,
             # Deposit/redemption status
             "deposit_closed_reason": deposit_closed_reason,
+            "deposits_open": deposits_open,
             "redemption_closed_reason": redemption_closed_reason,
             "deposit_next_open": deposit_next_open,
             "redemption_next_open": redemption_next_open,

--- a/eth_defi/research/vault_metrics.py
+++ b/eth_defi/research/vault_metrics.py
@@ -3030,6 +3030,7 @@ def format_lifetime_table(
             "id": "id",
             "trading_strategy_link": "Link",
             "deposit_closed_reason": "Deposit closed reason",
+            "deposits_open": "Deposits open",
             "redemption_closed_reason": "Redemption closed reason",
             "deposit_next_open": "Deposit next open",
             "redemption_next_open": "Redemption next open",

--- a/eth_defi/vault/base.py
+++ b/eth_defi/vault/base.py
@@ -1654,11 +1654,13 @@ class VaultBase(ABC):
         """Get human-readable reason why deposits are closed.
 
         - Override in protocol-specific subclasses
-        - Default behaviour: assume deposits are always open (return None)
+        - Default behaviour: no closure reason is known (return None)
 
         :return:
             Human-readable string explaining why deposits are closed,
-            or None if deposits are open.
+            or None if deposits are open or the adapter cannot determine a
+            closure reason. Use :py:meth:`fetch_deposit_open` for explicit
+            tri-state availability metadata.
 
             Example reasons:
 
@@ -1666,6 +1668,22 @@ class VaultBase(ABC):
             - "Vault paused by admin"
             - "Max deposit cap reached"
             - "Vault utilisation too high"
+        """
+        return None
+
+    def fetch_deposit_open(self) -> bool | None:  # noqa: PLR6301
+        """Fetch the current protocol-defined deposit availability.
+
+        This is deliberately a tri-state value. ``True`` and ``False`` mean
+        that the adapter read an authoritative vault-wide state; ``None``
+        means that the generic adapter cannot safely determine the state.  It
+        is separate from :py:meth:`fetch_deposit_closed_reason`, because an
+        absent human-readable reason does not prove that deposits are open.
+
+        :return:
+            ``True`` when deposits are open, ``False`` when they are closed,
+            or ``None`` when the protocol does not expose a reliable global
+            availability read.
         """
         return None
 

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -617,15 +617,15 @@ metadata database and reader state; enable price history only after inspecting
 the result.
 
 ```shell
-source ~/vault-scanner/vault-rpc.env && \\
-(cd ~/vault-scanner/web3-ethereum-defi && \\
-  docker compose run --rm \\
-  -e T3TRIS_CHAIN_IDS=4663 \\
-  -e T3TRIS_VAULT_ADDRESSES="0x5b93dd3eb7fd224565498045f5e1a2ebda49e672,0xd4d607239dcbdb5cc3a301266433810bb63c63bf" \\
-  -e T3TRIS_FETCH_API=false \\
-  -e T3TRIS_REFRESH_EXISTING_METADATA=true \\
-  -e T3TRIS_SCAN_PRICES=false \\
-  --entrypoint /bin/bash vault-scanner-oneshot \\
+source ~/vault-scanner/vault-rpc.env && \
+(cd ~/vault-scanner/web3-ethereum-defi && \
+  docker compose run --rm \
+  -e T3TRIS_CHAIN_IDS=4663 \
+  -e T3TRIS_VAULT_ADDRESSES="0x5b93dd3eb7fd224565498045f5e1a2ebda49e672,0xd4d607239dcbdb5cc3a301266433810bb63c63bf" \
+  -e T3TRIS_FETCH_API=false \
+  -e T3TRIS_REFRESH_EXISTING_METADATA=true \
+  -e T3TRIS_SCAN_PRICES=false \
+  --entrypoint /bin/bash vault-scanner-oneshot \
   -lc "python scripts/erc-4626/fix-t3tris-vaults.py")
 ```
 

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -588,6 +588,8 @@ source .local-test.env && poetry run python scripts/erc-4626/fix-t3tris-vaults.p
 | `DRY_RUN` | Optional. Show planned work without writing metadata or prices. Default: false. |
 | `T3TRIS_FETCH_API` | Optional. Fetch the live T3tris API and prefer it over the baked snapshot. Default: true. |
 | `T3TRIS_VERIFIED_ONLY` | Optional. Process only API-verified vaults, while retaining reviewed migration vaults. Default: false. |
+| `T3TRIS_CHAIN_IDS` | Optional. Comma-separated chain IDs that restrict the repair scope. |
+| `T3TRIS_VAULT_ADDRESSES` | Optional. Comma-separated vault addresses that restrict the repair scope. |
 | `T3TRIS_SCAN_PRICES` | Optional. Set to `false` to update only leads and metadata. Default: true. |
 | `T3TRIS_REWRITE_TARGETED` | Optional. Rescan every selected T3tris vault from its first known API block and rewrite only that vault's rows. Default: false. |
 | `T3TRIS_REFRESH_EXISTING_METADATA` | Optional. Refresh existing good metadata rows as well as missing or broken rows. Default: false. |
@@ -600,8 +602,32 @@ source .local-test.env && poetry run python scripts/erc-4626/fix-t3tris-vaults.p
 | `READER_STATE_DATABASE` | Optional. Reader-state pickle path. Default: production reader state DB. |
 
 The script reads RPC URLs using normal `JSON_RPC_<CHAIN_NAME>` variables where
-the chain is known by `eth_defi.chain`. T3tris currently returns Arbitrum vaults,
-so set `JSON_RPC_ARBITRUM` in `.local-test.env`.
+the chain is known by `eth_defi.chain`. T3tris currently has Arbitrum and
+Robinhood deployments, so configure `JSON_RPC_ARBITRUM` and/or
+`JSON_RPC_ROBINHOOD` as needed.
+
+#### Robinhood migration
+
+Use the same targeted migration script for the reviewed Morini and Kingfisher
+vaults on Robinhood. The chain and address filters ensure that it refreshes
+Kingfisher's old generic ERC-4626 row and adds Morini without resetting the
+global discovery cursor or changing unrelated vaults. Run this metadata-only
+repair inside the production one-shot container. This preserves the mounted
+metadata database and reader state; enable price history only after inspecting
+the result.
+
+```shell
+source ~/vault-scanner/vault-rpc.env && \\
+(cd ~/vault-scanner/web3-ethereum-defi && \\
+  docker compose run --rm \\
+  -e T3TRIS_CHAIN_IDS=4663 \\
+  -e T3TRIS_VAULT_ADDRESSES="0x5b93dd3eb7fd224565498045f5e1a2ebda49e672,0xd4d607239dcbdb5cc3a301266433810bb63c63bf" \\
+  -e T3TRIS_FETCH_API=false \\
+  -e T3TRIS_REFRESH_EXISTING_METADATA=true \\
+  -e T3TRIS_SCAN_PRICES=false \\
+  --entrypoint /bin/bash vault-scanner-oneshot \\
+  -lc "python scripts/erc-4626/fix-t3tris-vaults.py")
+```
 
 ### fix-frankencoin-tvl.py
 

--- a/scripts/erc-4626/fix-t3tris-vaults.py
+++ b/scripts/erc-4626/fix-t3tris-vaults.py
@@ -470,6 +470,9 @@ def filter_references(refs: list[T3trisVaultReference]) -> list[T3trisVaultRefer
         refs = [ref for ref in refs if ref.chain_id in chain_ids]
     if addresses is not None:
         refs = [ref for ref in refs if ref.address.lower() in addresses]
+        unmatched_addresses = addresses - {ref.address.lower() for ref in refs}
+        if unmatched_addresses:
+            raise ValueError(f"T3TRIS_VAULT_ADDRESSES did not match selected references: {sorted(unmatched_addresses)}")
 
     if not parse_bool_env("T3TRIS_VERIFIED_ONLY", default=False):
         return refs

--- a/scripts/erc-4626/fix-t3tris-vaults.py
+++ b/scripts/erc-4626/fix-t3tris-vaults.py
@@ -41,6 +41,10 @@ Useful environment variables:
      - Fetch the live T3tris API and prefer it over the baked snapshot. Default: ``true``.
    * - ``T3TRIS_VERIFIED_ONLY``
      - If ``true``, process only API-verified vaults. Default: ``false``.
+   * - ``T3TRIS_CHAIN_IDS``
+     - Optional comma-separated EVM chain IDs to repair.
+   * - ``T3TRIS_VAULT_ADDRESSES``
+     - Optional comma-separated vault addresses to repair.
    * - ``T3TRIS_SCAN_PRICES``
      - If ``false``, update only leads and metadata. Default: ``true``.
    * - ``T3TRIS_REWRITE_TARGETED``
@@ -109,7 +113,7 @@ logger = logging.getLogger(__name__)
 
 T3TRIS_API_URL = "https://api.t3tris.finance/api/v1/vaults"
 USER_AGENT = "web3-ethereum-defi-t3tris-maintenance/1.0"
-SUPPORTED_CHAIN_IDS = {42161}
+SUPPORTED_CHAIN_IDS = {42161, 4663}
 
 #: Baked snapshot from ``GET https://api.t3tris.finance/api/v1/vaults``.
 #:
@@ -152,6 +156,24 @@ T3TRIS_VAULT_SNAPSHOT_JSON = """
       "createdAtBlock": "481469145",
       "createdAtTs": 1783458649,
       "curatorName": null,
+      "verified": true
+    },
+    {
+      "chainId": 4663,
+      "address": "0x5b93dd3eb7fd224565498045f5e1a2ebda49e672",
+      "name": "Morini StockMarketTRBasisTrade Vault",
+      "createdAtBlock": "27650917",
+      "createdAtTs": 1785849175,
+      "curatorName": "Morini Capital",
+      "verified": true
+    },
+    {
+      "chainId": 4663,
+      "address": "0xd4d607239dcbdb5cc3a301266433810bb63c63bf",
+      "name": "The Kingfisher Vault",
+      "createdAtBlock": "21034332",
+      "createdAtTs": 1785185732,
+      "curatorName": "The Kingfisher",
       "verified": true
     }
   ]
@@ -218,6 +240,49 @@ def parse_bool_env(name: str, *, default: bool = False) -> bool:
     if value is None:
         return default
     return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def parse_chain_id_filter() -> set[int] | None:
+    """Parse an optional T3tris repair chain filter from the environment.
+
+    The generic repair normally processes every supported T3tris chain. A
+    migration uses this filter to constrain its writes to one reviewed chain
+    while still reusing the same API and snapshot validation.
+
+    :return:
+        Set of selected EVM chain IDs, or ``None`` when no filter is set.
+
+    :raise ValueError:
+        If the environment value contains an invalid integer chain ID.
+    """
+    value = os.environ.get("T3TRIS_CHAIN_IDS")
+    if not value:
+        return None
+    return {int(chain_id.strip()) for chain_id in value.split(",") if chain_id.strip()}
+
+
+def parse_address_filter() -> set[str] | None:
+    """Parse an optional T3tris repair address filter from the environment.
+
+    Addresses are normalised to lower case so they can be compared with the
+    canonical :py:class:`T3trisVaultReference` specifications without relying
+    on the checksum casing returned by an API.
+
+    :return:
+        Lowercase selected vault addresses, or ``None`` when no filter is set.
+
+    :raise ValueError:
+        If an environment entry is not an EVM address.
+    """
+    value = os.environ.get("T3TRIS_VAULT_ADDRESSES")
+    if not value:
+        return None
+
+    addresses = {address.strip().lower() for address in value.split(",") if address.strip()}
+    invalid_addresses = {address for address in addresses if not Web3.is_address(address)}
+    if invalid_addresses:
+        raise ValueError(f"Invalid T3TRIS_VAULT_ADDRESSES entries: {sorted(invalid_addresses)}")
+    return addresses
 
 
 def parse_optional_int_env(name: str) -> int | None:
@@ -387,7 +452,25 @@ def load_t3tris_vault_references() -> list[T3trisVaultReference]:
 
 
 def filter_references(refs: list[T3trisVaultReference]) -> list[T3trisVaultReference]:
-    """Apply operator filters."""
+    """Apply verified, chain and address filters to repair references.
+
+    Reviewed migration references retain their existing verified-only
+    exemption. Chain and address filters are strict operational scopes and
+    therefore apply to all references, including reviewed migrations.
+
+    :param refs:
+        De-duplicated T3tris references from the API, snapshot and registry.
+
+    :return:
+        References selected for this repair invocation.
+    """
+    chain_ids = parse_chain_id_filter()
+    addresses = parse_address_filter()
+    if chain_ids is not None:
+        refs = [ref for ref in refs if ref.chain_id in chain_ids]
+    if addresses is not None:
+        refs = [ref for ref in refs if ref.address.lower() in addresses]
+
     if not parse_bool_env("T3TRIS_VERIFIED_ONLY", default=False):
         return refs
 

--- a/tests/erc_4626/test_classification.py
+++ b/tests/erc_4626/test_classification.py
@@ -221,6 +221,13 @@ def test_chain_probe_filtering():
     assert _should_yield_probe("strategist", MANTLE) is True
     assert _should_yield_probe("strategist", ETHEREUM_MAINNET) is False
 
+    # T3tris deployments use the same protocol-specific accounting getter on
+    # Arbitrum and Robinhood. Without the Robinhood probe, discovery retains a
+    # generic ERC-4626 lead but cannot instantiate the T3tris adapter.
+    assert _should_yield_probe("getGrossTVL", ARBITRUM) is True
+    assert _should_yield_probe("getGrossTVL", ROBINHOOD) is True
+    assert _should_yield_probe("getGrossTVL", ETHEREUM_MAINNET) is False
+
     # Disabled protocols (empty sets) never yield
     assert _should_yield_probe("outputToLp0Route", ETHEREUM_MAINNET) is False  # Baklava
     assert _should_yield_probe("agent", ARBITRUM) is False  # Astrolab
@@ -243,6 +250,9 @@ def test_chain_probe_filtering():
     func_names_eth = [p.func_name for p in probes_eth]
     assert "strategy" in func_names_eth
     assert "queue" in func_names_eth
+
+    probes_robinhood = list(create_probe_calls([test_address], chain_id=ROBINHOOD))
+    assert "getGrossTVL" in {probe.func_name for probe in probes_robinhood}
 
     royco_tranche_probe_names = ["getRawNAV"]
     assert sum(1 for func_name in func_names_eth if func_name in royco_tranche_probe_names) == 1

--- a/tests/erc_4626/vault_protocol/test_t3tris.py
+++ b/tests/erc_4626/vault_protocol/test_t3tris.py
@@ -97,7 +97,7 @@ class _FakeT3trisCall:
     def __init__(self, *, value: bool):
         self.value = value
 
-    def call(self) -> bool:
+    def call(self, **kwargs) -> bool:
         """Return the configured ABI call result."""
         return self.value
 
@@ -115,6 +115,10 @@ class _FakeT3trisStatusVault:
         functions.isDepositEnabled = lambda: _FakeT3trisCall(value=deposits_open)
         functions.isDepositWhitelistEnabled = lambda: _FakeT3trisCall(value=whitelist_enabled)
         self.vault_contract = type("FakeContract", (), {"functions": functions})()
+
+    def _get_block_identifier(self) -> str:
+        """Use the same latest-state default as a normal vault adapter."""
+        return "latest"
 
 
 def _make_t3tris_reader() -> T3trisHistoricalReader:

--- a/tests/erc_4626/vault_protocol/test_t3tris.py
+++ b/tests/erc_4626/vault_protocol/test_t3tris.py
@@ -3,6 +3,7 @@
 import datetime
 import os
 from decimal import Decimal
+from types import SimpleNamespace
 
 import flaky
 import pytest
@@ -10,12 +11,13 @@ from web3 import Web3
 
 from eth_defi.erc_4626.classification import create_vault_instance_autodetect
 from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.erc_4626.scan import _fetch_activity_status  # noqa: PLC2701
 from eth_defi.erc_4626.vault import ERC4626HistoricalReader
 from eth_defi.erc_4626.vault_protocol.t3tris.vault import STALE_NAV_CORRECTED_ERROR, STALE_NAV_FIRST_SAMPLE_ERROR, T3trisHistoricalReader, T3trisVault
 from eth_defi.event_reader.multicall_batcher import EncodedCall, EncodedCallResult
 from eth_defi.provider.multi_provider import create_multi_provider_web3
 from eth_defi.testing.anvil_fork_pool import AnvilForkPool
-from eth_defi.vault.base import VaultHistoricalRead, VaultHistoricalReader, VaultSpec
+from eth_defi.vault.base import DEPOSIT_CLOSED_BY_ADMIN, VaultHistoricalRead, VaultHistoricalReader, VaultSpec
 from eth_defi.vault.fee import VaultFeeMode
 from eth_defi.vault.risk import VaultTechnicalRisk
 
@@ -89,6 +91,32 @@ class _FakeReaderState:
         )
 
 
+class _FakeT3trisCall:
+    """Minimal Web3 call object returning one fixed value."""
+
+    def __init__(self, *, value: bool):
+        self.value = value
+
+    def call(self) -> bool:
+        """Return the configured ABI call result."""
+        return self.value
+
+
+class _FakeT3trisStatusVault:
+    """Bind T3tris status methods to a minimal contract double."""
+
+    can_check_deposit = T3trisVault.can_check_deposit
+    fetch_deposit_open = T3trisVault.fetch_deposit_open
+    fetch_deposit_closed_reason = T3trisVault.fetch_deposit_closed_reason
+    is_whitelisted_deposit = T3trisVault.is_whitelisted_deposit
+
+    def __init__(self, *, deposits_open: bool, whitelist_enabled: bool):
+        functions = type("FakeFunctions", (), {})()
+        functions.isDepositEnabled = lambda: _FakeT3trisCall(value=deposits_open)
+        functions.isDepositWhitelistEnabled = lambda: _FakeT3trisCall(value=whitelist_enabled)
+        self.vault_contract = type("FakeContract", (), {"functions": functions})()
+
+
 def _make_t3tris_reader() -> T3trisHistoricalReader:
     """Create a T3tris reader without Web3 dependencies."""
     reader = T3trisHistoricalReader.__new__(T3trisHistoricalReader)
@@ -137,6 +165,7 @@ def _make_t3tris_sample(
     total_supply: Decimal,
     share_price: Decimal,
     is_vault_open: bool = False,
+    is_deposit_enabled: bool = True,
     last_valuation_timestamp: int = 1,
     state: _FakeReaderState | None = None,
 ) -> list[EncodedCallResult]:
@@ -149,6 +178,7 @@ def _make_t3tris_sample(
         _make_call_result("convertToAssets", int(share_price * scale), block_number=block_number, timestamp=timestamp, state=state),
         _make_call_result("maxDeposit", 0, block_number=block_number, timestamp=timestamp, state=state),
         _make_call_result("isVaultOpen", int(is_vault_open), block_number=block_number, timestamp=timestamp, state=state),
+        _make_call_result("isDepositEnabled", int(is_deposit_enabled), block_number=block_number, timestamp=timestamp, state=state),
         _make_call_result("lastValuationTimestamp", last_valuation_timestamp, block_number=block_number, timestamp=timestamp, state=state),
     ]
 
@@ -161,6 +191,7 @@ def _process_t3tris_sample(
     total_supply: Decimal,
     share_price: Decimal,
     is_vault_open: bool = False,
+    is_deposit_enabled: bool = True,
     last_valuation_timestamp: int = 1,
     state: _FakeReaderState | None = None,
     failed_calls: set[str] | None = None,
@@ -173,6 +204,7 @@ def _process_t3tris_sample(
         total_supply=total_supply,
         share_price=share_price,
         is_vault_open=is_vault_open,
+        is_deposit_enabled=is_deposit_enabled,
         last_valuation_timestamp=last_valuation_timestamp,
         state=state,
     )
@@ -182,6 +214,57 @@ def _process_t3tris_sample(
                 result.success = False
                 result.result = b""
     return reader.process_result(block_number, timestamp, call_results)
+
+
+def test_t3tris_reader_records_native_historical_deposit_state() -> None:
+    """Historical rows must use T3tris deposit state, not ERC-4626 maxDeposit."""
+    reader = _make_t3tris_reader()
+
+    enabled_read = _process_t3tris_sample(
+        reader,
+        block_number=1,
+        total_assets=Decimal("100"),
+        total_supply=Decimal("100"),
+        share_price=Decimal("1"),
+        is_deposit_enabled=True,
+    )
+    disabled_read = _process_t3tris_sample(
+        reader,
+        block_number=2,
+        total_assets=Decimal("100"),
+        total_supply=Decimal("100"),
+        share_price=Decimal("1"),
+        is_deposit_enabled=False,
+    )
+
+    assert enabled_read.max_deposit == Decimal("0")
+    assert enabled_read.deposits_open is True
+    assert disabled_read.deposits_open is False
+
+
+def test_t3tris_current_deposit_state_uses_native_status_and_separate_policy() -> None:
+    """Current metadata must distinguish closure from whitelist permission."""
+    permissionless_open_vault = _FakeT3trisStatusVault(deposits_open=True, whitelist_enabled=False)
+    whitelisted_closed_vault = _FakeT3trisStatusVault(deposits_open=False, whitelist_enabled=True)
+
+    assert permissionless_open_vault.can_check_deposit() is False
+    assert permissionless_open_vault.fetch_deposit_open() is True
+    assert permissionless_open_vault.fetch_deposit_closed_reason() is None
+    assert permissionless_open_vault.is_whitelisted_deposit() is False
+
+    assert whitelisted_closed_vault.fetch_deposit_open() is False
+    assert whitelisted_closed_vault.fetch_deposit_closed_reason() == DEPOSIT_CLOSED_BY_ADMIN
+    assert whitelisted_closed_vault.is_whitelisted_deposit() is True
+
+
+def test_current_metadata_records_deposit_status_for_empty_vault() -> None:
+    """Current deposit status must not depend on a vault crossing the TVL threshold."""
+    vault = SimpleNamespace(fetch_deposit_open=lambda: True)
+
+    status = _fetch_activity_status(vault, total_assets=Decimal("0"))
+
+    assert status["_deposits_open"] is True
+    assert status["_deposit_closed_reason"] is None
 
 
 def test_t3tris_reader_updates_state_once_with_corrected_values() -> None:

--- a/tests/erc_4626/vault_protocol/test_t3tris_repair_script.py
+++ b/tests/erc_4626/vault_protocol/test_t3tris_repair_script.py
@@ -2,6 +2,7 @@
 
 import datetime
 import importlib.util
+import json
 import sys
 import types
 from pathlib import Path
@@ -119,3 +120,46 @@ def test_t3tris_repair_uses_configuration_threshold_for_reviewed_migration() -> 
     assert lead.configuration_count == 1
     assert detection.deposit_count == 0
     assert detection.configuration_count == 1
+
+
+def test_t3tris_repair_accepts_robinhood_api_vaults() -> None:
+    """The targeted repair must retain Robinhood vaults from the official API."""
+    module = _load_fix_t3tris_module()
+
+    refs = module.parse_t3tris_payload(
+        {
+            "vaults": [
+                {
+                    "chainId": 4663,
+                    "address": "0x5b93dd3eb7fd224565498045f5e1a2ebda49e672",
+                    "name": "Morini StockMarketTRBasisTrade Vault",
+                    "createdAtBlock": "27650917",
+                    "createdAtTs": 1785849175,
+                    "curatorName": "Morini Capital",
+                    "verified": True,
+                }
+            ]
+        }
+    )
+
+    assert len(refs) == 1
+    assert refs[0].chain_id in module.SUPPORTED_CHAIN_IDS
+    assert refs[0].address.lower() == "0x5b93dd3eb7fd224565498045f5e1a2ebda49e672"
+
+
+def test_t3tris_repair_can_limit_a_migration_to_reviewed_robinhood_vaults(monkeypatch) -> None:
+    """Chain and address filters must keep a migration's writes exact."""
+    module = _load_fix_t3tris_module()
+    monkeypatch.setenv("T3TRIS_CHAIN_IDS", "4663")
+    monkeypatch.setenv(
+        "T3TRIS_VAULT_ADDRESSES",
+        "0x5b93dd3eb7fd224565498045f5e1a2ebda49e672,0xd4d607239dcbdb5cc3a301266433810bb63c63bf",
+    )
+
+    refs = module.filter_references(module.parse_t3tris_payload(json.loads(module.T3TRIS_VAULT_SNAPSHOT_JSON)))
+
+    assert [ref.chain_id for ref in refs] == [4663, 4663]
+    assert {ref.address.lower() for ref in refs} == {
+        "0x5b93dd3eb7fd224565498045f5e1a2ebda49e672",
+        "0xd4d607239dcbdb5cc3a301266433810bb63c63bf",
+    }


### PR DESCRIPTION
## Why

T3tris Robinhood vaults were discovered only as generic ERC-4626 leads because the protocol classifier restricted its distinguishing `getGrossTVL` probe to Arbitrum. This missed Morini entirely and left Kingfisher with incorrect generic metadata. T3tris async vaults also made `maxDeposit=0` look like a public capacity cap even when protocol deposits were enabled.

## Lessons learnt

A discovery lead can exist without a protocol adapter when its classifier probe is omitted for a deployed chain. ERC-4626 `maxDeposit` is not a universal public-deposit status signal for asynchronous vaults; use a protocol-native admission state where available.

## Summary

- Enable T3tris classification on Robinhood, add its reviewed vaults to the targeted repair snapshot, and provide strict chain/address migration filters.
- Record T3tris native deposit availability both historically and in current scan metadata, while keeping unknown generic state tri-state.
- Correct the capped/open interpretation and document the production-safe Robinhood migration command.

## Related issues and PRs

Continues the T3tris vault-list and Robinhood discovery audit.

## Unrelated CI and test fixes

None.