### PR TITLE
fix: improve confirmation timeout gas diagnostics

### DIFF
--- a/eth_defi/confirmation.py
+++ b/eth_defi/confirmation.py
@@ -12,31 +12,28 @@ Some notes
 import datetime
 import logging
 import time
+from _decimal import Decimal
+from dataclasses import dataclass
 from pprint import pformat
-
 from typing import Collection, Dict, List, Set, Union, cast
 
-from _decimal import Decimal
 from eth_account.datastructures import SignedTransaction
-
-from eth_defi.compat import native_datetime_utc_now
-from eth_defi.event_reader.fast_json_rpc import get_last_headers
-from eth_defi.provider.anvil import is_anvil
 from hexbytes import HexBytes
 from web3 import Web3
 from web3.exceptions import TransactionNotFound
 from web3.providers import BaseProvider
 
+from eth_defi.compat import native_datetime_utc_now
+from eth_defi.event_reader.fast_json_rpc import get_last_headers
 from eth_defi.hotwallet import SignedTransactionWithNonce
-from eth_defi.provider.anvil import mine
+from eth_defi.provider.anvil import is_anvil, mine
 from eth_defi.provider.fallback import FallbackProvider, get_fallback_provider
 from eth_defi.provider.mev_blocker import MEVBlockerProvider
 from eth_defi.provider.named import get_provider_name
 from eth_defi.revert_reason import fetch_transaction_revert_reason
 from eth_defi.timestamp import get_latest_block_timestamp
-from eth_defi.tx import decode_signed_transaction, get_tx_broadcast_data
+from eth_defi.tx import DecodeFailure, decode_signed_transaction, get_tx_broadcast_data
 from eth_defi.utils import to_unix_timestamp
-
 
 logger = logging.getLogger(__name__)
 
@@ -372,6 +369,300 @@ def broadcast_and_wait_transactions_to_complete(
 SignedTxType = Union[SignedTransaction, SignedTransactionWithNonce]
 
 
+def _format_gas_price(value: int) -> str:
+    """Format a wei-denominated gas price for an exception message.
+
+    Keep the exact wei value and include a compact gwei equivalent so an
+    operator can compare signed and network pricing without doing conversion.
+
+    :param value:
+        Gas price in wei.
+
+    :return:
+        Human-readable gas price containing wei and gwei values.
+    """
+    gwei = f"{value / 10**9:.9f}".rstrip("0").rstrip(".")
+    return f"{value} wei ({gwei} gwei)"
+
+
+def _parse_gas_price(value: object) -> int | None:
+    """Parse a Python or JSON-RPC gas-price value.
+
+    Web3 transaction data normally contains integers, while raw JSON-RPC
+    responses contain hexadecimal strings. Other values are unusable for
+    diagnostics and return ``None``.
+
+    :param value:
+        Candidate gas-price value.
+
+    :return:
+        Parsed integer, or ``None`` for an unsupported value.
+    """
+    if type(value) is int:
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value, 0)
+        except ValueError:
+            return None
+    return None
+
+
+def _get_gas_price_from_source(source: dict | None) -> tuple[int | None, int | None, str | None]:
+    """Extract EIP-1559 or legacy gas-price fields from transaction data.
+
+    EIP-1559 transactions use their maximum fee as the inclusion cap. Legacy
+    transactions use ``gasPrice`` directly.
+
+    :param source:
+        Decoded or retained transaction fields.
+
+    :return:
+        Gas-price cap, optional priority fee and formatted field description.
+    """
+    if not source:
+        return None, None, None
+
+    max_fee_per_gas = _parse_gas_price(source.get("maxFeePerGas"))
+    if max_fee_per_gas is not None:
+        priority_fee_per_gas = _parse_gas_price(source.get("maxPriorityFeePerGas"))
+        priority_description = _format_gas_price(priority_fee_per_gas) if priority_fee_per_gas is not None else "unavailable"
+        description = f"maxFeePerGas={_format_gas_price(max_fee_per_gas)}, maxPriorityFeePerGas={priority_description}"
+        return max_fee_per_gas, priority_fee_per_gas, description
+
+    legacy_gas_price = _parse_gas_price(source.get("gasPrice"))
+    if legacy_gas_price is not None:
+        return legacy_gas_price, None, f"gasPrice={_format_gas_price(legacy_gas_price)}"
+
+    return None, None, None
+
+
+def _get_signed_transaction_gas_price(signed_tx: SignedTxType) -> tuple[int | None, int | None, str]:
+    """Read gas pricing from a signed transaction.
+
+    Prefer retained source fields and decode the raw transaction only when
+    needed, because not every signed-transaction wrapper retains its source.
+
+    :param signed_tx:
+        Signed transaction whose submitted gas pricing is needed.
+
+    :return:
+        Gas-price cap, optional priority fee and formatted field description.
+    """
+    source = getattr(signed_tx, "source", None)
+    gas_price, priority_fee, description = _get_gas_price_from_source(source)
+    if gas_price is not None:
+        return gas_price, priority_fee, description
+
+    try:
+        raw_transaction = get_tx_broadcast_data(signed_tx)
+        decoded_source = decode_signed_transaction(raw_transaction)
+    except (AttributeError, DecodeFailure, TypeError, ValueError) as e:
+        logger.warning("Could not decode signed transaction gas price for timeout diagnostics: %s", e)
+        return None, None, "unavailable; the signed transaction source could not be recovered"
+
+    gas_price, priority_fee, description = _get_gas_price_from_source(decoded_source)
+    if gas_price is None:
+        return None, None, "unavailable from the signed transaction"
+    return gas_price, priority_fee, description
+
+
+@dataclass(slots=True, frozen=True)
+class _NetworkGasPrice:
+    """Best-effort network pricing captured for timeout diagnostics."""
+
+    price: int | None
+    priority_fee: int | None
+    source: str
+    is_base_fee: bool = False
+
+
+def _get_single_attempt_provider(web3: Web3) -> BaseProvider:
+    """Get one provider without the fallback provider's retry loop.
+
+    Unwrap both MEV Blocker and fallback providers so timeout diagnostics make
+    exactly one transport attempt instead of starting another failover cycle.
+
+    :param web3:
+        Web3 connection used by transaction confirmation.
+
+    :return:
+        Active raw provider for a single diagnostic request.
+    """
+    provider = web3.provider
+    if isinstance(provider, MEVBlockerProvider):
+        provider = provider.call_provider
+    if isinstance(provider, FallbackProvider):
+        return provider.get_active_provider()
+    return provider
+
+
+def _fetch_rpc_gas_price(provider: BaseProvider, method: str) -> tuple[int | None, str | None]:
+    """Fetch one integer gas-price value through raw JSON-RPC.
+
+    Diagnostic RPC failures are returned as text so they cannot replace the
+    original confirmation timeout.
+
+    :param provider:
+        Provider used for one raw request.
+
+    :param method:
+        Integer-valued JSON-RPC method to call.
+
+    :return:
+        Parsed value and optional failure description.
+    """
+    try:
+        response = provider.make_request(method, [])
+        if response.get("error"):
+            return None, f"{method} returned RPC error {response['error']}"
+        value = _parse_gas_price(response.get("result"))
+        if value is None or value < 0:
+            return None, f"{method} returned invalid value {response.get('result')!r}"
+        return value, None
+    except Exception as e:
+        # Raw provider failures vary by transport and must not replace the
+        # original ConfirmationTimedOut.
+        return None, f"{method} failed with {type(e).__name__}: {e}"
+
+
+def _fetch_current_network_gas_price(provider: BaseProvider) -> _NetworkGasPrice:
+    """Fetch current network pricing without masking a confirmation timeout.
+
+    Try ``eth_gasPrice`` first because chains may customise it to return their
+    recommended next-block price. If that RPC method is unavailable, fall back
+    to the latest block's EIP-1559 base fee. The caller supplies a provider for
+    a single raw RPC attempt so diagnostics cannot restart the
+    fallback provider's multi-minute retry cycle. Raw JSON-RPC values are parsed
+    here without depending on Web3 middleware.
+
+    :param provider:
+        Active Web3 provider used directly for diagnostic RPC calls.
+
+    :return:
+        Node-reported gas price, priority fee suggestion and source details.
+    """
+    gas_price, gas_price_error = _fetch_rpc_gas_price(provider, "eth_gasPrice")
+    priority_fee, priority_fee_error = _fetch_rpc_gas_price(provider, "eth_maxPriorityFeePerGas")
+    errors = [error for error in (gas_price_error, priority_fee_error) if error]
+
+    if gas_price is not None:
+        source = "eth_gasPrice"
+        if errors:
+            source += "; " + "; ".join(errors)
+        return _NetworkGasPrice(gas_price, priority_fee, source)
+
+    try:
+        response = provider.make_request("eth_getBlockByNumber", ["latest", False])
+        if response.get("error"):
+            errors.append(f"eth_getBlockByNumber returned RPC error {response['error']}")
+        else:
+            latest_block = response.get("result") or {}
+            base_fee = _parse_gas_price(latest_block.get("baseFeePerGas"))
+            if base_fee is not None and base_fee >= 0:
+                source = "latest block baseFeePerGas fallback; " + "; ".join(errors)
+                return _NetworkGasPrice(base_fee, priority_fee, source, is_base_fee=True)
+            errors.append(f"eth_getBlockByNumber returned invalid baseFeePerGas {latest_block.get('baseFeePerGas')!r}")
+    except Exception as e:
+        # Transport exceptions are diagnostic data and must not replace the
+        # original ConfirmationTimedOut.
+        errors.append(f"latest block lookup failed with {type(e).__name__}: {e}")
+
+    return _NetworkGasPrice(None, priority_fee, "; ".join(errors))
+
+
+def format_confirmation_timeout_gas_diagnostics(
+    provider: BaseProvider,
+    txs: Collection[SignedTxType],
+    unconfirmed_txs: Collection[HexBytes],
+) -> str:
+    """Format submitted and current network gas prices after a timeout.
+
+    :param provider:
+        Single-attempt provider for raw diagnostic RPC calls.
+
+    :param txs:
+        All signed transactions in the confirmation batch.
+
+    :param unconfirmed_txs:
+        Hashes that remained unconfirmed when the timeout elapsed.
+
+    :return:
+        Multi-line gas-price diagnostics for ``ConfirmationTimedOut``.
+    """
+    network = _fetch_current_network_gas_price(provider)
+    lines = ["Gas price diagnostics:"]
+
+    if network.price is None:
+        lines.append(f"Current network gas price unavailable: {network.source}.")
+    elif network.is_base_fee:
+        lines.append(f"Latest block base fee: {_format_gas_price(network.price)} (excludes priority fee; source: {network.source}).")
+    else:
+        lines.append(f"Current network gas price: {_format_gas_price(network.price)} (source: {network.source}).")
+    if network.priority_fee is not None:
+        lines.append(f"Current network priority fee: {_format_gas_price(network.priority_fee)} (source: eth_maxPriorityFeePerGas).")
+
+    unconfirmed_hashes = set(unconfirmed_txs)
+    for signed_tx in txs:
+        if signed_tx.hash not in unconfirmed_hashes:
+            continue
+
+        tx_hash = signed_tx.hash.hex()
+        used_price, used_priority_fee, used_price_description = _get_signed_transaction_gas_price(signed_tx)
+        lines.append(f"Transaction {tx_hash} used gas price: {used_price_description}.")
+
+        if used_price is None:
+            continue
+
+        effective_priority_fee = used_priority_fee
+        if network.is_base_fee and network.price is not None and used_priority_fee is not None:
+            effective_priority_fee = min(used_priority_fee, max(0, used_price - network.price))
+        priority_underpriced = effective_priority_fee is not None and network.priority_fee is not None and effective_priority_fee < network.priority_fee
+
+        if network.price is None and priority_underpriced:
+            lines.append(f"Likely transaction gas-price mispricing for {tx_hash}: maxPriorityFeePerGas {_format_gas_price(used_priority_fee)} is below the node's current priority-fee suggestion {_format_gas_price(network.priority_fee)}. The transaction may be deprioritised; maxFeePerGas sufficiency could not be assessed because the current network price was unavailable.")
+        elif network.price is None:
+            lines.append(f"Gas-price mispricing for {tx_hash} could not be assessed because the current network price was unavailable.")
+        elif used_price < network.price:
+            if network.is_base_fee:
+                lines.append(f"Likely transaction gas-price mispricing for {tx_hash}: the transaction cap {_format_gas_price(used_price)} is below the latest block base fee {_format_gas_price(network.price)} and cannot be included until the base fee falls.")
+            else:
+                lines.append(f"Likely transaction gas-price mispricing for {tx_hash}: the transaction cap {_format_gas_price(used_price)} is below the node's current suggested network price {_format_gas_price(network.price)}. The transaction may remain deprioritised or be dropped.")
+        elif priority_underpriced and network.is_base_fee:
+            lines.append(f"Likely transaction gas-price mispricing for {tx_hash}: the effective priority fee {_format_gas_price(effective_priority_fee)} is below the node's current priority-fee suggestion {_format_gas_price(network.priority_fee)}. The effective priority fee is limited by maxPriorityFeePerGas and by maxFeePerGas minus the base fee, so the transaction may be deprioritised.")
+        elif priority_underpriced:
+            lines.append(f"Likely transaction gas-price mispricing for {tx_hash}: maxPriorityFeePerGas {_format_gas_price(used_priority_fee)} is below the node's current priority-fee suggestion {_format_gas_price(network.priority_fee)}. The transaction may be deprioritised even though its maxFeePerGas is sufficient.")
+        else:
+            lines.append(f"The transaction cap for {tx_hash} is not below the available network fee reference at timeout. Gas pricing may have differed at initial broadcast; investigate nonce ordering, broadcast acceptance, and RPC propagation.")
+
+    return "\n".join(lines)
+
+
+def _fetch_timed_out_transaction(provider: BaseProvider, tx_hash: HexBytes) -> dict | None:
+    """Fetch a timed-out transaction through one raw JSON-RPC request.
+
+    Raw providers require a ``0x``-prefixed transaction hash. An RPC error is
+    distinct from a successful null result, which means the node does not know
+    the transaction.
+
+    :param provider:
+        Provider used for one raw request.
+
+    :param tx_hash:
+        Transaction hash to query.
+
+    :return:
+        Transaction data, or ``None`` when the node does not know the hash.
+
+    :raise ValueError:
+        The provider returned a JSON-RPC error response.
+    """
+    response = provider.make_request("eth_getTransactionByHash", [tx_hash.to_0x_hex()])
+    if response.get("error"):
+        raise ValueError(f"eth_getTransactionByHash returned RPC error {response['error']}")
+    return response.get("result")
+
+
 def _broadcast_multiple_nodes(
     providers: Collection[BaseProvider],
     signed_tx: SignedTxType,
@@ -576,7 +867,9 @@ def wait_and_broadcast_multiple_nodes(
         Map of transaction hashes -> receipt
 
     :raise ConfirmationTimedOut:
-        If we cannot get transactions out
+        If we cannot get transactions out. The exception includes the signed
+        transaction gas-price fields, best-effort current network gas and
+        priority fees, and an underpricing hint when the signed values are lower.
 
     :raise NonceMismatch:
         Starting nonce does not match what we see on chain.
@@ -761,19 +1054,31 @@ def wait_and_broadcast_multiple_nodes(
             time.sleep(poll_delay.total_seconds())
 
             if native_datetime_utc_now() > started_at + max_timeout:
-                for tx_hash in unconfirmed_txs:
-                    try:
-                        tx_data = web3.eth.get_transaction(tx_hash)
-                        logger.error("Data for transaction %s was %s", tx_hash.hex(), tx_data)
-                    except TransactionNotFound as e:
-                        # Happens on LlamaNodes - we have broadcasted the transaction
-                        # but its nodes do not see it yet
-                        name = get_provider_name(web3.provider)
-                        logger.warning("Node %s missing transaction broadcast %s", name, tx_hash.hex())
-                        logger.exception(e)
-
                 unconfirmed_tx_strs = ", ".join([tx_hash.hex() for tx_hash in unconfirmed_txs])
-                raise ConfirmationTimedOut(f"Transaction confirmation failed. Started: {started_at}, timed out after {max_timeout} ({max_timeout.total_seconds()}s). Poll delay: {poll_delay.total_seconds()}s. Still unconfirmed: {unconfirmed_tx_strs}")
+                try:
+                    diagnostic_provider = _get_single_attempt_provider(web3)
+                    for tx_hash in unconfirmed_txs:
+                        try:
+                            tx_data = _fetch_timed_out_transaction(diagnostic_provider, tx_hash)
+                            if tx_data:
+                                logger.error("Data for transaction %s was %s", tx_hash.hex(), tx_data)
+                            else:
+                                logger.warning("Node %s missing transaction broadcast %s", get_provider_name(diagnostic_provider), tx_hash.hex())
+                        except Exception as e:
+                            # Provider-specific transport and RPC failures are
+                            # diagnostic data and must not replace the timeout.
+                            logger.warning("Could not fetch timed-out transaction %s: %s", tx_hash.hex(), e)
+                    gas_diagnostics = format_confirmation_timeout_gas_diagnostics(
+                        diagnostic_provider,
+                        txs,
+                        unconfirmed_txs,
+                    )
+                except Exception as e:
+                    # Timeout diagnostics are best effort and must never mask
+                    # the original ConfirmationTimedOut.
+                    logger.warning("Could not construct gas-price timeout diagnostics: %s", e)
+                    gas_diagnostics = f"Gas price diagnostics unavailable: {type(e).__name__}: {e}"
+                raise ConfirmationTimedOut(f"Transaction confirmation failed. Started: {started_at}, timed out after {max_timeout} ({max_timeout.total_seconds()}s). Poll delay: {poll_delay.total_seconds()}s. Still unconfirmed: {unconfirmed_tx_strs}\n{gas_diagnostics}")
 
         if native_datetime_utc_now() >= next_node_switch:
             if transact_provider:

--- a/tests/rpc/test_confirmation_timeout_diagnostics.py
+++ b/tests/rpc/test_confirmation_timeout_diagnostics.py
@@ -1,0 +1,223 @@
+"""Test transaction confirmation timeout gas-price diagnostics."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from eth_account import Account
+from hexbytes import HexBytes
+from web3.providers import BaseProvider
+
+from eth_defi import confirmation
+from eth_defi.confirmation import format_confirmation_timeout_gas_diagnostics
+from eth_defi.hotwallet import SignedTransactionWithNonce
+from eth_defi.provider.fallback import FallbackProvider
+
+
+def _create_signed_transaction(source: dict, hash_byte: str = "12") -> SignedTransactionWithNonce:
+    """Create a minimal signed transaction carrying diagnostic source fields."""
+    return SignedTransactionWithNonce(
+        rawTransaction=HexBytes("0x01"),
+        hash=HexBytes("0x" + hash_byte * 32),
+        r=0,
+        s=0,
+        v=0,
+        nonce=7,
+        address="0x" + "34" * 20,
+        source=source,
+    )
+
+
+def test_confirmation_timeout_reports_likely_underpriced_transaction() -> None:
+    """Test a timeout explains when an EIP-1559 fee cap is below the network price."""
+    provider = MagicMock(spec=BaseProvider)
+
+    def make_request(method: str, params: list) -> dict:
+        """Return gas pricing from one diagnostic provider."""
+        assert params == []
+        values = {
+            "eth_gasPrice": hex(81_880_000_000),
+            "eth_maxPriorityFeePerGas": hex(1_000_000_000),
+        }
+        return {"jsonrpc": "2.0", "id": 1, "result": values[method]}
+
+    # Mock the provider to test diagnostic formatting without an external RPC.
+    provider.make_request.side_effect = make_request
+    signed_tx = _create_signed_transaction(
+        {
+            "maxFeePerGas": 4_000_000_000,
+            "maxPriorityFeePerGas": 100_000_000,
+        }
+    )
+    low_priority_tx = _create_signed_transaction(
+        {
+            "maxFeePerGas": 100_000_000_000,
+            "maxPriorityFeePerGas": 100_000_000,
+        },
+        hash_byte="56",
+    )
+
+    diagnostics = format_confirmation_timeout_gas_diagnostics(
+        provider,
+        [signed_tx, low_priority_tx],
+        [signed_tx.hash, low_priority_tx.hash],
+    )
+
+    assert "Current network gas price: 81880000000 wei (81.88 gwei)" in diagnostics
+    assert "Current network priority fee: 1000000000 wei (1 gwei)" in diagnostics
+    assert "maxFeePerGas=4000000000 wei (4 gwei)" in diagnostics
+    assert "maxPriorityFeePerGas=100000000 wei (0.1 gwei)" in diagnostics
+    assert "Likely transaction gas-price mispricing" in diagnostics
+    assert "may remain deprioritised or be dropped" in diagnostics
+    assert "maxPriorityFeePerGas 100000000 wei (0.1 gwei) is below" in diagnostics
+    assert "may be deprioritised" in diagnostics
+
+
+def test_confirmation_timeout_handles_network_gas_price_failure() -> None:
+    """Test gas diagnostic RPC failures do not replace the original timeout."""
+    provider = MagicMock(spec=BaseProvider)
+    method_unavailable = ValueError("method unavailable")
+    rpc_offline = ConnectionError("RPC offline")
+
+    def make_request_with_base_fee_fallback(method: str, params: list) -> dict:
+        """Fail gas suggestion calls and expose only the latest block base fee."""
+        if method == "eth_gasPrice":
+            raise method_unavailable
+        if method == "eth_maxPriorityFeePerGas":
+            assert params == []
+            return {"jsonrpc": "2.0", "id": 1, "result": hex(2_000_000_000)}
+        assert method == "eth_getBlockByNumber"
+        assert params == ["latest", False]
+        return {"jsonrpc": "2.0", "id": 1, "result": {"baseFeePerGas": hex(7_000_000_000)}}
+
+    # Mock failures because timeout diagnostics must degrade gracefully when
+    # optional RPC methods are unavailable.
+    provider.make_request.side_effect = make_request_with_base_fee_fallback
+    signed_tx = _create_signed_transaction({"gasPrice": "0x12a05f200"})
+    decoded_tx = Account.create().sign_transaction(
+        {
+            "chainId": 1,
+            "nonce": 0,
+            "to": "0x" + "78" * 20,
+            "value": 0,
+            "gas": 21_000,
+            "gasPrice": 6_000_000_000,
+        }
+    )
+    constrained_tip_tx = _create_signed_transaction(
+        {
+            "maxFeePerGas": 7_500_000_000,
+            "maxPriorityFeePerGas": 2_000_000_000,
+        },
+        hash_byte="90",
+    )
+
+    fallback_diagnostics = format_confirmation_timeout_gas_diagnostics(
+        provider,
+        [signed_tx, decoded_tx, constrained_tip_tx],
+        [signed_tx.hash, decoded_tx.hash, constrained_tip_tx.hash],
+    )
+
+    assert "Latest block base fee: 7000000000 wei (7 gwei)" in fallback_diagnostics
+    assert "latest block baseFeePerGas fallback" in fallback_diagnostics
+    assert "Likely transaction gas-price mispricing" in fallback_diagnostics
+    assert "cannot be included until the base fee falls" in fallback_diagnostics
+    assert "gasPrice=6000000000 wei (6 gwei)" in fallback_diagnostics
+    assert "effective priority fee 500000000 wei (0.5 gwei) is below" in fallback_diagnostics
+    assert "limited by maxPriorityFeePerGas and by maxFeePerGas minus the base fee" in fallback_diagnostics
+
+    def make_failed_request(method: str, params: list) -> dict:
+        """Simulate an unavailable diagnostic provider."""
+        if method == "eth_getBlockByNumber":
+            assert params == ["latest", False]
+            raise rpc_offline
+        assert params == []
+        raise method_unavailable
+
+    provider.make_request.side_effect = make_failed_request
+    unavailable_diagnostics = format_confirmation_timeout_gas_diagnostics(
+        provider,
+        [signed_tx],
+        [signed_tx.hash],
+    )
+
+    assert "Current network gas price unavailable" in unavailable_diagnostics
+    assert "eth_gasPrice failed with ValueError: method unavailable" in unavailable_diagnostics
+    assert "latest block lookup failed with ConnectionError: RPC offline" in unavailable_diagnostics
+    assert "gasPrice=5000000000 wei (5 gwei)" in unavailable_diagnostics
+    assert "could not be assessed" in unavailable_diagnostics
+
+
+def test_confirmation_timeout_uses_single_provider_for_diagnostics() -> None:
+    """Test timeout diagnostics bypass the fallback provider retry loop."""
+    web3 = MagicMock()
+    active_provider = MagicMock(spec=BaseProvider)
+    fallback_provider = MagicMock(spec=FallbackProvider)
+    web3.provider = active_provider
+
+    assert confirmation._get_single_attempt_provider(web3) is active_provider
+
+    web3.provider = fallback_provider
+    fallback_provider.get_active_provider.return_value = active_provider
+
+    assert confirmation._get_single_attempt_provider(web3) is active_provider
+
+
+def test_confirmation_timeout_reports_priority_fee_when_network_price_is_unavailable() -> None:
+    """Test a usable priority-fee reference is not hidden by other RPC failures."""
+    provider = MagicMock(spec=BaseProvider)
+    rpc_offline = ConnectionError("RPC offline")
+    method_unavailable = ValueError("method unavailable")
+
+    def make_request(method: str, params: list) -> dict:
+        """Return only the node's priority-fee suggestion."""
+        if method == "eth_maxPriorityFeePerGas":
+            assert params == []
+            return {"jsonrpc": "2.0", "id": 1, "result": hex(1_000_000_000)}
+        if method == "eth_getBlockByNumber":
+            assert params == ["latest", False]
+            raise rpc_offline
+        assert method == "eth_gasPrice"
+        assert params == []
+        raise method_unavailable
+
+    provider.make_request.side_effect = make_request
+    signed_tx = _create_signed_transaction(
+        {
+            "maxFeePerGas": 10_000_000_000,
+            "maxPriorityFeePerGas": 100_000_000,
+        }
+    )
+
+    diagnostics = format_confirmation_timeout_gas_diagnostics(
+        provider,
+        [signed_tx],
+        [signed_tx.hash],
+    )
+
+    assert "Current network gas price unavailable" in diagnostics
+    assert "Current network priority fee: 1000000000 wei (1 gwei)" in diagnostics
+    assert "maxPriorityFeePerGas 100000000 wei (0.1 gwei) is below" in diagnostics
+    assert "maxFeePerGas sufficiency could not be assessed" in diagnostics
+
+
+def test_fetch_timed_out_transaction_uses_prefixed_hash_and_reports_rpc_errors() -> None:
+    """Test raw transaction lookup separates a missing transaction from an RPC error."""
+    provider = MagicMock(spec=BaseProvider)
+    tx_hash = HexBytes("0x" + "ab" * 32)
+    provider.make_request.return_value = {"jsonrpc": "2.0", "id": 1, "result": None}
+
+    missing_transaction = confirmation._fetch_timed_out_transaction(provider, tx_hash)
+
+    assert missing_transaction is None
+    provider.make_request.assert_called_once_with(
+        "eth_getTransactionByHash",
+        [tx_hash.to_0x_hex()],
+    )
+
+    provider.make_request.return_value = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "error": {"code": -32602, "message": "invalid argument"},
+    }
+    with pytest.raises(ValueError, match="eth_getTransactionByHash returned RPC error"):
+        confirmation._fetch_timed_out_transaction(provider, tx_hash)


### PR DESCRIPTION
## Why

A transaction confirmation timeout previously reported only the missing hash. During the HyperAI incident this hid the decisive evidence: the transaction was signed with a 4 gwei fee cap while HyperEVM's observed base fee was 81.88 gwei. Operators need the submitted fee fields, a best-effort current network reference, and careful wording that distinguishes a base fee, a node gas-price suggestion and a priority fee.

The diagnostic path must also remain secondary to the original `ConfirmationTimedOut`. It must not trigger another multi-provider retry cycle or replace the timeout with a failing RPC or decoding call.

## Lessons learnt

Raw provider calls avoid restarting fallback-provider retries, but they also bypass Web3 formatting. Transaction hashes must therefore be explicitly `0x`-prefixed and JSON-RPC error responses must be distinguished from successful null results. For EIP-1559 transactions the effective priority fee is constrained by both `maxPriorityFeePerGas` and `maxFeePerGas - baseFee`; comparing only the declared priority fee can produce a misleading diagnosis.

## Summary

- Include each unconfirmed transaction's signed legacy or EIP-1559 gas fields in `ConfirmationTimedOut`.
- Query one active provider for `eth_gasPrice`, `eth_maxPriorityFeePerGas`, and a latest-block base-fee fallback without restarting failover retries.
- Report likely fee-cap or effective-priority-fee mispricing while keeping uncertain cases explicitly qualified.
- Preserve the original timeout when diagnostic RPC calls or signed-transaction decoding fail.
- Add focused coverage for fee-cap underpricing, effective-tip constraints, raw hash formatting, RPC failures, provider unwrapping, source decoding and graceful fallback behaviour.

## Related issues and PRs

- Consumed by tradingstrategy-ai/trade-executor#1629.
- Supports the follow-up to tradingstrategy-ai/trade-executor#1479 after its fixed HyperEVM cap was exceeded by the network base fee.
