### PR TITLE
fix: refresh Enzyme Blue vault prices

### DIFF
--- a/docs/source/vaults/enzyme/index.rst
+++ b/docs/source/vaults/enzyme/index.rst
@@ -17,21 +17,20 @@ discovers every reviewed Blue vault on Ethereum, Polygon, Base and Arbitrum from
 persistent Dispatcher ``VaultProxyDeployed`` event. It records the canonical
 VaultProxy together with its ComptrollerProxy accessor, reads current GAV,
 share supply and fees through a direct VaultBase adapter, and backfills GAV,
-TVL and gross share price using one historical Multicall batch per chain.
-Blue factory detections retain a truthful zero ERC-4626 deposit count because
-their investor actions use Enzyme-specific events. The ``enzyme_blue_like``
-feature therefore bypasses the generic activity threshold, as does
-``enzyme_onyx_like``, so ordinary scanner cycles continue both histories after
-the initial migration.
+TVL and gross share price using batched historical Multicall reads.
+Blue and Onyx factory detections retain a zero ERC-4626 deposit count because
+their investor actions use protocol-specific events. Their feature flags bypass
+the generic activity threshold so recurring scans continue both histories.
 
-The historical Blue reader deliberately derives gross share value from GAV and
-share supply. The release-aware onchain source for a fee-adjusted value is
-``FundValueCalculatorRouter.calcNetShareValue()``, but adding it would require a
-third call in every Multicall batch for each vault and sampled block. Instead,
-consumer-facing net return presentation estimates the deduction from the
-exported user-facing fee schedule. Historical fee configurations remain
-unsupported, so the reader does not invent changing fee rates or mix Enzyme's
-offchain API data into the deterministic onchain history.
+The historical Blue reader derives gross share value from GAV and share supply.
+The future exact source is Enzyme's release-aware
+`FundValueCalculatorRouter.calcNetShareValue()
+<https://github.com/enzymefinance/protocol/blob/dev/contracts/persistent/fund-value-calculator/FundValueCalculatorRouter.sol>`__,
+called through ``eth_call`` so fee settlement is simulated but not persisted.
+It requires a third call per vault and sampled block. Until that is implemented,
+the frontend fee-fill step will subtract the current exported fees to estimate
+net value. Historical fee rates and performance-fee state can change, so this
+is not an exact historical net share value.
 
 Enzyme onyx
 -----------

--- a/docs/source/vaults/enzyme/index.rst
+++ b/docs/source/vaults/enzyme/index.rst
@@ -18,6 +18,20 @@ persistent Dispatcher ``VaultProxyDeployed`` event. It records the canonical
 VaultProxy together with its ComptrollerProxy accessor, reads current GAV,
 share supply and fees through a direct VaultBase adapter, and backfills GAV,
 TVL and gross share price using one historical Multicall batch per chain.
+Blue factory detections retain a truthful zero ERC-4626 deposit count because
+their investor actions use Enzyme-specific events. The ``enzyme_blue_like``
+feature therefore bypasses the generic activity threshold, as does
+``enzyme_onyx_like``, so ordinary scanner cycles continue both histories after
+the initial migration.
+
+The historical Blue reader deliberately derives gross share value from GAV and
+share supply. The release-aware onchain source for a fee-adjusted value is
+``FundValueCalculatorRouter.calcNetShareValue()``, but adding it would require a
+third call in every Multicall batch for each vault and sampled block. Instead,
+consumer-facing net return presentation estimates the deduction from the
+exported user-facing fee schedule. Historical fee configurations remain
+unsupported, so the reader does not invent changing fee rates or mix Enzyme's
+offchain API data into the deterministic onchain history.
 
 Enzyme onyx
 -----------

--- a/eth_defi/enzyme/blue_historical.py
+++ b/eth_defi/enzyme/blue_historical.py
@@ -80,12 +80,9 @@ class EnzymeBlueVaultHistoricalReader(VaultHistoricalReader):
         if raw_total_supply is not None:
             total_supply = Decimal(raw_total_supply) / Decimal(10**self.vault.share_token.decimals)
         if total_assets is not None and total_supply not in {None, Decimal(0)}:
-            # Keep the onchain history gross and deterministic. A release-aware
-            # net read must use FundValueCalculatorRouter.calcNetShareValue().
-            # TODO: Add that third historical call once release-aware router
-            # deployments and historical fee configurations are supported.
-            # Until then the frontend subtracts the exported user-facing fees
-            # for its estimated net curve; do not approximate changing fees here.
+            # GAV divided by supply omits dilution from fees accrued since settlement.
+            # TODO: Read FundValueCalculatorRouter.calcNetShareValue() for exact net value.
+            # Until then, the frontend fee-fill step will subtract exported fees.
             share_price = total_assets / total_supply
 
         state = getattr(self, "reader_state", None)

--- a/eth_defi/enzyme/blue_historical.py
+++ b/eth_defi/enzyme/blue_historical.py
@@ -80,6 +80,12 @@ class EnzymeBlueVaultHistoricalReader(VaultHistoricalReader):
         if raw_total_supply is not None:
             total_supply = Decimal(raw_total_supply) / Decimal(10**self.vault.share_token.decimals)
         if total_assets is not None and total_supply not in {None, Decimal(0)}:
+            # Keep the onchain history gross and deterministic. A release-aware
+            # net read must use FundValueCalculatorRouter.calcNetShareValue().
+            # TODO: Add that third historical call once release-aware router
+            # deployments and historical fee configurations are supported.
+            # Until then the frontend subtracts the exported user-facing fees
+            # for its estimated net curve; do not approximate changing fees here.
             share_price = total_assets / total_supply
 
         state = getattr(self, "reader_state", None)

--- a/eth_defi/erc_4626/core.py
+++ b/eth_defi/erc_4626/core.py
@@ -945,12 +945,14 @@ def is_activity_filter_exempt(detection: "ERC4262VaultDetection") -> bool:
 
     Some shared vault database entries are not discovered from canonical
     ERC-4626 ``Deposit`` and ``Withdraw`` events emitted by the vault address.
-    Mellow Core Vaults are the first EVM example: the vault identity comes from
-    ``Factory.Created`` while user flow events live on per-asset queue
-    contracts. Upshift multi-asset vaults are another exception: older
-    production metadata can be seeded or refreshed by address after the custom
-    event support lands, and targeted price rescans should not be blocked by a
-    stale low deposit counter. T3tris migration-pool vaults are handled
+    Enzyme Blue and Onyx are confirmed by their respective Dispatcher and
+    SharesFactory events, but neither architecture emits ERC-4626 deposits from
+    its canonical vault identity. Mellow Core Vaults have the same split: the
+    vault identity comes from ``Factory.Created`` while user flow events live on
+    per-asset queue contracts. Upshift multi-asset vaults are another exception:
+    older production metadata can be seeded or refreshed by address after the
+    custom event support lands, and targeted price rescans should not be blocked
+    by a stale low deposit counter. T3tris migration-pool vaults are handled
     separately by :py:func:`passes_price_scan_activity_filter`, which requires
     a recorded configuration event instead of broadly exempting the protocol.
 
@@ -966,6 +968,7 @@ def is_activity_filter_exempt(detection: "ERC4262VaultDetection") -> bool:
         for feature in (
             ERC4626Feature.mellow_like,
             ERC4626Feature.enzyme_onyx_like,
+            ERC4626Feature.enzyme_blue_like,
             ERC4626Feature.upshift_multi_asset_like,
         )
     )

--- a/eth_defi/erc_4626/core.py
+++ b/eth_defi/erc_4626/core.py
@@ -945,14 +945,14 @@ def is_activity_filter_exempt(detection: "ERC4262VaultDetection") -> bool:
 
     Some shared vault database entries are not discovered from canonical
     ERC-4626 ``Deposit`` and ``Withdraw`` events emitted by the vault address.
-    Enzyme Blue and Onyx are confirmed by their respective Dispatcher and
-    SharesFactory events, but neither architecture emits ERC-4626 deposits from
-    its canonical vault identity. Mellow Core Vaults have the same split: the
-    vault identity comes from ``Factory.Created`` while user flow events live on
-    per-asset queue contracts. Upshift multi-asset vaults are another exception:
-    older production metadata can be seeded or refreshed by address after the
-    custom event support lands, and targeted price rescans should not be blocked
-    by a stale low deposit counter. T3tris migration-pool vaults are handled
+    Enzyme Blue and Onyx use protocol-specific investor actions, so their
+    factory-confirmed vaults have no canonical ERC-4626 deposit count. Mellow
+    Core Vaults have the same split: the vault identity comes from
+    ``Factory.Created`` while user flow events live on per-asset queue
+    contracts. Upshift multi-asset vaults are another exception: older
+    production metadata can be seeded or refreshed by address after the custom
+    event support lands, and targeted price rescans should not be blocked by a
+    stale low deposit counter. T3tris migration-pool vaults are handled
     separately by :py:func:`passes_price_scan_activity_filter`, which requires
     a recorded configuration event instead of broadly exempting the protocol.
 

--- a/eth_defi/erc_4626/discovery_base.py
+++ b/eth_defi/erc_4626/discovery_base.py
@@ -741,8 +741,6 @@ def create_enzyme_blue_potential_vault_match(candidate: "EnzymeBlueVaultFactoryC
         address=candidate.address,
         first_seen_at_block=candidate.created_block,
         first_seen_at=candidate.created_at,
-        # Blue flow events do not use the ERC-4626 Deposit signature. The
-        # feature-based activity exemption keeps this factory lead price-scannable.
         deposit_count=0,
         withdrawal_count=0,
         enzyme_blue_factory_candidate=candidate,
@@ -759,8 +757,6 @@ def create_enzyme_blue_factory_detection(candidate: "EnzymeBlueVaultFactoryCandi
         first_seen_at_block=candidate.created_block,
         first_seen_at=candidate.created_at,
         updated_at=native_datetime_utc_now(),
-        # Preserve the truthful event count; the Blue feature bypasses the
-        # ERC-4626 deposit-count gate in every shared price-scan entry point.
         deposit_count=0,
         redeem_count=0,
     )

--- a/eth_defi/erc_4626/discovery_base.py
+++ b/eth_defi/erc_4626/discovery_base.py
@@ -741,6 +741,8 @@ def create_enzyme_blue_potential_vault_match(candidate: "EnzymeBlueVaultFactoryC
         address=candidate.address,
         first_seen_at_block=candidate.created_block,
         first_seen_at=candidate.created_at,
+        # Blue flow events do not use the ERC-4626 Deposit signature. The
+        # feature-based activity exemption keeps this factory lead price-scannable.
         deposit_count=0,
         withdrawal_count=0,
         enzyme_blue_factory_candidate=candidate,
@@ -757,6 +759,8 @@ def create_enzyme_blue_factory_detection(candidate: "EnzymeBlueVaultFactoryCandi
         first_seen_at_block=candidate.created_block,
         first_seen_at=candidate.created_at,
         updated_at=native_datetime_utc_now(),
+        # Preserve the truthful event count; the Blue feature bypasses the
+        # ERC-4626 deposit-count gate in every shared price-scan entry point.
         deposit_count=0,
         redeem_count=0,
     )

--- a/eth_defi/vault/scan_all_chains.py
+++ b/eth_defi/vault/scan_all_chains.py
@@ -797,10 +797,8 @@ def scan_prices_for_chain(
             if VaultSpec(chain_id, detection.address.lower()) in excluded_specs:
                 continue
 
-            # Skip vaults with low activity while retaining hardcoded protocol
-            # vaults and protocol-specific alternative evidence. Mellow stores
-            # zero counts because its canonical Vault does not emit user flows;
-            # T3tris migration pools use a reviewed configuration event.
+            # Protocol-specific features can provide activity evidence when the
+            # canonical vault address does not emit ERC-4626 deposit events.
             if detection.address.lower() not in HARDCODED_PROTOCOLS and not passes_price_scan_activity_filter(detection, min_deposit_threshold):
                 continue
 

--- a/scripts/erc-4626/scan-prices.py
+++ b/scripts/erc-4626/scan-prices.py
@@ -227,10 +227,8 @@ def _run_scan(stats: RPCRequestStats, metrics: dict) -> None:
         detection = row["_detection_data"]
         address = detection.address
 
-        # Mellow Core Vault identities come from Factory.Created, while user
-        # flow events live on DepositQueue/RedeemQueue contracts. The metadata
-        # database stores zero counts for compatibility, so use the central
-        # feature-based exemption instead of looking at count field names.
+        # Use the shared filter because some protocol features provide activity
+        # evidence without ERC-4626 deposit events at the canonical vault address.
         if address.lower() not in HARDCODED_PROTOCOLS and not passes_price_scan_activity_filter(detection, min_deposit_threshold):
             # print(f"Vault does not have enough deposits: {address}, has: {detection.deposit_count}, threshold {min_deposit_threshold}")
             continue

--- a/tests/enzyme/test_onyx_vault.py
+++ b/tests/enzyme/test_onyx_vault.py
@@ -18,7 +18,7 @@ from eth_defi.enzyme.onyx_permission import aggregate_onyx_vault_permission, cla
 from eth_defi.enzyme.onyx_vault import ONYX_VALUE_ASSET_COMPARABILITY_TOKENS, EnzymeVault
 from eth_defi.erc_4626 import discovery_base
 from eth_defi.erc_4626.classification import create_probe_calls, create_vault_instance
-from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name, is_activity_filter_exempt, passes_price_scan_activity_filter
+from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name, passes_price_scan_activity_filter
 from eth_defi.erc_4626.discovery_base import LeadScanReport, VaultDiscoveryBase, _prepare_probe_leads, create_enzyme_factory_detection, create_enzyme_potential_vault_match  # noqa: PLC2701
 from eth_defi.erc_4626.hypersync_discovery import HypersyncVaultDiscover
 from eth_defi.erc_4626.scan import fetch_deposit_permission
@@ -240,19 +240,19 @@ def test_enzyme_risk_is_low() -> None:
 
 
 @pytest.mark.parametrize("feature", [ERC4626Feature.enzyme_blue_like, ERC4626Feature.enzyme_onyx_like])
-def test_enzyme_factory_leads_bypass_erc4626_activity_threshold(feature: ERC4626Feature) -> None:
-    """Keep Blue and Onyx factory discoveries eligible with zero ERC-4626 deposits.
+def test_enzyme_vaults_bypass_price_scan_activity_threshold(feature: ERC4626Feature) -> None:
+    """Keep Blue and Onyx vaults eligible with zero ERC-4626 deposits.
 
-    Both architectures use protocol-specific investor actions, so their
-    factory-confirmed vault identities must survive the shared price scanner's
-    generic ERC-4626 activity threshold.
+    Both architectures use protocol-specific investor actions and must survive
+    the shared price scanner's generic ERC-4626 activity threshold.
 
     :param feature:
         Enzyme architecture feature under test.
+    :return:
+        None.
     """
 
     detection = SimpleNamespace(features={feature}, deposit_count=0)
-    assert is_activity_filter_exempt(detection) is True
     assert passes_price_scan_activity_filter(detection, min_deposit_threshold=5) is True
 
 

--- a/tests/enzyme/test_onyx_vault.py
+++ b/tests/enzyme/test_onyx_vault.py
@@ -18,7 +18,7 @@ from eth_defi.enzyme.onyx_permission import aggregate_onyx_vault_permission, cla
 from eth_defi.enzyme.onyx_vault import ONYX_VALUE_ASSET_COMPARABILITY_TOKENS, EnzymeVault
 from eth_defi.erc_4626 import discovery_base
 from eth_defi.erc_4626.classification import create_probe_calls, create_vault_instance
-from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name, is_activity_filter_exempt
+from eth_defi.erc_4626.core import ERC4626Feature, get_vault_protocol_name, is_activity_filter_exempt, passes_price_scan_activity_filter
 from eth_defi.erc_4626.discovery_base import LeadScanReport, VaultDiscoveryBase, _prepare_probe_leads, create_enzyme_factory_detection, create_enzyme_potential_vault_match  # noqa: PLC2701
 from eth_defi.erc_4626.hypersync_discovery import HypersyncVaultDiscover
 from eth_defi.erc_4626.scan import fetch_deposit_permission
@@ -239,11 +239,21 @@ def test_enzyme_risk_is_low() -> None:
     assert get_vault_risk("Enzyme") is VaultTechnicalRisk.low
 
 
-def test_enzyme_factory_leads_bypass_erc4626_activity_threshold() -> None:
-    """Keep valid factory-discovered Shares vaults eligible for price scanning."""
+@pytest.mark.parametrize("feature", [ERC4626Feature.enzyme_blue_like, ERC4626Feature.enzyme_onyx_like])
+def test_enzyme_factory_leads_bypass_erc4626_activity_threshold(feature: ERC4626Feature) -> None:
+    """Keep Blue and Onyx factory discoveries eligible with zero ERC-4626 deposits.
 
-    detection = SimpleNamespace(features={ERC4626Feature.enzyme_onyx_like})
+    Both architectures use protocol-specific investor actions, so their
+    factory-confirmed vault identities must survive the shared price scanner's
+    generic ERC-4626 activity threshold.
+
+    :param feature:
+        Enzyme architecture feature under test.
+    """
+
+    detection = SimpleNamespace(features={feature}, deposit_count=0)
     assert is_activity_filter_exempt(detection) is True
+    assert passes_price_scan_activity_filter(detection, min_deposit_threshold=5) is True
 
 
 def test_enzyme_factory_lead_skips_generic_erc4626_probes() -> None:


### PR DESCRIPTION
## Why

Enzyme Blue vaults are discovered from Dispatcher `VaultProxyDeployed` events and do not emit canonical ERC-4626 `Deposit` events from the VaultProxy address. Their persisted `deposit_count` is therefore correctly zero. The recurring price scanners applied the generic five-deposit activity threshold without exempting `enzyme_blue_like`, so Blue histories stopped refreshing after their initial migration. Onyx already used the same shared exemption mechanism.

Historical Blue pricing also needs an explicit gross-versus-net contract. The current reader derives gross share value from GAV divided by share supply. This excludes dilution from manager and protocol fees accrued since their last settlement, so it must not be described as exact investor net share value.

## Lessons learnt

Protocol-specific discovery and recurring price eligibility must use the same feature signal. Event counters should remain truthful rather than being inflated to pass a generic filter, and every scanner entry point should delegate to one shared predicate.

The exact release-aware Blue net-value source is `FundValueCalculatorRouter.calcNetShareValue()`. Under `eth_call`, Enzyme simulates continuous fee settlement and protocol-fee dilution without persisting state. Adding this value while retaining GAV and supply requires a third historical call per vault and sampled block. Until that reader is implemented, frontend fee filling can only estimate net value from current exported fees; historical rates and performance-fee state may differ.

## Summary

- Exempt `enzyme_blue_like` from the shared price-scan activity threshold, matching the existing Onyx treatment.
- Add a parametrised regression proving zero-deposit Blue and Onyx detections both survive the actual public price-scan filter.
- Audit every production deposit-count gate: all recurring scanners and settlement selection use the corrected shared helper.
- Confirm the remaining direct `deposit_count > 0` lead filter already accepts both Enzyme factory candidate types before checking event counts.
- Simplify scanner comments so they describe protocol-specific activity evidence without incomplete protocol lists.
- Keep Blue historical values on the existing fast two-call GAV-and-supply path for now.
- Add line comments identifying the value as gross and recording the exact router call required for future net history.
- Document the frontend fee-fill estimate, its limitations, and the release-aware onchain source.
- Correct documentation that previously described the historical pipeline as one Multicall batch per chain; it performs batched historical Multicall reads.

## Related issues and PRs

- Follow-up to #1482 and #1487.

## Unrelated CI and test fixes

- None.