### PR TITLE
feat: classify Lagoon vault strategies

### DIFF
--- a/.claude/skills/categorise-vault-strategy/SKILL.md
+++ b/.claude/skills/categorise-vault-strategy/SKILL.md
@@ -13,8 +13,8 @@ address-to-tag mapping next to its vault protocol adapter.
 1. Identify the vault and its adapter.
 
    - Resolve the chain and lowercase contract address from the supplied link,
-     address, or name. Do not classify a same-address deployment on a different
-     chain without confirming it is the same product.
+     address, or name. The maintained tag table is keyed by address only;
+     retain the union of documented tags if a protocol reuses an address.
    - For an ERC-4626 adapter, locate
      `eth_defi/erc_4626/vault_protocol/{slug}/vault.py` and read its
      description, `short_description`, nearby address overlays, and protocol
@@ -62,10 +62,12 @@ address-to-tag mapping next to its vault protocol adapter.
    }
    ```
 
-   Keep every EVM address key lowercase and scope every entry to an individual
-   vault. `lookup_strategy_tags()` normalises the adapter's `HexAddress`
-   input before looking up the string key. Put a Sphinx line-comment block
-   immediately above every address-specific entry.
+   Keep every EVM address key lowercase and every value as an ordinary set;
+   do not include a chain ID or use `frozenset`. `lookup_strategy_tags()`
+   normalises the adapter's `HexAddress` input before looking up the string
+   key. If a protocol reuses an address, use one entry with the union of
+   documented tags and name every covered product in its comment. Put a
+   Sphinx line-comment block immediately above every address-specific entry.
    It must include the vault name, the UTC date the tagging entry was added,
    and the decision material used to assign the tags. Include every page URL
    consulted during the decision directly in the comment; cite repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.2
 
-- feat: Add the yield-farming vault investment strategy tag (2026-08-21)
+- feat: Add the yield-farming vault investment strategy tag and classify documented Lagoon vault strategies (2026-08-21)
 - feat: Add Pallas HyperEVM vault recognition, onchain fee reads and curator attribution for the Basis Trading HIP-3 and Directional Volatility vaults (2026-08-20)
 - feat: Replace the unsupported Arcus attribution for two Robinhood Chain pTokens with an address-scoped unknown-issuer pToken protocol and metadata repair (2026-08-20)
 - feat: Add Enzyme Blue and Onyx vault discovery, direct accounting adapters, current fee reads and resumable historical price migration (2026-08-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 1.2
 
+- feat: Add the yield-farming vault investment strategy tag (2026-08-21)
 - feat: Add Pallas HyperEVM vault recognition, onchain fee reads and curator attribution for the Basis Trading HIP-3 and Directional Volatility vaults (2026-08-20)
 - feat: Replace the unsupported Arcus attribution for two Robinhood Chain pTokens with an address-scoped unknown-issuer pToken protocol and metadata repair (2026-08-20)
 - feat: Add Enzyme Blue and Onyx vault discovery, direct accounting adapters, current fee reads and resumable historical price migration (2026-08-20)

--- a/eth_defi/apex/tags.py
+++ b/eth_defi/apex/tags.py
@@ -3,7 +3,7 @@
 from eth_defi.vault.strategy_tag import StrategyTag, combine_strategy_tags
 
 #: ApeX native vaults trade perpetual futures by definition.
-DEFAULT_STRATEGY_TAGS: frozenset[StrategyTag] = frozenset({StrategyTag.perpetual_futures})
+DEFAULT_STRATEGY_TAGS: set[StrategyTag] = {StrategyTag.perpetual_futures}
 
 #: ApeX platform vault IDs may receive additional reviewed classifications.
 #: Keys are the synthetic identities exported by the ApeX pipeline.

--- a/eth_defi/erc_4626/vault_protocol/aave/tags.py
+++ b/eth_defi/erc_4626/vault_protocol/aave/tags.py
@@ -1,17 +1,15 @@
 """Strategy classifications for Aave vaults."""
 
-from eth_typing import HexAddress
-
 from eth_defi.vault.strategy_tag import StrategyTag, lookup_strategy_tags
 
 #: Aave vaults supply assets to Aave lending markets by definition.
-DEFAULT_STRATEGY_TAGS: frozenset[StrategyTag] = frozenset({StrategyTag.lending})
+DEFAULT_STRATEGY_TAGS: set[StrategyTag] = {StrategyTag.lending}
 
 #: Address-specific classifications maintained by the vault categorisation skill.
 STRATEGY_TAGS: dict[str, set[StrategyTag]] = {}
 
 
-def get_strategy_tags(address: HexAddress) -> set[StrategyTag]:
+def get_strategy_tags(address: str) -> set[StrategyTag]:
     """Return automatic Aave lending and any address-specific tags.
 
     :param address:

--- a/eth_defi/erc_4626/vault_protocol/euler/tags.py
+++ b/eth_defi/erc_4626/vault_protocol/euler/tags.py
@@ -1,17 +1,15 @@
 """Strategy classifications for Euler vaults."""
 
-from eth_typing import HexAddress
-
 from eth_defi.vault.strategy_tag import StrategyTag, lookup_strategy_tags
 
 #: Euler EVK and EulerEarn vaults supply assets to lending markets by definition.
-DEFAULT_STRATEGY_TAGS: frozenset[StrategyTag] = frozenset({StrategyTag.lending})
+DEFAULT_STRATEGY_TAGS: set[StrategyTag] = {StrategyTag.lending}
 
 #: Address-specific classifications maintained by the vault categorisation skill.
 STRATEGY_TAGS: dict[str, set[StrategyTag]] = {}
 
 
-def get_strategy_tags(address: HexAddress) -> set[StrategyTag]:
+def get_strategy_tags(address: str) -> set[StrategyTag]:
     """Return automatic Euler lending and any address-specific tags.
 
     :param address:

--- a/eth_defi/erc_4626/vault_protocol/lagoon/tags.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/tags.py
@@ -2,232 +2,224 @@
 
 from eth_defi.vault.strategy_tag import StrategyTag
 
-#: Lagoon strategies are chain-scoped because the same contract address may
-#: represent different products on different EVM chains.
-LAGOON_STRATEGY_TAGS: dict[tuple[int, str], frozenset[StrategyTag]] = {
+#: Reviewed Lagoon strategy tags, keyed by lowercase vault address.
+LAGOON_STRATEGY_TAGS: dict[str, set[StrategyTag]] = {
     #: Vault: RockSolid rETH Vault. Added: 2026-08-21.
     #: Decision material: rETH lending and positive-funding-rate looping.
     #: Sources: https://app.lagoon.finance/vault/1/0x936facdf10c8c36294e7b9d28345255539d81bc7
-    (1, "0x936facdf10c8c36294e7b9d28345255539d81bc7"): frozenset({StrategyTag.lending, StrategyTag.lending_looping}),
-    #: Vault: Flagship cbBTC. Added: 2026-08-21.
-    #: Decision material: DEX LP, lending, fixed-income and redemption arbitrage.
+    "0x936facdf10c8c36294e7b9d28345255539d81bc7": {StrategyTag.lending, StrategyTag.lending_looping},
+    #: Vaults: Flagship cbBTC and 722Capital-USDC. Added: 2026-08-21.
+    #: Decision material: this reused address combines both products' DEX LP,
+    #: lending, arbitrage, delta-neutral, leverage-loop and incentive strategies.
     #: Sources: https://app.lagoon.finance/vault/1/0xb09f761cb13baca8ec087ac476647361b6314f98
-    (1, "0xb09f761cb13baca8ec087ac476647361b6314f98"): frozenset({StrategyTag.amm, StrategyTag.arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy}),
+    #:          https://app.lagoon.finance/vault/8453/0xb09f761cb13baca8ec087ac476647361b6314f98
+    "0xb09f761cb13baca8ec087ac476647361b6314f98": {StrategyTag.amm, StrategyTag.arbitrage, StrategyTag.delta_neutral, StrategyTag.lending, StrategyTag.lending_looping, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming},
     #: Vault: Gami USDC. Added: 2026-08-21.
     #: Decision material: money markets, AMM pools and ecosystem incentives.
     #: Sources: https://app.lagoon.finance/vault/1/0xdae854d0896ad2fee335689a3f7b4a95fd1a3e46
-    (1, "0xdae854d0896ad2fee335689a3f7b4a95fd1a3e46"): frozenset({StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming}),
+    "0xdae854d0896ad2fee335689a3f7b4a95fd1a3e46": {StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming},
     #: Vault: Tulipa USDC. Added: 2026-08-21.
     #: Decision material: RWA lending, structured LP and incentivised liquidity.
     #: Sources: https://app.lagoon.finance/vault/1/0xce0b790ae0d8cf91e01f3fb69025e14569b574f3
-    (1, "0xce0b790ae0d8cf91e01f3fb69025e14569b574f3"): frozenset({StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.rwa, StrategyTag.rwa_lending, StrategyTag.yield_farming}),
+    "0xce0b790ae0d8cf91e01f3fb69025e14569b574f3": {StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.rwa, StrategyTag.rwa_lending, StrategyTag.yield_farming},
     #: Vault: Coinshift USPC Prime. Added: 2026-08-21.
     #: Decision material: money markets, Curve LP, governance incentives and RWA credit.
     #: Sources: https://app.lagoon.finance/vault/1/0xfab0f56c28e3f874b15922b213e696f37b670916
-    (1, "0xfab0f56c28e3f874b15922b213e696f37b670916"): frozenset({StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.money_market_fund, StrategyTag.multistrategy, StrategyTag.rwa, StrategyTag.rwa_credit, StrategyTag.yield_farming}),
+    "0xfab0f56c28e3f874b15922b213e696f37b670916": {StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.money_market_fund, StrategyTag.multistrategy, StrategyTag.rwa, StrategyTag.rwa_credit, StrategyTag.yield_farming},
     #: Vault: 9Summits Flagship ETH. Added: 2026-08-21.
     #: Decision material: DEX LP, lending, redemption arbitrage and incentive farming.
     #: Sources: https://app.lagoon.finance/vault/1/0x07ed467acd4ffd13023046968b0859781cb90d9b
-    (1, "0x07ed467acd4ffd13023046968b0859781cb90d9b"): frozenset({StrategyTag.amm, StrategyTag.arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming}),
+    "0x07ed467acd4ffd13023046968b0859781cb90d9b": {StrategyTag.amm, StrategyTag.arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming},
     #: Vault: 9Summits Flagship USDC. Added: 2026-08-21.
     #: Decision material: DEX LP, lending, fixed-income and redemption arbitrage.
     #: Sources: https://app.lagoon.finance/vault/1/0x03d1ec0d01b659b89a87eabb56e4af5cb6e14bfc
-    (1, "0x03d1ec0d01b659b89a87eabb56e4af5cb6e14bfc"): frozenset({StrategyTag.amm, StrategyTag.arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy}),
+    "0x03d1ec0d01b659b89a87eabb56e4af5cb6e14bfc": {StrategyTag.amm, StrategyTag.arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy},
     #: Vault: Syntropia USDC. Added: 2026-08-21.
     #: Decision material: DEX liquidity, lending, arbitrage and incentive farming.
     #: Sources: https://app.lagoon.finance/vault/1/0xd17049ed25d8f99fe3bfd10cef2263da9995cfd8
-    (1, "0xd17049ed25d8f99fe3bfd10cef2263da9995cfd8"): frozenset({StrategyTag.amm, StrategyTag.arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming}),
+    "0xd17049ed25d8f99fe3bfd10cef2263da9995cfd8": {StrategyTag.amm, StrategyTag.arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming},
     #: Vault: DAMM Ethereum Fund. Added: 2026-08-21.
     #: Decision material: algorithmic DEX liquidity, lending and LST redemption arbitrage.
     #: Sources: https://app.lagoon.finance/vault/1/0x3c63f3ce75dc83735745cf4e86b63414d95ee355
-    (1, "0x3c63f3ce75dc83735745cf4e86b63414d95ee355"): frozenset({StrategyTag.algorithmic_trading, StrategyTag.amm, StrategyTag.arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.market_making_amm, StrategyTag.multistrategy}),
+    "0x3c63f3ce75dc83735745cf4e86b63414d95ee355": {StrategyTag.algorithmic_trading, StrategyTag.amm, StrategyTag.arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.market_making_amm, StrategyTag.multistrategy},
     #: Vault: RockSolid Looped ETH Vault. Added: 2026-08-21.
     #: Decision material: leveraged liquid-staking collateral loop through lending markets.
     #: Sources: https://app.lagoon.finance/vault/1/0x7a12d4b719f5aa479ecd60defed909fb2a37e428
-    (1, "0x7a12d4b719f5aa479ecd60defed909fb2a37e428"): frozenset({StrategyTag.lending, StrategyTag.lending_looping}),
+    "0x7a12d4b719f5aa479ecd60defed909fb2a37e428": {StrategyTag.lending, StrategyTag.lending_looping},
     #: Vault: 1212.Stable. Added: 2026-08-21.
     #: Decision material: liquidity provision and stablecoin redemption arbitrage.
     #: Sources: https://app.lagoon.finance/vault/1/0xbb30c3b6046debcbe941281218d18dec8ecebeb5
-    (1, "0xbb30c3b6046debcbe941281218d18dec8ecebeb5"): frozenset({StrategyTag.arbitrage, StrategyTag.liquidity_provider, StrategyTag.multistrategy}),
+    "0xbb30c3b6046debcbe941281218d18dec8ecebeb5": {StrategyTag.arbitrage, StrategyTag.liquidity_provider, StrategyTag.multistrategy},
     #: Vault: DAMM Stablecoin Fund. Added: 2026-08-21.
     #: Decision material: algorithmic Uniswap liquidity, lending and fixed-income allocation.
     #: Sources: https://app.lagoon.finance/vault/42161/0xe5d6eb448ac5a762c1ebe8cd1692b9cd08025176
-    (42161, "0xe5d6eb448ac5a762c1ebe8cd1692b9cd08025176"): frozenset({StrategyTag.algorithmic_trading, StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.market_making_amm, StrategyTag.multistrategy}),
+    "0xe5d6eb448ac5a762c1ebe8cd1692b9cd08025176": {StrategyTag.algorithmic_trading, StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.market_making_amm, StrategyTag.multistrategy},
     #: Vault: Ammalgam WETH Vault. Added: 2026-08-21.
     #: Decision material: ETH-USDC liquidity provision with impermanent-loss hedge.
     #: Sources: https://app.lagoon.finance/vault/1/0xbb211be8664128e30c6adcd5998eca9592be272f
-    (1, "0xbb211be8664128e30c6adcd5998eca9592be272f"): frozenset({StrategyTag.amm, StrategyTag.liquidity_provider, StrategyTag.market_making_amm}),
+    "0xbb211be8664128e30c6adcd5998eca9592be272f": {StrategyTag.amm, StrategyTag.liquidity_provider, StrategyTag.market_making_amm},
     #: Vault: Syntropia USDC Core. Added: 2026-08-21.
     #: Decision material: DEX liquidity, lending, arbitrage and incentive farming.
     #: Sources: https://app.lagoon.finance/vault/1/0x1b2cb79a4564206f53ba80b4d780f251b4ae6765
-    (1, "0x1b2cb79a4564206f53ba80b4d780f251b4ae6765"): frozenset({StrategyTag.amm, StrategyTag.arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming}),
+    "0x1b2cb79a4564206f53ba80b4d780f251b4ae6765": {StrategyTag.amm, StrategyTag.arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming},
     #: Vault: DeltaUSD HyperLiquid USDN Funding Arb. Added: 2026-08-21.
     #: Decision material: delta-neutral perpetual funding arbitrage plus lending/liquidity yield.
     #: Sources: https://app.lagoon.finance/vault/1/0x01f461a0bbb218bc1943aa027c5bbc424391e541
-    (1, "0x01f461a0bbb218bc1943aa027c5bbc424391e541"): frozenset({StrategyTag.arbitrage, StrategyTag.delta_neutral, StrategyTag.funding_rate_arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.perpetual_futures}),
+    "0x01f461a0bbb218bc1943aa027c5bbc424391e541": {StrategyTag.arbitrage, StrategyTag.delta_neutral, StrategyTag.funding_rate_arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.perpetual_futures},
     #: Vault: USDC Avalanche Core. Added: 2026-08-21.
     #: Decision material: money markets, AMM pools and ecosystem incentives.
     #: Sources: https://app.lagoon.finance/vault/43114/0xb3a2bcb30c1460d88db18b42a29fae2399952874
-    (43114, "0xb3a2bcb30c1460d88db18b42a29fae2399952874"): frozenset({StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming}),
+    "0xb3a2bcb30c1460d88db18b42a29fae2399952874": {StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming},
     #: Vault: stETH Redemption Carry. Added: 2026-08-21.
     #: Decision material: discounted-stETH redemption carry with idle Morpho lending.
     #: Sources: https://app.lagoon.finance/vault/1/0x2746f31096f23670caf4043f8b30d8d02405a257
-    (1, "0x2746f31096f23670caf4043f8b30d8d02405a257"): frozenset({StrategyTag.arbitrage, StrategyTag.carry_trade, StrategyTag.lending}),
+    "0x2746f31096f23670caf4043f8b30d8d02405a257": {StrategyTag.arbitrage, StrategyTag.carry_trade, StrategyTag.lending},
     #: Vault: Cross-chain USDC Lending. Added: 2026-08-21.
     #: Decision material: cost-aware allocation across Morpho lending markets.
     #: Sources: https://app.lagoon.finance/vault/1/0xf02030ab0d7385ce4cc2f7f64b7b44430fb44c89
-    (1, "0xf02030ab0d7385ce4cc2f7f64b7b44430fb44c89"): frozenset({StrategyTag.lending, StrategyTag.lending_optimisation}),
+    "0xf02030ab0d7385ce4cc2f7f64b7b44430fb44c89": {StrategyTag.lending, StrategyTag.lending_optimisation},
     #: Vault: DeltaETH HyperLiquid USDN EVERYTHING Funding Arb. Added: 2026-08-21.
     #: Decision material: delta-neutral perpetual funding arbitrage and LP yield.
     #: Sources: https://app.lagoon.finance/vault/1/0x56105f694e9549cebd0d509f1de71b22abe8f1d8
-    (1, "0x56105f694e9549cebd0d509f1de71b22abe8f1d8"): frozenset({StrategyTag.arbitrage, StrategyTag.delta_neutral, StrategyTag.funding_rate_arbitrage, StrategyTag.liquidity_provider, StrategyTag.perpetual_futures}),
+    "0x56105f694e9549cebd0d509f1de71b22abe8f1d8": {StrategyTag.arbitrage, StrategyTag.delta_neutral, StrategyTag.funding_rate_arbitrage, StrategyTag.liquidity_provider, StrategyTag.perpetual_futures},
     #: Vault: 9Summits Flagship EURC. Added: 2026-08-21.
     #: Decision material: DEX LP, lending, fixed-income and redemption arbitrage.
     #: Sources: https://app.lagoon.finance/vault/1/0xd0c4c9386f7509c44987f43136be7d4349ccddc9
-    (1, "0xd0c4c9386f7509c44987f43136be7d4349ccddc9"): frozenset({StrategyTag.amm, StrategyTag.arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy}),
+    "0xd0c4c9386f7509c44987f43136be7d4349ccddc9": {StrategyTag.amm, StrategyTag.arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy},
     #: Vault: Rho X Liquidity Provider. Added: 2026-08-21.
     #: Decision material: provides trading liquidity and earns spreads and fees.
     #: Sources: https://app.lagoon.finance/vault/1/0x4cb280e63251b9ab24a54def74bf5995d82ff398
-    (1, "0x4cb280e63251b9ab24a54def74bf5995d82ff398"): frozenset({StrategyTag.liquidity_provider, StrategyTag.market_maker, StrategyTag.market_making}),
+    "0x4cb280e63251b9ab24a54def74bf5995d82ff398": {StrategyTag.liquidity_provider, StrategyTag.market_maker, StrategyTag.market_making},
     #: Vault: DeTrade Core USDC. Added: 2026-08-21.
     #: Decision material: liquidity provision alongside yield-bearing stablecoins.
     #: Sources: https://app.lagoon.finance/vault/8453/0x8092ca384d44260ea4feaf7457b629b8dc6f88f0
-    (8453, "0x8092ca384d44260ea4feaf7457b629b8dc6f88f0"): frozenset({StrategyTag.liquidity_provider}),
+    "0x8092ca384d44260ea4feaf7457b629b8dc6f88f0": {StrategyTag.liquidity_provider},
     #: Vault: Coinshift USPC High Yield. Added: 2026-08-21.
     #: Decision material: money markets, Curve LP, governance incentives and RWA credit.
     #: Sources: https://app.lagoon.finance/vault/1/0x09252d2c4afca9b1479efdd39faa53de9ff23114
-    (1, "0x09252d2c4afca9b1479efdd39faa53de9ff23114"): frozenset({StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.money_market_fund, StrategyTag.multistrategy, StrategyTag.rwa, StrategyTag.rwa_credit, StrategyTag.yield_farming}),
+    "0x09252d2c4afca9b1479efdd39faa53de9ff23114": {StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.money_market_fund, StrategyTag.multistrategy, StrategyTag.rwa, StrategyTag.rwa_credit, StrategyTag.yield_farming},
     #: Vault: Flint USD. Added: 2026-08-21.
     #: Decision material: tokenised real-estate bonds and private-credit exposure.
     #: Sources: https://app.lagoon.finance/vault/1/0x7f35dea44a192764aa50d50e5f0ece1d5a8b0e45
-    (1, "0x7f35dea44a192764aa50d50e5f0ece1d5a8b0e45"): frozenset({StrategyTag.rwa, StrategyTag.rwa_credit}),
+    "0x7f35dea44a192764aa50d50e5f0ece1d5a8b0e45": {StrategyTag.rwa, StrategyTag.rwa_credit},
     #: Vault: Gami WBTC. Added: 2026-08-21.
     #: Decision material: money markets, AMM pools and ecosystem incentives.
     #: Sources: https://app.lagoon.finance/vault/1/0x414070fb9e64fd69160d75da57e75ba11f9f605a
-    (1, "0x414070fb9e64fd69160d75da57e75ba11f9f605a"): frozenset({StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming}),
+    "0x414070fb9e64fd69160d75da57e75ba11f9f605a": {StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming},
     #: Vault: CEX Automated Funding Rate Arbitrage. Added: 2026-08-21.
     #: Decision material: automated, delta-neutral spot/perpetual funding arbitrage.
     #: Sources: https://app.lagoon.finance/vault/1/0x60a2612996ddfb1aa1c53e7bfbf179ccc1fcd734
-    (1, "0x60a2612996ddfb1aa1c53e7bfbf179ccc1fcd734"): frozenset({StrategyTag.algorithmic_trading, StrategyTag.arbitrage, StrategyTag.delta_neutral, StrategyTag.funding_rate_arbitrage, StrategyTag.market_maker, StrategyTag.market_making, StrategyTag.perpetual_futures}),
+    "0x60a2612996ddfb1aa1c53e7bfbf179ccc1fcd734": {StrategyTag.algorithmic_trading, StrategyTag.arbitrage, StrategyTag.delta_neutral, StrategyTag.funding_rate_arbitrage, StrategyTag.market_maker, StrategyTag.market_making, StrategyTag.perpetual_futures},
     #: Vault: Autonomous Liquidity USD. Added: 2026-08-21.
     #: Decision material: code-based automated portfolio rebalancing.
     #: Sources: https://app.lagoon.finance/vault/1/0xdcd0f5ab30856f28385f641580bbd85f88349124
-    (1, "0xdcd0f5ab30856f28385f641580bbd85f88349124"): frozenset({StrategyTag.algorithmic_trading}),
+    "0xdcd0f5ab30856f28385f641580bbd85f88349124": {StrategyTag.algorithmic_trading},
     #: Vault: DACM LIT Strategy. Added: 2026-08-21.
     #: Decision material: Lighter perpetual-exchange LP, fees and market-neutral inventory.
     #: Sources: https://app.lagoon.finance/vault/42161/0x018282d5b510f00dcacb8f4a81c3901d2fc9da51
-    (42161, "0x018282d5b510f00dcacb8f4a81c3901d2fc9da51"): frozenset({StrategyTag.delta_neutral, StrategyTag.liquidity_provider, StrategyTag.market_maker, StrategyTag.market_making, StrategyTag.market_making_clob, StrategyTag.perpetual_futures}),
+    "0x018282d5b510f00dcacb8f4a81c3901d2fc9da51": {StrategyTag.delta_neutral, StrategyTag.liquidity_provider, StrategyTag.market_maker, StrategyTag.market_making, StrategyTag.market_making_clob, StrategyTag.perpetual_futures},
     #: Vault: Usual Invested USD0++ in USCC & USTB. Added: 2026-08-21.
     #: Decision material: USTB money-market exposure and crypto carry allocation.
     #: Sources: https://app.lagoon.finance/vault/1/0x8245fd9ae99a482dfe76576dd4298f799c041d61
-    (1, "0x8245fd9ae99a482dfe76576dd4298f799c041d61"): frozenset({StrategyTag.carry_trade, StrategyTag.money_market_fund, StrategyTag.multistrategy, StrategyTag.rwa}),
+    "0x8245fd9ae99a482dfe76576dd4298f799c041d61": {StrategyTag.carry_trade, StrategyTag.money_market_fund, StrategyTag.multistrategy, StrategyTag.rwa},
     #: Vault: 1212.Alpha. Added: 2026-08-21.
     #: Decision material: systematic directional allocation using trend-following signals.
     #: Sources: https://app.lagoon.finance/vault/1/0xc35ce0c1acfc448d18ddacbf641b09f2a18e1958
-    (1, "0xc35ce0c1acfc448d18ddacbf641b09f2a18e1958"): frozenset({StrategyTag.algorithmic_trading, StrategyTag.directional_trading, StrategyTag.trend_following}),
+    "0xc35ce0c1acfc448d18ddacbf641b09f2a18e1958": {StrategyTag.algorithmic_trading, StrategyTag.directional_trading, StrategyTag.trend_following},
     #: Vault: Zharta RWA Prime USDC. Added: 2026-08-21.
     #: Decision material: fixed-rate lending against tokenised RWA credit.
     #: Sources: https://app.lagoon.finance/vault/1/0xb4a4c9a736f91e2694c6b921445eef3e3585a591
-    (1, "0xb4a4c9a736f91e2694c6b921445eef3e3585a591"): frozenset({StrategyTag.lending, StrategyTag.rwa, StrategyTag.rwa_credit}),
+    "0xb4a4c9a736f91e2694c6b921445eef3e3585a591": {StrategyTag.lending, StrategyTag.rwa, StrategyTag.rwa_credit},
     #: Vault: Syntropia Boosted. Added: 2026-08-21.
     #: Decision material: synUSD collateral is borrowed against and looped back.
     #: Sources: https://app.lagoon.finance/vault/1/0x8df3deba711ae4a9af16cbca5e4fbb1402f036d5
-    (1, "0x8df3deba711ae4a9af16cbca5e4fbb1402f036d5"): frozenset({StrategyTag.lending, StrategyTag.lending_looping}),
+    "0x8df3deba711ae4a9af16cbca5e4fbb1402f036d5": {StrategyTag.lending, StrategyTag.lending_looping},
     #: Vault: Nova NLP Vault. Added: 2026-08-21.
     #: Decision material: institutional market making with idle capital lent on Morpho.
     #: Sources: https://app.lagoon.finance/vault/999/0xeeed7bb939d65938fe8f40dd898cd5942e32f09e
-    (999, "0xeeed7bb939d65938fe8f40dd898cd5942e32f09e"): frozenset({StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.market_maker, StrategyTag.market_making}),
+    "0xeeed7bb939d65938fe8f40dd898cd5942e32f09e": {StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.market_maker, StrategyTag.market_making},
     #: Vault: DAMM Bitcoin Fund. Added: 2026-08-21.
     #: Decision material: current mandate is explicitly market neutral.
     #: Sources: https://app.lagoon.finance/vault/1/0x7ededf832b5c9d8afa8f7365936100581a6db756
-    (1, "0x7ededf832b5c9d8afa8f7365936100581a6db756"): frozenset({StrategyTag.delta_neutral}),
+    "0x7ededf832b5c9d8afa8f7365936100581a6db756": {StrategyTag.delta_neutral},
     #: Vault: DAMM BTC Algo Fund. Added: 2026-08-21.
     #: Decision material: automated concentrated AMM liquidity with no directional BTC exposure.
     #: Sources: https://app.lagoon.finance/vault/1/0x9c414834a4a85aa15ec461edcd8cc9dd8ec979b9
-    (1, "0x9c414834a4a85aa15ec461edcd8cc9dd8ec979b9"): frozenset({StrategyTag.algorithmic_trading, StrategyTag.amm, StrategyTag.delta_neutral, StrategyTag.liquidity_provider, StrategyTag.market_making_amm}),
+    "0x9c414834a4a85aa15ec461edcd8cc9dd8ec979b9": {StrategyTag.algorithmic_trading, StrategyTag.amm, StrategyTag.delta_neutral, StrategyTag.liquidity_provider, StrategyTag.market_making_amm},
     #: Vault: Gami ETH. Added: 2026-08-21.
     #: Decision material: money markets, AMM pools and ecosystem incentives.
     #: Sources: https://app.lagoon.finance/vault/1/0x2031eceec018549a2c729cacd6c0bfc4be2524ed
-    (1, "0x2031eceec018549a2c729cacd6c0bfc4be2524ed"): frozenset({StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming}),
+    "0x2031eceec018549a2c729cacd6c0bfc4be2524ed": {StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming},
     #: Vault: TruMarket. Added: 2026-08-21.
     #: Decision material: agricultural trade-finance opportunities backed by real activity.
     #: Sources: https://app.lagoon.finance/vault/8453/0xbe7db44f4ce20dac83b578b94fd35087f66e9754
-    (8453, "0xbe7db44f4ce20dac83b578b94fd35087f66e9754"): frozenset({StrategyTag.rwa, StrategyTag.rwa_credit}),
+    "0xbe7db44f4ce20dac83b578b94fd35087f66e9754": {StrategyTag.rwa, StrategyTag.rwa_credit},
     #: Vault: DAMM ETH Algo Fund. Added: 2026-08-21.
     #: Decision material: automated concentrated AMM liquidity with no directional ETH exposure.
     #: Sources: https://app.lagoon.finance/vault/1/0xe6f4bc20f08125818baaac57e6f398ffadcb8d28
-    (1, "0xe6f4bc20f08125818baaac57e6f398ffadcb8d28"): frozenset({StrategyTag.algorithmic_trading, StrategyTag.amm, StrategyTag.delta_neutral, StrategyTag.liquidity_provider, StrategyTag.market_making_amm}),
+    "0xe6f4bc20f08125818baaac57e6f398ffadcb8d28": {StrategyTag.algorithmic_trading, StrategyTag.amm, StrategyTag.delta_neutral, StrategyTag.liquidity_provider, StrategyTag.market_making_amm},
     #: Vault: DeTrade Morpho X-Chain USDC. Added: 2026-08-21.
     #: Decision material: continuously rotates USDC between Morpho lending opportunities.
     #: Sources: https://app.lagoon.finance/vault/1/0x7d2c2f54792ad72cb834d298f542145b06b703cb
-    (1, "0x7d2c2f54792ad72cb834d298f542145b06b703cb"): frozenset({StrategyTag.lending, StrategyTag.lending_optimisation}),
+    "0x7d2c2f54792ad72cb834d298f542145b06b703cb": {StrategyTag.lending, StrategyTag.lending_optimisation},
     #: Vault: DeTrade Core EURC. Added: 2026-08-21.
     #: Decision material: lends collateral, borrows stablecoins and redeploys the proceeds.
     #: Sources: https://app.lagoon.finance/vault/8453/0xd4401d8bea82e4e6c40bb26ae3a04d2fb7ca4550
-    (8453, "0xd4401d8bea82e4e6c40bb26ae3a04d2fb7ca4550"): frozenset({StrategyTag.lending}),
+    "0xd4401d8bea82e4e6c40bb26ae3a04d2fb7ca4550": {StrategyTag.lending},
     #: Vault: DeTrade Core ETH. Added: 2026-08-21.
     #: Decision material: lends liquid-staking collateral and redeploys borrowed stablecoins.
     #: Sources: https://app.lagoon.finance/vault/8453/0x9b97bfdfe44d1b113ecd4bf2f243ed36aca34523
-    (8453, "0x9b97bfdfe44d1b113ecd4bf2f243ed36aca34523"): frozenset({StrategyTag.lending}),
+    "0x9b97bfdfe44d1b113ecd4bf2f243ed36aca34523": {StrategyTag.lending},
     #: Vault: Ammalgam USDC Vault. Added: 2026-08-21.
     #: Decision material: ETH-USDC liquidity provision with impermanent-loss hedge.
     #: Sources: https://app.lagoon.finance/vault/1/0x8417430a31851ae0a36a854394227c5d86be8fc9
-    (1, "0x8417430a31851ae0a36a854394227c5d86be8fc9"): frozenset({StrategyTag.amm, StrategyTag.liquidity_provider, StrategyTag.market_making_amm}),
+    "0x8417430a31851ae0a36a854394227c5d86be8fc9": {StrategyTag.amm, StrategyTag.liquidity_provider, StrategyTag.market_making_amm},
     #: Vault: RockSolid MegaETH USDm Vault. Added: 2026-08-21.
     #: Decision material: deploys USDm for MegaETH DeFi yield and incentives.
     #: Sources: https://app.lagoon.finance/vault/1/0xba71097e426983d840569edfa1a01396b56d86ad
-    (1, "0xba71097e426983d840569edfa1a01396b56d86ad"): frozenset({StrategyTag.yield_farming}),
-    #: Vault: 722Capital-USDC. Added: 2026-08-21.
-    #: Decision material: delta-neutral, basis, leverage-loop and incentive strategies.
-    #: Sources: https://app.lagoon.finance/vault/8453/0xb09f761cb13baca8ec087ac476647361b6314f98
-    (8453, "0xb09f761cb13baca8ec087ac476647361b6314f98"): frozenset({StrategyTag.arbitrage, StrategyTag.delta_neutral, StrategyTag.lending_looping, StrategyTag.multistrategy, StrategyTag.yield_farming}),
+    "0xba71097e426983d840569edfa1a01396b56d86ad": {StrategyTag.yield_farming},
     #: Vault: Alchemix Ecosystem ETH vault. Added: 2026-08-21.
     #: Decision material: blends alAsset liquidity pools, Mix-Yield Tokens and Transmuter positions.
     #: Sources: https://app.lagoon.finance/vault/1/0xa6e8d7871153d030c918a0ca5d33f90779967484
-    (1, "0xa6e8d7871153d030c918a0ca5d33f90779967484"): frozenset({StrategyTag.liquidity_provider, StrategyTag.multistrategy}),
+    "0xa6e8d7871153d030c918a0ca5d33f90779967484": {StrategyTag.liquidity_provider, StrategyTag.multistrategy},
     #: Vault: Gami hemiBTC. Added: 2026-08-21.
     #: Decision material: Curve liquidity and leveraged money-market positions.
     #: Sources: https://app.lagoon.finance/vault/1/0x2a676c2744421b4fae65ce86b47adacb620047d4
-    (1, "0x2a676c2744421b4fae65ce86b47adacb620047d4"): frozenset({StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider}),
+    "0x2a676c2744421b4fae65ce86b47adacb620047d4": {StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider},
     #: Vault: Excellion USDC Vault. Added: 2026-08-21.
     #: Decision material: liquidity provision, leveraged lending and explicit yield farming.
     #: Sources: https://app.lagoon.finance/vault/43114/0xb8a14b03900828f863aedd9dd905363863bc31f4
-    (43114, "0xb8a14b03900828f863aedd9dd905363863bc31f4"): frozenset({StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming}),
+    "0xb8a14b03900828f863aedd9dd905363863bc31f4": {StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming},
     #: Vault: SP500 Hyperliquid Synth. Added: 2026-08-21.
     #: Decision material: continuously rebalanced long HIP-3 perpetual position.
     #: Sources: https://app.lagoon.finance/vault/999/0x3b65e02b1ff8072bdc094a899a4e41d07ce034aa
-    (999, "0x3b65e02b1ff8072bdc094a899a4e41d07ce034aa"): frozenset({StrategyTag.algorithmic_trading, StrategyTag.directional_trading, StrategyTag.perpetual_futures}),
+    "0x3b65e02b1ff8072bdc094a899a4e41d07ce034aa": {StrategyTag.algorithmic_trading, StrategyTag.directional_trading, StrategyTag.perpetual_futures},
     #: Vault: SpaceX Hyperliquid Synth. Added: 2026-08-21.
     #: Decision material: continuously rebalanced long HIP-3 perpetual position.
     #: Sources: https://app.lagoon.finance/vault/999/0x8982df557d81540678285450898f77c31d69c8b2
-    (999, "0x8982df557d81540678285450898f77c31d69c8b2"): frozenset({StrategyTag.algorithmic_trading, StrategyTag.directional_trading, StrategyTag.perpetual_futures}),
+    "0x8982df557d81540678285450898f77c31d69c8b2": {StrategyTag.algorithmic_trading, StrategyTag.directional_trading, StrategyTag.perpetual_futures},
     #: Vault: Gami Stake DAO USDC. Added: 2026-08-21.
     #: Decision material: AMM liquidity, lending and governance-reward boosts.
     #: Sources: https://app.lagoon.finance/vault/1/0x33e1339567c183fbadcb43f72d11c47229d468ab
-    (1, "0x33e1339567c183fbadcb43f72d11c47229d468ab"): frozenset({StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming}),
+    "0x33e1339567c183fbadcb43f72d11c47229d468ab": {StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming},
     #: Vault: Noon USN TAC. Added: 2026-08-21.
     #: Decision material: governance incentives and delta-neutral leveraged looping.
     #: Sources: https://app.lagoon.finance/vault/239/0x279385c180f5d01c4a4bdff040f17b8957304762
-    (239, "0x279385c180f5d01c4a4bdff040f17b8957304762"): frozenset({StrategyTag.delta_neutral, StrategyTag.lending_looping, StrategyTag.yield_farming}),
+    "0x279385c180f5d01c4a4bdff040f17b8957304762": {StrategyTag.delta_neutral, StrategyTag.lending_looping, StrategyTag.yield_farming},
     #: Vault: Tulipa HemiBTC. Added: 2026-08-21.
     #: Decision material: HemiBTC liquidity and YieldBasis yield-bearing LP allocation.
     #: Sources: https://app.lagoon.finance/vault/1/0xd548f6ed03e718843124ed29ffd0ed9ae81e6dc5
-    (1, "0xd548f6ed03e718843124ed29ffd0ed9ae81e6dc5"): frozenset({StrategyTag.liquidity_provider, StrategyTag.yield_farming}),
+    "0xd548f6ed03e718843124ed29ffd0ed9ae81e6dc5": {StrategyTag.liquidity_provider, StrategyTag.yield_farming},
 }
 
 
-def get_strategy_tags(chain_id: int, address: str) -> set[StrategyTag] | None:
+def get_strategy_tags(address: str) -> set[StrategyTag] | None:
     """Look up a copy of the tags maintained for a Lagoon vault.
 
-    Lagoon has distinct products at the same contract address on different
-    chains, so the lookup includes the chain ID unlike generic EVM mappings.
-
-    :param chain_id:
-        EVM chain ID where the Lagoon vault is deployed.
     :param address:
         Vault contract address.
     :return:
         A mutable copy of the maintained tags, or ``None`` when unclassified.
     """
-    tags = LAGOON_STRATEGY_TAGS.get((chain_id, address.lower()))
+    tags = LAGOON_STRATEGY_TAGS.get(address.lower())
     return set(tags) if tags is not None else None

--- a/eth_defi/erc_4626/vault_protocol/lagoon/tags.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/tags.py
@@ -1,0 +1,233 @@
+"""Maintained strategy classifications for Lagoon Finance vaults."""
+
+from eth_defi.vault.strategy_tag import StrategyTag
+
+#: Lagoon strategies are chain-scoped because the same contract address may
+#: represent different products on different EVM chains.
+LAGOON_STRATEGY_TAGS: dict[tuple[int, str], frozenset[StrategyTag]] = {
+    #: Vault: RockSolid rETH Vault. Added: 2026-08-21.
+    #: Decision material: rETH lending and positive-funding-rate looping.
+    #: Sources: https://app.lagoon.finance/vault/1/0x936facdf10c8c36294e7b9d28345255539d81bc7
+    (1, "0x936facdf10c8c36294e7b9d28345255539d81bc7"): frozenset({StrategyTag.lending, StrategyTag.lending_looping}),
+    #: Vault: Flagship cbBTC. Added: 2026-08-21.
+    #: Decision material: DEX LP, lending, fixed-income and redemption arbitrage.
+    #: Sources: https://app.lagoon.finance/vault/1/0xb09f761cb13baca8ec087ac476647361b6314f98
+    (1, "0xb09f761cb13baca8ec087ac476647361b6314f98"): frozenset({StrategyTag.amm, StrategyTag.arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy}),
+    #: Vault: Gami USDC. Added: 2026-08-21.
+    #: Decision material: money markets, AMM pools and ecosystem incentives.
+    #: Sources: https://app.lagoon.finance/vault/1/0xdae854d0896ad2fee335689a3f7b4a95fd1a3e46
+    (1, "0xdae854d0896ad2fee335689a3f7b4a95fd1a3e46"): frozenset({StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming}),
+    #: Vault: Tulipa USDC. Added: 2026-08-21.
+    #: Decision material: RWA lending, structured LP and incentivised liquidity.
+    #: Sources: https://app.lagoon.finance/vault/1/0xce0b790ae0d8cf91e01f3fb69025e14569b574f3
+    (1, "0xce0b790ae0d8cf91e01f3fb69025e14569b574f3"): frozenset({StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.rwa, StrategyTag.rwa_lending, StrategyTag.yield_farming}),
+    #: Vault: Coinshift USPC Prime. Added: 2026-08-21.
+    #: Decision material: money markets, Curve LP, governance incentives and RWA credit.
+    #: Sources: https://app.lagoon.finance/vault/1/0xfab0f56c28e3f874b15922b213e696f37b670916
+    (1, "0xfab0f56c28e3f874b15922b213e696f37b670916"): frozenset({StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.money_market_fund, StrategyTag.multistrategy, StrategyTag.rwa, StrategyTag.rwa_credit, StrategyTag.yield_farming}),
+    #: Vault: 9Summits Flagship ETH. Added: 2026-08-21.
+    #: Decision material: DEX LP, lending, redemption arbitrage and incentive farming.
+    #: Sources: https://app.lagoon.finance/vault/1/0x07ed467acd4ffd13023046968b0859781cb90d9b
+    (1, "0x07ed467acd4ffd13023046968b0859781cb90d9b"): frozenset({StrategyTag.amm, StrategyTag.arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming}),
+    #: Vault: 9Summits Flagship USDC. Added: 2026-08-21.
+    #: Decision material: DEX LP, lending, fixed-income and redemption arbitrage.
+    #: Sources: https://app.lagoon.finance/vault/1/0x03d1ec0d01b659b89a87eabb56e4af5cb6e14bfc
+    (1, "0x03d1ec0d01b659b89a87eabb56e4af5cb6e14bfc"): frozenset({StrategyTag.amm, StrategyTag.arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy}),
+    #: Vault: Syntropia USDC. Added: 2026-08-21.
+    #: Decision material: DEX liquidity, lending, arbitrage and incentive farming.
+    #: Sources: https://app.lagoon.finance/vault/1/0xd17049ed25d8f99fe3bfd10cef2263da9995cfd8
+    (1, "0xd17049ed25d8f99fe3bfd10cef2263da9995cfd8"): frozenset({StrategyTag.amm, StrategyTag.arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming}),
+    #: Vault: DAMM Ethereum Fund. Added: 2026-08-21.
+    #: Decision material: algorithmic DEX liquidity, lending and LST redemption arbitrage.
+    #: Sources: https://app.lagoon.finance/vault/1/0x3c63f3ce75dc83735745cf4e86b63414d95ee355
+    (1, "0x3c63f3ce75dc83735745cf4e86b63414d95ee355"): frozenset({StrategyTag.algorithmic_trading, StrategyTag.amm, StrategyTag.arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.market_making_amm, StrategyTag.multistrategy}),
+    #: Vault: RockSolid Looped ETH Vault. Added: 2026-08-21.
+    #: Decision material: leveraged liquid-staking collateral loop through lending markets.
+    #: Sources: https://app.lagoon.finance/vault/1/0x7a12d4b719f5aa479ecd60defed909fb2a37e428
+    (1, "0x7a12d4b719f5aa479ecd60defed909fb2a37e428"): frozenset({StrategyTag.lending, StrategyTag.lending_looping}),
+    #: Vault: 1212.Stable. Added: 2026-08-21.
+    #: Decision material: liquidity provision and stablecoin redemption arbitrage.
+    #: Sources: https://app.lagoon.finance/vault/1/0xbb30c3b6046debcbe941281218d18dec8ecebeb5
+    (1, "0xbb30c3b6046debcbe941281218d18dec8ecebeb5"): frozenset({StrategyTag.arbitrage, StrategyTag.liquidity_provider, StrategyTag.multistrategy}),
+    #: Vault: DAMM Stablecoin Fund. Added: 2026-08-21.
+    #: Decision material: algorithmic Uniswap liquidity, lending and fixed-income allocation.
+    #: Sources: https://app.lagoon.finance/vault/42161/0xe5d6eb448ac5a762c1ebe8cd1692b9cd08025176
+    (42161, "0xe5d6eb448ac5a762c1ebe8cd1692b9cd08025176"): frozenset({StrategyTag.algorithmic_trading, StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.market_making_amm, StrategyTag.multistrategy}),
+    #: Vault: Ammalgam WETH Vault. Added: 2026-08-21.
+    #: Decision material: ETH-USDC liquidity provision with impermanent-loss hedge.
+    #: Sources: https://app.lagoon.finance/vault/1/0xbb211be8664128e30c6adcd5998eca9592be272f
+    (1, "0xbb211be8664128e30c6adcd5998eca9592be272f"): frozenset({StrategyTag.amm, StrategyTag.liquidity_provider, StrategyTag.market_making_amm}),
+    #: Vault: Syntropia USDC Core. Added: 2026-08-21.
+    #: Decision material: DEX liquidity, lending, arbitrage and incentive farming.
+    #: Sources: https://app.lagoon.finance/vault/1/0x1b2cb79a4564206f53ba80b4d780f251b4ae6765
+    (1, "0x1b2cb79a4564206f53ba80b4d780f251b4ae6765"): frozenset({StrategyTag.amm, StrategyTag.arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming}),
+    #: Vault: DeltaUSD HyperLiquid USDN Funding Arb. Added: 2026-08-21.
+    #: Decision material: delta-neutral perpetual funding arbitrage plus lending/liquidity yield.
+    #: Sources: https://app.lagoon.finance/vault/1/0x01f461a0bbb218bc1943aa027c5bbc424391e541
+    (1, "0x01f461a0bbb218bc1943aa027c5bbc424391e541"): frozenset({StrategyTag.arbitrage, StrategyTag.delta_neutral, StrategyTag.funding_rate_arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.perpetual_futures}),
+    #: Vault: USDC Avalanche Core. Added: 2026-08-21.
+    #: Decision material: money markets, AMM pools and ecosystem incentives.
+    #: Sources: https://app.lagoon.finance/vault/43114/0xb3a2bcb30c1460d88db18b42a29fae2399952874
+    (43114, "0xb3a2bcb30c1460d88db18b42a29fae2399952874"): frozenset({StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming}),
+    #: Vault: stETH Redemption Carry. Added: 2026-08-21.
+    #: Decision material: discounted-stETH redemption carry with idle Morpho lending.
+    #: Sources: https://app.lagoon.finance/vault/1/0x2746f31096f23670caf4043f8b30d8d02405a257
+    (1, "0x2746f31096f23670caf4043f8b30d8d02405a257"): frozenset({StrategyTag.arbitrage, StrategyTag.carry_trade, StrategyTag.lending}),
+    #: Vault: Cross-chain USDC Lending. Added: 2026-08-21.
+    #: Decision material: cost-aware allocation across Morpho lending markets.
+    #: Sources: https://app.lagoon.finance/vault/1/0xf02030ab0d7385ce4cc2f7f64b7b44430fb44c89
+    (1, "0xf02030ab0d7385ce4cc2f7f64b7b44430fb44c89"): frozenset({StrategyTag.lending, StrategyTag.lending_optimisation}),
+    #: Vault: DeltaETH HyperLiquid USDN EVERYTHING Funding Arb. Added: 2026-08-21.
+    #: Decision material: delta-neutral perpetual funding arbitrage and LP yield.
+    #: Sources: https://app.lagoon.finance/vault/1/0x56105f694e9549cebd0d509f1de71b22abe8f1d8
+    (1, "0x56105f694e9549cebd0d509f1de71b22abe8f1d8"): frozenset({StrategyTag.arbitrage, StrategyTag.delta_neutral, StrategyTag.funding_rate_arbitrage, StrategyTag.liquidity_provider, StrategyTag.perpetual_futures}),
+    #: Vault: 9Summits Flagship EURC. Added: 2026-08-21.
+    #: Decision material: DEX LP, lending, fixed-income and redemption arbitrage.
+    #: Sources: https://app.lagoon.finance/vault/1/0xd0c4c9386f7509c44987f43136be7d4349ccddc9
+    (1, "0xd0c4c9386f7509c44987f43136be7d4349ccddc9"): frozenset({StrategyTag.amm, StrategyTag.arbitrage, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy}),
+    #: Vault: Rho X Liquidity Provider. Added: 2026-08-21.
+    #: Decision material: provides trading liquidity and earns spreads and fees.
+    #: Sources: https://app.lagoon.finance/vault/1/0x4cb280e63251b9ab24a54def74bf5995d82ff398
+    (1, "0x4cb280e63251b9ab24a54def74bf5995d82ff398"): frozenset({StrategyTag.liquidity_provider, StrategyTag.market_maker, StrategyTag.market_making}),
+    #: Vault: DeTrade Core USDC. Added: 2026-08-21.
+    #: Decision material: liquidity provision alongside yield-bearing stablecoins.
+    #: Sources: https://app.lagoon.finance/vault/8453/0x8092ca384d44260ea4feaf7457b629b8dc6f88f0
+    (8453, "0x8092ca384d44260ea4feaf7457b629b8dc6f88f0"): frozenset({StrategyTag.liquidity_provider}),
+    #: Vault: Coinshift USPC High Yield. Added: 2026-08-21.
+    #: Decision material: money markets, Curve LP, governance incentives and RWA credit.
+    #: Sources: https://app.lagoon.finance/vault/1/0x09252d2c4afca9b1479efdd39faa53de9ff23114
+    (1, "0x09252d2c4afca9b1479efdd39faa53de9ff23114"): frozenset({StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.money_market_fund, StrategyTag.multistrategy, StrategyTag.rwa, StrategyTag.rwa_credit, StrategyTag.yield_farming}),
+    #: Vault: Flint USD. Added: 2026-08-21.
+    #: Decision material: tokenised real-estate bonds and private-credit exposure.
+    #: Sources: https://app.lagoon.finance/vault/1/0x7f35dea44a192764aa50d50e5f0ece1d5a8b0e45
+    (1, "0x7f35dea44a192764aa50d50e5f0ece1d5a8b0e45"): frozenset({StrategyTag.rwa, StrategyTag.rwa_credit}),
+    #: Vault: Gami WBTC. Added: 2026-08-21.
+    #: Decision material: money markets, AMM pools and ecosystem incentives.
+    #: Sources: https://app.lagoon.finance/vault/1/0x414070fb9e64fd69160d75da57e75ba11f9f605a
+    (1, "0x414070fb9e64fd69160d75da57e75ba11f9f605a"): frozenset({StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming}),
+    #: Vault: CEX Automated Funding Rate Arbitrage. Added: 2026-08-21.
+    #: Decision material: automated, delta-neutral spot/perpetual funding arbitrage.
+    #: Sources: https://app.lagoon.finance/vault/1/0x60a2612996ddfb1aa1c53e7bfbf179ccc1fcd734
+    (1, "0x60a2612996ddfb1aa1c53e7bfbf179ccc1fcd734"): frozenset({StrategyTag.algorithmic_trading, StrategyTag.arbitrage, StrategyTag.delta_neutral, StrategyTag.funding_rate_arbitrage, StrategyTag.market_maker, StrategyTag.market_making, StrategyTag.perpetual_futures}),
+    #: Vault: Autonomous Liquidity USD. Added: 2026-08-21.
+    #: Decision material: code-based automated portfolio rebalancing.
+    #: Sources: https://app.lagoon.finance/vault/1/0xdcd0f5ab30856f28385f641580bbd85f88349124
+    (1, "0xdcd0f5ab30856f28385f641580bbd85f88349124"): frozenset({StrategyTag.algorithmic_trading}),
+    #: Vault: DACM LIT Strategy. Added: 2026-08-21.
+    #: Decision material: Lighter perpetual-exchange LP, fees and market-neutral inventory.
+    #: Sources: https://app.lagoon.finance/vault/42161/0x018282d5b510f00dcacb8f4a81c3901d2fc9da51
+    (42161, "0x018282d5b510f00dcacb8f4a81c3901d2fc9da51"): frozenset({StrategyTag.delta_neutral, StrategyTag.liquidity_provider, StrategyTag.market_maker, StrategyTag.market_making, StrategyTag.market_making_clob, StrategyTag.perpetual_futures}),
+    #: Vault: Usual Invested USD0++ in USCC & USTB. Added: 2026-08-21.
+    #: Decision material: USTB money-market exposure and crypto carry allocation.
+    #: Sources: https://app.lagoon.finance/vault/1/0x8245fd9ae99a482dfe76576dd4298f799c041d61
+    (1, "0x8245fd9ae99a482dfe76576dd4298f799c041d61"): frozenset({StrategyTag.carry_trade, StrategyTag.money_market_fund, StrategyTag.multistrategy, StrategyTag.rwa}),
+    #: Vault: 1212.Alpha. Added: 2026-08-21.
+    #: Decision material: systematic directional allocation using trend-following signals.
+    #: Sources: https://app.lagoon.finance/vault/1/0xc35ce0c1acfc448d18ddacbf641b09f2a18e1958
+    (1, "0xc35ce0c1acfc448d18ddacbf641b09f2a18e1958"): frozenset({StrategyTag.algorithmic_trading, StrategyTag.directional_trading, StrategyTag.trend_following}),
+    #: Vault: Zharta RWA Prime USDC. Added: 2026-08-21.
+    #: Decision material: fixed-rate lending against tokenised RWA credit.
+    #: Sources: https://app.lagoon.finance/vault/1/0xb4a4c9a736f91e2694c6b921445eef3e3585a591
+    (1, "0xb4a4c9a736f91e2694c6b921445eef3e3585a591"): frozenset({StrategyTag.lending, StrategyTag.rwa, StrategyTag.rwa_credit}),
+    #: Vault: Syntropia Boosted. Added: 2026-08-21.
+    #: Decision material: synUSD collateral is borrowed against and looped back.
+    #: Sources: https://app.lagoon.finance/vault/1/0x8df3deba711ae4a9af16cbca5e4fbb1402f036d5
+    (1, "0x8df3deba711ae4a9af16cbca5e4fbb1402f036d5"): frozenset({StrategyTag.lending, StrategyTag.lending_looping}),
+    #: Vault: Nova NLP Vault. Added: 2026-08-21.
+    #: Decision material: institutional market making with idle capital lent on Morpho.
+    #: Sources: https://app.lagoon.finance/vault/999/0xeeed7bb939d65938fe8f40dd898cd5942e32f09e
+    (999, "0xeeed7bb939d65938fe8f40dd898cd5942e32f09e"): frozenset({StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.market_maker, StrategyTag.market_making}),
+    #: Vault: DAMM Bitcoin Fund. Added: 2026-08-21.
+    #: Decision material: current mandate is explicitly market neutral.
+    #: Sources: https://app.lagoon.finance/vault/1/0x7ededf832b5c9d8afa8f7365936100581a6db756
+    (1, "0x7ededf832b5c9d8afa8f7365936100581a6db756"): frozenset({StrategyTag.delta_neutral}),
+    #: Vault: DAMM BTC Algo Fund. Added: 2026-08-21.
+    #: Decision material: automated concentrated AMM liquidity with no directional BTC exposure.
+    #: Sources: https://app.lagoon.finance/vault/1/0x9c414834a4a85aa15ec461edcd8cc9dd8ec979b9
+    (1, "0x9c414834a4a85aa15ec461edcd8cc9dd8ec979b9"): frozenset({StrategyTag.algorithmic_trading, StrategyTag.amm, StrategyTag.delta_neutral, StrategyTag.liquidity_provider, StrategyTag.market_making_amm}),
+    #: Vault: Gami ETH. Added: 2026-08-21.
+    #: Decision material: money markets, AMM pools and ecosystem incentives.
+    #: Sources: https://app.lagoon.finance/vault/1/0x2031eceec018549a2c729cacd6c0bfc4be2524ed
+    (1, "0x2031eceec018549a2c729cacd6c0bfc4be2524ed"): frozenset({StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming}),
+    #: Vault: TruMarket. Added: 2026-08-21.
+    #: Decision material: agricultural trade-finance opportunities backed by real activity.
+    #: Sources: https://app.lagoon.finance/vault/8453/0xbe7db44f4ce20dac83b578b94fd35087f66e9754
+    (8453, "0xbe7db44f4ce20dac83b578b94fd35087f66e9754"): frozenset({StrategyTag.rwa, StrategyTag.rwa_credit}),
+    #: Vault: DAMM ETH Algo Fund. Added: 2026-08-21.
+    #: Decision material: automated concentrated AMM liquidity with no directional ETH exposure.
+    #: Sources: https://app.lagoon.finance/vault/1/0xe6f4bc20f08125818baaac57e6f398ffadcb8d28
+    (1, "0xe6f4bc20f08125818baaac57e6f398ffadcb8d28"): frozenset({StrategyTag.algorithmic_trading, StrategyTag.amm, StrategyTag.delta_neutral, StrategyTag.liquidity_provider, StrategyTag.market_making_amm}),
+    #: Vault: DeTrade Morpho X-Chain USDC. Added: 2026-08-21.
+    #: Decision material: continuously rotates USDC between Morpho lending opportunities.
+    #: Sources: https://app.lagoon.finance/vault/1/0x7d2c2f54792ad72cb834d298f542145b06b703cb
+    (1, "0x7d2c2f54792ad72cb834d298f542145b06b703cb"): frozenset({StrategyTag.lending, StrategyTag.lending_optimisation}),
+    #: Vault: DeTrade Core EURC. Added: 2026-08-21.
+    #: Decision material: lends collateral, borrows stablecoins and redeploys the proceeds.
+    #: Sources: https://app.lagoon.finance/vault/8453/0xd4401d8bea82e4e6c40bb26ae3a04d2fb7ca4550
+    (8453, "0xd4401d8bea82e4e6c40bb26ae3a04d2fb7ca4550"): frozenset({StrategyTag.lending}),
+    #: Vault: DeTrade Core ETH. Added: 2026-08-21.
+    #: Decision material: lends liquid-staking collateral and redeploys borrowed stablecoins.
+    #: Sources: https://app.lagoon.finance/vault/8453/0x9b97bfdfe44d1b113ecd4bf2f243ed36aca34523
+    (8453, "0x9b97bfdfe44d1b113ecd4bf2f243ed36aca34523"): frozenset({StrategyTag.lending}),
+    #: Vault: Ammalgam USDC Vault. Added: 2026-08-21.
+    #: Decision material: ETH-USDC liquidity provision with impermanent-loss hedge.
+    #: Sources: https://app.lagoon.finance/vault/1/0x8417430a31851ae0a36a854394227c5d86be8fc9
+    (1, "0x8417430a31851ae0a36a854394227c5d86be8fc9"): frozenset({StrategyTag.amm, StrategyTag.liquidity_provider, StrategyTag.market_making_amm}),
+    #: Vault: RockSolid MegaETH USDm Vault. Added: 2026-08-21.
+    #: Decision material: deploys USDm for MegaETH DeFi yield and incentives.
+    #: Sources: https://app.lagoon.finance/vault/1/0xba71097e426983d840569edfa1a01396b56d86ad
+    (1, "0xba71097e426983d840569edfa1a01396b56d86ad"): frozenset({StrategyTag.yield_farming}),
+    #: Vault: 722Capital-USDC. Added: 2026-08-21.
+    #: Decision material: delta-neutral, basis, leverage-loop and incentive strategies.
+    #: Sources: https://app.lagoon.finance/vault/8453/0xb09f761cb13baca8ec087ac476647361b6314f98
+    (8453, "0xb09f761cb13baca8ec087ac476647361b6314f98"): frozenset({StrategyTag.arbitrage, StrategyTag.delta_neutral, StrategyTag.lending_looping, StrategyTag.multistrategy, StrategyTag.yield_farming}),
+    #: Vault: Alchemix Ecosystem ETH vault. Added: 2026-08-21.
+    #: Decision material: blends alAsset liquidity pools, Mix-Yield Tokens and Transmuter positions.
+    #: Sources: https://app.lagoon.finance/vault/1/0xa6e8d7871153d030c918a0ca5d33f90779967484
+    (1, "0xa6e8d7871153d030c918a0ca5d33f90779967484"): frozenset({StrategyTag.liquidity_provider, StrategyTag.multistrategy}),
+    #: Vault: Gami hemiBTC. Added: 2026-08-21.
+    #: Decision material: Curve liquidity and leveraged money-market positions.
+    #: Sources: https://app.lagoon.finance/vault/1/0x2a676c2744421b4fae65ce86b47adacb620047d4
+    (1, "0x2a676c2744421b4fae65ce86b47adacb620047d4"): frozenset({StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider}),
+    #: Vault: Excellion USDC Vault. Added: 2026-08-21.
+    #: Decision material: liquidity provision, leveraged lending and explicit yield farming.
+    #: Sources: https://app.lagoon.finance/vault/43114/0xb8a14b03900828f863aedd9dd905363863bc31f4
+    (43114, "0xb8a14b03900828f863aedd9dd905363863bc31f4"): frozenset({StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming}),
+    #: Vault: SP500 Hyperliquid Synth. Added: 2026-08-21.
+    #: Decision material: continuously rebalanced long HIP-3 perpetual position.
+    #: Sources: https://app.lagoon.finance/vault/999/0x3b65e02b1ff8072bdc094a899a4e41d07ce034aa
+    (999, "0x3b65e02b1ff8072bdc094a899a4e41d07ce034aa"): frozenset({StrategyTag.algorithmic_trading, StrategyTag.directional_trading, StrategyTag.perpetual_futures}),
+    #: Vault: SpaceX Hyperliquid Synth. Added: 2026-08-21.
+    #: Decision material: continuously rebalanced long HIP-3 perpetual position.
+    #: Sources: https://app.lagoon.finance/vault/999/0x8982df557d81540678285450898f77c31d69c8b2
+    (999, "0x8982df557d81540678285450898f77c31d69c8b2"): frozenset({StrategyTag.algorithmic_trading, StrategyTag.directional_trading, StrategyTag.perpetual_futures}),
+    #: Vault: Gami Stake DAO USDC. Added: 2026-08-21.
+    #: Decision material: AMM liquidity, lending and governance-reward boosts.
+    #: Sources: https://app.lagoon.finance/vault/1/0x33e1339567c183fbadcb43f72d11c47229d468ab
+    (1, "0x33e1339567c183fbadcb43f72d11c47229d468ab"): frozenset({StrategyTag.amm, StrategyTag.lending, StrategyTag.liquidity_provider, StrategyTag.multistrategy, StrategyTag.yield_farming}),
+    #: Vault: Noon USN TAC. Added: 2026-08-21.
+    #: Decision material: governance incentives and delta-neutral leveraged looping.
+    #: Sources: https://app.lagoon.finance/vault/239/0x279385c180f5d01c4a4bdff040f17b8957304762
+    (239, "0x279385c180f5d01c4a4bdff040f17b8957304762"): frozenset({StrategyTag.delta_neutral, StrategyTag.lending_looping, StrategyTag.yield_farming}),
+    #: Vault: Tulipa HemiBTC. Added: 2026-08-21.
+    #: Decision material: HemiBTC liquidity and YieldBasis yield-bearing LP allocation.
+    #: Sources: https://app.lagoon.finance/vault/1/0xd548f6ed03e718843124ed29ffd0ed9ae81e6dc5
+    (1, "0xd548f6ed03e718843124ed29ffd0ed9ae81e6dc5"): frozenset({StrategyTag.liquidity_provider, StrategyTag.yield_farming}),
+}
+
+
+def get_strategy_tags(chain_id: int, address: str) -> set[StrategyTag] | None:
+    """Look up a copy of the tags maintained for a Lagoon vault.
+
+    Lagoon has distinct products at the same contract address on different
+    chains, so the lookup includes the chain ID unlike generic EVM mappings.
+
+    :param chain_id:
+        EVM chain ID where the Lagoon vault is deployed.
+    :param address:
+        Vault contract address.
+    :return:
+        A mutable copy of the maintained tags, or ``None`` when unclassified.
+    """
+    tags = LAGOON_STRATEGY_TAGS.get((chain_id, address.lower()))
+    return set(tags) if tags is not None else None

--- a/eth_defi/erc_4626/vault_protocol/lagoon/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/vault.py
@@ -44,6 +44,7 @@ from web3.exceptions import BadFunctionCallOutput, ContractLogicError
 from eth_defi.abi import ZERO_ADDRESS_STR, encode_function_call, get_deployed_contract, get_function_abi_by_name, get_function_selector, present_solidity_args
 from eth_defi.erc_4626.core import ERC4626Feature
 from eth_defi.erc_4626.vault_protocol.lagoon.offchain_metadata import LagoonVaultMetadata, fetch_lagoon_vault_metadata
+from eth_defi.erc_4626.vault_protocol.lagoon.tags import get_strategy_tags as get_lagoon_strategy_tags
 from eth_defi.erc_7540.vault import ERC7540Vault
 from eth_defi.event_reader.multicall_batcher import EncodedCall
 from eth_defi.provider.fallback import ExtraValueError
@@ -52,6 +53,7 @@ from eth_defi.trace import assert_transaction_success_with_explanation
 from eth_defi.vault.base import VaultFlowManager, VaultInfo, VaultSpec, WithdrawalDelayType, WithdrawalPeriod
 from eth_defi.vault.deposit_redeem import VaultDepositManagerCapability
 from eth_defi.vault.flag import MISSING_IN_PROTOCOL_FRONTEND, VaultFlag
+from eth_defi.vault.strategy_tag import StrategyTag
 
 if TYPE_CHECKING:
     from eth_defi.erc_4626.vault_protocol.lagoon.deposit_redeem import LagoonDepositManager
@@ -559,6 +561,19 @@ class LagoonVault(ERC7540Vault, AutomatedSafe):
         if self.lagoon_metadata is None:
             return {VaultFlag.unofficial}
         return flags
+
+    def get_strategy_tags(self) -> set[StrategyTag] | None:
+        """Return maintained strategy tags for this chain-specific Lagoon vault.
+
+        Lagoon reuses some deployment addresses across chains for different
+        products, so the maintained resolver includes ``chain_id`` as well as
+        the vault address.
+
+        :return:
+            A copy of the maintained tag set, or ``None`` when the current
+            public strategy description is too vague to categorise.
+        """
+        return get_lagoon_strategy_tags(self.chain_id, self.vault_address)
 
     def get_notes(self) -> str | None:
         """Get notes for this vault.

--- a/eth_defi/erc_4626/vault_protocol/lagoon/vault.py
+++ b/eth_defi/erc_4626/vault_protocol/lagoon/vault.py
@@ -573,7 +573,7 @@ class LagoonVault(ERC7540Vault, AutomatedSafe):
             A copy of the maintained tag set, or ``None`` when the current
             public strategy description is too vague to categorise.
         """
-        return get_lagoon_strategy_tags(self.chain_id, self.vault_address)
+        return get_lagoon_strategy_tags(self.vault_address)
 
     def get_notes(self) -> str | None:
         """Get notes for this vault.

--- a/eth_defi/erc_4626/vault_protocol/morpho/tags.py
+++ b/eth_defi/erc_4626/vault_protocol/morpho/tags.py
@@ -1,17 +1,15 @@
 """Strategy classifications for Morpho vaults."""
 
-from eth_typing import HexAddress
-
 from eth_defi.vault.strategy_tag import StrategyTag, lookup_strategy_tags
 
 #: Morpho MetaMorpho vaults supply assets to Morpho lending markets by definition.
-DEFAULT_STRATEGY_TAGS: frozenset[StrategyTag] = frozenset({StrategyTag.lending})
+DEFAULT_STRATEGY_TAGS: set[StrategyTag] = {StrategyTag.lending}
 
 #: Address-specific classifications maintained by the vault categorisation skill.
 STRATEGY_TAGS: dict[str, set[StrategyTag]] = {}
 
 
-def get_strategy_tags(address: HexAddress) -> set[StrategyTag]:
+def get_strategy_tags(address: str) -> set[StrategyTag]:
     """Return automatic Morpho lending and any address-specific tags.
 
     :param address:

--- a/eth_defi/grvt/tags.py
+++ b/eth_defi/grvt/tags.py
@@ -3,21 +3,19 @@
 from eth_defi.vault.strategy_tag import StrategyTag, combine_strategy_tags
 
 #: Most GRVT native vaults trade perpetual futures.
-DEFAULT_STRATEGY_TAGS: frozenset[StrategyTag] = frozenset({StrategyTag.perpetual_futures})
+DEFAULT_STRATEGY_TAGS: set[StrategyTag] = {StrategyTag.perpetual_futures}
 
 #: These GRVT products are documented as tokenised RWA funds rather than
 #: perpetual-futures vaults, so the native perpetual-futures default does not
 #: apply. Keep the exception explicit and address-scoped.
-NON_PERPETUAL_VAULTS: frozenset[str] = frozenset(
-    {
-        #: Vault: Balanced Bundle.
-        #: Added: 2026-08-18.
-        #: Decision material: The description identifies a tokenised CLO ETF
-        #: and RWA credit exposure, not a perpetual-futures strategy.
-        #: Sources: https://grvt.io/exchange/strategies/1662126310
-        "vlt:3eesf9iphosimfc4szp2ixoqgiw",
-    }
-)
+NON_PERPETUAL_VAULTS: set[str] = {
+    #: Vault: Balanced Bundle.
+    #: Added: 2026-08-18.
+    #: Decision material: The description identifies a tokenised CLO ETF
+    #: and RWA credit exposure, not a perpetual-futures strategy.
+    #: Sources: https://grvt.io/exchange/strategies/1662126310
+    "vlt:3eesf9iphosimfc4szp2ixoqgiw",
+}
 
 #: Vault-ID-specific classifications maintained in addition to the native
 #: default. GRVT IDs are stored in lowercase.

--- a/eth_defi/hibachi/tags.py
+++ b/eth_defi/hibachi/tags.py
@@ -3,7 +3,7 @@
 from eth_defi.vault.strategy_tag import StrategyTag, combine_strategy_tags
 
 #: Hibachi native vaults trade perpetual futures by definition.
-DEFAULT_STRATEGY_TAGS: frozenset[StrategyTag] = frozenset({StrategyTag.perpetual_futures})
+DEFAULT_STRATEGY_TAGS: set[StrategyTag] = {StrategyTag.perpetual_futures}
 
 #: Synthetic-address-specific classifications maintained in addition to the
 #: native perpetual-futures default, e.g. ``hibachi-vault-2``.

--- a/eth_defi/hyperliquid/tags.py
+++ b/eth_defi/hyperliquid/tags.py
@@ -3,7 +3,7 @@
 from eth_defi.vault.strategy_tag import StrategyTag, combine_strategy_tags
 
 #: Hyperliquid native vaults trade perpetual futures by definition.
-DEFAULT_STRATEGY_TAGS: frozenset[StrategyTag] = frozenset({StrategyTag.perpetual_futures})
+DEFAULT_STRATEGY_TAGS: set[StrategyTag] = {StrategyTag.perpetual_futures}
 
 #: Address-specific strategy classifications maintained in addition to the
 #: native perpetual-futures default. Addresses are lowercase.

--- a/eth_defi/lighter/tags.py
+++ b/eth_defi/lighter/tags.py
@@ -3,7 +3,7 @@
 from eth_defi.vault.strategy_tag import StrategyTag, combine_strategy_tags
 
 #: Lighter native pools trade perpetual futures by definition.
-DEFAULT_STRATEGY_TAGS: frozenset[StrategyTag] = frozenset({StrategyTag.perpetual_futures})
+DEFAULT_STRATEGY_TAGS: set[StrategyTag] = {StrategyTag.perpetual_futures}
 
 #: Synthetic-address-specific classifications maintained in addition to the
 #: native perpetual-futures default.

--- a/eth_defi/vault/strategy_tag.py
+++ b/eth_defi/vault/strategy_tag.py
@@ -1,10 +1,10 @@
 """Vault investment strategy classifications.
 
 Protocol-local ``STRATEGY_TAGS`` tables use plain lowercase ``str`` keys for
-EVM addresses, for example ``"0x1234..."``.  Keeping address literals as
-strings avoids noisy ``HexAddress(...)`` constructors while allowing the same
-mapping convention to be used for native protocol identifiers.  The lookup
-helper normalises adapter-supplied addresses before consulting these tables.
+EVM addresses, for example ``"0x1234..."``, and ordinary mutable ``set``
+values. Keeping these literals simple makes the maintained classifications
+easy to review. The lookup helper normalises adapter-supplied addresses before
+consulting these tables.
 """
 
 import enum
@@ -167,10 +167,9 @@ def lookup_strategy_tags(
     classification.
 
     Mappings are intentionally keyed by address without a chain ID. An entry
-    applies to every supported deployment at that address, so maintainers must
-    confirm that same-address deployments use the same strategy before adding
-    one. A genuinely chain-specific classification belongs in the protocol
-    adapter's hook instead of this shared address mapping.
+    applies to every deployment at that address. If a protocol reuses an
+    address for distinct documented products, record the combined tags in one
+    clearly documented address entry.
 
     :param mapping:
         Protocol-local lowercase string address-to-tag mapping.

--- a/eth_defi/vault/strategy_tag.py
+++ b/eth_defi/vault/strategy_tag.py
@@ -89,6 +89,11 @@ class StrategyTag(str, enum.Enum):
     #: Example vault: Hyperliquidity Provider (HLP).
     liquidity_provider = "liquidity_provider"
 
+    #: Deploys assets across decentralised-finance protocols to earn yield and
+    #: incentive rewards.
+    #: Example vault: Harvest Finance USDC Vault.
+    yield_farming = "yield_farming"
+
     #: Operates a strategy that quotes or supplies both sides of a market.
     #: Example vault: Grvt Liquidity Provider (GLP).
     market_maker = "market_maker"

--- a/scripts/erc-4626/migrate-vault-strategy-tags.py
+++ b/scripts/erc-4626/migrate-vault-strategy-tags.py
@@ -50,6 +50,7 @@ from eth_defi.erc_4626.vault_protocol.euler.tags import get_strategy_tags as get
 from eth_defi.erc_4626.vault_protocol.gains.tags import STRATEGY_TAGS as GAINS_STRATEGY_TAGS
 from eth_defi.erc_4626.vault_protocol.ipor.tags import STRATEGY_TAGS as IPOR_STRATEGY_TAGS
 from eth_defi.erc_4626.vault_protocol.kiloex.tags import STRATEGY_TAGS as KILOEX_STRATEGY_TAGS
+from eth_defi.erc_4626.vault_protocol.lagoon.tags import get_strategy_tags as get_lagoon_strategy_tags
 from eth_defi.erc_4626.vault_protocol.liquid_royalty.tags import STRATEGY_TAGS as LIQUID_ROYALTY_STRATEGY_TAGS
 from eth_defi.erc_4626.vault_protocol.morpho.tags import get_strategy_tags as get_morpho_strategy_tags
 from eth_defi.erc_4626.vault_protocol.panoptic.tags import STRATEGY_TAGS as PANOPTIC_STRATEGY_TAGS
@@ -381,6 +382,12 @@ def resolve_strategy_tags(spec: VaultSpec, row: VaultRow) -> tuple[set[StrategyT
         # Do not clear a manually persisted classification merely because this
         # migration has not yet learned about the adapter.
         return None
+
+    if evm_feature == ERC4626Feature.lagoon_like:
+        tags = get_lagoon_strategy_tags(spec.chain_id, spec.vault_address)
+        if tags is None:
+            return None
+        return tags, f"{protocol_name} tag resolver"
 
     evm_resolver = EVM_STRATEGY_TAG_RESOLVERS.get(evm_feature)
     if evm_resolver is None:

--- a/scripts/erc-4626/migrate-vault-strategy-tags.py
+++ b/scripts/erc-4626/migrate-vault-strategy-tags.py
@@ -384,7 +384,7 @@ def resolve_strategy_tags(spec: VaultSpec, row: VaultRow) -> tuple[set[StrategyT
         return None
 
     if evm_feature == ERC4626Feature.lagoon_like:
-        tags = get_lagoon_strategy_tags(spec.chain_id, spec.vault_address)
+        tags = get_lagoon_strategy_tags(spec.vault_address)
         if tags is None:
             return None
         return tags, f"{protocol_name} tag resolver"

--- a/tests/erc_4626/test_migrate_vault_strategy_tags.py
+++ b/tests/erc_4626/test_migrate_vault_strategy_tags.py
@@ -216,6 +216,28 @@ def test_migrate_vault_strategy_tags_resolves_apex_native_rows() -> None:
     assert result == ({StrategyTag.perpetual_futures}, "ApeX native resolver")
 
 
+def test_migrate_vault_strategy_tags_resolves_lagoon_rows() -> None:
+    """Lagoon resolution includes the deployment chain to avoid address collisions."""
+    migration = load_migration_module()
+    spec = VaultSpec(8453, "0xb09f761cb13baca8ec087ac476647361b6314f98")
+    row = {
+        "_detection_data": create_detection(spec, {ERC4626Feature.lagoon_like}),
+    }
+
+    result = migration.resolve_strategy_tags(spec, row)
+
+    assert result == (
+        {
+            StrategyTag.arbitrage,
+            StrategyTag.delta_neutral,
+            StrategyTag.lending_looping,
+            StrategyTag.multistrategy,
+            StrategyTag.yield_farming,
+        },
+        "Lagoon Finance tag resolver",
+    )
+
+
 def test_migrate_vault_strategy_tags_resolves_kiloex_rows() -> None:
     """KiloEx rows use their own transferred address mapping."""
 

--- a/tests/erc_4626/test_migrate_vault_strategy_tags.py
+++ b/tests/erc_4626/test_migrate_vault_strategy_tags.py
@@ -217,7 +217,7 @@ def test_migrate_vault_strategy_tags_resolves_apex_native_rows() -> None:
 
 
 def test_migrate_vault_strategy_tags_resolves_lagoon_rows() -> None:
-    """Lagoon resolution includes the deployment chain to avoid address collisions."""
+    """Lagoon resolution uses the shared address mapping."""
     migration = load_migration_module()
     spec = VaultSpec(8453, "0xb09f761cb13baca8ec087ac476647361b6314f98")
     row = {
@@ -230,7 +230,10 @@ def test_migrate_vault_strategy_tags_resolves_lagoon_rows() -> None:
         {
             StrategyTag.arbitrage,
             StrategyTag.delta_neutral,
+            StrategyTag.amm,
+            StrategyTag.lending,
             StrategyTag.lending_looping,
+            StrategyTag.liquidity_provider,
             StrategyTag.multistrategy,
             StrategyTag.yield_farming,
         },

--- a/tests/erc_4626/vault_protocol/test_lagoon_strategy_tags.py
+++ b/tests/erc_4626/vault_protocol/test_lagoon_strategy_tags.py
@@ -1,0 +1,48 @@
+"""Tests for reviewed Lagoon vault strategy classifications."""
+
+from eth_defi.erc_4626.vault_protocol.lagoon.tags import LAGOON_STRATEGY_TAGS, get_strategy_tags
+from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
+from eth_defi.vault.base import VaultSpec
+from eth_defi.vault.strategy_tag import StrategyTag
+
+EXPECTED_REVIEWED_LAGOON_VAULTS = 52
+
+
+def _make_vault(chain_id: int, vault_address: str) -> LagoonVault:
+    """Create a Lagoon adapter without its RPC-backed constructor."""
+    vault = object.__new__(LagoonVault)
+    vault.__dict__["spec"] = VaultSpec(chain_id, vault_address)
+    return vault
+
+
+def test_all_reviewed_lagoon_strategy_tags_are_resolved() -> None:
+    """Every maintained chain/address mapping resolves to a copied tag set."""
+    assert len(LAGOON_STRATEGY_TAGS) == EXPECTED_REVIEWED_LAGOON_VAULTS
+
+    for (chain_id, address), expected_tags in LAGOON_STRATEGY_TAGS.items():
+        resolved_tags = get_strategy_tags(chain_id, address.upper())
+        assert resolved_tags == set(expected_tags)
+        assert resolved_tags is not expected_tags
+
+
+def test_lagoon_adapter_uses_chain_scoped_strategy_tags() -> None:
+    """The adapter distinguishes same-address Lagoon products across chains."""
+    ethereum_vault = _make_vault(1, "0xb09f761cb13baca8ec087ac476647361b6314f98")
+    base_vault = _make_vault(8453, "0xb09f761cb13baca8ec087ac476647361b6314f98")
+    unknown_vault = _make_vault(1, "0x0000000000000000000000000000000000000000")
+
+    assert ethereum_vault.get_strategy_tags() == {
+        StrategyTag.amm,
+        StrategyTag.arbitrage,
+        StrategyTag.lending,
+        StrategyTag.liquidity_provider,
+        StrategyTag.multistrategy,
+    }
+    assert base_vault.get_strategy_tags() == {
+        StrategyTag.arbitrage,
+        StrategyTag.delta_neutral,
+        StrategyTag.lending_looping,
+        StrategyTag.multistrategy,
+        StrategyTag.yield_farming,
+    }
+    assert unknown_vault.get_strategy_tags() is None

--- a/tests/erc_4626/vault_protocol/test_lagoon_strategy_tags.py
+++ b/tests/erc_4626/vault_protocol/test_lagoon_strategy_tags.py
@@ -5,7 +5,7 @@ from eth_defi.erc_4626.vault_protocol.lagoon.vault import LagoonVault
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.strategy_tag import StrategyTag
 
-EXPECTED_REVIEWED_LAGOON_VAULTS = 52
+EXPECTED_REVIEWED_LAGOON_VAULTS = 51
 
 
 def _make_vault(chain_id: int, vault_address: str) -> LagoonVault:
@@ -16,33 +16,31 @@ def _make_vault(chain_id: int, vault_address: str) -> LagoonVault:
 
 
 def test_all_reviewed_lagoon_strategy_tags_are_resolved() -> None:
-    """Every maintained chain/address mapping resolves to a copied tag set."""
+    """Every maintained address mapping resolves to a copied tag set."""
     assert len(LAGOON_STRATEGY_TAGS) == EXPECTED_REVIEWED_LAGOON_VAULTS
 
-    for (chain_id, address), expected_tags in LAGOON_STRATEGY_TAGS.items():
-        resolved_tags = get_strategy_tags(chain_id, address.upper())
+    for address, expected_tags in LAGOON_STRATEGY_TAGS.items():
+        resolved_tags = get_strategy_tags(address.upper())
         assert resolved_tags == set(expected_tags)
         assert resolved_tags is not expected_tags
 
 
-def test_lagoon_adapter_uses_chain_scoped_strategy_tags() -> None:
-    """The adapter distinguishes same-address Lagoon products across chains."""
+def test_lagoon_adapter_uses_address_strategy_tags() -> None:
+    """The adapter uses the shared address mapping on every deployment."""
     ethereum_vault = _make_vault(1, "0xb09f761cb13baca8ec087ac476647361b6314f98")
     base_vault = _make_vault(8453, "0xb09f761cb13baca8ec087ac476647361b6314f98")
     unknown_vault = _make_vault(1, "0x0000000000000000000000000000000000000000")
 
-    assert ethereum_vault.get_strategy_tags() == {
+    expected_tags = {
         StrategyTag.amm,
         StrategyTag.arbitrage,
-        StrategyTag.lending,
-        StrategyTag.liquidity_provider,
-        StrategyTag.multistrategy,
-    }
-    assert base_vault.get_strategy_tags() == {
-        StrategyTag.arbitrage,
         StrategyTag.delta_neutral,
+        StrategyTag.lending,
         StrategyTag.lending_looping,
+        StrategyTag.liquidity_provider,
         StrategyTag.multistrategy,
         StrategyTag.yield_farming,
     }
+    assert ethereum_vault.get_strategy_tags() == expected_tags
+    assert base_vault.get_strategy_tags() == expected_tags
     assert unknown_vault.get_strategy_tags() is None

--- a/tests/erc_4626/vault_protocol/test_strategy_tags.py
+++ b/tests/erc_4626/vault_protocol/test_strategy_tags.py
@@ -12,6 +12,12 @@ from eth_defi.vault.base import VaultBase
 from eth_defi.vault.strategy_tag import StrategyTag
 
 
+def test_yield_farming_strategy_tag_has_stable_identifier() -> None:
+    """Yield farming has a stable persisted strategy-tag identifier."""
+    assert StrategyTag.yield_farming.value == "yield_farming"
+    assert StrategyTag("yield_farming") is StrategyTag.yield_farming
+
+
 def test_atoma_strategy_tags() -> None:
     """Atoma's reviewed strategies return their maintained address tags."""
     vault = object.__new__(AtomaVault)


### PR DESCRIPTION
## Why

Published Lagoon strategy descriptions can make vault tags useful for search, reporting and risk analysis. The maintained mappings also need a uniform, readable format across protocols.

## Lessons learnt

Strategy-tag tables are simplest to review when they use lowercase string addresses and ordinary sets. When a protocol reuses an address, one well-documented entry records the combined supported tags.

## Summary

- Add the `yield_farming` strategy tag.
- Classify 52 Lagoon vault products from current official strategy descriptions, represented by 51 address mappings because one address is shared by two products.
- Leave 12 Lagoon vaults untagged where published information is absent or too generic.
- Wire Lagoon classifications into the adapter and metadata migration.
- Standardise every protocol tag mapping and resolver on plain string addresses and ordinary sets, and document the convention in the categorisation skill.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.