### PR TITLE
fix: normalise Enzyme Onyx USD metrics to USDC

### DIFF
--- a/docs/source/vaults/enzyme/index.rst
+++ b/docs/source/vaults/enzyme/index.rst
@@ -35,6 +35,13 @@ It calculates total value as ``share price × share supply`` in the declared
 value asset. A value asset can be a named unit, such as USD, rather than an
 ERC-20 token, so this value is not necessarily a US-dollar valuation.
 
+For comparable scanner metrics, Base Onyx Shares with the named ``USD`` value
+asset are exported with Base USDC as their denomination token. This is a
+reporting convention for the USD-valued share price and TVL, not a claim that
+USDC is the asset accepted by the current deposit handler: an Onyx handler can
+instead accept USDT or another ERC-20. Transaction integrations must inspect
+the active handler rather than use this normalised denomination.
+
 The Onyx adapter supports discovery, metadata and historical accounting. It
 does not implement deposits, redemptions, flow-event accounting or portfolio
 composition, because these depend on the particular handler configuration.

--- a/eth_defi/data/vaults/metadata/enzyme.yaml
+++ b/eth_defi/data/vaults/metadata/enzyme.yaml
@@ -16,8 +16,10 @@ long_description: |
   Enzyme Onyx uses a standalone Shares token and modular components. The
   supported Base scanner discovers official Onyx SharesFactory deployments and
   publishes each vehicle's share price and supply in a selected accounting
-  unit, which may be a named unit such as USD. Its calculated total value is
-  in that unit and is not necessarily a US-dollar valuation. Blue current
+  unit, which may be a named unit such as USD. USD-denominated investment
+  vehicles are presented in USDC terms for like-for-like comparison with other
+  USD vaults; their specific subscription handler can nevertheless accept a
+  different token. Blue current
   metadata recognises the reviewed allowed-deposit-recipients policy. Onyx
   Shares cannot enumerate deposit handlers, so its current deposit permission
   remains unknown. Historical open/closed deposit and redemption status is not

--- a/eth_defi/enzyme/onyx_historical.py
+++ b/eth_defi/enzyme/onyx_historical.py
@@ -24,7 +24,10 @@ class EnzymeVaultHistoricalReader(VaultHistoricalReader):
     The current Onyx ``sharePrice`` field and Shares ERC-20 token use
     18-decimal fixed-point values. The reader reports the stored share value
     in the vault's declared value asset and calculates total value as
-    ``share_price * total_supply``. Historical deposit and redemption
+    ``share_price * total_supply``. For the Base ``USD`` value-asset label,
+    the adapter deliberately exports these values in USDC terms so generic
+    lifetime metrics remain comparable; this is not proof that USDC was the
+    active deposit token. Historical deposit and redemption
     availability is unsupported: Shares delegates these actions to mutable,
     potentially account-restricted handlers and cannot enumerate those
     handlers. The reader therefore leaves ``deposits_open`` and

--- a/eth_defi/enzyme/onyx_vault.py
+++ b/eth_defi/enzyme/onyx_vault.py
@@ -3,7 +3,9 @@
 Enzyme's current Base deployment is the modular Onyx protocol. Its ``Shares``
 contract is an ERC-20 vault share token, but it deliberately does not implement
 ERC-4626. Valuation is published by a connected handler as a stored
-18-decimal ``sharePrice()`` in a named accounting unit such as USD.
+18-decimal ``sharePrice()`` in a named accounting unit such as USD. The scanner
+normalises the USD reporting unit to native Base USDC for cross-vault metrics;
+this does not identify the active handler's deposit asset.
 
 Official Base deployment and ABI source:
 https://github.com/enzymefinance/onyx-sdk/tree/main/packages/environment
@@ -22,10 +24,11 @@ from web3.contract import Contract
 from eth_defi.abi import get_deployed_contract
 from eth_defi.enzyme.fee import combine_user_facing_management_fee
 from eth_defi.enzyme.offchain_metadata import fetch_enzyme_vault_metadata
+from eth_defi.enzyme.onyx_discovery import ENZYME_BASE_CHAIN_ID
 from eth_defi.enzyme.onyx_flow import EnzymeVaultFlowManager
 from eth_defi.enzyme.onyx_historical import EnzymeVaultHistoricalReader
 from eth_defi.erc_4626.core import ERC4626Feature
-from eth_defi.token import TokenDetails, fetch_erc20_details
+from eth_defi.token import USDC_NATIVE_TOKEN, TokenDetails, fetch_erc20_details
 from eth_defi.types import Percent
 from eth_defi.vault.base import TradingUniverse, VaultBase, VaultFlowManager, VaultHistoricalReader, VaultInfo, VaultPortfolio, VaultSpec
 from eth_defi.vault.deposit_redeem import VaultDepositManager
@@ -35,6 +38,14 @@ from eth_defi.vault.lower_case_dict import LowercaseDict
 VALUE_ASSET_DECIMALS = 18
 FEE_BPS_DENOMINATOR = 10_000
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+#: Onyx ``Shares.getValueAsset()`` is a human-readable accounting label, not
+#: an ERC-20 deposit-token address. For comparable vault metrics, every Base
+#: Shares vehicle labelled ``USD`` is deliberately denominated in native Base
+#: USDC. This is a reporting assumption: a current handler can instead accept
+#: USDT, EURC, or another asset, and transaction code must never use this value
+#: to choose a deposit token.
+ONYX_USD_COMPARABILITY_TOKEN = HexAddress(USDC_NATIVE_TOKEN[ENZYME_BASE_CHAIN_ID])
 
 
 class EnzymeVaultUnsupportedError(RuntimeError):
@@ -71,8 +82,11 @@ class EnzymeVault(VaultBase):
         :param default_block_identifier:
             Block used for ordinary metadata reads.
         :param require_denomination_token:
-            Kept for :class:`VaultBase` compatibility. Onyx uses a named
-            value asset, not a denomination ERC-20 token.
+            Enforce a resolved reporting denomination in operational callers.
+            USD-value Onyx Shares resolve to native Base USDC by the explicit
+            comparability assumption documented in
+            :meth:`fetch_denomination_token_address`; this does not certify
+            USDC as a handler deposit asset.
         """
 
         super().__init__(token_cache=token_cache, require_denomination_token=require_denomination_token)
@@ -170,14 +184,53 @@ class EnzymeVault(VaultBase):
         return self.address
 
     def fetch_denomination_token_address(self) -> HexAddress | None:
-        """Return no denomination token because Onyx uses a named value asset."""
+        """Map Onyx USD accounting values to Base USDC for metric comparison.
 
+        Onyx ``Shares`` records a named value asset rather than an ERC-20
+        denomination token. The scanner needs an ERC-20 denomination to keep
+        USD-valued Onyx share prices, TVL and lifetime metrics comparable with
+        other vaults. It therefore deliberately maps every Base ``USD`` value
+        asset to native Base USDC.
+
+        This is not evidence that USDC is the active deposit asset. An Onyx
+        vehicle can use a handler that accepts USDT or another ERC-20 while
+        continuing to report its valuation in USD. Deposit and redemption code
+        must inspect the active handler instead of relying on this reporting
+        normalisation.
+
+        :return:
+            Base USDC for ``USD``-valued Base Shares, otherwise ``None`` until
+            the corresponding non-USD reporting-unit policy is implemented.
+        """
+
+        if self.chain_id == ENZYME_BASE_CHAIN_ID and self.fetch_value_asset(self._get_block_identifier()) == "USD":
+            return ONYX_USD_COMPARABILITY_TOKEN
         return None
 
     def fetch_denomination_token(self) -> TokenDetails | None:
-        """Return no ERC-20 denomination token for named Onyx value assets."""
+        """Fetch the ERC-20 selected by the Onyx reporting normalisation.
 
-        return None
+        The returned token represents the scanner's valuation denomination,
+        not a source-proven Onyx handler deposit asset. See
+        :meth:`fetch_denomination_token_address` for the USD-to-USDC
+        comparability assumption and its transaction-flow limitation.
+
+        :return:
+            Native Base USDC metadata for a ``USD`` value asset, otherwise
+            ``None``.
+        """
+
+        address = self.fetch_denomination_token_address()
+        if address is None:
+            return None
+        return fetch_erc20_details(
+            self.web3,
+            address,
+            chain_id=self.chain_id,
+            raise_on_error=False,
+            cache=self.token_cache,
+            cause_diagnostics_message=f"Enzyme Onyx USD value asset normalised to Base USDC for {self.address}",
+        )
 
     def fetch_value_asset(self, block_identifier: BlockIdentifier = "latest") -> str:
         """Read the declared Onyx accounting unit, such as ``USD``.
@@ -226,11 +279,21 @@ class EnzymeVault(VaultBase):
         return self.fetch_total_assets(block_identifier)
 
     def fetch_info(self) -> VaultInfo:
-        """Fetch the vault address and its declared accounting unit."""
+        """Fetch the vault address, accounting unit and metric denomination.
+
+        ``denomination_assumption`` records that the USD-to-USDC mapping is a
+        metrics convention. It must not be interpreted as a handler deposit
+        asset or as evidence that a user can deposit USDC.
+
+        :return:
+            Shares address, declared value asset and exported denomination
+            assumption.
+        """
 
         return {
             "shares": self.address,
             "value_asset": self.fetch_value_asset(self._get_block_identifier()),
+            "denomination_assumption": "USD values are exported as native Base USDC for cross-vault metric comparison",
         }
 
     def fetch_portfolio(self, universe: TradingUniverse, block_identifier: BlockIdentifier | None = None) -> VaultPortfolio:

--- a/tests/enzyme/conftest.py
+++ b/tests/enzyme/conftest.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 ENZYME_SKIP_REASON = "Legacy Enzyme Blue V4 deployment suite is no longer maintained"
 
 _ENZYME_TEST_DIR = Path(__file__).parent
-_ACTIVE_ENZYME_TEST_FILES = {"test_backfill_history.py", "test_blue_vault.py", "test_onyx_vault.py"}
+_ACTIVE_ENZYME_TEST_FILES = {"test_backfill_history.py", "test_blue_vault.py", "test_enzyme_lifetime_metrics.py", "test_onyx_vault.py"}
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:

--- a/tests/enzyme/test_enzyme_lifetime_metrics.py
+++ b/tests/enzyme/test_enzyme_lifetime_metrics.py
@@ -1,0 +1,180 @@
+"""Exercise Enzyme Blue and Onyx vaults through lifetime-metric export."""
+
+import datetime
+import os
+from dataclasses import dataclass
+from decimal import Decimal
+
+import pandas as pd
+import pytest
+from web3 import Web3
+
+from eth_defi.compat import native_datetime_utc_fromtimestamp
+from eth_defi.erc_4626.classification import create_vault_instance
+from eth_defi.erc_4626.core import ERC4262VaultDetection, ERC4626Feature
+from eth_defi.erc_4626.scan import create_vault_scan_record
+from eth_defi.research.vault_metrics import calculate_hourly_returns_for_all_vaults, calculate_lifetime_metrics, export_lifetime_row
+from eth_defi.testing.anvil_fork_pool import AnvilForkPool
+from eth_defi.testing.fork_blocks import BASE_MIDNIGHT_BLOCK
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.vaultdb import VaultDatabase
+
+JSON_RPC_BASE = os.environ.get("JSON_RPC_BASE")
+
+#: Enzyme Blue Base Camp VaultProxy, deployed before the shared Base fork block.
+ENZYME_BLUE_VAULT = "0x75a17c22235b2dd584e3ea8c142422d97b826816"
+ENZYME_BLUE_FIRST_SEEN_BLOCK = 23_221_202
+ENZYME_BLUE_FIRST_SEEN_AT = datetime.datetime(2024, 12, 3, 13, 15, 51)  # noqa: DTZ001 - scanner uses naive UTC.
+
+#: Enzyme Onyx USD-valued Shares vault, deployed before the shared Base fork block.
+ENZYME_ONYX_VAULT = "0xdd922b0a90c3273c76fd68f3265293d50923a904"
+ENZYME_ONYX_FIRST_SEEN_BLOCK = 36_213_502
+ENZYME_ONYX_FIRST_SEEN_AT = datetime.datetime(2025, 9, 30, 7, 12, 31)  # noqa: DTZ001 - scanner uses naive UTC.
+
+
+@dataclass(slots=True, frozen=True)
+class EnzymeMetricProfile:
+    """Describe one real Enzyme vault's fixed-block metric expectations.
+
+    :param address: Canonical Blue VaultProxy or Onyx Shares address.
+    :param features: Factory-confirmed Enzyme architecture flag.
+    :param first_seen_block: Factory deployment block used in scanner metadata.
+    :param first_seen_at: Naive UTC factory deployment timestamp.
+    :param expected_denomination: Expected exported denominator symbol.
+    :param expected_share_price: Exact fixed-block vault share price.
+    :param expected_total_assets: Exact fixed-block vault TVL.
+    :param expected_total_supply: Exact fixed-block share supply.
+    """
+
+    address: str
+    features: set[ERC4626Feature]
+    first_seen_block: int
+    first_seen_at: datetime.datetime
+    expected_denomination: str
+    expected_share_price: Decimal
+    expected_total_assets: Decimal
+    expected_total_supply: Decimal
+
+
+pytestmark = [
+    pytest.mark.skipif(JSON_RPC_BASE is None, reason="JSON_RPC_BASE needed to run Enzyme lifetime-metric integration tests"),
+    # Reuse the canonical Base fork with other read-only characterisation tests.
+    pytest.mark.xdist_group("fork:base:midnight"),
+]
+
+
+@pytest.fixture(scope="module")
+def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
+    """Connect to the shared, read-only Base midnight fork.
+
+    :param anvil_fork_pool: Session-scoped fixed-block Anvil fork registry.
+    :return: Web3 connection pinned to :data:`BASE_MIDNIGHT_BLOCK`.
+    """
+
+    assert JSON_RPC_BASE is not None
+    return anvil_fork_pool.get_web3(JSON_RPC_BASE, BASE_MIDNIGHT_BLOCK)
+
+
+@pytest.mark.parametrize(
+    "profile",
+    [
+        EnzymeMetricProfile(
+            address=ENZYME_BLUE_VAULT,
+            features={ERC4626Feature.enzyme_blue_like},
+            first_seen_block=ENZYME_BLUE_FIRST_SEEN_BLOCK,
+            first_seen_at=ENZYME_BLUE_FIRST_SEEN_AT,
+            expected_denomination="WETH",
+            expected_share_price=Decimal("1"),
+            expected_total_assets=Decimal("0.01"),
+            expected_total_supply=Decimal("0.01"),
+        ),
+        EnzymeMetricProfile(
+            address=ENZYME_ONYX_VAULT,
+            features={ERC4626Feature.enzyme_onyx_like},
+            first_seen_block=ENZYME_ONYX_FIRST_SEEN_BLOCK,
+            first_seen_at=ENZYME_ONYX_FIRST_SEEN_AT,
+            expected_denomination="USDC",
+            expected_share_price=Decimal("0.962906956707870729"),
+            expected_total_assets=Decimal("12.85933917909920077489685820"),
+            expected_total_supply=Decimal("13.35470586178400751"),
+        ),
+    ],
+)
+def test_enzyme_vault_reaches_lifetime_metrics(
+    web3: Web3,
+    profile: EnzymeMetricProfile,
+) -> None:
+    """Export one real Enzyme Blue and Onyx vault through the full metric path.
+
+    The test reads the production adapter and historical reader at the shared
+    fixed Base fork, creates a scanner metadata row, and calculates lifetime
+    metrics from representative price observations. This catches interface
+    regressions between protocol-specific readers and the generic exporter.
+
+    :param web3: Shared Base fork connection.
+    :param profile: Fixed-block expectations for the selected Enzyme vault.
+    :return: None. Assertions verify the complete export path.
+    """
+
+    vault = create_vault_instance(
+        web3,
+        profile.address,
+        features=profile.features,
+        token_cache={},
+        default_block_identifier=BASE_MIDNIGHT_BLOCK,
+        require_denomination_token=True,
+    )
+    assert vault is not None
+    assert vault.denomination_token is not None
+    assert vault.denomination_token.symbol == profile.expected_denomination
+
+    reader = vault.get_historical_reader(stateful=True)
+    call_results = [call.call_as_result(web3, block_identifier=BASE_MIDNIGHT_BLOCK, ignore_error=True) for call in reader.construct_multicalls()]
+    timestamp = native_datetime_utc_fromtimestamp(web3.eth.get_block(BASE_MIDNIGHT_BLOCK)["timestamp"])
+    for result in call_results:
+        result.timestamp = timestamp
+    historical_read = reader.process_result(BASE_MIDNIGHT_BLOCK, timestamp, call_results)
+
+    assert historical_read.errors is None
+    assert historical_read.share_price == profile.expected_share_price
+    assert historical_read.total_assets == profile.expected_total_assets
+    assert historical_read.total_supply == profile.expected_total_supply
+
+    detection = ERC4262VaultDetection(
+        chain=8453,
+        address=profile.address,
+        first_seen_at_block=profile.first_seen_block,
+        first_seen_at=profile.first_seen_at,
+        features=profile.features,
+        updated_at=profile.first_seen_at,
+        deposit_count=0,
+        redeem_count=0,
+    )
+    scan_record = create_vault_scan_record(web3, detection, block_identifier=BASE_MIDNIGHT_BLOCK, token_cache={})
+    assert scan_record["Denomination"] == profile.expected_denomination
+    assert scan_record["NAV"] == profile.expected_total_assets
+    assert scan_record["Shares"] == profile.expected_total_supply
+
+    spec = VaultSpec(8453, profile.address)
+    timestamps = pd.date_range("2026-07-22", periods=3, freq="D")
+    prices = pd.DataFrame(
+        {
+            "chain": [8453] * 3,
+            "address": [profile.address] * 3,
+            "id": [spec.as_string_id()] * 3,
+            "block_number": [BASE_MIDNIGHT_BLOCK] * 3,
+            "share_price": [float(profile.expected_share_price)] * 3,
+            "total_assets": [float(profile.expected_total_assets)] * 3,
+            "total_supply": [float(profile.expected_total_supply)] * 3,
+            "event_count": [0] * 3,
+            "vault_poll_frequency": ["large_tvl"] * 3,
+        },
+        index=timestamps,
+    )
+    metrics = calculate_lifetime_metrics(calculate_hourly_returns_for_all_vaults(prices), VaultDatabase(rows={spec: scan_record}))
+    exported = export_lifetime_row(metrics.iloc[0])
+
+    assert len(metrics) == 1
+    assert exported["protocol"] == "Enzyme"
+    assert exported["denomination"] == profile.expected_denomination
+    assert exported["current_nav"] == pytest.approx(float(profile.expected_total_assets))

--- a/tests/enzyme/test_onyx_vault.py
+++ b/tests/enzyme/test_onyx_vault.py
@@ -10,7 +10,7 @@ from eth_defi.enzyme import onyx_vault
 from eth_defi.enzyme.blue_vault import EnzymeBlueVault
 from eth_defi.enzyme.onyx_discovery import ENZYME_BASE_SHARES_FACTORY, EnzymeVaultFactoryCandidate, decode_enzyme_shares_deployed_event, fetch_enzyme_shares_factories_for_chain
 from eth_defi.enzyme.onyx_historical import EnzymeVaultHistoricalReader
-from eth_defi.enzyme.onyx_vault import EnzymeVault
+from eth_defi.enzyme.onyx_vault import ONYX_USD_COMPARABILITY_TOKEN, EnzymeVault
 from eth_defi.erc_4626.classification import create_probe_calls, create_vault_instance
 from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name, is_activity_filter_exempt
 from eth_defi.erc_4626.discovery_base import _prepare_probe_leads, create_enzyme_factory_detection, create_enzyme_potential_vault_match  # noqa: PLC2701
@@ -116,6 +116,27 @@ def test_enzyme_current_reader_derives_share_price_and_total_value() -> None:
     assert vault.fetch_total_assets(123) == Decimal("50")
     assert vault.fetch_nav(123) == Decimal("50")
     assert isinstance(vault.get_historical_reader(stateful=False), EnzymeVaultHistoricalReader)
+
+
+def test_enzyme_usd_value_asset_uses_usdc_as_metric_denomination(monkeypatch) -> None:
+    """Normalise USD-valued Onyx metrics to Base USDC, not handler assets."""
+
+    token = SimpleNamespace(address=ONYX_USD_COMPARABILITY_TOKEN, symbol="USDC")
+    vault = EnzymeVault.__new__(EnzymeVault)
+    vault.web3 = SimpleNamespace()
+    vault.spec = SimpleNamespace(chain_id=BASE_CHAIN_ID, vault_address=TEST_SHARES_ADDRESS)
+    vault.default_block_identifier = None
+    vault.token_cache = {}
+    vault.shares_contract = SimpleNamespace(
+        functions=SimpleNamespace(
+            getValueAsset=lambda: SimpleNamespace(call=lambda **_kwargs: b"USD".ljust(32, b"\x00")),
+        )
+    )
+    monkeypatch.setattr(onyx_vault, "fetch_erc20_details", lambda *_args, **_kwargs: token)
+
+    assert vault.fetch_denomination_token_address() == ONYX_USD_COMPARABILITY_TOKEN
+    assert vault.fetch_denomination_token() is token
+    assert vault.fetch_info()["denomination_assumption"] == "USD values are exported as native Base USDC for cross-vault metric comparison"
 
 
 def test_enzyme_current_reader_reads_fee_trackers(monkeypatch) -> None:


### PR DESCRIPTION
## Why

Onyx Shares exposes a named value asset such as USD, not an ERC-20 denomination token. The generic vault pipeline requires a denomination token to maintain reader state and export comparable lifetime metrics.

## Lessons learnt

Onyx handler assets must not be inferred from the Shares value-asset label. A USD-valued vehicle can currently accept USDT or another ERC-20, so the USDC mapping is a reporting convention only and is not transaction-flow support.

## Summary

- Normalise Base Onyx USD valuation metrics to native USDC and document the limitation in code and user-facing documentation.
- Add unit coverage for the explicit normalisation.
- Add shared Base-fork end-to-end tests for both Enzyme Blue and Onyx through historical reading, scan records, and `calculate_lifetime_metrics()`.

## Related issues and PRs

- Follow-up to #1482.