### PR TITLE
fix: migrate Arcus vault metadata for JSON export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- fix: Add a targeted Arcus pToken metadata migration so pre-existing Robinhood Chain vault rows export with Arcus protocol and curator data (2026-08-17)
 - feat: Add Robinhood-only Arcus pToken recognition through its reviewed bridge-vault selector, address-scoped product copy and protocol-curator attribution (2026-08-14)
 - feat: Add read-only Barker H1 HyperEVM vault tracking with hardcoded address recognition (2026-08-08)
 - fix: Start initial and post-wipe-out Hypercore performance curves at their first $1,000 NAV observation (2026-08-08)

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -831,6 +831,40 @@ defaults to dry-run mode and creates a non-overwriting
 `*.bak-lagoon-fee-mode` backup before writing. Run `export-data-files.py`
 afterwards to publish regenerated fee-adjusted metrics.
 
+### migrate-arcus-vault-metadata.py
+
+Reclassify the two reviewed Arcus BTC and HOOD pTokens on Robinhood Chain after
+the Arcus detector was added to an already-progressed incremental scanner. The
+script rebuilds only their metadata rows, retaining the discovery event counts
+and first-seen blocks that already exist in the metadata database. It does not
+modify reader-state or raw/cleaned price parquet files.
+
+Inspect the proposed changes first:
+
+```shell
+source .local-test.env && \
+DRY_RUN=true \
+poetry run python scripts/erc-4626/migrate-arcus-vault-metadata.py
+```
+
+Then write the metadata repair and regenerate a local vault JSON for review:
+
+```shell
+source .local-test.env && \
+DRY_RUN=false \
+poetry run python scripts/erc-4626/migrate-arcus-vault-metadata.py
+
+OUTPUT_JSON=/tmp/top-vaults-by-chain.json \
+VAULT_EXPORT_STATE_PATH=/tmp/vault-export-state.json \
+poetry run python scripts/erc-4626/vault-analysis-json.py
+```
+
+`JSON_RPC_ROBINHOOD` is required to confirm that both pTokens still classify as
+Arcus. Set `VAULT_DB_PATH` to operate on a downloaded or test metadata pickle.
+The script defaults to dry-run mode and writes a non-overwriting
+`*.bak-arcus-metadata` backup before it changes the metadata database. The
+production scanner's normal post-processing cycle uploads the regenerated JSON.
+
 ### clean-prices.py
 
 Clean raw scanned vault data. Reads `vault-prices-1h.parquet` and generates `cleaned-vault-prices-1h.parquet`.

--- a/scripts/erc-4626/migrate-arcus-vault-metadata.py
+++ b/scripts/erc-4626/migrate-arcus-vault-metadata.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Reclassify persisted Arcus pToken metadata for the vault JSON export.
+
+PR #1473 added Arcus pToken detection after the Robinhood Chain scanner had
+already discovered the reviewed BTC and HOOD pTokens. Incremental discovery
+does not revisit existing metadata rows, so they remain labelled ``<unknown
+ERC-7540>`` until this targeted repair rebuilds their metadata with the Arcus
+reader.
+
+The migration only updates the two reviewed metadata rows. It preserves their
+observed discovery blocks and event counts, and never changes reader-state or
+raw/cleaned price Parquet files. Existing price history is already sufficient
+for the JSON exporter. Run the normal export after applying this migration.
+
+Usage:
+
+.. code-block:: shell
+
+    source .local-test.env && DRY_RUN=true \\
+        poetry run python scripts/erc-4626/migrate-arcus-vault-metadata.py
+
+    source .local-test.env && DRY_RUN=false \\
+        poetry run python scripts/erc-4626/migrate-arcus-vault-metadata.py
+
+Environment variables:
+
+- ``JSON_RPC_ROBINHOOD``: Robinhood Chain JSON-RPC endpoint. Required to
+  verify the current Arcus classification and refresh metadata.
+- ``VAULT_DB_PATH``: Optional metadata pickle path. Defaults to the production
+  vault metadata database.
+- ``DRY_RUN``: Report affected rows without writing. Defaults to ``true``.
+- ``LOG_LEVEL``: Optional log level. Defaults to ``info``.
+"""
+
+import dataclasses
+import datetime
+import logging
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+from eth_typing import HexAddress
+from tabulate import tabulate
+from web3 import Web3
+
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.erc_4626.classification import detect_vault_features
+from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
+from eth_defi.erc_4626.discovery_base import PotentialVaultMatch
+from eth_defi.erc_4626.scan import create_vault_scan_record
+from eth_defi.erc_4626.vault_protocol.arcus.constants import ARCUS_BTC_3X_LONG_VAULT, ARCUS_CHAIN_ID, ARCUS_HOOD_3X_LONG_VAULT
+from eth_defi.provider.multi_provider import create_multi_provider_web3
+from eth_defi.token import TokenDiskCache
+from eth_defi.utils import setup_console_logging
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.vaultdb import DEFAULT_VAULT_DATABASE, VaultDatabase, VaultRow
+
+logger = logging.getLogger(__name__)
+
+#: Exact reviewed Arcus pTokens that PR #1473 supports.
+REVIEWED_ARCUS_VAULT_SPECS: Final[tuple[VaultSpec, ...]] = (
+    VaultSpec(ARCUS_CHAIN_ID, ARCUS_BTC_3X_LONG_VAULT),
+    VaultSpec(ARCUS_CHAIN_ID, ARCUS_HOOD_3X_LONG_VAULT),
+)
+
+
+@dataclass(slots=True, frozen=True)
+class ArcusMetadataMigrationResult:
+    """Summarise one Arcus metadata migration run.
+
+    :param inspected_rows:
+        Number of reviewed Arcus rows checked.
+    :param migrated_rows:
+        Number of stale rows rebuilt, or that would be rebuilt in dry-run mode.
+    :param seeded_leads:
+        Number of missing target-only lead records restored from metadata.
+    """
+
+    #: Number of reviewed Arcus rows inspected.
+    inspected_rows: int
+
+    #: Number of stale metadata rows rebuilt.
+    migrated_rows: int
+
+    #: Number of target-only leads restored from persisted metadata.
+    seeded_leads: int
+
+
+def parse_bool_env(name: str, *, default: bool) -> bool:
+    """Read one strictly validated boolean environment variable.
+
+    :param name:
+        Environment variable name.
+    :param default:
+        Value used when the variable is absent.
+    :return:
+        Parsed boolean value.
+    :raises ValueError:
+        If a supplied value is not a recognised boolean literal.
+    """
+
+    value = os.environ.get(name)
+    if value is None:
+        return default
+
+    normalised = value.strip().lower()
+    if normalised in {"1", "true", "yes"}:
+        return True
+    if normalised in {"0", "false", "no"}:
+        return False
+    raise ValueError(f"{name} must be true or false, got {value!r}")
+
+
+def create_backup_path(vault_db_path: Path) -> Path:
+    """Choose a unique sibling backup path for a metadata database.
+
+    :param vault_db_path:
+        Metadata database about to be updated.
+    :return:
+        A non-existing path next to ``vault_db_path``.
+    """
+
+    backup_path = Path(f"{vault_db_path}.bak-arcus-metadata")
+    backup_index = 1
+    while backup_path.exists():
+        backup_path = Path(f"{vault_db_path}.bak-arcus-metadata.{backup_index}")
+        backup_index += 1
+    return backup_path
+
+
+def get_existing_detection(row: VaultRow, spec: VaultSpec) -> ERC4262VaultDetection:
+    """Extract and validate the persisted detector data for a reviewed vault.
+
+    The existing detection is the authoritative source for observed discovery
+    blocks and flow counts. Reconstructing either from a new current-state
+    read could falsify export history.
+
+    :param row:
+        Existing metadata row for the reviewed vault.
+    :param spec:
+        Expected vault database identity.
+    :return:
+        Persisted detection object matching ``spec``.
+    :raises ValueError:
+        If a target row has no compatible persisted detection.
+    """
+
+    detection = row.get("_detection_data")
+    if not isinstance(detection, ERC4262VaultDetection):
+        raise ValueError(f"Arcus target {spec} has no persisted ERC-4626 detection")
+    if detection.chain != spec.chain_id or detection.address.lower() != spec.vault_address.lower():
+        raise ValueError(f"Arcus target {spec} has mismatched persisted detection {detection.get_spec()}")
+    return detection
+
+
+def create_reclassified_detection(existing: ERC4262VaultDetection, features: set[ERC4626Feature], updated_at: datetime.datetime) -> ERC4262VaultDetection:
+    """Preserve observed history while replacing stale classification features.
+
+    :param existing:
+        Existing persisted discovery result for one reviewed pToken.
+    :param features:
+        Current onchain feature classification.
+    :param updated_at:
+        Naive UTC metadata refresh timestamp.
+    :return:
+        Updated detection retaining all original discovery information.
+    :raises ValueError:
+        If the current target no longer has the reviewed Arcus signature.
+    """
+
+    if ERC4626Feature.arcus_like not in features:
+        raise ValueError(f"Arcus target {existing.get_spec()} did not classify as Arcus: {features}")
+    return dataclasses.replace(existing, features=features, updated_at=updated_at)
+
+
+def needs_metadata_refresh(row: VaultRow, detection: ERC4262VaultDetection) -> bool:
+    """Determine whether a persisted record lacks Arcus export metadata.
+
+    :param row:
+        Existing metadata row.
+    :param detection:
+        Its persisted detection result.
+    :return:
+        ``True`` when rebuilding the row is required.
+    """
+
+    return row.get("Protocol") != "Arcus" or ERC4626Feature.arcus_like not in detection.features or ERC4626Feature.arcus_like not in row.get("features", set()) or row.get("_manager_name") != "Arcus" or not row.get("_short_description") or not row.get("_description")
+
+
+def create_lead_from_detection(detection: ERC4262VaultDetection) -> PotentialVaultMatch:
+    """Restore a missing target lead without altering its observed activity.
+
+    :param detection:
+        Persisted Arcus discovery data.
+    :return:
+        Equivalent lead record for the reviewed pToken.
+    """
+
+    return PotentialVaultMatch(
+        chain=detection.chain,
+        address=HexAddress(detection.address.lower()),
+        first_seen_at_block=detection.first_seen_at_block,
+        first_seen_at=detection.first_seen_at,
+        deposit_count=detection.deposit_count,
+        withdrawal_count=detection.redeem_count,
+        configuration_count=detection.configuration_count,
+    )
+
+
+def migrate_arcus_metadata(
+    web3: Web3,
+    vault_db: VaultDatabase,
+    token_cache: TokenDiskCache,
+    *,
+    dry_run: bool,
+    updated_at: datetime.datetime,
+) -> ArcusMetadataMigrationResult:
+    """Rebuild stale metadata rows for only the reviewed Arcus pTokens.
+
+    All target validation and RPC reads finish before any in-memory database
+    mutation. Consequently a failed target does not leave a partially migrated
+    production pickle. The caller writes the pickle only after this function
+    returns successfully.
+
+    :param web3:
+        Robinhood Chain Web3 client used for detection and metadata reads.
+    :param vault_db:
+        Existing vault metadata database.
+    :param token_cache:
+        Temporary ERC-20 metadata cache for scanner row construction.
+    :param dry_run:
+        Do not mutate the supplied database when ``True``.
+    :param updated_at:
+        Naive UTC refresh timestamp.
+    :return:
+        Target-only migration counters.
+    :raises ValueError:
+        If the RPC chain or existing target state is unexpected.
+    """
+
+    if web3.eth.chain_id != ARCUS_CHAIN_ID:
+        raise ValueError(f"JSON_RPC_ROBINHOOD returned chain {web3.eth.chain_id}, expected {ARCUS_CHAIN_ID}")
+
+    replacements: dict[VaultSpec, VaultRow] = {}
+    restored_leads: dict[VaultSpec, PotentialVaultMatch] = {}
+    report_rows: list[dict[str, object]] = []
+
+    for spec in REVIEWED_ARCUS_VAULT_SPECS:
+        row = vault_db.rows.get(spec)
+        if row is None:
+            raise ValueError(f"Arcus target {spec} is missing from the metadata database; do not reset whole-chain discovery")
+
+        existing_detection = get_existing_detection(row, spec)
+        features = detect_vault_features(web3, spec.vault_address, verbose=False)
+        detection = create_reclassified_detection(existing_detection, features, updated_at)
+        refresh = needs_metadata_refresh(row, existing_detection)
+
+        if refresh:
+            rebuilt_row = create_vault_scan_record(web3, detection, web3.eth.block_number, token_cache)
+            if rebuilt_row.get("Protocol") != "Arcus":
+                raise ValueError(f"Arcus target {spec} rebuilt with unexpected protocol {rebuilt_row.get('Protocol')!r}")
+            replacements[spec] = rebuilt_row
+
+        if spec not in vault_db.leads:
+            restored_leads[spec] = create_lead_from_detection(existing_detection)
+
+        report_rows.append(
+            {
+                "address": spec.vault_address,
+                "previous protocol": row.get("Protocol", "<missing>"),
+                "action": "refresh metadata" if refresh else "already current",
+            }
+        )
+
+    print(tabulate(report_rows, headers="keys", tablefmt="rounded_outline"))
+
+    result = ArcusMetadataMigrationResult(
+        inspected_rows=len(REVIEWED_ARCUS_VAULT_SPECS),
+        migrated_rows=len(replacements),
+        seeded_leads=len(restored_leads),
+    )
+    if dry_run:
+        return result
+
+    vault_db.rows.update(replacements)
+    vault_db.leads.update(restored_leads)
+    return result
+
+
+def main() -> None:
+    """Run the Arcus metadata migration from the environment configuration.
+
+    :return:
+        ``None`` after displaying the dry-run plan or saving the updated
+        metadata pickle and backup.
+    """
+
+    setup_console_logging(
+        default_log_level=os.environ.get("LOG_LEVEL", "info"),
+        log_file=Path("logs/migrate-arcus-vault-metadata.log"),
+    )
+    json_rpc_url = os.environ.get("JSON_RPC_ROBINHOOD")
+    if not json_rpc_url:
+        message = "JSON_RPC_ROBINHOOD is required for the Arcus metadata migration"
+        raise ValueError(message)
+
+    vault_db_path = Path(os.environ.get("VAULT_DB_PATH", str(DEFAULT_VAULT_DATABASE))).expanduser()
+    if not vault_db_path.exists():
+        raise ValueError(f"Vault metadata database does not exist: {vault_db_path}")
+
+    dry_run = parse_bool_env("DRY_RUN", default=True)
+    web3 = create_multi_provider_web3(json_rpc_url)
+    vault_db = VaultDatabase.read(vault_db_path)
+
+    with tempfile.TemporaryDirectory(prefix="arcus-metadata-token-cache-") as cache_directory:
+        result = migrate_arcus_metadata(
+            web3,
+            vault_db,
+            TokenDiskCache(Path(cache_directory) / "tokens.sqlite"),
+            dry_run=dry_run,
+            updated_at=native_datetime_utc_now(),
+        )
+
+    if dry_run:
+        print(f"Dry run: {result.migrated_rows} Arcus metadata rows and {result.seeded_leads} target leads would be updated. Reader state and price files are unchanged.")
+        return
+
+    if result.migrated_rows == 0 and result.seeded_leads == 0:
+        print("Arcus metadata is already current; no files changed.")
+        return
+
+    backup_path = create_backup_path(vault_db_path)
+    shutil.copy2(vault_db_path, backup_path)
+    vault_db.write(vault_db_path)
+    print(f"Updated {result.migrated_rows} Arcus metadata rows and restored {result.seeded_leads} target leads. Metadata backup: {backup_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/erc_4626/test_migrate_arcus_vault_metadata.py
+++ b/tests/erc_4626/test_migrate_arcus_vault_metadata.py
@@ -1,0 +1,205 @@
+"""Tests for the targeted Arcus vault metadata migration."""
+
+import datetime
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
+from eth_defi.erc_4626.vault_protocol.arcus.constants import ARCUS_BTC_3X_LONG_VAULT, ARCUS_CHAIN_ID, ARCUS_HOOD_3X_LONG_VAULT
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.vaultdb import VaultDatabase
+
+#: Number of reviewed Arcus pTokens in this migration.
+ARCUS_TARGET_COUNT = 2
+
+#: Historical event counts retained from the public vault JSON.
+BTC_DEPOSIT_COUNT = 11
+HOOD_DEPOSIT_COUNT = 13
+BTC_REDEEM_COUNT = 3
+HOOD_REDEEM_COUNT = 5
+
+#: Naive UTC fixture timestamps.
+FIRST_SEEN_AT = datetime.datetime(2026, 8, 1, 12, 0, 0, tzinfo=datetime.UTC).replace(tzinfo=None)
+UPDATED_AT = datetime.datetime(2026, 8, 17, 12, 0, 0, tzinfo=datetime.UTC).replace(tzinfo=None)
+
+
+def load_migration_module():
+    """Load the hyphenated Arcus maintenance script as a module.
+
+    :return:
+        Imported migration module.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "erc-4626" / "migrate-arcus-vault-metadata.py"
+    spec = importlib.util.spec_from_file_location("migrate_arcus_vault_metadata", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def create_detection(address: str, deposit_count: int, redeem_count: int) -> ERC4262VaultDetection:
+    """Create a persisted pre-Arcus detection fixture.
+
+    :param address:
+        Arcus pToken address.
+    :param deposit_count:
+        Observed deposit event count.
+    :param redeem_count:
+        Observed redemption event count.
+    :return:
+        Generic ERC-7540 detection saved before Arcus support.
+    """
+
+    return ERC4262VaultDetection(
+        chain=ARCUS_CHAIN_ID,
+        address=address,
+        first_seen_at_block=30_000_000,
+        first_seen_at=FIRST_SEEN_AT,
+        features={ERC4626Feature.erc_7540_like},
+        updated_at=FIRST_SEEN_AT,
+        deposit_count=deposit_count,
+        redeem_count=redeem_count,
+    )
+
+
+def create_stale_arcus_row(detection: ERC4262VaultDetection) -> dict:
+    """Create the legacy export metadata row for one pToken.
+
+    :param detection:
+        Stale generic persisted detector state.
+    :return:
+        Minimal old scanner row.
+    """
+
+    return {
+        "Name": "Legacy Arcus pToken",
+        "Protocol": "<unknown ERC-7540>",
+        "features": set(detection.features),
+        "_detection_data": detection,
+        "_manager_name": None,
+        "_short_description": None,
+        "_description": None,
+    }
+
+
+def create_refreshed_arcus_row(detection: ERC4262VaultDetection) -> dict:
+    """Create the scanner row produced by the Arcus adapter.
+
+    :param detection:
+        Reclassified Arcus detection.
+    :return:
+        Minimal current scanner row.
+    """
+
+    return {
+        "Name": "Arcus pToken",
+        "Protocol": "Arcus",
+        "features": set(detection.features),
+        "_detection_data": detection,
+        "_manager_name": "Arcus",
+        "_short_description": "Reviewed Arcus pToken.",
+        "_description": "Reviewed Arcus pToken metadata.",
+    }
+
+
+def test_migrate_arcus_metadata_reclassifies_only_reviewed_rows(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """Refresh stale Arcus rows without changing unrelated scanner state."""
+
+    module = load_migration_module()
+    btc_spec = VaultSpec(ARCUS_CHAIN_ID, ARCUS_BTC_3X_LONG_VAULT)
+    hood_spec = VaultSpec(ARCUS_CHAIN_ID, ARCUS_HOOD_3X_LONG_VAULT)
+    other_spec = VaultSpec(1, "0x0000000000000000000000000000000000000001")
+    btc_detection = create_detection(ARCUS_BTC_3X_LONG_VAULT, deposit_count=BTC_DEPOSIT_COUNT, redeem_count=BTC_REDEEM_COUNT)
+    hood_detection = create_detection(ARCUS_HOOD_3X_LONG_VAULT, deposit_count=HOOD_DEPOSIT_COUNT, redeem_count=HOOD_REDEEM_COUNT)
+    unrelated_row = {"Name": "Unrelated vault", "Protocol": "Morpho"}
+    vault_db = VaultDatabase(
+        rows={
+            btc_spec: create_stale_arcus_row(btc_detection),
+            hood_spec: create_stale_arcus_row(hood_detection),
+            other_spec: unrelated_row,
+        },
+        leads={other_spec: object()},
+        last_scanned_block={ARCUS_CHAIN_ID: 50_000_000},
+    )
+
+    monkeypatch.setattr(module, "detect_vault_features", lambda *_args, **_kwargs: {ERC4626Feature.erc_7540_like, ERC4626Feature.arcus_like})
+    monkeypatch.setattr(module, "create_vault_scan_record", lambda _web3, detection, *_args: create_refreshed_arcus_row(detection))
+    web3 = type("Web3Stub", (), {"eth": type("EthStub", (), {"chain_id": ARCUS_CHAIN_ID, "block_number": 50_000_010})()})()
+
+    result = module.migrate_arcus_metadata(
+        web3,
+        vault_db,
+        token_cache=object(),
+        dry_run=False,
+        updated_at=UPDATED_AT,
+    )
+    capsys.readouterr()
+
+    assert result.inspected_rows == ARCUS_TARGET_COUNT
+    assert result.migrated_rows == ARCUS_TARGET_COUNT
+    assert result.seeded_leads == ARCUS_TARGET_COUNT
+    assert vault_db.rows[btc_spec]["Protocol"] == "Arcus"
+    assert vault_db.rows[hood_spec]["Protocol"] == "Arcus"
+    assert vault_db.rows[btc_spec]["_detection_data"].deposit_count == BTC_DEPOSIT_COUNT
+    assert vault_db.rows[hood_spec]["_detection_data"].redeem_count == HOOD_REDEEM_COUNT
+    assert vault_db.rows[btc_spec]["_detection_data"].updated_at == UPDATED_AT
+    assert vault_db.leads[btc_spec].deposit_count == BTC_DEPOSIT_COUNT
+    assert vault_db.leads[hood_spec].withdrawal_count == HOOD_REDEEM_COUNT
+    assert vault_db.rows[other_spec] is unrelated_row
+    assert vault_db.leads[other_spec] is not None
+    assert vault_db.last_scanned_block == {ARCUS_CHAIN_ID: 50_000_000}
+
+
+def test_migrate_arcus_metadata_dry_run_does_not_mutate(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """Report target rows without changing metadata or lead records in dry-run mode."""
+
+    module = load_migration_module()
+    btc_spec = VaultSpec(ARCUS_CHAIN_ID, ARCUS_BTC_3X_LONG_VAULT)
+    hood_spec = VaultSpec(ARCUS_CHAIN_ID, ARCUS_HOOD_3X_LONG_VAULT)
+    btc_detection = create_detection(ARCUS_BTC_3X_LONG_VAULT, deposit_count=BTC_DEPOSIT_COUNT, redeem_count=BTC_REDEEM_COUNT)
+    hood_detection = create_detection(ARCUS_HOOD_3X_LONG_VAULT, deposit_count=HOOD_DEPOSIT_COUNT, redeem_count=HOOD_REDEEM_COUNT)
+    vault_db = VaultDatabase(
+        rows={
+            btc_spec: create_stale_arcus_row(btc_detection),
+            hood_spec: create_stale_arcus_row(hood_detection),
+        }
+    )
+    original_btc_row = vault_db.rows[btc_spec]
+
+    monkeypatch.setattr(module, "detect_vault_features", lambda *_args, **_kwargs: {ERC4626Feature.erc_7540_like, ERC4626Feature.arcus_like})
+    monkeypatch.setattr(module, "create_vault_scan_record", lambda _web3, detection, *_args: create_refreshed_arcus_row(detection))
+    web3 = type("Web3Stub", (), {"eth": type("EthStub", (), {"chain_id": ARCUS_CHAIN_ID, "block_number": 50_000_010})()})()
+
+    result = module.migrate_arcus_metadata(
+        web3,
+        vault_db,
+        token_cache=object(),
+        dry_run=True,
+        updated_at=UPDATED_AT,
+    )
+    capsys.readouterr()
+
+    assert result.migrated_rows == ARCUS_TARGET_COUNT
+    assert result.seeded_leads == ARCUS_TARGET_COUNT
+    assert vault_db.rows[btc_spec] is original_btc_row
+    assert vault_db.rows[btc_spec]["Protocol"] == "<unknown ERC-7540>"
+    assert btc_spec not in vault_db.leads
+    assert hood_spec not in vault_db.leads
+
+
+def test_create_backup_path_does_not_overwrite_existing_backups(tmp_path: Path) -> None:
+    """Create incremented Arcus backup names when a prior backup exists."""
+
+    module = load_migration_module()
+    vault_db_path = tmp_path / "vault-metadata-db.pickle"
+    first_backup = tmp_path / "vault-metadata-db.pickle.bak-arcus-metadata"
+    second_backup = tmp_path / "vault-metadata-db.pickle.bak-arcus-metadata.1"
+    first_backup.touch()
+    second_backup.touch()
+
+    assert module.create_backup_path(vault_db_path) == tmp_path / "vault-metadata-db.pickle.bak-arcus-metadata.2"


### PR DESCRIPTION
## Why

Arcus pTokens were discovered before PR #1473 added their classifier, so their persisted rows remain labelled as unknown ERC-7540 vaults in the public JSON export.

## Lessons learnt

Incremental vault discovery does not reclassify existing metadata when protocol detection is added; targeted repairs must preserve existing discovery and price history.

## Summary

- Add a dry-run-by-default, backup-first migration for the two reviewed Arcus Robinhood Chain pTokens.
- Preserve discovery blocks, event counts, reader state and price Parquet data while rebuilding stale metadata with the Arcus reader.
- Document the operator workflow and add focused regression coverage.

## Related issues and PRs

- Follows #1473.

## Unrelated CI and test fixes

- None.