### PR TITLE
fix: collect Hyperliquid exposure in production HF scanner

### DIFF
--- a/eth_defi/hyperliquid/daily_metrics.py
+++ b/eth_defi/hyperliquid/daily_metrics.py
@@ -1455,8 +1455,8 @@ def run_daily_scan(
     desc = "Fetching Hyperliquid vault details"
     results = Parallel(n_jobs=max_workers, backend="threading")(delayed(_process_vault_worker)(session, db, summary, cutoff_date, timeout, flow_backfill_days) for summary in tqdm(filtered, desc=desc))
 
-    success_count = sum(1 for r in results if r)
-    fail_count = sum(1 for r in results if not r)
+    success_count = sum(results)
+    fail_count = len(results) - success_count
 
     position_attempts = collect_hyperliquid_vault_observations(
         session,
@@ -1502,7 +1502,7 @@ def run_daily_scan(
     db.save()
 
     logger.info(
-        "Daily scan complete. Processed %d vaults (%d successful, %d failed, %d position reads) into %s",
+        "Daily scan complete. Processed %d vaults (%d successful, %d failed, %d position observation attempts) into %s",
         len(filtered),
         success_count,
         fail_count,

--- a/eth_defi/hyperliquid/high_freq_metrics.py
+++ b/eth_defi/hyperliquid/high_freq_metrics.py
@@ -1,6 +1,6 @@
 """High-frequency Hyperliquid vault metrics pipeline.
 
-Collects vault share prices, PnL, TVL and flow data. The ``default 4 h``
+Collects vault share prices, PnL, TVL, flow and current-position data. The ``default 4 h``
 interval is the *scan trigger* cadence (how often we poll), **not** the data
 resolution: the ``vaultDetails`` API serves the ``day`` period at a fixed
 ~20 min resolution, which is the finest it ever offers. Polling harder yields
@@ -51,6 +51,7 @@ from eth_defi.hyperliquid.deposit import (
     aggregate_daily_flows,
     fetch_vault_deposits,
 )
+from eth_defi.hyperliquid.perp_metrics import collect_hyperliquid_vault_observations
 from eth_defi.hyperliquid.session import HyperliquidSession
 from eth_defi.hyperliquid.vault import (
     HyperliquidVault,
@@ -787,12 +788,20 @@ def run_high_freq_scan(
         desc = "Fetching HF Hyperliquid vault details"
         results = Parallel(n_jobs=n_workers, backend="threading")(delayed(_hf_worker)(s) for s in tqdm(filtered, desc=desc))
 
-        success_count = sum(1 for r in results if r)
-        fail_count = sum(1 for r in results if not r)
+        success_count = sum(results)
+        fail_count = len(results) - success_count
     else:
         logger.info("No vaults matched filters, skipping parallel fetch")
         success_count = 0
         fail_count = 0
+
+    position_attempts = collect_hyperliquid_vault_observations(
+        session,
+        db.con,
+        filtered,
+        max_workers=max_workers,
+        timeout=timeout,
+    )
 
     # Lifecycle maintenance (runs unconditionally)
     if vault_addresses is None:
@@ -831,10 +840,11 @@ def run_high_freq_scan(
     db.save()
 
     logger.info(
-        "HF scan complete. Processed %d vaults (%d successful, %d failed) into %s",
+        "HF scan complete. Processed %d vaults (%d successful, %d failed, %d position observation attempts) into %s",
         len(filtered),
         success_count,
         fail_count,
+        position_attempts,
         db_path,
     )
 

--- a/eth_defi/hyperliquid/perp_metrics.py
+++ b/eth_defi/hyperliquid/perp_metrics.py
@@ -113,7 +113,7 @@ def _fetch_hyperliquid_vault_bundle(
     :param session:
         Configured public Hyperliquid session.
     :param summary:
-        Vault identity and account equity discovered by the daily scanner.
+        Vault identity and account equity discovered by the native vault scanner.
     :param timeout:
         HTTP request timeout in seconds.
     :return:
@@ -153,9 +153,9 @@ def collect_hyperliquid_vault_observations(
     :param session:
         Configured public Hyperliquid HTTP session.
     :param connection:
-        Owner-thread daily metrics DuckDB connection.
+        Owner-thread native metrics DuckDB connection.
     :param summaries:
-        Vaults already selected by the daily scanner.
+        Vaults already selected by the native vault scanner.
     :param max_workers:
         Threaded HTTP worker count.
     :param timeout:
@@ -164,7 +164,10 @@ def collect_hyperliquid_vault_observations(
         Number of attempted vault observations.
     """
     selected = tuple(summaries)
-    results = Parallel(n_jobs=max_workers, backend="threading")(delayed(_fetch_hyperliquid_vault_bundle)(session, summary, timeout) for summary in selected)
+    if not selected:
+        return 0
+    worker_count = min(max_workers, len(selected))
+    results = Parallel(n_jobs=worker_count, backend="threading")(delayed(_fetch_hyperliquid_vault_bundle)(session, summary, timeout) for summary in selected)
     for bundle, payload in results:
         write_perp_vault_observation_bundle(connection, bundle, payload)
     return len(results)

--- a/eth_defi/vault/post_processing.py
+++ b/eth_defi/vault/post_processing.py
@@ -548,6 +548,8 @@ def merge_native_protocols(
                     hypercore_df = build_hypercore_prices_dataframe(daily_db=daily_db, hf_db=hf_db)
                     if daily_db is not None:
                         _append_perp_metric_snapshots(daily_db, perp_snapshots)
+                    if hf_db is not None:
+                        _append_perp_metric_snapshots(hf_db, perp_snapshots)
             finally:
                 if daily_db is not None:
                     daily_db.close()

--- a/scripts/hyperliquid/README-hyperliquid-vaults-high-frequency.md
+++ b/scripts/hyperliquid/README-hyperliquid-vaults-high-frequency.md
@@ -2,11 +2,12 @@
 
 ## Overview
 
-The high-frequency (HF) pipeline is an alternative Hyperliquid vault data collector
-that operates at configurable sub-daily intervals (default 4h, down to 1h). It
-runs alongside the existing daily pipeline, using a separate DuckDB database with
-timestamp-precision rows and optional Webshare rotating proxies for parallel
-throughput.
+The high-frequency (HF) pipeline is the production Hyperliquid vault data
+collector. It operates at configurable sub-daily intervals (default 4h, down to
+1h), using a separate DuckDB database with timestamp-precision rows and optional
+Webshare rotating proxies for parallel throughput. The older daily pipeline is
+retained for legacy history, standalone use and combined Parquet reads, but the
+looped production scanner does not run it.
 
 The motivation is more responsive PnL tracking. The daily pipeline produces one
 data point per vault per day. For vaults with intra-day volatility or for
@@ -22,40 +23,21 @@ points are.
 ```
 Hyperliquid API
 ├── stats-data (bulk GET) ── filter by TVL ─→ vault list
-└── vaultDetails (per-vault POST, via post_info with proxy rotation)
-        │
-        ├── portfolio: allTime / month / week / day
-        │   └── _merge_portfolio_periods() → highest available resolution
-        │       └── portfolio_to_combined_dataframe()
-        │           └── _calculate_share_price() → share_price, total_assets, pnl
-        │
-        └── userNonFundingLedgerUpdates (deposit/withdrawal events)
-            └── aggregate_daily_flows(events)
-                │
-                ▼
-        Raw API timestamps preserved (no flooring or normalisation)
-                │
-                ▼
-        HyperliquidHighFreqPriceRow (timestamp, not date)
-                │
-                ▼
-        hyperliquid-vaults-hf.duckdb
-        ├── vault_metadata (shared schema, from base class)
-        └── vault_high_freq_prices (PK: vault_address, timestamp)
-                │
-                ▼
-        merge_hypercore_prices_to_parquet()
-        ├── reads BOTH daily + HF DuckDB databases
-        ├── _prepare_hypercore_export() — shared forward-fill + deposit status
-        ├── deduplicates on (address, timestamp) — HF wins on collision
-        └── writes combined data to parquet
-                │
-                ▼
-        vault-prices-1h.parquet (chain 9999 rows replaced with combined data)
-                │
-                ▼
-        process_raw_vault_scan_data() → cleaned-vault-prices-1h.parquet
-        (forward_fill_vault() resamples to 1h when needed downstream)
+├── vaultDetails (per-vault POST, via post_info with proxy rotation)
+│   └── portfolio: allTime / month / week / day
+│       └── _merge_portfolio_periods() → portfolio_to_combined_dataframe()
+│           └── _calculate_share_price() → HyperliquidHighFreqPriceRow
+├── userNonFundingLedgerUpdates (per-vault POST)
+│   └── aggregate_daily_flows(events) → price-row flow fields
+└── clearinghouseState (per-vault POST)
+    └── collect_hyperliquid_vault_observations() → current position observations
+
+HyperliquidHighFreqMetricsDatabase (hyperliquid-vaults-hf.duckdb)
+├── vault_metadata and vault_high_freq_prices
+│   └── merge_hypercore_prices_to_parquet() → vault-prices-1h.parquet
+│       └── process_raw_vault_scan_data() → cleaned-vault-prices-1h.parquet
+└── perp_vault_* observation tables
+    └── generic temporal join → `other_data.perp_dex` exposure metrics
 ```
 
 ### Key components
@@ -125,10 +107,10 @@ only way to retain 20-min history permanently is to snapshot the `day` period
 into our own DuckDB before those points age out of the 24h window — which is the
 whole point of this pipeline.
 
-The daily pipeline calls this once per day, truncates every timestamp to `.date()`,
-and stores one row per vault per calendar day. This discards all intra-day
-resolution — the `day` period's ~20-min data points are collapsed into a single
-daily entry.
+When explicitly run, the legacy daily pipeline truncates every timestamp to
+`.date()` and stores one row per vault per calendar day. This discards all
+intra-day resolution — the `day` period's ~20-min data points are collapsed
+into a single daily entry.
 
 ### What the HF pipeline does differently
 
@@ -269,7 +251,8 @@ for sparse columns. This means:
 
 `post_processing.py` opens whichever Hyperliquid databases exist on disc
 (daily and/or HF) and passes both to `merge_hypercore_prices_to_parquet()`.
-Both databases are always merged regardless of the `HYPERCORE_MODE` setting.
+When both databases exist, they are merged regardless of the active
+`HYPERCORE_MODE` setting.
 
 ### Integration via scan_all_chains.py
 
@@ -284,9 +267,15 @@ SCAN_HYPERCORE=true HYPERCORE_MODE=high_freq SCAN_CYCLES="Hypercore=4h" \
   poetry run python scripts/erc-4626/scan-vaults-all-chains.py
 ```
 
-Both DuckDB paths are always available:
+The price merge reads either database when it exists:
 - `hyperliquid-vaults.duckdb` — daily pipeline
 - `hyperliquid-vaults-hf.duckdb` — HF pipeline
+
+The looped production Compose service defaults to `HYPERCORE_MODE=high_freq`.
+It is therefore this scanner that persists current public positions for the
+shared perp-Dex exposure export. Set `HYPERCORE_MODE=daily` only for an
+intentional standalone or compatibility run; that database is otherwise
+inactive in production.
 
 ### Potential issues and caveats
 

--- a/scripts/hyperliquid/README-hyperliquid-vaults.md
+++ b/scripts/hyperliquid/README-hyperliquid-vaults.md
@@ -15,9 +15,19 @@ Current public positions are stored through the shared perp DEX observation
 tables and attached to the combined daily/high-frequency price frame by the
 generic temporal join. If the newest price row precedes the account read, the
 same bounded latest-row alignment used by other delayed native feeds applies.
-`perp_metrics_observed_at` retains the actual one-second-resolution measurement
-time through raw Parquet, cleaned Parquet and `other_data.perp_dex`, including
-when the values are stale.
+`perp_metrics_observed_at` retains the actual measurement time through raw
+Parquet, cleaned Parquet and `other_data.perp_dex`, including when the values
+are stale.
+
+### Production scan mode
+
+Production uses the high-frequency scanner (`HYPERCORE_MODE=high_freq`) every
+four hours. It collects both the price history and the current public position
+observations used for long, short, gross and net exposure derivations. The
+daily scanner and its `hyperliquid-vaults.duckdb` database remain for legacy
+history, standalone use and combined Parquet reads, but are not part of the
+looped production schedule. Do not expect new daily-scanner rows or position
+observations unless an operator explicitly runs `HYPERCORE_MODE=daily`.
 
 ## Architecture
 
@@ -374,9 +384,9 @@ The sync runs in **two** entry points with identical semantics:
   progress via `print()` for interactive use.
 - [`eth_defi/vault/scan_all_chains.py::_run_hypercore_scan`](../../eth_defi/vault/scan_all_chains.py)
   — the docker production path that `scan-vaults-all-chains.py` routes
-  all Hypercore scans through. Logs via the module logger. This is the
-  path both docker compose services (`vault-scanner` daily and
-  `vault-scanner-looped` HF) go through.
+  all Hypercore scans through. Logs via the module logger. The looped
+  production service selects the high-frequency scanner; daily mode runs
+  only when it is explicitly selected for a compatibility or maintenance run.
 
 Both paths use the same `GS_*` environment variables, the same
 `fetch_vault_review_statuses()` / `sync_vault_review_sheet()` functions,

--- a/tests/erc_4626/test_native_protocol_batch_merge.py
+++ b/tests/erc_4626/test_native_protocol_batch_merge.py
@@ -76,8 +76,8 @@ def test_merge_native_protocols_rewrites_parquet_once_and_preserves_empty_source
     class FakeDatabase:
         """Provide the close method required by the post-processing pipeline."""
 
-        def __init__(self, _: Path) -> None:
-            pass
+        def __init__(self, path: Path) -> None:
+            self.path = path
 
         def close(self) -> None:
             pass
@@ -104,6 +104,8 @@ def test_merge_native_protocols_rewrites_parquet_once_and_preserves_empty_source
     monkeypatch.setattr(post_processing, "build_hibachi_prices_dataframe", lambda _: pd.DataFrame())
     monkeypatch.setattr(post_processing, "build_hypercore_prices_dataframe", lambda **_: fresh_hypercore)
     monkeypatch.setattr(post_processing, "build_apex_prices_dataframe", lambda _: fresh_apex)
+    perp_snapshot_paths: list[Path] = []
+    monkeypatch.setattr(post_processing, "_append_perp_metric_snapshots", lambda database, _: perp_snapshot_paths.append(database.path))
 
     writes = 0
     original_write = VaultHistoricalRead.write_uncleaned_arrow_table
@@ -159,6 +161,7 @@ def test_merge_native_protocols_rewrites_parquet_once_and_preserves_empty_source
     assert set(result_df.loc[result_df["address"].str.startswith("lighter-"), "chain"]) == {LIGHTER_CHAIN_ID}
     assert result_df.loc[result_df["address"] == "hypercore-new", "account_pnl"].iloc[0] == pytest.approx(123.0)
     assert result_df.loc[result_df["address"] == "apex-vault-new", "share_price"].iloc[0] == pytest.approx(1.0)
+    assert {hyperliquid_db_path, hyperliquid_hf_db_path}.issubset(perp_snapshot_paths)
 
 
 def test_partial_lighter_merge_preserves_other_deployment_and_legacy_partition(

--- a/tests/hyperliquid/test_high_freq_metrics.py
+++ b/tests/hyperliquid/test_high_freq_metrics.py
@@ -28,9 +28,62 @@ from eth_defi.hyperliquid.high_freq_metrics import (
     HyperliquidHighFreqMetricsDatabase,
     HyperliquidHighFreqPriceRow,
     fetch_and_store_vault_high_freq,
+    run_high_freq_scan,
 )
 from eth_defi.hyperliquid.session import create_hyperliquid_session
 from eth_defi.hyperliquid.vault import HyperliquidVault, PortfolioHistory, VaultSummary, fetch_all_vaults
+
+
+def test_high_freq_scan_collects_perp_vault_observations(tmp_path) -> None:
+    """Ensure the production HF path writes shared position observations.
+
+    Production selects ``HYPERCORE_MODE=high_freq``. The collector must run in
+    that path, rather than only in the inactive daily compatibility scanner.
+
+    :param tmp_path:
+        Temporary DuckDB database location supplied by pytest.
+    """
+    summary = VaultSummary(
+        name="Test vault",
+        vault_address="0x0000000000000000000000000000000000000001",
+        leader="0x0000000000000000000000000000000000000002",
+        tvl=Decimal("10000"),
+        is_closed=False,
+        relationship_type="normal",
+    )
+    session = SimpleNamespace()
+
+    def clone_for_worker(proxy_start_index: int) -> SimpleNamespace:
+        """Return the single fake session used by this one-worker test."""
+        assert proxy_start_index == 0
+        return session
+
+    session.clone_for_worker = clone_for_worker
+    db_path = tmp_path / "hf-perp-observations.duckdb"
+
+    with (
+        patch("eth_defi.hyperliquid.high_freq_metrics.fetch_all_vaults", return_value=[summary]),
+        patch("eth_defi.hyperliquid.high_freq_metrics.fetch_and_store_vault_high_freq", return_value=True),
+        patch("eth_defi.hyperliquid.high_freq_metrics.collect_hyperliquid_vault_observations", return_value=1) as collect,
+    ):
+        db = run_high_freq_scan(
+            session,
+            db_path=db_path,
+            max_workers=1,
+            min_tvl=0,
+            flow_backfill_days=0,
+        )
+
+    try:
+        collect.assert_called_once_with(
+            session,
+            db.con,
+            [summary],
+            max_workers=1,
+            timeout=30.0,
+        )
+    finally:
+        db.close()
 
 
 @pytest.mark.timeout(180)


### PR DESCRIPTION
## Why

Production scans Hyperliquid in high-frequency mode, but the current-position collector only ran in the inactive daily path. Post-processing also read position observations only from the daily database. As a result, gross exposure facts were never exported from production scans.

## Lessons learnt

Native scanner mode and the database read by post-processing must be traced together: writing observations in the active scanner is insufficient unless the same database is included in the temporal exposure merge.

## Summary

- Collect Hyperliquid current-position observations in the high-frequency scanner.
- Read shared perp-Dex observations from both daily and HF Hyperliquid databases during post-processing.
- Bound empty/oversized observation worker pools, simplify result counting, and clarify attempt logging.
- Correct the scanner/API data-flow documentation and explain the inactive production daily mode.
- Add regressions for HF collection and HF database inclusion in the native merge.

## Related issues and PRs

Continues the gross-exposure metric work merged in #1363.

## Unrelated CI and test fixes

None.