### PR TITLE
Categorise ApeX vault strategies

### DIFF
--- a/.claude/skills/categorise-vault-strategy/SKILL.md
+++ b/.claude/skills/categorise-vault-strategy/SKILL.md
@@ -117,6 +117,26 @@ address-to-tag mapping next to its vault protocol adapter.
    `perpetual_futures` tag and an address-specific tag added by its mapping.
    Format modified Python files and run the focused test.
 
+6. Schedule the production database migration.
+
+   - Do not update `~/.tradingstrategy/vaults/vault-metadata-db.pickle` on a
+     local development machine as part of this workflow. The pickle is a
+     materialised cache; the resolver and focused tests are the source-controlled
+     change.
+   - After opening the pull request, post the production migration instructions
+     below as a pull-request comment. The operator must run them only after the
+     code is merged and deployed.
+   - Stop the persistent scanner before the migration so it cannot overwrite
+     the metadata pickle. Run the dry run, inspect its output, then apply the
+     migration and restart the scanner:
+
+     ```shell
+     source ~/vault-scanner/vault-rpc.env && (cd ~/vault-scanner/web3-ethereum-defi && docker compose stop vault-scanner-looped)
+     source ~/vault-scanner/vault-rpc.env && (cd ~/vault-scanner/web3-ethereum-defi && docker compose run --rm --entrypoint /bin/bash vault-scanner-oneshot -lc 'DRY_RUN=true python scripts/erc-4626/migrate-vault-strategy-tags.py')
+     source ~/vault-scanner/vault-rpc.env && (cd ~/vault-scanner/web3-ethereum-defi && docker compose run --rm --entrypoint /bin/bash vault-scanner-oneshot -lc 'DRY_RUN=false python scripts/erc-4626/migrate-vault-strategy-tags.py')
+     source ~/vault-scanner/vault-rpc.env && (cd ~/vault-scanner/web3-ethereum-defi && docker compose up -d vault-scanner-looped)
+     ```
+
 ## Chat output
 
 When reporting a completed categorisation, output one entry per vault with:
@@ -124,3 +144,4 @@ When reporting a completed categorisation, output one entry per vault with:
 - Vault name
 - Vault address
 - Tags added
+- Link to the production migration comment when a pull request was opened.

--- a/eth_defi/apex/tags.py
+++ b/eth_defi/apex/tags.py
@@ -1,13 +1,47 @@
 """Maintained strategy classifications for ApeX native vaults."""
 
-from eth_defi.vault.strategy_tag import StrategyTag, combine_strategy_tags
+from eth_defi.vault.strategy_tag import StrategyTag
 
-#: ApeX native vaults trade perpetual futures by definition.
-DEFAULT_STRATEGY_TAGS: frozenset[StrategyTag] = frozenset({StrategyTag.perpetual_futures})
+#: User-created ApeX vaults do not publish their strategy details. Categorise
+#: them as discretionary perpetual-futures strategies unless ApeX documents a
+#: different strategy.
+DEFAULT_STRATEGY_TAGS: frozenset[StrategyTag] = frozenset(
+    {
+        StrategyTag.discretionary_trading,
+        StrategyTag.perpetual_futures,
+    }
+)
 
-#: ApeX platform vault IDs may receive additional reviewed classifications.
+#: ApeX platform vault IDs with an explicit, non-discretionary strategy.
 #: Keys are the synthetic identities exported by the ApeX pipeline.
-STRATEGY_TAGS: dict[str, set[StrategyTag]] = {}
+STRATEGY_TAGS: dict[str, set[StrategyTag]] = {
+    #: Vault: Protocol Vault.
+    #: Added: 2026-08-23.
+    #: Decision material: ApeX describes its flagship protocol-operated vault
+    #: as the equivalent of a market-making/liquidity-provider vault. Returns
+    #: derive from perpetual-exchange liquidation fees, not directional trades.
+    #: Sources:
+    #: - https://www.apex.exchange/blog/detail/Introducing-Protocol-Vaults-on-ApeX-Omni-Stable-Returns-Backed-by-Real-Fees
+    #: - eth_defi/apex/constants.py
+    "apex-vault-10000": {
+        StrategyTag.liquidity_provider,
+        StrategyTag.market_maker,
+        StrategyTag.market_making,
+    },
+    #: Vault: New Vault (New User Vault).
+    #: Added: 2026-08-23.
+    #: Decision material: ApeX says this onboarding vault earns the same
+    #: perpetual-exchange liquidation-fee yield as the Protocol Vault, giving
+    #: it the same protocol liquidity-provider/market-making classification.
+    #: Sources:
+    #: - https://www.apex.exchange/blog/detail/weekly-update-11may2026
+    #: - eth_defi/apex/constants.py
+    "apex-vault-10001": {
+        StrategyTag.liquidity_provider,
+        StrategyTag.market_maker,
+        StrategyTag.market_making,
+    },
+}
 
 
 def get_strategy_tags(address: str) -> set[StrategyTag]:
@@ -16,7 +50,11 @@ def get_strategy_tags(address: str) -> set[StrategyTag]:
     :param address:
         ApeX synthetic vault identifier, such as ``apex-vault-10001``.
     :return:
-        A fresh tag set containing the perpetual-futures default and any
-        address-specific classifications.
+        A fresh tag set containing the discretionary perpetual-futures default,
+        or the documented classification for an official vault.
     """
-    return combine_strategy_tags(DEFAULT_STRATEGY_TAGS, STRATEGY_TAGS, address)
+    specific_tags = STRATEGY_TAGS.get(address.lower())
+    if specific_tags is None:
+        return set(DEFAULT_STRATEGY_TAGS)
+
+    return {StrategyTag.perpetual_futures} | set(specific_tags)

--- a/tests/perp_dex/test_perp_dex_strategy_tags.py
+++ b/tests/perp_dex/test_perp_dex_strategy_tags.py
@@ -4,6 +4,8 @@ import datetime
 
 import pytest
 
+from eth_defi.apex import tags as apex_tags
+from eth_defi.apex.vault_data_export import create_apex_vault_row
 from eth_defi.grvt import tags as grvt_tags
 from eth_defi.grvt.vault_data_export import create_grvt_vault_row
 from eth_defi.hibachi import tags as hibachi_tags
@@ -20,6 +22,16 @@ EXPECTED_GRVT_VAULT_COUNT = 26
 def test_native_perp_dex_vault_rows_have_default_strategy_tag() -> None:
     """Native perp DEX exporters persist the perpetual-futures tag."""
     timestamp = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC).replace(tzinfo=None)
+    _, apex = create_apex_vault_row(
+        "test",
+        name="ApeX test vault",
+        description=None,
+        tvl=1_000,
+        share_count=1_000,
+        created_at=timestamp,
+        first_seen=timestamp,
+        status="normal",
+    )
     _, hyperliquid = create_hyperliquid_vault_row(
         "0x0000000000000000000000000000000000000001",
         "Hyperliquid test vault",
@@ -31,7 +43,21 @@ def test_native_perp_dex_vault_rows_have_default_strategy_tag() -> None:
     _, hibachi = create_hibachi_vault_row(1, "HIB", "Hibachi test vault", None, 1_000)
     _, lighter = create_lighter_pool_row(1, "Lighter test pool", None, 1_000, timestamp)
 
+    assert apex["_strategy_tags"] == {StrategyTag.discretionary_trading, StrategyTag.perpetual_futures}
     assert all(row["_strategy_tags"] == {StrategyTag.perpetual_futures} for row in (hyperliquid, grvt, hibachi, lighter))
+
+
+def test_apex_official_vaults_are_market_makers() -> None:
+    """ApeX's official liquidation-fee vaults have their documented tags."""
+    expected = {
+        StrategyTag.liquidity_provider,
+        StrategyTag.market_maker,
+        StrategyTag.market_making,
+        StrategyTag.perpetual_futures,
+    }
+
+    assert apex_tags.get_strategy_tags("apex-vault-10000") == expected
+    assert apex_tags.get_strategy_tags("apex-vault-10001") == expected
 
 
 def test_native_perp_dex_tag_mappings_add_to_default(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Why

ApeX user-created vaults lack published strategy metadata. Classifying them as discretionary provides a consistent default, while retaining a distinct evidence-based classification for ApeX's documented protocol liquidity vaults.

## Lessons learnt

ApeX's Protocol Vault and New Vault earn liquidation-fee revenue rather than taking directional positions, so they are protocol liquidity-provider and market-making vaults.

## Summary

- Classify ordinary ApeX vaults as discretionary perpetual-futures strategies.
- Classify the Protocol Vault and New Vault as liquidity-provider market-making strategies.
- Add focused native-perp tag coverage.

## Related issues and PRs

None.