### PR TITLE
notes: mark VI-USDC-QA_G illiquid

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -391,6 +391,8 @@ BORROWABLE_USDC_SILOID_142_ILLIQUID = "Borrowable USDC Deposit, SiloId: 142 is i
 
 BORROWABLE_USDC_SILOID_145_ILLIQUID = "Borrowable USDC Deposit, SiloId: 145 is illiquid"
 
+VI_USDC_QA_G_ILLIQUID = "VI-USDC-QA_G is illiquid."
+
 
 #: Protocol-wide flags and notes.
 #:
@@ -855,6 +857,8 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0xc7990369da608c2f4903715e3bd22f2970536c29": (None, MAINST_VAULT),
     # Altura Vault Tokens (AVLT) on Hyperliquid
     "0xd0ee0cf300dfb598270cd7f4d0c6e0d8f6e13f29": (VaultFlag.controversial, CONTROVERSIAL_VAULT),
+    # VI-USDC-QA_G (Euler on Sonic)
+    "0xd80c3e98c9093b41645c07c2b6d956136f89559b": (VaultFlag.illiquid, VI_USDC_QA_G_ILLIQUID),
 }
 
 for addr in VAULT_FLAGS_AND_NOTES.keys():

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -185,6 +185,7 @@ def test_old_mainnet_out_of_gas_contract_is_skipped_by_multicall_blacklist() -> 
         ("0xa5eed1615cd883dd6883ca3a385f525e3beb4e79", "Euler", VaultFlag.illiquid, "Stream xUSD"),
         ("0x70c329d6f06b33fa6b75e335b35168b1de84217b", "Euler", VaultFlag.illiquid, "Stream xUSD"),
         ("0xeaf77df5d03306bca4ee8b58b6821e6aca76309d", "Euler", VaultFlag.illiquid, "Stream xUSD"),
+        ("0xd80c3e98c9093b41645c07c2b6d956136f89559b", "Euler", VaultFlag.illiquid, "illiquid"),
         ("0xd0ee0cf300dfb598270cd7f4d0c6e0d8f6e13f29", "Altura", VaultFlag.controversial, "controversial"),
         ("0xda2f1b3cba732d779cff56f0cf9d3bc8aea6cd8d", "Yearn", VaultFlag.subvault, "not intended"),
         ("0x8092c20351cf4048b464df2144dc8a4dd49ce71d", "Morpho", VaultFlag.subvault, "not intended"),


### PR DESCRIPTION
## Why

VI-USDC-QA_G has zero available liquidity and full utilisation, so it should not be presented as a usable vault.

## Lessons learnt

Manual vault flags are address-based and apply across chains, so the canonical Sonic contract address must be lowercased.

## Summary

- Marked the Sonic Euler VI-USDC-QA_G vault as illiquid.
- Added regression coverage for its flag, note, and risk classification.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.