### PR TITLE
notes: Mark Curve Boosted crvUSD-sUSDe Lender as subvault

### DIFF
--- a/eth_defi/vault/flag.py
+++ b/eth_defi/vault/flag.py
@@ -673,6 +673,8 @@ VAULT_FLAGS_AND_NOTES: dict[str, tuple[VaultFlag | None, str]] = {
     "0x85968bf0f1f110c707fef10a59f80118f349c058": (VaultFlag.subvault, SUBVAULT),
     # Curve Boosted crvUSD-sfrxUSD Lender
     "0xf91a9a1c782a1c11b627f6e576d92c7d72cdd4af": (VaultFlag.subvault, SUBVAULT),
+    # Curve Boosted crvUSD-sUSDe Lender
+    "0x6abbda8243f4bf130a97beae759a6e91522520b9": (VaultFlag.subvault, SUBVAULT),
     # dgnHYPE (D2 Finance on Arbitrum)
     "0x64167cd42859f64cff2aa4b63c3175ccef9659dd": (VaultFlag.subvault, SUBVAULT),
     # Convex crvUSD-sfrxUSD Lender

--- a/tests/vault/test_flag.py
+++ b/tests/vault/test_flag.py
@@ -126,6 +126,7 @@ def test_old_mainnet_out_of_gas_contract_is_skipped_by_multicall_blacklist() -> 
         ("0xd0ee0cf300dfb598270cd7f4d0c6e0d8f6e13f29", "Altura", VaultFlag.controversial, "controversial"),
         ("0xda2f1b3cba732d779cff56f0cf9d3bc8aea6cd8d", "Yearn", VaultFlag.subvault, "not intended"),
         ("0x8092c20351cf4048b464df2144dc8a4dd49ce71d", "Morpho", VaultFlag.subvault, "not intended"),
+        ("0x6abbda8243f4bf130a97beae759a6e91522520b9", "Yearn", VaultFlag.subvault, "not intended"),
         ("0x049e8aab2d3ca187e47d74cf8171ad266f18643e", "Yearn", VaultFlag.subvault, "not intended"),
         ("0xc9f01b5c6048b064e6d925d1c2d7206d4feef8a3", "Yearn", VaultFlag.subvault, "not intended"),
         ("0x93fec6639717b6215a48e5a72a162c50dcc40d68", "Yearn", VaultFlag.subvault, "not intended"),


### PR DESCRIPTION
## Why

Curve Boosted crvUSD-sUSDe Lender is a strategy component vault and should not be shown as a primary end-user vault.

## Lessons learnt

Subvaults are represented with the shared `SUBVAULT` note and `VaultFlag.subvault` exclusion flag in `eth_defi.vault.flag`.

## Summary

- Marked `0x6abbda8243f4bf130a97beae759a6e91522520b9` as `VaultFlag.subvault`.
- Added focused vault flag test coverage.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.