### PR TITLE
fix: add one-use T3tris Robinhood migration

### DIFF
--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -629,6 +629,24 @@ source ~/vault-scanner/vault-rpc.env && \
   -lc "python scripts/erc-4626/fix-t3tris-vaults.py")
 ```
 
+### migrate-t3tris-robinhood-vaults.py
+
+One-use production migration for the audited Robinhood T3tris vaults Morini
+and Kingfisher. Its chain, vault addresses, metadata refresh, baked snapshot
+and metadata-only mode are hardcoded; it cannot widen the repair scope or
+rewrite price data. Set DRY_RUN=true for a no-write inspection.
+
+```shell
+source ~/vault-scanner/vault-rpc.env && \\
+(cd ~/vault-scanner/web3-ethereum-defi && \\
+  docker compose run --rm \\
+  -e DRY_RUN=true \\
+  --entrypoint /bin/bash vault-scanner-oneshot \\
+  -lc "python scripts/erc-4626/migrate-t3tris-robinhood-vaults.py")
+```
+
+After inspecting the dry-run output, omit -e DRY_RUN=true to apply it.
+
 ### fix-frankencoin-tvl.py
 
 Manual repair script for Frankencoin savings vault TVL in the uncleaned price

--- a/scripts/erc-4626/migrate-t3tris-robinhood-vaults.py
+++ b/scripts/erc-4626/migrate-t3tris-robinhood-vaults.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Perform the one-use T3tris Robinhood vault metadata migration.
+
+This deliberately non-configurable migration repairs only the audited Morini
+and Kingfisher T3tris vaults on Robinhood. It fixes the chain, addresses,
+baked snapshot, metadata refresh and metadata-only mode in code. It cannot
+reset discovery, select another chain, or rewrite price data.
+
+Set DRY_RUN=true to inspect the migration before applying it.
+"""
+
+import os
+import runpy
+from pathlib import Path
+
+#: Robinhood Chain.
+ROBINHOOD_CHAIN_ID = "4663"
+
+#: Audited T3tris Robinhood vaults, in deterministic order.
+T3TRIS_ROBINHOOD_VAULT_ADDRESSES = (
+    "0x5b93dd3eb7fd224565498045f5e1a2ebda49e672",
+    "0xd4d607239dcbdb5cc3a301266433810bb63c63bf",
+)
+
+
+def main() -> None:
+    """Run the fixed-scope T3tris Robinhood metadata repair.
+
+    The shared repair owns the tested lead upsert and metadata classification
+    flow. This one-use entrypoint fixes every operational scope setting before
+    loading it, while preserving an operator-provided DRY_RUN value.
+    """
+    os.environ["T3TRIS_CHAIN_IDS"] = ROBINHOOD_CHAIN_ID
+    os.environ["T3TRIS_VAULT_ADDRESSES"] = ",".join(T3TRIS_ROBINHOOD_VAULT_ADDRESSES)
+    os.environ["T3TRIS_FETCH_API"] = "false"
+    os.environ["T3TRIS_REFRESH_EXISTING_METADATA"] = "true"
+    os.environ["T3TRIS_SCAN_PRICES"] = "false"
+    runpy.run_path(Path(__file__).with_name("fix-t3tris-vaults.py"), run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

The audited Robinhood T3tris repair should be executable without manually supplying scope-defining environment filters.

## Lessons learnt

A one-use production migration is safer when the reviewed addresses and destructive scope are fixed in code.

## Summary

- Add a fixed-scope Morini and Kingfisher metadata migration entrypoint.
- Document dry-run and production execution.

## Related issues and PRs

Follow-up to #1469.

## Unrelated CI and test fixes

None.