### PR TITLE
feat: categorise native grid trading vaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.2
 
-- feat: Classify the Systemic Strategies L/S Grids Hyperliquid vault as directional grid trading (2026-08-18)
+- feat: Classify explicitly documented grid-trading vaults across Hyperliquid, GRVT and Lighter (2026-08-18)
 - feat: Add vault investment strategy tag classifications across ERC-4626 adapters, tokenised funds and native perpetual DEX exports (2026-08-18)
 - fix: Add a targeted Arcus pToken metadata migration so pre-existing Robinhood Chain vault rows export with Arcus protocol and curator data (2026-08-17)
 - feat: Add Robinhood-only Arcus pToken recognition through its reviewed bridge-vault selector, address-scoped product copy and protocol-curator attribution (2026-08-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- feat: Classify the Systemic Strategies L/S Grids Hyperliquid vault as directional grid trading (2026-08-18)
 - feat: Add vault investment strategy tag classifications across ERC-4626 adapters, tokenised funds and native perpetual DEX exports (2026-08-18)
 - fix: Add a targeted Arcus pToken metadata migration so pre-existing Robinhood Chain vault rows export with Arcus protocol and curator data (2026-08-17)
 - feat: Add Robinhood-only Arcus pToken recognition through its reviewed bridge-vault selector, address-scoped product copy and protocol-curator attribution (2026-08-14)

--- a/eth_defi/grvt/tags.py
+++ b/eth_defi/grvt/tags.py
@@ -145,9 +145,11 @@ STRATEGY_TAGS: dict[str, set[StrategyTag]] = {
     },
     #: Vault: Ignight Inverse-Trend.
     #: Added: 2026-08-17.
-    #: Decision material: The description calls the counter-trend
-    #: accumulation strategy automated, with predefined price intervals and a
-    #: fixed schedule; this supports algorithmic directional mean reversion.
+    #: Updated: 2026-08-18.
+    #: Decision material: The description calls the counter-trend accumulation
+    #: strategy automated, with predefined price intervals and a fixed
+    #: schedule. Its maintained category explicitly says Grid Trading. This
+    #: supports algorithmic directional grid trading and mean reversion.
     #: Sources:
     #: - https://edge.grvt.io/query
     #: - https://grvt.io/exchange/strategies/1756934834
@@ -155,6 +157,7 @@ STRATEGY_TAGS: dict[str, set[StrategyTag]] = {
     "vlt:32aef5qkjhkibvf8inqq9oqsyep": {
         StrategyTag.algorithmic_trading,
         StrategyTag.directional_trading,
+        StrategyTag.grid_trading,
         StrategyTag.mean_reversion,
     },
     #: Vault: Grvt Liquidity Provider (GLP).

--- a/eth_defi/hyperliquid/tags.py
+++ b/eth_defi/hyperliquid/tags.py
@@ -119,6 +119,77 @@ STRATEGY_TAGS: dict[str, set[StrategyTag]] = {
     #: - https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint
     #: - eth_defi/hyperliquid/vault.py
     "0xdb25411e42659d910136dbe9c0f8330d952b5df8": {StrategyTag.statistical_arbitrage},
+    #: Vault: ETHbotic.
+    #: Added: 2026-08-18.
+    #: Decision material: The current vault description explicitly says it
+    #: uses advanced automation and smart grid strategies, supporting
+    #: algorithmic grid trading.
+    #: Sources:
+    #: - https://app.hyperliquid.xyz/vaults/0x30f14b7169c657a03d0b6c722b969bee04b8f642
+    #: - https://api.hyperliquid.xyz/info
+    "0x30f14b7169c657a03d0b6c722b969bee04b8f642": {
+        StrategyTag.algorithmic_trading,
+        StrategyTag.grid_trading,
+    },
+    #: Vault: Gizbar Gird.
+    #: Added: 2026-08-18.
+    #: Decision material: The current vault description explicitly says it
+    #: runs long-only grid strategies on trending assets, supporting
+    #: directional grid trading.
+    #: Sources:
+    #: - https://app.hyperliquid.xyz/vaults/0xbe9ee55bc95b43b6a31bad63d5934492b99c6a87
+    #: - https://api.hyperliquid.xyz/info
+    "0xbe9ee55bc95b43b6a31bad63d5934492b99c6a87": {
+        StrategyTag.directional_trading,
+        StrategyTag.grid_trading,
+    },
+    #: Vault: Gucky_1coin_1dot5x.
+    #: Added: 2026-08-18.
+    #: Decision material: The current vault description explicitly calls the
+    #: strategy reverse grid trading, using dollar-cost averaging and
+    #: multiple re-entries.
+    #: Sources:
+    #: - https://app.hyperliquid.xyz/vaults/0xd2f03635901956b950737bbf02463dfad9f2e9e1
+    #: - https://api.hyperliquid.xyz/info
+    "0xd2f03635901956b950737bbf02463dfad9f2e9e1": {StrategyTag.grid_trading},
+    #: Vault: Gucky_2coin_1dot75x.
+    #: Added: 2026-08-18.
+    #: Decision material: The current vault description explicitly calls the
+    #: strategy reverse grid trading, using dollar-cost averaging and
+    #: multiple re-entries.
+    #: Sources:
+    #: - https://app.hyperliquid.xyz/vaults/0x3a6747c8e913085e243a2c22d188dafa8c6a612a
+    #: - https://api.hyperliquid.xyz/info
+    "0x3a6747c8e913085e243a2c22d188dafa8c6a612a": {StrategyTag.grid_trading},
+    #: Vault: Gucky_4coin_2dot5x.
+    #: Added: 2026-08-18.
+    #: Decision material: The current vault description explicitly calls the
+    #: strategy reverse grid trading, using dollar-cost averaging and
+    #: multiple re-entries.
+    #: Sources:
+    #: - https://app.hyperliquid.xyz/vaults/0x73f6553d3a6b570ab37957b32a75c7fc0ebff6e9
+    #: - https://api.hyperliquid.xyz/info
+    "0x73f6553d3a6b570ab37957b32a75c7fc0ebff6e9": {StrategyTag.grid_trading},
+    #: Vault: Hype $1 Club.
+    #: Added: 2026-08-18.
+    #: Decision material: The current vault description explicitly calls the
+    #: strategy automated grid trading on HYPE, supporting algorithmic grid
+    #: trading.
+    #: Sources:
+    #: - https://app.hyperliquid.xyz/vaults/0x7833b1d61c016fefaa52a1da509b6daa2fbfd71b
+    #: - https://api.hyperliquid.xyz/info
+    "0x7833b1d61c016fefaa52a1da509b6daa2fbfd71b": {
+        StrategyTag.algorithmic_trading,
+        StrategyTag.grid_trading,
+    },
+    #: Vault: Proven grid trading.
+    #: Added: 2026-08-18.
+    #: Decision material: The current vault description explicitly calls the
+    #: strategy a proven grid strategy backed by four years of testing.
+    #: Sources:
+    #: - https://app.hyperliquid.xyz/vaults/0xa91dc75e17795cf4c0e4e5b4fc29d3f07432b895
+    #: - https://api.hyperliquid.xyz/info
+    "0xa91dc75e17795cf4c0e4e5b4fc29d3f07432b895": {StrategyTag.grid_trading},
     #: Vault: [ Systemic Strategies ] L/S Grids.
     #: Added: 2026-08-18.
     #: Decision material: The current vault description says it uses grids to
@@ -130,6 +201,19 @@ STRATEGY_TAGS: dict[str, set[StrategyTag]] = {
     #: - https://app.hyperliquid.xyz/vaults/0x07fd993f0fa3a185f7207adccd29f7a87404689d
     #: - https://api.hyperliquid.xyz/info
     "0x07fd993f0fa3a185f7207adccd29f7a87404689d": {
+        StrategyTag.directional_trading,
+        StrategyTag.grid_trading,
+    },
+    #: Vault: wmm.club | grid-hype-long-2x.
+    #: Added: 2026-08-18.
+    #: Decision material: The current vault description explicitly says this
+    #: is an algorithm-managed infinite grid on HYPE with long-only exposure,
+    #: supporting algorithmic directional grid trading.
+    #: Sources:
+    #: - https://app.hyperliquid.xyz/vaults/0x3dc8751d34ac4e5786e9cd1c52a001d2fe58dc37
+    #: - https://api.hyperliquid.xyz/info
+    "0x3dc8751d34ac4e5786e9cd1c52a001d2fe58dc37": {
+        StrategyTag.algorithmic_trading,
         StrategyTag.directional_trading,
         StrategyTag.grid_trading,
     },

--- a/eth_defi/hyperliquid/tags.py
+++ b/eth_defi/hyperliquid/tags.py
@@ -119,6 +119,20 @@ STRATEGY_TAGS: dict[str, set[StrategyTag]] = {
     #: - https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint
     #: - eth_defi/hyperliquid/vault.py
     "0xdb25411e42659d910136dbe9c0f8330d952b5df8": {StrategyTag.statistical_arbitrage},
+    #: Vault: [ Systemic Strategies ] L/S Grids.
+    #: Added: 2026-08-18.
+    #: Decision material: The current vault description says it uses grids to
+    #: go long assets with low inflation or unlocks and short assets with high
+    #: inflation or unlocks. This explicitly supports grid-trading and
+    #: directional long/short classifications.
+    #: Sources:
+    #: - http://100.103.237.120:5182/vaults/systemic-strategies-l-s-grids
+    #: - https://app.hyperliquid.xyz/vaults/0x07fd993f0fa3a185f7207adccd29f7a87404689d
+    #: - https://api.hyperliquid.xyz/info
+    "0x07fd993f0fa3a185f7207adccd29f7a87404689d": {
+        StrategyTag.directional_trading,
+        StrategyTag.grid_trading,
+    },
     #: Vault: Wilkins Capital.
     #: Added: 2026-08-17.
     #: Decision material: The Hyperliquid vault description explicitly says

--- a/eth_defi/lighter/tags.py
+++ b/eth_defi/lighter/tags.py
@@ -19,6 +19,17 @@ STRATEGY_TAGS: dict[str, set[StrategyTag]] = {
         StrategyTag.algorithmic_trading,
         StrategyTag.pair_trading,
     },
+    #: Vault: Steady Wealth Builder.
+    #: Added: 2026-08-18.
+    #: Decision material: The current Lighter description explicitly calls
+    #: this a long-only DCA grid strategy, supporting directional grid trading.
+    #: Sources:
+    #: - https://app.lighter.xyz/public-pools/281474976552443
+    #: - https://mainnet.zklighter.elliot.ai/api/v1/account?by=index&value=281474976552443
+    "lighter-pool-281474976552443": {
+        StrategyTag.directional_trading,
+        StrategyTag.grid_trading,
+    },
 }
 
 

--- a/tests/perp_dex/test_perp_dex_strategy_tags.py
+++ b/tests/perp_dex/test_perp_dex_strategy_tags.py
@@ -68,13 +68,20 @@ def test_grvt_rwa_bundle_vaults_do_not_receive_perpetual_futures_default() -> No
         assert StrategyTag.perpetual_futures not in grvt_tags.get_strategy_tags(address)
 
 
-def test_grvt_ai_grid_vault_is_grid_trading() -> None:
-    """The AI Grid Trading vault has the specific grid-trading tag."""
+def test_grvt_grid_vaults_are_grid_trading() -> None:
+    """GRVT vaults with explicit grid descriptions receive the tag."""
     assert grvt_tags.get_strategy_tags("VLT:35jPjdfRWaEuJ0W7He4wI5vbOaG") == {
         StrategyTag.algorithmic_trading,
         StrategyTag.directional_trading,
         StrategyTag.grid_trading,
         StrategyTag.multistrategy,
+        StrategyTag.perpetual_futures,
+    }
+    assert grvt_tags.get_strategy_tags("VLT:32Aef5QKjhKibVf8inQq9OQsYEP") == {
+        StrategyTag.algorithmic_trading,
+        StrategyTag.directional_trading,
+        StrategyTag.grid_trading,
+        StrategyTag.mean_reversion,
         StrategyTag.perpetual_futures,
     }
 
@@ -116,6 +123,49 @@ def test_hyperliquid_statistical_arbitrage_vaults_are_tagged() -> None:
 def test_systemic_strategies_ls_grids_is_directional_grid_trading() -> None:
     """Systemic Strategies L/S Grids receives its description-backed tags."""
     assert hyperliquid_tags.get_strategy_tags("0x07fd993f0fa3a185f7207adccd29f7a87404689d") == {
+        StrategyTag.directional_trading,
+        StrategyTag.grid_trading,
+        StrategyTag.perpetual_futures,
+    }
+
+
+@pytest.mark.parametrize(
+    ("vault_address", "specific_tags"),
+    [
+        (
+            "0x30f14b7169c657a03d0b6c722b969bee04b8f642",
+            {StrategyTag.algorithmic_trading, StrategyTag.grid_trading},
+        ),
+        (
+            "0xbe9ee55bc95b43b6a31bad63d5934492b99c6a87",
+            {StrategyTag.directional_trading, StrategyTag.grid_trading},
+        ),
+        ("0xd2f03635901956b950737bbf02463dfad9f2e9e1", {StrategyTag.grid_trading}),
+        ("0x3a6747c8e913085e243a2c22d188dafa8c6a612a", {StrategyTag.grid_trading}),
+        ("0x73f6553d3a6b570ab37957b32a75c7fc0ebff6e9", {StrategyTag.grid_trading}),
+        (
+            "0x7833b1d61c016fefaa52a1da509b6daa2fbfd71b",
+            {StrategyTag.algorithmic_trading, StrategyTag.grid_trading},
+        ),
+        ("0xa91dc75e17795cf4c0e4e5b4fc29d3f07432b895", {StrategyTag.grid_trading}),
+        (
+            "0x3dc8751d34ac4e5786e9cd1c52a001d2fe58dc37",
+            {
+                StrategyTag.algorithmic_trading,
+                StrategyTag.directional_trading,
+                StrategyTag.grid_trading,
+            },
+        ),
+    ],
+)
+def test_hyperliquid_grid_descriptions_are_tagged(vault_address: str, specific_tags: set[StrategyTag]) -> None:
+    """Explicit Hyperliquid grid descriptions receive all supported tags."""
+    assert hyperliquid_tags.get_strategy_tags(vault_address) == specific_tags | {StrategyTag.perpetual_futures}
+
+
+def test_lighter_grid_description_is_tagged() -> None:
+    """The long-only Lighter grid pool receives its supported tags."""
+    assert lighter_tags.get_strategy_tags("lighter-pool-281474976552443") == {
         StrategyTag.directional_trading,
         StrategyTag.grid_trading,
         StrategyTag.perpetual_futures,

--- a/tests/perp_dex/test_perp_dex_strategy_tags.py
+++ b/tests/perp_dex/test_perp_dex_strategy_tags.py
@@ -113,6 +113,15 @@ def test_hyperliquid_statistical_arbitrage_vaults_are_tagged() -> None:
     assert hyperliquid_tags.get_strategy_tags("0xdb25411e42659d910136dbe9c0f8330d952b5df8") == expected
 
 
+def test_systemic_strategies_ls_grids_is_directional_grid_trading() -> None:
+    """Systemic Strategies L/S Grids receives its description-backed tags."""
+    assert hyperliquid_tags.get_strategy_tags("0x07fd993f0fa3a185f7207adccd29f7a87404689d") == {
+        StrategyTag.directional_trading,
+        StrategyTag.grid_trading,
+        StrategyTag.perpetual_futures,
+    }
+
+
 def test_hlp_and_fire_liquidity_provider_are_market_makers() -> None:
     """Protocol liquidity pools receive consistent market-making tags."""
     expected = {


### PR DESCRIPTION
## Why

Explicitly documented grid-trading strategies were not consistently exposed in native perpetual DEX vault metadata. This prevents strategy-aware consumers from distinguishing them from generic perpetual-futures vaults.

## Lessons learnt

Native perpetual DEX classifications are additive: each maintained address mapping supplements the platform default perpetual-futures tag. Classifications must follow the published strategy text; for example, Crosshair remains unclassified because grid appears only in an unrelated website URL, not in its strategy description.

## Summary

- Add source-documented grid-trading classifications for nine Hyperliquid vaults, including Systemic Strategies L/S Grids.
- Extend the existing GRVT Ignight Inverse-Trend mapping with grid trading.
- Add source-documented directional grid-trading classification for the Lighter Steady Wealth Builder pool.
- Add exact no-RPC coverage for every newly classified resolved tag set.
- Update the changelog.

## Related issues and PRs

Continues the strategy-tag framework introduced in #1474.

## Unrelated CI and test fixes

None.