### PR TITLE
fix: extend robust receipt visibility timeout

### DIFF
--- a/eth_defi/provider/receipt.py
+++ b/eth_defi/provider/receipt.py
@@ -12,8 +12,8 @@ from web3.exceptions import (
     MultipleFailedRequests,
     ProviderConnectionError,
     RequestTimedOut,
-    TransactionNotFound,
     TooManyRequests,
+    TransactionNotFound,
     Web3RPCError,
 )
 from web3.providers import BaseProvider
@@ -23,7 +23,6 @@ from eth_defi.chain import get_evm_block_time
 from eth_defi.provider.anvil import is_anvil
 from eth_defi.provider.fallback import FallbackProvider
 from eth_defi.provider.named import get_provider_name
-
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +72,14 @@ DEFAULT_CONFIRMATION_BLOCK_COUNT = 2
 #: ``confirmation_block_count``. An explicit ``confirmation_block_count=0`` (the
 #: documented pure receipt-visibility opt-out) also disables this default.
 DEFAULT_CONFIRMATION_BLOCK_TIME: float = 25.0
+
+#: Default upper bound in seconds for receipt visibility polling.
+#:
+#: The 2026-08-11 Derive incident showed that a two-minute window was too short:
+#: its Lagoon NAV transaction mined two seconds after broadcast, but the Derive RPC
+#: reported a chain head 139 blocks behind that receipt for the whole 120-second wait.
+#: The 210-second default adds a 90-second recovery margin for this measured failure.
+DEFAULT_RECEIPT_VISIBILITY_TIMEOUT: float = 210.0
 
 
 class ReceiptVisibilityTimedOut(TimeoutError):
@@ -237,7 +244,7 @@ def _get_insufficient_confirmations(
 def wait_for_transaction_receipt_robust(
     web3: Web3,
     tx_hash: HexBytes | str,
-    timeout: float = 120.0,
+    timeout: float = DEFAULT_RECEIPT_VISIBILITY_TIMEOUT,
     poll_delay: float = 1.0,
     max_poll_delay: float = 5.0,
     confirmation_block_count: int | None = None,
@@ -259,7 +266,14 @@ def wait_for_transaction_receipt_robust(
     :param tx_hash:
         Transaction hash to wait for.
     :param timeout:
-        Maximum seconds to wait.
+        Maximum seconds to wait. Defaults to 210 seconds (3 minutes 30 seconds).
+
+        This leaves a 90-second margin over the measured 120-second receipt
+        visibility timeout during the 2026-08-11 Derive incident: the Lagoon
+        NAV transaction was mined two seconds after broadcast, but Derive's RPC
+        reported a chain head 139 blocks behind that receipt for the whole
+        two-minute wait. Callers that need a different operational bound can
+        pass an explicit value.
     :param poll_delay:
         Initial delay between polling rounds.
     :param max_poll_delay:

--- a/tests/rpc/test_receipt.py
+++ b/tests/rpc/test_receipt.py
@@ -1,5 +1,6 @@
 """Robust receipt visibility helper tests."""
 
+import inspect
 import shutil
 
 import pytest
@@ -17,7 +18,6 @@ from eth_defi.provider.receipt import (
     get_read_providers,
     wait_for_transaction_receipt_robust,
 )
-
 
 TX_HASH = "0x" + "12" * 32
 BLOCK_HASH = "0x" + "34" * 32
@@ -455,6 +455,20 @@ def test_wait_for_transaction_receipt_robust_default_confirmations(monkeypatch: 
     # 3. Check block numbers were polled until two confirmations were reached.
     assert receipt_module.DEFAULT_CONFIRMATION_BLOCK_COUNT == 2
     assert provider_1.calls.count("eth_blockNumber") == 2
+
+
+def test_wait_for_transaction_receipt_robust_default_timeout():
+    """Expose the extended receipt visibility timeout for transient Derive RPC lag.
+
+    1. Inspect the public robust receipt helper signature.
+    2. Assert its default allows three minutes and thirty seconds for recovery.
+    """
+
+    # 1. Inspect the public robust receipt helper signature.
+    signature = inspect.signature(wait_for_transaction_receipt_robust)
+
+    # 2. Assert its default allows three minutes and thirty seconds for recovery.
+    assert signature.parameters["timeout"].default == receipt_module.DEFAULT_RECEIPT_VISIBILITY_TIMEOUT
 
 
 def test_wait_for_transaction_receipt_robust_confirmation_block_time(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Why

On 2026-08-11, the Vega Lagoon strategy broadcast a Derive NAV transaction that mined successfully two seconds later. Derive's RPC served that receipt but reported its chain head 139 blocks behind the receipt for the full 120-second receipt-visibility window, crashing the executor despite the on-chain success.

Extending the default window to three minutes and thirty seconds gives transient RPC recovery an additional 90 seconds while retaining callers' ability to provide a tighter explicit timeout.

## Lessons learnt

Receipt availability and the provider's reported chain tip can diverge on a load-balanced RPC. A receipt wait must therefore have an operational window sized for the provider's observed recovery behaviour, not only for transaction inclusion time.

## Summary

- Set the robust receipt visibility default timeout to 210 seconds.
- Document the measured Derive incident in the public API documentation.
- Add a regression test for the public default.
