### PR TITLE
fix: map all Enzyme Onyx value assets

### DIFF
--- a/docs/source/vaults/enzyme/index.rst
+++ b/docs/source/vaults/enzyme/index.rst
@@ -35,12 +35,15 @@ It calculates total value as ``share price × share supply`` in the declared
 value asset. A value asset can be a named unit, such as USD, rather than an
 ERC-20 token, so this value is not necessarily a US-dollar valuation.
 
-For comparable scanner metrics, Base Onyx Shares with the named ``USD`` value
-asset are exported with Base USDC as their denomination token. This is a
-reporting convention for the USD-valued share price and TVL, not a claim that
-USDC is the asset accepted by the current deposit handler: an Onyx handler can
-instead accept USDT or another ERC-20. Transaction integrations must inspect
-the active handler rather than use this normalised denomination.
+For comparable scanner metrics, each currently discovered Base Onyx named value
+asset is exported with a canonical Base ERC-20 denomination: ``USD`` with USDC,
+``BTC`` with cbBTC, and ``EUR`` with EURC. This is a reporting convention for
+the share price and TVL, not a claim that the corresponding token is accepted
+by the current deposit handler: an USD-valued Onyx handler can instead accept
+USDT or another ERC-20. Transaction integrations must inspect the active
+handler rather than use this normalised denomination. A new, unsupported named
+value asset fails before historical scanning instead of producing rows without
+a denomination token.
 
 The Onyx adapter supports discovery, metadata and historical accounting. It
 does not implement deposits, redemptions, flow-event accounting or portfolio

--- a/eth_defi/data/vaults/metadata/enzyme.yaml
+++ b/eth_defi/data/vaults/metadata/enzyme.yaml
@@ -16,10 +16,10 @@ long_description: |
   Enzyme Onyx uses a standalone Shares token and modular components. The
   supported Base scanner discovers official Onyx SharesFactory deployments and
   publishes each vehicle's share price and supply in a selected accounting
-  unit, which may be a named unit such as USD. USD-denominated investment
-  vehicles are presented in USDC terms for like-for-like comparison with other
-  USD vaults; their specific subscription handler can nevertheless accept a
-  different token. Blue current
+  unit, which may be a named unit such as USD, BTC or EUR. These investment
+  vehicles are presented in canonical Base USDC, cbBTC or EURC terms for
+  like-for-like comparison with other vaults; their specific subscription
+  handler can nevertheless accept a different token. Blue current
   metadata recognises the reviewed allowed-deposit-recipients policy. Onyx
   Shares cannot enumerate deposit handlers, so its current deposit permission
   remains unknown. Historical open/closed deposit and redemption status is not

--- a/eth_defi/enzyme/onyx_historical.py
+++ b/eth_defi/enzyme/onyx_historical.py
@@ -24,9 +24,10 @@ class EnzymeVaultHistoricalReader(VaultHistoricalReader):
     The current Onyx ``sharePrice`` field and Shares ERC-20 token use
     18-decimal fixed-point values. The reader reports the stored share value
     in the vault's declared value asset and calculates total value as
-    ``share_price * total_supply``. For the Base ``USD`` value-asset label,
-    the adapter deliberately exports these values in USDC terms so generic
-    lifetime metrics remain comparable; this is not proof that USDC was the
+    ``share_price * total_supply``. For the Base ``USD``, ``BTC`` and ``EUR``
+    value-asset labels, the adapter deliberately exports these values in USDC,
+    cbBTC and EURC terms respectively so generic lifetime metrics retain an
+    ERC-20 denomination. This is not proof that the mapped token was the
     active deposit token. Historical deposit and redemption
     availability is unsupported: Shares delegates these actions to mutable,
     potentially account-restricted handlers and cannot enumerate those

--- a/eth_defi/enzyme/onyx_vault.py
+++ b/eth_defi/enzyme/onyx_vault.py
@@ -40,12 +40,22 @@ FEE_BPS_DENOMINATOR = 10_000
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 #: Onyx ``Shares.getValueAsset()`` is a human-readable accounting label, not
-#: an ERC-20 deposit-token address. For comparable vault metrics, every Base
-#: Shares vehicle labelled ``USD`` is deliberately denominated in native Base
-#: USDC. This is a reporting assumption: a current handler can instead accept
-#: USDT, EURC, or another asset, and transaction code must never use this value
-#: to choose a deposit token.
-ONYX_USD_COMPARABILITY_TOKEN = HexAddress(USDC_NATIVE_TOKEN[ENZYME_BASE_CHAIN_ID])
+#: an ERC-20 deposit-token address. Every currently discovered Base label has
+#: a canonical ERC-20 used only to export comparable scanner metrics. This
+#: mapping must reflect the value shown to an investor, not a protocol-internal
+#: handler implementation: a handler can accept USDT, EURC, or another asset
+#: while the Shares vehicle reports its NAV in USD, BTC, or EUR.
+#:
+#: Never use these addresses to select a subscription or redemption token. The
+#: transaction flow must inspect the active handler instead.
+ONYX_VALUE_ASSET_COMPARABILITY_TOKENS: dict[str, HexAddress] = {
+    "USD": HexAddress(USDC_NATIVE_TOKEN[ENZYME_BASE_CHAIN_ID]),
+    "BTC": HexAddress("0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf"),  # Base cbBTC
+    "EUR": HexAddress("0x60a3e35cc302bfa44cb288bc5a4f316fdb1adb42"),  # Base EURC
+}
+
+#: Compatibility alias for callers that need the USD reporting normalisation.
+ONYX_USD_COMPARABILITY_TOKEN = ONYX_VALUE_ASSET_COMPARABILITY_TOKENS["USD"]
 
 
 class EnzymeVaultUnsupportedError(RuntimeError):
@@ -183,31 +193,45 @@ class EnzymeVault(VaultBase):
         del block_identifier
         return self.address
 
-    def fetch_denomination_token_address(self) -> HexAddress | None:
-        """Map Onyx USD accounting values to Base USDC for metric comparison.
+    def fetch_denomination_token_address(self) -> HexAddress:
+        """Map every supported Onyx value asset to a canonical Base ERC-20.
 
         Onyx ``Shares`` records a named value asset rather than an ERC-20
         denomination token. The scanner needs an ERC-20 denomination to keep
-        USD-valued Onyx share prices, TVL and lifetime metrics comparable with
-        other vaults. It therefore deliberately maps every Base ``USD`` value
-        asset to native Base USDC.
+        its share prices, TVL and lifetime metrics comparable with other vaults.
+        It deliberately maps each reviewed Base value-asset label to its
+        canonical ERC-20: ``USD`` to USDC, ``BTC`` to cbBTC, and ``EUR`` to
+        EURC. The mapping covers all 16 Onyx Shares discovered from the
+        official Base SharesFactory as of 2026-08-21.
 
-        This is not evidence that USDC is the active deposit asset. An Onyx
-        vehicle can use a handler that accepts USDT or another ERC-20 while
-        continuing to report its valuation in USD. Deposit and redemption code
-        must inspect the active handler instead of relying on this reporting
-        normalisation.
+        This is not evidence that the canonical token is the active deposit
+        asset. For example, an USD-valued vehicle can use a handler that
+        accepts USDT while continuing to report its NAV in USD. Deposit and
+        redemption code must inspect the active handler instead of relying on
+        this reporting normalisation. An unknown label raises immediately so a
+        historical scan cannot proceed with a missing denomination token and
+        later fail inside the generic reader state.
 
         :return:
-            Base USDC for ``USD``-valued Base Shares, otherwise ``None`` until
-            the corresponding non-USD reporting-unit policy is implemented.
+            Canonical Base ERC-20 used to represent the Shares value asset in
+            scanner metrics.
+        :raise EnzymeVaultUnsupportedError:
+            If the vault is not on Base or Enzyme introduces a value-asset
+            label with no reviewed canonical ERC-20 mapping.
         """
 
-        if self.chain_id == ENZYME_BASE_CHAIN_ID and self.fetch_value_asset(self._get_block_identifier()) == "USD":
-            return ONYX_USD_COMPARABILITY_TOKEN
-        return None
+        if self.chain_id != ENZYME_BASE_CHAIN_ID:
+            raise EnzymeVaultUnsupportedError(f"Enzyme Onyx value-asset mappings are only configured for Base, got chain {self.chain_id}")
 
-    def fetch_denomination_token(self) -> TokenDetails | None:
+        value_asset = self.fetch_value_asset(self._get_block_identifier())
+        try:
+            return ONYX_VALUE_ASSET_COMPARABILITY_TOKENS[value_asset]
+        except KeyError as error:
+            supported_labels = ", ".join(sorted(ONYX_VALUE_ASSET_COMPARABILITY_TOKENS))
+            message = f"Enzyme Onyx Shares vault {self.address} reports unsupported value asset {value_asset!r}; add a reviewed Base ERC-20 mapping before historical scanning. Supported labels: {supported_labels}"
+            raise EnzymeVaultUnsupportedError(message) from error
+
+    def fetch_denomination_token(self) -> TokenDetails:
         """Fetch the ERC-20 selected by the Onyx reporting normalisation.
 
         The returned token represents the scanner's valuation denomination,
@@ -216,21 +240,21 @@ class EnzymeVault(VaultBase):
         comparability assumption and its transaction-flow limitation.
 
         :return:
-            Native Base USDC metadata for a ``USD`` value asset, otherwise
-            ``None``.
+            Metadata for the canonical Base ERC-20 used by the mapped Onyx
+            value asset.
         """
 
-        address = self.fetch_denomination_token_address()
-        if address is None:
-            return None
-        return fetch_erc20_details(
+        token = fetch_erc20_details(
             self.web3,
-            address,
+            self.fetch_denomination_token_address(),
             chain_id=self.chain_id,
             raise_on_error=False,
             cache=self.token_cache,
-            cause_diagnostics_message=f"Enzyme Onyx USD value asset normalised to Base USDC for {self.address}",
+            cause_diagnostics_message=f"Enzyme Onyx value asset normalised to a canonical Base ERC-20 for {self.address}",
         )
+        if token is None:
+            raise EnzymeVaultUnsupportedError(f"Could not read canonical denomination-token metadata for Enzyme Onyx Shares vault {self.address}")
+        return token
 
     def fetch_value_asset(self, block_identifier: BlockIdentifier = "latest") -> str:
         """Read the declared Onyx accounting unit, such as ``USD``.
@@ -281,9 +305,9 @@ class EnzymeVault(VaultBase):
     def fetch_info(self) -> VaultInfo:
         """Fetch the vault address, accounting unit and metric denomination.
 
-        ``denomination_assumption`` records that the USD-to-USDC mapping is a
-        metrics convention. It must not be interpreted as a handler deposit
-        asset or as evidence that a user can deposit USDC.
+        ``denomination_assumption`` records that the named-value-asset mapping
+        is a metrics convention. It must not be interpreted as a handler
+        deposit asset or as evidence that a user can deposit the mapped token.
 
         :return:
             Shares address, declared value asset and exported denomination
@@ -293,7 +317,7 @@ class EnzymeVault(VaultBase):
         return {
             "shares": self.address,
             "value_asset": self.fetch_value_asset(self._get_block_identifier()),
-            "denomination_assumption": "USD values are exported as native Base USDC for cross-vault metric comparison",
+            "denomination_assumption": "Onyx USD, BTC and EUR values are exported as canonical Base USDC, cbBTC and EURC metrics respectively",
         }
 
     def fetch_portfolio(self, universe: TradingUniverse, block_identifier: BlockIdentifier | None = None) -> VaultPortfolio:

--- a/tests/enzyme/test_enzyme_lifetime_metrics.py
+++ b/tests/enzyme/test_enzyme_lifetime_metrics.py
@@ -31,6 +31,12 @@ ENZYME_ONYX_VAULT = "0xdd922b0a90c3273c76fd68f3265293d50923a904"
 ENZYME_ONYX_FIRST_SEEN_BLOCK = 36_213_502
 ENZYME_ONYX_FIRST_SEEN_AT = datetime.datetime(2025, 9, 30, 7, 12, 31)  # noqa: DTZ001 - scanner uses naive UTC.
 
+#: Enzyme Onyx EUR-valued Shares vault. It verifies that a non-USD value asset
+#: reaches the generic historical reader state with an ERC-20 denomination.
+ENZYME_ONYX_EUR_VAULT = "0x48e7c4b85ed4e8b7b0921101c21a806e49dd5006"
+ENZYME_ONYX_EUR_FIRST_SEEN_BLOCK = 44_432_466
+ENZYME_ONYX_EUR_FIRST_SEEN_AT = datetime.datetime(2026, 4, 8, 13, 17, 59)  # noqa: DTZ001 - scanner uses naive UTC.
+
 
 @dataclass(slots=True, frozen=True)
 class EnzymeMetricProfile:
@@ -97,6 +103,16 @@ def web3(anvil_fork_pool: AnvilForkPool) -> Web3:
             expected_share_price=Decimal("0.962906956707870729"),
             expected_total_assets=Decimal("12.85933917909920077489685820"),
             expected_total_supply=Decimal("13.35470586178400751"),
+        ),
+        EnzymeMetricProfile(
+            address=ENZYME_ONYX_EUR_VAULT,
+            features={ERC4626Feature.enzyme_onyx_like},
+            first_seen_block=ENZYME_ONYX_EUR_FIRST_SEEN_BLOCK,
+            first_seen_at=ENZYME_ONYX_EUR_FIRST_SEEN_AT,
+            expected_denomination="EURC",
+            expected_share_price=Decimal("1"),
+            expected_total_assets=Decimal("100"),
+            expected_total_supply=Decimal("100"),
         ),
     ],
 )

--- a/tests/enzyme/test_onyx_vault.py
+++ b/tests/enzyme/test_onyx_vault.py
@@ -4,13 +4,14 @@ import datetime
 from decimal import Decimal
 from types import SimpleNamespace
 
+import pytest
 from eth_abi import encode
 
 from eth_defi.enzyme import onyx_vault
 from eth_defi.enzyme.blue_vault import EnzymeBlueVault
 from eth_defi.enzyme.onyx_discovery import ENZYME_BASE_SHARES_FACTORY, EnzymeVaultFactoryCandidate, decode_enzyme_shares_deployed_event, fetch_enzyme_shares_factories_for_chain
 from eth_defi.enzyme.onyx_historical import EnzymeVaultHistoricalReader
-from eth_defi.enzyme.onyx_vault import ONYX_USD_COMPARABILITY_TOKEN, EnzymeVault
+from eth_defi.enzyme.onyx_vault import ONYX_VALUE_ASSET_COMPARABILITY_TOKENS, EnzymeVault
 from eth_defi.erc_4626.classification import create_probe_calls, create_vault_instance
 from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name, is_activity_filter_exempt
 from eth_defi.erc_4626.discovery_base import _prepare_probe_leads, create_enzyme_factory_detection, create_enzyme_potential_vault_match  # noqa: PLC2701
@@ -118,10 +119,19 @@ def test_enzyme_current_reader_derives_share_price_and_total_value() -> None:
     assert isinstance(vault.get_historical_reader(stateful=False), EnzymeVaultHistoricalReader)
 
 
-def test_enzyme_usd_value_asset_uses_usdc_as_metric_denomination(monkeypatch) -> None:
-    """Normalise USD-valued Onyx metrics to Base USDC, not handler assets."""
+@pytest.mark.parametrize(
+    ("value_asset", "expected_symbol"),
+    [
+        ("USD", "USDC"),
+        ("BTC", "cbBTC"),
+        ("EUR", "EURC"),
+    ],
+)
+def test_enzyme_value_assets_use_canonical_metric_denominations(monkeypatch, value_asset: str, expected_symbol: str) -> None:
+    """Normalise every discovered Onyx value asset without using handler assets."""
 
-    token = SimpleNamespace(address=ONYX_USD_COMPARABILITY_TOKEN, symbol="USDC")
+    expected_address = ONYX_VALUE_ASSET_COMPARABILITY_TOKENS[value_asset]
+    token = SimpleNamespace(address=expected_address, symbol=expected_symbol)
     vault = EnzymeVault.__new__(EnzymeVault)
     vault.web3 = SimpleNamespace()
     vault.spec = SimpleNamespace(chain_id=BASE_CHAIN_ID, vault_address=TEST_SHARES_ADDRESS)
@@ -129,14 +139,30 @@ def test_enzyme_usd_value_asset_uses_usdc_as_metric_denomination(monkeypatch) ->
     vault.token_cache = {}
     vault.shares_contract = SimpleNamespace(
         functions=SimpleNamespace(
-            getValueAsset=lambda: SimpleNamespace(call=lambda **_kwargs: b"USD".ljust(32, b"\x00")),
+            getValueAsset=lambda: SimpleNamespace(call=lambda **_kwargs: value_asset.encode("ascii").ljust(32, b"\x00")),
         )
     )
     monkeypatch.setattr(onyx_vault, "fetch_erc20_details", lambda *_args, **_kwargs: token)
 
-    assert vault.fetch_denomination_token_address() == ONYX_USD_COMPARABILITY_TOKEN
+    assert vault.fetch_denomination_token_address() == expected_address
     assert vault.fetch_denomination_token() is token
-    assert vault.fetch_info()["denomination_assumption"] == "USD values are exported as native Base USDC for cross-vault metric comparison"
+    assert vault.fetch_info()["denomination_assumption"] == "Onyx USD, BTC and EUR values are exported as canonical Base USDC, cbBTC and EURC metrics respectively"
+
+
+def test_enzyme_unknown_value_asset_fails_before_historical_reader() -> None:
+    """Reject a new named value asset instead of leaving its denomination null."""
+
+    vault = EnzymeVault.__new__(EnzymeVault)
+    vault.spec = SimpleNamespace(chain_id=BASE_CHAIN_ID, vault_address=TEST_SHARES_ADDRESS)
+    vault.default_block_identifier = None
+    vault.shares_contract = SimpleNamespace(
+        functions=SimpleNamespace(
+            getValueAsset=lambda: SimpleNamespace(call=lambda **_kwargs: b"GOLD".ljust(32, b"\x00")),
+        )
+    )
+
+    with pytest.raises(onyx_vault.EnzymeVaultUnsupportedError, match="unsupported value asset 'GOLD'"):
+        vault.fetch_denomination_token_address()
 
 
 def test_enzyme_current_reader_reads_fee_trackers(monkeypatch) -> None:


### PR DESCRIPTION
## Why

The Enzyme Onyx historical backfill could still fail inside generic reader state when a Shares vehicle declared the `BTC` or `EUR` value asset. PR #1486 normalised USD values to USDC but left those supported onchain labels without an ERC-20 denomination token.

## Lessons learnt

Onyx `getValueAsset()` is a named valuation unit rather than a deposit-token address. Every currently discovered label needs an explicit reporting-token mapping, and a future unknown label must fail at adapter construction rather than part-way through a historical scan.

## Summary

- Map USD, BTC and EUR Onyx values to Base USDC, cbBTC and EURC respectively.
- Raise a descriptive adapter error for an unknown label or unavailable canonical-token metadata.
- Add current and historical lifetime-metric coverage for a real EUR Onyx Shares vault, and document the reporting convention.

## Related issues and PRs

- Follow-up to #1486.