### PR TITLE
fix: repair Enzyme Blue metadata descriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -490,6 +490,7 @@ Consult these for domain-specific context. Logo READMEs under `eth_defi/data/vau
 | `eth_defi/xerberus/README-xerberus.md` | Xerberus vault risk scores — per-vault pool ratings, DuckDB, export, scripts |
 | `eth_defi/currency_api/README-currency-api.md` | Historical exchange rate ingestion (fawazahmed0 Exchange API) into DuckDB |
 | `eth_defi/data/vaults/README.md` | Vault protocol metadata and logo system |
+| `eth_defi/enzyme/README-Enzyme-vaults.md` | Enzyme Blue and Onyx architecture, metadata and migration operations |
 | `eth_defi/tokenised_fund/asseto/README-Asseto.md` | Asseto dynamic registry, daily NAV history and operations |
 | `eth_defi/erc_4626/vault_protocol/README-reader-states.md` | Vault reader states and warmup system |
 | `eth_defi/erc_4626/vault_protocol/README-utilisation.md` | Utilisation and available liquidity metrics for lending vaults |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,25 @@ otherwise the test cannot find environment variables.
 
 Avoid running the whole test suite as it takes several minutes. Only run specific test cases.
 
+### External integration tests
+
+Every new or materially changed external integration must include at least one
+minimal real integration test that exercises the actual provider end-to-end.
+For authenticated APIs, this means using a supplied API token and verifying a
+real successful response; mocked requests and fixture-only tests are necessary
+unit coverage but do not replace this check.
+
+- Prefer an automatic CI integration test whenever credentials can be supplied
+  securely and the provider is reliable enough for CI.
+- Otherwise, provide a focused manual command, guarded by the required
+  environment variable or token, so an operator can run the check without
+  modifying source code. Never print, commit or include a token in the command
+  or its output.
+- The pull request that adds the integration must include a PR comment with
+  the real-test result: the exact test or command, whether it passed, the date,
+  and the redacted environment or provider used. State clearly when the result
+  is a manual run rather than CI.
+
 Hypersync block scan tests (`tests/erc_4626/test_scan.py`) are disabled on CI by
 default because they dominated the CI critical path; they still run locally. To
 run them on CI (e.g. when touching Hypersync discovery code), see

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,9 @@ unit coverage but do not replace this check.
 - The pull request that adds the integration must include a PR comment with
   the real-test result: the exact test or command, whether it passed, the date,
   and the redacted environment or provider used. State clearly when the result
-  is a manual run rather than CI.
+  is a manual run rather than CI. If the provider rate-limits a bulk migration,
+  record the response and the safe retry plan instead of repeatedly retrying
+  the same request burst.
 
 Hypersync block scan tests (`tests/erc_4626/test_scan.py`) are disabled on CI by
 default because they dominated the CI critical path; they still run locally. To

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,12 @@ services:
       CHAIN_ORDER: ${CHAIN_ORDER:-}
       HYPERSYNC_API_KEY: ${HYPERSYNC_API_KEY:-}
       HYPERSYNC_RPM: ${HYPERSYNC_RPM:-}
+
+      # Enzyme Blue offchain-metadata migration only. The recurring scanner
+      # reads the resulting local cache and deliberately does not receive this
+      # credential.
+      ENZYME_BLUE_API_TOKEN: ${ENZYME_BLUE_API_TOKEN:-}
+
       JSON_RPC_ETHEREUM: ${JSON_RPC_ETHEREUM:-}
       JSON_RPC_BERACHAIN: ${JSON_RPC_BERACHAIN:-}
       JSON_RPC_UNICHAIN: ${JSON_RPC_UNICHAIN:-}

--- a/docs/source/vaults/enzyme/index.rst
+++ b/docs/source/vaults/enzyme/index.rst
@@ -246,8 +246,10 @@ shared scanner writer lock while the metadata pickle is loaded and replaced.
 Blue permission reads cover Sulu and the deprecated Encore and Phoenix policy
 managers and whitelist identifiers used by the Enzyme website. Current NAV and
 fee fields remain blank when a deprecated vault can no longer execute its old
-release calls; name, symbol, denomination and architecture-specific
-descriptions remain mandatory.
+release calls; name, symbol, denomination and the architecture-specific
+description policy remain mandatory. Blue API fields are optional, whereas
+Onyx must have an empty short description and the explicit unavailable
+long-description marker.
 
 .. code-block:: shell
 
@@ -258,8 +260,9 @@ Offchain description migration
 ------------------------------
 
 ``scripts/enzyme/migrate-offchain-metadata.py`` fetches Enzyme Blue vault
-taglines and descriptions above its accounting-unit TVL threshold from Enzyme's authenticated ``GetVault``
-API, warms the durable adapter cache and updates the public metadata pickle.
+taglines and descriptions above its recorded accounting-unit NAV threshold from
+Enzyme's authenticated ``GetVault`` API, warms the durable adapter cache and
+updates the public metadata pickle.
 It is deliberately a separate migration: it has no JSON-RPC or Hypersync work,
 does not change historical price data, and does not attempt unsupported Onyx
 UI scraping. It starts in dry-run mode and writes neither cache nor database
@@ -276,7 +279,9 @@ to override its location.
 To conserve Enzyme API quota, only Blue rows with a recorded NAV greater than
 1,000 in a reviewed USD-pegged accounting unit, 1 in an ETH-equivalent unit,
 or 0.1 in a BTC-equivalent unit are collected. The migration does not convert
-unsupported denominations through an inferred exchange rate.
+unsupported denominations through an inferred exchange rate. It also clears
+the exact retired generated Blue fallback pair locally for every Blue row; this
+does not make an API request and ensures older rows do not retain invented copy.
 
 Create an API token in the `Enzyme application
 <https://app.enzyme.finance/account/api-tokens>`__, then run:

--- a/docs/source/vaults/enzyme/index.rst
+++ b/docs/source/vaults/enzyme/index.rst
@@ -273,10 +273,10 @@ Create an API token in the `Enzyme application
 .. code-block:: shell
 
     source .local-test.env
-    ENZYME_API_TOKEN="$ENZYME_API_TOKEN" \
+    ENZYME_BLUE_API_TOKEN="$ENZYME_BLUE_API_TOKEN" \
         poetry run python scripts/enzyme/migrate-offchain-metadata.py
 
-    ENZYME_API_TOKEN="$ENZYME_API_TOKEN" DRY_RUN=false MAX_WORKERS=8 \
+    ENZYME_BLUE_API_TOKEN="$ENZYME_BLUE_API_TOKEN" DRY_RUN=false MAX_WORKERS=1 \
         poetry run python scripts/enzyme/migrate-offchain-metadata.py
 
 For production, first stop ``vault-scanner-looped`` and run this command in
@@ -294,9 +294,29 @@ mounted production state, then restart the looped service:
     cd ~/vault-scanner/web3-ethereum-defi
     docker compose stop vault-scanner-looped
     docker compose run --rm --entrypoint /bin/bash \
-        -e MAX_WORKERS=8 vault-scanner-oneshot \
-        -lc 'poetry run python scripts/enzyme/migrate-current-metadata.py'
+        -e ENZYME_BLUE_API_TOKEN -e MAX_WORKERS=1 vault-scanner-oneshot \
+        -lc 'poetry run python scripts/enzyme/migrate-offchain-metadata.py'
     docker compose start vault-scanner-looped
+
+Vault export
+------------
+
+``scripts/enzyme/export-vaults.py`` prints the local Enzyme database as a
+Markdown table, including its stored short-description column. It is read-only
+and never contacts Enzyme, JSON-RPC or Hypersync. Its ``Total value`` column
+is the vault's accounting-unit NAV, not USD-normalised TVL, so rows with
+different denominations must not be ranked together. To review the twenty
+largest rows among selected USD-pegged accounting units, run:
+
+.. code-block:: shell
+
+    VALUE_UNITS=USDC,DAI,USDT SORT_BY_TOTAL_VALUE=true LIMIT=20 \
+        poetry run python scripts/enzyme/export-vaults.py
+
+``VALUE_UNITS`` is a case-insensitive comma-separated filter,
+``SORT_BY_TOTAL_VALUE=true`` sorts the selected records descending by their
+reported NAV, and ``LIMIT`` caps the output. The command does not infer a
+live USD exchange rate or guarantee that a pegged asset is worth one dollar.
 
 Links
 -----

--- a/docs/source/vaults/enzyme/index.rst
+++ b/docs/source/vaults/enzyme/index.rst
@@ -257,8 +257,8 @@ descriptions remain mandatory.
 Offchain description migration
 ------------------------------
 
-``scripts/enzyme/migrate-offchain-metadata.py`` fetches all existing Enzyme
-Blue vault taglines and descriptions from Enzyme's authenticated ``GetVault``
+``scripts/enzyme/migrate-offchain-metadata.py`` fetches Enzyme Blue vault
+taglines and descriptions above its accounting-unit TVL threshold from Enzyme's authenticated ``GetVault``
 API, warms the durable adapter cache and updates the public metadata pickle.
 It is deliberately a separate migration: it has no JSON-RPC or Hypersync work,
 does not change historical price data, and does not attempt unsupported Onyx
@@ -272,6 +272,11 @@ minimal migration-only checkpoint resumes after an interruption without
 repeating completed API reads. It is deleted only after the cache and metadata
 pickle have both been updated successfully; set ``ENZYME_METADATA_STATE_PATH``
 to override its location.
+
+To conserve Enzyme API quota, only Blue rows with a recorded NAV greater than
+1,000 in a reviewed USD-pegged accounting unit, 1 in an ETH-equivalent unit,
+or 0.1 in a BTC-equivalent unit are collected. The migration does not convert
+unsupported denominations through an inferred exchange rate.
 
 Create an API token in the `Enzyme application
 <https://app.enzyme.finance/account/api-tokens>`__, then run:

--- a/docs/source/vaults/enzyme/index.rst
+++ b/docs/source/vaults/enzyme/index.rst
@@ -91,7 +91,7 @@ metadata migration gathers all existing Blue rows through a bounded,
 authenticated batch and writes a versioned JSON cache under
 ``~/.tradingstrategy/cache/enzyme/vault-metadata.json``. Blue adapters read
 that cache without credentials, so the scheduled scanner remains deterministic
-and does not turn a temporary API failure into a database-wide fallback
+and does not turn a temporary API failure into a database-wide description
 rewrite.
 
 The migration retains a successful API response with empty fields: this is
@@ -103,9 +103,8 @@ this data. The scanner therefore does not scrape a gated interface or consume
 an undocumented endpoint. Every refreshed Onyx row has an empty short
 description and the exact long-description marker ``Description is not
 publicly available``; a dedicated migration marker refreshes older generic
-copy once. Blue falls back to generic architecture-level copy only when its
-official API response has no manager text. A small reviewed address registry
-may supplement the Blue cache for exceptional metadata that has no API source.
+copy once. Blue leaves each description field empty when its official API
+response has no manager text.
 
 Deposit permission and availability
 -----------------------------------
@@ -233,7 +232,7 @@ Current metadata migration
 --------------------------
 
 ``scripts/enzyme/migrate-current-metadata.py`` is the safe production entry
-point for applying cached Blue descriptions (or generic Blue fallback copy),
+point for applying cached optional Blue descriptions,
 the explicit Onyx unavailable marker, direct address-specific links and current
 Blue and Onyx permission data to existing Enzyme rows. It reuses the
 targeted factory discovery and durable metadata batching while forcibly
@@ -266,6 +265,13 @@ does not change historical price data, and does not attempt unsupported Onyx
 UI scraping. It starts in dry-run mode and writes neither cache nor database
 if any API response fails. A real run creates a timestamped backup of the
 metadata pickle before modifying it.
+
+While collecting, a real run writes the successful API replies to
+``enzyme-offchain-metadata-state.json`` next to the metadata pickle. This
+minimal migration-only checkpoint resumes after an interruption without
+repeating completed API reads. It is deleted only after the cache and metadata
+pickle have both been updated successfully; set ``ENZYME_METADATA_STATE_PATH``
+to override its location.
 
 Create an API token in the `Enzyme application
 <https://app.enzyme.finance/account/api-tokens>`__, then run:

--- a/docs/source/vaults/enzyme/index.rst
+++ b/docs/source/vaults/enzyme/index.rst
@@ -280,8 +280,12 @@ To conserve Enzyme API quota, only Blue rows with a recorded NAV greater than
 1,000 in a reviewed USD-pegged accounting unit, 1 in an ETH-equivalent unit,
 or 0.1 in a BTC-equivalent unit are collected. The migration does not convert
 unsupported denominations through an inferred exchange rate. It also clears
-the exact retired generated Blue fallback pair locally for every Blue row; this
-does not make an API request and ensures older rows do not retain invented copy.
+the exact retired generated Blue fallback fields locally for every Blue row;
+this does not make an API request and ensures older rows do not retain invented
+copy.
+After a complete cache/database update, later runs reuse the cache without a
+token. Set ``ENZYME_METADATA_REFRESH=true`` with a token to fetch all eligible
+Blue rows again.
 
 Create an API token in the `Enzyme application
 <https://app.enzyme.finance/account/api-tokens>`__, then run:
@@ -311,7 +315,7 @@ mounted production state, then restart the looped service:
     docker compose stop vault-scanner-looped
     docker compose run --rm --entrypoint /bin/bash \
         -e ENZYME_BLUE_API_TOKEN -e MAX_WORKERS=1 vault-scanner-oneshot \
-        -lc 'poetry run python scripts/enzyme/migrate-offchain-metadata.py'
+        -c 'poetry run python scripts/enzyme/migrate-offchain-metadata.py'
     docker compose start vault-scanner-looped
 
 Vault export
@@ -319,7 +323,8 @@ Vault export
 
 ``scripts/enzyme/export-vaults.py`` prints the local Enzyme database as a
 Markdown table, including its stored short-description column. It is read-only
-and never contacts Enzyme, JSON-RPC or Hypersync. Its ``Total value`` column
+and never contacts Enzyme, JSON-RPC or Hypersync. Its
+``Total value (accounting unit)`` column
 is the vault's accounting-unit NAV, not USD-normalised TVL, so rows with
 different denominations must not be ranked together. To review the twenty
 largest rows among selected USD-pegged accounting units, run:

--- a/eth_defi/enzyme/README-Enzyme-vaults.md
+++ b/eth_defi/enzyme/README-Enzyme-vaults.md
@@ -51,8 +51,11 @@ To conserve the Enzyme API quota, the migration only reads vaults whose
 recorded accounting-unit NAV exceeds 1,000 in a reviewed USD-pegged unit, 1 in
 an ETH-equivalent unit, or 0.1 in a BTC-equivalent unit. Unsupported
 denominations are skipped rather than converted through an inferred price. The
-exact retired generated fallback pair is cleared locally for every Blue row,
+exact retired generated fallback fields are cleared locally for every Blue row,
 without an API request, so older databases cannot keep invented copy.
+After a complete cache/database update, later runs reuse the cache without a
+token. Set ``ENZYME_METADATA_REFRESH=true`` with a token to fetch every
+eligible Blue row again.
 
 Create a token in the Enzyme application, store it only in the operator's
 secret environment, and run the migration serially. The provider can return
@@ -120,7 +123,7 @@ source ~/vault-scanner/vault-rpc.env
 cd ~/vault-scanner/web3-ethereum-defi
 docker compose stop vault-scanner-looped
 docker compose --profile oneshot run --rm --entrypoint /bin/bash vault-scanner-oneshot \
-  -lc 'DRY_RUN=false MAX_WORKERS=1 poetry run python scripts/enzyme/migrate-offchain-metadata.py'
+  -c 'DRY_RUN=false MAX_WORKERS=1 poetry run python scripts/enzyme/migrate-offchain-metadata.py'
 docker compose start vault-scanner-looped
 ```
 

--- a/eth_defi/enzyme/README-Enzyme-vaults.md
+++ b/eth_defi/enzyme/README-Enzyme-vaults.md
@@ -50,7 +50,9 @@ published cache without a token.
 To conserve the Enzyme API quota, the migration only reads vaults whose
 recorded accounting-unit NAV exceeds 1,000 in a reviewed USD-pegged unit, 1 in
 an ETH-equivalent unit, or 0.1 in a BTC-equivalent unit. Unsupported
-denominations are skipped rather than converted through an inferred price.
+denominations are skipped rather than converted through an inferred price. The
+exact retired generated fallback pair is cleared locally for every Blue row,
+without an API request, so older databases cannot keep invented copy.
 
 Create a token in the Enzyme application, store it only in the operator's
 secret environment, and run the migration serially. The provider can return

--- a/eth_defi/enzyme/README-Enzyme-vaults.md
+++ b/eth_defi/enzyme/README-Enzyme-vaults.md
@@ -47,6 +47,11 @@ deleted after the complete cache/database update; set
 ``ENZYME_METADATA_STATE_PATH`` to use another location. Adapters read the
 published cache without a token.
 
+To conserve the Enzyme API quota, the migration only reads vaults whose
+recorded accounting-unit NAV exceeds 1,000 in a reviewed USD-pegged unit, 1 in
+an ETH-equivalent unit, or 0.1 in a BTC-equivalent unit. Unsupported
+denominations are skipped rather than converted through an inferred price.
+
 Create a token in the Enzyme application, store it only in the operator's
 secret environment, and run the migration serially. The provider can return
 ``429`` with ``Retry-After``; do not increase concurrency to work around it.

--- a/eth_defi/enzyme/README-Enzyme-vaults.md
+++ b/eth_defi/enzyme/README-Enzyme-vaults.md
@@ -1,0 +1,117 @@
+# Enzyme vaults
+
+This package supports the two separate Enzyme vault architectures: Enzyme Blue
+and Enzyme Onyx. Both issue ERC-20 investor shares, but neither should be
+treated as a generic ERC-4626 vault. The shared scanner preserves their
+architecture-specific discovery, accounting and metadata rules.
+
+## Enzyme Blue
+
+Blue is Enzyme's VaultProxy/ComptrollerProxy architecture. The VaultProxy is
+the investor share token; the paired ComptrollerProxy controls fund accounting,
+assets and investor actions. Blue discovery follows the reviewed Dispatcher
+`VaultProxyDeployed` events on Ethereum, Polygon, Base and Arbitrum.
+
+The adapter reads current gross asset value, share supply and fee configuration.
+Historical reads derive gross share value from GAV and outstanding shares. The
+currently exported management fee is the user-facing current rate and the
+protocol fee is also exported separately; consumers must not add the latter a
+second time. Exact historical net share value needs the release-aware
+FundValueCalculatorRouter and is not yet exported.
+
+Blue deposit permission comes from current PolicyManager configuration. The
+``ALLOWED_DEPOSIT_RECIPIENTS`` policy makes a vault ``whitelisted``; without
+that policy it is ``permissionless`` for wallet identity. This does not
+guarantee that every deposit will succeed, because other fund policies and
+approvals can still apply.
+
+### Blue descriptions
+
+Vault share-token contracts provide a name but no manager-authored strategy
+text. Enzyme's authenticated
+[GetVault API](https://sdk.enzyme.finance/api/endpoints/vault/) is the
+authoritative source for Blue listing metadata:
+
+- API ``tagline`` becomes the short description.
+- API ``description`` becomes the long description.
+- An empty successful response means that the manager has supplied no public
+  copy. The scanner then retains its generic Blue fallback text.
+
+The scheduled scanner never makes a per-vault API request. Instead,
+``scripts/enzyme/migrate-offchain-metadata.py`` creates the versioned cache at
+``~/.tradingstrategy/cache/enzyme/vault-metadata.json`` and updates the local
+vault database in one transaction. Adapters read that cache without a token.
+
+Create a token in the Enzyme application, store it only in the operator's
+secret environment, and run the migration serially. The provider can return
+``429`` with ``Retry-After``; do not increase concurrency to work around it.
+
+```shell
+source .local-test.env
+DRY_RUN=true MAX_WORKERS=1 poetry run python scripts/enzyme/migrate-offchain-metadata.py
+DRY_RUN=false MAX_WORKERS=1 poetry run python scripts/enzyme/migrate-offchain-metadata.py
+```
+
+The variable must be named ``ENZYME_BLUE_API_TOKEN``. Never commit it, print
+it, or put it in a command line.
+
+## Enzyme Onyx
+
+Onyx is a separate modular architecture. Current support covers official Base
+SharesFactory deployments, whose standalone Shares token represents the
+investor's interest in a vehicle. Discovery follows the factory's
+``ProxyDeployed`` events.
+
+Onyx Shares are ERC-20 tokens rather than ERC-4626 vaults. The adapter reads
+stored share price and share supply, then reports total value as their product
+in the declared value asset. A named asset such as ``USD`` is an accounting
+unit, not proof of a USD-denominated token balance or a current one-dollar
+exchange rate. For scanner compatibility, reviewed named values use a canonical
+Base reporting token: USD maps to USDC, BTC to cbBTC and EUR to EURC. Deposit
+code must inspect the active handler instead of relying on this convention.
+
+Onyx deposit permission is reconstructed from active deposit-handler events
+and checked at the fixed metadata block with batched Multicall reads. The
+adapter supports discovery, metadata and historical accounting, but not
+generic deposits, redemptions, flow accounting or portfolio composition: all
+depend on the active handler configuration.
+
+### Onyx descriptions
+
+Enzyme does not document a public API for manager-entered Onyx taglines or
+descriptions. Do not scrape a signed-in interface or call an undocumented
+endpoint. Every refreshed Onyx row therefore has:
+
+- no short description; and
+- the long description ``Description is not publicly available``.
+
+Run the current-metadata migration once after upgrading an existing database
+so its Onyx rows receive this explicit marker:
+
+```shell
+DRY_RUN=true poetry run python scripts/enzyme/migrate-current-metadata.py
+MAX_WORKERS=8 poetry run python scripts/enzyme/migrate-current-metadata.py
+```
+
+This migration uses configured RPC and Hypersync credentials, preserves price
+history, and stores a resumable checkpoint alongside the local vault database.
+
+## Running migrations in the scanner container
+
+``docker-compose.yml`` passes ``ENZYME_BLUE_API_TOKEN`` only to
+``vault-scanner-oneshot``. The token must be exported in the environment that
+launches Compose; it is not baked into the image or persisted in the repository.
+Stop the looped scanner before modifying its shared metadata state.
+
+```shell
+source ~/vault-scanner/vault-rpc.env
+cd ~/vault-scanner/web3-ethereum-defi
+docker compose stop vault-scanner-looped
+docker compose --profile oneshot run --rm --entrypoint /bin/bash vault-scanner-oneshot \
+  -lc 'DRY_RUN=false MAX_WORKERS=1 poetry run python scripts/enzyme/migrate-offchain-metadata.py'
+docker compose start vault-scanner-looped
+```
+
+The container mounts ``~/.tradingstrategy`` as persistent scanner state. Do
+not run the migration in an unmounted container, remove its metadata pickle or
+delete the timestamp caches while doing metadata maintenance.

--- a/eth_defi/enzyme/README-Enzyme-vaults.md
+++ b/eth_defi/enzyme/README-Enzyme-vaults.md
@@ -35,12 +35,17 @@ authoritative source for Blue listing metadata:
 - API ``tagline`` becomes the short description.
 - API ``description`` becomes the long description.
 - An empty successful response means that the manager has supplied no public
-  copy. The scanner then retains its generic Blue fallback text.
+  copy. The scanner leaves that description field empty.
 
 The scheduled scanner never makes a per-vault API request. Instead,
 ``scripts/enzyme/migrate-offchain-metadata.py`` creates the versioned cache at
 ``~/.tradingstrategy/cache/enzyme/vault-metadata.json`` and updates the local
-vault database in one transaction. Adapters read that cache without a token.
+vault database in one transaction. In apply mode it checkpoints successful API
+replies in ``enzyme-offchain-metadata-state.json`` beside the metadata pickle,
+then resumes only the missing replies after an interruption. The checkpoint is
+deleted after the complete cache/database update; set
+``ENZYME_METADATA_STATE_PATH`` to use another location. Adapters read the
+published cache without a token.
 
 Create a token in the Enzyme application, store it only in the operator's
 secret environment, and run the migration serially. The provider can return

--- a/eth_defi/enzyme/blue_vault.py
+++ b/eth_defi/enzyme/blue_vault.py
@@ -160,15 +160,15 @@ class EnzymeBlueVault(VaultBase):
 
     @property
     def description(self) -> str | None:
-        """Return complete offchain listing copy for this Blue vault."""
+        """Return optional official offchain listing copy for this Blue vault."""
 
-        return resolve_enzyme_blue_vault_metadata(self.name, self.api_metadata).description
+        return resolve_enzyme_blue_vault_metadata(self.api_metadata).description
 
     @property
     def short_description(self) -> str | None:
-        """Return complete offchain table copy for this Blue vault."""
+        """Return optional official offchain table copy for this Blue vault."""
 
-        return resolve_enzyme_blue_vault_metadata(self.name, self.api_metadata).short_description
+        return resolve_enzyme_blue_vault_metadata(self.api_metadata).short_description
 
     def get_strategy_tags(self) -> set[StrategyTag] | None:
         """Return documented strategy tags for this Blue vault.
@@ -186,9 +186,9 @@ class EnzymeBlueVault(VaultBase):
 
     @property
     def manager_name(self) -> str | None:
-        """Return optional curated manager name."""
+        """Return optional official manager name."""
 
-        return resolve_enzyme_blue_vault_metadata(self.name, self.api_metadata).manager_name
+        return resolve_enzyme_blue_vault_metadata(self.api_metadata).manager_name
 
     def fetch_share_token(self) -> TokenDetails:
         """Fetch the VaultProxy ERC-20 share token."""

--- a/eth_defi/enzyme/blue_vault.py
+++ b/eth_defi/enzyme/blue_vault.py
@@ -22,7 +22,7 @@ from eth_defi.abi import ZERO_ADDRESS, get_deployed_contract
 from eth_defi.enzyme.blue_discovery import ENZYME_BLUE_DEPLOYMENTS
 from eth_defi.enzyme.blue_historical import EnzymeBlueVaultHistoricalReader
 from eth_defi.enzyme.fee import combine_user_facing_management_fee
-from eth_defi.enzyme.offchain_metadata import create_enzyme_vault_link, load_enzyme_blue_vault_metadata, resolve_enzyme_blue_vault_metadata
+from eth_defi.enzyme.offchain_metadata import create_enzyme_vault_link, load_enzyme_blue_vault_metadata
 from eth_defi.enzyme.onyx_flow import EnzymeVaultFlowManager
 from eth_defi.enzyme.tags import get_strategy_tags as lookup_strategy_tags
 from eth_defi.erc_4626.core import ERC4626Feature
@@ -162,13 +162,13 @@ class EnzymeBlueVault(VaultBase):
     def description(self) -> str | None:
         """Return optional official offchain listing copy for this Blue vault."""
 
-        return resolve_enzyme_blue_vault_metadata(self.api_metadata).description
+        return self.api_metadata.description if self.api_metadata else None
 
     @property
     def short_description(self) -> str | None:
         """Return optional official offchain table copy for this Blue vault."""
 
-        return resolve_enzyme_blue_vault_metadata(self.api_metadata).short_description
+        return self.api_metadata.short_description if self.api_metadata else None
 
     def get_strategy_tags(self) -> set[StrategyTag] | None:
         """Return documented strategy tags for this Blue vault.
@@ -188,7 +188,7 @@ class EnzymeBlueVault(VaultBase):
     def manager_name(self) -> str | None:
         """Return optional official manager name."""
 
-        return resolve_enzyme_blue_vault_metadata(self.api_metadata).manager_name
+        return self.api_metadata.manager_name if self.api_metadata else None
 
     def fetch_share_token(self) -> TokenDetails:
         """Fetch the VaultProxy ERC-20 share token."""

--- a/eth_defi/enzyme/offchain_metadata.py
+++ b/eth_defi/enzyme/offchain_metadata.py
@@ -332,16 +332,6 @@ def load_enzyme_blue_vault_metadata(chain_id: int, vault_proxy_address: HexAddre
     return _load_cached_enzyme_vault_metadata().get(key)
 
 
-def resolve_enzyme_blue_vault_metadata(override: EnzymeVaultMetadata | None) -> EnzymeVaultMetadata:
-    """Normalise optional official Enzyme Blue metadata.
-
-    :param override: Optional official API or curator metadata.
-    :return: Official metadata, or an empty record when Enzyme supplied no copy.
-    """
-
-    return override or EnzymeVaultMetadata()
-
-
 def _load_cached_enzyme_vault_metadata() -> dict[tuple[int, HexAddress], EnzymeVaultMetadata]:
     """Load the process-wide read-only metadata cache once.
 

--- a/eth_defi/enzyme/offchain_metadata.py
+++ b/eth_defi/enzyme/offchain_metadata.py
@@ -9,11 +9,10 @@ management application, but its scanner rows therefore retain an explicit
 unavailable marker until Enzyme publishes a supported reader.
 
 The production scanner never makes thousands of API requests as a side effect
-of scanning a chain.  ``scripts/enzyme/migrate-offchain-metadata.py`` fetches
+of scanning a chain. ``scripts/enzyme/migrate-offchain-metadata.py`` fetches
 the reviewed Blue metadata and saves it in a durable, multiprocess-safe cache.
-Blue adapters read this cache and fall back only when the official source has
-no manager-entered copy. A small in-source registry remains available for
-reviewed exceptional Blue metadata that has no API source.
+Blue adapters read this cache only; when Enzyme has no manager-entered copy,
+both description fields remain absent rather than using inferred fallback text.
 """
 
 import json
@@ -83,22 +82,12 @@ class EnzymeVaultMetadata:
     manager_name: str | None = None
 
 
-#: Entries are keyed by ``(chain id, lower-case canonical Blue VaultProxy
-#: address)``. Blue vaults are discovered dynamically from reviewed protocol
-#: events, so this registry is enrichment only and never an allowlist.
-#:
-#: The official Blue API cache takes precedence over this registry only when it
-#: contains manager-entered copy. Keep this registry for reviewed exceptional
-#: Blue entries that cannot be fetched from a documented API.
-ENZYME_BLUE_VAULT_METADATA: dict[tuple[int, HexAddress], EnzymeVaultMetadata] = {}
-
-
 def _normalise_optional_text(value: object) -> str | None:
     """Turn an optional API text field into meaningful listing copy.
 
     Connect JSON omits absent protobuf scalar fields, while managers can also
     save whitespace-only values. Treat both cases as missing instead of
-    replacing useful fallback copy with blank text.
+    publishing invented strategy copy.
 
     :param value: Raw JSON field value.
     :return: Stripped non-empty string or ``None``.
@@ -227,8 +216,8 @@ def _metadata_key(chain_id: int, shares_address: HexAddress | str) -> tuple[int,
 def load_enzyme_vault_metadata_cache(cache_path: Path = DEFAULT_ENZYME_METADATA_CACHE_PATH) -> dict[tuple[int, HexAddress], EnzymeVaultMetadata]:
     """Load durable API metadata without making an HTTP request.
 
-    A malformed cache is ignored with a warning. Blue adapters then use generic
-    fallback copy until a successful authenticated migration replaces the cache.
+    A malformed cache is ignored with a warning. Blue adapters then expose no
+    offchain copy until a successful authenticated migration replaces the cache.
 
     :param cache_path: Versioned JSON cache written by the migration.
     :return: Address-indexed official Enzyme Blue metadata.
@@ -278,8 +267,8 @@ def write_enzyme_vault_metadata_cache(
     """Atomically replace the durable Enzyme metadata cache.
 
     Cache entries with no text are retained. They document a successful API
-    read whose vault has not supplied descriptions, while allowing the Blue
-    adapter to select generic fallback copy.
+    read whose vault has not supplied descriptions, so the Blue adapter can
+    expose no text rather than infer a strategy.
 
     :param metadata: Complete address-indexed cache contents.
     :param cache_path: JSON cache destination.
@@ -325,67 +314,32 @@ def create_enzyme_vault_link(chain_id: int, shares_address: HexAddress | str) ->
     return f"https://app.enzyme.finance/vault/{address}?network={network}"
 
 
-def create_enzyme_blue_fallback_metadata(vault_name: str) -> EnzymeVaultMetadata:
-    """Create safe listing metadata for an uncurated Enzyme Blue vault.
-
-    A share-token name is an identifier, not evidence of a strategy. This
-    generic copy applies only when the official Blue API has no manager text.
-
-    :param vault_name: Onchain Blue VaultProxy ERC-20 name.
-    :return: Complete generic Blue listing copy.
-    """
-
-    display_name = vault_name.strip() or "Unnamed vault"
-    return EnzymeVaultMetadata(
-        short_description="Enzyme Blue tokenised digital-asset investment vehicle.",
-        description=(f"{display_name} is an Enzyme Blue tokenised investment vehicle. Investors hold ERC-20 shares while the vault manager controls the investment configuration and portfolio operations. No manager-provided strategy description is available in this catalogue entry."),
-    )
-
-
 def load_enzyme_blue_vault_metadata(chain_id: int, vault_proxy_address: HexAddress | str) -> EnzymeVaultMetadata | None:
-    """Look up cached or manually curated Enzyme Blue listing metadata.
+    """Look up cached Enzyme Blue listing metadata.
 
     This adapter-facing function deliberately never calls the authenticated API.
     The metadata migration warms the durable cache in a bounded batch, keeping
     ordinary scanner cycles deterministic and independent of API credentials.
-    Manually reviewed metadata wins over an API entry only when it contains a
-    field not present in the API response.
+    The cache contains successful empty responses, allowing callers to
+    distinguish absent manager copy from a transient API failure.
 
     :param chain_id: EVM chain id of the Blue vault.
     :param vault_proxy_address: Canonical Blue VaultProxy address.
-    :return: Cached or curated metadata, or ``None`` when fallback copy applies.
+    :return: Cached API metadata, or ``None`` when no successful cache entry exists.
     """
 
     key = _metadata_key(chain_id, vault_proxy_address)
-    curated = ENZYME_BLUE_VAULT_METADATA.get(key)
-    cached = _load_cached_enzyme_vault_metadata().get(key)
-    if curated is None:
-        return cached
-    if cached is None:
-        return curated
-    return EnzymeVaultMetadata(
-        description=curated.description or cached.description,
-        short_description=curated.short_description or cached.short_description,
-        manager_name=curated.manager_name or cached.manager_name,
-    )
+    return _load_cached_enzyme_vault_metadata().get(key)
 
 
-def resolve_enzyme_blue_vault_metadata(vault_name: str, override: EnzymeVaultMetadata | None) -> EnzymeVaultMetadata:
-    """Merge optional source metadata with generic Enzyme Blue fallback copy.
+def resolve_enzyme_blue_vault_metadata(override: EnzymeVaultMetadata | None) -> EnzymeVaultMetadata:
+    """Normalise optional official Enzyme Blue metadata.
 
-    :param vault_name: Onchain Blue VaultProxy name used in fallback text.
     :param override: Optional official API or curator metadata.
-    :return: Complete Blue listing metadata.
+    :return: Official metadata, or an empty record when Enzyme supplied no copy.
     """
 
-    fallback = create_enzyme_blue_fallback_metadata(vault_name)
-    if override is None:
-        return fallback
-    return EnzymeVaultMetadata(
-        description=override.description or fallback.description,
-        short_description=override.short_description or fallback.short_description,
-        manager_name=override.manager_name,
-    )
+    return override or EnzymeVaultMetadata()
 
 
 def _load_cached_enzyme_vault_metadata() -> dict[tuple[int, HexAddress], EnzymeVaultMetadata]:

--- a/scripts/enzyme/backfill-history.py
+++ b/scripts/enzyme/backfill-history.py
@@ -657,9 +657,9 @@ def has_complete_current_metadata(vault_db: VaultDatabase, candidate: EnzymeFact
     Both Enzyme architectures require a conclusive current permission result.
     Blue reads its PolicyManager; Onyx uses the chain-level active handler
     index and batched current handler configuration. Name, symbol, denomination
-    token and appropriate architecture-specific descriptions are mandatory
-    catalogue identity fields. Blue must have both descriptions; Onyx must have
-    no short description and the explicit public unavailable marker. Current
+    token and architecture-specific description policy are mandatory catalogue
+    identity fields. Blue descriptions are optional official API fields; Onyx
+    must have no short description and the explicit public unavailable marker. Current
     NAV, share supply, and fees remain best-effort values: deprecated or
     invalid vault configurations can no longer execute their valuation or
     release extension calls, and repeatedly retrying them cannot recover those
@@ -678,8 +678,6 @@ def has_complete_current_metadata(vault_db: VaultDatabase, candidate: EnzymeFact
     if isinstance(candidate, EnzymeVaultFactoryCandidate):
         if row.get("_short_description") is not None or row.get("_description") != ONYX_PUBLIC_DESCRIPTION_UNAVAILABLE:
             return False
-    elif not row.get("_short_description") or not row.get("_description"):
-        return False
     try:
         permission = VaultDepositPermission(row.get("_deposit_permission", VaultDepositPermission.unknown.value))
     except (TypeError, ValueError):

--- a/scripts/enzyme/export-vaults.py
+++ b/scripts/enzyme/export-vaults.py
@@ -12,6 +12,12 @@ Usage::
 Environment variables:
 
 - ``VAULT_DB_PATH``: metadata database path.
+- ``VALUE_UNITS``: optional comma-separated accounting-unit filter, such as
+  ``USDC,DAI,USDT``. Use this before comparing total values: Enzyme's NAV is
+  not normalised to USD by the local database.
+- ``SORT_BY_TOTAL_VALUE``: set to ``true`` to order the selected rows by
+  descending reported total value.
+- ``LIMIT``: optional positive maximum number of rows to output.
 - ``LOG_LEVEL``: optional console log level, default ``warning``.
 """
 
@@ -40,6 +46,65 @@ def parse_path_env(name: str, default: Path) -> Path:
     """
 
     return Path(os.environ.get(name, str(default))).expanduser()
+
+
+def parse_bool_env(name: str) -> bool:
+    """Read a conventional boolean environment variable.
+
+    This keeps the report reproducible from a shell without adding command
+    line arguments to an operational script.
+
+    :param name: Environment variable name.
+    :return: Parsed boolean value.
+    :raises ValueError: If a configured value is not a recognised boolean.
+    """
+
+    value = os.environ.get(name)
+    if value is None:
+        return False
+
+    normalised_value = value.strip().lower()
+    if normalised_value in {"1", "true", "yes", "on"}:
+        return True
+    if normalised_value in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"{name} must be a boolean, got {value!r}")
+
+
+def parse_limit_env(name: str = "LIMIT") -> int | None:
+    """Read an optional positive row limit from the environment.
+
+    :param name: Environment variable name.
+    :return: Row limit, or ``None`` when no limit was configured.
+    :raises ValueError: If the configured limit is not a positive integer.
+    """
+
+    value = os.environ.get(name)
+    if value is None:
+        return None
+
+    limit = int(value)
+    if limit < 1:
+        raise ValueError(f"{name} must be a positive integer, got {value!r}")
+    return limit
+
+
+def parse_value_units_env(name: str = "VALUE_UNITS") -> frozenset[str] | None:
+    """Read an optional case-insensitive accounting-unit filter.
+
+    :param name: Environment variable containing comma-separated asset symbols.
+    :return: Uppercase selected symbols, or ``None`` when filtering is disabled.
+    :raises ValueError: If the variable is set but contains no symbols.
+    """
+
+    value = os.environ.get(name)
+    if value is None:
+        return None
+
+    units = frozenset(unit.strip().upper() for unit in value.split(",") if unit.strip())
+    if not units:
+        raise ValueError(f"{name} must contain at least one accounting unit")
+    return units
 
 
 def format_metric(value: object) -> str:
@@ -85,7 +150,9 @@ def main() -> None:
 
     The report reads existing metadata only and does not contact RPC providers
     or update scanner state. It includes both current Enzyme feature families,
-    preserving their accounting units instead of labelling all values as USD.
+    including each vault's stored short description.  It preserves accounting
+    units instead of incorrectly labelling all NAV values as USD; use
+    ``VALUE_UNITS`` when comparing the reported total values.
 
     :return: None.
     """
@@ -94,9 +161,23 @@ def main() -> None:
     vault_db_path = parse_path_env("VAULT_DB_PATH", DEFAULT_VAULT_DATABASE)
     vault_db = VaultDatabase.read(vault_db_path)
     rows = {spec: row for spec, row in vault_db.rows.items() if row.get("Protocol") == "Enzyme"}
+    value_units = parse_value_units_env()
+    sort_by_total_value = parse_bool_env("SORT_BY_TOTAL_VALUE")
+    limit = parse_limit_env()
+    if value_units:
+        rows = {spec: row for spec, row in rows.items() if (row.get("Denomination") or (row.get("_vault_info") or {}).get("value_asset") or "").upper() in value_units}
     logger.info("Exporting %d Enzyme vault rows from %s", len(rows), vault_db_path)
     table = []
-    for spec, row in sorted(rows.items(), key=lambda item: (item[0].chain_id, item[1].get("Name") or "")):
+    if sort_by_total_value:
+        sorted_rows = sorted(
+            rows.items(),
+            key=lambda item: (item[1].get("NAV") is not None, item[1].get("NAV") or Decimal(0)),
+            reverse=True,
+        )
+    else:
+        sorted_rows = sorted(rows.items(), key=lambda item: (item[0].chain_id, item[1].get("Name") or ""))
+
+    for spec, row in sorted_rows[:limit]:
         tvl = row.get("NAV")
         shares = row.get("Shares")
         share_price = tvl / shares if tvl is not None and shares not in {None, 0} else None
@@ -108,7 +189,7 @@ def main() -> None:
                 "Name": row.get("Name"),
                 "Short description": row.get("_short_description") or "—",
                 "Value unit": value_unit,
-                "Total value": format_metric(tvl),
+                "Total value (accounting unit)": format_metric(tvl),
                 "Share price": format_metric(share_price),
                 "Performance fee": format_metric(row.get("Perf fee")),
                 "Management fee (user-facing)": format_metric(row.get("Mgmt fee")),

--- a/scripts/enzyme/export-vaults.py
+++ b/scripts/enzyme/export-vaults.py
@@ -165,7 +165,7 @@ def main() -> None:
     sort_by_total_value = parse_bool_env("SORT_BY_TOTAL_VALUE")
     limit = parse_limit_env()
     if value_units:
-        rows = {spec: row for spec, row in rows.items() if (row.get("Denomination") or (row.get("_vault_info") or {}).get("value_asset") or "").upper() in value_units}
+        rows = {spec: row for spec, row in rows.items() if (row.get("Denomination") or "").upper() in value_units}
     logger.info("Exporting %d Enzyme vault rows from %s", len(rows), vault_db_path)
     table = []
     if sort_by_total_value:
@@ -181,7 +181,7 @@ def main() -> None:
         tvl = row.get("NAV")
         shares = row.get("Shares")
         share_price = tvl / shares if tvl is not None and shares not in {None, 0} else None
-        value_unit = row.get("Denomination") or (row.get("_vault_info") or {}).get("value_asset") or "—"
+        value_unit = row.get("Denomination") or "—"
         table.append(
             {
                 "Chain": get_chain_name(spec.chain_id),

--- a/scripts/enzyme/migrate-current-metadata.py
+++ b/scripts/enzyme/migrate-current-metadata.py
@@ -9,7 +9,7 @@ state and timestamp caches.
 
 For every factory-confirmed Enzyme Blue and Onyx vault, the migration provides:
 
-- cached or generic Blue descriptions and the explicit unavailable marker for
+- cached optional Blue descriptions and the explicit unavailable marker for
   Onyx;
 - a direct address-specific Enzyme application link;
 - mandatory current name, symbol and denomination, plus best-effort total

--- a/scripts/enzyme/migrate-offchain-metadata.py
+++ b/scripts/enzyme/migrate-offchain-metadata.py
@@ -16,7 +16,8 @@ The command starts in dry-run mode. It never alters historical prices, scanner
 reader state or discovery leads. A failed API response aborts before either the
 database or cache is written. In apply mode, successful responses are saved in
 a small migration-only state file after each request batch, so a later retry
-does not repeat completed API reads.
+does not repeat completed API reads. The exact retired generated Blue fallback
+text is also cleared locally without an API request.
 
 Usage::
 
@@ -69,7 +70,6 @@ from eth_defi.enzyme.offchain_metadata import (
     create_enzyme_api_session,
     fetch_enzyme_api_vault_metadata,
     load_enzyme_vault_metadata_cache,
-    resolve_enzyme_blue_vault_metadata,
     write_enzyme_vault_metadata_cache,
 )
 from eth_defi.erc_4626.core import ERC4626Feature
@@ -83,11 +83,16 @@ ENZYME_METADATA_STATE_VERSION = 1
 #: The database stores values in each vault's denomination, not a universal
 #: USD price feed. Keep symbols only where the denomination itself is a
 #: reviewed USD, ETH or BTC equivalent.
-MINIMUM_NAV_BY_DENOMINATION = {
+MINIMUM_NAV_BY_VALUE_UNIT = {
     **dict.fromkeys({"USD", "USDC", "USDC.E", "USDT", "USDT0", "USD₮0", "DAI", "USDS", "SUSD", "BUSD", "FRAX", "USDE", "SUSDE"}, Decimal("1000")),
     **dict.fromkeys({"ETH", "WETH", "STETH", "WSTETH", "RETH", "CBETH", "WEETH", "OSETH"}, Decimal("1")),
     **dict.fromkeys({"BTC", "WBTC", "CBBTC", "IBTC", "TBTC", "FBTC", "LBTC"}, Decimal("0.1")),
 }
+
+#: Exact retired Blue fallback text. It is cleared locally without an API read
+#: so the current API-only description policy also repairs older database rows.
+LEGACY_BLUE_SHORT_DESCRIPTION = "Enzyme Blue tokenised digital-asset investment vehicle."
+LEGACY_BLUE_DESCRIPTION_SUFFIX = " is an Enzyme Blue tokenised investment vehicle. Investors hold ERC-20 shares while the vault manager controls the investment configuration and portfolio operations. No manager-provided strategy description is available in this catalogue entry."
 
 
 @dataclass(slots=True, frozen=True)
@@ -99,8 +104,11 @@ class EnzymeMetadataFetchResult:
     :param error: Request or schema error, if collection failed.
     """
 
+    #: Existing Enzyme Blue vault identity.
     vault_spec: VaultSpec
+    #: Parsed response, including a valid empty API reply.
     metadata: EnzymeVaultMetadata | None = None
+    #: Request or response-validation error.
     error: str | None = None
 
 
@@ -114,9 +122,13 @@ class EnzymeMetadataUpdate:
     :param changed_fields: Fields whose persisted value differs.
     """
 
+    #: Existing database row identity.
     vault_spec: VaultSpec
+    #: Official API tagline, if supplied.
     short_description: str | None
+    #: Official API long description, if supplied.
     description: str | None
+    #: Public row fields that differ from the successful API reply.
     changed_fields: tuple[str, ...]
 
 
@@ -285,15 +297,15 @@ def get_metadata_value_unit(row: VaultRow) -> str | None:
     return value_unit.upper() if isinstance(value_unit, str) else None
 
 
-def has_description_metadata_tvl(row: VaultRow) -> bool:
-    """Check whether a Blue row meets the documented API-collection threshold.
+def has_description_metadata_minimum_value(row: VaultRow) -> bool:
+    """Check whether a Blue row meets the API-collection value threshold.
 
     :param row: Persisted Blue vault metadata row with accounting-unit NAV.
     :return: ``True`` only above the reviewed USD, ETH or BTC-equivalent limit.
     """
 
     value_unit = get_metadata_value_unit(row)
-    threshold = MINIMUM_NAV_BY_DENOMINATION.get(value_unit)
+    threshold = MINIMUM_NAV_BY_VALUE_UNIT.get(value_unit)
     if threshold is None:
         return False
     try:
@@ -303,15 +315,42 @@ def has_description_metadata_tvl(row: VaultRow) -> bool:
     return nav.is_finite() and nav > threshold
 
 
-def iter_enzyme_blue_rows(vault_db: VaultDatabase) -> Iterator[tuple[VaultSpec, VaultRow]]:
-    """Yield Enzyme Blue rows above the metadata-collection TVL threshold.
+def iter_all_enzyme_blue_rows(vault_db: VaultDatabase) -> Iterator[tuple[VaultSpec, VaultRow]]:
+    """Yield every existing Enzyme Blue row in deterministic order.
 
     :param vault_db: Loaded vault metadata database.
-    :return: Eligible Blue identity and row pairs in deterministic request order.
+    :return: Existing Blue identity and row pairs in deterministic order.
     """
 
-    rows = ((spec, row) for spec, row in vault_db.rows.items() if is_enzyme_blue_row(row) and has_description_metadata_tvl(row))
+    rows = ((spec, row) for spec, row in vault_db.rows.items() if is_enzyme_blue_row(row))
     yield from sorted(rows, key=lambda item: (item[0].chain_id, item[0].vault_address.lower()))
+
+
+def is_legacy_blue_fallback(row: VaultRow) -> bool:
+    """Return whether a Blue row contains only the retired generated fallback.
+
+    Matching both fields, including the persisted name, avoids clearing a
+    manager-supplied description that happens to mention Enzyme Blue.
+
+    :param row: Existing Enzyme Blue metadata row.
+    :return: ``True`` only for the exact old generated pair of descriptions.
+    """
+
+    display_name = (row.get("Name") or "").strip() or "Unnamed vault"
+    return row.get("_short_description") == LEGACY_BLUE_SHORT_DESCRIPTION and row.get("_description") == f"{display_name}{LEGACY_BLUE_DESCRIPTION_SUFFIX}"
+
+
+def create_legacy_fallback_clear_update(vault_spec: VaultSpec, row: VaultRow) -> EnzymeMetadataUpdate | None:
+    """Plan removal of the exact retired generated Blue fallback.
+
+    :param vault_spec: Existing Blue VaultProxy identity.
+    :param row: Existing Blue metadata row.
+    :return: Clearing update, or ``None`` when the row has no legacy fallback.
+    """
+
+    if not is_legacy_blue_fallback(row):
+        return None
+    return EnzymeMetadataUpdate(vault_spec, None, None, ("_short_description", "_description"))
 
 
 def fetch_one_enzyme_metadata(
@@ -352,13 +391,12 @@ def create_metadata_update(vault_spec: VaultSpec, row: VaultRow, metadata: Enzym
     :return: API replacement values, which can be absent when Enzyme has no copy.
     """
 
-    resolved = resolve_enzyme_blue_vault_metadata(metadata)
     updates = {
-        "_short_description": resolved.short_description,
-        "_description": resolved.description,
+        "_short_description": metadata.short_description,
+        "_description": metadata.description,
     }
     changed_fields = tuple(field for field, value in updates.items() if row.get(field) != value)
-    return EnzymeMetadataUpdate(vault_spec, resolved.short_description, resolved.description, changed_fields)
+    return EnzymeMetadataUpdate(vault_spec, metadata.short_description, metadata.description, changed_fields)
 
 
 def apply_metadata_updates(vault_db: VaultDatabase, updates: list[EnzymeMetadataUpdate]) -> None:
@@ -379,17 +417,13 @@ def apply_metadata_updates(vault_db: VaultDatabase, updates: list[EnzymeMetadata
 
 
 def main() -> None:  # noqa: PLR0914 - Keeps the one-shot migration transaction visible in one place.
-    """Fetch all existing Enzyme Blue descriptions and optionally persist them.
+    """Fetch eligible Blue descriptions and optionally persist metadata repairs.
 
     :return: None after printing the migration plan or completing a safe write.
     :raise RuntimeError: If any official API response fails before a real write.
     """
 
     dry_run = parse_bool_env("DRY_RUN", default=True)
-    api_token = os.environ.get("ENZYME_BLUE_API_TOKEN")
-    if not api_token:
-        message = "ENZYME_BLUE_API_TOKEN is required to fetch official Enzyme Blue vault metadata"
-        raise RuntimeError(message)
     max_workers = int(os.environ.get("MAX_WORKERS", "1"))
     timeout = float(os.environ.get("API_TIMEOUT", "30"))
     if max_workers < 1:
@@ -404,39 +438,49 @@ def main() -> None:  # noqa: PLR0914 - Keeps the one-shot migration transaction 
         raise FileNotFoundError(f"Vault metadata database does not exist: {vault_db_path}")
     cache_path = resolve_cache_path()
     vault_db = VaultDatabase.read(vault_db_path)
-    selected_rows = list(iter_enzyme_blue_rows(vault_db))
-    if not selected_rows:
-        print("No Enzyme Blue rows found; no metadata collection is needed.")
+    blue_rows = list(iter_all_enzyme_blue_rows(vault_db))
+    selected_rows = [(spec, row) for spec, row in blue_rows if has_description_metadata_minimum_value(row)]
+    legacy_clear_updates = [update for spec, row in blue_rows if (update := create_legacy_fallback_clear_update(spec, row))]
+    if not selected_rows and not legacy_clear_updates:
+        print("No Enzyme Blue metadata updates are needed.")
         return
 
-    selected_specs = {spec for spec, _row in selected_rows}
     state_path = resolve_state_path(vault_db_path)
-    state = load_metadata_state(state_path, selected_specs)
-    missing_specs = [spec for spec, _row in selected_rows if spec not in state]
-    session = create_enzyme_api_session(max_workers)
-    try:
-        with tqdm(total=len(selected_rows), initial=len(state), desc="Fetching Enzyme Blue metadata") as progress:
-            for start in range(0, len(missing_specs), max_workers):
-                batch_specs = missing_specs[start : start + max_workers]
-                batch_results = Parallel(n_jobs=max_workers, backend="threading")(delayed(fetch_one_enzyme_metadata)(spec, api_token=api_token, timeout=timeout, session=session) for spec in batch_specs)
-                successes = [result for result in batch_results if result.metadata is not None]
-                state.update({result.vault_spec: result.metadata for result in successes})
-                if not dry_run and successes:
-                    write_metadata_state(state_path, state)
-                progress.update(len(batch_results))
-                failures = [result for result in batch_results if result.error]
-                if failures:
-                    examples = "; ".join(f"{item.vault_spec.vault_address}: {item.error}" for item in failures[:3])
-                    raise RuntimeError(f"Enzyme metadata fetch failed for {len(failures)} vaults; state was saved for {len(state)} of {len(selected_rows)} rows. Examples: {examples}")
-    finally:
-        session.close()
+    state: dict[VaultSpec, EnzymeVaultMetadata] = {}
+    missing_specs: list[VaultSpec] = []
+    successful: list[EnzymeMetadataFetchResult] = []
+    if selected_rows:
+        api_token = os.environ.get("ENZYME_BLUE_API_TOKEN")
+        if not api_token:
+            message = "ENZYME_BLUE_API_TOKEN is required to fetch official Enzyme Blue vault metadata"
+            raise RuntimeError(message)
+        selected_specs = {spec for spec, _row in selected_rows}
+        state = load_metadata_state(state_path, selected_specs)
+        missing_specs = [spec for spec, _row in selected_rows if spec not in state]
+        session = create_enzyme_api_session(max_workers)
+        try:
+            with tqdm(total=len(selected_rows), initial=len(state), desc="Fetching Enzyme Blue metadata") as progress:
+                for start in range(0, len(missing_specs), max_workers):
+                    batch_specs = missing_specs[start : start + max_workers]
+                    batch_results = Parallel(n_jobs=max_workers, backend="threading")(delayed(fetch_one_enzyme_metadata)(spec, api_token=api_token, timeout=timeout, session=session) for spec in batch_specs)
+                    successes = [result for result in batch_results if result.metadata is not None]
+                    state.update({result.vault_spec: result.metadata for result in successes})
+                    if not dry_run and successes:
+                        write_metadata_state(state_path, state)
+                    progress.update(len(batch_results))
+                    failures = [result for result in batch_results if result.error]
+                    if failures:
+                        examples = "; ".join(f"{item.vault_spec.vault_address}: {item.error}" for item in failures[:3])
+                        raise RuntimeError(f"Enzyme metadata fetch failed for {len(failures)} vaults; state was saved for {len(state)} of {len(selected_rows)} rows. Examples: {examples}")
+        finally:
+            session.close()
 
-    assert len(state) == len(selected_rows)
-    successful = [EnzymeMetadataFetchResult(spec, metadata=state[spec]) for spec, _row in selected_rows]
+        assert len(state) == len(selected_rows)
+        successful = [EnzymeMetadataFetchResult(spec, metadata=state[spec]) for spec, _row in selected_rows]
 
     rows_by_spec = dict(selected_rows)
-    updates = [create_metadata_update(result.vault_spec, rows_by_spec[result.vault_spec], result.metadata) for result in successful]
-    changed_updates = [update for update in updates if update.changed_fields]
+    api_updates = [create_metadata_update(result.vault_spec, rows_by_spec[result.vault_spec], result.metadata) for result in successful]
+    changed_updates = legacy_clear_updates + [update for update in api_updates if update.changed_fields]
     with_short_description = sum(result.metadata.short_description is not None for result in successful)
     with_description = sum(result.metadata.description is not None for result in successful)
     print(
@@ -444,6 +488,7 @@ def main() -> None:  # noqa: PLR0914 - Keeps the one-shot migration transaction 
             [
                 ["Eligible Enzyme Blue rows", len(selected_rows)],
                 ["Resumed API replies", len(selected_rows) - len(missing_specs)],
+                ["Legacy fallback rows cleared", len(legacy_clear_updates)],
                 ["Official API taglines", with_short_description],
                 ["Official API descriptions", with_description],
                 ["Rows with database changes", len(changed_updates)],
@@ -456,16 +501,18 @@ def main() -> None:  # noqa: PLR0914 - Keeps the one-shot migration transaction 
     if dry_run:
         return
 
-    cached_metadata = load_enzyme_vault_metadata_cache(cache_path)
-    cached_metadata.update({(result.vault_spec.chain_id, HexAddress(result.vault_spec.vault_address.lower())): result.metadata for result in successful})
     backup_path = resolve_backup_path(vault_db_path)
     backup_path.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(vault_db_path, backup_path)
-    write_enzyme_vault_metadata_cache(cached_metadata, cache_path)
+    if successful:
+        cached_metadata = load_enzyme_vault_metadata_cache(cache_path)
+        cached_metadata.update({(result.vault_spec.chain_id, HexAddress(result.vault_spec.vault_address.lower())): result.metadata for result in successful})
+        write_enzyme_vault_metadata_cache(cached_metadata, cache_path)
     apply_metadata_updates(vault_db, changed_updates)
     vault_db.write(vault_db_path)
-    state_path.unlink()
-    print(f"Updated {len(changed_updates)} Enzyme Blue rows. Metadata backup: {backup_path}. Cache: {cache_path}. Removed completed state: {state_path}.")
+    if selected_rows:
+        state_path.unlink()
+    print(f"Updated {len(changed_updates)} Enzyme Blue rows. Metadata backup: {backup_path}. Cache: {cache_path}.")
 
 
 if __name__ == "__main__":

--- a/scripts/enzyme/migrate-offchain-metadata.py
+++ b/scripts/enzyme/migrate-offchain-metadata.py
@@ -14,8 +14,9 @@ does not alter Onyx rows or scrape a gated UI.
 
 The command starts in dry-run mode. It never alters historical prices, scanner
 reader state or discovery leads. A failed API response aborts before either the
-database or cache is written, so a temporary offchain failure cannot replace
-existing descriptions with fallbacks.
+database or cache is written. In apply mode, successful responses are saved in
+a small migration-only state file after each request batch, so a later retry
+does not repeat completed API reads.
 
 Usage::
 
@@ -31,6 +32,9 @@ Environment variables:
 - ``DRY_RUN``: print proposed changes without writing, default ``true``.
 - ``VAULT_DB_PATH``: metadata pickle to update, default pipeline location.
 - ``ENZYME_METADATA_CACHE_PATH``: persistent API cache location.
+- ``ENZYME_METADATA_STATE_PATH``: resumable migration state path. Defaults to
+  ``enzyme-offchain-metadata-state.json`` next to the vault database and is
+  deleted only after a complete cache/database update.
 - ``MAX_WORKERS``: bounded concurrent API requests, default ``1``. Keep this
   conservative because Enzyme returns ``429`` with a ``Retry-After`` header
   when a token exceeds its request quota.
@@ -41,6 +45,7 @@ Official API documentation:
 https://sdk.enzyme.finance/api/overview/
 """
 
+import json
 import os
 import shutil
 from collections.abc import Iterator
@@ -51,6 +56,7 @@ from eth_typing import HexAddress
 from joblib import Parallel, delayed
 from requests import RequestException, Session
 from tabulate import tabulate
+from tqdm_loggable.auto import tqdm
 
 from eth_defi.compat import native_datetime_utc_now
 from eth_defi.enzyme.offchain_metadata import (
@@ -63,8 +69,11 @@ from eth_defi.enzyme.offchain_metadata import (
     write_enzyme_vault_metadata_cache,
 )
 from eth_defi.erc_4626.core import ERC4626Feature
+from eth_defi.utils import wait_other_writers
 from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.vaultdb import VaultDatabase, VaultRow, get_pipeline_data_dir
+
+ENZYME_METADATA_STATE_VERSION = 1
 
 
 @dataclass(slots=True, frozen=True)
@@ -92,8 +101,8 @@ class EnzymeMetadataUpdate:
     """
 
     vault_spec: VaultSpec
-    short_description: str
-    description: str
+    short_description: str | None
+    description: str | None
     changed_fields: tuple[str, ...]
 
 
@@ -155,6 +164,87 @@ def resolve_backup_path(vault_db_path: Path) -> Path:
     return vault_db_path.with_name(f"{vault_db_path.stem}.before-enzyme-offchain-metadata-{timestamp}{vault_db_path.suffix}")
 
 
+def resolve_state_path(vault_db_path: Path) -> Path:
+    """Resolve the durable state file for unfinished API collection.
+
+    :param vault_db_path: Metadata pickle updated only after full collection.
+    :return: Explicit state path or a small sibling JSON file.
+    """
+
+    configured_path = os.environ.get("ENZYME_METADATA_STATE_PATH")
+    if configured_path:
+        return Path(configured_path).expanduser()
+    return vault_db_path.with_name("enzyme-offchain-metadata-state.json")
+
+
+def load_metadata_state(state_path: Path, selected_specs: set[VaultSpec]) -> dict[VaultSpec, EnzymeVaultMetadata]:
+    """Load successful API replies saved by an interrupted migration.
+
+    :param state_path: Migration-only JSON checkpoint path.
+    :param selected_specs: Currently eligible Blue vault identities.
+    :return: Valid completed API replies that still belong to this migration.
+    :raise RuntimeError: If the operator must inspect a malformed state file.
+    """
+
+    if not state_path.exists():
+        return {}
+    try:
+        with state_path.open() as inp:
+            payload = json.load(inp)
+        if not isinstance(payload, dict) or payload.get("version") != ENZYME_METADATA_STATE_VERSION:
+            message = "unsupported state version"
+            raise ValueError(message)
+        records = payload.get("vaults")
+        if not isinstance(records, list):
+            message = "vaults must be a list"
+            raise ValueError(message)
+        state = {}
+        for record in records:
+            if not isinstance(record, dict) or not isinstance(record.get("chain_id"), int) or not isinstance(record.get("address"), str):
+                message = "invalid vault record"
+                raise ValueError(message)
+            short_description = record.get("short_description")
+            description = record.get("description")
+            if short_description is not None and not isinstance(short_description, str):
+                message = "invalid short description"
+                raise ValueError(message)
+            if description is not None and not isinstance(description, str):
+                message = "invalid description"
+                raise ValueError(message)
+            vault_spec = VaultSpec(record["chain_id"], record["address"].lower())
+            if vault_spec in selected_specs:
+                state[vault_spec] = EnzymeVaultMetadata(short_description=short_description, description=description)
+        return state
+    except (OSError, json.JSONDecodeError, ValueError) as error:
+        raise RuntimeError(f"Cannot resume Enzyme metadata state {state_path}: {error}") from error
+
+
+def write_metadata_state(state_path: Path, state: dict[VaultSpec, EnzymeVaultMetadata]) -> None:
+    """Atomically checkpoint successful API replies without publishing them.
+
+    :param state_path: Migration-only JSON checkpoint path.
+    :param state: Address-indexed successful official API replies.
+    :return: None after atomically replacing the checkpoint.
+    """
+
+    records = [
+        {
+            "chain_id": spec.chain_id,
+            "address": spec.vault_address.lower(),
+            "short_description": metadata.short_description,
+            "description": metadata.description,
+        }
+        for spec, metadata in sorted(state.items(), key=lambda item: (item[0].chain_id, item[0].vault_address.lower()))
+    ]
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = state_path.with_suffix(f"{state_path.suffix}.tmp")
+    with wait_other_writers(state_path):
+        with temporary_path.open("wt") as out:
+            json.dump({"version": ENZYME_METADATA_STATE_VERSION, "vaults": records}, out, indent=2, sort_keys=True)
+            out.write("\n")
+        temporary_path.replace(state_path)
+
+
 def is_enzyme_blue_row(row: VaultRow) -> bool:
     """Return whether a database row was factory-confirmed as Enzyme Blue.
 
@@ -211,17 +301,15 @@ def fetch_one_enzyme_metadata(
 
 
 def create_metadata_update(vault_spec: VaultSpec, row: VaultRow, metadata: EnzymeVaultMetadata) -> EnzymeMetadataUpdate:
-    """Resolve official API fields against the safe Blue fallback copy.
+    """Replace description fields with a successful official API response.
 
     :param vault_spec: Existing Blue VaultProxy identity.
     :param row: Existing metadata row.
     :param metadata: Successful official API result, possibly without text.
-    :return: Complete replacement values for the migration-owned fields.
+    :return: API replacement values, which can be absent when Enzyme has no copy.
     """
 
-    resolved = resolve_enzyme_blue_vault_metadata(row.get("Name") or "", metadata)
-    assert resolved.short_description is not None
-    assert resolved.description is not None
+    resolved = resolve_enzyme_blue_vault_metadata(metadata)
     updates = {
         "_short_description": resolved.short_description,
         "_description": resolved.description,
@@ -234,7 +322,7 @@ def apply_metadata_updates(vault_db: VaultDatabase, updates: list[EnzymeMetadata
     """Apply only description fields owned by this migration in memory.
 
     :param vault_db: Loaded database to modify.
-    :param updates: Planned API/fallback description updates.
+    :param updates: Planned API description updates.
     :return: None after replacing changed rows in memory.
     """
 
@@ -278,18 +366,30 @@ def main() -> None:  # noqa: PLR0914 - Keeps the one-shot migration transaction 
         print("No Enzyme Blue rows found; no metadata collection is needed.")
         return
 
+    selected_specs = {spec for spec, _row in selected_rows}
+    state_path = resolve_state_path(vault_db_path)
+    state = load_metadata_state(state_path, selected_specs)
+    missing_specs = [spec for spec, _row in selected_rows if spec not in state]
     session = create_enzyme_api_session(max_workers)
     try:
-        results = Parallel(n_jobs=max_workers, backend="threading")(delayed(fetch_one_enzyme_metadata)(spec, api_token=api_token, timeout=timeout, session=session) for spec, _row in selected_rows)
+        with tqdm(total=len(selected_rows), initial=len(state), desc="Fetching Enzyme Blue metadata") as progress:
+            for start in range(0, len(missing_specs), max_workers):
+                batch_specs = missing_specs[start : start + max_workers]
+                batch_results = Parallel(n_jobs=max_workers, backend="threading")(delayed(fetch_one_enzyme_metadata)(spec, api_token=api_token, timeout=timeout, session=session) for spec in batch_specs)
+                successes = [result for result in batch_results if result.metadata is not None]
+                state.update({result.vault_spec: result.metadata for result in successes})
+                if not dry_run and successes:
+                    write_metadata_state(state_path, state)
+                progress.update(len(batch_results))
+                failures = [result for result in batch_results if result.error]
+                if failures:
+                    examples = "; ".join(f"{item.vault_spec.vault_address}: {item.error}" for item in failures[:3])
+                    raise RuntimeError(f"Enzyme metadata fetch failed for {len(failures)} vaults; state was saved for {len(state)} of {len(selected_rows)} rows. Examples: {examples}")
     finally:
         session.close()
 
-    failures = [result for result in results if result.error]
-    successful = [result for result in results if result.metadata is not None]
-    if failures:
-        examples = "; ".join(f"{item.vault_spec.vault_address}: {item.error}" for item in failures[:3])
-        raise RuntimeError(f"Enzyme metadata fetch failed for {len(failures)} of {len(results)} vaults; no changes were written. Examples: {examples}")
-    assert len(successful) == len(selected_rows)
+    assert len(state) == len(selected_rows)
+    successful = [EnzymeMetadataFetchResult(spec, metadata=state[spec]) for spec, _row in selected_rows]
 
     rows_by_spec = dict(selected_rows)
     updates = [create_metadata_update(result.vault_spec, rows_by_spec[result.vault_spec], result.metadata) for result in successful]
@@ -300,6 +400,7 @@ def main() -> None:  # noqa: PLR0914 - Keeps the one-shot migration transaction 
         tabulate(
             [
                 ["Existing Enzyme Blue rows", len(selected_rows)],
+                ["Resumed API replies", len(selected_rows) - len(missing_specs)],
                 ["Official API taglines", with_short_description],
                 ["Official API descriptions", with_description],
                 ["Rows with database changes", len(changed_updates)],
@@ -320,7 +421,8 @@ def main() -> None:  # noqa: PLR0914 - Keeps the one-shot migration transaction 
     write_enzyme_vault_metadata_cache(cached_metadata, cache_path)
     apply_metadata_updates(vault_db, changed_updates)
     vault_db.write(vault_db_path)
-    print(f"Updated {len(changed_updates)} Enzyme Blue rows. Metadata backup: {backup_path}. Cache: {cache_path}.")
+    state_path.unlink()
+    print(f"Updated {len(changed_updates)} Enzyme Blue rows. Metadata backup: {backup_path}. Cache: {cache_path}. Removed completed state: {state_path}.")
 
 
 if __name__ == "__main__":

--- a/scripts/enzyme/migrate-offchain-metadata.py
+++ b/scripts/enzyme/migrate-offchain-metadata.py
@@ -29,13 +29,16 @@ Usage::
 
 Environment variables:
 
-- ``ENZYME_BLUE_API_TOKEN``: required bearer token generated in the Enzyme app.
+- ``ENZYME_BLUE_API_TOKEN``: bearer token generated in the Enzyme app, required
+  when an eligible row must be fetched or explicitly refreshed.
 - ``DRY_RUN``: print proposed changes without writing, default ``true``.
 - ``VAULT_DB_PATH``: metadata pickle to update, default pipeline location.
 - ``ENZYME_METADATA_CACHE_PATH``: persistent API cache location.
 - ``ENZYME_METADATA_STATE_PATH``: resumable migration state path. Defaults to
   ``enzyme-offchain-metadata-state.json`` next to the vault database and is
   deleted only after a complete cache/database update.
+- ``ENZYME_METADATA_REFRESH``: fetch every eligible Blue row again instead of
+  reusing a completed cache entry, default ``false``.
 - Only Blue vaults whose recorded accounting-unit NAV exceeds 1,000 USD,
   1 ETH or 0.1 BTC equivalents are collected. Unsupported denominations are
   skipped rather than converted using an inferred exchange rate.
@@ -84,7 +87,7 @@ ENZYME_METADATA_STATE_VERSION = 1
 #: USD price feed. Keep symbols only where the denomination itself is a
 #: reviewed USD, ETH or BTC equivalent.
 MINIMUM_NAV_BY_VALUE_UNIT = {
-    **dict.fromkeys({"USD", "USDC", "USDC.E", "USDT", "USDT0", "USD₮0", "DAI", "USDS", "SUSD", "BUSD", "FRAX", "USDE", "SUSDE"}, Decimal("1000")),
+    **dict.fromkeys({"USD", "USDC", "USDC.E", "USDBC", "USDT", "USDT0", "USD₮0", "DAI", "USDS", "SUSD", "BUSD", "FRAX", "USDE", "SUSDE", "GHO", "PYUSD", "RLUSD"}, Decimal("1000")),
     **dict.fromkeys({"ETH", "WETH", "STETH", "WSTETH", "RETH", "CBETH", "WEETH", "OSETH"}, Decimal("1")),
     **dict.fromkeys({"BTC", "WBTC", "CBBTC", "IBTC", "TBTC", "FBTC", "LBTC"}, Decimal("0.1")),
 }
@@ -293,7 +296,7 @@ def get_metadata_value_unit(row: VaultRow) -> str | None:
     :return: Uppercase accounting-unit symbol, if known.
     """
 
-    value_unit = row.get("Denomination") or (row.get("_vault_info") or {}).get("value_asset")
+    value_unit = row.get("Denomination")
     return value_unit.upper() if isinstance(value_unit, str) else None
 
 
@@ -326,31 +329,29 @@ def iter_all_enzyme_blue_rows(vault_db: VaultDatabase) -> Iterator[tuple[VaultSp
     yield from sorted(rows, key=lambda item: (item[0].chain_id, item[0].vault_address.lower()))
 
 
-def is_legacy_blue_fallback(row: VaultRow) -> bool:
-    """Return whether a Blue row contains only the retired generated fallback.
-
-    Matching both fields, including the persisted name, avoids clearing a
-    manager-supplied description that happens to mention Enzyme Blue.
-
-    :param row: Existing Enzyme Blue metadata row.
-    :return: ``True`` only for the exact old generated pair of descriptions.
-    """
-
-    display_name = (row.get("Name") or "").strip() or "Unnamed vault"
-    return row.get("_short_description") == LEGACY_BLUE_SHORT_DESCRIPTION and row.get("_description") == f"{display_name}{LEGACY_BLUE_DESCRIPTION_SUFFIX}"
-
-
 def create_legacy_fallback_clear_update(vault_spec: VaultSpec, row: VaultRow) -> EnzymeMetadataUpdate | None:
-    """Plan removal of the exact retired generated Blue fallback.
+    """Plan removal of retired generated Blue fallback fields independently.
+
+    The old resolver filled absent API fields separately, so a row can contain
+    a real manager field alongside one invented fallback field. Each exact
+    generated fragment is therefore cleared independently and the other field
+    is preserved.
 
     :param vault_spec: Existing Blue VaultProxy identity.
     :param row: Existing Blue metadata row.
-    :return: Clearing update, or ``None`` when the row has no legacy fallback.
+    :return: Field-preserving clearing update, or ``None`` when no legacy copy exists.
     """
 
-    if not is_legacy_blue_fallback(row):
+    has_legacy_short = row.get("_short_description") == LEGACY_BLUE_SHORT_DESCRIPTION
+    has_legacy_description = str(row.get("_description")).endswith(LEGACY_BLUE_DESCRIPTION_SUFFIX)
+    if not has_legacy_short and not has_legacy_description:
         return None
-    return EnzymeMetadataUpdate(vault_spec, None, None, ("_short_description", "_description"))
+    return EnzymeMetadataUpdate(
+        vault_spec,
+        None if has_legacy_short else row.get("_short_description"),
+        None if has_legacy_description else row.get("_description"),
+        tuple(field for field, enabled in (("_short_description", has_legacy_short), ("_description", has_legacy_description)) if enabled),
+    )
 
 
 def fetch_one_enzyme_metadata(
@@ -416,6 +417,71 @@ def apply_metadata_updates(vault_db: VaultDatabase, updates: list[EnzymeMetadata
         vault_db.rows[update.vault_spec] = row
 
 
+def fetch_enzyme_metadata(
+    selected_rows: list[tuple[VaultSpec, VaultRow]],
+    *,
+    state_path: Path,
+    cache_path: Path,
+    dry_run: bool,
+    max_workers: int,
+    timeout: float,
+) -> tuple[dict[VaultSpec, EnzymeVaultMetadata], int, dict[tuple[int, HexAddress], EnzymeVaultMetadata]]:
+    """Collect eligible official metadata, resuming state and completed cache entries.
+
+    The API request follows Enzyme's `GetVault documentation
+    <https://sdk.enzyme.finance/api/endpoints/vault/>`__. A completed cache is
+    reused by default, whereas ``ENZYME_METADATA_REFRESH=true`` intentionally
+    reads every eligible vault again.
+
+    :param selected_rows: Eligible Blue database rows in deterministic order.
+    :param state_path: Migration-only state checkpoint path.
+    :param cache_path: Durable official metadata cache path.
+    :param dry_run: Whether successful replies must remain transient.
+    :param max_workers: Bounded request concurrency.
+    :param timeout: Per-request API timeout in seconds.
+    :return: Collected metadata, request count and existing durable cache.
+    :raise RuntimeError: If a required token is absent or any API read fails.
+    """
+
+    if not selected_rows:
+        return {}, 0, {}
+
+    selected_specs = {spec for spec, _row in selected_rows}
+    state = load_metadata_state(state_path, selected_specs)
+    cached_metadata = load_enzyme_vault_metadata_cache(cache_path)
+    if not parse_bool_env("ENZYME_METADATA_REFRESH", default=False):
+        state.update({spec: metadata for spec in selected_specs - state.keys() if (metadata := cached_metadata.get((spec.chain_id, HexAddress(spec.vault_address.lower())))) is not None})
+    missing_specs = [spec for spec, _row in selected_rows if spec not in state]
+    if not missing_specs:
+        return state, 0, cached_metadata
+
+    api_token = os.environ.get("ENZYME_BLUE_API_TOKEN")
+    if not api_token:
+        message = "ENZYME_BLUE_API_TOKEN is required to fetch official Enzyme Blue vault metadata"
+        raise RuntimeError(message)
+    session = create_enzyme_api_session(max_workers)
+    try:
+        with tqdm(total=len(selected_rows), initial=len(state), desc="Fetching Enzyme Blue metadata") as progress:
+            for start in range(0, len(missing_specs), max_workers):
+                batch_specs = missing_specs[start : start + max_workers]
+                batch_results = Parallel(n_jobs=max_workers, backend="threading")(delayed(fetch_one_enzyme_metadata)(spec, api_token=api_token, timeout=timeout, session=session) for spec in batch_specs)
+                successes = [result for result in batch_results if result.metadata is not None]
+                state.update({result.vault_spec: result.metadata for result in successes})
+                if not dry_run and successes:
+                    write_metadata_state(state_path, state)
+                progress.update(len(batch_results))
+                failures = [result for result in batch_results if result.error]
+                if failures:
+                    examples = "; ".join(f"{item.vault_spec.vault_address}: {item.error}" for item in failures[:3])
+                    checkpoint_status = "no checkpoint was written in dry-run mode" if dry_run else f"state was saved for {len(state)} of {len(selected_rows)} rows"
+                    raise RuntimeError(f"Enzyme metadata fetch failed for {len(failures)} vaults; {checkpoint_status}. Examples: {examples}")
+    finally:
+        session.close()
+
+    assert len(state) == len(selected_rows)
+    return state, len(missing_specs), cached_metadata
+
+
 def main() -> None:  # noqa: PLR0914 - Keeps the one-shot migration transaction visible in one place.
     """Fetch eligible Blue descriptions and optionally persist metadata repairs.
 
@@ -446,52 +512,35 @@ def main() -> None:  # noqa: PLR0914 - Keeps the one-shot migration transaction 
         return
 
     state_path = resolve_state_path(vault_db_path)
-    state: dict[VaultSpec, EnzymeVaultMetadata] = {}
-    missing_specs: list[VaultSpec] = []
-    successful: list[EnzymeMetadataFetchResult] = []
-    if selected_rows:
-        api_token = os.environ.get("ENZYME_BLUE_API_TOKEN")
-        if not api_token:
-            message = "ENZYME_BLUE_API_TOKEN is required to fetch official Enzyme Blue vault metadata"
-            raise RuntimeError(message)
-        selected_specs = {spec for spec, _row in selected_rows}
-        state = load_metadata_state(state_path, selected_specs)
-        missing_specs = [spec for spec, _row in selected_rows if spec not in state]
-        session = create_enzyme_api_session(max_workers)
-        try:
-            with tqdm(total=len(selected_rows), initial=len(state), desc="Fetching Enzyme Blue metadata") as progress:
-                for start in range(0, len(missing_specs), max_workers):
-                    batch_specs = missing_specs[start : start + max_workers]
-                    batch_results = Parallel(n_jobs=max_workers, backend="threading")(delayed(fetch_one_enzyme_metadata)(spec, api_token=api_token, timeout=timeout, session=session) for spec in batch_specs)
-                    successes = [result for result in batch_results if result.metadata is not None]
-                    state.update({result.vault_spec: result.metadata for result in successes})
-                    if not dry_run and successes:
-                        write_metadata_state(state_path, state)
-                    progress.update(len(batch_results))
-                    failures = [result for result in batch_results if result.error]
-                    if failures:
-                        examples = "; ".join(f"{item.vault_spec.vault_address}: {item.error}" for item in failures[:3])
-                        raise RuntimeError(f"Enzyme metadata fetch failed for {len(failures)} vaults; state was saved for {len(state)} of {len(selected_rows)} rows. Examples: {examples}")
-        finally:
-            session.close()
-
-        assert len(state) == len(selected_rows)
-        successful = [EnzymeMetadataFetchResult(spec, metadata=state[spec]) for spec, _row in selected_rows]
+    state, request_count, cached_metadata = fetch_enzyme_metadata(
+        selected_rows,
+        state_path=state_path,
+        cache_path=cache_path,
+        dry_run=dry_run,
+        max_workers=max_workers,
+        timeout=timeout,
+    )
+    successful = [EnzymeMetadataFetchResult(spec, metadata=state[spec]) for spec, _row in selected_rows]
 
     rows_by_spec = dict(selected_rows)
     api_updates = [create_metadata_update(result.vault_spec, rows_by_spec[result.vault_spec], result.metadata) for result in successful]
     changed_updates = legacy_clear_updates + [update for update in api_updates if update.changed_fields]
+    unsupported_value_units = sum(get_metadata_value_unit(row) not in MINIMUM_NAV_BY_VALUE_UNIT for _spec, row in blue_rows)
+    below_minimum_or_missing_value = len(blue_rows) - len(selected_rows) - unsupported_value_units
     with_short_description = sum(result.metadata.short_description is not None for result in successful)
     with_description = sum(result.metadata.description is not None for result in successful)
     print(
         tabulate(
             [
+                ["All Enzyme Blue rows", len(blue_rows)],
                 ["Eligible Enzyme Blue rows", len(selected_rows)],
-                ["Resumed API replies", len(selected_rows) - len(missing_specs)],
-                ["Legacy fallback rows cleared", len(legacy_clear_updates)],
+                ["Below minimum or missing NAV", below_minimum_or_missing_value],
+                ["Unsupported value units", unsupported_value_units],
+                ["Reused official API replies", len(selected_rows) - request_count],
+                ["Legacy fallback rows repaired", len(legacy_clear_updates)],
                 ["Official API taglines", with_short_description],
                 ["Official API descriptions", with_description],
-                ["Rows with database changes", len(changed_updates)],
+                ["Rows with database changes", len({update.vault_spec for update in changed_updates})],
                 ["Mode", "dry run" if dry_run else "apply"],
             ],
             headers=["Item", "Count"],
@@ -501,18 +550,20 @@ def main() -> None:  # noqa: PLR0914 - Keeps the one-shot migration transaction 
     if dry_run:
         return
 
-    backup_path = resolve_backup_path(vault_db_path)
-    backup_path.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(vault_db_path, backup_path)
-    if successful:
-        cached_metadata = load_enzyme_vault_metadata_cache(cache_path)
-        cached_metadata.update({(result.vault_spec.chain_id, HexAddress(result.vault_spec.vault_address.lower())): result.metadata for result in successful})
+    cache_updates = {(result.vault_spec.chain_id, HexAddress(result.vault_spec.vault_address.lower())): result.metadata for result in successful}
+    cache_changed = any(cached_metadata.get(key) != metadata for key, metadata in cache_updates.items())
+    if cache_changed:
+        cached_metadata.update(cache_updates)
         write_enzyme_vault_metadata_cache(cached_metadata, cache_path)
-    apply_metadata_updates(vault_db, changed_updates)
-    vault_db.write(vault_db_path)
-    if selected_rows:
+    if changed_updates:
+        backup_path = resolve_backup_path(vault_db_path)
+        backup_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(vault_db_path, backup_path)
+        apply_metadata_updates(vault_db, changed_updates)
+        vault_db.write(vault_db_path)
+    if selected_rows and state_path.exists():
         state_path.unlink()
-    print(f"Updated {len(changed_updates)} Enzyme Blue rows. Metadata backup: {backup_path}. Cache: {cache_path}.")
+    print(f"Updated {len({update.vault_spec for update in changed_updates})} Enzyme Blue rows. Cache updated: {cache_changed}.")
 
 
 if __name__ == "__main__":

--- a/scripts/enzyme/migrate-offchain-metadata.py
+++ b/scripts/enzyme/migrate-offchain-metadata.py
@@ -35,6 +35,9 @@ Environment variables:
 - ``ENZYME_METADATA_STATE_PATH``: resumable migration state path. Defaults to
   ``enzyme-offchain-metadata-state.json`` next to the vault database and is
   deleted only after a complete cache/database update.
+- Only Blue vaults whose recorded accounting-unit NAV exceeds 1,000 USD,
+  1 ETH or 0.1 BTC equivalents are collected. Unsupported denominations are
+  skipped rather than converted using an inferred exchange rate.
 - ``MAX_WORKERS``: bounded concurrent API requests, default ``1``. Keep this
   conservative because Enzyme returns ``429`` with a ``Retry-After`` header
   when a token exceeds its request quota.
@@ -50,6 +53,7 @@ import os
 import shutil
 from collections.abc import Iterator
 from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 
 from eth_typing import HexAddress
@@ -74,6 +78,16 @@ from eth_defi.vault.base import VaultSpec
 from eth_defi.vault.vaultdb import VaultDatabase, VaultRow, get_pipeline_data_dir
 
 ENZYME_METADATA_STATE_VERSION = 1
+
+#: Minimum recorded NAV by accounting-unit family for API metadata collection.
+#: The database stores values in each vault's denomination, not a universal
+#: USD price feed. Keep symbols only where the denomination itself is a
+#: reviewed USD, ETH or BTC equivalent.
+MINIMUM_NAV_BY_DENOMINATION = {
+    **dict.fromkeys({"USD", "USDC", "USDC.E", "USDT", "USDT0", "USD₮0", "DAI", "USDS", "SUSD", "BUSD", "FRAX", "USDE", "SUSDE"}, Decimal("1000")),
+    **dict.fromkeys({"ETH", "WETH", "STETH", "WSTETH", "RETH", "CBETH", "WEETH", "OSETH"}, Decimal("1")),
+    **dict.fromkeys({"BTC", "WBTC", "CBBTC", "IBTC", "TBTC", "FBTC", "LBTC"}, Decimal("0.1")),
+}
 
 
 @dataclass(slots=True, frozen=True)
@@ -260,14 +274,43 @@ def is_enzyme_blue_row(row: VaultRow) -> bool:
     return ERC4626Feature.enzyme_blue_like.value in feature_values
 
 
-def iter_enzyme_blue_rows(vault_db: VaultDatabase) -> Iterator[tuple[VaultSpec, VaultRow]]:
-    """Yield existing Enzyme Blue rows in deterministic request order.
+def get_metadata_value_unit(row: VaultRow) -> str | None:
+    """Read the persisted accounting-unit symbol used for the NAV threshold.
 
-    :param vault_db: Loaded vault metadata database.
-    :return: Existing Blue identity and row pairs.
+    :param row: Persisted vault metadata row.
+    :return: Uppercase accounting-unit symbol, if known.
     """
 
-    rows = ((spec, row) for spec, row in vault_db.rows.items() if is_enzyme_blue_row(row))
+    value_unit = row.get("Denomination") or (row.get("_vault_info") or {}).get("value_asset")
+    return value_unit.upper() if isinstance(value_unit, str) else None
+
+
+def has_description_metadata_tvl(row: VaultRow) -> bool:
+    """Check whether a Blue row meets the documented API-collection threshold.
+
+    :param row: Persisted Blue vault metadata row with accounting-unit NAV.
+    :return: ``True`` only above the reviewed USD, ETH or BTC-equivalent limit.
+    """
+
+    value_unit = get_metadata_value_unit(row)
+    threshold = MINIMUM_NAV_BY_DENOMINATION.get(value_unit)
+    if threshold is None:
+        return False
+    try:
+        nav = Decimal(str(row.get("NAV")))
+    except (InvalidOperation, ValueError):
+        return False
+    return nav.is_finite() and nav > threshold
+
+
+def iter_enzyme_blue_rows(vault_db: VaultDatabase) -> Iterator[tuple[VaultSpec, VaultRow]]:
+    """Yield Enzyme Blue rows above the metadata-collection TVL threshold.
+
+    :param vault_db: Loaded vault metadata database.
+    :return: Eligible Blue identity and row pairs in deterministic request order.
+    """
+
+    rows = ((spec, row) for spec, row in vault_db.rows.items() if is_enzyme_blue_row(row) and has_description_metadata_tvl(row))
     yield from sorted(rows, key=lambda item: (item[0].chain_id, item[0].vault_address.lower()))
 
 
@@ -399,7 +442,7 @@ def main() -> None:  # noqa: PLR0914 - Keeps the one-shot migration transaction 
     print(
         tabulate(
             [
-                ["Existing Enzyme Blue rows", len(selected_rows)],
+                ["Eligible Enzyme Blue rows", len(selected_rows)],
                 ["Resumed API replies", len(selected_rows) - len(missing_specs)],
                 ["Official API taglines", with_short_description],
                 ["Official API descriptions", with_description],

--- a/scripts/enzyme/migrate-offchain-metadata.py
+++ b/scripts/enzyme/migrate-offchain-metadata.py
@@ -19,19 +19,21 @@ existing descriptions with fallbacks.
 
 Usage::
 
-    source .local-test.env && ENZYME_API_TOKEN=... \\
+    source .local-test.env && ENZYME_BLUE_API_TOKEN=... \\
         poetry run python scripts/enzyme/migrate-offchain-metadata.py
 
-    source .local-test.env && ENZYME_API_TOKEN=... DRY_RUN=false \\
+    source .local-test.env && ENZYME_BLUE_API_TOKEN=... DRY_RUN=false \\
         poetry run python scripts/enzyme/migrate-offchain-metadata.py
 
 Environment variables:
 
-- ``ENZYME_API_TOKEN``: required bearer token generated in the Enzyme app.
+- ``ENZYME_BLUE_API_TOKEN``: required bearer token generated in the Enzyme app.
 - ``DRY_RUN``: print proposed changes without writing, default ``true``.
 - ``VAULT_DB_PATH``: metadata pickle to update, default pipeline location.
 - ``ENZYME_METADATA_CACHE_PATH``: persistent API cache location.
-- ``MAX_WORKERS``: bounded concurrent API requests, default ``8``.
+- ``MAX_WORKERS``: bounded concurrent API requests, default ``1``. Keep this
+  conservative because Enzyme returns ``429`` with a ``Retry-After`` header
+  when a token exceeds its request quota.
 - ``API_TIMEOUT``: per-request timeout in seconds, default ``30``.
 - ``BACKUP_PATH``: optional database backup destination for a real run.
 
@@ -253,11 +255,11 @@ def main() -> None:  # noqa: PLR0914 - Keeps the one-shot migration transaction 
     """
 
     dry_run = parse_bool_env("DRY_RUN", default=True)
-    api_token = os.environ.get("ENZYME_API_TOKEN")
+    api_token = os.environ.get("ENZYME_BLUE_API_TOKEN")
     if not api_token:
-        message = "ENZYME_API_TOKEN is required to fetch official Enzyme vault metadata"
+        message = "ENZYME_BLUE_API_TOKEN is required to fetch official Enzyme Blue vault metadata"
         raise RuntimeError(message)
-    max_workers = int(os.environ.get("MAX_WORKERS", "8"))
+    max_workers = int(os.environ.get("MAX_WORKERS", "1"))
     timeout = float(os.environ.get("API_TIMEOUT", "30"))
     if max_workers < 1:
         message = "MAX_WORKERS must be positive"

--- a/scripts/erc-4626/README-vault-scripts.md
+++ b/scripts/erc-4626/README-vault-scripts.md
@@ -748,9 +748,9 @@ uses the same one-scan-per-chain discovery and durable metadata batches as the
 historical backfill, but forcibly disables raw-price scanning, cleaned-Parquet
 replacement and unconditional metadata refreshes.
 
-The migration fills missing short and long descriptions, repairs direct vault
-links locally, refreshes complete current adapter metadata for affected rows,
-and resolves current deposit permission for Blue and Onyx. Blue uses the
+The migration applies the architecture-specific description policy, repairs
+direct vault links locally, refreshes complete current adapter metadata for
+affected rows, and resolves current deposit permission for Blue and Onyx. Blue uses the
 reviewed release PolicyManager addresses and investor-whitelist identifiers
 published by Enzyme, matching the policies used by the Enzyme website. Onyx
 uses an event-reconstructed active handler set plus current-state Multicall:
@@ -759,7 +759,9 @@ allowlist/controller restriction or admin-only mint handler is whitelisted,
 and an unreviewed hook or handler remains unknown. A vault with no active
 deposit handler is permissionless for identity policy, while no handler can
 currently accept a deposit.
-Name, symbol, denomination and both descriptions are mandatory; current NAV
+Name, symbol and denomination are mandatory. Blue descriptions are optional
+official API fields; Onyx has no short description and uses the explicit
+``Description is not publicly available`` long-description marker. Current NAV
 and fees can be blank for deprecated vaults whose old valuation or extension
 calls no longer execute. A completed row is skipped after an interruption, and
 a successful metadata-only run marks

--- a/tests/enzyme/test_enzyme_lifetime_metrics.py
+++ b/tests/enzyme/test_enzyme_lifetime_metrics.py
@@ -148,8 +148,8 @@ def test_enzyme_vault_reaches_lifetime_metrics(
         assert vault.short_description is None
         assert vault.description == ONYX_PUBLIC_DESCRIPTION_UNAVAILABLE
     else:
-        assert vault.short_description
-        assert vault.description
+        assert vault.short_description is None or isinstance(vault.short_description, str)
+        assert vault.description is None or isinstance(vault.description, str)
 
     reader = vault.get_historical_reader(stateful=True)
     call_results = [call.call_as_result(web3, block_identifier=BASE_MIDNIGHT_BLOCK, ignore_error=True) for call in reader.construct_multicalls()]

--- a/tests/enzyme/test_enzyme_offchain_metadata.py
+++ b/tests/enzyme/test_enzyme_offchain_metadata.py
@@ -1,6 +1,7 @@
 """Test Enzyme API description collection and safe fallback copy."""
 
 import importlib.util
+import os
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
@@ -11,6 +12,7 @@ from eth_defi.enzyme import offchain_metadata
 from eth_defi.enzyme.offchain_metadata import (
     ENZYME_API_VAULT_URL,
     EnzymeVaultMetadata,
+    create_enzyme_api_session,
     create_enzyme_blue_fallback_metadata,
     create_enzyme_vault_link,
     fetch_enzyme_api_vault_metadata,
@@ -29,6 +31,12 @@ MIGRATION_SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "enzym
 BLUE_SPEC = VaultSpec(1, VAULT_ADDRESS)
 BLUE_METADATA_KEY = (BLUE_SPEC.chain_id, HexAddress(BLUE_SPEC.vault_address.lower()))
 ONYX_SPEC = VaultSpec(8453, "0x000000000000000000000000000000000000c0Fe")
+
+#: Enzyme Blue Base Camp VaultProxy. The endpoint may validly return no
+#: manager-entered text, but a successful authenticated response validates the
+#: real Connect API request, token and schema path.
+LIVE_ENZYME_BLUE_VAULT = "0x75a17c22235b2dd584e3ea8c142422d97b826816"
+ENZYME_BLUE_API_TOKEN = os.environ.get("ENZYME_BLUE_API_TOKEN")
 
 
 def load_offchain_metadata_migration_module() -> ModuleType:
@@ -170,6 +178,34 @@ def test_fetch_enzyme_api_vault_metadata_uses_official_connect_endpoint() -> Non
     }
     assert kwargs["headers"]["Authorization"] == "Bearer test-token"
     assert kwargs["headers"]["Connect-Protocol-Version"] == "1"
+
+
+@pytest.mark.skipif(not ENZYME_BLUE_API_TOKEN, reason="ENZYME_BLUE_API_TOKEN needed to exercise the live Enzyme Blue API")
+def test_fetch_enzyme_api_vault_metadata_live() -> None:
+    """Authenticate to the real Enzyme Blue ``GetVault`` endpoint.
+
+    The selected VaultProxy can validly have no manager-entered listing copy.
+    This test therefore asserts a successful authenticated response and the
+    parsed result shape, rather than making a volatile assertion about current
+    manager text. It runs automatically wherever the token is available.
+
+    :return: None after the live authenticated read succeeds.
+    """
+
+    session = create_enzyme_api_session(max_workers=1)
+    try:
+        metadata = fetch_enzyme_api_vault_metadata(
+            session,
+            chain_id=8453,
+            shares_address=LIVE_ENZYME_BLUE_VAULT,
+            api_token=ENZYME_BLUE_API_TOKEN,
+            timeout=30,
+        )
+    finally:
+        session.close()
+
+    assert isinstance(metadata, EnzymeVaultMetadata)
+    assert all(value is None or isinstance(value, str) for value in (metadata.short_description, metadata.description, metadata.manager_name))
 
 
 def test_enzyme_metadata_cache_round_trip_retains_empty_api_reply(tmp_path) -> None:

--- a/tests/enzyme/test_enzyme_offchain_metadata.py
+++ b/tests/enzyme/test_enzyme_offchain_metadata.py
@@ -229,6 +229,26 @@ def test_offchain_metadata_state_resumes_successful_api_replies(tmp_path) -> Non
     assert loaded == {BLUE_SPEC: EnzymeVaultMetadata(short_description="Official tagline")}
 
 
+@pytest.mark.parametrize(
+    ("denomination", "nav", "expected"),
+    [
+        ("USDC", "1000", False),
+        ("USDC", "1000.01", True),
+        ("WETH", "1", False),
+        ("WETH", "1.01", True),
+        ("cbBTC", "0.1", False),
+        ("cbBTC", "0.100001", True),
+        ("EURC", "100000", False),
+    ],
+)
+def test_description_metadata_tvl_threshold(denomination: str, nav: str, expected: object) -> None:
+    """Collect only vaults above the reviewed accounting-unit limits."""
+
+    module = load_offchain_metadata_migration_module()
+
+    assert module.has_description_metadata_tvl({"Denomination": denomination, "NAV": nav}) is expected
+
+
 def test_offchain_metadata_migration_changes_only_existing_enzyme_blue_copy() -> None:
     """Apply official fields to Blue without changing Onyx or unrelated metadata."""
 
@@ -241,6 +261,8 @@ def test_offchain_metadata_migration_changes_only_existing_enzyme_blue_copy() ->
                 "_detection_data": SimpleNamespace(features={ERC4626Feature.enzyme_blue_like}),
                 "_short_description": "Old short copy",
                 "_description": "Old long copy",
+                "Denomination": "USDC",
+                "NAV": 1_001,
                 "unrelated_field": "preserved",
             },
             ONYX_SPEC: {

--- a/tests/enzyme/test_enzyme_offchain_metadata.py
+++ b/tests/enzyme/test_enzyme_offchain_metadata.py
@@ -18,7 +18,6 @@ from eth_defi.enzyme.offchain_metadata import (
     load_enzyme_blue_vault_metadata,
     load_enzyme_vault_metadata_cache,
     parse_enzyme_api_vault_metadata,
-    resolve_enzyme_blue_vault_metadata,
     write_enzyme_vault_metadata_cache,
 )
 from eth_defi.erc_4626.core import ERC4626Feature
@@ -50,24 +49,6 @@ def load_offchain_metadata_migration_module() -> ModuleType:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
-
-
-def test_missing_enzyme_blue_copy_stays_absent() -> None:
-    """Do not infer strategy text when Enzyme has supplied no copy."""
-
-    metadata = resolve_enzyme_blue_vault_metadata(None)
-
-    assert metadata.short_description is None
-    assert metadata.description is None
-
-
-def test_partial_enzyme_api_copy_keeps_missing_field_absent() -> None:
-    """Keep an absent API field absent when the other field has text."""
-
-    metadata = resolve_enzyme_blue_vault_metadata(EnzymeVaultMetadata(description="Official strategy narrative."))
-
-    assert metadata.description == "Official strategy narrative."
-    assert metadata.short_description is None
 
 
 def test_load_enzyme_blue_metadata_reads_cached_api_fields(monkeypatch) -> None:
@@ -241,12 +222,12 @@ def test_offchain_metadata_state_resumes_successful_api_replies(tmp_path) -> Non
         ("EURC", "100000", False),
     ],
 )
-def test_description_metadata_tvl_threshold(denomination: str, nav: str, expected: object) -> None:
+def test_description_metadata_minimum_value(denomination: str, nav: str, expected: object) -> None:
     """Collect only vaults above the reviewed accounting-unit limits."""
 
     module = load_offchain_metadata_migration_module()
 
-    assert module.has_description_metadata_tvl({"Denomination": denomination, "NAV": nav}) is expected
+    assert module.has_description_metadata_minimum_value({"Denomination": denomination, "NAV": nav}) is expected
 
 
 def test_offchain_metadata_migration_changes_only_existing_enzyme_blue_copy() -> None:
@@ -275,7 +256,7 @@ def test_offchain_metadata_migration_changes_only_existing_enzyme_blue_copy() ->
         }
     )
 
-    selected_rows = list(module.iter_enzyme_blue_rows(vault_db))
+    selected_rows = list(module.iter_all_enzyme_blue_rows(vault_db))
     assert selected_rows == [(BLUE_SPEC, vault_db.rows[BLUE_SPEC])]
 
     update = module.create_metadata_update(
@@ -309,3 +290,26 @@ def test_offchain_metadata_migration_clears_empty_api_copy() -> None:
 
     assert update.short_description is None
     assert update.description is None
+
+
+def test_offchain_metadata_migration_clears_only_exact_legacy_fallback() -> None:
+    """Clear a retired generated pair without touching similarly worded copy."""
+
+    module = load_offchain_metadata_migration_module()
+    legacy_row = {
+        "Name": "Legacy Blue vault",
+        "_short_description": module.LEGACY_BLUE_SHORT_DESCRIPTION,
+        "_description": f"Legacy Blue vault{module.LEGACY_BLUE_DESCRIPTION_SUFFIX}",
+    }
+    manager_row = {
+        "Name": "Manager Blue vault",
+        "_short_description": module.LEGACY_BLUE_SHORT_DESCRIPTION,
+        "_description": "Manager Blue vault is an Enzyme Blue investment vehicle with a manager-authored strategy.",
+    }
+
+    update = module.create_legacy_fallback_clear_update(BLUE_SPEC, legacy_row)
+
+    assert update is not None
+    assert update.short_description is None
+    assert update.description is None
+    assert module.create_legacy_fallback_clear_update(BLUE_SPEC, manager_row) is None

--- a/tests/enzyme/test_enzyme_offchain_metadata.py
+++ b/tests/enzyme/test_enzyme_offchain_metadata.py
@@ -1,4 +1,4 @@
-"""Test Enzyme API description collection and safe fallback copy."""
+"""Test Enzyme API description collection without inferred fallback copy."""
 
 import importlib.util
 import os
@@ -13,7 +13,6 @@ from eth_defi.enzyme.offchain_metadata import (
     ENZYME_API_VAULT_URL,
     EnzymeVaultMetadata,
     create_enzyme_api_session,
-    create_enzyme_blue_fallback_metadata,
     create_enzyme_vault_link,
     fetch_enzyme_api_vault_metadata,
     load_enzyme_blue_vault_metadata,
@@ -53,45 +52,36 @@ def load_offchain_metadata_migration_module() -> ModuleType:
     return module
 
 
-def test_enzyme_blue_fallback_has_complete_listing_copy() -> None:
-    """Provide generic Blue copy when the official API has no manager text."""
+def test_missing_enzyme_blue_copy_stays_absent() -> None:
+    """Do not infer strategy text when Enzyme has supplied no copy."""
 
-    metadata = create_enzyme_blue_fallback_metadata("Example vault")
+    metadata = resolve_enzyme_blue_vault_metadata(None)
 
-    assert metadata.short_description
-    assert metadata.description
-    assert "Example vault" in metadata.description
-
-
-def test_curated_enzyme_copy_overrides_only_the_provided_fields() -> None:
-    """Retain the fallback field when a curator supplies partial metadata."""
-
-    metadata = resolve_enzyme_blue_vault_metadata(
-        "Example vault",
-        EnzymeVaultMetadata(description="Curator-supplied strategy narrative."),
-    )
-
-    assert metadata.description == "Curator-supplied strategy narrative."
-    assert metadata.short_description == "Enzyme Blue tokenised digital-asset investment vehicle."
+    assert metadata.short_description is None
+    assert metadata.description is None
 
 
-def test_load_enzyme_blue_metadata_merges_curated_and_cached_fields(monkeypatch) -> None:
-    """Retain complementary manager copy from both supported metadata sources."""
+def test_partial_enzyme_api_copy_keeps_missing_field_absent() -> None:
+    """Keep an absent API field absent when the other field has text."""
 
-    monkeypatch.setattr(
-        offchain_metadata,
-        "ENZYME_BLUE_VAULT_METADATA",
-        {BLUE_METADATA_KEY: EnzymeVaultMetadata(description="Curated strategy narrative.")},
-    )
+    metadata = resolve_enzyme_blue_vault_metadata(EnzymeVaultMetadata(description="Official strategy narrative."))
+
+    assert metadata.description == "Official strategy narrative."
+    assert metadata.short_description is None
+
+
+def test_load_enzyme_blue_metadata_reads_cached_api_fields(monkeypatch) -> None:
+    """Read the exact successful official API response from the cache."""
+
     monkeypatch.setattr(
         offchain_metadata,
         "_cached_enzyme_vault_metadata",
-        {BLUE_METADATA_KEY: EnzymeVaultMetadata(short_description="Official tagline")},
+        {BLUE_METADATA_KEY: EnzymeVaultMetadata(short_description="Official tagline", description="Official strategy narrative.")},
     )
 
     assert load_enzyme_blue_vault_metadata(*BLUE_METADATA_KEY) == EnzymeVaultMetadata(
         short_description="Official tagline",
-        description="Curated strategy narrative.",
+        description="Official strategy narrative.",
     )
 
 
@@ -223,6 +213,22 @@ def test_enzyme_metadata_cache_round_trip_retains_empty_api_reply(tmp_path) -> N
     assert loaded == metadata
 
 
+def test_offchain_metadata_state_resumes_successful_api_replies(tmp_path) -> None:
+    """Keep completed official replies when the migration is interrupted."""
+
+    module = load_offchain_metadata_migration_module()
+    state_path = tmp_path / "enzyme-offchain-metadata-state.json"
+    state = {
+        BLUE_SPEC: EnzymeVaultMetadata(short_description="Official tagline"),
+        ONYX_SPEC: EnzymeVaultMetadata(description="Not selected"),
+    }
+
+    module.write_metadata_state(state_path, state)
+    loaded = module.load_metadata_state(state_path, {BLUE_SPEC})
+
+    assert loaded == {BLUE_SPEC: EnzymeVaultMetadata(short_description="Official tagline")}
+
+
 def test_offchain_metadata_migration_changes_only_existing_enzyme_blue_copy() -> None:
     """Apply official fields to Blue without changing Onyx or unrelated metadata."""
 
@@ -265,8 +271,8 @@ def test_offchain_metadata_migration_changes_only_existing_enzyme_blue_copy() ->
     assert vault_db.rows[ONYX_SPEC]["_short_description"] == "Keep Onyx fallback"
 
 
-def test_offchain_metadata_migration_reverts_empty_api_copy_to_safe_fallback() -> None:
-    """Replace obsolete text only after a successful authoritative empty reply."""
+def test_offchain_metadata_migration_clears_empty_api_copy() -> None:
+    """Clear obsolete text after a successful authoritative empty reply."""
 
     module = load_offchain_metadata_migration_module()
     row = {
@@ -279,5 +285,5 @@ def test_offchain_metadata_migration_reverts_empty_api_copy_to_safe_fallback() -
 
     update = module.create_metadata_update(BLUE_SPEC, row, EnzymeVaultMetadata())
 
-    assert update.short_description == "Enzyme Blue tokenised digital-asset investment vehicle."
-    assert "No manager-provided strategy description is available" in update.description
+    assert update.short_description is None
+    assert update.description is None

--- a/tests/enzyme/test_enzyme_offchain_metadata.py
+++ b/tests/enzyme/test_enzyme_offchain_metadata.py
@@ -292,16 +292,16 @@ def test_offchain_metadata_migration_clears_empty_api_copy() -> None:
     assert update.description is None
 
 
-def test_offchain_metadata_migration_clears_only_exact_legacy_fallback() -> None:
-    """Clear a retired generated pair without touching similarly worded copy."""
+def test_offchain_metadata_migration_clears_legacy_fields_independently() -> None:
+    """Clear each retired generated field without discarding official copy."""
 
     module = load_offchain_metadata_migration_module()
     legacy_row = {
-        "Name": "Legacy Blue vault",
+        "Name": "Renamed Blue vault",
         "_short_description": module.LEGACY_BLUE_SHORT_DESCRIPTION,
-        "_description": f"Legacy Blue vault{module.LEGACY_BLUE_DESCRIPTION_SUFFIX}",
+        "_description": f"Previous Blue vault{module.LEGACY_BLUE_DESCRIPTION_SUFFIX}",
     }
-    manager_row = {
+    official_description_row = {
         "Name": "Manager Blue vault",
         "_short_description": module.LEGACY_BLUE_SHORT_DESCRIPTION,
         "_description": "Manager Blue vault is an Enzyme Blue investment vehicle with a manager-authored strategy.",
@@ -312,4 +312,8 @@ def test_offchain_metadata_migration_clears_only_exact_legacy_fallback() -> None
     assert update is not None
     assert update.short_description is None
     assert update.description is None
-    assert module.create_legacy_fallback_clear_update(BLUE_SPEC, manager_row) is None
+    partial_update = module.create_legacy_fallback_clear_update(BLUE_SPEC, official_description_row)
+    assert partial_update is not None
+    assert partial_update.short_description is None
+    assert partial_update.description == official_description_row["_description"]
+    assert partial_update.changed_fields == ("_short_description",)


### PR DESCRIPTION
# Why

Enzyme Blue manager descriptions are authoritative only when returned by Enzyme’s authenticated GetVault API. The catalogue must not retain earlier generated fallback text, including partial fallback fields, and the maintenance migration must remain safe under API rate limits. Enzyme Onyx has no supported public description endpoint, so its intentionally blank short description and explicit unavailable long-description marker need an auditable repair path.

# Lessons learnt

An authenticated empty API response is evidence that copy is absent, not an invitation to infer it. A resumable migration also needs a durable completed-cache path: retrying thousands of successful reads wastes quota and can reproduce rate limiting. Existing databases can contain partial old fallback fields, so migrations must repair each owned field independently rather than assuming a complete pair.

# Summary

- Require a minimal real external-integration test and a redacted PR run record for new or materially changed integrations.
- Add an opt-in live Enzyme Blue GetVault test which runs automatically when ENZYME_BLUE_API_TOKEN is available.
- Keep Blue descriptions only when delivered by GetVault; successful empty fields clear stale copy.
- Keep Onyx short descriptions empty and use Description is not publicly available as the long-description marker.
- Add a resumable Blue metadata migration with an atomic state file, completed-cache reuse, explicit refresh control, and exact legacy-field repair.
- Limit new GetVault requests to 1,000 recorded USD-unit NAV, 1 ETH-unit NAV, or 0.1 BTC-unit NAV; expose below-threshold and unsupported-unit counts instead of mislabelling NAV as USD TVL.
- Add a read-only Enzyme export with short descriptions, unit filters, sorting and limits; it labels values as accounting-unit total value.
- Document Blue and Onyx architecture, metadata provenance, production operations and Compose credential scoping.
- Pass ENZYME_BLUE_API_TOKEN only to the profile-only one-shot scanner service.

# Related issues and PRs

Follow-up to #1497, which introduced Enzyme Blue metadata collection.

# Unrelated CI and test fixes

None.