### PR TITLE
fix: update ApeX strategy tag test expectations

### DIFF
--- a/tests/apex/test_apex_export.py
+++ b/tests/apex/test_apex_export.py
@@ -76,7 +76,10 @@ def test_apex_synthetic_identity_is_a_shared_vault_spec() -> None:
     assert row["_fees"].fee_mode is None
     assert row["Perf fee"] is None
     assert row["_lockup"] == datetime.timedelta(days=1)
-    assert row["_strategy_tags"] == {StrategyTag.perpetual_futures}
+    assert row["_strategy_tags"] == {
+        StrategyTag.discretionary_trading,
+        StrategyTag.perpetual_futures,
+    }
     assert get_vault_protocol_name({ERC4626Feature.apex_native}) == "ApeX"
 
 
@@ -172,3 +175,9 @@ def test_apex_official_vault_export_uses_curated_descriptions(tmp_path: Path) ->
     assert "flagship official vault" in row["_description"]
     assert row["_short_description"].startswith("ApeX Omni's flagship")
     assert row["_lockup"] is None
+    assert row["_strategy_tags"] == {
+        StrategyTag.liquidity_provider,
+        StrategyTag.market_maker,
+        StrategyTag.market_making,
+        StrategyTag.perpetual_futures,
+    }


### PR DESCRIPTION
## Why

The ApeX strategy tag mapping now classifies user-created ApeX vaults as discretionary perpetual-futures strategies, while official ApeX protocol vaults receive liquidity-provider and market-making tags. The export test still expected the previous single-tag result, causing CI to fail.

## Lessons learnt

When adding maintained native vault tag mappings, the export tests need to assert both the default native-vault classification and any official-vault override so the intended policy is explicit.

## Summary

- Updated the ApeX export test to expect `discretionary_trading` plus `perpetual_futures` for user-created vaults.
- Added an assertion that official ApeX vaults export liquidity-provider, market-maker, market-making and perpetual-futures tags.

## Related issues and PRs

None.

## Unrelated CI and test fixes

None.